### PR TITLE
cmux-tui: document the npx ENOTEMPTY cache failure and hint the fix in the launcher

### DIFF
--- a/cmux-tui/README.md
+++ b/cmux-tui/README.md
@@ -90,6 +90,8 @@ ssh -T dev@buildbox cmux relay --session agents
 
 The Unix-only `machine-agent` shares an existing local session through one outbound SSH registration with cmux.cloud. It prints a one-time pairing code and opens no listener. The final command is a low-level raw JSON-lines diagnostic. Use the machine rail or `cmux ssh` for the managed remote lifecycle.
 
+If `npx cmux@latest` fails with an npm `ENOTEMPTY: directory not empty, rename` error, the npx package cache is stale; see [Troubleshooting npx installs](docs/getting-started.md#troubleshooting-npx-installs).
+
 Use `--term <value>` to set `TERM` for child PTYs. Without it, children get `xterm-256color`; `CMUX_TUI_TERM` can override the terminal runtime default, with `CMUX_MUX_TERM` retained as a legacy fallback.
 
 ## Browser ownership

--- a/cmux-tui/dist/npm/cmux/bin/cmux.js
+++ b/cmux-tui/dist/npm/cmux/bin/cmux.js
@@ -35,7 +35,9 @@ try {
 } catch {
   console.error(
     `cmux: platform package ${pkg} is not installed. Reinstall cmux, ` +
-      `or set npm to install optional dependencies (--include=optional).`
+      `or set npm to install optional dependencies (--include=optional). ` +
+      `Under npx, a stale cache can also cause this (or an ENOTEMPTY rename ` +
+      `error during install): run \`rm -rf ~/.npm/_npx\` and retry.`
   );
   process.exit(1);
 }

--- a/cmux-tui/docs/getting-started.md
+++ b/cmux-tui/docs/getting-started.md
@@ -108,6 +108,26 @@ npx cmux machine-agent --session agents
 
 Run this command from an interactive terminal with `/dev/tty`; the agent fails closed without a controlling terminal, including on reconnects. The first registration prints the one-time code used by `+ ssh host` on cmux.cloud.
 
+## Troubleshooting npx installs
+
+`npx cmux@latest` can fail inside npm before cmux runs:
+
+```text
+npm error code ENOTEMPTY
+npm error syscall rename
+npm error path ~/.npm/_npx/<hash>/node_modules/cmux-tui-darwin-arm64
+npm error ENOTEMPTY: directory not empty, rename ...
+```
+
+This is a long-standing npm bug in the `npx` package cache, not a cmux failure. It triggers when the cache holds an older cmux version and npm upgrades it in place, and it hits packages with per-platform binary dependencies (cmux ships `cmux-tui-<platform>` optional dependencies) most often. Clear the npx cache and rerun:
+
+```bash
+rm -rf ~/.npm/_npx
+npx cmux@latest
+```
+
+A global install avoids the npx cache entirely: `npm install -g cmux`, then run `cmux` and upgrade with `npm install -g cmux@latest`.
+
 ## Sessions and sockets
 
 The default socket path is:


### PR DESCRIPTION
A user hit this on `npx cmux@latest`:

```text
npm error code ENOTEMPTY
npm error syscall rename
npm error path ~/.npm/_npx/<hash>/node_modules/cmux-tui-darwin-arm64
npm error ENOTEMPTY: directory not empty, rename ...
```

This is a long-standing npm bug in the npx package cache, reported across npm 8 through 10 (for example https://github.com/npm/cli/issues/4622). It triggers when the cache holds an older cmux version and npm upgrades it in place, and packages with per-platform binary optional dependencies hit it most often. The abort happens inside npm before `bin/cmux.js` runs, so no launcher code can prevent it. The standard workaround is `rm -rf ~/.npm/_npx`.

Changes:
- `docs/getting-started.md`: new "Troubleshooting npx installs" section with the error signature, cause, cache-clear workaround, and the global-install alternative that avoids the npx cache.
- `README.md`: one-line pointer to that section from the `npx cmux` usage block.
- `dist/npm/cmux/bin/cmux.js`: the missing-platform-package error now also mentions the stale npx cache and the cache-clear command, since a corrupt cache can produce that state too. The shim change ships with the next npm publish.

No behavior change beyond error text. No tests cover the shim; docs-level change otherwise.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10886"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790372838&installation_model_id=21920&pr_number=10886&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10886&signature=7fd61b956de4339f334bef3fa8f14afa8f79369c410b84046b190be6d1cf9a48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents a known npm bug that makes `npx cmux@latest` fail with an `ENOTEMPTY` rename error when the `~/.npm/_npx` cache holds an older cmux build, and points users to the cache-clear workaround.

- Adds a Troubleshooting npx installs section to `docs/getting-started.md` with the error signature, cause, `rm -rf ~/.npm/_npx` workaround, and global-install alternative.
- Links that section from the `npx cmux` usage block in `README.md`.
- The launcher's missing-platform-package error now also mentions the stale npx cache, since that state can produce the same failure.
- No behavior change beyond error text; the launcher change ships with the next npm publish.

<sup>Written for commit 8c83105dffeb234e4f4563cb6ac1670a0fa5e5f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guidance for resolving `npx` installation failures caused by stale npm cache entries.
  * Documented cache-clearing commands and a global installation alternative.
  * Added a link from the `cmux-tui` run instructions to the detailed troubleshooting section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->