### PR TITLE
chatmux-relay: redial promptly after a VM suspend/resume (clock-jump + read-liveness watchdog)

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/error.rs
+++ b/cmux-tui/crates/chatmux-relay/src/error.rs
@@ -11,6 +11,10 @@ pub enum RelayError {
     PairingExpired { message: String },
     /// Socket loss, network failure: print and reconnect with backoff.
     Transient { message: String },
+    /// The host slept, or the socket went silent past its read deadline. The
+    /// TCP connection is presumed dead even when the OS still reports it
+    /// established; redial immediately with no backoff delay.
+    WakeRedial { message: String },
 }
 
 impl RelayError {
@@ -22,11 +26,16 @@ impl RelayError {
         RelayError::Transient { message: message.into() }
     }
 
+    pub fn wake_redial(message: impl Into<String>) -> RelayError {
+        RelayError::WakeRedial { message: message.into() }
+    }
+
     pub fn message(&self) -> &str {
         match self {
             RelayError::Fatal { message, .. }
             | RelayError::PairingExpired { message }
-            | RelayError::Transient { message } => message,
+            | RelayError::Transient { message }
+            | RelayError::WakeRedial { message } => message,
         }
     }
 }

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -1,7 +1,11 @@
 //! Connected state: hello negotiation, heartbeats, trust sync, reconnect
 //! with jittered exponential backoff, and the exec/PTY frame dispatch.
 //! Behavior port of `stayOnline` / `relaySession` in
-//! `packages/relay/bin/cmux-relay.mjs`.
+//! `packages/relay/bin/cmux-relay.mjs`, plus a suspend/read-liveness
+//! watchdog the JS relay never had: a wall-vs-monotonic clock-jump detector
+//! and an inbound-traffic deadline that together redial promptly after a VM
+//! pause or host sleep instead of waiting out the kernel's TCP
+//! retransmission timeout on a zombie socket.
 //!
 //! Slices 2/3: `action_request` runs the exec verbs (`actions`); the
 //! `pty_*` family drives the PtyManager (`pty`). Both re-check the machine's
@@ -51,6 +55,22 @@ const MAX_PTY_INGRESS_FRAMES: usize = 64;
 // Keep room for the workspace fs_write 2 MiB payload plus its JSON envelope.
 const MAX_INBOUND_FRAME_BYTES: usize = 4 << 20;
 const CONNECTION_TASK_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
