### PR TITLE
cmux-tui: unbreak main verification (clippy x2 + npm archive guard)

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -843,10 +843,11 @@ pub fn default_terminal_cwd() -> Option<String> {
 }
 
 fn default_terminal_cwd_from(launch: Option<&Path>) -> Option<String> {
-    if let Some(dir) = launch {
-        if dir.parent().is_some() && dir.is_dir() {
-            return Some(dir.to_string_lossy().into_owned());
-        }
+    if let Some(dir) = launch
+        && dir.parent().is_some()
+        && dir.is_dir()
+    {
+        return Some(dir.to_string_lossy().into_owned());
     }
     home_dir().map(|path| path.to_string_lossy().into_owned())
 }

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -87,22 +87,6 @@ pub struct TabNotificationView {
 }
 
 impl TreeView {
-    /// Remove pane tabs that cannot be backed by an attached surface.
-    ///
-    /// Remote tree snapshots and surface detach events travel on separate
-    /// streams. Applying this filter before publishing a snapshot keeps the
-    /// renderer from observing a tab whose surface has already been removed.
-    pub fn retain_surfaces(&mut self, surfaces: &HashSet<SurfaceId>) {
-        for workspace in &mut self.workspaces {
-            for screen in &mut workspace.screens {
-                for pane in &mut screen.panes {
-                    pane.tabs.retain(|tab| surfaces.contains(&tab.surface));
-                    pane.active_tab = pane.active_tab.min(pane.tabs.len().saturating_sub(1));
-                }
-            }
-        }
-    }
-
     /// Retain the server's authoritative tab topology, removing only tabs
     /// with explicit detach/retire evidence. The local surface mirror is a
     /// lazy cache and can be empty during startup or reconnect.
@@ -662,29 +646,6 @@ mod tests {
 
         assert_eq!(screen.display_name(0), "0");
         assert_eq!(screen.display_name(9), "9");
-    }
-
-    #[test]
-    fn retain_surfaces_drops_missing_tabs_and_clamps_active_index() {
-        let mut tree = parse_tree(&json!({
-            "workspaces": [{
-                "id": 1, "active": true,
-                "screens": [{
-                    "id": 2, "active": true, "active_pane": 3,
-                    "layout": {"type": "leaf", "pane": 3},
-                    "panes": [{"id": 3, "active_tab": 1, "tabs": [
-                        {"surface": 7, "title": "gone"},
-                        {"surface": 8, "title": "kept"}
-                    ]}]
-                }]
-            }]
-        }));
-
-        tree.retain_surfaces(&HashSet::from([8]));
-
-        let pane = &tree.workspaces[0].screens[0].panes[0];
-        assert_eq!(pane.tabs.iter().map(|tab| tab.surface).collect::<Vec<_>>(), vec![8]);
-        assert_eq!(pane.active_tab, 0);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -650,11 +650,27 @@ mod tests {
 
     #[test]
     fn retain_not_retired_keeps_tabs_when_local_catalog_is_empty() {
-        let mut tree = parse_tree(
-            &json!({"workspaces":[{"id":1,"screens":[{"id":2,"panes":[{"id":3,"tabs":[{"surface":7},{"surface":8}],"active_tab":1}]}]}]}),
-        );
+        // The fixture must be a COMPLETE tree: parse_tree drops
+        // underspecified workspaces/screens, and this test shipped with a
+        // minimal shape that parsed to an empty tree (the panic was masked
+        // in CI by a clippy failure earlier in the same job).
+        let mut tree = parse_tree(&json!({
+            "workspaces": [{
+                "id": 1, "active": true,
+                "screens": [{
+                    "id": 2, "active": true, "active_pane": 3,
+                    "layout": {"type": "leaf", "pane": 3},
+                    "panes": [{"id": 3, "active_tab": 1, "tabs": [
+                        {"surface": 7, "title": "a"},
+                        {"surface": 8, "title": "b"}
+                    ]}]
+                }]
+            }]
+        }));
         tree.retain_not_retired(&HashSet::new());
-        assert_eq!(tree.workspaces[0].screens[0].panes[0].tabs.len(), 2);
+        let pane = &tree.workspaces[0].screens[0].panes[0];
+        assert_eq!(pane.tabs.len(), 2);
+        assert_eq!(pane.active_tab, 1);
     }
 
     #[test]

--- a/cmux-tui/dist/scripts/package_npm_artifact.py
+++ b/cmux-tui/dist/scripts/package_npm_artifact.py
@@ -14,7 +14,12 @@ from package_contract import PackageContractError, npm_executable_files, validat
 
 PACKAGE_ROOT = "npm-packages"
 MAX_MEMBERS = 1_024
-MAX_EXPANDED_BYTES = 512 * 1024 * 1024
+# Tar-bomb guard on the AGGREGATE four-platform archive, not a product
+# size budget (each install downloads exactly one platform package via
+# optionalDependencies). 512 MiB became too small once the Rust relay
+# binaries (chatmux-relay, cmux-relay) started riding every platform
+# package.
+MAX_EXPANDED_BYTES = 768 * 1024 * 1024
 
 
 def verify_executables(packages_dir: Path) -> None:

--- a/cmux-tui/scripts/smoke-tui.py
+++ b/cmux-tui/scripts/smoke-tui.py
@@ -690,17 +690,15 @@ assert has_sgr_parameters(color_output, (48, 5, 236)), color_output[-2000:]
 assert not has_sgr_parameters(color_output, (38, 2, 204, 102, 102)), color_output[-2000:]
 print("indexed color passthrough ok")
 
-inner_osc_query = """python3 - <<'PY'
-import os, select, termios, time, tty
+inner_osc_query = """import os, select, termios, time, tty
 fd = os.open('/dev/tty', os.O_RDWR)
 old = termios.tcgetattr(fd)
 try:
     tty.setraw(fd)
     os.write(fd, b'\\x1b]11;?\\x1b\\\\')
     data = b''
-    # Generous deadline: the shell may still be consuming the pasted
-    # heredoc and the TUI coalesces frames (this raced at 2s, and 8s
-    # still fails on saturated CI runners).
+    # Generous deadline: the TUI coalesces frames and saturated CI
+    # runners stall the reply (this raced at 2s and again at 8s).
     end = time.monotonic() + 30
     while time.monotonic() < end and not (data.endswith(b'\\x1b\\\\') or data.endswith(b'\\x07')):
         r, _, _ = select.select([fd], [], [], max(0, end - time.monotonic()))
@@ -711,9 +709,18 @@ finally:
     termios.tcsetattr(fd, termios.TCSADRAIN, old)
     os.close(fd)
 print(data.decode('ascii', 'ignore').replace('\\x1b', '<ESC>').replace('\\x07', '<BEL>'))
-PY
 """
-write_all(fd, inner_osc_query.replace("\n", "\r").encode())
+# Never PASTE the script through the pty: on saturated CI runners a
+# multi-line heredoc flood drops bytes in transit (observed as a
+# corrupted `tcsetattr` on screen), and no deadline fixes a mangled
+# program. The harness shares a filesystem with the TUI's shell, so
+# write the script to disk and type only the short invocation.
+with tempfile.NamedTemporaryFile(
+    "w", suffix="-osc-query.py", delete=False
+) as inner_script:
+    inner_script.write(inner_osc_query)
+    inner_script_path = inner_script.name
+write_all(fd, f"python3 {inner_script_path}\r".encode())
 wait_screen_contains(surface_id, "1313/1414/1515")
 print("inner OSC 11 query receives seeded background ok")
 write_all(fd, b"\x03")


### PR DESCRIPTION
Three upstream drifts red every fresh branch's cmux-tui verification (hit on feat-tui-on-exit-policy's --full runs; none caused by that branch):

1. collapsible_if in platform.rs from #10757 (rust 1.95 clippy, CI runs -D warnings) — let-chain collapse, no behavior change.
2. dead retain_surfaces in session/tree.rs from #10756/81bd256cf4 — the shipped code calls retain_not_retired (the commit's own comment rejects the negative-filter approach retain_surfaces implements); deleted with its only test.
3. npm archive expanded-size guard (512 MiB) now trips: the Rust relay binaries riding every platform package pushed the AGGREGATE four-platform archive over it. The guard is a tar-bomb bound, not a user budget (installs download one platform package) — raised to 768 MiB with a comment. If per-platform size is a concern, that is a separate conversation about stripping/bundling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved server-reported tabs when the local surface catalog is temporarily empty.
  * Improved active-tab retention by matching tabs using their surface identity.
  * Prevented non-retired tabs from being removed incorrectly.
  * Improved session tree stability during temporary surface catalog synchronization gaps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->