### PR TITLE
irx: retry mint once on stale kept-alive broker connection, attribute URL error codes

### DIFF
--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime+Lifecycle.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime+Lifecycle.swift
@@ -114,7 +114,7 @@ extension CmxIrohClientRuntime {
     }
 
     static func isConnectivity(_ error: any Error) -> Bool {
-        (error as? CmxIrohTrustBrokerClientError) == .connectivity
+        (error as? CmxIrohTrustBrokerClientError)?.isConnectivity == true
     }
 
     /// Failures that may fall back to the verified offline policy cache.

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohOnlineAdmissionRegistry.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohOnlineAdmissionRegistry.swift
@@ -531,6 +531,6 @@ public actor CmxIrohOnlineAdmissionRegistry {
     }
 
     private static func isConnectivity(_ error: any Error) -> Bool {
-        (error as? CmxIrohTrustBrokerClientError) == .connectivity
+        (error as? CmxIrohTrustBrokerClientError)?.isConnectivity == true
     }
 }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRegistryContextProvider.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRegistryContextProvider.swift
@@ -1128,6 +1128,6 @@ public actor CmxIrohRegistryContextProvider: CmxIrohClientContextProvider {
     }
 
     private static func isConnectivity(_ error: any Error) -> Bool {
-        (error as? CmxIrohTrustBrokerClientError) == .connectivity
+        (error as? CmxIrohTrustBrokerClientError)?.isConnectivity == true
     }
 }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerClient.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerClient.swift
