### PR TITLE
chatmux-relay: rustfmt fix for #10863

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/journal_forwarder.rs
+++ b/cmux-tui/crates/chatmux-relay/src/journal_forwarder.rs
@@ -1905,8 +1905,7 @@ mod tests {
         {
             let pool = shared.pool.lock().expect("lock pool");
             assert!(pool.flush_again);
-            let total =
-                pool.pending.iter().map(|entry| entry.records.len()).sum::<usize>();
+            let total = pool.pending.iter().map(|entry| entry.records.len()).sum::<usize>();
             assert_eq!(total, MAX_BATCH_RECORDS);
         }
         remove_cursor_test_path(&root).await;


### PR DESCRIPTION
My #10863 was clippy-clean but not rustfmt-canonical (one over-wrapped let). cargo fmt --check now clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10864"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790346404&installation_model_id=21920&pr_number=10864&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10864&signature=8a1c13ead3ae7c3d4ee98f0d925289945a779bd446768136399d5c6c7690e6a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Formats the `journal_forwarder.rs` test code so `cargo fmt --check` passes on the `chatmux-relay` crate. No behavior changes.

<sup>Written for commit 9c6964e44bff92d85da81d4e42c087e7ade835be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified test code formatting without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->