### PR TITLE
Add Mistral Vibe CLI agent integration

### DIFF
--- a/CLI/CMUXCLI+AgentHookCatalog.swift
+++ b/CLI/CMUXCLI+AgentHookCatalog.swift
@@ -253,6 +253,23 @@ extension CMUXCLI {
             ],
             feedHookEvents: ["PreToolUse", "PostToolUse"]
         ),
+        AgentHookDef(
+            name: "vibe", displayName: "Mistral Vibe", statusKey: "vibe",
+            configDir: ".vibe", configFile: "hooks.toml",
+            configDirEnvOverride: "VIBE_HOME",
+            createConfigDirIfMissing: true,
+            sessionStoreSuffix: "vibe", disableEnvVar: "CMUX_VIBE_HOOKS_DISABLED",
+            hookMarker: "cmux hooks vibe", format: .tomlArrayTable,
+            events: [
+                // Vibe has no SessionStart or SessionEnd hook. post_agent fires
+                // after each turn; the stop handler upserts the session record
+                // (with session_id from the hook payload) and publishes the
+                // surface resume binding on the first turn, so session restore
+                // works even without an explicit session-start event.
+                .init(agentEvent: "post_agent", cmuxSubcommand: "stop"),
+            ],
+            feedHookEvents: ["pre_tool", "post_tool"]
+        ),
     ]
 
     static func agentDef(named name: String) -> AgentHookDef? {

--- a/CLI/CMUXCLI+VibeHooks.swift
+++ b/CLI/CMUXCLI+VibeHooks.swift
@@ -5,6 +5,9 @@ extension CMUXCLI {
     private static let vibeLifecycleHookTimeoutSeconds: Double = 60
     private static let vibeFeedHookTimeoutSeconds: Double = 120
 
+    /// Builds the lifecycle and feed hook events for a Vibe agent definition.
+    /// - Parameter def: The Vibe agent hook definition.
+    /// - Returns: Vibe hook events ready for TOML serialization.
     func vibeHookEvents(def: AgentHookDef) -> [VibeHookConfig.Event] {
         var events = def.events.map { event in
             VibeHookConfig.Event(
@@ -25,6 +28,9 @@ extension CMUXCLI {
         return events
     }
 
+    /// Installs cmux-owned hooks into the Vibe config file at `~/.vibe/hooks.toml`.
+    /// - Parameter def: The Vibe agent hook definition.
+    /// - Throws: A `CLIError` if the config directory is a file or cannot be created.
     func installVibeHooks(_ def: AgentHookDef) throws {
         let fm = FileManager.default
         let configDir = def.resolvedConfigDir()
@@ -105,6 +111,9 @@ extension CMUXCLI {
         ))
     }
 
+    /// Removes cmux-owned hooks from the Vibe config file at `~/.vibe/hooks.toml`.
+    /// - Parameter def: The Vibe agent hook definition.
+    /// - Throws: A `CLIError` if the config file cannot be read or written.
     func uninstallVibeHooks(_ def: AgentHookDef) throws {
         let fm = FileManager.default
         let configDir = def.resolvedConfigDir()

--- a/CLI/CMUXCLI+VibeHooks.swift
+++ b/CLI/CMUXCLI+VibeHooks.swift
@@ -1,0 +1,142 @@
+import CMUXAgentLaunch
+import Foundation
+
+extension CMUXCLI {
+    private static let vibeLifecycleHookTimeoutSeconds: Double = 60
+    private static let vibeFeedHookTimeoutSeconds: Double = 120
+
+    func vibeHookEvents(def: AgentHookDef) -> [VibeHookConfig.Event] {
+        var events = def.events.map { event in
+            VibeHookConfig.Event(
+                name: "cmux-\(event.cmuxSubcommand)",
+                type: event.agentEvent,
+                command: hookCommand(for: def, event: event),
+                timeout: Self.vibeLifecycleHookTimeoutSeconds
+            )
+        }
+        events.append(contentsOf: def.feedHookEvents.map { agentEvent in
+            VibeHookConfig.Event(
+                name: "cmux-feed-\(agentEvent)",
+                type: agentEvent,
+                command: feedHookCommand(for: def, agentEvent: agentEvent),
+                timeout: Self.vibeFeedHookTimeoutSeconds
+            )
+        })
+        return events
+    }
+
+    func installVibeHooks(_ def: AgentHookDef) throws {
+        let fm = FileManager.default
+        let configDir = def.resolvedConfigDir()
+        let filePath = "\(configDir)/\(def.configFile)"
+        let events = vibeHookEvents(def: def)
+        let skipConfirm = ProcessInfo.processInfo.arguments.contains("--yes")
+            || ProcessInfo.processInfo.arguments.contains("-y")
+
+        let configDirectoryFileError = String.localizedStringWithFormat(
+            String(
+                localized: "cli.hooks.error.configDirectoryIsFile",
+                defaultValue: "cmux could not create the hooks directory: a file exists at %@. Remove or rename the conflicting file, then run `cmux hooks setup` again."
+            ),
+            configDir
+        )
+        var isConfigDirectory = ObjCBool(false)
+        let configPathExists = fm.fileExists(atPath: configDir, isDirectory: &isConfigDirectory)
+        if configPathExists, !isConfigDirectory.boolValue {
+            throw CLIError(message: configDirectoryFileError)
+        }
+
+        let oldString = try readAgentHookConfig(filePath: filePath, displayName: def.displayName)
+        let newString = VibeHookConfig.installing(events: events, in: oldString)
+
+        if oldString == newString {
+            print(String.localizedStringWithFormat(
+                String(
+                    localized: "cli.hooks.vibe.alreadyUpToDate",
+                    defaultValue: "%@ hooks already up to date at %@"
+                ),
+                def.displayName,
+                filePath
+            ))
+            return
+        }
+
+        if !skipConfirm {
+            Self.printInstallPreview(
+                path: filePath,
+                oldContent: oldString,
+                newContent: newString,
+                fallbackContent: newString
+            )
+            print(String(
+                localized: "cli.hooks.vibe.confirmProceed",
+                defaultValue: "\nProceed? [y/N] "
+            ), terminator: "")
+            guard readLine()?.lowercased().hasPrefix("y") == true else {
+                print(String(
+                    localized: "cli.hooks.vibe.aborted",
+                    defaultValue: "Aborted."
+                ))
+                return
+            }
+        }
+
+        if !configPathExists {
+            do {
+                try fm.createDirectory(atPath: configDir, withIntermediateDirectories: true)
+            } catch {
+                throw CLIError(message: configDirectoryFileError)
+            }
+        }
+        try newString.write(toFile: filePath, atomically: true, encoding: .utf8)
+        print(String.localizedStringWithFormat(
+            String(
+                localized: "cli.hooks.vibe.installed",
+                defaultValue: "%@ hooks installed at %@"
+            ),
+            def.displayName,
+            filePath
+        ))
+    }
+
+    func uninstallVibeHooks(_ def: AgentHookDef) throws {
+        let fm = FileManager.default
+        let configDir = def.resolvedConfigDir()
+        let filePath = "\(configDir)/\(def.configFile)"
+
+        guard fm.fileExists(atPath: filePath) else {
+            print(String.localizedStringWithFormat(
+                String(
+                    localized: "cli.hooks.vibe.noneFound",
+                    defaultValue: "No %@ found at %@"
+                ),
+                def.configFile,
+                filePath
+            ))
+            return
+        }
+
+        let oldString = try readAgentHookConfig(filePath: filePath, displayName: def.displayName)
+        let newString = VibeHookConfig.uninstalling(from: oldString)
+
+        guard oldString != newString else {
+            print(String.localizedStringWithFormat(
+                String(
+                    localized: "cli.hooks.vibe.removedZero",
+                    defaultValue: "Removed 0 cmux hook(s) from %@"
+                ),
+                filePath
+            ))
+            return
+        }
+
+        try newString.write(toFile: filePath, atomically: true, encoding: .utf8)
+        print(String.localizedStringWithFormat(
+            String(
+                localized: "cli.hooks.vibe.removed",
+                defaultValue: "Removed Mistral Vibe cmux hooks from %@"
+            ),
+            filePath
+        ))
+    }
+}

--- a/CLI/CMUXCLI+VibeHooks.swift
+++ b/CLI/CMUXCLI+VibeHooks.swift
@@ -47,7 +47,7 @@ extension CMUXCLI {
         }
 
         let oldString = try readAgentHookConfig(filePath: filePath, displayName: def.displayName)
-        let newString = VibeHookConfig.installing(events: events, in: oldString)
+        let newString = VibeHookConfig().installing(events: events, in: oldString)
 
         if oldString == newString {
             print(String.localizedStringWithFormat(
@@ -85,7 +85,13 @@ extension CMUXCLI {
             do {
                 try fm.createDirectory(atPath: configDir, withIntermediateDirectories: true)
             } catch {
-                throw CLIError(message: configDirectoryFileError)
+                throw CLIError(message: String.localizedStringWithFormat(
+                    String(
+                        localized: "cli.hooks.error.configDirectoryCreateFailed",
+                        defaultValue: "cmux could not create the hooks directory at %@. Check the directory permissions, then run `cmux hooks setup` again."
+                    ),
+                    configDir
+                ))
             }
         }
         try newString.write(toFile: filePath, atomically: true, encoding: .utf8)
@@ -117,7 +123,7 @@ extension CMUXCLI {
         }
 
         let oldString = try readAgentHookConfig(filePath: filePath, displayName: def.displayName)
-        let newString = VibeHookConfig.uninstalling(from: oldString)
+        let newString = VibeHookConfig().uninstalling(from: oldString)
 
         guard oldString != newString else {
             print(String.localizedStringWithFormat(
@@ -134,8 +140,9 @@ extension CMUXCLI {
         print(String.localizedStringWithFormat(
             String(
                 localized: "cli.hooks.vibe.removed",
-                defaultValue: "Removed Mistral Vibe cmux hooks from %@"
+                defaultValue: "Removed %@ cmux hooks from %@"
             ),
+            def.displayName,
             filePath
         ))
     }

--- a/CLI/FeedEventClassifier.swift
+++ b/CLI/FeedEventClassifier.swift
@@ -337,6 +337,12 @@ struct FeedEventClassifier {
             "agentSpawn": .sessionStart,
             "stop": .response,
         ],
+        // Vibe has its own approval UI (tool permissions handled in the TUI),
+        // so feed events are telemetry only — no blocking approval wait.
+        "vibe": [
+            "pre_tool": .toolStart,
+            "post_tool": .toolEnd,
+        ],
     ]
 
     /// Shared event spellings for sources that have a verified blocking

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -32524,6 +32524,10 @@ export default CMUXSessionRestore;
             try installHermesAgentHooks(def)
             return
         }
+        if def.name == "vibe" {
+            try installVibeHooks(def)
+            return
+        }
         if case .antigravityJSON = def.format {
             try installAntigravityHooks(def)
             return
@@ -32902,6 +32906,10 @@ export default CMUXSessionRestore;
         }
         if def.name == "hermes-agent" {
             try uninstallHermesAgentHooks(def)
+            return
+        }
+        if def.name == "vibe" {
+            try uninstallVibeHooks(def)
             return
         }
         if case .antigravityJSON = def.format {

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
@@ -195,6 +195,8 @@ public enum AgentLaunchSanitizer {
             return preserveOptions(args, policy: qoderPolicy)
         case "kimi":
             return preserveOptions(args, policy: kimiPolicy)
+        case "vibe":
+            return preserveOptions(args, policy: vibePolicy)
         case "ollama":
             return OllamaLaunchArgumentsPreserver().preservedArguments(args)
         default:

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerVibePolicy.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerVibePolicy.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+extension AgentLaunchSanitizer {
+    /// Preserves interactive Vibe configuration without replaying a prior session selector or one-shot mode.
+    static let vibePolicy = Policy(
+        valueOptions: [
+            "--workdir",
+            "--add-dir",
+            "--agent",
+            "--resume", "-c",
+            "--prompt", "-p",
+            "--max-turns",
+            "--max-price",
+            "--max-tokens",
+            "--output",
+            "--worktree",
+        ],
+        optionalValueOptions: [
+            "--resume", "-c",
+            "--prompt", "-p",
+            "--worktree",
+        ],
+        booleanOptions: [
+            "--auto-approve", "--yolo",
+            "--trust",
+            "--setup", "--check-upgrade",
+            "-v", "--version",
+            "-h", "--help",
+        ],
+        variadicOptions: [
+            "--enabled-tools",
+            "--disabled-tools",
+        ],
+        nonRestorableCommands: [],
+        droppedOptions: [
+            "--resume", "-c",
+            "--prompt", "-p",
+            "--max-turns", "--max-price", "--max-tokens",
+            "--output",
+        ],
+        droppedOptionPrefixes: [
+            "--resume=",
+            "--prompt=", "-p=",
+            "--max-turns=", "--max-price=", "--max-tokens=",
+            "--output=",
+        ],
+        rejectOptions: [
+            "--setup", "--check-upgrade",
+            "-v", "--version", "-h", "--help",
+        ]
+    )
+}

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerVibePolicy.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerVibePolicy.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 extension AgentLaunchSanitizer {
-    /// Preserves interactive Vibe configuration without replaying a prior session selector or one-shot mode.
+    /// Preserves interactive Vibe configuration without replaying a prior session selector (`--resume`/`-c`/`--continue`) or one-shot programmatic mode (`--prompt`/`-p`, `--max-turns`, etc.). Session selectors and programmatic flags are dropped so cmux can re-add `--resume <sessionId>` on restore; setup/version flags are rejected entirely as non-restorable.
     static let vibePolicy = Policy(
         valueOptions: [
             "--workdir",

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerVibePolicy.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerVibePolicy.swift
@@ -7,7 +7,7 @@ extension AgentLaunchSanitizer {
             "--workdir",
             "--add-dir",
             "--agent",
-            "--resume", "-c",
+            "--resume",
             "--prompt", "-p",
             "--max-turns",
             "--max-price",
@@ -16,13 +16,14 @@ extension AgentLaunchSanitizer {
             "--worktree",
         ],
         optionalValueOptions: [
-            "--resume", "-c",
+            "--resume",
             "--prompt", "-p",
             "--worktree",
         ],
         booleanOptions: [
             "--auto-approve", "--yolo",
             "--trust",
+            "--continue", "-c",
             "--setup", "--check-upgrade",
             "-v", "--version",
             "-h", "--help",
@@ -33,7 +34,7 @@ extension AgentLaunchSanitizer {
         ],
         nonRestorableCommands: [],
         droppedOptions: [
-            "--resume", "-c",
+            "--resume", "-c", "--continue",
             "--prompt", "-p",
             "--max-turns", "--max-price", "--max-tokens",
             "--output",

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentResumeArgv.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentResumeArgv.swift
@@ -393,6 +393,8 @@ public struct AgentResumeArgv: Sendable, Equatable {
             return withOption("qoder", executable: "qodercli", option: "--resume", sessionId: sessionId, executablePath: executablePath, arguments: arguments)
         case "kimi":
             return withOption("kimi", executable: "kimi", option: "--resume", sessionId: sessionId, executablePath: executablePath, arguments: arguments)
+        case "vibe":
+            return withOption("vibe", executable: "vibe", option: "--resume", sessionId: sessionId, executablePath: executablePath, arguments: arguments)
         default:
             return nil
         }

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/RegisteredAgentResumeKind.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/RegisteredAgentResumeKind.swift
@@ -16,6 +16,8 @@ public enum RegisteredAgentResumeKind: String, Sendable {
     case grok
     /// Kimi Code.
     case kimi
+    /// Mistral Vibe CLI.
+    case vibe
 
     /// The canonical Vault `resumeCommand` template for this built-in agent.
     public var commandTemplate: String {
@@ -26,7 +28,7 @@ public enum RegisteredAgentResumeKind: String, Sendable {
             "{{executable}} --conversation {{sessionId}}"
         case .grok:
             "{{executable}} -r {{sessionId}}"
-        case .kimi:
+        case .kimi, .vibe:
             "{{executable}} --resume {{sessionId}}"
         }
     }

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/VibeHookConfig.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/VibeHookConfig.swift
@@ -1,0 +1,164 @@
+import Foundation
+
+/// Builds and removes cmux-owned Mistral Vibe hook blocks in TOML config files.
+///
+/// Vibe stores hooks in `~/.vibe/hooks.toml` as `[[hooks]]` array-of-tables with
+/// `name`, `type`, `command`, and `timeout` fields. This mirrors the marker-delimited
+/// text-transform approach used by ``KimiCodeHookConfig`` but emits the Vibe schema.
+public enum VibeHookConfig {
+    /// A Vibe hook event entry written as a TOML `[[hooks]]` table.
+    public struct Event: Equatable, Sendable {
+        /// The Vibe hook name (e.g. "cmux-stop").
+        public var name: String
+        /// The Vibe hook type: "post_agent", "pre_tool", or "post_tool".
+        public var type: String
+        /// The complete command string to execute for the event.
+        public var command: String
+        /// The hook timeout in seconds.
+        public var timeout: Double
+
+        /// Creates a Vibe hook event.
+        /// - Parameters:
+        ///   - name: The Vibe hook name.
+        ///   - type: The Vibe hook type ("post_agent", "pre_tool", "post_tool").
+        ///   - command: The complete command string to execute.
+        ///   - timeout: The hook timeout in seconds.
+        public init(name: String, type: String, command: String, timeout: Double) {
+            self.name = name
+            self.type = type
+            self.command = command
+            self.timeout = timeout
+        }
+    }
+
+    private static let beginMarker =
+        "# cmux-vibe-hooks-8a3f5c2d-1b4e-4f7a-9d6c-2e8b1a3f5c7d begin"
+    private static let endMarker =
+        "# cmux-vibe-hooks-8a3f5c2d-1b4e-4f7a-9d6c-2e8b1a3f5c7d end"
+
+    /// Returns TOML content with exactly one cmux-owned Vibe hooks block.
+    /// - Parameters:
+    ///   - events: Hook events to write, in output order.
+    ///   - existing: Existing TOML config content.
+    /// - Returns: The updated TOML content.
+    public static func installing(events: [Event], in existing: String) -> String {
+        var lines = tomlLines(from: existing)
+        removeCmuxVibeHooksBlock(from: &lines)
+
+        var block: [String] = [beginMarker]
+        for event in events {
+            block.append(contentsOf: hookTableLines(event: event))
+        }
+        block.append(endMarker)
+
+        if !lines.isEmpty, lines.last?.isEmpty == false {
+            lines.append("")
+        }
+        lines.append(contentsOf: block)
+        return tomlContent(from: lines)
+    }
+
+    /// Returns whether the content already carries a cmux-owned Vibe hooks block.
+    /// - Parameter existing: Existing TOML config content.
+    /// - Returns: `true` when a cmux marker block is present.
+    public static func containsCmuxBlock(in existing: String) -> Bool {
+        tomlLines(from: existing).contains { line in
+            line.trimmingCharacters(in: .whitespaces) == beginMarker
+        }
+    }
+
+    /// Returns TOML content after removing cmux-owned Vibe hooks blocks.
+    /// - Parameter existing: Existing TOML config content.
+    /// - Returns: The TOML content without cmux-owned Vibe hook blocks.
+    public static func uninstalling(from existing: String) -> String {
+        var lines = tomlLines(from: existing)
+        removeCmuxVibeHooksBlock(from: &lines)
+        return tomlContent(from: lines)
+    }
+
+    private static func hookTableLines(event: Event) -> [String] {
+        return [
+            "[[hooks]]",
+            "name = \"\(tomlBasicStringContent(event.name))\"",
+            "type = \"\(tomlBasicStringContent(event.type))\"",
+            "command = \"\(tomlBasicStringContent(event.command))\"",
+            "timeout = \(VibeHookConfig.formatTimeout(event.timeout))",
+            "",
+        ]
+    }
+
+    private static func formatTimeout(_ timeout: Double) -> String {
+        if timeout == timeout.rounded() {
+            return String(format: "%.1f", timeout)
+        }
+        return String(timeout)
+    }
+
+    private static func removeCmuxVibeHooksBlock(from lines: inout [String]) {
+        var index = 0
+        while index < lines.count {
+            guard lines[index].trimmingCharacters(in: .whitespaces) == beginMarker else {
+                index += 1
+                continue
+            }
+            if let endIndex = lines[index...].firstIndex(where: {
+                $0.trimmingCharacters(in: .whitespaces) == endMarker
+            }) {
+                lines.removeSubrange(index...endIndex)
+            } else {
+                lines.remove(at: index)
+            }
+        }
+    }
+
+    private static func tomlBasicStringContent(_ value: String) -> String {
+        var escaped = ""
+        escaped.reserveCapacity(value.count)
+
+        for scalar in value.unicodeScalars {
+            switch scalar.value {
+            case 0x08:
+                escaped += "\\b"
+            case 0x09:
+                escaped += "\\t"
+            case 0x0A:
+                escaped += "\\n"
+            case 0x0C:
+                escaped += "\\f"
+            case 0x0D:
+                escaped += "\\r"
+            case 0x22:
+                escaped += "\\\""
+            case 0x5C:
+                escaped += "\\\\"
+            case 0x00...0x1F, 0x7F...0x9F:
+                if scalar.value <= 0xFFFF {
+                    escaped += String(format: "\\u%04X", scalar.value)
+                } else {
+                    escaped += String(format: "\\U%08X", scalar.value)
+                }
+            default:
+                escaped.unicodeScalars.append(scalar)
+            }
+        }
+
+        return escaped
+    }
+
+    /// Splits TOML content into lines, tolerating CRLF endings.
+    private static func tomlLines(from content: String) -> [String] {
+        guard !content.isEmpty else { return [] }
+        var lines = content.components(separatedBy: "\n").map { line in
+            line.hasSuffix("\r") ? String(line.dropLast()) : line
+        }
+        if lines.last == "" {
+            lines.removeLast()
+        }
+        return lines
+    }
+
+    private static func tomlContent(from lines: [String]) -> String {
+        guard !lines.isEmpty else { return "" }
+        return lines.joined(separator: "\n") + "\n"
+    }
+}

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/VibeHookConfig.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/VibeHookConfig.swift
@@ -106,7 +106,10 @@ public struct VibeHookConfig: Sendable {
     /// Single-pass scan that appends non-cmux lines to an output array and
     /// skips owned content until the end marker. An unterminated begin marker
     /// is dropped and its buffered lines are restored so user TOML after an
-    /// orphaned marker is never lost.
+    /// orphaned marker is never lost. If a new begin marker is encountered
+    /// while skipping (orphaned marker followed by user TOML then a valid
+    /// block), the buffered user lines are restored before tracking the new
+    /// block.
     private func removeCmuxVibeHooksBlock(from lines: inout [String]) {
         var result: [String] = []
         var candidate: [String] = []
@@ -116,6 +119,9 @@ public struct VibeHookConfig: Sendable {
             if skipUntilEnd {
                 if trimmed == endMarker {
                     skipUntilEnd = false
+                    candidate.removeAll(keepingCapacity: true)
+                } else if trimmed == beginMarker {
+                    result.append(contentsOf: candidate)
                     candidate.removeAll(keepingCapacity: true)
                 } else {
                     candidate.append(line)

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/VibeHookConfig.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/VibeHookConfig.swift
@@ -105,15 +105,20 @@ public struct VibeHookConfig: Sendable {
 
     /// Single-pass scan that appends non-cmux lines to an output array and
     /// skips owned content until the end marker. An unterminated begin marker
-    /// is dropped without affecting following content.
+    /// is dropped and its buffered lines are restored so user TOML after an
+    /// orphaned marker is never lost.
     private func removeCmuxVibeHooksBlock(from lines: inout [String]) {
         var result: [String] = []
+        var candidate: [String] = []
         var skipUntilEnd = false
         for line in lines {
             let trimmed = line.trimmingCharacters(in: .whitespaces)
             if skipUntilEnd {
                 if trimmed == endMarker {
                     skipUntilEnd = false
+                    candidate.removeAll(keepingCapacity: true)
+                } else {
+                    candidate.append(line)
                 }
                 continue
             }
@@ -122,6 +127,9 @@ public struct VibeHookConfig: Sendable {
                 continue
             }
             result.append(line)
+        }
+        if skipUntilEnd {
+            result.append(contentsOf: candidate)
         }
         lines = result
     }

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/VibeHookConfig.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/VibeHookConfig.swift
@@ -5,7 +5,7 @@ import Foundation
 /// Vibe stores hooks in `~/.vibe/hooks.toml` as `[[hooks]]` array-of-tables with
 /// `name`, `type`, `command`, and `timeout` fields. This mirrors the marker-delimited
 /// text-transform approach used by ``KimiCodeHookConfig`` but emits the Vibe schema.
-public enum VibeHookConfig {
+public struct VibeHookConfig: Sendable {
     /// A Vibe hook event entry written as a TOML `[[hooks]]` table.
     public struct Event: Equatable, Sendable {
         /// The Vibe hook name (e.g. "cmux-stop").
@@ -31,9 +31,18 @@ public enum VibeHookConfig {
         }
     }
 
-    private static let beginMarker =
+    private let beginMarker: String
+    private let endMarker: String
+
+    /// Creates a Vibe hook config writer.
+    public init() {
+        self.beginMarker = Self.defaultBeginMarker
+        self.endMarker = Self.defaultEndMarker
+    }
+
+    private static let defaultBeginMarker =
         "# cmux-vibe-hooks-8a3f5c2d-1b4e-4f7a-9d6c-2e8b1a3f5c7d begin"
-    private static let endMarker =
+    private static let defaultEndMarker =
         "# cmux-vibe-hooks-8a3f5c2d-1b4e-4f7a-9d6c-2e8b1a3f5c7d end"
 
     /// Returns TOML content with exactly one cmux-owned Vibe hooks block.
@@ -41,7 +50,7 @@ public enum VibeHookConfig {
     ///   - events: Hook events to write, in output order.
     ///   - existing: Existing TOML config content.
     /// - Returns: The updated TOML content.
-    public static func installing(events: [Event], in existing: String) -> String {
+    public func installing(events: [Event], in existing: String) -> String {
         var lines = tomlLines(from: existing)
         removeCmuxVibeHooksBlock(from: &lines)
 
@@ -61,7 +70,7 @@ public enum VibeHookConfig {
     /// Returns whether the content already carries a cmux-owned Vibe hooks block.
     /// - Parameter existing: Existing TOML config content.
     /// - Returns: `true` when a cmux marker block is present.
-    public static func containsCmuxBlock(in existing: String) -> Bool {
+    public func containsCmuxBlock(in existing: String) -> Bool {
         tomlLines(from: existing).contains { line in
             line.trimmingCharacters(in: .whitespaces) == beginMarker
         }
@@ -70,48 +79,54 @@ public enum VibeHookConfig {
     /// Returns TOML content after removing cmux-owned Vibe hooks blocks.
     /// - Parameter existing: Existing TOML config content.
     /// - Returns: The TOML content without cmux-owned Vibe hook blocks.
-    public static func uninstalling(from existing: String) -> String {
+    public func uninstalling(from existing: String) -> String {
         var lines = tomlLines(from: existing)
         removeCmuxVibeHooksBlock(from: &lines)
         return tomlContent(from: lines)
     }
 
-    private static func hookTableLines(event: Event) -> [String] {
+    private func hookTableLines(event: Event) -> [String] {
         return [
             "[[hooks]]",
             "name = \"\(tomlBasicStringContent(event.name))\"",
             "type = \"\(tomlBasicStringContent(event.type))\"",
             "command = \"\(tomlBasicStringContent(event.command))\"",
-            "timeout = \(VibeHookConfig.formatTimeout(event.timeout))",
+            "timeout = \(formatTimeout(event.timeout))",
             "",
         ]
     }
 
-    private static func formatTimeout(_ timeout: Double) -> String {
+    private func formatTimeout(_ timeout: Double) -> String {
         if timeout == timeout.rounded() {
             return String(format: "%.1f", timeout)
         }
         return String(timeout)
     }
 
-    private static func removeCmuxVibeHooksBlock(from lines: inout [String]) {
-        var index = 0
-        while index < lines.count {
-            guard lines[index].trimmingCharacters(in: .whitespaces) == beginMarker else {
-                index += 1
+    /// Single-pass scan that appends non-cmux lines to an output array and
+    /// skips owned content until the end marker. An unterminated begin marker
+    /// is dropped without affecting following content.
+    private func removeCmuxVibeHooksBlock(from lines: inout [String]) {
+        var result: [String] = []
+        var skipUntilEnd = false
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if skipUntilEnd {
+                if trimmed == endMarker {
+                    skipUntilEnd = false
+                }
                 continue
             }
-            if let endIndex = lines[index...].firstIndex(where: {
-                $0.trimmingCharacters(in: .whitespaces) == endMarker
-            }) {
-                lines.removeSubrange(index...endIndex)
-            } else {
-                lines.remove(at: index)
+            if trimmed == beginMarker {
+                skipUntilEnd = true
+                continue
             }
+            result.append(line)
         }
+        lines = result
     }
 
-    private static func tomlBasicStringContent(_ value: String) -> String {
+    private func tomlBasicStringContent(_ value: String) -> String {
         var escaped = ""
         escaped.reserveCapacity(value.count)
 
@@ -146,7 +161,7 @@ public enum VibeHookConfig {
     }
 
     /// Splits TOML content into lines, tolerating CRLF endings.
-    private static func tomlLines(from content: String) -> [String] {
+    private func tomlLines(from content: String) -> [String] {
         guard !content.isEmpty else { return [] }
         var lines = content.components(separatedBy: "\n").map { line in
             line.hasSuffix("\r") ? String(line.dropLast()) : line
@@ -157,7 +172,7 @@ public enum VibeHookConfig {
         return lines
     }
 
-    private static func tomlContent(from lines: [String]) -> String {
+    private func tomlContent(from lines: [String]) -> String {
         guard !lines.isEmpty else { return "" }
         return lines.joined(separator: "\n") + "\n"
     }

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/VibeHookConfigTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/VibeHookConfigTests.swift
@@ -1,0 +1,219 @@
+import CMUXAgentLaunch
+import Testing
+
+@Suite("VibeHookConfig")
+struct VibeHookConfigTests {
+    @Test("Installs hooks into empty config")
+    func installsHooksIntoEmptyConfig() {
+        let events = [
+            VibeHookConfig.Event(
+                name: "cmux-stop",
+                type: "post_agent",
+                command: "cmux hooks vibe stop",
+                timeout: 60
+            ),
+            VibeHookConfig.Event(
+                name: "cmux-pre-tool",
+                type: "pre_tool",
+                command: "cmux hooks feed --source vibe --event pre_tool",
+                timeout: 120
+            ),
+        ]
+
+        let installed = VibeHookConfig.installing(events: events, in: "")
+
+        #expect(installed == """
+        # cmux-vibe-hooks-8a3f5c2d-1b4e-4f7a-9d6c-2e8b1a3f5c7d begin
+        [[hooks]]
+        name = "cmux-stop"
+        type = "post_agent"
+        command = "cmux hooks vibe stop"
+        timeout = 60.0
+
+        [[hooks]]
+        name = "cmux-pre-tool"
+        type = "pre_tool"
+        command = "cmux hooks feed --source vibe --event pre_tool"
+        timeout = 120.0
+
+        # cmux-vibe-hooks-8a3f5c2d-1b4e-4f7a-9d6c-2e8b1a3f5c7d end
+
+        """)
+    }
+
+    @Test("Install preserves existing user content with separating blank line")
+    func installPreservesExistingUserContentWithSeparatingBlankLine() {
+        let existing = """
+        active_model = "mistral-medium-3.5"
+        theme = "auto"
+
+        """
+        let events = [
+            VibeHookConfig.Event(name: "cmux-stop", type: "post_agent", command: "cmux hooks vibe stop", timeout: 60),
+        ]
+
+        let installed = VibeHookConfig.installing(events: events, in: existing)
+
+        #expect(installed == """
+        active_model = "mistral-medium-3.5"
+        theme = "auto"
+
+        # cmux-vibe-hooks-8a3f5c2d-1b4e-4f7a-9d6c-2e8b1a3f5c7d begin
+        [[hooks]]
+        name = "cmux-stop"
+        type = "post_agent"
+        command = "cmux hooks vibe stop"
+        timeout = 60.0
+
+        # cmux-vibe-hooks-8a3f5c2d-1b4e-4f7a-9d6c-2e8b1a3f5c7d end
+
+        """)
+    }
+
+    @Test("Install is idempotent")
+    func installIsIdempotent() {
+        let existing = "active_model = \"mistral-medium-3.5\"\n"
+        let events = [
+            VibeHookConfig.Event(name: "cmux-stop", type: "post_agent", command: "cmux hooks vibe stop", timeout: 60),
+        ]
+
+        let installed = VibeHookConfig.installing(events: events, in: existing)
+
+        #expect(VibeHookConfig.installing(events: events, in: installed) == installed)
+    }
+
+    @Test("Reinstall replaces stale cmux block")
+    func reinstallReplacesStaleCmuxBlock() {
+        let stale = VibeHookConfig.installing(
+            events: [VibeHookConfig.Event(name: "cmux-stop", type: "post_agent", command: "cmux hooks vibe stop", timeout: 60)],
+            in: "active_model = \"mistral-medium-3.5\"\n"
+        )
+
+        let reinstalled = VibeHookConfig.installing(
+            events: [VibeHookConfig.Event(name: "cmux-stop", type: "post_agent", command: "cmux hooks vibe stop", timeout: 30)],
+            in: stale
+        )
+
+        #expect(reinstalled.components(separatedBy: "# cmux-vibe-hooks-8a3f5c2d-1b4e-4f7a-9d6c-2e8b1a3f5c7d begin").count == 2)
+        #expect(reinstalled.contains("timeout = 30.0"))
+        #expect(!reinstalled.contains("timeout = 60.0"))
+    }
+
+    @Test("Install uninstall round trip restores normalized existing content")
+    func installUninstallRoundTripRestoresNormalizedExistingContent() {
+        let existing = "active_model = \"mistral-medium-3.5\"\ntheme = \"auto\"\n\n"
+        let events = [
+            VibeHookConfig.Event(name: "cmux-stop", type: "post_agent", command: "cmux hooks vibe stop", timeout: 60),
+        ]
+
+        let installed = VibeHookConfig.installing(events: events, in: existing)
+
+        #expect(VibeHookConfig.uninstalling(from: installed) == existing)
+    }
+
+    @Test("Uninstall without cmux block leaves content unchanged")
+    func uninstallWithoutCmuxBlockLeavesContentUnchanged() {
+        let existing = """
+        active_model = "mistral-medium-3.5"
+        theme = "auto"
+
+        """
+
+        #expect(VibeHookConfig.uninstalling(from: existing) == existing)
+    }
+
+    @Test("Detects whether a config carries a cmux block")
+    func detectsWhetherConfigCarriesCmuxBlock() {
+        let userOnly = """
+        active_model = "mistral-medium-3.5"
+
+        [[hooks]]
+        name = "my-hook"
+        type = "post_agent"
+        command = "echo hello"
+
+        """
+        let installed = VibeHookConfig.installing(
+            events: [
+                VibeHookConfig.Event(
+                    name: "cmux-stop",
+                    type: "post_agent",
+                    command: "cmux hooks vibe stop",
+                    timeout: 60
+                ),
+            ],
+            in: userOnly
+        )
+
+        #expect(!VibeHookConfig.containsCmuxBlock(in: ""))
+        #expect(!VibeHookConfig.containsCmuxBlock(in: userOnly))
+        #expect(VibeHookConfig.containsCmuxBlock(in: installed))
+        #expect(!VibeHookConfig.containsCmuxBlock(
+            in: VibeHookConfig.uninstalling(from: installed)
+        ))
+    }
+
+    @Test("Uninstall removes orphaned begin marker without dropping following TOML")
+    func uninstallRemovesOrphanedBeginMarkerWithoutDroppingFollowingTOML() {
+        let existing = """
+        active_model = "mistral-medium-3.5"
+        # cmux-vibe-hooks-8a3f5c2d-1b4e-4f7a-9d6c-2e8b1a3f5c7d begin
+        theme = "auto"
+
+        """
+
+        #expect(VibeHookConfig.uninstalling(from: existing) == """
+        active_model = "mistral-medium-3.5"
+        theme = "auto"
+
+        """)
+    }
+
+    @Test("Escapes TOML basic string content")
+    func escapesTOMLBasicStringContent() {
+        let events = [
+            VibeHookConfig.Event(
+                name: "cmux-stop",
+                type: "post_agent",
+                command: "cmux hooks \"vibe\" \\\tstop",
+                timeout: 60
+            ),
+        ]
+
+        let installed = VibeHookConfig.installing(events: events, in: "")
+
+        #expect(installed.contains(#"command = "cmux hooks \"vibe\" \\\tstop""#))
+    }
+
+    @Test("Handles CRLF line endings")
+    func handlesCRLFLineEndings() {
+        let eventsV1 = [
+            VibeHookConfig.Event(name: "cmux-stop", type: "post_agent", command: "cmux hooks vibe stop", timeout: 60),
+        ]
+        let crlfExisting = "active_model = \"mistral-medium-3.5\"\r\ntheme = \"auto\"\r\n"
+
+        #expect(
+            VibeHookConfig.uninstalling(from: crlfExisting)
+                == "active_model = \"mistral-medium-3.5\"\ntheme = \"auto\"\n"
+        )
+
+        let installed = VibeHookConfig.installing(events: eventsV1, in: crlfExisting)
+        #expect(VibeHookConfig.containsCmuxBlock(in: installed))
+
+        let crlfInstalled = installed.replacingOccurrences(of: "\n", with: "\r\n")
+        #expect(VibeHookConfig.containsCmuxBlock(in: crlfInstalled))
+
+        let eventsV2 = [
+            VibeHookConfig.Event(name: "cmux-stop", type: "post_agent", command: "cmux hooks vibe stop", timeout: 30),
+        ]
+        let refreshed = VibeHookConfig.installing(events: eventsV2, in: crlfInstalled)
+        #expect(refreshed.components(separatedBy: "# cmux-vibe-hooks-8a3f5c2d-1b4e-4f7a-9d6c-2e8b1a3f5c7d begin").count == 2)
+        #expect(refreshed.contains("timeout = 30.0"))
+        #expect(!refreshed.contains("timeout = 60.0"))
+
+        #expect(
+            VibeHookConfig.uninstalling(from: crlfInstalled)
+                == VibeHookConfig.uninstalling(from: installed)
+        )
+    }
+}

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/VibeHookConfigTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/VibeHookConfigTests.swift
@@ -169,6 +169,34 @@ struct VibeHookConfigTests {
         """)
     }
 
+    @Test("Uninstall with orphaned begin marker preserves all following lines")
+    func uninstallWithOrphanedBeginMarkerPreservesAllFollowingLines() {
+        let existing = """
+        active_model = "mistral-medium-3.5"
+        # cmux-vibe-hooks-8a3f5c2d-1b4e-4f7a-9d6c-2e8b1a3f5c7d begin
+        theme = "auto"
+        log_level = "DEBUG"
+
+        [[hooks]]
+        name = "my-hook"
+        type = "post_agent"
+        command = "echo hello"
+
+        """
+
+        #expect(VibeHookConfig().uninstalling(from: existing) == """
+        active_model = "mistral-medium-3.5"
+        theme = "auto"
+        log_level = "DEBUG"
+
+        [[hooks]]
+        name = "my-hook"
+        type = "post_agent"
+        command = "echo hello"
+
+        """)
+    }
+
     @Test("Escapes TOML basic string content")
     func escapesTOMLBasicStringContent() {
         let events = [

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/VibeHookConfigTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/VibeHookConfigTests.swift
@@ -197,7 +197,28 @@ struct VibeHookConfigTests {
         """)
     }
 
-    @Test("Escapes TOML basic string content")
+    @Test("Uninstall with orphaned marker, user TOML, then valid block preserves user TOML")
+    func uninstallWithOrphanedMarkerUserTOMLThenValidBlockPreservesUserTOML() {
+        let existing = """
+        active_model = "mistral-medium-3.5"
+        # cmux-vibe-hooks-8a3f5c2d-1b4e-4f7a-9d6c-2e8b1a3f5c7d begin
+        theme = "auto"
+        # cmux-vibe-hooks-8a3f5c2d-1b4e-4f7a-9d6c-2e8b1a3f5c7d begin
+        name = "cmux-stop"
+        type = "post_agent"
+        command = "cmux hooks vibe stop"
+        timeout = 60.0
+
+        # cmux-vibe-hooks-8a3f5c2d-1b4e-4f7a-9d6c-2e8b1a3f5c7d end
+
+        """
+
+        #expect(VibeHookConfig().uninstalling(from: existing) == """
+        active_model = "mistral-medium-3.5"
+        theme = "auto"
+
+        """)
+    }
     func escapesTOMLBasicStringContent() {
         let events = [
             VibeHookConfig.Event(

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/VibeHookConfigTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/VibeHookConfigTests.swift
@@ -20,7 +20,7 @@ struct VibeHookConfigTests {
             ),
         ]
 
-        let installed = VibeHookConfig.installing(events: events, in: "")
+        let installed = VibeHookConfig().installing(events: events, in: "")
 
         #expect(installed == """
         # cmux-vibe-hooks-8a3f5c2d-1b4e-4f7a-9d6c-2e8b1a3f5c7d begin
@@ -52,7 +52,7 @@ struct VibeHookConfigTests {
             VibeHookConfig.Event(name: "cmux-stop", type: "post_agent", command: "cmux hooks vibe stop", timeout: 60),
         ]
 
-        let installed = VibeHookConfig.installing(events: events, in: existing)
+        let installed = VibeHookConfig().installing(events: events, in: existing)
 
         #expect(installed == """
         active_model = "mistral-medium-3.5"
@@ -77,19 +77,19 @@ struct VibeHookConfigTests {
             VibeHookConfig.Event(name: "cmux-stop", type: "post_agent", command: "cmux hooks vibe stop", timeout: 60),
         ]
 
-        let installed = VibeHookConfig.installing(events: events, in: existing)
+        let installed = VibeHookConfig().installing(events: events, in: existing)
 
-        #expect(VibeHookConfig.installing(events: events, in: installed) == installed)
+        #expect(VibeHookConfig().installing(events: events, in: installed) == installed)
     }
 
     @Test("Reinstall replaces stale cmux block")
     func reinstallReplacesStaleCmuxBlock() {
-        let stale = VibeHookConfig.installing(
+        let stale = VibeHookConfig().installing(
             events: [VibeHookConfig.Event(name: "cmux-stop", type: "post_agent", command: "cmux hooks vibe stop", timeout: 60)],
             in: "active_model = \"mistral-medium-3.5\"\n"
         )
 
-        let reinstalled = VibeHookConfig.installing(
+        let reinstalled = VibeHookConfig().installing(
             events: [VibeHookConfig.Event(name: "cmux-stop", type: "post_agent", command: "cmux hooks vibe stop", timeout: 30)],
             in: stale
         )
@@ -106,9 +106,9 @@ struct VibeHookConfigTests {
             VibeHookConfig.Event(name: "cmux-stop", type: "post_agent", command: "cmux hooks vibe stop", timeout: 60),
         ]
 
-        let installed = VibeHookConfig.installing(events: events, in: existing)
+        let installed = VibeHookConfig().installing(events: events, in: existing)
 
-        #expect(VibeHookConfig.uninstalling(from: installed) == existing)
+        #expect(VibeHookConfig().uninstalling(from: installed) == existing)
     }
 
     @Test("Uninstall without cmux block leaves content unchanged")
@@ -119,7 +119,7 @@ struct VibeHookConfigTests {
 
         """
 
-        #expect(VibeHookConfig.uninstalling(from: existing) == existing)
+        #expect(VibeHookConfig().uninstalling(from: existing) == existing)
     }
 
     @Test("Detects whether a config carries a cmux block")
@@ -133,7 +133,7 @@ struct VibeHookConfigTests {
         command = "echo hello"
 
         """
-        let installed = VibeHookConfig.installing(
+        let installed = VibeHookConfig().installing(
             events: [
                 VibeHookConfig.Event(
                     name: "cmux-stop",
@@ -145,11 +145,11 @@ struct VibeHookConfigTests {
             in: userOnly
         )
 
-        #expect(!VibeHookConfig.containsCmuxBlock(in: ""))
-        #expect(!VibeHookConfig.containsCmuxBlock(in: userOnly))
-        #expect(VibeHookConfig.containsCmuxBlock(in: installed))
-        #expect(!VibeHookConfig.containsCmuxBlock(
-            in: VibeHookConfig.uninstalling(from: installed)
+        #expect(!VibeHookConfig().containsCmuxBlock(in: ""))
+        #expect(!VibeHookConfig().containsCmuxBlock(in: userOnly))
+        #expect(VibeHookConfig().containsCmuxBlock(in: installed))
+        #expect(!VibeHookConfig().containsCmuxBlock(
+            in: VibeHookConfig().uninstalling(from: installed)
         ))
     }
 
@@ -162,7 +162,7 @@ struct VibeHookConfigTests {
 
         """
 
-        #expect(VibeHookConfig.uninstalling(from: existing) == """
+        #expect(VibeHookConfig().uninstalling(from: existing) == """
         active_model = "mistral-medium-3.5"
         theme = "auto"
 
@@ -180,7 +180,7 @@ struct VibeHookConfigTests {
             ),
         ]
 
-        let installed = VibeHookConfig.installing(events: events, in: "")
+        let installed = VibeHookConfig().installing(events: events, in: "")
 
         #expect(installed.contains(#"command = "cmux hooks \"vibe\" \\\tstop""#))
     }
@@ -193,27 +193,27 @@ struct VibeHookConfigTests {
         let crlfExisting = "active_model = \"mistral-medium-3.5\"\r\ntheme = \"auto\"\r\n"
 
         #expect(
-            VibeHookConfig.uninstalling(from: crlfExisting)
+            VibeHookConfig().uninstalling(from: crlfExisting)
                 == "active_model = \"mistral-medium-3.5\"\ntheme = \"auto\"\n"
         )
 
-        let installed = VibeHookConfig.installing(events: eventsV1, in: crlfExisting)
-        #expect(VibeHookConfig.containsCmuxBlock(in: installed))
+        let installed = VibeHookConfig().installing(events: eventsV1, in: crlfExisting)
+        #expect(VibeHookConfig().containsCmuxBlock(in: installed))
 
         let crlfInstalled = installed.replacingOccurrences(of: "\n", with: "\r\n")
-        #expect(VibeHookConfig.containsCmuxBlock(in: crlfInstalled))
+        #expect(VibeHookConfig().containsCmuxBlock(in: crlfInstalled))
 
         let eventsV2 = [
             VibeHookConfig.Event(name: "cmux-stop", type: "post_agent", command: "cmux hooks vibe stop", timeout: 30),
         ]
-        let refreshed = VibeHookConfig.installing(events: eventsV2, in: crlfInstalled)
+        let refreshed = VibeHookConfig().installing(events: eventsV2, in: crlfInstalled)
         #expect(refreshed.components(separatedBy: "# cmux-vibe-hooks-8a3f5c2d-1b4e-4f7a-9d6c-2e8b1a3f5c7d begin").count == 2)
         #expect(refreshed.contains("timeout = 30.0"))
         #expect(!refreshed.contains("timeout = 60.0"))
 
         #expect(
-            VibeHookConfig.uninstalling(from: crlfInstalled)
-                == VibeHookConfig.uninstalling(from: installed)
+            VibeHookConfig().uninstalling(from: crlfInstalled)
+                == VibeHookConfig().uninstalling(from: installed)
         )
     }
 }

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/VibeHookConfigTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/VibeHookConfigTests.swift
@@ -219,6 +219,8 @@ struct VibeHookConfigTests {
 
         """)
     }
+
+    @Test("Escapes TOML basic string content")
     func escapesTOMLBasicStringContent() {
         let events = [
             VibeHookConfig.Event(

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -3878,76 +3878,376 @@
     "cli.agentHook.error.notificationDelivery": {
       "extractionState": "manual",
       "localizations": {
-        "ar": { "stringUnit": { "state": "translated", "value": "فشل تسليم إشعار خطاف الوكيل لـ %@ %@." } },
-        "bs": { "stringUnit": { "state": "translated", "value": "Dostava obavijesti agentske kuke nije uspjela za %@ %@." } },
-        "da": { "stringUnit": { "state": "translated", "value": "Levering af agent-hook-notifikationen mislykkedes for %@ %@." } },
-        "de": { "stringUnit": { "state": "translated", "value": "Die Zustellung der Agent-Hook-Benachrichtigung ist für %@ %@ fehlgeschlagen." } },
-        "en": { "stringUnit": { "state": "translated", "value": "Agent hook notification delivery failed for %@ %@." } },
-        "es": { "stringUnit": { "state": "translated", "value": "No se pudo entregar la notificación del hook del agente para %@ %@." } },
-        "fr": { "stringUnit": { "state": "translated", "value": "Échec de la livraison de la notification du hook d’agent pour %@ %@." } },
-        "it": { "stringUnit": { "state": "translated", "value": "Impossibile recapitare la notifica dell’hook dell’agente per %@ %@." } },
-        "ja": { "stringUnit": { "state": "translated", "value": "%@ %@ のエージェントフック通知を配信できませんでした。" } },
-        "km": { "stringUnit": { "state": "translated", "value": "ការបញ្ជូនការជូនដំណឹង agent hook បានបរាជ័យសម្រាប់ %@ %@។" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "%@ %@에 대한 에이전트 훅 알림을 전달하지 못했습니다." } },
-        "nb": { "stringUnit": { "state": "translated", "value": "Levering av agent-hook-varslingen mislyktes for %@ %@." } },
-        "pl": { "stringUnit": { "state": "translated", "value": "Nie udało się dostarczyć powiadomienia haka agenta dla %@ %@." } },
-        "pt-BR": { "stringUnit": { "state": "translated", "value": "Falha ao entregar a notificação do hook do agente para %@ %@." } },
-        "ru": { "stringUnit": { "state": "translated", "value": "Не удалось доставить уведомление хука агента для %@ %@." } },
-        "th": { "stringUnit": { "state": "translated", "value": "ส่งการแจ้งเตือน agent hook สำหรับ %@ %@ ไม่สำเร็จ" } },
-        "tr": { "stringUnit": { "state": "translated", "value": "%@ %@ için aracı kancası bildirimi teslim edilemedi." } },
-        "uk": { "stringUnit": { "state": "translated", "value": "Не вдалося доставити сповіщення хуку агента для %@ %@." } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "无法传递 %@ %@ 的代理钩子通知。" } },
-        "zh-Hant": { "stringUnit": { "state": "translated", "value": "無法傳遞 %@ %@ 的代理程式掛鉤通知。" } }
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فشل تسليم إشعار خطاف الوكيل لـ %@ %@."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dostava obavijesti agentske kuke nije uspjela za %@ %@."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Levering af agent-hook-notifikationen mislykkedes for %@ %@."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Zustellung der Agent-Hook-Benachrichtigung ist für %@ %@ fehlgeschlagen."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agent hook notification delivery failed for %@ %@."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo entregar la notificación del hook del agente para %@ %@."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec de la livraison de la notification du hook d’agent pour %@ %@."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossibile recapitare la notifica dell’hook dell’agente per %@ %@."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ %@ のエージェントフック通知を配信できませんでした。"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ការបញ្ជូនការជូនដំណឹង agent hook បានបរាជ័យសម្រាប់ %@ %@។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ %@에 대한 에이전트 훅 알림을 전달하지 못했습니다."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Levering av agent-hook-varslingen mislyktes for %@ %@."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie udało się dostarczyć powiadomienia haka agenta dla %@ %@."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falha ao entregar a notificação do hook do agente para %@ %@."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось доставить уведомление хука агента для %@ %@."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ส่งการแจ้งเตือน agent hook สำหรับ %@ %@ ไม่สำเร็จ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ %@ için aracı kancası bildirimi teslim edilemedi."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не вдалося доставити сповіщення хуку агента для %@ %@."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法传递 %@ %@ 的代理钩子通知。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無法傳遞 %@ %@ 的代理程式掛鉤通知。"
+          }
+        }
       }
     },
     "cli.agentHook.error.journalAppend": {
       "extractionState": "manual",
       "localizations": {
-        "ar": { "stringUnit": { "state": "translated", "value": "فشل إلحاق سجل خطاف الوكيل لـ %@ %@." } },
-        "bs": { "stringUnit": { "state": "translated", "value": "Dodavanje agentske kuke u dnevnik nije uspjelo za %@ %@." } },
-        "da": { "stringUnit": { "state": "translated", "value": "Tilføjelse af agent-hook til journalen mislykkedes for %@ %@." } },
-        "de": { "stringUnit": { "state": "translated", "value": "Das Anhängen des Agent-Hooks an das Journal ist für %@ %@ fehlgeschlagen." } },
-        "en": { "stringUnit": { "state": "translated", "value": "Agent hook journal append failed for %@ %@." } },
-        "es": { "stringUnit": { "state": "translated", "value": "No se pudo añadir el hook del agente al diario para %@ %@." } },
-        "fr": { "stringUnit": { "state": "translated", "value": "Échec de l’ajout du hook d’agent au journal pour %@ %@." } },
-        "it": { "stringUnit": { "state": "translated", "value": "Impossibile aggiungere l’hook dell’agente al diario per %@ %@." } },
-        "ja": { "stringUnit": { "state": "translated", "value": "%@ %@ のエージェントフックのジャーナル追記に失敗しました。" } },
-        "km": { "stringUnit": { "state": "translated", "value": "ការបន្ថែម agent hook ទៅក្នុងកំណត់ហេតុបានបរាជ័យសម្រាប់ %@ %@។" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "%@ %@에 대한 에이전트 훅 저널 추가에 실패했습니다." } },
-        "nb": { "stringUnit": { "state": "translated", "value": "Det oppstod en feil ved å legge agent-hooken til journalen for %@ %@." } },
-        "pl": { "stringUnit": { "state": "translated", "value": "Nie udało się dodać haka agenta do dziennika dla %@ %@." } },
-        "pt-BR": { "stringUnit": { "state": "translated", "value": "Falha ao adicionar o hook do agente ao diário para %@ %@." } },
-        "ru": { "stringUnit": { "state": "translated", "value": "Не удалось добавить хук агента в журнал для %@ %@." } },
-        "th": { "stringUnit": { "state": "translated", "value": "เพิ่ม agent hook ลงในบันทึกประจำวันสำหรับ %@ %@ ไม่สำเร็จ" } },
-        "tr": { "stringUnit": { "state": "translated", "value": "%@ %@ için aracı kancasını günlüğe ekleme başarısız oldu." } },
-        "uk": { "stringUnit": { "state": "translated", "value": "Не вдалося додати хук агента до журналу для %@ %@." } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "无法将 %@ %@ 的代理钩子追加到日志。" } },
-        "zh-Hant": { "stringUnit": { "state": "translated", "value": "無法將 %@ %@ 的代理程式掛鉤追加到日誌。" } }
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فشل إلحاق سجل خطاف الوكيل لـ %@ %@."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dodavanje agentske kuke u dnevnik nije uspjelo za %@ %@."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tilføjelse af agent-hook til journalen mislykkedes for %@ %@."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das Anhängen des Agent-Hooks an das Journal ist für %@ %@ fehlgeschlagen."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agent hook journal append failed for %@ %@."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo añadir el hook del agente al diario para %@ %@."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec de l’ajout du hook d’agent au journal pour %@ %@."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossibile aggiungere l’hook dell’agente al diario per %@ %@."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ %@ のエージェントフックのジャーナル追記に失敗しました。"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ការបន្ថែម agent hook ទៅក្នុងកំណត់ហេតុបានបរាជ័យសម្រាប់ %@ %@។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ %@에 대한 에이전트 훅 저널 추가에 실패했습니다."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Det oppstod en feil ved å legge agent-hooken til journalen for %@ %@."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie udało się dodać haka agenta do dziennika dla %@ %@."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falha ao adicionar o hook do agente ao diário para %@ %@."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось добавить хук агента в журнал для %@ %@."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เพิ่ม agent hook ลงในบันทึกประจำวันสำหรับ %@ %@ ไม่สำเร็จ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ %@ için aracı kancasını günlüğe ekleme başarısız oldu."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не вдалося додати хук агента до журналу для %@ %@."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法将 %@ %@ 的代理钩子追加到日志。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無法將 %@ %@ 的代理程式掛鉤追加到日誌。"
+          }
+        }
       }
     },
     "cli.agentHook.error.targetResolution": {
       "extractionState": "manual",
       "localizations": {
-        "ar": { "stringUnit": { "state": "translated", "value": "فشل حل هدف خطاف الوكيل لـ %@ %@." } },
-        "bs": { "stringUnit": { "state": "translated", "value": "Rješavanje odredišta agentske kuke nije uspjelo za %@ %@." } },
-        "da": { "stringUnit": { "state": "translated", "value": "Agent-hook-målløsning mislykkedes for %@ %@." } },
-        "de": { "stringUnit": { "state": "translated", "value": "Die Zielauflösung des Agent-Hooks ist für %@ %@ fehlgeschlagen." } },
-        "en": { "stringUnit": { "state": "translated", "value": "Agent hook target resolution failed for %@ %@." } },
-        "es": { "stringUnit": { "state": "translated", "value": "No se pudo resolver el destino del hook del agente para %@ %@." } },
-        "fr": { "stringUnit": { "state": "translated", "value": "Échec de la résolution de la cible du hook d’agent pour %@ %@." } },
-        "it": { "stringUnit": { "state": "translated", "value": "Risoluzione della destinazione dell’hook dell’agente non riuscita per %@ %@." } },
-        "ja": { "stringUnit": { "state": "translated", "value": "%@ %@ のエージェントフック配信先を解決できませんでした。" } },
-        "km": { "stringUnit": { "state": "translated", "value": "ការដោះស្រាយគោលដៅ agent hook បានបរាជ័យសម្រាប់ %@ %@។" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "%@ %@에 대한 에이전트 훅 대상을 확인하지 못했습니다." } },
-        "nb": { "stringUnit": { "state": "translated", "value": "Fant ikke målet for agent-hooken for %@ %@." } },
-        "pl": { "stringUnit": { "state": "translated", "value": "Nie udało się rozpoznać celu haka agenta dla %@ %@." } },
-        "pt-BR": { "stringUnit": { "state": "translated", "value": "Falha ao resolver o destino do hook do agente para %@ %@." } },
-        "ru": { "stringUnit": { "state": "translated", "value": "Не удалось определить цель хука агента для %@ %@." } },
-        "th": { "stringUnit": { "state": "translated", "value": "ไม่สามารถแก้ไขปลายทาง agent hook สำหรับ %@ %@ ได้" } },
-        "tr": { "stringUnit": { "state": "translated", "value": "%@ %@ için aracı kancası hedefi çözülemedi." } },
-        "uk": { "stringUnit": { "state": "translated", "value": "Не вдалося визначити ціль хуку агента для %@ %@." } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "无法解析 %@ %@ 的代理钩子目标。" } },
-        "zh-Hant": { "stringUnit": { "state": "translated", "value": "無法解析 %@ %@ 的代理程式掛鉤目標。" } }
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فشل حل هدف خطاف الوكيل لـ %@ %@."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rješavanje odredišta agentske kuke nije uspjelo za %@ %@."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agent-hook-målløsning mislykkedes for %@ %@."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Zielauflösung des Agent-Hooks ist für %@ %@ fehlgeschlagen."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agent hook target resolution failed for %@ %@."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo resolver el destino del hook del agente para %@ %@."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec de la résolution de la cible du hook d’agent pour %@ %@."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Risoluzione della destinazione dell’hook dell’agente non riuscita per %@ %@."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ %@ のエージェントフック配信先を解決できませんでした。"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ការដោះស្រាយគោលដៅ agent hook បានបរាជ័យសម្រាប់ %@ %@។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ %@에 대한 에이전트 훅 대상을 확인하지 못했습니다."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fant ikke målet for agent-hooken for %@ %@."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie udało się rozpoznać celu haka agenta dla %@ %@."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falha ao resolver o destino do hook do agente para %@ %@."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось определить цель хука агента для %@ %@."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่สามารถแก้ไขปลายทาง agent hook สำหรับ %@ %@ ได้"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ %@ için aracı kancası hedefi çözülemedi."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не вдалося визначити ціль хуку агента для %@ %@."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法解析 %@ %@ 的代理钩子目标。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無法解析 %@ %@ 的代理程式掛鉤目標。"
+          }
+        }
       }
     },
     "agent.generic.notification.body.approvalNeeded": {
@@ -26531,36 +26831,86 @@
     "browser.error.urlAllowlist.attemptedURL": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "Attempted URL" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "試行したURL" } }
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attempted URL"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "試行したURL"
+          }
+        }
       }
     },
     "browser.error.urlAllowlist.message": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "This URL is not allowed by your organization's embedded-browser policy." } },
-        "ja": { "stringUnit": { "state": "translated", "value": "このURLは組織の内蔵ブラウザポリシーで許可されていません。" } }
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This URL is not allowed by your organization's embedded-browser policy."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このURLは組織の内蔵ブラウザポリシーで許可されていません。"
+          }
+        }
       }
     },
     "browser.error.urlAllowlist.userMessage": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "This URL is not allowed by the embedded-browser URL policy." } },
-        "ja": { "stringUnit": { "state": "translated", "value": "このURLは内蔵ブラウザのURLポリシーで許可されていません。" } }
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This URL is not allowed by the embedded-browser URL policy."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このURLは内蔵ブラウザのURLポリシーで許可されていません。"
+          }
+        }
       }
     },
     "browser.error.urlAllowlist.title": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "Blocked by your organization's policy" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "組織のポリシーによりブロックされました" } }
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Blocked by your organization's policy"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "組織のポリシーによりブロックされました"
+          }
+        }
       }
     },
     "browser.error.urlAllowlist.userTitle": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "Blocked by the embedded-browser URL policy" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "内蔵ブラウザのURLポリシーによりブロックされました" } }
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Blocked by the embedded-browser URL policy"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "内蔵ブラウザのURLポリシーによりブロックされました"
+          }
+        }
       }
     },
     "browser.error.insecure.message": {
@@ -35263,15 +35613,35 @@
     "cli.browser.error.urlBlockedByPolicy": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "Blocked by your organization's browser policy" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "組織のブラウザポリシーによりブロックされました" } }
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Blocked by your organization's browser policy"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "組織のブラウザポリシーによりブロックされました"
+          }
+        }
       }
     },
     "cli.browser.error.urlBlockedByUserPolicy": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "Blocked by the embedded-browser URL policy" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "内蔵ブラウザのURLポリシーによりブロックされました" } }
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Blocked by the embedded-browser URL policy"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "内蔵ブラウザのURLポリシーによりブロックされました"
+          }
+        }
       }
     },
     "cli.browser.error.operationFailed": {
@@ -52272,36 +52642,126 @@
     "cli.sessions.command": {
       "extractionState": "manual",
       "localizations": {
-        "ar": { "stringUnit": { "state": "translated", "value": "sessions [list] [options]" } },
-        "bs": { "stringUnit": { "state": "translated", "value": "sessions [list] [options]" } },
-        "da": { "stringUnit": { "state": "translated", "value": "sessions [list] [options]" } },
-        "de": { "stringUnit": { "state": "translated", "value": "sessions [list] [options]" } },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sessions [list] [options]"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sessions [list] [options]"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sessions [list] [options]"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sessions [list] [options]"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
             "value": "sessions [list] [options]"
           }
         },
-        "es": { "stringUnit": { "state": "translated", "value": "sessions [list] [options]" } },
-        "fr": { "stringUnit": { "state": "translated", "value": "sessions [list] [options]" } },
-        "it": { "stringUnit": { "state": "translated", "value": "sessions [list] [options]" } },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sessions [list] [options]"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sessions [list] [options]"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sessions [list] [options]"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
             "value": "sessions [list] [options]"
           }
         },
-        "km": { "stringUnit": { "state": "translated", "value": "sessions [list] [options]" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "sessions [list] [options]" } },
-        "nb": { "stringUnit": { "state": "translated", "value": "sessions [list] [options]" } },
-        "pl": { "stringUnit": { "state": "translated", "value": "sessions [list] [options]" } },
-        "pt-BR": { "stringUnit": { "state": "translated", "value": "sessions [list] [options]" } },
-        "ru": { "stringUnit": { "state": "translated", "value": "sessions [list] [options]" } },
-        "th": { "stringUnit": { "state": "translated", "value": "sessions [list] [options]" } },
-        "tr": { "stringUnit": { "state": "translated", "value": "sessions [list] [options]" } },
-        "uk": { "stringUnit": { "state": "translated", "value": "sessions [list] [options]" } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "sessions [list] [options]" } },
-        "zh-Hant": { "stringUnit": { "state": "translated", "value": "sessions [list] [options]" } }
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sessions [list] [options]"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sessions [list] [options]"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sessions [list] [options]"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sessions [list] [options]"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sessions [list] [options]"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sessions [list] [options]"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sessions [list] [options]"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sessions [list] [options]"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sessions [list] [options]"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sessions [list] [options]"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sessions [list] [options]"
+          }
+        }
       }
     },
     "cli.sessions.error.agentRequiresValue": {
@@ -55963,23 +56423,6 @@
         }
       }
     },
-    "cli.ssh.terminalExitPrompt.prompt": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "[cmux] press Enter to close this pane."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "[cmux] 閉じるには Enter を押してください。"
-          }
-        }
-      }
-    },
     "cli.sshPtyAttach.bridgeClosedReattaching": {
       "extractionState": "manual",
       "localizations": {
@@ -56012,24 +56455,114 @@
             "value": "[cmux] SSH が切断されました（%s）。%s 回目を %s 秒後に再試行します。入力は破棄されます。"
           }
         },
-        "ar": {"stringUnit": {"state": "translated", "value": "[cmux] انقطع اتصال SSH (%s)؛ إعادة المحاولة %s خلال %s ث؛ سيتم تجاهل الإدخال."}},
-        "bs": {"stringUnit": {"state": "translated", "value": "[cmux] SSH veza je prekinuta (%s); pokušaj %s za %s s; unos se odbacuje."}},
-        "da": {"stringUnit": {"state": "translated", "value": "[cmux] SSH afbrudt (%s); prøver igen %s om %s s; input kasseres."}},
-        "de": {"stringUnit": {"state": "translated", "value": "[cmux] SSH getrennt (%s); Versuch %s in %s s; Eingaben werden verworfen."}},
-        "es": {"stringUnit": {"state": "translated", "value": "[cmux] SSH desconectado (%s); reintento %s en %s s; la entrada se descarta."}},
-        "fr": {"stringUnit": {"state": "translated", "value": "[cmux] SSH déconnecté (%s) ; nouvelle tentative %s dans %s s ; saisie ignorée."}},
-        "it": {"stringUnit": {"state": "translated", "value": "[cmux] SSH disconnesso (%s); nuovo tentativo %s tra %s s; input scartato."}},
-        "km": {"stringUnit": {"state": "translated", "value": "[cmux] SSH បានផ្តាច់ (%s); ព្យាយាមម្ដងទៀត %s ក្នុង %s វិ; ទិន្នន័យបញ្ចូលត្រូវបានបោះចោល។"}},
-        "ko": {"stringUnit": {"state": "translated", "value": "[cmux] SSH 연결 끊김(%s); %s번째 재시도를 %s초 후 수행합니다; 입력은 버립니다."}},
-        "nb": {"stringUnit": {"state": "translated", "value": "[cmux] SSH frakoblet (%s); prøver igjen %s om %s s; inndata forkastes."}},
-        "pl": {"stringUnit": {"state": "translated", "value": "[cmux] SSH rozłączone (%s); ponowna próba %s za %s s; dane wejściowe zostaną odrzucone."}},
-        "pt-BR": {"stringUnit": {"state": "translated", "value": "[cmux] SSH desconectado (%s); nova tentativa %s em %s s; entrada descartada."}},
-        "ru": {"stringUnit": {"state": "translated", "value": "[cmux] SSH отключён (%s); повторная попытка %s через %s с; ввод будет отброшен."}},
-        "th": {"stringUnit": {"state": "translated", "value": "[cmux] SSH ถูกตัดการเชื่อมต่อ (%s); ลองใหม่ครั้งที่ %s ใน %s วินาที; อินพุตจะถูกทิ้ง"}},
-        "tr": {"stringUnit": {"state": "translated", "value": "[cmux] SSH bağlantısı kesildi (%s); %s. deneme %s sn içinde; girdi atılacak."}},
-        "uk": {"stringUnit": {"state": "translated", "value": "[cmux] SSH від’єднано (%s); повторна спроба %s через %s с; введення буде відкинуто."}},
-        "zh-Hans": {"stringUnit": {"state": "translated", "value": "[cmux] SSH 已断开（%s）；重试第 %s 次（%s 秒后）；输入将被丢弃。"}},
-        "zh-Hant": {"stringUnit": {"state": "translated", "value": "[cmux] SSH 已中斷（%s）；重試第 %s 次（%s 秒後）；輸入將被捨棄。"}}
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[cmux] انقطع اتصال SSH (%s)؛ إعادة المحاولة %s خلال %s ث؛ سيتم تجاهل الإدخال."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[cmux] SSH veza je prekinuta (%s); pokušaj %s za %s s; unos se odbacuje."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[cmux] SSH afbrudt (%s); prøver igen %s om %s s; input kasseres."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[cmux] SSH getrennt (%s); Versuch %s in %s s; Eingaben werden verworfen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[cmux] SSH desconectado (%s); reintento %s en %s s; la entrada se descarta."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[cmux] SSH déconnecté (%s) ; nouvelle tentative %s dans %s s ; saisie ignorée."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[cmux] SSH disconnesso (%s); nuovo tentativo %s tra %s s; input scartato."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[cmux] SSH បានផ្តាច់ (%s); ព្យាយាមម្ដងទៀត %s ក្នុង %s វិ; ទិន្នន័យបញ្ចូលត្រូវបានបោះចោល។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[cmux] SSH 연결 끊김(%s); %s번째 재시도를 %s초 후 수행합니다; 입력은 버립니다."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[cmux] SSH frakoblet (%s); prøver igjen %s om %s s; inndata forkastes."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[cmux] SSH rozłączone (%s); ponowna próba %s za %s s; dane wejściowe zostaną odrzucone."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[cmux] SSH desconectado (%s); nova tentativa %s em %s s; entrada descartada."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[cmux] SSH отключён (%s); повторная попытка %s через %s с; ввод будет отброшен."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[cmux] SSH ถูกตัดการเชื่อมต่อ (%s); ลองใหม่ครั้งที่ %s ใน %s วินาที; อินพุตจะถูกทิ้ง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[cmux] SSH bağlantısı kesildi (%s); %s. deneme %s sn içinde; girdi atılacak."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[cmux] SSH від’єднано (%s); повторна спроба %s через %s с; введення буде відкинуто."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[cmux] SSH 已断开（%s）；重试第 %s 次（%s 秒后）；输入将被丢弃。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[cmux] SSH 已中斷（%s）；重試第 %s 次（%s 秒後）；輸入將被捨棄。"
+          }
+        }
       }
     },
     "cli.sshPtyAttach.retryReason.hostUnreachable": {
@@ -56047,24 +56580,114 @@
             "value": "ホストに接続できません"
           }
         },
-        "ar": {"stringUnit": {"state": "translated", "value": "المضيف غير قابل للوصول"}},
-        "bs": {"stringUnit": {"state": "translated", "value": "host nije dostupan"}},
-        "da": {"stringUnit": {"state": "translated", "value": "værten kan ikke nås"}},
-        "de": {"stringUnit": {"state": "translated", "value": "Host nicht erreichbar"}},
-        "es": {"stringUnit": {"state": "translated", "value": "host inaccesible"}},
-        "fr": {"stringUnit": {"state": "translated", "value": "hôte inaccessible"}},
-        "it": {"stringUnit": {"state": "translated", "value": "host non raggiungibile"}},
-        "km": {"stringUnit": {"state": "translated", "value": "មិនអាចចូលដល់ម៉ាស៊ីន"}},
-        "ko": {"stringUnit": {"state": "translated", "value": "호스트에 연결할 수 없음"}},
-        "nb": {"stringUnit": {"state": "translated", "value": "vert utilgjengelig"}},
-        "pl": {"stringUnit": {"state": "translated", "value": "host nieosiągalny"}},
-        "pt-BR": {"stringUnit": {"state": "translated", "value": "host inacessível"}},
-        "ru": {"stringUnit": {"state": "translated", "value": "хост недоступен"}},
-        "th": {"stringUnit": {"state": "translated", "value": "เข้าถึงโฮสต์ไม่ได้"}},
-        "tr": {"stringUnit": {"state": "translated", "value": "ana bilgisayara ulaşılamıyor"}},
-        "uk": {"stringUnit": {"state": "translated", "value": "хост недоступний"}},
-        "zh-Hans": {"stringUnit": {"state": "translated", "value": "主机不可达"}},
-        "zh-Hant": {"stringUnit": {"state": "translated", "value": "主機無法連線"}}
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "المضيف غير قابل للوصول"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "host nije dostupan"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "værten kan ikke nås"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Host nicht erreichbar"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "host inaccesible"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hôte inaccessible"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "host non raggiungibile"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "មិនអាចចូលដល់ម៉ាស៊ីន"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "호스트에 연결할 수 없음"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vert utilgjengelig"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "host nieosiągalny"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "host inacessível"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "хост недоступен"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เข้าถึงโฮสต์ไม่ได้"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ana bilgisayara ulaşılamıyor"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "хост недоступний"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "主机不可达"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "主機無法連線"
+          }
+        }
       }
     },
     "cli.sshPtyAttach.retryReason.controlMasterUnavailable": {
@@ -56082,24 +56705,114 @@
             "value": "SSH 認証または制御接続を利用できません"
           }
         },
-        "ar": {"stringUnit": {"state": "translated", "value": "مصادقة/تحكم SSH غير متاح"}},
-        "bs": {"stringUnit": {"state": "translated", "value": "SSH autentikacija/kontrola nije dostupna"}},
-        "da": {"stringUnit": {"state": "translated", "value": "SSH-godkendelse/-kontrol er utilgængelig"}},
-        "de": {"stringUnit": {"state": "translated", "value": "SSH-Authentifizierung/-Steuerung nicht verfügbar"}},
-        "es": {"stringUnit": {"state": "translated", "value": "autenticación/control SSH no disponible"}},
-        "fr": {"stringUnit": {"state": "translated", "value": "authentification/contrôle SSH indisponible"}},
-        "it": {"stringUnit": {"state": "translated", "value": "autenticazione/controllo SSH non disponibile"}},
-        "km": {"stringUnit": {"state": "translated", "value": "មិនមានការផ្ទៀងផ្ទាត់/ការគ្រប់គ្រង SSH"}},
-        "ko": {"stringUnit": {"state": "translated", "value": "SSH 인증/제어를 사용할 수 없음"}},
-        "nb": {"stringUnit": {"state": "translated", "value": "SSH-autentisering/-kontroll utilgjengelig"}},
-        "pl": {"stringUnit": {"state": "translated", "value": "uwierzytelnianie/kontrola SSH niedostępna"}},
-        "pt-BR": {"stringUnit": {"state": "translated", "value": "autenticação/controle SSH indisponível"}},
-        "ru": {"stringUnit": {"state": "translated", "value": "аутентификация/управление SSH недоступны"}},
-        "th": {"stringUnit": {"state": "translated", "value": "การยืนยันตัวตน/การควบคุม SSH ใช้งานไม่ได้"}},
-        "tr": {"stringUnit": {"state": "translated", "value": "SSH kimlik doğrulama/kontrolü kullanılamıyor"}},
-        "uk": {"stringUnit": {"state": "translated", "value": "автентифікація/керування SSH недоступні"}},
-        "zh-Hans": {"stringUnit": {"state": "translated", "value": "SSH 身份验证/控制不可用"}},
-        "zh-Hant": {"stringUnit": {"state": "translated", "value": "SSH 驗證/控制無法使用"}}
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مصادقة/تحكم SSH غير متاح"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH autentikacija/kontrola nije dostupna"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH-godkendelse/-kontrol er utilgængelig"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH-Authentifizierung/-Steuerung nicht verfügbar"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "autenticación/control SSH no disponible"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "authentification/contrôle SSH indisponible"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "autenticazione/controllo SSH non disponibile"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "មិនមានការផ្ទៀងផ្ទាត់/ការគ្រប់គ្រង SSH"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH 인증/제어를 사용할 수 없음"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH-autentisering/-kontroll utilgjengelig"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "uwierzytelnianie/kontrola SSH niedostępna"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "autenticação/controle SSH indisponível"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "аутентификация/управление SSH недоступны"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การยืนยันตัวตน/การควบคุม SSH ใช้งานไม่ได้"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH kimlik doğrulama/kontrolü kullanılamıyor"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "автентифікація/керування SSH недоступні"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH 身份验证/控制不可用"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH 驗證/控制無法使用"
+          }
+        }
       }
     },
     "cli.sshPtyAttach.retryReason.daemonNotReady": {
@@ -56117,24 +56830,114 @@
             "value": "リモートサービスを起動しています"
           }
         },
-        "ar": {"stringUnit": {"state": "translated", "value": "الخدمة البعيدة قيد التشغيل"}},
-        "bs": {"stringUnit": {"state": "translated", "value": "udaljena usluga se pokreće"}},
-        "da": {"stringUnit": {"state": "translated", "value": "fjerntjenesten starter"}},
-        "de": {"stringUnit": {"state": "translated", "value": "Remote-Dienst wird gestartet"}},
-        "es": {"stringUnit": {"state": "translated", "value": "el servicio remoto se está iniciando"}},
-        "fr": {"stringUnit": {"state": "translated", "value": "le service distant démarre"}},
-        "it": {"stringUnit": {"state": "translated", "value": "il servizio remoto si avvia"}},
-        "km": {"stringUnit": {"state": "translated", "value": "សេវាពីចម្ងាយកំពុងចាប់ផ្តើម"}},
-        "ko": {"stringUnit": {"state": "translated", "value": "원격 서비스 시작 중"}},
-        "nb": {"stringUnit": {"state": "translated", "value": "fjerntjenesten starter"}},
-        "pl": {"stringUnit": {"state": "translated", "value": "usługa zdalna uruchamia się"}},
-        "pt-BR": {"stringUnit": {"state": "translated", "value": "o serviço remoto está iniciando"}},
-        "ru": {"stringUnit": {"state": "translated", "value": "удалённая служба запускается"}},
-        "th": {"stringUnit": {"state": "translated", "value": "กำลังเริ่มบริการระยะไกล"}},
-        "tr": {"stringUnit": {"state": "translated", "value": "uzak hizmet başlatılıyor"}},
-        "uk": {"stringUnit": {"state": "translated", "value": "віддалена служба запускається"}},
-        "zh-Hans": {"stringUnit": {"state": "translated", "value": "远程服务正在启动"}},
-        "zh-Hant": {"stringUnit": {"state": "translated", "value": "遠端服務正在啟動"}}
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الخدمة البعيدة قيد التشغيل"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "udaljena usluga se pokreće"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "fjerntjenesten starter"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remote-Dienst wird gestartet"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "el servicio remoto se está iniciando"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "le service distant démarre"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "il servizio remoto si avvia"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "សេវាពីចម្ងាយកំពុងចាប់ផ្តើម"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "원격 서비스 시작 중"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "fjerntjenesten starter"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "usługa zdalna uruchamia się"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "o serviço remoto está iniciando"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "удалённая служба запускается"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "กำลังเริ่มบริการระยะไกล"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "uzak hizmet başlatılıyor"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "віддалена служба запускається"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "远程服务正在启动"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "遠端服務正在啟動"
+          }
+        }
       }
     },
     "cli.sshPtyAttach.retryReason.bridgeClosed": {
@@ -56152,24 +56955,114 @@
             "value": "接続が中断されました"
           }
         },
-        "ar": {"stringUnit": {"state": "translated", "value": "انقطع الاتصال"}},
-        "bs": {"stringUnit": {"state": "translated", "value": "veza je prekinuta"}},
-        "da": {"stringUnit": {"state": "translated", "value": "forbindelsen blev afbrudt"}},
-        "de": {"stringUnit": {"state": "translated", "value": "Verbindung unterbrochen"}},
-        "es": {"stringUnit": {"state": "translated", "value": "conexión interrumpida"}},
-        "fr": {"stringUnit": {"state": "translated", "value": "connexion interrompue"}},
-        "it": {"stringUnit": {"state": "translated", "value": "connessione interrotta"}},
-        "km": {"stringUnit": {"state": "translated", "value": "ការតភ្ជាប់ត្រូវបានផ្អាក"}},
-        "ko": {"stringUnit": {"state": "translated", "value": "연결 중단"}},
-        "nb": {"stringUnit": {"state": "translated", "value": "tilkoblingen ble avbrutt"}},
-        "pl": {"stringUnit": {"state": "translated", "value": "połączenie przerwane"}},
-        "pt-BR": {"stringUnit": {"state": "translated", "value": "conexão interrompida"}},
-        "ru": {"stringUnit": {"state": "translated", "value": "соединение прервано"}},
-        "th": {"stringUnit": {"state": "translated", "value": "การเชื่อมต่อถูกขัดจังหวะ"}},
-        "tr": {"stringUnit": {"state": "translated", "value": "bağlantı kesildi"}},
-        "uk": {"stringUnit": {"state": "translated", "value": "з’єднання перервано"}},
-        "zh-Hans": {"stringUnit": {"state": "translated", "value": "连接中断"}},
-        "zh-Hant": {"stringUnit": {"state": "translated", "value": "連線中斷"}}
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "انقطع الاتصال"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "veza je prekinuta"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "forbindelsen blev afbrudt"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbindung unterbrochen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "conexión interrumpida"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "connexion interrompue"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "connessione interrotta"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ការតភ្ជាប់ត្រូវបានផ្អាក"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "연결 중단"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tilkoblingen ble avbrutt"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "połączenie przerwane"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "conexão interrompida"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "соединение прервано"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การเชื่อมต่อถูกขัดจังหวะ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bağlantı kesildi"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "з’єднання перервано"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "连接中断"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "連線中斷"
+          }
+        }
       }
     },
     "cli.sshPtyAttach.retryReason.noProgress": {
@@ -56187,74 +57080,256 @@
             "value": "リモートサービスから進展がありません"
           }
         },
-        "ar": {"stringUnit": {"state": "translated", "value": "لم تتقدم الخدمة البعيدة"}},
-        "bs": {"stringUnit": {"state": "translated", "value": "udaljena usluga nije napredovala"}},
-        "da": {"stringUnit": {"state": "translated", "value": "fjerntjenesten gjorde ingen fremskridt"}},
-        "de": {"stringUnit": {"state": "translated", "value": "Remote-Dienst kommt nicht voran"}},
-        "es": {"stringUnit": {"state": "translated", "value": "el servicio remoto no avanzó"}},
-        "fr": {"stringUnit": {"state": "translated", "value": "le service distant n’avance pas"}},
-        "it": {"stringUnit": {"state": "translated", "value": "il servizio remoto non avanza"}},
-        "km": {"stringUnit": {"state": "translated", "value": "សេវាពីចម្ងាយមិនមានការរីកចម្រើន"}},
-        "ko": {"stringUnit": {"state": "translated", "value": "원격 서비스가 진행되지 않음"}},
-        "nb": {"stringUnit": {"state": "translated", "value": "fjerntjenesten gjorde ingen fremgang"}},
-        "pl": {"stringUnit": {"state": "translated", "value": "usługa zdalna nie robi postępów"}},
-        "pt-BR": {"stringUnit": {"state": "translated", "value": "o serviço remoto não avançou"}},
-        "ru": {"stringUnit": {"state": "translated", "value": "удалённая служба не продвигается"}},
-        "th": {"stringUnit": {"state": "translated", "value": "บริการระยะไกลไม่คืบหน้า"}},
-        "tr": {"stringUnit": {"state": "translated", "value": "uzak hizmet ilerleme göstermedi"}},
-        "uk": {"stringUnit": {"state": "translated", "value": "віддалена служба не просувається"}},
-        "zh-Hans": {"stringUnit": {"state": "translated", "value": "远程服务没有进展"}},
-        "zh-Hant": {"stringUnit": {"state": "translated", "value": "遠端服務沒有進展"}}
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لم تتقدم الخدمة البعيدة"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "udaljena usluga nije napredovala"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "fjerntjenesten gjorde ingen fremskridt"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remote-Dienst kommt nicht voran"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "el servicio remoto no avanzó"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "le service distant n’avance pas"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "il servizio remoto non avanza"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "សេវាពីចម្ងាយមិនមានការរីកចម្រើន"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "원격 서비스가 진행되지 않음"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "fjerntjenesten gjorde ingen fremgang"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "usługa zdalna nie robi postępów"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "o serviço remoto não avançou"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "удалённая служба не продвигается"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "บริการระยะไกลไม่คืบหน้า"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "uzak hizmet ilerleme göstermedi"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "віддалена служба не просувається"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "远程服务没有进展"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "遠端服務沒有進展"
+          }
+        }
       }
     },
     "cli.sshPtyAttach.terminalInputFlushFailed": {
       "extractionState": "manual",
       "localizations": {
-        "en": {"stringUnit": {"state": "translated", "value": "SSH terminal input could not be reset; reconnecting."}},
-        "ja": {"stringUnit": {"state": "translated", "value": "SSH ターミナル入力をリセットできませんでした。再接続します。"}},
-        "ar": {"stringUnit": {"state": "translated", "value": "تعذر إعادة ضبط إدخال طرفية SSH؛ جارٍ إعادة الاتصال."}},
-        "bs": {"stringUnit": {"state": "translated", "value": "Ulaz SSH terminala nije moguće resetovati; ponovno povezivanje."}},
-        "da": {"stringUnit": {"state": "translated", "value": "SSH-terminalinput kunne ikke nulstilles; opretter forbindelse igen."}},
-        "de": {"stringUnit": {"state": "translated", "value": "SSH-Terminaleingabe konnte nicht zurückgesetzt werden; Verbindung wird wiederhergestellt."}},
-        "es": {"stringUnit": {"state": "translated", "value": "No se pudo restablecer la entrada del terminal SSH; reconectando."}},
-        "fr": {"stringUnit": {"state": "translated", "value": "L’entrée du terminal SSH n’a pas pu être réinitialisée ; reconnexion."}},
-        "it": {"stringUnit": {"state": "translated", "value": "Impossibile reimpostare l’input del terminale SSH; riconnessione."}},
-        "km": {"stringUnit": {"state": "translated", "value": "មិនអាចកំណត់ការបញ្ចូលស្ថានីយ SSH ឡើងវិញបានទេ; កំពុងភ្ជាប់ឡើងវិញ។"}},
-        "ko": {"stringUnit": {"state": "translated", "value": "SSH 터미널 입력을 재설정할 수 없습니다. 다시 연결합니다."}},
-        "nb": {"stringUnit": {"state": "translated", "value": "SSH-terminalinndata kunne ikke tilbakestilles; kobler til på nytt."}},
-        "pl": {"stringUnit": {"state": "translated", "value": "Nie można zresetować wejścia terminala SSH; ponowne łączenie."}},
-        "pt-BR": {"stringUnit": {"state": "translated", "value": "Não foi possível redefinir a entrada do terminal SSH; reconectando."}},
-        "ru": {"stringUnit": {"state": "translated", "value": "Не удалось сбросить ввод терминала SSH; выполняется переподключение."}},
-        "th": {"stringUnit": {"state": "translated", "value": "รีเซ็ตอินพุตเทอร์มินัล SSH ไม่ได้ กำลังเชื่อมต่อใหม่"}},
-        "tr": {"stringUnit": {"state": "translated", "value": "SSH terminal girişi sıfırlanamadı; yeniden bağlanılıyor."}},
-        "uk": {"stringUnit": {"state": "translated", "value": "Не вдалося скинути ввід термінала SSH; повторне підключення."}},
-        "zh-Hans": {"stringUnit": {"state": "translated", "value": "无法重置 SSH 终端输入；正在重新连接。"}},
-        "zh-Hant": {"stringUnit": {"state": "translated", "value": "無法重設 SSH 終端輸入；正在重新連線。"}}
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH terminal input could not be reset; reconnecting."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH ターミナル入力をリセットできませんでした。再接続します。"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تعذر إعادة ضبط إدخال طرفية SSH؛ جارٍ إعادة الاتصال."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ulaz SSH terminala nije moguće resetovati; ponovno povezivanje."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH-terminalinput kunne ikke nulstilles; opretter forbindelse igen."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH-Terminaleingabe konnte nicht zurückgesetzt werden; Verbindung wird wiederhergestellt."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo restablecer la entrada del terminal SSH; reconectando."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L’entrée du terminal SSH n’a pas pu être réinitialisée ; reconnexion."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossibile reimpostare l’input del terminale SSH; riconnessione."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "មិនអាចកំណត់ការបញ្ចូលស្ថានីយ SSH ឡើងវិញបានទេ; កំពុងភ្ជាប់ឡើងវិញ។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH 터미널 입력을 재설정할 수 없습니다. 다시 연결합니다."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH-terminalinndata kunne ikke tilbakestilles; kobler til på nytt."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie można zresetować wejścia terminala SSH; ponowne łączenie."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não foi possível redefinir a entrada do terminal SSH; reconectando."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось сбросить ввод терминала SSH; выполняется переподключение."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "รีเซ็ตอินพุตเทอร์มินัล SSH ไม่ได้ กำลังเชื่อมต่อใหม่"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH terminal girişi sıfırlanamadı; yeniden bağlanılıyor."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не вдалося скинути ввід термінала SSH; повторне підключення."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法重置 SSH 终端输入；正在重新连接。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無法重設 SSH 終端輸入；正在重新連線。"
+          }
+        }
       }
     },
     "cli.sshPtyAttach.terminalInputTransitionFailed": {
       "extractionState": "manual",
       "localizations": {
-        "en": {"stringUnit": {"state": "translated", "value": "SSH terminal input could not enter reconnect mode."}},
-        "ja": {"stringUnit": {"state": "translated", "value": "SSH ターミナル入力を再接続モードに切り替えられませんでした。"}},
-        "ar": {"stringUnit": {"state": "translated", "value": "تعذر إدخال طرفية SSH في وضع إعادة الاتصال."}},
-        "bs": {"stringUnit": {"state": "translated", "value": "Ulaz SSH terminala nije moguće prebaciti u režim ponovnog povezivanja."}},
-        "da": {"stringUnit": {"state": "translated", "value": "SSH-terminalinput kunne ikke skifte til genforbindelsestilstand."}},
-        "de": {"stringUnit": {"state": "translated", "value": "SSH-Terminaleingabe konnte nicht in den Wiederverbindungsmodus wechseln."}},
-        "es": {"stringUnit": {"state": "translated", "value": "No se pudo cambiar la entrada del terminal SSH al modo de reconexión."}},
-        "fr": {"stringUnit": {"state": "translated", "value": "L’entrée du terminal SSH n’a pas pu passer en mode reconnexion."}},
-        "it": {"stringUnit": {"state": "translated", "value": "Impossibile passare l’input del terminale SSH alla modalità di riconnessione."}},
-        "km": {"stringUnit": {"state": "translated", "value": "មិនអាចប្តូរការបញ្ចូលស្ថានីយ SSH ទៅរបៀបភ្ជាប់ឡើងវិញបានទេ។"}},
-        "ko": {"stringUnit": {"state": "translated", "value": "SSH 터미널 입력을 재연결 모드로 전환할 수 없습니다."}},
-        "nb": {"stringUnit": {"state": "translated", "value": "SSH-terminalinndata kunne ikke gå inn i tilkoblingsmodus."}},
-        "pl": {"stringUnit": {"state": "translated", "value": "Nie można przełączyć wejścia terminala SSH w tryb ponownego łączenia."}},
-        "pt-BR": {"stringUnit": {"state": "translated", "value": "Não foi possível colocar a entrada do terminal SSH no modo de reconexão."}},
-        "ru": {"stringUnit": {"state": "translated", "value": "Не удалось перевести ввод терминала SSH в режим переподключения."}},
-        "th": {"stringUnit": {"state": "translated", "value": "ไม่สามารถเปลี่ยนอินพุตเทอร์มินัล SSH เป็นโหมดเชื่อมต่อใหม่ได้"}},
-        "tr": {"stringUnit": {"state": "translated", "value": "SSH terminal girişi yeniden bağlanma moduna geçirilemedi."}},
-        "uk": {"stringUnit": {"state": "translated", "value": "Не вдалося перевести ввід термінала SSH у режим повторного підключення."}},
-        "zh-Hans": {"stringUnit": {"state": "translated", "value": "无法将 SSH 终端输入切换到重连模式。"}},
-        "zh-Hant": {"stringUnit": {"state": "translated", "value": "無法將 SSH 終端輸入切換至重新連線模式。"}}
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH reattach stopped because queued terminal input could not be discarded safely."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キューに入ったターミナル入力を安全に破棄できなかったため、SSH の再接続を停止しました。"
+          }
+        }
       }
     },
     "cli.sshPtyAttach.bridgeClosedReattachingInputDiscard": {
@@ -56440,23 +57515,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "[cmux] リモートセッションが失われました。新しいシェルを開始します。"
-          }
-        }
-      }
-    },
-    "cli.sshPtyAttach.terminalInputTransitionFailed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "SSH reattach stopped because queued terminal input could not be discarded safely."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キューに入ったターミナル入力を安全に破棄できなかったため、SSH の再接続を停止しました。"
           }
         }
       }
@@ -58987,22 +60045,52 @@
     "cli.vm.tui.protocolMismatch": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "cmux-tui protocol mismatch: client %1$@ speaks protocol %2$d, the machine daemon %3$@ speaks protocol %4$d. %5$@" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "cmux-tui のプロトコルが一致しません: クライアント %1$@ はプロトコル %2$d、マシンのデーモン %3$@ はプロトコル %4$d です。%5$@" } }
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux-tui protocol mismatch: client %1$@ speaks protocol %2$d, the machine daemon %3$@ speaks protocol %4$d. %5$@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux-tui のプロトコルが一致しません: クライアント %1$@ はプロトコル %2$d、マシンのデーモン %3$@ はプロトコル %4$d です。%5$@"
+          }
+        }
       }
     },
     "cli.vm.tui.staleClient": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "Update cmux (its bundled cmux-tui client is older than the machine's daemon)." } },
-        "ja": { "stringUnit": { "state": "translated", "value": "cmux を更新してください（同梱の cmux-tui クライアントがマシンのデーモンより古いです）。" } }
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update cmux (its bundled cmux-tui client is older than the machine's daemon)."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux を更新してください（同梱の cmux-tui クライアントがマシンのデーモンより古いです）。"
+          }
+        }
       }
     },
     "cli.vm.tui.staleDaemon": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "The machine's cmux-tui daemon is older than this client; reconnect once the machine has updated." } },
-        "ja": { "stringUnit": { "state": "translated", "value": "マシンの cmux-tui デーモンがこのクライアントより古いです。マシンが更新されてから再接続してください。" } }
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The machine's cmux-tui daemon is older than this client; reconnect once the machine has updated."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "マシンの cmux-tui デーモンがこのクライアントより古いです。マシンが更新されてから再接続してください。"
+          }
+        }
       }
     },
     "cli.vm.wait.ready": {
@@ -126799,13 +127887,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Upgrade to Reconnect\u2026"
+            "value": "Upgrade to Reconnect…"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "アップグレードして再接続\u2026"
+            "value": "アップグレードして再接続…"
           }
         }
       }
@@ -144459,351 +145547,1751 @@
     "mobile.pairing.irohInstruction": {
       "extractionState": "manual",
       "localizations": {
-        "ar": { "stringUnit": { "state": "translated", "value": "ثبّت cmux على جهاز iPhone وسجّل الدخول بالحساب نفسه. يتصل تلقائيًا — لا حاجة إلى رمز." } },
-        "bs": { "stringUnit": { "state": "translated", "value": "Instalirajte cmux na svoj iPhone i prijavite se istim računom. Povezuje se automatski — kôd nije potreban." } },
-        "da": { "stringUnit": { "state": "translated", "value": "Installer cmux på din iPhone, og log ind med den samme konto. Den forbinder automatisk — ingen kode nødvendig." } },
-        "de": { "stringUnit": { "state": "translated", "value": "Installiere cmux auf deinem iPhone und melde dich mit demselben Konto an. Die Verbindung erfolgt automatisch — kein Code nötig." } },
-        "en": { "stringUnit": { "state": "translated", "value": "Install cmux on your iPhone and sign in with the same account. It connects automatically — no code needed." } },
-        "es": { "stringUnit": { "state": "translated", "value": "Instala cmux en tu iPhone e inicia sesión con la misma cuenta. Se conecta automáticamente: no se necesita código." } },
-        "fr": { "stringUnit": { "state": "translated", "value": "Installez cmux sur votre iPhone et connectez-vous avec le même compte. La connexion est automatique — aucun code nécessaire." } },
-        "it": { "stringUnit": { "state": "translated", "value": "Installa cmux sul tuo iPhone e accedi con lo stesso account. Si connette automaticamente — nessun codice necessario." } },
-        "ja": { "stringUnit": { "state": "translated", "value": "iPhoneにcmuxをインストールし、同じアカウントにサインインしてください。自動的に接続されます。コードは不要です。" } },
-        "km": { "stringUnit": { "state": "translated", "value": "ដំឡើង cmux នៅលើ iPhone របស់អ្នក ហើយចូលគណនីដូចគ្នា។ វាភ្ជាប់ដោយស្វ័យប្រវត្តិ — មិនត្រូវការកូដទេ។" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "iPhone에 cmux를 설치하고 동일한 계정으로 로그인하세요. 자동으로 연결되며 코드가 필요 없습니다." } },
-        "nb": { "stringUnit": { "state": "translated", "value": "Installer cmux på iPhonen din og logg på med samme konto. Den kobler til automatisk — ingen kode nødvendig." } },
-        "pl": { "stringUnit": { "state": "translated", "value": "Zainstaluj cmux na swoim iPhonie i zaloguj się na to samo konto. Łączy się automatycznie — kod nie jest potrzebny." } },
-        "pt-BR": { "stringUnit": { "state": "translated", "value": "Instale o cmux no seu iPhone e entre com a mesma conta. Ele conecta automaticamente — nenhum código necessário." } },
-        "ru": { "stringUnit": { "state": "translated", "value": "Установите cmux на iPhone и войдите в ту же учётную запись. Подключение происходит автоматически — код не нужен." } },
-        "th": { "stringUnit": { "state": "translated", "value": "ติดตั้ง cmux บน iPhone ของคุณและลงชื่อเข้าด้วยบัญชีเดียวกัน ระบบจะเชื่อมต่อโดยอัตโนมัติ — ไม่ต้องใช้โค้ด" } },
-        "tr": { "stringUnit": { "state": "translated", "value": "iPhone'unuza cmux'u yükleyin ve aynı hesapla oturum açın. Otomatik olarak bağlanır — kod gerekmez." } },
-        "uk": { "stringUnit": { "state": "translated", "value": "Установіть cmux на iPhone та увійдіть у той самий обліковий запис. Підключення відбувається автоматично — код не потрібен." } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "在 iPhone 上安装 cmux 并使用同一账户登录。它会自动连接——无需扫码。" } },
-        "zh-Hant": { "stringUnit": { "state": "translated", "value": "在 iPhone 上安裝 cmux 並使用同一帳戶登入。它會自動連線——無需掃碼。" } }
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ثبّت cmux على جهاز iPhone وسجّل الدخول بالحساب نفسه. يتصل تلقائيًا — لا حاجة إلى رمز."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalirajte cmux na svoj iPhone i prijavite se istim računom. Povezuje se automatski — kôd nije potreban."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installer cmux på din iPhone, og log ind med den samme konto. Den forbinder automatisk — ingen kode nødvendig."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installiere cmux auf deinem iPhone und melde dich mit demselben Konto an. Die Verbindung erfolgt automatisch — kein Code nötig."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Install cmux on your iPhone and sign in with the same account. It connects automatically — no code needed."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instala cmux en tu iPhone e inicia sesión con la misma cuenta. Se conecta automáticamente: no se necesita código."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installez cmux sur votre iPhone et connectez-vous avec le même compte. La connexion est automatique — aucun code nécessaire."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installa cmux sul tuo iPhone e accedi con lo stesso account. Si connette automaticamente — nessun codice necessario."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhoneにcmuxをインストールし、同じアカウントにサインインしてください。自動的に接続されます。コードは不要です。"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ដំឡើង cmux នៅលើ iPhone របស់អ្នក ហើយចូលគណនីដូចគ្នា។ វាភ្ជាប់ដោយស្វ័យប្រវត្តិ — មិនត្រូវការកូដទេ។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone에 cmux를 설치하고 동일한 계정으로 로그인하세요. 자동으로 연결되며 코드가 필요 없습니다."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installer cmux på iPhonen din og logg på med samme konto. Den kobler til automatisk — ingen kode nødvendig."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zainstaluj cmux na swoim iPhonie i zaloguj się na to samo konto. Łączy się automatycznie — kod nie jest potrzebny."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instale o cmux no seu iPhone e entre com a mesma conta. Ele conecta automaticamente — nenhum código necessário."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Установите cmux на iPhone и войдите в ту же учётную запись. Подключение происходит автоматически — код не нужен."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ติดตั้ง cmux บน iPhone ของคุณและลงชื่อเข้าด้วยบัญชีเดียวกัน ระบบจะเชื่อมต่อโดยอัตโนมัติ — ไม่ต้องใช้โค้ด"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone'unuza cmux'u yükleyin ve aynı hesapla oturum açın. Otomatik olarak bağlanır — kod gerekmez."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Установіть cmux на iPhone та увійдіть у той самий обліковий запис. Підключення відбувається автоматично — код не потрібен."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 iPhone 上安装 cmux 并使用同一账户登录。它会自动连接——无需扫码。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 iPhone 上安裝 cmux 並使用同一帳戶登入。它會自動連線——無需掃碼。"
+          }
+        }
       }
     },
     "mobile.pairing.subheading": {
       "extractionState": "manual",
       "localizations": {
-        "ar": { "stringUnit": { "state": "translated", "value": "زامن مساحات عمل الطرفية مع جهاز iPhone الخاص بك." } },
-        "bs": { "stringUnit": { "state": "translated", "value": "Sinhronizujte svoje terminalske radne prostore sa svojim iPhoneom." } },
-        "da": { "stringUnit": { "state": "translated", "value": "Synkroniser dine terminal-arbejdsområder til din iPhone." } },
-        "de": { "stringUnit": { "state": "translated", "value": "Synchronisiere deine Terminal-Arbeitsbereiche mit deinem iPhone." } },
-        "en": { "stringUnit": { "state": "translated", "value": "Sync your terminal workspaces to your iPhone." } },
-        "es": { "stringUnit": { "state": "translated", "value": "Sincroniza tus espacios de trabajo de terminal con tu iPhone." } },
-        "fr": { "stringUnit": { "state": "translated", "value": "Synchronisez vos espaces de travail de terminal avec votre iPhone." } },
-        "it": { "stringUnit": { "state": "translated", "value": "Sincronizza i tuoi spazi di lavoro del terminale con il tuo iPhone." } },
-        "ja": { "stringUnit": { "state": "translated", "value": "ターミナルのワークスペースをiPhoneと同期します。" } },
-        "km": { "stringUnit": { "state": "translated", "value": "ធ្វើសមកាលកម្មកន្លែងធ្វើការតឺមីណាល់របស់អ្នកទៅ iPhone របស់អ្នក។" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "터미널 워크스페이스를 iPhone과 동기화하세요." } },
-        "nb": { "stringUnit": { "state": "translated", "value": "Synkroniser terminalarbeidsområdene dine til iPhonen din." } },
-        "pl": { "stringUnit": { "state": "translated", "value": "Synchronizuj swoje terminalowe przestrzenie robocze z iPhone'em." } },
-        "pt-BR": { "stringUnit": { "state": "translated", "value": "Sincronize seus espaços de trabalho de terminal com o seu iPhone." } },
-        "ru": { "stringUnit": { "state": "translated", "value": "Синхронизируйте рабочие пространства терминала со своим iPhone." } },
-        "th": { "stringUnit": { "state": "translated", "value": "ซิงค์เวิร์กสเปซเทอร์มินัลของคุณไปยัง iPhone ของคุณ" } },
-        "tr": { "stringUnit": { "state": "translated", "value": "Terminal çalışma alanlarınızı iPhone'unuzla eşitleyin." } },
-        "uk": { "stringUnit": { "state": "translated", "value": "Синхронізуйте робочі простори термінала зі своїм iPhone." } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "将您的终端工作区同步到 iPhone。" } },
-        "zh-Hant": { "stringUnit": { "state": "translated", "value": "將您的終端機工作區同步到 iPhone。" } }
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "زامن مساحات عمل الطرفية مع جهاز iPhone الخاص بك."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sinhronizujte svoje terminalske radne prostore sa svojim iPhoneom."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Synkroniser dine terminal-arbejdsområder til din iPhone."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Synchronisiere deine Terminal-Arbeitsbereiche mit deinem iPhone."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sync your terminal workspaces to your iPhone."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincroniza tus espacios de trabajo de terminal con tu iPhone."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Synchronisez vos espaces de travail de terminal avec votre iPhone."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronizza i tuoi spazi di lavoro del terminale con il tuo iPhone."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナルのワークスペースをiPhoneと同期します。"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ធ្វើសមកាលកម្មកន្លែងធ្វើការតឺមីណាល់របស់អ្នកទៅ iPhone របស់អ្នក។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "터미널 워크스페이스를 iPhone과 동기화하세요."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Synkroniser terminalarbeidsområdene dine til iPhonen din."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Synchronizuj swoje terminalowe przestrzenie robocze z iPhone'em."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronize seus espaços de trabalho de terminal com o seu iPhone."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Синхронизируйте рабочие пространства терминала со своим iPhone."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ซิงค์เวิร์กสเปซเทอร์มินัลของคุณไปยัง iPhone ของคุณ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal çalışma alanlarınızı iPhone'unuzla eşitleyin."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Синхронізуйте робочі простори термінала зі своїм iPhone."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将您的终端工作区同步到 iPhone。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "將您的終端機工作區同步到 iPhone。"
+          }
+        }
       }
     },
     "mobile.pairing.transportPicker": {
       "extractionState": "manual",
       "localizations": {
-        "ar": { "stringUnit": { "state": "translated", "value": "الاتصال" } },
-        "bs": { "stringUnit": { "state": "translated", "value": "Veza" } },
-        "da": { "stringUnit": { "state": "translated", "value": "Forbindelse" } },
-        "de": { "stringUnit": { "state": "translated", "value": "Verbindung" } },
-        "en": { "stringUnit": { "state": "translated", "value": "Connection" } },
-        "es": { "stringUnit": { "state": "translated", "value": "Conexión" } },
-        "fr": { "stringUnit": { "state": "translated", "value": "Connexion" } },
-        "it": { "stringUnit": { "state": "translated", "value": "Connessione" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "接続" } },
-        "km": { "stringUnit": { "state": "translated", "value": "ការតភ្ជាប់" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "연결" } },
-        "nb": { "stringUnit": { "state": "translated", "value": "Tilkobling" } },
-        "pl": { "stringUnit": { "state": "translated", "value": "Połączenie" } },
-        "pt-BR": { "stringUnit": { "state": "translated", "value": "Conexão" } },
-        "ru": { "stringUnit": { "state": "translated", "value": "Подключение" } },
-        "th": { "stringUnit": { "state": "translated", "value": "การเชื่อมต่อ" } },
-        "tr": { "stringUnit": { "state": "translated", "value": "Bağlantı" } },
-        "uk": { "stringUnit": { "state": "translated", "value": "Підключення" } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "连接" } },
-        "zh-Hant": { "stringUnit": { "state": "translated", "value": "連線" } }
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الاتصال"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Veza"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Forbindelse"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbindung"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connection"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conexión"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connexion"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connessione"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接続"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ការតភ្ជាប់"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "연결"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tilkobling"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Połączenie"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conexão"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подключение"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การเชื่อมต่อ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bağlantı"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Підключення"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "连接"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "連線"
+          }
+        }
       }
     },
     "mobile.pairing.getApp.badge.caption": {
       "extractionState": "manual",
       "localizations": {
-        "ar": { "stringUnit": { "state": "translated", "value": "نزّل cmux لجهاز" } },
-        "bs": { "stringUnit": { "state": "translated", "value": "Preuzmite cmux za" } },
-        "da": { "stringUnit": { "state": "translated", "value": "Hent cmux til" } },
-        "de": { "stringUnit": { "state": "translated", "value": "Lade cmux für" } },
-        "en": { "stringUnit": { "state": "translated", "value": "Download cmux for" } },
-        "es": { "stringUnit": { "state": "translated", "value": "Descarga cmux para" } },
-        "fr": { "stringUnit": { "state": "translated", "value": "Téléchargez cmux pour" } },
-        "it": { "stringUnit": { "state": "translated", "value": "Scarica cmux per" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "cmuxをダウンロード" } },
-        "km": { "stringUnit": { "state": "translated", "value": "ទាញយក cmux សម្រាប់" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "cmux 다운로드" } },
-        "nb": { "stringUnit": { "state": "translated", "value": "Last ned cmux til" } },
-        "pl": { "stringUnit": { "state": "translated", "value": "Pobierz cmux na" } },
-        "pt-BR": { "stringUnit": { "state": "translated", "value": "Baixe o cmux para" } },
-        "ru": { "stringUnit": { "state": "translated", "value": "Скачать cmux для" } },
-        "th": { "stringUnit": { "state": "translated", "value": "ดาวน์โหลด cmux สำหรับ" } },
-        "tr": { "stringUnit": { "state": "translated", "value": "cmux'u indirin" } },
-        "uk": { "stringUnit": { "state": "translated", "value": "Завантажити cmux для" } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "下载 cmux" } },
-        "zh-Hant": { "stringUnit": { "state": "translated", "value": "下載 cmux" } }
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نزّل cmux لجهاز"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preuzmite cmux za"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hent cmux til"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lade cmux für"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download cmux for"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descarga cmux para"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Téléchargez cmux pour"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scarica cmux per"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmuxをダウンロード"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ទាញយក cmux សម្រាប់"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux 다운로드"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last ned cmux til"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pobierz cmux na"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Baixe o cmux para"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скачать cmux для"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ดาวน์โหลด cmux สำหรับ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux'u indirin"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Завантажити cmux для"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下载 cmux"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下載 cmux"
+          }
+        }
       }
     },
     "mobile.pairing.getApp.badge.platform": {
       "extractionState": "manual",
       "localizations": {
-        "ar": { "stringUnit": { "state": "translated", "value": "iPhone" } },
-        "bs": { "stringUnit": { "state": "translated", "value": "iPhone" } },
-        "da": { "stringUnit": { "state": "translated", "value": "iPhone" } },
-        "de": { "stringUnit": { "state": "translated", "value": "iPhone" } },
-        "en": { "stringUnit": { "state": "translated", "value": "iPhone" } },
-        "es": { "stringUnit": { "state": "translated", "value": "iPhone" } },
-        "fr": { "stringUnit": { "state": "translated", "value": "iPhone" } },
-        "it": { "stringUnit": { "state": "translated", "value": "iPhone" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "iPhone版" } },
-        "km": { "stringUnit": { "state": "translated", "value": "iPhone" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "iPhone용" } },
-        "nb": { "stringUnit": { "state": "translated", "value": "iPhone" } },
-        "pl": { "stringUnit": { "state": "translated", "value": "iPhone" } },
-        "pt-BR": { "stringUnit": { "state": "translated", "value": "iPhone" } },
-        "ru": { "stringUnit": { "state": "translated", "value": "iPhone" } },
-        "th": { "stringUnit": { "state": "translated", "value": "iPhone" } },
-        "tr": { "stringUnit": { "state": "translated", "value": "iPhone" } },
-        "uk": { "stringUnit": { "state": "translated", "value": "iPhone" } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "iPhone 版" } },
-        "zh-Hant": { "stringUnit": { "state": "translated", "value": "iPhone 版" } }
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone版"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone용"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone 版"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone 版"
+          }
+        }
       }
     },
     "mobile.pairing.heading": {
       "extractionState": "manual",
       "localizations": {
-        "ar": { "stringUnit": { "state": "translated", "value": "اقرن جهاز iPhone الخاص بك" } },
-        "bs": { "stringUnit": { "state": "translated", "value": "Uparite svoj iPhone" } },
-        "da": { "stringUnit": { "state": "translated", "value": "Par din iPhone" } },
-        "de": { "stringUnit": { "state": "translated", "value": "iPhone koppeln" } },
-        "en": { "stringUnit": { "state": "translated", "value": "Pair your iPhone" } },
-        "es": { "stringUnit": { "state": "translated", "value": "Empareja tu iPhone" } },
-        "fr": { "stringUnit": { "state": "translated", "value": "Jumelez votre iPhone" } },
-        "it": { "stringUnit": { "state": "translated", "value": "Abbina il tuo iPhone" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "iPhoneをペアリング" } },
-        "km": { "stringUnit": { "state": "translated", "value": "ផ្គូផ្គង iPhone របស់អ្នក" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "iPhone 페어링" } },
-        "nb": { "stringUnit": { "state": "translated", "value": "Par iPhonen din" } },
-        "pl": { "stringUnit": { "state": "translated", "value": "Sparuj swojego iPhone'a" } },
-        "pt-BR": { "stringUnit": { "state": "translated", "value": "Emparelhe seu iPhone" } },
-        "ru": { "stringUnit": { "state": "translated", "value": "Подключите свой iPhone" } },
-        "th": { "stringUnit": { "state": "translated", "value": "จับคู่ iPhone ของคุณ" } },
-        "tr": { "stringUnit": { "state": "translated", "value": "iPhone'unuzu eşleyin" } },
-        "uk": { "stringUnit": { "state": "translated", "value": "Підключіть свій iPhone" } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "配对您的 iPhone" } },
-        "zh-Hant": { "stringUnit": { "state": "translated", "value": "配對您的 iPhone" } }
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اقرن جهاز iPhone الخاص بك"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uparite svoj iPhone"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Par din iPhone"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone koppeln"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pair your iPhone"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Empareja tu iPhone"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jumelez votre iPhone"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abbina il tuo iPhone"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhoneをペアリング"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ផ្គូផ្គង iPhone របស់អ្នក"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone 페어링"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Par iPhonen din"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sparuj swojego iPhone'a"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emparelhe seu iPhone"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подключите свой iPhone"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "จับคู่ iPhone ของคุณ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone'unuzu eşleyin"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Підключіть свій iPhone"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "配对您的 iPhone"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "配對您的 iPhone"
+          }
+        }
       }
     },
     "mobile.pairing.scanInstruction": {
       "extractionState": "manual",
       "localizations": {
-        "ar": { "stringUnit": { "state": "translated", "value": "في cmux على جهاز iPhone، سجّل الدخول بالحساب نفسه، واختر Tailscale، ثم امسح هذا الرمز." } },
-        "bs": { "stringUnit": { "state": "translated", "value": "U cmux-u na svom iPhoneu prijavite se istim računom, odaberite Tailscale, a zatim skenirajte ovaj kôd." } },
-        "da": { "stringUnit": { "state": "translated", "value": "I cmux på din iPhone skal du logge ind med den samme konto, vælge Tailscale og derefter scanne denne kode." } },
-        "de": { "stringUnit": { "state": "translated", "value": "Melde dich in cmux auf deinem iPhone mit demselben Konto an, wähle Tailscale und scanne dann diesen Code." } },
-        "en": { "stringUnit": { "state": "translated", "value": "In cmux on your iPhone, sign in with the same account, choose Tailscale, then scan this code." } },
-        "es": { "stringUnit": { "state": "translated", "value": "En cmux en tu iPhone, inicia sesión con la misma cuenta, elige Tailscale y luego escanea este código." } },
-        "fr": { "stringUnit": { "state": "translated", "value": "Dans cmux sur votre iPhone, connectez-vous avec le même compte, choisissez Tailscale, puis scannez ce code." } },
-        "it": { "stringUnit": { "state": "translated", "value": "In cmux sul tuo iPhone, accedi con lo stesso account, scegli Tailscale e poi scansiona questo codice." } },
-        "ja": { "stringUnit": { "state": "translated", "value": "iPhoneのcmuxで同じアカウントにサインインし、Tailscaleを選択して、このコードをスキャンしてください。" } },
-        "km": { "stringUnit": { "state": "translated", "value": "នៅក្នុង cmux លើ iPhone របស់អ្នក ចូលគណនីដូចគ្នា ជ្រើសរើស Tailscale បន្ទាប់មកស្កេនកូដនេះ។" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "iPhone의 cmux에서 동일한 계정으로 로그인하고 Tailscale을 선택한 다음 이 코드를 스캔하세요." } },
-        "nb": { "stringUnit": { "state": "translated", "value": "I cmux på iPhonen din logger du på med samme konto, velger Tailscale og skanner deretter denne koden." } },
-        "pl": { "stringUnit": { "state": "translated", "value": "W cmux na swoim iPhonie zaloguj się na to samo konto, wybierz Tailscale, a następnie zeskanuj ten kod." } },
-        "pt-BR": { "stringUnit": { "state": "translated", "value": "No cmux no seu iPhone, entre com a mesma conta, escolha Tailscale e depois escaneie este código." } },
-        "ru": { "stringUnit": { "state": "translated", "value": "В cmux на iPhone войдите в ту же учётную запись, выберите Tailscale, затем отсканируйте этот код." } },
-        "th": { "stringUnit": { "state": "translated", "value": "ใน cmux บน iPhone ของคุณ ให้ลงชื่อเข้าด้วยบัญชีเดียวกัน เลือก Tailscale แล้วสแกนโค้ดนี้" } },
-        "tr": { "stringUnit": { "state": "translated", "value": "iPhone'unuzdaki cmux'ta aynı hesapla oturum açın, Tailscale'i seçin ve ardından bu kodu tarayın." } },
-        "uk": { "stringUnit": { "state": "translated", "value": "У cmux на iPhone увійдіть у той самий обліковий запис, виберіть Tailscale, а потім відскануйте цей код." } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "在 iPhone 上的 cmux 中，使用同一账户登录，选择 Tailscale，然后扫描此码。" } },
-        "zh-Hant": { "stringUnit": { "state": "translated", "value": "在 iPhone 上的 cmux 中，使用同一帳戶登入，選擇 Tailscale，然後掃描此代碼。" } }
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "في cmux على جهاز iPhone، سجّل الدخول بالحساب نفسه، واختر Tailscale، ثم امسح هذا الرمز."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "U cmux-u na svom iPhoneu prijavite se istim računom, odaberite Tailscale, a zatim skenirajte ovaj kôd."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I cmux på din iPhone skal du logge ind med den samme konto, vælge Tailscale og derefter scanne denne kode."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Melde dich in cmux auf deinem iPhone mit demselben Konto an, wähle Tailscale und scanne dann diesen Code."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In cmux on your iPhone, sign in with the same account, choose Tailscale, then scan this code."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En cmux en tu iPhone, inicia sesión con la misma cuenta, elige Tailscale y luego escanea este código."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dans cmux sur votre iPhone, connectez-vous avec le même compte, choisissez Tailscale, puis scannez ce code."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In cmux sul tuo iPhone, accedi con lo stesso account, scegli Tailscale e poi scansiona questo codice."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhoneのcmuxで同じアカウントにサインインし、Tailscaleを選択して、このコードをスキャンしてください。"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "នៅក្នុង cmux លើ iPhone របស់អ្នក ចូលគណនីដូចគ្នា ជ្រើសរើស Tailscale បន្ទាប់មកស្កេនកូដនេះ។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone의 cmux에서 동일한 계정으로 로그인하고 Tailscale을 선택한 다음 이 코드를 스캔하세요."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I cmux på iPhonen din logger du på med samme konto, velger Tailscale og skanner deretter denne koden."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "W cmux na swoim iPhonie zaloguj się na to samo konto, wybierz Tailscale, a następnie zeskanuj ten kod."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No cmux no seu iPhone, entre com a mesma conta, escolha Tailscale e depois escaneie este código."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "В cmux на iPhone войдите в ту же учётную запись, выберите Tailscale, затем отсканируйте этот код."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ใน cmux บน iPhone ของคุณ ให้ลงชื่อเข้าด้วยบัญชีเดียวกัน เลือก Tailscale แล้วสแกนโค้ดนี้"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone'unuzdaki cmux'ta aynı hesapla oturum açın, Tailscale'i seçin ve ardından bu kodu tarayın."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "У cmux на iPhone увійдіть у той самий обліковий запис, виберіть Tailscale, а потім відскануйте цей код."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 iPhone 上的 cmux 中，使用同一账户登录，选择 Tailscale，然后扫描此码。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 iPhone 上的 cmux 中，使用同一帳戶登入，選擇 Tailscale，然後掃描此代碼。"
+          }
+        }
       }
     },
     "mobile.pairing.signedInAs": {
       "extractionState": "manual",
       "localizations": {
-        "ar": { "stringUnit": { "state": "translated", "value": "تم تسجيل الدخول باسم %@" } },
-        "bs": { "stringUnit": { "state": "translated", "value": "Prijavljeni ste kao %@" } },
-        "da": { "stringUnit": { "state": "translated", "value": "Logget ind som %@" } },
-        "de": { "stringUnit": { "state": "translated", "value": "Angemeldet als %@" } },
-        "en": { "stringUnit": { "state": "translated", "value": "Signed in as %@" } },
-        "es": { "stringUnit": { "state": "translated", "value": "Sesión iniciada como %@" } },
-        "fr": { "stringUnit": { "state": "translated", "value": "Connecté en tant que %@" } },
-        "it": { "stringUnit": { "state": "translated", "value": "Accesso effettuato come %@" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "%@でサインイン中" } },
-        "km": { "stringUnit": { "state": "translated", "value": "បានចូលជា %@" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "%@(으)로 로그인됨" } },
-        "nb": { "stringUnit": { "state": "translated", "value": "Pålogget som %@" } },
-        "pl": { "stringUnit": { "state": "translated", "value": "Zalogowano jako %@" } },
-        "pt-BR": { "stringUnit": { "state": "translated", "value": "Conectado como %@" } },
-        "ru": { "stringUnit": { "state": "translated", "value": "Выполнен вход как %@" } },
-        "th": { "stringUnit": { "state": "translated", "value": "ลงชื่อเข้าเป็น %@" } },
-        "tr": { "stringUnit": { "state": "translated", "value": "%@ olarak oturum açıldı" } },
-        "uk": { "stringUnit": { "state": "translated", "value": "Ви увійшли як %@" } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "已登录为 %@" } },
-        "zh-Hant": { "stringUnit": { "state": "translated", "value": "已登入為 %@" } }
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تم تسجيل الدخول باسم %@"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prijavljeni ste kao %@"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Logget ind som %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Angemeldet als %@"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signed in as %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sesión iniciada como %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connecté en tant que %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accesso effettuato come %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@でサインイン中"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "បានចូលជា %@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@(으)로 로그인됨"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pålogget som %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zalogowano jako %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectado como %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выполнен вход как %@"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ลงชื่อเข้าเป็น %@"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ olarak oturum açıldı"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ви увійшли як %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已登录为 %@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已登入為 %@"
+          }
+        }
       }
     },
     "mobile.pairing.transport.iroh.detail": {
       "extractionState": "manual",
       "localizations": {
-        "ar": { "stringUnit": { "state": "translated", "value": "تعثر أجهزة iPhone المسجّلة الدخول إلى حسابك على هذا الـ Mac تلقائيًا عبر Iroh — بتشفير من طرف إلى طرف، مباشرةً عند الإمكان، وعبر مُرحّل cmux عند التعذّر. لا حاجة إلى رمز." } },
-        "bs": { "stringUnit": { "state": "translated", "value": "iPhone uređaji prijavljeni na vaš račun automatski pronalaze ovaj Mac preko Iroha — s end-to-end enkripcijom, direktno kad je moguće, a preko cmux releja kad nije. Kôd nije potreban." } },
-        "da": { "stringUnit": { "state": "translated", "value": "iPhones, der er logget ind på din konto, finder automatisk denne Mac via Iroh — end-to-end-krypteret, direkte når det er muligt og via et cmux-relæ, når det ikke er. Ingen kode nødvendig." } },
-        "de": { "stringUnit": { "state": "translated", "value": "iPhones, die mit deinem Konto angemeldet sind, finden diesen Mac automatisch über Iroh — Ende-zu-Ende-verschlüsselt, direkt wenn möglich, sonst über ein cmux-Relay. Kein Code nötig." } },
-        "en": { "stringUnit": { "state": "translated", "value": "iPhones signed in to your account find this Mac automatically over Iroh — end-to-end encrypted, direct when possible, through a cmux relay when not. No code needed." } },
-        "es": { "stringUnit": { "state": "translated", "value": "Los iPhone con sesión iniciada en tu cuenta encuentran este Mac automáticamente a través de Iroh: cifrado de extremo a extremo, directo cuando es posible y mediante un relay de cmux cuando no. No se necesita código." } },
-        "fr": { "stringUnit": { "state": "translated", "value": "Les iPhone connectés à votre compte trouvent automatiquement ce Mac via Iroh — chiffré de bout en bout, en direct quand c'est possible, via un relais cmux sinon. Aucun code nécessaire." } },
-        "it": { "stringUnit": { "state": "translated", "value": "Gli iPhone con l'accesso effettuato al tuo account trovano questo Mac automaticamente tramite Iroh — crittografato end-to-end, in modo diretto quando possibile e tramite un relay cmux quando non lo è. Nessun codice necessario." } },
-        "ja": { "stringUnit": { "state": "translated", "value": "アカウントにサインインしたiPhoneは、Irohを介してこのMacを自動的に検出します。エンドツーエンド暗号化で、可能な場合は直接、そうでない場合はcmuxリレー経由で接続します。コードは不要です。" } },
-        "km": { "stringUnit": { "state": "translated", "value": "iPhone ដែលបានចូលគណនីរបស់អ្នក រកឃើញ Mac នេះដោយស្វ័យប្រវត្តិតាមរយៈ Iroh — អ៊ិនគ្រីបពីចុងដល់ចុង ដោយផ្ទាល់នៅពេលអាច និងតាមរយៈ relay របស់ cmux នៅពេលមិនអាច។ មិនត្រូវការកូដទេ។" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "계정에 로그인된 iPhone은 Iroh를 통해 이 Mac을 자동으로 찾습니다. 종단 간 암호화되며, 가능하면 직접, 불가능하면 cmux 릴레이를 통해 연결합니다. 코드가 필요 없습니다." } },
-        "nb": { "stringUnit": { "state": "translated", "value": "iPhoner som er logget på kontoen din, finner denne Macen automatisk via Iroh — ende-til-ende-kryptert, direkte når det er mulig og via et cmux-relé når det ikke er det. Ingen kode nødvendig." } },
-        "pl": { "stringUnit": { "state": "translated", "value": "iPhone'y zalogowane na Twoje konto automatycznie znajdują tego Maca przez Iroh — z szyfrowaniem end-to-end, bezpośrednio gdy to możliwe, a przez przekaźnik cmux gdy nie. Kod nie jest potrzebny." } },
-        "pt-BR": { "stringUnit": { "state": "translated", "value": "iPhones conectados à sua conta encontram este Mac automaticamente via Iroh — criptografado de ponta a ponta, direto quando possível e por um relay do cmux quando não. Nenhum código necessário." } },
-        "ru": { "stringUnit": { "state": "translated", "value": "iPhone, вошедшие в вашу учётную запись, находят этот Mac автоматически через Iroh — со сквозным шифрованием, напрямую, когда это возможно, и через ретранслятор cmux, когда нет. Код не нужен." } },
-        "th": { "stringUnit": { "state": "translated", "value": "iPhone ที่ลงชื่อเข้าบัญชีของคุณจะพบ Mac เครื่องนี้โดยอัตโนมัติผ่าน Iroh — เข้ารหัสจากต้นทางถึงปลายทาง เชื่อมต่อโดยตรงเมื่อทำได้ และผ่านรีเลย์ของ cmux เมื่อทำไม่ได้ ไม่ต้องใช้โค้ด" } },
-        "tr": { "stringUnit": { "state": "translated", "value": "Hesabınızda oturum açmış iPhone'lar bu Mac'i Iroh üzerinden otomatik olarak bulur — uçtan uca şifreli, mümkün olduğunda doğrudan, olmadığında bir cmux aktarıcısı üzerinden. Kod gerekmez." } },
-        "uk": { "stringUnit": { "state": "translated", "value": "iPhone, що увійшли у ваш обліковий запис, знаходять цей Mac автоматично через Iroh — з наскрізним шифруванням, напряму, коли це можливо, і через ретранслятор cmux, коли ні. Код не потрібен." } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "登录了您账户的 iPhone 会通过 Iroh 自动发现这台 Mac——端到端加密，可行时直接连接，否则经由 cmux 中继。无需扫码。" } },
-        "zh-Hant": { "stringUnit": { "state": "translated", "value": "登入您帳戶的 iPhone 會透過 Iroh 自動發現這台 Mac——端對端加密，可行時直接連線，否則經由 cmux 中繼。無需掃碼。" } }
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تعثر أجهزة iPhone المسجّلة الدخول إلى حسابك على هذا الـ Mac تلقائيًا عبر Iroh — بتشفير من طرف إلى طرف، مباشرةً عند الإمكان، وعبر مُرحّل cmux عند التعذّر. لا حاجة إلى رمز."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone uređaji prijavljeni na vaš račun automatski pronalaze ovaj Mac preko Iroha — s end-to-end enkripcijom, direktno kad je moguće, a preko cmux releja kad nije. Kôd nije potreban."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhones, der er logget ind på din konto, finder automatisk denne Mac via Iroh — end-to-end-krypteret, direkte når det er muligt og via et cmux-relæ, når det ikke er. Ingen kode nødvendig."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhones, die mit deinem Konto angemeldet sind, finden diesen Mac automatisch über Iroh — Ende-zu-Ende-verschlüsselt, direkt wenn möglich, sonst über ein cmux-Relay. Kein Code nötig."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhones signed in to your account find this Mac automatically over Iroh — end-to-end encrypted, direct when possible, through a cmux relay when not. No code needed."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los iPhone con sesión iniciada en tu cuenta encuentran este Mac automáticamente a través de Iroh: cifrado de extremo a extremo, directo cuando es posible y mediante un relay de cmux cuando no. No se necesita código."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les iPhone connectés à votre compte trouvent automatiquement ce Mac via Iroh — chiffré de bout en bout, en direct quand c'est possible, via un relais cmux sinon. Aucun code nécessaire."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gli iPhone con l'accesso effettuato al tuo account trovano questo Mac automaticamente tramite Iroh — crittografato end-to-end, in modo diretto quando possibile e tramite un relay cmux quando non lo è. Nessun codice necessario."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アカウントにサインインしたiPhoneは、Irohを介してこのMacを自動的に検出します。エンドツーエンド暗号化で、可能な場合は直接、そうでない場合はcmuxリレー経由で接続します。コードは不要です。"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone ដែលបានចូលគណនីរបស់អ្នក រកឃើញ Mac នេះដោយស្វ័យប្រវត្តិតាមរយៈ Iroh — អ៊ិនគ្រីបពីចុងដល់ចុង ដោយផ្ទាល់នៅពេលអាច និងតាមរយៈ relay របស់ cmux នៅពេលមិនអាច។ មិនត្រូវការកូដទេ។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "계정에 로그인된 iPhone은 Iroh를 통해 이 Mac을 자동으로 찾습니다. 종단 간 암호화되며, 가능하면 직접, 불가능하면 cmux 릴레이를 통해 연결합니다. 코드가 필요 없습니다."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhoner som er logget på kontoen din, finner denne Macen automatisk via Iroh — ende-til-ende-kryptert, direkte når det er mulig og via et cmux-relé når det ikke er det. Ingen kode nødvendig."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone'y zalogowane na Twoje konto automatycznie znajdują tego Maca przez Iroh — z szyfrowaniem end-to-end, bezpośrednio gdy to możliwe, a przez przekaźnik cmux gdy nie. Kod nie jest potrzebny."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhones conectados à sua conta encontram este Mac automaticamente via Iroh — criptografado de ponta a ponta, direto quando possível e por um relay do cmux quando não. Nenhum código necessário."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone, вошедшие в вашу учётную запись, находят этот Mac автоматически через Iroh — со сквозным шифрованием, напрямую, когда это возможно, и через ретранслятор cmux, когда нет. Код не нужен."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone ที่ลงชื่อเข้าบัญชีของคุณจะพบ Mac เครื่องนี้โดยอัตโนมัติผ่าน Iroh — เข้ารหัสจากต้นทางถึงปลายทาง เชื่อมต่อโดยตรงเมื่อทำได้ และผ่านรีเลย์ของ cmux เมื่อทำไม่ได้ ไม่ต้องใช้โค้ด"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hesabınızda oturum açmış iPhone'lar bu Mac'i Iroh üzerinden otomatik olarak bulur — uçtan uca şifreli, mümkün olduğunda doğrudan, olmadığında bir cmux aktarıcısı üzerinden. Kod gerekmez."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone, що увійшли у ваш обліковий запис, знаходять цей Mac автоматично через Iroh — з наскрізним шифруванням, напряму, коли це можливо, і через ретранслятор cmux, коли ні. Код не потрібен."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "登录了您账户的 iPhone 会通过 Iroh 自动发现这台 Mac——端到端加密，可行时直接连接，否则经由 cmux 中继。无需扫码。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "登入您帳戶的 iPhone 會透過 Iroh 自動發現這台 Mac——端對端加密，可行時直接連線，否則經由 cmux 中繼。無需掃碼。"
+          }
+        }
       }
     },
     "mobile.pairing.transport.status.connected": {
       "extractionState": "manual",
       "localizations": {
-        "ar": { "stringUnit": { "state": "translated", "value": "متصل" } },
-        "bs": { "stringUnit": { "state": "translated", "value": "Povezano" } },
-        "da": { "stringUnit": { "state": "translated", "value": "Forbundet" } },
-        "de": { "stringUnit": { "state": "translated", "value": "Verbunden" } },
-        "en": { "stringUnit": { "state": "translated", "value": "Connected" } },
-        "es": { "stringUnit": { "state": "translated", "value": "Conectado" } },
-        "fr": { "stringUnit": { "state": "translated", "value": "Connecté" } },
-        "it": { "stringUnit": { "state": "translated", "value": "Connesso" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "接続済み" } },
-        "km": { "stringUnit": { "state": "translated", "value": "បានភ្ជាប់" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "연결됨" } },
-        "nb": { "stringUnit": { "state": "translated", "value": "Tilkoblet" } },
-        "pl": { "stringUnit": { "state": "translated", "value": "Połączono" } },
-        "pt-BR": { "stringUnit": { "state": "translated", "value": "Conectado" } },
-        "ru": { "stringUnit": { "state": "translated", "value": "Подключено" } },
-        "th": { "stringUnit": { "state": "translated", "value": "เชื่อมต่อแล้ว" } },
-        "tr": { "stringUnit": { "state": "translated", "value": "Bağlı" } },
-        "uk": { "stringUnit": { "state": "translated", "value": "Підключено" } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "已连接" } },
-        "zh-Hant": { "stringUnit": { "state": "translated", "value": "已連線" } }
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "متصل"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Povezano"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Forbundet"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbunden"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connected"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connecté"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connesso"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接続済み"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "បានភ្ជាប់"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "연결됨"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tilkoblet"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Połączono"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectado"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подключено"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เชื่อมต่อแล้ว"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bağlı"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Підключено"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已连接"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已連線"
+          }
+        }
       }
     },
     "mobile.pairing.transport.status.notDetected": {
       "extractionState": "manual",
       "localizations": {
-        "ar": { "stringUnit": { "state": "translated", "value": "لم يُكتشف" } },
-        "bs": { "stringUnit": { "state": "translated", "value": "Nije otkriveno" } },
-        "da": { "stringUnit": { "state": "translated", "value": "Ikke fundet" } },
-        "de": { "stringUnit": { "state": "translated", "value": "Nicht erkannt" } },
-        "en": { "stringUnit": { "state": "translated", "value": "Not detected" } },
-        "es": { "stringUnit": { "state": "translated", "value": "No detectado" } },
-        "fr": { "stringUnit": { "state": "translated", "value": "Non détecté" } },
-        "it": { "stringUnit": { "state": "translated", "value": "Non rilevato" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "未検出" } },
-        "km": { "stringUnit": { "state": "translated", "value": "រកមិនឃើញ" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "감지되지 않음" } },
-        "nb": { "stringUnit": { "state": "translated", "value": "Ikke funnet" } },
-        "pl": { "stringUnit": { "state": "translated", "value": "Nie wykryto" } },
-        "pt-BR": { "stringUnit": { "state": "translated", "value": "Não detectado" } },
-        "ru": { "stringUnit": { "state": "translated", "value": "Не обнаружено" } },
-        "th": { "stringUnit": { "state": "translated", "value": "ไม่พบ" } },
-        "tr": { "stringUnit": { "state": "translated", "value": "Algılanmadı" } },
-        "uk": { "stringUnit": { "state": "translated", "value": "Не виявлено" } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "未检测到" } },
-        "zh-Hant": { "stringUnit": { "state": "translated", "value": "未偵測到" } }
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لم يُكتشف"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nije otkriveno"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ikke fundet"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht erkannt"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not detected"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No detectado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non détecté"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non rilevato"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未検出"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "រកមិនឃើញ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "감지되지 않음"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ikke funnet"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie wykryto"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não detectado"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не обнаружено"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่พบ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Algılanmadı"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не виявлено"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未检测到"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未偵測到"
+          }
+        }
       }
     },
     "mobile.pairing.transport.status.notRegistered": {
       "extractionState": "manual",
       "localizations": {
-        "ar": { "stringUnit": { "state": "translated", "value": "غير مسجّل" } },
-        "bs": { "stringUnit": { "state": "translated", "value": "Nije registrovano" } },
-        "da": { "stringUnit": { "state": "translated", "value": "Ikke registreret" } },
-        "de": { "stringUnit": { "state": "translated", "value": "Nicht registriert" } },
-        "en": { "stringUnit": { "state": "translated", "value": "Not registered" } },
-        "es": { "stringUnit": { "state": "translated", "value": "No registrado" } },
-        "fr": { "stringUnit": { "state": "translated", "value": "Non enregistré" } },
-        "it": { "stringUnit": { "state": "translated", "value": "Non registrato" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "未登録" } },
-        "km": { "stringUnit": { "state": "translated", "value": "មិនទាន់ចុះឈ្មោះ" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "등록되지 않음" } },
-        "nb": { "stringUnit": { "state": "translated", "value": "Ikke registrert" } },
-        "pl": { "stringUnit": { "state": "translated", "value": "Niezarejestrowano" } },
-        "pt-BR": { "stringUnit": { "state": "translated", "value": "Não registrado" } },
-        "ru": { "stringUnit": { "state": "translated", "value": "Не зарегистрировано" } },
-        "th": { "stringUnit": { "state": "translated", "value": "ยังไม่ได้ลงทะเบียน" } },
-        "tr": { "stringUnit": { "state": "translated", "value": "Kayıtlı değil" } },
-        "uk": { "stringUnit": { "state": "translated", "value": "Не зареєстровано" } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "未注册" } },
-        "zh-Hant": { "stringUnit": { "state": "translated", "value": "未註冊" } }
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "غير مسجّل"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nije registrovano"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ikke registreret"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht registriert"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not registered"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No registrado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non enregistré"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non registrato"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未登録"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "មិនទាន់ចុះឈ្មោះ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "등록되지 않음"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ikke registrert"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Niezarejestrowano"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não registrado"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не зарегистрировано"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ยังไม่ได้ลงทะเบียน"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kayıtlı değil"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не зареєстровано"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未注册"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未註冊"
+          }
+        }
       }
     },
     "mobile.pairing.transport.status.ready": {
       "extractionState": "manual",
       "localizations": {
-        "ar": { "stringUnit": { "state": "translated", "value": "جاهز" } },
-        "bs": { "stringUnit": { "state": "translated", "value": "Spremno" } },
-        "da": { "stringUnit": { "state": "translated", "value": "Klar" } },
-        "de": { "stringUnit": { "state": "translated", "value": "Bereit" } },
-        "en": { "stringUnit": { "state": "translated", "value": "Ready" } },
-        "es": { "stringUnit": { "state": "translated", "value": "Listo" } },
-        "fr": { "stringUnit": { "state": "translated", "value": "Prêt" } },
-        "it": { "stringUnit": { "state": "translated", "value": "Pronto" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "準備完了" } },
-        "km": { "stringUnit": { "state": "translated", "value": "រួចរាល់" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "준비됨" } },
-        "nb": { "stringUnit": { "state": "translated", "value": "Klar" } },
-        "pl": { "stringUnit": { "state": "translated", "value": "Gotowe" } },
-        "pt-BR": { "stringUnit": { "state": "translated", "value": "Pronto" } },
-        "ru": { "stringUnit": { "state": "translated", "value": "Готово" } },
-        "th": { "stringUnit": { "state": "translated", "value": "พร้อม" } },
-        "tr": { "stringUnit": { "state": "translated", "value": "Hazır" } },
-        "uk": { "stringUnit": { "state": "translated", "value": "Готово" } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "就绪" } },
-        "zh-Hant": { "stringUnit": { "state": "translated", "value": "就緒" } }
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جاهز"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spremno"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klar"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bereit"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ready"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Listo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prêt"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pronto"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "準備完了"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "រួចរាល់"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "준비됨"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klar"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gotowe"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pronto"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Готово"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "พร้อม"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hazır"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Готово"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "就绪"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "就緒"
+          }
+        }
       }
     },
     "mobile.pairing.transport.tailscale.detail": {
       "extractionState": "manual",
       "localizations": {
-        "ar": { "stringUnit": { "state": "translated", "value": "يُقرِن هذا الرمز عبر Tailscale بدلًا من ذلك. يجب أن يكون كلا الجهازين متصلًا بشبكة Tailscale نفسها." } },
-        "bs": { "stringUnit": { "state": "translated", "value": "Ovaj kôd uparuje preko Tailscalea. Oba uređaja moraju biti povezana na istu Tailscale mrežu." } },
-        "da": { "stringUnit": { "state": "translated", "value": "Denne kode parrer via Tailscale i stedet. Begge enheder skal være forbundet til det samme Tailscale-netværk." } },
-        "de": { "stringUnit": { "state": "translated", "value": "Dieser Code koppelt stattdessen über Tailscale. Beide Geräte müssen mit demselben Tailscale-Netzwerk verbunden sein." } },
-        "en": { "stringUnit": { "state": "translated", "value": "This code pairs over Tailscale instead. Both devices must be connected to the same Tailscale network." } },
-        "es": { "stringUnit": { "state": "translated", "value": "Este código empareja a través de Tailscale. Ambos dispositivos deben estar conectados a la misma red de Tailscale." } },
-        "fr": { "stringUnit": { "state": "translated", "value": "Ce code jumelle via Tailscale à la place. Les deux appareils doivent être connectés au même réseau Tailscale." } },
-        "it": { "stringUnit": { "state": "translated", "value": "Questo codice abbina invece tramite Tailscale. Entrambi i dispositivi devono essere connessi alla stessa rete Tailscale." } },
-        "ja": { "stringUnit": { "state": "translated", "value": "このコードは代わりにTailscale経由でペアリングします。両方のデバイスが同じTailscaleネットワークに接続されている必要があります。" } },
-        "km": { "stringUnit": { "state": "translated", "value": "កូដនេះផ្គូផ្គងតាមរយៈ Tailscale ជំនួសវិញ។ ឧបករណ៍ទាំងពីរត្រូវតែភ្ជាប់ទៅបណ្ដាញ Tailscale ដូចគ្នា។" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "이 코드는 대신 Tailscale을 통해 페어링합니다. 두 기기가 동일한 Tailscale 네트워크에 연결되어 있어야 합니다." } },
-        "nb": { "stringUnit": { "state": "translated", "value": "Denne koden parer via Tailscale i stedet. Begge enhetene må være koblet til det samme Tailscale-nettverket." } },
-        "pl": { "stringUnit": { "state": "translated", "value": "Ten kod paruje natomiast przez Tailscale. Oba urządzenia muszą być połączone z tą samą siecią Tailscale." } },
-        "pt-BR": { "stringUnit": { "state": "translated", "value": "Este código emparelha via Tailscale. Os dois dispositivos precisam estar conectados à mesma rede Tailscale." } },
-        "ru": { "stringUnit": { "state": "translated", "value": "Этот код выполняет подключение через Tailscale. Оба устройства должны быть подключены к одной и той же сети Tailscale." } },
-        "th": { "stringUnit": { "state": "translated", "value": "โค้ดนี้ใช้จับคู่ผ่าน Tailscale แทน อุปกรณ์ทั้งสองต้องเชื่อมต่อกับเครือข่าย Tailscale เดียวกัน" } },
-        "tr": { "stringUnit": { "state": "translated", "value": "Bu kod bunun yerine Tailscale üzerinden eşler. Her iki cihaz da aynı Tailscale ağına bağlı olmalıdır." } },
-        "uk": { "stringUnit": { "state": "translated", "value": "Цей код виконує підключення через Tailscale. Обидва пристрої мають бути підключені до однієї мережі Tailscale." } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "此码改为通过 Tailscale 配对。两台设备必须连接到同一个 Tailscale 网络。" } },
-        "zh-Hant": { "stringUnit": { "state": "translated", "value": "此代碼改為透過 Tailscale 配對。兩台裝置必須連線到同一個 Tailscale 網路。" } }
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يُقرِن هذا الرمز عبر Tailscale بدلًا من ذلك. يجب أن يكون كلا الجهازين متصلًا بشبكة Tailscale نفسها."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ovaj kôd uparuje preko Tailscalea. Oba uređaja moraju biti povezana na istu Tailscale mrežu."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Denne kode parrer via Tailscale i stedet. Begge enheder skal være forbundet til det samme Tailscale-netværk."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieser Code koppelt stattdessen über Tailscale. Beide Geräte müssen mit demselben Tailscale-Netzwerk verbunden sein."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This code pairs over Tailscale instead. Both devices must be connected to the same Tailscale network."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este código empareja a través de Tailscale. Ambos dispositivos deben estar conectados a la misma red de Tailscale."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ce code jumelle via Tailscale à la place. Les deux appareils doivent être connectés au même réseau Tailscale."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Questo codice abbina invece tramite Tailscale. Entrambi i dispositivi devono essere connessi alla stessa rete Tailscale."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このコードは代わりにTailscale経由でペアリングします。両方のデバイスが同じTailscaleネットワークに接続されている必要があります。"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "កូដនេះផ្គូផ្គងតាមរយៈ Tailscale ជំនួសវិញ។ ឧបករណ៍ទាំងពីរត្រូវតែភ្ជាប់ទៅបណ្ដាញ Tailscale ដូចគ្នា។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 코드는 대신 Tailscale을 통해 페어링합니다. 두 기기가 동일한 Tailscale 네트워크에 연결되어 있어야 합니다."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Denne koden parer via Tailscale i stedet. Begge enhetene må være koblet til det samme Tailscale-nettverket."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ten kod paruje natomiast przez Tailscale. Oba urządzenia muszą być połączone z tą samą siecią Tailscale."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este código emparelha via Tailscale. Os dois dispositivos precisam estar conectados à mesma rede Tailscale."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Этот код выполняет подключение через Tailscale. Оба устройства должны быть подключены к одной и той же сети Tailscale."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "โค้ดนี้ใช้จับคู่ผ่าน Tailscale แทน อุปกรณ์ทั้งสองต้องเชื่อมต่อกับเครือข่าย Tailscale เดียวกัน"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bu kod bunun yerine Tailscale üzerinden eşler. Her iki cihaz da aynı Tailscale ağına bağlı olmalıdır."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Цей код виконує підключення через Tailscale. Обидва пристрої мають бути підключені до однієї мережі Tailscale."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此码改为通过 Tailscale 配对。两台设备必须连接到同一个 Tailscale 网络。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此代碼改為透過 Tailscale 配對。兩台裝置必須連線到同一個 Tailscale 網路。"
+          }
+        }
       }
     },
     "mobile.pairing.manual.copyIP": {
@@ -145112,91 +147600,6 @@
         }
       }
     },
-    "mobile.panel.artifact.error.forbidden": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "That file is not currently shown in this panel."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "そのファイルは現在このパネルに表示されていません。"
-          }
-        }
-      }
-    },
-    "mobile.panel.artifact.error.internal": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "cmux couldn't complete the panel file request."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "パネルのファイル要求を完了できませんでした。"
-          }
-        }
-      }
-    },
-    "mobile.panel.artifact.error.invalidParams": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "cmux couldn't tell which panel or file was requested."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "どのパネルのどのファイルが要求されたか判別できませんでした。"
-          }
-        }
-      }
-    },
-    "mobile.panel.artifact.error.methodNotFound": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "cmux doesn't recognize that panel file request."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "そのパネルのファイル要求を認識できませんでした。"
-          }
-        }
-      }
-    },
-    "mobile.panel.artifact.error.panelNotFound": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "That file panel is no longer available."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "そのファイルパネルは利用できなくなりました。"
-          }
-        }
-      }
-    },
     "mobile.taskComposer.error.capabilityDisabled": {
       "extractionState": "manual",
       "localizations": {
@@ -145261,193 +147664,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "そのターミナルは利用できなくなりました。"
-          }
-        }
-      }
-    },
-    "mobile.workspaceChanges.error.capabilityDisabled": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Workspace changes are not enabled on this Mac"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "このMacではワークスペースの変更機能が有効になっていません"
-          }
-        }
-      }
-    },
-    "mobile.workspaceChanges.error.invalidContentRequest": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The workspace, path, or revision is missing or invalid"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ワークスペース、パス、またはリビジョンの指定が無効です"
-          }
-        }
-      }
-    },
-    "mobile.workspaceChanges.error.invalidPath": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Missing or invalid path"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "パスが指定されていないか、無効です"
-          }
-        }
-      }
-    },
-    "mobile.workspaceChanges.error.invalidWorkspaceID": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The workspace identifier is missing or invalid"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ワークスペースの識別子が指定されていないか無効です"
-          }
-        }
-      }
-    },
-    "mobile.workspaceChanges.error.invalidWorkspaceIDs": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A selected workspace identifier is invalid"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "選択したワークスペースの識別子が無効です"
-          }
-        }
-      }
-    },
-    "mobile.workspaceChanges.error.notRepository": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Workspace directory is not a Git repository"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ワークスペースのディレクトリはGitリポジトリではありません"
-          }
-        }
-      }
-    },
-    "mobile.workspaceChanges.error.pathNotChanged": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Path is not in the workspace changes"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "パスはワークスペースの変更に含まれていません"
-          }
-        }
-      }
-    },
-    "mobile.workspaceChanges.error.pathOutsideRepository": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Path must stay inside the repository"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "パスはリポジトリ内に収まっている必要があります"
-          }
-        }
-      }
-    },
-    "mobile.workspaceChanges.error.readFailed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to read workspace diff"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ワークスペースの差分を読み込めませんでした"
-          }
-        }
-      }
-    },
-    "mobile.workspaceChanges.error.workspaceIDsCount": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Between 1 and 64 workspaces can be requested at once"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "一度にリクエストできるワークスペースは1〜64件です"
-          }
-        }
-      }
-    },
-    "mobile.workspaceChanges.error.workspaceUnavailable": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Workspace or effective directory not found"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ワークスペースまたは有効なディレクトリが見つかりません"
           }
         }
       }
@@ -178955,75 +181171,245 @@
     "settings.browser.httpAllowlist.reset": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "Reset to Defaults" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "デフォルトに戻す" } }
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset to Defaults"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デフォルトに戻す"
+          }
+        }
       }
     },
     "settings.browser.urlAllowlist": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "Embedded Browser URL Allowlist" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "内蔵ブラウザURL許可リスト" } }
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Embedded Browser URL Allowlist"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "内蔵ブラウザURL許可リスト"
+          }
+        }
       }
     },
     "settings.browser.urlAllowlist.description": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "Restricts embedded-browser navigation to matching hosts or URL patterns. A suggested localhost list is shown; saving it opts into the restriction. Remove entries to block them, or, when no managed policy applies, clear the list to allow all web origins. Invalid-only values fail closed. Internal cmux documents remain available." } },
-        "ja": { "stringUnit": { "state": "translated", "value": "内蔵ブラウザの移動を、一致するホストまたはURLパターンに制限します。localhostの候補リストが表示され、保存すると制限が有効になります。エントリを削除するとそのURLをブロックし、管理ポリシーがない場合にリストを空にするとすべてのWebオリジンを許可します。無効なルールだけの値は安全側でブロックされます。cmux内部ドキュメントは引き続き利用できます。" } }
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restricts embedded-browser navigation to matching hosts or URL patterns. A suggested localhost list is shown; saving it opts into the restriction. Remove entries to block them, or, when no managed policy applies, clear the list to allow all web origins. Invalid-only values fail closed. Internal cmux documents remain available."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "内蔵ブラウザの移動を、一致するホストまたはURLパターンに制限します。localhostの候補リストが表示され、保存すると制限が有効になります。エントリを削除するとそのURLをブロックし、管理ポリシーがない場合にリストを空にするとすべてのWebオリジンを許可します。無効なルールだけの値は安全側でブロックされます。cmux内部ドキュメントは引き続き利用できます。"
+          }
+        }
       }
     },
     "settings.browser.urlAllowlist.hint": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "One rule per line: localhost, *.localhost, example.com, https://git.example.com, or http://localhost:3000. Remove entries to block them." } },
-        "ja": { "stringUnit": { "state": "translated", "value": "1行に1ルール: localhost、*.localhost、example.com、https://git.example.com、または http://localhost:3000。エントリを削除するとそのURLをブロックします。" } }
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "One rule per line: localhost, *.localhost, example.com, https://git.example.com, or http://localhost:3000. Remove entries to block them."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1行に1ルール: localhost、*.localhost、example.com、https://git.example.com、または http://localhost:3000。エントリを削除するとそのURLをブロックします。"
+          }
+        }
       }
     },
     "settings.browser.urlAllowlist.invalidRule": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "One or more rules are invalid. Invalid-only values fail closed; use a host or HTTP(S) URL pattern." } },
-        "ja": { "stringUnit": { "state": "translated", "value": "無効なルールがあります。無効なルールだけの値は安全側でブロックされます。ホストまたはHTTP(S) URLパターンを使用してください。" } }
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "One or more rules are invalid. Invalid-only values fail closed; use a host or HTTP(S) URL pattern."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無効なルールがあります。無効なルールだけの値は安全側でブロックされます。ホストまたはHTTP(S) URLパターンを使用してください。"
+          }
+        }
       }
     },
     "settings.browser.urlAllowlist.save": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "Save" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "保存" } }
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存"
+          }
+        }
       }
     },
     "settings.browser.urlAllowlist.reset": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "Reset to Defaults" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "デフォルトに戻す" } }
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset to Defaults"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デフォルトに戻す"
+          }
+        }
       }
     },
     "settings.search.alias.setting.browser.url-allowlist": {
       "extractionState": "manual",
       "localizations": {
-        "ar": { "stringUnit": { "state": "translated", "value": "browser.urlAllowlist قائمة سماح URL localhost حرف بدل مخطط منفذ سياسة المؤسسة" } },
-        "bs": { "stringUnit": { "state": "translated", "value": "browser.urlAllowlist lista dozvoljenih URL-ova localhost zamjenski znak shema port organizacijska politika" } },
-        "da": { "stringUnit": { "state": "translated", "value": "browser.urlAllowlist URL-tilladelsesliste localhost jokertegn skema port organisationspolitik" } },
-        "de": { "stringUnit": { "state": "translated", "value": "browser.urlAllowlist URL-Zulassungsliste localhost Wildcard Schema Port Organisationsrichtlinie" } },
-        "en": { "stringUnit": { "state": "translated", "value": "browser.urlAllowlist URL allowlist localhost wildcard scheme port organization policy" } },
-        "es": { "stringUnit": { "state": "translated", "value": "browser.urlAllowlist lista de URL permitidas localhost comodín esquema puerto política de la organización" } },
-        "fr": { "stringUnit": { "state": "translated", "value": "browser.urlAllowlist liste d’autorisation URL localhost caractère générique schéma port politique de l’organisation" } },
-        "it": { "stringUnit": { "state": "translated", "value": "browser.urlAllowlist elenco URL consentiti localhost carattere jolly schema porta criterio organizzativo" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "browser.urlAllowlist URL許可リスト localhost ワイルドカード スキーム ポート 組織 ポリシー" } },
-        "km": { "stringUnit": { "state": "translated", "value": "browser.urlAllowlist URL allowlist localhost wildcard scheme port organization policy" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "browser.urlAllowlist URL 허용 목록 localhost 와일드카드 스킴 포트 조직 정책" } },
-        "nb": { "stringUnit": { "state": "translated", "value": "browser.urlAllowlist URL-tillatelsesliste localhost jokertegn skjema port organisasjonspolicy" } },
-        "pl": { "stringUnit": { "state": "translated", "value": "browser.urlAllowlist lista dozwolonych URL localhost wildcard schemat port polityka organizacji" } },
-        "pt-BR": { "stringUnit": { "state": "translated", "value": "browser.urlAllowlist lista de URLs permitidas localhost curinga esquema porta política da organização" } },
-        "ru": { "stringUnit": { "state": "translated", "value": "browser.urlAllowlist список разрешённых URL localhost подстановочный знак схема порт политика организации" } },
-        "th": { "stringUnit": { "state": "translated", "value": "browser.urlAllowlist รายการ URL ที่อนุญาต localhost wildcard รูปแบบ พอร์ต นโยบายองค์กร" } },
-        "tr": { "stringUnit": { "state": "translated", "value": "browser.urlAllowlist URL izin listesi localhost joker karakter şema bağlantı noktası kuruluş politikası" } },
-        "uk": { "stringUnit": { "state": "translated", "value": "browser.urlAllowlist список дозволених URL localhost шаблон схема порт політика організації" } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "browser.urlAllowlist URL 允许列表 localhost 通配符 协议 端口 组织策略" } },
-        "zh-Hant": { "stringUnit": { "state": "translated", "value": "browser.urlAllowlist URL 允許清單 localhost 萬用字元 通訊協定 連接埠 組織政策" } }
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "browser.urlAllowlist قائمة سماح URL localhost حرف بدل مخطط منفذ سياسة المؤسسة"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "browser.urlAllowlist lista dozvoljenih URL-ova localhost zamjenski znak shema port organizacijska politika"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "browser.urlAllowlist URL-tilladelsesliste localhost jokertegn skema port organisationspolitik"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "browser.urlAllowlist URL-Zulassungsliste localhost Wildcard Schema Port Organisationsrichtlinie"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "browser.urlAllowlist URL allowlist localhost wildcard scheme port organization policy"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "browser.urlAllowlist lista de URL permitidas localhost comodín esquema puerto política de la organización"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "browser.urlAllowlist liste d’autorisation URL localhost caractère générique schéma port politique de l’organisation"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "browser.urlAllowlist elenco URL consentiti localhost carattere jolly schema porta criterio organizzativo"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "browser.urlAllowlist URL許可リスト localhost ワイルドカード スキーム ポート 組織 ポリシー"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "browser.urlAllowlist URL allowlist localhost wildcard scheme port organization policy"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "browser.urlAllowlist URL 허용 목록 localhost 와일드카드 스킴 포트 조직 정책"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "browser.urlAllowlist URL-tillatelsesliste localhost jokertegn skjema port organisasjonspolicy"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "browser.urlAllowlist lista dozwolonych URL localhost wildcard schemat port polityka organizacji"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "browser.urlAllowlist lista de URLs permitidas localhost curinga esquema porta política da organização"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "browser.urlAllowlist список разрешённых URL localhost подстановочный знак схема порт политика организации"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "browser.urlAllowlist รายการ URL ที่อนุญาต localhost wildcard รูปแบบ พอร์ต นโยบายองค์กร"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "browser.urlAllowlist URL izin listesi localhost joker karakter şema bağlantı noktası kuruluş politikası"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "browser.urlAllowlist список дозволених URL localhost шаблон схема порт політика організації"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "browser.urlAllowlist URL 允许列表 localhost 通配符 协议 端口 组织策略"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "browser.urlAllowlist URL 允許清單 localhost 萬用字元 通訊協定 連接埠 組織政策"
+          }
+        }
       }
     },
     "settings.browser.import": {
@@ -270483,6 +272869,839 @@
           "stringUnit": {
             "state": "translated",
             "value": "作成"
+          }
+        }
+      }
+    },
+    "cli.hooks.vibe.alreadyUpToDate": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hooks already up to date at %@"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hooks already up to date at %@"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hooks already up to date at %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hooks already up to date at %@"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hooks already up to date at %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hooks already up to date at %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hooks already up to date at %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hooks already up to date at %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hooks already up to date at %@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hooks already up to date at %@"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hooks already up to date at %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hooks already up to date at %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hooks already up to date at %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hooks already up to date at %@"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hooks already up to date at %@"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hooks already up to date at %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hooks already up to date at %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hooks already up to date at %@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hooks already up to date at %@"
+          }
+        }
+      }
+    },
+    "cli.hooks.vibe.confirmProceed": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\nProceed? [y/N] "
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\nProceed? [y/N] "
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\nProceed? [y/N] "
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\nProceed? [y/N] "
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\nProceed? [y/N] "
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\nProceed? [y/N] "
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\nProceed? [y/N] "
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\nProceed? [y/N] "
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\nProceed? [y/N] "
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\nProceed? [y/N] "
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\nProceed? [y/N] "
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\nProceed? [y/N] "
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\nProceed? [y/N] "
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\nProceed? [y/N] "
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\nProceed? [y/N] "
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\nProceed? [y/N] "
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\nProceed? [y/N] "
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\nProceed? [y/N] "
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\nProceed? [y/N] "
+          }
+        }
+      }
+    },
+    "cli.hooks.vibe.aborted": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aborted."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aborted."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aborted."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aborted."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aborted."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aborted."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aborted."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aborted."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aborted."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aborted."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aborted."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aborted."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aborted."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aborted."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aborted."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aborted."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aborted."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aborted."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aborted."
+          }
+        }
+      }
+    },
+    "cli.hooks.vibe.installed": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hooks installed at %@"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hooks installed at %@"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hooks installed at %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hooks installed at %@"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hooks installed at %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hooks installed at %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hooks installed at %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hooks installed at %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hooks installed at %@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hooks installed at %@"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hooks installed at %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hooks installed at %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hooks installed at %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hooks installed at %@"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hooks installed at %@"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hooks installed at %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hooks installed at %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hooks installed at %@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hooks installed at %@"
+          }
+        }
+      }
+    },
+    "cli.hooks.vibe.noneFound": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No %@ found at %@"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No %@ found at %@"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No %@ found at %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No %@ found at %@"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No %@ found at %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No %@ found at %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No %@ found at %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No %@ found at %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No %@ found at %@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No %@ found at %@"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No %@ found at %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No %@ found at %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No %@ found at %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No %@ found at %@"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No %@ found at %@"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No %@ found at %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No %@ found at %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No %@ found at %@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No %@ found at %@"
+          }
+        }
+      }
+    },
+    "cli.hooks.vibe.removedZero": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removed 0 cmux hook(s) from %@"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removed 0 cmux hook(s) from %@"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removed 0 cmux hook(s) from %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removed 0 cmux hook(s) from %@"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removed 0 cmux hook(s) from %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removed 0 cmux hook(s) from %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removed 0 cmux hook(s) from %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removed 0 cmux hook(s) from %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removed 0 cmux hook(s) from %@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removed 0 cmux hook(s) from %@"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removed 0 cmux hook(s) from %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removed 0 cmux hook(s) from %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removed 0 cmux hook(s) from %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removed 0 cmux hook(s) from %@"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removed 0 cmux hook(s) from %@"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removed 0 cmux hook(s) from %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removed 0 cmux hook(s) from %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removed 0 cmux hook(s) from %@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removed 0 cmux hook(s) from %@"
+          }
+        }
+      }
+    },
+    "cli.hooks.vibe.removed": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removed %@ cmux hooks from %@"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removed %@ cmux hooks from %@"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removed %@ cmux hooks from %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removed %@ cmux hooks from %@"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removed %@ cmux hooks from %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removed %@ cmux hooks from %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removed %@ cmux hooks from %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removed %@ cmux hooks from %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removed %@ cmux hooks from %@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removed %@ cmux hooks from %@"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removed %@ cmux hooks from %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removed %@ cmux hooks from %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removed %@ cmux hooks from %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removed %@ cmux hooks from %@"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removed %@ cmux hooks from %@"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removed %@ cmux hooks from %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removed %@ cmux hooks from %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removed %@ cmux hooks from %@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removed %@ cmux hooks from %@"
           }
         }
       }

--- a/Sources/CmuxTaskManagerCodingAgentDefinition+BuiltIns.swift
+++ b/Sources/CmuxTaskManagerCodingAgentDefinition+BuiltIns.swift
@@ -59,6 +59,16 @@ extension CmuxTaskManagerCodingAgentDefinition {
             argumentNeedles: ["kimi-cli", "kimi-code"]
         ),
         .init(
+            id: "vibe",
+            displayName: String(localized: "agent.vibe.displayName", defaultValue: "Mistral Vibe"),
+            assetName: nil,
+            launchKinds: ["vibe"],
+            // Vibe's Python entrypoint overwrites its OS process title/argv with
+            // "Vibe CLI". Identity comes from the executable basename or launch kind.
+            directBasenames: ["vibe", "Vibe CLI", "mistral-vibe"],
+            argumentNeedles: ["mistral-vibe", "vibe"]
+        ),
+        .init(
             id: "ollama",
             displayName: String(localized: "agent.ollama.displayName", defaultValue: "Ollama"),
             assetName: nil,

--- a/Sources/CmuxTaskManagerCodingAgentDefinition+BuiltIns.swift
+++ b/Sources/CmuxTaskManagerCodingAgentDefinition+BuiltIns.swift
@@ -60,13 +60,15 @@ extension CmuxTaskManagerCodingAgentDefinition {
         ),
         .init(
             id: "vibe",
-            displayName: String(localized: "agent.vibe.displayName", defaultValue: "Mistral Vibe"),
+            displayName: "Mistral Vibe",
             assetName: nil,
             launchKinds: ["vibe"],
             // Vibe's Python entrypoint overwrites its OS process title/argv with
-            // "Vibe CLI". Identity comes from the executable basename or launch kind.
-            directBasenames: ["vibe", "Vibe CLI", "mistral-vibe"],
-            argumentNeedles: ["mistral-vibe", "vibe"]
+            // "Vibe CLI". Identity comes from the executable basename or launch kind;
+            // no argument needles — a bare "vibe" token would also match wrappers
+            // like `npm run vibe`.
+            directBasenames: ["vibe", "mistral-vibe"],
+            argumentNeedles: []
         ),
         .init(
             id: "ollama",

--- a/Sources/CmuxVaultAgentRegistration+RegisteredResumeKind.swift
+++ b/Sources/CmuxVaultAgentRegistration+RegisteredResumeKind.swift
@@ -9,6 +9,7 @@ extension CmuxVaultAgentRegistration {
         if self == Self.builtInAntigravity { return .antigravity }
         if self == Self.builtInGrok { return .grok }
         if self == Self.builtInKimi { return .kimi }
+        if self == Self.builtInVibe { return .vibe }
         return nil
     }
 }

--- a/Sources/RestorableAgentTypes.swift
+++ b/Sources/RestorableAgentTypes.swift
@@ -19,6 +19,7 @@ enum RestorableAgentKind: Codable, Hashable, Sendable {
     case factory
     case qoder
     case kimi
+    case vibe
     case ollama
     case custom(String)
 
@@ -40,7 +41,7 @@ enum RestorableAgentKind: Codable, Hashable, Sendable {
         .codebuddy,
         .factory,
         .qoder,
-        // Kimi and Ollama are registry-owned like Pi/Grok/Antigravity: leaving them
+        // Kimi, Vibe, and Ollama are registry-owned like Pi/Grok/Antigravity: leaving them
         // out keeps their ids available to pre-existing custom Vault registrations
         // while direct native values still encode.
     ]
@@ -65,6 +66,7 @@ enum RestorableAgentKind: Codable, Hashable, Sendable {
         case "factory": self = .factory
         case "qoder": self = .qoder
         case "kimi": self = .kimi
+        case "vibe": self = .vibe
         case "ollama": self = .ollama
         default:
             guard CmuxVaultAgentRegistration.isValidID(value) else { return nil }
@@ -102,6 +104,7 @@ enum RestorableAgentKind: Codable, Hashable, Sendable {
         case .factory: return "factory"
         case .qoder: return "qoder"
         case .kimi: return "kimi"
+        case .vibe: return "vibe"
         case .ollama: return "ollama"
         case .custom(let id): return id
         }
@@ -134,6 +137,8 @@ enum RestorableAgentKind: Codable, Hashable, Sendable {
         case .qoder: return "Qoder"
         case .kimi:
             return String(localized: "agent.kimi.displayName", defaultValue: "Kimi Code")
+        case .vibe:
+            return String(localized: "agent.vibe.displayName", defaultValue: "Mistral Vibe")
         case .ollama:
             return String(localized: "agent.ollama.displayName", defaultValue: "Ollama")
         case .custom(let id): return id

--- a/Sources/RestorableAgentTypes.swift
+++ b/Sources/RestorableAgentTypes.swift
@@ -138,7 +138,7 @@ enum RestorableAgentKind: Codable, Hashable, Sendable {
         case .kimi:
             return String(localized: "agent.kimi.displayName", defaultValue: "Kimi Code")
         case .vibe:
-            return String(localized: "agent.vibe.displayName", defaultValue: "Mistral Vibe")
+            return "Mistral Vibe"
         case .ollama:
             return String(localized: "agent.ollama.displayName", defaultValue: "Ollama")
         case .custom(let id): return id

--- a/Sources/VaultAgentRegistry+Vibe.swift
+++ b/Sources/VaultAgentRegistry+Vibe.swift
@@ -1,11 +1,12 @@
 import CMUXAgentLaunch
 
 extension CmuxVaultAgentRegistration {
-    /// True only for cmux's exact built-in registration, not user registrations reusing its id.
+    /// True only for cmux's exact built-in Vibe registration, not user registrations reusing its id.
     var isBuiltInVibe: Bool {
         self == Self.builtInVibe
     }
 
+    /// The built-in Vault registration for Mistral Vibe, using `--resume` for session restore.
     static var builtInVibe: CmuxVaultAgentRegistration {
         CmuxVaultAgentRegistration(
             id: "vibe",

--- a/Sources/VaultAgentRegistry+Vibe.swift
+++ b/Sources/VaultAgentRegistry+Vibe.swift
@@ -10,7 +10,11 @@ extension CmuxVaultAgentRegistration {
         CmuxVaultAgentRegistration(
             id: "vibe",
             name: RestorableAgentKind.vibe.displayName,
-            detect: CmuxVaultAgentDetectRule(processNames: ["vibe", "Vibe CLI", "mistral-vibe"]),
+            // Do not include "Vibe CLI" here: it is a mutable process title set
+            // via setproctitle, not an executable basename. Matching on it would
+            // bind an unrelated process to Vibe. Detection relies on the
+            // executable-path basename or validated cmux launch metadata.
+            detect: CmuxVaultAgentDetectRule(processNames: ["vibe", "mistral-vibe"]),
             sessionIdSource: .argvOption("--resume"),
             resumeCommand: RegisteredAgentResumeKind.vibe.commandTemplate,
             cwd: .preserve

--- a/Sources/VaultAgentRegistry+Vibe.swift
+++ b/Sources/VaultAgentRegistry+Vibe.swift
@@ -1,0 +1,19 @@
+import CMUXAgentLaunch
+
+extension CmuxVaultAgentRegistration {
+    /// True only for cmux's exact built-in registration, not user registrations reusing its id.
+    var isBuiltInVibe: Bool {
+        self == Self.builtInVibe
+    }
+
+    static var builtInVibe: CmuxVaultAgentRegistration {
+        CmuxVaultAgentRegistration(
+            id: "vibe",
+            name: RestorableAgentKind.vibe.displayName,
+            detect: CmuxVaultAgentDetectRule(processNames: ["vibe", "Vibe CLI", "mistral-vibe"]),
+            sessionIdSource: .argvOption("--resume"),
+            resumeCommand: RegisteredAgentResumeKind.vibe.commandTemplate,
+            cwd: .preserve
+        )
+    }
+}

--- a/Sources/VaultAgentRegistry.swift
+++ b/Sources/VaultAgentRegistry.swift
@@ -477,6 +477,7 @@ struct CmuxVaultAgentRegistry: Sendable {
             CmuxVaultAgentRegistration.builtInAntigravity,
             CmuxVaultAgentRegistration.builtInGrok,
             CmuxVaultAgentRegistration.builtInKimi,
+            CmuxVaultAgentRegistration.builtInVibe,
             CmuxVaultAgentRegistration.builtInHermes,
         ]
         for path in configPaths(homeDirectory: homeDirectory, workingDirectory: workingDirectory, environment: environment, fileManager: fileManager) {

--- a/docs/agent-hooks.md
+++ b/docs/agent-hooks.md
@@ -11,7 +11,7 @@ cmux hooks setup --agent <agent>
 cmux hooks uninstall <agent>
 ```
 
-Supported agent names are `codex`, `grok`, `opencode`, `pi`, `omp`, `campfire`, `amp`, `cursor`, `gemini`, `kimi`, `kiro`, `rovodev` (or `rovo`), `copilot`, `codebuddy`, `factory`, and `qoder`. `cmux hooks setup` skips agents whose binary is not on `PATH` and prints a summary.
+Supported agent names are `codex`, `grok`, `opencode`, `pi`, `omp`, `campfire`, `amp`, `cursor`, `gemini`, `kimi`, `vibe`, `kiro`, `rovodev` (or `rovo`), `copilot`, `codebuddy`, `factory`, and `qoder`. `cmux hooks setup` skips agents whose binary is not on `PATH` and prints a summary.
 
 ## Integrations
 
@@ -34,6 +34,7 @@ Supported agent names are `codex`, `grok`, `opencode`, `pi`, `omp`, `campfire`, 
 | Factory | `droid` | `~/.factory/settings.json` | `droid --resume <id>` | PreToolUse |
 | Qoder | `qodercli` | `~/.qoder/settings.json` | `qodercli --resume <id>` | PreToolUse |
 | Kimi Code | `kimi` | `~/.kimi-code/config.toml` or `~/.kimi/config.toml` | not yet | PreToolUse, PostToolUse |
+| Mistral Vibe | `vibe` | `~/.vibe/hooks.toml` | `vibe --resume <id>` | pre_tool, post_tool |
 
 OpenCode also supports project-local Feed installation:
 
@@ -150,6 +151,7 @@ and browser state. Restored agent terminals stay idle until you resume them manu
 | Gemini | none | `CMUX_GEMINI_HOOKS_DISABLED=1` |
 | Kiro CLI | `KIRO_HOME` | `CMUX_KIRO_HOOKS_DISABLED=1` |
 | Kimi Code | `KIMI_CODE_HOME`, `KIMI_SHARE_DIR` | `CMUX_KIMI_HOOKS_DISABLED=1` |
+| Mistral Vibe | `VIBE_HOME` | `CMUX_VIBE_HOOKS_DISABLED=1` |
 | Rovo Dev | none | `CMUX_ROVODEV_HOOKS_DISABLED=1` |
 | Copilot | `COPILOT_HOME` | `CMUX_COPILOT_HOOKS_DISABLED=1` |
 | CodeBuddy | `CODEBUDDY_CONFIG_DIR` | `CMUX_CODEBUDDY_HOOKS_DISABLED=1` |

--- a/docs/agent-hooks.md
+++ b/docs/agent-hooks.md
@@ -34,7 +34,7 @@ Supported agent names are `codex`, `grok`, `opencode`, `pi`, `omp`, `campfire`, 
 | Factory | `droid` | `~/.factory/settings.json` | `droid --resume <id>` | PreToolUse |
 | Qoder | `qodercli` | `~/.qoder/settings.json` | `qodercli --resume <id>` | PreToolUse |
 | Kimi Code | `kimi` | `~/.kimi-code/config.toml` or `~/.kimi/config.toml` | not yet | PreToolUse, PostToolUse |
-| Mistral Vibe | `vibe` | `~/.vibe/hooks.toml` | `vibe --resume <id>` | pre_tool, post_tool |
+| Mistral Vibe | `vibe` | `~/.vibe/hooks.toml` | `vibe --resume <id>` | pre_tool, post_tool (telemetry only) |
 
 OpenCode also supports project-local Feed installation:
 


### PR DESCRIPTION
## Summary

Adds native cmux hook support for **Mistral Vibe** (`mistral-vibe`), enabling session restore, Feed telemetry, and process detection on par with Codex, Claude Code, Gemini, and the other supported agents.

After this change, `cmux hooks setup vibe` installs hooks into `~/.vibe/hooks.toml`, and cmux can detect, track, and resume Vibe sessions after an app quit/relaunch — the gap that prompted this PR.

## How it works

Vibe stores hooks in `~/.vibe/hooks.toml` as `[[hooks]]` array-of-tables with `name`, `type`, `command`, and `timeout` fields. A new `VibeHookConfig` (modeled on `KimiCodeHookConfig`) handles marker-delimited install/uninstall of that schema.

Vibe's hook event model differs from most supported agents: it has `post_agent`, `pre_tool`, and `post_tool` — no `SessionStart` or `SessionEnd`. The event mapping is:

| Vibe hook | cmux subcommand | Purpose |
|---|---|---|
| `post_agent` | `stop` | Registers the session via `store.upsert` + `publishAgentSurfaceResumeBinding` on the first turn (Vibe has no SessionStart) |
| `pre_tool` | feed (`--source vibe`) | Feed telemetry only — Vibe has its own approval UI |
| `post_tool` | feed (`--source vibe`) | Feed telemetry only |

The `stop` handler's upsert path records the session (the `session_id` comes from Vibe's hook payload stdin JSON, which `extractClaudeHookSessionId` already reads via the `session_id` key). On app relaunch, cmux rebuilds the workspace and runs `vibe --resume <sessionId>`.

## Changes

**CMUXAgentLaunch package** (builds via `swift build`):
- `VibeHookConfig.swift` — new TOML writer for Vibe's `hooks.toml` schema
- `VibeHookConfigTests.swift` — tests (install, idempotent, reinstall, uninstall, CRLF, escaping)
- `RegisteredAgentResumeKind.swift` — `.vibe` case with `{{executable}} --resume {{sessionId}}` template
- `AgentResumeArgv.swift` — `"vibe"` case in `builtInKind`

**App sources**:
- `RestorableAgentTypes.swift` — `.vibe` case (registry-owned, not in `allCases`, same pattern as Kimi)
- `VaultAgentRegistry+Vibe.swift` — `builtInVibe` registration with `argvOption("--resume")`
- `VaultAgentRegistry.swift` — register `builtInVibe` in `load()`
- `CmuxVaultAgentRegistration+RegisteredResumeKind.swift` — vibe → `.vibe` mapping
- `CmuxTaskManagerCodingAgentDefinition+BuiltIns.swift` — vibe process detection entry

**CLI sources**:
- `CMUXCLI+AgentHookCatalog.swift` — new `vibe` `AgentHookDef` with `.tomlArrayTable` format
- `CMUXCLI+VibeHooks.swift` — install/uninstall driver
- `cmux.swift` — dispatch `vibe` before `.tomlArrayTable` in `installAgentHooks`/`uninstallAgentHooks`
- `FeedEventClassifier.swift` — `vibe` entry with `.toolStart`/`.toolEnd` semantics

**Docs**:
- `docs/agent-hooks.md` — integration table, supported names, env overrides

## Verification

- `swift build` in `Packages/macOS/CMUXAgentLaunch` passes.
- The CLI and app target changes follow the exact pattern of existing agents (Kimi for TOML, Gemini for hook-only session capture, Hermes for telemetry-only feed). They cannot be compiled standalone outside Xcode — the full project build is left to CI.
- `VibeHookConfigTests` follow the same test suite as `KimiCodeHookConfigTests` (the `Testing` module is not available via `swift test`; tests run through Xcode).

## Notes for reviewers

- Vibe's `post_agent` → `stop` mapping means the session is registered on the first turn end, not at session start. This is a deliberate trade-off since Vibe has no SessionStart hook. The `stop` handler's `store.upsert` + `publishAgentSurfaceResumeBinding` path (cmux.swift:34901) creates the resume binding, so session restore works correctly.
- Vibe's process name is `Vibe CLI` (set via `setproctitle`), like Kimi's `Kimi Code`. The `directBasenames` list includes both the real binary name and the overridden process title.
- `VIBE_HOME` is supported as a config directory override, matching Vibe's own environment variable.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10860"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790341400&installation_model_id=21920&pr_number=10860&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10860&signature=56804ed20a57b7b66b939264ca678c617bf960ccdd7ce99110fae3328c216ad8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added built-in support for Mistral Vibe as a coding agent.
  * Added session resume support with preserved launch options.
  * Added hook installation, updating, preview, and removal, including confirmation bypass.
  * Added lifecycle and tool event reporting without actionable approval prompts.
  * Added custom configuration locations and automatic directory creation.
  * Improved launch option handling during session restoration.

* **Documentation**
  * Documented Vibe setup, configuration, session resuming, and hook controls.

* **Tests**
  * Added coverage for hook management, formatting, replacement, removal, and content preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->