### PR TITLE
Fix Dock resize when adjacent pane is a browser (#10892)

### DIFF
--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -2876,10 +2876,12 @@ final class WindowBrowserPortal: NSObject {
         guard let containerView = entry.containerView else { return }
         if let context {
             containerView.setPaneDropContext(context)
-        } else if entry.visibleInUI, !containerView.isHidden {
-            // A visible portal can lose its SwiftUI routing snapshot during
-            // reparenting. Keep the stable Dock ownership until the portal is
-            // actually hidden or released.
+        } else if !containerView.isHidden {
+            // A mounted portal can lose its SwiftUI routing snapshot during
+            // reparenting before the entry's visibility flag catches up. Use
+            // the physical slot state here: while the slot is still visible,
+            // retain its stable Dock ownership until a real hide/release path
+            // calls clearPaneDropContext().
             containerView.setPaneDropContext(nil)
         } else {
             containerView.clearPaneDropContext()

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -2451,6 +2451,10 @@ final class WindowBrowserPortal: NSObject {
         if let existing = entry.containerView {
             if let paneDropContext = entry.paneDropContext {
                 existing.setPaneDropContext(paneDropContext)
+            } else if entry.visibleInUI, !existing.isHidden {
+                // Keep a visible slot's stable ownership while its entry is
+                // being rebound during the same transient recovery window.
+                existing.setPaneDropContext(nil)
             } else {
                 existing.clearPaneDropContext()
             }

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -2451,12 +2451,11 @@ final class WindowBrowserPortal: NSObject {
         if let existing = entry.containerView {
             if let paneDropContext = entry.paneDropContext {
                 existing.setPaneDropContext(paneDropContext)
-            } else if entry.visibleInUI, !existing.isHidden {
-                // Keep a visible slot's stable ownership while its entry is
-                // being rebound during the same transient recovery window.
-                existing.setPaneDropContext(nil)
             } else {
-                existing.clearPaneDropContext()
+                // A missing entry snapshot is a transient routing gap during
+                // portal rebinds. Keep the slot's stable ownership until an
+                // explicit hide/release path clears it.
+                existing.setPaneDropContext(nil)
             }
             existing.setSearchOverlay(entry.searchOverlay)
             existing.setDesignComposer(entry.designComposer)

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -1315,10 +1315,21 @@ final class WindowBrowserSlotView: NSView {
 
     func setPaneDropContext(_ context: BrowserPaneDropContext?) {
         paneDropTargetView.dropContext = context
-        // The pane context is the authoritative ownership snapshot. Resolving
-        // through AppDelegate here raced Dock creation/split callbacks and
-        // permanently classified a Dock browser as a main-area slot.
-        isRightSidebarDockSlot = context?.isDockHosted == true
+        // The pane context is the authoritative ownership snapshot whenever it
+        // is available. A nil context is also used by portal recovery while a
+        // visible slot keeps its frame, so do not erase the stable Dock
+        // classification during that transient routing-context gap.
+        if let context {
+            isRightSidebarDockSlot = context.isDockHosted
+        }
+    }
+
+    /// Clears both the active drop-routing context and the stable Dock
+    /// ownership classification. This is for a real hide/release, not for the
+    /// transient context gaps that occur while a visible portal is reparented.
+    func clearPaneDropContext() {
+        paneDropTargetView.dropContext = nil
+        isRightSidebarDockSlot = false
     }
 
     var currentPaneDropContext: BrowserPaneDropContext? {
@@ -2438,7 +2449,11 @@ final class WindowBrowserPortal: NSObject {
 
     private func ensureContainerView(for entry: Entry, webView: WKWebView) -> WindowBrowserSlotView {
         if let existing = entry.containerView {
-            existing.setPaneDropContext(entry.paneDropContext)
+            if let paneDropContext = entry.paneDropContext {
+                existing.setPaneDropContext(paneDropContext)
+            } else {
+                existing.clearPaneDropContext()
+            }
             existing.setSearchOverlay(entry.searchOverlay)
             existing.setDesignComposer(entry.designComposer)
             existing.setOmnibarSuggestions(entry.omnibarSuggestions)
@@ -2446,7 +2461,9 @@ final class WindowBrowserPortal: NSObject {
             return existing
         }
         let created = WindowBrowserSlotView(frame: .zero)
-        created.setPaneDropContext(entry.paneDropContext)
+        if let paneDropContext = entry.paneDropContext {
+            created.setPaneDropContext(paneDropContext)
+        }
         created.setSearchOverlay(entry.searchOverlay)
         created.setDesignComposer(entry.designComposer)
         created.setOmnibarSuggestions(entry.omnibarSuggestions)
@@ -2853,7 +2870,17 @@ final class WindowBrowserPortal: NSObject {
         guard entry.paneDropContext != context else { return }
         entry.paneDropContext = context
         entriesByWebViewId[webViewId] = entry
-        entry.containerView?.setPaneDropContext(context)
+        guard let containerView = entry.containerView else { return }
+        if let context {
+            containerView.setPaneDropContext(context)
+        } else if entry.visibleInUI, !containerView.isHidden {
+            // A visible portal can lose its SwiftUI routing snapshot during
+            // reparenting. Keep the stable Dock ownership until the portal is
+            // actually hidden or released.
+            containerView.setPaneDropContext(nil)
+        } else {
+            containerView.clearPaneDropContext()
+        }
     }
 
     func paneDropContext(forWebViewId webViewId: ObjectIdentifier) -> BrowserPaneDropContext? {
@@ -3012,12 +3039,22 @@ final class WindowBrowserPortal: NSObject {
         )
     }
 
-    func bind(webView: WKWebView, to anchorView: NSView, visibleInUI: Bool, zPriority: Int = 0) {
+    func bind(
+        webView: WKWebView,
+        to anchorView: NSView,
+        visibleInUI: Bool,
+        zPriority: Int = 0,
+        paneDropContext: BrowserPaneDropContext? = nil
+    ) {
         guard ensureInstalled() else { return }
 
         let webViewId = ObjectIdentifier(webView)
         let anchorId = ObjectIdentifier(anchorView)
         let previousEntry = entriesByWebViewId[webViewId]
+        // A non-nil context supplied by a reconciler is an atomic ownership
+        // seed. Otherwise retain the entry snapshot until SwiftUI delivers its
+        // next authoritative update.
+        let resolvedPaneDropContext = paneDropContext ?? previousEntry?.paneDropContext
         let shouldPreserveExternalFullscreenHost =
             webView.cmuxIsManagedByExternalFullscreenWindow(relativeTo: window)
         let containerView = ensureContainerView(
@@ -3068,7 +3105,7 @@ final class WindowBrowserPortal: NSObject {
             visibleInUI: visibleInUI,
             zPriority: zPriority,
             dropZone: previousEntry?.dropZone,
-            paneDropContext: previousEntry?.paneDropContext,
+            paneDropContext: resolvedPaneDropContext,
             searchOverlay: previousEntry?.searchOverlay,
             designComposer: previousEntry?.designComposer,
             omnibarSuggestions: previousEntry?.omnibarSuggestions,
@@ -3076,6 +3113,11 @@ final class WindowBrowserPortal: NSObject {
             transientRecoveryReason: previousEntry?.transientRecoveryReason,
             transientRecoveryRetriesRemaining: previousEntry?.transientRecoveryRetriesRemaining ?? 0
         )
+        if let resolvedPaneDropContext {
+            containerView.setPaneDropContext(resolvedPaneDropContext)
+        } else if previousEntry == nil {
+            containerView.clearPaneDropContext()
+        }
 
         let didChangeAnchor: Bool = {
             guard let previousAnchor = previousEntry?.anchorView else { return true }
@@ -3273,7 +3315,7 @@ final class WindowBrowserPortal: NSObject {
             containerView.setSearchOverlay(nil)
             containerView.setDesignComposer(nil)
             containerView.setOmnibarSuggestions(nil)
-            containerView.setPaneDropContext(nil)
+            containerView.clearPaneDropContext()
             containerView.setPortalDragDropZone(nil)
             containerView.setDropZoneOverlay(zone: nil)
             // Tab/workspace visibility changes should hide the portal slot without forcing
@@ -3717,7 +3759,11 @@ final class WindowBrowserPortal: NSObject {
         containerView.setSearchOverlay(shouldHide ? nil : entry.searchOverlay)
         containerView.setDesignComposer(shouldHide ? nil : entry.designComposer)
         containerView.setOmnibarSuggestions(shouldHide ? nil : entry.omnibarSuggestions)
-        containerView.setPaneDropContext(containerView.isHidden ? nil : entry.paneDropContext)
+        if containerView.isHidden {
+            containerView.clearPaneDropContext()
+        } else {
+            containerView.setPaneDropContext(entry.paneDropContext)
+        }
         containerView.setDropZoneOverlay(zone: containerView.isHidden ? nil : entry.dropZone)
         if revealedForDisplay {
             refreshReasons.append("reveal")
@@ -3991,7 +4037,13 @@ enum BrowserWindowPortalRegistry {
         return portal
     }
 
-    static func bind(webView: WKWebView, to anchorView: NSView, visibleInUI: Bool, zPriority: Int = 0) {
+    static func bind(
+        webView: WKWebView,
+        to anchorView: NSView,
+        visibleInUI: Bool,
+        zPriority: Int = 0,
+        paneDropContext: BrowserPaneDropContext? = nil
+    ) {
         guard let window = anchorView.window else { return }
 
         let windowId = ObjectIdentifier(window)
@@ -4003,7 +4055,13 @@ enum BrowserWindowPortalRegistry {
             portalsByWindowId[oldWindowId]?.detachWebView(withId: webViewId)
         }
 
-        nextPortal.bind(webView: webView, to: anchorView, visibleInUI: visibleInUI, zPriority: zPriority)
+        nextPortal.bind(
+            webView: webView,
+            to: anchorView,
+            visibleInUI: visibleInUI,
+            zPriority: zPriority,
+            paneDropContext: paneDropContext
+        )
         webViewToWindowId[webViewId] = windowId
         pruneWebViewMappings(for: windowId, validWebViewIds: nextPortal.webViewIds())
         postRegistryDidChange(for: webView)

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -1315,7 +1315,10 @@ final class WindowBrowserSlotView: NSView {
 
     func setPaneDropContext(_ context: BrowserPaneDropContext?) {
         paneDropTargetView.dropContext = context
-        isRightSidebarDockSlot = context.map { AppDelegate.shared?.dockForPane($0.paneId) != nil } ?? false
+        // The pane context is the authoritative ownership snapshot. Resolving
+        // through AppDelegate here raced Dock creation/split callbacks and
+        // permanently classified a Dock browser as a main-area slot.
+        isRightSidebarDockSlot = context?.isDockHosted == true
     }
 
     var currentPaneDropContext: BrowserPaneDropContext? {

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -694,6 +694,15 @@ final class WindowBrowserHostView: NSView {
             return false
         }
 
+        // The portal is installed above the SwiftUI content, so its cached slot
+        // frames can lag the native divider while a right-sidebar resize is in
+        // flight. Ask the live view hierarchy underneath the portal first. This
+        // delegates ownership to the actual synchronous tracker whenever the
+        // AppKit sidebar path is active, independent of portal geometry timing.
+        if shouldPassThroughToLiveSidebarDivider(at: point) {
+            return true
+        }
+
         // Browser portal host sits above SwiftUI content. Allow pointer/mouse events
         // to reach the SwiftUI sidebar divider resizer zone.
         let visibleSlots = subviews.compactMap { $0 as? WindowBrowserSlotView }
@@ -762,6 +771,37 @@ final class WindowBrowserHostView: NSView {
         let trailingGap = bounds.maxX - dividerX
         guard trailingGap > Self.minimumVisibleLeadingContentWidth else { return false }
         return SidebarResizeInteraction.Edge.trailing.hitRange(dividerX: dividerX).contains(point.x)
+    }
+
+    private func shouldPassThroughToLiveSidebarDivider(at point: NSPoint) -> Bool {
+        guard let rootView = dividerSearchRootView(),
+              let hostIndex = rootView.subviews.firstIndex(where: { $0 === self }),
+              let window else {
+            return false
+        }
+
+        let windowPoint = convert(point, to: nil)
+        for sibling in rootView.subviews[..<hostIndex].reversed() {
+            guard sibling.window === window,
+                  !sibling.isHidden,
+                  sibling.alphaValue > 0 else {
+                continue
+            }
+            let pointInSibling = sibling.convert(windowPoint, from: nil)
+            guard sibling.bounds.contains(pointInSibling),
+                  let hitView = sibling.hitTest(pointInSibling) else {
+                continue
+            }
+
+            var current: NSView? = hitView
+            while let view = current {
+                if view is SidebarDividerTrackingView {
+                    return true
+                }
+                current = view.superview
+            }
+        }
+        return false
     }
 
     private func updateDividerCursor(
@@ -3320,7 +3360,14 @@ final class WindowBrowserPortal: NSObject {
             containerView.setSearchOverlay(nil)
             containerView.setDesignComposer(nil)
             containerView.setOmnibarSuggestions(nil)
-            containerView.clearPaneDropContext()
+            if entry.visibleInUI {
+                // Anchor/geometry recovery can hide a still-owned slot for one
+                // pass. Keep its Dock classification through that transient
+                // state; an explicit visibility update or release clears it.
+                containerView.setPaneDropContext(nil)
+            } else {
+                containerView.clearPaneDropContext()
+            }
             containerView.setPortalDragDropZone(nil)
             containerView.setDropZoneOverlay(zone: nil)
             // Tab/workspace visibility changes should hide the portal slot without forcing
@@ -3765,7 +3812,13 @@ final class WindowBrowserPortal: NSObject {
         containerView.setDesignComposer(shouldHide ? nil : entry.designComposer)
         containerView.setOmnibarSuggestions(shouldHide ? nil : entry.omnibarSuggestions)
         if containerView.isHidden {
-            containerView.clearPaneDropContext()
+            if entry.visibleInUI {
+                // The hidden slot may be waiting for a transient anchor/window
+                // recovery. Preserve ownership until the slot is truly released.
+                containerView.setPaneDropContext(nil)
+            } else {
+                containerView.clearPaneDropContext()
+            }
         } else {
             containerView.setPaneDropContext(entry.paneDropContext)
         }

--- a/Sources/DockSplitStore+PortalReconcile.swift
+++ b/Sources/DockSplitStore+PortalReconcile.swift
@@ -277,6 +277,16 @@ extension DockSplitStore {
                 paneDropContext: paneDropContext
             )
         }
+        if let paneDropContext {
+            // Reconciliation can observe an already-bound portal whose SwiftUI
+            // update has not delivered its Dock context yet. Refresh ownership
+            // independently of the attachment/readiness check so that an
+            // existing slot cannot remain classified as ordinary content.
+            BrowserWindowPortalRegistry.updatePaneDropContext(
+                for: webView,
+                context: paneDropContext
+            )
+        }
 
         if !wasReady && !dockBrowserPortalReady(browser) {
             BrowserWindowPortalRegistry.synchronizeForAnchor(anchorView)

--- a/Sources/DockSplitStore+PortalReconcile.swift
+++ b/Sources/DockSplitStore+PortalReconcile.swift
@@ -249,6 +249,14 @@ extension DockSplitStore {
         guard dockBrowserPortalAnchorReady(anchorView) else { return true }
 
         let webView = browser.webView
+        let paneDropContext = paneId(forPanelId: browser.id).map {
+            BrowserPaneDropContext(
+                workspaceId: workspaceId,
+                panelId: browser.id,
+                paneId: $0,
+                isDockHosted: true
+            )
+        }
         let snapshot = BrowserWindowPortalRegistry.debugSnapshot(for: webView)
         if snapshot?.visibleInUI == false {
             BrowserWindowPortalRegistry.updateEntryVisibility(
@@ -265,7 +273,8 @@ extension DockSplitStore {
                 webView: webView,
                 to: anchorView,
                 visibleInUI: true,
-                zPriority: 1
+                zPriority: 1,
+                paneDropContext: paneDropContext
             )
         }
 

--- a/Sources/DockSplitStore+PortalReconcile.swift
+++ b/Sources/DockSplitStore+PortalReconcile.swift
@@ -277,16 +277,15 @@ extension DockSplitStore {
                 paneDropContext: paneDropContext
             )
         }
-        if let paneDropContext {
-            // Reconciliation can observe an already-bound portal whose SwiftUI
-            // update has not delivered its Dock context yet. Refresh ownership
-            // independently of the attachment/readiness check so that an
-            // existing slot cannot remain classified as ordinary content.
-            BrowserWindowPortalRegistry.updatePaneDropContext(
-                for: webView,
-                context: paneDropContext
-            )
-        }
+        // Reconciliation is also responsible for clearing an obsolete active
+        // drop target when the panel-to-pane mapping briefly disappears. The
+        // portal keeps Dock divider ownership separately while its visible slot
+        // is mounted, so a nil context is safe here and will not lose the
+        // trailing-edge hit-test classification.
+        BrowserWindowPortalRegistry.updatePaneDropContext(
+            for: webView,
+            context: paneDropContext
+        )
 
         if !wasReady && !dockBrowserPortalReady(browser) {
             BrowserWindowPortalRegistry.synchronizeForAnchor(anchorView)

--- a/Sources/PaneDropRoutingSupport.swift
+++ b/Sources/PaneDropRoutingSupport.swift
@@ -16,6 +16,22 @@ struct PaneDropContext: Equatable {
     let workspaceId: UUID
     let panelId: UUID
     let paneId: PaneID
+    /// Whether the target pane is owned by a right-sidebar Dock rather than a
+    /// workspace's main Bonsplit tree. This travels with the pane snapshot so
+    /// portal hit-testing does not depend on a transient global lookup.
+    let isDockHosted: Bool
+
+    init(
+        workspaceId: UUID,
+        panelId: UUID,
+        paneId: PaneID,
+        isDockHosted: Bool = false
+    ) {
+        self.workspaceId = workspaceId
+        self.panelId = panelId
+        self.paneId = paneId
+        self.isDockHosted = isDockHosted
+    }
 }
 
 typealias TerminalPaneDropContext = PaneDropContext

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -5539,6 +5539,10 @@ struct WebViewRepresentable: NSViewRepresentable {
         private var hostedWebViewConstraints: [NSLayoutConstraint] = []
         private weak var localInlineSlotView: WindowBrowserSlotView?
         private var localInlineSlotConstraints: [NSLayoutConstraint] = []
+        // The SwiftUI anchor remains mounted while the live web view is
+        // reparented into WindowBrowserHostView. It must not remain an
+        // AppKit hit-test target during that portal-owned interval.
+        private var isWindowPortalHosting = false
         private weak var hostedInspectorSideDockContainerView: HostedInspectorSideDockContainerView?
         private var hostedInspectorSideDockConstraints: [NSLayoutConstraint] = []
         private weak var hostedInspectorFrontendWebView: WKWebView?
@@ -6042,6 +6046,7 @@ struct WebViewRepresentable: NSViewRepresentable {
         }
 
         func prepareForWindowPortalHosting() {
+            isWindowPortalHosting = true
             cancelHostedWebKitPresentationRefresh()
             hostedInspectorDockConfigurationSyncScheduler.cancel()
             notifyHostedWebKitHidden(reason: "prepareForWindowPortalHosting")
@@ -6049,6 +6054,10 @@ struct WebViewRepresentable: NSViewRepresentable {
             hostedInspectorFrontendWebView = nil
             lastHostedInspectorManualSideDockAllowed = nil
             lastHostedInspectorDetachedFromHostWindow = nil
+        }
+
+        func setWindowPortalHosting(_ isHosting: Bool) {
+            isWindowPortalHosting = isHosting
         }
 
         func clearStaleHostedInspectorOwnershipState() {
@@ -6503,6 +6512,10 @@ struct WebViewRepresentable: NSViewRepresentable {
         }
 
         override func hitTest(_ point: NSPoint) -> NSView? {
+            // WindowBrowserHostView owns the live web view while portal mode is
+            // active. Returning nil here prevents a retained, transparent
+            // SwiftUI anchor from stealing the sidebar divider underneath it.
+            guard !isWindowPortalHosting else { return nil }
             let hostedInspectorHit = hostedInspectorDividerHit(at: point)
             updateDividerCursor(at: point, hostedInspectorHit: hostedInspectorHit)
             let passThrough = shouldPassThroughToSidebarResizer(at: point, hostedInspectorHit: hostedInspectorHit)
@@ -7375,6 +7388,7 @@ struct WebViewRepresentable: NSViewRepresentable {
 
     private func updateUsingLocalInlineHosting(_ nsView: NSView, context: Context, webView: WKWebView) -> Bool {
         guard let host = nsView as? HostContainerView else { return false }
+        host.setWindowPortalHosting(false)
         let slotView = host.ensureLocalInlineSlotView()
         slotView.setDesignComposer(designComposer)
         let isAlreadyInLocalHost = host.containsManagedLocalInlineContent(webView)
@@ -7994,7 +8008,8 @@ struct WebViewRepresentable: NSViewRepresentable {
             return BrowserPaneDropContext(
                 workspaceId: panel.workspaceId,
                 panelId: panel.id,
-                paneId: paneId
+                paneId: paneId,
+                isDockHosted: true
             )
         }
         guard let app = AppDelegate.shared,
@@ -8006,7 +8021,8 @@ struct WebViewRepresentable: NSViewRepresentable {
         return BrowserPaneDropContext(
             workspaceId: panel.workspaceId,
             panelId: panel.id,
-            paneId: resolvedPaneId
+            paneId: resolvedPaneId,
+            isDockHosted: false
         )
     }
 }

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -7663,7 +7663,8 @@ struct WebViewRepresentable: NSViewRepresentable {
         host.onDidMoveToWindow = { [weak host, weak webView, weak coordinator, weak portalAnchorView, weak browserPanel = panel] in
             guard let host, let webView, let coordinator, let portalAnchorView, let browserPanel else { return }
             guard coordinator.attachGeneration == generation else { return }
-            guard currentPaneDropContext()?.paneId.id == paneId.id else { return }
+            guard let currentPaneDropContext = currentPaneDropContext(),
+                  currentPaneDropContext.paneId.id == paneId.id else { return }
             guard browserPanel.claimPortalHost(
                 hostId: ObjectIdentifier(host),
                 paneId: paneId,
@@ -7677,7 +7678,8 @@ struct WebViewRepresentable: NSViewRepresentable {
                 webView: webView,
                 to: portalAnchorView,
                 visibleInUI: coordinator.desiredPortalVisibleInUI,
-                zPriority: coordinator.desiredPortalZPriority
+                zPriority: coordinator.desiredPortalZPriority,
+                paneDropContext: currentPaneDropContext
             )
             BrowserWindowPortalRegistry.refresh(
                 webView: webView,
@@ -7687,7 +7689,7 @@ struct WebViewRepresentable: NSViewRepresentable {
                 for: webView,
                 height: coordinator.desiredPortalVisibleInUI ? paneTopChromeHeight : 0
             )
-            BrowserWindowPortalRegistry.updatePaneDropContext(for: webView, context: activePaneDropContext)
+            BrowserWindowPortalRegistry.updatePaneDropContext(for: webView, context: currentPaneDropContext)
             BrowserWindowPortalRegistry.updateSearchOverlay(for: webView, configuration: activeSearchOverlay)
             BrowserWindowPortalRegistry.updateDesignComposer(for: webView, configuration: activeDesignComposer)
             BrowserWindowPortalRegistry.updateOmnibarSuggestions(for: webView, configuration: activeOmnibarSuggestions)
@@ -7697,7 +7699,8 @@ struct WebViewRepresentable: NSViewRepresentable {
         host.onGeometryChanged = { [weak host, weak webView, weak coordinator, weak portalAnchorView, weak browserPanel = panel] in
             guard let host, let webView, let coordinator, let portalAnchorView, let browserPanel else { return }
             guard coordinator.attachGeneration == generation else { return }
-            guard currentPaneDropContext()?.paneId.id == paneId.id else { return }
+            guard let currentPaneDropContext = currentPaneDropContext(),
+                  currentPaneDropContext.paneId.id == paneId.id else { return }
             guard browserPanel.claimPortalHost(
                 hostId: ObjectIdentifier(host),
                 paneId: paneId,
@@ -7714,7 +7717,8 @@ struct WebViewRepresentable: NSViewRepresentable {
                     webView: webView,
                     to: portalAnchorView,
                     visibleInUI: coordinator.desiredPortalVisibleInUI,
-                    zPriority: coordinator.desiredPortalZPriority
+                    zPriority: coordinator.desiredPortalZPriority,
+                    paneDropContext: currentPaneDropContext
                 )
                 BrowserWindowPortalRegistry.refresh(
                     webView: webView,
@@ -7724,7 +7728,7 @@ struct WebViewRepresentable: NSViewRepresentable {
                     for: webView,
                     height: coordinator.desiredPortalVisibleInUI ? paneTopChromeHeight : 0
                 )
-                BrowserWindowPortalRegistry.updatePaneDropContext(for: webView, context: activePaneDropContext)
+                BrowserWindowPortalRegistry.updatePaneDropContext(for: webView, context: currentPaneDropContext)
                 BrowserWindowPortalRegistry.updateSearchOverlay(for: webView, configuration: activeSearchOverlay)
                 BrowserWindowPortalRegistry.updateDesignComposer(for: webView, configuration: activeDesignComposer)
                 BrowserWindowPortalRegistry.updateOmnibarSuggestions(for: webView, configuration: activeOmnibarSuggestions)
@@ -7757,7 +7761,8 @@ struct WebViewRepresentable: NSViewRepresentable {
                     webView: webView,
                     to: portalAnchorView,
                     visibleInUI: coordinator.desiredPortalVisibleInUI,
-                    zPriority: coordinator.desiredPortalZPriority
+                    zPriority: coordinator.desiredPortalZPriority,
+                    paneDropContext: activePaneDropContext
                 )
                 // Force a rendering-state reattach after portal host replacement
                 // (e.g. after a pane split). Without this, WKWebView can freeze

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -3330,6 +3330,38 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             ),
             "Rebinding a visible Dock browser without a fresh context must preserve divider ownership"
         )
+
+        // The visibility update can also win the race and arrive before the
+        // context clear. The slot is still mounted and visible in that order,
+        // so the ownership snapshot must survive until the next real bind.
+        portal.updatePaneDropContext(
+            forWebViewId: ObjectIdentifier(dockWebView),
+            context: dockContext
+        )
+        portal.updateEntryVisibility(
+            forWebViewId: ObjectIdentifier(dockWebView),
+            visibleInUI: false,
+            zPriority: 0
+        )
+        portal.updatePaneDropContext(
+            forWebViewId: ObjectIdentifier(dockWebView),
+            context: nil
+        )
+        portal.bind(
+            webView: dockWebView,
+            to: dockAnchor,
+            visibleInUI: true,
+            paneDropContext: nil
+        )
+
+        XCTAssertNil(
+            host.performHitTest(
+                at: dividerPointInHost,
+                currentEvent: event,
+                dragPasteboard: pasteboard
+            ),
+            "Dock ownership must survive either ordering of transient visibility and context updates"
+        )
     }
 
     private func dropZoneOverlay(in slot: WindowBrowserSlotView, excluding webView: WKWebView) -> NSView? {

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -1323,6 +1323,14 @@ final class WindowBrowserHostViewTests: XCTestCase {
         }
     }
 
+    /// Models an AppKit hosting wrapper that claims its entire bounds instead
+    /// of forwarding `hitTest` to a nested SwiftUI overlay.
+    private final class NonPropagatingHostingView: NSView {
+        override func hitTest(_ point: NSPoint) -> NSView? {
+            bounds.contains(point) ? self : nil
+        }
+    }
+
     private final class FakeTabBarBackgroundNSView: NSView {
         override func hitTest(_ point: NSPoint) -> NSView? {
             bounds.contains(point) ? self : nil
@@ -1800,6 +1808,193 @@ final class WindowBrowserHostViewTests: XCTestCase {
                 dragPasteboard: pasteboard
             ) === mainContent,
             "Following the live divider must not make ordinary browser content pass through"
+        )
+    }
+
+    func testHostViewReturnsLiveSidebarDividerThroughHostingWrapper() throws {
+        // SwiftUI can place the native divider tracker below an AppKit hosting
+        // wrapper whose hitTest returns the wrapper itself. The browser portal
+        // must still hand the event to the live tracker, rather than merely
+        // hoping that a second root hit-test discovers it.
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 260),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView,
+              let container = contentView.superview else {
+            XCTFail("Expected window content container")
+            return
+        }
+
+        let wrapper = NonPropagatingHostingView(frame: contentView.bounds)
+        contentView.addSubview(wrapper)
+        let liveDivider = SidebarDividerTrackingView(
+            frame: NSRect(x: 206, y: 0, width: 10, height: contentView.bounds.height)
+        )
+        liveDivider.onBegan = {}
+        liveDivider.onChanged = { _ in }
+        liveDivider.onEnded = {}
+        wrapper.addSubview(liveDivider)
+
+        let hostFrame = container.convert(contentView.bounds, from: contentView)
+        let host = WindowBrowserHostView(frame: hostFrame)
+        host.autoresizingMask = [.width, .height]
+        container.addSubview(host, positioned: .above, relativeTo: contentView)
+
+        let mainSlot = WindowBrowserSlotView(
+            frame: NSRect(x: 0, y: 0, width: 210, height: host.bounds.height)
+        )
+        let staleDockSlot = WindowBrowserSlotView(
+            frame: NSRect(x: 300, y: 0, width: 120, height: host.bounds.height)
+        )
+        let mainContent = CapturingView(frame: mainSlot.bounds)
+        let staleDockContent = CapturingView(frame: staleDockSlot.bounds)
+        mainSlot.addSubview(mainContent)
+        staleDockSlot.addSubview(staleDockContent)
+        host.addSubview(mainSlot)
+        host.addSubview(staleDockSlot)
+
+        let dock = DockSplitStore(workspaceId: UUID(), baseDirectoryProvider: { nil })
+        let dockPane = try XCTUnwrap(dock.bonsplitController.allPaneIds.first)
+        staleDockSlot.setPaneDropContext(BrowserPaneDropContext(
+            workspaceId: dock.workspaceId,
+            panelId: UUID(),
+            paneId: dockPane,
+            isDockHosted: true
+        ))
+        defer { dock.retire() }
+
+        contentView.layoutSubtreeIfNeeded()
+        let dividerPointInHost = NSPoint(x: 210, y: host.bounds.midY)
+        let dividerPointInWindow = host.convert(dividerPointInHost, to: nil)
+        let event = makeMouseEvent(
+            type: .leftMouseDown,
+            location: dividerPointInWindow,
+            window: window
+        )
+        let pasteboard = NSPasteboard(
+            name: NSPasteboard.Name("cmux.test.issue-10892.hosting-wrapper.\(UUID().uuidString)")
+        )
+        pasteboard.clearContents()
+
+        XCTAssertTrue(
+            host.performHitTest(
+                at: dividerPointInHost,
+                currentEvent: event,
+                dragPasteboard: pasteboard
+            ) === liveDivider,
+            "The portal must route a Dock divider hit directly to the live tracker even when its hosting wrapper claims hit testing"
+        )
+
+        let mainContentPoint = NSPoint(x: 100, y: host.bounds.midY)
+        XCTAssertTrue(
+            host.performHitTest(
+                at: mainContentPoint,
+                currentEvent: event,
+                dragPasteboard: pasteboard
+            ) === mainContent,
+            "A hosting-wrapper fallback must not make ordinary browser content pass through"
+        )
+    }
+
+    func testHostViewPrefersLiveSidebarDividerOverlappingHostedSplit() throws {
+        // A stale WebKit/NSSplitView divider can overlap the real Dock divider
+        // for one layout turn. The live sidebar tracker is the concrete owner
+        // at that point; a hosted-content region must not preempt it.
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 260),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView,
+              let container = contentView.superview else {
+            XCTFail("Expected window content container")
+            return
+        }
+
+        let liveDivider = SidebarDividerTrackingView(
+            frame: NSRect(x: 206, y: 0, width: 10, height: contentView.bounds.height)
+        )
+        liveDivider.onBegan = {}
+        liveDivider.onChanged = { _ in }
+        liveDivider.onEnded = {}
+        contentView.addSubview(liveDivider)
+
+        let hostFrame = container.convert(contentView.bounds, from: contentView)
+        let host = WindowBrowserHostView(frame: hostFrame)
+        host.autoresizingMask = [.width, .height]
+        container.addSubview(host, positioned: .above, relativeTo: contentView)
+
+        let mainSlot = WindowBrowserSlotView(
+            frame: NSRect(x: 0, y: 0, width: 210, height: host.bounds.height)
+        )
+        let staleDockSlot = WindowBrowserSlotView(
+            frame: NSRect(x: 300, y: 0, width: 120, height: host.bounds.height)
+        )
+        let mainContent = CapturingView(frame: mainSlot.bounds)
+        let staleDockContent = CapturingView(frame: staleDockSlot.bounds)
+        mainSlot.addSubview(mainContent)
+        staleDockSlot.addSubview(staleDockContent)
+        host.addSubview(mainSlot)
+        host.addSubview(staleDockSlot)
+
+        let hostedSplit = NSSplitView(
+            frame: NSRect(x: 200, y: 0, width: 20, height: host.bounds.height)
+        )
+        hostedSplit.isVertical = true
+        hostedSplit.dividerStyle = .thin
+        hostedSplit.addSubview(NSView(frame: NSRect(x: 0, y: 0, width: 10, height: hostedSplit.bounds.height)))
+        hostedSplit.addSubview(NSView(frame: NSRect(x: 11, y: 0, width: 9, height: hostedSplit.bounds.height)))
+        host.addSubview(hostedSplit)
+
+        let dock = DockSplitStore(workspaceId: UUID(), baseDirectoryProvider: { nil })
+        let dockPane = try XCTUnwrap(dock.bonsplitController.allPaneIds.first)
+        staleDockSlot.setPaneDropContext(BrowserPaneDropContext(
+            workspaceId: dock.workspaceId,
+            panelId: UUID(),
+            paneId: dockPane,
+            isDockHosted: true
+        ))
+        defer { dock.retire() }
+
+        contentView.layoutSubtreeIfNeeded()
+        hostedSplit.layoutSubtreeIfNeeded()
+        let hostedDividerX = hostedSplit.convert(
+            NSPoint(x: hostedSplit.arrangedSubviews[0].frame.maxX, y: hostedSplit.bounds.midY),
+            to: host
+        ).x
+        liveDivider.frame = NSRect(
+            x: hostedDividerX - 5,
+            y: 0,
+            width: 10,
+            height: contentView.bounds.height
+        )
+        contentView.layoutSubtreeIfNeeded()
+
+        let dividerPointInHost = NSPoint(x: hostedDividerX, y: host.bounds.midY)
+        let dividerPointInWindow = host.convert(dividerPointInHost, to: nil)
+        let event = makeMouseEvent(
+            type: .leftMouseDown,
+            location: dividerPointInWindow,
+            window: window
+        )
+        let pasteboard = NSPasteboard(
+            name: NSPasteboard.Name("cmux.test.issue-10892.hosted-overlap.\(UUID().uuidString)")
+        )
+        pasteboard.clearContents()
+
+        XCTAssertTrue(
+            host.performHitTest(
+                at: dividerPointInHost,
+                currentEvent: event,
+                dragPasteboard: pasteboard
+            ) === liveDivider,
+            "A live Dock tracker must win over a stale hosted vertical divider at the same point"
         )
     }
 

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -3716,6 +3716,31 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             "The initial Dock browser binding must pass its shared divider through"
         )
 
+        // The physical slot can be reset while the portal entry still carries
+        // the same authoritative context. A repeated update must reassert the
+        // live slot classification instead of being discarded as an entry no-op.
+        dockSlot.clearPaneDropContext()
+        XCTAssertNotNil(
+            host.performHitTest(
+                at: dividerPointInHost,
+                currentEvent: event,
+                dragPasteboard: pasteboard
+            ),
+            "Resetting the physical slot should temporarily expose the ownership gap"
+        )
+        portal.updatePaneDropContext(
+            forWebViewId: ObjectIdentifier(dockWebView),
+            context: dockContext
+        )
+        XCTAssertNil(
+            host.performHitTest(
+                at: dividerPointInHost,
+                currentEvent: event,
+                dragPasteboard: pasteboard
+            ),
+            "An unchanged portal context must still restore Dock divider ownership on the physical slot"
+        )
+
         // These two updates model the portal's transient recovery ordering:
         // the routing context is unavailable and visibility is stale, but the
         // visible slot/frame remains mounted until the replacement bind settles.

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -1712,6 +1712,97 @@ final class WindowBrowserHostViewTests: XCTestCase {
         )
     }
 
+    func testHostViewDefersToLiveSidebarDividerWhenDockSlotFrameIsStale() throws {
+        // During a right-sidebar resize, SwiftUI can move its native divider
+        // before the window-level browser portal receives the matching slot
+        // geometry update. The portal must follow the live resizer underneath
+        // it instead of trusting a stale Dock slot frame for one event turn.
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 260),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView,
+              let container = contentView.superview else {
+            XCTFail("Expected window content container")
+            return
+        }
+
+        let hostFrame = container.convert(contentView.bounds, from: contentView)
+        let host = WindowBrowserHostView(frame: hostFrame)
+        host.autoresizingMask = [.width, .height]
+        container.addSubview(host, positioned: .above, relativeTo: contentView)
+
+        let liveDivider = SidebarDividerTrackingView(
+            frame: NSRect(x: 206, y: 0, width: 10, height: contentView.bounds.height)
+        )
+        liveDivider.onBegan = {}
+        liveDivider.onChanged = { _ in }
+        liveDivider.onEnded = {}
+        // This is the actual native SwiftUI/AppKit resizer under the portal.
+        // Its frame is already at x=210, while the portal's Dock slot below
+        // intentionally retains the previous x=300 snapshot.
+        contentView.addSubview(liveDivider)
+
+        let mainSlot = WindowBrowserSlotView(
+            frame: NSRect(x: 0, y: 0, width: 210, height: host.bounds.height)
+        )
+        let staleDockSlot = WindowBrowserSlotView(
+            frame: NSRect(x: 300, y: 0, width: 120, height: host.bounds.height)
+        )
+        let mainContent = CapturingView(frame: mainSlot.bounds)
+        let staleDockContent = CapturingView(frame: staleDockSlot.bounds)
+        mainSlot.addSubview(mainContent)
+        staleDockSlot.addSubview(staleDockContent)
+        host.addSubview(mainSlot)
+        host.addSubview(staleDockSlot)
+
+        let dock = DockSplitStore(workspaceId: UUID(), baseDirectoryProvider: { nil })
+        let dockPane = try XCTUnwrap(dock.bonsplitController.allPaneIds.first)
+        let dockContext = BrowserPaneDropContext(
+            workspaceId: dock.workspaceId,
+            panelId: UUID(),
+            paneId: dockPane,
+            isDockHosted: true
+        )
+        staleDockSlot.setPaneDropContext(dockContext)
+        defer { dock.retire() }
+
+        contentView.layoutSubtreeIfNeeded()
+        let dividerPointInHost = NSPoint(x: 210, y: host.bounds.midY)
+        let dividerPointInWindow = host.convert(dividerPointInHost, to: nil)
+        let event = makeMouseEvent(
+            type: .leftMouseDown,
+            location: dividerPointInWindow,
+            window: window
+        )
+        let pasteboard = NSPasteboard(
+            name: NSPasteboard.Name("cmux.test.issue-10892.stale-frame.\(UUID().uuidString)")
+        )
+        pasteboard.clearContents()
+
+        XCTAssertNil(
+            host.performHitTest(
+                at: dividerPointInHost,
+                currentEvent: event,
+                dragPasteboard: pasteboard
+            ),
+            "The browser portal must defer to the live Dock divider even when its cached slot frame is stale"
+        )
+
+        let mainContentPoint = NSPoint(x: 100, y: host.bounds.midY)
+        XCTAssertTrue(
+            host.performHitTest(
+                at: mainContentPoint,
+                currentEvent: event,
+                dragPasteboard: pasteboard
+            ) === mainContent,
+            "Following the live divider must not make ordinary browser content pass through"
+        )
+    }
+
     func testWindowPortalAnchorDoesNotStealPointerHitsFromSidebarDivider() {
         let host = WebViewRepresentable.HostContainerView(
             frame: NSRect(x: 0, y: 0, width: 240, height: 180)

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -3213,6 +3213,125 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         RunLoop.current.run(until: Date().addingTimeInterval(0.25))
     }
 
+    private func makeMouseEvent(
+        type: NSEvent.EventType,
+        location: NSPoint,
+        window: NSWindow
+    ) -> NSEvent {
+        guard let event = NSEvent.mouseEvent(
+            with: type,
+            location: location,
+            modifierFlags: [],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1.0
+        ) else {
+            fatalError("Failed to create \(type) mouse event")
+        }
+        return event
+    }
+
+    func testPortalRebindKeepsDockDividerOwnershipAfterTransientVisibilityClear() throws {
+        // A browser pane immediately left of the Dock shares the trailing edge
+        // with the Dock browser. During portal churn, visibility can be cleared
+        // before the existing visible slot is rebound. Rebinding without a new
+        // pane snapshot must not make the browser reclaim the Dock divider.
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 500, height: 320),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        realizeWindowLayout(window)
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let mainAnchor = NSView(frame: NSRect(x: 0, y: 0, width: 220, height: 260))
+        let dockAnchor = NSView(frame: NSRect(x: 220, y: 0, width: 220, height: 260))
+        contentView.addSubview(mainAnchor)
+        contentView.addSubview(dockAnchor)
+
+        let portal = WindowBrowserPortal(window: window)
+        defer { portal.tearDown() }
+        let mainWebView = CmuxWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        let dockWebView = CmuxWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        let dockContext = BrowserPaneDropContext(
+            workspaceId: UUID(),
+            panelId: UUID(),
+            paneId: PaneID(id: UUID()),
+            isDockHosted: true
+        )
+
+        portal.bind(webView: mainWebView, to: mainAnchor, visibleInUI: true)
+        portal.bind(
+            webView: dockWebView,
+            to: dockAnchor,
+            visibleInUI: true,
+            paneDropContext: dockContext
+        )
+        contentView.layoutSubtreeIfNeeded()
+
+        guard let dockSlot = dockWebView.superview as? WindowBrowserSlotView,
+              let host = dockSlot.superview as? WindowBrowserHostView else {
+            XCTFail("Expected Dock browser slot in the window portal host")
+            return
+        }
+        let dividerPointInHost = NSPoint(x: dockSlot.frame.minX, y: host.bounds.midY)
+        let dividerPointInWindow = host.convert(dividerPointInHost, to: nil)
+        let event = makeMouseEvent(
+            type: .leftMouseDown,
+            location: dividerPointInWindow,
+            window: window
+        )
+        let pasteboard = NSPasteboard(
+            name: NSPasteboard.Name("cmux.test.issue-10892.rebind.\(UUID().uuidString)")
+        )
+        pasteboard.clearContents()
+
+        XCTAssertNil(
+            host.performHitTest(
+                at: dividerPointInHost,
+                currentEvent: event,
+                dragPasteboard: pasteboard
+            ),
+            "The initial Dock browser binding must pass its shared divider through"
+        )
+
+        // These two updates model the portal's transient recovery ordering:
+        // the routing context is unavailable and visibility is stale, but the
+        // visible slot/frame remains mounted until the replacement bind settles.
+        portal.updatePaneDropContext(
+            forWebViewId: ObjectIdentifier(dockWebView),
+            context: nil
+        )
+        portal.updateEntryVisibility(
+            forWebViewId: ObjectIdentifier(dockWebView),
+            visibleInUI: false,
+            zPriority: 0
+        )
+        portal.bind(
+            webView: dockWebView,
+            to: dockAnchor,
+            visibleInUI: true,
+            paneDropContext: nil
+        )
+
+        XCTAssertNil(
+            host.performHitTest(
+                at: dividerPointInHost,
+                currentEvent: event,
+                dragPasteboard: pasteboard
+            ),
+            "Rebinding a visible Dock browser without a fresh context must preserve divider ownership"
+        )
+    }
+
     private func dropZoneOverlay(in slot: WindowBrowserSlotView, excluding webView: WKWebView) -> NSView? {
         let candidates = slot.subviews + (slot.superview?.subviews ?? [])
         return candidates.first(where: {

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -1331,6 +1331,19 @@ final class WindowBrowserHostViewTests: XCTestCase {
         }
     }
 
+    /// Models a hosting wrapper whose native hit-test result is an unrelated
+    /// content leaf, even though a divider tracker is a sibling in the same
+    /// hosted hierarchy. This is the shape produced by some AppKit/SwiftUI
+    /// wrappers while their content subtree is being reconciled.
+    private final class LeafClaimingHostingView: NSView {
+        weak var claimedLeaf: NSView?
+
+        override func hitTest(_ point: NSPoint) -> NSView? {
+            guard bounds.contains(point) else { return nil }
+            return claimedLeaf ?? self
+        }
+    }
+
     private final class FakeTabBarBackgroundNSView: NSView {
         override func hitTest(_ point: NSPoint) -> NSView? {
             bounds.contains(point) ? self : nil
@@ -1791,13 +1804,13 @@ final class WindowBrowserHostViewTests: XCTestCase {
         )
         pasteboard.clearContents()
 
-        XCTAssertNil(
+        XCTAssertTrue(
             host.performHitTest(
                 at: dividerPointInHost,
                 currentEvent: event,
                 dragPasteboard: pasteboard
-            ),
-            "The browser portal must defer to the live Dock divider even when its cached slot frame is stale"
+            ) === liveDivider,
+            "The browser portal must route the stale-frame Dock divider directly to the live tracker"
         )
 
         let mainContentPoint = NSPoint(x: 100, y: host.bounds.midY)
@@ -1900,6 +1913,116 @@ final class WindowBrowserHostViewTests: XCTestCase {
         )
     }
 
+    func testHostViewFindsLiveSidebarDividerWhenHostingWrapperClaimsContentLeaf() throws {
+        // A SwiftUI/AppKit wrapper can report a content leaf for the pointer
+        // even when the native divider tracker is its sibling. The portal must
+        // inspect the visible hosted hierarchy, rather than treating that leaf
+        // as proof that no sidebar divider is present.
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 260),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView,
+              let container = contentView.superview else {
+            XCTFail("Expected window content container")
+            return
+        }
+
+        let wrapper = LeafClaimingHostingView(frame: contentView.bounds)
+        let liveDivider = SidebarDividerTrackingView(
+            frame: NSRect(x: 206, y: 0, width: 10, height: contentView.bounds.height)
+        )
+        liveDivider.onBegan = {}
+        liveDivider.onChanged = { _ in }
+        liveDivider.onEnded = {}
+        let claimedContentLeaf = CapturingView(frame: wrapper.bounds)
+        wrapper.claimedLeaf = claimedContentLeaf
+        wrapper.addSubview(liveDivider)
+        wrapper.addSubview(claimedContentLeaf)
+        contentView.addSubview(wrapper)
+
+        let hostFrame = container.convert(contentView.bounds, from: contentView)
+        let host = WindowBrowserHostView(frame: hostFrame)
+        host.autoresizingMask = [.width, .height]
+        container.addSubview(host, positioned: .above, relativeTo: contentView)
+
+        // The browser pane and Dock pane share an edge, matching the reported
+        // `new-pane --type browser --direction right` topology.
+        let paneWidth: CGFloat = 210
+        let browserSlot = WindowBrowserSlotView(
+            frame: NSRect(x: 0, y: 0, width: paneWidth, height: host.bounds.height)
+        )
+        let dockSlot = WindowBrowserSlotView(
+            frame: NSRect(x: paneWidth, y: 0, width: paneWidth, height: host.bounds.height)
+        )
+        let browserContent = CapturingView(frame: browserSlot.bounds)
+        let dockContent = CapturingView(frame: dockSlot.bounds)
+        browserSlot.addSubview(browserContent)
+        dockSlot.addSubview(dockContent)
+        host.addSubview(browserSlot)
+        host.addSubview(dockSlot)
+
+        let dock = DockSplitStore(workspaceId: UUID(), baseDirectoryProvider: { nil })
+        let dockPane = try XCTUnwrap(dock.bonsplitController.allPaneIds.first)
+        dockSlot.setPaneDropContext(BrowserPaneDropContext(
+            workspaceId: dock.workspaceId,
+            panelId: UUID(),
+            paneId: dockPane,
+            isDockHosted: true
+        ))
+        defer { dock.retire() }
+
+        contentView.layoutSubtreeIfNeeded()
+        let dividerPointInHost = NSPoint(x: paneWidth, y: host.bounds.midY)
+        let dividerPointInContent = contentView.convert(
+            host.convert(dividerPointInHost, to: nil),
+            from: nil
+        )
+        XCTAssertTrue(
+            wrapper.hitTest(wrapper.convert(dividerPointInContent, from: contentView)) === claimedContentLeaf,
+            "The fixture must model a hosting wrapper that claims an unrelated content leaf"
+        )
+
+        let dividerPointInWindow = host.convert(dividerPointInHost, to: nil)
+        let event = makeMouseEvent(
+            type: .leftMouseDown,
+            location: dividerPointInWindow,
+            window: window
+        )
+        let pasteboard = NSPasteboard(
+            name: NSPasteboard.Name("cmux.test.issue-10892.wrapper-leaf.\(UUID().uuidString)")
+        )
+        pasteboard.clearContents()
+
+        XCTAssertTrue(
+            host.performHitTest(
+                at: dividerPointInHost,
+                currentEvent: event,
+                dragPasteboard: pasteboard
+            ) === liveDivider,
+            "The browser portal must route the shared browser/Dock divider to the live tracker when a wrapper claims a content leaf"
+        )
+
+        let rootPointInContainer = container.convert(dividerPointInWindow, from: nil)
+        XCTAssertTrue(
+            container.hitTest(rootPointInContainer) === liveDivider,
+            "The window's normal AppKit hit-test path must preserve live Dock divider ownership"
+        )
+
+        let browserPoint = NSPoint(x: paneWidth - 32, y: host.bounds.midY)
+        XCTAssertTrue(
+            host.performHitTest(
+                at: browserPoint,
+                currentEvent: event,
+                dragPasteboard: pasteboard
+            ) === browserContent,
+            "Finding a live tracker must not make ordinary browser content pass through"
+        )
+    }
+
     func testHostViewPrefersLiveSidebarDividerOverlappingHostedSplit() throws {
         // A stale WebKit/NSSplitView divider can overlap the real Dock divider
         // for one layout turn. The live sidebar tracker is the concrete owner
@@ -1968,9 +2091,13 @@ final class WindowBrowserHostViewTests: XCTestCase {
             NSPoint(x: hostedSplit.arrangedSubviews[0].frame.maxX, y: hostedSplit.bounds.midY),
             to: host
         ).x
+        let liveDividerOrigin = contentView.convert(
+            NSPoint(x: hostedDividerX - 5, y: 0),
+            from: host
+        )
         liveDivider.frame = NSRect(
-            x: hostedDividerX - 5,
-            y: 0,
+            x: liveDividerOrigin.x,
+            y: liveDividerOrigin.y,
             width: 10,
             height: contentView.bounds.height
         )

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -1576,7 +1576,8 @@ final class WindowBrowserHostViewTests: XCTestCase {
         dockSlot.setPaneDropContext(BrowserPaneDropContext(
             workspaceId: dock.workspaceId,
             panelId: UUID(),
-            paneId: dockPane
+            paneId: dockPane,
+            isDockHosted: true
         ))
         dock.ownedPaneIds = indexedPaneIds
 
@@ -1600,6 +1601,28 @@ final class WindowBrowserHostViewTests: XCTestCase {
                 dragPasteboard: pasteboard
             ),
             "A browser pane immediately left of the Dock must pass the Dock divider through to the SwiftUI resizer"
+        )
+
+        let mainContentPoint = NSPoint(x: slotWidth - 32, y: host.bounds.midY)
+        XCTAssertTrue(
+            host.performHitTest(
+                at: mainContentPoint,
+                currentEvent: event,
+                dragPasteboard: pasteboard
+            ) === mainContent,
+            "Only the shared browser/Dock divider band should pass through; browser content must remain interactive"
+        )
+    }
+
+    func testWindowPortalAnchorDoesNotStealPointerHitsFromSidebarDivider() {
+        let host = WebViewRepresentable.HostContainerView(
+            frame: NSRect(x: 0, y: 0, width: 240, height: 180)
+        )
+        host.prepareForWindowPortalHosting()
+
+        XCTAssertNil(
+            host.hitTest(NSPoint(x: 120, y: 90)),
+            "A retained SwiftUI browser anchor must defer pointer ownership while the window portal hosts its web view"
         )
     }
 

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -1635,6 +1635,114 @@ final class WindowBrowserHostViewTests: XCTestCase {
         )
     }
 
+    func testHostViewForwardsDockDividerMouseDownToLiveSidebarTracker() throws {
+        // The portal host is a window-level sibling above the SwiftUI tree. A
+        // browser pane immediately left of the Dock must hand ownership to the
+        // host and let it forward the synchronous divider drag to the native
+        // tracker below, even when a hosting wrapper claims the underlying hit.
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 260),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView,
+              let container = contentView.superview else {
+            XCTFail("Expected window content container")
+            return
+        }
+
+        let wrapper = NonPropagatingHostingView(frame: contentView.bounds)
+        contentView.addSubview(wrapper)
+
+        var eventNames: [String] = []
+        var changedTranslation: CGFloat?
+        let liveDivider = SidebarDividerTrackingView(
+            frame: NSRect(x: 206, y: 0, width: 10, height: contentView.bounds.height)
+        )
+        liveDivider.onBegan = { eventNames.append("began") }
+        liveDivider.onChanged = { translation in
+            eventNames.append("changed")
+            changedTranslation = translation
+            // Post the terminating event only after the tracker has received
+            // the drag, so its synchronous loop exercises the real callback
+            // path without relying on a timer or a test sleep.
+            let up = self.makeMouseEvent(
+                type: .leftMouseUp,
+                location: NSPoint(x: 238, y: 130),
+                window: window
+            )
+            window.postEvent(up, atStart: true)
+        }
+        liveDivider.onEnded = { eventNames.append("ended") }
+        wrapper.addSubview(liveDivider)
+
+        let hostFrame = container.convert(contentView.bounds, from: contentView)
+        let host = WindowBrowserHostView(frame: hostFrame)
+        host.autoresizingMask = [.width, .height]
+        container.addSubview(host, positioned: .above, relativeTo: contentView)
+
+        let paneWidth: CGFloat = 210
+        let browserSlot = WindowBrowserSlotView(
+            frame: NSRect(x: 0, y: 0, width: paneWidth, height: host.bounds.height)
+        )
+        let dockSlot = WindowBrowserSlotView(
+            frame: NSRect(x: paneWidth, y: 0, width: paneWidth, height: host.bounds.height)
+        )
+        browserSlot.addSubview(CapturingView(frame: browserSlot.bounds))
+        dockSlot.addSubview(CapturingView(frame: dockSlot.bounds))
+        host.addSubview(browserSlot)
+        host.addSubview(dockSlot)
+
+        let dock = DockSplitStore(workspaceId: UUID(), baseDirectoryProvider: { nil })
+        let dockPane = try XCTUnwrap(dock.bonsplitController.allPaneIds.first)
+        dockSlot.setPaneDropContext(BrowserPaneDropContext(
+            workspaceId: dock.workspaceId,
+            panelId: UUID(),
+            paneId: dockPane,
+            isDockHosted: true
+        ))
+        defer { dock.retire() }
+
+        window.makeKeyAndOrderFront(nil)
+        contentView.layoutSubtreeIfNeeded()
+
+        let dividerPointInHost = NSPoint(x: paneWidth, y: host.bounds.midY)
+        let dividerPointInWindow = host.convert(dividerPointInHost, to: nil)
+        let down = self.makeMouseEvent(
+            type: .leftMouseDown,
+            location: dividerPointInWindow,
+            window: window
+        )
+        let hit = container.hitTest(container.convert(dividerPointInWindow, from: nil))
+        XCTAssertTrue(
+            hit === host,
+            "The portal must own the shared divider before forwarding it to the live sidebar tracker. actual=\(String(describing: hit))"
+        )
+        guard hit === host else { return }
+
+        let drag = self.makeMouseEvent(
+            type: .leftMouseDragged,
+            location: NSPoint(x: dividerPointInWindow.x + 32, y: dividerPointInWindow.y),
+            window: window
+        )
+        window.postEvent(drag, atStart: true)
+        host.mouseDown(with: down)
+
+        XCTAssertEqual(
+            eventNames,
+            ["began", "changed", "ended"],
+            "A shared browser/Dock divider hit must follow the native sidebar drag lifecycle"
+        )
+        XCTAssertEqual(
+            changedTranslation,
+            32,
+            accuracy: 0.5,
+            "The forwarded drag must reach the native sidebar tracker"
+        )
+    }
+
     func testHostViewKeepsDockDividerPassThroughDuringTransientPortalContextClear() throws {
         // Portal reparenting can briefly clear a visible slot's drop context while
         // preserving its existing frame. The Dock divider must remain owned by the

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -1614,6 +1614,104 @@ final class WindowBrowserHostViewTests: XCTestCase {
         )
     }
 
+    func testHostViewKeepsDockDividerPassThroughDuringTransientPortalContextClear() throws {
+        // Portal reparenting can briefly clear a visible slot's drop context while
+        // preserving its existing frame. The Dock divider must remain owned by the
+        // SwiftUI resizer throughout that recovery window, rather than flickering
+        // back to the browser's WebKit hit target.
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 260),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView,
+              let container = contentView.superview else {
+            XCTFail("Expected window content container")
+            return
+        }
+
+        let hostFrame = container.convert(contentView.bounds, from: contentView)
+        let host = WindowBrowserHostView(frame: hostFrame)
+        host.autoresizingMask = [.width, .height]
+        container.addSubview(host, positioned: .above, relativeTo: contentView)
+
+        let slotWidth: CGFloat = 210
+        let mainSlot = WindowBrowserSlotView(
+            frame: NSRect(x: 0, y: 0, width: slotWidth, height: host.bounds.height)
+        )
+        let dockSlot = WindowBrowserSlotView(
+            frame: NSRect(x: slotWidth, y: 0, width: slotWidth, height: host.bounds.height)
+        )
+        let mainContent = CapturingView(frame: mainSlot.bounds)
+        let dockContent = CapturingView(frame: dockSlot.bounds)
+        mainSlot.addSubview(mainContent)
+        dockSlot.addSubview(dockContent)
+        host.addSubview(mainSlot)
+        host.addSubview(dockSlot)
+
+        let dock = DockSplitStore(workspaceId: UUID(), baseDirectoryProvider: { nil })
+        let dockPane = try XCTUnwrap(dock.bonsplitController.allPaneIds.first)
+        let indexedPaneIds = dock.ownedPaneIds
+        defer {
+            dock.ownedPaneIds = indexedPaneIds
+            dock.retire()
+        }
+        dockSlot.setPaneDropContext(BrowserPaneDropContext(
+            workspaceId: dock.workspaceId,
+            panelId: UUID(),
+            paneId: dockPane,
+            isDockHosted: true
+        ))
+
+        contentView.layoutSubtreeIfNeeded()
+        let dividerPointInHost = NSPoint(x: slotWidth, y: host.bounds.midY)
+        let dividerPointInWindow = host.convert(dividerPointInHost, to: nil)
+        let event = makeMouseEvent(
+            type: .leftMouseDown,
+            location: dividerPointInWindow,
+            window: window
+        )
+        let pasteboard = NSPasteboard(
+            name: NSPasteboard.Name("cmux.test.issue-10892.transient.\(UUID().uuidString)")
+        )
+        pasteboard.clearContents()
+
+        XCTAssertNil(
+            host.performHitTest(
+                at: dividerPointInHost,
+                currentEvent: event,
+                dragPasteboard: pasteboard
+            )
+        )
+
+        // Keep the visible Dock slot in place while its active drop-routing
+        // context is temporarily unavailable, matching portal recovery paths.
+        dockSlot.setPaneDropContext(nil)
+
+        for _ in 0..<8 {
+            XCTAssertNil(
+                host.performHitTest(
+                    at: dividerPointInHost,
+                    currentEvent: event,
+                    dragPasteboard: pasteboard
+                ),
+                "Transient portal recovery must not hand the shared Dock divider back to the browser"
+            )
+        }
+
+        let mainContentPoint = NSPoint(x: slotWidth - 32, y: host.bounds.midY)
+        XCTAssertTrue(
+            host.performHitTest(
+                at: mainContentPoint,
+                currentEvent: event,
+                dragPasteboard: pasteboard
+            ) === mainContent,
+            "Transient Dock ownership preservation must not make ordinary browser content pass through"
+        )
+    }
+
     func testWindowPortalAnchorDoesNotStealPointerHitsFromSidebarDivider() {
         let host = WebViewRepresentable.HostContainerView(
             frame: NSRect(x: 0, y: 0, width: 240, height: 180)

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -1524,6 +1524,85 @@ final class WindowBrowserHostViewTests: XCTestCase {
         XCTAssertTrue(host.hitTest(contentPointInHost) === child)
     }
 
+    func testHostViewPassesThroughDockDividerWhenBrowserSlotsShareTheTrailingEdge() throws {
+        // Reproduce the #10892 topology through the real window-level browser
+        // portal: a browser pane is immediately to the left of a Dock browser
+        // pane, and the Dock's pane index is populated after its portal slot is
+        // attached. The app/sidebar divider must remain owned by SwiftUI.
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 260),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView,
+              let container = contentView.superview else {
+            XCTFail("Expected window content container")
+            return
+        }
+
+        let hostFrame = container.convert(contentView.bounds, from: contentView)
+        let host = WindowBrowserHostView(frame: hostFrame)
+        host.autoresizingMask = [.width, .height]
+        container.addSubview(host, positioned: .above, relativeTo: contentView)
+
+        let slotWidth: CGFloat = 210
+        let mainSlot = WindowBrowserSlotView(
+            frame: NSRect(x: 0, y: 0, width: slotWidth, height: host.bounds.height)
+        )
+        let dockSlot = WindowBrowserSlotView(
+            frame: NSRect(x: slotWidth, y: 0, width: slotWidth, height: host.bounds.height)
+        )
+        let mainContent = CapturingView(frame: mainSlot.bounds)
+        let dockContent = CapturingView(frame: dockSlot.bounds)
+        mainSlot.addSubview(mainContent)
+        dockSlot.addSubview(dockContent)
+        host.addSubview(mainSlot)
+        host.addSubview(dockSlot)
+
+        // This mirrors the real Dock lifecycle: the slot receives its pane
+        // context while the live Dock ownership index is still catching up.
+        // The context itself identifies the Dock pane; hit-testing must not
+        // permanently cache the initial "not a Dock" answer.
+        let dock = DockSplitStore(workspaceId: UUID(), baseDirectoryProvider: { nil })
+        let dockPane = try XCTUnwrap(dock.bonsplitController.allPaneIds.first)
+        let indexedPaneIds = dock.ownedPaneIds
+        dock.ownedPaneIds.removeAll()
+        defer {
+            dock.ownedPaneIds = indexedPaneIds
+            dock.retire()
+        }
+        dockSlot.setPaneDropContext(BrowserPaneDropContext(
+            workspaceId: dock.workspaceId,
+            panelId: UUID(),
+            paneId: dockPane
+        ))
+        dock.ownedPaneIds = indexedPaneIds
+
+        contentView.layoutSubtreeIfNeeded()
+        let dividerPointInHost = NSPoint(x: slotWidth, y: host.bounds.midY)
+        let dividerPointInWindow = host.convert(dividerPointInHost, to: nil)
+        let event = makeMouseEvent(
+            type: .leftMouseDown,
+            location: dividerPointInWindow,
+            window: window
+        )
+        let pasteboard = NSPasteboard(
+            name: NSPasteboard.Name("cmux.test.issue-10892.\(UUID().uuidString)")
+        )
+        pasteboard.clearContents()
+
+        XCTAssertNil(
+            host.performHitTest(
+                at: dividerPointInHost,
+                currentEvent: event,
+                dragPasteboard: pasteboard
+            ),
+            "A browser pane immediately left of the Dock must pass the Dock divider through to the SwiftUI resizer"
+        )
+    }
+
     func testWindowBrowserPortalIgnoresHostedInspectorSplitResizeNotifications() {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 420, height: 260),

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -1640,6 +1640,8 @@ final class WindowBrowserHostViewTests: XCTestCase {
         // browser pane immediately left of the Dock must hand ownership to the
         // host and let it forward the synchronous divider drag to the native
         // tracker below, even when a hosting wrapper claims the underlying hit.
+        // The second drag below also models the short SwiftUI reparent gap that
+        // can occur between AppKit's hit-test and mouseDown callbacks.
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 420, height: 260),
             styleMask: [.titled, .closable],
@@ -1740,6 +1742,63 @@ final class WindowBrowserHostViewTests: XCTestCase {
             32,
             accuracy: 0.5,
             "The forwarded drag must reach the native sidebar tracker"
+        )
+
+        // AppKit may ask for another hit-test while SwiftUI is moving the
+        // divider tracker between hosting wrappers. Preserve the original
+        // handoff even if the concrete tracker is detached for that turn.
+        eventNames.removeAll()
+        changedTranslation = nil
+        let reparentDown = self.makeMouseEvent(
+            type: .leftMouseDown,
+            location: dividerPointInWindow,
+            window: window
+        )
+        let pasteboard = NSPasteboard(
+            name: NSPasteboard.Name("cmux.test.issue-10892.reparent.\(UUID().uuidString)")
+        )
+        pasteboard.clearContents()
+        XCTAssertTrue(
+            host.performHitTest(
+                at: dividerPointInHost,
+                currentEvent: reparentDown,
+                dragPasteboard: pasteboard
+            ) === host,
+            "The portal must record the Dock divider handoff before a tracker reparent"
+        )
+
+        liveDivider.removeFromSuperview()
+        XCTAssertNil(
+            host.performHitTest(
+                at: dividerPointInHost,
+                currentEvent: reparentDown,
+                dragPasteboard: pasteboard
+            ),
+            "A transiently detached tracker should still leave the browser/Dock divider pass-through path"
+        )
+        XCTAssertTrue(
+            host.acceptsFirstMouse(for: reparentDown),
+            "The portal must not consume the retained Dock handoff while AppKit checks first-mouse activation"
+        )
+
+        let reparentDrag = self.makeMouseEvent(
+            type: .leftMouseDragged,
+            location: NSPoint(x: dividerPointInWindow.x + 28, y: dividerPointInWindow.y),
+            window: window
+        )
+        window.postEvent(reparentDrag, atStart: true)
+        host.mouseDown(with: reparentDown)
+
+        XCTAssertEqual(
+            eventNames,
+            ["began", "changed", "ended"],
+            "A Dock divider handoff must survive a transient tracker reparent"
+        )
+        XCTAssertEqual(
+            changedTranslation,
+            28,
+            accuracy: 0.5,
+            "A reparented Dock divider must continue receiving native drag translation"
         )
     }
 
@@ -1917,8 +1976,8 @@ final class WindowBrowserHostViewTests: XCTestCase {
                 at: dividerPointInHost,
                 currentEvent: event,
                 dragPasteboard: pasteboard
-            ) === liveDivider,
-            "The browser portal must route the stale-frame Dock divider directly to the live tracker"
+            ) === host,
+            "The browser portal must own the stale-frame Dock divider before forwarding it to the live tracker"
         )
 
         let mainContentPoint = NSPoint(x: 100, y: host.bounds.midY)
@@ -1935,8 +1994,8 @@ final class WindowBrowserHostViewTests: XCTestCase {
     func testHostViewReturnsLiveSidebarDividerThroughHostingWrapper() throws {
         // SwiftUI can place the native divider tracker below an AppKit hosting
         // wrapper whose hitTest returns the wrapper itself. The browser portal
-        // must still hand the event to the live tracker, rather than merely
-        // hoping that a second root hit-test discovers it.
+        // must own the event itself and forward it to the live tracker, rather
+        // than returning a sibling that AppKit may dispatch inconsistently.
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 420, height: 260),
             styleMask: [.titled, .closable],
@@ -2006,8 +2065,8 @@ final class WindowBrowserHostViewTests: XCTestCase {
                 at: dividerPointInHost,
                 currentEvent: event,
                 dragPasteboard: pasteboard
-            ) === liveDivider,
-            "The portal must route a Dock divider hit directly to the live tracker even when its hosting wrapper claims hit testing"
+            ) === host,
+            "The portal must own a Dock divider hit even when its hosting wrapper claims hit testing"
         )
 
         let mainContentPoint = NSPoint(x: 100, y: host.bounds.midY)
@@ -2110,14 +2169,14 @@ final class WindowBrowserHostViewTests: XCTestCase {
                 at: dividerPointInHost,
                 currentEvent: event,
                 dragPasteboard: pasteboard
-            ) === liveDivider,
-            "The browser portal must route the shared browser/Dock divider to the live tracker when a wrapper claims a content leaf"
+            ) === host,
+            "The browser portal must own the shared browser/Dock divider when a wrapper claims a content leaf"
         )
 
         let rootPointInContainer = container.convert(dividerPointInWindow, from: nil)
         XCTAssertTrue(
-            container.hitTest(rootPointInContainer) === liveDivider,
-            "The window's normal AppKit hit-test path must preserve live Dock divider ownership"
+            container.hitTest(rootPointInContainer) === host,
+            "The window's normal AppKit hit-test path must preserve portal ownership for the live Dock divider"
         )
 
         let browserPoint = NSPoint(x: paneWidth - 32, y: host.bounds.midY)
@@ -2228,8 +2287,8 @@ final class WindowBrowserHostViewTests: XCTestCase {
                 at: dividerPointInHost,
                 currentEvent: event,
                 dragPasteboard: pasteboard
-            ) === liveDivider,
-            "A live Dock tracker must win over a stale hosted vertical divider at the same point"
+            ) === host,
+            "A live Dock tracker must make the portal host win over a stale hosted vertical divider at the same point"
         )
     }
 


### PR DESCRIPTION
## Summary

Fixes #10892. The right sidebar (Dock) divider now remains draggable when a browser pane is immediately adjacent, including while Dock pane ownership is still converging.

## Reproduction

1. Open a workspace with the right sidebar (Dock) visible.
2. Add a browser pane on the right side of the split so it sits immediately next to the Dock (e.g. `cmux new-pane --type browser --direction right ...`).
3. Try to drag the divider between the browser pane and the Dock to resize the Dock.

Expected: the Dock resizes as it does when a terminal pane is adjacent.
Actual: the divider cannot be dragged; the sidebar width does not change.

## Root cause

Window-level browser portal slots were classifying Dock ownership by querying `AppDelegate` at the moment the pane-drop context was attached. Dock stores and their pane indexes can still be settling at that point, so a Dock browser slot was cached as ordinary content. The trailing-edge heuristic then used the Dock browser's right edge (the window edge) instead of its left edge (the browser/Dock divider), allowing the WKWebView portal to win the hit test. The retained SwiftUI browser anchor could also remain a transparent AppKit hit target while its web view was owned by the window portal.

The pane context now carries explicit Dock ownership, the portal consumes that snapshot, and portal-mode anchors defer hit testing. Terminal portal routing is unchanged.

## Verification

- Added an AppKit behavior regression through `WindowBrowserHostView.performHitTest` for the browser/Dock topology and a retained portal-anchor hit-test regression.
- `git diff --check`
- `swiftc -parse` on changed Swift sources/tests
- Fleet tagged Debug build completed with `CMUX_SKIP_ZIG_BUILD=1 ... reload-cloud.sh --builder fleet --tag issue-10892-dock-resize-browser`.
- Full focused XCTest execution is pending a fleet test slot with the `cmux-unit` scheme.

No user-facing strings changed; no localization files require updates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #10892 so the Dock divider stays draggable when a browser pane is immediately adjacent, including while Dock pane ownership is still converging and across portal recovery windows. Browser portal hit-testing now defers to the live sidebar divider tracker, and mouse drags are forwarded to that tracker so the native resize lifecycle runs uninterrupted.

- Pane drop contexts now carry explicit Dock ownership instead of relying on a transient global lookup at drop time.
- Visible portal slots keep their Dock classification during transient routing gaps and rebinding; only a real hide or release clears it.
- The window browser portal defers hit-testing to the live sidebar divider tracker, so stale slot frames and AppKit hosting wrappers no longer steal divider clicks.
- Retained SwiftUI browser anchors stop hit-testing while the window portal hosts their web view.
- Mouse drags at the browser/Dock divider are forwarded to the native sidebar tracker so the began/changed/ended drag lifecycle completes with correct translation.
- Adds regression tests covering the browser/Dock topology, portal recovery, visibility race orderings, stale divider geometry, hosting wrappers, and drag forwarding.

<sup>Written for commit 9181cee5ab645c2f6a24cc6676dcf78b6528d2cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sidebar divider interactions when browser panes share an edge.
  * Prevented browser portal anchors from intercepting clicks intended for sidebar controls.
  * Improved browser pane placement and drop behavior in right-side docks.
  * Preserved correct divider behavior during portal transitions and Dock updates.
  * Improved drop-target tracking while browser panes are temporarily reparented or repositioned.

* **Tests**
  * Added coverage for shared sidebar dividers, pointer interaction during portal hosting, and transient portal context changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->