### PR TITLE
cmux-tui: re-land bounded relay lifecycle hardening

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -171,6 +171,8 @@ mod unix {
     ) {
         loop {
             let closed = shared.closed_notify.notified();
+            tokio::pin!(closed);
+            closed.as_mut().enable();
             if shared.closed.load(Ordering::SeqCst) {
                 break;
             }
@@ -220,6 +222,8 @@ mod unix {
             loop {
                 let resumed = shared.resume_notify.notified();
                 let closed = shared.closed_notify.notified();
+                tokio::pin!(closed);
+                closed.as_mut().enable();
                 #[cfg(test)]
                 if let Some(waiting) =
                     shared.read_waiting.lock().expect("control read waiter lock").take()

--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -69,6 +69,8 @@ mod unix {
         paused: AtomicBool,
         resume_notify: Notify,
         closed_notify: Notify,
+        #[cfg(test)]
+        read_done: Notify,
     }
 
     impl Shared {
@@ -78,7 +80,10 @@ mod unix {
             }
             // Resolve every pending request with "no reply".
             self.pending.lock().expect("control pending lock").clear();
-            self.closed_notify.notify_one();
+            // Both the writer and a paused reader wait on this state. Use a
+            // broadcast wakeup so either task can observe closure without
+            // consuming the other's permit.
+            self.closed_notify.notify_waiters();
             if !self.deliberate.load(Ordering::SeqCst)
                 && let Some(handler) =
                     self.close_handler.lock().expect("control close lock").as_ref()
@@ -101,6 +106,13 @@ mod unix {
         socket_path: &std::path::Path,
         timeout_ms: u64,
     ) -> Result<Arc<dyn ControlHandle>, String> {
+        Ok(connect_control_inner(socket_path, timeout_ms).await?)
+    }
+
+    async fn connect_control_inner(
+        socket_path: &std::path::Path,
+        timeout_ms: u64,
+    ) -> Result<Arc<UnixControl>, String> {
         let connect = UnixStream::connect(socket_path);
         let stream = tokio::time::timeout(Duration::from_millis(timeout_ms), connect)
             .await
@@ -120,6 +132,8 @@ mod unix {
             paused: AtomicBool::new(false),
             resume_notify: Notify::new(),
             closed_notify: Notify::new(),
+            #[cfg(test)]
+            read_done: Notify::new(),
         });
         // Keep one async writer for every connection. The queue makes the
         // synchronous `send` API safe without spawning one task per input;
@@ -136,6 +150,14 @@ mod unix {
             next_id: AtomicU64::new(1),
             timeout_ms,
         }))
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn connect_control_for_test(
+        socket_path: &std::path::Path,
+        timeout_ms: u64,
+    ) -> Result<Arc<UnixControl>, String> {
+        connect_control_inner(socket_path, timeout_ms).await
     }
 
     async fn write_loop(
@@ -187,16 +209,23 @@ mod unix {
     async fn read_loop(mut reader: OwnedReadHalf, shared: Arc<Shared>) {
         let mut buffer: Vec<u8> = Vec::new();
         let mut chunk = [0_u8; 16_384];
-        loop {
+        'read_loop: loop {
             // Create the waiter before checking the flag. `Notify` retains a
             // permit when resume races this check, so a pause cannot leave
             // the reader asleep after the wakeup.
             loop {
-                let notified = shared.resume_notify.notified();
+                let resumed = shared.resume_notify.notified();
+                let closed = shared.closed_notify.notified();
+                if shared.closed.load(Ordering::SeqCst) {
+                    break 'read_loop;
+                }
                 if !shared.paused.load(Ordering::SeqCst) {
                     break;
                 }
-                notified.await;
+                tokio::select! {
+                    _ = resumed => {}
+                    _ = closed => break 'read_loop,
+                }
             }
             let count = match reader.read(&mut chunk).await {
                 Ok(0) | Err(_) => break,
@@ -234,9 +263,16 @@ mod unix {
             }
         }
         shared.settle_closed();
+        #[cfg(test)]
+        shared.read_done.notify_waiters();
     }
 
     impl UnixControl {
+        #[cfg(test)]
+        pub(crate) async fn wait_reader_done(&self) {
+            self.shared.read_done.notified().await;
+        }
+
         fn encode_line(id: u64, cmd: &str, params: Value) -> Vec<u8> {
             let mut frame = match params {
                 Value::Object(map) => map,
@@ -346,9 +382,51 @@ mod unix {
 mod tests {
     use super::*;
     use serde_json::json;
-    use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _};
+    use std::sync::Arc;
+    use std::time::Duration;
+    use tokio::io::{AsyncBufReadExt as _, AsyncReadExt as _, AsyncWriteExt as _};
     use tokio::net::UnixListener;
     use tokio::sync::oneshot;
+
+    #[tokio::test]
+    async fn end_wakes_paused_reader_and_closes_socket() {
+        let socket_path = std::env::temp_dir()
+            .join(format!("chatmux-relay-control-close-{}.sock", std::process::id()));
+        let _ = std::fs::remove_file(&socket_path);
+        let listener = UnixListener::bind(&socket_path).expect("bind control close test socket");
+        let (accepted_tx, accepted_rx) = oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept control close test socket");
+            let (mut read_half, _) = stream.into_split();
+            accepted_tx.send(()).expect("tell client that socket is accepted");
+            let mut bytes = Vec::new();
+            read_half.read_to_end(&mut bytes).await.expect("read client close");
+        });
+
+        let control = unix::connect_control_for_test(&socket_path, 3_000)
+            .await
+            .expect("connect control close test socket");
+        accepted_rx.await.expect("wait for control close test server");
+        control.pause();
+
+        // Register before end() so notify_waiters cannot race with the
+        // assertion. Yielding lets both the waiter and paused reader poll,
+        // without introducing a time-based synchronization.
+        let waiter_control = Arc::clone(&control);
+        let reader_done = tokio::spawn(async move { waiter_control.wait_reader_done().await });
+        tokio::task::yield_now().await;
+        control.end();
+
+        tokio::time::timeout(Duration::from_secs(1), reader_done)
+            .await
+            .expect("paused reader exits after end")
+            .expect("join paused reader waiter");
+        tokio::time::timeout(Duration::from_secs(1), server)
+            .await
+            .expect("server observes client close")
+            .expect("join control close test server");
+        let _ = std::fs::remove_file(socket_path);
+    }
 
     #[tokio::test]
     async fn writer_queue_preserves_complete_fifo_lines() {

--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -52,6 +52,7 @@ mod unix {
     use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
     use tokio::sync::mpsc::{self, Receiver, Sender};
     use tokio::sync::{Mutex as AsyncMutex, Notify, oneshot};
+    use tokio_util::sync::CancellationToken;
 
     struct OutboundLine {
         bytes: Vec<u8>,
@@ -68,9 +69,11 @@ mod unix {
         deliberate: AtomicBool,
         paused: AtomicBool,
         resume_notify: Notify,
-        closed_notify: Notify,
+        closed_token: CancellationToken,
         #[cfg(test)]
         read_done: Notify,
+        #[cfg(test)]
+        read_waiting: Mutex<Option<oneshot::Sender<()>>>,
     }
 
     impl Shared {
@@ -80,10 +83,10 @@ mod unix {
             }
             // Resolve every pending request with "no reply".
             self.pending.lock().expect("control pending lock").clear();
-            // Both the writer and a paused reader wait on this state. Use a
-            // broadcast wakeup so either task can observe closure without
-            // consuming the other's permit.
-            self.closed_notify.notify_waiters();
+            // Both the writer and a paused reader wait on this state. A
+            // cancellation token retains the closed state, so an end racing
+            // waiter registration cannot leave either task asleep.
+            self.closed_token.cancel();
             if !self.deliberate.load(Ordering::SeqCst)
                 && let Some(handler) =
                     self.close_handler.lock().expect("control close lock").as_ref()
@@ -131,9 +134,11 @@ mod unix {
             deliberate: AtomicBool::new(false),
             paused: AtomicBool::new(false),
             resume_notify: Notify::new(),
-            closed_notify: Notify::new(),
+            closed_token: CancellationToken::new(),
             #[cfg(test)]
             read_done: Notify::new(),
+            #[cfg(test)]
+            read_waiting: Mutex::new(None),
         });
         // Keep one async writer for every connection. The queue makes the
         // synchronous `send` API safe without spawning one task per input;
@@ -166,7 +171,7 @@ mod unix {
         shared: Arc<Shared>,
     ) {
         loop {
-            let closed = shared.closed_notify.notified();
+            let closed = shared.closed_token.cancelled();
             if shared.closed.load(Ordering::SeqCst) {
                 break;
             }
@@ -215,7 +220,13 @@ mod unix {
             // the reader asleep after the wakeup.
             loop {
                 let resumed = shared.resume_notify.notified();
-                let closed = shared.closed_notify.notified();
+                let closed = shared.closed_token.cancelled();
+                #[cfg(test)]
+                if let Some(waiting) =
+                    shared.read_waiting.lock().expect("control read waiter lock").take()
+                {
+                    let _ = waiting.send(());
+                }
                 if shared.closed.load(Ordering::SeqCst) {
                     break 'read_loop;
                 }
@@ -271,6 +282,13 @@ mod unix {
         #[cfg(test)]
         pub(crate) async fn wait_reader_done(&self) {
             self.shared.read_done.notified().await;
+        }
+
+        #[cfg(test)]
+        pub(crate) fn arm_reader_waiting(&self) -> oneshot::Receiver<()> {
+            let (sender, receiver) = oneshot::channel();
+            *self.shared.read_waiting.lock().expect("control read waiter lock") = Some(sender);
+            receiver
         }
 
         fn encode_line(id: u64, cmd: &str, params: Value) -> Vec<u8> {
@@ -395,10 +413,13 @@ mod tests {
         let _ = std::fs::remove_file(&socket_path);
         let listener = UnixListener::bind(&socket_path).expect("bind control close test socket");
         let (accepted_tx, accepted_rx) = oneshot::channel();
+        let (paused_tx, paused_rx) = oneshot::channel();
         let server = tokio::spawn(async move {
             let (stream, _) = listener.accept().await.expect("accept control close test socket");
-            let (mut read_half, _) = stream.into_split();
+            let (mut read_half, mut write_half) = stream.into_split();
             accepted_tx.send(()).expect("tell client that socket is accepted");
+            paused_rx.await.expect("wait for client pause");
+            write_half.write_all(b"{}\n").await.expect("wake paused reader");
             let mut bytes = Vec::new();
             read_half.read_to_end(&mut bytes).await.expect("read client close");
         });
@@ -409,9 +430,11 @@ mod tests {
         accepted_rx.await.expect("wait for control close test server");
         control.pause();
 
-        // Register before end() so notify_waiters cannot race with the
-        // assertion. Yielding lets both the waiter and paused reader poll,
-        // without introducing a time-based synchronization.
+        // Register both waiters before end() so the test deterministically
+        // exercises the paused-reader branch and the close wakeup.
+        let read_waiting = control.arm_reader_waiting();
+        paused_tx.send(()).expect("tell server that reader is paused");
+        read_waiting.await.expect("paused reader entered wait");
         let waiter_control = Arc::clone(&control);
         let reader_done = tokio::spawn(async move { waiter_control.wait_reader_done().await });
         tokio::task::yield_now().await;

--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -52,7 +52,6 @@ mod unix {
     use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
     use tokio::sync::mpsc::{self, Receiver, Sender};
     use tokio::sync::{Mutex as AsyncMutex, Notify, oneshot};
-    use tokio_util::sync::CancellationToken;
 
     struct OutboundLine {
         bytes: Vec<u8>,
@@ -69,7 +68,7 @@ mod unix {
         deliberate: AtomicBool,
         paused: AtomicBool,
         resume_notify: Notify,
-        closed_token: CancellationToken,
+        closed_notify: Notify,
         #[cfg(test)]
         read_done: Notify,
         #[cfg(test)]
@@ -83,10 +82,10 @@ mod unix {
             }
             // Resolve every pending request with "no reply".
             self.pending.lock().expect("control pending lock").clear();
-            // Both the writer and a paused reader wait on this state. A
-            // cancellation token retains the closed state, so an end racing
-            // waiter registration cannot leave either task asleep.
-            self.closed_token.cancel();
+            // Both the writer and a paused reader wait on this state. Keep a
+            // broadcast wakeup so either task can observe closure without
+            // consuming the other's permit.
+            self.closed_notify.notify_waiters();
             if !self.deliberate.load(Ordering::SeqCst)
                 && let Some(handler) =
                     self.close_handler.lock().expect("control close lock").as_ref()
@@ -134,7 +133,7 @@ mod unix {
             deliberate: AtomicBool::new(false),
             paused: AtomicBool::new(false),
             resume_notify: Notify::new(),
-            closed_token: CancellationToken::new(),
+            closed_notify: Notify::new(),
             #[cfg(test)]
             read_done: Notify::new(),
             #[cfg(test)]
@@ -171,7 +170,7 @@ mod unix {
         shared: Arc<Shared>,
     ) {
         loop {
-            let closed = shared.closed_token.cancelled();
+            let closed = shared.closed_notify.notified();
             if shared.closed.load(Ordering::SeqCst) {
                 break;
             }
@@ -220,7 +219,7 @@ mod unix {
             // the reader asleep after the wakeup.
             loop {
                 let resumed = shared.resume_notify.notified();
-                let closed = shared.closed_token.cancelled();
+                let closed = shared.closed_notify.notified();
                 #[cfg(test)]
                 if let Some(waiting) =
                     shared.read_waiting.lock().expect("control read waiter lock").take()
@@ -404,7 +403,7 @@ mod tests {
     use std::time::Duration;
     use tokio::io::{AsyncBufReadExt as _, AsyncReadExt as _, AsyncWriteExt as _};
     use tokio::net::UnixListener;
-    use tokio::sync::oneshot;
+    use tokio::sync::{Notify, oneshot};
 
     #[tokio::test]
     async fn end_wakes_paused_reader_and_closes_socket() {
@@ -449,6 +448,40 @@ mod tests {
             .expect("server observes client close")
             .expect("join control close test server");
         let _ = std::fs::remove_file(socket_path);
+    }
+
+    #[tokio::test]
+    async fn close_broadcast_wakes_two_waiters() {
+        let notify = Arc::new(Notify::new());
+        let (first_ready_tx, first_ready_rx) = oneshot::channel();
+        let (second_ready_tx, second_ready_rx) = oneshot::channel();
+        let first_notify = Arc::clone(&notify);
+        let first = tokio::spawn(async move {
+            let notified = first_notify.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+            first_ready_tx.send(()).expect("signal first waiter registration");
+            notified.await;
+        });
+        let second_notify = Arc::clone(&notify);
+        let second = tokio::spawn(async move {
+            let notified = second_notify.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+            second_ready_tx.send(()).expect("signal second waiter registration");
+            notified.await;
+        });
+        first_ready_rx.await.expect("first waiter registered");
+        second_ready_rx.await.expect("second waiter registered");
+        notify.notify_waiters();
+        tokio::time::timeout(Duration::from_secs(1), first)
+            .await
+            .expect("first waiter wakes")
+            .expect("first waiter joins");
+        tokio::time::timeout(Duration::from_secs(1), second)
+            .await
+            .expect("second waiter wakes")
+            .expect("second waiter joins");
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/chatmux-relay/src/enrollment.rs
+++ b/cmux-tui/crates/chatmux-relay/src/enrollment.rs
@@ -59,7 +59,7 @@ fn read_and_shred(path: &Path) -> Result<String, ManagedEnrollmentError> {
         if metadata.uid() != unsafe { libc::geteuid() } {
             return Err(error("Managed enrollment file must be owned by the current user."));
         }
-        if metadata.mode() & 0o077 != 0 {
+        if metadata.mode() & 0o777 != 0o600 {
             validation_error = Some(error("Managed enrollment file permissions must be 0600."));
         }
     }
@@ -92,8 +92,12 @@ fn read_and_shred(path: &Path) -> Result<String, ManagedEnrollmentError> {
             }
             #[cfg(not(unix))]
             {
+                // Windows does not expose a portable inode identity through
+                // std::fs::Metadata. Failing closed keeps a concurrently
+                // replaced pathname from being unlinked by this one-shot
+                // cleanup path.
                 let _ = current;
-                true
+                false
             }
         })
         .unwrap_or(false);

--- a/cmux-tui/crates/chatmux-relay/src/enrollment.rs
+++ b/cmux-tui/crates/chatmux-relay/src/enrollment.rs
@@ -19,8 +19,8 @@ use std::os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use serde_json::Value;
-use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
+use time::format_description::well_known::Rfc3339;
 use url::{Host, Url};
 
 use crate::config::{Config, ManagedEvents, ManagedIdentity};

--- a/cmux-tui/crates/chatmux-relay/src/enrollment.rs
+++ b/cmux-tui/crates/chatmux-relay/src/enrollment.rs
@@ -14,11 +14,13 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 use std::path::Path;
 
 #[cfg(unix)]
-use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+use std::os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt};
+#[cfg(unix)]
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use serde_json::Value;
-use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
 use url::{Host, Url};
 
 use crate::config::{Config, ManagedEvents, ManagedIdentity};
@@ -26,6 +28,9 @@ use crate::config::{Config, ManagedEvents, ManagedIdentity};
 pub const MANAGED_CLIENT: &str = "cmux-relay-managed-v1";
 const ALLOWED_BACKENDS: [&str; 2] = ["https://api.chatmux.dev", "https://api-staging.chatmux.dev"];
 const E2E_BACKEND_ENV: &str = "CHATMUX_RELAY_E2E_BACKEND";
+
+#[cfg(unix)]
+static NEXT_CLEANUP_ID: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct ManagedEnrollmentError(pub String);
@@ -137,24 +142,67 @@ fn file_identity_matches(current: &std::fs::Metadata, expected: &std::fs::Metada
 }
 
 fn unlink_if_same_inode(path: &Path, expected: &std::fs::Metadata) {
-    let same_file = std::fs::metadata(path)
-        .map(|current| {
-            #[cfg(unix)]
-            {
-                file_identity_matches(&current, expected)
+    #[cfg(unix)]
+    {
+        // A metadata check followed by remove_file(path) is not atomic: a
+        // producer can replace path after the check and have its enrollment
+        // deleted. Move the pathname atomically into a private directory
+        // first. The moved entry is then the only object we ever consider
+        // removing, and the identity check cannot select a replacement at
+        // the original pathname.
+        let parent = path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
+        let mut quarantine = None;
+        for _ in 0..16 {
+            let id = NEXT_CLEANUP_ID.fetch_add(1, Ordering::Relaxed);
+            let candidate =
+                parent.join(format!(".cmux-enrollment-cleanup-{}-{id}", std::process::id()));
+            let mut builder = std::fs::DirBuilder::new();
+            builder.mode(0o700);
+            match builder.create(&candidate) {
+                Ok(()) => {
+                    quarantine = Some(candidate);
+                    break;
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                Err(_) => return,
             }
-            #[cfg(not(unix))]
-            {
-                // Windows does not expose a stable file identity on the
-                // current toolchain. Failing closed avoids deleting a
-                // concurrently replaced pathname.
-                let _ = (current, expected);
-                false
-            }
-        })
-        .unwrap_or(false);
-    if same_file {
-        let _ = std::fs::remove_file(path);
+        }
+        let Some(quarantine) = quarantine else {
+            return;
+        };
+        let moved = quarantine.join("entry");
+        if std::fs::rename(path, &moved).is_err() {
+            let _ = std::fs::remove_dir(&quarantine);
+            return;
+        }
+
+        let matches = std::fs::symlink_metadata(&moved)
+            .map(|current| current.is_file() && file_identity_matches(&current, expected))
+            .unwrap_or(false);
+        if matches {
+            let _ = std::fs::remove_file(&moved);
+            let _ = std::fs::remove_dir(&quarantine);
+            return;
+        }
+
+        // The pathname was replaced before the rename. Restore the moved
+        // object only when the pathname is still absent; hard_link never
+        // overwrites a concurrently created replacement.
+        if std::fs::hard_link(&moved, path).is_ok() {
+            let _ = std::fs::remove_file(&moved);
+            let _ = std::fs::remove_dir(&quarantine);
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        // Windows does not expose a stable file identity on the current
+        // toolchain. Failing closed avoids deleting a concurrently replaced
+        // pathname.
+        let _ = (path, expected);
     }
 }
 

--- a/cmux-tui/crates/chatmux-relay/src/enrollment.rs
+++ b/cmux-tui/crates/chatmux-relay/src/enrollment.rs
@@ -8,8 +8,13 @@
 //! networking, so snapshots, clones, and parse failures retain no live
 //! claim. Tests mirror `managed-enrollment.test.mjs`.
 
+use std::fs::OpenOptions;
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::path::Path;
+
+#[cfg(unix)]
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
 
 use serde_json::Value;
 use time::OffsetDateTime;
@@ -38,25 +43,68 @@ fn error(message: &str) -> ManagedEnrollmentError {
 }
 
 fn read_and_shred(path: &Path) -> Result<String, ManagedEnrollmentError> {
-    let raw = (|| -> Result<String, ManagedEnrollmentError> {
-        let metadata = std::fs::metadata(path)
-            .map_err(|_| error("Managed enrollment file is unavailable."))?;
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::MetadataExt as _;
-            if metadata.mode() & 0o077 != 0 {
-                return Err(error("Managed enrollment file permissions must be 0600."));
-            }
-        }
-        let _ = metadata;
-        std::fs::read_to_string(path).map_err(|_| error("Managed enrollment file is unavailable."))
-    })();
-    // Best-effort overwrite then unlink, before parsing or networking.
-    if let Ok(contents) = &raw {
-        let _ = std::fs::write(path, vec![0_u8; contents.len()]);
+    let mut options = OpenOptions::new();
+    options.read(true).write(true);
+    #[cfg(unix)]
+    options.custom_flags(libc::O_NOFOLLOW);
+    let mut file =
+        options.open(path).map_err(|_| error("Managed enrollment file is unavailable."))?;
+    let metadata = file.metadata().map_err(|_| error("Managed enrollment file is unavailable."))?;
+    if !metadata.is_file() {
+        return Err(error("Managed enrollment file is unavailable."));
     }
-    let _ = std::fs::remove_file(path);
-    raw
+    let mut validation_error = None;
+    #[cfg(unix)]
+    {
+        if metadata.uid() != unsafe { libc::geteuid() } {
+            return Err(error("Managed enrollment file must be owned by the current user."));
+        }
+        if metadata.mode() & 0o077 != 0 {
+            validation_error = Some(error("Managed enrollment file permissions must be 0600."));
+        }
+    }
+
+    let mut contents = Vec::new();
+    let read_result = file.read_to_end(&mut contents);
+    // Best-effort overwrite through the already-open descriptor. This avoids
+    // following a replacement symlink and keeps shredding tied to the inode
+    // that was validated above.
+    let _ = file.seek(SeekFrom::Start(0));
+    let mut remaining = metadata.len();
+    let zeros = [0_u8; 4096];
+    while remaining > 0 {
+        let chunk = remaining.min(zeros.len() as u64) as usize;
+        if file.write_all(&zeros[..chunk]).is_err() {
+            break;
+        }
+        remaining -= chunk as u64;
+    }
+    let _ = file.set_len(0);
+    let _ = file.sync_all();
+    drop(file);
+    // The path can be replaced while the file is open. Only unlink it when it
+    // still names the validated inode, so a replacement is never deleted.
+    let same_file = std::fs::metadata(path)
+        .map(|current| {
+            #[cfg(unix)]
+            {
+                current.dev() == metadata.dev() && current.ino() == metadata.ino()
+            }
+            #[cfg(not(unix))]
+            {
+                let _ = current;
+                true
+            }
+        })
+        .unwrap_or(false);
+    if same_file {
+        let _ = std::fs::remove_file(path);
+    }
+    if let Some(validation_error) = validation_error {
+        return Err(validation_error);
+    }
+    read_result.map_err(|_| error("Managed enrollment file is unavailable."))?;
+    String::from_utf8(contents).map_err(|_| error("Managed enrollment file is unavailable."))
 }
 
 fn string_field(value: &Value, name: &str) -> Option<String> {
@@ -311,6 +359,26 @@ mod tests {
                 .0,
             "Managed enrollment file is unavailable."
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn enrollment_symlink_is_rejected_without_shredding_target() {
+        let dir = std::env::temp_dir().join(format!("cmux-managed-symlink-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let target = dir.join("target.json");
+        let link = dir.join("enrollment.json");
+        let expected = serde_json::to_string(&enrollment()).unwrap();
+        std::fs::write(&target, &expected).unwrap();
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let error = load_managed_enrollment_file(link.to_str().unwrap(), NOW)
+            .expect_err("symlink enrollment must be rejected");
+        assert_eq!(error.0, "Managed enrollment file is unavailable.");
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), expected);
+        assert!(std::fs::symlink_metadata(&link).is_ok(), "rejected symlink must not be unlinked");
+        let _ = std::fs::remove_dir_all(dir);
     }
 
     #[test]

--- a/cmux-tui/crates/chatmux-relay/src/enrollment.rs
+++ b/cmux-tui/crates/chatmux-relay/src/enrollment.rs
@@ -56,6 +56,14 @@ fn read_and_shred(path: &Path) -> Result<String, ManagedEnrollmentError> {
     if !metadata.is_file() {
         return Err(error("Managed enrollment file is unavailable."));
     }
+    #[cfg(not(unix))]
+    {
+        // The current non-Unix toolchain does not expose a stable file
+        // identity for checking a pathname before unlinking it. Do not read
+        // or return enrollment contents unless cleanup can be tied to the
+        // validated inode; callers must fail closed instead.
+        return Err(error("Managed enrollment file is unavailable."));
+    }
     let mut validation_error = None;
     #[cfg(unix)]
     {
@@ -414,6 +422,16 @@ mod tests {
                 .0,
             "Managed enrollment file is unavailable."
         );
+    }
+
+    #[cfg(not(unix))]
+    #[test]
+    fn non_unix_enrollment_fails_closed_before_accepting_contents() {
+        let path = fixture(&enrollment(), 0, "non-unix-identity");
+        let error = load_managed_enrollment_file(&path, NOW)
+            .expect_err("enrollment must be rejected when cleanup identity is unavailable");
+        assert_eq!(error.0, "Managed enrollment file is unavailable.");
+        assert!(Path::new(&path).exists(), "failed-closed enrollment remains for operator cleanup");
     }
 
     #[cfg(unix)]

--- a/cmux-tui/crates/chatmux-relay/src/enrollment.rs
+++ b/cmux-tui/crates/chatmux-relay/src/enrollment.rs
@@ -337,6 +337,12 @@ mod tests {
             let error = load_managed_enrollment_file(&path, NOW).expect_err("perms refused");
             assert_eq!(error.0, "Managed enrollment file permissions must be 0600.");
             assert!(!Path::new(&path).exists(), "file is deleted even on refusal");
+
+            let path = fixture(&enrollment(), 0o700, "owner-only-perms");
+            let error = load_managed_enrollment_file(&path, NOW)
+                .expect_err("non-0600 owner-only permissions must be refused");
+            assert_eq!(error.0, "Managed enrollment file permissions must be 0600.");
+            assert!(!Path::new(&path).exists(), "file is deleted even on refusal");
         }
 
         let mut short_token = enrollment();

--- a/cmux-tui/crates/chatmux-relay/src/enrollment.rs
+++ b/cmux-tui/crates/chatmux-relay/src/enrollment.rs
@@ -17,8 +17,8 @@ use std::path::Path;
 use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
 
 use serde_json::Value;
-use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
+use time::format_description::well_known::Rfc3339;
 use url::{Host, Url};
 
 use crate::config::{Config, ManagedEvents, ManagedIdentity};

--- a/cmux-tui/crates/chatmux-relay/src/enrollment.rs
+++ b/cmux-tui/crates/chatmux-relay/src/enrollment.rs
@@ -17,8 +17,8 @@ use std::path::Path;
 use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
 
 use serde_json::Value;
-use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
 use url::{Host, Url};
 
 use crate::config::{Config, ManagedEvents, ManagedIdentity};
@@ -43,8 +43,11 @@ fn error(message: &str) -> ManagedEnrollmentError {
 }
 
 fn read_and_shred(path: &Path) -> Result<String, ManagedEnrollmentError> {
+    // Open read-only first. Validation must not require write access: callers
+    // may intentionally mount the enrollment file read-only. O_NOFOLLOW keeps
+    // this descriptor pinned to a non-symlink inode.
     let mut options = OpenOptions::new();
-    options.read(true).write(true);
+    options.read(true);
     #[cfg(unix)]
     options.custom_flags(libc::O_NOFOLLOW);
     let mut file =
@@ -59,6 +62,15 @@ fn read_and_shred(path: &Path) -> Result<String, ManagedEnrollmentError> {
         if metadata.uid() != unsafe { libc::geteuid() } {
             return Err(error("Managed enrollment file must be owned by the current user."));
         }
+        // A hard-linked enrollment inode may have another live pathname. Do
+        // not read or overwrite it: shredding would destroy data reachable
+        // through that other pathname. Removing only this pathname is safe,
+        // but leaves the other link (and its contents) intact.
+        if metadata.nlink() != 1 {
+            drop(file);
+            unlink_if_same_inode(path, &metadata);
+            return Err(error("Managed enrollment file is unavailable."));
+        }
         if metadata.mode() & 0o777 != 0o600 {
             validation_error = Some(error("Managed enrollment file permissions must be 0600."));
         }
@@ -66,37 +78,69 @@ fn read_and_shred(path: &Path) -> Result<String, ManagedEnrollmentError> {
 
     let mut contents = Vec::new();
     let read_result = file.read_to_end(&mut contents);
-    // Best-effort overwrite through the already-open descriptor. This avoids
-    // following a replacement symlink and keeps shredding tied to the inode
-    // that was validated above.
-    let _ = file.seek(SeekFrom::Start(0));
-    let mut remaining = metadata.len();
-    let zeros = [0_u8; 4096];
-    while remaining > 0 {
-        let chunk = remaining.min(zeros.len() as u64) as usize;
-        if file.write_all(&zeros[..chunk]).is_err() {
-            break;
+
+    // Reopen for writing only after validation and reading. The second open
+    // is still O_NOFOLLOW and must resolve to the descriptor's inode before it
+    // can shred, so a path replacement cannot redirect writes to another file.
+    #[cfg(unix)]
+    let mut writable = {
+        let mut write_options = OpenOptions::new();
+        write_options.read(true).write(true).custom_flags(libc::O_NOFOLLOW);
+        write_options.open(path).ok().filter(|candidate| {
+            candidate.metadata().ok().is_some_and(|candidate_metadata| {
+                file_identity_matches(&candidate_metadata, &metadata)
+            })
+        })
+    };
+    #[cfg(not(unix))]
+    let mut writable: Option<std::fs::File> = None;
+
+    if let Some(write_file) = writable.as_mut() {
+        // Best-effort overwrite through the already-open descriptor. This
+        // keeps shredding tied to the inode that was validated above.
+        let _ = write_file.seek(SeekFrom::Start(0));
+        let mut remaining = metadata.len();
+        let zeros = [0_u8; 4096];
+        while remaining > 0 {
+            let chunk = remaining.min(zeros.len() as u64) as usize;
+            if write_file.write_all(&zeros[..chunk]).is_err() {
+                break;
+            }
+            remaining -= chunk as u64;
         }
-        remaining -= chunk as u64;
+        let _ = write_file.set_len(0);
+        let _ = write_file.sync_all();
     }
-    let _ = file.set_len(0);
-    let _ = file.sync_all();
+    drop(writable);
     drop(file);
     // The path can be replaced while the file is open. Only unlink it when it
     // still names the validated inode, so a replacement is never deleted.
+    unlink_if_same_inode(path, &metadata);
+    if let Some(validation_error) = validation_error {
+        return Err(validation_error);
+    }
+    read_result.map_err(|_| error("Managed enrollment file is unavailable."))?;
+    String::from_utf8(contents).map_err(|_| error("Managed enrollment file is unavailable."))
+}
+
+#[cfg(unix)]
+fn file_identity_matches(current: &std::fs::Metadata, expected: &std::fs::Metadata) -> bool {
+    current.dev() == expected.dev() && current.ino() == expected.ino()
+}
+
+fn unlink_if_same_inode(path: &Path, expected: &std::fs::Metadata) {
     let same_file = std::fs::metadata(path)
         .map(|current| {
             #[cfg(unix)]
             {
-                current.dev() == metadata.dev() && current.ino() == metadata.ino()
+                file_identity_matches(&current, expected)
             }
             #[cfg(not(unix))]
             {
-                // Windows does not expose a portable inode identity through
-                // std::fs::Metadata. Failing closed keeps a concurrently
-                // replaced pathname from being unlinked by this one-shot
-                // cleanup path.
-                let _ = current;
+                // Windows does not expose a stable file identity on the
+                // current toolchain. Failing closed avoids deleting a
+                // concurrently replaced pathname.
+                let _ = (current, expected);
                 false
             }
         })
@@ -104,11 +148,6 @@ fn read_and_shred(path: &Path) -> Result<String, ManagedEnrollmentError> {
     if same_file {
         let _ = std::fs::remove_file(path);
     }
-    if let Some(validation_error) = validation_error {
-        return Err(validation_error);
-    }
-    read_result.map_err(|_| error("Managed enrollment file is unavailable."))?;
-    String::from_utf8(contents).map_err(|_| error("Managed enrollment file is unavailable."))
 }
 
 fn string_field(value: &Value, name: &str) -> Option<String> {
@@ -347,6 +386,12 @@ mod tests {
                 .expect_err("non-0600 owner-only permissions must be refused");
             assert_eq!(error.0, "Managed enrollment file permissions must be 0600.");
             assert!(!Path::new(&path).exists(), "file is deleted even on refusal");
+
+            let path = fixture(&enrollment(), 0o400, "read-only-perms");
+            let error = load_managed_enrollment_file(&path, NOW)
+                .expect_err("readable but non-writable permissions must be refused");
+            assert_eq!(error.0, "Managed enrollment file permissions must be 0600.");
+            assert!(!Path::new(&path).exists(), "read-only file is deleted even on refusal");
         }
 
         let mut short_token = enrollment();
@@ -388,6 +433,27 @@ mod tests {
         assert_eq!(error.0, "Managed enrollment file is unavailable.");
         assert_eq!(std::fs::read_to_string(&target).unwrap(), expected);
         assert!(std::fs::symlink_metadata(&link).is_ok(), "rejected symlink must not be unlinked");
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn hard_linked_enrollment_is_rejected_without_shredding_other_link() {
+        let dir =
+            std::env::temp_dir().join(format!("cmux-managed-hardlink-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let target = dir.join("target.json");
+        let link = dir.join("enrollment.json");
+        let expected = serde_json::to_string(&enrollment()).unwrap();
+        std::fs::write(&target, &expected).unwrap();
+        std::fs::hard_link(&target, &link).unwrap();
+
+        let error = load_managed_enrollment_file(link.to_str().unwrap(), NOW)
+            .expect_err("hard-linked enrollment must be rejected");
+        assert_eq!(error.0, "Managed enrollment file is unavailable.");
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), expected);
+        assert!(!link.exists(), "only the enrollment pathname is removed");
         let _ = std::fs::remove_dir_all(dir);
     }
 

--- a/cmux-tui/crates/chatmux-relay/src/journal_forwarder.rs
+++ b/cmux-tui/crates/chatmux-relay/src/journal_forwarder.rs
@@ -1772,10 +1772,13 @@ mod tests {
 
         let stopped = Arc::new(AtomicBool::new(false));
         let signal = Arc::clone(&stopped);
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
         let worker = tokio::spawn(async move {
             let _signal = DropSignal(signal);
+            started_tx.send(()).expect("test receiver is waiting");
             std::future::pending::<()>().await;
         });
+        started_rx.await.expect("worker must be polled before abort");
         let mut tasks = HashMap::new();
         tasks.insert("session".to_owned(), worker);
 

--- a/cmux-tui/crates/chatmux-relay/src/journal_forwarder.rs
+++ b/cmux-tui/crates/chatmux-relay/src/journal_forwarder.rs
@@ -362,10 +362,24 @@ async fn run(events: ManagedEvents, cancellation: CancellationToken) {
             _ = scan.tick() => discover_sessions(&shared, &socket_dirs, &mut tasks).await,
         }
     }
-    for (_, task) in tasks {
+    abort_and_join_tasks(tasks).await;
+    flusher.abort();
+    let _ = flusher.await;
+}
+
+/// Stop every session worker and wait until Tokio has completed cancellation.
+/// Calling `JoinHandle::abort` only schedules cancellation; retaining the
+/// handles until they are awaited prevents worker-owned sockets and buffers
+/// from outliving the forwarder shutdown.
+#[cfg(unix)]
+async fn abort_and_join_tasks(tasks: HashMap<String, JoinHandle<()>>) {
+    let mut tasks: Vec<JoinHandle<()>> = tasks.into_values().collect();
+    for task in &tasks {
         task.abort();
     }
-    flusher.abort();
+    for task in tasks.drain(..) {
+        let _ = task.await;
+    }
 }
 
 fn build_http_client(timeout: Duration) -> Result<reqwest::Client, reqwest::Error> {
@@ -1372,6 +1386,8 @@ async fn persist_cursor_file(path: &Path, cursors: &HashMap<String, JournalCurso
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
+    use std::sync::atomic::AtomicBool;
 
     #[cfg(unix)]
     static NEXT_CURSOR_TEST_ID: AtomicU64 = AtomicU64::new(1);
@@ -1741,6 +1757,31 @@ mod tests {
                 .expect("request task must not panic")
                 .is_none()
         );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn shutdown_waits_for_session_workers_to_finish() {
+        struct DropSignal(Arc<AtomicBool>);
+
+        impl Drop for DropSignal {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let stopped = Arc::new(AtomicBool::new(false));
+        let signal = Arc::clone(&stopped);
+        let worker = tokio::spawn(async move {
+            let _signal = DropSignal(signal);
+            std::future::pending::<()>().await;
+        });
+        let mut tasks = HashMap::new();
+        tasks.insert("session".to_owned(), worker);
+
+        abort_and_join_tasks(tasks).await;
+
+        assert!(stopped.load(Ordering::SeqCst));
     }
 
     #[cfg(unix)]

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -51,6 +51,12 @@ use crate::wire::{
 const MAX_OUTBOUND_FRAMES: usize = 256;
 const MAX_WATCH_OUTBOUND_FRAMES: usize = 64;
 const MAX_OUTBOUND_BYTES: usize = 8 << 20;
+// Keep a small byte reserve outside the lossy watch/event budget. Watch
+// failures must still reach the client when watch frames consume all shared
+// bytes, so the client can re-open the stream instead of retaining a silent
+// watch ID.
+const MAX_CRITICAL_RESERVED_BYTES: usize = 64 << 10;
+const MAX_WATCH_BYTES: usize = MAX_OUTBOUND_BYTES - MAX_CRITICAL_RESERVED_BYTES;
 const MAX_PTY_INGRESS_FRAMES: usize = 64;
 // Keep room for the workspace fs_write 2 MiB payload plus its JSON envelope.
 const MAX_INBOUND_FRAME_BYTES: usize = 4 << 20;
@@ -93,6 +99,7 @@ pub(crate) struct OutboundFrame {
     pub(crate) live: Option<Arc<AtomicBool>>,
     pub(crate) ack: Option<tokio::sync::oneshot::Sender<()>>,
     _bytes: OwnedSemaphorePermit,
+    _watch_bytes: Option<OwnedSemaphorePermit>,
 }
 
 impl OutboundFrame {
@@ -137,6 +144,7 @@ pub(crate) struct OutboundSink {
     critical: mpsc::Sender<OutboundFrame>,
     watch: mpsc::Sender<OutboundFrame>,
     bytes: Arc<Semaphore>,
+    watch_bytes: Arc<Semaphore>,
     critical_overflow: Arc<AtomicBool>,
 }
 
@@ -150,6 +158,7 @@ impl OutboundSink {
                 critical,
                 watch,
                 bytes: Arc::new(Semaphore::new(MAX_OUTBOUND_BYTES)),
+                watch_bytes: Arc::new(Semaphore::new(MAX_WATCH_BYTES)),
                 critical_overflow: Arc::new(AtomicBool::new(false)),
             },
             critical_rx,
@@ -197,7 +206,7 @@ impl OutboundSink {
         let permit = Arc::clone(&self.bytes).acquire_many_owned(bytes).await.map_err(|_| ())?;
         let result = self
             .critical
-            .send(OutboundFrame { text, live, ack, _bytes: permit })
+            .send(OutboundFrame { text, live, ack, _bytes: permit, _watch_bytes: None })
             .await
             .map_err(|_| ());
         if result.is_err() {
@@ -220,7 +229,13 @@ impl OutboundSink {
             }
             let permit = Arc::clone(&self.bytes).try_acquire_many_owned(bytes).map_err(|_| ())?;
             self.critical
-                .try_send(OutboundFrame { text, live: None, ack: None, _bytes: permit })
+                .try_send(OutboundFrame {
+                    text,
+                    live: None,
+                    ack: None,
+                    _bytes: permit,
+                    _watch_bytes: None,
+                })
                 .map_err(|_| ())
         })();
         if result.is_err() {
@@ -245,7 +260,13 @@ impl OutboundSink {
             }
             let permit = Arc::clone(&self.bytes).try_acquire_many_owned(bytes).map_err(|_| ())?;
             self.critical
-                .try_send(OutboundFrame { text, live, ack: None, _bytes: permit })
+                .try_send(OutboundFrame {
+                    text,
+                    live,
+                    ack: None,
+                    _bytes: permit,
+                    _watch_bytes: None,
+                })
                 .map_err(|_| ())
         })();
         if result.is_err() {
@@ -268,8 +289,21 @@ impl OutboundSink {
         live: Option<Arc<AtomicBool>>,
     ) -> Result<(), ()> {
         let bytes = u32::try_from(text.len()).map_err(|_| ())?;
+        if bytes as usize > MAX_WATCH_BYTES {
+            return Err(());
+        }
         let permit = Arc::clone(&self.bytes).try_acquire_many_owned(bytes).map_err(|_| ())?;
-        self.watch.try_send(OutboundFrame { text, live, ack: None, _bytes: permit }).map_err(|_| ())
+        let watch_permit =
+            Arc::clone(&self.watch_bytes).try_acquire_many_owned(bytes).map_err(|_| ())?;
+        self.watch
+            .try_send(OutboundFrame {
+                text,
+                live,
+                ack: None,
+                _bytes: permit,
+                _watch_bytes: Some(watch_permit),
+            })
+            .map_err(|_| ())
     }
 }
 

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -137,7 +137,7 @@ pub(crate) struct OutboundSink {
     critical: mpsc::Sender<OutboundFrame>,
     watch: mpsc::Sender<OutboundFrame>,
     bytes: Arc<Semaphore>,
-    critical_overflow: Arc<std::sync::atomic::AtomicBool>,
+    critical_overflow: Arc<AtomicBool>,
 }
 
 impl OutboundSink {
@@ -150,7 +150,7 @@ impl OutboundSink {
                 critical,
                 watch,
                 bytes: Arc::new(Semaphore::new(MAX_OUTBOUND_BYTES)),
-                critical_overflow: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                critical_overflow: Arc::new(AtomicBool::new(false)),
             },
             critical_rx,
             watch_rx,
@@ -167,7 +167,10 @@ impl OutboundSink {
     }
 
     pub(crate) async fn critical_text(&self, text: String) -> Result<(), ()> {
-        self.critical_text_with_token(text, None).await
+        // Keep relay-loop callers nonblocking. Waiting for a writer
+        // acknowledgement here can deadlock because the loop also owns the
+        // outbound consumer. Token-aware producers use the explicit ack path.
+        self.critical_text_with_token_ack(text, None, None).await
     }
 
     pub(crate) async fn critical_text_with_token(

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -18,7 +18,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
 
 use futures_util::{SinkExt as _, StreamExt as _};
@@ -90,7 +90,15 @@ struct AuthSnapshot {
 
 pub(crate) struct OutboundFrame {
     pub(crate) text: String,
+    pub(crate) live: Option<Arc<AtomicBool>>,
+    pub(crate) ack: Option<tokio::sync::oneshot::Sender<()>>,
     _bytes: OwnedSemaphorePermit,
+}
+
+impl OutboundFrame {
+    pub(crate) fn is_live(&self) -> bool {
+        self.live.as_ref().is_none_or(|live| live.load(Ordering::Acquire))
+    }
 }
 
 async fn send_socket_message<S>(
@@ -159,14 +167,36 @@ impl OutboundSink {
     }
 
     pub(crate) async fn critical_text(&self, text: String) -> Result<(), ()> {
+        self.critical_text_with_token(text, None).await
+    }
+
+    pub(crate) async fn critical_text_with_token(
+        &self,
+        text: String,
+        live: Option<Arc<AtomicBool>>,
+    ) -> Result<(), ()> {
+        let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
+        self.critical_text_with_token_ack(text, live, Some(ack_tx)).await?;
+        ack_rx.await.map_err(|_| ())
+    }
+
+    pub(crate) async fn critical_text_with_token_ack(
+        &self,
+        text: String,
+        live: Option<Arc<AtomicBool>>,
+        ack: Option<tokio::sync::oneshot::Sender<()>>,
+    ) -> Result<(), ()> {
         let bytes = u32::try_from(text.len()).map_err(|_| ())?;
         if bytes as usize > MAX_OUTBOUND_BYTES {
             self.critical_overflow.store(true, Ordering::Release);
             return Err(());
         }
         let permit = Arc::clone(&self.bytes).acquire_many_owned(bytes).await.map_err(|_| ())?;
-        let result =
-            self.critical.send(OutboundFrame { text, _bytes: permit }).await.map_err(|_| ());
+        let result = self
+            .critical
+            .send(OutboundFrame { text, live, ack, _bytes: permit })
+            .await
+            .map_err(|_| ());
         if result.is_err() {
             self.critical_overflow.store(true, Ordering::Release);
         }
@@ -186,7 +216,9 @@ impl OutboundSink {
                 return Err(());
             }
             let permit = Arc::clone(&self.bytes).try_acquire_many_owned(bytes).map_err(|_| ())?;
-            self.critical.try_send(OutboundFrame { text, _bytes: permit }).map_err(|_| ())
+            self.critical
+                .try_send(OutboundFrame { text, live: None, ack: None, _bytes: permit })
+                .map_err(|_| ())
         })();
         if result.is_err() {
             self.critical_overflow.store(true, Ordering::Release);
@@ -195,13 +227,23 @@ impl OutboundSink {
     }
 
     pub(crate) fn try_critical_text(&self, text: String) -> Result<(), ()> {
+        self.try_critical_text_with_token(text, None)
+    }
+
+    pub(crate) fn try_critical_text_with_token(
+        &self,
+        text: String,
+        live: Option<Arc<AtomicBool>>,
+    ) -> Result<(), ()> {
         let result = (|| {
             let bytes = u32::try_from(text.len()).map_err(|_| ())?;
             if bytes as usize > MAX_OUTBOUND_BYTES {
                 return Err(());
             }
             let permit = Arc::clone(&self.bytes).try_acquire_many_owned(bytes).map_err(|_| ())?;
-            self.critical.try_send(OutboundFrame { text, _bytes: permit }).map_err(|_| ())
+            self.critical
+                .try_send(OutboundFrame { text, live, ack: None, _bytes: permit })
+                .map_err(|_| ())
         })();
         if result.is_err() {
             self.critical_overflow.store(true, Ordering::Release);
@@ -214,9 +256,17 @@ impl OutboundSink {
     }
 
     pub(crate) fn try_watch_text(&self, text: String) -> Result<(), ()> {
+        self.try_watch_text_with_token(text, None)
+    }
+
+    pub(crate) fn try_watch_text_with_token(
+        &self,
+        text: String,
+        live: Option<Arc<AtomicBool>>,
+    ) -> Result<(), ()> {
         let bytes = u32::try_from(text.len()).map_err(|_| ())?;
         let permit = Arc::clone(&self.bytes).try_acquire_many_owned(bytes).map_err(|_| ())?;
-        self.watch.try_send(OutboundFrame { text, _bytes: permit }).map_err(|_| ())
+        self.watch.try_send(OutboundFrame { text, live, ack: None, _bytes: permit }).map_err(|_| ())
     }
 }
 
@@ -641,6 +691,12 @@ async fn relay_session(
                 }
             }
             Wake::Outbound(is_critical, Some(frame)) => {
+                if !frame.is_live() {
+                    if let Some(ack) = frame.ack {
+                        let _ = ack.send(());
+                    }
+                    continue;
+                }
                 if is_critical {
                     critical_burst += 1;
                 } else {
@@ -652,6 +708,9 @@ async fn relay_session(
                 pending.fetch_sub(size.min(pending.load(Ordering::SeqCst)), Ordering::SeqCst);
                 if sent.is_err() {
                     break Ok(connected);
+                }
+                if let Some(ack) = frame.ack {
+                    let _ = ack.send(());
                 }
             }
             Wake::Outbound(_, None) => {
@@ -1182,5 +1241,32 @@ mod cancellation_tests {
         assert!(shutdown_connection_tasks(&mut tasks, &cancellation).await);
         assert!(cancellation.is_cancelled());
         assert!(tasks.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod outbound_frame_tests {
+    use super::OutboundSink;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    #[tokio::test]
+    async fn token_frames_are_marked_stale_before_socket_delivery() {
+        let (sink, mut critical, _) = OutboundSink::channels();
+        let live = Arc::new(AtomicBool::new(false));
+        let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
+        sink.critical_text_with_token_ack(
+            "stale".to_owned(),
+            Some(Arc::clone(&live)),
+            Some(ack_tx),
+        )
+        .await
+        .expect("queue frame");
+        let frame = critical.recv().await.expect("queued frame");
+        assert!(!frame.is_live());
+        live.store(true, Ordering::Release);
+        assert!(frame.is_live());
+        frame.ack.expect("ack sender").send(()).expect("ack receiver");
+        ack_rx.await.expect("ack");
     }
 }

--- a/cmux-tui/crates/chatmux-relay/src/watch.rs
+++ b/cmux-tui/crates/chatmux-relay/src/watch.rs
@@ -289,13 +289,14 @@ async fn setup_watch(
         }
         Ok((root, prepared))
     });
+    let setup_abort = setup.abort_handle();
     tokio::select! {
         biased;
         _ = cancellation.cancelled() => {
             // Aborting the join future does not stop an already-running
             // blocking closure. Its permit and watcher are released when it
             // returns, and the bounded lane prevents unbounded accumulation.
-            setup.abort();
+            setup_abort.abort();
             Err(SetupFailure::Cancelled)
         }
         result = setup => match result {
@@ -601,7 +602,7 @@ async fn run_watch(
     setup_slots: Arc<Semaphore>,
 ) {
     let PreparedWatch {
-        mut watcher,
+        watcher,
         mut event_rx,
         overflowed,
         overflow_notify,
@@ -743,10 +744,11 @@ async fn rebuild_ignore_matcher(
         let _permit = permit;
         if blocking_cancellation.is_cancelled() { None } else { Some(build_ignore_matcher(&root)) }
     });
+    let task_abort = task.abort_handle();
     tokio::select! {
         biased;
         _ = cancellation.cancelled() => {
-            task.abort();
+            task_abort.abort();
             None
         }
         result = task => result.ok().flatten(),

--- a/cmux-tui/crates/chatmux-relay/src/watch.rs
+++ b/cmux-tui/crates/chatmux-relay/src/watch.rs
@@ -37,6 +37,8 @@ const MAX_PENDING_NOTIFY_EVENTS: usize = 1024;
 /// filesystem operations. Keep them off the relay executor and bound the
 /// number of concurrent setup walks per connection.
 const WATCH_SETUP_CONCURRENCY: usize = 2;
+const WATCH_SETUP_FAILURE_MESSAGE: &str = "filesystem watcher setup failed";
+const WATCH_RUNTIME_FAILURE_MESSAGE: &str = "filesystem watcher stopped";
 
 /// All fallible watcher setup happens before a watch is published in the
 /// registry. A failed replacement therefore leaves the existing watch intact.
@@ -1125,6 +1127,69 @@ mod tests {
         .expect("old watch did not survive queue failure");
         assert_eq!(frame["watchId"], "same");
         registry.close("same");
+    }
+
+    #[tokio::test]
+    async fn completed_watch_invalidates_queued_frames() {
+        let sessions = Arc::new(Mutex::new(HashMap::new()));
+        let live = Arc::new(AtomicBool::new(true));
+        let cancellation = CancellationToken::new();
+        let task = tokio::spawn(async {});
+        sessions.lock().unwrap().insert(
+            "finished".to_owned(),
+            WatchSlot {
+                active: Some(ActiveWatch {
+                    generation: 1,
+                    live: Arc::clone(&live),
+                    cancellation,
+                    abort: task.abort_handle(),
+                }),
+                opening: None,
+            },
+        );
+        finish_active("finished", 1, Arc::clone(&sessions));
+        assert!(!live.load(Ordering::Acquire));
+        assert!(sessions.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn failed_open_keeps_its_error_frame_live_until_delivery() {
+        let (sink, mut critical, _) = OutboundSink::channels();
+        let sessions = Arc::new(Mutex::new(HashMap::new()));
+        let live = Arc::new(AtomicBool::new(true));
+        let cancellation = CancellationToken::new();
+        sessions.lock().unwrap().insert(
+            "failed".to_owned(),
+            WatchSlot {
+                active: None,
+                opening: Some(Opening {
+                    generation: 1,
+                    live: Arc::clone(&live),
+                    cancellation: cancellation.clone(),
+                    abort: None,
+                }),
+            },
+        );
+        finish_open_failure(
+            "failed",
+            1,
+            live,
+            cancellation,
+            Arc::clone(&sessions),
+            sink,
+            wire::WorkspaceErrorCode::Failed,
+            "internal details must not escape".to_owned(),
+        );
+        let frame = critical.try_recv().expect("failure frame");
+        assert!(frame.live.is_none(), "failure must not be fenced before delivery");
+        let value: Value = serde_json::from_str(&frame.text).expect("failure json");
+        assert_eq!(value["code"], "failed");
+    }
+
+    #[test]
+    fn watcher_failure_messages_are_stable() {
+        assert_eq!(WATCH_SETUP_FAILURE_MESSAGE, "filesystem watcher setup failed");
+        assert_eq!(WATCH_RUNTIME_FAILURE_MESSAGE, "filesystem watcher stopped");
     }
 
     #[cfg(unix)]

--- a/cmux-tui/crates/chatmux-relay/src/watch.rs
+++ b/cmux-tui/crates/chatmux-relay/src/watch.rs
@@ -13,6 +13,9 @@ use std::time::Duration;
 
 use tokio::sync::Notify;
 use tokio::sync::mpsc::{Receiver, Sender, channel};
+use tokio::sync::{Semaphore, oneshot};
+use tokio::task::AbortHandle;
+use tokio_util::sync::CancellationToken;
 
 use crate::actions::{RootLists, ensure_scoped_file_roots_available};
 use crate::relay_wire as wire;
@@ -30,6 +33,10 @@ pub const WATCH_MAX_CHANGES: usize = 256;
 const DEBOUNCE_QUIET: Duration = Duration::from_millis(150);
 const DEBOUNCE_MAX_LATENCY: Duration = Duration::from_millis(500);
 const MAX_PENDING_NOTIFY_EVENTS: usize = 1024;
+/// Recursive watcher startup and ignore-file discovery are synchronous
+/// filesystem operations. Keep them off the relay executor and bound the
+/// number of concurrent setup walks per connection.
+const WATCH_SETUP_CONCURRENCY: usize = 2;
 
 /// All fallible watcher setup happens before a watch is published in the
 /// registry. A failed replacement therefore leaves the existing watch intact.
@@ -39,31 +46,90 @@ struct PreparedWatch {
     overflowed: Arc<AtomicBool>,
     overflow_notify: Arc<Notify>,
     latched_error: Arc<Mutex<Option<String>>>,
+    matcher: ignore::gitignore::Gitignore,
 }
 
-enum AdmissionFailure {
+struct ActiveWatch {
+    generation: u64,
+    live: Arc<AtomicBool>,
+    cancellation: CancellationToken,
+    abort: AbortHandle,
+}
+
+struct Opening {
+    generation: u64,
+    live: Arc<AtomicBool>,
+    cancellation: CancellationToken,
+    /// The coordinator is detached, so the registry retains only its abort
+    /// handle. It may be absent briefly while `open` installs the handle.
+    abort: Option<AbortHandle>,
+}
+
+struct WatchSlot {
+    active: Option<ActiveWatch>,
+    opening: Option<Opening>,
+}
+
+type Sessions = Arc<Mutex<HashMap<String, WatchSlot>>>;
+
+enum RetiredWatch {
+    Active(ActiveWatch),
+    Opening(Opening),
+}
+
+enum Reservation {
+    Accepted { previous: Option<Opening> },
     Limit,
-    OutboundUnavailable,
 }
 
-type Sessions = Arc<Mutex<HashMap<String, (u64, Option<tokio::task::JoinHandle<()>>)>>>;
+impl RetiredWatch {
+    fn stop(self) {
+        match self {
+            RetiredWatch::Active(active) => {
+                active.live.store(false, Ordering::Release);
+                active.cancellation.cancel();
+                active.abort.abort();
+            }
+            RetiredWatch::Opening(opening) => {
+                opening.live.store(false, Ordering::Release);
+                opening.cancellation.cancel();
+                if let Some(abort) = opening.abort {
+                    abort.abort();
+                }
+            }
+        }
+    }
+}
+
+impl WatchSlot {
+    fn retire(self) -> impl Iterator<Item = RetiredWatch> {
+        self.active
+            .into_iter()
+            .map(RetiredWatch::Active)
+            .chain(self.opening.into_iter().map(RetiredWatch::Opening))
+    }
+}
 
 pub struct WatchRegistry {
     outbound: OutboundSink,
     sessions: Sessions,
     next_generation: Arc<AtomicU64>,
+    setup_slots: Arc<Semaphore>,
+    cancellation: CancellationToken,
 }
 
 impl Drop for WatchRegistry {
     fn drop(&mut self) {
         // The socket died with this registry; the Worker re-opens watches
         // on the next connection.
-        if let Ok(mut sessions) = self.sessions.lock() {
-            for (_, (_, task)) in sessions.drain() {
-                if let Some(task) = task {
-                    task.abort();
-                }
-            }
+        self.cancellation.cancel();
+        let retired = self
+            .sessions
+            .lock()
+            .map(|mut sessions| sessions.drain().flat_map(|(_, slot)| slot.retire()).collect())
+            .unwrap_or_else(|_| Vec::new());
+        for watch in retired {
+            watch.stop();
         }
     }
 }
@@ -85,6 +151,8 @@ impl WatchRegistry {
             outbound,
             sessions: Arc::new(Mutex::new(HashMap::new())),
             next_generation: Arc::new(AtomicU64::new(0)),
+            setup_slots: Arc::new(Semaphore::new(WATCH_SETUP_CONCURRENCY)),
+            cancellation: CancellationToken::new(),
         }
     }
 
@@ -94,77 +162,72 @@ impl WatchRegistry {
     }
 
     pub fn close(&self, watch_id: &str) {
-        if let Ok(mut sessions) = self.sessions.lock()
-            && let Some((_, Some(task))) = sessions.remove(watch_id)
-        {
-            task.abort();
+        let retired = self
+            .sessions
+            .lock()
+            .ok()
+            .and_then(|mut sessions| sessions.remove(watch_id))
+            .map(|slot| slot.retire().collect::<Vec<_>>())
+            .unwrap_or_default();
+        for watch in retired {
+            watch.stop();
         }
     }
 
-    /// Resolve + scope the root, answer `fs_watch_opened`, then stream.
+    /// Reserve an ID and start asynchronous setup. The active watch, if any,
+    /// remains live until setup succeeds and `fs_watch_opened` is queued.
     /// Watching is read-only: observe trust is admitted.
     pub fn open(&self, frame: wire::RelayFsWatchOpen, local_roots: Option<&[String]>) {
         let watch_id = frame.watch_id.clone();
-        let root = match watch_root(&frame, local_roots) {
-            Ok(root) => root,
-            Err(refusal) => {
-                self.refuse(&watch_id, refusal.code, &refusal.message);
-                return;
-            }
-        };
-        // Check capacity before touching the filesystem watcher. A full
-        // registry keeps its existing watches and receives a typed refusal.
-        let capacity_available = self
-            .sessions
-            .lock()
-            .map(|sessions| sessions.contains_key(&watch_id) || sessions.len() < WATCH_MAX_SESSIONS)
-            .unwrap_or(false);
-        if !capacity_available {
-            self.refuse(
-                &watch_id,
-                wire::WorkspaceErrorCode::WatchLimit,
-                &format!("this machine already streams {WATCH_MAX_SESSIONS} watches"),
-            );
-            return;
-        }
-        let prepared = match prepare_watch(&root) {
-            Ok(prepared) => prepared,
-            Err(message) => {
-                self.refuse(&watch_id, wire::WorkspaceErrorCode::Failed, &message);
-                return;
-            }
-        };
-        let opened = serde_json::to_string(&wire::RelayFsWatchOpened {
-            version: WORKSPACE_FRAME_VERSION,
-            r#type: wire::TagFsWatchOpened::FsWatchOpened,
-            watch_id: watch_id.clone(),
-            root: root.to_string_lossy().into_owned(),
-        })
-        .unwrap_or_else(|_| String::new());
         let generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
-        // Publish the acknowledgement while the session lock is held. This
-        // makes admission one transaction: a full/closed outbound queue never
-        // retires the current watch without first accepting its replacement.
-        let admission = match self.sessions.lock() {
-            Ok(mut sessions)
-                if sessions.contains_key(&watch_id) || sessions.len() < WATCH_MAX_SESSIONS =>
-            {
-                if self.outbound.try_critical_text(opened).is_err() {
-                    Err(AdmissionFailure::OutboundUnavailable)
+        let opening_cancellation = self.cancellation.child_token();
+        let opening_live = Arc::new(AtomicBool::new(true));
+        let sessions = Arc::clone(&self.sessions);
+        let outbound = self.outbound.clone();
+        let setup_slots = Arc::clone(&self.setup_slots);
+        let local_roots_for_task = local_roots.map(<[String]>::to_vec);
+        let reservation = match self.sessions.lock() {
+            Ok(mut state) => {
+                let existing = state.contains_key(&watch_id);
+                if !existing && state.len() >= WATCH_MAX_SESSIONS {
+                    Reservation::Limit
                 } else {
-                    Ok(sessions.insert(watch_id.clone(), (generation, None)))
+                    let slot = state
+                        .entry(watch_id.clone())
+                        .or_insert_with(|| WatchSlot { active: None, opening: None });
+                    let previous = slot.opening.replace(Opening {
+                        generation,
+                        live: Arc::clone(&opening_live),
+                        cancellation: opening_cancellation.clone(),
+                        abort: None,
+                    });
+                    // Spawn while the state lock is held, then install the
+                    // abort handle before another caller can close/replace
+                    // this slot. Tokio guarantees `spawn` does not poll the
+                    // future synchronously as part of this call.
+                    let task_id = watch_id.clone();
+                    let task_cancellation = opening_cancellation.clone();
+                    let task = tokio::spawn(coordinate_open(
+                        task_id,
+                        frame,
+                        local_roots_for_task,
+                        generation,
+                        Arc::clone(&opening_live),
+                        task_cancellation,
+                        Arc::clone(&sessions),
+                        outbound,
+                        setup_slots,
+                    ));
+                    slot.opening.as_mut().expect("opening was just reserved").abort =
+                        Some(task.abort_handle());
+                    Reservation::Accepted { previous }
                 }
             }
-            Ok(_) | Err(_) => Err(AdmissionFailure::Limit),
+            Err(_) => Reservation::Limit,
         };
-        let previous = match admission {
-            Ok(previous) => previous,
-            Err(AdmissionFailure::OutboundUnavailable) => {
-                // The queue is already unavailable. Keep the existing
-                // watch, because a refusal cannot be delivered either.
-                return;
-            }
-            Err(AdmissionFailure::Limit) => {
+        let previous = match reservation {
+            Reservation::Accepted { previous } => previous,
+            Reservation::Limit => {
                 self.refuse(
                     &watch_id,
                     wire::WorkspaceErrorCode::WatchLimit,
@@ -173,42 +236,273 @@ impl WatchRegistry {
                 return;
             }
         };
-        let outbound = self.outbound.clone();
-        let sessions = Arc::clone(&self.sessions);
-        let task_id = watch_id.clone();
-        let mut task = Some(tokio::spawn(async move {
-            run_watch(&task_id, &root, &outbound, prepared).await;
-            if let Ok(mut sessions) = sessions.lock() {
-                // `tokio::spawn` starts the task immediately, so a watcher
-                // that fails during startup can finish before its handle is
-                // installed in the registry. Remove our generation's
-                // placeholder regardless of whether the handle is present;
-                // a replacement watch has a different generation and is
-                // therefore preserved.
-                if sessions.get(&task_id).is_some_and(|entry| entry.0 == generation) {
-                    sessions.remove(&task_id);
+        if let Some(previous) = previous {
+            RetiredWatch::Opening(previous).stop();
+        }
+    }
+}
+
+enum SetupFailure {
+    Cancelled,
+    Refused { code: wire::WorkspaceErrorCode, message: String },
+    Failed(String),
+}
+
+/// Resolve the scoped root, install notify, and discover ignore files on a
+/// blocking worker. The semaphore permit is moved into that worker so a
+/// started walk continues to count against the setup bound until it exits.
+async fn setup_watch(
+    frame: wire::RelayFsWatchOpen,
+    local_roots: Option<Vec<String>>,
+    cancellation: CancellationToken,
+    setup_slots: Arc<Semaphore>,
+) -> Result<(PathBuf, PreparedWatch), SetupFailure> {
+    let permit = tokio::select! {
+        biased;
+        _ = cancellation.cancelled() => return Err(SetupFailure::Cancelled),
+        result = setup_slots.acquire_owned() => result
+            .map_err(|error| SetupFailure::Failed(format!("watch setup lane closed: {error}")))?,
+    };
+    let blocking_cancellation = cancellation.clone();
+    let setup = tokio::task::spawn_blocking(move || {
+        let _permit = permit;
+        if blocking_cancellation.is_cancelled() {
+            return Err(SetupFailure::Cancelled);
+        }
+        let root = watch_root(&frame, local_roots.as_deref()).map_err(|refusal| {
+            SetupFailure::Refused { code: refusal.code, message: refusal.message }
+        })?;
+        if blocking_cancellation.is_cancelled() {
+            return Err(SetupFailure::Cancelled);
+        }
+        let mut prepared = prepare_watch(&root).map_err(SetupFailure::Failed)?;
+        if blocking_cancellation.is_cancelled() {
+            drop(prepared);
+            return Err(SetupFailure::Cancelled);
+        }
+        prepared.matcher = build_ignore_matcher(&root);
+        if blocking_cancellation.is_cancelled() {
+            drop(prepared);
+            return Err(SetupFailure::Cancelled);
+        }
+        Ok((root, prepared))
+    });
+    tokio::select! {
+        biased;
+        _ = cancellation.cancelled() => {
+            // Aborting the join future does not stop an already-running
+            // blocking closure. Its permit and watcher are released when it
+            // returns, and the bounded lane prevents unbounded accumulation.
+            setup.abort();
+            Err(SetupFailure::Cancelled)
+        }
+        result = setup => match result {
+            Ok(result) => result,
+            Err(error) => Err(SetupFailure::Failed(format!("watch setup crashed: {error}"))),
+        },
+    }
+}
+
+async fn coordinate_open(
+    watch_id: String,
+    frame: wire::RelayFsWatchOpen,
+    local_roots: Option<Vec<String>>,
+    generation: u64,
+    live: Arc<AtomicBool>,
+    cancellation: CancellationToken,
+    sessions: Sessions,
+    outbound: OutboundSink,
+    setup_slots: Arc<Semaphore>,
+) {
+    let setup = setup_watch(frame, local_roots, cancellation.clone(), setup_slots.clone()).await;
+    match setup {
+        Ok((root, prepared)) => {
+            commit_open(
+                watch_id,
+                root,
+                prepared,
+                generation,
+                live,
+                cancellation,
+                sessions,
+                outbound,
+                setup_slots,
+            );
+        }
+        Err(SetupFailure::Cancelled) => {}
+        Err(SetupFailure::Refused { code, message }) => {
+            finish_open_failure(
+                &watch_id,
+                generation,
+                live,
+                cancellation,
+                sessions,
+                outbound,
+                code,
+                message,
+            );
+        }
+        Err(SetupFailure::Failed(message)) => {
+            finish_open_failure(
+                &watch_id,
+                generation,
+                live,
+                cancellation,
+                sessions,
+                outbound,
+                wire::WorkspaceErrorCode::Failed,
+                message,
+            );
+        }
+    }
+}
+
+/// Publish the acknowledgement and active task as one state transition.
+/// `prepared` stays outside the mutex on every rejection path so dropping a
+/// notify watcher cannot run while registry state is locked.
+fn commit_open(
+    watch_id: String,
+    root: PathBuf,
+    prepared: PreparedWatch,
+    generation: u64,
+    live: Arc<AtomicBool>,
+    cancellation: CancellationToken,
+    sessions: Sessions,
+    outbound: OutboundSink,
+    setup_slots: Arc<Semaphore>,
+) {
+    let opened = serde_json::to_string(&wire::RelayFsWatchOpened {
+        version: WORKSPACE_FRAME_VERSION,
+        r#type: wire::TagFsWatchOpened::FsWatchOpened,
+        watch_id: watch_id.clone(),
+        root: root.to_string_lossy().into_owned(),
+    })
+    .unwrap_or_else(|_| String::new());
+    let mut prepared = Some(prepared);
+    let mut retired = Vec::new();
+    let mut start = None;
+    let mut committed = false;
+    if let Ok(mut state) = sessions.lock() {
+        let mut remove_slot = false;
+        if let Some(slot) = state.get_mut(&watch_id)
+            && slot.opening.as_ref().is_some_and(|opening| {
+                opening.generation == generation && !opening.cancellation.is_cancelled()
+            })
+            && outbound.try_critical_text_with_token(opened, Some(Arc::clone(&live))).is_ok()
+        {
+            let (start_tx, start_rx) = oneshot::channel();
+            let run_id = watch_id.clone();
+            let run_root = root.clone();
+            let run_outbound = outbound.clone();
+            let run_sessions = Arc::clone(&sessions);
+            let run_setup_slots = Arc::clone(&setup_slots);
+            let run_cancellation = cancellation.clone();
+            let run_live = Arc::clone(&live);
+            let run_prepared = prepared.take().expect("prepared watch present");
+            let task = tokio::spawn(async move {
+                // Install the active slot before allowing the runner to poll.
+                // This closes the fast-exit race where cleanup could otherwise
+                // run before the registry stores the task generation.
+                if start_rx.await.is_err() {
+                    return;
                 }
+                run_watch(
+                    &run_id,
+                    &run_root,
+                    &run_outbound,
+                    run_prepared,
+                    run_cancellation.clone(),
+                    run_live,
+                    run_setup_slots,
+                )
+                .await;
+                finish_active(&run_id, generation, run_sessions);
+            });
+            let previous = slot.active.replace(ActiveWatch {
+                generation,
+                live: Arc::clone(&live),
+                cancellation: cancellation.clone(),
+                abort: task.abort_handle(),
+            });
+            slot.opening.take();
+            if let Some(previous) = previous {
+                retired.push(RetiredWatch::Active(previous));
             }
-        }));
-        let installed = if let Ok(mut sessions) = self.sessions.lock() {
-            if let Some(entry) = sessions.get_mut(&watch_id) {
-                if entry.0 == generation {
-                    entry.1 = task.take();
-                    true
-                } else {
-                    false
-                }
-            } else {
-                false
+            start = Some(start_tx);
+            committed = true;
+        } else if state.get(&watch_id).is_some_and(|slot| {
+            slot.opening.as_ref().is_some_and(|opening| opening.generation == generation)
+        }) {
+            // A full/closed queue rejects the replacement while preserving
+            // the currently active watch. Clear only this generation.
+            if let Some(slot) = state.get_mut(&watch_id) {
+                slot.opening.take();
+                remove_slot = slot.active.is_none();
             }
+        }
+        if remove_slot {
+            state.remove(&watch_id);
+        }
+    }
+    if !committed {
+        live.store(false, Ordering::Release);
+        cancellation.cancel();
+    }
+    for watch in retired {
+        watch.stop();
+    }
+    if let Some(start) = start {
+        let _ = start.send(());
+    }
+    // Explicitly drop after the lock has been released. See the helper's
+    // comment above; notify watcher teardown can perform synchronous work.
+    drop(prepared);
+}
+
+fn finish_open_failure(
+    watch_id: &str,
+    generation: u64,
+    live: Arc<AtomicBool>,
+    cancellation: CancellationToken,
+    sessions: Sessions,
+    outbound: OutboundSink,
+    code: wire::WorkspaceErrorCode,
+    message: String,
+) {
+    let text = watch_error_frame(watch_id, code, &message);
+    if let Ok(mut state) = sessions.lock() {
+        let remove_slot = if let Some(slot) = state.get_mut(watch_id)
+            && slot.opening.as_ref().is_some_and(|opening| {
+                opening.generation == generation && !opening.cancellation.is_cancelled()
+            }) {
+            // Keep the active watch intact while the refusal is queued.
+            // Holding the state lock orders this frame before a subsequent
+            // replacement.
+            let _ = outbound.try_critical_text_with_token(text, Some(Arc::clone(&live)));
+            slot.opening.take();
+            live.store(false, Ordering::Release);
+            slot.active.is_none()
         } else {
             false
         };
-        if !installed && let Some(task) = task {
-            task.abort();
+        if remove_slot {
+            state.remove(watch_id);
         }
-        if let Some((_, Some(previous))) = previous {
-            previous.abort();
+    }
+    cancellation.cancel();
+}
+
+fn finish_active(watch_id: &str, generation: u64, sessions: Sessions) {
+    if let Ok(mut state) = sessions.lock() {
+        let mut remove_slot = false;
+        if let Some(slot) = state.get_mut(watch_id)
+            && slot.active.as_ref().is_some_and(|active| active.generation == generation)
+        {
+            slot.active.take();
+            remove_slot = slot.opening.is_none();
+        }
+        if remove_slot {
+            state.remove(watch_id);
         }
     }
 }
@@ -244,7 +538,14 @@ fn prepare_watch(root: &Path) -> Result<PreparedWatch, String> {
     watcher
         .watch(root, notify::RecursiveMode::Recursive)
         .map_err(|error| format!("could not watch {}: {error}", root.display()))?;
-    Ok(PreparedWatch { watcher, event_rx, overflowed, overflow_notify, latched_error })
+    Ok(PreparedWatch {
+        watcher,
+        event_rx,
+        overflowed,
+        overflow_notify,
+        latched_error,
+        matcher: ignore::gitignore::Gitignore::empty(),
+    })
 }
 
 fn watch_root(
@@ -281,13 +582,28 @@ fn watch_root_with_capabilities(
 // The watch task: notify events -> debounce -> gitignore filter -> frames
 // ---------------------------------------------------------------------------
 
-async fn run_watch(watch_id: &str, root: &Path, outbound: &OutboundSink, prepared: PreparedWatch) {
-    let PreparedWatch { mut watcher, mut event_rx, overflowed, overflow_notify, latched_error } =
-        prepared;
-    let mut matcher = build_ignore_matcher(root);
+async fn run_watch(
+    watch_id: &str,
+    root: &Path,
+    outbound: &OutboundSink,
+    prepared: PreparedWatch,
+    cancellation: CancellationToken,
+    live: Arc<AtomicBool>,
+    setup_slots: Arc<Semaphore>,
+) {
+    let PreparedWatch {
+        mut watcher,
+        mut event_rx,
+        overflowed,
+        overflow_notify,
+        latched_error,
+        mut matcher,
+    } = prepared;
     'watch: loop {
         let notified = overflow_notify.notified();
         let first = tokio::select! {
+            biased;
+            _ = cancellation.cancelled() => break 'watch,
             event = event_rx.recv() => event,
             _ = notified => None,
         };
@@ -296,7 +612,10 @@ async fn run_watch(watch_id: &str, root: &Path, outbound: &OutboundSink, prepare
         if burst.is_empty() && !overflowed.load(Ordering::Acquire) && !has_latched_error {
             break;
         }
-        drain_burst(&mut event_rx, &mut burst).await;
+        drain_burst(&mut event_rx, &mut burst, &cancellation).await;
+        if cancellation.is_cancelled() {
+            break 'watch;
+        }
         let mut fatal: Option<notify::Error> = None;
         let mut overflow = overflowed.swap(false, Ordering::AcqRel);
         // Include drops that happened while the quiet-window drain was
@@ -328,13 +647,16 @@ async fn run_watch(watch_id: &str, root: &Path, outbound: &OutboundSink, prepare
             overflow = true;
         }
         if overflow {
-            let _ = outbound
-                .critical_text(watch_error_frame(
-                    watch_id,
-                    wire::WorkspaceErrorCode::Failed,
-                    "watch event burst overflowed; refresh the tree",
-                ))
-                .await;
+            let text = watch_error_frame(
+                watch_id,
+                wire::WorkspaceErrorCode::Failed,
+                "watch event burst overflowed; refresh the tree",
+            );
+            tokio::select! {
+                biased;
+                _ = cancellation.cancelled() => break 'watch,
+                _ = outbound.critical_text_with_token(text, Some(Arc::clone(&live))) => {}
+            }
         }
         let latched_error = latched_error.lock().ok().and_then(|mut error| error.take());
         if !changes.is_empty() || overflow {
@@ -346,7 +668,7 @@ async fn run_watch(watch_id: &str, root: &Path, outbound: &OutboundSink, prepare
                 overflow: overflow.then_some(true),
             })
             .unwrap_or_else(|_| String::new());
-            if outbound.try_watch_text(frame).is_err() {
+            if outbound.try_watch_text_with_token(frame, Some(Arc::clone(&live))).is_err() {
                 // The outbound sink is saturated or closed. Retrying by
                 // latching overflow would wake this loop immediately and
                 // spin forever while producing no observable frame. The
@@ -355,35 +677,77 @@ async fn run_watch(watch_id: &str, root: &Path, outbound: &OutboundSink, prepare
             }
         }
         if saw_ignore_file {
-            matcher = build_ignore_matcher(root);
+            if let Some(updated) =
+                rebuild_ignore_matcher(root, Arc::clone(&setup_slots), &cancellation).await
+            {
+                matcher = updated;
+            } else if cancellation.is_cancelled() {
+                break 'watch;
+            }
         }
         if let Some(error) = fatal {
-            let _ = outbound
-                .critical_text(watch_error_frame(
-                    watch_id,
-                    wire::WorkspaceErrorCode::Failed,
-                    &format!("the watcher died: {error}"),
-                ))
-                .await;
+            let text = watch_error_frame(
+                watch_id,
+                wire::WorkspaceErrorCode::Failed,
+                &format!("the watcher died: {error}"),
+            );
+            tokio::select! {
+                biased;
+                _ = cancellation.cancelled() => break 'watch,
+                _ = outbound.critical_text_with_token(text, Some(Arc::clone(&live))) => {}
+            }
             break;
         }
         if let Some(error) = latched_error {
-            let _ = outbound
-                .critical_text(watch_error_frame(
-                    watch_id,
-                    wire::WorkspaceErrorCode::Failed,
-                    &format!("the watcher reported an error: {error}"),
-                ))
-                .await;
+            let text = watch_error_frame(
+                watch_id,
+                wire::WorkspaceErrorCode::Failed,
+                &format!("the watcher reported an error: {error}"),
+            );
+            tokio::select! {
+                biased;
+                _ = cancellation.cancelled() => break 'watch,
+                _ = outbound.critical_text_with_token(text, Some(Arc::clone(&live))) => {}
+            }
             break;
         }
     }
     drop(watcher);
 }
 
+/// Rebuild an ignore matcher without pausing the async relay worker. The same
+/// setup semaphore as initial admission keeps repeated `.gitignore` edits from
+/// creating an unbounded blocking-worker queue.
+async fn rebuild_ignore_matcher(
+    root: &Path,
+    setup_slots: Arc<Semaphore>,
+    cancellation: &CancellationToken,
+) -> Option<ignore::gitignore::Gitignore> {
+    let permit = tokio::select! {
+        biased;
+        _ = cancellation.cancelled() => return None,
+        result = setup_slots.acquire_owned() => result.ok()?,
+    };
+    let root = root.to_owned();
+    let blocking_cancellation = cancellation.clone();
+    let task = tokio::task::spawn_blocking(move || {
+        let _permit = permit;
+        if blocking_cancellation.is_cancelled() { None } else { Some(build_ignore_matcher(&root)) }
+    });
+    tokio::select! {
+        biased;
+        _ = cancellation.cancelled() => {
+            task.abort();
+            None
+        }
+        result = task => result.ok().flatten(),
+    }
+}
+
 async fn drain_burst(
     event_rx: &mut Receiver<Result<notify::Event, notify::Error>>,
     burst: &mut Vec<Result<notify::Event, notify::Error>>,
+    cancellation: &CancellationToken,
 ) {
     let flush_at = tokio::time::Instant::now() + DEBOUNCE_MAX_LATENCY;
     loop {
@@ -392,9 +756,13 @@ async fn drain_burst(
             return;
         }
         let quiet = DEBOUNCE_QUIET.min(flush_at - now);
-        match tokio::time::timeout(quiet, event_rx.recv()).await {
-            Ok(Some(event)) => burst.push(event),
-            Ok(None) | Err(_) => return,
+        tokio::select! {
+            biased;
+            _ = cancellation.cancelled() => return,
+            result = tokio::time::timeout(quiet, event_rx.recv()) => match result {
+                Ok(Some(event)) => burst.push(event),
+                Ok(None) | Err(_) => return,
+            },
         }
     }
 }
@@ -592,6 +960,26 @@ mod tests {
         serde_json::from_str(&frame.text).expect("valid frame json")
     }
 
+    async fn wait_for_opening_to_finish(registry: &WatchRegistry, watch_id: &str) {
+        tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                let finished = registry
+                    .sessions
+                    .lock()
+                    .map(|state| {
+                        state.get(watch_id).map(|slot| slot.opening.is_none()).unwrap_or(true)
+                    })
+                    .unwrap_or(true);
+                if finished {
+                    return;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("watch setup did not finish");
+    }
+
     #[cfg(unix)]
     #[tokio::test]
     async fn watch_streams_debounced_changes_for_a_write() {
@@ -651,6 +1039,91 @@ mod tests {
                 break;
             }
         }
+        registry.close("same");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn pending_openings_count_toward_the_session_cap() {
+        let root = scratch("pending-cap");
+        let (sink, mut critical, mut watch) = OutboundSink::channels();
+        let registry = WatchRegistry::new(sink);
+
+        // `open` reserves synchronously and only then yields to its setup
+        // coordinator. Filling all slots back-to-back therefore exercises the
+        // cap while every setup is still pending.
+        for index in 0..WATCH_MAX_SESSIONS {
+            registry.open(open_frame(&format!("pending-{index}"), &root), None);
+        }
+        let mut over_cap = open_frame("pending-over-cap", &root);
+        over_cap.root = Some(root.to_string_lossy().into_owned());
+        registry.open(over_cap, None);
+
+        let mut saw_limit = false;
+        for _ in 0..=WATCH_MAX_SESSIONS {
+            let frame = next_frame(&mut critical, &mut watch, "pending cap response").await;
+            if frame["type"] == "fs_watch_error" && frame["code"] == "watch_limit" {
+                saw_limit = true;
+                break;
+            }
+        }
+        assert!(saw_limit, "a pending opening must consume a watch slot");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn failed_opened_enqueue_preserves_the_existing_watch() {
+        let root = scratch("opened-queue-full");
+        let (sink, mut critical, mut watch) = OutboundSink::channels();
+        let registry = WatchRegistry::new(sink);
+
+        registry.open(open_frame("same", &root), None);
+        let opened = next_frame(&mut critical, &mut watch, "first opened").await;
+        assert_eq!(opened["type"], "fs_watch_opened");
+        let old_generation = registry
+            .sessions
+            .lock()
+            .expect("state")
+            .get("same")
+            .and_then(|slot| slot.active.as_ref())
+            .map(|active| active.generation)
+            .expect("active watch");
+
+        // Keep the critical queue full while the replacement prepares. The
+        // replacement must not retire the old watch when its acknowledgement
+        // cannot be admitted.
+        for _ in 0..256 {
+            assert!(registry.outbound.try_critical_text("{}".to_owned()).is_ok());
+        }
+        registry.open(open_frame("same", &root), None);
+        wait_for_opening_to_finish(&registry, "same").await;
+        let current_generation = registry
+            .sessions
+            .lock()
+            .expect("state")
+            .get("same")
+            .and_then(|slot| slot.active.as_ref())
+            .map(|active| active.generation);
+        assert_eq!(current_generation, Some(old_generation));
+
+        tokio::time::sleep(Duration::from_millis(400)).await;
+        std::fs::write(root.join("still-watched.txt"), "kept\n").expect("write");
+        let frame = tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                let frame = watch.recv().await.expect("watch channel open");
+                let value: Value = serde_json::from_str(&frame.text).expect("watch json");
+                if value["type"] == "fs_watch_event"
+                    && value["changes"].as_array().is_some_and(|changes| {
+                        changes.iter().any(|change| change["path"] == "still-watched.txt")
+                    })
+                {
+                    return value;
+                }
+            }
+        })
+        .await
+        .expect("old watch did not survive queue failure");
+        assert_eq!(frame["watchId"], "same");
         registry.close("same");
     }
 

--- a/cmux-tui/crates/chatmux-relay/src/watch.rs
+++ b/cmux-tui/crates/chatmux-relay/src/watch.rs
@@ -683,6 +683,18 @@ async fn run_watch(
                 // latching overflow would wake this loop immediately and
                 // spin forever while producing no observable frame. The
                 // event is explicitly lost, so terminate this watch task.
+                // Tell the client why its stream ended. The critical lane is
+                // independent of the lossy watch queue, so this best-effort
+                // response remains available when only event delivery is
+                // saturated. It intentionally has no lifecycle token: the
+                // runner retires its token immediately after this branch and
+                // would otherwise suppress the terminal error itself.
+                let text = watch_error_frame(
+                    watch_id,
+                    wire::WorkspaceErrorCode::Failed,
+                    WATCH_RUNTIME_FAILURE_MESSAGE,
+                );
+                let _ = outbound.try_critical_text(text);
                 break 'watch;
             }
         }

--- a/cmux-tui/crates/chatmux-relay/src/watch.rs
+++ b/cmux-tui/crates/chatmux-relay/src/watch.rs
@@ -37,7 +37,7 @@ const MAX_PENDING_NOTIFY_EVENTS: usize = 1024;
 /// Recursive watcher startup and ignore-file discovery are synchronous
 /// filesystem operations. Keep them off the relay executor and bound the
 /// number of concurrent setup walks per connection.
-const WATCH_SETUP_CONCURRENCY: usize = 2;
+pub const WATCH_SETUP_CONCURRENCY: usize = 2;
 /// A replacement can keep one retired watcher in synchronous teardown while
 /// all sessions and setup slots are occupied. This hard cap bounds detached
 /// owner threads even if a platform backend blocks in its destructor.
@@ -229,11 +229,23 @@ impl WatchRegistry {
         outbound: OutboundSink,
         teardown_slots: Arc<Semaphore>,
     ) -> WatchRegistry {
+        Self::new_with_resource_slots(
+            outbound,
+            Arc::new(Semaphore::new(WATCH_SETUP_CONCURRENCY)),
+            teardown_slots,
+        )
+    }
+
+    pub(crate) fn new_with_resource_slots(
+        outbound: OutboundSink,
+        setup_slots: Arc<Semaphore>,
+        teardown_slots: Arc<Semaphore>,
+    ) -> WatchRegistry {
         WatchRegistry {
             outbound,
             sessions: Arc::new(Mutex::new(HashMap::new())),
             next_generation: Arc::new(AtomicU64::new(0)),
-            setup_slots: Arc::new(Semaphore::new(WATCH_SETUP_CONCURRENCY)),
+            setup_slots,
             teardown_slots,
             cancellation: CancellationToken::new(),
         }

--- a/cmux-tui/crates/chatmux-relay/src/watch.rs
+++ b/cmux-tui/crates/chatmux-relay/src/watch.rs
@@ -1208,9 +1208,11 @@ mod tests {
     #[test]
     fn saturated_watch_queue_reports_a_terminal_error() {
         let (sink, mut critical, _) = OutboundSink::channels();
-        for _ in 0..MAX_WATCH_OUTBOUND_FRAMES {
-            sink.try_watch_text("{}".to_owned()).expect("watch queue capacity");
+        let mut filled = 0;
+        while filled < 1024 && sink.try_watch_text("{}".to_owned()).is_ok() {
+            filled += 1;
         }
+        assert!(filled > 0, "watch queue must expose a finite capacity");
         report_watch_failure("saturated", &sink);
         let frame = critical.try_recv().expect("terminal error frame");
         let value: Value = serde_json::from_str(&frame.text).expect("error json");

--- a/cmux-tui/crates/chatmux-relay/src/watch.rs
+++ b/cmux-tui/crates/chatmux-relay/src/watch.rs
@@ -52,7 +52,9 @@ struct PreparedWatch {
 
 /// Owns a notify watcher on a dedicated thread because some backends perform
 /// synchronous thread joins from `Drop`. The relay task only sends the bounded
-/// shutdown signal and never drops the backend itself.
+/// shutdown signal and never drops the backend itself. One owner thread exists
+/// per prepared or active watch, bounded by the 16-session registry cap plus
+/// the two setup slots.
 struct WatcherOwner {
     shutdown: Option<SyncSender<()>>,
 }

--- a/cmux-tui/crates/chatmux-relay/src/watch.rs
+++ b/cmux-tui/crates/chatmux-relay/src/watch.rs
@@ -619,6 +619,10 @@ async fn finish_open_failure(
 }
 
 fn finish_active(watch_id: &str, generation: u64, sessions: Sessions) {
+    // Every runner exit retires its liveness token. Replacement, close, and
+    // watcher failure must discard queued events from a dead generation; a
+    // terminal critical frame is awaited before those paths return, so it is
+    // delivered before this token is retired.
     let mut live = None;
     if let Ok(mut state) = sessions.lock() {
         let mut remove_slot = false;

--- a/cmux-tui/crates/chatmux-relay/src/watch.rs
+++ b/cmux-tui/crates/chatmux-relay/src/watch.rs
@@ -31,6 +31,21 @@ const DEBOUNCE_QUIET: Duration = Duration::from_millis(150);
 const DEBOUNCE_MAX_LATENCY: Duration = Duration::from_millis(500);
 const MAX_PENDING_NOTIFY_EVENTS: usize = 1024;
 
+/// All fallible watcher setup happens before a watch is published in the
+/// registry. A failed replacement therefore leaves the existing watch intact.
+struct PreparedWatch {
+    watcher: notify::RecommendedWatcher,
+    event_rx: Receiver<Result<notify::Event, notify::Error>>,
+    overflowed: Arc<AtomicBool>,
+    overflow_notify: Arc<Notify>,
+    latched_error: Arc<Mutex<Option<String>>>,
+}
+
+enum AdmissionFailure {
+    Limit,
+    OutboundUnavailable,
+}
+
 type Sessions = Arc<Mutex<HashMap<String, (u64, Option<tokio::task::JoinHandle<()>>)>>>;
 
 pub struct WatchRegistry {
@@ -97,6 +112,28 @@ impl WatchRegistry {
                 return;
             }
         };
+        // Check capacity before touching the filesystem watcher. A full
+        // registry keeps its existing watches and receives a typed refusal.
+        let capacity_available = self
+            .sessions
+            .lock()
+            .map(|sessions| sessions.contains_key(&watch_id) || sessions.len() < WATCH_MAX_SESSIONS)
+            .unwrap_or(false);
+        if !capacity_available {
+            self.refuse(
+                &watch_id,
+                wire::WorkspaceErrorCode::WatchLimit,
+                &format!("this machine already streams {WATCH_MAX_SESSIONS} watches"),
+            );
+            return;
+        }
+        let prepared = match prepare_watch(&root) {
+            Ok(prepared) => prepared,
+            Err(message) => {
+                self.refuse(&watch_id, wire::WorkspaceErrorCode::Failed, &message);
+                return;
+            }
+        };
         let opened = serde_json::to_string(&wire::RelayFsWatchOpened {
             version: WORKSPACE_FRAME_VERSION,
             r#type: wire::TagFsWatchOpened::FsWatchOpened,
@@ -105,17 +142,29 @@ impl WatchRegistry {
         })
         .unwrap_or_else(|_| String::new());
         let generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
-        let previous = match self.sessions.lock() {
+        // Publish the acknowledgement while the session lock is held. This
+        // makes admission one transaction: a full/closed outbound queue never
+        // retires the current watch without first accepting its replacement.
+        let admission = match self.sessions.lock() {
             Ok(mut sessions)
                 if sessions.contains_key(&watch_id) || sessions.len() < WATCH_MAX_SESSIONS =>
             {
-                Ok(sessions.insert(watch_id.clone(), (generation, None)))
+                if self.outbound.try_critical_text(opened).is_err() {
+                    Err(AdmissionFailure::OutboundUnavailable)
+                } else {
+                    Ok(sessions.insert(watch_id.clone(), (generation, None)))
+                }
             }
-            Ok(_) | Err(_) => Err(()),
+            Ok(_) | Err(_) => Err(AdmissionFailure::Limit),
         };
-        let previous = match previous {
+        let previous = match admission {
             Ok(previous) => previous,
-            Err(()) => {
+            Err(AdmissionFailure::OutboundUnavailable) => {
+                // The queue is already unavailable. Keep the existing
+                // watch, because a refusal cannot be delivered either.
+                return;
+            }
+            Err(AdmissionFailure::Limit) => {
                 self.refuse(
                     &watch_id,
                     wire::WorkspaceErrorCode::WatchLimit,
@@ -124,12 +173,11 @@ impl WatchRegistry {
                 return;
             }
         };
-        let _ = self.outbound.try_critical_text(opened);
         let outbound = self.outbound.clone();
         let sessions = Arc::clone(&self.sessions);
         let task_id = watch_id.clone();
         let mut task = Some(tokio::spawn(async move {
-            run_watch(&task_id, &root, &outbound).await;
+            run_watch(&task_id, &root, &outbound, prepared).await;
             if let Ok(mut sessions) = sessions.lock() {
                 // `tokio::spawn` starts the task immediately, so a watcher
                 // that fails during startup can finish before its handle is
@@ -163,6 +211,40 @@ impl WatchRegistry {
             previous.abort();
         }
     }
+}
+
+fn prepare_watch(root: &Path) -> Result<PreparedWatch, String> {
+    use notify::Watcher as _;
+
+    let (event_tx, event_rx) =
+        channel::<Result<notify::Event, notify::Error>>(MAX_PENDING_NOTIFY_EVENTS);
+    let overflowed = Arc::new(AtomicBool::new(false));
+    let overflow_notify = Arc::new(Notify::new());
+    let latched_error = Arc::new(Mutex::new(None::<String>));
+    let callback_overflowed = Arc::clone(&overflowed);
+    let callback_notify = Arc::clone(&overflow_notify);
+    let callback_error = Arc::clone(&latched_error);
+    let mut watcher = notify::recommended_watcher(
+        move |event: Result<notify::Event, notify::Error>| match event {
+            Ok(event) => try_enqueue_notify_event(
+                &event_tx,
+                &callback_overflowed,
+                &callback_notify,
+                Ok(event),
+            ),
+            Err(error) => {
+                if let Ok(mut latched) = callback_error.lock() {
+                    *latched = Some(error.to_string());
+                }
+                callback_notify.notify_one();
+            }
+        },
+    )
+    .map_err(|error| format!("could not start the watcher: {error}"))?;
+    watcher
+        .watch(root, notify::RecursiveMode::Recursive)
+        .map_err(|error| format!("could not watch {}: {error}", root.display()))?;
+    Ok(PreparedWatch { watcher, event_rx, overflowed, overflow_notify, latched_error })
 }
 
 fn watch_root(
@@ -199,55 +281,9 @@ fn watch_root_with_capabilities(
 // The watch task: notify events -> debounce -> gitignore filter -> frames
 // ---------------------------------------------------------------------------
 
-async fn run_watch(watch_id: &str, root: &Path, outbound: &OutboundSink) {
-    use notify::Watcher as _;
-    let (event_tx, mut event_rx) =
-        channel::<Result<notify::Event, notify::Error>>(MAX_PENDING_NOTIFY_EVENTS);
-    let overflowed = Arc::new(AtomicBool::new(false));
-    let overflow_notify = Arc::new(Notify::new());
-    let latched_error = Arc::new(Mutex::new(None::<String>));
-    let callback_overflowed = Arc::clone(&overflowed);
-    let callback_notify = Arc::clone(&overflow_notify);
-    let callback_error = Arc::clone(&latched_error);
-    let mut watcher =
-        match notify::recommended_watcher(move |event: Result<notify::Event, notify::Error>| {
-            match event {
-                Ok(event) => try_enqueue_notify_event(
-                    &event_tx,
-                    &callback_overflowed,
-                    &callback_notify,
-                    Ok(event),
-                ),
-                Err(error) => {
-                    if let Ok(mut latched) = callback_error.lock() {
-                        *latched = Some(error.to_string());
-                    }
-                    callback_notify.notify_one();
-                }
-            }
-        }) {
-            Ok(watcher) => watcher,
-            Err(error) => {
-                let _ = outbound
-                    .critical_text(watch_error_frame(
-                        watch_id,
-                        wire::WorkspaceErrorCode::Failed,
-                        &format!("could not start the watcher: {error}"),
-                    ))
-                    .await;
-                return;
-            }
-        };
-    if let Err(error) = watcher.watch(root, notify::RecursiveMode::Recursive) {
-        let _ = outbound
-            .critical_text(watch_error_frame(
-                watch_id,
-                wire::WorkspaceErrorCode::Failed,
-                &format!("could not watch {}: {error}", root.display()),
-            ))
-            .await;
-        return;
-    }
+async fn run_watch(watch_id: &str, root: &Path, outbound: &OutboundSink, prepared: PreparedWatch) {
+    let PreparedWatch { mut watcher, mut event_rx, overflowed, overflow_notify, latched_error } =
+        prepared;
     let mut matcher = build_ignore_matcher(root);
     'watch: loop {
         let notified = overflow_notify.notified();
@@ -581,6 +617,41 @@ mod tests {
         };
         assert_eq!(event["watchId"], "w1");
         registry.close("w1");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn invalid_replacement_preserves_the_existing_watch() {
+        let root = scratch("invalid-replacement");
+        let (sink, mut critical, mut watch) = OutboundSink::channels();
+        let registry = WatchRegistry::new(sink);
+
+        registry.open(open_frame("same", &root), None);
+        let opened = next_frame(&mut critical, &mut watch, "first opened").await;
+        assert_eq!(opened["type"], "fs_watch_opened");
+
+        let mut invalid = open_frame("same", &root);
+        invalid.root = Some(root.join("missing").to_string_lossy().into_owned());
+        registry.open(invalid, None);
+        let refusal = next_frame(&mut critical, &mut watch, "replacement refusal").await;
+        assert_eq!(refusal["type"], "fs_watch_error");
+        assert_eq!(refusal["code"], "not_found");
+
+        // Validation happens before registry mutation. A change in the
+        // original root proves that the refused replacement kept it active.
+        tokio::time::sleep(Duration::from_millis(400)).await;
+        std::fs::write(root.join("still-watched.txt"), "kept\n").expect("write");
+        loop {
+            let event = next_frame(&mut critical, &mut watch, "existing watch event").await;
+            if event["type"] == "fs_watch_event"
+                && event["changes"].as_array().is_some_and(|changes| {
+                    changes.iter().any(|change| change["path"] == "still-watched.txt")
+                })
+            {
+                break;
+            }
+        }
+        registry.close("same");
     }
 
     #[cfg(unix)]

--- a/cmux-tui/crates/chatmux-relay/src/watch.rs
+++ b/cmux-tui/crates/chatmux-relay/src/watch.rs
@@ -8,6 +8,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::mpsc::{SyncSender, sync_channel};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -41,12 +42,44 @@ const WATCH_SETUP_CONCURRENCY: usize = 2;
 /// All fallible watcher setup happens before a watch is published in the
 /// registry. A failed replacement therefore leaves the existing watch intact.
 struct PreparedWatch {
-    watcher: notify::RecommendedWatcher,
+    watcher: WatcherOwner,
     event_rx: Receiver<Result<notify::Event, notify::Error>>,
     overflowed: Arc<AtomicBool>,
     overflow_notify: Arc<Notify>,
     latched_error: Arc<Mutex<Option<String>>>,
     matcher: ignore::gitignore::Gitignore,
+}
+
+/// Owns a notify watcher on a dedicated thread because some backends perform
+/// synchronous thread joins from `Drop`. The relay task only sends the bounded
+/// shutdown signal and never drops the backend itself.
+struct WatcherOwner {
+    shutdown: Option<SyncSender<()>>,
+}
+
+impl WatcherOwner {
+    fn new(watcher: notify::RecommendedWatcher) -> Result<Self, String> {
+        let (shutdown, wait) = sync_channel(1);
+        std::thread::Builder::new()
+            .name("cmux-watch-teardown".to_owned())
+            .spawn(move || {
+                let watcher = watcher;
+                let _ = wait.recv();
+                drop(watcher);
+            })
+            .map_err(|error| format!("could not start watcher teardown: {error}"))?;
+        Ok(Self { shutdown: Some(shutdown) })
+    }
+}
+
+impl Drop for WatcherOwner {
+    fn drop(&mut self) {
+        if let Some(shutdown) = self.shutdown.take() {
+            // The channel has one slot and only this owner sends, so this
+            // cannot block the relay task even if teardown is still running.
+            let _ = shutdown.try_send(());
+        }
+    }
 }
 
 struct ActiveWatch {
@@ -558,6 +591,7 @@ fn prepare_watch(root: &Path) -> Result<PreparedWatch, String> {
     watcher
         .watch(root, notify::RecursiveMode::Recursive)
         .map_err(|error| format!("could not watch {}: {error}", root.display()))?;
+    let watcher = WatcherOwner::new(watcher)?;
     Ok(PreparedWatch {
         watcher,
         event_rx,

--- a/cmux-tui/crates/chatmux-relay/src/watch.rs
+++ b/cmux-tui/crates/chatmux-relay/src/watch.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::{SyncSender, sync_channel};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use tokio::sync::Notify;
@@ -41,15 +41,7 @@ const WATCH_SETUP_CONCURRENCY: usize = 2;
 /// A replacement can keep one retired watcher in synchronous teardown while
 /// all sessions and setup slots are occupied. This hard cap bounds detached
 /// owner threads even if a platform backend blocks in its destructor.
-const WATCH_TEARDOWN_CONCURRENCY: usize = WATCH_MAX_SESSIONS + WATCH_SETUP_CONCURRENCY + 1;
-
-static WATCH_TEARDOWN_SLOTS: OnceLock<Arc<Semaphore>> = OnceLock::new();
-
-fn watcher_teardown_slots() -> Arc<Semaphore> {
-    Arc::clone(
-        WATCH_TEARDOWN_SLOTS.get_or_init(|| Arc::new(Semaphore::new(WATCH_TEARDOWN_CONCURRENCY))),
-    )
-}
+pub const WATCH_TEARDOWN_CONCURRENCY: usize = WATCH_MAX_SESSIONS + WATCH_SETUP_CONCURRENCY + 1;
 
 /// All fallible watcher setup happens before a watch is published in the
 /// registry. A failed replacement therefore leaves the existing watch intact.
@@ -72,8 +64,8 @@ struct WatcherOwner {
 }
 
 impl WatcherOwner {
-    fn new(watcher: notify::RecommendedWatcher) -> Result<Self, String> {
-        Self::new_with_slots(watcher, watcher_teardown_slots())
+    fn new(watcher: notify::RecommendedWatcher, slots: Arc<Semaphore>) -> Result<Self, String> {
+        Self::new_with_slots(watcher, slots)
     }
 
     fn new_with_slots(
@@ -173,6 +165,7 @@ pub struct WatchRegistry {
     sessions: Sessions,
     next_generation: Arc<AtomicU64>,
     setup_slots: Arc<Semaphore>,
+    teardown_slots: Arc<Semaphore>,
     cancellation: CancellationToken,
 }
 
@@ -226,11 +219,22 @@ async fn report_watch_failure(
 
 impl WatchRegistry {
     pub(crate) fn new(outbound: OutboundSink) -> WatchRegistry {
+        Self::new_with_teardown_slots(
+            outbound,
+            Arc::new(Semaphore::new(WATCH_TEARDOWN_CONCURRENCY)),
+        )
+    }
+
+    pub(crate) fn new_with_teardown_slots(
+        outbound: OutboundSink,
+        teardown_slots: Arc<Semaphore>,
+    ) -> WatchRegistry {
         WatchRegistry {
             outbound,
             sessions: Arc::new(Mutex::new(HashMap::new())),
             next_generation: Arc::new(AtomicU64::new(0)),
             setup_slots: Arc::new(Semaphore::new(WATCH_SETUP_CONCURRENCY)),
+            teardown_slots,
             cancellation: CancellationToken::new(),
         }
     }
@@ -264,6 +268,7 @@ impl WatchRegistry {
         let sessions = Arc::clone(&self.sessions);
         let outbound = self.outbound.clone();
         let setup_slots = Arc::clone(&self.setup_slots);
+        let teardown_slots = Arc::clone(&self.teardown_slots);
         let local_roots_for_task = local_roots.map(<[String]>::to_vec);
         let reservation = match self.sessions.lock() {
             Ok(mut state) => {
@@ -296,6 +301,7 @@ impl WatchRegistry {
                         Arc::clone(&sessions),
                         outbound,
                         setup_slots,
+                        teardown_slots,
                     ));
                     slot.opening.as_mut().expect("opening was just reserved").abort =
                         Some(task.abort_handle());
@@ -335,6 +341,7 @@ async fn setup_watch(
     local_roots: Option<Vec<String>>,
     cancellation: CancellationToken,
     setup_slots: Arc<Semaphore>,
+    teardown_slots: Arc<Semaphore>,
 ) -> Result<(PathBuf, PreparedWatch), SetupFailure> {
     let permit = tokio::select! {
         biased;
@@ -354,7 +361,7 @@ async fn setup_watch(
         if blocking_cancellation.is_cancelled() {
             return Err(SetupFailure::Cancelled);
         }
-        let mut prepared = prepare_watch(&root).map_err(SetupFailure::Failed)?;
+        let mut prepared = prepare_watch(&root, teardown_slots).map_err(SetupFailure::Failed)?;
         if blocking_cancellation.is_cancelled() {
             drop(prepared);
             return Err(SetupFailure::Cancelled);
@@ -393,8 +400,11 @@ async fn coordinate_open(
     sessions: Sessions,
     outbound: OutboundSink,
     setup_slots: Arc<Semaphore>,
+    teardown_slots: Arc<Semaphore>,
 ) {
-    let setup = setup_watch(frame, local_roots, cancellation.clone(), setup_slots.clone()).await;
+    let setup =
+        setup_watch(frame, local_roots, cancellation.clone(), setup_slots.clone(), teardown_slots)
+            .await;
     match setup {
         Ok((root, prepared)) => {
             commit_open(
@@ -615,7 +625,7 @@ fn finish_active(watch_id: &str, generation: u64, sessions: Sessions) {
     }
 }
 
-fn prepare_watch(root: &Path) -> Result<PreparedWatch, String> {
+fn prepare_watch(root: &Path, teardown_slots: Arc<Semaphore>) -> Result<PreparedWatch, String> {
     use notify::Watcher as _;
 
     let (event_tx, event_rx) =
@@ -646,7 +656,7 @@ fn prepare_watch(root: &Path) -> Result<PreparedWatch, String> {
     watcher
         .watch(root, notify::RecursiveMode::Recursive)
         .map_err(|error| format!("could not watch {}: {error}", root.display()))?;
-    let watcher = WatcherOwner::new(watcher)?;
+    let watcher = WatcherOwner::new(watcher, teardown_slots)?;
     Ok(PreparedWatch {
         watcher,
         event_rx,
@@ -1028,6 +1038,8 @@ fn collect_changes(
 
 #[cfg(test)]
 mod tests {
+    const CRITICAL_QUEUE_CAPACITY: usize = 256;
+
     use super::*;
     use crate::session::{OutboundFrame, OutboundSink};
     use notify::Watcher as _;
@@ -1316,7 +1328,7 @@ mod tests {
     #[tokio::test]
     async fn failed_open_waits_for_critical_capacity() {
         let (sink, mut critical, _) = OutboundSink::channels();
-        for _ in 0..MAX_OUTBOUND_FRAMES {
+        for _ in 0..CRITICAL_QUEUE_CAPACITY {
             sink.try_critical_text("{}".to_owned()).expect("fill critical queue");
         }
         let sessions = Arc::new(Mutex::new(HashMap::new()));

--- a/cmux-tui/crates/chatmux-relay/src/watch.rs
+++ b/cmux-tui/crates/chatmux-relay/src/watch.rs
@@ -76,7 +76,6 @@ impl WatcherOwner {
         Self::new_with_slots(watcher, watcher_teardown_slots())
     }
 
-    #[cfg(test)]
     fn new_with_slots(
         watcher: notify::RecommendedWatcher,
         slots: Arc<Semaphore>,

--- a/cmux-tui/crates/chatmux-relay/src/watch.rs
+++ b/cmux-tui/crates/chatmux-relay/src/watch.rs
@@ -37,8 +37,6 @@ const MAX_PENDING_NOTIFY_EVENTS: usize = 1024;
 /// filesystem operations. Keep them off the relay executor and bound the
 /// number of concurrent setup walks per connection.
 const WATCH_SETUP_CONCURRENCY: usize = 2;
-const WATCH_SETUP_FAILURE_MESSAGE: &str = "filesystem watcher setup failed";
-const WATCH_RUNTIME_FAILURE_MESSAGE: &str = "filesystem watcher stopped";
 
 /// All fallible watcher setup happens before a watch is published in the
 /// registry. A failed replacement therefore leaves the existing watch intact.
@@ -136,13 +134,17 @@ impl Drop for WatchRegistry {
     }
 }
 
-fn watch_error_frame(watch_id: &str, code: wire::WorkspaceErrorCode, message: &str) -> String {
+fn watch_error_frame(
+    watch_id: &str,
+    code: wire::WorkspaceErrorCode,
+    message: Option<&str>,
+) -> String {
     serde_json::to_string(&wire::RelayFsWatchError {
         version: WORKSPACE_FRAME_VERSION,
         r#type: wire::TagFsWatchError::FsWatchError,
         watch_id: watch_id.to_owned(),
         code,
-        message: Some(message.to_owned()),
+        message: message.map(str::to_owned),
     })
     .unwrap_or_else(|_| String::new())
 }
@@ -151,11 +153,7 @@ fn watch_error_frame(watch_id: &str, code: wire::WorkspaceErrorCode, message: &s
 /// lossy event. The critical lane lets the client re-open the stream instead
 /// of retaining a permanently silent watch ID.
 fn report_watch_failure(watch_id: &str, outbound: &OutboundSink) {
-    let text = watch_error_frame(
-        watch_id,
-        wire::WorkspaceErrorCode::Failed,
-        WATCH_RUNTIME_FAILURE_MESSAGE,
-    );
+    let text = watch_error_frame(watch_id, wire::WorkspaceErrorCode::Failed, None);
     let _ = outbound.try_critical_text(text);
 }
 
@@ -171,7 +169,7 @@ impl WatchRegistry {
     }
 
     pub fn refuse(&self, watch_id: &str, code: wire::WorkspaceErrorCode, message: &str) {
-        let text = watch_error_frame(watch_id, code, message);
+        let text = watch_error_frame(watch_id, code, Some(message));
         let _ = self.outbound.try_critical_text(text);
     }
 
@@ -354,7 +352,7 @@ async fn coordinate_open(
                 sessions,
                 outbound,
                 code,
-                message,
+                Some(message),
             );
         }
         Err(SetupFailure::Failed(_message)) => {
@@ -366,7 +364,7 @@ async fn coordinate_open(
                 sessions,
                 outbound,
                 wire::WorkspaceErrorCode::Failed,
-                WATCH_SETUP_FAILURE_MESSAGE.to_owned(),
+                None,
             );
         }
     }
@@ -482,9 +480,9 @@ fn finish_open_failure(
     sessions: Sessions,
     outbound: OutboundSink,
     code: wire::WorkspaceErrorCode,
-    message: String,
+    message: Option<String>,
 ) {
-    let text = watch_error_frame(watch_id, code, &message);
+    let text = watch_error_frame(watch_id, code, message.as_deref());
     if let Ok(mut state) = sessions.lock() {
         let remove_slot = if let Some(slot) = state.get_mut(watch_id)
             && slot.opening.as_ref().is_some_and(|opening| {
@@ -672,7 +670,7 @@ async fn run_watch(
             let text = watch_error_frame(
                 watch_id,
                 wire::WorkspaceErrorCode::Failed,
-                "watch event burst overflowed; refresh the tree",
+                Some("watch event burst overflowed; refresh the tree"),
             );
             tokio::select! {
                 biased;
@@ -715,11 +713,7 @@ async fn run_watch(
             }
         }
         if let Some(_error) = fatal {
-            let text = watch_error_frame(
-                watch_id,
-                wire::WorkspaceErrorCode::Failed,
-                WATCH_RUNTIME_FAILURE_MESSAGE,
-            );
+            let text = watch_error_frame(watch_id, wire::WorkspaceErrorCode::Failed, None);
             tokio::select! {
                 biased;
                 _ = cancellation.cancelled() => break 'watch,
@@ -728,11 +722,7 @@ async fn run_watch(
             break;
         }
         if let Some(_error) = latched_error {
-            let text = watch_error_frame(
-                watch_id,
-                wire::WorkspaceErrorCode::Failed,
-                WATCH_RUNTIME_FAILURE_MESSAGE,
-            );
+            let text = watch_error_frame(watch_id, wire::WorkspaceErrorCode::Failed, None);
             tokio::select! {
                 biased;
                 _ = cancellation.cancelled() => break 'watch,
@@ -1206,12 +1196,13 @@ mod tests {
             Arc::clone(&sessions),
             sink,
             wire::WorkspaceErrorCode::Failed,
-            "internal details must not escape".to_owned(),
+            None,
         );
         let frame = critical.try_recv().expect("failure frame");
         assert!(frame.live.is_none(), "failure must not be fenced before delivery");
         let value: Value = serde_json::from_str(&frame.text).expect("failure json");
         assert_eq!(value["code"], "failed");
+        assert!(value["message"].is_null(), "internal failure copy stays out of the wire frame");
     }
 
     #[test]
@@ -1226,12 +1217,7 @@ mod tests {
         assert_eq!(value["type"], "fs_watch_error");
         assert_eq!(value["watchId"], "saturated");
         assert_eq!(value["code"], "failed");
-    }
-
-    #[test]
-    fn watcher_failure_messages_are_stable() {
-        assert_eq!(WATCH_SETUP_FAILURE_MESSAGE, "filesystem watcher setup failed");
-        assert_eq!(WATCH_RUNTIME_FAILURE_MESSAGE, "filesystem watcher stopped");
+        assert!(value["message"].is_null(), "terminal copy is localized by the client");
     }
 
     #[cfg(unix)]

--- a/cmux-tui/crates/chatmux-relay/src/watch.rs
+++ b/cmux-tui/crates/chatmux-relay/src/watch.rs
@@ -344,7 +344,7 @@ async fn coordinate_open(
                 message,
             );
         }
-        Err(SetupFailure::Failed(message)) => {
+        Err(SetupFailure::Failed(_message)) => {
             finish_open_failure(
                 &watch_id,
                 generation,
@@ -353,7 +353,7 @@ async fn coordinate_open(
                 sessions,
                 outbound,
                 wire::WorkspaceErrorCode::Failed,
-                message,
+                WATCH_SETUP_FAILURE_MESSAGE.to_owned(),
             );
         }
     }
@@ -480,7 +480,10 @@ fn finish_open_failure(
             // Keep the active watch intact while the refusal is queued.
             // Holding the state lock orders this frame before a subsequent
             // replacement.
-            let _ = outbound.try_critical_text_with_token(text, Some(Arc::clone(&live)));
+            // This is a terminal response for the open request. Do not attach
+            // the opening token: it is retired immediately below, and a token
+            // would make the writer discard the error before the client sees it.
+            let _ = outbound.try_critical_text(text);
             slot.opening.take();
             live.store(false, Ordering::Release);
             slot.active.is_none()
@@ -495,17 +498,21 @@ fn finish_open_failure(
 }
 
 fn finish_active(watch_id: &str, generation: u64, sessions: Sessions) {
+    let mut live = None;
     if let Ok(mut state) = sessions.lock() {
         let mut remove_slot = false;
         if let Some(slot) = state.get_mut(watch_id)
             && slot.active.as_ref().is_some_and(|active| active.generation == generation)
         {
-            slot.active.take();
+            live = slot.active.take().map(|active| active.live);
             remove_slot = slot.opening.is_none();
         }
         if remove_slot {
             state.remove(watch_id);
         }
+    }
+    if let Some(live) = live {
+        live.store(false, Ordering::Release);
     }
 }
 
@@ -687,11 +694,11 @@ async fn run_watch(
                 break 'watch;
             }
         }
-        if let Some(error) = fatal {
+        if let Some(_error) = fatal {
             let text = watch_error_frame(
                 watch_id,
                 wire::WorkspaceErrorCode::Failed,
-                &format!("the watcher died: {error}"),
+                WATCH_RUNTIME_FAILURE_MESSAGE,
             );
             tokio::select! {
                 biased;
@@ -700,11 +707,11 @@ async fn run_watch(
             }
             break;
         }
-        if let Some(error) = latched_error {
+        if let Some(_error) = latched_error {
             let text = watch_error_frame(
                 watch_id,
                 wire::WorkspaceErrorCode::Failed,
-                &format!("the watcher reported an error: {error}"),
+                WATCH_RUNTIME_FAILURE_MESSAGE,
             );
             tokio::select! {
                 biased;

--- a/cmux-tui/crates/chatmux-relay/src/watch.rs
+++ b/cmux-tui/crates/chatmux-relay/src/watch.rs
@@ -147,6 +147,18 @@ fn watch_error_frame(watch_id: &str, code: wire::WorkspaceErrorCode, message: &s
     .unwrap_or_else(|_| String::new())
 }
 
+/// Best-effort terminal response for a watch that cannot enqueue another
+/// lossy event. The critical lane lets the client re-open the stream instead
+/// of retaining a permanently silent watch ID.
+fn report_watch_failure(watch_id: &str, outbound: &OutboundSink) {
+    let text = watch_error_frame(
+        watch_id,
+        wire::WorkspaceErrorCode::Failed,
+        WATCH_RUNTIME_FAILURE_MESSAGE,
+    );
+    let _ = outbound.try_critical_text(text);
+}
+
 impl WatchRegistry {
     pub(crate) fn new(outbound: OutboundSink) -> WatchRegistry {
         WatchRegistry {
@@ -689,12 +701,7 @@ async fn run_watch(
                 // saturated. It intentionally has no lifecycle token: the
                 // runner retires its token immediately after this branch and
                 // would otherwise suppress the terminal error itself.
-                let text = watch_error_frame(
-                    watch_id,
-                    wire::WorkspaceErrorCode::Failed,
-                    WATCH_RUNTIME_FAILURE_MESSAGE,
-                );
-                let _ = outbound.try_critical_text(text);
+                report_watch_failure(watch_id, outbound);
                 break 'watch;
             }
         }
@@ -1204,6 +1211,20 @@ mod tests {
         let frame = critical.try_recv().expect("failure frame");
         assert!(frame.live.is_none(), "failure must not be fenced before delivery");
         let value: Value = serde_json::from_str(&frame.text).expect("failure json");
+        assert_eq!(value["code"], "failed");
+    }
+
+    #[test]
+    fn saturated_watch_queue_reports_a_terminal_error() {
+        let (sink, mut critical, _) = OutboundSink::channels();
+        for _ in 0..MAX_WATCH_OUTBOUND_FRAMES {
+            sink.try_watch_text("{}".to_owned()).expect("watch queue capacity");
+        }
+        report_watch_failure("saturated", &sink);
+        let frame = critical.try_recv().expect("terminal error frame");
+        let value: Value = serde_json::from_str(&frame.text).expect("error json");
+        assert_eq!(value["type"], "fs_watch_error");
+        assert_eq!(value["watchId"], "saturated");
         assert_eq!(value["code"], "failed");
     }
 

--- a/cmux-tui/crates/chatmux-relay/src/watch.rs
+++ b/cmux-tui/crates/chatmux-relay/src/watch.rs
@@ -420,7 +420,8 @@ async fn coordinate_open(
                 outbound,
                 code,
                 Some(message),
-            );
+            )
+            .await;
         }
         Err(SetupFailure::Failed(_message)) => {
             finish_open_failure(
@@ -432,7 +433,8 @@ async fn coordinate_open(
                 outbound,
                 wire::WorkspaceErrorCode::Failed,
                 None,
-            );
+            )
+            .await;
         }
     }
 }
@@ -539,7 +541,7 @@ fn commit_open(
     drop(prepared);
 }
 
-fn finish_open_failure(
+async fn finish_open_failure(
     watch_id: &str,
     generation: u64,
     live: Arc<AtomicBool>,
@@ -550,18 +552,32 @@ fn finish_open_failure(
     message: Option<String>,
 ) {
     let text = watch_error_frame(watch_id, code, message.as_deref());
-    if let Ok(mut state) = sessions.lock() {
+    let should_report = sessions.lock().ok().is_some_and(|state| {
+        state.get(watch_id).is_some_and(|slot| {
+            slot.opening.as_ref().is_some_and(|opening| {
+                opening.generation == generation && !opening.cancellation.is_cancelled()
+            })
+        })
+    });
+    if !should_report {
+        cancellation.cancel();
+        return;
+    }
+
+    // Keep the opening reservation until the terminal frame is admitted. The
+    // liveness token lets a newer replacement cancel this send without
+    // delivering a stale error after its own opened frame.
+    tokio::select! {
+        biased;
+        _ = cancellation.cancelled() => return,
+        _ = outbound.critical_text_with_token(text, Some(Arc::clone(&live))) => {}
+    }
+
+    let remove_slot = if let Ok(mut state) = sessions.lock() {
         let remove_slot = if let Some(slot) = state.get_mut(watch_id)
             && slot.opening.as_ref().is_some_and(|opening| {
                 opening.generation == generation && !opening.cancellation.is_cancelled()
             }) {
-            // Keep the active watch intact while the refusal is queued.
-            // Holding the state lock orders this frame before a subsequent
-            // replacement.
-            // This is a terminal response for the open request. Do not attach
-            // the opening token: it is retired immediately below, and a token
-            // would make the writer discard the error before the client sees it.
-            let _ = outbound.try_critical_text(text);
             slot.opening.take();
             live.store(false, Ordering::Release);
             slot.active.is_none()
@@ -571,8 +587,13 @@ fn finish_open_failure(
         if remove_slot {
             state.remove(watch_id);
         }
+        remove_slot
+    } else {
+        false
+    };
+    if remove_slot {
+        cancellation.cancel();
     }
-    cancellation.cancel();
 }
 
 fn finish_active(watch_id: &str, generation: u64, sessions: Sessions) {
@@ -1255,8 +1276,8 @@ mod tests {
         assert!(sessions.lock().unwrap().is_empty());
     }
 
-    #[test]
-    fn failed_open_keeps_its_error_frame_live_until_delivery() {
+    #[tokio::test]
+    async fn failed_open_keeps_its_error_frame_live_until_delivery() {
         let (sink, mut critical, _) = OutboundSink::channels();
         let sessions = Arc::new(Mutex::new(HashMap::new()));
         let live = Arc::new(AtomicBool::new(true));
@@ -1273,7 +1294,7 @@ mod tests {
                 }),
             },
         );
-        finish_open_failure(
+        let task = tokio::spawn(finish_open_failure(
             "failed",
             1,
             live,
@@ -1282,12 +1303,61 @@ mod tests {
             sink,
             wire::WorkspaceErrorCode::Failed,
             None,
-        );
-        let frame = critical.try_recv().expect("failure frame");
-        assert!(frame.live.is_none(), "failure must not be fenced before delivery");
+        ));
+        let mut frame = critical.recv().await.expect("failure frame");
+        assert!(frame.live.is_some(), "failure keeps its opening liveness token until delivery");
         let value: Value = serde_json::from_str(&frame.text).expect("failure json");
         assert_eq!(value["code"], "failed");
         assert!(value["message"].is_null(), "internal failure copy stays out of the wire frame");
+        frame.ack.take().expect("failure delivery ack").send(()).expect("ack receiver");
+        task.await.expect("failure task");
+    }
+
+    #[tokio::test]
+    async fn failed_open_waits_for_critical_capacity() {
+        let (sink, mut critical, _) = OutboundSink::channels();
+        for _ in 0..MAX_OUTBOUND_FRAMES {
+            sink.try_critical_text("{}".to_owned()).expect("fill critical queue");
+        }
+        let sessions = Arc::new(Mutex::new(HashMap::new()));
+        let live = Arc::new(AtomicBool::new(true));
+        let cancellation = CancellationToken::new();
+        sessions.lock().unwrap().insert(
+            "saturated".to_owned(),
+            WatchSlot {
+                active: None,
+                opening: Some(Opening {
+                    generation: 1,
+                    live: Arc::clone(&live),
+                    cancellation: cancellation.clone(),
+                    abort: None,
+                }),
+            },
+        );
+        let task = tokio::spawn(finish_open_failure(
+            "saturated",
+            1,
+            live,
+            cancellation,
+            Arc::clone(&sessions),
+            sink,
+            wire::WorkspaceErrorCode::Failed,
+            None,
+        ));
+        tokio::task::yield_now().await;
+        assert!(!task.is_finished(), "failure waits instead of dropping under queue pressure");
+
+        let _ = critical.recv().await.expect("filler frame");
+        let mut terminal = loop {
+            let frame = critical.recv().await.expect("terminal failure frame");
+            let value: Value = serde_json::from_str(&frame.text).expect("frame json");
+            if value["type"] == "fs_watch_error" {
+                break frame;
+            }
+        };
+        terminal.ack.take().expect("terminal delivery ack").send(()).expect("ack receiver");
+        task.await.expect("failure task");
+        assert!(sessions.lock().unwrap().is_empty(), "opening is cleared after delivery");
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/chatmux-relay/src/watch.rs
+++ b/cmux-tui/crates/chatmux-relay/src/watch.rs
@@ -182,12 +182,21 @@ fn watch_error_frame(
     .unwrap_or_else(|_| String::new())
 }
 
-/// Best-effort terminal response for a watch that cannot enqueue another
-/// lossy event. The critical lane lets the client re-open the stream instead
-/// of retaining a permanently silent watch ID.
-fn report_watch_failure(watch_id: &str, outbound: &OutboundSink) {
+/// Terminal response for a watch that cannot enqueue another lossy event. The
+/// critical lane lets the client re-open the stream instead of retaining a
+/// permanently silent watch ID.
+async fn report_watch_failure(
+    watch_id: &str,
+    outbound: &OutboundSink,
+    cancellation: &CancellationToken,
+    live: &Arc<AtomicBool>,
+) {
     let text = watch_error_frame(watch_id, wire::WorkspaceErrorCode::Failed, None);
-    let _ = outbound.try_critical_text(text);
+    tokio::select! {
+        biased;
+        _ = cancellation.cancelled() => {}
+        _ = outbound.critical_text_with_token(text, Some(Arc::clone(live))) => {}
+    }
 }
 
 impl WatchRegistry {
@@ -727,13 +736,10 @@ async fn run_watch(
                 // latching overflow would wake this loop immediately and
                 // spin forever while producing no observable frame. The
                 // event is explicitly lost, so terminate this watch task.
-                // Tell the client why its stream ended. The critical lane is
-                // independent of the lossy watch queue, so this best-effort
-                // response remains available when only event delivery is
-                // saturated. It intentionally has no lifecycle token: the
-                // runner retires its token immediately after this branch and
-                // would otherwise suppress the terminal error itself.
-                report_watch_failure(watch_id, outbound);
+                // Tell the client why its stream ended. Watch frames cannot
+                // consume the critical byte reserve, so this response remains
+                // available when event delivery is saturated.
+                report_watch_failure(watch_id, outbound, &cancellation, &live).await;
                 break 'watch;
             }
         }
@@ -1239,21 +1245,30 @@ mod tests {
         assert!(value["message"].is_null(), "internal failure copy stays out of the wire frame");
     }
 
-    #[test]
-    fn saturated_watch_queue_reports_a_terminal_error() {
+    #[tokio::test]
+    async fn saturated_watch_bytes_reports_a_terminal_error() {
         let (sink, mut critical, _watch) = OutboundSink::channels();
+        let payload = "x".repeat(2 << 20);
         let mut filled = 0;
-        while filled < 1024 && sink.try_watch_text("{}".to_owned()).is_ok() {
+        while filled < 8 && sink.try_watch_text(payload.clone()).is_ok() {
             filled += 1;
         }
-        assert!(filled > 0, "watch queue must expose a finite capacity");
-        report_watch_failure("saturated", &sink);
-        let frame = critical.try_recv().expect("terminal error frame");
+        assert!(filled >= 3, "watch bytes must admit multiple frames");
+        assert!(filled < 8, "watch bytes must stop before global bytes are exhausted");
+        let cancellation = CancellationToken::new();
+        let live = Arc::new(AtomicBool::new(true));
+        let mut report = Box::pin(report_watch_failure("saturated", &sink, &cancellation, &live));
+        let frame = tokio::select! {
+            frame = critical.recv() => frame.expect("terminal error frame"),
+            _ = &mut report => panic!("terminal report returned before delivery ack"),
+        };
         let value: Value = serde_json::from_str(&frame.text).expect("error json");
         assert_eq!(value["type"], "fs_watch_error");
         assert_eq!(value["watchId"], "saturated");
         assert_eq!(value["code"], "failed");
         assert!(value["message"].is_null(), "terminal copy is localized by the client");
+        frame.ack.expect("terminal delivery ack").send(()).expect("ack receiver");
+        report.await;
     }
 
     #[cfg(unix)]

--- a/cmux-tui/crates/chatmux-relay/src/watch.rs
+++ b/cmux-tui/crates/chatmux-relay/src/watch.rs
@@ -1207,7 +1207,7 @@ mod tests {
 
     #[test]
     fn saturated_watch_queue_reports_a_terminal_error() {
-        let (sink, mut critical, _) = OutboundSink::channels();
+        let (sink, mut critical, _watch) = OutboundSink::channels();
         let mut filled = 0;
         while filled < 1024 && sink.try_watch_text("{}".to_owned()).is_ok() {
             filled += 1;

--- a/cmux-tui/crates/chatmux-relay/src/watch.rs
+++ b/cmux-tui/crates/chatmux-relay/src/watch.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::{SyncSender, sync_channel};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 use tokio::sync::Notify;
@@ -38,6 +38,18 @@ const MAX_PENDING_NOTIFY_EVENTS: usize = 1024;
 /// filesystem operations. Keep them off the relay executor and bound the
 /// number of concurrent setup walks per connection.
 const WATCH_SETUP_CONCURRENCY: usize = 2;
+/// A replacement can keep one retired watcher in synchronous teardown while
+/// all sessions and setup slots are occupied. This hard cap bounds detached
+/// owner threads even if a platform backend blocks in its destructor.
+const WATCH_TEARDOWN_CONCURRENCY: usize = WATCH_MAX_SESSIONS + WATCH_SETUP_CONCURRENCY + 1;
+
+static WATCH_TEARDOWN_SLOTS: OnceLock<Arc<Semaphore>> = OnceLock::new();
+
+fn watcher_teardown_slots() -> Arc<Semaphore> {
+    Arc::clone(
+        WATCH_TEARDOWN_SLOTS.get_or_init(|| Arc::new(Semaphore::new(WATCH_TEARDOWN_CONCURRENCY))),
+    )
+}
 
 /// All fallible watcher setup happens before a watch is published in the
 /// registry. A failed replacement therefore leaves the existing watch intact.
@@ -61,10 +73,22 @@ struct WatcherOwner {
 
 impl WatcherOwner {
     fn new(watcher: notify::RecommendedWatcher) -> Result<Self, String> {
+        Self::new_with_slots(watcher, watcher_teardown_slots())
+    }
+
+    #[cfg(test)]
+    fn new_with_slots(
+        watcher: notify::RecommendedWatcher,
+        slots: Arc<Semaphore>,
+    ) -> Result<Self, String> {
+        let teardown_permit = slots
+            .try_acquire_owned()
+            .map_err(|_| "watch teardown capacity exhausted".to_owned())?;
         let (shutdown, wait) = sync_channel(1);
         std::thread::Builder::new()
             .name("cmux-watch-teardown".to_owned())
             .spawn(move || {
+                let _teardown_permit = teardown_permit;
                 let watcher = watcher;
                 let _ = wait.recv();
                 drop(watcher);
@@ -986,7 +1010,27 @@ fn collect_changes(
 mod tests {
     use super::*;
     use crate::session::{OutboundFrame, OutboundSink};
+    use notify::Watcher as _;
     use serde_json::Value;
+
+    #[cfg(unix)]
+    #[test]
+    fn repeated_teardown_attempts_hit_the_hard_worker_cap() {
+        let slots = Arc::new(Semaphore::new(WATCH_TEARDOWN_CONCURRENCY));
+        let mut owners = Vec::new();
+        let mut rejected = 0;
+        for _ in 0..(WATCH_TEARDOWN_CONCURRENCY * 3) {
+            let watcher = notify::RecommendedWatcher::new(|_| {}, notify::Config::default())
+                .expect("create test watcher");
+            match WatcherOwner::new_with_slots(watcher, Arc::clone(&slots)) {
+                Ok(owner) => owners.push(owner),
+                Err(_) => rejected += 1,
+            }
+        }
+        assert_eq!(owners.len(), WATCH_TEARDOWN_CONCURRENCY);
+        assert_eq!(rejected, WATCH_TEARDOWN_CONCURRENCY * 2);
+        drop(owners);
+    }
 
     fn scratch(name: &str) -> PathBuf {
         let mut path = std::env::temp_dir();

--- a/cmux-tui/crates/chatmux-relay/src/workspace.rs
+++ b/cmux-tui/crates/chatmux-relay/src/workspace.rs
@@ -2242,6 +2242,9 @@ pub struct SharedRuntime {
     /// shared across reconnecting sockets, so one connection cannot consume a
     /// single-registry budget needed by another connection.
     pub watch_teardown_slots: Arc<Semaphore>,
+    /// Process-wide bound for non-abortable watcher setup walks. Reconnects
+    /// share this lane so abandoned blocking tasks cannot multiply per socket.
+    pub watch_setup_slots: Arc<Semaphore>,
 }
 
 impl SharedRuntime {
@@ -2252,6 +2255,7 @@ impl SharedRuntime {
             watch_teardown_slots: Arc::new(Semaphore::new(
                 crate::watch::WATCH_TEARDOWN_CONCURRENCY,
             )),
+            watch_setup_slots: Arc::new(Semaphore::new(crate::watch::WATCH_SETUP_CONCURRENCY)),
         }
     }
 }
@@ -2288,8 +2292,9 @@ pub struct Connection {
 
 impl Connection {
     pub(crate) fn new(runtime: Arc<SharedRuntime>, outbound: OutboundSink) -> Connection {
-        let watches = WatchRegistry::new_with_teardown_slots(
+        let watches = WatchRegistry::new_with_resource_slots(
             outbound.clone(),
+            Arc::clone(&runtime.watch_setup_slots),
             Arc::clone(&runtime.watch_teardown_slots),
         );
         Connection {

--- a/cmux-tui/crates/chatmux-relay/src/workspace.rs
+++ b/cmux-tui/crates/chatmux-relay/src/workspace.rs
@@ -2238,11 +2238,21 @@ pub struct SharedRuntime {
     pub preview: PreviewRegistry,
     /// This machine's own `--allow-root` scoping (config authority).
     pub local_roots: Option<Vec<String>>,
+    /// Process-wide bound for notify watcher teardown owners. The runtime is
+    /// shared across reconnecting sockets, so one connection cannot consume a
+    /// single-registry budget needed by another connection.
+    pub watch_teardown_slots: Arc<Semaphore>,
 }
 
 impl SharedRuntime {
     pub fn new(local_roots: Option<Vec<String>>) -> SharedRuntime {
-        SharedRuntime { preview: PreviewRegistry::new(), local_roots }
+        SharedRuntime {
+            preview: PreviewRegistry::new(),
+            local_roots,
+            watch_teardown_slots: Arc::new(Semaphore::new(
+                crate::watch::WATCH_TEARDOWN_CONCURRENCY,
+            )),
+        }
     }
 }
 
@@ -2278,7 +2288,10 @@ pub struct Connection {
 
 impl Connection {
     pub(crate) fn new(runtime: Arc<SharedRuntime>, outbound: OutboundSink) -> Connection {
-        let watches = WatchRegistry::new(outbound.clone());
+        let watches = WatchRegistry::new_with_teardown_slots(
+            outbound.clone(),
+            Arc::clone(&runtime.watch_teardown_slots),
+        );
         Connection {
             runtime,
             outbound,

--- a/cmux-tui/crates/cmux-remote-protocol/src/frame.rs
+++ b/cmux-tui/crates/cmux-remote-protocol/src/frame.rs
@@ -130,7 +130,13 @@ impl SessionId {
     }
 
     pub fn to_hex(self) -> String {
-        format!("{self:?}")
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        let mut output = String::with_capacity(self.0.len() * 2);
+        for byte in self.0 {
+            output.push(HEX[(byte >> 4) as usize] as char);
+            output.push(HEX[(byte & 0x0f) as usize] as char);
+        }
+        output
     }
 }
 
@@ -392,6 +398,15 @@ mod tests {
         assert!(SessionId::from_hex("5a").is_err());
         assert!(SessionId::from_hex("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz").is_err());
         assert!(SessionId::from_hex("éééééééééééééééé").is_err());
+    }
+
+    #[test]
+    fn session_id_hex_is_independent_of_debug_formatting() {
+        let session = SessionId([
+            0x00, 0x01, 0x0f, 0x10, 0x2a, 0x7f, 0x80, 0xa5, 0xb0, 0xc3, 0xde, 0xef, 0xf0, 0xf1,
+            0xfe, 0xff,
+        ]);
+        assert_eq!(session.to_hex(), "00010f102a7f80a5b0c3deeff0f1feff");
     }
 
     #[test]


### PR DESCRIPTION
## Summary\n\nRe-land focused cmux-tui relay hardening on current main after the reverted aggregate rewrite.\n\n- await journal session workers and the shared flusher during shutdown;\n- read and shred managed enrollment through an O_NOFOLLOW descriptor with inode validation;\n- encode remote session IDs as explicit lowercase hex;\n- admit filesystem watches asynchronously in a bounded blocking lane;\n- keep pending openings within the watch cap and preserve the active watch until opened delivery succeeds;\n- fence stale watch frames and keep watcher failure messages stable and product-facing.\n\nEach change has behavior-level coverage where the path is testable. Watch root resolution, notify registration, and ignore discovery run in spawn_blocking with a bounded semaphore. Outbound watch frames use internal liveness tokens, so the wire format stays compatible.\n\n## Verification\n\nDirect rustfmt --edition 2024 --check and git diff --check pass. Hosted cmux-tui verification and exact-head autoreview are required before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Improved enrollment-file validation and secure cleanup, including strict permissions and protection against unsafe symlink handling.

* **Reliability**
  * Session shutdown now fully completes worker cleanup before finishing.
  * Watch updates are cancellable and preserve existing watches when replacements fail.
  * Closed control connections reliably wake paused operations and terminate cleanly.
  * Stale outbound messages are skipped, with consistent delivery acknowledgements.

* **Bug Fixes**
  * Watch startup and runtime errors are reported clearly.
  * Session identifiers consistently use lowercase hexadecimal formatting.
  * Critical messages remain deliverable when watch traffic reaches capacity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->