### PR TITLE
iOS: own the workspace-detail top bar so toolbar overflow is impossible by construction

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+OwnedTopBar.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+OwnedTopBar.swift
@@ -1,0 +1,103 @@
+#if os(iOS)
+import SwiftUI
+
+// MARK: - Owned top bar
+
+/// Self-laid-out replacement for the system navigation bar on the workspace
+/// detail screen.
+///
+/// The system bar arbitrates per-item overflow with no public control below
+/// iOS 27, which is how the trailing controls (and, over scrollable surfaces,
+/// the whole bar) kept folding into a More "…" menu whenever a width estimate
+/// undershot reality. Here the row is plain SwiftUI layout: the fixed pills
+/// take their intrinsic width first, the title takes exactly the remainder
+/// and truncates, and no overflow mechanism exists to trigger. The visual
+/// language is unchanged: the same back pill, title menu, Changes chip, and
+/// picker render inside the same Liquid Glass capsules the system drew, on
+/// the same terminal-theme bar fill.
+extension WorkspaceDetailView {
+    var workspaceOwnedTopBar: some View {
+        HStack(spacing: 13) {
+            if backButtonConfiguration != nil {
+                workspaceBackToolbarButton
+                    .frame(minWidth: 17, minHeight: 22)
+                    .ownedBarGlassButton()
+                    .fixedSize()
+            }
+            workspaceTitleMenu(usesNaturalWidth: true)
+                .ownedBarGlassButton()
+            Spacer(minLength: 13)
+            ownedBarTrailingCluster
+                .fixedSize()
+        }
+        .frame(height: 44)
+        .padding(.horizontal, 16)
+        .padding(.top, 3)
+        .padding(.bottom, 3)
+        .background(alignment: .top) {
+            store.activeTerminalTheme.terminalBackgroundColor
+                .ignoresSafeArea(edges: .top)
+        }
+        .environment(\.colorScheme, store.activeTerminalTheme.terminalColorScheme)
+    }
+
+    /// The trailing controls share one glass capsule, matching how the
+    /// system visually grouped the adjacent toolbar items.
+    private var ownedBarTrailingCluster: some View {
+        HStack(spacing: 15) {
+            if altScreenNoticeIsVisible {
+                AltScreenNoticeButton {
+                    displaySettings.showAltScreenNotice = false
+                }
+            }
+            if workspaceChangesAreAvailable {
+                WorkspaceChangesToolbarButton(
+                    chip: workspaceChangesChip,
+                    workspaceID: workspace.rpcWorkspaceID.rawValue,
+                    action: openWorkspaceChanges
+                )
+                // The chrome sits on the terminal theme's background, not the
+                // system scheme; resolve the counts' green/red for that.
+                .environment(\.colorScheme, store.activeTerminalTheme.terminalColorScheme)
+            }
+            terminalPickerToolbarButton
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, 8)
+        .frame(height: 44)
+        .ownedBarGlassSurface()
+    }
+}
+
+// MARK: - Glass parity helpers
+
+private extension View {
+    /// Liquid Glass control chrome for a standalone bar button or menu,
+    /// matching the capsule the system draws around toolbar items; material
+    /// fallback below iOS 26 mirrors the pre-glass bar look.
+    @ViewBuilder
+    func ownedBarGlassButton() -> some View {
+        if #available(iOS 26.0, *) {
+            self
+                .menuStyle(.button)
+                .buttonStyle(.glass)
+                .buttonBorderShape(.capsule)
+        } else {
+            self
+                .padding(.horizontal, 12)
+                .frame(minHeight: 38)
+                .background(.thinMaterial, in: Capsule())
+        }
+    }
+
+    /// Liquid Glass surface for the grouped trailing cluster.
+    @ViewBuilder
+    func ownedBarGlassSurface() -> some View {
+        if #available(iOS 26.0, *) {
+            self.glassEffect(.regular.interactive(), in: .capsule)
+        } else {
+            self.background(.thinMaterial, in: Capsule())
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+OwnedTopBar.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+OwnedTopBar.swift
@@ -20,12 +20,19 @@ extension WorkspaceDetailView {
         HStack(spacing: 13) {
             if backButtonConfiguration != nil {
                 workspaceBackToolbarButton
-                    .frame(minWidth: 17, minHeight: 22)
-                    .ownedBarGlassButton()
+                    .buttonStyle(.plain)
+                    .padding(.horizontal, 12)
+                    .frame(minWidth: 44)
+                    .frame(height: 44)
+                    .ownedBarGlassSurface()
                     .fixedSize()
             }
             workspaceTitleMenu(usesNaturalWidth: true)
-                .ownedBarGlassButton()
+                .menuStyle(.button)
+                .buttonStyle(.plain)
+                .padding(.horizontal, 14)
+                .frame(height: 44)
+                .ownedBarGlassSurface()
             Spacer(minLength: 13)
             ownedBarTrailingCluster
                 .fixedSize()
@@ -61,6 +68,7 @@ extension WorkspaceDetailView {
                 .environment(\.colorScheme, store.activeTerminalTheme.terminalColorScheme)
             }
             terminalPickerToolbarButton
+                .frame(width: 44, height: 44)
         }
         .buttonStyle(.plain)
         .padding(.horizontal, 8)
@@ -72,24 +80,6 @@ extension WorkspaceDetailView {
 // MARK: - Glass parity helpers
 
 private extension View {
-    /// Liquid Glass control chrome for a standalone bar button or menu,
-    /// matching the capsule the system draws around toolbar items; material
-    /// fallback below iOS 26 mirrors the pre-glass bar look.
-    @ViewBuilder
-    func ownedBarGlassButton() -> some View {
-        if #available(iOS 26.0, *) {
-            self
-                .menuStyle(.button)
-                .buttonStyle(.glass)
-                .buttonBorderShape(.capsule)
-        } else {
-            self
-                .padding(.horizontal, 12)
-                .frame(minHeight: 38)
-                .background(.thinMaterial, in: Capsule())
-        }
-    }
-
     /// Liquid Glass surface for the grouped trailing cluster.
     @ViewBuilder
     func ownedBarGlassSurface() -> some View {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -49,7 +49,7 @@ struct WorkspaceDetailView: View {
     @Environment(BrowserSurfaceStore.self) var browserStore
     @Environment(BrowserStreamStore.self) var browserStreamStore
     @Environment(MobileSimulatorStreamStore.self) var simulatorStreamStore
-    @Environment(MobileDisplaySettings.self) private var displaySettings
+    @Environment(MobileDisplaySettings.self) var displaySettings
     @Environment(ToastCenter.self) private var toasts
     @Environment(\.mobileChildPresentationProvider) private var childPresentationProvider
     @Environment(\.terminalFilesChipEnabled) var isTerminalFilesChipEnabled
@@ -190,7 +190,8 @@ struct WorkspaceDetailView: View {
             // terminal surface, which has no system scroll view.
             .mobilePinnedNavigationBar()
             .trackBarPresence(barPresence)
-            .toolbar { workspaceDetailToolbar }
+            .toolbar(.hidden, for: .navigationBar)
+            .safeAreaInset(edge: .top, spacing: 0) { workspaceOwnedTopBar }
             .task(id: workspace.rpcWorkspaceID.rawValue) {
                 await store.refreshMobileBrowserPanels(workspaceID: workspace.rpcWorkspaceID.rawValue)
                 syncSimulatorStreamPanels()
@@ -285,7 +286,7 @@ struct WorkspaceDetailView: View {
     }
 
     #if os(iOS)
-    private var altScreenNoticeIsVisible: Bool {
+    var altScreenNoticeIsVisible: Bool {
         guard let selectedTerminalID else { return false }
         return store.isAlternateScreen(surfaceID: selectedTerminalID)
             && displaySettings.showAltScreenNotice
@@ -411,6 +412,10 @@ struct WorkspaceDetailView: View {
     }
 
     private var workspaceTitleToolbarMenu: some View {
+        workspaceTitleMenu(usesNaturalWidth: false)
+    }
+
+    func workspaceTitleMenu(usesNaturalWidth: Bool) -> some View {
         let measuredWidths = structuralTrailingItemKeys.compactMap { trailingToolbarItemWidths[$0] }
         // Reconnect lives in the title menu now that no pill covers the
         // terminal; reauthentication keeps its own blocking banner.
@@ -439,6 +444,7 @@ struct WorkspaceDetailView: View {
         )
         return WorkspaceTitleMenu(
             value: value,
+            usesNaturalWidth: usesNaturalWidth,
             menuContent: {
                 WorkspaceTitleMenuContent(
                     workspaceName: value.workspaceName,
@@ -746,7 +752,7 @@ struct WorkspaceDetailView: View {
     #if os(iOS)
     /// Leading back-button island; iOS 26 supplies toolbar glass.
     @ViewBuilder
-    private var workspaceBackToolbarButton: some View {
+    var workspaceBackToolbarButton: some View {
         if let backButtonConfiguration {
             WorkspaceBackButton(
                 unreadCount: backButtonConfiguration.unreadCount,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenu.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenu.swift
@@ -2,11 +2,17 @@ import SwiftUI
 
 struct WorkspaceTitleMenu<Label: View, MenuContent: View>: View, Equatable {
     let value: WorkspaceTitleMenuValue
+    /// In the owned top bar the row's own layout hands the title exactly the
+    /// leftover width (fixed pills first, title truncates), so the
+    /// estimate-based cap is skipped entirely. The system-toolbar path keeps
+    /// the cap: there the system arbitrates item overflow and the title must
+    /// never claim the trailing items' space.
+    var usesNaturalWidth: Bool = false
     @ViewBuilder let menuContent: () -> MenuContent
     @ViewBuilder let label: () -> Label
 
     nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.value == rhs.value
+        lhs.value == rhs.value && lhs.usesNaturalWidth == rhs.usesNaturalWidth
     }
 
     @ViewBuilder
@@ -28,7 +34,16 @@ struct WorkspaceTitleMenu<Label: View, MenuContent: View>: View, Equatable {
         }
     }
 
+    @ViewBuilder
     private var fittedLabel: some View {
+        if usesNaturalWidth {
+            label()
+        } else {
+            cappedLabel
+        }
+    }
+
+    private var cappedLabel: some View {
         let cap = MobileLeadingToolbarTitleWidth(
             contentWidth: value.contentWidth,
             hasBackButton: value.hasBackButton,


### PR DESCRIPTION
Per Aziz: create a system where the top toolbar can NEVER collapse into a More menu, with 1-to-1 visual parity to the current design.

The system navigation bar arbitrates per-item overflow with no public control below iOS 27, so every width-estimate regression (title reserve, remount fallback, badge width) ended in a "…" fold. This replaces the system bar on the workspace detail with a self-laid-out row: `.toolbar(.hidden)` plus a `safeAreaInset(edge: .top)` bar where the fixed pills take intrinsic width first and the title takes exactly the remainder and truncates. SwiftUI stacks have no overflow mechanism, so the More menu is impossible by construction, and future toolbar additions cannot reintroduce it.

Parity: the same components render (WorkspaceBackButton, the title Menu with dot/spinner + title/subtitle, WorkspaceChangesToolbarButton, TerminalPickerMenu) inside Liquid Glass capsules via `glassEffect` on fixed frames (thin-material fallback below iOS 26), on the terminal-theme bar fill with the bar's color scheme applied. Metrics were calibrated against pixel measurements of the system bar: 50pt bar (44 + 3/3), 16pt side margins, 13pt back-to-title gap, one shared trailing capsule with 15pt spacing and 8pt padding, 44pt control frames. The title menu gains a natural-width mode that bypasses the estimate-based cap; the legacy system-toolbar path and its width model remain in-tree for A/B and will be deleted in a follow-up once dogfood approves. Back-swipe keeps working through the existing pop-gesture delegate in WorkspaceShellView.

Status: first pass. Verified live on an isolated iOS 27.0 simulator in the connected terminal state (structure, theming, grouping correct; measured deltas ≤3pt after calibration). Still to dogfood before merge: badge state, browser-restore title, menu interactions, alt-screen notice, iOS 26 fallback rendering, landscape, and the back swipe.

HIG: Navigation bars (https://developer.apple.com/design/human-interface-guidelines/navigation-bars) — all controls remain visible and reachable at all times; the custom bar preserves standard back behavior.

No user-facing strings changed (localization audit: none needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10923"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790395457&installation_model_id=21920&pr_number=10923&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10923&signature=c808bb4582fef0df53be94b91e2ba0b80465256ac910d83c8685adb6a759167f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the system navigation bar on the workspace detail with a self-laid-out row so the toolbar can never collapse into a More menu. The system bar previously folded trailing controls into "…" whenever a width estimate undershot; now fixed pills take intrinsic width first and the title truncates in the exact remainder, making overflow impossible by construction. Visual parity is preserved with the same components in the same Liquid Glass capsules, and back swipe keeps working through the existing pop-gesture delegate.

**Migration**
- The legacy system-toolbar path and its width model stay in-tree for A/B comparison and are removed in a follow-up once dogfood approves.

**Verification**
- Verified on an iOS 27.0 simulator in the connected terminal state.
- Badge state, browser-restore title, menu interactions, alt-screen notice, iOS 26 fallback, landscape, and back swipe still need dogfooding before merge.

<sup>Written for commit 616b0dd53c3135f114ad320fcb82530ba6464f23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a custom workspace navigation bar on iOS with back navigation, workspace title selection, terminal switching, change indicators, and alternate-screen notices.
  * Improved the title menu to support natural-width layouts for clearer workspace names.
  * Added adaptive visual styling for newer and earlier iOS versions.

* **UI Improvements**
  * Replaced the system navigation bar with a themed, glass-style workspace header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->