### PR TITLE
iOS: give the changes-hint banner dismiss button a 44pt hit target

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceChangesHintBanner.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceChangesHintBanner.swift
@@ -38,7 +38,12 @@ struct WorkspaceChangesHintBanner: View {
             Button(action: dismiss) {
                 Image(systemName: "xmark")
                     .font(.caption.weight(.semibold))
-                    .padding(5)
+                    // HIG default control size (44x44 pt). The icon alone is
+                    // ~12 pt; without this frame, taps aimed at the X land in
+                    // the full-width openChanges content shape next to it and
+                    // open the viewer instead of dismissing.
+                    .frame(width: 44, height: 44)
+                    .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
             .accessibilityLabel(String(


### PR DESCRIPTION
On iPhone, the workspace-detail changes hint banner (the one shown over the terminal) often opened the diff viewer when the X was pressed. The X was ~22x22pt (caption icon + 5pt padding) while the adjacent open-changes button claims the entire remaining row width via `contentShape(Rectangle())`, so taps aimed at the X frequently resolved to the open button.

Fix: the dismiss button now has an explicit 44x44pt frame with `contentShape(Rectangle())`, the HIG default control size, so taps at or near the X resolve to dismiss.

HIG page checked: [Accessibility, control-size table](https://developer.apple.com/design/human-interface-guidelines/accessibility) (iOS default 44x44pt, minimum 28x28pt).

No new user-facing strings (localization audit: existing `workspace.changes.hint.*` keys untouched). No regression test: the bug is touch-target geometry, and there is no behavior-level lane that exercises iOS touch hit-testing (iOS package tests do not run in CI); verification is on-simulator/on-device dogfood with tag `hintx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10883"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790369813&installation_model_id=21920&pr_number=10883&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10883&signature=8ca140079bf76c52b39f5a464cd8e41ce1eb9884d57ac0d5ec10f0e859a70f3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enlarges the iOS changes-hint banner dismiss button to the HIG default 44x44pt hit target so taps near the X dismiss the banner instead of opening the diff viewer.

The button previously had only about 22x22pt of tappable area, so taps aimed at the X often landed on the adjacent full-width open-changes button. No new user-facing strings and no migration needed; verification is manual on simulator or device.

<sup>Written for commit 3e44566a1f3e4e470780d9720c1d382fc99fb1fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the dismiss button’s tap area for more reliable interaction.
  * Increased the button’s touch target to meet standard accessibility sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->