### PR TITLE
feat: hide browser UI when browser is disabled

### DIFF
--- a/Sources/DockPanelView.swift
+++ b/Sources/DockPanelView.swift
@@ -152,6 +152,7 @@ struct DockPanelView: View {
 struct DockEmptyPaneView: View {
     let onNewTerminal: () -> Void
     let onNewBrowser: () -> Void
+    let browserAvailable: Bool
 
     var body: some View {
         VStack(spacing: 12) {
@@ -168,7 +169,7 @@ struct DockEmptyPaneView: View {
                         systemImage: "terminal.fill"
                     )
                 }
-                if BrowserAvailabilitySettings.isEnabled() {
+                if browserAvailable {
                     Button(action: onNewBrowser) {
                         Label(
                             String(localized: "dock.action.newBrowser", defaultValue: "New Browser"),

--- a/Sources/DockPanelView.swift
+++ b/Sources/DockPanelView.swift
@@ -168,11 +168,13 @@ struct DockEmptyPaneView: View {
                         systemImage: "terminal.fill"
                     )
                 }
-                Button(action: onNewBrowser) {
-                    Label(
-                        String(localized: "dock.action.newBrowser", defaultValue: "New Browser"),
-                        systemImage: "globe"
-                    )
+                if BrowserAvailabilitySettings.isEnabled() {
+                    Button(action: onNewBrowser) {
+                        Label(
+                            String(localized: "dock.action.newBrowser", defaultValue: "New Browser"),
+                            systemImage: "globe"
+                        )
+                    }
                 }
             }
             .buttonStyle(.bordered)

--- a/Sources/DockSplitContentView.swift
+++ b/Sources/DockSplitContentView.swift
@@ -12,6 +12,12 @@ struct DockSplitContentView: View {
     let windowAppearance: WindowAppearanceSnapshot
     let rightSidebarOwnsInputFocus: Bool
     let unreadPanelIDs: Set<UUID>
+    @State private var browserAvailabilityRevision = 0
+
+    private var browserAvailable: Bool {
+        let _ = browserAvailabilityRevision
+        return BrowserAvailabilitySettings.isEnabled()
+    }
 
     var body: some View {
         BonsplitView(controller: store.bonsplitController) { tab, paneId in
@@ -19,9 +25,16 @@ struct DockSplitContentView: View {
         } emptyPane: { paneId in
             DockEmptyPaneView(
                 onNewTerminal: { _ = store.newSurface(kind: .terminal, inPane: paneId, focus: true) },
-                onNewBrowser: { _ = store.newSurface(kind: .browser, inPane: paneId, focus: true) }
+                onNewBrowser: { _ = store.newSurface(kind: .browser, inPane: paneId, focus: true) },
+                browserAvailable: browserAvailable
             )
             .onTapGesture { store.bonsplitController.focusPane(paneId) }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: BrowserAvailabilitySettings.didChangeNotification)) { _ in
+            browserAvailabilityRevision &+= 1
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification)) { _ in
+            browserAvailabilityRevision &+= 1
         }
     }
 
@@ -49,7 +62,8 @@ struct DockSplitContentView: View {
         } else {
             DockEmptyPaneView(
                 onNewTerminal: { _ = store.newSurface(kind: .terminal, inPane: paneId, focus: true) },
-                onNewBrowser: { _ = store.newSurface(kind: .browser, inPane: paneId, focus: true) }
+                onNewBrowser: { _ = store.newSurface(kind: .browser, inPane: paneId, focus: true) },
+                browserAvailable: browserAvailable
             )
             .onTapGesture { store.bonsplitController.focusPane(paneId) }
         }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2547,6 +2547,8 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
     private var surfaceTabBarButtonGlobalConfigPath: String?
     private var surfaceTabBarButtonConfiguration: SurfaceTabBarButtonConfiguration?
     private var featureFlagsObserver: NSObjectProtocol?
+    private var browserAvailabilityObserver: NSObjectProtocol?
+    private var browserAvailabilityDefaultsObserver: NSObjectProtocol?
 
     /// The pane-tree sub-model (CmuxPanes): owns the panel registry, the
     /// surface-id mapping, and the pane-layout bookkeeping. The legacy
@@ -3962,6 +3964,26 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
                 self.reapplySurfaceTabBarButtonsForFeatureFlags()
             }
         }
+        browserAvailabilityObserver = NotificationCenter.default.addObserver(
+            forName: BrowserAvailabilitySettings.didChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self, !self.isRetiredFromOwningTabManager else { return }
+                self.reapplySurfaceTabBarButtonsForFeatureFlags()
+            }
+        }
+        browserAvailabilityDefaultsObserver = NotificationCenter.default.addObserver(
+            forName: UserDefaults.didChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self, !self.isRetiredFromOwningTabManager else { return }
+                self.reapplySurfaceTabBarButtonsForFeatureFlags()
+            }
+        }
     }
 
     private var sharedLiveAgentIndexObserver: NSObjectProtocol?
@@ -3979,6 +4001,12 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         }
         if let featureFlagsObserver {
             NotificationCenter.default.removeObserver(featureFlagsObserver)
+        }
+        if let browserAvailabilityObserver {
+            NotificationCenter.default.removeObserver(browserAvailabilityObserver)
+        }
+        if let browserAvailabilityDefaultsObserver {
+            NotificationCenter.default.removeObserver(browserAvailabilityDefaultsObserver)
         }
         deferredAgentResumeIndexTask?.cancel()
         activeRemoteSessionControllerID = nil
