### PR TITLE
iOS: back-button unread badge is a capsule so 99+ never overflows

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileLeadingToolbarTitleWidth.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileLeadingToolbarTitleWidth.swift
@@ -19,6 +19,13 @@ import CoreGraphics
 struct MobileLeadingToolbarTitleWidth {
     let contentWidth: CGFloat
     let hasBackButton: Bool
+    /// Other-workspace unread count folded into the back button. A badged
+    /// back button renders chevron + spacing + a mono badge circle, up to
+    /// ~32pt wider than the bare chevron; reserving only the bare width let
+    /// the title over-claim exactly when another workspace held unread, and
+    /// the resulting first-pass collapse is invisible to the recovery
+    /// ratchet, so it stuck until remount.
+    let backButtonUnreadCount: Int
     let hasTrailingCluster: Bool
     /// Sum of the measured content widths of the structurally visible trailing
     /// toolbar items, 0 until the first layout pass reports them.
@@ -37,6 +44,10 @@ struct MobileLeadingToolbarTitleWidth {
     let hadTrailingCollapse: Bool
 
     static let backButtonReserve: CGFloat = 44
+    /// Chevron-to-badge spacing plus the badge circle (18pt minimum, wider
+    /// for "99+"), matching WorkspaceBackButton's layout with slack.
+    static let backButtonBadgeReserve: CGFloat = 24
+    static let backButtonWideBadgeReserve: CGFloat = 32
     static let trailingReserveBase: CGFloat = 64
     /// Dogfood on a 402pt iPhone 17 measured ~22pt of dead gap between the
     /// title pill and the trailing capsule under the original 84pt margin +
@@ -61,6 +72,7 @@ struct MobileLeadingToolbarTitleWidth {
     init(
         contentWidth: CGFloat,
         hasBackButton: Bool,
+        backButtonUnreadCount: Int = 0,
         hasTrailingCluster: Bool,
         measuredTrailingItemsWidth: CGFloat = 0,
         measuredTrailingItemCount: Int = 0,
@@ -69,6 +81,7 @@ struct MobileLeadingToolbarTitleWidth {
     ) {
         self.contentWidth = contentWidth
         self.hasBackButton = hasBackButton
+        self.backButtonUnreadCount = backButtonUnreadCount
         self.hasTrailingCluster = hasTrailingCluster
         self.measuredTrailingItemsWidth = measuredTrailingItemsWidth
         self.measuredTrailingItemCount = measuredTrailingItemCount
@@ -78,9 +91,18 @@ struct MobileLeadingToolbarTitleWidth {
 
     var cap: CGFloat {
         guard contentWidth > 0 else { return Self.unmeasuredFallback }
-        let leading = hasBackButton ? Self.backButtonReserve : 0
         let recovery = hadTrailingCollapse ? Self.collapseRecoveryReserve : 0
-        return max(0, contentWidth - leading - trailingReserve - Self.barMarginsAndSpacing - recovery)
+        return max(0, contentWidth - leadingReserve - trailingReserve - Self.barMarginsAndSpacing - recovery)
+    }
+
+    private var leadingReserve: CGFloat {
+        guard hasBackButton else { return 0 }
+        guard backButtonUnreadCount > 0 else { return Self.backButtonReserve }
+        // WorkspaceBackButton caps the visible badge text at "99+".
+        let badge = backButtonUnreadCount > 99
+            ? Self.backButtonWideBadgeReserve
+            : Self.backButtonBadgeReserve
+        return Self.backButtonReserve + badge
     }
 
     private var trailingReserve: CGFloat {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileLeadingToolbarTitleWidth.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileLeadingToolbarTitleWidth.swift
@@ -44,10 +44,17 @@ struct MobileLeadingToolbarTitleWidth {
     let hadTrailingCollapse: Bool
 
     static let backButtonReserve: CGFloat = 44
-    /// Chevron-to-badge spacing plus the badge circle (18pt minimum, wider
-    /// for "99+"), matching WorkspaceBackButton's layout with slack.
+    /// Chevron-to-badge spacing (5pt) plus the badge capsule, matching
+    /// WorkspaceBackButton's layout with slack. The capsule is text width
+    /// + 10pt horizontal padding, floored at an 18pt circle: one digit stays
+    /// at the 18pt floor (23pt with spacing), two digits measure ~24.6pt
+    /// (~29.6), and the "99+" cap measures ~31.8pt (~36.8) in 11pt semibold
+    /// monospaced-digit SF. Each tier rounds up because an over-reserve only
+    /// truncates the title a few points earlier, while an under-reserve
+    /// re-creates the sticky first-pass More collapse.
     static let backButtonBadgeReserve: CGFloat = 24
-    static let backButtonWideBadgeReserve: CGFloat = 32
+    static let backButtonTwoDigitBadgeReserve: CGFloat = 32
+    static let backButtonWideBadgeReserve: CGFloat = 40
     static let trailingReserveBase: CGFloat = 64
     /// Dogfood on a 402pt iPhone 17 measured ~22pt of dead gap between the
     /// title pill and the trailing capsule under the original 84pt margin +
@@ -98,10 +105,13 @@ struct MobileLeadingToolbarTitleWidth {
     private var leadingReserve: CGFloat {
         guard hasBackButton else { return 0 }
         guard backButtonUnreadCount > 0 else { return Self.backButtonReserve }
-        // WorkspaceBackButton caps the visible badge text at "99+".
-        let badge = backButtonUnreadCount > 99
-            ? Self.backButtonWideBadgeReserve
-            : Self.backButtonBadgeReserve
+        // WorkspaceBackButton caps the visible badge text at "99+", so the
+        // capsule has exactly three widths: one digit, two digits, "99+".
+        let badge: CGFloat = switch backButtonUnreadCount {
+        case ..<10: Self.backButtonBadgeReserve
+        case ..<100: Self.backButtonTwoDigitBadgeReserve
+        default: Self.backButtonWideBadgeReserve
+        }
         return Self.backButtonReserve + badge
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceBackButton.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceBackButton.swift
@@ -20,13 +20,16 @@ struct WorkspaceBackButton: View {
                     .frame(width: 17, height: 22)
                 if unreadCount > 0 {
                     Text(countText)
-                        // Smaller than the chevron, on a small mono circle.
+                        // Smaller than the chevron, on a small mono badge. A
+                        // capsule stays a circle for one digit but widens into
+                        // a pill for "99+", so the count never overflows it.
                         .font(.caption2.weight(.semibold))
                         .monospacedDigit()
                         .foregroundStyle(badgeTextColor)
-                        .padding(2)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 2)
                         .frame(minWidth: 18, minHeight: 18)
-                        .background(badgeFillColor, in: .circle)
+                        .background(badgeFillColor, in: .capsule)
                 }
             }
         }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -421,6 +421,7 @@ struct WorkspaceDetailView: View {
         let value = WorkspaceTitleMenuValue(
             contentWidth: contentWidth,
             hasBackButton: backButtonConfiguration != nil,
+            backButtonUnreadCount: backButtonConfiguration?.unreadCount ?? 0,
             hasTrailingCluster: true,
             measuredTrailingItemsWidth: measuredWidths.reduce(0, +),
             measuredTrailingItemCount: measuredWidths.count,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenu.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenu.swift
@@ -32,6 +32,7 @@ struct WorkspaceTitleMenu<Label: View, MenuContent: View>: View, Equatable {
         let cap = MobileLeadingToolbarTitleWidth(
             contentWidth: value.contentWidth,
             hasBackButton: value.hasBackButton,
+            backButtonUnreadCount: value.backButtonUnreadCount,
             hasTrailingCluster: value.hasTrailingCluster,
             measuredTrailingItemsWidth: value.measuredTrailingItemsWidth,
             measuredTrailingItemCount: value.measuredTrailingItemCount,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenuValue.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenuValue.swift
@@ -4,6 +4,8 @@ import CoreGraphics
 struct WorkspaceTitleMenuValue: Equatable {
     let contentWidth: CGFloat
     let hasBackButton: Bool
+    /// Badge-aware back reserve; see `MobileLeadingToolbarTitleWidth`.
+    let backButtonUnreadCount: Int
     let hasTrailingCluster: Bool
     let measuredTrailingItemsWidth: CGFloat
     let measuredTrailingItemCount: Int

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileLeadingToolbarTitleWidthTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileLeadingToolbarTitleWidthTests.swift
@@ -177,3 +177,61 @@ import Testing
             >= MobileLeadingToolbarTitleWidth.unmeasuredTrailingItemReserve)
     }
 }
+
+extension MobileLeadingToolbarTitleWidthTests {
+    @Test func badgedBackButtonShrinksTheTitle() {
+        // iOS 27 sim dogfood: opening a workspace while another held unread
+        // rendered the chevron + badge back button ~24pt wider than the bare
+        // chevron the reserve assumed, folding the picker into the More menu
+        // from the first pass, invisibly to the recovery ratchet.
+        let bare = MobileLeadingToolbarTitleWidth(
+            contentWidth: 402,
+            hasBackButton: true,
+            hasTrailingCluster: true,
+            measuredTrailingItemsWidth: 126,
+            measuredTrailingItemCount: 2,
+            trailingItemCount: 2
+        )
+        let badged = MobileLeadingToolbarTitleWidth(
+            contentWidth: 402,
+            hasBackButton: true,
+            backButtonUnreadCount: 3,
+            hasTrailingCluster: true,
+            measuredTrailingItemsWidth: 126,
+            measuredTrailingItemCount: 2,
+            trailingItemCount: 2
+        )
+        let wideBadge = MobileLeadingToolbarTitleWidth(
+            contentWidth: 402,
+            hasBackButton: true,
+            backButtonUnreadCount: 250,
+            hasTrailingCluster: true,
+            measuredTrailingItemsWidth: 126,
+            measuredTrailingItemCount: 2,
+            trailingItemCount: 2
+        )
+
+        #expect(bare.cap - badged.cap
+            == MobileLeadingToolbarTitleWidth.backButtonBadgeReserve)
+        #expect(bare.cap - wideBadge.cap
+            == MobileLeadingToolbarTitleWidth.backButtonWideBadgeReserve)
+    }
+
+    @Test func badgeWithoutBackButtonReservesNothing() {
+        let value = MobileLeadingToolbarTitleWidth(
+            contentWidth: 402,
+            hasBackButton: false,
+            backButtonUnreadCount: 5,
+            hasTrailingCluster: true,
+            trailingItemCount: 1
+        )
+        let bare = MobileLeadingToolbarTitleWidth(
+            contentWidth: 402,
+            hasBackButton: false,
+            hasTrailingCluster: true,
+            trailingItemCount: 1
+        )
+
+        #expect(value.cap == bare.cap)
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileLeadingToolbarTitleWidthTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileLeadingToolbarTitleWidthTests.swift
@@ -201,6 +201,15 @@ extension MobileLeadingToolbarTitleWidthTests {
             measuredTrailingItemCount: 2,
             trailingItemCount: 2
         )
+        let twoDigitBadge = MobileLeadingToolbarTitleWidth(
+            contentWidth: 402,
+            hasBackButton: true,
+            backButtonUnreadCount: 42,
+            hasTrailingCluster: true,
+            measuredTrailingItemsWidth: 126,
+            measuredTrailingItemCount: 2,
+            trailingItemCount: 2
+        )
         let wideBadge = MobileLeadingToolbarTitleWidth(
             contentWidth: 402,
             hasBackButton: true,
@@ -213,8 +222,14 @@ extension MobileLeadingToolbarTitleWidthTests {
 
         #expect(bare.cap - badged.cap
             == MobileLeadingToolbarTitleWidth.backButtonBadgeReserve)
+        #expect(bare.cap - twoDigitBadge.cap
+            == MobileLeadingToolbarTitleWidth.backButtonTwoDigitBadgeReserve)
         #expect(bare.cap - wideBadge.cap
             == MobileLeadingToolbarTitleWidth.backButtonWideBadgeReserve)
+        // The capsule widens with the glyph count; the reserve must never
+        // shrink as the count grows.
+        #expect(badged.cap > twoDigitBadge.cap)
+        #expect(twoDigitBadge.cap > wideBadge.cap)
     }
 
     @Test func badgeWithoutBackButtonReservesNothing() {

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceTitleMenuValueTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceTitleMenuValueTests.swift
@@ -62,6 +62,7 @@ import Testing
         WorkspaceTitleMenuValue(
             contentWidth: 390,
             hasBackButton: true,
+            backButtonUnreadCount: 0,
             hasTrailingCluster: true,
             measuredTrailingItemsWidth: 0,
             measuredTrailingItemCount: 0,


### PR DESCRIPTION
The workspace back button folds the unread-workspace count into the button. Two defects around it:

**Badge overflow.** The count text used `.background(fill, in: .circle)` inside `frame(minWidth: 18)`; a SwiftUI circle in a wide rect keeps the smaller dimension (18pt) as its diameter, so the three-glyph "99+" cap spilled outside the circle on both sides. Fix: draw the fill as a capsule with 5pt horizontal padding. A single digit still resolves to the same 18pt circle, and wider counts widen into a pill that always contains the text.

**Toolbar More collapse with a badged back button.** The leading title cap reserved a flat 44pt for the back button, so any badge made the title over-claim and iOS folded the terminal picker into the system More menu from the first layout pass, invisible to the collapse-recovery ratchet (sticky until remount). This PR cherry-picks the open fix from https://github.com/manaflow-ai/cmux/pull/10790 (badge-aware `backButtonUnreadCount` reserve) and retiers its constants for the capsule geometry, which is wider than the old clipped circle at two-digit and 99+ counts. Measured in 11pt semibold monospaced-digit SF (badge + 5pt chevron spacing): one digit 23pt, two digits ~29.6pt, "99+" ~36.8pt → tiers 24/32/40. Tiers round up because an over-reserve only truncates the title a few points earlier, while an under-reserve re-creates the sticky collapse. Unit tests cover all three tiers and monotonicity.

HIG check: [Tab bars](https://developer.apple.com/design/human-interface-guidelines/tab-bars) describes badges as "a red oval containing white text", an oval that stretches with content, which is what this restores. cmux keeps its existing deliberate deviation of monochrome badge colors matched to the toolbar contrast.

Verified live in the isolated simulator `cmux-dev-bkbdg` (iPhone 17, iOS 27) against a tagged Mac seeded with 100+ unread workspaces: "99+" renders fully inside the pill, count 1 renders as the unchanged 18pt circle, and the freshly mounted detail toolbar keeps the terminal picker in the bar (no More fold) with the badge at its widest. Localization audit: no user-facing strings added or changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace title layout when the back button displays unread-count badges.
  * Added support for single-digit, multi-digit, and `99+` badges without overlapping the title.
  * Updated unread badges to expand into pill-shaped capsules for larger counts.

* **Tests**
  * Added coverage for badge-aware title sizing and back-button scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->