### PR TITLE
fix: restore session snapshot after crash (#9825)

### DIFF
--- a/Sources/AppDelegate+CrashSessionSnapshotRemoval.swift
+++ b/Sources/AppDelegate+CrashSessionSnapshotRemoval.swift
@@ -1,7 +1,24 @@
 import Foundation
 
 extension AppDelegate {
-    func syncManualRestoreSnapshotCachePruningCrashDiagnostics() {
+    /// Returns whether a missing primary snapshot has an independent recovery
+    /// signal. A clean missing primary still means the user intentionally began
+    /// fresh, while an unclean launch or crash-only teardown marker means the
+    /// `-previous` generation is the safe source of truth.
+    nonisolated static func shouldRecoverMissingPrimarySessionSnapshot(
+        previousLaunchWasUnclean: Bool,
+        crashOnlyPrimarySnapshotRemovalMarker: Bool
+    ) -> Bool {
+        previousLaunchWasUnclean || crashOnlyPrimarySnapshotRemovalMarker
+    }
+
+    /// Synchronizes the manual-restore cache while preserving a known-good
+    /// generation across an unclean launch. A primary snapshot can be valid JSON
+    /// yet represent a partially completed restore; keeping the prior copy gives
+    /// the user a rollback path and avoids destroying the only intact snapshot.
+    func syncManualRestoreSnapshotCachePruningCrashDiagnostics(
+        preserveExistingBackup: Bool = false
+    ) {
         guard let primaryURL = sessionSnapshotStore.defaultSnapshotFileURL(),
               let backupURL = sessionSnapshotStore.manualRestoreSnapshotFileURL() else {
             return
@@ -14,9 +31,13 @@ extension AppDelegate {
                 .snapshot else {
                 return
             }
+            if preserveExistingBackup,
+               case .loaded = sessionSnapshotStore.loadOutcome(fileURL: backupURL) {
+                return
+            }
             _ = sessionSnapshotStore.save(prunedSnapshot, fileURL: backupURL)
         case .missing:
-            if !Self.hasCrashOnlyPrimarySnapshotRemovalMarker() {
+            if !preserveExistingBackup && !Self.hasCrashOnlyPrimarySnapshotRemovalMarker() {
                 sessionSnapshotStore.removeSnapshot(fileURL: backupURL)
             }
         case .unusable:

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -857,6 +857,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var splitButtonTooltipRefreshScheduled = false
     private var didScheduleGhosttyCrashBreadcrumbCheck = false
     private var ghosttyCrashBreadcrumbTask: Task<Void, Never>?
+    /// Shared result for the one crash-artifact scan used by both the
+    /// diagnostic notification and the rare missing-primary recovery probe.
+    private var pendingCrashScanTask: Task<GhosttyCrashBreadcrumb.PendingCrash?, Never>?
+    private var isWaitingForStartupCrashRecoveryProbe = false
+    private var deferredInitialMainWindowBootstrapDebugSource: String?
     struct PendingConfiguredShortcutChord {
         let firstStroke: ShortcutStroke
         let windowNumber: Int?
@@ -1088,6 +1093,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var lastCascadePoint = NSPoint.zero
     private(set) var startupSessionSnapshot: AppSessionSnapshot?
     private var didPrepareStartupSessionSnapshot = false
+    /// Classification of the process that preceded this launch. Captured before
+    /// the current run arms its sentinel so a crash can recover a missing primary
+    /// snapshot from the immutable `-previous` copy.
+    private var previousSessionLaunchWasUnclean = false
+    private var didCaptureSessionLaunchState = false
+    private var didArmSessionLaunchSentinel = false
     var didAttemptStartupSessionRestore = false
     var isApplyingSessionRestore = false
     /// Durable navigation links that arrived before startup restore registered
@@ -1288,7 +1299,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 )
             }
         )
-        super.init(); Self.shared = self
+        super.init()
+        // Capture the prior process before composition-root wiring begins. The
+        // later configure/didFinish hooks remain idempotent fallbacks for
+        // delegate lifecycles that bypass the normal SwiftUI path.
+        captureSessionLaunchStateIfNeeded()
+        Self.shared = self
         mainThreadHangWatchdog.start()
         AgentChatThemeSync.start()
         // Inverts the surface registry's legacy AppDelegate.shared reach-up:
@@ -1619,6 +1635,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         NSApp.servicesProvider = self
 
         StartupBreadcrumbLog.append("appDelegate.didFinish.bootstrap.begin")
+        // Cover delegate lifecycles where SwiftUI has not called configure yet;
+        // both methods are idempotent and the snapshot probe remains gated to
+        // the missing-primary case.
+        captureSessionLaunchStateIfNeeded(environment: env)
+        prepareStartupSessionSnapshotIfNeeded()
         scheduleInitialMainWindowBootstrap(debugSource: "didFinishLaunching")
         StartupBreadcrumbLog.append("appDelegate.didFinish.complete")
 #if DEBUG
@@ -2285,11 +2306,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         BrowserProfileStore.shared.flushPendingSaves()
         ghosttyCrashBreadcrumbTask?.cancel()
         ghosttyCrashBreadcrumbTask = nil
+        pendingCrashScanTask?.cancel()
+        pendingCrashScanTask = nil
         notificationStore?.clearAll()
         GhosttyCrashBreadcrumb.markCleanExit()
         unregisterDisplayReconfigurationCallbackIfNeeded()
         StartupBreadcrumbLog.append("appDelegate.willTerminate.complete")
         enableSuddenTerminationIfNeeded()
+        // Remove the unclean-launch sentinel only after the full termination
+        // tail has completed; a teardown crash must remain recoverable next run.
+        if didArmSessionLaunchSentinel {
+            GhosttyCrashBreadcrumb.markSessionCleanExit()
+        }
     }
 
     func applicationWillResignActive(_ notification: Notification) {
@@ -2317,6 +2345,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         settingsRuntime: SettingsRuntime,
         auth: MacAuthComposition
     ) {
+        captureSessionLaunchStateIfNeeded()
         self.tabManager = tabManager
         if let tabDragTransferRegistryStorage {
             precondition(
@@ -2416,13 +2445,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #endif
     }
 
+    private func pendingCrashScanTaskIfNeeded() -> Task<GhosttyCrashBreadcrumb.PendingCrash?, Never> {
+        if let pendingCrashScanTask {
+            return pendingCrashScanTask
+        }
+        let task = Task {
+            await GhosttyCrashBreadcrumb.pendingCrashFromDefaultStorage()
+        }
+        pendingCrashScanTask = task
+        return task
+    }
+
     private func scheduleGhosttyCrashBreadcrumbIfNeeded(notificationStore: TerminalNotificationStore) {
         guard !didScheduleGhosttyCrashBreadcrumbCheck else { return }
         didScheduleGhosttyCrashBreadcrumbCheck = true
+        let pendingCrashScanTask = pendingCrashScanTaskIfNeeded()
 
-        ghosttyCrashBreadcrumbTask = Task { [weak self, weak notificationStore] in
+        ghosttyCrashBreadcrumbTask = Task { @MainActor [weak self, weak notificationStore] in
             defer { self?.ghosttyCrashBreadcrumbTask = nil }
-            guard let pendingCrash = await GhosttyCrashBreadcrumb.pendingCrashFromDefaultStorage(),
+            guard let pendingCrash = await pendingCrashScanTask.value,
                   !Task.isCancelled,
                   let notificationStore else { return }
             notificationStore.addNotification(
@@ -3498,14 +3539,88 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 #endif
 
+    private func captureSessionLaunchStateIfNeeded(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) {
+        guard !didCaptureSessionLaunchState else { return }
+        didCaptureSessionLaunchState = true
+        // Test processes must not leave a production lifecycle sentinel behind;
+        // this also keeps isolated unit-test app delegates from affecting the
+        // user's next launch.
+        guard !isRunningUnderXCTest(environment), !isRunningUnderXCTestCached else { return }
+        previousSessionLaunchWasUnclean = GhosttyCrashBreadcrumb.captureSessionLaunchState(
+            environment: environment
+        )
+        didArmSessionLaunchSentinel = true
+#if DEBUG
+        cmuxDebugLog(
+            "session.launchState previousUnclean=\(previousSessionLaunchWasUnclean ? 1 : 0)"
+        )
+#endif
+    }
+
     private func prepareStartupSessionSnapshotIfNeeded() {
         guard !didPrepareStartupSessionSnapshot else { return }
         didPrepareStartupSessionSnapshot = true
         Self.removeLegacyPersistedWindowGeometry()
-        syncManualRestoreSnapshotCachePruningCrashDiagnostics()
+        if shouldAwaitCrashRecoveryProbe() {
+            isWaitingForStartupCrashRecoveryProbe = true
+            let pendingCrashScanTask = pendingCrashScanTaskIfNeeded()
+            Task { @MainActor [weak self] in
+                let pendingCrash = await pendingCrashScanTask.value
+                guard let self, !Task.isCancelled, !self.isTerminatingApp else { return }
+                if pendingCrash != nil {
+                    self.previousSessionLaunchWasUnclean = true
+                }
+#if DEBUG
+                cmuxDebugLog(
+                    "session.restore.crashProbe pending=\(pendingCrash != nil ? 1 : 0)"
+                )
+#endif
+                self.isWaitingForStartupCrashRecoveryProbe = false
+                self.finishPreparingStartupSessionSnapshot()
+                self.resumeDeferredInitialMainWindowBootstrapIfNeeded()
+            }
+            return
+        }
+        finishPreparingStartupSessionSnapshot()
+    }
+
+    /// A missing primary with a backup is ambiguous until the asynchronous
+    /// crash-artifact probe completes. Defer cleanup and window bootstrap only
+    /// for that rare case; normal launches never wait on crash-file I/O.
+    private func shouldAwaitCrashRecoveryProbe() -> Bool {
+        guard SessionRestorePolicy.shouldAttemptRestore(),
+              !didHandleExplicitOpenIntentAtStartup,
+              !isRunningUnderXCTest(ProcessInfo.processInfo.environment),
+              !previousSessionLaunchWasUnclean,
+              !Self.hasCrashOnlyPrimarySnapshotRemovalMarker(),
+              let primaryURL = sessionSnapshotStore.defaultSnapshotFileURL(),
+              let backupURL = sessionSnapshotStore.manualRestoreSnapshotFileURL() else {
+            return false
+        }
+        return !FileManager.default.fileExists(atPath: primaryURL.path)
+            && FileManager.default.fileExists(atPath: backupURL.path)
+    }
+
+    private func finishPreparingStartupSessionSnapshot() {
+        syncManualRestoreSnapshotCachePruningCrashDiagnostics(
+            preserveExistingBackup: previousSessionLaunchWasUnclean
+        )
         let sanitizedStartupSnapshot = loadStartupSessionSnapshotPruningCrashDiagnostics()
-        guard SessionRestorePolicy.shouldAttemptRestore() else { return }
+        guard SessionRestorePolicy.shouldAttemptRestore(),
+              !didHandleExplicitOpenIntentAtStartup else { return }
         startupSessionSnapshot = sanitizedStartupSnapshot
+    }
+
+    private func resumeDeferredInitialMainWindowBootstrapIfNeeded() {
+        guard !didHandleExplicitOpenIntentAtStartup,
+              let debugSource = deferredInitialMainWindowBootstrapDebugSource else {
+            deferredInitialMainWindowBootstrapDebugSource = nil
+            return
+        }
+        deferredInitialMainWindowBootstrapDebugSource = nil
+        scheduleInitialMainWindowBootstrap(debugSource: debugSource)
     }
 
     private func loadStartupSessionSnapshotPruningCrashDiagnostics() -> AppSessionSnapshot? {
@@ -3519,7 +3634,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             }
             return loadManualRestoreSessionSnapshotPruningCrashDiagnostics()
         case .missing:
-            if Self.hasCrashOnlyPrimarySnapshotRemovalMarker() {
+            if Self.shouldRecoverMissingPrimarySessionSnapshot(
+                previousLaunchWasUnclean: previousSessionLaunchWasUnclean,
+                crashOnlyPrimarySnapshotRemovalMarker: Self.hasCrashOnlyPrimarySnapshotRemovalMarker()
+            ) {
                 return loadManualRestoreSessionSnapshotPruningCrashDiagnostics()
             }
             return nil
@@ -7622,6 +7740,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         didScheduleInitialMainWindowBootstrap = true
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
+            if self.didHandleExplicitOpenIntentAtStartup {
+                self.didScheduleInitialMainWindowBootstrap = false
+                return
+            }
+            if self.isWaitingForStartupCrashRecoveryProbe {
+                self.didScheduleInitialMainWindowBootstrap = false
+                if self.deferredInitialMainWindowBootstrapDebugSource == nil {
+                    self.deferredInitialMainWindowBootstrapDebugSource = debugSource
+                }
+                return
+            }
             if self.shouldDeferInitialMainWindowBootstrapForExternalConfirmation { self.didScheduleInitialMainWindowBootstrap = false; return }
             self.bootstrapInitialMainWindowIfNeeded(debugSource: debugSource)
         }

--- a/Sources/GhosttyCrashBreadcrumb.swift
+++ b/Sources/GhosttyCrashBreadcrumb.swift
@@ -10,6 +10,10 @@ enum GhosttyCrashBreadcrumb {
     static let lastShownCrashDefaultsKey = "ghosttyCrashBreadcrumb.lastShownCrashAt"
     static let notificationTabId = UUID(uuidString: "00000000-0000-0000-0000-000000003873")!
 
+    private static let sessionLifecycleDirectoryName = "lifecycle"
+    private static let sessionLaunchSentinelFileName = "running.sentinel"
+    private static let fallbackBundleIdentifier = "com.cmuxterm.app"
+
     nonisolated static var defaultCrashDirectoryURL: URL {
         SessionPersistencePolicy.defaultCmuxCrashDirectoryURL()
     }
@@ -101,6 +105,134 @@ enum GhosttyCrashBreadcrumb {
 
     nonisolated static func markCleanExit(defaults: UserDefaults = .standard, date: Date = Date()) {
         defaults.set(date, forKey: lastCleanExitDefaultsKey)
+    }
+
+    /// Captures whether the previous app process reached its clean-shutdown
+    /// tail, then arms a sentinel for the current process. The read must happen
+    /// before the sentinel is written; callers use the returned value to decide
+    /// whether a missing primary session snapshot may recover its backup.
+    nonisolated static func captureSessionLaunchState(
+        fileManager: FileManager = .default,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Bool {
+        let wasUnclean = priorSessionLaunchWasUnclean(
+            fileManager: fileManager,
+            homeDirectory: homeDirectory,
+            environment: environment
+        )
+        markSessionLaunchRunning(
+            fileManager: fileManager,
+            homeDirectory: homeDirectory,
+            environment: environment
+        )
+        return wasUnclean
+    }
+
+    /// Returns true when a prior process left its launch sentinel behind. The
+    /// sentinel is scoped by bundle identifier so tagged development builds do
+    /// not classify one another's exits as crashes.
+    nonisolated static func priorSessionLaunchWasUnclean(
+        fileManager: FileManager = .default,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Bool {
+        let url = sessionLaunchSentinelURL(
+            homeDirectory: homeDirectory,
+            environment: environment
+        )
+        var isDirectory: ObjCBool = false
+        return fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory)
+            && !isDirectory.boolValue
+    }
+
+    /// Marks this process as running. Failure is deliberately ignored: launch
+    /// must continue even when the state directory is unavailable.
+    nonisolated static func markSessionLaunchRunning(
+        fileManager: FileManager = .default,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) {
+        let url = sessionLaunchSentinelURL(
+            homeDirectory: homeDirectory,
+            environment: environment
+        )
+        do {
+            try fileManager.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true,
+                attributes: nil
+            )
+            guard let data = "pid=\(ProcessInfo.processInfo.processIdentifier)\n".data(using: .utf8) else {
+                return
+            }
+            try data.write(to: url, options: .atomic)
+        } catch {
+            // Best effort. An unwritable state directory simply means the next
+            // launch cannot classify this run and falls back conservatively.
+        }
+    }
+
+    /// Removes the current process sentinel after all clean-termination work
+    /// has completed. A teardown crash therefore remains classified as unclean.
+    nonisolated static func markSessionCleanExit(
+        fileManager: FileManager = .default,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) {
+        let url = sessionLaunchSentinelURL(
+            homeDirectory: homeDirectory,
+            environment: environment
+        )
+        do {
+            if fileManager.fileExists(atPath: url.path) {
+                try fileManager.removeItem(at: url)
+            }
+        } catch {
+            // Never block termination on sentinel cleanup.
+        }
+    }
+
+    /// Returns the per-bundle sentinel location. Exposed internally for
+    /// deterministic lifecycle tests; production callers use the methods above.
+    nonisolated static func sessionLaunchSentinelURL(
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> URL {
+        let stateRoot: URL
+        if let xdgStateHome = environment["XDG_STATE_HOME"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !xdgStateHome.isEmpty {
+            stateRoot = URL(
+                fileURLWithPath: (xdgStateHome as NSString).expandingTildeInPath,
+                isDirectory: true
+            )
+            .appendingPathComponent("cmux", isDirectory: true)
+        } else {
+            stateRoot = homeDirectory
+                .appendingPathComponent(".local", isDirectory: true)
+                .appendingPathComponent("state", isDirectory: true)
+                .appendingPathComponent("cmux", isDirectory: true)
+        }
+
+        return stateRoot
+            .appendingPathComponent(sessionLifecycleDirectoryName, isDirectory: true)
+            .appendingPathComponent(sessionLifecycleScope(environment: environment), isDirectory: true)
+            .appendingPathComponent(sessionLaunchSentinelFileName, isDirectory: false)
+    }
+
+    private static func sessionLifecycleScope(environment: [String: String]) -> String {
+        let rawBundleIdentifier = environment["CMUX_BUNDLE_ID"]
+            ?? Bundle.main.bundleIdentifier
+            ?? fallbackBundleIdentifier
+        let trimmedBundleIdentifier = rawBundleIdentifier.trimmingCharacters(in: .whitespacesAndNewlines)
+        let source = trimmedBundleIdentifier.isEmpty ? fallbackBundleIdentifier : trimmedBundleIdentifier
+        let allowed = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._-")
+        let replacement = UnicodeScalar("_")
+        let scalars = source.unicodeScalars.map { allowed.contains($0) ? $0 : replacement }
+        let sanitized = String(String.UnicodeScalarView(scalars))
+            .trimmingCharacters(in: CharacterSet(charactersIn: "._-"))
+        return sanitized.isEmpty ? fallbackBundleIdentifier : sanitized
     }
 
     private static func crashReportMatchesCurrentExecutable(_ url: URL, currentExecutableURL: URL?) -> Bool {

--- a/cmuxTests/CrashDiagnosticSessionPolicyTests.swift
+++ b/cmuxTests/CrashDiagnosticSessionPolicyTests.swift
@@ -378,6 +378,76 @@ struct CrashDiagnosticSessionPolicyTests {
         #expect(!AppDelegate.hasCrashOnlyPrimarySnapshotRemovalMarker(defaults: defaults))
     }
 
+    @Test
+    func missingPrimaryRecoveryRequiresAnUncleanLaunchSignal() {
+        #expect(
+            !AppDelegate.shouldRecoverMissingPrimarySessionSnapshot(
+                previousLaunchWasUnclean: false,
+                crashOnlyPrimarySnapshotRemovalMarker: false
+            )
+        )
+        #expect(
+            AppDelegate.shouldRecoverMissingPrimarySessionSnapshot(
+                previousLaunchWasUnclean: true,
+                crashOnlyPrimarySnapshotRemovalMarker: false
+            )
+        )
+        #expect(
+            AppDelegate.shouldRecoverMissingPrimarySessionSnapshot(
+                previousLaunchWasUnclean: false,
+                crashOnlyPrimarySnapshotRemovalMarker: true
+            )
+        )
+    }
+
+    @Test
+    func sessionLaunchSentinelClassifiesAndClearsUncleanRuns() throws {
+        let homeDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-session-launch-state-\(UUID().uuidString)", isDirectory: true)
+        let environment = ["CMUX_BUNDLE_ID": "com.cmux.tests.sentinel"]
+        defer { try? FileManager.default.removeItem(at: homeDirectory) }
+
+        #expect(
+            !GhosttyCrashBreadcrumb.priorSessionLaunchWasUnclean(
+                homeDirectory: homeDirectory,
+                environment: environment
+            )
+        )
+        #expect(
+            !GhosttyCrashBreadcrumb.captureSessionLaunchState(
+                homeDirectory: homeDirectory,
+                environment: environment
+            )
+        )
+        #expect(
+            GhosttyCrashBreadcrumb.priorSessionLaunchWasUnclean(
+                homeDirectory: homeDirectory,
+                environment: environment
+            )
+        )
+
+        // A second process would observe the first process's sentinel as an
+        // unclean prior run. This is the launch classification used by startup
+        // snapshot recovery.
+        #expect(
+            GhosttyCrashBreadcrumb.captureSessionLaunchState(
+                homeDirectory: homeDirectory,
+                environment: environment
+            )
+        )
+
+        GhosttyCrashBreadcrumb.markSessionCleanExit(
+            homeDirectory: homeDirectory,
+            environment: environment
+        )
+        #expect(
+            !GhosttyCrashBreadcrumb.priorSessionLaunchWasUnclean(
+                homeDirectory: homeDirectory,
+                environment: environment
+            )
+        )
+    }
+
     private func emptyWorkspaceSnapshot(currentDirectory: String) -> SessionWorkspaceSnapshot {
         SessionWorkspaceSnapshot(
             processTitle: "Terminal",


### PR DESCRIPTION
## Summary

- Track a bundle-scoped unclean-launch sentinel and classify the prior process before arming the current run.
- Preserve and automatically restore the previous session snapshot when the primary snapshot is missing after an unclean launch or crash-only teardown.
- Share the asynchronous crash-artifact scan with the existing diagnostic notification and defer initial window bootstrap only for the ambiguous missing-primary case; explicit open intents still cancel restore.
- Add Swift Testing coverage for missing-primary classification and sentinel lifecycle behavior.

## Checks

- swiftc -parse for the changed app sources and regression test
- git diff --check
- scripts/check-pbxproj.sh
- scripts/lint-pbxproj-test-wiring.sh
- scripts/check-package-resolved-policy.py
- scripts/check-workspace-package-groups.py --check
- No tagged build, XCUITest, or launch was intentionally run per the dispatch restriction.
- An accidental bare xcodebuild invocation while composing the original PR body exited during package resolution because vendor/bonsplit/Package.swift is absent; no build started.
- The mandated Swift file-budget command could not run because this checkout has neither scripts/swift_file_length_budget.py nor .github/swift-file-length-budget.tsv.

The branch was based on c5960aefda; current origin/main is newer, so rebase or merge should be handled by the next owner before dogfood.

Fixes #9825