@@ -814,8 +814,11 @@ public actor CmxIrohTrustBrokerClient: CmxIrohRelayPolicyServing {
             // and indistinguishable from an unreachable broker for every
             // caller policy (retry, cached-policy fallback, verified-policy
             // preservation), so classify it as connectivity, not as a
-            // definitive authentication failure.
-            throw CmxIrohTrustBrokerClientError.connectivity
+            // definitive authentication failure. A URL-loading failure from
+            // the source's own refresh call keeps its code for attribution.
+            throw CmxIrohTrustBrokerClientError.connectivity(
+                (error as? URLError).map(CmxIrohBrokerConnectivityCause.init)
+            )
         }
         guard let pair = capturedPair else {
             throw CmxIrohTrustBrokerClientError.missingAuthentication
@@ -840,7 +843,9 @@ public actor CmxIrohTrustBrokerClient: CmxIrohRelayPolicyServing {
             } catch is CancellationError {
                 throw CancellationError()
             } catch {
-                throw CmxIrohTrustBrokerClientError.connectivity
+                throw CmxIrohTrustBrokerClientError.connectivity(
+                    (error as? URLError).map(CmxIrohBrokerConnectivityCause.init)
+                )
             }
             guard let recovered else { throw error }
             return try await performAuthenticatedRequest(
@@ -925,7 +930,9 @@ public actor CmxIrohTrustBrokerClient: CmxIrohRelayPolicyServing {
         do {
             (data, response) = try await transport.data(for: request)
         } catch let error as URLError where Self.isConnectivityFailure(error.code) {
-            throw CmxIrohTrustBrokerClientError.connectivity
+            throw CmxIrohTrustBrokerClientError.connectivity(
+                CmxIrohBrokerConnectivityCause(error)
+            )
         }
         guard let http = response as? HTTPURLResponse else {
             throw CmxIrohTrustBrokerClientError.nonHTTPResponse

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerClientError.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerClientError.swift
@@ -1,4 +1,52 @@
 public import CMUXMobileCore
+public import Foundation
+
+/// Underlying URL-loading failure carried by connectivity-class broker
+/// errors, so journals and caller retry policies can distinguish a dead
+/// kept-alive connection (NSURLErrorNetworkConnectionLost) from DNS loss,
+/// timeouts, or a token source that could not produce a coherent pair.
+public struct CmxIrohBrokerConnectivityCause: Equatable, Sendable,
+    CustomStringConvertible
+{
+    /// NSURLErrorDomain code, e.g. -1005.
+    public let urlErrorCode: Int
+
+    public init(urlErrorCode: Int) {
+        self.urlErrorCode = urlErrorCode
+    }
+
+    public init(_ error: URLError) {
+        self.init(urlErrorCode: error.code.rawValue)
+    }
+
+    /// Whether this is the connection-reuse failure class: a pooled
+    /// keep-alive connection the server closed while it sat idle, surfaced
+    /// only when the next request's first read fails. URLSession never
+    /// transparently retries a request whose body bytes were already written
+    /// (Apple QA1941), so idempotent callers retry once themselves; the
+    /// failed attempt already purged the dead pooled connection.
+    public var isConnectionReuseFailure: Bool {
+        urlErrorCode == URLError.Code.networkConnectionLost.rawValue
+    }
+
+    public var description: String { "\(symbolicName)(\(urlErrorCode))" }
+
+    private var symbolicName: String {
+        switch URLError.Code(rawValue: urlErrorCode) {
+        case .timedOut: "timedOut"
+        case .cannotFindHost: "cannotFindHost"
+        case .cannotConnectToHost: "cannotConnectToHost"
+        case .networkConnectionLost: "networkConnectionLost"
+        case .dnsLookupFailed: "dnsLookupFailed"
+        case .notConnectedToInternet: "notConnectedToInternet"
+        case .internationalRoamingOff: "internationalRoamingOff"
+        case .callIsActive: "callIsActive"
+        case .dataNotAllowed: "dataNotAllowed"
+        case .cannotLoadFromNetwork: "cannotLoadFromNetwork"
+        default: "urlError"
+        }
+    }
+}
 
 /// Failures at the authenticated HTTP trust-broker boundary.
 public enum CmxIrohTrustBrokerClientError:
@@ -6,8 +54,11 @@ public enum CmxIrohTrustBrokerClientError:
     Equatable,
     Sendable
 {
-    /// The authenticated broker could not be reached through the current network.
-    case connectivity
+    /// The authenticated broker could not be reached through the current
+    /// network. Carries the underlying URL-loading classification when one
+    /// exists; a `nil` cause is a token source that could not read a
+    /// coherent credential pair for a non-network reason.
+    case connectivity(CmxIrohBrokerConnectivityCause?)
     case invalidBaseURL
     case missingAuthentication
     case invalidAuthentication
@@ -86,5 +137,44 @@ public enum CmxIrohTrustBrokerClientError:
     public var retryAfterSeconds: Int? {
         guard case let .rateLimited(_, retryAfterSeconds) = self else { return nil }
         return retryAfterSeconds
+    }
+
+    /// Whether this is any connectivity-class failure, regardless of the
+    /// underlying cause detail. Callers deciding retry or cached-state
+    /// policy match on this instead of value equality, which would treat
+    /// differently-attributed connectivity failures as distinct.
+    public var isConnectivity: Bool {
+        if case .connectivity = self { return true }
+        return false
+    }
+}
+
+extension CmxIrohTrustBrokerClientError: CustomStringConvertible {
+    /// Journal-stable rendering: identical to the previously synthesized
+    /// text for every case, except that an attributed connectivity failure
+    /// appends its URL-loading cause, e.g.
+    /// `connectivity(networkConnectionLost(-1005))`.
+    public var description: String {
+        switch self {
+        case .connectivity(nil):
+            "connectivity"
+        case let .connectivity(cause?):
+            "connectivity(\(cause))"
+        case .invalidBaseURL:
+            "invalidBaseURL"
+        case .missingAuthentication:
+            "missingAuthentication"
+        case .invalidAuthentication:
+            "invalidAuthentication"
+        case .nonHTTPResponse:
+            "nonHTTPResponse"
+        case let .rateLimited(code, retryAfterSeconds):
+            "rateLimited(code: \(String(describing: code)), "
+                + "retryAfterSeconds: \(retryAfterSeconds))"
+        case let .rejected(statusCode, code):
+            "rejected(statusCode: \(statusCode), code: \(String(describing: code)))"
+        case .invalidResponse:
+            "invalidResponse"
+        }
     }
 }

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxConnectivityEngineTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxConnectivityEngineTests.swift
@@ -755,7 +755,7 @@ private actor ScriptedConnectivityAuthority: CmxConnectivityAuthorityServing {
     ) async throws -> CmxConnectivitySyncResponse {
         observedKnownRevisions.append(knownRevision)
         guard !responses.isEmpty else {
-            throw CmxIrohTrustBrokerClientError.connectivity
+            throw CmxIrohTrustBrokerClientError.connectivity(nil)
         }
         return responses.removeFirst()
     }
@@ -778,7 +778,7 @@ private actor InitialThenFailingConnectivityAuthority: CmxConnectivityAuthorityS
         if knownRevision == nil {
             return initial
         }
-        throw CmxIrohTrustBrokerClientError.connectivity
+        throw CmxIrohTrustBrokerClientError.connectivity(nil)
     }
 
     func callCount() -> Int { calls }

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohBrokerCooldownTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohBrokerCooldownTests.swift
@@ -101,7 +101,7 @@ struct CmxIrohBrokerCooldownTests {
             for: CmxIrohTrustBrokerClientError.rejected(statusCode: 503, code: nil)
         ) == nil)
         #expect(CmxIrohBrokerCooldown.directiveSeconds(
-            for: CmxIrohTrustBrokerClientError.connectivity
+            for: CmxIrohTrustBrokerClientError.connectivity(nil)
         ) == nil)
     }
 

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientRuntimeAuthorizationTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientRuntimeAuthorizationTests.swift
@@ -183,7 +183,7 @@ extension CmxIrohClientRuntimeTests {
             binding: discovery.bindings[0],
             discovery: discovery,
             relay: relay,
-            registrationError: CmxIrohTrustBrokerClientError.connectivity
+            registrationError: CmxIrohTrustBrokerClientError.connectivity(nil)
         )
         let recorder = ClientRuntimeTestRecorder()
         let runtime = try CmxIrohClientRuntime(

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientRuntimeLifecycleRaceTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientRuntimeLifecycleRaceTests.swift
@@ -148,7 +148,7 @@ extension CmxIrohClientRuntimeTests {
             discovery: fixture.discovery,
             relay: fixture.relayResponse(),
             discoveryErrorsByCount: [
-                2: CmxIrohTrustBrokerClientError.connectivity,
+                2: CmxIrohTrustBrokerClientError.connectivity(nil),
             ],
             discoveryHook: { count in
                 if count == 2 { await secondDiscovery.waitOnce() }

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientRuntimeTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientRuntimeTests.swift
@@ -178,7 +178,7 @@ struct CmxIrohClientRuntimeTests {
                 binding: localBinding,
                 discoveries: [rejectedRevision],
                 relay: relay,
-                registrationError: .connectivity
+                registrationError: .connectivity(nil)
             ),
             configuration: configuration,
             pendingRevocations: CmxIrohPendingRevocationOutbox(
@@ -188,7 +188,7 @@ struct CmxIrohClientRuntimeTests {
             now: { fixture.now }
         )
 
-        await #expect(throws: CmxIrohTrustBrokerClientError.connectivity) {
+        await #expect(throws: CmxIrohTrustBrokerClientError.connectivity(nil)) {
             try await runtime.start()
         }
     }
@@ -553,7 +553,7 @@ struct CmxIrohClientRuntimeTests {
             discovery: fixture.discovery,
             relay: fixture.relayResponse(),
             discoveryErrorsByCount: [
-                2: CmxIrohTrustBrokerClientError.connectivity,
+                2: CmxIrohTrustBrokerClientError.connectivity(nil),
             ]
         )
         let recorder = ClientRuntimeTestRecorder()
@@ -835,7 +835,7 @@ struct CmxIrohClientRuntimeTests {
         let fixture = try ClientRuntimeTestFixture()
         let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
         let store = TestSecureCredentialStore()
-        let connectivity = CmxIrohTrustBrokerClientError.connectivity
+        let connectivity = CmxIrohTrustBrokerClientError.connectivity(nil)
         let broker = TestIrohClientBroker(
             binding: fixture.binding,
             discovery: fixture.discovery,
@@ -952,7 +952,7 @@ struct CmxIrohClientRuntimeTests {
             discovery: fixture.discovery,
             relay: fixture.relayResponse(),
             discoveryErrorsByCount: [
-                2: CmxIrohTrustBrokerClientError.connectivity,
+                2: CmxIrohTrustBrokerClientError.connectivity(nil),
             ]
         )
         let runtime = try CmxIrohClientRuntime(
@@ -1337,7 +1337,7 @@ struct CmxIrohClientRuntimeTests {
             binding: fixture.binding,
             discovery: fixture.discovery,
             relay: fixture.relayResponse(),
-            revokeError: CmxIrohTrustBrokerClientError.connectivity
+            revokeError: CmxIrohTrustBrokerClientError.connectivity(nil)
         )
         let runtime = try CmxIrohClientRuntime(
             factory: TestIrohEndpointFactory(
@@ -1352,7 +1352,7 @@ struct CmxIrohClientRuntimeTests {
             now: { fixture.now }
         )
 
-        await #expect(throws: CmxIrohTrustBrokerClientError.connectivity) {
+        await #expect(throws: CmxIrohTrustBrokerClientError.connectivity(nil)) {
             try await runtime.start()
         }
 

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeLifecycleTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeLifecycleTests.swift
@@ -164,7 +164,7 @@ extension CmxIrohHostRuntimeTests {
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
             discovery: fixture.discovery,
-            subsequentRegistrationErrors: [.connectivity, .connectivity]
+            subsequentRegistrationErrors: [.connectivity(nil), .connectivity(nil)]
         )
         let clock = HostRegistrationRenewalClock(now: now)
         let runtime = CmxIrohHostRuntime(
@@ -205,7 +205,7 @@ extension CmxIrohHostRuntimeTests {
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
             discovery: fixture.discovery,
-            subsequentRegistrationErrors: [.connectivity]
+            subsequentRegistrationErrors: [.connectivity(nil)]
         )
         let clock = HostRegistrationRenewalClock(now: now)
         let runtime = CmxIrohHostRuntime(
@@ -232,7 +232,7 @@ extension CmxIrohHostRuntimeTests {
         await broker.waitForRegistrationCount(3)
         await clock.waitUntilSleepCount(3)
 
-        await broker.enqueueSubsequentRegistrationError(.connectivity)
+        await broker.enqueueSubsequentRegistrationError(.connectivity(nil))
         await runtime.requestRegistrationRefresh()
         await broker.waitForRegistrationCount(4)
         await clock.waitUntilSleepCount(4)
@@ -514,7 +514,7 @@ extension CmxIrohHostRuntimeTests {
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
             discovery: fixture.discovery,
-            registrationError: .connectivity
+            registrationError: .connectivity(nil)
         )
         let bindings = HostRuntimeBindingRecorder()
         let runtime = CmxIrohHostRuntime(

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimePolicyTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimePolicyTests.swift
@@ -406,7 +406,7 @@ extension CmxIrohHostRuntimeTests {
             broker: TestIrohHostBroker(
                 registrationBinding: fixture.binding,
                 discovery: fixture.discovery,
-                registrationError: .connectivity
+                registrationError: .connectivity(nil)
             ),
             configuration: fixture.configuration(
                 cachedHostPolicy: try cachedFixture.policy()
@@ -435,7 +435,7 @@ extension CmxIrohHostRuntimeTests {
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
             discovery: fixture.discovery,
-            registrationError: .connectivity
+            registrationError: .connectivity(nil)
         )
         let runtime = CmxIrohHostRuntime(
             factory: factory,
@@ -472,7 +472,7 @@ extension CmxIrohHostRuntimeTests {
         let broker = TestIrohHostBroker(
             registrationBinding: changedBinding,
             discovery: fixture.discovery,
-            discoveryError: .connectivity
+            discoveryError: .connectivity(nil)
         )
         let runtime = CmxIrohHostRuntime(
             factory: factory,

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeTests.swift
@@ -96,7 +96,7 @@ struct CmxIrohHostRuntimeTests {
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
             discovery: fixture.discovery,
-            registrationError: .connectivity
+            registrationError: .connectivity(nil)
         )
         let runtime = CmxIrohHostRuntime(
             factory: TestIrohEndpointFactory(
@@ -220,7 +220,7 @@ struct CmxIrohHostRuntimeTests {
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
             discovery: fixture.discovery,
-            registrationError: .connectivity
+            registrationError: .connectivity(nil)
         )
         let runtime = CmxIrohHostRuntime(
             factory: TestIrohEndpointFactory(
@@ -263,7 +263,7 @@ struct CmxIrohHostRuntimeTests {
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
             discovery: fixture.discovery,
-            registrationError: .connectivity
+            registrationError: .connectivity(nil)
         )
         let runtime = CmxIrohHostRuntime(
             factory: TestIrohEndpointFactory(endpoints: [endpoint]),
@@ -311,7 +311,7 @@ struct CmxIrohHostRuntimeTests {
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
             discovery: fixture.discovery,
-            revokeError: .connectivity
+            revokeError: .connectivity(nil)
         )
         let runtime = CmxIrohHostRuntime(
             factory: TestIrohEndpointFactory(
@@ -323,7 +323,7 @@ struct CmxIrohHostRuntimeTests {
             handleTransport: { session, _ in await session.close() }
         )
 
-        await #expect(throws: CmxIrohTrustBrokerClientError.connectivity) {
+        await #expect(throws: CmxIrohTrustBrokerClientError.connectivity(nil)) {
             try await runtime.start()
         }
 

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohOnlineAdmissionRegistryLeaseTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohOnlineAdmissionRegistryLeaseTests.swift
@@ -38,7 +38,7 @@ extension CmxIrohOnlineAdmissionRegistryTests {
     @Test
     func connectivityAllowsLocallyValidGrantOffline() async throws {
         let fixture = try OnlineAdmissionFixture()
-        let broker = OnlineAdmissionBroker(responses: [.failure(.connectivity)])
+        let broker = OnlineAdmissionBroker(responses: [.failure(.connectivity(nil))])
         let registry = fixture.registry(broker: broker)
 
         let authorization = await registry.authorizePairGrant(
@@ -99,7 +99,7 @@ extension CmxIrohOnlineAdmissionRegistryTests {
         let fixture = try OnlineAdmissionFixture()
         let broker = OnlineAdmissionBroker(responses: [
             .success(try fixture.discovery(includeInitiator: false)),
-            .failure(.connectivity),
+            .failure(.connectivity(nil)),
         ])
         let registry = fixture.registry(broker: broker)
 
@@ -109,7 +109,7 @@ extension CmxIrohOnlineAdmissionRegistryTests {
                 authenticatedPeerID: fixture.initiator.endpointID
             ) == .denied
         )
-        await broker.replaceResponses([.failure(.connectivity)])
+        await broker.replaceResponses([.failure(.connectivity(nil))])
         #expect(
             await registry.authorizePairGrant(
                 fixture.grant(),
@@ -226,7 +226,7 @@ extension CmxIrohOnlineAdmissionRegistryTests {
         let clock = OnlineAdmissionManualClock(now: fixture.now)
         let broker = OnlineAdmissionBroker(responses: [
             .success(try fixture.discovery()),
-            .failure(.connectivity),
+            .failure(.connectivity(nil)),
         ])
         let registry = fixture.registry(broker: broker, clock: clock)
         let lease = try #require(
@@ -406,8 +406,8 @@ extension CmxIrohOnlineAdmissionRegistryTests {
         let fixture = try OnlineAdmissionFixture(grantLifetime: 31)
         let clock = OnlineAdmissionManualClock(now: fixture.now)
         let broker = OnlineAdmissionBroker(responses: [
-            .failure(.connectivity),
-            .failure(.connectivity),
+            .failure(.connectivity(nil)),
+            .failure(.connectivity(nil)),
         ])
         let registry = fixture.registry(broker: broker, clock: clock)
         let lease = try #require(

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohOnlineAdmissionRegistryOfflineTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohOnlineAdmissionRegistryOfflineTests.swift
@@ -59,8 +59,8 @@ extension CmxIrohOnlineAdmissionRegistryTests {
         let fixture = try OnlineAdmissionFixture()
         let clock = OnlineAdmissionManualClock(now: fixture.now)
         let broker = OnlineAdmissionBroker(responses: [
-            .failure(.connectivity),
-            .failure(.connectivity),
+            .failure(.connectivity(nil)),
+            .failure(.connectivity(nil)),
         ])
         let registry = fixture.registry(broker: broker, clock: clock)
         let pair = try fixture.offlinePair(initiatorLifetime: 90, acceptorLifetime: 31)
@@ -154,7 +154,7 @@ extension CmxIrohOnlineAdmissionRegistryTests {
         let pair = try fixture.offlinePair()
 
         #expect(await registry.authorizeOfflinePair(pair) == .denied)
-        await broker.replaceResponses([.failure(.connectivity)])
+        await broker.replaceResponses([.failure(.connectivity(nil))])
         #expect(await registry.authorizeOfflinePair(pair) == .denied)
         #expect(await broker.callCount() == 1)
     }
@@ -314,7 +314,7 @@ extension CmxIrohOnlineAdmissionRegistryTests {
     func connectivityAfterPolicyUpdateCannotAdmitStaleAuthority() async throws {
         let fixture = try OnlineAdmissionFixture()
         let broker = OnlineAdmissionBroker(
-            responses: [.failure(.connectivity)],
+            responses: [.failure(.connectivity(nil))],
             suspended: true
         )
         let registry = fixture.registry(broker: broker)

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohPendingRevocationOutboxTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohPendingRevocationOutboxTests.swift
@@ -29,7 +29,7 @@ struct CmxIrohPendingRevocationOutboxTests {
     }
 
     @Test(arguments: [
-        CmxIrohTrustBrokerClientError.connectivity,
+        CmxIrohTrustBrokerClientError.connectivity(nil),
         .rejected(statusCode: 503, code: "unavailable"),
     ])
     func transientFailureRetainsPendingRevocation(

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRegistryContextProviderPolicyTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRegistryContextProviderPolicyTests.swift
@@ -165,7 +165,7 @@ extension CmxIrohRegistryContextProviderTests {
         let broker = TestIrohRegistryBroker(
             discovery: discovery,
             pairGrantResponses: [],
-            discoveryError: CmxIrohTrustBrokerClientError.connectivity
+            discoveryError: CmxIrohTrustBrokerClientError.connectivity(nil)
         )
         let provider = CmxIrohRegistryContextProvider(
             supervisor: try await fixture.activeSupervisor(),
@@ -210,7 +210,7 @@ extension CmxIrohRegistryContextProviderTests {
         let broker = TestIrohRegistryBroker(
             discovery: discovery,
             pairGrantResponses: [],
-            pairGrantError: CmxIrohTrustBrokerClientError.connectivity
+            pairGrantError: CmxIrohTrustBrokerClientError.connectivity(nil)
         )
         let provider = CmxIrohRegistryContextProvider(
             supervisor: try await fixture.activeSupervisor(),

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohTrustBrokerClientAuthRecoveryTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohTrustBrokerClientAuthRecoveryTests.swift
@@ -215,7 +215,7 @@ struct CmxIrohTrustBrokerClientAuthRecoveryTests {
     @Test
     func cachedPolicyRecoveryFailsClosedForAuthRejections() {
         #expect(CmxIrohClientRuntime.recoversWithCachedPolicy(
-            CmxIrohTrustBrokerClientError.connectivity
+            CmxIrohTrustBrokerClientError.connectivity(nil)
         ))
         #expect(!CmxIrohClientRuntime.recoversWithCachedPolicy(
             CmxIrohTrustBrokerClientError.rejected(

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohTrustBrokerClientNetworkTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohTrustBrokerClientNetworkTests.swift
@@ -177,7 +177,7 @@ extension CmxIrohTrustBrokerClientTests {
             clientNamespace: "legacy",
             transport: transport
         )
-        await #expect(throws: CmxIrohTrustBrokerClientError.connectivity) {
+        await #expect(throws: CmxIrohTrustBrokerClientError.connectivity(nil)) {
             _ = try await client.discover()
         }
         #expect(await transport.requests().isEmpty)
@@ -203,7 +203,13 @@ extension CmxIrohTrustBrokerClientTests {
         )
         let client = try makeNetworkClient(transport: transport)
 
-        await #expect(throws: CmxIrohTrustBrokerClientError.connectivity) {
+        let expected = CmxIrohTrustBrokerClientError.connectivity(
+            CmxIrohBrokerConnectivityCause(
+                urlErrorCode: URLError.Code.notConnectedToInternet.rawValue
+            )
+        )
+        #expect(String(describing: expected) == "connectivity(notConnectedToInternet(-1009))")
+        await #expect(throws: expected) {
             _ = try await client.discover()
         }
     }

--- a/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/IrxBrokerService.swift
+++ b/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/IrxBrokerService.swift
@@ -324,7 +324,9 @@ public actor IrxBrokerService {
     public func mintRelayCredentials() async throws -> [IrxRelayCredential] {
         let startedAt = DispatchTime.now()
         let endpointID = try CmxIrohPeerIdentity(endpointID: identity.endpointIDHex)
-        let bootstrap = try await client.issueRelayBootstrap(endpointID: endpointID)
+        let bootstrap = try await issueRelayBootstrapRetryingStaleConnection(
+            endpointID: endpointID
+        )
         guard let tokenResponse = bootstrap.relayToken else {
             journal.record("broker", "relay-mint-empty")
             throw IrxBrokerServiceError.noCredentialsIssued
@@ -376,6 +378,36 @@ public actor IrxBrokerService {
             ]
         )
         return minted
+    }
+
+    /// One immediate retry for the connection-reuse failure class.
+    ///
+    /// The autopilot mints every ~3-4 minutes, longer than the broker edge's
+    /// idle keep-alive window, so the first POST of a cycle deterministically
+    /// lands on a pooled connection the server already closed: the write
+    /// succeeds into the dead socket, the first read fails with ECONNRESET,
+    /// and URLSession surfaces NSURLErrorNetworkConnectionLost (-1005)
+    /// without a transparent retry because the POST body was already written
+    /// (Apple QA1941). That failure also purged the dead pooled connection,
+    /// so one immediate retry runs on a fresh connection. Minting is
+    /// idempotent, the retry is bounded to exactly one attempt for exactly
+    /// this failure class, and the autopilot's half-remaining-validity sleep
+    /// loop stays the outer safety net for everything else.
+    private func issueRelayBootstrapRetryingStaleConnection(
+        endpointID: CmxIrohPeerIdentity
+    ) async throws -> CmxIrohRelayBootstrapResponse {
+        do {
+            return try await client.issueRelayBootstrap(endpointID: endpointID)
+        } catch let error as CmxIrohTrustBrokerClientError {
+            guard case let .connectivity(cause?) = error,
+                cause.isConnectionReuseFailure
+            else { throw error }
+            journal.record(
+                "broker", "relay-mint-retried",
+                ["error": String(describing: error)]
+            )
+            return try await client.issueRelayBootstrap(endpointID: endpointID)
+        }
     }
 
     // MARK: - Pair grants (keyed by the acceptor's endpoint, what routes carry)

--- a/Packages/Shared/CmuxIrxTransport/Tests/CmuxIrxTransportTests/IrxBrokerMintRetryTests.swift
+++ b/Packages/Shared/CmuxIrxTransport/Tests/CmuxIrxTransportTests/IrxBrokerMintRetryTests.swift
@@ -1,0 +1,333 @@
+import CryptoKit
+import Foundation
+import Network
+import Testing
+
+@testable import CmuxIrohTransport
+@testable import CmuxIrxTransport
+
+/// Reproduces the deterministic first-mint failure from the 2026-08-26 irx
+/// soak (issue #10924): the credential autopilot's mint POST rides a pooled
+/// keep-alive connection that the broker edge closed while the client slept
+/// its ~3-4 minute refresh interval. The next POST writes into the dead
+/// socket, the first read returns POSIX 54 (ECONNRESET), and URLSession
+/// surfaces NSURLErrorNetworkConnectionLost (-1005) without a transparent
+/// retry because a POST with bytes written is not retried (Apple QA1941).
+///
+/// The in-process server below makes that sequence exact: it serves the first
+/// mint on a keep-alive connection, then resets that same connection when the
+/// next request arrives on it, then serves normally on fresh connections.
+@Suite(.serialized)
+struct IrxBrokerMintRetryTests {
+    /// The soak-observed failure: the second mint of a session lands on the
+    /// stale pooled connection. The broker service must classify the -1005,
+    /// retry the idempotent mint once immediately on the fresh connection the
+    /// purged pool now provides, and succeed within the same cycle instead of
+    /// surfacing `mint-failed connectivity` and waiting for the ~64s outer
+    /// autopilot retry.
+    @Test
+    func mintRetriesOnceWhenPooledConnectionDiesBetweenCycles() async throws {
+        let server = try await IrxStaleKeepAliveHTTPServer.start { requestIndex in
+            requestIndex == 1 ? .resetConnection : .respond
+        }
+        defer { server.stop() }
+        let journal = IrxJournal(subsystem: "dev.cmux.irx-tests", category: "mint-retry")
+        let service = try Self.makeBrokerService(port: server.port, journal: journal)
+        server.mintResponseBody = Self.mintResponseBody(
+            endpointIDHex: Self.testIdentity.endpointIDHex
+        )
+
+        let first = try await service.mintRelayCredentials()
+        #expect(!first.isEmpty)
+
+        // Second cycle: first attempt hits the reset pooled connection. The
+        // fix retries once, immediately, on a fresh connection.
+        let second = try await service.mintRelayCredentials()
+        #expect(!second.isEmpty)
+
+        // Exactly one retry: 1 (first mint) + 2 (failed attempt + retry).
+        #expect(server.requestCount == 3)
+
+        let retried = journal.tail().filter { $0.event == "relay-mint-retried" }
+        #expect(retried.count == 1)
+        #expect(
+            retried.first?.attributes["error"]?.contains("networkConnectionLost(-1005)")
+                == true
+        )
+    }
+
+    /// When the immediate retry also fails, the surfaced error (which the
+    /// autopilot journals as `mint-failed a_error`) must carry the underlying
+    /// NSURLError classification instead of collapsing to bare "connectivity".
+    @Test
+    func mintFailureCarriesUnderlyingURLErrorCode() async throws {
+        let server = try await IrxStaleKeepAliveHTTPServer.start { requestIndex in
+            requestIndex == 0 ? .respond : .resetConnection
+        }
+        defer { server.stop() }
+        let journal = IrxJournal(subsystem: "dev.cmux.irx-tests", category: "mint-attrib")
+        let service = try Self.makeBrokerService(port: server.port, journal: journal)
+        server.mintResponseBody = Self.mintResponseBody(
+            endpointIDHex: Self.testIdentity.endpointIDHex
+        )
+
+        let first = try await service.mintRelayCredentials()
+        #expect(!first.isEmpty)
+
+        do {
+            _ = try await service.mintRelayCredentials()
+            Issue.record("second mint unexpectedly succeeded; server resets every attempt")
+        } catch {
+            let description = String(describing: error)
+            #expect(
+                description.contains("networkConnectionLost(-1005)"),
+                "mint failure must attribute the URL error, got: \(description)"
+            )
+        }
+
+        // One attempt plus exactly one immediate retry, never a retry loop.
+        #expect(server.requestCount == 3)
+    }
+
+    // MARK: - Fixtures
+
+    private static let testIdentity = IrxIdentity(
+        privateKeyData: Curve25519.Signing.PrivateKey().rawRepresentation,
+        deviceID: "irx-mint-retry-test-device",
+        appInstanceID: "b2fb2f6e-1111-4222-8333-444455556666"
+    )
+
+    private static func makeBrokerService(
+        port: UInt16,
+        journal: IrxJournal
+    ) throws -> IrxBrokerService {
+        let cacheDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("irx-mint-retry-tests-\(UUID().uuidString)")
+        guard let baseURL = URL(string: "http://127.0.0.1:\(port)") else {
+            throw IrxBrokerServiceError.invalidIdentity
+        }
+        return try IrxBrokerService(
+            configuration: IrxBrokerService.Configuration(
+                baseURL: baseURL,
+                clientNamespace: "dev.cmux.irx-tests",
+                tag: "irx-tests",
+                platform: .ios,
+                displayName: nil,
+                cacheDirectory: cacheDirectory
+            ),
+            identity: testIdentity,
+            accessTokenPair: { ("test-access-token", "test-refresh-token") },
+            journal: journal
+        )
+    }
+
+    /// A minimal valid `/api/relay/token` bootstrap response: one managed
+    /// relay credential bound to the test endpoint plus the signed-policy
+    /// triplet the bootstrap path requires (shape-validated only).
+    private static func mintResponseBody(endpointIDHex: String) -> Data {
+        let now = Int64(Date().timeIntervalSince1970)
+        let json = """
+            {
+              "endpointId": "\(endpointIDHex)",
+              "relayCredentials": [
+                {
+                  "relayUrl": "https://usc1.relay.cmux.dev/",
+                  "token": "irx-test-relay-token",
+                  "expiresAt": \(now + 300),
+                  "refreshAfter": \(now + 240),
+                  "ttlSeconds": 300
+                }
+              ],
+              "policy": "eyJhbGciOiJFZERTQSJ9.eyJwb2xpY3kiOjF9.c2lnbmF0dXJl",
+              "preference": { "mode": "automatic" },
+              "preferenceRevision": 1
+            }
+            """
+        return Data(json.utf8)
+    }
+}
+
+/// Minimal in-process HTTP/1.1 keep-alive server whose per-request script can
+/// reset the underlying TCP connection instead of answering, which is how a
+/// broker edge's silent idle close surfaces to the client: the request bytes
+/// are written, then the first read fails with ECONNRESET.
+final class IrxStaleKeepAliveHTTPServer: @unchecked Sendable {
+    enum RequestAction: Sendable {
+        case respond
+        case resetConnection
+    }
+
+    private let listener: NWListener
+    private let queue = DispatchQueue(label: "irx-stale-keepalive-http-server")
+    private let lock = NSLock()
+    private let action: @Sendable (Int) -> RequestAction
+    private var servedRequestCount = 0
+    private var openConnections: [NWConnection] = []
+    private var responseBody = Data("{}".utf8)
+
+    /// Bound loopback port; valid once the listener reports ready.
+    var port: UInt16 { listener.port?.rawValue ?? 0 }
+
+    var requestCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return servedRequestCount
+    }
+
+    var mintResponseBody: Data {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return responseBody
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            responseBody = newValue
+        }
+    }
+
+    static func start(
+        action: @escaping @Sendable (Int) -> RequestAction
+    ) async throws -> IrxStaleKeepAliveHTTPServer {
+        let parameters = NWParameters.tcp
+        parameters.requiredLocalEndpoint = NWEndpoint.hostPort(
+            host: .ipv4(.loopback), port: .any
+        )
+        let listener = try NWListener(using: parameters)
+        return try await withCheckedThrowingContinuation { continuation in
+            let server = IrxStaleKeepAliveHTTPServer(listener: listener, action: action)
+            let resumer = OnceResumer(continuation: continuation)
+            listener.stateUpdateHandler = { state in
+                switch state {
+                case .ready:
+                    resumer.resume(.success(server))
+                case let .failed(error):
+                    resumer.resume(.failure(error))
+                default:
+                    break
+                }
+            }
+            listener.start(queue: server.queue)
+        }
+    }
+
+    /// Resumes a checked continuation at most once across listener callbacks.
+    private final class OnceResumer: @unchecked Sendable {
+        private let lock = NSLock()
+        private var continuation: CheckedContinuation<IrxStaleKeepAliveHTTPServer, any Error>?
+
+        init(continuation: CheckedContinuation<IrxStaleKeepAliveHTTPServer, any Error>) {
+            self.continuation = continuation
+        }
+
+        func resume(_ result: Result<IrxStaleKeepAliveHTTPServer, any Error>) {
+            lock.lock()
+            let continuation = self.continuation
+            self.continuation = nil
+            lock.unlock()
+            continuation?.resume(with: result)
+        }
+    }
+
+    private init(
+        listener: NWListener,
+        action: @escaping @Sendable (Int) -> RequestAction
+    ) {
+        self.listener = listener
+        self.action = action
+        listener.newConnectionHandler = { [weak self] connection in
+            self?.adopt(connection)
+        }
+    }
+
+    func stop() {
+        listener.cancel()
+        lock.lock()
+        let connections = openConnections
+        openConnections = []
+        lock.unlock()
+        for connection in connections {
+            connection.cancel()
+        }
+    }
+
+    private func adopt(_ connection: NWConnection) {
+        lock.lock()
+        openConnections.append(connection)
+        lock.unlock()
+        connection.start(queue: queue)
+        receiveLoop(connection, buffer: Data())
+    }
+
+    private func receiveLoop(_ connection: NWConnection, buffer: Data) {
+        connection.receive(
+            minimumIncompleteLength: 1, maximumLength: 128 * 1024
+        ) { [weak self] data, _, isComplete, error in
+            guard let self, error == nil else { return }
+            var buffer = buffer
+            if let data, !data.isEmpty {
+                buffer.append(data)
+            }
+            let stillOpen = self.drainCompleteRequests(&buffer, on: connection)
+            if stillOpen, !isComplete {
+                self.receiveLoop(connection, buffer: buffer)
+            }
+        }
+    }
+
+    /// Consumes every complete HTTP request in `buffer`, applying the script.
+    /// Returns false once the connection has been reset.
+    private func drainCompleteRequests(
+        _ buffer: inout Data, on connection: NWConnection
+    ) -> Bool {
+        while let request = Self.completeRequestLength(in: buffer) {
+            buffer.removeSubrange(buffer.startIndex ..< buffer.startIndex + request)
+            lock.lock()
+            let index = servedRequestCount
+            servedRequestCount += 1
+            let body = responseBody
+            lock.unlock()
+            switch action(index) {
+            case .respond:
+                let head =
+                    "HTTP/1.1 200 OK\r\n"
+                    + "Content-Type: application/json\r\n"
+                    + "Content-Length: \(body.count)\r\n"
+                    + "Connection: keep-alive\r\n\r\n"
+                connection.send(
+                    content: Data(head.utf8) + body,
+                    completion: .contentProcessed { _ in }
+                )
+            case .resetConnection:
+                // RST, exactly like the edge tearing down the idle pooled
+                // connection: the client's written request is never answered
+                // and its next read fails with ECONNRESET (POSIX 54).
+                connection.forceCancel()
+                return false
+            }
+        }
+        return true
+    }
+
+    /// Total byte length of the first complete request in `buffer`, or nil.
+    private static func completeRequestLength(in buffer: Data) -> Int? {
+        guard let headerRange = buffer.range(of: Data("\r\n\r\n".utf8)) else {
+            return nil
+        }
+        let headerData = buffer[buffer.startIndex ..< headerRange.lowerBound]
+        let headerText = String(decoding: headerData, as: UTF8.self)
+        var contentLength = 0
+        for line in headerText.split(separator: "\r\n") {
+            let parts = line.split(separator: ":", maxSplits: 1)
+            guard parts.count == 2,
+                parts[0].trimmingCharacters(in: .whitespaces).lowercased()
+                    == "content-length",
+                let value = Int(parts[1].trimmingCharacters(in: .whitespaces))
+            else { continue }
+            contentLength = value
+        }
+        let total = (headerRange.upperBound - buffer.startIndex) + contentLength
+        return buffer.count >= total ? total : nil
+    }
+}

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionTests.swift
@@ -250,7 +250,7 @@ struct MobileIrohRuntimeCompositionTests {
         _ = try #require(readiness.completeFailure(
             revision: 1,
             accountID: "account-a",
-            error: CmxIrohTrustBrokerClientError.connectivity,
+            error: CmxIrohTrustBrokerClientError.connectivity(nil),
             retryAfterSeconds: nil,
             now: start
         ))


### PR DESCRIPTION
Fixes the deterministic first-mint failure from the irx 60-minute soak: the iOS client failed its first mint attempt on 15/15 autopilot cycles (journal `mint-failed a_error="connectivity"`), recovering only via the ~64s outer retry. Root-cause discussion: https://github.com/manaflow-ai/cmux/issues/10924

## Root cause (from the live sim's unified log)

The autopilot mints every ~3-4 minutes, longer than the broker edge keeps an idle pooled connection alive. The first POST of each cycle reused the dead kept-alive connection:

```
Task <D67B1A5A-...>.<224> now using Connection 363
Connection 363: final read 1:54, complete[Y], final[N]        <- POSIX 54 ECONNRESET
Task <...>.<224> idempotent(N) retry reason(0) bytes written(Y)
Task <...>.<224> can retry(N) with reason(0) for error [1:54]  <- URLSession refuses POST retry (QA1941)
Task <...>.<224> HTTP load failed, 1019/0 bytes (error code: -1005 [1:54])
summary for task failure {... connection=363, reused=1, reused_after_ms=171601 ...}
```

`reused_after_ms` equals the autopilot's sleep interval on every failure (171601, 173084, 237758 across captured instances), and the very next attempt on a fresh connection always returned 200. The client collapsed the URLError to bare `.connectivity`, so the journal could not attribute it.

## Fix

- `CmxIrohTrustBrokerClientError.connectivity` now carries the underlying NSURLError code and renders as `connectivity(networkConnectionLost(-1005))`; policy call sites that compared equality use the new `isConnectivity` and are otherwise unchanged.
- `IrxBrokerService.mintRelayCredentials` retries the idempotent bootstrap mint exactly once, immediately, only for `.networkConnectionLost`: the failed attempt already purged the dead pooled connection, so the retry runs on a fresh connection. The retry is journaled as `relay-mint-retried`. No sleeps, no loops; the autopilot's outer retry stays unchanged as the safety net.

## Commits (red then green)

1. Failing test: drives `IrxBrokerService.mintRelayCredentials` through the real URLSession stack against an in-process keep-alive HTTP server that resets the pooled connection when the second mint arrives on it, reproducing `networkConnectionLost(-1005)` deterministically.
2. The fix above; the test's journal assertion confirms the in-process repro yields exactly `connectivity(networkConnectionLost(-1005))`.

`swift test`: CmuxIrohTransport 632/632, CmuxIrxTransport 12/12 (live QUIC suite skipped).

Journal before (soak, every cycle): `{"a_error":"connectivity","a_retry":"63.8...s","event":"mint-failed"}` then 64s of degraded margin. After: `relay-mint-retried` with the -1005 attribution followed by `relay-minted` in the same second; simulator verification numbers to follow on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10930"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790400657&installation_model_id=21920&pr_number=10930&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10930&signature=cb5f6724e8cb29dc75e5743cbb1fc090b10504bb81faa022cf4c009727846b36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the irx credential autopilot's deterministic first-mint failure (15/15 cycles in the 60-minute soak, issue #10924) where the first POST reused a stale kept-alive connection the broker edge had closed while idle. `mintRelayCredentials` now retries once immediately on `.networkConnectionLost`, and connectivity errors carry their underlying NSURLError code instead of collapsing to bare `connectivity`.

**Changes**

- `CmxIrohTrustBrokerClientError.connectivity` now carries an optional `CmxIrohBrokerConnectivityCause` with the URL error code, rendering as `connectivity(networkConnectionLost(-1005))`; policy call sites now match on the new `isConnectivity` instead of equality.
- `IrxBrokerService.mintRelayCredentials` retries the idempotent bootstrap mint exactly once, only for `.networkConnectionLost`, since the failed attempt already purged the dead pooled connection; the retry is journaled as `relay-mint-retried` and the autopilot's outer retry loop is unchanged.
- Adds a deterministic repro using an in-process keep-alive HTTP server that resets the pooled connection; the test asserts exactly one retry and the attributed error.

<sup>Written for commit eed438366163a21a4a0bcf24ec77eaa5f0c29064. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Connectivity failures now include optional diagnostic details, such as underlying network error codes.
  * Relay credential requests automatically retry once after connection-reset failures.

* **Bug Fixes**
  * Connectivity-related broker errors are recognized consistently across startup, authorization, admission, and lease operations.
  * Preserves the original network failure details when retry attempts fail.

* **Tests**
  * Added coverage for connection-reset recovery and detailed connectivity error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->