### PR TITLE
fix(relay): validate pairing config without symlink races

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/config.rs
+++ b/cmux-tui/crates/chatmux-relay/src/config.rs
@@ -369,12 +369,13 @@ mod tests {
 
         let (sender, receiver) = mpsc::channel();
         let worker_path = path.clone();
-        std::thread::spawn(move || {
+        let worker = std::thread::spawn(move || {
             sender.send(load_config_checked(&worker_path)).unwrap();
         });
         let result = receiver
             .recv_timeout(Duration::from_secs(1))
             .expect("FIFO config validation must not block");
+        worker.join().expect("FIFO config worker should exit");
         assert!(result.is_err(), "FIFO must be rejected as non-regular");
 
         std::fs::remove_dir_all(path.parent().unwrap()).ok();

--- a/cmux-tui/crates/chatmux-relay/src/config.rs
+++ b/cmux-tui/crates/chatmux-relay/src/config.rs
@@ -127,7 +127,13 @@ fn read_config(path: &Path) -> std::io::Result<Vec<u8>> {
     let mut options = OpenOptions::new();
     options.read(true);
     #[cfg(unix)]
-    options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+    {
+        // A malicious replacement with a FIFO must not make startup wait for
+        // a writer before the descriptor can be validated as a regular file.
+        // O_NONBLOCK makes read-only FIFO opens return immediately; regular
+        // files continue to use normal blocking reads.
+        options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK);
+    }
     let file = options.open(path)?;
     let metadata = file.metadata()?;
     if !metadata.is_file() {
@@ -345,6 +351,32 @@ mod tests {
         symlink(&target, &path).unwrap();
         assert!(load_config(&path).is_none());
         assert!(load_config_checked(&path).is_err());
+        std::fs::remove_dir_all(path.parent().unwrap()).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fifo_config_is_rejected_without_blocking() {
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStrExt as _;
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        let path = scratch("fifo/config.json");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let c_path = CString::new(path.as_os_str().as_bytes()).unwrap();
+        assert_eq!(unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) }, 0);
+
+        let (sender, receiver) = mpsc::channel();
+        let worker_path = path.clone();
+        std::thread::spawn(move || {
+            sender.send(load_config_checked(&worker_path)).unwrap();
+        });
+        let result = receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("FIFO config validation must not block");
+        assert!(result.is_err(), "FIFO must be rejected as non-regular");
+
         std::fs::remove_dir_all(path.parent().unwrap()).ok();
     }
 

--- a/cmux-tui/crates/chatmux-relay/src/config.rs
+++ b/cmux-tui/crates/chatmux-relay/src/config.rs
@@ -5,8 +5,12 @@
 //! trailing newline, written with mode 0600. Unknown fields written by other
 //! (newer or older) relay builds are preserved across load/save.
 
+use std::fs::OpenOptions;
 use std::io::{Read as _, Write as _};
 use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
 
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
@@ -107,17 +111,45 @@ fn home_dir() -> PathBuf {
 }
 
 fn read_config(path: &Path) -> std::io::Result<Vec<u8>> {
-    // Do not accept a config symlink. `metadata` follows links, which could
-    // make a compromised config path read credentials from an unrelated file.
-    // `symlink_metadata` performs the check on the directory entry itself.
-    let metadata = std::fs::symlink_metadata(path)?;
-    if !metadata.file_type().is_file() {
+    // Open first and validate the descriptor. On Unix, O_NOFOLLOW closes the
+    // pathname-swap window between a metadata check and the read.
+    #[cfg(not(unix))]
+    {
+        let metadata = std::fs::symlink_metadata(path)?;
+        if !metadata.file_type().is_file() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "relay config is not a regular file",
+            ));
+        }
+    }
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+    let file = options.open(path)?;
+    let metadata = file.metadata()?;
+    if !metadata.is_file() {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
             "relay config is not a regular file",
         ));
     }
-    let file = std::fs::File::open(path)?;
+    #[cfg(unix)]
+    {
+        if metadata.uid() != unsafe { libc::geteuid() } {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "relay config is not owned by the current user",
+            ));
+        }
+        if metadata.mode() & 0o777 != 0o600 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "relay config permissions are not 0600",
+            ));
+        }
+    }
     let mut bytes = Vec::new();
     file.take(MAX_CONFIG_BYTES + 1).read_to_end(&mut bytes)?;
     Ok(bytes)

