### PR TITLE
cmux-tui release: fix the dispatcher/publisher mutual-wait deadlock

### DIFF
--- a/.github/workflows/cmux-tui-release.yml
+++ b/.github/workflows/cmux-tui-release.yml
@@ -109,12 +109,17 @@ jobs:
         run: |
           set -euo pipefail
           started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          wait_for_publisher() {
+          # Discovery only — NEVER wait for the publisher's conclusion here:
+          # each publisher's validate-version step waits for THIS run to
+          # conclude successfully, so a dispatcher that watches the
+          # publisher deadlocks the release (both sides poll each other;
+          # the publisher's shorter timeout loses). Broke 0.13.0; the
+          # publishers self-guard with their own validation + gated
+          # environments, and this run's summary links the runs.
+          record_publisher() {
             local workflow="$1"
             local label="$2"
             local run_id=""
-            local status=""
-            local conclusion=""
             local delay=2
             local discovery_deadline=$((SECONDS + 300))
             while (( SECONDS < discovery_deadline )); do
@@ -135,28 +140,8 @@ jobs:
               echo "$label publisher run was not visible after dispatch" >&2
               return 1
             fi
-
-            delay=5
-            local completion_deadline=$((SECONDS + 3600))
-            while (( SECONDS < completion_deadline )); do
-              IFS=$'\t' read -r status conclusion <<<"$(
-                gh run view "$run_id" --repo "$GITHUB_REPOSITORY" \
-                  --json status,conclusion --jq '[.status, (.conclusion // "")] | @tsv'
-              )"
-              if [[ "$status" == "completed" ]]; then
-                if [[ "$conclusion" != "success" ]]; then
-                  echo "$label publisher run $run_id concluded $conclusion" >&2
-                  return 1
-                fi
-                echo "$label publisher run $run_id completed successfully"
-                echo "- $label publisher run: $run_id (success)" >> "$GITHUB_STEP_SUMMARY"
-                return 0
-              fi
-              sleep "$delay"
-              (( delay = delay < 60 ? delay + 5 : 60 ))
-            done
-            echo "$label publisher run $run_id did not complete within 60 minutes" >&2
-            return 1
+            echo "$label publisher run dispatched: $run_id"
+            echo "- $label publisher run: https://github.com/$GITHUB_REPOSITORY/actions/runs/$run_id" >> "$GITHUB_STEP_SUMMARY"
           }
           export TAG SOURCE_SHA STARTED_AT="$started_at"
 
@@ -183,8 +168,8 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
           if [[ "$PUBLISH_NPM" == "true" ]]; then
-            wait_for_publisher tui-publish-npm.yml "npm"
+            record_publisher tui-publish-npm.yml "npm"
           fi
           if [[ "$PUBLISH_PYPI" == "true" ]]; then
-            wait_for_publisher tui-publish-pypi.yml "PyPI"
+            record_publisher tui-publish-pypi.yml "PyPI"
           fi


### PR DESCRIPTION
The publisher workflows' `validate-version` waits for the RELEASE run to conclude successfully (b95d5b85a6, pre-0.12.1, worked); the conclusion-watch added to the release run's dispatch step AFTER 0.12.1 (abb6c79a7e / 8dba321a5d) makes both sides wait on each other. Every release since deadlocks: the publisher's ~2min artifact poll times out, fails, the dispatcher sees the failure and fails the release run — which then blocks all manual publisher retries too, since they require a SUCCESSFUL artifact run (hit on 0.13.0, runs 32998045028 / 33000114554 / 33000849343).

Fix: the dispatcher fires and records (discovery + run URL in the step summary) but never waits. The publishers keep every guard they have — validation, artifact reuse without rebuild, gated environments. actionlint clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10879"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790361844&installation_model_id=21920&pr_number=10879&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10879&signature=61efaabe7d6b3cf59f5af2cb337dd31cf9d3e14046db4377b9400428afac9f9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the release dispatcher deadlock where it waited for publisher runs to finish while the publishers wait for the release run to succeed, blocking all releases since 0.13.0.

The dispatcher now discovers and records publisher run URLs in the step summary but does not wait for them to conclude. Publisher-side guards (validation, artifact reuse, gated environments) remain unchanged.

<sup>Written for commit 7ad4a60a55bf1fcbe75d0e2b97ee1aa31d532f7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release reporting by recording publisher workflow run IDs and links in the job summary.
  * Release workflows now complete without waiting for separate package publishing workflows, while still detecting their runs within five minutes.
  * Publisher workflows independently validate and report their outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->