### PR TITLE
cmux-tui: per-terminal exit policy --on-exit close|keep on workspace/pane run

### DIFF
--- a/cmux-tui/bindings/cpp/.cmux-resource-api.json
+++ b/cmux-tui/bindings/cpp/.cmux-resource-api.json
@@ -1,5 +1,5 @@
 {
-  "catalog_sha256": "8745cc1783d716c6a03f4494dd8644d086456251d7c143880e77c7d2abf03f0f",
+  "catalog_sha256": "fb00ea2a07c1d8a954dbf9e4a6c684e20b6545176e21d48e4777debaed5d80b1",
   "operations": {
     "agent.list": {
       "class": "read"

--- a/cmux-tui/bindings/go/.cmux-resource-api.json
+++ b/cmux-tui/bindings/go/.cmux-resource-api.json
@@ -1,5 +1,5 @@
 {
-  "catalog_sha256": "8745cc1783d716c6a03f4494dd8644d086456251d7c143880e77c7d2abf03f0f",
+  "catalog_sha256": "fb00ea2a07c1d8a954dbf9e4a6c684e20b6545176e21d48e4777debaed5d80b1",
   "operations": {
     "agent.list": {
       "class": "read"

--- a/cmux-tui/bindings/java/.cmux-resource-api.json
+++ b/cmux-tui/bindings/java/.cmux-resource-api.json
@@ -1,5 +1,5 @@
 {
-  "catalog_sha256": "8745cc1783d716c6a03f4494dd8644d086456251d7c143880e77c7d2abf03f0f",
+  "catalog_sha256": "fb00ea2a07c1d8a954dbf9e4a6c684e20b6545176e21d48e4777debaed5d80b1",
   "operations": {
     "agent.list": {
       "class": "read"

--- a/cmux-tui/bindings/python/.cmux-resource-api.json
+++ b/cmux-tui/bindings/python/.cmux-resource-api.json
@@ -1,5 +1,5 @@
 {
-  "catalog_sha256": "8745cc1783d716c6a03f4494dd8644d086456251d7c143880e77c7d2abf03f0f",
+  "catalog_sha256": "fb00ea2a07c1d8a954dbf9e4a6c684e20b6545176e21d48e4777debaed5d80b1",
   "operations": {
     "agent.list": {
       "class": "read"

--- a/cmux-tui/bindings/rust/.cmux-resource-api.json
+++ b/cmux-tui/bindings/rust/.cmux-resource-api.json
@@ -1,5 +1,5 @@
 {
-  "catalog_sha256": "8745cc1783d716c6a03f4494dd8644d086456251d7c143880e77c7d2abf03f0f",
+  "catalog_sha256": "fb00ea2a07c1d8a954dbf9e4a6c684e20b6545176e21d48e4777debaed5d80b1",
   "operations": {
     "agent.list": {
       "class": "read"

--- a/cmux-tui/bindings/typescript/.cmux-resource-api.json
+++ b/cmux-tui/bindings/typescript/.cmux-resource-api.json
@@ -1,5 +1,5 @@
 {
-  "catalog_sha256": "8745cc1783d716c6a03f4494dd8644d086456251d7c143880e77c7d2abf03f0f",
+  "catalog_sha256": "fb00ea2a07c1d8a954dbf9e4a6c684e20b6545176e21d48e4777debaed5d80b1",
   "operations": {
     "agent.list": {
       "class": "read"

--- a/cmux-tui/bindings/zig/.cmux-resource-api.json
+++ b/cmux-tui/bindings/zig/.cmux-resource-api.json
@@ -1,5 +1,5 @@
 {
-  "catalog_sha256": "8745cc1783d716c6a03f4494dd8644d086456251d7c143880e77c7d2abf03f0f",
+  "catalog_sha256": "fb00ea2a07c1d8a954dbf9e4a6c684e20b6545176e21d48e4777debaed5d80b1",
   "operations": {
     "agent.list": {
       "class": "read"

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -64,8 +64,8 @@ use crate::workspace_registry::{
     RegistryBrowser, RegistryBrowserReconnect, RegistryCommit, RegistryLayoutNode,
     RegistrySnapshot, RegistryTab, RegistryTerminal, RegistryViewport, RegistryWorkspace,
     ResourceChange, ResourceEffectOutcome, ResourceEffectPreparation, ResourcePatch,
-    ResourcePatchCommit, ResourceTopologySnapshot, TerminalLifecycle, TerminalRegistrySnapshot,
-    WorkspaceMutation, WorkspaceRegistry,
+    ResourcePatchCommit, ResourceTopologySnapshot, TerminalLifecycle, TerminalOnExit,
+    TerminalRegistrySnapshot, WorkspaceMutation, WorkspaceRegistry,
 };
 use crate::{
     PairingChallenge, PairingDecision, PairingError, PaneId, ScreenId, SplitDir, SplitId,
@@ -1177,6 +1177,7 @@ struct TerminalReservationRequest {
     fingerprint: Value,
     expected_generation: Option<String>,
     expected_revision: Option<u64>,
+    on_exit: TerminalOnExit,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2679,6 +2680,7 @@ impl Mux {
                         lifecycle: TerminalLifecycle::Launching,
                         launch_spec: serde_json::json!({"legacy_import":true}),
                         exit: None,
+                        on_exit: TerminalOnExit::Close,
                     };
                     let mut registry = self.workspace_registry.lock().unwrap();
                     let revision = commit_terminal_transition(
@@ -6160,6 +6162,10 @@ impl Mux {
                 lifecycle: TerminalLifecycle::Launching,
                 launch_spec,
                 exit: None,
+                on_exit: reservation
+                    .as_ref()
+                    .map(|reservation| reservation.on_exit)
+                    .unwrap_or_default(),
             };
             let reserve_replayed = {
                 let mut registry = self.workspace_registry.lock().unwrap();
@@ -6292,6 +6298,7 @@ impl Mux {
                 lifecycle: TerminalLifecycle::Launching,
                 launch_spec,
                 exit: None,
+                on_exit: reservation.on_exit,
             };
             {
                 let mut registry = self.workspace_registry.lock().unwrap();
@@ -7478,6 +7485,22 @@ impl Mux {
         incarnation: &str,
         workspace_key: &str,
     ) -> anyhow::Result<SurfaceId> {
+        self.seed_running_terminal_with_on_exit_for_test(
+            terminal_id,
+            incarnation,
+            workspace_key,
+            TerminalOnExit::Close,
+        )
+    }
+
+    #[cfg(all(test, unix))]
+    pub(crate) fn seed_running_terminal_with_on_exit_for_test(
+        self: &Arc<Self>,
+        terminal_id: &str,
+        incarnation: &str,
+        workspace_key: &str,
+        on_exit: TerminalOnExit,
+    ) -> anyhow::Result<SurfaceId> {
         let mut registry = self.workspace_registry.lock().unwrap();
         commit_terminal_transition(
             &mut registry,
@@ -7490,6 +7513,7 @@ impl Mux {
                 lifecycle: TerminalLifecycle::Launching,
                 launch_spec: serde_json::json!({}),
                 exit: None,
+                on_exit,
             },
         )?;
         commit_terminal_lifecycle(
@@ -10912,6 +10936,7 @@ impl Mux {
             expected_generation,
             expected_revision,
             mutation,
+            None,
         )
     }
 
@@ -10927,6 +10952,7 @@ impl Mux {
         expected_generation: Option<&str>,
         expected_revision: Option<u64>,
         mutation: &WorkspaceMutation,
+        on_exit: Option<TerminalOnExit>,
     ) -> anyhow::Result<TerminalPlacementResult> {
         let workspace_key = self
             .state
@@ -10945,6 +10971,7 @@ impl Mux {
             cwd.as_deref(),
             name.as_deref(),
             size,
+            on_exit,
         )?;
         let replay =
             { self.workspace_registry.lock().unwrap().replay_terminal(mutation, &fingerprint)? };
@@ -10964,6 +10991,7 @@ impl Mux {
             fingerprint,
             expected_generation: expected_generation.map(str::to_string),
             expected_revision,
+            on_exit: on_exit.unwrap_or_default(),
         };
         let (placement, surface, created_path) = self.create_terminal_in_workspace_impl(
             workspace,
@@ -12949,10 +12977,20 @@ impl Mux {
         } else {
             terminal_exit_snapshot_in_state(&registry, &state, terminal_id)?
         };
+        // The keep policy commits the identical exit latch but leaves the
+        // views and the live screen surface in place. This only holds while
+        // the runtime terminal emulator is alive: after a daemon restart the
+        // in-memory VT is gone, so reconciliation degrades a kept-exited
+        // terminal to the normal detach below.
+        let keep_live_views = terminal.on_exit == TerminalOnExit::Keep
+            && public_terminal_id
+                .as_ref()
+                .is_some_and(|public_id| state.terminal_catalog.contains_key(public_id));
         let detach_projection = if matches!(
             terminal.lifecycle,
             TerminalLifecycle::Exited | TerminalLifecycle::Tombstoned
-        ) {
+        ) || keep_live_views
+        {
             None
         } else if let Some(public_terminal_id) = public_terminal_id.as_ref() {
             self.terminal_exit_detach_projection_locked(
@@ -14106,9 +14144,11 @@ impl Mux {
                         spec.cwd.as_deref(),
                         None,
                         size,
+                        None,
                     )?,
                     expected_generation: None,
                     expected_revision: None,
+                    on_exit: TerminalOnExit::Close,
                 };
                 let surface = self.spawn_surface_in_workspace_reserved(
                     workspace_key,
@@ -14903,13 +14943,19 @@ fn terminal_create_fingerprint(
     cwd: Option<&str>,
     name: Option<&str>,
     size: Option<(u16, u16)>,
+    on_exit: Option<TerminalOnExit>,
 ) -> anyhow::Result<Value> {
-    let request = serde_json::json!({
+    let mut request = serde_json::json!({
         "argv": argv,
         "cwd": cwd,
         "name": name,
         "size": size,
     });
+    // Absent stays absent: a stored creation intent minted before the exit
+    // policy existed must recompute its original digest after an upgrade.
+    if let Some(on_exit) = on_exit {
+        request["on_exit"] = Value::String(on_exit.as_str().to_string());
+    }
     let digest = Sha256::digest(serde_json::to_vec(&request)?);
     let request_sha256 = digest.iter().map(|byte| format!("{byte:02x}")).collect::<String>();
     Ok(serde_json::json!({
@@ -18920,6 +18966,7 @@ mod tests {
             Some(&cwd),
             Some(&name),
             Some((80, 24)),
+            Some(TerminalOnExit::Keep),
         )
         .unwrap();
         assert!(!serde_json::to_string(&fingerprint).unwrap().contains(sentinel));
@@ -18958,6 +19005,7 @@ mod tests {
                         lifecycle: TerminalLifecycle::Launching,
                         launch_spec: serde_json::json!({"command_present":true}),
                         exit: None,
+                        on_exit: TerminalOnExit::Close,
                     },
                     &serde_json::json!({"terminal_id":TERMINAL}),
                 )
@@ -24579,6 +24627,7 @@ mod tests {
                         lifecycle: TerminalLifecycle::Launching,
                         launch_spec: serde_json::json!({"command_present":true}),
                         exit: None,
+                        on_exit: TerminalOnExit::Close,
                     },
                     &serde_json::json!({"terminal_id":TERMINAL}),
                 )
@@ -24695,6 +24744,7 @@ mod tests {
             lifecycle: TerminalLifecycle::Launching,
             launch_spec: serde_json::json!({"command":["/bin/sh"]}),
             exit: None,
+            on_exit: TerminalOnExit::Close,
         };
         {
             let mut registry = WorkspaceRegistry::open(&root, session).unwrap();
@@ -24869,6 +24919,175 @@ mod tests {
         std::fs::remove_dir_all(root).unwrap();
     }
 
+    /// A keep-policy terminal only retains its views while the in-memory VT
+    /// is alive. After a daemon restart the surface is gone, so restart
+    /// reconciliation degrades the kept terminal to the normal detach while
+    /// preserving the exact durable exit receipt.
+    #[cfg(unix)]
+    #[test]
+    fn restart_degrades_keep_policy_terminal_to_the_normal_detach() {
+        use std::fs::{File, OpenOptions};
+        use std::io::Write;
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+        const TERMINAL: &str = "0000000000004000800000000000004b";
+        const INCARNATION: &str = "1000000000004000800000000000004b";
+        let root = std::env::temp_dir().join(format!(
+            "cmux-mux-keep-exit-restart-{}",
+            crate::workspace_registry::new_uuid_v4()
+        ));
+        let session = "recover-keep-exit";
+        let workspace = RegistryWorkspace {
+            id: 1,
+            public_id: restore_workspace_id(43),
+            key: "workspace-keep-exit".into(),
+            name: "Keep".into(),
+            group_key: session.into(),
+        };
+        let screen = restore_screen_id(43);
+        let pane = restore_pane_id(43);
+        let tab = restore_tab_id(43);
+        let terminal_public_id = restore_terminal_id(43);
+        let terminal = RegistryTerminal {
+            terminal_id: TERMINAL.into(),
+            workspace_key: workspace.key.clone(),
+            incarnation: None,
+            lifecycle: TerminalLifecycle::Launching,
+            launch_spec: serde_json::json!({"command":["/bin/sh"]}),
+            exit: None,
+            on_exit: TerminalOnExit::Keep,
+        };
+        {
+            let mut registry = WorkspaceRegistry::open(&root, session).unwrap();
+            registry
+                .commit_resource_patch(
+                    &WorkspaceMutation::new("seed-keep-exit", "test").unwrap(),
+                    "workspace.create",
+                    &serde_json::json!({"fixture":"keep-exit"}),
+                    None,
+                    Some(0),
+                    &ResourcePatch {
+                        changes: vec![
+                            ResourceChange::UpsertWorkspace {
+                                workspace: workspace.clone(),
+                                position: 0,
+                                active_screen: Some(screen.clone()),
+                            },
+                            ResourceChange::UpsertScreen(RegistryScreen {
+                                public_id: screen.clone(),
+                                workspace_id: workspace.public_id.clone(),
+                                position: 0,
+                                name: None,
+                                layout: RegistryLayoutNode::Leaf { pane: pane.clone() },
+                                active_pane: pane.clone(),
+                                zoomed_pane: None,
+                                auto_layout: None,
+                                viewport: RegistryViewport::default(),
+                            }),
+                            ResourceChange::UpsertPane(RegistryPane {
+                                public_id: pane.clone(),
+                                screen_id: screen.clone(),
+                                name: None,
+                                active_tab: Some(tab.clone()),
+                                creation_ordinal: 1,
+                            }),
+                            ResourceChange::UpsertTerminal {
+                                public_id: terminal_public_id.clone(),
+                                terminal,
+                            },
+                            ResourceChange::UpsertTab(RegistryTab {
+                                public_id: tab.clone(),
+                                pane_id: pane.clone(),
+                                position: 0,
+                                content_id: ContentPublicId::Terminal(terminal_public_id.clone()),
+                                name: None,
+                                browser_url: None,
+                                terminal_id: Some(TERMINAL.into()),
+                            }),
+                            ResourceChange::SetWorkspaceOrder {
+                                workspace_ids: vec![workspace.public_id.clone()],
+                            },
+                            ResourceChange::SetScreenOrder {
+                                workspace_id: workspace.public_id.clone(),
+                                screen_ids: vec![screen],
+                            },
+                            ResourceChange::SetTabOrder {
+                                pane_id: pane,
+                                tab_ids: vec![tab.clone()],
+                            },
+                            ResourceChange::SetActiveWorkspace {
+                                workspace_id: Some(workspace.public_id),
+                            },
+                        ],
+                    },
+                    &serde_json::json!({"created":true}),
+                    &serde_json::json!([{"kind":"fixture.created"}]),
+                )
+                .unwrap();
+            commit_terminal_lifecycle(
+                &mut registry,
+                "terminal-ready",
+                "seed-running-terminal",
+                TERMINAL,
+                TerminalLifecycle::Running,
+                Some(INCARNATION),
+                None,
+            )
+            .unwrap();
+        }
+
+        let host_root = crate::terminal_host_runtime::terminal_host_root(&root, session);
+        std::fs::create_dir_all(&host_root).unwrap();
+        std::fs::set_permissions(&host_root, std::fs::Permissions::from_mode(0o700)).unwrap();
+        let exit = TerminalExit {
+            outcome: crate::terminal_host_protocol::TerminalExitOutcome::Exit { code: 3 },
+            exited_at_ms: 7_654_321,
+        };
+        let sidecar = crate::terminal_host_runtime::TerminalHostExitRecord::new(
+            &TerminalHostIdentity { terminal_id: TERMINAL.into(), incarnation: INCARNATION.into() },
+            exit,
+        );
+        let sidecar_path = sidecar.record_path(&host_root);
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&sidecar_path)
+            .unwrap();
+        file.write_all(&serde_json::to_vec(&sidecar).unwrap()).unwrap();
+        file.sync_all().unwrap();
+        File::open(&host_root).unwrap().sync_all().unwrap();
+
+        let options =
+            SurfaceOptions { terminal_host_root: Some(host_root), ..SurfaceOptions::default() };
+        let mux = Mux::open_persistent(session, options, &root).unwrap();
+        let waited = mux.wait_for_terminal_exit(&terminal_public_id, Some(Duration::ZERO)).unwrap();
+        assert_eq!(waited["state"], "exited");
+        assert_eq!(waited["outcome"], serde_json::json!({"kind":"exit","code":3}));
+        let resolved = mux.resolve_terminal(TERMINAL).unwrap().unwrap();
+        assert_eq!(resolved.terminal.lifecycle, TerminalLifecycle::Exited);
+        assert_eq!(resolved.surface, None, "restart must not resurrect the kept screen");
+        let events = mux.resource_events_after(1).unwrap();
+        let changes = events
+            .batches
+            .iter()
+            .flat_map(|batch| batch.changes.as_array().unwrap().clone())
+            .collect::<Vec<_>>();
+        assert!(changes.iter().any(|change| {
+            change["kind"] == "delete"
+                && change["resource"] == "tab"
+                && change["id"] == tab.as_str()
+        }));
+        assert!(!changes.iter().any(|change| {
+            change["kind"] == "delete"
+                && change["resource"] == "terminal"
+                && change["id"] == terminal_public_id.as_str()
+        }));
+        mux.shutdown();
+        drop(mux);
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
     #[cfg(unix)]
     #[test]
     fn restart_keeps_exited_terminal_as_detached_receipt_until_explicit_close() {
@@ -24905,6 +25124,7 @@ mod tests {
                 lifecycle: TerminalLifecycle::Launching,
                 launch_spec: serde_json::json!({}),
                 exit: None,
+                on_exit: TerminalOnExit::Close,
             };
             commit_terminal_transition(
                 &mut registry,
@@ -25058,6 +25278,69 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn keep_policy_exit_latches_the_receipt_but_retains_tab_and_screen_surface() {
+        const TERMINAL: &str = "0000000000004000800000000000004a";
+        const INCARNATION: &str = "1000000000004000800000000000004a";
+        let mux = test_mux();
+        let workspace = mux
+            .create_empty_workspace(
+                Some("keep-exit".into()),
+                Some("018f6e21-7b70-7e70-8000-00000000104a".into()),
+                None,
+            )
+            .unwrap();
+        let surface = mux
+            .seed_running_terminal_with_on_exit_for_test(
+                TERMINAL,
+                INCARNATION,
+                &workspace.key,
+                TerminalOnExit::Keep,
+            )
+            .unwrap();
+        let pane = mux.with_state(|state| state.pane_of(surface).unwrap());
+        let terminal =
+            mux.workspace_registry.lock().unwrap().terminal_resource_id(TERMINAL).unwrap().unwrap();
+        let exit = TerminalExit {
+            outcome: crate::terminal_host_protocol::TerminalExitOutcome::Exit { code: 7 },
+            exited_at_ms: 9_999_999,
+        };
+        assert!(mux.persist_terminal_exit_for_test(&terminal, &exit).unwrap());
+
+        mux.surface_exited(surface);
+
+        // The durable latch is identical to the close policy.
+        let waited = mux.wait_for_terminal_exit(&terminal, Some(Duration::ZERO)).unwrap();
+        assert_eq!(waited["state"], "exited");
+        assert_eq!(waited["outcome"], serde_json::json!({"kind":"exit","code":7}));
+        let resolved = mux.resolve_terminal(TERMINAL).unwrap().unwrap();
+        assert_eq!(resolved.terminal.lifecycle, TerminalLifecycle::Exited);
+        // The views and the runtime screen surface stay behind it.
+        assert_eq!(resolved.surface, Some(surface));
+        mux.with_state(|state| {
+            assert!(state.surfaces.contains_key(&surface));
+            assert_eq!(state.panes[&pane].tabs, vec![surface]);
+        });
+
+        // Re-observed exits stay first-writer-wins, and detach reconciliation
+        // is a no-op while the runtime surface lives.
+        let revision = mux.workspace_registry.lock().unwrap().resource_revision().unwrap();
+        mux.surface_exited(surface);
+        assert!(!mux.detach_exited_terminal_topology(TERMINAL).unwrap());
+        assert_eq!(mux.workspace_registry.lock().unwrap().resource_revision().unwrap(), revision);
+        mux.with_state(|state| {
+            assert_eq!(state.panes[&pane].tabs, vec![surface]);
+        });
+
+        // Explicit close still cleans the kept terminal up completely.
+        mux.close_terminal(TERMINAL, INCARNATION).unwrap();
+        let closed = mux.resolve_terminal(TERMINAL).unwrap().unwrap();
+        assert_eq!(closed.terminal.lifecycle, TerminalLifecycle::Tombstoned);
+        assert_eq!(closed.surface, None);
+        mux.with_state(|state| assert!(!state.surfaces.contains_key(&surface)));
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn failed_exit_detach_retry_does_not_keep_mux_alive() {
         const TERMINAL: &str = "0000000000004000800000000000003e";
         const INCARNATION: &str = "1000000000004000800000000000003e";
@@ -25111,6 +25394,7 @@ mod tests {
                 lifecycle: TerminalLifecycle::Launching,
                 launch_spec: serde_json::json!({}),
                 exit: None,
+                on_exit: TerminalOnExit::Close,
             },
         )
         .unwrap();
@@ -25187,6 +25471,7 @@ mod tests {
                 lifecycle: TerminalLifecycle::Launching,
                 launch_spec: serde_json::json!({"command_present":true}),
                 exit: None,
+                on_exit: TerminalOnExit::Close,
             };
             commit_terminal_transition(
                 &mut registry,
@@ -25240,6 +25525,7 @@ mod tests {
                     lifecycle: TerminalLifecycle::Launching,
                     launch_spec: serde_json::json!({}),
                     exit: None,
+                    on_exit: TerminalOnExit::Close,
                 },
             )
             .unwrap();
@@ -25316,6 +25602,7 @@ mod tests {
                     lifecycle: TerminalLifecycle::Launching,
                     launch_spec: serde_json::json!({}),
                     exit: None,
+                    on_exit: TerminalOnExit::Close,
                 },
             )
             .unwrap();
@@ -25357,6 +25644,7 @@ mod tests {
                     lifecycle: TerminalLifecycle::Launching,
                     launch_spec: serde_json::json!({}),
                     exit: None,
+                    on_exit: TerminalOnExit::Close,
                 },
             )
             .unwrap();
@@ -25421,6 +25709,7 @@ mod tests {
                     lifecycle: TerminalLifecycle::Launching,
                     launch_spec: serde_json::json!({}),
                     exit: None,
+                    on_exit: TerminalOnExit::Close,
                 },
             )
             .unwrap();
@@ -25464,6 +25753,7 @@ mod tests {
                     lifecycle: TerminalLifecycle::Launching,
                     launch_spec: serde_json::json!({}),
                     exit: None,
+                    on_exit: TerminalOnExit::Close,
                 },
             )
             .unwrap();
@@ -25530,6 +25820,7 @@ mod tests {
                     lifecycle: TerminalLifecycle::Launching,
                     launch_spec: serde_json::json!({"command_present":true}),
                     exit: None,
+                    on_exit: TerminalOnExit::Close,
                 },
             )
             .unwrap();
@@ -25734,6 +26025,7 @@ mod tests {
                     lifecycle: TerminalLifecycle::Launching,
                     launch_spec: serde_json::json!({}),
                     exit: None,
+                    on_exit: TerminalOnExit::Close,
                 },
             )
             .unwrap();

--- a/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
@@ -15,7 +15,7 @@ use crate::server::MAX_CREATION_SELECTOR_FALLBACKS;
 use crate::workspace_registry::{
     RegistryPane, RegistryScreen, RegistryViewportColumn, ResourceCreationPreparation,
     ResourceCreationRecovery, ResourcePatchCommit, ResourceWorkspaceClose, TerminalLifecycle,
-    TerminalResourceCloseCommit,
+    TerminalOnExit, TerminalResourceCloseCommit,
 };
 use crate::{ResolvedResourcePath, ResourceSelectors, ResourceTarget, SurfaceKind};
 
@@ -47,6 +47,7 @@ struct TerminalEffectOptions {
     name: Option<String>,
     created_screen_name: Option<String>,
     size: Option<(u16, u16)>,
+    on_exit: Option<TerminalOnExit>,
 }
 
 struct CreatedTerminalEffect {
@@ -2560,6 +2561,15 @@ impl Mux {
             return Ok(false);
         };
         let mut state = self.state.lock().unwrap();
+        // A keep-policy terminal retains its views while the runtime screen
+        // surface is alive; reconciliation must not force-detach it out from
+        // under a live daemon. Without a runtime (a daemon restart dropped
+        // the in-memory VT) the kept terminal degrades to the normal detach.
+        if terminal.on_exit == TerminalOnExit::Keep
+            && state.terminal_catalog.contains_key(&terminal_public_id)
+        {
+            return Ok(false);
+        }
         let Some(projection) = self.terminal_exit_detach_projection_locked(
             &registry,
             &state,
@@ -3508,6 +3518,7 @@ impl Mux {
                         name: optional_owned_string(fields, "terminal_name")?,
                         created_screen_name: None,
                         size: effect_cell_size(fields)?,
+                        on_exit: None,
                     },
                 )
                 .map(|created| created.path)
@@ -3533,6 +3544,7 @@ impl Mux {
                         name: optional_owned_string(fields, "name")?,
                         created_screen_name: None,
                         size: effect_cell_size(fields)?,
+                        on_exit: effect_on_exit(fields)?,
                     },
                 )
                 .map(|created| created.path)
@@ -3563,6 +3575,7 @@ impl Mux {
                             name: None,
                             created_screen_name: name,
                             size: effect_cell_size(fields)?,
+                            on_exit: None,
                         },
                     ),
                 }
@@ -3622,6 +3635,7 @@ impl Mux {
                             name: None,
                             created_screen_name: None,
                             size: effect_cell_size(fields)?,
+                            on_exit: None,
                         },
                     ),
                     None => self.effect_create_workspace_terminal(
@@ -3633,6 +3647,7 @@ impl Mux {
                             name: None,
                             created_screen_name: None,
                             size: effect_cell_size(fields)?,
+                            on_exit: None,
                         },
                     ),
                 }
@@ -3673,6 +3688,7 @@ impl Mux {
                     optional_owned_string(fields, "cwd")?,
                     optional_owned_string(fields, "name")?,
                     effect_cell_size(fields)?,
+                    effect_on_exit(fields)?,
                 )
                 .map(|created| created.path)
             }
@@ -3686,6 +3702,7 @@ impl Mux {
                         optional_owned_string(fields, "cwd")?,
                         optional_owned_string(fields, "name")?,
                         effect_cell_size(fields)?,
+                        None,
                     ),
                     None if slots.workspace.is_some() => self.effect_create_terminal_in_workspace(
                         intent,
@@ -3696,6 +3713,7 @@ impl Mux {
                             name: optional_owned_string(fields, "name")?,
                             created_screen_name: None,
                             size: effect_cell_size(fields)?,
+                            on_exit: None,
                         },
                     ),
                     None => self.effect_create_workspace_terminal(
@@ -3707,6 +3725,7 @@ impl Mux {
                             name: optional_owned_string(fields, "name")?,
                             created_screen_name: None,
                             size: effect_cell_size(fields)?,
+                            on_exit: None,
                         },
                     ),
                 }
@@ -3904,6 +3923,7 @@ impl Mux {
         Ok((key, public_id, mutation))
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn effect_terminal_reservation(
         &self,
         intent: &Value,
@@ -3912,6 +3932,7 @@ impl Mux {
         cwd: Option<&str>,
         name: Option<&str>,
         size: Option<(u16, u16)>,
+        on_exit: Option<TerminalOnExit>,
     ) -> anyhow::Result<TerminalReservationRequest> {
         let stored = intent["terminal_reservation"]
             .as_object()
@@ -3939,9 +3960,11 @@ impl Mux {
                 cwd,
                 name,
                 size,
+                on_exit,
             )?,
             expected_generation: None,
             expected_revision: None,
+            on_exit: on_exit.unwrap_or_default(),
         })
     }
 
@@ -3987,7 +4010,7 @@ impl Mux {
         workspace: WorkspaceId,
         options: TerminalEffectOptions,
     ) -> anyhow::Result<CreatedTerminalEffect> {
-        let TerminalEffectOptions { argv, cwd, name, created_screen_name, size } = options;
+        let TerminalEffectOptions { argv, cwd, name, created_screen_name, size, on_exit } = options;
         let workspace_key = self
             .with_state(|state| state.workspace_by_id(workspace).map(|item| item.key.clone()))
             .with_context(|| format!("workspace {workspace} disappeared"))?;
@@ -3998,6 +4021,7 @@ impl Mux {
             cwd.as_deref(),
             name.as_deref(),
             size,
+            on_exit,
         )?;
         let terminal_hex = reservation.terminal_id.to_hex();
         let result = self.create_terminal_in_workspace_with_mutation(
@@ -4010,6 +4034,7 @@ impl Mux {
             None,
             None,
             &reservation.mutation,
+            on_exit,
         )?;
         let surface =
             result.created_surface.context("created terminal result omitted its local surface")?;
@@ -4024,6 +4049,7 @@ impl Mux {
         Ok(CreatedTerminalEffect { path })
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn effect_add_terminal_tab(
         self: &Arc<Self>,
         intent: &Value,
@@ -4032,6 +4058,7 @@ impl Mux {
         cwd: Option<String>,
         name: Option<String>,
         size: Option<(u16, u16)>,
+        on_exit: Option<TerminalOnExit>,
     ) -> anyhow::Result<CreatedTerminalEffect> {
         let workspace_key = self
             .workspace_key_for_pane(target)
@@ -4044,6 +4071,7 @@ impl Mux {
             cwd.as_deref(),
             name.as_deref(),
             size,
+            on_exit,
         )?;
         let surface =
             self.spawn_surface_in_workspace_reserved(&workspace_key, cwd, size, argv, reservation)?;
@@ -4123,6 +4151,7 @@ impl Mux {
             cwd.as_deref(),
             None,
             size,
+            None,
         )?;
         let surface =
             self.spawn_surface_in_workspace_reserved(&workspace_key, cwd, size, None, reservation)?;
@@ -4223,6 +4252,7 @@ impl Mux {
             cwd.as_deref(),
             None,
             size,
+            None,
         )?;
         let surface =
             self.spawn_surface_in_workspace_reserved(&workspace_key, cwd, size, None, reservation)?;
@@ -4614,6 +4644,16 @@ fn optional_owned_string(
                 .as_str()
                 .map(str::to_string)
                 .with_context(|| format!("field {name:?} must be a string"))
+        })
+        .transpose()
+}
+
+fn effect_on_exit(fields: &Map<String, Value>) -> anyhow::Result<Option<TerminalOnExit>> {
+    fields
+        .get("on_exit")
+        .map(|value| {
+            let value = value.as_str().context("field \"on_exit\" must be a string")?;
+            TerminalOnExit::parse(value)
         })
         .transpose()
 }

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -843,10 +843,11 @@ pub fn default_terminal_cwd() -> Option<String> {
 }
 
 fn default_terminal_cwd_from(launch: Option<&Path>) -> Option<String> {
-    if let Some(dir) = launch {
-        if dir.parent().is_some() && dir.is_dir() {
-            return Some(dir.to_string_lossy().into_owned());
-        }
+    if let Some(dir) = launch
+        && dir.parent().is_some()
+        && dir.is_dir()
+    {
+        return Some(dir.to_string_lossy().into_owned());
     }
     home_dir().map(|path| path.to_string_lossy().into_owned())
 }

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -4258,10 +4258,11 @@ impl Surface {
             }
             #[cfg(unix)]
             PtyRuntime::Hosted(host) => host.send(MessageKind::Input, bytes),
+            // A keep-on-exit terminal outlives its child, so typing into the
+            // dead PTY is an expected interaction: drop the bytes silently
+            // instead of failing every keystroke on the final screen.
             #[cfg(unix)]
-            PtyRuntime::ExitedHosted => {
-                Err(std::io::Error::new(std::io::ErrorKind::BrokenPipe, "terminal host has exited"))
-            }
+            PtyRuntime::ExitedHosted => Ok(()),
         }
     }
 
@@ -4283,11 +4284,10 @@ impl Surface {
             if let PtyRuntime::Hosted(host) = &*runtime {
                 return host.send(MessageKind::Paste, bytes);
             }
+            // Keep-on-exit terminals accept and drop paste input the same
+            // way as keystrokes: the final screen is read-only, not broken.
             if matches!(&*runtime, PtyRuntime::ExitedHosted) {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::BrokenPipe,
-                    "terminal host has exited",
-                ));
+                return Ok(());
             }
         }
         let bracketed = {
@@ -8018,7 +8018,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn exited_host_placeholder_preserves_identity_and_rejects_input() {
+    fn exited_host_placeholder_preserves_identity_and_swallows_input() {
         let mux = Mux::new_for_test("exited-host-placeholder", SurfaceOptions::default());
         let identity = crate::terminal_host_runtime::TerminalHostIdentity {
             terminal_id: crate::terminal_host::TerminalId::random().unwrap().to_hex(),
@@ -8038,10 +8038,10 @@ mod tests {
             Some(TerminalHostConnectionState::Exited)
         );
         assert!(surface.is_dead());
-        assert_eq!(
-            surface.write_bytes(b"must not reach a dead host").unwrap_err().kind(),
-            std::io::ErrorKind::BrokenPipe
-        );
+        // Keep-on-exit terminals stay interactive surfaces after their child
+        // dies, so input to the dead PTY is a harmless no-op, not an error.
+        surface.write_bytes(b"must not reach a dead host").unwrap();
+        surface.write_paste(b"must not reach a dead host").unwrap();
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -332,6 +332,37 @@ impl TerminalLifecycle {
     }
 }
 
+/// Per-terminal policy for the terminal's views when its hosted process
+/// exits. `Close` (the default) detaches every view and drops the runtime
+/// surface, leaving only the durable exit receipt. `Keep` retains the tabs
+/// and the live screen surface next to that receipt while the daemon runs;
+/// after a daemon restart the in-memory VT is gone, so a kept-exited
+/// terminal degrades to the normal detach during reconciliation.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TerminalOnExit {
+    #[default]
+    Close,
+    Keep,
+}
+
+impl TerminalOnExit {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Close => "close",
+            Self::Keep => "keep",
+        }
+    }
+
+    pub fn parse(value: &str) -> anyhow::Result<Self> {
+        match value {
+            "close" => Ok(Self::Close),
+            "keep" => Ok(Self::Keep),
+            other => anyhow::bail!("invalid terminal on-exit policy {other:?}"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RegistryTerminal {
     pub terminal_id: String,
@@ -340,6 +371,10 @@ pub struct RegistryTerminal {
     pub lifecycle: TerminalLifecycle,
     pub launch_spec: Value,
     pub exit: Option<Value>,
+    /// Defaults on decode so durable JSON written before the policy existed
+    /// (stored intents, journal changes) keeps deserializing as close.
+    #[serde(default)]
+    pub on_exit: TerminalOnExit,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -2561,6 +2596,15 @@ impl WorkspaceRegistry {
             migrate_terminal_hosts_to_session_ownership(&tx)?;
             tx.commit()?;
         }
+        // Probe the actual table shape instead of the stamped schema number:
+        // the column ships without a version bump so older builds keep opening
+        // this registry (they omit the column on writes and the durable
+        // default applies).
+        if !terminal_hosts_has_on_exit_column(&connection)? {
+            let tx = connection.unchecked_transaction()?;
+            migrate_terminal_hosts_add_on_exit(&tx)?;
+            tx.commit()?;
+        }
         if migrate_existing_registry {
             connection.execute_batch("PRAGMA foreign_keys=ON;")?;
             let violation = connection
@@ -2791,7 +2835,7 @@ impl WorkspaceRegistry {
         let revision = current_terminal_revision(&self.connection)?;
         let mut statement = self.connection.prepare(
             "SELECT terminal_id, workspace_key, incarnation, lifecycle,
-                    launch_spec_json, exit_json
+                    launch_spec_json, exit_json, on_exit
              FROM terminal_hosts
              WHERE lifecycle != 'tombstoned'
              ORDER BY created_revision ASC, terminal_id ASC",
@@ -2804,6 +2848,7 @@ impl WorkspaceRegistry {
                 row.get::<_, String>(3)?,
                 row.get::<_, String>(4)?,
                 row.get::<_, Option<String>>(5)?,
+                row.get::<_, String>(6)?,
             ))
         })?;
         let terminals =
@@ -2915,14 +2960,15 @@ impl WorkspaceRegistry {
         tx.execute(
             "INSERT INTO terminal_hosts(
                terminal_id, workspace_key, incarnation, lifecycle, launch_spec_json,
-               exit_json, created_revision, updated_revision, deleted_revision
-             ) VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?7, ?8)
+               exit_json, on_exit, created_revision, updated_revision, deleted_revision
+             ) VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?8, ?9)
              ON CONFLICT(terminal_id) DO UPDATE SET
                workspace_key=excluded.workspace_key,
                incarnation=excluded.incarnation,
                lifecycle=excluded.lifecycle,
                launch_spec_json=excluded.launch_spec_json,
                exit_json=excluded.exit_json,
+               on_exit=excluded.on_exit,
                updated_revision=excluded.updated_revision,
                deleted_revision=excluded.deleted_revision",
             params![
@@ -2932,6 +2978,7 @@ impl WorkspaceRegistry {
                 terminal.lifecycle.as_str(),
                 launch_spec_json,
                 exit_json,
+                terminal.on_exit.as_str(),
                 sqlite_revision,
                 (terminal.lifecycle == TerminalLifecycle::Tombstoned).then_some(sqlite_revision),
             ],
@@ -3915,6 +3962,7 @@ fn create_terminal_schema(transaction: &Transaction<'_>) -> anyhow::Result<()> {
            ),
            launch_spec_json TEXT NOT NULL,
            exit_json TEXT,
+           on_exit TEXT NOT NULL DEFAULT 'close' CHECK(on_exit IN ('close','keep')),
            created_revision INTEGER NOT NULL,
            updated_revision INTEGER NOT NULL,
            deleted_revision INTEGER
@@ -3958,6 +4006,27 @@ fn terminal_hosts_has_workspace_foreign_key(connection: &Connection) -> anyhow::
         }
     }
     Ok(false)
+}
+
+fn terminal_hosts_has_on_exit_column(connection: &Connection) -> anyhow::Result<bool> {
+    let mut statement = connection.prepare("PRAGMA table_info(terminal_hosts)")?;
+    let mut rows = statement.query([])?;
+    while let Some(row) = rows.next()? {
+        if row.get::<_, String>(1)? == "on_exit" {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+/// Add the per-terminal exit policy to registries created before the column
+/// existed. Every pre-existing terminal keeps today's close-on-exit behavior.
+fn migrate_terminal_hosts_add_on_exit(transaction: &Transaction<'_>) -> anyhow::Result<()> {
+    transaction.execute_batch(
+        "ALTER TABLE terminal_hosts ADD COLUMN on_exit TEXT NOT NULL DEFAULT 'close'
+           CHECK(on_exit IN ('close','keep'));",
+    )?;
+    Ok(())
 }
 
 /// Remove the legacy ownership edge from terminals to workspaces. The
@@ -4688,6 +4757,9 @@ fn validate_terminal_transition(
     {
         anyhow::bail!("terminal launch spec cannot change during a live incarnation");
     }
+    if existing.on_exit != desired.on_exit {
+        anyhow::bail!("terminal on-exit policy is fixed at reservation");
+    }
     Ok(())
 }
 
@@ -4705,10 +4777,10 @@ fn require_live_workspace(connection: &Connection, workspace_key: &str) -> anyho
     Ok(())
 }
 
-type StoredTerminal = (String, String, Option<String>, String, String, Option<String>);
+type StoredTerminal = (String, String, Option<String>, String, String, Option<String>, String);
 
 fn terminal_from_stored(stored: StoredTerminal) -> anyhow::Result<RegistryTerminal> {
-    let (terminal_id, workspace_key, incarnation, lifecycle, launch_spec, exit) = stored;
+    let (terminal_id, workspace_key, incarnation, lifecycle, launch_spec, exit, on_exit) = stored;
     Ok(RegistryTerminal {
         terminal_id,
         workspace_key,
@@ -4716,6 +4788,7 @@ fn terminal_from_stored(stored: StoredTerminal) -> anyhow::Result<RegistryTermin
         lifecycle: TerminalLifecycle::parse(&lifecycle)?,
         launch_spec: serde_json::from_str(&launch_spec)?,
         exit: exit.map(|value| serde_json::from_str(&value)).transpose()?,
+        on_exit: TerminalOnExit::parse(&on_exit)?,
     })
 }
 
@@ -4726,11 +4799,19 @@ fn read_terminal(
     let stored = connection
         .query_row(
             "SELECT terminal_id, workspace_key, incarnation, lifecycle,
-                    launch_spec_json, exit_json
+                    launch_spec_json, exit_json, on_exit
              FROM terminal_hosts WHERE terminal_id = ?1",
             [terminal_id],
             |row| {
-                Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?, row.get(5)?))
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                    row.get(5)?,
+                    row.get(6)?,
+                ))
             },
         )
         .optional()?;

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/public_projection_store.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/public_projection_store.rs
@@ -599,6 +599,7 @@ mod tests {
                                 lifecycle: TerminalLifecycle::Launching,
                                 launch_spec: json!({}),
                                 exit: None,
+                                on_exit: TerminalOnExit::Close,
                             },
                         },
                         ResourceChange::UpsertTab(RegistryTab {

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/resource_store.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/resource_store.rs
@@ -2394,14 +2394,15 @@ fn upsert_resource_terminal(
     transaction.execute(
         "INSERT INTO terminal_hosts(
            terminal_id, workspace_key, incarnation, lifecycle, launch_spec_json,
-           exit_json, created_revision, updated_revision, deleted_revision
-         ) VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?7, ?8)
+           exit_json, on_exit, created_revision, updated_revision, deleted_revision
+         ) VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?8, ?9)
          ON CONFLICT(terminal_id) DO UPDATE SET
            workspace_key=excluded.workspace_key,
            incarnation=excluded.incarnation,
            lifecycle=excluded.lifecycle,
            launch_spec_json=excluded.launch_spec_json,
            exit_json=excluded.exit_json,
+           on_exit=excluded.on_exit,
            updated_revision=excluded.updated_revision,
            deleted_revision=excluded.deleted_revision",
         params![
@@ -2411,6 +2412,7 @@ fn upsert_resource_terminal(
             terminal.lifecycle.as_str(),
             launch_spec,
             exit,
+            terminal.on_exit.as_str(),
             revision,
             (terminal.lifecycle == TerminalLifecycle::Tombstoned).then_some(revision),
         ],

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/tests.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/tests.rs
@@ -1179,6 +1179,7 @@ fn terminal(id: &str, workspace_key: &str) -> RegistryTerminal {
         lifecycle: TerminalLifecycle::Launching,
         launch_spec: json!({"command":["/bin/zsh"],"cwd":"/tmp","rows":24,"cols":80}),
         exit: None,
+        on_exit: TerminalOnExit::Close,
     }
 }
 
@@ -3525,6 +3526,154 @@ fn first_exit_metadata_wins_and_exited_ids_cannot_be_relaunched() {
         registry.terminal_record(TERMINAL_ONE).unwrap().unwrap().lifecycle,
         TerminalLifecycle::Exited
     );
+}
+
+#[test]
+fn terminal_on_exit_policy_round_trips_and_is_fixed_at_reservation() {
+    let mut registry = WorkspaceRegistry::in_memory("test").unwrap();
+    seed_workspace(&mut registry, "one");
+    let mut keep = terminal(TERMINAL_ONE, "one");
+    keep.on_exit = TerminalOnExit::Keep;
+    registry
+        .commit_terminal(
+            &WorkspaceMutation::new("reserve-keep", "browser").unwrap(),
+            &json!({"op":"reserve-terminal","terminal_id":TERMINAL_ONE}),
+            None,
+            Some(0),
+            "terminal-reserved",
+            &keep,
+            &json!({"terminal_id":TERMINAL_ONE}),
+        )
+        .unwrap();
+    assert_eq!(
+        registry.terminal_record(TERMINAL_ONE).unwrap().unwrap().on_exit,
+        TerminalOnExit::Keep
+    );
+    assert_eq!(registry.terminal_snapshot().unwrap().terminals[0].on_exit, TerminalOnExit::Keep);
+
+    let mut repolicied = keep.clone();
+    repolicied.lifecycle = TerminalLifecycle::Adopting;
+    repolicied.incarnation = Some(INCARNATION_ONE.into());
+    repolicied.on_exit = TerminalOnExit::Close;
+    let error = registry
+        .commit_terminal(
+            &WorkspaceMutation::new("adopt-repolicied", "daemon").unwrap(),
+            &json!({"op":"adopt-terminal","terminal_id":TERMINAL_ONE}),
+            None,
+            Some(1),
+            "terminal-adopting",
+            &repolicied,
+            &json!({"terminal_id":TERMINAL_ONE}),
+        )
+        .unwrap_err();
+    assert!(error.to_string().contains("on-exit policy is fixed at reservation"));
+
+    let mut adopting = keep;
+    adopting.lifecycle = TerminalLifecycle::Adopting;
+    adopting.incarnation = Some(INCARNATION_ONE.into());
+    registry
+        .commit_terminal(
+            &WorkspaceMutation::new("adopt-keep", "daemon").unwrap(),
+            &json!({"op":"adopt-terminal","terminal_id":TERMINAL_ONE}),
+            None,
+            Some(1),
+            "terminal-adopting",
+            &adopting,
+            &json!({"terminal_id":TERMINAL_ONE}),
+        )
+        .unwrap();
+    assert_eq!(
+        registry.terminal_record(TERMINAL_ONE).unwrap().unwrap().on_exit,
+        TerminalOnExit::Keep
+    );
+}
+
+/// Registries created before the exit-policy column existed gain it on open;
+/// every pre-existing terminal keeps today's close-on-exit behavior.
+#[test]
+fn registries_created_before_on_exit_gain_the_column_with_close_default() {
+    let root = temp_root("on-exit-column-migration");
+    {
+        let mut registry = WorkspaceRegistry::open(&root, "session").unwrap();
+        seed_workspace(&mut registry, "one");
+        let mut keep = terminal(TERMINAL_ONE, "one");
+        keep.on_exit = TerminalOnExit::Keep;
+        registry
+            .commit_terminal(
+                &WorkspaceMutation::new("reserve-keep", "browser").unwrap(),
+                &json!({"op":"reserve-terminal","terminal_id":TERMINAL_ONE}),
+                None,
+                Some(0),
+                "terminal-reserved",
+                &keep,
+                &json!({"terminal_id":TERMINAL_ONE}),
+            )
+            .unwrap();
+    }
+
+    // Recreate the pre-policy table shape: same rows, no on_exit column.
+    let session_dir = root.join(session_storage_component("session"));
+    let connection = Connection::open(session_dir.join("workspace-registry.sqlite3")).unwrap();
+    connection
+        .execute_batch(
+            "PRAGMA foreign_keys=OFF;
+             DROP INDEX IF EXISTS terminal_incarnation;
+             DROP INDEX IF EXISTS live_terminals_by_workspace;
+             CREATE TABLE terminal_hosts_pre_on_exit (
+               terminal_id TEXT PRIMARY KEY NOT NULL,
+               workspace_key TEXT NOT NULL,
+               incarnation TEXT,
+               lifecycle TEXT NOT NULL CHECK(
+                 lifecycle IN ('launching','adopting','running','exited','tombstoned')
+               ),
+               launch_spec_json TEXT NOT NULL,
+               exit_json TEXT,
+               created_revision INTEGER NOT NULL,
+               updated_revision INTEGER NOT NULL,
+               deleted_revision INTEGER
+             );
+             INSERT INTO terminal_hosts_pre_on_exit(
+               terminal_id, workspace_key, incarnation, lifecycle, launch_spec_json,
+               exit_json, created_revision, updated_revision, deleted_revision
+             )
+             SELECT terminal_id, workspace_key, incarnation, lifecycle, launch_spec_json,
+                    exit_json, created_revision, updated_revision, deleted_revision
+             FROM terminal_hosts;
+             DROP TABLE terminal_hosts;
+             ALTER TABLE terminal_hosts_pre_on_exit RENAME TO terminal_hosts;
+             PRAGMA foreign_keys=ON;",
+        )
+        .unwrap();
+    drop(connection);
+
+    let mut registry = WorkspaceRegistry::open(&root, "session").unwrap();
+    assert_eq!(
+        registry.terminal_record(TERMINAL_ONE).unwrap().unwrap().on_exit,
+        TerminalOnExit::Close
+    );
+
+    // The migrated column stores and reloads a fresh keep reservation.
+    let mut keep = terminal(TERMINAL_TWO, "one");
+    keep.on_exit = TerminalOnExit::Keep;
+    registry
+        .commit_terminal(
+            &WorkspaceMutation::new("reserve-keep-two", "browser").unwrap(),
+            &json!({"op":"reserve-terminal","terminal_id":TERMINAL_TWO}),
+            None,
+            Some(1),
+            "terminal-reserved",
+            &keep,
+            &json!({"terminal_id":TERMINAL_TWO}),
+        )
+        .unwrap();
+    drop(registry);
+    let registry = WorkspaceRegistry::open(&root, "session").unwrap();
+    assert_eq!(
+        registry.terminal_record(TERMINAL_TWO).unwrap().unwrap().on_exit,
+        TerminalOnExit::Keep
+    );
+    drop(registry);
+    fs::remove_dir_all(root).unwrap();
 }
 
 #[test]

--- a/cmux-tui/crates/cmux-tui/src/cli.rs
+++ b/cmux-tui/crates/cmux-tui/src/cli.rs
@@ -513,8 +513,8 @@ USAGE
   cmux workspace list
   cmux workspace create [--name <value>] [--empty] [--correlation-key <value>] [--expected-revision <revision>]
   cmux workspace <selector> show|rename|move|focus|close
-  cmux workspace <selector> run [--correlation-key <value>] -- <argv...>
-  cmux workspace <selector> run [--correlation-key <value>] shell <script>
+  cmux workspace <selector> run [--on-exit <close|keep>] [--correlation-key <value>] -- <argv...>
+  cmux workspace <selector> run [--on-exit <close|keep>] [--correlation-key <value>] shell <script>
   cmux workspace <selector> layout apply [OPTIONS]
   cmux workspace <selector> screen ...
   Nested panes support split --right or --down.
@@ -545,7 +545,7 @@ USAGE
   cmux pane <selector> zoom [--enabled <bool>]
   cmux pane <selector> split ratio set --split <id> --ratio <value>
   cmux pane <selector> viewport width set --columns <value>
-  cmux pane <selector> run [--correlation-key <value>] -- <argv...>
+  cmux pane <selector> run [--on-exit <close|keep>] [--correlation-key <value>] -- <argv...>
   cmux pane <selector> tab ...
 ";
 

--- a/cmux-tui/crates/cmux-tui/src/cli/command.rs
+++ b/cmux-tui/crates/cmux-tui/src/cli/command.rs
@@ -2106,6 +2106,19 @@ fn run_params(
     if let Some(name) = flags.take("name") {
         params.insert("name".into(), Value::String(name));
     }
+    if let Some(policy) = flags.take("on-exit") {
+        match policy.as_str() {
+            "close" | "keep" => {
+                params.insert("on_exit".into(), Value::String(policy));
+            }
+            "shell" => {
+                return Err(UsageError::new("--on-exit shell is not supported yet"));
+            }
+            _ => {
+                return Err(UsageError::new("--on-exit must be close or keep"));
+            }
+        }
+    }
     Ok(params)
 }
 
@@ -3462,6 +3475,31 @@ mod tests {
     }
 
     #[test]
+    fn run_on_exit_policy_is_validated_and_forwarded_verbatim() {
+        for scope in [["workspace", "current"], ["pane", "current"]] {
+            let kept = protocol(&[scope[0], scope[1], "run", "--on-exit", "keep", "--", "true"]);
+            assert_eq!(kept.params["on_exit"], "keep");
+
+            let closed = protocol(&[scope[0], scope[1], "run", "--on-exit", "close", "--", "true"]);
+            assert_eq!(closed.params["on_exit"], "close");
+
+            let default = protocol(&[scope[0], scope[1], "run", "--", "true"]);
+            assert!(default.params.get("on_exit").is_none());
+
+            let shell_policy =
+                parse(&strings(&[scope[0], scope[1], "run", "--on-exit", "shell", "--", "true"]));
+            assert!(
+                shell_policy.is_err_and(|error| error.to_string().contains("not supported yet")),
+                "--on-exit shell must be a typed not-yet-supported usage error"
+            );
+            assert!(
+                parse(&strings(&[scope[0], scope[1], "run", "--on-exit", "sh", "--", "true"]))
+                    .is_err()
+            );
+        }
+    }
+
+    #[test]
     fn input_commands_enforce_variant_constraints() {
         const TERMINAL: &str = "term_00000000000000000000000000000008";
         const BROWSER: &str = "browser_00000000000000000000000000000009";
@@ -4001,6 +4039,8 @@ mod tests {
                     "100",
                     "--rows",
                     "40",
+                    "--on-exit",
+                    "keep",
                     "--correlation-key",
                     "create-42",
                     "--",
@@ -4124,6 +4164,8 @@ mod tests {
                     "90",
                     "--rows",
                     "30",
+                    "--on-exit",
+                    "keep",
                     "--correlation-key",
                     "create-42",
                     "--",

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -87,22 +87,6 @@ pub struct TabNotificationView {
 }
 
 impl TreeView {
-    /// Remove pane tabs that cannot be backed by an attached surface.
-    ///
-    /// Remote tree snapshots and surface detach events travel on separate
-    /// streams. Applying this filter before publishing a snapshot keeps the
-    /// renderer from observing a tab whose surface has already been removed.
-    pub fn retain_surfaces(&mut self, surfaces: &HashSet<SurfaceId>) {
-        for workspace in &mut self.workspaces {
-            for screen in &mut workspace.screens {
-                for pane in &mut screen.panes {
-                    pane.tabs.retain(|tab| surfaces.contains(&tab.surface));
-                    pane.active_tab = pane.active_tab.min(pane.tabs.len().saturating_sub(1));
-                }
-            }
-        }
-    }
-
     /// Retain the server's authoritative tab topology, removing only tabs
     /// with explicit detach/retire evidence. The local surface mirror is a
     /// lazy cache and can be empty during startup or reconnect.
@@ -662,29 +646,6 @@ mod tests {
 
         assert_eq!(screen.display_name(0), "0");
         assert_eq!(screen.display_name(9), "9");
-    }
-
-    #[test]
-    fn retain_surfaces_drops_missing_tabs_and_clamps_active_index() {
-        let mut tree = parse_tree(&json!({
-            "workspaces": [{
-                "id": 1, "active": true,
-                "screens": [{
-                    "id": 2, "active": true, "active_pane": 3,
-                    "layout": {"type": "leaf", "pane": 3},
-                    "panes": [{"id": 3, "active_tab": 1, "tabs": [
-                        {"surface": 7, "title": "gone"},
-                        {"surface": 8, "title": "kept"}
-                    ]}]
-                }]
-            }]
-        }));
-
-        tree.retain_surfaces(&HashSet::from([8]));
-
-        let pane = &tree.workspaces[0].screens[0].panes[0];
-        assert_eq!(pane.tabs.iter().map(|tab| tab.surface).collect::<Vec<_>>(), vec![8]);
-        assert_eq!(pane.active_tab, 0);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -650,11 +650,27 @@ mod tests {
 
     #[test]
     fn retain_not_retired_keeps_tabs_when_local_catalog_is_empty() {
-        let mut tree = parse_tree(
-            &json!({"workspaces":[{"id":1,"screens":[{"id":2,"panes":[{"id":3,"tabs":[{"surface":7},{"surface":8}],"active_tab":1}]}]}]}),
-        );
+        // The fixture must be a COMPLETE tree: parse_tree drops
+        // underspecified workspaces/screens, and this test shipped with a
+        // minimal shape that parsed to an empty tree (the panic was masked
+        // in CI by a clippy failure earlier in the same job).
+        let mut tree = parse_tree(&json!({
+            "workspaces": [{
+                "id": 1, "active": true,
+                "screens": [{
+                    "id": 2, "active": true, "active_pane": 3,
+                    "layout": {"type": "leaf", "pane": 3},
+                    "panes": [{"id": 3, "active_tab": 1, "tabs": [
+                        {"surface": 7, "title": "a"},
+                        {"surface": 8, "title": "b"}
+                    ]}]
+                }]
+            }]
+        }));
         tree.retain_not_retired(&HashSet::new());
-        assert_eq!(tree.workspaces[0].screens[0].panes[0].tabs.len(), 2);
+        let pane = &tree.workspaces[0].screens[0].panes[0];
+        assert_eq!(pane.tabs.len(), 2);
+        assert_eq!(pane.active_tab, 1);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/tests/terminal_host_recovery.rs
+++ b/cmux-tui/crates/cmux-tui/tests/terminal_host_recovery.rs
@@ -409,6 +409,267 @@ fn short_lived_resource_terminal_journals_initial_output_after_its_topology() {
 }
 
 #[test]
+fn keep_on_exit_retains_tab_and_final_screen_until_close_and_degrades_on_restart() {
+    let mut harness = RecoveryHarness::start("keep-on-exit");
+    let marker = format!("keep-on-exit-marker-{}", std::process::id());
+    let created = resource_request(
+        &harness.socket,
+        "keep-workspace",
+        "workspace.create",
+        serde_json::json!({
+            "machine":"current",
+            "session":"current",
+            "name":"Keep on exit",
+            "initial_content":"empty",
+        }),
+        Some("keep-workspace"),
+    );
+    let workspace = created["value"]["workspace_id"].as_str().unwrap();
+
+    // The catalog constrains on_exit to its supported enum values.
+    let unsupported = request_response(
+        &harness.socket,
+        serde_json::json!({
+            "protocol":"cmux.protocol/2",
+            "type":"request",
+            "id":"keep-run-unsupported",
+            "operation":"workspace.run",
+            "idempotency_key":"keep-run-unsupported",
+            "params":{
+                "machine":"current",
+                "session":"current",
+                "workspace":workspace,
+                "argv":["/bin/sh","-c","exit 0"],
+                "on_exit":"shell",
+            },
+        }),
+    );
+    assert_eq!(unsupported["ok"], false, "on_exit shell must be rejected: {unsupported}");
+    assert_eq!(unsupported["error"]["code"], "validation.invalid");
+
+    let run = resource_request(
+        &harness.socket,
+        "keep-run",
+        "workspace.run",
+        serde_json::json!({
+            "machine":"current",
+            "session":"current",
+            "workspace":workspace,
+            "argv":["/bin/sh","-c",format!("printf '{marker}\\n'; exit 9")],
+            "on_exit":"keep",
+        }),
+        Some("keep-run"),
+    );
+    let path = run["value"].clone();
+    let terminal = path["terminal_id"].as_str().unwrap().to_string();
+    let tab = path["tab_id"].as_str().unwrap().to_string();
+    let waited = resource_request(
+        &harness.socket,
+        "keep-wait",
+        "terminal.wait_exit",
+        serde_json::json!({
+            "machine":"current",
+            "session":"current",
+            "terminal":terminal,
+            "timeout_ms":"10000",
+        }),
+        None,
+    );
+    assert_eq!(waited["state"], "exited");
+    assert_eq!(waited["outcome"], serde_json::json!({"kind":"exit","code":9}));
+
+    // The exit is latched, but the tab and the final screen stay live.
+    resource_request(
+        &harness.socket,
+        "keep-tab-show",
+        "tab.get",
+        serde_json::json!({"machine":"current","session":"current","tab":tab}),
+        None,
+    );
+    let screen = resource_request(
+        &harness.socket,
+        "keep-screen-read",
+        "terminal.screen.read",
+        serde_json::json!({"machine":"current","session":"current","terminal":terminal}),
+        None,
+    );
+    assert!(
+        screen["text"].as_str().unwrap().contains(&marker),
+        "kept terminal lost its final screen: {screen}"
+    );
+    let history = resource_request(
+        &harness.socket,
+        "keep-history-read",
+        "terminal.history.read",
+        serde_json::json!({
+            "machine":"current",
+            "session":"current",
+            "terminal":terminal,
+            "limit":100,
+        }),
+        None,
+    );
+    assert!(history["rows"].is_array(), "kept terminal lost its history: {history}");
+
+    // Input to the dead PTY is a harmless no-op, not an error.
+    resource_request(
+        &harness.socket,
+        "keep-dead-write",
+        "terminal.input.write",
+        serde_json::json!({
+            "machine":"current",
+            "session":"current",
+            "terminal":terminal,
+            "text":"ignored\n",
+        }),
+        Some("keep-dead-write"),
+    );
+    let latched = resource_request(
+        &harness.socket,
+        "keep-wait-again",
+        "terminal.wait_exit",
+        serde_json::json!({
+            "machine":"current",
+            "session":"current",
+            "terminal":terminal,
+            "timeout_ms":"0",
+        }),
+        None,
+    );
+    assert_eq!(latched, waited, "kept terminal re-minted its exit receipt");
+
+    // A daemon restart drops the in-memory VT, so the kept terminal degrades
+    // to the normal detach while the durable receipt survives.
+    harness.sigkill();
+    harness.restart();
+    let after_restart = resource_request(
+        &harness.socket,
+        "keep-wait-restarted",
+        "terminal.wait_exit",
+        serde_json::json!({
+            "machine":"current",
+            "session":"current",
+            "terminal":terminal,
+            "timeout_ms":"5000",
+        }),
+        None,
+    );
+    assert_eq!(after_restart["state"], "exited");
+    assert_eq!(after_restart["outcome"], serde_json::json!({"kind":"exit","code":9}));
+    let detached_read = request_response(
+        &harness.socket,
+        serde_json::json!({
+            "protocol":"cmux.protocol/2",
+            "type":"request",
+            "id":"keep-screen-read-restarted",
+            "operation":"terminal.screen.read",
+            "params":{"machine":"current","session":"current","terminal":terminal},
+        }),
+    );
+    assert_eq!(
+        detached_read["ok"], false,
+        "restart must degrade the kept screen to a detached receipt: {detached_read}"
+    );
+    let detached_tab = request_response(
+        &harness.socket,
+        serde_json::json!({
+            "protocol":"cmux.protocol/2",
+            "type":"request",
+            "id":"keep-tab-show-restarted",
+            "operation":"tab.get",
+            "params":{"machine":"current","session":"current","tab":tab},
+        }),
+    );
+    assert_eq!(detached_tab["ok"], false, "restart left a kept tab behind: {detached_tab}");
+}
+
+#[test]
+fn keep_on_exit_terminal_close_cleans_up_the_live_tab_and_surface() {
+    let harness = RecoveryHarness::start("keep-on-exit-close");
+    let run = resource_request(
+        &harness.socket,
+        "keep-close-run",
+        "workspace.create",
+        serde_json::json!({
+            "machine":"current",
+            "session":"current",
+            "name":"Keep close",
+            "initial_content":"terminal",
+        }),
+        Some("keep-close-workspace"),
+    );
+    let workspace = run["value"]["workspace_id"].as_str().unwrap();
+    let run = resource_request(
+        &harness.socket,
+        "keep-close-run-terminal",
+        "pane.run",
+        serde_json::json!({
+            "machine":"current",
+            "session":"current",
+            "workspace":workspace,
+            "screen":"current",
+            "pane":"current",
+            "argv":["/bin/sh","-c","exit 0"],
+            "on_exit":"keep",
+        }),
+        Some("keep-close-run-terminal"),
+    );
+    let path = run["value"].clone();
+    let terminal = path["terminal_id"].as_str().unwrap().to_string();
+    let tab = path["tab_id"].as_str().unwrap().to_string();
+    resource_request(
+        &harness.socket,
+        "keep-close-wait",
+        "terminal.wait_exit",
+        serde_json::json!({
+            "machine":"current",
+            "session":"current",
+            "terminal":terminal,
+            "timeout_ms":"10000",
+        }),
+        None,
+    );
+    resource_request(
+        &harness.socket,
+        "keep-close-tab-show",
+        "tab.get",
+        serde_json::json!({"machine":"current","session":"current","tab":tab}),
+        None,
+    );
+
+    // The existing close path cleans up the kept-exited terminal fully.
+    resource_request(
+        &harness.socket,
+        "keep-close-close",
+        "terminal.close",
+        serde_json::json!({"machine":"current","session":"current","terminal":terminal}),
+        Some("keep-close-close"),
+    );
+    let closed_tab = request_response(
+        &harness.socket,
+        serde_json::json!({
+            "protocol":"cmux.protocol/2",
+            "type":"request",
+            "id":"keep-close-tab-closed",
+            "operation":"tab.get",
+            "params":{"machine":"current","session":"current","tab":tab},
+        }),
+    );
+    assert_eq!(closed_tab["ok"], false, "terminal close left the kept tab behind: {closed_tab}");
+    let closed_read = request_response(
+        &harness.socket,
+        serde_json::json!({
+            "protocol":"cmux.protocol/2",
+            "type":"request",
+            "id":"keep-close-screen-read",
+            "operation":"terminal.screen.read",
+            "params":{"machine":"current","session":"current","terminal":terminal},
+        }),
+    );
+    assert_eq!(closed_read["ok"], false, "terminal close left the kept screen live: {closed_read}");
+}
+
+#[test]
 fn hosted_exit_detaches_existing_and_later_render_streams() {
     let harness = RecoveryHarness::start("hosted-exit-detaches-render");
     let marker = format!("hosted-exit-marker-{}", std::process::id());

--- a/cmux-tui/dist/scripts/package_npm_artifact.py
+++ b/cmux-tui/dist/scripts/package_npm_artifact.py
@@ -14,7 +14,12 @@ from package_contract import PackageContractError, npm_executable_files, validat
 
 PACKAGE_ROOT = "npm-packages"
 MAX_MEMBERS = 1_024
-MAX_EXPANDED_BYTES = 512 * 1024 * 1024
+# Tar-bomb guard on the AGGREGATE four-platform archive, not a product
+# size budget (each install downloads exactly one platform package via
+# optionalDependencies). 512 MiB became too small once the Rust relay
+# binaries (chatmux-relay, cmux-relay) started riding every platform
+# package.
+MAX_EXPANDED_BYTES = 768 * 1024 * 1024
 
 
 def verify_executables(packages_dir: Path) -> None:

--- a/cmux-tui/scripts/smoke-tui.py
+++ b/cmux-tui/scripts/smoke-tui.py
@@ -690,17 +690,15 @@ assert has_sgr_parameters(color_output, (48, 5, 236)), color_output[-2000:]
 assert not has_sgr_parameters(color_output, (38, 2, 204, 102, 102)), color_output[-2000:]
 print("indexed color passthrough ok")
 
-inner_osc_query = """python3 - <<'PY'
-import os, select, termios, time, tty
+inner_osc_query = """import os, select, termios, time, tty
 fd = os.open('/dev/tty', os.O_RDWR)
 old = termios.tcgetattr(fd)
 try:
     tty.setraw(fd)
     os.write(fd, b'\\x1b]11;?\\x1b\\\\')
     data = b''
-    # Generous deadline: the shell may still be consuming the pasted
-    # heredoc and the TUI coalesces frames (this raced at 2s, and 8s
-    # still fails on saturated CI runners).
+    # Generous deadline: the TUI coalesces frames and saturated CI
+    # runners stall the reply (this raced at 2s and again at 8s).
     end = time.monotonic() + 30
     while time.monotonic() < end and not (data.endswith(b'\\x1b\\\\') or data.endswith(b'\\x07')):
         r, _, _ = select.select([fd], [], [], max(0, end - time.monotonic()))
@@ -711,9 +709,18 @@ finally:
     termios.tcsetattr(fd, termios.TCSADRAIN, old)
     os.close(fd)
 print(data.decode('ascii', 'ignore').replace('\\x1b', '<ESC>').replace('\\x07', '<BEL>'))
-PY
 """
-write_all(fd, inner_osc_query.replace("\n", "\r").encode())
+# Never PASTE the script through the pty: on saturated CI runners a
+# multi-line heredoc flood drops bytes in transit (observed as a
+# corrupted `tcsetattr` on screen), and no deadline fixes a mangled
+# program. The harness shares a filesystem with the TUI's shell, so
+# write the script to disk and type only the short invocation.
+with tempfile.NamedTemporaryFile(
+    "w", suffix="-osc-query.py", delete=False
+) as inner_script:
+    inner_script.write(inner_osc_query)
+    inner_script_path = inner_script.name
+write_all(fd, f"python3 {inner_script_path}\r".encode())
 wait_screen_contains(surface_id, "1313/1414/1515")
 print("inner OSC 11 query receives seeded background ok")
 write_all(fd, b"\x03")

--- a/cmux-tui/spec/cli.md
+++ b/cmux-tui/spec/cli.md
@@ -211,6 +211,12 @@ cmux workspace current run shell 'cargo test && printf ready'
 
 The client never reads or expands `$SHELL`.
 
+Both run forms accept `--on-exit <close|keep>`. `close` (the default)
+detaches every view when the process exits and leaves only the durable exit
+receipt. `keep` retains the tab and the final screen next to that receipt
+until the terminal is closed; after a daemon restart a kept-exited terminal
+degrades to the normal detach.
+
 ## Resource paths
 
 ```text

--- a/cmux-tui/spec/resource-operations-v2.json
+++ b/cmux-tui/spec/resource-operations-v2.json
@@ -7905,6 +7905,17 @@
             },
             "description": "When present, exact name bytes are preserved, including empty, whitespace, and Unicode."
           },
+          "on_exit": {
+            "required": false,
+            "type": {
+              "kind": "enum",
+              "values": [
+                "close",
+                "keep"
+              ]
+            },
+            "description": "Policy for the terminal's views when its process exits. close (the default) detaches every view and leaves only the durable exit receipt; keep retains the tab and the final screen next to that receipt until the terminal is closed or the daemon restarts."
+          },
           "cols": {
             "required": false,
             "type": {
@@ -12344,6 +12355,17 @@
               "name": "string"
             },
             "description": "When present, exact name bytes are preserved, including empty, whitespace, and Unicode."
+          },
+          "on_exit": {
+            "required": false,
+            "type": {
+              "kind": "enum",
+              "values": [
+                "close",
+                "keep"
+              ]
+            },
+            "description": "Policy for the terminal's views when its process exits. close (the default) detaches every view and leaves only the durable exit receipt; keep retains the tab and the final screen next to that receipt until the terminal is closed or the daemon restarts."
           },
           "cols": {
             "required": false,


### PR DESCRIPTION
Adds the first per-terminal exit policy to hosted terminals, requested for chatmux's cmux-tui-native background jobs (run tabs must be able to outlive their process).

- `workspace <sel> run --on-exit close|keep` (and `pane run`): `close` is the default and is byte-identical to today. `keep` commits the IDENTICAL exit latch (lifecycle→exited, exit_json, snapshot, terminal.exited journal record, first-writer-wins) but skips the detach projection while the runtime surface is alive: the tab stays, screen/history reads keep working, input to the dead PTY is a silent no-op, and `terminal close` cleans up through the unchanged close path.
- Live-vs-restart discriminator is "runtime present in the terminal catalog": one centralized gate in `detach_exited_terminal_topology` serves every reconciliation caller, and a daemon restart (in-memory VT gone) degrades a kept terminal to the normal detach, documented in comments.
- Persistence: `terminal_hosts.on_exit` column (CHECK close|keep, DEFAULT close) with a guarded in-place migration; `RegistryTerminal.on_exit` immutable after reservation; creation fingerprints include the field only when a request names it, so pre-upgrade stored intents keep their digests.
- Spec: `on_exit` enum on `workspace.run`/`pane.run` in resource-operations-v2.json + regenerated binding catalogs; CLI flag with validation + spec/cli.md docs.
- `--on-exit shell` (respawn the user shell into the same tab) is deliberately NOT in this PR: the respawn retargets a live surface to a new host incarnation, which touches per-incarnation journal-generation attribution and multiview-shared runtime Arcs. The CLI rejects it with a typed usage error and the wire enum rejects it as validation.invalid. It ships as its own PR with a widening migration for the CHECK constraint.

Tests: two new real-daemon recovery tests (keep retains tab + readable screen + no-op input + restart degrade; keep + terminal.close full cleanup), registry round-trip/migration/reservation-immutability tests, CLI validation + catalog vectors. cargo fmt/clippy clean; spec inventory + SDK schema + resource-api boundary checks green. Known pre-existing failures (serve_paused_*_socket_parent, SUN_LEN) fail identically on clean main in this environment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790331397&installation_model_id=21920&pr_number=10839&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10839&signature=9b8be6fce209d7078c69bcab74f950ca76fe463e4fc71907b310937493bc91cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `--on-exit close|keep` to workspace and pane run commands.
  - `keep` preserves the terminal tab, final screen, history, and exit status after process exit.
  - `close` remains the default, detaching terminal views while retaining the exit status.
  - Kept terminals can be explicitly closed and safely accept input after exit.

- **Bug Fixes**
  - Improved recovery behavior for kept terminals after daemon restarts.
  - Existing registries migrate automatically with backward-compatible defaults.
  - Invalid exit policies are rejected with clear usage errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->