### PR TITLE
cmux-tui: freeze operation catalog count at 125

### DIFF
--- a/cmux-tui/scripts/test_check_resource_api_boundary.py
+++ b/cmux-tui/scripts/test_check_resource_api_boundary.py
@@ -680,7 +680,7 @@ class ContractRegistryTests(unittest.TestCase):
         catalog = json.loads(
             (SCRIPT.parents[1] / "spec/resource-operations-v2.json").read_text(encoding="utf-8")
         )
-        self.assertEqual(len(catalog["operations"]), 124)
+        self.assertEqual(len(catalog["operations"]), 125)
         self.assertEqual(len(catalog["local_operations"]), 6)
         self.assertEqual(
             set(catalog["types"]["MachineSnapshot"]["fields"]),


### PR DESCRIPTION
main is red: [terminal.output_read](https://github.com/manaflow-ai/cmux/commit/0bb4bb3b4170) grew `spec/resource-operations-v2.json` and the Rust count tests to 125 operations but left the frozen assertion in `scripts/test_check_resource_api_boundary.py` at 124. The protocol-contract and inventory jobs of the cmux-tui SDKs workflow fail on main (run 33001341716) and on every PR merge ref. One line: 124 -> 125. `python3 cmux-tui/scripts/test_check_resource_api_boundary.py` passes locally with it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10890"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790373635&installation_model_id=21920&pr_number=10890&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10890&signature=ad816e17208f74b42684a1d105d8dbc4ba106670d6b9a5b7a7ea3da51794e3e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the frozen operation catalog count from 124 to 125 so the Python boundary test matches the current spec and Rust count tests. This fixes the failing protocol-contract and inventory jobs in the cmux-tui SDKs workflow.

<sup>Written for commit 4d9da6976c45c54c7cefd12b9ad3c6b9fc234554. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the live catalog regression check to reflect the current total of 125 operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->