### PR TITLE
fix: retry transient agent-index failures before cancelling deferred session-restore resumes

### DIFF
--- a/Sources/DockSplitStore+RestoredAgentLifecycle.swift
+++ b/Sources/DockSplitStore+RestoredAgentLifecycle.swift
@@ -207,6 +207,13 @@ extension DockSplitStore {
             }
         }
         let originalBinding = binding
+#if DEBUG
+        cmuxDebugLog(
+            "session.restore.binding.retire panel=\(panelId.uuidString.prefix(5)) " +
+            "kind=\(binding.kind ?? "unknown") " +
+            "session=\((binding.checkpointId ?? "").prefix(8))"
+        )
+#endif
         binding.autoResume = false
         if binding.hasCompleteManagedSessionIdentity {
             managedAgentResumeBindingsByPanelId[panelId] = binding
@@ -422,6 +429,14 @@ extension DockSplitStore {
 
 extension DockSplitStore {
     /// Defers one Dock restore launch until the off-main shared agent index is ready.
+    ///
+    /// A nil index (refresh timeout) and an incomplete index (a hook store or
+    /// agent state database that could not be read this pass) are transient on
+    /// agent-heavy machines; retry a bounded number of times before failing
+    /// closed, matching `Workspace.deferAgentResumeRestore`.
+    static let deferredAgentResumeIndexMaxAttempts = 3
+    static let deferredAgentResumeIndexRetryDelay: Duration = .seconds(2)
+
     func deferAgentResumeRestore(
         panelId: UUID,
         restore: DeferredAgentResumeRestore
@@ -429,11 +444,35 @@ extension DockSplitStore {
         deferredAgentResumeRestoresByPanelId[panelId] = restore
         guard deferredAgentResumeIndexTask == nil else { return }
         deferredAgentResumeIndexTask = Task { @MainActor [weak self] in
-            let index = await SharedLiveAgentIndex.shared.indexRefreshingNow()
+            var attempt = 1
+            var index = await SharedLiveAgentIndex.shared.indexRefreshingNow()
+            while index == nil || index?.isComplete == false,
+                  attempt < Self.deferredAgentResumeIndexMaxAttempts,
+                  !Task.isCancelled {
+#if DEBUG
+                cmuxDebugLog(
+                    "session.restore.deferredResume.retry attempt=\(attempt) " +
+                    "indexNil=\(index == nil ? 1 : 0) " +
+                    "incomplete=\(index?.isComplete == false ? 1 : 0)"
+                )
+#endif
+                try? await ContinuousClock().sleep(
+                    for: Self.deferredAgentResumeIndexRetryDelay
+                )
+                guard !Task.isCancelled else { break }
+                attempt += 1
+                index = await SharedLiveAgentIndex.shared.indexRefreshingNow()
+            }
             guard !Task.isCancelled else { return }
             guard let self else { return }
             self.deferredAgentResumeIndexTask = nil
             guard let index else {
+#if DEBUG
+                cmuxDebugLog(
+                    "session.restore.deferredResume.failClosed " +
+                    "reason=indexUnavailable attempts=\(attempt)"
+                )
+#endif
                 self.clearDeferredAgentResumeRestores()
                 return
             }
@@ -458,18 +497,18 @@ extension DockSplitStore {
             guard AgentSessionAutoResumeSettings.isEnabled(
                 defaults: agentSessionAutoResumeDefaults
             ) else {
-                cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore)
+                cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore, reason: "autoResumeDisabled")
                 continue
             }
             guard index.isComplete else {
-                cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore)
+                cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore, reason: "indexIncompleteAfterRetries")
                 continue
             }
             guard deferredAgentResumeRestoreMatchesCurrentSession(
                 panelId: panelId,
                 restore: restore
             ) else {
-                cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore)
+                cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore, reason: "sessionMismatch")
                 continue
             }
             let currentResumeBinding: SurfaceResumeBindingSnapshot?
@@ -478,7 +517,7 @@ extension DockSplitStore {
                       currentBinding.isAgentHookBinding,
                       currentBinding.isSameManagedSession(as: capturedBinding),
                       currentBinding.autoResume == true else {
-                    cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore)
+                    cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore, reason: "bindingRetiredOrChanged")
                     continue
                 }
                 currentResumeBinding = currentBinding
