### PR TITLE
Present terminal renderers in on-screen windows that never report an occlusion .visible bit (fixes the display-liveness CI regression from #10815)

### DIFF
--- a/Packages/Shared/CmuxIrxTransport/Tests/CmuxIrxTransportTests/IrxLiveQUICTests.swift
+++ b/Packages/Shared/CmuxIrxTransport/Tests/CmuxIrxTransportTests/IrxLiveQUICTests.swift
@@ -206,8 +206,12 @@ struct IrxLiveQUICTests {
         }
 
         let first = try await engine.ensureSession(trigger: "test")
-        // Keepalive proves liveness within one interval (5s) + deadline.
-        try await Task.sleep(for: .seconds(6))
+        // Keepalive proves liveness within one interval (5s) + deadline: wait for the first
+        // pong instead of sleeping a fixed span, so the assertion tracks the real event.
+        let pongDeadline = ContinuousClock.now + .seconds(8)
+        while journal.counterSnapshot()["pong"] ?? 0 < 1, ContinuousClock.now < pongDeadline {
+            try await Task.sleep(for: .milliseconds(100))
+        }
         #expect(await !first.connection.isClosed)
         #expect(journal.counterSnapshot()["pong"] ?? 0 >= 1)
 

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalRendererWindowVisibility.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalRendererWindowVisibility.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// The one rule for "is the hosting window visible enough to present a renderer".
+///
+/// `NSWindow.occlusionState` is the authoritative signal on a real display: a
+/// miniaturized, fully covered, or inactive-Space window drops the `.visible`
+/// bit and the renderer is released. On a virtual/headless display (the CI
+/// display-churn harness runs the app on a `CGVirtualDisplay`) AppKit never
+/// raises `.visible` for a window that is nevertheless ordered in and drawing,
+/// so gating presentation on that bit alone leaves the terminal at zero
+/// presents forever. Until a window has reported `.visible` at least once, its
+/// ordinary on-screen state is trusted instead; a key window is always visible.
+public enum TerminalRendererWindowVisibility {
+    public static func isVisible(
+        occlusionVisible: Bool,
+        windowHasReportedVisible: Bool,
+        isWindowVisible: Bool,
+        isMiniaturized: Bool,
+        isOnActiveSpace: Bool,
+        isKeyWindow: Bool
+    ) -> Bool {
+        if occlusionVisible || isKeyWindow { return true }
+        // Occlusion has been trustworthy for this window: honor its verdict.
+        if windowHasReportedVisible { return false }
+        return isWindowVisible && !isMiniaturized && isOnActiveSpace
+    }
+}

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalRendererWindowVisibilityTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalRendererWindowVisibilityTests.swift
@@ -1,0 +1,46 @@
+import Testing
+@testable import CmuxTerminal
+
+/// The presentation gate must never leave an on-screen window unpresented just
+/// because AppKit never reported `.visible` for it (virtual/headless displays),
+/// while a window whose occlusion state has proven trustworthy still releases
+/// when it is miniaturized, covered, or on an inactive Space.
+struct TerminalRendererWindowVisibilityTests {
+    private func visible(
+        occlusion: Bool = false,
+        reported: Bool = false,
+        onScreen: Bool = true,
+        miniaturized: Bool = false,
+        activeSpace: Bool = true,
+        key: Bool = false
+    ) -> Bool {
+        TerminalRendererWindowVisibility.isVisible(
+            occlusionVisible: occlusion,
+            windowHasReportedVisible: reported,
+            isWindowVisible: onScreen,
+            isMiniaturized: miniaturized,
+            isOnActiveSpace: activeSpace,
+            isKeyWindow: key
+        )
+    }
+
+    @Test func onScreenWindowThatNeverReportedVisiblePresents() {
+        #expect(visible())
+    }
+
+    @Test func keyWindowAlwaysPresents() {
+        #expect(visible(reported: true, key: true))
+        #expect(visible(onScreen: false, key: true))
+    }
+
+    @Test func occlusionVerdictWinsOnceTheWindowHasReportedVisible() {
+        #expect(visible(occlusion: true, reported: true))
+        #expect(!visible(occlusion: false, reported: true))
+    }
+
+    @Test func untrustedOcclusionStillHonorsMiniaturizedHiddenAndInactiveSpace() {
+        #expect(!visible(miniaturized: true))
+        #expect(!visible(onScreen: false))
+        #expect(!visible(activeSpace: false))
+    }
+}

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3911,6 +3911,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private var trackingArea: NSTrackingArea?
     private var windowObserver: NSObjectProtocol?
     private var windowOcclusionObserver: NSObjectProtocol?
+    private var windowKeyObservers: [NSObjectProtocol] = []
+    /// Windows that have reported an occlusion `.visible` bit at least once, so the
+    /// visibility rule knows when that signal is trustworthy (see
+    /// `TerminalRendererWindowVisibility`). Weak: windows come and go.
+    private static let windowsThatReportedVisible = NSHashTable<NSWindow>.weakObjects()
     private var lastScrollEventTime: CFTimeInterval = 0
     private let scrollSpeedAccumulator = TerminalScrollSpeedAccumulator()
     private var visibleInUI: Bool = true
@@ -4534,6 +4539,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             NotificationCenter.default.removeObserver(windowOcclusionObserver)
             self.windowOcclusionObserver = nil
         }
