### PR TITLE
ios: keep an 8pt seam between the terminal render and the composer bar

### DIFF
--- a/Packages/iOS/CmuxMobileTerminal/Package.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Package.swift
@@ -43,7 +43,7 @@ let package = Package(
         ),
         .testTarget(
             name: "CmuxMobileTerminalTests",
-            dependencies: ["CmuxMobileTerminal"],
+            dependencies: ["CmuxMobileTerminal", "CmuxMobileTerminalKit"],
             swiftSettings: [
                 .swiftLanguageMode(.v6),
             ],

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceHostView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceHostView.swift
@@ -45,7 +45,11 @@ import UIKit
 /// dock, whichever authority is seating it. `chrome` and `blank` change only
 /// on chrome mutations and content measurements. There is no settle-fold and
 /// no presentation rebasing: with no grid renegotiation there is nothing to
-/// mask.
+/// mask. While the chrome is visible the grid container additionally
+/// reserves `TerminalLetterboxGeometry.dockSeamPadding`, so the render's
+/// bottom edge rides that many points ABOVE the dock top instead of flush
+/// against the toolbar — the seam lives in the grid, not in these
+/// constraints, so the cap arithmetic above is unchanged.
 @MainActor
 public final class GhosttySurfaceHostView: UIView {
     public let surfaceView: GhosttySurfaceView
@@ -563,15 +567,17 @@ public final class GhosttySurfaceHostView: UIView {
         maximumTerminalDockPresentationGap
     }
 
-    /// The pixel seam between the render's bottom edge and the dock's top
-    /// edge. Both derive from one constraint system laid out in one pass, so
-    /// on every frame of every keyboard transition this must equal the
-    /// blank-space absorption slack (zero whenever content reaches the
+    /// The pixel deviation between the render's bottom edge and its designed
+    /// seat, `hostedDockSeamPadding` above the dock's top edge (the grid
+    /// container reserves that seam so content never sits flush against the
+    /// toolbar). Both edges derive from one constraint system laid out in one
+    /// pass, so on every frame of every keyboard transition this must equal
+    /// the blank-space absorption slack (zero whenever content reaches the
     /// composer bar).
     private var terminalDockPresentationGap: CGFloat {
         guard let terminalBottom = surfaceView.hostedTerminalPresentationBottom(in: self),
               let dockTop = surfaceView.hostedBottomDockPresentationTop(in: self) else { return 0 }
-        return abs(terminalBottom - dockTop)
+        return abs(terminalBottom - (dockTop - surfaceView.hostedDockSeamPadding))
     }
     #endif
 }

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -558,6 +558,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             "terminalDockPresentationGap=\(terminalDockPresentationGap)",
             "terminalDockMaxPresentationGap=\(maximumTerminalDockPresentationGap)",
             "keyboardSlack=\(keyboardSlack)",
+            "dockSeamPadding=\(pointValue(hostedDockSeamPadding))",
             "screenScale=\(pointValue(preferredScreenScale))",
             "bottomSafeArea=\(pointValue(safeAreaInsetsBottom))",
             "keyboardGuideTop=\(keyboardDockTargetTop)",
@@ -1395,13 +1396,21 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
 
     /// The steady-state bottom chrome band in points: what
     /// `renderWrapper.bottom` must sit BELOW the dock top so the full-height
-    /// render's bottom edge lands exactly on the dock top (composer bar).
-    /// Matches `bounds.height - layoutViewportRect.height` by construction and
-    /// never contains the keyboard.
+    /// render's bottom edge lands `hostedDockSeamPadding` above the dock top
+    /// (composer bar) — the grid container reserves that seam, so this
+    /// matches `bounds.height - layoutViewportRect.height - hostedDockSeamPadding`
+    /// by construction and never contains the keyboard.
     var hostedBottomChromeReservation: CGFloat {
         chromeHidden
             ? 0
             : max(0, composerBandHeight) + reservedToolbarHeight + safeAreaInsetsBottom
+    }
+
+    /// The seam the grid container reserves above the dock while the chrome
+    /// is visible: the render's bottom edge lands this many points above the
+    /// dock top instead of flush against the toolbar.
+    var hostedDockSeamPadding: CGFloat {
+        chromeHidden ? 0 : TerminalLetterboxGeometry.dockSeamPadding
     }
 
     func hostedBottomReservation(

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/TerminalDockSeamPaddingTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/TerminalDockSeamPaddingTests.swift
@@ -1,0 +1,41 @@
+#if canImport(UIKit)
+import CmuxMobileTerminalKit
+import CoreGraphics
+import Testing
+
+/// The bottom-pinned terminal render must not sit flush against the composer
+/// bar: while the chrome is visible the grid container reserves a small seam
+/// above the dock so the last row of content keeps clear air over the
+/// toolbar. With the chrome hidden there is no bar to keep clear of, so the
+/// grid still reclaims the full bounds.
+struct TerminalDockSeamPaddingTests {
+    // iPhone 16-ish portrait: 402x874 bounds, 34pt home indicator, 44pt
+    // toolbar, 120pt open composer band.
+    private static let phoneBounds = CGSize(width: 402, height: 874)
+
+    @Test("chrome-visible container reserves a seam above the composer bar")
+    func chromeVisibleReservesSeam() {
+        let size = TerminalLetterboxGeometry.terminalContainerSize(
+            bounds: Self.phoneBounds,
+            composerBandHeight: 120,
+            toolbarHeight: 44,
+            bottomSafeAreaInset: 34,
+            chromeHidden: false
+        )
+        // 874 - (34 safe area + 44 toolbar + 120 composer + 8 seam) = 668.
+        #expect(size.height == 668)
+    }
+
+    @Test("chrome hidden reclaims the full bounds — no seam without a bar")
+    func chromeHiddenHasNoSeam() {
+        let size = TerminalLetterboxGeometry.terminalContainerSize(
+            bounds: Self.phoneBounds,
+            composerBandHeight: 120,
+            toolbarHeight: 44,
+            bottomSafeAreaInset: 34,
+            chromeHidden: true
+        )
+        #expect(size.height == 874)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalLetterboxGeometry.swift
+++ b/Packages/iOS/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalLetterboxGeometry.swift
@@ -29,8 +29,19 @@ public struct TerminalLetterboxGeometry {
         keyboardHeight > 0 ? max(0, keyboardHeight) : max(0, bottomSafeAreaInset)
     }
 
+    /// The vertical seam kept between the rendered terminal's bottom edge and
+    /// the dock (composer bar) top while the bottom chrome is visible, in
+    /// points. Without it the last row of content sits flush against the
+    /// toolbar pills, which reads as crowding. Reserved inside the grid
+    /// container — never applied as a render offset — so the render still
+    /// rides the dock through the host's unchanged constraint system and
+    /// nothing clips; the render's bottom edge simply lands this many points
+    /// above the dock top.
+    public static let dockSeamPadding: CGFloat = 8
+
     /// The terminal grid container size after reserving the steady-state bottom
-    /// chrome (bottom safe area + composer band + persistent toolbar), in points.
+    /// chrome (bottom safe area + composer band + persistent toolbar) plus the
+    /// dock seam, in points.
     ///
     /// The keyboard is deliberately NOT an input. The grid keeps its
     /// keyboard-down size while the keyboard is up; the render is translated so
@@ -42,9 +53,9 @@ public struct TerminalLetterboxGeometry {
     /// keyboard toggles.
     ///
     /// - Chrome visible: the grid is the full bounds height minus the bottom
-    ///   safe area, the composer band, and the toolbar.
+    ///   safe area, the composer band, the toolbar, and `dockSeamPadding`.
     /// - Chrome hidden (HIDE button): the grid reclaims everything; nothing is
-    ///   reserved.
+    ///   reserved (there is no bar to keep a seam against).
     ///
     /// - Parameters:
     ///   - bounds: The host view bounds size in points.
@@ -63,6 +74,7 @@ public struct TerminalLetterboxGeometry {
         let reservedBottom: CGFloat = chromeHidden
             ? 0
             : max(0, composerBandHeight) + max(0, toolbarHeight) + max(0, bottomSafeAreaInset)
+                + dockSeamPadding
         let bottomInset = min(reservedBottom, max(0, bounds.height - 1))
         let containerW = max(1, bounds.width)
         let containerH = max(1, bounds.height - bottomInset)

--- a/Packages/iOS/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/TerminalLetterboxGeometryTests.swift
+++ b/Packages/iOS/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/TerminalLetterboxGeometryTests.swift
@@ -113,7 +113,7 @@ struct TerminalLetterboxGeometryTests {
     private static let toolbar: CGFloat = 44
     private static let keyboard: CGFloat = 336
 
-    @Test("bare container: full bounds minus only the safe area (no composer/toolbar)")
+    @Test("bare container: full bounds minus the safe area and the dock seam")
     func fullHeightBare() {
         let size = TerminalLetterboxGeometry.terminalContainerSize(
             bounds: Self.phoneBounds,
@@ -123,10 +123,10 @@ struct TerminalLetterboxGeometryTests {
             chromeHidden: false
         )
         #expect(size.width == 402)
-        #expect(size.height == 840) // 874 - 34
+        #expect(size.height == 832) // 874 - 34 - 8 seam
     }
 
-    @Test("chrome visible: reserves safe area + toolbar + composer band")
+    @Test("chrome visible: reserves safe area + toolbar + composer band + seam")
     func fullHeightWithChrome() {
         let composer: CGFloat = 120
         let size = TerminalLetterboxGeometry.terminalContainerSize(
@@ -136,8 +136,16 @@ struct TerminalLetterboxGeometryTests {
             bottomSafeAreaInset: Self.homeIndicator,
             chromeHidden: false
         )
-        // 874 - (34 safe area + 44 toolbar + 120 composer) = 676.
-        #expect(size.height == 676)
+        // 874 - (34 safe area + 44 toolbar + 120 composer + 8 seam) = 668.
+        #expect(size.height == 668)
+    }
+
+    // The seam is a design constant, not a derived value: the bottom-pinned
+    // render must keep a small band of clear air above the composer bar
+    // instead of pressing the last row of content into the toolbar pills.
+    @Test("dock seam padding is a small stable constant reserved in the grid")
+    func dockSeamPaddingContract() {
+        #expect(TerminalLetterboxGeometry.dockSeamPadding == 8)
     }
 
     // The keyboard is not a parameter of `terminalContainerSize` AT ALL: the

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/TerminalKeyboardFullHeightPinTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/TerminalKeyboardFullHeightPinTests.swift
@@ -127,10 +127,14 @@ struct TerminalKeyboardFullHeightPinTests {
             }
         }
 
-        // Initial handshake: a real render exists and its bottom edge sits on
-        // the dock top.
+        // Initial handshake: a real render exists and its bottom edge sits at
+        // the designed seat — `dockSeamPadding` above the dock top while the
+        // chrome is visible, so content never presses into the toolbar.
         #expect(await pump { !delegate.reports.isEmpty }, "no natural-grid report after attach")
-        #expect(await pump { gap() <= 1 }, "render bottom never attached to the dock top; gap=\(gap())")
+        #expect(
+            await pump { abs(gap() - view.hostedDockSeamPadding) <= 1 },
+            "render bottom never attached to its padded dock seat; gap=\(gap())"
+        )
 
         // Hand the seat to the plain bottom constraint and ride a keyboard.
         view.setChromeHidden(true)


### PR DESCRIPTION
The bottom-pinned terminal render sat flush against the composer bar's toolbar pills (Aziz dogfood screenshot, keyboard up). The grid container now reserves `TerminalLetterboxGeometry.dockSeamPadding` (8pt) whenever the bottom chrome is visible, so the render's bottom edge lands 8pt above the dock top in every keyboard state. Chrome-hidden still reclaims the full bounds since there is no bar to keep clear of.

The seam lives in the grid reservation, not in the host constraint system: the content cap, natural cap, and dock seat are byte-identical, nothing clips, the PTY grid shrinks by 8pt once at mount (never per keyboard toggle), and the debug probe keeps its `gap == keyboardSlack` contract by measuring the render edge against the padded seat (`dock.top - seam`). A `dockSeamPadding` probe key is added for UITest observability.

Commit 1 is the red regression test (grid must reserve the seam), commit 2 the implementation. `CmuxMobileTerminalKit` tests pass locally (118/118); the `cmuxFeatureTests` iroh mock build breakage on main (`MobileIrohRuntimeCompositionCooldownTests`) is pre-existing and untouched.

HIG basis: [Layout](https://developer.apple.com/design/human-interface-guidelines/layout) — keep content clear of interactive controls and give it breathing room instead of letting it crowd adjacent bars; 8pt is the platform's base spacing increment. [Virtual keyboards](https://developer.apple.com/design/human-interface-guidelines/virtual-keyboards) — "place custom controls above the keyboard thoughtfully": the composer bar is exactly such an input-accessory control stack riding the keyboard layout guide, and the seam keeps terminal content visually distinct from it. No intentional deviations.

Dictionary: **dock** = the composer band + persistent toolbar assembly pinned above the keyboard; **content cap** = the layout inequality that stops the render wrapper at the dock; **keyboardSlack** = keyboard intrusion absorbed by blank rows before the render slides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10895"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790376489&installation_model_id=21920&pr_number=10895&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10895&signature=9e1a196be3b7111e9d0e2b12be5f58e2071c6296f89718084457ab04c56f1cf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The bottom-pinned terminal render now keeps an 8pt seam above the composer bar while the chrome is visible, so the last row of content no longer presses into the toolbar pills.

- The grid container reserves `TerminalLetterboxGeometry.dockSeamPadding` (8pt) above the dock; chrome-hidden still reclaims the full bounds.
- The seam lives in the grid reservation, not the host constraint system, so the PTY grid shrinks once at mount and the render still rides the dock in every keyboard state.
- Adds a `dockSeamPadding` probe key and updates the debug `gap` contract to measure against the padded seat (`dock.top - seam`).

<sup>Written for commit 52461d180fa776920589b730b822c4fa74c265cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added an 8-point visual gap between the terminal render and the bottom composer dock when chrome is visible.
  * Improved terminal positioning so the rendered content sits above dock controls without overlap.
  * Preserved the full terminal height when bottom chrome is hidden.

* **Tests**
  * Added and updated coverage to verify dock spacing and terminal positioning across visible and hidden chrome states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