@@ -494,7 +533,7 @@ extension DockSplitStore {
                 guard let capturedBinding = restore.resumeBinding,
                       let currentResumeBinding,
                       capturedBinding == currentResumeBinding else {
-                    cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore)
+                    cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore, reason: "remoteBindingChanged")
                     continue
                 }
             }
@@ -526,7 +565,7 @@ extension DockSplitStore {
                     revalidateProcessEvidence: false
                 )
             guard !ownershipIsBlocked else {
-                cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore)
+                cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore, reason: "ownershipAmbiguous")
                 continue
             }
 
@@ -547,7 +586,7 @@ extension DockSplitStore {
             } else if let binding = currentResumeBinding ?? restore.resumeBinding {
                 if restore.restoresRemoteWorkspaceTerminalSnapshot {
                     guard binding.launchFlavor.remoteContext == restore.remoteResumeContext else {
-                        cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore)
+                        cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore, reason: "remoteContextChanged")
                         continue
                     }
                 }
@@ -573,7 +612,7 @@ extension DockSplitStore {
                 claim = nil
             }
             guard let startupInput, !startupInput.isEmpty else {
-                cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore)
+                cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore, reason: "noResumeCommand")
                 continue
             }
             if let claim,
@@ -581,7 +620,7 @@ extension DockSplitStore {
                    kind: claim.kind,
                    sessionId: claim.sessionId
                ) {
-                cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore)
+                cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore, reason: "resumeClaimHeld")
                 continue
             }
             if let claim {
@@ -658,8 +697,17 @@ extension DockSplitStore {
     func cancelDeferredAgentResumeRestore(
         panelId: UUID,
         restore: DeferredAgentResumeRestore,
-        startRuntime: Bool = true
+        startRuntime: Bool = true,
+        reason: String = "unspecified"
     ) {
+#if DEBUG
+        cmuxDebugLog(
+            "session.restore.deferredResume.cancel panel=\(panelId.uuidString.prefix(5)) " +
+            "reason=\(reason) " +
+            "kind=\(restore.restorableAgent?.kind.rawValue ?? restore.resumeBinding?.kind ?? "unknown") " +
+            "session=\((restore.restorableAgent?.sessionId ?? restore.resumeBinding?.checkpointId ?? "").prefix(8))"
+        )
+#endif
         if startRuntime {
             (panels[panelId] as? TerminalPanel)?.surface.cancelStartupRestoreAdmission()
         } else {
@@ -753,7 +801,8 @@ extension DockSplitStore {
                 cancelDeferredAgentResumeRestore(
                     panelId: panelId,
                     restore: restore,
-                    startRuntime: startRuntime
+                    startRuntime: startRuntime,
+                    reason: "clearAll"
                 )
             } else {
                 if startRuntime {

--- a/Sources/Workspace+AgentLifecycle.swift
+++ b/Sources/Workspace+AgentLifecycle.swift
@@ -384,6 +384,13 @@ extension Workspace {
            ) {
             return
         }
+#if DEBUG
+        cmuxDebugLog(
+            "session.restore.binding.retire panel=\(panelId.uuidString.prefix(5)) " +
+            "kind=\(binding.kind ?? "unknown") " +
+            "session=\((binding.checkpointId ?? "").prefix(8))"
+        )
+#endif
         binding.autoResume = false
         surfaceResumeBindingsByPanelId[panelId] = binding
     }
@@ -609,6 +616,14 @@ extension Workspace {
     /// live-agent index is intentionally asynchronous. Keeping the request on
     /// the owner lets the terminal join its topology first and avoids a main
     /// actor hook-store scan.
+    /// A nil index (refresh timeout) and an incomplete index (a hook store or
+    /// agent state database that could not be read this pass) are transient on
+    /// agent-heavy machines: concurrent agents rewrite the stores and hold the
+    /// Codex state database busy. Retry a bounded number of times before
+    /// failing closed, so a moment of churn cannot silently cancel a restore.
+    static let deferredAgentResumeIndexMaxAttempts = 3
+    static let deferredAgentResumeIndexRetryDelay: Duration = .seconds(2)
+
     func deferAgentResumeRestore(
         panelId: UUID,
         restore: DeferredAgentResumeRestore
@@ -616,11 +631,35 @@ extension Workspace {
         deferredAgentResumeRestoresByPanelId[panelId] = restore
         guard deferredAgentResumeIndexTask == nil else { return }
         deferredAgentResumeIndexTask = Task { @MainActor [weak self] in
-            let index = await SharedLiveAgentIndex.shared.indexRefreshingNow()
+            var attempt = 1
+            var index = await SharedLiveAgentIndex.shared.indexRefreshingNow()
+            while index == nil || index?.isComplete == false,
+                  attempt < Self.deferredAgentResumeIndexMaxAttempts,
+                  !Task.isCancelled {
+#if DEBUG
+                cmuxDebugLog(
+                    "session.restore.deferredResume.retry attempt=\(attempt) " +
+                    "indexNil=\(index == nil ? 1 : 0) " +
+                    "incomplete=\(index?.isComplete == false ? 1 : 0)"
+                )
+#endif
+                try? await ContinuousClock().sleep(
+                    for: Self.deferredAgentResumeIndexRetryDelay
+                )
+                guard !Task.isCancelled else { break }
+                attempt += 1
+                index = await SharedLiveAgentIndex.shared.indexRefreshingNow()
+            }
             guard !Task.isCancelled else { return }
             guard let self else { return }
             self.deferredAgentResumeIndexTask = nil
             guard let index else {
+#if DEBUG
+                cmuxDebugLog(
+                    "session.restore.deferredResume.failClosed " +
+                    "reason=indexUnavailable attempts=\(attempt)"
+                )
+#endif
                 self.clearDeferredAgentResumeRestores()
                 return
             }
@@ -645,18 +684,18 @@ extension Workspace {
             guard AgentSessionAutoResumeSettings.isEnabled(
                 defaults: agentSessionAutoResumeDefaults
             ) else {
-                cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore)
+                cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore, reason: "autoResumeDisabled")
                 continue
             }
             guard index.isComplete else {
-                cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore)
+                cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore, reason: "indexIncompleteAfterRetries")
                 continue
             }
             guard deferredAgentResumeRestoreMatchesCurrentSession(
                 panelId: panelId,
                 restore: restore
             ) else {
-                cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore)
+                cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore, reason: "sessionMismatch")
                 continue
             }
             let currentResumeBinding: SurfaceResumeBindingSnapshot?
@@ -665,7 +704,7 @@ extension Workspace {
                       currentBinding.isAgentHookBinding,
                       currentBinding.isSameManagedSession(as: capturedBinding),
                       currentBinding.autoResume == true else {
-                    cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore)
+                    cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore, reason: "bindingRetiredOrChanged")
                     continue
                 }
                 currentResumeBinding = currentBinding
@@ -681,7 +720,7 @@ extension Workspace {
                 guard let capturedBinding = restore.resumeBinding,
                       let currentResumeBinding,
                       capturedBinding == currentResumeBinding else {
-                    cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore)
+                    cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore, reason: "remoteBindingChanged")
                     continue
                 }
             }
@@ -713,7 +752,7 @@ extension Workspace {
                     revalidateProcessEvidence: false
                 )
             guard !ownershipIsBlocked else {
-                cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore)
+                cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore, reason: "ownershipAmbiguous")
                 continue
             }
 
