### PR TITLE
fix(portal): ask bonsplit which pane owns a tab instead of scanning

### DIFF
--- a/Sources/Panels/TerminalPanelView.swift
+++ b/Sources/Panels/TerminalPanelView.swift
@@ -207,7 +207,9 @@ struct TerminalPanelView: View {
               let tabId = workspace.surfaceIdFromPanelId(panel.id) else {
             return false
         }
-        return workspace.bonsplitController.selectedTab(inPane: currentPane)?.id == tabId
+        // See the resolver in WorkspaceContentView: selectedTab would
+        // subscribe this update to every tab title in the pane.
+        return workspace.bonsplitController.selectedTabId(inPane: currentPane) == tabId
     }
 
     private var effectiveTerminalAgentContext: String {

--- a/Sources/Workspace+WorkspaceSurfaceTreeReading.swift
+++ b/Sources/Workspace+WorkspaceSurfaceTreeReading.swift
@@ -18,11 +18,17 @@ extension Workspace: WorkspaceSurfaceTreeReading {
         paneTree.surfaceId(forPanelId: panelId)
     }
 
+    /// The pane that currently holds this panel's surface.
+    ///
+    /// Bonsplit keeps a pane-ownership index, so ask it. The scan this replaced
+    /// built a `Tab` for every tab in every pane, and `Tab.init(from:)` copies
+    /// all fourteen `TabItem` properties. Run inside a SwiftUI update, as the
+    /// portal-ownership resolver does, that subscribed the update to every tab
+    /// title in the window, so an animating title invalidated the terminal
+    /// surfaces. `DockSplitStore.paneId(forPanelId:)` already did it this way.
     func paneId(forPanelId panelId: UUID) -> PaneID? {
         guard let tabId = surfaceIdFromPanelId(panelId) else { return nil }
-        return bonsplitController.allPaneIds.first { paneId in
-            bonsplitController.tabs(inPane: paneId).contains(where: { $0.id == tabId })
-        }
+        return bonsplitController.paneId(containing: tabId)
     }
 
     func indexInPane(forPanelId panelId: UUID) -> Int? {

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -86,7 +86,10 @@ private struct WorkspacePanelContentHostView: View {
                       let tabId = workspace.surfaceIdFromPanelId(panel.id) else {
                     return false
                 }
-                return workspace.bonsplitController.selectedTab(inPane: paneId)?.id == tabId
+                // selectedTabId, not selectedTab: building a Tab reads every
+                // TabItem property, which subscribes this update to the tab's
+                // title. Portal ownership only needs identity.
+                return workspace.bonsplitController.selectedTabId(inPane: paneId) == tabId
             },
             onFocus: onFocus,
             onRequestPanelFocus: onRequestPanelFocus,


### PR DESCRIPTION
**Status:** updated onto `main` (`78f4c82504`) as merge commit `75b1f9a63f`. No conflicts.

**Reviewer's guide**
- Three call sites, two shapes: `Workspace.paneId(forPanelId:)`, `Sources/Panels/TerminalPanelView.swift`, `Sources/WorkspaceContentView.swift`.
- Both replacement APIs (`paneId(containing:)`, `selectedTabId(inPane:)`) are already in the pinned bonsplit, and `DockSplitStore` and `PaneDropContainer` already use them.
- Behaviour is unchanged; the diff is about not reading `TabItem` fields inside a view update.

---

Portal ownership checks were reading tab titles. They run inside a SwiftUI update, so an animating spinner title invalidated every terminal surface in the window. This stops that.

Three call sites, two shapes.

`Workspace.paneId(forPanelId:)` walked every pane:

```swift
bonsplitController.allPaneIds.first { paneId in
    bonsplitController.tabs(inPane: paneId).contains(where: { $0.id == tabId })
}
```

`tabs(inPane:)` maps each `TabItem` through `Tab.init(from:)`, which copies all fourteen properties, `title` among them. Reading a title inside a view update subscribes that update to the title, so a scan looking for one id subscribed the caller to every tab in the window.

Bonsplit already keeps a pane-ownership index. `paneId(containing:)` is a dictionary lookup and touches no tab fields. `DockSplitStore.paneId(forPanelId:)` was already calling it.

The other two sites asked `selectedTab(inPane:)?.id == tabId` when the id was all they wanted. `selectedTabId(inPane:)` answers that without building a `Tab`.

## Measurements

Instruments SwiftUI template, 20 seconds, attached to a Release build with eight agent tabs writing spinner frames into their titles.

| | before | after |
|---|---|---|
| `currentPortalPaneOwner` | 75 ms | 0.1 ms |
| `Workspace.paneId(forPanelId:)` | all of the above | 0.1 ms |

The after capture had the workload to do: 560 `TabItem.title` invalidations in 20.7 seconds, about 27 a second. The call site just stopped answering them.

What this doesn't claim. Process CPU didn't move measurably, because 75 ms out of a 5000 ms capture is under 2%. And the 68 ms of `tabs(inPane:)` still in the after capture is real, but every sample of it comes from `Workspace.sidebarOrderedPanelIds()`, which has the same shape and is its own change.

Behavior is unchanged. `paneId(containing:)` and the scan return the same pane, and `selectedTabId` returns the id `selectedTab?.id` would have.
