### PR TITLE
Fix premature Codex completion notifications

### DIFF
--- a/CLI/CMUXCLI+AgentHookDefinitions.swift
+++ b/CLI/CMUXCLI+AgentHookDefinitions.swift
@@ -182,7 +182,11 @@ extension CMUXCLI {
         "session-finalize": .sessionFinalize,
     ]
 
-    static func hookCommandString(for def: AgentHookDef, event: AgentHookDef.HookEvent) -> String {
+    static func hookCommandString(
+        for def: AgentHookDef,
+        event: AgentHookDef.HookEvent,
+        materializeCodexScripts: Bool = true
+    ) -> String {
         let command = "cmux hooks \(def.name) \(event.cmuxSubcommand)"
         let inline: String
         if def.name == "codex", codexHookCanRunFireAndForget(event.cmuxSubcommand) {
@@ -191,7 +195,11 @@ extension CMUXCLI {
             inline = agentHookShellCommand(command, for: def)
         }
         if def.name == "codex" {
-            return codexPersistentHookScriptCommand(inline, eventTag: event.cmuxSubcommand)
+            return codexPersistentHookScriptCommand(
+                inline,
+                eventTag: event.cmuxSubcommand,
+                materialize: materializeCodexScripts
+            )
         }
         return inline
     }
@@ -202,8 +210,13 @@ extension CMUXCLI {
     /// the `command` string directly and fail an inline shell snippet with
     /// "No such file or directory (os error 2)". Falls back to the inline command
     /// on any write failure, so the persistent install can never regress.
-    private static func codexPersistentHookScriptCommand(_ inlineCommand: String, eventTag: String) -> String {
-        guard let dir = codexHookScriptsDirectory(),
+    private static func codexPersistentHookScriptCommand(
+        _ inlineCommand: String,
+        eventTag: String,
+        materialize: Bool = true
+    ) -> String {
+        guard materialize,
+              let dir = codexHookScriptsDirectory(),
               let path = writeCodexHookScript(
                   subcommand: "persistent-\(eventTag)", body: inlineCommand, in: dir
               ) else {
@@ -216,7 +229,11 @@ extension CMUXCLI {
         subcommand == "session-start" || subcommand == "prompt-submit" || subcommand == "stop"
     }
 
-    static func feedHookCommandString(for def: AgentHookDef, agentEvent: String) -> String {
+    static func feedHookCommandString(
+        for def: AgentHookDef,
+        agentEvent: String,
+        materializeCodexScripts: Bool = true
+    ) -> String {
         if def.name == "codex",
            let injectedEvent = CodexHookInjectionSchema.current.events.first(where: {
                $0.agentEvent == agentEvent
@@ -235,7 +252,8 @@ extension CMUXCLI {
             }
             return codexPersistentHookScriptCommand(
                 inline,
-                eventTag: "feed-\(agentEvent)"
+                eventTag: "feed-\(agentEvent)",
+                materialize: materializeCodexScripts
             )
         }
 
@@ -256,7 +274,11 @@ extension CMUXCLI {
             )
         }
         if def.name == "codex" {
-            return codexPersistentHookScriptCommand(inline, eventTag: "feed-\(agentEvent)")
+            return codexPersistentHookScriptCommand(
+                inline,
+                eventTag: "feed-\(agentEvent)",
+                materialize: materializeCodexScripts
+            )
         }
         return inline
     }
@@ -484,15 +506,32 @@ extension CMUXCLI {
         "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
     }
 
-    static func isCmuxOwnedHookCommand(_ command: String, for def: AgentHookDef, includeLegacy: Bool = true) -> Bool {
+    static func isCmuxOwnedHookCommand(
+        _ command: String,
+        for def: AgentHookDef,
+        includeLegacy: Bool = true,
+        materializeCodexScripts: Bool = true
+    ) -> Bool {
         if case .pinned(let marker) = def.dispatch, command.contains(marker) {
             return true
         }
         if def.name == "codex", isCmuxOwnedCodexHookScriptCommand(command) {
             return true
         }
-        if def.events.contains(where: { hookCommandString(for: def, event: $0) == command })
-            || def.feedHookEvents.contains(where: { feedHookCommandString(for: def, agentEvent: $0) == command })
+        if def.events.contains(where: {
+            hookCommandString(
+                for: def,
+                event: $0,
+                materializeCodexScripts: materializeCodexScripts
+            ) == command
+        })
+            || def.feedHookEvents.contains(where: {
+                feedHookCommandString(
+                    for: def,
+                    agentEvent: $0,
+                    materializeCodexScripts: materializeCodexScripts
+                ) == command
+            })
         {
             return true
         }

--- a/CLI/CMUXCLI+AgentHookDefinitions.swift
+++ b/CLI/CMUXCLI+AgentHookDefinitions.swift
@@ -500,7 +500,7 @@ extension CMUXCLI {
     }
 
     private static func isCmuxOwnedCodexHookScriptCommand(_ command: String) -> Bool {
-        guard let hooksDirectory = codexHookScriptsDirectory() else { return false }
+        let hooksDirectory = codexHookScriptsURL()
         let url = URL(fileURLWithPath: command, isDirectory: false)
         let name = url.lastPathComponent
         return CodexHookScriptName(filename: name) != nil

--- a/CLI/CMUXCLI+AgentHookDefinitions.swift
+++ b/CLI/CMUXCLI+AgentHookDefinitions.swift
@@ -160,7 +160,9 @@ extension CMUXCLI {
     }
 
     enum AgentHookAction {
-        case sessionStart, promptSubmit, stop, notification, approvalResponse, shellObserved, shellDone, shellFailed, sessionEnd, sessionFinalize, noop
+        case sessionStart, promptSubmit, stop, notification, approvalResponse
+        case codexSubagentStart, codexSubagentStop
+        case shellObserved, shellDone, shellFailed, sessionEnd, sessionFinalize, noop
     }
 
     static let subcommandActions: [String: AgentHookAction] = [
@@ -171,6 +173,8 @@ extension CMUXCLI {
         "notify": .notification,
         "agent-response": .stop,
         "approval-response": .approvalResponse,
+        "subagent-start": .codexSubagentStart,
+        "subagent-stop": .codexSubagentStop,
         "shell-exec": .promptSubmit,
         "shell-done": .shellDone,
         "shell-failed": .shellFailed,
@@ -217,10 +221,18 @@ extension CMUXCLI {
            let injectedEvent = CodexHookInjectionSchema.current.events.first(where: {
                $0.agentEvent == agentEvent
            }) {
-            let inline = codexFireAndForgetAgentHookShellCommand(
-                "cmux hooks codex \(injectedEvent.cmuxSubcommand)",
-                for: def
-            )
+            let inline: String
+            if injectedEvent.isSynchronous {
+                inline = codexSynchronousAgentHookShellCommand(
+                    "cmux hooks feed --source codex --event \(agentEvent)",
+                    for: def
+                )
+            } else {
+                inline = codexFireAndForgetAgentHookShellCommand(
+                    "cmux hooks codex \(injectedEvent.cmuxSubcommand)",
+                    for: def
+                )
+            }
             return codexPersistentHookScriptCommand(
                 inline,
                 eventTag: "feed-\(agentEvent)"
@@ -271,7 +283,7 @@ extension CMUXCLI {
         return "{ \(command); }"
     }
 
-    private static func agentHookShellCommand(
+    static func agentHookShellCommand(
         _ command: String,
         for def: AgentHookDef,
         noOpCommand: String = "echo '{}'"
@@ -282,6 +294,17 @@ extension CMUXCLI {
         let routedArguments = command.hasPrefix("cmux ") ? String(command.dropFirst("cmux ".count)) : command
         let noOpSnippet = shellNoOpSnippet(noOpCommand)
         return "cmux_cli=\"${CMUX_BUNDLED_CLI_PATH:-}\"; if [ -z \"$cmux_cli\" ] || [ ! -x \"$cmux_cli\" ]; then cmux_cli=\"$(command -v cmux 2>/dev/null || true)\"; fi; if [ -n \"$CMUX_SURFACE_ID\" ] && [ \"$\(def.disableEnvVar)\" != \"1\" ] && [ -n \"$cmux_cli\" ]; then { if [ -n \"${CMUX_SOCKET_PATH:-}\" ]; then \"$cmux_cli\" --socket \"$CMUX_SOCKET_PATH\" \(routedArguments); else \"$cmux_cli\" \(routedArguments); fi; } || \(noOpSnippet); else \(noOpSnippet); fi"
+    }
+
+    /// Synchronous Codex lifecycle hook command. Capturing the callback's
+    /// parent PID before dispatch prevents a descendant from reusing an
+    /// inherited `CMUX_CODEX_PID` as its own owner identity.
+    static func codexSynchronousAgentHookShellCommand(
+        _ command: String,
+        for def: AgentHookDef
+    ) -> String {
+        let dispatch = agentHookShellCommand(command, for: def)
+        return "CMUX_CODEX_HOOK_PID=\"${PPID:-}\"; export CMUX_CODEX_HOOK_PID; \(dispatch)"
     }
 
     private static func exitTwoPropagatingAgentHookShellCommand(

--- a/CLI/CMUXCLI+CodexFireAndForgetHooks.swift
+++ b/CLI/CMUXCLI+CodexFireAndForgetHooks.swift
@@ -3,24 +3,29 @@ import Foundation
 
 extension CMUXCLI {
     /// Emit, NUL-separated to stdout, the exact codex arg list the wrapper must
-    /// splice ahead of the user's args to enable + inject cmux's fire-and-forget
-    /// hooks for one codex invocation when no persistent cmux channel is
-    /// installed. Returns the arg list:
+    /// splice ahead of the user's args to enable cmux hooks for one Codex
+    /// invocation without rewriting the user's Codex configuration. Returns
+    /// activation flags followed by one `-c` pair for every event that is not
+    /// already supplied by a cmux-owned persistent hook:
     ///   --enable\0hooks\0--dangerously-bypass-hook-trust\0
     ///   -c\0hooks.SessionStart=[{hooks=[{type="command",command='''<hook>''',timeout=10000}]}]\0
     ///   -c\0hooks.UserPromptSubmit=...\0 ... (one `-c` pair per event)
     /// Turn/status hooks use `codexFireAndForgetAgentHookShellCommand(...)`;
     /// native child lifecycle hooks synchronously commit their ledger event and
     /// then return. All larger socket delivery remains non-blocking.
-    /// Before emission, an existing cmux-owned persistent hook channel is
-    /// reconciled in place and supersedes wrapper injection for this launch.
+    /// Persistent hooks are inventoried read-only so the wrapper does not add a
+    /// duplicate cmux producer. Codex combines hook sources, so user-owned hooks
+    /// continue to run alongside these process-local entries. Only explicit
+    /// `cmux hooks codex install` or `uninstall` commands mutate `CODEX_HOME`.
     /// No live socket is required.
     func emitCodexWrapperInjectArgs() throws {
         guard let codexDef = Self.agentDef(named: "codex") else {
             throw CLIError(message: "Codex hook integration is unavailable.")
         }
-        let usesPersistentChannel = reconcileCodexPersistentHooksForWrapper()
-        let eventsToInject = usesPersistentChannel ? [] : CodexHookInjectionSchema.current.events
+        let persistentEvents = codexPersistentHookEventNamesForWrapper()
+        let eventsToInject = CodexHookInjectionSchema.current.events.filter {
+            !persistentEvents.contains($0.agentEvent)
+        }
         // Prefer a #!/bin/sh SCRIPT FILE as the hook command over an inline shell
         // snippet. Some codex-compatible runtimes (subrouters, proxies) exec the
         // `command` string directly as a program instead of via a shell, so an
@@ -31,14 +36,7 @@ extension CMUXCLI {
         // invocations, so they are written once into a cmux-owned dir (~/.cmux/
         // hooks), not the user's ~/.codex. Any write failure falls back to the
         // inline snippet so the working path can never regress.
-        let hooksDir = Self.codexHookScriptsDirectory()
-        defer {
-            Self.garbageCollectCodexHookScripts(
-                retaining: Self.currentCodexWrapperHookScriptFilenames(for: codexDef)
-                    .union(Self.installedCodexHookScriptFilenames(for: codexDef))
-            )
-        }
-        guard !eventsToInject.isEmpty else { return }
+        let hooksDir = eventsToInject.isEmpty ? nil : Self.codexHookScriptsDirectory()
         var args: [String] = ["--enable", "hooks", "--dangerously-bypass-hook-trust"]
         for event in eventsToInject {
             let hookBody = Self.codexWrapperHookBody(event: event, for: codexDef)
@@ -78,16 +76,20 @@ extension CMUXCLI {
     /// `~/.cmux/hooks` (NOT the user's `~/.codex`), created on demand. Returns
     /// nil if it cannot be created, so the caller falls back to inline commands.
     static func codexHookScriptsDirectory() -> URL? {
-        let home = FileManager.default.homeDirectoryForCurrentUser
-        let dir = home
-            .appendingPathComponent(".cmux", isDirectory: true)
-            .appendingPathComponent("hooks", isDirectory: true)
+        let dir = codexHookScriptsURL()
         do {
             try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
             return dir
         } catch {
             return nil
         }
+    }
+
+    /// The hook-script directory path without creating it.
+    static func codexHookScriptsURL() -> URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".cmux", isDirectory: true)
+            .appendingPathComponent("hooks", isDirectory: true)
     }
 
     /// Writes (idempotently) a `#!/bin/sh` hook script for one event into `dir`
@@ -153,10 +155,10 @@ extension CMUXCLI {
             .appendingPathComponent(def.configFile, isDirectory: false)
         guard let data = try? Data(contentsOf: fileURL),
               let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let hooks = root["hooks"] as? [String: Any],
-              let hooksDirectory = codexHookScriptsDirectory()?.standardizedFileURL else {
+              let hooks = root["hooks"] as? [String: Any] else {
             return []
         }
+        let hooksDirectory = codexHookScriptsURL().standardizedFileURL
 
         var filenames = Set<String>()
         for value in hooks.values {

--- a/CLI/CMUXCLI+CodexFireAndForgetHooks.swift
+++ b/CLI/CMUXCLI+CodexFireAndForgetHooks.swift
@@ -7,10 +7,11 @@ extension CMUXCLI {
     /// hooks for one codex invocation when no persistent cmux channel is
     /// installed. Returns the arg list:
     ///   --enable\0hooks\0--dangerously-bypass-hook-trust\0
-    ///   -c\0hooks.SessionStart=[{hooks=[{type="command",command='''<ff>''',timeout=10000}]}]\0
+    ///   -c\0hooks.SessionStart=[{hooks=[{type="command",command='''<hook>''',timeout=10000}]}]\0
     ///   -c\0hooks.UserPromptSubmit=...\0 ... (one `-c` pair per event)
-    /// where `<ff>` is `codexFireAndForgetAgentHookShellCommand(...)` so each
-    /// hook returns `{}` to codex instantly and backgrounds the real cmux call.
+    /// Turn/status hooks use `codexFireAndForgetAgentHookShellCommand(...)`;
+    /// native child lifecycle hooks synchronously commit their ledger event and
+    /// then return. All larger socket delivery remains non-blocking.
     /// Before emission, an existing cmux-owned persistent hook channel is
     /// reconciled in place and supersedes wrapper injection for this launch.
     /// No live socket is required.

--- a/CLI/CMUXCLI+CodexFireAndForgetHooks.swift
+++ b/CLI/CMUXCLI+CodexFireAndForgetHooks.swift
@@ -40,16 +40,14 @@ extension CMUXCLI {
         guard !eventsToInject.isEmpty else { return }
         var args: [String] = ["--enable", "hooks", "--dangerously-bypass-hook-trust"]
         for event in eventsToInject {
-            let ff = Self.codexFireAndForgetAgentHookShellCommand(
-                "cmux hooks codex \(event.cmuxSubcommand)", for: codexDef
-            )
+            let hookBody = Self.codexWrapperHookBody(event: event, for: codexDef)
             let command: String
             if let scriptPath = hooksDir.flatMap({
-                Self.writeCodexHookScript(subcommand: event.cmuxSubcommand, body: ff, in: $0)
+                Self.writeCodexHookScript(subcommand: event.cmuxSubcommand, body: hookBody, in: $0)
             }), !scriptPath.contains("'''") {
                 command = scriptPath
             } else {
-                command = ff
+                command = hookBody
             }
             // TOML multi-line literal string ('''...''') preserves bytes verbatim
             // and may contain single quotes, so the embedded `echo '{}'` / `sh -c
@@ -129,15 +127,23 @@ extension CMUXCLI {
     /// Names that the current wrapper schema may reference from a live session.
     static func currentCodexWrapperHookScriptFilenames(for def: AgentHookDef) -> Set<String> {
         Set(CodexHookInjectionSchema.current.events.compactMap { event in
-            let body = codexFireAndForgetAgentHookShellCommand(
-                "cmux hooks codex \(event.cmuxSubcommand)",
-                for: def
-            )
+            let body = codexWrapperHookBody(event: event, for: def)
             return CodexHookScriptName(
                 contents: "#!/bin/sh\n\(body)\n",
                 subcommand: event.cmuxSubcommand
             )?.filename
         })
+    }
+
+    private static func codexWrapperHookBody(
+        event: CodexHookInjectionEvent,
+        for def: AgentHookDef
+    ) -> String {
+        let command = "cmux hooks codex \(event.cmuxSubcommand)"
+        if event.isSynchronous {
+            return codexSynchronousAgentHookShellCommand(command, for: def)
+        }
+        return codexFireAndForgetAgentHookShellCommand(command, for: def)
     }
 
     /// Cmux-generated script names referenced by the active persistent config.
@@ -225,7 +231,8 @@ extension CMUXCLI {
             "cmux_cli=\"${CMUX_BUNDLED_CLI_PATH:-}\"",
             "if [ -z \"$cmux_cli\" ] || [ ! -x \"$cmux_cli\" ]; then cmux_cli=\"$(command -v cmux 2>/dev/null || true)\"; fi",
             "agent_pid=\"${CMUX_CODEX_PID:-${PPID:-}}\"",
-            "if [ -n \"$CMUX_SURFACE_ID\" ] && [ \"$\(def.disableEnvVar)\" != \"1\" ] && [ -n \"$cmux_cli\" ]; then payload=\"$(mktemp \"${TMPDIR:-/tmp}/cmux-codex-hook.XXXXXX\" 2>/dev/null || mktemp -t cmux-codex-hook 2>/dev/null)\" || { \(noOp); exit 0; }; cat >\"$payload\" || true; if [ -n \"${CMUX_SOCKET_PATH:-}\" ]; then CMUX_CODEX_PID=\"$agent_pid\" nohup sh -c '\(runner)' cmux-codex-hook \"$payload\" \"$cmux_cli\" --socket \"$CMUX_SOCKET_PATH\" \(routedArguments) >/dev/null 2>&1 & else CMUX_CODEX_PID=\"$agent_pid\" nohup sh -c '\(runner)' cmux-codex-hook \"$payload\" \"$cmux_cli\" \(routedArguments) >/dev/null 2>&1 & fi; echo '{}'; else \(noOp); fi",
+            "hook_pid=\"${CMUX_CODEX_HOOK_PID:-${PPID:-}}\"",
+            "if [ -n \"$CMUX_SURFACE_ID\" ] && [ \"$\(def.disableEnvVar)\" != \"1\" ] && [ -n \"$cmux_cli\" ]; then payload=\"$(mktemp \"${TMPDIR:-/tmp}/cmux-codex-hook.XXXXXX\" 2>/dev/null || mktemp -t cmux-codex-hook 2>/dev/null)\" || { \(noOp); exit 0; }; cat >\"$payload\" || true; if [ -n \"${CMUX_SOCKET_PATH:-}\" ]; then CMUX_CODEX_PID=\"$agent_pid\" CMUX_CODEX_HOOK_PID=\"$hook_pid\" nohup sh -c '\(runner)' cmux-codex-hook \"$payload\" \"$cmux_cli\" --socket \"$CMUX_SOCKET_PATH\" \(routedArguments) >/dev/null 2>&1 & else CMUX_CODEX_PID=\"$agent_pid\" CMUX_CODEX_HOOK_PID=\"$hook_pid\" nohup sh -c '\(runner)' cmux-codex-hook \"$payload\" \"$cmux_cli\" \(routedArguments) >/dev/null 2>&1 & fi; echo '{}'; else \(noOp); fi",
         ].joined(separator: "; ")
     }
 }

--- a/CLI/CMUXCLI+CodexFireAndForgetHooks.swift
+++ b/CLI/CMUXCLI+CodexFireAndForgetHooks.swift
@@ -43,7 +43,7 @@ extension CMUXCLI {
         process.executableURL = URL(fileURLWithPath: "/bin/sh")
         process.arguments = [
             "-c",
-            "nohup \"$0\" hooks codex stop < \"$1\" >/dev/null 2>&1 & rm -f \"$1\"",
+            "nohup /bin/sh -c '\"$0\" hooks codex stop < \"$1\" >/dev/null 2>&1; rm -f \"$1\"' \"$0\" \"$1\" >/dev/null 2>&1 &",
             selfPath,
             payloadURL.path,
         ]

--- a/CLI/CMUXCLI+CodexFireAndForgetHooks.swift
+++ b/CLI/CMUXCLI+CodexFireAndForgetHooks.swift
@@ -2,6 +2,65 @@ import CMUXAgentLaunch
 import Foundation
 
 extension CMUXCLI {
+    /// Schedules the normal Codex Stop path after the final child exits.
+    ///
+    /// Native child hooks must acknowledge the lifecycle write quickly, so the
+    /// larger notification/store projection runs in a detached CLI process.
+    /// The child-stop marker lets that process skip legacy prompt-depth
+    /// inference; the ledger itself remains the single settlement authority.
+    func spawnDetachedCodexSettledStop(
+        payload: String,
+        environment: [String: String],
+        telemetry: CLISocketSentryTelemetry
+    ) {
+        let selfPath: String = {
+            if let first = ProcessInfo.processInfo.arguments.first,
+               first.hasPrefix("/"),
+               FileManager.default.isExecutableFile(atPath: first) {
+                return first
+            }
+            if let bundled = normalizedHookValue(environment["CMUX_BUNDLED_CLI_PATH"]),
+               FileManager.default.isExecutableFile(atPath: bundled) {
+                return bundled
+            }
+            return "cmux"
+        }()
+        let payloadURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "cmux-codex-settled-stop-\(UUID().uuidString).json"
+            )
+        let payloadData = Data(payload.utf8)
+        guard FileManager.default.createFile(
+            atPath: payloadURL.path,
+            contents: payloadData,
+            attributes: [.posixPermissions: NSNumber(value: Int16(0o600))]
+        ) else {
+            telemetry.breadcrumb("codex-hook.settled-stop.payload-write-failed")
+            return
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = [
+            "-c",
+            "nohup \"$0\" hooks codex stop < \"$1\" >/dev/null 2>&1 & rm -f \"$1\"",
+            selfPath,
+            payloadURL.path,
+        ]
+        var childEnvironment = environment
+        childEnvironment["CMUX_CODEX_SETTLED_CHILD_STOP"] = "1"
+        process.environment = childEnvironment
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+        } catch {
+            try? FileManager.default.removeItem(at: payloadURL)
+            telemetry.breadcrumb("codex-hook.settled-stop.spawn-failed")
+        }
+    }
+
     /// Emit, NUL-separated to stdout, the exact codex arg list the wrapper must
     /// splice ahead of the user's args to enable cmux hooks for one Codex
     /// invocation without rewriting the user's Codex configuration. Returns

--- a/CLI/CMUXCLI+CodexFireAndForgetHooks.swift
+++ b/CLI/CMUXCLI+CodexFireAndForgetHooks.swift
@@ -232,7 +232,9 @@ extension CMUXCLI {
             "cmux_cli=\"${CMUX_BUNDLED_CLI_PATH:-}\"",
             "if [ -z \"$cmux_cli\" ] || [ ! -x \"$cmux_cli\" ]; then cmux_cli=\"$(command -v cmux 2>/dev/null || true)\"; fi",
             "agent_pid=\"${CMUX_CODEX_PID:-${PPID:-}}\"",
-            "hook_pid=\"${CMUX_CODEX_HOOK_PID:-${PPID:-}}\"",
+            // The hook shell's immediate parent is the callback owner. Do not
+            // reuse an inherited observation from an outer Codex process.
+            "hook_pid=\"${PPID:-}\"",
             "if [ -n \"$CMUX_SURFACE_ID\" ] && [ \"$\(def.disableEnvVar)\" != \"1\" ] && [ -n \"$cmux_cli\" ]; then payload=\"$(mktemp \"${TMPDIR:-/tmp}/cmux-codex-hook.XXXXXX\" 2>/dev/null || mktemp -t cmux-codex-hook 2>/dev/null)\" || { \(noOp); exit 0; }; cat >\"$payload\" || true; if [ -n \"${CMUX_SOCKET_PATH:-}\" ]; then CMUX_CODEX_PID=\"$agent_pid\" CMUX_CODEX_HOOK_PID=\"$hook_pid\" nohup sh -c '\(runner)' cmux-codex-hook \"$payload\" \"$cmux_cli\" --socket \"$CMUX_SOCKET_PATH\" \(routedArguments) >/dev/null 2>&1 & else CMUX_CODEX_PID=\"$agent_pid\" CMUX_CODEX_HOOK_PID=\"$hook_pid\" nohup sh -c '\(runner)' cmux-codex-hook \"$payload\" \"$cmux_cli\" \(routedArguments) >/dev/null 2>&1 & fi; echo '{}'; else \(noOp); fi",
         ].joined(separator: "; ")
     }

--- a/CLI/CMUXCLI+CodexFireAndForgetHooks.swift
+++ b/CLI/CMUXCLI+CodexFireAndForgetHooks.swift
@@ -26,6 +26,11 @@ extension CMUXCLI {
         let eventsToInject = CodexHookInjectionSchema.current.events.filter {
             !persistentEvents.contains($0.agentEvent)
         }
+        // A complete persistent channel is already the user's selected Codex
+        // configuration. Do not even pass an activation override in that case;
+        // this preserves an intentional `features.hooks = false` choice. A
+        // partial or legacy channel still gets only its missing events below.
+        guard !eventsToInject.isEmpty else { return }
         // Prefer a #!/bin/sh SCRIPT FILE as the hook command over an inline shell
         // snippet. Some codex-compatible runtimes (subrouters, proxies) exec the
         // `command` string directly as a program instead of via a shell, so an

--- a/CLI/CodexTurnLedger.swift
+++ b/CLI/CodexTurnLedger.swift
@@ -295,9 +295,6 @@ final class CodexTurnLedger {
                         record.settledTurnIDs.append(key)
                     }
                     let shouldNotify = !record.notifiedTurnIDs.contains(key)
-                    if shouldNotify {
-                        record.notifiedTurnIDs.append(key)
-                    }
                     decision = self.decision(
                         ownership: .foreground,
                         settlement: .settled,

--- a/CLI/CodexTurnLedger.swift
+++ b/CLI/CodexTurnLedger.swift
@@ -1,0 +1,499 @@
+import Foundation
+
+/// Durable, bounded owner and settlement state for Codex hooks.
+///
+/// This repository is intentionally separate from the general hook-session
+/// snapshot: native child callbacks must commit a tiny record synchronously,
+/// while loading a potentially large resume store would make the hook boundary
+/// depend on unrelated session data. Every mutation is one locked transaction;
+/// no delivery timing or transcript observation participates in settlement.
+final class CodexTurnLedger {
+    private enum Event {
+        case sessionStart
+        case promptSubmit(turnID: String?)
+        case subagentStart(id: String?, turnID: String?)
+        case subagentStop(id: String?, turnID: String?)
+        case stop(turnID: String?)
+        case sessionEnd
+        case observation
+    }
+
+    private static let defaultFilename = "codex-turn-ledger.json"
+    static let maximumRecords = 256
+    static let maximumChildrenPerTurn = 128
+    static let maximumTurnKeys = 64
+    static let maximumTerminalChildrenPerTurn = 256
+    static let maximumRememberedTurns = 128
+    static let maximumIdentifierBytes = 512
+
+    let path: String
+    let fileManager: FileManager
+    let encoder = JSONEncoder()
+    let decoder = JSONDecoder()
+
+    static func normalized(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty,
+              value.utf8.count <= maximumIdentifierBytes else { return nil }
+        return value
+    }
+
+    init(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default
+    ) {
+        let rawPath = Self.normalized(environment[CodexHookInvocation.ledgerPathEnvironmentKey])
+            ?? Self.normalized(environment["CMUX_AGENT_HOOK_STATE_DIR"]).map {
+                URL(fileURLWithPath: NSString(string: $0).expandingTildeInPath, isDirectory: true)
+                    .appendingPathComponent(Self.defaultFilename, isDirectory: false)
+                    .path
+            }
+            ?? URL(fileURLWithPath: "~/.cmuxterm", isDirectory: true)
+                .appendingPathComponent(Self.defaultFilename, isDirectory: false)
+                .path
+        self.path = NSString(string: rawPath).expandingTildeInPath
+        self.fileManager = fileManager
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    }
+
+    func sessionStart(
+        sessionID: String,
+        workspaceID: String?,
+        surfaceID: String?,
+        invocation: CodexHookInvocation
+    ) throws -> CodexTurnLedgerDecision {
+        try apply(
+            .sessionStart,
+            sessionID: sessionID,
+            workspaceID: workspaceID,
+            surfaceID: surfaceID,
+            invocation: invocation
+        )
+    }
+
+    func promptSubmit(
+        sessionID: String,
+        turnID: String?,
+        workspaceID: String?,
+        surfaceID: String?,
+        invocation: CodexHookInvocation
+    ) throws -> CodexTurnLedgerDecision {
+        try apply(
+            .promptSubmit(turnID: turnID),
+            sessionID: sessionID,
+            workspaceID: workspaceID,
+            surfaceID: surfaceID,
+            invocation: invocation
+        )
+    }
+
+    func subagentStart(
+        sessionID: String,
+        agentID: String?,
+        turnID: String?,
+        workspaceID: String?,
+        surfaceID: String?,
+        invocation: CodexHookInvocation
+    ) throws -> CodexTurnLedgerDecision {
+        try apply(
+            .subagentStart(id: agentID, turnID: turnID),
+            sessionID: sessionID,
+            workspaceID: workspaceID,
+            surfaceID: surfaceID,
+            invocation: invocation
+        )
+    }
+
+    func subagentStop(
+        sessionID: String,
+        agentID: String?,
+        turnID: String?,
+        workspaceID: String?,
+        surfaceID: String?,
+        invocation: CodexHookInvocation
+    ) throws -> CodexTurnLedgerDecision {
+        try apply(
+            .subagentStop(id: agentID, turnID: turnID),
+            sessionID: sessionID,
+            workspaceID: workspaceID,
+            surfaceID: surfaceID,
+            invocation: invocation
+        )
+    }
+
+    func stop(
+        sessionID: String,
+        turnID: String?,
+        workspaceID: String?,
+        surfaceID: String?,
+        invocation: CodexHookInvocation
+    ) throws -> CodexTurnLedgerDecision {
+        try apply(
+            .stop(turnID: turnID),
+            sessionID: sessionID,
+            workspaceID: workspaceID,
+            surfaceID: surfaceID,
+            invocation: invocation
+        )
+    }
+
+    func sessionEnd(
+        sessionID: String,
+        workspaceID: String?,
+        surfaceID: String?,
+        invocation: CodexHookInvocation
+    ) throws -> CodexTurnLedgerDecision {
+        try apply(
+            .sessionEnd,
+            sessionID: sessionID,
+            workspaceID: workspaceID,
+            surfaceID: surfaceID,
+            invocation: invocation
+        )
+    }
+
+    func observe(
+        sessionID: String,
+        workspaceID: String?,
+        surfaceID: String?,
+        invocation: CodexHookInvocation
+    ) throws -> CodexTurnLedgerDecision {
+        try apply(
+            .observation,
+            sessionID: sessionID,
+            workspaceID: workspaceID,
+            surfaceID: surfaceID,
+            invocation: invocation
+        )
+    }
+
+    private func apply(
+        _ event: Event,
+        sessionID: String,
+        workspaceID: String?,
+        surfaceID: String?,
+        invocation: CodexHookInvocation
+    ) throws -> CodexTurnLedgerDecision {
+        let normalizedSessionID = Self.normalized(sessionID) ?? ""
+        guard !normalizedSessionID.isEmpty else { return .ignored }
+        return try withLockedState { state in
+            let normalizedWorkspaceID = Self.normalized(workspaceID) ?? ""
+            let normalizedSurfaceID = Self.normalized(surfaceID) ?? ""
+            let existing = state.records[normalizedSessionID]
+            let ownerRecord = normalizedSurfaceID.isEmpty
+                ? nil
+                : state.surfaceOwners[normalizedSurfaceID].flatMap { state.records[$0] }
+            let ownership = self.ownership(
+                event: event,
+                sessionID: normalizedSessionID,
+                invocation: invocation,
+                existing: existing,
+                surfaceOwner: ownerRecord
+            )
+
+            if case .sessionStart = event, ownership == .foreground {
+                let isSameOwner = existing.map { self.sameOwner($0.owner, invocation) } ?? false
+                var record = existing ?? self.makeRecord(
+                    workspaceID: normalizedWorkspaceID,
+                    surfaceID: normalizedSurfaceID,
+                    invocation: invocation
+                )
+                record.workspaceID = normalizedWorkspaceID.isEmpty ? record.workspaceID : normalizedWorkspaceID
+                record.surfaceID = normalizedSurfaceID.isEmpty ? record.surfaceID : normalizedSurfaceID
+                if !isSameOwner {
+                    record = self.makeRecord(
+                        workspaceID: record.workspaceID,
+                        surfaceID: record.surfaceID,
+                        invocation: invocation
+                    )
+                    if let oldOwner = ownerRecord,
+                       let oldSessionID = state.surfaceOwners[normalizedSurfaceID],
+                       oldSessionID != normalizedSessionID,
+                       self.sameOwner(oldOwner.owner, invocation) == false {
+                        state.records.removeValue(forKey: oldSessionID)
+    }
+}
+                state.records[normalizedSessionID] = record
+                if !normalizedSurfaceID.isEmpty {
+                    state.surfaceOwners[normalizedSurfaceID] = normalizedSessionID
+                }
+                self.prune(&state)
+                return self.decision(
+                    ownership: .foreground,
+                    settlement: .none,
+                    activeChildCount: self.activeChildCount(record),
+                    turnID: record.activeTurnID,
+                    shouldNotify: false
+                )
+            }
+
+            guard ownership == .foreground else {
+                return self.decision(
+                    ownership: ownership,
+                    settlement: .none,
+                    activeChildCount: existing.map(self.activeChildCount) ?? ownerRecord.map(self.activeChildCount) ?? 0,
+                    turnID: existing?.activeTurnID,
+                    shouldNotify: false
+                )
+            }
+
+            var record = existing ?? ownerRecord ?? self.makeRecord(
+                workspaceID: normalizedWorkspaceID,
+                surfaceID: normalizedSurfaceID,
+                invocation: invocation
+            )
+            if !normalizedWorkspaceID.isEmpty { record.workspaceID = normalizedWorkspaceID }
+            if !normalizedSurfaceID.isEmpty { record.surfaceID = normalizedSurfaceID }
+            if existing == nil {
+                state.records[normalizedSessionID] = record
+                if !normalizedSurfaceID.isEmpty { state.surfaceOwners[normalizedSurfaceID] = normalizedSessionID }
+            }
+
+            let decision: CodexTurnLedgerDecision
+            switch event {
+            case .promptSubmit(let turnID):
+                record.activeTurnID = Self.normalized(turnID) ?? record.activeTurnID
+                decision = self.decision(
+                    ownership: .foreground,
+                    settlement: .none,
+                    activeChildCount: self.activeChildCount(record),
+                    turnID: record.activeTurnID,
+                    shouldNotify: false
+                )
+            case .subagentStart(let id, let turnID):
+                self.startChild(id: id, turnID: turnID, in: &record)
+                decision = self.decision(
+                    ownership: .foreground,
+                    settlement: .none,
+                    activeChildCount: self.activeChildCount(record),
+                    turnID: Self.normalized(turnID) ?? record.activeTurnID,
+                    shouldNotify: false
+                )
+            case .subagentStop(let id, let turnID):
+                self.stopChild(id: id, turnID: turnID, in: &record)
+                decision = self.decision(
+                    ownership: .foreground,
+                    settlement: .none,
+                    activeChildCount: self.activeChildCount(record),
+                    turnID: Self.normalized(turnID) ?? record.activeTurnID,
+                    shouldNotify: false
+                )
+            case .stop(let turnID):
+                let key = self.turnKey(turnID ?? record.activeTurnID)
+                let active = self.activeChildCount(record)
+                if active > 0 {
+                    record.pendingTurns[key] = CodexTurnLedgerPending(turnID: Self.normalized(turnID ?? record.activeTurnID))
+                    decision = self.decision(
+                        ownership: .foreground,
+                        settlement: .pending,
+                        activeChildCount: active,
+                        turnID: Self.normalized(turnID ?? record.activeTurnID),
+                        shouldNotify: false
+                    )
+                } else if record.settledTurnIDs.contains(key) {
+                    decision = self.decision(
+                        ownership: .foreground,
+                        settlement: .duplicate,
+                        activeChildCount: 0,
+                        turnID: Self.normalized(turnID ?? record.activeTurnID),
+                        shouldNotify: false
+                    )
+                } else {
+                    record.pendingTurns.removeValue(forKey: key)
+                    record.settledTurnIDs.append(key)
+                    let shouldNotify = !record.notifiedTurnIDs.contains(key)
+                    if shouldNotify { record.notifiedTurnIDs.append(key) }
+                    decision = self.decision(
+                        ownership: .foreground,
+                        settlement: .settled,
+                        activeChildCount: 0,
+                        turnID: Self.normalized(turnID ?? record.activeTurnID),
+                        shouldNotify: shouldNotify
+                    )
+                }
+            case .sessionEnd:
+                if let mappedSurface = Self.normalized(record.surfaceID),
+                   state.surfaceOwners[mappedSurface] == normalizedSessionID {
+                    state.surfaceOwners.removeValue(forKey: mappedSurface)
+                }
+                state.records.removeValue(forKey: normalizedSessionID)
+                return self.decision(
+                    ownership: .foreground,
+                    settlement: .none,
+                    activeChildCount: 0,
+                    turnID: nil,
+                    shouldNotify: false
+                )
+            case .observation, .sessionStart:
+                decision = self.decision(
+                    ownership: .foreground,
+                    settlement: .none,
+                    activeChildCount: self.activeChildCount(record),
+                    turnID: record.activeTurnID,
+                    shouldNotify: false
+                )
+            }
+
+            record.updatedAt = Date.now.timeIntervalSince1970
+            self.trim(&record)
+            state.records[normalizedSessionID] = record
+            if !record.surfaceID.isEmpty { state.surfaceOwners[record.surfaceID] = normalizedSessionID }
+            self.prune(&state)
+            return decision
+        }
+    }
+
+    private func ownership(
+        event: Event,
+        sessionID: String,
+        invocation: CodexHookInvocation,
+        existing: CodexTurnLedgerRecord?,
+        surfaceOwner: CodexTurnLedgerRecord?
+    ) -> CodexTurnLedgerOwnership {
+        if let owner = existing ?? surfaceOwner {
+            if invocation.parentToken != nil,
+               invocation.parentToken == owner.owner.token,
+               invocation.parentToken?.isEmpty == false {
+                return .nested
+            }
+            if invocation.hasNestedAgentAncestor { return .nested }
+            if sameOwner(owner.owner, invocation) {
+                return .foreground
+            }
+            if existing != nil,
+               let token = invocation.token,
+               let ownerToken = owner.owner.token,
+               token == ownerToken {
+                // A hook shell may sit between the foreground Codex and the
+                // CLI, so its observed PID can differ while the session id and
+                // invocation token remain the same. A second known agent (or an
+                // explicit parent token) was handled above; this is the safe
+                // same-session foreground case.
+                return .foreground
+            }
+            if existing != nil,
+               invocation.token == nil,
+               owner.owner.token == nil {
+                // Legacy hooks have no token, but Codex's session id is still
+                // authoritative for its own callbacks. A nested process with
+                // a new session id is handled by the occupied-surface branch
+                // below and remains fail-closed.
+                return .foreground
+            }
+            if let token = invocation.token,
+               let ownerToken = owner.owner.token,
+               token == ownerToken {
+                // A shared token with a different observed process is an
+                // inherited outer environment, never a new foreground turn.
+                return .nested
+            }
+            if case .sessionStart = event {
+                // A fresh wrapper token is a legitimate top-level replacement;
+                // nested wrapper launches carry parentToken and were handled
+                // above. Legacy unwrapped launches are admitted only when the
+                // prior process generation is demonstrably gone or older.
+                if let incoming = invocation.ownerGeneration,
+                   let previous = owner.owner.generation,
+                   incoming > previous {
+                    return .foreground
+                }
+                if owner.owner.pid != invocation.ownerPID {
+                    // A new unwrapped top-level process has no inherited
+                    // owner claim. A nested direct exec keeps the exact outer
+                    // numeric claim and therefore does not enter this arm.
+                    if invocation.ownerPID == nil
+                        || owner.owner.pid.flatMap({ AgentPIDProcessIdentity(pid: pid_t($0)) }) == nil {
+                        return .foreground
+                    }
+                }
+                return invocation.token == nil ? .unknown : .foreground
+            }
+            // An event for an unknown session on an occupied surface is not
+            // allowed to invent a new owner. This is the fail-closed boundary
+            // that protects the foreground resume identity.
+            return .unknown
+        }
+        // A direct top-level launch may have no SessionStart (old Codex or a
+        // manually installed hook). Preserve that compatibility, but once an
+        // owner exists the branch above is authoritative.
+        return .foreground
+    }
+
+    private func sameOwner(_ owner: CodexTurnLedgerOwner, _ invocation: CodexHookInvocation) -> Bool {
+        if let ownerGeneration = owner.generation,
+           let observedGeneration = invocation.observedGeneration {
+            return ownerGeneration == observedGeneration
+        }
+        if let ownerPID = owner.pid,
+           let observedPID = invocation.observedPID {
+            return ownerPID == observedPID
+        }
+        if let ownerToken = owner.token,
+           let token = invocation.token {
+            return ownerToken == token && invocation.observedPID == nil
+        }
+        return owner.pid == nil && invocation.ownerPID == nil
+    }
+
+    private func makeRecord(
+        workspaceID: String,
+        surfaceID: String,
+        invocation: CodexHookInvocation
+    ) -> CodexTurnLedgerRecord {
+        CodexTurnLedgerRecord(
+            workspaceID: workspaceID,
+            surfaceID: surfaceID,
+            owner: CodexTurnLedgerOwner(
+                token: invocation.token,
+                pid: invocation.ownerPID ?? invocation.observedPID,
+                generation: invocation.ownerGeneration ?? invocation.observedGeneration
+            ),
+            activeTurnID: nil,
+            activeChildrenByTurn: [:],
+            unknownChildrenByTurn: [:],
+            terminalChildrenByTurn: [:],
+            pendingTurns: [:],
+            settledTurnIDs: [],
+            notifiedTurnIDs: [],
+            updatedAt: Date.now.timeIntervalSince1970
+        )
+    }
+
+    private func startChild(id: String?, turnID: String?, in record: inout CodexTurnLedgerRecord) {
+        let key = turnKey(turnID ?? record.activeTurnID)
+        guard record.activeChildrenByTurn[key] != nil || record.unknownChildrenByTurn[key] != nil || record.activeChildrenByTurn.count + record.unknownChildrenByTurn.count < Self.maximumTurnKeys else {
+            record.unknownChildrenByTurn[key, default: 0] += 1
+            return
+        }
+        guard let id = Self.normalized(id), id.utf8.count <= Self.maximumIdentifierBytes else {
+            record.unknownChildrenByTurn[key, default: 0] += 1
+            return
+        }
+        if record.terminalChildrenByTurn[key]?.contains(id) == true { return }
+        var children = record.activeChildrenByTurn[key] ?? []
+        if !children.contains(id) {
+            if children.count >= Self.maximumChildrenPerTurn {
+                record.unknownChildrenByTurn[key, default: 0] += 1
+            } else {
+                children.append(id)
+                record.activeChildrenByTurn[key] = children
+            }
+        }
+    }
+
+    private func stopChild(id: String?, turnID: String?, in record: inout CodexTurnLedgerRecord) {
+        let key = turnKey(turnID ?? record.activeTurnID)
+        guard let id = Self.normalized(id), id.utf8.count <= Self.maximumIdentifierBytes else { return }
+        var children = record.activeChildrenByTurn[key] ?? []
+        children.removeAll { $0 == id }
+        if children.isEmpty {
+            record.activeChildrenByTurn.removeValue(forKey: key)
+        } else {
+            record.activeChildrenByTurn[key] = children
+        }
+        var terminal = record.terminalChildrenByTurn[key] ?? []
+        if !terminal.contains(id) { terminal.append(id) }
+        record.terminalChildrenByTurn[key] = terminal
+    }
+
+}

--- a/CLI/CodexTurnLedger.swift
+++ b/CLI/CodexTurnLedger.swift
@@ -413,9 +413,16 @@ final class CodexTurnLedger {
             // that protects the foreground resume identity.
             return .unknown
         }
-        // A direct top-level launch may have no SessionStart (old Codex or a
-        // manually installed hook). Preserve that compatibility, but once an
-        // owner exists the branch above is authoritative.
+        // Legacy direct launches may omit SessionStart; preserve them unless
+        // a tokenized child contradicts the claimed owner PID.
+        if invocation.token != nil,
+           invocation.ownerPID != nil,
+           invocation.observedPID != invocation.ownerPID {
+            if case .sessionStart = event {
+                return .foreground
+            }
+            return .unknown
+        }
         return .foreground
     }
 
@@ -481,19 +488,5 @@ final class CodexTurnLedger {
         }
     }
 
-    private func stopChild(id: String?, turnID: String?, in record: inout CodexTurnLedgerRecord) {
-        let key = turnKey(turnID ?? record.activeTurnID)
-        guard let id = Self.normalized(id), id.utf8.count <= Self.maximumIdentifierBytes else { return }
-        var children = record.activeChildrenByTurn[key] ?? []
-        children.removeAll { $0 == id }
-        if children.isEmpty {
-            record.activeChildrenByTurn.removeValue(forKey: key)
-        } else {
-            record.activeChildrenByTurn[key] = children
-        }
-        var terminal = record.terminalChildrenByTurn[key] ?? []
-        if !terminal.contains(id) { terminal.append(id) }
-        record.terminalChildrenByTurn[key] = terminal
-    }
 
 }

--- a/CLI/CodexTurnLedger.swift
+++ b/CLI/CodexTurnLedger.swift
@@ -56,6 +56,8 @@ final class CodexTurnLedger {
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
     }
 
+    deinit {}
+
     func sessionStart(
         sessionID: String,
         workspaceID: String?,
@@ -192,6 +194,9 @@ final class CodexTurnLedger {
                 surfaceOwner: ownerRecord
             )
             if existing == nil, ownerRecord == nil, state.records.count >= Self.maximumRecords {
+                self.prune(&state, retainingAtMost: Self.maximumRecords - 1)
+            }
+            if existing == nil, ownerRecord == nil, state.records.count >= Self.maximumRecords {
                 return .ignored
             }
 
@@ -215,8 +220,8 @@ final class CodexTurnLedger {
                        oldSessionID != normalizedSessionID,
                        self.sameOwner(oldOwner.owner, invocation) == false {
                         state.records.removeValue(forKey: oldSessionID)
-    }
-}
+                    }
+                }
                 state.records[normalizedSessionID] = record
                 if !normalizedSurfaceID.isEmpty {
                     state.surfaceOwners[normalizedSurfaceID] = normalizedSessionID
@@ -256,7 +261,13 @@ final class CodexTurnLedger {
             let decision: CodexTurnLedgerDecision
             switch event {
             case .promptSubmit(let turnID):
-                record.activeTurnID = Self.normalized(turnID) ?? record.activeTurnID
+                let normalizedTurnID = Self.normalized(turnID)
+                record.activeTurnID = normalizedTurnID
+                let key = self.turnKey(normalizedTurnID)
+                record.pendingTurns.removeValue(forKey: key)
+                record.settledTurnIDs.removeAll { $0 == key }
+                record.notifiedTurnIDs.removeAll { $0 == key }
+                record.terminalChildrenByTurn.removeValue(forKey: key)
                 decision = self.decision(
                     ownership: .foreground,
                     settlement: .none,
@@ -274,14 +285,35 @@ final class CodexTurnLedger {
                     shouldNotify: false
                 )
             case .subagentStop(let id, let turnID):
+                let key = self.turnKey(turnID ?? record.activeTurnID)
+                let validChildID = Self.normalized(id) != nil
                 self.stopChild(id: id, turnID: turnID, in: &record)
-                decision = self.decision(
-                    ownership: .foreground,
-                    settlement: .none,
-                    activeChildCount: self.activeChildCount(record),
-                    turnID: Self.normalized(turnID) ?? record.activeTurnID,
-                    shouldNotify: false
-                )
+                if validChildID,
+                   self.activeChildCount(for: key, in: record) == 0,
+                   let pending = record.pendingTurns.removeValue(forKey: key) {
+                    if !record.settledTurnIDs.contains(key) {
+                        record.settledTurnIDs.append(key)
+                    }
+                    let shouldNotify = !record.notifiedTurnIDs.contains(key)
+                    if shouldNotify {
+                        record.notifiedTurnIDs.append(key)
+                    }
+                    decision = self.decision(
+                        ownership: .foreground,
+                        settlement: .settled,
+                        activeChildCount: self.activeChildCount(record),
+                        turnID: pending.turnID,
+                        shouldNotify: shouldNotify
+                    )
+                } else {
+                    decision = self.decision(
+                        ownership: .foreground,
+                        settlement: .none,
+                        activeChildCount: self.activeChildCount(record),
+                        turnID: Self.normalized(turnID) ?? record.activeTurnID,
+                        shouldNotify: false
+                    )
+                }
             case .stop(let turnID):
                 let key = self.turnKey(turnID ?? record.activeTurnID)
                 let active = self.activeChildCount(record)
@@ -295,12 +327,16 @@ final class CodexTurnLedger {
                         shouldNotify: false
                     )
                 } else if record.settledTurnIDs.contains(key) {
+                    let shouldNotify = !record.notifiedTurnIDs.contains(key)
+                    if shouldNotify {
+                        record.notifiedTurnIDs.append(key)
+                    }
                     decision = self.decision(
                         ownership: .foreground,
-                        settlement: .duplicate,
+                        settlement: shouldNotify ? .settled : .duplicate,
                         activeChildCount: 0,
                         turnID: Self.normalized(turnID ?? record.activeTurnID),
-                        shouldNotify: false
+                        shouldNotify: shouldNotify
                     )
                 } else {
                     record.pendingTurns.removeValue(forKey: key)
@@ -369,8 +405,7 @@ final class CodexTurnLedger {
                let ownerToken = owner.owner.token,
                token == ownerToken {
                 if invocation.hasExplicitObservedPID,
-                   let ownerPID = owner.owner.pid,
-                   invocation.observedPID != ownerPID {
+                   owner.owner.pid != invocation.ownerPID {
                     return .nested
                 }
                 // A hook shell may sit between the foreground Codex and the
@@ -384,7 +419,7 @@ final class CodexTurnLedger {
                invocation.token == nil,
                owner.owner.token == nil {
                 if invocation.hasExplicitObservedPID,
-                   owner.owner.pid != invocation.observedPID {
+                   owner.owner.pid != invocation.ownerPID {
                     return .nested
                 }
                 return .foreground

--- a/CLI/CodexTurnLedger.swift
+++ b/CLI/CodexTurnLedger.swift
@@ -379,10 +379,10 @@ final class CodexTurnLedger {
             if existing != nil,
                invocation.token == nil,
                owner.owner.token == nil {
-                // Legacy hooks have no token, but Codex's session id is still
-                // authoritative for its own callbacks. A nested process with
-                // a new session id is handled by the occupied-surface branch
-                // below and remains fail-closed.
+                if invocation.hasExplicitObservedPID,
+                   owner.owner.pid != invocation.observedPID {
+                    return .nested
+                }
                 return .foreground
             }
             if let token = invocation.token,
@@ -420,8 +420,7 @@ final class CodexTurnLedger {
         }
         // Legacy direct launches may omit SessionStart; preserve them unless
         // a tokenized child contradicts the claimed owner PID.
-        if invocation.token != nil,
-           invocation.ownerPID != nil,
+        if invocation.ownerPID != nil,
            invocation.observedPID != invocation.ownerPID {
             if case .sessionStart = event {
                 return .foreground

--- a/CLI/CodexTurnLedger.swift
+++ b/CLI/CodexTurnLedger.swift
@@ -364,6 +364,11 @@ final class CodexTurnLedger {
                let token = invocation.token,
                let ownerToken = owner.owner.token,
                token == ownerToken {
+                if invocation.hasExplicitObservedPID,
+                   let ownerPID = owner.owner.pid,
+                   invocation.observedPID != ownerPID {
+                    return .nested
+                }
                 // A hook shell may sit between the foreground Codex and the
                 // CLI, so its observed PID can differ while the session id and
                 // invocation token remain the same. A second known agent (or an

--- a/CLI/CodexTurnLedger.swift
+++ b/CLI/CodexTurnLedger.swift
@@ -177,6 +177,7 @@ final class CodexTurnLedger {
         let normalizedSessionID = Self.normalized(sessionID) ?? ""
         guard !normalizedSessionID.isEmpty else { return .ignored }
         return try withLockedState { state in
+            self.prune(&state)
             let normalizedWorkspaceID = Self.normalized(workspaceID) ?? ""
             let normalizedSurfaceID = Self.normalized(surfaceID) ?? ""
             let existing = state.records[normalizedSessionID]
@@ -190,6 +191,9 @@ final class CodexTurnLedger {
                 existing: existing,
                 surfaceOwner: ownerRecord
             )
+            if existing == nil, ownerRecord == nil, state.records.count >= Self.maximumRecords {
+                return .ignored
+            }
 
             if case .sessionStart = event, ownership == .foreground {
                 let isSameOwner = existing.map { self.sameOwner($0.owner, invocation) } ?? false
@@ -345,7 +349,7 @@ final class CodexTurnLedger {
 
     private func ownership(
         event: Event,
-        sessionID: String,
+        sessionID _: String,
         invocation: CodexHookInvocation,
         existing: CodexTurnLedgerRecord?,
         surfaceOwner: CodexTurnLedgerRecord?
@@ -473,24 +477,22 @@ final class CodexTurnLedger {
     private func startChild(id: String?, turnID: String?, in record: inout CodexTurnLedgerRecord) {
         let key = turnKey(turnID ?? record.activeTurnID)
         guard record.activeChildrenByTurn[key] != nil || record.unknownChildrenByTurn[key] != nil || record.activeChildrenByTurn.count + record.unknownChildrenByTurn.count < Self.maximumTurnKeys else {
-            record.unknownChildrenByTurn[key, default: 0] += 1
+            incrementUnknownChildCount(key, in: &record)
             return
         }
         guard let id = Self.normalized(id), id.utf8.count <= Self.maximumIdentifierBytes else {
-            record.unknownChildrenByTurn[key, default: 0] += 1
+            incrementUnknownChildCount(key, in: &record)
             return
         }
         if record.terminalChildrenByTurn[key]?.contains(id) == true { return }
         var children = record.activeChildrenByTurn[key] ?? []
         if !children.contains(id) {
             if children.count >= Self.maximumChildrenPerTurn {
-                record.unknownChildrenByTurn[key, default: 0] += 1
+                incrementUnknownChildCount(key, in: &record)
             } else {
                 children.append(id)
                 record.activeChildrenByTurn[key] = children
             }
         }
     }
-
-
 }

--- a/CLI/CodexTurnLedgerModels.swift
+++ b/CLI/CodexTurnLedgerModels.swift
@@ -140,11 +140,79 @@ struct CodexTurnLedgerRecord: Codable, Equatable {
     var settledTurnIDs: [String]
     var notifiedTurnIDs: [String]
     var updatedAt: TimeInterval
+
+    init(
+        workspaceID: String,
+        surfaceID: String,
+        owner: CodexTurnLedgerOwner,
+        activeTurnID: String?,
+        activeChildrenByTurn: [String: [String]],
+        unknownChildrenByTurn: [String: Int],
+        terminalChildrenByTurn: [String: [String]],
+        pendingTurns: [String: CodexTurnLedgerPending],
+        settledTurnIDs: [String],
+        notifiedTurnIDs: [String],
+        updatedAt: TimeInterval
+    ) {
+        self.workspaceID = workspaceID
+        self.surfaceID = surfaceID
+        self.owner = owner
+        self.activeTurnID = activeTurnID
+        self.activeChildrenByTurn = activeChildrenByTurn
+        self.unknownChildrenByTurn = unknownChildrenByTurn
+        self.terminalChildrenByTurn = terminalChildrenByTurn
+        self.pendingTurns = pendingTurns
+        self.settledTurnIDs = settledTurnIDs
+        self.notifiedTurnIDs = notifiedTurnIDs
+        self.updatedAt = updatedAt
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        workspaceID = try container.decodeIfPresent(String.self, forKey: .workspaceID) ?? ""
+        surfaceID = try container.decodeIfPresent(String.self, forKey: .surfaceID) ?? ""
+        owner = try container.decodeIfPresent(CodexTurnLedgerOwner.self, forKey: .owner)
+            ?? CodexTurnLedgerOwner(token: nil, pid: nil, generation: nil)
+        activeTurnID = try container.decodeIfPresent(String.self, forKey: .activeTurnID)
+        activeChildrenByTurn = try container.decodeIfPresent(
+            [String: [String]].self,
+            forKey: .activeChildrenByTurn
+        ) ?? [:]
+        unknownChildrenByTurn = try container.decodeIfPresent(
+            [String: Int].self,
+            forKey: .unknownChildrenByTurn
+        ) ?? [:]
+        terminalChildrenByTurn = try container.decodeIfPresent(
+            [String: [String]].self,
+            forKey: .terminalChildrenByTurn
+        ) ?? [:]
+        pendingTurns = try container.decodeIfPresent(
+            [String: CodexTurnLedgerPending].self,
+            forKey: .pendingTurns
+        ) ?? [:]
+        settledTurnIDs = try container.decodeIfPresent([String].self, forKey: .settledTurnIDs) ?? []
+        notifiedTurnIDs = try container.decodeIfPresent([String].self, forKey: .notifiedTurnIDs) ?? []
+        updatedAt = try container.decodeIfPresent(TimeInterval.self, forKey: .updatedAt) ?? 0
+    }
 }
 
 struct CodexTurnLedgerFile: Codable {
     var records: [String: CodexTurnLedgerRecord] = [:]
     var surfaceOwners: [String: String] = [:]
+
+    init() {}
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        records = try container.decodeIfPresent(
+            [String: CodexTurnLedgerRecord].self,
+            forKey: .records
+        ) ?? [:]
+        surfaceOwners = try container.decodeIfPresent(
+            [String: String].self,
+            forKey: .surfaceOwners
+        ) ?? [:]
+    }
 }
 
 extension CMUXCLI {

--- a/CLI/CodexTurnLedgerModels.swift
+++ b/CLI/CodexTurnLedgerModels.swift
@@ -18,6 +18,7 @@ struct CodexHookInvocation: Equatable, Sendable {
     let observedPID: Int?
     let ownerGeneration: CodexProcessGeneration?
     let observedGeneration: CodexProcessGeneration?
+    let hasExplicitObservedPID: Bool
     let hasNestedAgentAncestor: Bool
 
     init(
@@ -28,7 +29,9 @@ struct CodexHookInvocation: Equatable, Sendable {
         token = Self.normalized(environment[Self.tokenEnvironmentKey])
         parentToken = Self.normalized(environment[Self.parentTokenEnvironmentKey])
         ownerPID = Self.positivePID(environment[Self.ownerPIDEnvironmentKey])
-        observedPID = Self.positivePID(environment[Self.observedPIDEnvironmentKey])
+        let explicitObservedPID = Self.positivePID(environment[Self.observedPIDEnvironmentKey])
+        hasExplicitObservedPID = explicitObservedPID != nil
+        observedPID = explicitObservedPID
             ?? fallbackObservedPID.flatMap { $0 > 0 ? $0 : nil }
         ownerGeneration = ownerPID.flatMap { CodexProcessGeneration(pid: $0) }
         observedGeneration = observedPID.flatMap { CodexProcessGeneration(pid: $0) }

--- a/CLI/CodexTurnLedgerModels.swift
+++ b/CLI/CodexTurnLedgerModels.swift
@@ -1,0 +1,166 @@
+import Foundation
+
+/// The process identity carried by one Codex hook invocation.
+///
+/// CMUX_CODEX_PID is a launch-time claim and is inherited by descendants.
+/// The hook shell also supplies CMUX_CODEX_HOOK_PID, identifying the process
+/// that actually caused the callback.
+struct CodexHookInvocation: Equatable, Sendable {
+    static let tokenEnvironmentKey = "CMUX_CODEX_INVOCATION_ID"
+    static let parentTokenEnvironmentKey = "CMUX_CODEX_PARENT_INVOCATION_ID"
+    static let ownerPIDEnvironmentKey = "CMUX_CODEX_PID"
+    static let observedPIDEnvironmentKey = "CMUX_CODEX_HOOK_PID"
+    static let ledgerPathEnvironmentKey = "CMUX_CODEX_TURN_LEDGER_PATH"
+
+    let token: String?
+    let parentToken: String?
+    let ownerPID: Int?
+    let observedPID: Int?
+    let ownerGeneration: CodexProcessGeneration?
+    let observedGeneration: CodexProcessGeneration?
+    let hasNestedAgentAncestor: Bool
+
+    init(
+        environment: [String: String],
+        fallbackObservedPID: Int? = Int(getppid()),
+        hasNestedAgentAncestor: Bool = false
+    ) {
+        token = Self.normalized(environment[Self.tokenEnvironmentKey])
+        parentToken = Self.normalized(environment[Self.parentTokenEnvironmentKey])
+        ownerPID = Self.positivePID(environment[Self.ownerPIDEnvironmentKey])
+        observedPID = Self.positivePID(environment[Self.observedPIDEnvironmentKey])
+            ?? fallbackObservedPID.flatMap { $0 > 0 ? $0 : nil }
+        ownerGeneration = ownerPID.flatMap { CodexProcessGeneration(pid: $0) }
+        observedGeneration = observedPID.flatMap { CodexProcessGeneration(pid: $0) }
+        self.hasNestedAgentAncestor = hasNestedAgentAncestor
+    }
+
+    private static func normalized(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty,
+              value.utf8.count <= 128,
+              value.unicodeScalars.allSatisfy({
+                  $0.isASCII && !$0.properties.isWhitespace && !CharacterSet.controlCharacters.contains($0)
+              }) else {
+            return nil
+        }
+        return value
+    }
+
+    private static func positivePID(_ value: String?) -> Int? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              let pid = Int(value),
+              pid > 0,
+              pid <= Int(Int32.max) else {
+            return nil
+        }
+        return pid
+    }
+}
+
+/// Exact kernel process generation used by the Codex ownership ledger.
+struct CodexProcessGeneration: Codable, Equatable, Comparable, Sendable {
+    let pid: Int
+    let startSeconds: Int64
+    let startMicroseconds: Int64
+
+    init(pid: Int, startSeconds: Int64, startMicroseconds: Int64) {
+        self.pid = pid
+        self.startSeconds = startSeconds
+        self.startMicroseconds = startMicroseconds
+    }
+
+    init?(pid: Int) {
+        guard let identity = AgentPIDProcessIdentity(pid: pid_t(pid)) else { return nil }
+        self.init(
+            pid: Int(identity.pid),
+            startSeconds: identity.startSeconds,
+            startMicroseconds: identity.startMicroseconds
+        )
+    }
+
+    static func < (lhs: Self, rhs: Self) -> Bool {
+        if lhs.startSeconds != rhs.startSeconds { return lhs.startSeconds < rhs.startSeconds }
+        if lhs.startMicroseconds != rhs.startMicroseconds { return lhs.startMicroseconds < rhs.startMicroseconds }
+        return lhs.pid < rhs.pid
+    }
+}
+
+enum CodexTurnLedgerOwnership: Equatable, Sendable {
+    case foreground
+    case nested
+    case unknown
+}
+
+enum CodexTurnLedgerSettlement: Equatable, Sendable {
+    case none
+    case pending
+    case settled
+    case duplicate
+}
+
+struct CodexTurnLedgerDecision: Equatable, Sendable {
+    let ownership: CodexTurnLedgerOwnership
+    let settlement: CodexTurnLedgerSettlement
+    let activeChildCount: Int
+    let turnID: String?
+    let shouldNotify: Bool
+
+    static let ignored = Self(
+        ownership: .unknown,
+        settlement: .none,
+        activeChildCount: 0,
+        turnID: nil,
+        shouldNotify: false
+    )
+}
+
+struct CodexTurnLedgerOwner: Codable, Equatable {
+    var token: String?
+    var pid: Int?
+    var generation: CodexProcessGeneration?
+}
+
+struct CodexTurnLedgerPending: Codable, Equatable {
+    let turnID: String?
+}
+
+struct CodexTurnLedgerRecord: Codable, Equatable {
+    var workspaceID: String
+    var surfaceID: String
+    var owner: CodexTurnLedgerOwner
+    var activeTurnID: String?
+    var activeChildrenByTurn: [String: [String]]
+    var unknownChildrenByTurn: [String: Int]
+    var terminalChildrenByTurn: [String: [String]]
+    var pendingTurns: [String: CodexTurnLedgerPending]
+    var settledTurnIDs: [String]
+    var notifiedTurnIDs: [String]
+    var updatedAt: TimeInterval
+}
+
+struct CodexTurnLedgerFile: Codable {
+    var records: [String: CodexTurnLedgerRecord] = [:]
+    var surfaceOwners: [String: String] = [:]
+}
+
+extension CMUXCLI {
+    /// Builds one Codex invocation identity per hook. The inherited owner PID
+    /// remains a claim and never supplies the nested decision alone.
+    func codexHookInvocation(environment: [String: String]) -> CodexHookInvocation {
+        let initial = CodexHookInvocation(environment: environment)
+        let nested = nestedAgentSessionDetected(
+            currentAgentPID: initial.observedPID,
+            env: environment
+        )
+        return CodexHookInvocation(
+            environment: environment,
+            fallbackObservedPID: initial.observedPID,
+            hasNestedAgentAncestor: nested
+        )
+    }
+
+    func codexTurnLedger(environment: [String: String]) -> CodexTurnLedger {
+        CodexTurnLedger(environment: environment)
+    }
+}

--- a/CLI/CodexTurnLedgerPersistence.swift
+++ b/CLI/CodexTurnLedgerPersistence.swift
@@ -85,7 +85,7 @@ extension CodexTurnLedger {
 
     func prune(
         _ state: inout CodexTurnLedgerFile,
-        retainingAtMost limit: Int = Self.maximumRecords
+        retainingAtMost limit: Int = CodexTurnLedger.maximumRecords
     ) {
         guard state.records.count > limit else { return }
         let removable = state.records

--- a/CLI/CodexTurnLedgerPersistence.swift
+++ b/CLI/CodexTurnLedgerPersistence.swift
@@ -28,6 +28,12 @@ extension CodexTurnLedger {
         return min(Self.maximumChildrenPerTurn * Self.maximumTurnKeys, exact + unknown)
     }
 
+    func activeChildCount(for key: String, in record: CodexTurnLedgerRecord) -> Int {
+        let exact = record.activeChildrenByTurn[key]?.count ?? 0
+        let unknown = record.unknownChildrenByTurn[key] ?? 0
+        return min(Self.maximumChildrenPerTurn, exact + unknown)
+    }
+
     func turnKey(_ turnID: String?) -> String {
         Self.normalized(turnID) ?? "@current"
     }
@@ -49,10 +55,18 @@ extension CodexTurnLedger {
     }
 
     func trim(_ record: inout CodexTurnLedgerRecord) {
+        let protectedKeys = Set(
+            [turnKey(record.activeTurnID)]
+                + Array(record.activeChildrenByTurn.keys)
+                + Array(record.unknownChildrenByTurn.keys)
+                + Array(record.pendingTurns.keys)
+        )
         func trimDictionary<T>(_ dictionary: inout [String: T], limit: Int) {
             guard dictionary.count > limit else { return }
-            let keys = dictionary.keys.sorted()
-            for key in keys.prefix(dictionary.count - limit) {
+            let removableKeys = dictionary.keys
+                .filter { !protectedKeys.contains($0) }
+                .sorted()
+            for key in removableKeys.prefix(dictionary.count - limit) {
                 dictionary.removeValue(forKey: key)
             }
         }
@@ -69,8 +83,11 @@ extension CodexTurnLedger {
         }
     }
 
-    func prune(_ state: inout CodexTurnLedgerFile) {
-        guard state.records.count > Self.maximumRecords else { return }
+    func prune(
+        _ state: inout CodexTurnLedgerFile,
+        retainingAtMost limit: Int = Self.maximumRecords
+    ) {
+        guard state.records.count > limit else { return }
         let removable = state.records
             .filter {
                 $0.value.activeChildrenByTurn.isEmpty
@@ -78,9 +95,14 @@ extension CodexTurnLedger {
                     && $0.value.pendingTurns.isEmpty
             }
             .sorted { $0.value.updatedAt < $1.value.updatedAt }
-        for (sessionID, _) in removable.prefix(state.records.count - Self.maximumRecords) {
+        let removableIDs = Set(
+            removable.prefix(state.records.count - limit).map(\.key)
+        )
+        for sessionID in removableIDs {
             state.records.removeValue(forKey: sessionID)
-            state.surfaceOwners = state.surfaceOwners.filter { $0.value != sessionID }
+        }
+        state.surfaceOwners = state.surfaceOwners.filter {
+            state.records[$0.value] != nil && !removableIDs.contains($0.value)
         }
     }
 
@@ -135,9 +157,6 @@ extension CodexTurnLedger {
         guard let data = fileManager.contents(atPath: path) else {
             return CodexTurnLedgerFile()
         }
-        guard let state = try? decoder.decode(CodexTurnLedgerFile.self, from: data) else {
-            throw CLIError(message: "Codex turn ledger is corrupt")
-        }
-        return state
+        return (try? decoder.decode(CodexTurnLedgerFile.self, from: data)) ?? CodexTurnLedgerFile()
     }
 }

--- a/CLI/CodexTurnLedgerPersistence.swift
+++ b/CLI/CodexTurnLedgerPersistence.swift
@@ -2,6 +2,11 @@ import Darwin
 import Foundation
 
 extension CodexTurnLedger {
+    func incrementUnknownChildCount(_ key: String, in record: inout CodexTurnLedgerRecord) {
+        let current = record.unknownChildrenByTurn[key, default: 0]
+        record.unknownChildrenByTurn[key] = min(Self.maximumChildrenPerTurn, current + 1)
+    }
+
     func stopChild(id: String?, turnID: String?, in record: inout CodexTurnLedgerRecord) {
         let key = turnKey(turnID ?? record.activeTurnID)
         guard let id = Self.normalized(id), id.utf8.count <= Self.maximumIdentifierBytes else { return }
@@ -79,6 +84,8 @@ extension CodexTurnLedger {
         }
     }
 
+    /// Serializes only the cross-process read/modify/atomic-replace transaction;
+    /// the lock is released before any socket or UI work begins.
     func withLockedState<T>(
         _ body: (inout CodexTurnLedgerFile) throws -> T
     ) throws -> T {

--- a/CLI/CodexTurnLedgerPersistence.swift
+++ b/CLI/CodexTurnLedgerPersistence.swift
@@ -1,0 +1,117 @@
+import Darwin
+import Foundation
+
+extension CodexTurnLedger {
+    func activeChildCount(_ record: CodexTurnLedgerRecord) -> Int {
+        let exact = record.activeChildrenByTurn.values.reduce(0) { $0 + $1.count }
+        let unknown = record.unknownChildrenByTurn.values.reduce(0, +)
+        return exact + unknown
+    }
+
+    func turnKey(_ turnID: String?) -> String {
+        Self.normalized(turnID) ?? "@current"
+    }
+
+    func decision(
+        ownership: CodexTurnLedgerOwnership,
+        settlement: CodexTurnLedgerSettlement,
+        activeChildCount: Int,
+        turnID: String?,
+        shouldNotify: Bool
+    ) -> CodexTurnLedgerDecision {
+        CodexTurnLedgerDecision(
+            ownership: ownership,
+            settlement: settlement,
+            activeChildCount: max(0, activeChildCount),
+            turnID: Self.normalized(turnID),
+            shouldNotify: shouldNotify
+        )
+    }
+
+    func trim(_ record: inout CodexTurnLedgerRecord) {
+        func trimDictionary<T>(_ dictionary: inout [String: T], limit: Int) {
+            guard dictionary.count > limit else { return }
+            let keys = dictionary.keys.sorted()
+            for key in keys.prefix(dictionary.count - limit) {
+                dictionary.removeValue(forKey: key)
+            }
+        }
+        trimDictionary(&record.activeChildrenByTurn, limit: Self.maximumTurnKeys)
+        trimDictionary(&record.unknownChildrenByTurn, limit: Self.maximumTurnKeys)
+        trimDictionary(&record.terminalChildrenByTurn, limit: Self.maximumTurnKeys)
+        trimDictionary(&record.pendingTurns, limit: Self.maximumTurnKeys)
+        record.settledTurnIDs = Array(record.settledTurnIDs.suffix(Self.maximumRememberedTurns))
+        record.notifiedTurnIDs = Array(record.notifiedTurnIDs.suffix(Self.maximumRememberedTurns))
+        for key in record.terminalChildrenByTurn.keys {
+            record.terminalChildrenByTurn[key] = Array(
+                record.terminalChildrenByTurn[key, default: []].suffix(Self.maximumTerminalChildrenPerTurn)
+            )
+        }
+    }
+
+    func prune(_ state: inout CodexTurnLedgerFile) {
+        guard state.records.count > Self.maximumRecords else { return }
+        let removable = state.records
+            .filter {
+                $0.value.activeChildrenByTurn.isEmpty
+                    && $0.value.unknownChildrenByTurn.isEmpty
+                    && $0.value.pendingTurns.isEmpty
+            }
+            .sorted { $0.value.updatedAt < $1.value.updatedAt }
+        for (sessionID, _) in removable.prefix(state.records.count - Self.maximumRecords) {
+            state.records.removeValue(forKey: sessionID)
+            state.surfaceOwners = state.surfaceOwners.filter { $0.value != sessionID }
+        }
+    }
+
+    func withLockedState<T>(
+        _ body: (inout CodexTurnLedgerFile) throws -> T
+    ) throws -> T {
+        let lockPath = path + ".lock"
+        let parent = URL(fileURLWithPath: path).deletingLastPathComponent()
+        try fileManager.createDirectory(at: parent, withIntermediateDirectories: true)
+        let fd = open(lockPath, O_CREAT | O_RDWR, mode_t(S_IRUSR | S_IWUSR))
+        guard fd >= 0 else {
+            throw CLIError(message: "Failed to open Codex turn ledger lock")
+        }
+        defer { Darwin.close(fd) }
+        guard flock(fd, LOCK_EX) == 0 else {
+            throw CLIError(message: "Failed to lock Codex turn ledger")
+        }
+        defer { _ = flock(fd, LOCK_UN) }
+
+        var state = try load()
+        let result = try body(&state)
+        let data = try encoder.encode(state)
+        let temporary = parent.appendingPathComponent(
+            ".\(parent.lastPathComponent).codex-ledger.\(UUID().uuidString).tmp"
+        )
+        guard fileManager.createFile(
+            atPath: temporary.path,
+            contents: data,
+            attributes: [.posixPermissions: NSNumber(value: Int16(0o600))]
+        ) else {
+            throw CLIError(message: "Failed to write Codex turn ledger")
+        }
+        let renameResult = temporary.path.withCString { source in
+            path.withCString { destination in
+                Darwin.rename(source, destination)
+            }
+        }
+        guard renameResult == 0 else {
+            try? fileManager.removeItem(at: temporary)
+            throw CLIError(message: "Failed to commit Codex turn ledger")
+        }
+        return result
+    }
+
+    func load() throws -> CodexTurnLedgerFile {
+        guard let data = fileManager.contents(atPath: path) else {
+            return CodexTurnLedgerFile()
+        }
+        guard let state = try? decoder.decode(CodexTurnLedgerFile.self, from: data) else {
+            throw CLIError(message: "Codex turn ledger is corrupt")
+        }
+        return state
+    }
+}

--- a/CLI/CodexTurnLedgerPersistence.swift
+++ b/CLI/CodexTurnLedgerPersistence.swift
@@ -2,6 +2,21 @@ import Darwin
 import Foundation
 
 extension CodexTurnLedger {
+    func stopChild(id: String?, turnID: String?, in record: inout CodexTurnLedgerRecord) {
+        let key = turnKey(turnID ?? record.activeTurnID)
+        guard let id = Self.normalized(id), id.utf8.count <= Self.maximumIdentifierBytes else { return }
+        var children = record.activeChildrenByTurn[key] ?? []
+        children.removeAll { $0 == id }
+        if children.isEmpty {
+            record.activeChildrenByTurn.removeValue(forKey: key)
+        } else {
+            record.activeChildrenByTurn[key] = children
+        }
+        var terminal = record.terminalChildrenByTurn[key] ?? []
+        if !terminal.contains(id) { terminal.append(id) }
+        record.terminalChildrenByTurn[key] = terminal
+    }
+
     func activeChildCount(_ record: CodexTurnLedgerRecord) -> Int {
         let exact = record.activeChildrenByTurn.values.reduce(0) { $0 + $1.count }
         let unknown = record.unknownChildrenByTurn.values.reduce(0, +)

--- a/CLI/CodexTurnLedgerPersistence.swift
+++ b/CLI/CodexTurnLedgerPersistence.swift
@@ -91,7 +91,11 @@ extension CodexTurnLedger {
     ) throws -> T {
         let lockPath = path + ".lock"
         let parent = URL(fileURLWithPath: path).deletingLastPathComponent()
-        try fileManager.createDirectory(at: parent, withIntermediateDirectories: true)
+        try fileManager.createDirectory(
+            at: parent,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: NSNumber(value: Int16(0o700))]
+        )
         let fd = open(lockPath, O_CREAT | O_RDWR, mode_t(S_IRUSR | S_IWUSR))
         guard fd >= 0 else {
             throw CLIError(message: "Failed to open Codex turn ledger lock")

--- a/CLI/CodexTurnLedgerPersistence.swift
+++ b/CLI/CodexTurnLedgerPersistence.swift
@@ -25,7 +25,7 @@ extension CodexTurnLedger {
     func activeChildCount(_ record: CodexTurnLedgerRecord) -> Int {
         let exact = record.activeChildrenByTurn.values.reduce(0) { $0 + $1.count }
         let unknown = record.unknownChildrenByTurn.values.reduce(0, +)
-        return exact + unknown
+        return min(Self.maximumChildrenPerTurn * Self.maximumTurnKeys, exact + unknown)
     }
 
     func turnKey(_ turnID: String?) -> String {

--- a/CLI/CodexTurnLifecycleCoordinator.swift
+++ b/CLI/CodexTurnLifecycleCoordinator.swift
@@ -7,6 +7,12 @@ struct CodexTurnLifecycleCoordinator {
     let ledger: CodexTurnLedger
     let invocation: CodexHookInvocation
 
+    /// Whether this callback came from a pre-ledger, unwrapped Codex launch.
+    /// Legacy prompt-stack cleanup is allowed only for this compatibility lane.
+    var usesLegacyIdentity: Bool {
+        invocation.token == nil && invocation.ownerPID == nil
+    }
+
     init(environment: [String: String], cli: CMUXCLI) {
         invocation = cli.codexHookInvocation(environment: environment)
         ledger = cli.codexTurnLedger(environment: environment)

--- a/CLI/CodexTurnLifecycleCoordinator.swift
+++ b/CLI/CodexTurnLifecycleCoordinator.swift
@@ -1,0 +1,139 @@
+import Foundation
+
+/// Owns the Codex hook boundary between process identity, child work, and
+/// completion settlement. The generic hook adapter delegates here before it
+/// mutates the resume/session snapshot or paints the pane.
+struct CodexTurnLifecycleCoordinator {
+    let ledger: CodexTurnLedger
+    let invocation: CodexHookInvocation
+
+    init(environment: [String: String], cli: CMUXCLI) {
+        invocation = cli.codexHookInvocation(environment: environment)
+        ledger = cli.codexTurnLedger(environment: environment)
+    }
+
+    func sessionStart(
+        sessionID: String,
+        workspaceID: String?,
+        surfaceID: String?
+    ) -> CodexTurnLedgerDecision {
+        (try? ledger.sessionStart(
+            sessionID: sessionID,
+            workspaceID: workspaceID,
+            surfaceID: surfaceID,
+            invocation: invocation
+        )) ?? .ignored
+    }
+
+    func promptSubmit(
+        sessionID: String,
+        turnID: String?,
+        workspaceID: String?,
+        surfaceID: String?
+    ) -> CodexTurnLedgerDecision {
+        (try? ledger.promptSubmit(
+            sessionID: sessionID,
+            turnID: turnID,
+            workspaceID: workspaceID,
+            surfaceID: surfaceID,
+            invocation: invocation
+        )) ?? .ignored
+    }
+
+    func subagent(
+        sessionID: String,
+        agentID: String?,
+        turnID: String?,
+        workspaceID: String?,
+        surfaceID: String?,
+        starts: Bool
+    ) -> CodexTurnLedgerDecision {
+        let result: Result<CodexTurnLedgerDecision, Error>
+        if starts {
+            result = Result {
+                try ledger.subagentStart(
+                    sessionID: sessionID,
+                    agentID: agentID,
+                    turnID: turnID,
+                    workspaceID: workspaceID,
+                    surfaceID: surfaceID,
+                    invocation: invocation
+                )
+            }
+        } else {
+            result = Result {
+                try ledger.subagentStop(
+                    sessionID: sessionID,
+                    agentID: agentID,
+                    turnID: turnID,
+                    workspaceID: workspaceID,
+                    surfaceID: surfaceID,
+                    invocation: invocation
+                )
+            }
+        }
+        return (try? result.get()) ?? .ignored
+    }
+
+    func stop(
+        sessionID: String,
+        turnID: String?,
+        workspaceID: String?,
+        surfaceID: String?
+    ) -> CodexTurnLedgerDecision {
+        (try? ledger.stop(
+            sessionID: sessionID,
+            turnID: turnID,
+            workspaceID: workspaceID,
+            surfaceID: surfaceID,
+            invocation: invocation
+        )) ?? .ignored
+    }
+
+    func observe(
+        sessionID: String,
+        workspaceID: String?,
+        surfaceID: String?
+    ) -> CodexTurnLedgerDecision {
+        (try? ledger.observe(
+            sessionID: sessionID,
+            workspaceID: workspaceID,
+            surfaceID: surfaceID,
+            invocation: invocation
+        )) ?? .ignored
+    }
+
+    func sessionEnd(
+        sessionID: String,
+        workspaceID: String?,
+        surfaceID: String?
+    ) -> CodexTurnLedgerDecision {
+        (try? ledger.sessionEnd(
+            sessionID: sessionID,
+            workspaceID: workspaceID,
+            surfaceID: surfaceID,
+            invocation: invocation
+        )) ?? .ignored
+    }
+
+    /// Records a native feed lifecycle event before the feed frame is sent.
+    /// Keeping this operation here ensures wrapper and persistent-feed
+    /// producers share exactly the same owner/settlement path.
+    func recordFeedLifecycle(
+        sessionID: String,
+        eventName: String,
+        agentID: String?,
+        turnID: String?,
+        workspaceID: String?,
+        surfaceID: String?
+    ) -> CodexTurnLedgerDecision {
+        subagent(
+            sessionID: sessionID,
+            agentID: agentID,
+            turnID: turnID,
+            workspaceID: workspaceID,
+            surfaceID: surfaceID,
+            starts: eventName == "SubagentStart"
+        )
+    }
+}

--- a/CLI/CodexTurnLifecycleCoordinator.swift
+++ b/CLI/CodexTurnLifecycleCoordinator.swift
@@ -133,13 +133,19 @@ struct CodexTurnLifecycleCoordinator {
         workspaceID: String?,
         surfaceID: String?
     ) -> CodexTurnLedgerDecision {
-        subagent(
+        let starts: Bool
+        switch eventName {
+        case "SubagentStart": starts = true
+        case "SubagentStop": starts = false
+        default: return .ignored
+        }
+        return subagent(
             sessionID: sessionID,
             agentID: agentID,
             turnID: turnID,
             workspaceID: workspaceID,
             surfaceID: surfaceID,
-            starts: eventName == "SubagentStart"
+            starts: starts
         )
     }
 }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -2084,6 +2084,21 @@ final class ClaudeHookSessionStore {
         }
     }
 
+    /// Removes a provisional completion summary without changing the session's
+    /// ownership or turn-depth state. A Codex Stop with live children is not a
+    /// user-visible completion and must not be reused by a later notification.
+    func clearNotificationSummary(sessionId: String) throws {
+        let normalized = normalizeSessionId(sessionId)
+        guard !normalized.isEmpty else { return }
+        try withLockedState { state in
+            guard var record = state.sessions[normalized] else { return }
+            record.lastSubtitle = nil
+            record.lastBody = nil
+            record.lastNotificationStatus = nil
+            state.sessions[normalized] = record
+        }
+    }
+
     func recentlyEmittedNotification(
         sessionId: String,
         fingerprint: String,
@@ -34866,9 +34881,10 @@ export default CMUXSessionRestore;
                     defaultValue: "Task completed"
                 )
             let antigravityHasActiveBackgroundWork = hasActiveAntigravityBackgroundWork()
+            let hasActiveBackgroundWork = antigravityHasActiveBackgroundWork || codexHasActiveBackgroundWork
             let stopNotificationStatus: AgentHookNotificationStatus = (codexFailure == nil && antigravityFailure == nil) ? .idle : .error
             let lifecycleAfterStop: AgentHibernationLifecycleState = {
-                if antigravityHasActiveBackgroundWork && stopNotificationStatus == .idle {
+                if hasActiveBackgroundWork && stopNotificationStatus == .idle {
                     return .running
                 }
                 return stopNotificationStatus == .idle ? .idle : .needsInput
@@ -34962,7 +34978,7 @@ export default CMUXSessionRestore;
                 workspaceId: workspaceId,
                 surfaceId: surfaceId,
                 isSubagent: isNestedAgentSession,
-                pendingWork: antigravityHasActiveBackgroundWork || codexHasActiveBackgroundWork,
+                pendingWork: hasActiveBackgroundWork,
                 detail: stopHadFailure ? body : nil,
                 responseTimeout: def.name == "cursor" ? cursorCriticalTimeout() : nil
             )
@@ -34973,12 +34989,15 @@ export default CMUXSessionRestore;
                                   pid: pid,
                                   launchCommand: resumeLaunchCommand,
                                   agentLifecycle: lifecycleAfterStop,
-                                  lastSubtitle: subtitle,
-                                  lastBody: body,
-                                  lastNotificationStatus: stopNotificationStatus,
+                                  lastSubtitle: (def.name == "codex" && codexHasActiveBackgroundWork) ? nil : subtitle,
+                                  lastBody: (def.name == "codex" && codexHasActiveBackgroundWork) ? nil : body,
+                                  lastNotificationStatus: (def.name == "codex" && codexHasActiveBackgroundWork) ? nil : stopNotificationStatus,
                                   updateLastNotificationStatus: true,
-                                  runtimeStatus: ((antigravityHasActiveBackgroundWork || codexHasActiveBackgroundWork) && stopNotificationStatus == .idle) ? .running : runtimeStatus(for: stopNotificationStatus),
+                                  runtimeStatus: (hasActiveBackgroundWork && stopNotificationStatus == .idle) ? .running : runtimeStatus(for: stopNotificationStatus),
                                   updateRuntimeStatus: true)
+                if def.name == "codex", codexHasActiveBackgroundWork {
+                    try? store.clearNotificationSummary(sessionId: sessionId)
+                }
                 publishAgentSurfaceResumeBinding(
                     client: client,
                     workspaceId: workspaceId,
@@ -35021,7 +35040,7 @@ export default CMUXSessionRestore;
             // would mark the dedupe fingerprint and swallow the real final ping.
             let shouldPublishStopNotification = def.publishesStopNotification
                 && !stopNotificationAlreadyRouted
-                && (!(antigravityHasActiveBackgroundWork || codexHasActiveBackgroundWork) || stopNotificationStatus == .error)
+                && (!hasActiveBackgroundWork || stopNotificationStatus == .error)
             let hasGrokTranscriptContext = def.name == "grok" && normalizedHookValue(cwd) != nil
             let shouldPublishGrokStopFallbackNotification = def.name == "grok"
                 && stopNotificationStatus == .idle
@@ -35042,7 +35061,7 @@ export default CMUXSessionRestore;
                 // Tag successful turn-end pings; error alerts always deliver.
                 let stopMeta: String? = stopNotificationStatus == .idle
                     ? AgentHookNotifyCategory.turnComplete.metaSegment(
-                        pending: antigravityHasActiveBackgroundWork || codexHasActiveBackgroundWork,
+                        pending: hasActiveBackgroundWork,
                         agentKind: def.name,
                         isSubagent: isNestedAgentSession
                     )
@@ -35127,7 +35146,7 @@ export default CMUXSessionRestore;
                             client: client
                         )
                     }
-                } else if antigravityHasActiveBackgroundWork || codexHasActiveBackgroundWork {
+                } else if hasActiveBackgroundWork {
                     let runningStatus = String(localized: "agent.generic.status.running", defaultValue: "Running")
                     if def.name == "cursor" {
                         sendCursorCriticalCommand(

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -33091,8 +33091,9 @@ export default CMUXSessionRestore;
             ?? normalizedHookValue(env["CMUX_AGENT_LAUNCH_CWD"])
             ?? normalizedHookValue(env["PWD"]) ?? (def.name == "codex" ? normalizedHookValue(FileManager.default.currentDirectoryPath) : nil)
         let sessionId = resolvedAgentHookSessionId(def: def, input: input, env: env, cwd: hookCwd)
-        let codexInvocation = def.name == "codex" ? codexHookInvocation(environment: env) : nil
-        let codexLedger = def.name == "codex" ? codexTurnLedger(environment: env) : nil
+        let codexLifecycle = def.name == "codex"
+            ? CodexTurnLifecycleCoordinator(environment: env, cli: self)
+            : nil
         let cursorShellHasAuthoritativeSession = input.sessionId?.isEmpty == false
         let mappedSessionForPolicy = cursorShellEvent
             ? (sessionId.isEmpty ? nil : (try? store.lookup(sessionId: sessionId, deadline: cursorShellDeadline)))
@@ -34088,7 +34089,7 @@ export default CMUXSessionRestore;
 
         switch action {
         case .codexSubagentStart, .codexSubagentStop:
-            guard def.name == "codex", let codexLedger, let codexInvocation else {
+            guard def.name == "codex", let codexLifecycle else {
                 break
             }
             let mapped = sessionId.isEmpty ? nil : (try? store.lookup(sessionId: sessionId))
@@ -34101,43 +34102,18 @@ export default CMUXSessionRestore;
                 firstString(in: $0, keys: ["agent_id", "agentId"])
             }
             let turnId = normalizedHookValue(input.turnId)
-            let decision: CodexTurnLedgerDecision
-            do {
-                if case .codexSubagentStart = action {
-                    decision = try codexLedger.subagentStart(
-                        sessionID: sessionId,
-                        agentID: agentId,
-                        turnID: turnId,
-                        workspaceID: workspaceId,
-                        surfaceID: surfaceId,
-                        invocation: codexInvocation
-                    )
-                } else {
-                    decision = try codexLedger.subagentStop(
-                        sessionID: sessionId,
-                        agentID: agentId,
-                        turnID: turnId,
-                        workspaceID: workspaceId,
-                        surfaceID: surfaceId,
-                        invocation: codexInvocation
-                    )
-                }
-            } catch {
-                // A failed lifecycle commit is not evidence that work drained.
-                // Keep the event unattributed and let the next parent Stop fail
-                // closed rather than allowing a false completion.
-                telemetry.captureError(stage: "codex-child-lifecycle", error: error)
-                if let workspaceId, let surfaceId {
-                    emitJournal(
-                        .stateChanged,
-                        workspaceId: workspaceId,
-                        surfaceId: surfaceId,
-                        isSubagent: true,
-                        detail: "child-lifecycle-commit-failed"
-                    )
-                }
-                return
-            }
+            let starts = {
+                if case .codexSubagentStart = action { return true }
+                return false
+            }()
+            let decision = codexLifecycle.subagent(
+                sessionID: sessionId,
+                agentID: agentId,
+                turnID: turnId,
+                workspaceID: workspaceId,
+                surfaceID: surfaceId,
+                starts: starts
+            )
             if let workspaceId, let surfaceId {
                 let childJournalKind: AgentJournalEventKind = {
                     if case .codexSubagentStart = action {
@@ -34166,14 +34142,13 @@ export default CMUXSessionRestore;
             let workspaceId = target.workspaceId
             let surfaceId = target.surfaceId
             let pid = inferredPID
-            if def.name == "codex", let codexLedger, let codexInvocation {
-                let ownership = try? codexLedger.sessionStart(
+            if let codexLifecycle {
+                let ownership = codexLifecycle.sessionStart(
                     sessionID: sessionId,
                     workspaceID: workspaceId,
-                    surfaceID: surfaceId,
-                    invocation: codexInvocation
+                    surfaceID: surfaceId
                 )
-                guard ownership?.ownership == .foreground else {
+                guard ownership.ownership == .foreground else {
                     telemetry.breadcrumb("codex-hook.session-start.nested-or-unknown")
                     emitJournal(
                         .sessionStarted,
@@ -34336,15 +34311,14 @@ export default CMUXSessionRestore;
             }
             let workspaceId = target.workspaceId
             let surfaceId = target.surfaceId
-            if def.name == "codex", let codexLedger, let codexInvocation {
-                let ownership = try? codexLedger.promptSubmit(
+            if let codexLifecycle {
+                let ownership = codexLifecycle.promptSubmit(
                     sessionID: sessionId,
                     turnID: input.turnId,
                     workspaceID: workspaceId,
-                    surfaceID: surfaceId,
-                    invocation: codexInvocation
+                    surfaceID: surfaceId
                 )
-                guard ownership?.ownership == .foreground else {
+                guard ownership.ownership == .foreground else {
                     telemetry.breadcrumb("codex-hook.prompt-submit.nested-or-unknown")
                     emitJournal(
                         .turnStarted,
@@ -34766,16 +34740,14 @@ export default CMUXSessionRestore;
             let codexStopDecision: CodexTurnLedgerDecision? = {
                 guard def.name == "codex",
                       !sessionId.isEmpty,
-                      let codexLedger,
-                      let codexInvocation else {
+                      let codexLifecycle else {
                     return nil
                 }
-                return try? codexLedger.stop(
+                return codexLifecycle.stop(
                     sessionID: sessionId,
                     turnID: input.turnId,
                     workspaceID: resolvedDirectWorkspaceArg ?? mapped?.workspaceId,
-                    surfaceID: resolvedDirectSurfaceArg ?? mapped?.surfaceId,
-                    invocation: codexInvocation
+                    surfaceID: resolvedDirectSurfaceArg ?? mapped?.surfaceId
                 )
             }()
             if def.name == "codex", !sessionId.isEmpty {
@@ -35303,15 +35275,13 @@ export default CMUXSessionRestore;
             }
 
         case .notification:
-            if def.name == "codex", !sessionId.isEmpty,
-               let codexLedger, let codexInvocation {
-                let ownership = try? codexLedger.observe(
+            if let codexLifecycle, !sessionId.isEmpty {
+                let ownership = codexLifecycle.observe(
                     sessionID: sessionId,
                     workspaceID: resolvedDirectWorkspaceArg,
-                    surfaceID: resolvedDirectSurfaceArg,
-                    invocation: codexInvocation
+                    surfaceID: resolvedDirectSurfaceArg
                 )
-                guard ownership?.ownership == .foreground else {
+                guard ownership.ownership == .foreground else {
                     telemetry.breadcrumb("codex-hook.notification.nested-or-unknown")
                     print("{}")
                     return
@@ -35748,15 +35718,13 @@ export default CMUXSessionRestore;
             sendAgentFeedTelemetryUnlessSuppressed(workspaceId: workspaceId, surfaceId: surfaceId)
 
         case .sessionEnd:
-            if def.name == "codex", !sessionId.isEmpty,
-               let codexLedger, let codexInvocation {
-                let ownership = try? codexLedger.sessionEnd(
+            if let codexLifecycle, !sessionId.isEmpty {
+                let ownership = codexLifecycle.sessionEnd(
                     sessionID: sessionId,
                     workspaceID: resolvedDirectWorkspaceArg,
-                    surfaceID: resolvedDirectSurfaceArg,
-                    invocation: codexInvocation
+                    surfaceID: resolvedDirectSurfaceArg
                 )
-                guard ownership?.ownership == .foreground else {
+                guard ownership.ownership == .foreground else {
                     telemetry.breadcrumb("codex-hook.session-end.nested-or-unknown")
                     print("{}")
                     return
@@ -35831,15 +35799,13 @@ export default CMUXSessionRestore;
             }
 
         case .sessionFinalize:
-            if def.name == "codex", !sessionId.isEmpty,
-               let codexLedger, let codexInvocation {
-                let ownership = try? codexLedger.sessionEnd(
+            if let codexLifecycle, !sessionId.isEmpty {
+                let ownership = codexLifecycle.sessionEnd(
                     sessionID: sessionId,
                     workspaceID: resolvedDirectWorkspaceArg,
-                    surfaceID: resolvedDirectSurfaceArg,
-                    invocation: codexInvocation
+                    surfaceID: resolvedDirectSurfaceArg
                 )
-                guard ownership?.ownership == .foreground else {
+                guard ownership.ownership == .foreground else {
                     telemetry.breadcrumb("codex-hook.session-finalize.nested-or-unknown")
                     print("{}")
                     return
@@ -38222,44 +38188,20 @@ export default CMUXSessionRestore;
         // whether a foreground turn is settled; transcript text is not part of
         // the lifecycle decision.
         if source == "codex",
-           hookEventName == "SubagentStart" || hookEventName == "SubagentStop",
-           let codexInvocation = Optional(codexHookInvocation(environment: env)) {
-            let childID = firstString(in: stdinObj, keys: ["agent_id", "agentId"])
-            let childTurnID = firstString(in: stdinObj, keys: ["turn_id", "turnId"])
-            let childWorkspaceID = feedWorkspaceId(
-                rawObject: stdinObj,
-                fallback: env["CMUX_WORKSPACE_ID"]
+           hookEventName == "SubagentStart" || hookEventName == "SubagentStop" {
+            let lifecycle = CodexTurnLifecycleCoordinator(environment: env, cli: self)
+            _ = lifecycle.recordFeedLifecycle(
+                sessionID: sessionId,
+                eventName: hookEventName,
+                agentID: firstString(in: stdinObj, keys: ["agent_id", "agentId"]),
+                turnID: firstString(in: stdinObj, keys: ["turn_id", "turnId"]),
+                workspaceID: feedWorkspaceId(
+                    rawObject: stdinObj,
+                    fallback: env["CMUX_WORKSPACE_ID"]
+                ),
+                surfaceID: firstString(in: stdinObj, keys: ["surface_id", "surfaceId"])
+                    ?? env["CMUX_SURFACE_ID"]
             )
-            let childSurfaceID = firstString(
-                in: stdinObj,
-                keys: ["surface_id", "surfaceId"]
-            ) ?? env["CMUX_SURFACE_ID"]
-            let ledger = codexTurnLedger(environment: env)
-            do {
-                if hookEventName == "SubagentStart" {
-                    _ = try ledger.subagentStart(
-                        sessionID: sessionId,
-                        agentID: childID,
-                        turnID: childTurnID,
-                        workspaceID: childWorkspaceID,
-                        surfaceID: childSurfaceID,
-                        invocation: codexInvocation
-                    )
-                } else {
-                    _ = try ledger.subagentStop(
-                        sessionID: sessionId,
-                        agentID: childID,
-                        turnID: childTurnID,
-                        workspaceID: childWorkspaceID,
-                        surfaceID: childSurfaceID,
-                        invocation: codexInvocation
-                    )
-                }
-            } catch {
-                // Feed telemetry remains best-effort, but a lifecycle write
-                // failure must never be interpreted as proof that work drained.
-                telemetry.captureError(stage: "codex-child-lifecycle", error: error)
-            }
         }
 
         var eventDict: [String: Any] = [

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -33076,6 +33076,8 @@ export default CMUXSessionRestore;
             ?? normalizedHookValue(env["CMUX_AGENT_LAUNCH_CWD"])
             ?? normalizedHookValue(env["PWD"]) ?? (def.name == "codex" ? normalizedHookValue(FileManager.default.currentDirectoryPath) : nil)
         let sessionId = resolvedAgentHookSessionId(def: def, input: input, env: env, cwd: hookCwd)
+        let codexInvocation = def.name == "codex" ? codexHookInvocation(environment: env) : nil
+        let codexLedger = def.name == "codex" ? codexTurnLedger(environment: env) : nil
         let cursorShellHasAuthoritativeSession = input.sessionId?.isEmpty == false
         let mappedSessionForPolicy = cursorShellEvent
             ? (sessionId.isEmpty ? nil : (try? store.lookup(sessionId: sessionId, deadline: cursorShellDeadline)))
@@ -34070,6 +34072,73 @@ export default CMUXSessionRestore;
         }
 
         switch action {
+        case .codexSubagentStart, .codexSubagentStop:
+            guard def.name == "codex", let codexLedger, let codexInvocation else {
+                break
+            }
+            let mapped = sessionId.isEmpty ? nil : (try? store.lookup(sessionId: sessionId))
+            let target = resolveAgentHookTarget(mapped: mapped)
+            let workspaceId = target?.workspaceId ?? resolvedDirectWorkspaceArg ?? mapped?.workspaceId
+            let surfaceId = target?.surfaceId ?? resolvedDirectSurfaceArg ?? mapped?.surfaceId
+            let agentId = input.rawObject.flatMap {
+                firstString(in: $0, keys: ["agent_id", "agentId"])
+            } ?? input.object.flatMap {
+                firstString(in: $0, keys: ["agent_id", "agentId"])
+            }
+            let turnId = normalizedHookValue(input.turnId)
+            let decision: CodexTurnLedgerDecision
+            do {
+                if case .codexSubagentStart = action {
+                    decision = try codexLedger.subagentStart(
+                        sessionID: sessionId,
+                        agentID: agentId,
+                        turnID: turnId,
+                        workspaceID: workspaceId,
+                        surfaceID: surfaceId,
+                        invocation: codexInvocation
+                    )
+                } else {
+                    decision = try codexLedger.subagentStop(
+                        sessionID: sessionId,
+                        agentID: agentId,
+                        turnID: turnId,
+                        workspaceID: workspaceId,
+                        surfaceID: surfaceId,
+                        invocation: codexInvocation
+                    )
+                }
+            } catch {
+                // A failed lifecycle commit is not evidence that work drained.
+                // Keep the event unattributed and let the next parent Stop fail
+                // closed rather than allowing a false completion.
+                telemetry.captureError(stage: "codex-child-lifecycle", error: error)
+                if let workspaceId, let surfaceId {
+                    emitJournal(
+                        .stateChanged,
+                        workspaceId: workspaceId,
+                        surfaceId: surfaceId,
+                        isSubagent: true,
+                        detail: "child-lifecycle-commit-failed"
+                    )
+                }
+                return
+            }
+            if let workspaceId, let surfaceId {
+                let childJournalKind: AgentJournalEventKind = {
+                    if case .codexSubagentStart = action {
+                        return .childSpawned
+                    }
+                    return .childCompleted
+                }()
+                emitJournal(
+                    childJournalKind,
+                    workspaceId: workspaceId,
+                    surfaceId: surfaceId,
+                    isSubagent: true,
+                    detail: decision.ownership == .foreground ? nil : "child-lifecycle-nested"
+                )
+            }
+
         case .sessionStart:
             let mapped = sessionId.isEmpty ? nil : (try? store.lookup(sessionId: sessionId))
             guard let target = resolveAgentHookTarget(mapped: mapped) else {
@@ -34082,6 +34151,26 @@ export default CMUXSessionRestore;
             let workspaceId = target.workspaceId
             let surfaceId = target.surfaceId
             let pid = inferredPID
+            if def.name == "codex", let codexLedger, let codexInvocation {
+                let ownership = try? codexLedger.sessionStart(
+                    sessionID: sessionId,
+                    workspaceID: workspaceId,
+                    surfaceID: surfaceId,
+                    invocation: codexInvocation
+                )
+                guard ownership?.ownership == .foreground else {
+                    telemetry.breadcrumb("codex-hook.session-start.nested-or-unknown")
+                    emitJournal(
+                        .sessionStarted,
+                        workspaceId: workspaceId,
+                        surfaceId: surfaceId,
+                        isSubagent: true,
+                        detail: "nested-session-start"
+                    )
+                    print("{}")
+                    return
+                }
+            }
             let suppressVisibleMutations = shouldSuppressNestedAgentVisibleMutations(currentAgentPID: pid, env: env)
             let launchCommand = agentLaunchCommandFromEnvironment(
                 env,
@@ -34232,6 +34321,27 @@ export default CMUXSessionRestore;
             }
             let workspaceId = target.workspaceId
             let surfaceId = target.surfaceId
+            if def.name == "codex", let codexLedger, let codexInvocation {
+                let ownership = try? codexLedger.promptSubmit(
+                    sessionID: sessionId,
+                    turnID: input.turnId,
+                    workspaceID: workspaceId,
+                    surfaceID: surfaceId,
+                    invocation: codexInvocation
+                )
+                guard ownership?.ownership == .foreground else {
+                    telemetry.breadcrumb("codex-hook.prompt-submit.nested-or-unknown")
+                    emitJournal(
+                        .turnStarted,
+                        workspaceId: workspaceId,
+                        surfaceId: surfaceId,
+                        isSubagent: true,
+                        detail: "nested-prompt-submit"
+                    )
+                    print("{}")
+                    return
+                }
+            }
             var cursorPromptApprovalNotificationKeys: [String] = []
             var cursorPromptShouldPreservePendingState = false
             if def.name == "cursor", !sessionId.isEmpty {
@@ -34638,6 +34748,33 @@ export default CMUXSessionRestore;
                 }
             }
             let mapped = sessionId.isEmpty ? nil : (try? store.lookup(sessionId: sessionId))
+            let codexStopDecision: CodexTurnLedgerDecision? = {
+                guard def.name == "codex",
+                      !sessionId.isEmpty,
+                      let codexLedger,
+                      let codexInvocation else {
+                    return nil
+                }
+                return try? codexLedger.stop(
+                    sessionID: sessionId,
+                    turnID: input.turnId,
+                    workspaceID: resolvedDirectWorkspaceArg ?? mapped?.workspaceId,
+                    surfaceID: resolvedDirectSurfaceArg ?? mapped?.surfaceId,
+                    invocation: codexInvocation
+                )
+            }()
+            if def.name == "codex", !sessionId.isEmpty {
+                guard codexStopDecision?.ownership == .foreground else {
+                    telemetry.breadcrumb("codex-hook.stop.nested-or-unknown")
+                    print("{}")
+                    return
+                }
+                if codexStopDecision?.settlement == .duplicate {
+                    telemetry.breadcrumb("codex-hook.stop.duplicate-settled")
+                    print("{}")
+                    return
+                }
+            }
             guard let target = resolveAgentHookTarget(mapped: mapped) else {
                 reportTargetResolutionFailure()
                 emitJournal(.turnCompleted, workspaceId: nil, surfaceId: nil, unattributedReason: "target-unresolved")
@@ -34661,23 +34798,16 @@ export default CMUXSessionRestore;
             }
             let pid = preferredAgentHookEventPID(agentName: def.name, mappedPID: mapped?.pid, inferredPID: inferredPID)
             let codexFailure: CodexHookFailureSummary?
-            let codexSubagentSignals: CodexTranscriptSubagentSignals
             if def.name == "codex" {
                 codexFailure = summarizeCodexHookFailure(parsedInput: input, sessionId: sessionId, env: env)
-                if subagentNotificationSuppressionEnabled(env: env),
-                   let transcriptPath = normalizedHookValue(input.transcriptPath)
-                    ?? findCodexTranscriptPath(sessionId: sessionId, env: env) {
-                    codexSubagentSignals = readCodexTranscriptSubagentSignals(
-                        path: transcriptPath,
-                        turnId: input.turnId
-                    )
-                } else {
-                    codexSubagentSignals = CodexTranscriptSubagentSignals()
-                }
             } else {
                 codexFailure = nil
-                codexSubagentSignals = CodexTranscriptSubagentSignals()
             }
+            // Native child lifecycle is the sole Codex background-work
+            // authority. Transcript-tail signals are deliberately excluded:
+            // their flush order is not a completion boundary.
+            let codexHasActiveBackgroundWork = def.name == "codex"
+                && (codexStopDecision?.activeChildCount ?? 0) > 0
             let antigravityFailure: AgentHookNotificationSummary? = {
                 guard def.name == "antigravity", let rawObject = input.rawObject else { return nil }
                 let signal = firstString(in: rawObject, keys: ["terminationReason", "reason", "type", "kind"]) ?? ""
@@ -34731,13 +34861,10 @@ export default CMUXSessionRestore;
                 ?? antigravityFailure?.body
                 ?? lastMsg.map { truncate(normalizedSingleLine($0), maxLength: 200) }
                 ?? grokAssistantMessage.map { truncate(normalizedSingleLine($0), maxLength: 200) }
-                ?? String.localizedStringWithFormat(
-                    String(
-                        localized: "agent.codex.completion.body.sessionCompleted",
-                        defaultValue: "%@ session completed"
-                    ),
-                    def.displayName
-            )
+                ?? String(
+                    localized: "agent.generic.notification.body.taskCompleted",
+                    defaultValue: "Task completed"
+                )
             let antigravityHasActiveBackgroundWork = hasActiveAntigravityBackgroundWork()
             let stopNotificationStatus: AgentHookNotificationStatus = (codexFailure == nil && antigravityFailure == nil) ? .idle : .error
             let lifecycleAfterStop: AgentHibernationLifecycleState = {
@@ -34748,32 +34875,15 @@ export default CMUXSessionRestore;
             }()
             let staleIdleStopHasNewerRunningSession = lifecycleAfterStop == .idle &&
                 hasNewerRunningSession(workspaceId: workspaceId, surfaceId: surfaceId)
-            let terminalActivePromptTurnIdsForStop: Set<String>
-            if !staleIdleStopHasNewerRunningSession,
-               def.name == "codex",
-               let incomingTurnId = normalizedHookValue(input.turnId) {
-                let activePromptTurnStack = mapped?.activePromptTurnIds?
-                    .compactMap({ normalizedHookValue($0) }) ?? []
-                let activePromptTurnId = activePromptTurnStack.last ?? normalizedHookValue(mapped?.activePromptTurnId)
-                let activeTurnIds = activePromptTurnStack.isEmpty
-                    ? activePromptTurnId.map { [$0] } ?? []
-                    : activePromptTurnStack
-                let activeTurnIdsToCheck = activeTurnIds.filter { $0 != incomingTurnId }
-                if !activeTurnIdsToCheck.isEmpty,
-                   let transcriptPath = normalizedHookValue(input.transcriptPath ?? mapped?.transcriptPath)
-                       ?? findCodexTranscriptPath(sessionId: sessionId, env: env) {
-                    terminalActivePromptTurnIdsForStop = codexTranscriptTerminalTurnIds(
-                        path: transcriptPath,
-                        turnIds: Set(activeTurnIdsToCheck)
-                    )
-                } else {
-                    terminalActivePromptTurnIdsForStop = []
-                }
-            } else {
-                terminalActivePromptTurnIdsForStop = []
-            }
+            // Codex settlement is owned by CodexTurnLedger. A transcript tail
+            // cannot prove prompt ordering and is intentionally not consulted.
+            let terminalActivePromptTurnIdsForStop: Set<String> = []
             let nestedPromptStop: Bool
-            if !sessionId.isEmpty, !staleIdleStopHasNewerRunningSession {
+            if def.name == "codex", codexStopDecision?.settlement == .settled {
+                // The ledger admitted this exact terminal boundary; do not let
+                // a prior pending Stop's tombstone make it look nested.
+                nestedPromptStop = false
+            } else if !sessionId.isEmpty, !staleIdleStopHasNewerRunningSession {
                 nestedPromptStop = (try? store.recordPromptStop(
                     sessionId: sessionId,
                     workspaceId: workspaceId,
@@ -34797,21 +34907,26 @@ export default CMUXSessionRestore;
             } else {
                 nestedPromptStop = false
             }
-            // One ancestry walk per hook event, shared by the suppression gate
-            // and the notify payload's subagent tag.
-            let isNestedAgentSession = nestedAgentSessionDetected(
-                currentAgentPID: pid,
-                nestedPromptEvent: nestedPromptStop,
-                transcriptSubagentSession: codexSubagentSignals.isSubagentSession,
-                env: env
-            )
-            let suppressVisibleMutations = shouldSuppressNestedAgentVisibleMutations(
-                currentAgentPID: pid,
-                nestedPromptEvent: nestedPromptStop,
-                transcriptSubagentSession: codexSubagentSignals.isSubagentSession,
-                precomputedNestedDetection: isNestedAgentSession,
-                env: env
-            ) || staleIdleStopHasNewerRunningSession
+            // Codex ownership was admitted before any store mutation. Other
+            // integrations retain their existing ancestry-based suppression.
+            let isNestedAgentSession: Bool
+            let suppressVisibleMutations: Bool
+            if def.name == "codex" {
+                isNestedAgentSession = false
+                suppressVisibleMutations = staleIdleStopHasNewerRunningSession
+            } else {
+                isNestedAgentSession = nestedAgentSessionDetected(
+                    currentAgentPID: pid,
+                    nestedPromptEvent: nestedPromptStop,
+                    env: env
+                )
+                suppressVisibleMutations = shouldSuppressNestedAgentVisibleMutations(
+                    currentAgentPID: pid,
+                    nestedPromptEvent: nestedPromptStop,
+                    precomputedNestedDetection: isNestedAgentSession,
+                    env: env
+                ) || staleIdleStopHasNewerRunningSession
+            }
             if def.name == "cursor", !sessionId.isEmpty {
                 guard acquireCursorLifecycleLease(surfaceId: surfaceId) else {
                     print("{}")
@@ -34819,7 +34934,7 @@ export default CMUXSessionRestore;
                 }
             }
             let suppressCompletionNotification = suppressVisibleMutations
-                || codexSubagentSignals.hasSubagentNotificationRelay
+                || codexHasActiveBackgroundWork
             let cursorStopApprovalNotificationKeys: [String] = {
                 guard def.name == "cursor", !sessionId.isEmpty else { return [] }
                 return (try? store.clearCursorShellApprovals(
@@ -34847,7 +34962,7 @@ export default CMUXSessionRestore;
                 workspaceId: workspaceId,
                 surfaceId: surfaceId,
                 isSubagent: isNestedAgentSession,
-                pendingWork: antigravityHasActiveBackgroundWork,
+                pendingWork: antigravityHasActiveBackgroundWork || codexHasActiveBackgroundWork,
                 detail: stopHadFailure ? body : nil,
                 responseTimeout: def.name == "cursor" ? cursorCriticalTimeout() : nil
             )
@@ -34862,7 +34977,7 @@ export default CMUXSessionRestore;
                                   lastBody: body,
                                   lastNotificationStatus: stopNotificationStatus,
                                   updateLastNotificationStatus: true,
-                                  runtimeStatus: (antigravityHasActiveBackgroundWork && stopNotificationStatus == .idle) ? .running : runtimeStatus(for: stopNotificationStatus),
+                                  runtimeStatus: ((antigravityHasActiveBackgroundWork || codexHasActiveBackgroundWork) && stopNotificationStatus == .idle) ? .running : runtimeStatus(for: stopNotificationStatus),
                                   updateRuntimeStatus: true)
                 publishAgentSurfaceResumeBinding(
                     client: client,
@@ -34906,13 +35021,14 @@ export default CMUXSessionRestore;
             // would mark the dedupe fingerprint and swallow the real final ping.
             let shouldPublishStopNotification = def.publishesStopNotification
                 && !stopNotificationAlreadyRouted
-                && (!antigravityHasActiveBackgroundWork || stopNotificationStatus == .error)
+                && (!(antigravityHasActiveBackgroundWork || codexHasActiveBackgroundWork) || stopNotificationStatus == .error)
             let hasGrokTranscriptContext = def.name == "grok" && normalizedHookValue(cwd) != nil
             let shouldPublishGrokStopFallbackNotification = def.name == "grok"
                 && stopNotificationStatus == .idle
                 && (grokAssistantMessage != nil || !hasGrokTranscriptContext)
             let shouldPublishStopAlert = (shouldPublishStopNotification || shouldPublishGrokStopFallbackNotification)
                 && !suppressCompletionNotification
+                && (codexStopDecision?.shouldNotify ?? true)
             if suppressVisibleMutations {
                 telemetry.breadcrumb(
                     staleIdleStopHasNewerRunningSession
@@ -34926,7 +35042,7 @@ export default CMUXSessionRestore;
                 // Tag successful turn-end pings; error alerts always deliver.
                 let stopMeta: String? = stopNotificationStatus == .idle
                     ? AgentHookNotifyCategory.turnComplete.metaSegment(
-                        pending: antigravityHasActiveBackgroundWork,
+                        pending: antigravityHasActiveBackgroundWork || codexHasActiveBackgroundWork,
                         agentKind: def.name,
                         isSubagent: isNestedAgentSession
                     )
@@ -35011,7 +35127,7 @@ export default CMUXSessionRestore;
                             client: client
                         )
                     }
-                } else if antigravityHasActiveBackgroundWork {
+                } else if antigravityHasActiveBackgroundWork || codexHasActiveBackgroundWork {
                     let runningStatus = String(localized: "agent.generic.status.running", defaultValue: "Running")
                     if def.name == "cursor" {
                         sendCursorCriticalCommand(
@@ -35168,6 +35284,20 @@ export default CMUXSessionRestore;
             }
 
         case .notification:
+            if def.name == "codex", !sessionId.isEmpty,
+               let codexLedger, let codexInvocation {
+                let ownership = try? codexLedger.observe(
+                    sessionID: sessionId,
+                    workspaceID: resolvedDirectWorkspaceArg,
+                    surfaceID: resolvedDirectSurfaceArg,
+                    invocation: codexInvocation
+                )
+                guard ownership?.ownership == .foreground else {
+                    telemetry.breadcrumb("codex-hook.notification.nested-or-unknown")
+                    print("{}")
+                    return
+                }
+            }
             let mapped = sessionId.isEmpty
                 ? nil
                 : (try? store.lookup(sessionId: sessionId, deadline: cursorShellDeadline))
@@ -35599,6 +35729,20 @@ export default CMUXSessionRestore;
             sendAgentFeedTelemetryUnlessSuppressed(workspaceId: workspaceId, surfaceId: surfaceId)
 
         case .sessionEnd:
+            if def.name == "codex", !sessionId.isEmpty,
+               let codexLedger, let codexInvocation {
+                let ownership = try? codexLedger.sessionEnd(
+                    sessionID: sessionId,
+                    workspaceID: resolvedDirectWorkspaceArg,
+                    surfaceID: resolvedDirectSurfaceArg,
+                    invocation: codexInvocation
+                )
+                guard ownership?.ownership == .foreground else {
+                    telemetry.breadcrumb("codex-hook.session-end.nested-or-unknown")
+                    print("{}")
+                    return
+                }
+            }
             if def.name == "codex", !sessionId.isEmpty {
                 retireCodexMonitorLeases(sessionId: sessionId, turnId: nil, env: env)
             }
@@ -35668,6 +35812,20 @@ export default CMUXSessionRestore;
             }
 
         case .sessionFinalize:
+            if def.name == "codex", !sessionId.isEmpty,
+               let codexLedger, let codexInvocation {
+                let ownership = try? codexLedger.sessionEnd(
+                    sessionID: sessionId,
+                    workspaceID: resolvedDirectWorkspaceArg,
+                    surfaceID: resolvedDirectSurfaceArg,
+                    invocation: codexInvocation
+                )
+                guard ownership?.ownership == .foreground else {
+                    telemetry.breadcrumb("codex-hook.session-finalize.nested-or-unknown")
+                    print("{}")
+                    return
+                }
+            }
             let endingSession = sessionId.isEmpty
                 ? nil
                 : (try? store.lookup(sessionId: sessionId, deadline: cursorShellDeadline))
@@ -36371,6 +36529,8 @@ export default CMUXSessionRestore;
         case "shell-exec": return "PreToolUse"
         case "shell-done": return "PostToolUse"
         case "shell-failed": return "PostToolUseFailure"
+        case "subagent-start": return "SubagentStart"
+        case "subagent-stop": return "SubagentStop"
         case "stop", "idle": return "Stop"
         case "session-end": return "SessionEnd"
         case "notification", "notify": return "Notification"
@@ -38037,6 +38197,51 @@ export default CMUXSessionRestore;
             in: stdinObj,
             keys: ["session_id", "sessionId", "conversation_id", "conversationId"]
         ) ?? stableFallbackFeedSessionId(source: source, rawObject: stdinObj, agentPid: agentPid)
+
+        // Native Codex child events are committed before their telemetry frame
+        // is sent. This is the only source used by the Stop path to decide
+        // whether a foreground turn is settled; transcript text is not part of
+        // the lifecycle decision.
+        if source == "codex",
+           hookEventName == "SubagentStart" || hookEventName == "SubagentStop",
+           let codexInvocation = Optional(codexHookInvocation(environment: env)) {
+            let childID = firstString(in: stdinObj, keys: ["agent_id", "agentId"])
+            let childTurnID = firstString(in: stdinObj, keys: ["turn_id", "turnId"])
+            let childWorkspaceID = feedWorkspaceId(
+                rawObject: stdinObj,
+                fallback: env["CMUX_WORKSPACE_ID"]
+            )
+            let childSurfaceID = firstString(
+                in: stdinObj,
+                keys: ["surface_id", "surfaceId"]
+            ) ?? env["CMUX_SURFACE_ID"]
+            let ledger = codexTurnLedger(environment: env)
+            do {
+                if hookEventName == "SubagentStart" {
+                    _ = try ledger.subagentStart(
+                        sessionID: sessionId,
+                        agentID: childID,
+                        turnID: childTurnID,
+                        workspaceID: childWorkspaceID,
+                        surfaceID: childSurfaceID,
+                        invocation: codexInvocation
+                    )
+                } else {
+                    _ = try ledger.subagentStop(
+                        sessionID: sessionId,
+                        agentID: childID,
+                        turnID: childTurnID,
+                        workspaceID: childWorkspaceID,
+                        surfaceID: childSurfaceID,
+                        invocation: codexInvocation
+                    )
+                }
+            } catch {
+                // Feed telemetry remains best-effort, but a lifecycle write
+                // failure must never be interpreted as proof that work drained.
+                telemetry.captureError(stage: "codex-child-lifecycle", error: error)
+            }
+        }
 
         var eventDict: [String: Any] = [
             "session_id": "\(source)-\(sessionId)",

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -32093,19 +32093,43 @@ export default CMUXSessionRestore;
         ))
     }
 
-    private static func jsonHookValueContainsCmuxOwnedCommand(_ value: Any, for def: AgentHookDef) -> Bool {
+    private static func jsonHookValueContainsCmuxOwnedCommand(
+        _ value: Any,
+        for def: AgentHookDef,
+        materializeCodexScripts: Bool = true
+    ) -> Bool {
         if let command = value as? String {
-            return isCmuxOwnedHookCommand(command, for: def)
+            return isCmuxOwnedHookCommand(
+                command,
+                for: def,
+                materializeCodexScripts: materializeCodexScripts
+            )
         }
         if let array = value as? [Any] {
-            return array.contains { jsonHookValueContainsCmuxOwnedCommand($0, for: def) }
+            return array.contains {
+                jsonHookValueContainsCmuxOwnedCommand(
+                    $0,
+                    for: def,
+                    materializeCodexScripts: materializeCodexScripts
+                )
+            }
         }
         if let object = value as? [String: Any] {
             if let command = object["command"] as? String,
-               isCmuxOwnedHookCommand(command, for: def) {
+               isCmuxOwnedHookCommand(
+                   command,
+                   for: def,
+                   materializeCodexScripts: materializeCodexScripts
+               ) {
                 return true
             }
-            return object.values.contains { jsonHookValueContainsCmuxOwnedCommand($0, for: def) }
+            return object.values.contains {
+                jsonHookValueContainsCmuxOwnedCommand(
+                    $0,
+                    for: def,
+                    materializeCodexScripts: materializeCodexScripts
+                )
+            }
         }
         return false
     }
@@ -32411,7 +32435,11 @@ export default CMUXSessionRestore;
             return []
         }
         return Set(hooks.compactMap { eventName, value in
-            Self.jsonHookValueContainsCmuxOwnedCommand(value, for: def)
+            Self.jsonHookValueContainsCmuxOwnedCommand(
+                value,
+                for: def,
+                materializeCodexScripts: false
+            )
                 ? eventName
                 : nil
         })
@@ -32901,11 +32929,10 @@ export default CMUXSessionRestore;
         telemetry: CLISocketSentryTelemetry,
         socketPassword: String? = nil,
         rawInputOverride: String? = nil,
-        hookDeadline: Date? = nil,
-        codexStopDecisionOverride: CodexTurnLedgerDecision? = nil,
-        skipCodexLegacyPromptStop: Bool = false
+        hookDeadline: Date? = nil
     ) throws {
         let env = ProcessInfo.processInfo.environment
+        let skipCodexLegacyPromptStop = env["CMUX_CODEX_SETTLED_CHILD_STOP"] == "1"
         let subcommand = commandArgs.first?.lowercased() ?? ""
         let hookArgs = Array(commandArgs.dropFirst())
         let cursorShellEvent = def.name == "cursor" && subcommand == "shell-exec"
@@ -34117,21 +34144,11 @@ export default CMUXSessionRestore;
                decision.ownership == .foreground,
                decision.settlement == .settled,
                decision.shouldNotify {
-                // A parent Stop can arrive before its last child exits. Reuse
-                // the normal stop publication path with the already-authoritative
-                // ledger decision so completion is emitted exactly once.
-                try runGenericAgentHook(
-                    def: def,
-                    commandArgs: ["stop"],
-                    client: client,
-                    telemetry: telemetry,
-                    socketPassword: socketPassword,
-                    rawInputOverride: rawInput,
-                    hookDeadline: hookDeadline,
-                    codexStopDecisionOverride: decision,
-                    skipCodexLegacyPromptStop: true
+                spawnDetachedCodexSettledStop(
+                    payload: rawInput,
+                    environment: env,
+                    telemetry: telemetry
                 )
-                return
             }
 
         case .sessionStart:
@@ -34744,9 +34761,6 @@ export default CMUXSessionRestore;
                       let codexLifecycle else {
                     return nil
                 }
-                if let codexStopDecisionOverride {
-                    return codexStopDecisionOverride
-                }
                 return codexLifecycle.observe(
                     sessionID: sessionId,
                     workspaceID: resolvedDirectWorkspaceArg ?? mapped?.workspaceId,
@@ -34903,6 +34917,13 @@ export default CMUXSessionRestore;
             let nestedPromptStop: Bool
             if skipCodexLegacyPromptStop {
                 nestedPromptStop = false
+            } else if def.name == "codex", codexLifecycle?.usesLegacyIdentity == false {
+                // Tokenized wrapper launches use CodexTurnLedger as the sole
+                // ownership and settlement authority. Legacy prompt-depth
+                // inference cannot distinguish a repeated parent Stop while
+                // children drain from a nested turn, so keep it out of this
+                // modern path entirely.
+                nestedPromptStop = false
             } else if def.name == "codex", codexStopDecision?.settlement == .settled {
                 // The ledger admitted this exact terminal boundary; do not let
                 // a prior pending Stop's tombstone make it look nested.
@@ -34938,16 +34959,12 @@ export default CMUXSessionRestore;
             if def.name == "codex",
                !nestedPromptStop,
                let codexLifecycle {
-                if let codexStopDecisionOverride {
-                    codexStopDecision = codexStopDecisionOverride
-                } else {
-                    codexStopDecision = codexLifecycle.stop(
-                        sessionID: sessionId,
-                        turnID: input.turnId,
-                        workspaceID: workspaceId,
-                        surfaceID: surfaceId
-                    )
-                }
+                codexStopDecision = codexLifecycle.stop(
+                    sessionID: sessionId,
+                    turnID: input.turnId,
+                    workspaceID: workspaceId,
+                    surfaceID: surfaceId
+                )
             }
             if def.name == "codex",
                !nestedPromptStop,

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -34730,12 +34730,6 @@ export default CMUXSessionRestore;
             }
 
         case .stop:
-            if def.name == "codex", !sessionId.isEmpty {
-                let stopTurnId = input.turnId?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-                if !stopTurnId.isEmpty {
-                    retireCodexMonitorLeases(sessionId: sessionId, turnId: stopTurnId, env: env)
-                }
-            }
             let mapped = sessionId.isEmpty ? nil : (try? store.lookup(sessionId: sessionId))
             // Admit ownership before touching the legacy prompt-depth store.
             // A nested reviewer must not be able to create or mutate a generic
@@ -34759,6 +34753,15 @@ export default CMUXSessionRestore;
                     telemetry.breadcrumb("codex-hook.stop.nested-or-unknown")
                     print("{}")
                     return
+                }
+            }
+            // Retire only after the ledger admits this callback as the
+            // foreground owner. A nested reviewer must not tear down the
+            // foreground Codex transcript monitor while it inherits its PID.
+            if def.name == "codex", !sessionId.isEmpty {
+                let stopTurnId = input.turnId?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                if !stopTurnId.isEmpty {
+                    retireCodexMonitorLeases(sessionId: sessionId, turnId: stopTurnId, env: env)
                 }
             }
             guard let target = resolveAgentHookTarget(mapped: mapped) else {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -32110,10 +32110,7 @@ export default CMUXSessionRestore;
         return false
     }
 
-    private func installAgentHooks(
-        _ def: AgentHookDef,
-        automaticReconciliation: Bool = false
-    ) throws {
+    private func installAgentHooks(_ def: AgentHookDef) throws {
         try Self.validateHookInstallDispatch(for: def)
         if def.name == "opencode" { try installOpenCodePluginHooks(def); return }
         if def.name == "pi" { try installPiExtensionHooks(def); return }
@@ -32143,8 +32140,7 @@ export default CMUXSessionRestore;
         let fm = FileManager.default
         let configDir = def.resolvedConfigDir()
         let filePath = "\(configDir)/\(def.configFile)"
-        let skipConfirm = automaticReconciliation
-            || ProcessInfo.processInfo.arguments.contains("--yes")
+        let skipConfirm = ProcessInfo.processInfo.arguments.contains("--yes")
             || ProcessInfo.processInfo.arguments.contains("-y")
 
         let configDirectoryFileError = String.localizedStringWithFormat(
@@ -32160,9 +32156,7 @@ export default CMUXSessionRestore;
             if def.createConfigDirIfMissing {
                 throw CLIError(message: configDirectoryFileError)
             }
-            if !automaticReconciliation {
-                print("Required agent configuration is missing. Run `cmux hooks setup` after installing your agent CLI.")
-            }
+            print("Required agent configuration is missing. Run `cmux hooks setup` after installing your agent CLI.")
             return
         }
         if !configPathExists {
@@ -32173,9 +32167,7 @@ export default CMUXSessionRestore;
                     throw CLIError(message: configDirectoryFileError)
                 }
             } else {
-                if !automaticReconciliation {
-                    print("Required agent configuration is missing. Run `cmux hooks setup` after installing your agent CLI.")
-                }
+                print("Required agent configuration is missing. Run `cmux hooks setup` after installing your agent CLI.")
                 return
             }
         }
@@ -32186,12 +32178,6 @@ export default CMUXSessionRestore;
                 throw CLIError(message: "\(filePath) exists but is not valid JSON. Fix or remove it before installing hooks.")
             }
             existing = json
-        }
-
-        let existingHooksValue: Any = existing["hooks"] ?? [String: Any]()
-        if automaticReconciliation,
-           !Self.jsonHookValueContainsCmuxOwnedCommand(existingHooksValue, for: def) {
-            return
         }
 
         var hooks = existing["hooks"] as? [String: Any] ?? [:]
@@ -32337,9 +32323,7 @@ export default CMUXSessionRestore;
 
         if oldString == newString {
             // No-op install; skip the write and the prompt entirely.
-            if !automaticReconciliation {
-                print("\(def.displayName) hooks already up to date at \(filePath)")
-            }
+            print("\(def.displayName) hooks already up to date at \(filePath)")
         } else {
             if !skipConfirm {
                 Self.printInstallPreview(
@@ -32355,12 +32339,10 @@ export default CMUXSessionRestore;
                 }
             }
             try newData.write(to: URL(fileURLWithPath: filePath), options: .atomic)
-            if !automaticReconciliation {
-                print("\(def.displayName) hooks installed at \(filePath)")
-            }
+            print("\(def.displayName) hooks installed at \(filePath)")
         }
 
-        if !automaticReconciliation, let note = def.postInstallNote {
+        if let note = def.postInstallNote {
             print(note)
         }
 
@@ -32399,18 +32381,16 @@ export default CMUXSessionRestore;
                         }
                     }
                     try newContent.write(toFile: configPath, atomically: true, encoding: .utf8)
-                    if !automaticReconciliation {
-                        if def.name == "codex", !codexHookTrustEntries.isEmpty, trustInstall.installedTrust {
-                            print("Enabled hooks and approved cmux hooks in \(configPath)")
-                        } else {
-                            print("Enabled hooks in \(configPath)")
-                        }
+                    if def.name == "codex", !codexHookTrustEntries.isEmpty, trustInstall.installedTrust {
+                        print("Enabled hooks and approved cmux hooks in \(configPath)")
+                    } else {
+                        print("Enabled hooks in \(configPath)")
                     }
                 }
             }
         }
 
-        if def.name == "codex", !automaticReconciliation {
+        if def.name == "codex" {
             Self.garbageCollectCodexHookScripts(
                 retaining: Self.currentCodexWrapperHookScriptFilenames(for: def)
                     .union(Self.installedCodexHookScriptFilenames(for: def))
@@ -32418,21 +32398,23 @@ export default CMUXSessionRestore;
         }
     }
 
-    /// Repairs an opted-in persistent Codex channel before wrapper launch.
-    func reconcileCodexPersistentHooksForWrapper() -> Bool {
-        guard let def = Self.agentDef(named: "codex") else { return false }
-        try? installAgentHooks(def, automaticReconciliation: true)
-
+    /// Returns the cmux-owned events already present in Codex's persistent hook
+    /// file. This is intentionally read-only: wrapper launch must never turn
+    /// into an implicit hook install or rewrite `config.toml`/`hooks.json`.
+    func codexPersistentHookEventNamesForWrapper() -> Set<String> {
+        guard let def = Self.agentDef(named: "codex") else { return [] }
         let fileURL = URL(fileURLWithPath: def.resolvedConfigDir(), isDirectory: true)
             .appendingPathComponent(def.configFile, isDirectory: false)
         guard let data = try? Data(contentsOf: fileURL),
               let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let hooks = root["hooks"] as? [String: Any] else {
-            return false
+            return []
         }
-        return hooks.values.contains {
-            Self.jsonHookValueContainsCmuxOwnedCommand($0, for: def)
-        }
+        return Set(hooks.compactMap { eventName, value in
+            Self.jsonHookValueContainsCmuxOwnedCommand(value, for: def)
+                ? eventName
+                : nil
+        })
     }
 
     private func pruneLegacyGrokHookFileIfNeeded(

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -34742,7 +34742,6 @@ export default CMUXSessionRestore;
                 }
                 return codexLifecycle.observe(
                     sessionID: sessionId,
-                    turnID: input.turnId,
                     workspaceID: resolvedDirectWorkspaceArg ?? mapped?.workspaceId,
                     surfaceID: resolvedDirectSurfaceArg ?? mapped?.surfaceId
                 )

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -38286,7 +38286,7 @@ export default CMUXSessionRestore;
         if source == "codex",
            hookEventName == "SubagentStart" || hookEventName == "SubagentStop" {
             let lifecycle = CodexTurnLifecycleCoordinator(environment: env, cli: self)
-            _ = lifecycle.recordFeedLifecycle(
+            let decision = lifecycle.recordFeedLifecycle(
                 sessionID: sessionId,
                 eventName: hookEventName,
                 agentID: firstString(in: stdinObj, keys: ["agent_id", "agentId"]),
@@ -38298,6 +38298,22 @@ export default CMUXSessionRestore;
                 surfaceID: firstString(in: stdinObj, keys: ["surface_id", "surfaceId"])
                     ?? env["CMUX_SURFACE_ID"]
             )
+            if hookEventName == "SubagentStop",
+               decision.ownership == .foreground,
+               decision.settlement == .settled,
+               decision.shouldNotify,
+               let payload = String(data: stdinData, encoding: .utf8) {
+                // Persistent Codex feed hooks share the same ledger as the
+                // wrapper-injected child hooks. Once the final child drains,
+                // run the normal Stop projection out of band so the parent
+                // completion is published even when Codex emits no second
+                // parent Stop event.
+                spawnDetachedCodexSettledStop(
+                    payload: payload,
+                    environment: env,
+                    telemetry: telemetry
+                )
+            }
         }
 
         var eventDict: [String: Any] = [

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -32901,7 +32901,9 @@ export default CMUXSessionRestore;
         telemetry: CLISocketSentryTelemetry,
         socketPassword: String? = nil,
         rawInputOverride: String? = nil,
-        hookDeadline: Date? = nil
+        hookDeadline: Date? = nil,
+        codexStopDecisionOverride: CodexTurnLedgerDecision? = nil,
+        skipCodexLegacyPromptStop: Bool = false
     ) throws {
         let env = ProcessInfo.processInfo.environment
         let subcommand = commandArgs.first?.lowercased() ?? ""
@@ -34111,6 +34113,26 @@ export default CMUXSessionRestore;
                     detail: decision.ownership == .foreground ? nil : "child-lifecycle-nested"
                 )
             }
+            if case .codexSubagentStop = action,
+               decision.ownership == .foreground,
+               decision.settlement == .settled,
+               decision.shouldNotify {
+                // A parent Stop can arrive before its last child exits. Reuse
+                // the normal stop publication path with the already-authoritative
+                // ledger decision so completion is emitted exactly once.
+                try runGenericAgentHook(
+                    def: def,
+                    commandArgs: ["stop"],
+                    client: client,
+                    telemetry: telemetry,
+                    socketPassword: socketPassword,
+                    rawInputOverride: rawInput,
+                    hookDeadline: hookDeadline,
+                    codexStopDecisionOverride: decision,
+                    skipCodexLegacyPromptStop: true
+                )
+                return
+            }
 
         case .sessionStart:
             let mapped = sessionId.isEmpty ? nil : (try? store.lookup(sessionId: sessionId))
@@ -34722,6 +34744,9 @@ export default CMUXSessionRestore;
                       let codexLifecycle else {
                     return nil
                 }
+                if let codexStopDecisionOverride {
+                    return codexStopDecisionOverride
+                }
                 return codexLifecycle.observe(
                     sessionID: sessionId,
                     workspaceID: resolvedDirectWorkspaceArg ?? mapped?.workspaceId,
@@ -34876,7 +34901,9 @@ export default CMUXSessionRestore;
                 terminalActivePromptTurnIdsForStop = []
             }
             let nestedPromptStop: Bool
-            if def.name == "codex", codexStopDecision?.settlement == .settled {
+            if skipCodexLegacyPromptStop {
+                nestedPromptStop = false
+            } else if def.name == "codex", codexStopDecision?.settlement == .settled {
                 // The ledger admitted this exact terminal boundary; do not let
                 // a prior pending Stop's tombstone make it look nested.
                 nestedPromptStop = false
@@ -34911,12 +34938,16 @@ export default CMUXSessionRestore;
             if def.name == "codex",
                !nestedPromptStop,
                let codexLifecycle {
-                codexStopDecision = codexLifecycle.stop(
-                    sessionID: sessionId,
-                    turnID: input.turnId,
-                    workspaceID: workspaceId,
-                    surfaceID: surfaceId
-                )
+                if let codexStopDecisionOverride {
+                    codexStopDecision = codexStopDecisionOverride
+                } else {
+                    codexStopDecision = codexLifecycle.stop(
+                        sessionID: sessionId,
+                        turnID: input.turnId,
+                        workspaceID: workspaceId,
+                        surfaceID: surfaceId
+                    )
+                }
             }
             if def.name == "codex",
                !nestedPromptStop,

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -34794,7 +34794,7 @@ export default CMUXSessionRestore;
             // Native child lifecycle is the sole Codex background-work
             // authority. Transcript-tail signals are deliberately excluded:
             // their flush order is not a completion boundary.
-            let codexHasActiveBackgroundWork = def.name == "codex"
+            var codexHasActiveBackgroundWork = def.name == "codex"
                 && (codexStopDecision?.activeChildCount ?? 0) > 0
             let antigravityFailure: AgentHookNotificationSummary? = {
                 guard def.name == "antigravity", let rawObject = input.rawObject else { return nil }
@@ -34854,19 +34854,45 @@ export default CMUXSessionRestore;
                     defaultValue: "Task completed"
                 )
             let antigravityHasActiveBackgroundWork = hasActiveAntigravityBackgroundWork()
-            let hasActiveBackgroundWork = antigravityHasActiveBackgroundWork || codexHasActiveBackgroundWork
+            var hasActiveBackgroundWork = antigravityHasActiveBackgroundWork || codexHasActiveBackgroundWork
             let stopNotificationStatus: AgentHookNotificationStatus = (codexFailure == nil && antigravityFailure == nil) ? .idle : .error
-            let lifecycleAfterStop: AgentHibernationLifecycleState = {
+            var lifecycleAfterStop: AgentHibernationLifecycleState = {
                 if hasActiveBackgroundWork && stopNotificationStatus == .idle {
                     return .running
                 }
                 return stopNotificationStatus == .idle ? .idle : .needsInput
             }()
-            let staleIdleStopHasNewerRunningSession = lifecycleAfterStop == .idle &&
+            var staleIdleStopHasNewerRunningSession = lifecycleAfterStop == .idle &&
                 hasNewerRunningSession(workspaceId: workspaceId, surfaceId: surfaceId)
-            // Codex settlement is owned by CodexTurnLedger. A transcript tail
-            // cannot prove prompt ordering and is intentionally not consulted.
-            let terminalActivePromptTurnIdsForStop: Set<String> = []
+            // Current tokenized launches settle only from CodexTurnLedger. Keep
+            // this narrow transcript check for pre-ledger launches so stale
+            // prompt-depth records cannot strand an older session; it is never
+            // part of the modern child-work decision.
+            let terminalActivePromptTurnIdsForStop: Set<String>
+            if !staleIdleStopHasNewerRunningSession,
+               def.name == "codex",
+               codexLifecycle?.usesLegacyIdentity == true,
+               let incomingTurnId = normalizedHookValue(input.turnId) {
+                let activePromptTurnStack = mapped?.activePromptTurnIds?
+                    .compactMap({ normalizedHookValue($0) }) ?? []
+                let activePromptTurnId = activePromptTurnStack.last ?? normalizedHookValue(mapped?.activePromptTurnId)
+                let activeTurnIds = activePromptTurnStack.isEmpty
+                    ? activePromptTurnId.map { [$0] } ?? []
+                    : activePromptTurnStack
+                let activeTurnIdsToCheck = activeTurnIds.filter { $0 != incomingTurnId }
+                if !activeTurnIdsToCheck.isEmpty,
+                   let transcriptPath = normalizedHookValue(input.transcriptPath ?? mapped?.transcriptPath)
+                       ?? findCodexTranscriptPath(sessionId: sessionId, env: env) {
+                    terminalActivePromptTurnIdsForStop = codexTranscriptTerminalTurnIds(
+                        path: transcriptPath,
+                        turnIds: Set(activeTurnIdsToCheck)
+                    )
+                } else {
+                    terminalActivePromptTurnIdsForStop = []
+                }
+            } else {
+                terminalActivePromptTurnIdsForStop = []
+            }
             let nestedPromptStop: Bool
             if def.name == "codex", codexStopDecision?.settlement == .settled {
                 // The ledger admitted this exact terminal boundary; do not let
@@ -34910,10 +34936,30 @@ export default CMUXSessionRestore;
                     surfaceID: surfaceId
                 )
             }
+            if def.name == "codex",
+               !nestedPromptStop,
+               codexStopDecision?.ownership != .foreground {
+                telemetry.breadcrumb("codex-hook.stop.settlement-unavailable")
+                print("{}")
+                return
+            }
             if def.name == "codex", codexStopDecision?.settlement == .duplicate {
                 telemetry.breadcrumb("codex-hook.stop.duplicate-settled")
                 print("{}")
                 return
+            }
+            // A native child callback may win the ledger lock between the
+            // ownership observation and the deferred Stop settlement. Rebuild
+            // the lifecycle projection from that final authoritative count so
+            // the store, journal, and visible badge cannot disagree.
+            if def.name == "codex" {
+                codexHasActiveBackgroundWork = (codexStopDecision?.activeChildCount ?? 0) > 0
+                hasActiveBackgroundWork = antigravityHasActiveBackgroundWork || codexHasActiveBackgroundWork
+                lifecycleAfterStop = hasActiveBackgroundWork && stopNotificationStatus == .idle
+                    ? .running
+                    : (stopNotificationStatus == .idle ? .idle : .needsInput)
+                staleIdleStopHasNewerRunningSession = lifecycleAfterStop == .idle &&
+                    hasNewerRunningSession(workspaceId: workspaceId, surfaceId: surfaceId)
             }
             // Codex ownership was admitted before any store mutation. Other
             // integrations retain their existing ancestry-based suppression.

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -34737,27 +34737,26 @@ export default CMUXSessionRestore;
                 }
             }
             let mapped = sessionId.isEmpty ? nil : (try? store.lookup(sessionId: sessionId))
-            let codexStopDecision: CodexTurnLedgerDecision? = {
+            // Admit ownership before touching the legacy prompt-depth store.
+            // A nested reviewer must not be able to create or mutate a generic
+            // session record merely because it inherited the foreground PID.
+            let codexStopOwnership: CodexTurnLedgerDecision? = {
                 guard def.name == "codex",
                       !sessionId.isEmpty,
                       let codexLifecycle else {
                     return nil
                 }
-                return codexLifecycle.stop(
+                return codexLifecycle.observe(
                     sessionID: sessionId,
                     turnID: input.turnId,
                     workspaceID: resolvedDirectWorkspaceArg ?? mapped?.workspaceId,
                     surfaceID: resolvedDirectSurfaceArg ?? mapped?.surfaceId
                 )
             }()
+            var codexStopDecision = codexStopOwnership
             if def.name == "codex", !sessionId.isEmpty {
                 guard codexStopDecision?.ownership == .foreground else {
                     telemetry.breadcrumb("codex-hook.stop.nested-or-unknown")
-                    print("{}")
-                    return
-                }
-                if codexStopDecision?.settlement == .duplicate {
-                    telemetry.breadcrumb("codex-hook.stop.duplicate-settled")
                     print("{}")
                     return
                 }
@@ -34895,13 +34894,32 @@ export default CMUXSessionRestore;
             } else {
                 nestedPromptStop = false
             }
+            // The prompt-depth record is a compatibility ownership signal for
+            // legacy same-session nested turns. Do not settle the Codex ledger
+            // for that nested callback; otherwise the later parent Stop would
+            // be mistaken for a duplicate and could never notify.
+            if def.name == "codex",
+               !nestedPromptStop,
+               let codexLifecycle {
+                codexStopDecision = codexLifecycle.stop(
+                    sessionID: sessionId,
+                    turnID: input.turnId,
+                    workspaceID: workspaceId,
+                    surfaceID: surfaceId
+                )
+            }
+            if def.name == "codex", codexStopDecision?.settlement == .duplicate {
+                telemetry.breadcrumb("codex-hook.stop.duplicate-settled")
+                print("{}")
+                return
+            }
             // Codex ownership was admitted before any store mutation. Other
             // integrations retain their existing ancestry-based suppression.
             let isNestedAgentSession: Bool
             let suppressVisibleMutations: Bool
             if def.name == "codex" {
-                isNestedAgentSession = false
-                suppressVisibleMutations = staleIdleStopHasNewerRunningSession
+                isNestedAgentSession = nestedPromptStop
+                suppressVisibleMutations = nestedPromptStop || staleIdleStopHasNewerRunningSession
             } else {
                 isNestedAgentSession = nestedAgentSessionDetected(
                     currentAgentPID: pid,

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexHookInjectionEvent.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexHookInjectionEvent.swift
@@ -8,4 +8,22 @@ public struct CodexHookInjectionEvent: Equatable, Sendable {
 
     /// The timeout Codex applies to the hook command, in milliseconds.
     public let timeoutMs: Int
+
+    /// Whether the hook must finish its cmux-owned lifecycle write before
+    /// Codex advances to the next event. Completion/status hooks remain
+    /// fire-and-forget; child lifecycle events use the synchronous boundary.
+    public let isSynchronous: Bool
+
+    /// Creates one generated Codex hook event.
+    public init(
+        agentEvent: String,
+        cmuxSubcommand: String,
+        timeoutMs: Int,
+        isSynchronous: Bool = false
+    ) {
+        self.agentEvent = agentEvent
+        self.cmuxSubcommand = cmuxSubcommand
+        self.timeoutMs = timeoutMs
+        self.isSynchronous = isSynchronous
+    }
 }

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexHookInjectionSchema.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexHookInjectionSchema.swift
@@ -20,6 +20,8 @@ public struct CodexHookInjectionSchema: Equatable, Sendable {
         .init(agentEvent: "PreToolUse", cmuxSubcommand: "pre-tool-use", timeoutMs: 120000),
         .init(agentEvent: "PostToolUse", cmuxSubcommand: "post-tool-use", timeoutMs: 10000),
         .init(agentEvent: "PermissionRequest", cmuxSubcommand: "notification", timeoutMs: 120000),
+        .init(agentEvent: "SubagentStart", cmuxSubcommand: "subagent-start", timeoutMs: 10000, isSynchronous: true),
+        .init(agentEvent: "SubagentStop", cmuxSubcommand: "subagent-stop", timeoutMs: 10000, isSynchronous: true),
     ])
 
     /// Exact older shapes accepted by saved-layout and replay sanitization.

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexHookInjectionSchema.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexHookInjectionSchema.swift
@@ -30,6 +30,17 @@ public struct CodexHookInjectionSchema: Equatable, Sendable {
     /// arbitrary prefixes: hook config is user-controlled argv.
     static let recognized = [
         current,
+        // The immediately previous wrapper generation had the same six
+        // events but no native child callbacks. Keep it removable from saved
+        // launch argv so an upgrade cannot leave two Stop producers active.
+        Self(events: [
+            .init(agentEvent: "SessionStart", cmuxSubcommand: "session-start", timeoutMs: 10000),
+            .init(agentEvent: "UserPromptSubmit", cmuxSubcommand: "prompt-submit", timeoutMs: 10000),
+            .init(agentEvent: "Stop", cmuxSubcommand: "stop", timeoutMs: 10000),
+            .init(agentEvent: "PreToolUse", cmuxSubcommand: "pre-tool-use", timeoutMs: 120000),
+            .init(agentEvent: "PostToolUse", cmuxSubcommand: "post-tool-use", timeoutMs: 10000),
+            .init(agentEvent: "PermissionRequest", cmuxSubcommand: "notification", timeoutMs: 120000),
+        ]),
         Self(events: [
             .init(agentEvent: "SessionStart", cmuxSubcommand: "session-start", timeoutMs: 10000),
             .init(agentEvent: "UserPromptSubmit", cmuxSubcommand: "prompt-submit", timeoutMs: 10000),

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexHookScriptName.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexHookScriptName.swift
@@ -88,6 +88,11 @@ private let recognizedLegacyCodexHookSubcommands: Set<String> = [
     "persistent-feed-PostCompact",
     "persistent-feed-SubagentStart",
     "persistent-feed-SubagentStop",
+    // Transitional wrapper generations emitted the native child events before
+    // content-addressed script names were enforced. Keep those paths
+    // removable so a captured launch cannot replay stale cmux hooks.
+    "subagent-start",
+    "subagent-stop",
 ]
 
 private func isLowercaseCodexHookHexadecimal(_ byte: UInt8) -> Bool {

--- a/Resources/bin/cmux-codex-wrapper
+++ b/Resources/bin/cmux-codex-wrapper
@@ -235,6 +235,10 @@ fi
 # a direct `codex exec` that bypasses this wrapper retains the outer token and
 # is distinguished by its live hook-process identity.
 CMUX_CODEX_PARENT_INVOCATION_ID="${CMUX_CODEX_INVOCATION_ID:-}"
+# A hook callback records its own immediate Codex parent. Never let a wrapper
+# launched from inside a callback inherit that callback's observation as if it
+# were the new process's identity.
+unset CMUX_CODEX_HOOK_PID
 if command -v uuidgen >/dev/null 2>&1; then
     CMUX_CODEX_INVOCATION_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
 else
@@ -265,14 +269,13 @@ export CMUX_AGENT_LAUNCH_CWD="$PWD"
 
 # Select the launch's cmux hook channel. The cmux CLI first reconciles an
 # installed cmux-owned persistent channel, when present; otherwise it emits the
-# exact arg list (NUL-separated) that enables hooks and injects cmux's
-# FIRE-AND-FORGET hook command for each event. Fire-and-forget is critical:
-# codex runs hooks
-# synchronously and BLOCKS until they return, so a synchronous `cmux hooks codex
-# <sub>` made every launch hang ~35s on "Running SessionStart hook". The emitted
-# command captures codex's stdin payload to a temp file, nohup-backgrounds the
-# real cmux call with a 30s watchdog, and `echo '{}'` returns to codex instantly,
-# so detection still binds the real session id while codex never blocks.
+# exact arg list (NUL-separated) that enables hooks and injects cmux commands.
+# Turn/status hooks remain FIRE-AND-FORGET: codex runs hooks synchronously and
+# would block on a full socket round trip. Native child lifecycle hooks are the
+# exception; they synchronously commit the tiny cmux-owned ledger event before
+# returning, while all larger telemetry remains detached. The generated command
+# captures codex's stdin payload to a temp file, backgrounds the asynchronous
+# call with a 30s watchdog, and returns `{}` to codex immediately.
 #
 # Resolving the args via the CLI (instead of re-deriving fragile shell here)
 # avoids quoting bugs in the fire-and-forget command (it contains single quotes

--- a/Resources/bin/cmux-codex-wrapper
+++ b/Resources/bin/cmux-codex-wrapper
@@ -2,9 +2,9 @@
 # cmux codex wrapper - per-invocation Codex hook injection + launch detection.
 #
 # When running inside a cmux terminal (CMUX_SURFACE_ID is set), this wrapper
-# makes `codex` carry exactly one cmux hook channel. If ~/.codex/hooks.json has
-# a cmux-owned persistent channel, the emitter reconciles it and emits no
-# overlapping overrides; otherwise it injects hooks for THIS invocation only.
+# makes `codex` carry exactly one cmux producer per event. The emitter reads
+# ~/.codex/hooks.json without changing it, then injects only missing cmux hooks
+# for THIS invocation. It never rewrites the user's Codex settings.
 # Codex's own SessionStart/UserPromptSubmit/Stop/PreToolUse/PostToolUse/
 # PermissionRequest then fire back into cmux with Codex's real session_id.
 # Those hook payloads are the source of truth for session identity; the wrapper
@@ -267,9 +267,9 @@ export CMUX_AGENT_LAUNCH_CWD="$PWD"
     [[ -n "$cmux_codex_argv_b64" ]] && export CMUX_AGENT_LAUNCH_ARGV_B64="$cmux_codex_argv_b64"
 }
 
-# Select the launch's cmux hook channel. The cmux CLI first reconciles an
-# installed cmux-owned persistent channel, when present; otherwise it emits the
-# exact arg list (NUL-separated) that enables hooks and injects cmux commands.
+# Select the launch's cmux hook channel. The cmux CLI inventories installed
+# cmux-owned events read-only, then emits the exact NUL-separated arguments that
+# enable hooks for this run and inject only the missing cmux commands.
 # Turn/status hooks remain FIRE-AND-FORGET: codex runs hooks synchronously and
 # would block on a full socket round trip. Native child lifecycle hooks are the
 # exception; they synchronously commit the tiny cmux-owned ledger event before
@@ -307,7 +307,6 @@ if cmux_codex_read_inject_args; then
     exec "$REAL_CODEX" "${cmux_codex_injected_args[@]}" "$@"
 fi
 
-# A reconciled persistent channel intentionally emits no overrides; an emitter
-# failure also returns nothing. In both cases preserve the cmux surface context
-# so persistent, native, or future hooks can still bind this session.
+# An emitter failure returns nothing. Preserve the cmux surface context so
+# persistent, native, or future hooks can still bind this session.
 exec "$REAL_CODEX" "$@"

--- a/Resources/bin/cmux-codex-wrapper
+++ b/Resources/bin/cmux-codex-wrapper
@@ -229,7 +229,23 @@ fi
 
 # Export launch identity so the hook subprocesses and cmux's agent-pid /
 # ended-detection can bind this Codex to its surface and pid. Because we exec
-# codex below, $$ becomes the real codex pid.
+# codex below, $$ becomes the real codex pid. The invocation token is owned by
+# this wrapper generation. A wrapper launched from another Codex keeps the
+# inherited token as an explicit parent token, then gets a fresh child token;
+# a direct `codex exec` that bypasses this wrapper retains the outer token and
+# is distinguished by its live hook-process identity.
+CMUX_CODEX_PARENT_INVOCATION_ID="${CMUX_CODEX_INVOCATION_ID:-}"
+if command -v uuidgen >/dev/null 2>&1; then
+    CMUX_CODEX_INVOCATION_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
+else
+    CMUX_CODEX_INVOCATION_ID="cmux-codex-$$-$(date +%s)"
+fi
+export CMUX_CODEX_INVOCATION_ID
+if [[ -n "$CMUX_CODEX_PARENT_INVOCATION_ID" ]]; then
+    export CMUX_CODEX_PARENT_INVOCATION_ID
+else
+    unset CMUX_CODEX_PARENT_INVOCATION_ID
+fi
 export CMUX_CODEX_PID=$$
 export CMUX_CODEX_HOOK_CMUX_BIN="$(resolve_hook_cmux_bin)"
 export CMUX_AGENT_LAUNCH_KIND="codex"

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -940,6 +940,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		918100000000000000000081 /* CodexTranscriptFailureReadResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918100000000000000000080 /* CodexTranscriptFailureReadResult.swift */; };
 		918100000000000000000021 /* CodexTranscriptMonitorStopReplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918100000000000000000020 /* CodexTranscriptMonitorStopReplay.swift */; };
 		918100000000000000000071 /* CodexTranscriptSubagentSignals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918100000000000000000070 /* CodexTranscriptSubagentSignals.swift */; };
+		C3744E030000000000000002 /* AgentPIDProcessIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3744E040000000000000001 /* AgentPIDProcessIdentity.swift */; };
 		7520C0DF0000000000000001 /* CodexTurnCompletionOwnershipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7520C0DF0000000000000002 /* CodexTurnCompletionOwnershipTests.swift */; };
 		7520C0DF0000000000000003 /* CodexTurnLedger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7520C0DF0000000000000004 /* CodexTurnLedger.swift */; };
 		7520C0DF0000000000000005 /* CodexTurnLedgerModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7520C0DF0000000000000006 /* CodexTurnLedgerModels.swift */; };
@@ -10997,6 +10998,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 			buildActionMask = 2147483647;
 			files = (
 				D36A00030000000000000003 /* AgentHibernationLifecycleState.swift in Sources */,
+				C3744E030000000000000002 /* AgentPIDProcessIdentity.swift in Sources */,
 				918100000000000000000101 /* AgentHookFailureStage.swift in Sources */,
 				A76110010000000000000001 /* AgentHookNotificationPolicy.swift in Sources */,
 				89930002AABBCCDDEEFF0002 /* AgentProcessBindingResolution.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -917,7 +917,6 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A9F200000000000000000016 /* CodexAppServerQueuedInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F100000000000000000016 /* CodexAppServerQueuedInput.swift */; };
 		A9E02000000000000000000E /* CodexAppServerSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E01000000000000000000E /* CodexAppServerSession.swift */; };
 		A9E040000000000000000002 /* CodexAppServerSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E040000000000000000001 /* CodexAppServerSessionTests.swift */; };
-		7520C0DF0000000000000001 /* CodexTurnCompletionOwnershipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7520C0DF0000000000000002 /* CodexTurnCompletionOwnershipTests.swift */; };
 		C8711B000000000000000002 /* CodexCodeModeRolloutIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8711B000000000000000001 /* CodexCodeModeRolloutIdentityTests.swift */; };
 		918100000000000000000051 /* CodexHookFailureCandidate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918100000000000000000050 /* CodexHookFailureCandidate.swift */; };
 		918100000000000000000041 /* CodexHookFailureSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918100000000000000000040 /* CodexHookFailureSummary.swift */; };
@@ -941,6 +940,10 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		918100000000000000000081 /* CodexTranscriptFailureReadResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918100000000000000000080 /* CodexTranscriptFailureReadResult.swift */; };
 		918100000000000000000021 /* CodexTranscriptMonitorStopReplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918100000000000000000020 /* CodexTranscriptMonitorStopReplay.swift */; };
 		918100000000000000000071 /* CodexTranscriptSubagentSignals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918100000000000000000070 /* CodexTranscriptSubagentSignals.swift */; };
+		7520C0DF0000000000000001 /* CodexTurnCompletionOwnershipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7520C0DF0000000000000002 /* CodexTurnCompletionOwnershipTests.swift */; };
+		7520C0DF0000000000000003 /* CodexTurnLedger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7520C0DF0000000000000004 /* CodexTurnLedger.swift */; };
+		7520C0DF0000000000000005 /* CodexTurnLedgerModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7520C0DF0000000000000006 /* CodexTurnLedgerModels.swift */; };
+		7520C0DF0000000000000007 /* CodexTurnLedgerPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7520C0DF0000000000000008 /* CodexTurnLedgerPersistence.swift */; };
 		C4041001000000000000001B /* CommandClickFileOpenRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4041001000000000000001A /* CommandClickFileOpenRouter.swift */; };
 		C0DEC0DE000000000000F302 /* CommandPaletteEmojiTitleSearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEC0DE000000000000F301 /* CommandPaletteEmojiTitleSearchTests.swift */; };
 		C0DE86060000000000000001 /* CommandPaletteFocusRestoreCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE86060000000000000002 /* CommandPaletteFocusRestoreCoordinator.swift */; };
@@ -3762,7 +3765,6 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A9F100000000000000000016 /* CodexAppServerQueuedInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/CodexAppServerQueuedInput.swift; sourceTree = "<group>"; };
 		A9E01000000000000000000E /* CodexAppServerSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/CodexAppServerSession.swift; sourceTree = "<group>"; };
 		A9E040000000000000000001 /* CodexAppServerSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexAppServerSessionTests.swift; sourceTree = "<group>"; };
-		7520C0DF0000000000000002 /* CodexTurnCompletionOwnershipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTurnCompletionOwnershipTests.swift; sourceTree = "<group>"; };
 		C8711B000000000000000001 /* CodexCodeModeRolloutIdentityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexCodeModeRolloutIdentityTests.swift; sourceTree = "<group>"; };
 		918100000000000000000050 /* CodexHookFailureCandidate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexHookFailureCandidate.swift; sourceTree = "<group>"; };
 		918100000000000000000040 /* CodexHookFailureSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexHookFailureSummary.swift; sourceTree = "<group>"; };
@@ -3783,6 +3785,10 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		918100000000000000000080 /* CodexTranscriptFailureReadResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTranscriptFailureReadResult.swift; sourceTree = "<group>"; };
 		918100000000000000000020 /* CodexTranscriptMonitorStopReplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTranscriptMonitorStopReplay.swift; sourceTree = "<group>"; };
 		918100000000000000000070 /* CodexTranscriptSubagentSignals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTranscriptSubagentSignals.swift; sourceTree = "<group>"; };
+		7520C0DF0000000000000002 /* CodexTurnCompletionOwnershipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTurnCompletionOwnershipTests.swift; sourceTree = "<group>"; };
+		7520C0DF0000000000000004 /* CodexTurnLedger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTurnLedger.swift; sourceTree = "<group>"; };
+		7520C0DF0000000000000006 /* CodexTurnLedgerModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTurnLedgerModels.swift; sourceTree = "<group>"; };
+		7520C0DF0000000000000008 /* CodexTurnLedgerPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTurnLedgerPersistence.swift; sourceTree = "<group>"; };
 		C4041001000000000000001A /* CommandClickFileOpenRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandClickFileOpenRouter.swift; sourceTree = "<group>"; };
 		C0DEC0DE000000000000F301 /* CommandPaletteEmojiTitleSearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteEmojiTitleSearchTests.swift; sourceTree = "<group>"; };
 		C0DE86060000000000000002 /* CommandPaletteFocusRestoreCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteFocusRestoreCoordinator.swift; sourceTree = "<group>"; };
@@ -7856,6 +7862,9 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				918100000000000000000070 /* CodexTranscriptSubagentSignals.swift */,
 				918100000000000000000080 /* CodexTranscriptFailureReadResult.swift */,
 				918100000000000000000090 /* CodexMonitorOwnerState.swift */,
+				7520C0DF0000000000000006 /* CodexTurnLedgerModels.swift */,
+				7520C0DF0000000000000008 /* CodexTurnLedgerPersistence.swift */,
+				7520C0DF0000000000000004 /* CodexTurnLedger.swift */,
 				918100000000000000000100 /* AgentHookFailureStage.swift */,
 				7A3D532FF0A00E20DA31667F /* CMUXCLI+KimiHooks.swift */,
 				DF43B7BD28A755A6280428D6 /* CMUXCLI+RovoDevHooks.swift */,
@@ -11100,6 +11109,9 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				918100000000000000000081 /* CodexTranscriptFailureReadResult.swift in Sources */,
 				918100000000000000000021 /* CodexTranscriptMonitorStopReplay.swift in Sources */,
 				918100000000000000000071 /* CodexTranscriptSubagentSignals.swift in Sources */,
+				7520C0DF0000000000000003 /* CodexTurnLedger.swift in Sources */,
+				7520C0DF0000000000000005 /* CodexTurnLedgerModels.swift in Sources */,
+				7520C0DF0000000000000007 /* CodexTurnLedgerPersistence.swift in Sources */,
 				FEEDC1A50000000000000001 /* FeedEventClassifier.swift in Sources */,
 				C51A73B20000000000000002 /* IOSScreenshotCommandResultBox.swift in Sources */,
 				A5FB1308 /* JSONCObjectEditor+Remove.swift in Sources */,
@@ -11422,7 +11434,6 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 					A6AC72080000000000000001 /* CMUXWorkspaceLoadingCLIRegressionTests.swift in Sources */,
 				AAE06C3AEC68484DA33D42A1 /* CoalesceLatestPublisherDemandTests.swift in Sources */,
 				A9E040000000000000000002 /* CodexAppServerSessionTests.swift in Sources */,
-				7520C0DF0000000000000001 /* CodexTurnCompletionOwnershipTests.swift in Sources */,
 				C8711B000000000000000002 /* CodexCodeModeRolloutIdentityTests.swift in Sources */,
 				D96290010000000000000001 /* CodexResumeBindingVerificationRegressionTests.swift in Sources */,
 				C0DECAFE0000000000000003 /* CodexTeamsApprovalBridge.swift in Sources */,
@@ -11431,6 +11442,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C0DEBACC0000000000000003 /* CodexTeamsResumedBackfillTests.swift in Sources */,
 				C0DEBACC0000000000000002 /* CodexTeamsSocketFixture.swift in Sources */,
 				C0DE7100C0DE7100C0DE7100 /* CodexTerminalErrorNotificationTests.swift in Sources */,
+				7520C0DF0000000000000001 /* CodexTurnCompletionOwnershipTests.swift in Sources */,
 				C0DEC0DE000000000000F302 /* CommandPaletteEmojiTitleSearchTests.swift in Sources */,
 				C0DEC0DE000000000000F202 /* CommandPaletteNucleoFFILibrarySupport.swift in Sources */,
 				C0DEC0DE000000000000F102 /* CommandPaletteNucleoFFITests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -129,6 +129,7 @@
 		7939000FAA11BB22CC33DD0F /* AgentNotificationMoveRaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79390010AA11BB22CC33DD10 /* AgentNotificationMoveRaceTests.swift */; };
 		79460001AA11BB22CC33EE01 /* AgentNotificationMutationBoundaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79460002AA11BB22CC33EE02 /* AgentNotificationMutationBoundaryTests.swift */; };
 		C3744E030000000000000001 /* AgentPIDProcessIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3744E040000000000000001 /* AgentPIDProcessIdentity.swift */; };
+		C3744E030000000000000002 /* AgentPIDProcessIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3744E040000000000000001 /* AgentPIDProcessIdentity.swift */; };
 		B79500130000000000000001 /* AgentPortPublicationHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B79500130000000000000002 /* AgentPortPublicationHistory.swift */; };
 		B79500120000000000000001 /* AgentPortRootIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B79500120000000000000002 /* AgentPortRootIdentity.swift */; };
 		B79500050000000000000001 /* AgentPortScanPublication.swift in Sources */ = {isa = PBXBuildFile; fileRef = B79500050000000000000002 /* AgentPortScanPublication.swift */; };
@@ -940,7 +941,6 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		918100000000000000000081 /* CodexTranscriptFailureReadResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918100000000000000000080 /* CodexTranscriptFailureReadResult.swift */; };
 		918100000000000000000021 /* CodexTranscriptMonitorStopReplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918100000000000000000020 /* CodexTranscriptMonitorStopReplay.swift */; };
 		918100000000000000000071 /* CodexTranscriptSubagentSignals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918100000000000000000070 /* CodexTranscriptSubagentSignals.swift */; };
-		C3744E030000000000000002 /* AgentPIDProcessIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3744E040000000000000001 /* AgentPIDProcessIdentity.swift */; };
 		7520C0DF0000000000000001 /* CodexTurnCompletionOwnershipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7520C0DF0000000000000002 /* CodexTurnCompletionOwnershipTests.swift */; };
 		7520C0DF0000000000000003 /* CodexTurnLedger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7520C0DF0000000000000004 /* CodexTurnLedger.swift */; };
 		7520C0DF0000000000000005 /* CodexTurnLedgerModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7520C0DF0000000000000006 /* CodexTurnLedgerModels.swift */; };
@@ -10998,9 +10998,9 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 			buildActionMask = 2147483647;
 			files = (
 				D36A00030000000000000003 /* AgentHibernationLifecycleState.swift in Sources */,
-				C3744E030000000000000002 /* AgentPIDProcessIdentity.swift in Sources */,
 				918100000000000000000101 /* AgentHookFailureStage.swift in Sources */,
 				A76110010000000000000001 /* AgentHookNotificationPolicy.swift in Sources */,
+				C3744E030000000000000002 /* AgentPIDProcessIdentity.swift in Sources */,
 				89930002AABBCCDDEEFF0002 /* AgentProcessBindingResolution.swift in Sources */,
 				394139F275D94FB49356E9C7 /* AgentSurfaceResumeBindingClearOutcome.swift in Sources */,
 				805500000000000000000004 /* BrowserValueTextFormatter.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -944,6 +944,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		7520C0DF0000000000000003 /* CodexTurnLedger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7520C0DF0000000000000004 /* CodexTurnLedger.swift */; };
 		7520C0DF0000000000000005 /* CodexTurnLedgerModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7520C0DF0000000000000006 /* CodexTurnLedgerModels.swift */; };
 		7520C0DF0000000000000007 /* CodexTurnLedgerPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7520C0DF0000000000000008 /* CodexTurnLedgerPersistence.swift */; };
+		7520C0DF0000000000000009 /* CodexTurnLifecycleCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7520C0DF000000000000000A /* CodexTurnLifecycleCoordinator.swift */; };
 		C4041001000000000000001B /* CommandClickFileOpenRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4041001000000000000001A /* CommandClickFileOpenRouter.swift */; };
 		C0DEC0DE000000000000F302 /* CommandPaletteEmojiTitleSearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEC0DE000000000000F301 /* CommandPaletteEmojiTitleSearchTests.swift */; };
 		C0DE86060000000000000001 /* CommandPaletteFocusRestoreCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE86060000000000000002 /* CommandPaletteFocusRestoreCoordinator.swift */; };
@@ -3789,6 +3790,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		7520C0DF0000000000000004 /* CodexTurnLedger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTurnLedger.swift; sourceTree = "<group>"; };
 		7520C0DF0000000000000006 /* CodexTurnLedgerModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTurnLedgerModels.swift; sourceTree = "<group>"; };
 		7520C0DF0000000000000008 /* CodexTurnLedgerPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTurnLedgerPersistence.swift; sourceTree = "<group>"; };
+		7520C0DF000000000000000A /* CodexTurnLifecycleCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTurnLifecycleCoordinator.swift; sourceTree = "<group>"; };
 		C4041001000000000000001A /* CommandClickFileOpenRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandClickFileOpenRouter.swift; sourceTree = "<group>"; };
 		C0DEC0DE000000000000F301 /* CommandPaletteEmojiTitleSearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteEmojiTitleSearchTests.swift; sourceTree = "<group>"; };
 		C0DE86060000000000000002 /* CommandPaletteFocusRestoreCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteFocusRestoreCoordinator.swift; sourceTree = "<group>"; };
@@ -7864,6 +7866,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				918100000000000000000090 /* CodexMonitorOwnerState.swift */,
 				7520C0DF0000000000000006 /* CodexTurnLedgerModels.swift */,
 				7520C0DF0000000000000008 /* CodexTurnLedgerPersistence.swift */,
+				7520C0DF000000000000000A /* CodexTurnLifecycleCoordinator.swift */,
 				7520C0DF0000000000000004 /* CodexTurnLedger.swift */,
 				918100000000000000000100 /* AgentHookFailureStage.swift */,
 				7A3D532FF0A00E20DA31667F /* CMUXCLI+KimiHooks.swift */,
@@ -11112,6 +11115,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				7520C0DF0000000000000003 /* CodexTurnLedger.swift in Sources */,
 				7520C0DF0000000000000005 /* CodexTurnLedgerModels.swift in Sources */,
 				7520C0DF0000000000000007 /* CodexTurnLedgerPersistence.swift in Sources */,
+				7520C0DF0000000000000009 /* CodexTurnLifecycleCoordinator.swift in Sources */,
 				FEEDC1A50000000000000001 /* FeedEventClassifier.swift in Sources */,
 				C51A73B20000000000000002 /* IOSScreenshotCommandResultBox.swift in Sources */,
 				A5FB1308 /* JSONCObjectEditor+Remove.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -917,6 +917,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A9F200000000000000000016 /* CodexAppServerQueuedInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F100000000000000000016 /* CodexAppServerQueuedInput.swift */; };
 		A9E02000000000000000000E /* CodexAppServerSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E01000000000000000000E /* CodexAppServerSession.swift */; };
 		A9E040000000000000000002 /* CodexAppServerSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E040000000000000000001 /* CodexAppServerSessionTests.swift */; };
+		7520C0DF0000000000000001 /* CodexTurnCompletionOwnershipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7520C0DF0000000000000002 /* CodexTurnCompletionOwnershipTests.swift */; };
 		C8711B000000000000000002 /* CodexCodeModeRolloutIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8711B000000000000000001 /* CodexCodeModeRolloutIdentityTests.swift */; };
 		918100000000000000000051 /* CodexHookFailureCandidate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918100000000000000000050 /* CodexHookFailureCandidate.swift */; };
 		918100000000000000000041 /* CodexHookFailureSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918100000000000000000040 /* CodexHookFailureSummary.swift */; };
@@ -3761,6 +3762,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A9F100000000000000000016 /* CodexAppServerQueuedInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/CodexAppServerQueuedInput.swift; sourceTree = "<group>"; };
 		A9E01000000000000000000E /* CodexAppServerSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/CodexAppServerSession.swift; sourceTree = "<group>"; };
 		A9E040000000000000000001 /* CodexAppServerSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexAppServerSessionTests.swift; sourceTree = "<group>"; };
+		7520C0DF0000000000000002 /* CodexTurnCompletionOwnershipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTurnCompletionOwnershipTests.swift; sourceTree = "<group>"; };
 		C8711B000000000000000001 /* CodexCodeModeRolloutIdentityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexCodeModeRolloutIdentityTests.swift; sourceTree = "<group>"; };
 		918100000000000000000050 /* CodexHookFailureCandidate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexHookFailureCandidate.swift; sourceTree = "<group>"; };
 		918100000000000000000040 /* CodexHookFailureSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexHookFailureSummary.swift; sourceTree = "<group>"; };
@@ -8014,6 +8016,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C51A760000000000000000D2 /* SimulatorPanelThemeTests.swift */,
 				A9E050000000000000000001 /* AgentSessionWebRendererTests.swift */,
 				A9E040000000000000000001 /* CodexAppServerSessionTests.swift */,
+				7520C0DF0000000000000002 /* CodexTurnCompletionOwnershipTests.swift */,
 				8740D0018740D0018740D001 /* AgentHibernationEvaluationSchedulingTests.swift */,
 				F65760010000000000000002 /* AgentHibernationPlannerSwiftTests.swift */,
 				9090F0039090F0039090F003 /* AgentHibernationPanelCloseCleanupTests.swift */,
@@ -11419,6 +11422,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 					A6AC72080000000000000001 /* CMUXWorkspaceLoadingCLIRegressionTests.swift in Sources */,
 				AAE06C3AEC68484DA33D42A1 /* CoalesceLatestPublisherDemandTests.swift in Sources */,
 				A9E040000000000000000002 /* CodexAppServerSessionTests.swift in Sources */,
+				7520C0DF0000000000000001 /* CodexTurnCompletionOwnershipTests.swift in Sources */,
 				C8711B000000000000000002 /* CodexCodeModeRolloutIdentityTests.swift in Sources */,
 				D96290010000000000000001 /* CodexResumeBindingVerificationRegressionTests.swift in Sources */,
 				C0DECAFE0000000000000003 /* CodexTeamsApprovalBridge.swift in Sources */,

--- a/cmuxTests/CLICodexHookTimeoutRegressionTests.swift
+++ b/cmuxTests/CLICodexHookTimeoutRegressionTests.swift
@@ -82,77 +82,34 @@ struct CLICodexHookTimeoutRegressionTests {
         })
     }
 
-    @Test func codexWrapperReconcilesPersistentHooksToOneProducerPerEvent() throws {
+    @Test func codexWrapperPreservesPersistentSettingsAndInjectsOnlyMissingEvents() throws {
         let cliPath = try bundledCLIPath()
         let root = FileManager.default.temporaryDirectory
-            .appendingPathComponent("cmux-codex-one-producer-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("cmux-codex-settings-preserved-\(UUID().uuidString)", isDirectory: true)
         let codexHome = root.appendingPathComponent(".codex", isDirectory: true)
-        let hooksDirectory = root
-            .appendingPathComponent(".cmux", isDirectory: true)
-            .appendingPathComponent("hooks", isDirectory: true)
         try FileManager.default.createDirectory(at: codexHome, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: root) }
 
         let environment = codexHookTestEnvironment(root: root, codexHome: codexHome)
-        let install = runCodexHookProcess(
-            executablePath: cliPath,
-            arguments: ["hooks", "codex", "install", "--yes"],
-            environment: environment,
-            timeout: 10
-        )
-        #expect(!install.timedOut, Comment(rawValue: install.stderr))
-        #expect(install.status == 0, Comment(rawValue: install.stderr))
-
         let hooksURL = codexHome.appendingPathComponent("hooks.json", isDirectory: false)
-        var json = try #require(
-            JSONSerialization.jsonObject(with: Data(contentsOf: hooksURL)) as? [String: Any]
-        )
-        var hookGroups = try #require(json["hooks"] as? [String: Any])
-        var preToolGroups = try #require(hookGroups["PreToolUse"] as? [[String: Any]])
-        preToolGroups.insert(try #require(preToolGroups.first), at: 0)
+        let configURL = codexHome.appendingPathComponent("config.toml", isDirectory: false)
+        let hooksContent = #"""
+        {"custom":{"format":"must stay exact"},"hooks":{"Stop":[{"hooks":[{"type":"command","command":"cmux hooks codex stop","timeout":5},{"type":"command","command":"/usr/local/bin/user-stop","timeout":42}]}]}}
+        """#
+        let configContent = """
+        model = "gpt-5.5"
+        approval_policy = "on-request"
 
-        let legacyStopScript = hooksDirectory
-            .appendingPathComponent("cmux-codex-hook-stop.sh", isDirectory: false)
-        let staleHashedScript = hooksDirectory
-            .appendingPathComponent(
-                "cmux-codex-hook-0123456789abcdef-old-generation.sh",
-                isDirectory: false
-            )
-        let userScript = hooksDirectory
-            .appendingPathComponent("cmux-codex-hook-unrecognized.sh", isDirectory: false)
-        try makeCodexHookExecutableShellFile(at: legacyStopScript, lines: ["#!/bin/sh", "echo '{}'"])
-        try makeCodexHookExecutableShellFile(at: staleHashedScript, lines: ["#!/bin/sh", "echo '{}'"])
-        try makeCodexHookExecutableShellFile(at: userScript, lines: ["#!/bin/sh", "echo user-hook"])
-        let staleDate = Date(timeIntervalSince1970: 0)
-        try FileManager.default.setAttributes(
-            [.modificationDate: staleDate],
-            ofItemAtPath: legacyStopScript.path
-        )
-        try FileManager.default.setAttributes(
-            [.modificationDate: staleDate],
-            ofItemAtPath: staleHashedScript.path
-        )
+        [features]
+        hooks = false
 
-        var stopGroups = try #require(hookGroups["Stop"] as? [[String: Any]])
-        stopGroups.append([
-            "hooks": [[
-                "command": legacyStopScript.path,
-                "timeout": 10_000,
-                "type": "command",
-            ]],
-        ])
-        stopGroups.append([
-            "hooks": [[
-                "command": userScript.path,
-                "timeout": 10_000,
-                "type": "command",
-            ]],
-        ])
-        hookGroups["PreToolUse"] = preToolGroups
-        hookGroups["Stop"] = stopGroups
-        json["hooks"] = hookGroups
-        try JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted, .sortedKeys])
-            .write(to: hooksURL, options: .atomic)
+        [custom]
+        keep = "exactly"
+        """
+        try Data(hooksContent.utf8).write(to: hooksURL, options: .atomic)
+        try Data(configContent.utf8).write(to: configURL, options: .atomic)
+        let hooksBeforeLaunch = try Data(contentsOf: hooksURL)
+        let configBeforeLaunch = try Data(contentsOf: configURL)
 
         let emit = runCodexHookProcess(
             executablePath: cliPath,
@@ -164,31 +121,28 @@ struct CLICodexHookTimeoutRegressionTests {
         #expect(emit.status == 0, Comment(rawValue: emit.stderr))
 
         let emittedEvents = injectedCodexHookEventNames(emit.stdout)
-        let installedHooks = try codexHookEntries(in: codexHome)
-        let wrapperEvents = [
+        let emittedArguments = emit.stdout.split(separator: "\0").map(String.init)
+        #expect(Array(emittedArguments.prefix(3)) == [
+            "--enable",
+            "hooks",
+            "--dangerously-bypass-hook-trust",
+        ])
+        let expectedInjectedEvents: Set<String> = [
             "SessionStart",
             "UserPromptSubmit",
-            "Stop",
             "PreToolUse",
             "PostToolUse",
             "PermissionRequest",
+            "SubagentStart",
+            "SubagentStop",
         ]
-        for eventName in wrapperEvents {
-            let installedProducerCount = installedHooks.filter {
-                $0.eventName == eventName
-                    && ($0.body.contains("hooks codex ")
-                        || $0.body.contains("hooks feed --source codex"))
-            }.count
-            let emittedProducerCount = emittedEvents.filter { $0 == eventName }.count
-            #expect(
-                installedProducerCount + emittedProducerCount == 1,
-                "Expected one cmux producer for \(eventName), installed=\(installedProducerCount) emitted=\(emittedProducerCount)"
-            )
-        }
-        #expect(installedHooks.contains { $0.command == userScript.path })
-        #expect(!FileManager.default.fileExists(atPath: legacyStopScript.path))
-        #expect(!FileManager.default.fileExists(atPath: staleHashedScript.path))
-        #expect(FileManager.default.fileExists(atPath: userScript.path))
+        #expect(Set(emittedEvents) == expectedInjectedEvents)
+        #expect(emittedEvents.count == expectedInjectedEvents.count)
+
+        let hooksAfterLaunch = try Data(contentsOf: hooksURL)
+        let configAfterLaunch = try Data(contentsOf: configURL)
+        #expect(hooksAfterLaunch == hooksBeforeLaunch)
+        #expect(configAfterLaunch == configBeforeLaunch)
     }
 
     @Test func codexPermissionRequestHandlerPreservesFeedTelemetryAndNeedsInputState() throws {

--- a/cmuxTests/CodexTurnCompletionOwnershipTests.swift
+++ b/cmuxTests/CodexTurnCompletionOwnershipTests.swift
@@ -256,7 +256,7 @@ struct CodexTurnCompletionOwnershipTests {
         let arguments = command.first == "feed"
             ? ["hooks"] + command
             : ["hooks", "codex"] + command
-        harness.support.runProcess(
+        return harness.support.runProcess(
             executablePath: harness.context.cliPath,
             arguments: arguments,
             environment: environment,

--- a/cmuxTests/CodexTurnCompletionOwnershipTests.swift
+++ b/cmuxTests/CodexTurnCompletionOwnershipTests.swift
@@ -139,15 +139,18 @@ struct CodexTurnCompletionOwnershipTests {
             "One remaining child must not also mark the pane idle: \(partiallyDrainedCommands)"
         )
 
+        let beforeFinalChildStop = harness.context.state.snapshot().count
         try runFeedLifecycle(harness, event: "SubagentStop", id: "child-b")
-        let beforeFinalStop = harness.context.state.snapshot().count
-        try runHook(
-            harness,
-            subcommand: "stop",
-            input: stopPayload(harness, turnId: "turn-1")
+        #expect(
+            waitForConditionBlocking(timeout: 5) {
+                let snapshot = harness.context.state.snapshot()
+                return snapshot.contains { $0.hasPrefix("notify_target_async ") }
+                    && snapshot.contains { $0.hasPrefix("set_status codex Idle ") }
+            },
+            "The persistent child-stop path must settle the pending parent turn: \(harness.context.state.snapshot())"
         )
         let finalCommands = Array(
-            harness.context.state.snapshot().dropFirst(beforeFinalStop)
+            harness.context.state.snapshot().dropFirst(beforeFinalChildStop)
         )
         let finalNotifications = finalCommands.filter {
             $0.hasPrefix("notify_target_async ")
@@ -165,8 +168,9 @@ struct CodexTurnCompletionOwnershipTests {
             "The settled foreground turn must not remain Running: \(finalCommands)"
         )
 
-        // A second Stop for the same settled turn is a duplicate boundary and
-        // must not publish another completion or repaint the pane.
+        // A parent Stop arriving after the detached child-stop settlement is a
+        // duplicate boundary and must not publish another completion or repaint
+        // the pane.
         let beforeDuplicateStop = harness.context.state.snapshot().count
         try runHook(
             harness,

--- a/cmuxTests/CodexTurnCompletionOwnershipTests.swift
+++ b/cmuxTests/CodexTurnCompletionOwnershipTests.swift
@@ -1,0 +1,273 @@
+import Dispatch
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Behavior-level coverage for Codex completion ownership and native child
+/// lifecycle. The tests drive the real hook executable against the existing
+/// socket harness, so a passing result proves the visible mutation path rather
+/// than a source-text or hook-shape convention.
+@Suite(.serialized)
+struct CodexTurnCompletionOwnershipTests {
+    private struct Harness {
+        let support: ClaudeHookSurfaceResolutionSwiftTests
+        let context: ClaudeHookSurfaceResolutionSwiftTests.ClaudeHookContext
+        let handled: DispatchSemaphore
+        let environment: [String: String]
+        let sessionId: String
+        let token: String
+    }
+
+    @Test
+    func inheritedOuterPIDCannotLetNestedCodexStopSettleForegroundPane() throws {
+        let harness = try makeHarness(name: "codex-nested-inherited-pid")
+        defer { harness.context.cleanup() }
+
+        try runHook(
+            harness,
+            subcommand: "session-start",
+            input: sessionStartPayload(harness)
+        )
+        try runHook(
+            harness,
+            subcommand: "prompt-submit",
+            input: promptPayload(harness, turnId: "outer-turn")
+        )
+
+        let beforeNestedStop = harness.context.state.snapshot().count
+        var nestedEnvironment = harness.environment
+        // This is the exact failure mode from #7520: the child process keeps
+        // the outer CMUX_CODEX_PID, while the hook's observed process is new.
+        nestedEnvironment["CMUX_CODEX_HOOK_PID"] = "4243"
+        let nestedResult = runProcess(
+            harness,
+            subcommand: "stop",
+            input: #"{"session_id":"inner-autoreview","turn_id":"review-turn","cwd":"/tmp/review","hook_event_name":"Stop","last_assistant_message":"{\"findings\":[]}"}"#,
+            environment: nestedEnvironment
+        )
+        harness.support.assertSuccessfulHook(nestedResult)
+        #expect(harness.handled.wait(timeout: .now() + 5) == .success)
+
+        let nestedCommands = Array(
+            harness.context.state.snapshot().dropFirst(beforeNestedStop)
+        )
+        #expect(
+            !nestedCommands.contains { $0.hasPrefix("notify_target_async ") },
+            "A nested reviewer Stop must never publish foreground completion: \(nestedCommands)"
+        )
+        #expect(
+            !nestedCommands.contains { $0.hasPrefix("set_status codex Idle ") },
+            "A nested reviewer Stop must not make the foreground pane idle: \(nestedCommands)"
+        )
+        #expect(
+            !nestedCommands.contains { $0.contains("surface.resume.set") },
+            "A nested reviewer Stop must not replace the foreground resume identity: \(nestedCommands)"
+        )
+    }
+
+    @Test
+    func nativeChildrenKeepParentRunningUntilAllChildrenDrainThenNotifyOnce() throws {
+        let harness = try makeHarness(name: "codex-native-child-settlement")
+        defer { harness.context.cleanup() }
+
+        try runHook(
+            harness,
+            subcommand: "session-start",
+            input: sessionStartPayload(harness)
+        )
+        try runHook(
+            harness,
+            subcommand: "prompt-submit",
+            input: promptPayload(harness, turnId: "turn-1")
+        )
+        try runFeedLifecycle(harness, event: "SubagentStart", id: "child-a")
+        try runFeedLifecycle(harness, event: "SubagentStart", id: "child-b")
+
+        let beforePendingStop = harness.context.state.snapshot().count
+        try runHook(
+            harness,
+            subcommand: "stop",
+            input: stopPayload(harness, turnId: "turn-1")
+        )
+        let pendingCommands = Array(
+            harness.context.state.snapshot().dropFirst(beforePendingStop)
+        )
+        #expect(
+            !pendingCommands.contains { $0.hasPrefix("notify_target_async ") },
+            "A parent Stop with live children must not notify, even under an always-capable hook path: \(pendingCommands)"
+        )
+        #expect(
+            pendingCommands.contains { $0.hasPrefix("set_status codex Running ") },
+            "A parent Stop with live children must remain Running: \(pendingCommands)"
+        )
+        #expect(
+            pendingCommands.contains { $0.hasPrefix("set_agent_lifecycle codex running ") },
+            "The pending parent boundary must be recorded as running: \(pendingCommands)"
+        )
+
+        try runFeedLifecycle(harness, event: "SubagentStop", id: "child-a")
+        let beforePartiallyDrainedStop = harness.context.state.snapshot().count
+        try runHook(
+            harness,
+            subcommand: "stop",
+            input: stopPayload(harness, turnId: "turn-1")
+        )
+        let partiallyDrainedCommands = Array(
+            harness.context.state.snapshot().dropFirst(beforePartiallyDrainedStop)
+        )
+        #expect(
+            !partiallyDrainedCommands.contains { $0.hasPrefix("notify_target_async ") },
+            "One remaining child must continue to suppress completion: \(partiallyDrainedCommands)"
+        )
+        #expect(
+            partiallyDrainedCommands.contains { $0.hasPrefix("set_status codex Running ") },
+            "One remaining child must keep the pane Running: \(partiallyDrainedCommands)"
+        )
+
+        try runFeedLifecycle(harness, event: "SubagentStop", id: "child-b")
+        let beforeFinalStop = harness.context.state.snapshot().count
+        try runHook(
+            harness,
+            subcommand: "stop",
+            input: stopPayload(harness, turnId: "turn-1")
+        )
+        let finalCommands = Array(
+            harness.context.state.snapshot().dropFirst(beforeFinalStop)
+        )
+        let finalNotifications = finalCommands.filter {
+            $0.hasPrefix("notify_target_async ")
+        }
+        #expect(
+            finalNotifications.count == 1,
+            "The settled foreground turn must produce exactly one completion: \(finalCommands)"
+        )
+        #expect(
+            finalCommands.contains { $0.hasPrefix("set_status codex Idle ") },
+            "The settled foreground turn must become idle: \(finalCommands)"
+        )
+    }
+
+    @Test
+    func normalTopLevelStopStillNotifiesAndBecomesIdle() throws {
+        let harness = try makeHarness(name: "codex-normal-top-level-stop")
+        defer { harness.context.cleanup() }
+
+        try runHook(
+            harness,
+            subcommand: "session-start",
+            input: sessionStartPayload(harness)
+        )
+        try runHook(
+            harness,
+            subcommand: "prompt-submit",
+            input: promptPayload(harness, turnId: "normal-turn")
+        )
+        let beforeStop = harness.context.state.snapshot().count
+        try runHook(
+            harness,
+            subcommand: "stop",
+            input: stopPayload(harness, turnId: "normal-turn")
+        )
+        let commands = Array(harness.context.state.snapshot().dropFirst(beforeStop))
+        #expect(commands.filter { $0.hasPrefix("notify_target_async ") }.count == 1)
+        #expect(commands.contains { $0.hasPrefix("set_status codex Idle ") })
+    }
+
+    private func makeHarness(name: String) throws -> Harness {
+        let support = ClaudeHookSurfaceResolutionSwiftTests()
+        let context = try support.makeClaudeHookContext(name: name)
+        let handled = support.startClaudeSurfaceResolutionServer(
+            context: context,
+            surfaces: [(context.surfaceId, "surface:1", true)],
+            ttyName: "ttys-\(name)",
+            ttySurfaceId: context.surfaceId
+        )
+        let token = "codex-owner-\(name)"
+        let environment = [
+            "HOME": context.root.path,
+            "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+            "PWD": context.root.path,
+            "CMUX_SOCKET_PATH": context.socketPath,
+            "CMUX_WORKSPACE_ID": context.workspaceId,
+            "CMUX_SURFACE_ID": context.surfaceId,
+            "CMUX_CLI_TTY_NAME": "ttys-\(name)",
+            "CMUX_CODEX_PID": "4242",
+            "CMUX_CODEX_HOOK_PID": "4242",
+            "CMUX_CODEX_INVOCATION_ID": token,
+            "CMUX_AGENT_HOOK_STATE_DIR": context.root.path,
+            "CMUX_CODEX_TURN_LEDGER_PATH": context.root.appendingPathComponent("codex-turn-ledger.json").path,
+            "CMUX_CLI_SENTRY_DISABLED": "1",
+            "CMUX_AGENT_LAUNCH_KIND": "codex",
+            "CMUX_AGENT_LAUNCH_EXECUTABLE": "/usr/local/bin/codex",
+            "CMUX_AGENT_LAUNCH_CWD": context.root.path,
+        ]
+        return Harness(
+            support: support,
+            context: context,
+            handled: handled,
+            environment: environment,
+            sessionId: "session-\(name)",
+            token: token
+        )
+    }
+
+    private func runHook(
+        _ harness: Harness,
+        subcommand: String,
+        input: String,
+        environment: [String: String]? = nil
+    ) throws {
+        let result = runProcess(
+            harness,
+            subcommand: subcommand,
+            input: input,
+            environment: environment ?? harness.environment
+        )
+        #expect(harness.handled.wait(timeout: .now() + 5) == .success)
+        harness.support.assertSuccessfulHook(result)
+    }
+
+    private func runFeedLifecycle(
+        _ harness: Harness,
+        event: String,
+        id: String
+    ) throws {
+        try runHook(
+            harness,
+            subcommand: "feed --source codex --event \(event)",
+            input: #"{"session_id":"\#(harness.sessionId)","turn_id":"turn-1","agent_id":"\#(id)","cwd":"\#(harness.context.root.path)","hook_event_name":"\#(event)"}"#
+        )
+    }
+
+    private func runProcess(
+        _ harness: Harness,
+        subcommand: String,
+        input: String,
+        environment: [String: String]
+    ) -> ClaudeHookSurfaceResolutionSwiftTests.ProcessRunResult {
+        harness.support.runProcess(
+            executablePath: harness.context.cliPath,
+            arguments: ["hooks", "codex"] + subcommand.split(separator: " ").map(String.init),
+            environment: environment,
+            standardInput: input,
+            timeout: 5
+        )
+    }
+
+    private func sessionStartPayload(_ harness: Harness) -> String {
+        #"{"session_id":"\#(harness.sessionId)","cwd":"\#(harness.context.root.path)","hook_event_name":"SessionStart"}"#
+    }
+
+    private func promptPayload(_ harness: Harness, turnId: String) -> String {
+        #"{"session_id":"\#(harness.sessionId)","turn_id":"\#(turnId)","cwd":"\#(harness.context.root.path)","hook_event_name":"UserPromptSubmit"}"#
+    }
+
+    private func stopPayload(_ harness: Harness, turnId: String) -> String {
+        #"{"session_id":"\#(harness.sessionId)","turn_id":"\#(turnId)","cwd":"\#(harness.context.root.path)","hook_event_name":"Stop","last_assistant_message":"done"}"#
+    }
+}

--- a/cmuxTests/CodexTurnCompletionOwnershipTests.swift
+++ b/cmuxTests/CodexTurnCompletionOwnershipTests.swift
@@ -106,6 +106,10 @@ struct CodexTurnCompletionOwnershipTests {
             "A parent Stop with live children must remain Running: \(pendingCommands)"
         )
         #expect(
+            !pendingCommands.contains { $0.hasPrefix("set_status codex Idle ") },
+            "A pending parent Stop must not also mark the pane idle: \(pendingCommands)"
+        )
+        #expect(
             AgentJournalAppendCapture.captures(in: pendingCommands).contains {
                 $0.kind == "agent.turn.completed" && $0.pendingWork
             },
@@ -130,6 +134,10 @@ struct CodexTurnCompletionOwnershipTests {
             partiallyDrainedCommands.contains { $0.hasPrefix("set_status codex Running ") },
             "One remaining child must keep the pane Running: \(partiallyDrainedCommands)"
         )
+        #expect(
+            !partiallyDrainedCommands.contains { $0.hasPrefix("set_status codex Idle ") },
+            "One remaining child must not also mark the pane idle: \(partiallyDrainedCommands)"
+        )
 
         try runFeedLifecycle(harness, event: "SubagentStop", id: "child-b")
         let beforeFinalStop = harness.context.state.snapshot().count
@@ -151,6 +159,33 @@ struct CodexTurnCompletionOwnershipTests {
         #expect(
             finalCommands.contains { $0.hasPrefix("set_status codex Idle ") },
             "The settled foreground turn must become idle: \(finalCommands)"
+        )
+        #expect(
+            !finalCommands.contains { $0.hasPrefix("set_status codex Running ") },
+            "The settled foreground turn must not remain Running: \(finalCommands)"
+        )
+
+        // A second Stop for the same settled turn is a duplicate boundary and
+        // must not publish another completion or repaint the pane.
+        let beforeDuplicateStop = harness.context.state.snapshot().count
+        try runHook(
+            harness,
+            subcommand: "stop",
+            input: stopPayload(harness, turnId: "turn-1")
+        )
+        let duplicateCommands = Array(
+            harness.context.state.snapshot().dropFirst(beforeDuplicateStop)
+        )
+        let cumulativeNotifications = harness.context.state.snapshot().filter {
+            $0.hasPrefix("notify_target_async ")
+        }
+        #expect(
+            cumulativeNotifications.count == 1,
+            "A duplicate settled Stop must not publish a second completion: \(harness.context.state.snapshot())"
+        )
+        #expect(
+            !duplicateCommands.contains { $0.hasPrefix("set_status codex Idle ") },
+            "A duplicate settled Stop must not repaint the pane idle: \(duplicateCommands)"
         )
     }
 
@@ -178,6 +213,7 @@ struct CodexTurnCompletionOwnershipTests {
         let commands = Array(harness.context.state.snapshot().dropFirst(beforeStop))
         #expect(commands.filter { $0.hasPrefix("notify_target_async ") }.count == 1)
         #expect(commands.contains { $0.hasPrefix("set_status codex Idle ") })
+        #expect(!commands.contains { $0.hasPrefix("set_status codex Running ") })
     }
 
     private func makeHarness(name: String) throws -> Harness {
@@ -228,9 +264,10 @@ struct CodexTurnCompletionOwnershipTests {
             harness,
             subcommand: subcommand,
             input: input,
-            environment: environment ?? harness.environment
+            environment: environment ?? harness.environment,
+            timeout: 10
         )
-        #expect(harness.handled.wait(timeout: .now() + 5) == .success)
+        #expect(harness.handled.wait(timeout: .now() + 10) == .success)
         harness.support.assertSuccessfulHook(result)
     }
 
@@ -250,7 +287,8 @@ struct CodexTurnCompletionOwnershipTests {
         _ harness: Harness,
         subcommand: String,
         input: String,
-        environment: [String: String]
+        environment: [String: String],
+        timeout: TimeInterval = 5
     ) -> ClaudeHookSurfaceResolutionSwiftTests.ProcessRunResult {
         let command = subcommand.split(separator: " ").map(String.init)
         let arguments = command.first == "feed"
@@ -261,7 +299,7 @@ struct CodexTurnCompletionOwnershipTests {
             arguments: arguments,
             environment: environment,
             standardInput: input,
-            timeout: 5
+            timeout: timeout
         )
     }
 

--- a/cmuxTests/CodexTurnCompletionOwnershipTests.swift
+++ b/cmuxTests/CodexTurnCompletionOwnershipTests.swift
@@ -106,8 +106,10 @@ struct CodexTurnCompletionOwnershipTests {
             "A parent Stop with live children must remain Running: \(pendingCommands)"
         )
         #expect(
-            pendingCommands.contains { $0.hasPrefix("set_agent_lifecycle codex running ") },
-            "The pending parent boundary must be recorded as running: \(pendingCommands)"
+            AgentJournalAppendCapture.captures(in: pendingCommands).contains {
+                $0.kind == "agent.turn.completed" && $0.pendingWork
+            },
+            "The pending parent boundary must be journaled authoritatively: \(pendingCommands)"
         )
 
         try runFeedLifecycle(harness, event: "SubagentStop", id: "child-a")

--- a/cmuxTests/CodexTurnCompletionOwnershipTests.swift
+++ b/cmuxTests/CodexTurnCompletionOwnershipTests.swift
@@ -250,9 +250,13 @@ struct CodexTurnCompletionOwnershipTests {
         input: String,
         environment: [String: String]
     ) -> ClaudeHookSurfaceResolutionSwiftTests.ProcessRunResult {
+        let command = subcommand.split(separator: " ").map(String.init)
+        let arguments = command.first == "feed"
+            ? ["hooks"] + command
+            : ["hooks", "codex"] + command
         harness.support.runProcess(
             executablePath: harness.context.cliPath,
-            arguments: ["hooks", "codex"] + subcommand.split(separator: " ").map(String.init),
+            arguments: arguments,
             environment: environment,
             standardInput: input,
             timeout: 5


### PR DESCRIPTION
## Summary

- Add behavior regressions for nested Codex reviewer Stops, native child lifecycle, exact final completion, and normal top-level Stops.
- Supersedes the approach in #9512 without modifying that open PR.

Fixes #7520

## Regression provenance

The first commit (`be5ee2a567`) intentionally adds executable behavior tests before the implementation. CI should fail until the ownership/settlement implementation lands.

## Testing

- Pending CI red baseline for `CodexTurnCompletionOwnershipTests`.
- Implementation and final CI proof will follow in a separate commit.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790330736&installation_model_id=21920&pr_number=10838&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10838&signature=23e82fab56e00615b010cb3ad3f32179432a39ae65123a1d5087097d6f1c99f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Codex turn tracking for nested agents and child processes.
  * Completion notifications and runtime status now reflect child lifecycle events more accurately.
  * Prevented duplicate or premature completion notifications while child work remains active.
  * Added reliable handling for Codex subagent start and stop events.
  * Improved persistence and recovery of Codex turn state.

* **Tests**
  * Added coverage for nested processes, child-agent activity, exactly-once completion, and standard top-level stops.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->