--- a/cmux-tui/crates/chatmux-relay/src/config.rs
+++ b/cmux-tui/crates/chatmux-relay/src/config.rs
@@ -359,6 +359,20 @@ mod tests {
         std::fs::remove_dir_all(path.parent().unwrap()).ok();
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn owner_read_only_config_is_accepted() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let path = scratch("owner-read-only/config.json");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, r#"{"deviceId":"dev_read_only","token":"tok_read_only"}"#).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o400)).unwrap();
+        let config = load_config(&path).expect("owner-only read config loads");
+        assert_eq!(config.device_id, "dev_read_only");
+        assert!(load_config_checked(&path).unwrap().is_some());
+        std::fs::remove_dir_all(path.parent().unwrap()).ok();
+    }
+
     #[test]
     fn allowed_roots_enforce_count_and_byte_limits() {
         let roots = vec!["/srv".to_owned(); MAX_ALLOWED_ROOTS];

--- a/cmux-tui/crates/chatmux-relay/src/config.rs
+++ b/cmux-tui/crates/chatmux-relay/src/config.rs
@@ -1,4 +1,5 @@
-//! Local pairing config: `~/.config/chatmux-relay/config.json` (0600).
+//! Local pairing config: `~/.config/chatmux-relay/config.json` (owner-readable,
+//! normally 0600).
 //!
 //! Byte-level contract mirror of the JS relay (`packages/relay/bin/
 //! cmux-relay.mjs` `loadConfig`/`saveConfig`): pretty-printed JSON with a
@@ -143,10 +144,11 @@ fn read_config(path: &Path) -> std::io::Result<Vec<u8>> {
                 "relay config is not owned by the current user",
             ));
         }
-        if metadata.mode() & 0o777 != 0o600 {
+        let mode = metadata.mode();
+        if mode & 0o077 != 0 || mode & 0o400 == 0 {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::PermissionDenied,
-                "relay config permissions are not 0600",
+                "relay config is not owner-readable and private",
             ));
         }
     }

--- a/cmux-tui/crates/chatmux-relay/src/config.rs
+++ b/cmux-tui/crates/chatmux-relay/src/config.rs
@@ -271,6 +271,9 @@ mod tests {
             std::fs::create_dir_all(parent).unwrap();
         }
         std::fs::write(&path, serde_json::to_string(&raw).unwrap()).unwrap();
+        #[cfg(unix)]
+        std::fs::set_permissions(&path, std::os::unix::fs::PermissionsExt::from_mode(0o600))
+            .unwrap();
         let mut config = load_config(&path).expect("valid config loads");
         assert_eq!(config.device_id, "dev_abc");
         assert_eq!(config.extra.get("futureField"), raw.get("futureField"));
@@ -306,6 +309,19 @@ mod tests {
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
         std::fs::write(&target, r#"{"deviceId":"dev_link","token":"tok_link"}"#).unwrap();
         symlink(&target, &path).unwrap();
+        assert!(load_config(&path).is_none());
+        assert!(load_config_checked(&path).is_err());
+        std::fs::remove_dir_all(path.parent().unwrap()).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn loose_config_permissions_are_rejected_before_credentials_load() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let path = scratch("loose-perms/config.json");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, r#"{"deviceId":"dev_loose","token":"tok_loose"}"#).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
         assert!(load_config(&path).is_none());
         assert!(load_config_checked(&path).is_err());
         std::fs::remove_dir_all(path.parent().unwrap()).ok();


### PR DESCRIPTION
Validates the pairing config from its opened descriptor on Unix. Requires current-user ownership and exact 0600 permissions, and uses O_NOFOLLOW/O_CLOEXEC before reading. Keeps the existing fail-closed load behavior and adds a 0644 regression test.

Commits intentionally separate the regression test from the fix.

Verification: rustfmt --edition 2024 --check; git diff --check. Rust tests are hosted only because cmux-tui policy forbids local Cargo runs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10932"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790401778&installation_model_id=21920&pr_number=10932&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10932&signature=50e72afb042098a1e69fe571e9d6699afa810a801a8b518e930c722afcb99021"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a time-of-check/time-of-use race in pairing config validation by validating the opened file descriptor instead of the path, and rejects FIFO configs without blocking startup. On Unix, configs must be owned by the current user and private; owner-read-only (0400) configs now load, not only 0600.

- Opens the config with `O_NOFOLLOW`/`O_CLOEXEC`/`O_NONBLOCK` on Unix before any validation, closing the pathname-swap window and keeping FIFO opens from blocking.
- Rejects configs that are not regular files, are not owned by the current user, or grant any group or world permissions.
- Adds regression tests proving 0644 configs are rejected, 0400 configs are accepted, and FIFO configs fail without blocking.
- Existing fail-closed load behavior is unchanged; the test helper sets 0600 on valid configs.

<sup>Written for commit 79d5bda289b5ff5e87e8714fd6f3f69f7e7e88fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration file security by rejecting files that are not regular files, are owned by another user, or have overly permissive permissions.
  * Prevented configuration files from being followed through symbolic links on supported platforms.
  * Configuration files with owner-only read permissions are now accepted.
  * Added validation coverage to ensure secure and insecure configuration files are handled consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->