@@ -4029,6 +4057,7 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
             if builtInAction == .mobileConnect { return CmuxFeatureFlags.shared.isMobileConnectButtonEnabled }
             if builtInAction == .newAgentChat { return CmuxFeatureFlags.shared.isAgentChatUIEnabled }
             if builtInAction == .newSimulator { return CmuxFeatureFlags.shared.isSimulatorEnabled }
+            if builtInAction == .newBrowser { return BrowserAvailabilitySettings.isEnabled() }
             return true
         }
         let executableButtons = Dictionary(
@@ -9921,6 +9950,14 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         if let featureFlagsObserver {
             NotificationCenter.default.removeObserver(featureFlagsObserver)
             self.featureFlagsObserver = nil
+        }
+        if let browserAvailabilityObserver {
+            NotificationCenter.default.removeObserver(browserAvailabilityObserver)
+            self.browserAvailabilityObserver = nil
+        }
+        if let browserAvailabilityDefaultsObserver {
+            NotificationCenter.default.removeObserver(browserAvailabilityDefaultsObserver)
+            self.browserAvailabilityDefaultsObserver = nil
         }
         teardownAllPanels(retireDock: true)
         teardownRemoteConnection()

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -749,17 +749,16 @@ struct cmuxApp: App {
                     }
                 }
 
