### PR TITLE
docs(tui): use canonical resource commands

### DIFF
--- a/web/app/[locale]/(landing)/docs/tui/page.tsx
+++ b/web/app/[locale]/(landing)/docs/tui/page.tsx
@@ -152,8 +152,8 @@ cmux attach --session agents`}</CodeBlock>
       </DocsHeading>
       <p>{t("automationIntro")}</p>
       <CodeBlock lang="bash">{`cmux --session agents workspace list --json
-cmux --session agents workspace create --name review
-cmux --session agents workspace review run -- npm test
+workspace_id="$(cmux --session agents workspace create --name review --json | jq -r '.value.workspace_id')"
+cmux --session agents workspace "$workspace_id" run -- npm test
 cmux --session agents terminal <terminal-id> screen read`}</CodeBlock>
       <p>{t("automationBody")}</p>
 

--- a/web/app/[locale]/(landing)/docs/tui/page.tsx
+++ b/web/app/[locale]/(landing)/docs/tui/page.tsx
@@ -152,7 +152,8 @@ cmux attach --session agents`}</CodeBlock>
       </DocsHeading>
       <p>{t("automationIntro")}</p>
       <CodeBlock lang="bash">{`cmux --session agents workspace list --json
-cmux --session agents workspace current run -- npm test
+cmux --session agents workspace create --name review
+cmux --session agents workspace review run -- npm test
 cmux --session agents terminal <terminal-id> screen read`}</CodeBlock>
       <p>{t("automationBody")}</p>
 

--- a/web/app/[locale]/(landing)/docs/tui/page.tsx
+++ b/web/app/[locale]/(landing)/docs/tui/page.tsx
@@ -151,9 +151,9 @@ cmux attach --session agents`}</CodeBlock>
         {t("automationTitle")}
       </DocsHeading>
       <p>{t("automationIntro")}</p>
-      <CodeBlock lang="bash">{`cmux --session agents list-workspaces --json
-cmux --session agents run --new-workspace --name review -- npm test
-cmux --session agents read-screen --surface <surface-id>`}</CodeBlock>
+      <CodeBlock lang="bash">{`cmux --session agents workspace list --json
+cmux --session agents workspace current run -- npm test
+cmux --session agents terminal <terminal-id> screen read`}</CodeBlock>
       <p>{t("automationBody")}</p>
 
       <DocsHeading level={2} id="configuration">


### PR DESCRIPTION
## Summary

Replace rejected legacy flat commands in the public cmux-tui guide with the noun-first resource CLI. The examples now use `workspace list`, `workspace current run`, and `terminal <id> screen read`.

## Verification

`git diff --check` passed. This docs-only change needs a Vercel preview check.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10934"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790404208&installation_model_id=21920&pr_number=10934&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10934&signature=cd2ffbe7f4cef70cb951dcb4ed49f645bc7e1451704fba0bf8d77461d6413b73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the cmux TUI docs to use the noun-first resource CLI instead of the rejected legacy flat commands. Examples now show `workspace list`, `workspace create`, `workspace <id> run`, and `terminal <id> screen read`, including running tests in a named workspace.

<sup>Written for commit 04ab7444e49b05dc3d34dc129ff716780b807354. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated TUI automation examples to use the current CLI syntax.
  * Revised workspace listing, command execution, and terminal screen-reading examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->