+        windowKeyObservers.forEach { NotificationCenter.default.removeObserver($0) }
+        windowKeyObservers.removeAll()
         // Balance the cursor stack if the view is removed while hover is active
         if wordPathHoverActive {
             wordPathHoverActive = false
@@ -4582,14 +4589,25 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             guard let occludedWindow = notification.object as? NSWindow else { return }
             // Delivered on the main queue (`queue: .main`), which is the main actor.
             MainActor.assumeIsolated {
-                self?.terminalSurface?.setRendererWindowVisible(
-                    occludedWindow.occlusionState.contains(.visible)
-                )
+                self?.applyRendererWindowVisibility(for: occludedWindow)
             }
         }
-        terminalSurface?.setRendererWindowVisible(
-            window.occlusionState.contains(.visible)
-        )
+        // Key/main transitions do not always come with an occlusion change, and a
+        // window on a virtual display may never report `.visible` at all; both
+        // re-evaluate the same rule so an on-screen window is always presented.
+        for name in [NSWindow.didBecomeKeyNotification, NSWindow.didBecomeMainNotification, NSWindow.didResignKeyNotification] {
+            windowKeyObservers.append(NotificationCenter.default.addObserver(
+                forName: name,
+                object: window,
+                queue: .main
+            ) { [weak self] notification in
+                guard let keyWindow = notification.object as? NSWindow else { return }
+                MainActor.assumeIsolated {
+                    self?.applyRendererWindowVisibility(for: keyWindow)
+                }
+            })
+        }
+        applyRendererWindowVisibility(for: window)
 
         if let surface = terminalSurface?.surface,
            let displayID = window.screen?.displayID,
@@ -8257,6 +8275,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         if let windowOcclusionObserver {
             NotificationCenter.default.removeObserver(windowOcclusionObserver)
         }
+        windowKeyObservers.forEach { NotificationCenter.default.removeObserver($0) }
         if let trackingArea {
             removeTrackingArea(trackingArea)
         }
@@ -8287,9 +8306,30 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         }
     }
 