-                splitCommandButton(title: String(localized: "menu.file.newBrowserWorkspace", defaultValue: "New Browser Workspace"), shortcut: menuShortcut(for: .newBrowserWorkspace)) {
-                    if let appDelegate = AppDelegate.shared {
-                        appDelegate.performNewBrowserWorkspaceAction(
-                            tabManager: activeTabManager,
-                            debugSource: "menu.newBrowserWorkspace"
-                        )
-                    } else if BrowserAvailabilitySettings.isEnabled() {
-                        // Last-resort fallback for a missing AppDelegate; keep
-                        // the browser-availability gate identical to the
-                        // shared action path.
-                        activeTabManager.addWorkspaceIfActive(initialSurface: .browser)
+                if BrowserAvailabilitySettings.isEnabled() {
+                    splitCommandButton(title: String(localized: "menu.file.newBrowserWorkspace", defaultValue: "New Browser Workspace"), shortcut: menuShortcut(for: .newBrowserWorkspace)) {
+                        if let appDelegate = AppDelegate.shared {
+                            appDelegate.performNewBrowserWorkspaceAction(
+                                tabManager: activeTabManager,
+                                debugSource: "menu.newBrowserWorkspace"
+                            )
+                        } else {
+                            activeTabManager.addWorkspaceIfActive(initialSurface: .browser)
+                        }
                     }
                 }
 
@@ -958,81 +957,83 @@ struct cmuxApp: App {
             }
             Divider()
             surfaceNavigationCommandButtons()
-            splitCommandButton(title: String(localized: "menu.view.back", defaultValue: "Back"), shortcut: menuShortcut(for: .browserBack)) {
-                _ = performFocusedBrowserAction(.back)
-            }
+            if BrowserAvailabilitySettings.isEnabled() {
+                splitCommandButton(title: String(localized: "menu.view.back", defaultValue: "Back"), shortcut: menuShortcut(for: .browserBack)) {
+                    _ = performFocusedBrowserAction(.back)
+                }
 
-            splitCommandButton(title: String(localized: "menu.view.forward", defaultValue: "Forward"), shortcut: menuShortcut(for: .browserForward)) {
-                _ = performFocusedBrowserAction(.forward)
-            }
+                splitCommandButton(title: String(localized: "menu.view.forward", defaultValue: "Forward"), shortcut: menuShortcut(for: .browserForward)) {
+                    _ = performFocusedBrowserAction(.forward)
+                }
 
-            splitCommandButton(title: String(localized: "menu.view.reloadPage", defaultValue: "Reload Page"), shortcut: menuShortcut(for: .browserReload)) {
-                _ = performFocusedBrowserAction(.reload)
-            }
+                splitCommandButton(title: String(localized: "menu.view.reloadPage", defaultValue: "Reload Page"), shortcut: menuShortcut(for: .browserReload)) {
+                    _ = performFocusedBrowserAction(.reload)
+                }
 
-            splitCommandButton(title: String(localized: "menu.view.toggleDevTools", defaultValue: "Toggle Developer Tools"), shortcut: menuShortcut(for: .toggleBrowserDeveloperTools)) {
-                if !performFocusedBrowserAction(.toggleDeveloperTools) {
-                    NSSound.beep()
+                splitCommandButton(title: String(localized: "menu.view.toggleDevTools", defaultValue: "Toggle Developer Tools"), shortcut: menuShortcut(for: .toggleBrowserDeveloperTools)) {
+                    if !performFocusedBrowserAction(.toggleDeveloperTools) {
+                        NSSound.beep()
+                    }
                 }
-            }
-            splitCommandButton(title: String(localized: "menu.view.showJSConsole", defaultValue: "Show JavaScript Console"), shortcut: menuShortcut(for: .showBrowserJavaScriptConsole)) {
-                if !performFocusedBrowserAction(.showJavaScriptConsole) {
-                    NSSound.beep()
+                splitCommandButton(title: String(localized: "menu.view.showJSConsole", defaultValue: "Show JavaScript Console"), shortcut: menuShortcut(for: .showBrowserJavaScriptConsole)) {
+                    if !performFocusedBrowserAction(.showJavaScriptConsole) {
+                        NSSound.beep()
+                    }
                 }
-            }
-            splitCommandButton(title: String(localized: "menu.view.toggleReactGrab", defaultValue: "Toggle React Grab"), shortcut: menuShortcut(for: .toggleReactGrab)) {
-                if !performFocusedBrowserAction(.toggleReactGrab) {
-                    NSSound.beep()
+                splitCommandButton(title: String(localized: "menu.view.toggleReactGrab", defaultValue: "Toggle React Grab"), shortcut: menuShortcut(for: .toggleReactGrab)) {
+                    if !performFocusedBrowserAction(.toggleReactGrab) {
+                        NSSound.beep()
+                    }
                 }
-            }
-            splitCommandButton(title: String(localized: "menu.view.toggleDesignMode", defaultValue: "Toggle Design Mode"), shortcut: menuShortcut(for: .toggleBrowserDesignMode)) {
-                if !performFocusedBrowserAction(
-                    .toggleDesignMode(reason: "viewMenu")
-                ) {
-                    NSSound.beep()
+                splitCommandButton(title: String(localized: "menu.view.toggleDesignMode", defaultValue: "Toggle Design Mode"), shortcut: menuShortcut(for: .toggleBrowserDesignMode)) {
+                    if !performFocusedBrowserAction(
+                        .toggleDesignMode(reason: "viewMenu")
+                    ) {
+                        NSSound.beep()
+                    }
                 }
-            }
-            let browserFocusModeMenu = browserFocusModeMenuSnapshot
-            Button(browserFocusModeMenu.title) {
-                if !performFocusedBrowserAction(
-                    .toggleFocusMode(reason: "viewMenu")
-                ) {
-                    NSSound.beep()
+                let browserFocusModeMenu = browserFocusModeMenuSnapshot
+                Button(browserFocusModeMenu.title) {
+                    if !performFocusedBrowserAction(
+                        .toggleFocusMode(reason: "viewMenu")
+                    ) {
+                        NSSound.beep()
+                    }
                 }
-            }
-            .disabled(!browserFocusModeMenu.canToggle)
-            splitCommandButton(title: String(localized: "menu.view.zoomIn", defaultValue: "Zoom In"), shortcut: menuShortcut(for: .browserZoomIn)) {
-                if activeBrowserActionTarget != nil {
-                    _ = performFocusedBrowserAction(.zoomIn)
-                } else {
-                    _ = activeTabManager.zoomInFocusedBrowserOrTextFilePreview()
+                .disabled(!browserFocusModeMenu.canToggle)
+                splitCommandButton(title: String(localized: "menu.view.zoomIn", defaultValue: "Zoom In"), shortcut: menuShortcut(for: .browserZoomIn)) {
+                    if activeBrowserActionTarget != nil {
+                        _ = performFocusedBrowserAction(.zoomIn)
+                    } else {
+                        _ = activeTabManager.zoomInFocusedBrowserOrTextFilePreview()
+                    }
                 }
-            }
 
-            splitCommandButton(title: String(localized: "menu.view.zoomOut", defaultValue: "Zoom Out"), shortcut: menuShortcut(for: .browserZoomOut)) {
-                if activeBrowserActionTarget != nil {
-                    _ = performFocusedBrowserAction(.zoomOut)
-                } else {
-                    _ = activeTabManager.zoomOutFocusedBrowserOrTextFilePreview()
+                splitCommandButton(title: String(localized: "menu.view.zoomOut", defaultValue: "Zoom Out"), shortcut: menuShortcut(for: .browserZoomOut)) {
+                    if activeBrowserActionTarget != nil {
+                        _ = performFocusedBrowserAction(.zoomOut)
+                    } else {
+                        _ = activeTabManager.zoomOutFocusedBrowserOrTextFilePreview()
+                    }
                 }
-            }
 
-            splitCommandButton(title: String(localized: "menu.view.actualSize", defaultValue: "Actual Size"), shortcut: menuShortcut(for: .browserZoomReset)) {
-                if activeBrowserActionTarget != nil {
-                    _ = performFocusedBrowserAction(.resetZoom)
-                } else {
-                    _ = activeTabManager.resetZoomFocusedBrowserOrTextFilePreview()
+                splitCommandButton(title: String(localized: "menu.view.actualSize", defaultValue: "Actual Size"), shortcut: menuShortcut(for: .browserZoomReset)) {
+                    if activeBrowserActionTarget != nil {
+                        _ = performFocusedBrowserAction(.resetZoom)
+                    } else {
+                        _ = activeTabManager.resetZoomFocusedBrowserOrTextFilePreview()
+                    }
                 }
-            }
 
-            Button(String(localized: "menu.view.clearBrowserHistory", defaultValue: "Clear Browser History")) {
-                BrowserHistoryStore.shared.clearHistory()
-            }
+                Button(String(localized: "menu.view.clearBrowserHistory", defaultValue: "Clear Browser History")) {
+                    BrowserHistoryStore.shared.clearHistory()
+                }
 
-            Button(String(localized: "menu.view.importFromBrowser", defaultValue: "Import Browser Data…")) {
-                // Defer modal presentation until after AppKit finishes menu tracking.
-                DispatchQueue.main.async {
-                    BrowserDataImportCoordinator.shared.presentImportDialog()
+                Button(String(localized: "menu.view.importFromBrowser", defaultValue: "Import Browser Data…")) {
+                    // Defer modal presentation until after AppKit finishes menu tracking.
+                    DispatchQueue.main.async {
+                        BrowserDataImportCoordinator.shared.presentImportDialog()
+                    }
                 }
             }
 
@@ -1072,12 +1073,14 @@ struct cmuxApp: App {
                 performSplitFromMenu(direction: .down)
             }
 
-            splitCommandButton(title: String(localized: "menu.view.splitBrowserRight", defaultValue: "Split Browser Right"), shortcut: menuShortcut(for: .splitBrowserRight)) {
-                performBrowserSplitFromMenu(direction: .right)
-            }
+            if BrowserAvailabilitySettings.isEnabled() {
+                splitCommandButton(title: String(localized: "menu.view.splitBrowserRight", defaultValue: "Split Browser Right"), shortcut: menuShortcut(for: .splitBrowserRight)) {
+                    performBrowserSplitFromMenu(direction: .right)
+                }
 
-            splitCommandButton(title: String(localized: "menu.view.splitBrowserDown", defaultValue: "Split Browser Down"), shortcut: menuShortcut(for: .splitBrowserDown)) {
-                performBrowserSplitFromMenu(direction: .down)
+                splitCommandButton(title: String(localized: "menu.view.splitBrowserDown", defaultValue: "Split Browser Down"), shortcut: menuShortcut(for: .splitBrowserDown)) {
+                    performBrowserSplitFromMenu(direction: .down)
+                }
             }
 
             equalizeSplitsCommandButton()

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -1001,29 +1001,6 @@ struct cmuxApp: App {
                     }
                 }
                 .disabled(!browserFocusModeMenu.canToggle)
-                splitCommandButton(title: String(localized: "menu.view.zoomIn", defaultValue: "Zoom In"), shortcut: menuShortcut(for: .browserZoomIn)) {
-                    if activeBrowserActionTarget != nil {
-                        _ = performFocusedBrowserAction(.zoomIn)
-                    } else {
-                        _ = activeTabManager.zoomInFocusedBrowserOrTextFilePreview()
-                    }
-                }
-
-                splitCommandButton(title: String(localized: "menu.view.zoomOut", defaultValue: "Zoom Out"), shortcut: menuShortcut(for: .browserZoomOut)) {
-                    if activeBrowserActionTarget != nil {
-                        _ = performFocusedBrowserAction(.zoomOut)
-                    } else {
-                        _ = activeTabManager.zoomOutFocusedBrowserOrTextFilePreview()
-                    }
-                }
-
-                splitCommandButton(title: String(localized: "menu.view.actualSize", defaultValue: "Actual Size"), shortcut: menuShortcut(for: .browserZoomReset)) {
-                    if activeBrowserActionTarget != nil {
-                        _ = performFocusedBrowserAction(.resetZoom)
-                    } else {
-                        _ = activeTabManager.resetZoomFocusedBrowserOrTextFilePreview()
-                    }
-                }
 
                 Button(String(localized: "menu.view.clearBrowserHistory", defaultValue: "Clear Browser History")) {
                     BrowserHistoryStore.shared.clearHistory()
@@ -1034,6 +1011,30 @@ struct cmuxApp: App {
                     DispatchQueue.main.async {
                         BrowserDataImportCoordinator.shared.presentImportDialog()
                     }
+                }
+            }
+
+            splitCommandButton(title: String(localized: "menu.view.zoomIn", defaultValue: "Zoom In"), shortcut: menuShortcut(for: .browserZoomIn)) {
+                if activeBrowserActionTarget != nil {
+                    _ = performFocusedBrowserAction(.zoomIn)
+                } else {
+                    _ = activeTabManager.zoomInFocusedBrowserOrTextFilePreview()
+                }
+            }
+
+            splitCommandButton(title: String(localized: "menu.view.zoomOut", defaultValue: "Zoom Out"), shortcut: menuShortcut(for: .browserZoomOut)) {
+                if activeBrowserActionTarget != nil {
+                    _ = performFocusedBrowserAction(.zoomOut)
+                } else {
+                    _ = activeTabManager.zoomOutFocusedBrowserOrTextFilePreview()
+                }
+            }
+
+            splitCommandButton(title: String(localized: "menu.view.actualSize", defaultValue: "Actual Size"), shortcut: menuShortcut(for: .browserZoomReset)) {
+                if activeBrowserActionTarget != nil {
+                    _ = performFocusedBrowserAction(.resetZoom)
+                } else {
+                    _ = activeTabManager.resetZoomFocusedBrowserOrTextFilePreview()
                 }
             }
 

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -67,6 +67,7 @@ struct cmuxApp: App {
     @AppStorage(SocketControlSettings.appStorageKey) private var socketControlMode = SocketControlSettings.defaultMode.rawValue
     @AppStorage(BrowserToolbarAccessorySpacingDebugSettings.key) private var browserToolbarAccessorySpacingRaw = BrowserToolbarAccessorySpacingDebugSettings.defaultSpacing
     @State private var browserFocusModeMenuRevision = 0
+    @State private var browserAvailabilityRevision = 0
     @StateObject var focusHistoryMenuInvalidator: FocusHistoryMenuInvalidator
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     private var browserToolbarAccessorySpacing: Int {
@@ -411,6 +412,12 @@ struct cmuxApp: App {
                 .onReceive(NotificationCenter.default.publisher(for: .browserFocusModeStateDidChange)) { _ in
                     browserFocusModeMenuRevision &+= 1
                 }
+                .onReceive(NotificationCenter.default.publisher(for: BrowserAvailabilitySettings.didChangeNotification)) { _ in
+                    browserAvailabilityRevision &+= 1
+                }
+                .onReceive(NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification)) { _ in
+                    browserAvailabilityRevision &+= 1
+                }
         }
         .windowStyle(.hiddenTitleBar)
         .commands {
@@ -749,7 +756,7 @@ struct cmuxApp: App {
                     }
                 }
 
-                if BrowserAvailabilitySettings.isEnabled() {
+                if browserAvailabilityEnabled {
                     splitCommandButton(title: String(localized: "menu.file.newBrowserWorkspace", defaultValue: "New Browser Workspace"), shortcut: menuShortcut(for: .newBrowserWorkspace)) {
                         if let appDelegate = AppDelegate.shared {
                             appDelegate.performNewBrowserWorkspaceAction(
@@ -957,7 +964,7 @@ struct cmuxApp: App {
             }
             Divider()
             surfaceNavigationCommandButtons()
-            if BrowserAvailabilitySettings.isEnabled() {
+            if browserAvailabilityEnabled {
                 splitCommandButton(title: String(localized: "menu.view.back", defaultValue: "Back"), shortcut: menuShortcut(for: .browserBack)) {
                     _ = performFocusedBrowserAction(.back)
                 }
@@ -1074,7 +1081,7 @@ struct cmuxApp: App {
                 performSplitFromMenu(direction: .down)
             }
 
-            if BrowserAvailabilitySettings.isEnabled() {
+            if browserAvailabilityEnabled {
                 splitCommandButton(title: String(localized: "menu.view.splitBrowserRight", defaultValue: "Split Browser Right"), shortcut: menuShortcut(for: .splitBrowserRight)) {
                     performBrowserSplitFromMenu(direction: .right)
                 }
@@ -1192,6 +1199,11 @@ struct cmuxApp: App {
                 : String(localized: "menu.view.enterBrowserFocusMode", defaultValue: "Enter Browser Focus Mode"),
             canToggle: panel?.canToggleBrowserFocusMode == true
         )
+    }
+
+    private var browserAvailabilityEnabled: Bool {
+        let _ = browserAvailabilityRevision
+        return BrowserAvailabilitySettings.isEnabled()
     }
 
     private var activeBrowserActionTarget: BrowserActionTarget? {


### PR DESCRIPTION
## Summary

Hides browser-related UI elements when the built-in browser feature is disabled:

- **Tab bar**: the globe icon (new browser split button) is filtered out by `BrowserAvailabilitySettings.isEnabled()` in `applySurfaceTabBarButtons()`. Observes both `didChangeNotification` (Command Palette / policy) and `UserDefaults.didChangeNotification` (Settings toggle) to react to changes from any entrypoint.
- **View menu**: Back, Forward, Reload, DevTools, JS Console, React Grab, Design Mode, Focus Mode, Zoom In/Out/Actual Size, Clear Browser History, Import Browser Data, Split Browser Right/Down, and File menu's New Browser Workspace are wrapped with `BrowserAvailabilitySettings.isEnabled()`.
- **Dock empty pane**: the "New Browser" button is gated behind `BrowserAvailabilitySettings.isEnabled()`.

## Verification

- Swift syntax check passes for all modified files
- Build succeeds with `CMUX_SKIP_ZIG_BUILD=1`
- Manual test: disable browser via Command Palette or Settings, verify globe icon disappears from tab bar, browser items hidden in View menu, and New Browser button hidden in Dock empty pane

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790359092&installation_model_id=21920&pr_number=10878&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10878&signature=013f85b3d0ebf2ede41b5d3b19f7b7ce6bf5c349e7560eb47690885185e611a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hides browser UI when the built-in browser is disabled, except for zoom controls, which stay visible because they also drive text/file preview zoom.

- Tab bar globe icon, browser menu items (navigation, DevTools, history, split browser, New Browser Workspace), and the Dock's New Browser button now respect `BrowserAvailabilitySettings.isEnabled()`.
- Menu and Dock updates react immediately to changes from Command Palette, Settings, or CLI via tracked SwiftUI state.

<sup>Written for commit e40ba5299de89d03b135deb3e012bde0240fd303. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser-related options, including new browser windows, navigation, developer tools, history, imports, and split views, now appear only when browser functionality is enabled.
  * The New Browser button is hidden when browser functionality is unavailable, while the New Terminal button remains available.
  * Menus and toolbar buttons update automatically when browser availability changes.
  * Browser zoom controls remain available regardless of browser availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->