### PR TITLE
Cloud panel: real empty state, richer copy, aligned header meter

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -124853,6 +124853,40 @@
         }
       }
     },
+    "machines.empty.planIncludes": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your plan includes %d machines"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在のプランでは %d 台のマシンを利用できます"
+          }
+        }
+      }
+    },
+    "machines.empty.planIncludes.single": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your plan includes 1 machine"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在のプランでは 1 台のマシンを利用できます"
+          }
+        }
+      }
+    },
     "machines.empty.subtitle": {
       "extractionState": "manual",
       "localizations": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -124921,6 +124921,40 @@
         }
       }
     },
+    "machines.empty.upgrade": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Upgrade to use more than %d machines"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アップグレードすると %d 台を超えるマシンを利用できます"
+          }
+        }
+      }
+    },
+    "machines.empty.upgrade.single": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Upgrade to use more than 1 machine"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アップグレードすると複数のマシンを利用できます"
+          }
+        }
+      }
+    },
     "machines.freeAccess.countdown.daysHours": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/Cloud/CloudTreeNode.swift
+++ b/Sources/Cloud/CloudTreeNode.swift
@@ -250,6 +250,20 @@ enum CloudTreeNodeBuilder {
         return nodes
     }
 
+    /// True when `nodes(machines:snapshot:localWorkspaces:)` would produce no
+    /// rows. The panel swaps the outline for its empty state on this; it must
+    /// mirror `nodes` exactly (local catalog entries only count while
+    /// `includesLocalMachine` is on), or a fresh account renders a blank
+    /// outline instead of the empty state.
+    static func isEmpty(
+        machines: [MachineSnapshot],
+        snapshot: SurfaceCatalogSnapshot,
+        includeLocalMachine: Bool = CloudTreeNodeBuilder.includesLocalMachine
+    ) -> Bool {
+        guard machines.isEmpty else { return false }
+        return !snapshot.machines.contains { includeLocalMachine || !$0.id.isLocal }
+    }
+
     static func nodeID(machine: SurfaceMachineID) -> String { "machine:\(machine.rawValue)" }
     static func nodeID(workspacesGroup machine: SurfaceMachineID) -> String { "machine:\(machine.rawValue)/workspaces" }
     static func nodeID(workspace: String, machine: SurfaceMachineID) -> String { "machine:\(machine.rawValue)/ws/\(workspace)" }

