### PR TITLE
chatmux-relay: fix await_holding_lock from #10853 (main is red again)

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/journal_forwarder.rs
+++ b/cmux-tui/crates/chatmux-relay/src/journal_forwarder.rs
@@ -1899,11 +1899,16 @@ mod tests {
         while let Ok(cue) = cues.try_recv() {
             assert!(matches!(cue, FlushWake::Arm), "an in-flight POST defers the next flush");
         }
-        let pool = shared.pool.lock().expect("lock pool");
-        assert!(pool.flush_again);
-        let total = pool.pending.iter().map(|entry| entry.records.len()).sum::<usize>();
-        assert_eq!(total, MAX_BATCH_RECORDS);
-        drop(pool);
+        // Block scope, not drop(): clippy's await_holding_lock reasons
+        // about lexical scope, so an explicit drop before the await still
+        // trips it (rust-clippy#6446).
+        {
+            let pool = shared.pool.lock().expect("lock pool");
+            assert!(pool.flush_again);
+            let total =
+                pool.pending.iter().map(|entry| entry.records.len()).sum::<usize>();
+            assert_eq!(total, MAX_BATCH_RECORDS);
+        }
         remove_cursor_test_path(&root).await;
     }
 
@@ -1970,10 +1975,12 @@ mod tests {
         assert_eq!(cursors.get("alpha"), Some(&cursor("gen_a", "2")));
         assert_eq!(cursors.get("beta"), Some(&cursor("gen_b", "3")));
         drop(cursors);
-        let pool = shared.pool.lock().expect("lock pool");
-        assert!(pool.pending.is_empty());
-        assert!(!pool.flushing);
-        drop(pool);
+        // Block scope, not drop(): see the await_holding_lock note above.
+        {
+            let pool = shared.pool.lock().expect("lock pool");
+            assert!(pool.pending.is_empty());
+            assert!(!pool.flushing);
+        }
         remove_cursor_test_path(&root).await;
     }
 


### PR DESCRIPTION
Rust 1.95 clippy fails the workspace on two test-only MutexGuard-across-await points introduced by #10853 (journal_forwarder.rs pool-inspection tests). The guards were explicitly drop()ed before the await, but await_holding_lock reasons about lexical scope (rust-lang/rust-clippy#6446), so drop() does not satisfy it — block-scoped instead. clippy -D warnings clean, the three pooled tests pass unchanged. Hit on feat-tui-output-read's hosted verification.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10863"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790343754&installation_model_id=21920&pr_number=10863&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10863&signature=0a84029c36ff8e83cddbfb65e23e075b7692c463ff35c43c575eff116c25fa3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `await_holding_lock` clippy failure on Rust 1.95 by block-scoping two test-only `MutexGuard`s in `journal_forwarder.rs` instead of relying on explicit `drop()`, which the lint doesn't recognize.

- The guards were already dropped before the await, but clippy reasons about lexical scope (`rust-clippy#6446`).
- No behavior change; the three pooled tests pass unchanged.

<sup>Written for commit a816d492fd6b5d66366701aa733ce707f534274a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Unix-only test cleanup handling without changing runtime behavior or test expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->