### PR TITLE
fix(ci): skip defunct queued runs in the TestFlight upload-ordering waiter

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -117,6 +117,26 @@ jobs:
                       run_id: run.id,
                       per_page: 100,
                     });
+                    // A run can corrupt into queued limbo: no job ever starts
+                    // and GitHub rejects cancel, force-cancel, and rerun. Such
+                    // a run would block ordering for the full timeout, so skip
+                    // runs whose jobs never started after a generous pickup
+                    // window. Missing created_at parses to NaN and is treated
+                    // as fresh, never skipped.
+                    const anyJobStarted = jobs.data.jobs.some(
+                      (job) => job.status !== 'queued'
+                    );
+                    const createdAtMs = Date.parse(run.created_at ?? '');
+                    const stuckMinutes = Number.isFinite(createdAtMs)
+                      ? (Date.now() - createdAtMs) / 60_000
+                      : 0;
+                    if (!anyJobStarted && stuckMinutes >= 120) {
+                      core.warning(
+                        `ignoring defunct earlier TestFlight run ${run.id}: ` +
+                        `no job started after ${Math.round(stuckMinutes)} minutes`
+                      );
+                      continue;
+                    }
                     const uploadJob = jobs.data.jobs.find(
                       (job) => job.name === 'Upload to TestFlight'
                     );

--- a/tests/test_ios_testflight_main_push_filter.py
+++ b/tests/test_ios_testflight_main_push_filter.py
@@ -175,6 +175,7 @@ def run_decision_scenario(
     changed_files: tuple[str, ...] = (),
     blocking_prior_run: bool = False,
     upload_job_starts_late: bool = False,
+    zombie_prior_run: bool = False,
     ordering_api_failure: Optional[str] = None,
     compare_api_failure: bool = False,
     artifact_api_failure: bool = False,
@@ -253,6 +254,7 @@ def run_decision_scenario(
         "changedFiles": changed_files,
         "blockingPriorRun": blocking_prior_run,
         "uploadJobStartsLate": upload_job_starts_late,
+        "zombiePriorRun": zombie_prior_run,
         "orderingApiFailure": ordering_api_failure,
         "compareApiFailure": compare_api_failure,
         "artifactApiFailure": artifact_api_failure,
@@ -281,11 +283,17 @@ const priorRuns = (request) => {{
   const runs = pageRuns.map((run) => ({{
     id: run.id,
     status:
-      scenario.blockingPriorRun && run.id === firstPriorRunId
-        ? 'in_progress'
-        : 'completed',
+      scenario.zombiePriorRun && run.id === firstPriorRunId
+        ? 'queued'
+        : scenario.blockingPriorRun && run.id === firstPriorRunId
+          ? 'in_progress'
+          : 'completed',
     event: run.event,
     head_sha: run.sha,
+    created_at:
+      scenario.zombiePriorRun && run.id === firstPriorRunId
+        ? '2020-01-01T00:00:00Z'
+        : undefined,
   }}));
   const idleRunsBeforePage = (page - 1) * 100;
   const idleRunsOnPage = Math.min(
@@ -357,6 +365,13 @@ const github = {{
         const priorRun = allPriorRuns.find(
           (run) => run.id === Number(request.run_id)
         );
+        const isZombieRun =
+          scenario.zombiePriorRun &&
+          priorRun?.id === firstPriorRunId;
+        if (isZombieRun) {{
+          uploadJobStatuses.push(null);
+          return {{ data: {{ jobs: [] }} }};
+        }}
         const isBlockingRun =
           scenario.blockingPriorRun &&
           priorRun?.id === firstPriorRunId;
@@ -984,6 +999,24 @@ def test_ordering_ignores_later_active_runs() -> None:
     }
 
 
+def test_ordering_skips_defunct_queued_prior_run() -> None:
+    result = run_decision_scenario(
+        event_name="schedule",
+        schedule=IOS_SCHEDULES[0],
+        prior_sha="base-sha",
+        changed_files=("ios/cmux/App.swift",),
+        zombie_prior_run=True,
+    )
+
+    assert result["waitCalls"] == []
+    assert any("defunct" in str(warning) for warning in result["warnings"])
+    assert result["outputs"] == {
+        "should_build": "true",
+        "last_uploaded_sha": "base-sha",
+        "variant": "internal",
+    }
+
+
 def test_ordering_includes_manual_current_and_prior_runs() -> None:
     scenarios = (
         ("workflow_dispatch", "schedule"),
@@ -1128,6 +1161,7 @@ if __name__ == "__main__":
     test_scheduled_run_waits_before_upload_job_exists()
     test_ordering_retries_transient_api_failures()
     test_ordering_ignores_later_active_runs()
+    test_ordering_skips_defunct_queued_prior_run()
     test_ordering_includes_manual_current_and_prior_runs()
     test_mapping_keys_normalizes_quoted_yaml_keys()
     test_testflight_notes_use_the_same_ios_path_contract()


### PR DESCRIPTION
The CMUX INTERNAL lane has been wedged since 2026-08-26 15:10 UTC by run https://github.com/manaflow-ai/cmux/actions/runs/32984277677, which corrupted into queued limbo: no job ever started, and GitHub rejects cancel ("completed"), force-cancel ("has not been queued yet"), and rerun ("already running"). The upload-ordering waiter counts it as an earlier active run, so six runs burned the 5-hour timeout against it and four more stacked behind them; nothing has uploaded since 14:41 UTC, and the Iroh-primary change (#10889) is stuck in that queue.

Commit 1 is red: a harness scenario mocking exactly such a run (queued status, empty jobs list, created long ago) makes the waiter time out. Commit 2 is green: the waiter skips an earlier active run when none of its jobs has started after a 120-minute pickup window, with a warning naming the run id. Runs missing created_at parse to NaN and are treated as fresh, never skipped, and a genuinely starting run (jobs exist or window not elapsed) still blocks as before.

Verification: `python3 tests/test_ios_testflight_main_push_filter.py` red at commit 1 on the new scenario, all tests green at commit 2.

Note: runs already in flight snapshot the old workflow, so after merge the current stuck run must be cancelled and redispatched (or the zombie run deleted) for the lane to move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790399285&installation_model_id=21920&pr_number=10927&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10927&signature=1b8241c890551ee86b3d1f9bbb7e0b0722d4aab56dbc2a13788e273f24d52090"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the TestFlight upload-ordering waiter so a defunct queued run no longer blocks the lane for the full timeout. The waiter now skips an earlier active run when none of its jobs has started after a 120-minute pickup window and warns with the run id; runs without `created_at` are never skipped.

**Rollout Actions**
- After merge, cancel and redispatch the currently stuck run (or delete the zombie run) because in-flight runs keep the old workflow snapshot.

<sup>Written for commit 87d5685e8f0e0ad3307f7be7cc24b1c74be1985c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stalled TestFlight uploads from blocking newer uploads indefinitely.
  * Older queued runs with no active jobs are now skipped after two hours, allowing current uploads to proceed.
  * Added a warning when a defunct queued run is detected.

* **Tests**
  * Added regression coverage for stalled queued workflow runs and successful upload progression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->