### PR TITLE
Clear the three Swift warning buckets over the CI budget on main

### DIFF
--- a/Sources/Mobile/MobileHostIrxRuntime.swift
+++ b/Sources/Mobile/MobileHostIrxRuntime.swift
@@ -14,8 +14,8 @@ import OSLog
 final class MobileHostIrxRuntime {
     static let shared = MobileHostIrxRuntime()
 
-    static let enabledDefaultsKey = "cmux.irx.enabled"
-    static let forceRelayDefaultsKey = "cmux.irx.force-relay"
+    nonisolated static let enabledDefaultsKey = "cmux.irx.enabled"
+    nonisolated static let forceRelayDefaultsKey = "cmux.irx.force-relay"
 
     /// The activation gate, readable before any runtime exists. Release
     /// builds compile the code but can never enable it.

--- a/Sources/Surfaces/SurfaceSocketCommands.swift
+++ b/Sources/Surfaces/SurfaceSocketCommands.swift
@@ -191,7 +191,7 @@ extension TerminalController {
         }
         let destination = Self.surfaceDestination(surfaceResolvedParams(params), workspaceID: workspaceID)
         return v2VmCall(id: id, timeoutSeconds: 180) {
-            let catalog = SurfaceCatalog.shared
+            let catalog = await SurfaceCatalog.shared
             if await catalog.resources[resource] == nil {
                 // Ports are discovered by probing the machine; a port the person names may
                 // not have been seen yet. Re-sync, then register it so the provider can open it.
@@ -243,7 +243,7 @@ extension TerminalController {
         destination: SurfaceDestination?,
         focus: Bool
     ) async throws -> [String: Any] {
-        let catalog = SurfaceCatalog.shared
+        let catalog = await SurfaceCatalog.shared
         guard let provider = await catalog.provider(for: machine) else {
             throw SurfaceCatalogError.noProvider(machine)
         }


### PR DESCRIPTION
`tests-build-and-lag` on main fails its warning-budget gate with three buckets over budget:

- `Sources/Mobile/MobileHostIrxRuntime.swift` ×2 — `enabledDefaultsKey`/`forceRelayDefaultsKey` are main-actor-isolated statics read from the nonisolated activation gate (inherited from #10782). Marked `nonisolated` (they are string constants).
- `Sources/Surfaces/SurfaceSocketCommands.swift` ×2 — worker-lane handlers read `SurfaceCatalog.shared` synchronously; now awaited like the surrounding calls.

No behavior change. Verified with `swiftc -parse`; the gate is `python3 scripts/swift_warning_budget.py` on the CI build log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10905"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790383878&installation_model_id=21920&pr_number=10905&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10905&signature=6c80a71c39cce6044a3519e01e3dc7d3bec4763fc8f57e624d28184d0877f1f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears the three Swift warnings pushing the `tests-build-and-lag` CI job over its warning-budget gate on main. No behavior change.

- Marks the two `UserDefaults` key constants in `Sources/Mobile/MobileHostIrxRuntime.swift` as `nonisolated` so the nonisolated activation gate can read them without a main-actor warning.
- Awaits `SurfaceCatalog.shared` in `Sources/Surfaces/SurfaceSocketCommands.swift` instead of touching the main-actor property synchronously.

<sup>Written for commit 9f1d87e435a038bc4b5c6e2e994a356b7177d8e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with Swift concurrency when accessing runtime configuration settings.
  * Ensured terminal and socket operations correctly wait for shared surface data to become available.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->