### PR TITLE
iOS: support workspace and pane deeplinks

### DIFF
--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxNavigationURLRequest.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxNavigationURLRequest.swift
@@ -1,0 +1,252 @@
+public import Foundation
+
+/// Errors produced while parsing a cmux workspace navigation URL.
+public enum CmxNavigationURLParseError: Error, Equatable, Sendable {
+    /// The URL has a recognized navigation route but an invalid shape.
+    case unsupportedURLShape
+    /// One of the UUID route components is malformed.
+    case invalidIdentifier(String)
+}
+
+/// A parsed `workspace`, `pane`, or `surface` navigation URL.
+///
+/// The grammar is shared by macOS and iOS so links emitted by one app target
+/// have one parser and one set of validation rules. Callers provide the URL
+/// schemes registered by their app target; an unsupported scheme is ignored
+/// rather than treated as a malformed navigation request.
+public struct CmxNavigationURLRequest: Equatable, Sendable {
+    /// The destination encoded by a navigation URL.
+    public enum Target: Equatable, Sendable {
+        /// Open a workspace.
+        case workspace(UUID)
+        /// Open the selected surface in a workspace pane.
+        case pane(workspaceId: UUID, paneId: UUID)
+        /// Open a specific surface in a workspace.
+        case surface(workspaceId: UUID, surfaceId: UUID)
+    }
+
+    /// The URL delivered by the operating system.
+    public let originalURL: URL
+    /// The route destination.
+    public let target: Target
+    /// Optional restart-stable workspace identity carried by durable links.
+    public let stableFallbackWorkspaceId: UUID?
+    /// Optional restart-stable surface identity carried by durable links.
+    public let stableFallbackSurfaceId: UUID?
+
+    /// Creates a parsed navigation request.
+    /// - Parameters:
+    ///   - originalURL: The source URL.
+    ///   - target: The route destination.
+    ///   - stableFallbackWorkspaceId: Optional stable workspace fallback.
+    ///   - stableFallbackSurfaceId: Optional stable surface fallback.
+    public init(
+        originalURL: URL,
+        target: Target,
+        stableFallbackWorkspaceId: UUID? = nil,
+        stableFallbackSurfaceId: UUID? = nil
+    ) {
+        self.originalURL = originalURL
+        self.target = target
+        self.stableFallbackWorkspaceId = stableFallbackWorkspaceId
+        self.stableFallbackSurfaceId = stableFallbackSurfaceId
+    }
+
+    /// Parses a URL when its scheme belongs to the caller's active app target.
+    /// - Parameters:
+    ///   - url: The URL to parse.
+    ///   - supportedSchemes: Schemes registered by the caller. Comparison is
+    ///     case-insensitive.
+    /// - Returns: `success(nil)` for another cmux route or unsupported scheme,
+    ///   a request for a recognized route, or a validation error.
+    public static func parse(
+        _ url: URL,
+        supportedSchemes: Set<String>
+    ) -> Result<CmxNavigationURLRequest?, CmxNavigationURLParseError> {
+        guard isSupportedScheme(url.scheme, supportedSchemes: supportedSchemes) else {
+            return .success(nil)
+        }
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return .failure(.unsupportedURLShape)
+        }
+
+        let route = routeComponents(from: components)
+        guard route.first?.lowercased() == "workspace" else {
+            return .success(nil)
+        }
+
+        guard components.user == nil,
+              components.password == nil,
+              components.port == nil,
+              components.percentEncodedFragment == nil else {
+            return .failure(.unsupportedURLShape)
+        }
+        guard route.count == 2 || route.count == 4 else {
+            return .failure(.unsupportedURLShape)
+        }
+        guard let workspaceId = UUID(uuidString: route[1]) else {
+            return .failure(.invalidIdentifier("workspace"))
+        }
+
+        if route.count == 2 {
+            switch parseStableFallback(from: components, allowedNames: ["stable_workspace_id"]) {
+            case .success(let fallback):
+                return .success(
+                    CmxNavigationURLRequest(
+                        originalURL: url,
+                        target: .workspace(workspaceId),
+                        stableFallbackWorkspaceId: fallback?.workspaceId,
+                        stableFallbackSurfaceId: fallback?.surfaceId
+                    )
+                )
+            case .failure(let error):
+                return .failure(error)
+            }
+        }
+
+        let childKind = route[2].lowercased()
+        guard let childId = UUID(uuidString: route[3]) else {
+            switch childKind {
+            case "pane":
+                return .failure(.invalidIdentifier("pane"))
+            case "surface", "panel":
+                return .failure(.invalidIdentifier("surface"))
+            default:
+                return .failure(.unsupportedURLShape)
+            }
+        }
+
+        switch childKind {
+        case "pane":
+            // Pane links deliberately do not accept query items. Unlike a
+            // surface link, a pane has no stable child fallback identity.
+            guard components.percentEncodedQuery == nil else {
+                return .failure(.unsupportedURLShape)
+            }
+            return .success(
+                CmxNavigationURLRequest(
+                    originalURL: url,
+                    target: .pane(workspaceId: workspaceId, paneId: childId)
+                )
+            )
+        case "surface", "panel":
+            switch parseStableFallback(
+                from: components,
+                allowedNames: ["stable_workspace_id", "stable_surface_id"]
+            ) {
+            case .success(let fallback):
+                return .success(
+                    CmxNavigationURLRequest(
+                        originalURL: url,
+                        target: .surface(workspaceId: workspaceId, surfaceId: childId),
+                        stableFallbackWorkspaceId: fallback?.workspaceId,
+                        stableFallbackSurfaceId: fallback?.surfaceId
+                    )
+                )
+            case .failure(let error):
+                return .failure(error)
+            }
+        default:
+            return .failure(.unsupportedURLShape)
+        }
+    }
+
+    /// Builds a workspace navigation URL.
+    public static func workspaceLink(workspaceId: UUID, scheme: String) -> String {
+        "\(scheme)://workspace/\(workspaceId.uuidString)"
+    }
+
+    /// Builds a pane navigation URL.
+    public static func paneLink(workspaceId: UUID, paneId: UUID, scheme: String) -> String {
+        "\(scheme)://workspace/\(workspaceId.uuidString)/pane/\(paneId.uuidString)"
+    }
+
+    /// Builds a surface navigation URL, optionally carrying stable fallbacks.
+    public static func surfaceLink(
+        workspaceId: UUID,
+        surfaceId: UUID,
+        stableWorkspaceId: UUID? = nil,
+        stableSurfaceId: UUID? = nil,
+        scheme: String
+    ) -> String {
+        var link = "\(scheme)://workspace/\(workspaceId.uuidString)/surface/\(surfaceId.uuidString)"
+        var queryItems: [String] = []
+        if let stableWorkspaceId {
+            queryItems.append("stable_workspace_id=\(stableWorkspaceId.uuidString)")
+        }
+        if let stableSurfaceId {
+            queryItems.append("stable_surface_id=\(stableSurfaceId.uuidString)")
+        }
+        if !queryItems.isEmpty {
+            link += "?\(queryItems.joined(separator: "&"))"
+        }
+        return link
+    }
+
+    private static func isSupportedScheme(
+        _ scheme: String?,
+        supportedSchemes: Set<String>
+    ) -> Bool {
+        guard let scheme else { return false }
+        let normalized = scheme.lowercased()
+        return supportedSchemes.contains { $0.lowercased() == normalized }
+    }
+
+    private static func routeComponents(from components: URLComponents) -> [String] {
+        var route: [String] = []
+        if let host = components.host?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !host.isEmpty {
+            route.append(host)
+        }
+        route += components.path
+            .split(separator: "/", omittingEmptySubsequences: true)
+            .map(String.init)
+        return route
+    }
+
+    private static func parseStableFallback(
+        from components: URLComponents,
+        allowedNames: Set<String>
+    ) -> Result<(workspaceId: UUID?, surfaceId: UUID?)?, CmxNavigationURLParseError> {
+        guard components.percentEncodedQuery != nil else { return .success(nil) }
+        guard let items = components.queryItems, !items.isEmpty else {
+            return .failure(.unsupportedURLShape)
+        }
+
+        var stableWorkspaceId: UUID?
+        var stableSurfaceId: UUID?
+        var seenNames: Set<String> = []
+        for item in items {
+            guard allowedNames.contains(item.name),
+                  seenNames.insert(item.name).inserted,
+                  let value = item.value,
+                  !value.isEmpty else {
+                return .failure(.unsupportedURLShape)
+            }
+            guard let id = UUID(uuidString: value) else {
+                switch item.name {
+                case "stable_workspace_id":
+                    return .failure(.invalidIdentifier("stable_workspace"))
+                case "stable_surface_id":
+                    return .failure(.invalidIdentifier("stable_surface"))
+                default:
+                    return .failure(.unsupportedURLShape)
+                }
+            }
+            switch item.name {
+            case "stable_workspace_id":
+                stableWorkspaceId = id
+            case "stable_surface_id":
+                stableSurfaceId = id
+            default:
+                return .failure(.unsupportedURLShape)
+            }
+        }
+        return .success((workspaceId: stableWorkspaceId, surfaceId: stableSurfaceId))
+    }
+}
+
+/// Compatibility spelling used by the macOS target and older package clients.
+public typealias CMUXNavigationURLRequest = CmxNavigationURLRequest
+/// Compatibility spelling used by the macOS target and older package clients.
+public typealias CMUXNavigationURLParseError = CmxNavigationURLParseError

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/MobileStateSyncRecords.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/MobileStateSyncRecords.swift
@@ -39,6 +39,10 @@ public struct WorkspaceSyncRecord: MobileSyncRecord {
     public struct Surface: Codable, Equatable, Sendable {
         /// Stable surface identifier.
         public let surfaceID: String
+        /// Restart-stable surface identity used by durable navigation links.
+        public let stableSurfaceID: String?
+        /// Stable pane identifier containing this surface, when reported.
+        public let paneID: String?
         /// Open surface-kind wire string.
         public let kind: String
         /// User-facing surface title.
@@ -57,9 +61,13 @@ public struct WorkspaceSyncRecord: MobileSyncRecord {
             title: String,
             filePath: String?,
             todo: MobileTodoSnapshot? = nil,
-            isFocused: Bool = false
+            isFocused: Bool = false,
+            paneID: String? = nil,
+            stableSurfaceID: String? = nil
         ) {
             self.surfaceID = surfaceID
+            self.stableSurfaceID = stableSurfaceID
+            self.paneID = paneID
             self.kind = kind
             self.title = title
             self.isFocused = isFocused
@@ -70,6 +78,8 @@ public struct WorkspaceSyncRecord: MobileSyncRecord {
         public init(from decoder: any Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             surfaceID = try container.decode(String.self, forKey: .surfaceID)
+            stableSurfaceID = try container.decodeIfPresent(String.self, forKey: .stableSurfaceID)
+            paneID = try container.decodeIfPresent(String.self, forKey: .paneID)
             kind = try container.decode(String.self, forKey: .kind)
             title = try container.decode(String.self, forKey: .title)
             isFocused = try container.decodeIfPresent(Bool.self, forKey: .isFocused) ?? false
@@ -79,6 +89,8 @@ public struct WorkspaceSyncRecord: MobileSyncRecord {
 
         private enum CodingKeys: String, CodingKey {
             case surfaceID = "surface_id"
+            case stableSurfaceID = "stable_surface_id"
+            case paneID = "pane_id"
             case kind
             case title
             case isFocused = "is_focused"
@@ -126,6 +138,8 @@ public struct WorkspaceSyncRecord: MobileSyncRecord {
 
     /// Stable workspace identifier.
     public let id: String
+    /// Restart-stable workspace identity used by durable navigation links.
+    public let stableID: String?
     /// Owning Mac window identifier, when reported.
     public let windowID: String?
     /// User-facing workspace title.
@@ -170,6 +184,7 @@ public struct WorkspaceSyncRecord: MobileSyncRecord {
     /// Creates a workspace row from its wire fields.
     public init(
         id: String,
+        stableID: String? = nil,
         windowID: String?,
         title: String,
         customDescription: String? = nil,
@@ -189,6 +204,7 @@ public struct WorkspaceSyncRecord: MobileSyncRecord {
         simulators: [MobileSimulatorPanelDescriptor] = []
     ) {
         self.id = id
+        self.stableID = stableID
         self.windowID = windowID
         self.title = title
         self.customDescription = customDescription
@@ -211,6 +227,7 @@ public struct WorkspaceSyncRecord: MobileSyncRecord {
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         id = try container.decode(String.self, forKey: .id)
+        stableID = try container.decodeIfPresent(String.self, forKey: .stableID)
         windowID = try container.decodeIfPresent(String.self, forKey: .windowID)
         title = try container.decode(String.self, forKey: .title)
         customDescription = try container.decodeIfPresent(String.self, forKey: .customDescription)
@@ -238,6 +255,7 @@ public struct WorkspaceSyncRecord: MobileSyncRecord {
 
     private enum CodingKeys: String, CodingKey {
         case id
+        case stableID = "stable_id"
         case windowID = "window_id"
         case title
         case customDescription = "description"

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxNavigationURLRequestTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxNavigationURLRequestTests.swift
@@ -1,0 +1,102 @@
+import Foundation
+import Testing
+@testable import CMUXMobileCore
+
+@Suite struct CmxNavigationURLRequestTests {
+    private let scheme = "cmux-ios-test"
+    private let workspaceID = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+    private let paneID = UUID(uuidString: "22222222-2222-2222-2222-222222222222")!
+    private let surfaceID = UUID(uuidString: "33333333-3333-3333-3333-333333333333")!
+    private let stableWorkspaceID = UUID(uuidString: "44444444-4444-4444-4444-444444444444")!
+    private let stableSurfaceID = UUID(uuidString: "55555555-5555-5555-5555-555555555555")!
+
+    @Test func parsesWorkspacePaneAndSurfaceRoutes() throws {
+        let workspace = try #require(URL(string: "\(scheme)://workspace/\(workspaceID.uuidString)"))
+        let pane = try #require(URL(string: "\(scheme)://workspace/\(workspaceID.uuidString)/pane/\(paneID.uuidString)"))
+        let surface = try #require(URL(string: "\(scheme)://workspace/\(workspaceID.uuidString)/surface/\(surfaceID.uuidString)"))
+        let panel = try #require(URL(string: "\(scheme)://workspace/\(workspaceID.uuidString)/panel/\(surfaceID.uuidString)"))
+
+        #expect(try target(workspace) == .workspace(workspaceID))
+        #expect(try target(pane) == .pane(workspaceId: workspaceID, paneId: paneID))
+        #expect(try target(surface) == .surface(workspaceId: workspaceID, surfaceId: surfaceID))
+        #expect(try target(panel) == .surface(workspaceId: workspaceID, surfaceId: surfaceID))
+    }
+
+    @Test func surfaceRoutesPreserveStableFallbacks() throws {
+        let url = try #require(URL(string: CmxNavigationURLRequest.surfaceLink(
+            workspaceId: workspaceID,
+            surfaceId: surfaceID,
+            stableWorkspaceId: stableWorkspaceID,
+            stableSurfaceId: stableSurfaceID,
+            scheme: scheme
+        )))
+
+        let parsedRequest = try parsed(url)
+        let request = try #require(parsedRequest)
+        #expect(request.target == .surface(workspaceId: workspaceID, surfaceId: surfaceID))
+        #expect(request.stableFallbackWorkspaceId == stableWorkspaceID)
+        #expect(request.stableFallbackSurfaceId == stableSurfaceID)
+    }
+
+    @Test func ignoresOtherRoutesAndSchemes() throws {
+        let sshURL = try #require(URL(string: "\(scheme)://ssh?host=example.com"))
+        let foreignURL = try #require(URL(string: "cmux-other://workspace/\(workspaceID.uuidString)"))
+
+        #expect(try parsedOptional(sshURL) == nil)
+        #expect(try parsedOptional(foreignURL) == nil)
+    }
+
+    @Test func rejectsMalformedWorkspaceRoutes() throws {
+        let cases = [
+            ("\(scheme)://workspace/not-a-uuid", "workspace"),
+            ("\(scheme)://workspace/\(workspaceID.uuidString)/pane/not-a-uuid", "pane"),
+            ("\(scheme)://workspace/\(workspaceID.uuidString)/surface/not-a-uuid", "surface"),
+        ]
+
+        for (rawURL, component) in cases {
+            let url = try #require(URL(string: rawURL))
+            switch CmxNavigationURLRequest.parse(url, supportedSchemes: [scheme]) {
+            case .failure(.invalidIdentifier(let value)):
+                #expect(value == component)
+            default:
+                Issue.record("Expected invalid \(component) identifier rejection for \(rawURL)")
+            }
+        }
+    }
+
+    @Test func rejectsAuthorityFragmentsAndPaneQueries() throws {
+        let cases = [
+            "\(scheme)://user@workspace/\(workspaceID.uuidString)",
+            "\(scheme)://workspace/\(workspaceID.uuidString)#fragment",
+            "\(scheme)://workspace/\(workspaceID.uuidString)/pane/\(paneID.uuidString)?x=1",
+            "\(scheme)://workspace/\(workspaceID.uuidString)/surface/\(surfaceID.uuidString)/extra",
+        ]
+
+        for rawURL in cases {
+            let url = try #require(URL(string: rawURL))
+            switch CmxNavigationURLRequest.parse(url, supportedSchemes: [scheme]) {
+            case .failure(.unsupportedURLShape):
+                break
+            default:
+                Issue.record("Expected unsupported URL shape rejection for \(rawURL)")
+            }
+        }
+    }
+
+    private func parsed(_ url: URL) throws -> CmxNavigationURLRequest? {
+        switch CmxNavigationURLRequest.parse(url, supportedSchemes: [scheme]) {
+        case .success(let request):
+            return request
+        case .failure(let error):
+            throw error
+        }
+    }
+
+    private func parsedOptional(_ url: URL) throws -> CmxNavigationURLRequest? {
+        try parsed(url)
+    }
+
+    private func target(_ url: URL) throws -> CmxNavigationURLRequest.Target {
+        try #require(parsed(url)?.target)
+    }
+}

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileSyncWorkspaceListResponse.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileSyncWorkspaceListResponse.swift
@@ -10,6 +10,8 @@ public struct MobileSyncWorkspaceListResponse: Decodable, Sendable {
     public struct Workspace: Decodable, Sendable {
         /// Stable workspace identifier.
         public let id: String
+        /// Restart-stable workspace identity, when reported by the Mac.
+        public let stableID: String?
         /// Stable Mac window identifier, when reported.
         public let windowID: String?
         /// User-facing workspace title.
@@ -55,6 +57,7 @@ public struct MobileSyncWorkspaceListResponse: Decodable, Sendable {
 
         private enum CodingKeys: String, CodingKey {
             case id
+            case stableID = "stable_id"
             case windowID = "window_id"
             case title
             case customDescription = "description"
@@ -78,6 +81,7 @@ public struct MobileSyncWorkspaceListResponse: Decodable, Sendable {
         /// record mirror through the same apply path as the wire response).
         public init(
             id: String,
+            stableID: String? = nil,
             windowID: String?,
             title: String,
             customDescription: String? = nil,
@@ -96,6 +100,7 @@ public struct MobileSyncWorkspaceListResponse: Decodable, Sendable {
             simulators: [MobileSimulatorPanelDescriptor] = []
         ) {
             self.id = id
+            self.stableID = stableID
             self.windowID = windowID
             self.title = title
             self.customDescription = customDescription
@@ -117,6 +122,7 @@ public struct MobileSyncWorkspaceListResponse: Decodable, Sendable {
         public init(from decoder: any Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             id = try container.decode(String.self, forKey: .id)
+            stableID = try container.decodeIfPresent(String.self, forKey: .stableID)
             windowID = try container.decodeIfPresent(String.self, forKey: .windowID)
             title = try container.decode(String.self, forKey: .title)
             customDescription = try container.decodeIfPresent(String.self, forKey: .customDescription)
@@ -143,6 +149,10 @@ public struct MobileSyncWorkspaceListResponse: Decodable, Sendable {
     public struct Surface: Decodable, Equatable, Sendable {
         /// Stable Mac-local surface identifier.
         public let surfaceID: String
+        /// Restart-stable surface identity, when reported by the Mac.
+        public let stableSurfaceID: String?
+        /// Stable Mac-local pane identifier containing this surface, when reported.
+        public let paneID: String?
         /// Open surface-kind wire value.
         public let kind: String
         /// User-facing surface title.
@@ -156,6 +166,8 @@ public struct MobileSyncWorkspaceListResponse: Decodable, Sendable {
 
         private enum CodingKeys: String, CodingKey {
             case surfaceID = "surface_id"
+            case stableSurfaceID = "stable_surface_id"
+            case paneID = "pane_id"
             case kind
             case title
             case isFocused = "is_focused"
@@ -170,9 +182,13 @@ public struct MobileSyncWorkspaceListResponse: Decodable, Sendable {
             title: String,
             filePath: String?,
             todo: MobileTodoSnapshot? = nil,
-            isFocused: Bool = false
+            isFocused: Bool = false,
+            paneID: String? = nil,
+            stableSurfaceID: String? = nil
         ) {
             self.surfaceID = surfaceID
+            self.stableSurfaceID = stableSurfaceID
+            self.paneID = paneID
             self.kind = kind
             self.title = title
             self.isFocused = isFocused
@@ -183,6 +199,8 @@ public struct MobileSyncWorkspaceListResponse: Decodable, Sendable {
         public init(from decoder: any Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             surfaceID = try container.decode(String.self, forKey: .surfaceID)
+            stableSurfaceID = try container.decodeIfPresent(String.self, forKey: .stableSurfaceID)
+            paneID = try container.decodeIfPresent(String.self, forKey: .paneID)
             kind = try container.decode(String.self, forKey: .kind)
             title = try container.decode(String.self, forKey: .title)
             isFocused = try container.decodeIfPresent(Bool.self, forKey: .isFocused) ?? false

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileWorkspacePreview+RemoteMapping.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileWorkspacePreview+RemoteMapping.swift
@@ -7,6 +7,7 @@ extension MobileWorkspacePreview {
     public init(remote: MobileSyncWorkspaceListResponse.Workspace) {
         self.init(
             id: ID(rawValue: remote.id),
+            stableID: remote.stableID.map(ID.init(rawValue:)),
             windowID: remote.windowID,
             name: remote.title,
             customDescription: remote.customDescription,
@@ -36,7 +37,9 @@ extension MobileSurfacePreview {
             title: remote.title,
             filePath: remote.filePath,
             todo: remote.todo,
-            isFocused: remote.isFocused
+            isFocused: remote.isFocused,
+            paneID: remote.paneID.map(ID.init(rawValue:)),
+            stableID: remote.stableSurfaceID.map(ID.init(rawValue:))
         )
     }
 }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileExternalNavigationTargetResolver.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileExternalNavigationTargetResolver.swift
@@ -1,0 +1,223 @@
+public import CMUXMobileCore
+public import CmuxMobileShellModel
+import Foundation
+
+/// The phone-side selection to apply after opening an external navigation URL.
+public enum MobileExternalNavigationSelection: Equatable, Sendable {
+    /// Select a terminal surface.
+    case terminal(MobileTerminalPreview.ID)
+    /// Select a non-terminal Mac surface.
+    case surface(MobileSurfacePreview.ID)
+}
+
+/// The resolved workspace and optional child selection for one navigation URL.
+public struct MobileExternalNavigationResolution: Equatable, Sendable {
+    /// The current UI row id to select.
+    public let workspaceID: MobileWorkspacePreview.ID
+    /// The child surface to select, when the URL names one.
+    public let selection: MobileExternalNavigationSelection?
+
+    /// Creates a navigation resolution.
+    public init(
+        workspaceID: MobileWorkspacePreview.ID,
+        selection: MobileExternalNavigationSelection?
+    ) {
+        self.workspaceID = workspaceID
+        self.selection = selection
+    }
+}
+
+/// Pure workspace-list lookup for external workspace, pane, and surface links.
+///
+/// The resolver deliberately returns `.unavailable` when an identity is not in
+/// the current snapshot. The root scene parks the original URL and retries when
+/// the workspace topology changes, which covers cold launch and attach races.
+public struct MobileExternalNavigationTargetResolver: Sendable {
+    /// Whether a request found a current target.
+    public enum ResolutionResult: Equatable, Sendable {
+        /// The target can be applied now.
+        case resolved(MobileExternalNavigationResolution)
+        /// The workspace or child has not arrived in the current snapshot.
+        case unavailable
+    }
+
+    private let workspaces: [MobileWorkspacePreview]
+
+    /// Creates a resolver over one immutable workspace snapshot.
+    public init(workspaces: [MobileWorkspacePreview]) {
+        self.workspaces = workspaces
+    }
+
+    /// Resolves one parsed navigation request.
+    public func resolve(_ request: CmxNavigationURLRequest) -> ResolutionResult {
+        switch request.target {
+        case .workspace(let workspaceID):
+            guard let workspace = workspace(
+                runtimeID: workspaceID,
+                stableFallbackID: request.stableFallbackWorkspaceId
+            ) else { return .unavailable }
+            return .resolved(.init(workspaceID: workspace.id, selection: nil))
+
+        case .surface(let workspaceID, let surfaceID):
+            guard let workspace = workspace(
+                runtimeID: workspaceID,
+                stableFallbackID: request.stableFallbackWorkspaceId
+            ) else {
+                return resolveSurfaceAcrossWorkspaces(
+                    surfaceID: surfaceID,
+                    stableSurfaceID: request.stableFallbackSurfaceId
+                )
+            }
+            if let selection = selection(
+                surfaceID: surfaceID,
+                in: workspace
+            ) {
+                return .resolved(.init(workspaceID: workspace.id, selection: selection))
+            }
+            if let stableSurfaceID = request.stableFallbackSurfaceId,
+               let selection = selection(surfaceID: stableSurfaceID, in: workspace) {
+                return .resolved(.init(workspaceID: workspace.id, selection: selection))
+            }
+            return resolveSurfaceAcrossWorkspaces(
+                surfaceID: surfaceID,
+                stableSurfaceID: request.stableFallbackSurfaceId,
+                excluding: workspace.id
+            )
+
+        case .pane(let workspaceID, let paneID):
+            guard let workspace = workspace(
+                runtimeID: workspaceID,
+                stableFallbackID: request.stableFallbackWorkspaceId
+            ) else { return .unavailable }
+            let paneID = paneID.uuidString.lowercased()
+            let paneSurfaces = workspace.surfaces.filter {
+                $0.paneID?.rawValue.lowercased() == paneID
+            }
+            if let surface = preferredSurface(in: paneSurfaces, workspace: workspace) {
+                return .resolved(.init(
+                    workspaceID: workspace.id,
+                    selection: selection(for: surface, workspace: workspace)
+                ))
+            }
+
+            // Hosts predating pane metadata can still honor the workspace part
+            // of a pane URL. This is preferable to sending a recognized link
+            // through the pairing connector, and newer hosts retry above once
+            // their pane inventory arrives.
+            if workspace.surfaces.allSatisfy({ $0.paneID == nil }) {
+                return .resolved(.init(workspaceID: workspace.id, selection: nil))
+            }
+            return .unavailable
+        }
+    }
+
+    private func workspace(
+        runtimeID: UUID,
+        stableFallbackID: UUID?
+    ) -> MobileWorkspacePreview? {
+        let runtimeMatches = uniqueWorkspaces {
+            identifiersMatch($0.rpcWorkspaceID.rawValue, runtimeID)
+        }
+        if let runtimeMatches { return runtimeMatches }
+
+        // Workspace links copied from the Mac intentionally put the durable
+        // identity in the path (there is no query fallback on those links).
+        // Prefer that identity after the current-session id, matching the Mac
+        // resolver's runtime-before-stable rule.
+        let pathStableMatches = uniqueWorkspaces {
+            let stableID = $0.stableID?.rawValue ?? $0.id.rawValue
+            return identifiersMatch(stableID, runtimeID)
+        }
+        if let pathStableMatches { return pathStableMatches }
+
+        guard let stableFallbackID else { return nil }
+        return uniqueWorkspaces {
+            let stableID = $0.stableID?.rawValue ?? $0.id.rawValue
+            return identifiersMatch(stableID, stableFallbackID)
+        }
+    }
+
+    private func uniqueWorkspaces(
+        where predicate: (MobileWorkspacePreview) -> Bool
+    ) -> MobileWorkspacePreview? {
+        let matches = workspaces.filter(predicate)
+        guard matches.count == 1 else { return nil }
+        return matches[0]
+    }
+
+    private func resolveSurfaceAcrossWorkspaces(
+        surfaceID: UUID,
+        stableSurfaceID: UUID?,
+        excluding excludedWorkspaceID: MobileWorkspacePreview.ID? = nil
+    ) -> ResolutionResult {
+        let runtimeMatches = workspaces.filter { workspace in
+            workspace.id != excludedWorkspaceID
+                && selection(surfaceID: surfaceID, in: workspace) != nil
+        }
+        if runtimeMatches.count == 1,
+           let selection = selection(surfaceID: surfaceID, in: runtimeMatches[0]) {
+            return .resolved(.init(workspaceID: runtimeMatches[0].id, selection: selection))
+        }
+        guard let stableSurfaceID else { return .unavailable }
+        let stableMatches = workspaces.filter { workspace in
+            workspace.id != excludedWorkspaceID
+                && selection(surfaceID: stableSurfaceID, in: workspace) != nil
+        }
+        guard stableMatches.count == 1,
+              let selection = selection(surfaceID: stableSurfaceID, in: stableMatches[0]) else {
+            return .unavailable
+        }
+        return .resolved(.init(workspaceID: stableMatches[0].id, selection: selection))
+    }
+
+    private func selection(
+        surfaceID: UUID,
+        in workspace: MobileWorkspacePreview
+    ) -> MobileExternalNavigationSelection? {
+        if let terminal = workspace.terminals.first(where: {
+            identifiersMatch($0.id.rawValue, surfaceID)
+        }) {
+            return .terminal(terminal.id)
+        }
+        if let surface = workspace.surfaces.first(where: {
+            identifiersMatch($0.id.rawValue, surfaceID)
+                || ($0.stableID.map { identifiersMatch($0.rawValue, surfaceID) } ?? false)
+        }) {
+            return selection(for: surface, workspace: workspace)
+        }
+        return nil
+    }
+
+    private func identifiersMatch(_ rawValue: String, _ id: UUID) -> Bool {
+        identifiersMatch(rawValue, id.uuidString)
+    }
+
+    private func identifiersMatch(_ lhs: String, _ rhs: String) -> Bool {
+        lhs.caseInsensitiveCompare(rhs) == .orderedSame
+    }
+
+    private func selection(
+        for surface: MobileSurfacePreview,
+        workspace: MobileWorkspacePreview
+    ) -> MobileExternalNavigationSelection {
+        if let terminal = workspace.terminals.first(where: {
+            identifiersMatch($0.id.rawValue, surface.id.rawValue)
+        }) {
+            return .terminal(terminal.id)
+        }
+        return .surface(surface.id)
+    }
+
+    private func preferredSurface(
+        in surfaces: [MobileSurfacePreview],
+        workspace: MobileWorkspacePreview
+    ) -> MobileSurfacePreview? {
+        surfaces.first(where: { $0.isFocused })
+            ?? surfaces.first(where: { surface in
+                workspace.terminals.contains(where: { terminal in
+                    identifiersMatch(terminal.id.rawValue, surface.id.rawValue)
+                })
+            })
+            ?? surfaces.first
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ExternalNavigation.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ExternalNavigation.swift
@@ -1,0 +1,50 @@
+public import CMUXMobileCore
+public import Foundation
+
+/// Outcome of handing one external URL to the mobile workspace shell.
+public enum MobileExternalNavigationURLResult: Equatable, Sendable {
+    /// The URL is not a recognized workspace navigation route.
+    case notNavigation
+    /// The route was applied to the current workspace snapshot.
+    case handled
+    /// The route is recognized but its target is not loaded yet.
+    case deferred
+    /// The URL uses a recognized scheme and route but fails validation.
+    case invalid(CmxNavigationURLParseError)
+}
+
+extension MobileShellComposite {
+    /// Parses and applies a workspace, pane, or surface URL.
+    ///
+    /// The caller supplies the exact schemes registered by its app target. A
+    /// deferred result is safe to retry after ``workspaceTopologyVersion``
+    /// changes; no pairing connection is attempted for recognized routes.
+    @discardableResult
+    public func handleExternalNavigationURL(
+        _ url: URL,
+        supportedSchemes: Set<String>
+    ) -> MobileExternalNavigationURLResult {
+        switch CmxNavigationURLRequest.parse(url, supportedSchemes: supportedSchemes) {
+        case .success(nil):
+            return .notNavigation
+        case .failure(let error):
+            return .invalid(error)
+        case .success(.some(let request)):
+            switch MobileExternalNavigationTargetResolver(workspaces: workspaces).resolve(request) {
+            case .unavailable:
+                return .deferred
+            case .resolved(let resolution):
+                navigateToWorkspaceForDeeplink(resolution.workspaceID)
+                switch resolution.selection {
+                case .none:
+                    break
+                case .some(.terminal(let terminalID)):
+                    selectTerminal(terminalID)
+                case .some(.surface(let surfaceID)):
+                    selectMacSurface(surfaceID)
+                }
+                return .handled
+            }
+        }
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+StateSync.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+StateSync.swift
@@ -369,6 +369,7 @@ extension MobileShellComposite {
         let workspaces = stateSyncMirror.workspaces.orderedRecords.map { record in
             MobileSyncWorkspaceListResponse.Workspace(
                 id: record.id,
+                stableID: record.stableID,
                 windowID: record.windowID,
                 title: record.title,
                 customDescription: record.customDescription,
@@ -397,7 +398,10 @@ extension MobileShellComposite {
                         kind: surface.kind,
                         title: surface.title,
                         filePath: surface.filePath,
-                        todo: surface.todo
+                        todo: surface.todo,
+                        isFocused: surface.isFocused,
+                        paneID: surface.paneID,
+                        stableSurfaceID: surface.stableSurfaceID
                     )
                 },
                 simulators: record.simulators

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileExternalNavigationTargetResolverTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileExternalNavigationTargetResolverTests.swift
@@ -1,0 +1,131 @@
+import CMUXMobileCore
+import CmuxMobileShellModel
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+@Suite struct MobileExternalNavigationTargetResolverTests {
+    private let scheme = "cmux-ios-test"
+    private let workspaceUUID = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+    private let paneUUID = UUID(uuidString: "22222222-2222-2222-2222-222222222222")!
+    private let terminalUUID = UUID(uuidString: "33333333-3333-3333-3333-333333333333")!
+    private let stableWorkspaceUUID = UUID(uuidString: "66666666-6666-6666-6666-666666666666")!
+    private let stableSurfaceUUID = UUID(uuidString: "77777777-7777-7777-7777-777777777777")!
+
+    @Test func resolvesWorkspaceAndTerminalSurfaceTargets() throws {
+        let workspace = makeWorkspace()
+        let resolver = MobileExternalNavigationTargetResolver(workspaces: [workspace])
+        let workspaceRequest = try request("\(scheme)://workspace/\(workspaceUUID.uuidString)")
+        let surfaceRequest = try request(
+            "\(scheme)://workspace/\(workspaceUUID.uuidString)/surface/\(terminalUUID.uuidString)"
+        )
+
+        #expect(
+            resolver.resolve(workspaceRequest)
+                == .resolved(.init(workspaceID: workspace.id, selection: nil))
+        )
+        #expect(
+            resolver.resolve(surfaceRequest)
+                == .resolved(
+                    .init(
+                        workspaceID: workspace.id,
+                        selection: .terminal(.init(rawValue: terminalUUID.uuidString))
+                    )
+                )
+        )
+    }
+
+    @Test func resolvesPaneToItsRepresentedTerminalSurface() throws {
+        let workspace = makeWorkspace()
+        let resolver = MobileExternalNavigationTargetResolver(workspaces: [workspace])
+        let request = try request(
+            "\(scheme)://workspace/\(workspaceUUID.uuidString)/pane/\(paneUUID.uuidString)"
+        )
+
+        #expect(
+            resolver.resolve(request)
+                == .resolved(
+                    .init(
+                        workspaceID: workspace.id,
+                        selection: .terminal(.init(rawValue: terminalUUID.uuidString))
+                    )
+                )
+        )
+    }
+
+    @Test func resolvesDurableWorkspaceAndSurfaceIdentities() throws {
+        let workspace = makeWorkspace()
+        let resolver = MobileExternalNavigationTargetResolver(workspaces: [workspace])
+        let workspaceRequest = try request(
+            "\(scheme)://workspace/\(stableWorkspaceUUID.uuidString)"
+        )
+        let surfaceRequest = try request(
+            "\(scheme)://workspace/\(stableWorkspaceUUID.uuidString)/surface/\(stableSurfaceUUID.uuidString)"
+        )
+
+        #expect(
+            resolver.resolve(workspaceRequest)
+                == .resolved(.init(workspaceID: workspace.id, selection: nil))
+        )
+        #expect(
+            resolver.resolve(surfaceRequest)
+                == .resolved(
+                    .init(
+                        workspaceID: workspace.id,
+                        selection: .terminal(.init(rawValue: terminalUUID.uuidString))
+                    )
+                )
+        )
+    }
+
+    @Test func defersWhenWorkspaceOrChildIsNotLoaded() throws {
+        let workspace = makeWorkspace()
+        let resolver = MobileExternalNavigationTargetResolver(workspaces: [workspace])
+        let missingWorkspace = try request(
+            "\(scheme)://workspace/44444444-4444-4444-4444-444444444444"
+        )
+        let missingSurface = try request(
+            "\(scheme)://workspace/\(workspaceUUID.uuidString)/surface/55555555-5555-5555-5555-555555555555"
+        )
+
+        #expect(resolver.resolve(missingWorkspace) == .unavailable)
+        #expect(resolver.resolve(missingSurface) == .unavailable)
+    }
+
+    private func makeWorkspace() -> MobileWorkspacePreview {
+        let terminalID = MobileTerminalPreview.ID(rawValue: terminalUUID.uuidString)
+        return MobileWorkspacePreview(
+            id: .init(rawValue: workspaceUUID.uuidString),
+            stableID: .init(rawValue: stableWorkspaceUUID.uuidString),
+            name: "Workspace",
+            terminals: [MobileTerminalPreview(id: terminalID, name: "Terminal")],
+            surfaces: [
+                MobileSurfacePreview(
+                    id: .init(rawValue: terminalUUID.uuidString),
+                    kind: .terminal,
+                    title: "Terminal",
+                    paneID: .init(rawValue: paneUUID.uuidString),
+                    stableID: .init(rawValue: stableSurfaceUUID.uuidString)
+                ),
+            ]
+        )
+    }
+
+    private func request(_ rawURL: String) throws -> CmxNavigationURLRequest {
+        let url = try #require(URL(string: rawURL))
+        switch CmxNavigationURLRequest.parse(url, supportedSchemes: [scheme]) {
+        case .success(.some(let request)):
+            return request
+        case .success(nil):
+            Issue.record("Expected navigation URL: \(rawURL)")
+            throw TestError.invalidURL
+        case .failure(let error):
+            Issue.record("Unexpected parse error: \(error)")
+            throw TestError.invalidURL
+        }
+    }
+
+    private enum TestError: Error {
+        case invalidURL
+    }
+}

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileSurfacePreview.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileSurfacePreview.swift
@@ -63,6 +63,11 @@ public struct MobileSurfacePreview: Identifiable, Equatable, Sendable {
 
     /// Stable Mac-local surface identifier.
     public let id: ID
+    /// Restart-stable surface identity used by durable navigation links.
+    public let stableID: ID?
+    /// Stable Mac-local pane identifier, when the host reports pane topology.
+    /// Older hosts omit this value; the surface remains routable by its own id.
+    public let paneID: ID?
     /// Open, forward-compatible surface kind.
     public let kind: Kind
     /// User-facing surface title.
@@ -81,9 +86,13 @@ public struct MobileSurfacePreview: Identifiable, Equatable, Sendable {
         title: String,
         filePath: String? = nil,
         todo: MobileTodoSnapshot? = nil,
-        isFocused: Bool = false
+        isFocused: Bool = false,
+        paneID: ID? = nil,
+        stableID: ID? = nil
     ) {
         self.id = id
+        self.stableID = stableID
+        self.paneID = paneID
         self.kind = kind
         self.title = title
         self.isFocused = isFocused

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspacePreview.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspacePreview.swift
@@ -32,6 +32,9 @@ public struct MobileWorkspacePreview: Identifiable, Equatable, Sendable {
     /// multi-Mac list it may be scoped by the owning Mac so two Macs can expose
     /// the same local workspace id without colliding in SwiftUI navigation.
     public var id: ID
+    /// Restart-stable workspace identity used by durable navigation links.
+    /// `nil` when connected to a Mac that predates this additive field.
+    public var stableID: ID?
     /// The Mac-local workspace identifier to send back over RPC.
     ///
     /// Aggregated rows can use a Mac-scoped ``id`` for UI identity while keeping
@@ -139,6 +142,7 @@ public struct MobileWorkspacePreview: Identifiable, Equatable, Sendable {
     ///   - surfaces: Every Mac-rendered surface, in spatial order.
     public init(
         id: ID,
+        stableID: ID? = nil,
         macDeviceID: String? = nil,
         macDisplayName: String? = nil,
         windowID: String? = nil,
@@ -158,6 +162,7 @@ public struct MobileWorkspacePreview: Identifiable, Equatable, Sendable {
         simulators: [MobileSimulatorPanelDescriptor] = []
     ) {
         self.id = id
+        self.stableID = stableID
         self.remoteWorkspaceID = nil
         self.macDeviceID = macDeviceID
         self.macDisplayName = macDisplayName

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
@@ -308,6 +308,9 @@ struct CMUXMobileRootView: View {
         // mutation without allocating ID arrays on every body evaluation.
         .onChange(of: store.workspaceTopologyVersion) { _, _ in
             pushCoordinator.workspacesDidChange()
+            if MobileExternalNavigationURLPolicy.recognizes(pendingAttachURL) {
+                _ = consumePendingURLIfReady()
+            }
         }
         #if DEBUG
         // The UI-test auto-open hook observes the same workspace-arrival
@@ -366,6 +369,36 @@ struct CMUXMobileRootView: View {
         .onOpenURL { url in
             let rawURL = url.absoluteString
             diagnosticLog?.recordAppEvent(.appOpenURLReceived)
+            #if os(iOS)
+            if MobileExternalNavigationURLPolicy.recognizes(rawURL),
+               (!isAuthenticated || authManager.isRestoringSession) {
+                pendingAttachURL = rawURL
+                diagnosticLog?.recordAppEvent(.appOpenURLDeferredForAuthentication)
+                return
+            }
+            switch store.handleExternalNavigationURL(
+                url,
+                supportedSchemes: MobileExternalNavigationURLPolicy.supportedSchemes
+            ) {
+            case .notNavigation:
+                break
+            case .handled:
+                pendingAttachURL = nil
+                diagnosticLog?.recordAppEvent(.appOpenURLHandled)
+                return
+            case .deferred:
+                pendingAttachURL = rawURL
+                diagnosticLog?.recordAppEvent(.appOpenURLDeferredForAuthentication)
+                return
+            case .invalid:
+                pendingAttachURL = nil
+                diagnosticLog?.recordAppEvent(
+                    .appOpenURLRejected,
+                    failure: .protocolViolation
+                )
+                return
+            }
+            #endif
             if MobileRootAuthGate.isAttachURL(url) {
                 connectAttachURL(rawURL)
                 return
@@ -1147,6 +1180,33 @@ struct CMUXMobileRootView: View {
             connectAttachURL(rawURL)
             return true
         }
+        #if os(iOS)
+        if MobileExternalNavigationURLPolicy.recognizes(rawURL) {
+            guard isAuthenticated, !authManager.isRestoringSession else { return false }
+        }
+        if let url = URL(string: rawURL) {
+            switch store.handleExternalNavigationURL(
+                url,
+                supportedSchemes: MobileExternalNavigationURLPolicy.supportedSchemes
+            ) {
+            case .handled:
+                pendingAttachURL = nil
+                diagnosticLog?.recordAppEvent(.appOpenURLHandled)
+                return true
+            case .deferred:
+                return false
+            case .invalid:
+                pendingAttachURL = nil
+                diagnosticLog?.recordAppEvent(
+                    .appOpenURLRejected,
+                    failure: .protocolViolation
+                )
+                return true
+            case .notNavigation:
+                break
+            }
+        }
+        #endif
         guard isAuthenticated else { return false }
         pendingAttachURL = nil
         startOpenURLConnection(rawURL, followUp: .reconnectIfDisconnected)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileExternalNavigationURLPolicy.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileExternalNavigationURLPolicy.swift
@@ -1,0 +1,30 @@
+import CMUXMobileCore
+import Foundation
+
+#if os(iOS)
+/// URL-scheme policy for iOS workspace navigation links.
+enum MobileExternalNavigationURLPolicy {
+    /// The historical schemes plus the exact scheme registered by this bundle.
+    /// Keeping the set explicit prevents a random custom scheme from entering
+    /// the workspace router or bypassing the pairing URL gate.
+    static var supportedSchemes: Set<String> {
+        var schemes = Set(CmxPairingURLScheme.all)
+        if let current = CmxPairingURLSchemeResolver().resolved?.rawValue {
+            schemes.insert(current)
+        }
+        return schemes
+    }
+
+    /// Whether a raw URL is a recognized navigation route, including malformed
+    /// routes that should be consumed rather than sent to pairing.
+    static func recognizes(_ rawURL: String?) -> Bool {
+        guard let rawURL, let url = URL(string: rawURL) else { return false }
+        switch CmxNavigationURLRequest.parse(url, supportedSchemes: supportedSchemes) {
+        case .success(nil):
+            return false
+        case .success(.some), .failure:
+            return true
+        }
+    }
+}
+#endif

--- a/Sources/CmuxSSHURLRequest.swift
+++ b/Sources/CmuxSSHURLRequest.swift
@@ -1,4 +1,54 @@
+import CMUXMobileCore
 import Foundation
+
+/// The macOS target's compatibility spelling for the shared navigation parser.
+typealias CmuxNavigationURLParseError = CmxNavigationURLParseError
+/// The macOS target's compatibility spelling for the shared navigation parser.
+typealias CmuxNavigationURLRequest = CmxNavigationURLRequest
+
+extension CmxNavigationURLRequest {
+    /// Schemes accepted by the currently running macOS app build.
+    static var activeSupportedSchemes: Set<String> {
+        [AuthEnvironment.callbackScheme.lowercased()]
+    }
+
+    /// Parses a navigation URL using the active macOS callback scheme.
+    static func parse(
+        _ url: URL
+    ) -> Result<CmxNavigationURLRequest?, CmxNavigationURLParseError> {
+        parse(url, supportedSchemes: activeSupportedSchemes)
+    }
+
+    /// Builds a workspace link using the active macOS callback scheme.
+    static func workspaceLink(workspaceId: UUID) -> String {
+        workspaceLink(workspaceId: workspaceId, scheme: AuthEnvironment.callbackScheme)
+    }
+
+    /// Builds a pane link using the active macOS callback scheme.
+    static func paneLink(workspaceId: UUID, paneId: UUID) -> String {
+        paneLink(
+            workspaceId: workspaceId,
+            paneId: paneId,
+            scheme: AuthEnvironment.callbackScheme
+        )
+    }
+
+    /// Builds a surface link using the active macOS callback scheme.
+    static func surfaceLink(
+        workspaceId: UUID,
+        surfaceId: UUID,
+        stableWorkspaceId: UUID? = nil,
+        stableSurfaceId: UUID? = nil
+    ) -> String {
+        surfaceLink(
+            workspaceId: workspaceId,
+            surfaceId: surfaceId,
+            stableWorkspaceId: stableWorkspaceId,
+            stableSurfaceId: stableSurfaceId,
+            scheme: AuthEnvironment.callbackScheme
+        )
+    }
+}
 
 enum CmuxSSHURLParseError: Error, Equatable {
     case missingDestination
@@ -518,219 +568,6 @@ struct CmuxSSHURLRequest: Equatable {
         }
         let prefix = String(name.prefix(64))
         return prefix.count == name.count ? name : "\(prefix)..."
-    }
-}
-
-enum CmuxNavigationURLParseError: Error, Equatable {
-    case unsupportedURLShape
-    case invalidIdentifier(String)
-}
-
-struct CmuxNavigationURLRequest: Equatable {
-    enum Target: Equatable {
-        case workspace(UUID)
-        case pane(workspaceId: UUID, paneId: UUID)
-        case surface(workspaceId: UUID, surfaceId: UUID)
-    }
-
-    static var activeSupportedSchemes: Set<String> {
-        [AuthEnvironment.callbackScheme.lowercased()]
-    }
-
-    let originalURL: URL
-    let target: Target
-    let stableFallbackWorkspaceId: UUID?
-    let stableFallbackSurfaceId: UUID?
-
-    static func parse(
-        _ url: URL,
-        supportedSchemes: Set<String> = activeSupportedSchemes
-    ) -> Result<CmuxNavigationURLRequest?, CmuxNavigationURLParseError> {
-        guard isSupportedScheme(url.scheme, supportedSchemes: supportedSchemes) else {
-            return .success(nil)
-        }
-        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
-            return .failure(.unsupportedURLShape)
-        }
-
-        let route = routeComponents(from: components)
-        guard route.first?.lowercased() == "workspace" else {
-            return .success(nil)
-        }
-
-        guard components.user == nil,
-              components.password == nil,
-              components.port == nil,
-              components.percentEncodedFragment == nil else {
-            return .failure(.unsupportedURLShape)
-        }
-
-        guard route.count == 2 || route.count == 4 else {
-            return .failure(.unsupportedURLShape)
-        }
-        guard let workspaceId = UUID(uuidString: route[1]) else {
-            return .failure(.invalidIdentifier("workspace"))
-        }
-        if route.count == 2 {
-            let fallback: (workspaceId: UUID?, surfaceId: UUID?)?
-            switch parseStableFallback(from: components, allowedNames: ["stable_workspace_id"]) {
-            case .success(let parsedFallback):
-                fallback = parsedFallback
-            case .failure(let error):
-                return .failure(error)
-            }
-            return .success(CmuxNavigationURLRequest(
-                originalURL: url,
-                target: .workspace(workspaceId),
-                stableFallbackWorkspaceId: fallback?.workspaceId,
-                stableFallbackSurfaceId: fallback?.surfaceId
-            ))
-        }
-
-        let childKind = route[2].lowercased()
-        guard let childId = UUID(uuidString: route[3]) else {
-            switch childKind {
-            case "pane":
-                return .failure(.invalidIdentifier("pane"))
-            case "surface", "panel":
-                return .failure(.invalidIdentifier("surface"))
-            default:
-                return .failure(.unsupportedURLShape)
-            }
-        }
-
-        switch childKind {
-        case "pane":
-            if components.percentEncodedQuery != nil {
-                return .failure(.unsupportedURLShape)
-            }
-            return .success(
-                CmuxNavigationURLRequest(
-                    originalURL: url,
-                    target: .pane(workspaceId: workspaceId, paneId: childId),
-                    stableFallbackWorkspaceId: nil,
-                    stableFallbackSurfaceId: nil
-                )
-            )
-        case "surface", "panel":
-            let fallback: (workspaceId: UUID?, surfaceId: UUID?)?
-            switch parseStableFallback(
-                from: components,
-                allowedNames: ["stable_workspace_id", "stable_surface_id"]
-            ) {
-            case .success(let parsedFallback):
-                fallback = parsedFallback
-            case .failure(let error):
-                return .failure(error)
-            }
-            return .success(
-                CmuxNavigationURLRequest(
-                    originalURL: url,
-                    target: .surface(workspaceId: workspaceId, surfaceId: childId),
-                    stableFallbackWorkspaceId: fallback?.workspaceId,
-                    stableFallbackSurfaceId: fallback?.surfaceId
-                )
-            )
-        default:
-            return .failure(.unsupportedURLShape)
-        }
-    }
-
-    static func workspaceLink(workspaceId: UUID, scheme: String = AuthEnvironment.callbackScheme) -> String {
-        "\(scheme)://workspace/\(workspaceId.uuidString)"
-    }
-
-    static func paneLink(
-        workspaceId: UUID,
-        paneId: UUID,
-        scheme: String = AuthEnvironment.callbackScheme
-    ) -> String {
-        "\(scheme)://workspace/\(workspaceId.uuidString)/pane/\(paneId.uuidString)"
-    }
-
-    static func surfaceLink(
-        workspaceId: UUID,
-        surfaceId: UUID,
-        stableWorkspaceId: UUID? = nil,
-        stableSurfaceId: UUID? = nil,
-        scheme: String = AuthEnvironment.callbackScheme
-    ) -> String {
-        var link = "\(scheme)://workspace/\(workspaceId.uuidString)/surface/\(surfaceId.uuidString)"
-        var queryItems: [String] = []
-        if let stableWorkspaceId {
-            queryItems.append("stable_workspace_id=\(stableWorkspaceId.uuidString)")
-        }
-        if let stableSurfaceId {
-            queryItems.append("stable_surface_id=\(stableSurfaceId.uuidString)")
-        }
-        if !queryItems.isEmpty {
-            link += "?\(queryItems.joined(separator: "&"))"
-        }
-        return link
-    }
-
-    private static func isSupportedScheme(_ scheme: String?, supportedSchemes: Set<String>) -> Bool {
-        guard let scheme = scheme?.lowercased() else { return false }
-        return supportedSchemes.contains(scheme)
-    }
-
-    private static func routeComponents(from components: URLComponents) -> [String] {
-        var route: [String] = []
-        if let host = components.host?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !host.isEmpty {
-            route.append(host)
-        }
-        route += components.path
-            .split(separator: "/", omittingEmptySubsequences: true)
-            .map(String.init)
-        return route
-    }
-
-    private static func parseStableFallback(
-        from components: URLComponents,
-        allowedNames: Set<String>
-    ) -> Result<(workspaceId: UUID?, surfaceId: UUID?)?, CmuxNavigationURLParseError> {
-        guard components.percentEncodedQuery != nil else { return .success(nil) }
-        guard let items = components.queryItems, !items.isEmpty else {
-            return .failure(.unsupportedURLShape)
-        }
-
-        var stableWorkspaceId: UUID?
-        var stableSurfaceId: UUID?
-        var seenNames: Set<String> = []
-        for item in items {
-            guard allowedNames.contains(item.name),
-                  seenNames.insert(item.name).inserted,
-                  let value = item.value,
-                  !value.isEmpty else {
-                return .failure(.unsupportedURLShape)
-            }
-
-            guard let id = UUID(uuidString: value) else {
-                switch item.name {
-                case "stable_workspace_id":
-                    return .failure(.invalidIdentifier("stable_workspace"))
-                case "stable_surface_id":
-                    return .failure(.invalidIdentifier("stable_surface"))
-                default:
-                    return .failure(.unsupportedURLShape)
-                }
-            }
-
-            switch item.name {
-            case "stable_workspace_id":
-                stableWorkspaceId = id
-            case "stable_surface_id":
-                stableSurfaceId = id
-            default:
-                return .failure(.unsupportedURLShape)
-            }
-        }
-
-        return .success((
-            workspaceId: stableWorkspaceId,
-            surfaceId: stableSurfaceId
-        ))
     }
 }
 

--- a/Sources/Mobile/MobileStateSync.swift
+++ b/Sources/Mobile/MobileStateSync.swift
@@ -223,6 +223,7 @@ final class MobileStateSyncHost {
         )
         return WorkspaceSyncRecord(
             id: workspace.id.uuidString,
+            stableID: workspace.stableId.uuidString,
             windowID: windowID.uuidString,
             title: workspace.title,
             customDescription: description.value,

--- a/Sources/TerminalController+MobileSurfaces.swift
+++ b/Sources/TerminalController+MobileSurfaces.swift
@@ -71,11 +71,13 @@ extension TerminalController {
             }
             return WorkspaceSyncRecord.Surface(
                 surfaceID: panel.id.uuidString,
+                stableSurfaceID: panel.stableSurfaceId.uuidString,
                 kind: mobileSurfaceKind(for: panel.panelType).rawValue,
                 title: workspace.panelTitle(panelId: panel.id) ?? panel.displayTitle,
                 filePath: filePath,
                 todo: panel.panelType == .workspaceTodo ? mobileTodoSnapshot(in: workspace) : nil,
-                isFocused: panel.id == workspace.focusedPanelId
+                isFocused: panel.id == workspace.focusedPanelId,
+                paneID: workspace.paneId(forPanelId: panel.id)?.id.uuidString
             )
         }
     }

--- a/Sources/TerminalController+MobileWorkspaceList.swift
+++ b/Sources/TerminalController+MobileWorkspaceList.swift
@@ -252,11 +252,15 @@ extension TerminalController {
         let surfaces = mobileSurfaceDescriptors(in: workspace).map { surface -> [String: Any] in
             var payload: [String: Any] = [
                 "surface_id": surface.surfaceID,
+                "stable_surface_id": v2OrNull(surface.stableSurfaceID),
                 "kind": surface.kind,
                 "title": surface.title,
                 "is_focused": surface.isFocused,
                 "file_path": v2OrNull(surface.filePath),
             ]
+            if let paneID = surface.paneID {
+                payload["pane_id"] = paneID
+            }
             if let todo = surface.todo {
                 payload["todo"] = mobileTodoPayload(todo)
             }
@@ -272,6 +276,7 @@ extension TerminalController {
         )
         return [
             "id": workspace.id.uuidString,
+            "stable_id": workspace.stableId.uuidString,
             "window_id": v2OrNull(windowID?.uuidString),
             "title": workspace.title,
             // Durable workspace identity stays separate from the live activity


### PR DESCRIPTION
## Summary

- Extracted the strict workspace/pane/surface navigation URL grammar into CMUXMobileCore while retaining macOS callback-scheme compatibility.
- Added iOS external URL routing with authentication/startup deferral, topology-driven retry, workspace/pane/surface selection, and stable workspace/surface fallbacks.
- Extended legacy and v2 mobile workspace/surface inventory with stable workspace, stable surface, pane, and focus metadata.

## Testing

- `swift test --package-path Packages/Shared/CMUXMobileCore --filter CmxNavigationURLRequestTests` — 5 passed.
- `swift test --package-path Packages/iOS/CmuxMobileShell --filter MobileExternalNavigationTargetResolverTests` — 4 passed.
- `swift test --package-path Packages/Shared/CMUXMobileCore --filter MobileStateSyncFrameCodingTests` — 11 passed.
- `swift test --package-path Packages/iOS/CmuxMobileRPC --filter MobileCoreRPCIndependentEventTests` — 7 passed.
- `python3 scripts/check-workspace-package-groups.py --check` — passed.
- `python3 scripts/check-package-resolved-policy.py` — passed.
- `./scripts/lint-pbxproj-test-wiring.sh` — passed (703 test files).
- `swiftc -frontend -parse` over all changed Swift files — passed.
- The full CMUXMobileCore suite has 15 pre-existing DiagnosticEventPresentation failures in this checkout.
- CmuxMobileShellUI package build is blocked before compilation because the local GhosttyKit.xcframework has no binary artifact.
- Local Xcode/XCUITest and app launch were not run per task instructions.

## HIG

Navigation follows Apple’s [Navigation and search Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/navigation-and-search) by carrying an external destination into the requested workspace context and deferring it until that destination is available.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790332277&installation_model_id=21920&pr_number=10844&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10844&signature=d58aa02992791c81f31e9f1443382ab77e02d0e599d6a59b3aebabda461b95b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light-v2.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