--- a/Sources/Cloud/MachinesPanelView.swift
+++ b/Sources/Cloud/MachinesPanelView.swift
@@ -352,7 +352,19 @@ struct MachinesPanelView: View {
                 .buttonStyle(.borderedProminent)
                 .controlSize(.small)
                 .padding(.top, 2)
-                if let plan = viewModel.plan {
+                if let plan = viewModel.plan, !plan.isPaidPlan {
+                    // The upgrade nudge under the create button: same Pro flow
+                    // as the meter's at-limit hint and the ＋ at the ceiling.
+                    Button {
+                        ProUpgradePresenter.present()
+                    } label: {
+                        Text(upgradeNudgeLabel(plan))
+                            .cmuxFont(size: 11)
+                            .foregroundColor(.secondary.opacity(0.7))
+                            .underline()
+                    }
+                    .buttonStyle(.plain)
+                } else if let plan = viewModel.plan {
                     Text(planIncludesLabel(plan))
                         .cmuxFont(size: 11)
                         .foregroundColor(.secondary.opacity(0.7))
@@ -367,8 +379,23 @@ struct MachinesPanelView: View {
         .accessibilityIdentifier("CloudMachinesEmptyState")
     }
 
-    /// "Your plan includes 5 machines" under the create button, so the empty
-    /// state answers "what do I get" before the meter ever shows a count.
+    /// Free plans: "Upgrade to use more than 1 machine" — the ceiling plus the
+    /// way past it in one line.
+    private func upgradeNudgeLabel(_ plan: MachinePlanSnapshot) -> String {
+        if plan.isSingleMachinePlan {
+            return String(
+                localized: "machines.empty.upgrade.single",
+                defaultValue: "Upgrade to use more than 1 machine"
+            )
+        }
+        return String(
+            format: String(localized: "machines.empty.upgrade", defaultValue: "Upgrade to use more than %d machines"),
+            plan.maxActiveVms
+        )
+    }
+
+    /// Paid plans: "Your plan includes 5 machines" under the create button, so
+    /// the empty state answers "what do I get" before the meter shows a count.
     private func planIncludesLabel(_ plan: MachinePlanSnapshot) -> String {
         if plan.isSingleMachinePlan {
             return String(

--- a/Sources/Cloud/MachinesPanelView.swift
+++ b/Sources/Cloud/MachinesPanelView.swift
@@ -94,44 +94,47 @@ struct MachinesPanelView: View {
 
     private var controlBar: some View {
         HStack(spacing: 6) {
-            if let operation = viewModel.activeOperation {
-                HStack(spacing: 5) {
-                    ProgressView()
-                        .controlSize(.mini)
-                    Text(operation)
-                        .cmuxFont(size: 11)
-                        .foregroundColor(.secondary)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
+            Group {
+                if let operation = viewModel.activeOperation {
+                    HStack(spacing: 5) {
+                        ProgressView()
+                            .controlSize(.mini)
+                        Text(operation)
+                            .cmuxFont(size: 11)
+                            .foregroundColor(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                    }
+                } else if viewModel.lastErrorDescription != nil, !viewModel.machines.isEmpty {
+                    HStack(spacing: 5) {
+                        Image(systemName: "exclamationmark.triangle")
+                            .font(.system(size: 10, weight: .semibold))
+                        Text(String(localized: "machines.unavailable.stale", defaultValue: "Cloud unreachable \u{2014} showing last known"))
+                            .cmuxFont(size: 11)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                    }
+                    .foregroundColor(.orange.opacity(0.9))
+                    .help(viewModel.lastErrorDescription ?? "")
+                } else if let treeError = viewModel.treeErrorDescription {
+                    HStack(spacing: 5) {
+                        Image(systemName: "exclamationmark.triangle")
+                            .font(.system(size: 10, weight: .semibold))
+                        Text(String(localized: "machines.tree.error", defaultValue: "Cloud tree error"))
+                            .cmuxFont(size: 11)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                    }
+                    .foregroundColor(.orange.opacity(0.9))
+                    .help(treeError)
+                } else if let plan = viewModel.plan {
+                    MachinePlanMeter(plan: plan)
                 }
-                .padding(.leading, 8)
-            } else if viewModel.lastErrorDescription != nil, !viewModel.machines.isEmpty {
-                HStack(spacing: 5) {
-                    Image(systemName: "exclamationmark.triangle")
-                        .font(.system(size: 10, weight: .semibold))
-                    Text(String(localized: "machines.unavailable.stale", defaultValue: "Cloud unreachable \u{2014} showing last known"))
-                        .cmuxFont(size: 11)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                }
-                .foregroundColor(.orange.opacity(0.9))
-                .padding(.leading, 8)
-                .help(viewModel.lastErrorDescription ?? "")
-            } else if let treeError = viewModel.treeErrorDescription {
-                HStack(spacing: 5) {
-                    Image(systemName: "exclamationmark.triangle")
-                        .font(.system(size: 10, weight: .semibold))
-                    Text(String(localized: "machines.tree.error", defaultValue: "Cloud tree error"))
-                        .cmuxFont(size: 11)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                }
-                .foregroundColor(.orange.opacity(0.9))
-                .padding(.leading, 8)
-                .help(treeError)
-            } else if let plan = viewModel.plan {
-                MachinePlanMeter(plan: plan)
             }
+            // Bar leading is 8pt; +4 puts the leading text at 12pt — the same
+            // column as the mode-bar pill glyphs (4pt bar + 8pt pill inset)
+            // and the Files header icon.
+            .padding(.leading, 4)
             Spacer(minLength: 4)
             MachinesChromeIconButton(
                 symbolName: "arrow.clockwise",
@@ -154,9 +157,13 @@ struct MachinesPanelView: View {
 
     @ViewBuilder
     private var content: some View {
-        // This Mac is always a row once the local provider registered, so the
-        // empty state is only for "signed in, nothing at all to show yet".
-        if viewModel.machines.isEmpty, !viewModel.catalog.machines.contains(where: { $0.id.isLocal }) {
+        // Show the empty state exactly when the outline would render zero
+        // rows. The builder owns that decision (the tree is cloud-only while
+        // `includesLocalMachine` is off); deciding it here from the raw
+        // catalog previously left a blank panel for a signed-in account with
+        // no machines, because the catalog's This Mac entry counted as a row
+        // the tree never drew.
+        if CloudTreeNodeBuilder.isEmpty(machines: viewModel.machines, snapshot: viewModel.catalog) {
             emptyState
         } else {
             machinesList
@@ -322,11 +329,11 @@ struct MachinesPanelView: View {
                 }
                 .padding(.top, 2)
             } else if viewModel.hasLoadedOnce {
-                Image(systemName: "server.rack")
-                    .font(.system(size: 26, weight: .light))
+                Image(systemName: "cloud")
+                    .font(.system(size: 30, weight: .light))
                     .foregroundColor(.secondary.opacity(0.55))
                 Text(String(localized: "machines.empty.title", defaultValue: "No machines yet"))
-                    .cmuxFont(size: 13)
+                    .cmuxFont(size: 13, weight: .semibold)
                     .foregroundColor(.primary.opacity(0.85))
                 Text(String(
                     localized: "machines.empty.subtitle",
@@ -335,14 +342,21 @@ struct MachinesPanelView: View {
                 .cmuxFont(size: 12)
                 .foregroundColor(.secondary)
                 .multilineTextAlignment(.center)
-                .padding(.horizontal, 24)
+                .padding(.horizontal, 28)
                 Button {
                     requestNewMachine()
                 } label: {
                     Text(String(localized: "machines.empty.create", defaultValue: "New Machine"))
                         .cmuxFont(size: 12)
                 }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
                 .padding(.top, 2)
+                if let plan = viewModel.plan {
+                    Text(planIncludesLabel(plan))
+                        .cmuxFont(size: 11)
+                        .foregroundColor(.secondary.opacity(0.7))
+                }
             } else {
                 ProgressView()
                     .controlSize(.small)
@@ -350,6 +364,22 @@ struct MachinesPanelView: View {
             Spacer()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityIdentifier("CloudMachinesEmptyState")
+    }
+
+    /// "Your plan includes 5 machines" under the create button, so the empty
+    /// state answers "what do I get" before the meter ever shows a count.
+    private func planIncludesLabel(_ plan: MachinePlanSnapshot) -> String {
+        if plan.isSingleMachinePlan {
+            return String(
+                localized: "machines.empty.planIncludes.single",
+                defaultValue: "Your plan includes 1 machine"
+            )
+        }
+        return String(
+            format: String(localized: "machines.empty.planIncludes", defaultValue: "Your plan includes %d machines"),
+            plan.maxActiveVms
+        )
     }
 }
 
@@ -370,7 +400,6 @@ private struct MachinePlanMeter: View {
                     .foregroundColor(.orange)
             }
         }
-        .padding(.leading, 8)
         .help(meterHelp)
         .accessibilityElement(children: .combine)
     }

--- a/cmuxTests/MachinesPanelModelTests.swift
+++ b/cmuxTests/MachinesPanelModelTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Bonsplit
+import Testing
 import XCTest
 
 #if canImport(cmux_DEV)
@@ -662,37 +663,6 @@ final class CloudTreeScopeAndSignatureTests: XCTestCase {
         XCTAssertEqual(withLocal.first?.id, "machine:local")
     }
 
-    /// Regression: a signed-in account with no cloud machines rendered a blank
-    /// panel instead of the empty state, because the panel judged emptiness
-    /// from the raw catalog (whose This Mac entry counted as a row) while the
-    /// cloud-only tree drew nothing. The emptiness decision must match what
-    /// `nodes` actually renders.
-    func testEmptyDecisionMatchesWhatTheTreeRenders() {
-        let localOnly = SurfaceCatalogSnapshot(machines: [info(.local)], resources: [terminal(.local, "AAA")], projections: [])
-        XCTAssertTrue(
-            CloudTreeNodeBuilder.nodes(machines: [], snapshot: localOnly, localWorkspaces: []).isEmpty,
-            "precondition: the cloud-only tree renders nothing for a local-only catalog"
-        )
-        XCTAssertTrue(
-            CloudTreeNodeBuilder.isEmpty(machines: [], snapshot: localOnly),
-            "no cloud machines anywhere must show the empty state, even with This Mac in the catalog"
-        )
-        XCTAssertFalse(
-            CloudTreeNodeBuilder.isEmpty(machines: [], snapshot: localOnly, includeLocalMachine: true),
-            "once the tree shows This Mac again, the local entry is a row"
-        )
-
-        XCTAssertFalse(
-            CloudTreeNodeBuilder.isEmpty(machines: [machine("vivid-newt")], snapshot: .empty),
-            "a fleet machine is a row before the catalog hears about it"
-        )
-        let catalogOnly = SurfaceCatalogSnapshot(machines: [info(.cloud("quiet-owl"))], resources: [], projections: [])
-        XCTAssertFalse(
-            CloudTreeNodeBuilder.isEmpty(machines: [], snapshot: catalogOnly),
-            "a catalog-known cloud machine gets a placeholder row even while the fleet list lags"
-        )
-    }
-
     func testContentChangesKeepTheStructureSignature() {
         let snapshot = SurfaceCatalogSnapshot(machines: [info(.cloud("m"))], resources: [terminal(.cloud("m"), "term_1", title: "vim")], projections: [])
         let before = CloudTreeNodeBuilder.nodes(machines: [machine("m")], snapshot: snapshot, localWorkspaces: [])
@@ -719,5 +689,50 @@ final class CloudTreeScopeAndSignatureTests: XCTestCase {
         let terminalRow = CloudTreeNodeBuilder.flattened(existing).first { $0.id == "resource:m/terminal/term_1" }
         if case .terminal(let row)? = terminalRow?.kind { XCTAssertEqual(row.resource.title, "make") } else { XCTFail("terminal row missing") }
         XCTAssertEqual(CloudTreeNodeBuilder.contentSignature(existing), CloudTreeNodeBuilder.contentSignature(replacement))
+    }
+}
+
+/// Regression: a signed-in account with no cloud machines rendered a blank
+/// panel instead of the empty state, because the panel judged emptiness from
+/// the raw catalog (whose This Mac entry counted as a row) while the
+/// cloud-only tree drew nothing. The emptiness decision must match what
+/// `nodes` actually renders.
+@Suite struct CloudTreeEmptyDecisionTests {
+    private func info(_ machine: SurfaceMachineID) -> SurfaceMachineInfo {
+        SurfaceMachineInfo(id: machine, name: machine.rawValue, status: "running", image: "blaxel/xfce-vnc:latest", hasDesktop: false, memoryMb: nil, diskMb: nil, linkState: machine.isLocal ? .notApplicable : .connected, linkError: nil, cpuPercent: nil, memoryUsedMb: nil, diskUsedMb: nil)
+    }
+
+    private func terminal(_ machine: SurfaceMachineID, _ key: String) -> SurfaceResource {
+        SurfaceResource(id: SurfaceResourceID(machine: machine, kind: .terminal, key: key), title: "shell", detail: "/root", lifecycle: .running, agent: nil, remoteWorkspace: SurfaceRemoteWorkspace(id: "ws_0", name: "0", index: 0, focused: true), port: nil, url: nil)
+    }
+
+    private func machine(_ id: String) -> MachineSnapshot {
+        MachineSnapshot(id: id, provider: "blaxel", image: "blaxel/xfce-vnc:latest", isDesktop: true, activity: .ready, createdAt: nil, label: nil)
+    }
+
+    @Test func emptyDecisionMatchesWhatTheTreeRenders() {
+        let localOnly = SurfaceCatalogSnapshot(machines: [info(.local)], resources: [terminal(.local, "AAA")], projections: [])
+        #expect(
+            CloudTreeNodeBuilder.nodes(machines: [], snapshot: localOnly, localWorkspaces: []).isEmpty,
+            "precondition: the cloud-only tree renders nothing for a local-only catalog"
+        )
+        #expect(
+            CloudTreeNodeBuilder.isEmpty(machines: [], snapshot: localOnly),
+            "no cloud machines anywhere must show the empty state, even with This Mac in the catalog"
+        )
+        #expect(
+            !CloudTreeNodeBuilder.isEmpty(machines: [], snapshot: localOnly, includeLocalMachine: true),
+            "once the tree shows This Mac again, the local entry is a row"
+        )
+
+        #expect(
+            !CloudTreeNodeBuilder.isEmpty(machines: [machine("vivid-newt")], snapshot: .empty),
+            "a fleet machine is a row before the catalog hears about it"
+        )
+        let catalogOnly = SurfaceCatalogSnapshot(machines: [info(.cloud("quiet-owl"))], resources: [], projections: [])
+        #expect(
+            !CloudTreeNodeBuilder.isEmpty(machines: [], snapshot: catalogOnly),
+            "a catalog-known cloud machine gets a placeholder row even while the fleet list lags"
+        )
     }
 }

--- a/cmuxTests/MachinesPanelModelTests.swift
+++ b/cmuxTests/MachinesPanelModelTests.swift
@@ -662,6 +662,37 @@ final class CloudTreeScopeAndSignatureTests: XCTestCase {
         XCTAssertEqual(withLocal.first?.id, "machine:local")
     }
 
+    /// Regression: a signed-in account with no cloud machines rendered a blank
+    /// panel instead of the empty state, because the panel judged emptiness
+    /// from the raw catalog (whose This Mac entry counted as a row) while the
+    /// cloud-only tree drew nothing. The emptiness decision must match what
+    /// `nodes` actually renders.
+    func testEmptyDecisionMatchesWhatTheTreeRenders() {
+        let localOnly = SurfaceCatalogSnapshot(machines: [info(.local)], resources: [terminal(.local, "AAA")], projections: [])
+        XCTAssertTrue(
+            CloudTreeNodeBuilder.nodes(machines: [], snapshot: localOnly, localWorkspaces: []).isEmpty,
+            "precondition: the cloud-only tree renders nothing for a local-only catalog"
+        )
+        XCTAssertTrue(
+            CloudTreeNodeBuilder.isEmpty(machines: [], snapshot: localOnly),
+            "no cloud machines anywhere must show the empty state, even with This Mac in the catalog"
+        )
+        XCTAssertFalse(
+            CloudTreeNodeBuilder.isEmpty(machines: [], snapshot: localOnly, includeLocalMachine: true),
+            "once the tree shows This Mac again, the local entry is a row"
+        )
+
+        XCTAssertFalse(
+            CloudTreeNodeBuilder.isEmpty(machines: [machine("vivid-newt")], snapshot: .empty),
+            "a fleet machine is a row before the catalog hears about it"
+        )
+        let catalogOnly = SurfaceCatalogSnapshot(machines: [info(.cloud("quiet-owl"))], resources: [], projections: [])
+        XCTAssertFalse(
+            CloudTreeNodeBuilder.isEmpty(machines: [], snapshot: catalogOnly),
+            "a catalog-known cloud machine gets a placeholder row even while the fleet list lags"
+        )
+    }
+
     func testContentChangesKeepTheStructureSignature() {
         let snapshot = SurfaceCatalogSnapshot(machines: [info(.cloud("m"))], resources: [terminal(.cloud("m"), "term_1", title: "vim")], projections: [])
         let before = CloudTreeNodeBuilder.nodes(machines: [machine("m")], snapshot: snapshot, localWorkspaces: [])

--- a/scripts/install-cmux-tui-client.sh
+++ b/scripts/install-cmux-tui-client.sh
@@ -75,7 +75,10 @@ if [[ ! -f "$UNIVERSAL" ]]; then
   mv -f "$UNIVERSAL.tmp" "$UNIVERSAL"
 fi
 install -m 755 "$UNIVERSAL" "$DEST"
-lipo "$DEST" -verify_arch arm64 x86_64
+# One arch per invocation: some lipo builds (Xcode 27 beta 4) consume only one
+# arch after -verify_arch and read the second as an extra input file, failing
+# with "requires exactly one input file".
+for arch in arm64 x86_64; do lipo "$DEST" -verify_arch "$arch"; done
 PROBE="$("$DEST" remote-probe --json 2>/dev/null || true)"
 [[ "$PROBE" == *'"app":"cmux-tui"'* ]] || { echo "error: installed binary does not probe as cmux-tui: $PROBE" >&2; exit 1; }
 echo "Installed universal cmux-tui client (commit ${COMMIT:0:10}) at $DEST"

--- a/scripts/install-prebuilt-ghostty-cli-helper.sh
+++ b/scripts/install-prebuilt-ghostty-cli-helper.sh
@@ -29,5 +29,8 @@ fi
 mkdir -p "$(dirname "$DEST_PATH")"
 install -m 755 "$HELPER_PATH" "$DEST_PATH"
 
-lipo "$DEST_PATH" -verify_arch arm64 x86_64
+# One arch per invocation: some lipo builds (Xcode 27 beta 4) consume only one
+# arch after -verify_arch and read the second as an extra input file, failing
+# with "requires exactly one input file".
+for arch in arm64 x86_64; do lipo "$DEST_PATH" -verify_arch "$arch"; done
 echo "Installed universal Ghostty CLI helper at $DEST_PATH"


### PR DESCRIPTION
With zero cloud machines the Cloud tab rendered a completely blank body under the "0 of 5 machines" header. The panel decided emptiness from the raw surface catalog, whose This Mac entry counted as a row, while the cloud-only tree (`CloudTreeNodeBuilder.includesLocalMachine = false`) never drew it. The decision now lives next to `CloudTreeNodeBuilder.nodes` as `isEmpty` and mirrors it exactly, with a unit test covering the local-only catalog, fleet-only, catalog-only, and includeLocal cases.

The empty state itself gets a cloud glyph, a semibold title, a prominent New Machine button (routed through the same paywall-aware `requestNewMachine` path as the header ＋), and a plan-capacity line ("Your plan includes 5 machines", localized en/ja, singular variant for 1-machine plans).

The plan meter and the header's operation/error texts drop their extra 8pt indent. Leading header text now sits at 12pt, the same column as the mode-bar pill glyphs (4pt bar + 8pt pill inset) and the Files header icon.

Note on the two-commit regression ritual: the failing behavior was an inline SwiftUI view condition, so a test-only first commit could not compile against the pre-fix tree; the extracted `isEmpty` helper plus its test land together with the gate change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Cloud panel rendering a blank body for a signed-in account with zero cloud machines, and hardens the reload install scripts against Xcode 27 beta 4's `lipo`.

**Cloud panel**
- Emptiness is now decided by `CloudTreeNodeBuilder.isEmpty`, which mirrors exactly what the tree renders; the old check counted the catalog's This Mac entry as a row the cloud-only tree never drew.
- The empty state gains a cloud glyph, semibold title, and a prominent New Machine button routed through the same paywall-aware path as the header.
- Free plans get an "Upgrade to use more than N machines" link into the Pro flow; paid plans get "Your plan includes N machines" (localized en/ja, singular variants).
- Plan meter and header status texts drop the extra 8pt indent so leading text aligns at 12pt with the mode-bar glyphs and the Files header icon.
- Adds a Swift Testing regression test covering local-only, fleet-only, catalog-only, and `includeLocalMachine` cases.

**Scripts**
- The install scripts now verify one arch per `lipo` invocation, since Xcode 27 beta 4's `lipo` reads the second arch after `-verify_arch` as an extra input file.

<sup>Written for commit d3090ddb02b516f731c884144a57f83c83a4a2a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved the machines panel empty state with a clearer cloud illustration, prominent create button, and plan inclusion details.
  * Added an upgrade prompt for free plans.
  * Added English and Japanese translations for singular and plural plan messaging.
  * Empty-state behavior now accurately reflects available fleet and local machines.

* **Bug Fixes**
  * Corrected empty-state detection when machine data is still synchronizing or only available locally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->