+    /// Applies `TerminalRendererWindowVisibility` for the hosting window. The
+    /// occlusion `.visible` bit is remembered per window so the rule can tell a
+    /// trustworthy occlusion verdict from a virtual display that never sets it.
+    private func applyRendererWindowVisibility(for window: NSWindow) {
+        let occlusionVisible = window.occlusionState.contains(.visible)
+        if occlusionVisible {
+            Self.windowsThatReportedVisible.add(window)
+        }
+        terminalSurface?.setRendererWindowVisible(
+            TerminalRendererWindowVisibility.isVisible(
+                occlusionVisible: occlusionVisible,
+                windowHasReportedVisible: Self.windowsThatReportedVisible.contains(window),
+                isWindowVisible: window.isVisible,
+                isMiniaturized: window.isMiniaturized,
+                isOnActiveSpace: window.isOnActiveSpace,
+                isKeyWindow: window.isKeyWindow
+            )
+        )
+    }
+
     private func windowDidChangeScreen(_ notification: Notification) {
         guard let window else { return }
         guard let object = notification.object as? NSWindow, window == object else { return }
+        applyRendererWindowVisibility(for: window)
         guard let screen = window.screen else { return }
         guard let surface = terminalSurface?.surface else { return }
 

--- a/Sources/Mobile/MobileHostIrxRuntime.swift
+++ b/Sources/Mobile/MobileHostIrxRuntime.swift
@@ -14,8 +14,8 @@ import OSLog
 final class MobileHostIrxRuntime {
     static let shared = MobileHostIrxRuntime()
 
-    static let enabledDefaultsKey = "cmux.irx.enabled"
-    static let forceRelayDefaultsKey = "cmux.irx.force-relay"
+    nonisolated static let enabledDefaultsKey = "cmux.irx.enabled"
+    nonisolated static let forceRelayDefaultsKey = "cmux.irx.force-relay"
 
     /// irx is the PRIMARY transport: on by default in every configuration.
     /// An explicit `false` in defaults (the remote revert switch writes it)
@@ -333,7 +333,8 @@ final class MobileHostIrxRuntime {
                             trust: trust,
                             brokerClient: brokerClient,
                             isCurrent: { [weak self] in
-                                await MainActor.run { self?.generationToken == token }
+                                let runtime = self
+                                return await MainActor.run { runtime?.generationToken == token }
                             },
                             journal: journal
                         )
@@ -402,7 +403,8 @@ final class MobileHostIrxRuntime {
             artifactTransfers: artifactRegistry,
             independentEventWriter: eventWriter,
             isCurrent: { [weak self] in
-                await MainActor.run { self?.generationToken == token }
+                let runtime = self
+                return await MainActor.run { runtime?.generationToken == token }
             }
         )
         journal.record(

--- a/Sources/Surfaces/SurfaceSocketCommands.swift
+++ b/Sources/Surfaces/SurfaceSocketCommands.swift
@@ -191,7 +191,7 @@ extension TerminalController {
         }
         let destination = Self.surfaceDestination(surfaceResolvedParams(params), workspaceID: workspaceID)
         return v2VmCall(id: id, timeoutSeconds: 180) {
-            let catalog = SurfaceCatalog.shared
+            let catalog = await SurfaceCatalog.shared
             if await catalog.resources[resource] == nil {
                 // Ports are discovered by probing the machine; a port the person names may
                 // not have been seen yet. Re-sync, then register it so the provider can open it.
@@ -243,7 +243,7 @@ extension TerminalController {
         destination: SurfaceDestination?,
         focus: Bool
     ) async throws -> [String: Any] {
-        let catalog = SurfaceCatalog.shared
+        let catalog = await SurfaceCatalog.shared
         guard let provider = await catalog.provider(for: machine) else {
             throw SurfaceCatalogError.noProvider(machine)
         }


### PR DESCRIPTION
**Regression.** Since #10815 (581d900675) the `tests-build-and-lag` step *Run display UI regressions* fails deterministically on `main`: `DisplayResolutionRegressionUITests.testRapidDisplayResolutionChangesKeepTerminalResponsive — XCTAssertGreaterThanOrEqual failed: ("0") is less than ("6")` on both attempts (runs 33028942968 rerun, 33034886551 on a pre-#10887 baseline that includes #10815; the step last passed on 2026-08-19, run 32212616081, before #10815). Harness diagnostics show `renderWindowVisible=0` / `renderAppIsActive=0` throughout.

**Root cause.** #10815 presents the renderer only while `NSWindow.occlusionState.contains(.visible)`. The harness runs the app on a `CGVirtualDisplay` (`scripts/create-virtual-display.m`); AppKit never raises `.visible` there for a window that is ordered in and drawing, so the renderer stays released and presents never advance.

**Rule** (`TerminalRendererWindowVisibility`, one helper used by the occlusion observer, the initial attach, key/main transitions and screen changes): visible if the occlusion bit is set or the window is key; otherwise, until the window has reported `.visible` at least once, trust its on-screen state (`isVisible && !isMiniaturized && isOnActiveSpace`); once the bit has been seen, honor the occlusion verdict — so miniaturized, covered and inactive-Space windows still release GPU exactly as #10815 intended.

Tests: `TerminalRendererWindowVisibilityTests` (4 cases). No change to typing hot paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10922"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790393041&installation_model_id=21920&pr_number=10922&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10922&signature=b13fd7f24ca8ca482de6d913de29ab713261bd0fdb3e6ca697b1aa5f863d886b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the display-liveness CI regression from #10815: terminal renderers now present in on-screen windows that never report an occlusion `.visible` bit, and the IRX keepalive test waits for the first pong instead of sleeping a fixed span. Carries the warning-budget fixes from #10905 so the warning gate lets the display step run.

- Introduces `TerminalRendererWindowVisibility`: trusts a window's ordinary on-screen state (visible, not miniaturized, on the active Space) until `.visible` has been observed at least once, then honors the occlusion verdict; key windows always present.
- Re-evaluates visibility on key/main transitions and screen changes; miniaturized, covered, and inactive-Space windows still release the renderer as before.
- The keepalive test now polls for a pong with a deadline, so the assertion tracks the real liveness event.
- Clears the Swift warning buckets on this base: `nonisolated` IRX defaults keys, hoisted weak captures before `MainActor.run` hops, and awaited `SurfaceCatalog.shared` access.

<sup>Written for commit 7e47d56082e8cd77e2c58e73ae05ca6b274bbdb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal renderer visibility handling for virtual and headless displays.
  * Windows can now remain available when standard visibility is not reported.
  * Renderer visibility updates reliably when windows change focus, spaces, minimization, or screens.
  * Prevented rendering in minimized, off-screen, or inactive-space windows when visibility cannot be confirmed.
  * Improved connection keepalive reliability and asynchronous surface operations.
  * Improved mobile runtime compatibility during connection lifecycle events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->