@@ -734,7 +773,7 @@ extension Workspace {
             } else if let binding = currentResumeBinding ?? restore.resumeBinding {
                 if restore.restoresRemoteWorkspaceTerminalSnapshot {
                     guard binding.launchFlavor.remoteContext == restore.remoteResumeContext else {
-                        cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore)
+                        cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore, reason: "remoteContextChanged")
                         continue
                     }
                 }
@@ -760,7 +799,7 @@ extension Workspace {
                 claim = nil
             }
             guard let startupInput, !startupInput.isEmpty else {
-                cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore)
+                cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore, reason: "noResumeCommand")
                 continue
             }
             if let claim,
@@ -768,7 +807,7 @@ extension Workspace {
                    kind: claim.kind,
                    sessionId: claim.sessionId
                ) {
-                cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore)
+                cancelDeferredAgentResumeRestore(panelId: panelId, restore: restore, reason: "resumeClaimHeld")
                 continue
             }
             if let claim {
@@ -830,8 +869,17 @@ extension Workspace {
     func cancelDeferredAgentResumeRestore(
         panelId: UUID,
         restore: DeferredAgentResumeRestore,
-        startRuntime: Bool = true
+        startRuntime: Bool = true,
+        reason: String = "unspecified"
     ) {
+#if DEBUG
+        cmuxDebugLog(
+            "session.restore.deferredResume.cancel panel=\(panelId.uuidString.prefix(5)) " +
+            "reason=\(reason) " +
+            "kind=\(restore.restorableAgent?.kind.rawValue ?? restore.resumeBinding?.kind ?? "unknown") " +
+            "session=\((restore.restorableAgent?.sessionId ?? restore.resumeBinding?.checkpointId ?? "").prefix(8))"
+        )
+#endif
         if startRuntime {
             (panels[panelId] as? TerminalPanel)?.surface.cancelStartupRestoreAdmission()
         } else {
@@ -925,7 +973,8 @@ extension Workspace {
                 cancelDeferredAgentResumeRestore(
                     panelId: panelId,
                     restore: restore,
-                    startRuntime: startRuntime
+                    startRuntime: startRuntime,
+                    reason: "clearAll"
                 )
             } else {
                 if startRuntime {


### PR DESCRIPTION
At launch, session restore defers each agent relaunch until SharedLiveAgentIndex validates it. A refresh timeout (nil index) or an unreadable hook store / Codex state database (incomplete index) cancelled the admission outright, and every cancel path was silent. The pane came back as a bare shell, and the first shell command activity then retired the binding (autoResume=false), so all later restores skipped the session too. On agent-heavy machines both trigger conditions are routine churn. Observed live on 2026-08-26 at 17:36 PDT: one codex and two claude sessions lost auto-resume this way (the codex pane logged `surface.headless_window.adopt reason=startup-restore-cancelled`; the claude panes failed identically with no log line at all).

The fix retries the index fetch up to 3 times, 2 seconds apart, before failing closed. The backoff is a cancellable ContinuousClock sleep inside the existing deferredAgentResumeIndexTask, so teardown cancels it. Every cancel path now carries a reason string that lands in the debug log, and the binding-retire moment logs too, so the next silent restore failure names itself. Both copies of the machinery (Workspace and DockSplitStore) get the same change.

Not covered here: retiring a binding after a fail-closed cancel is still possible if all retries exhaust; distinguishing that from deliberate user takeover of the pane needs a lifecycle state change and is left for a follow-up. Unit seams for SharedLiveAgentIndex.shared in the defer path are also a follow-up; verification for this PR is a live quit/relaunch loop with hook-store churn, evidence in the PR thread.

Stacked on #10900.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790390842&installation_model_id=21920&pr_number=10915&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10915&signature=58bed871c76bf4e4157aedea33fb48afa35a8252c705f942d5f8e0539f76cb5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes session restore at launch so a transient agent-index failure no longer silently cancels deferred agent relaunches. Previously, a refresh timeout (nil index) or an unreadable hook store / Codex state database (incomplete index) cancelled the admission with no log, leaving a bare shell; the next shell command then retired the binding (`autoResume=false`), so all later restores skipped the session. Now the index fetch retries up to 3 times, 2 seconds apart, before failing closed, and every cancel path logs a reason string.

**Details**
- Retry uses a cancellable `ContinuousClock` sleep inside the existing `deferredAgentResumeIndexTask`, so teardown cancels it.
- Applied to both `Workspace` and `DockSplitStore` copies of the defer machinery, plus the binding-retire moment.
- If all retries exhaust, retiring the binding is still possible; distinguishing that from deliberate user takeover needs a lifecycle state change (follow-up).
- Verification was a live quit/relaunch loop with hook-store churn; unit seams for `SharedLiveAgentIndex.shared` in the defer path are a follow-up.

<sup>Written for commit 7bb017a7d6440f66440c25c566b1b8595b1c08ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