+/// One suspend/read-liveness sample per period while a socket is open.
+const LIVENESS_CHECK_INTERVAL: Duration = Duration::from_secs(5);
+/// Wall clock moving more than this relative to the monotonic clock between
+/// two liveness samples means the host slept under us (or the guest clock
+/// was stepped); either way the peer likely closed the socket while this
+/// process was not running, and no FIN/RST will ever arrive.
+const SUSPEND_CLOCK_JUMP: Duration = Duration::from_secs(30);
+/// The server answers every heartbeat with `heartbeat_ack` and marks a
+/// relay stale after 3 heartbeat intervals + 10s (the Relay DO `presence()`
+/// rule). Use the same budget here: a socket with no inbound traffic for
+/// that long is dead, whatever the OS says about the TCP connection.
+const READ_LIVENESS_HEARTBEATS: u32 = 3;
+const READ_LIVENESS_GRACE: Duration = Duration::from_secs(10);
+/// Before hello_accepted names the negotiated cadence, budget for the
+/// server-default 20s heartbeat interval.
+const PRE_HELLO_READ_DEADLINE: Duration = Duration::from_secs(70);
 
 pub struct SessionState {
     pub first_connect: bool,
@@ -246,6 +266,29 @@ fn now_ms() -> i64 {
         .unwrap_or_default()
 }
 
+/// True when the wall clock moved more than `threshold` relative to the
+/// monotonic clock between two liveness samples. Deltas, not absolutes: a
+/// wall clock that is wrong but ticking (a guest that never resynced after
+/// a pause) advances in step with the monotonic clock and never trips this;
+/// a host suspend advances the wall clock while the monotonic clock stands
+/// still, and a clock step moves it without any monotonic time passing.
+fn clock_jumped(wall_delta_ms: i64, monotonic_delta: Duration, threshold: Duration) -> bool {
+    let monotonic_ms = i64::try_from(monotonic_delta.as_millis()).unwrap_or(i64::MAX);
+    let threshold_ms = i64::try_from(threshold.as_millis()).unwrap_or(i64::MAX);
+    wall_delta_ms.saturating_sub(monotonic_ms).saturating_abs() > threshold_ms
+}
+
+/// How long a socket may stay silent before it is treated as dead. Follows
+/// the negotiated heartbeat cadence once hello_accepted names it.
+fn read_liveness_deadline(heartbeat_interval: Option<Duration>) -> Duration {
+    match heartbeat_interval {
+        Some(interval) => interval
+            .saturating_mul(READ_LIVENESS_HEARTBEATS)
+            .saturating_add(READ_LIVENESS_GRACE),
+        None => PRE_HELLO_READ_DEADLINE,
+    }
+}
+
 fn jitter() -> f64 {
     let mut byte = [0_u8; 1];
     let _ = getrandom::fill(&mut byte);
@@ -297,6 +340,15 @@ pub async fn stay_online(
             }
             Err(RelayError::Fatal { message, exit_code }) => {
                 return Err(RelayError::Fatal { message, exit_code });
+            }
+            Err(RelayError::WakeRedial { message }) => {
+                // The socket died silently (host suspend, or a peer that
+                // vanished without a FIN). The network itself is not known
+                // to be down, so redial now; a failed dial lands back on
+                // the normal backoff ladder below.
+                eprintln!("Relay redialing: {message}");
+                attempt = 0;
+                continue;
             }
             Err(error) => {
                 eprintln!("Relay offline: {error}");
@@ -480,6 +532,17 @@ async fn relay_session(
     let mut unknown_types: HashSet<String> = HashSet::new();
     let mut unknown_type_order: VecDeque<String> = VecDeque::new();
     let mut heartbeat: Option<tokio::time::Interval> = None;
+    let mut heartbeat_interval: Option<Duration> = None;
+    // Suspend and read-liveness watchdog. A VM pause or host sleep leaves
+    // this side holding an ESTABLISHED socket whose peer closed long ago;
+    // no FIN/RST arrives, so without this the relay would sit on the zombie
+    // socket until the kernel's TCP retransmission timeout (10+ minutes).
+    let mut liveness = tokio::time::interval(LIVENESS_CHECK_INTERVAL);
+    liveness.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    liveness.reset();
+    let mut last_inbound = tokio::time::Instant::now();
+    let mut last_wall_ms = now_ms();
+    let mut last_monotonic = tokio::time::Instant::now();
     let mut critical_burst = 0_u8;
 
     let result = loop {
@@ -505,6 +568,7 @@ async fn relay_session(
         enum Wake {
             Shutdown,
             Heartbeat,
+            Liveness,
             Outbound(bool, Option<OutboundFrame>),
             Incoming(Option<Result<Message, TungsteniteError>>),
         }
@@ -521,6 +585,7 @@ async fn relay_session(
                             None => std::future::pending().await,
                         }
                     }, if heartbeat.is_some() => Wake::Heartbeat,
+                    _ = liveness.tick() => Wake::Liveness,
                     _ = cancellation.cancelled() => Wake::Shutdown,
                     incoming = guard.next() => Wake::Incoming(incoming),
                 }
@@ -535,6 +600,7 @@ async fn relay_session(
                             None => std::future::pending().await,
                         }
                     }, if heartbeat.is_some() => Wake::Heartbeat,
+                    _ = liveness.tick() => Wake::Liveness,
                     _ = cancellation.cancelled() => Wake::Shutdown,
                     incoming = guard.next() => Wake::Incoming(incoming),
                 }
@@ -547,6 +613,31 @@ async fn relay_session(
                 let frame = heartbeat_frame(now_ms()).to_string();
                 if send_socket_text(&socket, frame, cancellation).await.is_err() {
                     break Ok(connected);
+                }
+            }
+            Wake::Liveness => {
+                critical_burst = 0;
+                let wall_ms = now_ms();
+                let monotonic = tokio::time::Instant::now();
+                let wall_delta_ms = wall_ms.saturating_sub(last_wall_ms);
+                let monotonic_delta = monotonic.saturating_duration_since(last_monotonic);
+                last_wall_ms = wall_ms;
+                last_monotonic = monotonic;
+                if clock_jumped(wall_delta_ms, monotonic_delta, SUSPEND_CLOCK_JUMP) {
+                    break Err(RelayError::wake_redial(format!(
+                        "the host slept or its clock jumped ({wall_delta_ms}ms of wall time \
+                         across {}ms of run time); the socket peer is presumed gone",
+                        monotonic_delta.as_millis()
+                    )));
+                }
+                let idle = monotonic.saturating_duration_since(last_inbound);
+                let deadline = read_liveness_deadline(heartbeat_interval);
+                if idle >= deadline {
+                    break Err(RelayError::wake_redial(format!(
+                        "no server traffic for {}s (deadline {}s); the socket is presumed dead",
+                        idle.as_secs(),
+                        deadline.as_secs()
+                    )));
                 }
             }
             Wake::Outbound(is_critical, Some(frame)) => {
@@ -573,6 +664,9 @@ async fn relay_session(
                     Some(Err(error)) => break Err(RelayError::transient(error.to_string())),
                     None => break Ok(connected),
                 };
+                // Any inbound traffic (heartbeat_ack included) proves the
+                // socket is alive; the read-liveness deadline restarts here.
+                last_inbound = tokio::time::Instant::now();
                 let text = match message {
                     Message::Text(text) => text,
                     Message::Ping(payload) => {
@@ -683,12 +777,12 @@ async fn relay_session(
                             snapshot.owner = config.owner_user_id.clone();
                             workspace.set_local_observe(local_observe);
                         }
-                        let mut interval = tokio::time::interval(Duration::from_millis(
-                            hello.heartbeat_interval_ms,
-                        ));
+                        let cadence = Duration::from_millis(hello.heartbeat_interval_ms);
+                        let mut interval = tokio::time::interval(cadence);
                         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
                         interval.reset();
                         heartbeat = Some(interval);
+                        heartbeat_interval = Some(cadence);
                     }
                     ServerFrame::UpgradeRequired { min_version, message } => {
                         let advertised = advertised_protocol();
@@ -984,6 +1078,66 @@ mod tests {
         assert_eq!(list["type"], "surface_list_result");
         assert_eq!(list["requestId"], "list_1");
         assert_eq!(list["surfaces"], serde_json::json!([]));
+    }
+}
+
+#[cfg(test)]
+mod liveness_tests {
+    use super::{
+        PRE_HELLO_READ_DEADLINE, READ_LIVENESS_GRACE, SUSPEND_CLOCK_JUMP, clock_jumped,
+        read_liveness_deadline,
+    };
+    use std::time::Duration;
+
+    #[test]
+    fn matching_clock_deltas_are_not_a_jump() {
+        // A healthy tick: 5s of wall time across 5s of run time. This is
+        // also the wrong-but-ticking guest clock (absolute offset does not
+        // matter; only the deltas are compared).
+        assert!(!clock_jumped(5_000, Duration::from_secs(5), SUSPEND_CLOCK_JUMP));
+    }
+
+    #[test]
+    fn wall_clock_running_ahead_of_monotonic_is_a_suspend() {
+        // Host sleep: 14 minutes of wall time passed while the monotonic
+        // clock (which excludes suspend) saw one 5s sample.
+        assert!(clock_jumped(840_000, Duration::from_secs(5), SUSPEND_CLOCK_JUMP));
+    }
+
+    #[test]
+    fn wall_clock_stepped_backward_is_a_jump() {
+        // A guest clock resync stepping backward after a pause is the same
+        // signal: real time passed that this process never observed.
+        assert!(clock_jumped(-835_000, Duration::from_secs(5), SUSPEND_CLOCK_JUMP));
+    }
+
+    #[test]
+    fn the_jump_threshold_is_exclusive() {
+        let threshold_ms = 5_000 + i64::try_from(SUSPEND_CLOCK_JUMP.as_millis()).expect("ms");
+        assert!(!clock_jumped(threshold_ms, Duration::from_secs(5), SUSPEND_CLOCK_JUMP));
+        assert!(clock_jumped(threshold_ms + 1, Duration::from_secs(5), SUSPEND_CLOCK_JUMP));
+    }
+
+    #[test]
+    fn extreme_deltas_saturate_instead_of_overflowing() {
+        assert!(clock_jumped(i64::MAX, Duration::ZERO, SUSPEND_CLOCK_JUMP));
+        assert!(clock_jumped(i64::MIN, Duration::ZERO, SUSPEND_CLOCK_JUMP));
+        assert!(clock_jumped(0, Duration::from_millis(u64::MAX), SUSPEND_CLOCK_JUMP));
+    }
+
+    #[test]
+    fn read_deadline_follows_the_negotiated_heartbeat_cadence() {
+        // 3 heartbeats + 10s grace, matching the server's staleness rule.
+        assert_eq!(read_liveness_deadline(Some(Duration::from_secs(20))), Duration::from_secs(70));
+        assert_eq!(
+            read_liveness_deadline(Some(Duration::from_secs(1))),
+            Duration::from_secs(3) + READ_LIVENESS_GRACE
+        );
+    }
+
+    #[test]
+    fn read_deadline_before_hello_uses_the_server_default_budget() {
+        assert_eq!(read_liveness_deadline(None), PRE_HELLO_READ_DEADLINE);
     }
 }
 

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -282,9 +282,9 @@ fn clock_jumped(wall_delta_ms: i64, monotonic_delta: Duration, threshold: Durati
 /// the negotiated heartbeat cadence once hello_accepted names it.
 fn read_liveness_deadline(heartbeat_interval: Option<Duration>) -> Duration {
     match heartbeat_interval {
-        Some(interval) => interval
-            .saturating_mul(READ_LIVENESS_HEARTBEATS)
-            .saturating_add(READ_LIVENESS_GRACE),
+        Some(interval) => {
+            interval.saturating_mul(READ_LIVENESS_HEARTBEATS).saturating_add(READ_LIVENESS_GRACE)
+        }
         None => PRE_HELLO_READ_DEADLINE,
     }
 }


### PR DESCRIPTION
## Problem (R4 staging drill)

On a Sprites sandbox the VM auto-pauses. During the pause the backend Relay DO marked the machine offline and dropped the server side of the WebSocket, but the paused guest never received the FIN/RST. After wake, the Rust relay (0.1.0-rc.5) held a zombie ESTABLISHED TLS socket and never re-dialed within the 90s observed window. The HTTPS events plane recovered fine.

## Part 1 verdict: pre-existing behavior in both — not a Rust regression

Under the same pause, the Node relay sits on the same zombie socket. Neither client has any liveness mechanism beyond TCP itself; the Rust port faithfully reproduced the Node behavior.

Node relay (`packages/relay/bin/cmux-relay.mjs` in the chatmux repo):
- Heartbeat is send-only: `setInterval` at the negotiated cadence, guarded only by `readyState === OPEN` (cmux-relay.mjs:727-735). Writes into a dead peer buffer in the kernel and "succeed".
- `heartbeat_ack` is received and discarded — no bookkeeping, no deadline (cmux-relay.mjs:768-769).
- The only reconnect triggers are the socket's own `error` (cmux-relay.mjs:845) and `close` (cmux-relay.mjs:846-851) events feeding the `stayOnline` backoff loop (cmux-relay.mjs:614-633). No read deadline, no client ping, no TCP keepalive (Node `ws` default), no suspend/wake detection.

Rust relay (`cmux-tui/crates/chatmux-relay/src/session.rs` at origin/main, pre-fix):
- Heartbeat is send-only: interval armed at `hello_accepted` (session.rs:686-691), sent on tick (session.rs:545-551). `ServerFrame::HeartbeatAck` is discarded (session.rs:702).
- Reconnect triggers only: read error (session.rs:573), stream end (session.rs:574), server Close frame (session.rs:583), or a failed send. Backoff in `stay_online` (session.rs:288-315).
- It answers server Pings (session.rs:578-582), but the Relay DO never sends pings (no auto-response or ping configured in `apps/backend/src/relay.ts`).

Server contract (`apps/backend/src/relay.ts`): default heartbeat interval 20s (relay.ts:109, relay.ts:181-186), every heartbeat answered with `heartbeat_ack` (relay.ts:1182-1199), presence goes stale after `3 * interval + 10s` (relay.ts:434).

Recovery physics for both clients: they keep writing heartbeats into the void, so the kernel's TCP retransmission timeout eventually errors the socket (~13-16 min at Linux defaults) — far beyond the 90s drill window, and consistent with "connected then nothing" in the in-guest log.

## Fix (Rust only — the Node relay is deleted at R6)

Two complementary detectors on one 5s sample interval inside the session select loop, both ending the session with a new `RelayError::WakeRedial` that `stay_online` treats as "redial now" (backoff attempt reset to zero, delay skipped; a failed redial lands back on the normal backoff ladder):

1. **Clock-jump detector** (`clock_jumped`): compares the wall-clock delta against the monotonic (`tokio::time::Instant`) delta between samples. A discrepancy over 30s in either direction means the host slept under us or the guest clock was stepped. Deltas, not absolutes — a wall clock that is wrong but ticking (the Sprites frozen-offset clock) advances in step with the monotonic clock and never trips this.
2. **Read-liveness deadline** (`read_liveness_deadline`): any inbound traffic (heartbeat_ack included) restarts the clock; silence for `3 heartbeat intervals + 10s` (70s at the default 20s cadence; same value pre-hello) declares the socket dead. This deliberately mirrors the Relay DO's own staleness rule, so both sides give up on a dead socket on the same budget.

Coverage of the two wake shapes:
- Sprites full-VM pause: both guest clocks freeze together, so the jump detector stays quiet by design — the read deadline is what recovers this case, ≤ ~75s after wake (70s budget + 5s sampling).
- Host suspend / clock step (laptop sleep, NTP step): wall time jumps relative to monotonic — the jump detector redials within one 5s sample.

No graceful close on the dead socket: breaking the session drops the stream, which is the force-close (a close handshake on a dead peer would hang).

Deliberately skipped: OS TCP keepalive. `tokio-tungstenite`'s `connect_async` does not expose socket options; wiring keepalive would mean hand-rolling the TCP+TLS dial. The two detectors above cover the failure mode portably.

## Not fixed here

The Sprites guest wall clock not resyncing after wake (~14 min behind in the drill) is a separate infra issue. This change is correct under that broken clock (delta comparison), but the clock itself needs an infra fix.

## Tests

Unit tests for the pure parts, matching the crate's existing `mod cancellation_tests` idiom in session.rs:
- `clock_jumped`: matching deltas (including the wrong-but-ticking clock), forward jump (suspend), backward step, exact-threshold exclusivity, and saturation at extreme deltas.
- `read_liveness_deadline`: follows the negotiated cadence (20s -> 70s), pre-hello default budget.

Hosted gate (fmt + clippy + tests, Linux + macOS): `verify-cmux-tui-hosted.sh --filter chatmux_relay` — run 33034263344 (green). An earlier run, 33034046003, failed on `cargo fmt` only (one chain-wrapping diff); fixed in the follow-up commit.

A live Sprites re-drill happens after merge + rc.6 (not in this PR).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The Rust relay now redials immediately after a VM pause or host sleep, instead of sitting on a zombie ESTABLISHED TCP socket until the kernel's timeout (10+ minutes). This is a Rust-only fix; the Node relay is deleted at R6.

- Adds a clock-jump detector that compares wall-clock vs monotonic deltas on a 5-second sample, triggering a redial if the host slept or the clock stepped.
- Adds a read-liveness deadline: any inbound traffic restarts the clock, and silence for 3 heartbeat intervals + 10s declares the socket dead, matching the server's staleness rule.
- New `WakeRedial` error resets backoff and redials immediately; a failed redial falls back to the normal backoff ladder.

<sup>Written for commit bdf87003d8e7348a8f61356786817daf59748311. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved relay connection recovery after device sleep, VM pauses, or clock changes.
  - Added proactive detection for stalled connections and immediate redialing when needed.
  - Improved connection liveness monitoring before and after initial connection setup.
  - Added safeguards for clock changes and edge cases affecting connection deadlines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->