### PR TITLE
fix(tui): preserve remote reader termination reasons

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/session/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/mod.rs
@@ -447,6 +447,14 @@ pub(crate) struct ClientFocus {
 }
 
 impl Session {
+    /// Returns the first reason recorded when a remote transport reader stops.
+    pub(crate) fn transport_disconnect_reason(&self) -> Option<String> {
+        match self {
+            Session::Local(_) => None,
+            Session::Remote(remote) => remote.transport_disconnect_reason(),
+        }
+    }
+
     /// Best-effort focus report: the client already navigated optimistically,
     /// so failures are ignored and remote sends are never awaited. On the
     /// local path and on a `client-focus-v1` server the report only writes

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3,7 +3,7 @@
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs;
-use std::io::{self, BufRead, BufReader, Write};
+use std::io::{self, BufRead, BufReader, Read, Write};
 use std::net::Shutdown;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -1478,6 +1478,9 @@ struct ExitedSurfaceState {
 
 pub struct RemoteSession {
     interactive_writer: InteractiveWriter,
+    /// The first reason the reader stopped. A clean EOF and a read failure
+    /// are distinct so callers can report transport diagnostics accurately.
+    disconnect_reason: Mutex<Option<String>>,
     pending: Mutex<HashMap<u64, PendingRemoteRequest>>,
     next_id: AtomicU64,
     attach_progress: AtomicU64,
@@ -1659,6 +1662,14 @@ fn read_json_line_with_progress_bounded<R: BufRead>(
     decode_json_line(bytes).map(Some)
 }
 
+fn remote_reader_end_reason(result: &io::Result<Option<String>>) -> Option<String> {
+    match result {
+        Ok(Some(_)) => None,
+        Ok(None) => Some("the daemon closed the connection".to_string()),
+        Err(error) => Some(error.to_string()),
+    }
+}
+
 impl RemoteMessageReader for JsonLineReader {
     fn receive(&mut self) -> io::Result<Option<String>> {
         self.receive_with_progress(&mut |_| {})
@@ -1816,6 +1827,7 @@ impl RemoteSession {
             .map_err(|error| anyhow::anyhow!("cannot start remote interactive writer: {error}"))?;
         let session = Arc::new(RemoteSession {
             interactive_writer,
+            disconnect_reason: Mutex::new(None),
             pending: Mutex::new(HashMap::new()),
             next_id: AtomicU64::new(1),
             attach_progress: AtomicU64::new(0),
@@ -1851,19 +1863,27 @@ impl RemoteSession {
                     session.report_read_progress(partial);
                 }
             };
-            while let Ok(Some(mut message)) = reader.receive_with_progress(&mut report_progress) {
+            let reason = loop {
+                let received = reader.receive_with_progress(&mut report_progress);
+                if let Some(reason) = remote_reader_end_reason(&received) {
+                    break Some(reason);
+                }
+                let Ok(Some(mut message)) = received else { unreachable!("end reason handled") };
                 if message.len() > REMOTE_SESSION_MESSAGE_MAX_BYTES {
-                    break;
+                    break Some(format!(
+                        "remote session message exceeds the \
+                         {REMOTE_SESSION_MESSAGE_MAX_BYTES}-byte limit"
+                    ));
                 }
                 let value = serde_json::from_str::<Value>(&message);
                 zeroize_string(&mut message);
                 let Ok(value) = value else { continue };
-                let Some(session) = reader_session.upgrade() else { break };
+                let Some(session) = reader_session.upgrade() else { break None };
                 session.handle_line(value);
-            }
-            // Connection lost: tell the app to quit.
+            };
+            // Connection lost: retain the reason before telling the app to quit.
             if let Some(session) = reader_session.upgrade() {
-                session.disconnect_transport();
+                session.disconnect_transport_with_reason(reason);
                 session.emit(MuxEvent::Empty);
             }
         })?;
@@ -2843,8 +2863,20 @@ impl RemoteSession {
     }
 
     fn disconnect_transport(&self) {
+        self.disconnect_transport_with_reason(None);
+    }
+
+    fn disconnect_transport_with_reason(&self, reason: Option<String>) {
+        if let Some(reason) = reason {
+            self.disconnect_reason.lock().unwrap().get_or_insert(reason);
+        }
         self.begin_shutdown();
         self.interactive_writer.close();
+    }
+
+    /// Returns the first reason recorded when the remote reader stopped.
+    pub fn transport_disconnect_reason(&self) -> Option<String> {
+        self.disconnect_reason.lock().unwrap().clone()
     }
 
     pub fn set_cell_pixel_size(
@@ -3788,6 +3820,7 @@ fn test_session_with_writer(
 ) -> Arc<RemoteSession> {
     Arc::new(RemoteSession {
         interactive_writer: InteractiveWriter::spawn(writer, Arc::new(NoopTransportAbort)).unwrap(),
+        disconnect_reason: Mutex::new(None),
         pending: Mutex::new(HashMap::new()),
         next_id: AtomicU64::new(1),
         attach_progress: AtomicU64::new(0),
@@ -5028,6 +5061,7 @@ mod tests {
     ) -> Arc<RemoteSession> {
         Arc::new(RemoteSession {
             interactive_writer: InteractiveWriter::spawn(writer, abort).unwrap(),
+            disconnect_reason: Mutex::new(None),
             pending: Mutex::new(HashMap::new()),
             next_id: AtomicU64::new(1),
             attach_progress: AtomicU64::new(0),
@@ -6133,6 +6167,37 @@ mod tests {
     }
 
     #[test]
+    fn remote_reader_end_reason_distinguishes_eof_from_read_failure() {
+        let eof: io::Result<Option<String>> = Ok(None);
+        assert_eq!(
+            remote_reader_end_reason(&eof).as_deref(),
+            Some("the daemon closed the connection")
+        );
+
+        let failure = Err(io::Error::new(io::ErrorKind::ConnectionReset, "peer reset"));
+        assert_eq!(remote_reader_end_reason(&failure).as_deref(), Some("peer reset"));
+
+        let message = Ok(Some("{}".to_string()));
+        assert!(remote_reader_end_reason(&message).is_none());
+    }
+
+    #[test]
+    fn json_reader_preserves_non_eof_read_errors() {
+        struct FailingReader;
+
+        impl Read for FailingReader {
+            fn read(&mut self, _buffer: &mut [u8]) -> io::Result<usize> {
+                Err(io::Error::new(io::ErrorKind::ConnectionReset, "peer reset"))
+            }
+        }
+
+        let mut reader = BufReader::new(FailingReader);
+        let result = read_json_line_with_progress(&mut reader, &mut |_| {});
+        assert_eq!(result.as_ref().unwrap_err().to_string(), "peer reset");
+        assert_eq!(remote_reader_end_reason(&result).as_deref(), Some("peer reset"));
+    }
+
+    #[test]
     fn remote_terminal_dimensions_are_bounded_by_dimension_and_total_cells() {
         assert_eq!(remote_terminal_size(&json!({})), Some((80, 24)));
         assert_eq!(remote_terminal_size(&json!({"cols": 4096, "rows": 256})), Some((4096, 256)));
@@ -6165,6 +6230,21 @@ mod tests {
 
         assert!(session.shutdown.load(Ordering::Acquire));
         assert!(closed.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn transport_disconnect_reason_is_first_writer_wins() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+
+        session.disconnect_transport_with_reason(Some("the daemon closed the connection".into()));
+        session.disconnect_transport_with_reason(Some("peer reset".into()));
+
+        assert_eq!(
+            session.transport_disconnect_reason().as_deref(),
+            Some("the daemon closed the connection")
+        );
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1476,11 +1476,20 @@ struct ExitedSurfaceState {
     handles: HashMap<SurfaceId, Weak<RemoteSurface>>,
 }
 
+#[derive(Default)]
+enum DisconnectState {
+    #[default]
+    Active,
+    LocalShutdown,
+    Remote(String),
+}
+
 pub struct RemoteSession {
     interactive_writer: InteractiveWriter,
-    /// The first reason the reader stopped. A clean EOF and a read failure
-    /// are distinct so callers can report transport diagnostics accurately.
-    disconnect_reason: Mutex<Option<String>>,
+    /// The first terminal state wins. Local shutdown is kept separate from a
+    /// reader failure so closing our own transport does not report a fake
+    /// remote diagnostic.
+    disconnect_state: Mutex<DisconnectState>,
     pending: Mutex<HashMap<u64, PendingRemoteRequest>>,
     next_id: AtomicU64,
     attach_progress: AtomicU64,
@@ -1827,7 +1836,7 @@ impl RemoteSession {
             .map_err(|error| anyhow::anyhow!("cannot start remote interactive writer: {error}"))?;
         let session = Arc::new(RemoteSession {
             interactive_writer,
-            disconnect_reason: Mutex::new(None),
+            disconnect_state: Mutex::new(DisconnectState::default()),
             pending: Mutex::new(HashMap::new()),
             next_id: AtomicU64::new(1),
             attach_progress: AtomicU64::new(0),
@@ -2867,16 +2876,24 @@ impl RemoteSession {
     }
 
     fn disconnect_transport_with_reason(&self, reason: Option<String>) {
-        if let Some(reason) = reason {
-            self.disconnect_reason.lock().unwrap().get_or_insert(reason);
+        let mut state = self.disconnect_state.lock().unwrap();
+        if matches!(&*state, DisconnectState::Active) {
+            *state = match reason {
+                Some(reason) => DisconnectState::Remote(reason),
+                None => DisconnectState::LocalShutdown,
+            };
         }
+        drop(state);
         self.begin_shutdown();
         self.interactive_writer.close();
     }
 
     /// Returns the first reason recorded when the remote reader stopped.
     pub fn transport_disconnect_reason(&self) -> Option<String> {
-        self.disconnect_reason.lock().unwrap().clone()
+        match &*self.disconnect_state.lock().unwrap() {
+            DisconnectState::Remote(reason) => Some(reason.clone()),
+            DisconnectState::Active | DisconnectState::LocalShutdown => None,
+        }
     }
 
     pub fn set_cell_pixel_size(
@@ -3820,7 +3837,7 @@ fn test_session_with_writer(
 ) -> Arc<RemoteSession> {
     Arc::new(RemoteSession {
         interactive_writer: InteractiveWriter::spawn(writer, Arc::new(NoopTransportAbort)).unwrap(),
-        disconnect_reason: Mutex::new(None),
+        disconnect_state: Mutex::new(DisconnectState::default()),
         pending: Mutex::new(HashMap::new()),
         next_id: AtomicU64::new(1),
         attach_progress: AtomicU64::new(0),
@@ -5061,7 +5078,7 @@ mod tests {
     ) -> Arc<RemoteSession> {
         Arc::new(RemoteSession {
             interactive_writer: InteractiveWriter::spawn(writer, abort).unwrap(),
-            disconnect_reason: Mutex::new(None),
+            disconnect_state: Mutex::new(DisconnectState::default()),
             pending: Mutex::new(HashMap::new()),
             next_id: AtomicU64::new(1),
             attach_progress: AtomicU64::new(0),
@@ -6245,6 +6262,18 @@ mod tests {
             session.transport_disconnect_reason().as_deref(),
             Some("the daemon closed the connection")
         );
+    }
+
+    #[test]
+    fn local_shutdown_does_not_preserve_reader_error() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+
+        session.disconnect_transport();
+        session.disconnect_transport_with_reason(Some("peer reset".into()));
+
+        assert_eq!(session.transport_disconnect_reason(), None);
     }
 
     #[test]


### PR DESCRIPTION
The remote JSON-lines reader used `while let Ok(Some(...))`, so clean EOF and read failures both fell through to the same generic disconnect path. This records the first termination reason, keeps EOF distinct from read errors, and exposes it through `Session` without changing the wire protocol.

Tests cover clean EOF, non-EOF read failure, successful messages, and first-writer-wins reason retention. Verification is limited to direct rustfmt and `git diff --check`; local cargo/rustc runs are intentionally skipped.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10937"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790404963&installation_model_id=21920&pr_number=10937&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10937&signature=fafe92265a778df43f25593102a576251514416ed78b03520930b61b5be67793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records the first reason a remote transport reader stops, so clean EOF and read failures are no longer reported as the same generic disconnect. The reason is exposed via `Session::transport_disconnect_reason()` without changing the wire protocol.

**Details**
- Messages exceeding the size limit now record that reason instead of ending silently.
- The first recorded reason wins, and later termination causes don't overwrite it.
- Local shutdown is tracked separately, so closing our own transport never surfaces a remote diagnostic.

<sup>Written for commit da0239d03a3398556c496cffeb9ee393aff7ffaa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote session disconnection reporting by distinguishing clean disconnects from transport read failures.
  * Preserved detailed diagnostics for oversized messages and other transport errors.
  * Ensured the first detected disconnection reason is retained for accurate troubleshooting.
  * Local sessions continue to report no remote transport disconnect reason.

* **Tests**
  * Added coverage for clean disconnects, read failures, error propagation, and first-reason-wins behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->