### PR TITLE
fix(remote-tmux): suppress inherited local agent routing

### DIFF
--- a/Sources/RemoteTmuxControlConnection+Commands.swift
+++ b/Sources/RemoteTmuxControlConnection+Commands.swift
@@ -18,6 +18,16 @@ extension RemoteTmuxControlConnection {
     /// mirrored by a local cmux over ssh-tmux (`tmux -CC`, no relay socket).
     static let mirrorMarkerEnvironmentKey = "CMUX_REMOTE_TMUX_MIRROR"
 
+    /// Host-local route values that must not cross into an ssh-tmux mirror.
+    /// Empty session values shadow stale tmux-global values and are observable
+    /// by an already-running shell's session-scoped environment refresh.
+    private static let mirrorSuppressedLocalRoutingEnvironmentKeys = [
+        "CMUX_PANEL_ID",
+        "CMUX_SOCKET",
+        "CMUX_SOCKET_PATH",
+        "CMUX_SURFACE_ID",
+    ]
+
     /// Pushes the mirror marker + identity pairs into the remote tmux SESSION
     /// environment. Called from the first post-attach `list-windows` result, so
     /// both paths — first connect and every reconnect — refresh values that
@@ -25,11 +35,12 @@ extension RemoteTmuxControlConnection {
     /// the `tmux -CC` attach has no cmux wrapper shell outside tmux on the
     /// remote, so nobody else ever re-publishes them).
     ///
-    /// Deliberately NOT pushed: `CMUX_SOCKET_PATH`. The ssh-tmux transport has
-    /// no relay/reverse forward, so the local Mac socket path is meaningless on
-    /// the remote host; publishing it would point remote `cmux` CLI invocations
-    /// at a dead socket. Notification delivery instead rides the OSC 777/9
-    /// intercept in ``RemoteTmuxSessionMirror`` (see
+    /// Host-local socket and surface values are pushed as EMPTY session values.
+    /// Merely omitting them is insufficient: tmux would expose a stale global
+    /// value inherited from the pane that created the session, and an existing
+    /// shell would retain its launch-time value. The ssh-tmux transport has no
+    /// relay/reverse forward, so agent notification delivery instead rides the
+    /// OSC 777/9 intercept in ``RemoteTmuxSessionMirror`` (see
     /// ``RemoteTmuxNotificationOSCFilter``).
     ///
     /// Session scope (`-t`, not `-g`): the shell-integration refresh path runs
@@ -42,6 +53,9 @@ extension RemoteTmuxControlConnection {
                 .map(RemoteTmuxHost.shellSingleQuoted)
         else { return }
         var pairs = mirrorEnvironment
+        for key in Self.mirrorSuppressedLocalRoutingEnvironmentKeys {
+            pairs[key] = ""
+        }
         pairs[Self.mirrorMarkerEnvironmentKey] = "1"
         let commands = Self.mirrorEnvironmentCommands(target: target, pairs: pairs)
         guard !commands.isEmpty else { return }
@@ -61,7 +75,7 @@ extension RemoteTmuxControlConnection {
             // would terminate the command line before tmux parses the quotes.
             guard RemoteTmuxHost.controlModeLineSafeName(key) != nil,
                   !key.contains(" "),
-                  RemoteTmuxHost.controlModeLineSafeName(value) != nil
+                  value.isEmpty || RemoteTmuxHost.controlModeLineSafeName(value) != nil
             else { return nil }
             return "set-environment -t \(target) \(key) "
                 + RemoteTmuxHost.shellSingleQuoted(value)

--- a/cmuxTests/RemoteTmuxMirrorEnvironmentPushTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorEnvironmentPushTests.swift
@@ -144,12 +144,21 @@ import Testing
         #expect(pushes.contains(
             "set-environment -t 'work' CMUX_WORKSPACE_ID '11111111-2222-3333-4444-555555555555'"
         ))
+        let localRouteClears: Set<String> = [
+            "set-environment -t 'work' CMUX_PANEL_ID ''",
+            "set-environment -t 'work' CMUX_SOCKET ''",
+            "set-environment -t 'work' CMUX_SOCKET_PATH ''",
+            "set-environment -t 'work' CMUX_SURFACE_ID ''",
+        ]
+        #expect(Set(pushes).isSuperset(of: localRouteClears))
         // Session scope is the point of the fix: `-g` values are invisible to
         // the session-scoped `show-environment` the shell integration runs.
         #expect(pushes.allSatisfy { !$0.contains(" -g ") })
-        // No relay exists on the ssh-tmux transport, so a local socket path
-        // must never be published to the remote.
-        #expect(commands.allSatisfy { !$0.contains("CMUX_SOCKET_PATH") })
+        // No relay exists on the ssh-tmux transport, so a non-empty local
+        // socket or surface route must never survive in the mirrored session.
+        #expect(pushes.allSatisfy {
+            !$0.contains("CMUX_SOCKET_PATH '") || $0.hasSuffix("CMUX_SOCKET_PATH ''")
+        })
         wire.connection.stop()
     }
 
@@ -190,6 +199,13 @@ import Testing
         #expect(pushes.contains(
             "set-environment -t 'work' CMUX_WORKSPACE_ID 'AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE'"
         ))
+        let localRouteClears: Set<String> = [
+            "set-environment -t 'work' CMUX_PANEL_ID ''",
+            "set-environment -t 'work' CMUX_SOCKET ''",
+            "set-environment -t 'work' CMUX_SOCKET_PATH ''",
+            "set-environment -t 'work' CMUX_SURFACE_ID ''",
+        ]
+        #expect(Set(pushes).isSuperset(of: localRouteClears))
         #expect(pushes.allSatisfy { !$0.contains(" -g ") })
         connection.stop()
     }


### PR DESCRIPTION
## Summary

- Shadow stale host-local `CMUX_SOCKET_PATH`, legacy socket, surface, and panel values with empty session-scoped values whenever an ssh-tmux mirror attaches or reconnects.
- Preserve mirror workspace identity and the OSC 777/9 notification route added by #10048.
- Add first-connect and reconnect regression coverage in a separate test-only commit.

This prevents an agent inside remote tmux from retaining the ordinary launcher pane as a second notification destination while allowing repeatedly closed and reopened mirror workspaces to receive notifications through the current OSC projection.

## Testing

- `RemoteTmuxMirrorEnvironmentPushTests`: 6 passed (and failed before the fix).
- `RemoteTmuxNotificationOSCFilterTests`: 20 passed.
- `lint-pbxproj-test-wiring`: passed (709 test files checked).
- `RemoteTmuxNotificationLifecycleTests`: 4 passed, 1 unrelated URL-routing assertion failed identically on the pre-fix commit.
- `./scripts/reload.sh --tag tmux-notif`: passed on pushed HEAD `c35890cc93`.

## Demo Video

- Video URL or attachment: Not available from the SSH-only development session; tagged app `cmux DEV tmux-notif` is ready for reporter dogfood.

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I verified no user-facing strings changed; localization catalogs do not need updates
- [ ] Manual reporter dogfood completed
- [ ] All automated checks and review comments are resolved