### PR TITLE
cmux-tui: align relay upload line limit with Unix ingress

### DIFF
--- a/cmux-tui/crates/cmux-remote-protocol/src/lib.rs
+++ b/cmux-tui/crates/cmux-remote-protocol/src/lib.rs
@@ -36,3 +36,9 @@ pub use rpc::{
 /// Maximum serialized server-to-client message accepted by remote session
 /// transports. Render attach and VT replay responses share this budget.
 pub const REMOTE_SESSION_MESSAGE_MAX_BYTES: usize = 32 * 1024 * 1024;
+
+/// Maximum serialized client-to-server JSON message accepted by Unix
+/// JSON-lines and relay mux transports. The line delimiter is not included.
+/// Keep this separate from [`REMOTE_SESSION_MESSAGE_MAX_BYTES`], because
+/// render attach responses need the larger server-to-client budget.
+pub const REMOTE_CLIENT_MESSAGE_MAX_BYTES: usize = 16 * 1024 * 1024;

--- a/cmux-tui/crates/cmux-remote/src/bridge.rs
+++ b/cmux-tui/crates/cmux-remote/src/bridge.rs
@@ -8,7 +8,7 @@ use cmux_remote_protocol::{MUX_INPUT_V1_FEATURE, RouteId, Service, ServiceContro
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::{Semaphore, oneshot};
 
-use crate::mux_codec::{MAX_MUX_DOWNLOAD_LINE_BYTES, MAX_MUX_LINE_BYTES};
+use crate::mux_codec::{MAX_MUX_DOWNLOAD_LINE_BYTES, MAX_MUX_LINE_BYTES, mux_line_payload_len};
 use crate::service::{ServiceError, ServiceMultiplexer, ServiceStream};
 use crate::services::ServicesError;
 
@@ -320,7 +320,7 @@ where
                     remote.close().await?;
                     break;
                 }
-                if line.len() > MAX_MUX_LINE_BYTES {
+                if mux_line_payload_len(&line) > MAX_MUX_LINE_BYTES.saturating_sub(1) {
                     return Err(BridgeError::MuxLineTooLarge(line.len()));
                 }
                 if mux_input_v1 && let Some(input) = crate::mux_input::encode_local_line(&line)? {

--- a/cmux-tui/crates/cmux-remote/src/bridge.rs
+++ b/cmux-tui/crates/cmux-remote/src/bridge.rs
@@ -8,7 +8,7 @@ use cmux_remote_protocol::{MUX_INPUT_V1_FEATURE, RouteId, Service, ServiceContro
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::{Semaphore, oneshot};
 
-use crate::mux_codec::MAX_MUX_LINE_BYTES;
+use crate::mux_codec::{MAX_MUX_DOWNLOAD_LINE_BYTES, MAX_MUX_LINE_BYTES};
 use crate::service::{ServiceError, ServiceMultiplexer, ServiceStream};
 use crate::services::ServicesError;
 
@@ -337,8 +337,9 @@ where
         }
     };
     let download = async move {
-        let mut assembler =
-            crate::mux_codec::MuxLineAssembler::<Option<crate::service::StreamBudget>>::default();
+        let mut assembler = crate::mux_codec::MuxLineAssembler::<
+            Option<crate::service::StreamBudget>,
+        >::with_maximum(MAX_MUX_DOWNLOAD_LINE_BYTES);
         loop {
             let chunk = if let Some(chunk) = initial.pop_front() {
                 Some(chunk)

--- a/cmux-tui/crates/cmux-remote/src/mux_codec.rs
+++ b/cmux-tui/crates/cmux-remote/src/mux_codec.rs
@@ -34,7 +34,7 @@ where
     read_bounded_line_with_limit(reader, line, MAX_MUX_UPLOAD_LINE_BYTES).await
 }
 
-async fn read_bounded_line_with_limit<R>(
+pub(crate) async fn read_bounded_line_with_limit<R>(
     reader: &mut R,
     line: &mut Vec<u8>,
     maximum: usize,
@@ -266,11 +266,39 @@ mod tests {
     }
 
     #[test]
-    fn relay_line_limit_rejects_oversized_input_before_packet_allocation() {
+    fn relay_line_limit_rejects_eof_line_one_byte_over_payload_limit() {
         let line = vec![b'x'; REMOTE_CLIENT_MESSAGE_MAX_BYTES + 1];
         assert!(matches!(
             encode_line(1, &line),
             Err(MuxCodecError::LineTooLarge(size)) if size == REMOTE_CLIENT_MESSAGE_MAX_BYTES + 1
+        ));
+    }
+
+    #[test]
+    fn relay_download_accepts_a_line_above_the_upload_limit() {
+        let line = vec![b'x'; REMOTE_CLIENT_MESSAGE_MAX_BYTES + 1];
+        let packets =
+            encode_line_with_limit(1, &line, MAX_MUX_DOWNLOAD_LINE_BYTES).expect("egress line");
+        let mut assembler = MuxLineAssembler::with_maximum(MAX_MUX_DOWNLOAD_LINE_BYTES);
+        let mut assembled = None;
+        for packet in packets {
+            assembled = assembler.push(Lane::Bulk, packet).unwrap().or(assembled);
+        }
+        assert_eq!(assembled.expect("complete egress line").1, line.as_slice());
+    }
+
+    #[test]
+    fn relay_upload_assembler_rejects_an_eof_line_over_its_payload_limit() {
+        let line = b"12345";
+        let packets = encode_line_with_limit(1, line, 6).expect("test egress line");
+        let mut assembler = MuxLineAssembler::with_maximum(5);
+        let mut result = None;
+        for packet in packets {
+            result = Some(assembler.push(Lane::Bulk, packet));
+        }
+        assert!(matches!(
+            result,
+            Some(Err(MuxCodecError::LineTooLarge(size))) if size == line.len()
         ));
     }
 

--- a/cmux-tui/crates/cmux-remote/src/mux_codec.rs
+++ b/cmux-tui/crates/cmux-remote/src/mux_codec.rs
@@ -3,22 +3,28 @@ use std::fmt;
 use std::io;
 
 use bytes::{BufMut, Bytes, BytesMut};
-use cmux_remote_protocol::{Lane, MAX_FRAME_PAYLOAD, REMOTE_SESSION_MESSAGE_MAX_BYTES};
+use cmux_remote_protocol::{
+    Lane, MAX_FRAME_PAYLOAD, REMOTE_CLIENT_MESSAGE_MAX_BYTES, REMOTE_SESSION_MESSAGE_MAX_BYTES,
+};
 use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncReadExt};
 
 const MAGIC: [u8; 4] = *b"CMXL";
 const HEADER_BYTES: usize = 4 + 8 + 4 + 4;
 const CHUNK_BYTES: usize = MAX_FRAME_PAYLOAD - HEADER_BYTES;
 // The local mux transport appends a newline after each serialized message.
-pub(crate) const MAX_MUX_LINE_BYTES: usize = REMOTE_SESSION_MESSAGE_MAX_BYTES + 1;
+// Keep the delimiter outside each directional payload budget. The shorter
+// alias is retained for upload callers and existing tests.
+pub(crate) const MAX_MUX_UPLOAD_LINE_BYTES: usize = REMOTE_CLIENT_MESSAGE_MAX_BYTES + 1;
+pub(crate) const MAX_MUX_DOWNLOAD_LINE_BYTES: usize = REMOTE_SESSION_MESSAGE_MAX_BYTES + 1;
+pub(crate) const MAX_MUX_LINE_BYTES: usize = MAX_MUX_UPLOAD_LINE_BYTES;
 const MAX_IN_FLIGHT_LINES: usize = 256;
-const MAX_IN_FLIGHT_BYTES: usize = MAX_MUX_LINE_BYTES * 2;
+const MAX_IN_FLIGHT_BYTES: usize = MAX_MUX_DOWNLOAD_LINE_BYTES * 2;
 
 pub(crate) async fn read_bounded_line<R>(reader: &mut R, line: &mut Vec<u8>) -> io::Result<usize>
 where
     R: AsyncBufRead + Unpin,
 {
-    read_bounded_line_with_limit(reader, line, MAX_MUX_LINE_BYTES).await
+    read_bounded_line_with_limit(reader, line, MAX_MUX_UPLOAD_LINE_BYTES).await
 }
 
 async fn read_bounded_line_with_limit<R>(
@@ -37,7 +43,15 @@ where
 }
 
 pub(crate) fn encode_line(message: u64, line: &[u8]) -> Result<Vec<Bytes>, MuxCodecError> {
-    if line.len() > MAX_MUX_LINE_BYTES {
+    encode_line_with_limit(message, line, MAX_MUX_UPLOAD_LINE_BYTES)
+}
+
+pub(crate) fn encode_line_with_limit(
+    message: u64,
+    line: &[u8],
+    maximum: usize,
+) -> Result<Vec<Bytes>, MuxCodecError> {
+    if line.len() > maximum {
         return Err(MuxCodecError::LineTooLarge(line.len()));
     }
     let parts = line.len().max(1).div_ceil(CHUNK_BYTES);
@@ -63,10 +77,22 @@ fn encode_part(message: u64, part: u32, parts: u32, payload: &[u8]) -> Bytes {
     encoded.freeze()
 }
 
-#[derive(Default)]
 pub(crate) struct MuxLineAssembler<R = ()> {
     lines: HashMap<u64, PartialLine<R>>,
     bytes: usize,
+    maximum: usize,
+}
+
+impl<R> Default for MuxLineAssembler<R> {
+    fn default() -> Self {
+        Self::with_maximum(MAX_MUX_DOWNLOAD_LINE_BYTES)
+    }
+}
+
+impl<R> MuxLineAssembler<R> {
+    pub(crate) fn with_maximum(maximum: usize) -> Self {
+        Self { lines: HashMap::new(), bytes: 0, maximum }
+    }
 }
 
 struct PartialLine<R> {
@@ -117,8 +143,7 @@ impl<R> MuxLineAssembler<R> {
         let message = u64::from_be_bytes(packet[4..12].try_into().unwrap());
         let part = u32::from_be_bytes(packet[12..16].try_into().unwrap());
         let parts = u32::from_be_bytes(packet[16..20].try_into().unwrap());
-        if parts == 0 || part >= parts || parts as usize > MAX_MUX_LINE_BYTES.div_ceil(CHUNK_BYTES)
-        {
+        if parts == 0 || part >= parts || parts as usize > self.maximum.div_ceil(CHUNK_BYTES) {
             return Err(MuxCodecError::InvalidPacket);
         }
         if !self.lines.contains_key(&message) {
@@ -144,7 +169,7 @@ impl<R> MuxLineAssembler<R> {
             return Err(MuxCodecError::InvalidPacket);
         }
         let payload = packet.slice(HEADER_BYTES..);
-        if line.bytes.saturating_add(payload.len()) > MAX_MUX_LINE_BYTES
+        if line.bytes.saturating_add(payload.len()) > self.maximum
             || self.bytes.saturating_add(payload.len()) > MAX_IN_FLIGHT_BYTES
         {
             return Err(MuxCodecError::LineTooLarge(line.bytes.saturating_add(payload.len())));
@@ -223,5 +248,35 @@ mod tests {
             complete = assembler.push(Lane::Bulk, part).unwrap().or(complete);
         }
         assert_eq!(complete.unwrap().1, large);
+    }
+
+    #[test]
+    fn relay_line_limit_accepts_the_unix_payload_maximum() {
+        let line = vec![b'x'; MAX_MUX_LINE_BYTES];
+        let packets = encode_line(1, &line).expect("the supported maximum must be encodable");
+        assert!(!packets.is_empty());
+    }
+
+    #[test]
+    fn relay_line_limit_rejects_oversized_input_before_packet_allocation() {
+        let line = vec![b'x'; MAX_MUX_LINE_BYTES + 1];
+        assert!(matches!(
+            encode_line(1, &line),
+            Err(MuxCodecError::LineTooLarge(size)) if size == MAX_MUX_LINE_BYTES + 1
+        ));
+    }
+
+    #[test]
+    fn relay_download_limit_keeps_server_egress_budget() {
+        assert_eq!(MAX_MUX_DOWNLOAD_LINE_BYTES - 1, REMOTE_SESSION_MESSAGE_MAX_BYTES);
+        assert!(MAX_MUX_DOWNLOAD_LINE_BYTES > MAX_MUX_UPLOAD_LINE_BYTES);
+        let line = vec![b'x'; 32];
+        let packets = encode_line_with_limit(1, &line, MAX_MUX_DOWNLOAD_LINE_BYTES).unwrap();
+        let mut assembler = MuxLineAssembler::with_maximum(MAX_MUX_DOWNLOAD_LINE_BYTES);
+        let mut assembled = None;
+        for packet in packets {
+            assembled = assembler.push(Lane::Bulk, packet).unwrap().or(assembled);
+        }
+        assert_eq!(assembled.unwrap().1, line);
     }
 }

--- a/cmux-tui/crates/cmux-remote/src/mux_codec.rs
+++ b/cmux-tui/crates/cmux-remote/src/mux_codec.rs
@@ -20,6 +20,13 @@ pub(crate) const MAX_MUX_LINE_BYTES: usize = MAX_MUX_UPLOAD_LINE_BYTES;
 const MAX_IN_FLIGHT_LINES: usize = 256;
 const MAX_IN_FLIGHT_BYTES: usize = MAX_MUX_DOWNLOAD_LINE_BYTES * 2;
 
+/// Return the serialized payload size for one JSONL message. A trailing LF is
+/// framing and is not part of the directional payload budget. EOF-terminated
+/// lines are valid on the relay path, so they must be measured as-is.
+pub(crate) fn mux_line_payload_len(line: &[u8]) -> usize {
+    line.strip_suffix(b"\n").map_or(line.len(), |payload| payload.len())
+}
+
 pub(crate) async fn read_bounded_line<R>(reader: &mut R, line: &mut Vec<u8>) -> io::Result<usize>
 where
     R: AsyncBufRead + Unpin,
@@ -51,7 +58,7 @@ pub(crate) fn encode_line_with_limit(
     line: &[u8],
     maximum: usize,
 ) -> Result<Vec<Bytes>, MuxCodecError> {
-    if line.len() > maximum {
+    if mux_line_payload_len(line) > maximum.saturating_sub(1) {
         return Err(MuxCodecError::LineTooLarge(line.len()));
     }
     let parts = line.len().max(1).div_ceil(CHUNK_BYTES);
@@ -188,11 +195,11 @@ impl<R> MuxLineAssembler<R> {
         for part in line.parts {
             joined.extend_from_slice(&part.expect("all parts received"));
         }
-        Ok(Some(AssembledMuxLine {
-            lane: line.lane,
-            payload: joined.freeze(),
-            _retained: line.retained,
-        }))
+        let payload = joined.freeze();
+        if mux_line_payload_len(&payload) > self.maximum.saturating_sub(1) {
+            return Err(MuxCodecError::LineTooLarge(payload.len()));
+        }
+        Ok(Some(AssembledMuxLine { lane: line.lane, payload, _retained: line.retained }))
     }
 }
 
@@ -252,17 +259,18 @@ mod tests {
 
     #[test]
     fn relay_line_limit_accepts_the_unix_payload_maximum() {
-        let line = vec![b'x'; MAX_MUX_LINE_BYTES];
+        let mut line = vec![b'x'; REMOTE_CLIENT_MESSAGE_MAX_BYTES];
+        line.push(b'\n');
         let packets = encode_line(1, &line).expect("the supported maximum must be encodable");
         assert!(!packets.is_empty());
     }
 
     #[test]
     fn relay_line_limit_rejects_oversized_input_before_packet_allocation() {
-        let line = vec![b'x'; MAX_MUX_LINE_BYTES + 1];
+        let line = vec![b'x'; REMOTE_CLIENT_MESSAGE_MAX_BYTES + 1];
         assert!(matches!(
             encode_line(1, &line),
-            Err(MuxCodecError::LineTooLarge(size)) if size == MAX_MUX_LINE_BYTES + 1
+            Err(MuxCodecError::LineTooLarge(size)) if size == REMOTE_CLIENT_MESSAGE_MAX_BYTES + 1
         ));
     }
 

--- a/cmux-tui/crates/cmux-remote/src/services.rs
+++ b/cmux-tui/crates/cmux-remote/src/services.rs
@@ -1307,12 +1307,17 @@ where
     let mut line = Vec::new();
     let mut message = 1_u64;
     loop {
-        let size = crate::mux_codec::read_bounded_line(&mut reader, &mut line).await?;
+        let size = crate::mux_codec::read_bounded_line_with_limit(
+            &mut reader,
+            &mut line,
+            crate::mux_codec::MAX_MUX_DOWNLOAD_LINE_BYTES,
+        )
+        .await?;
         if size == 0 {
             return Ok(());
         }
         if crate::mux_codec::mux_line_payload_len(&line)
-            > crate::mux_codec::MAX_MUX_LINE_BYTES.saturating_sub(1)
+            > crate::mux_codec::MAX_MUX_DOWNLOAD_LINE_BYTES.saturating_sub(1)
         {
             return Err(crate::mux_codec::MuxCodecError::LineTooLarge(line.len()).into());
         }
@@ -1325,7 +1330,11 @@ where
                 actual: Lane::Tunnel,
             });
         }
-        let packets = crate::mux_codec::encode_line(message, &line)?;
+        let packets = crate::mux_codec::encode_line_with_limit(
+            message,
+            &line,
+            crate::mux_codec::MAX_MUX_DOWNLOAD_LINE_BYTES,
+        )?;
         let encoded_bytes =
             packets.iter().try_fold(0_usize, |total, packet| total.checked_add(packet.len()));
         let Some(encoded_bytes) = encoded_bytes else {
@@ -1414,7 +1423,7 @@ where
     let download = async move {
         let mut assembler =
             crate::mux_codec::MuxLineAssembler::<Option<StreamBudget>>::with_maximum(
-                crate::mux_codec::MAX_MUX_DOWNLOAD_LINE_BYTES,
+                crate::mux_codec::MAX_MUX_UPLOAD_LINE_BYTES,
             );
         while let Some(mut chunk) = remote.receive().await? {
             if !chunk.payload.is_empty() {

--- a/cmux-tui/crates/cmux-remote/src/services.rs
+++ b/cmux-tui/crates/cmux-remote/src/services.rs
@@ -1311,7 +1311,9 @@ where
         if size == 0 {
             return Ok(());
         }
-        if line.len() > crate::mux_codec::MAX_MUX_LINE_BYTES {
+        if crate::mux_codec::mux_line_payload_len(&line)
+            > crate::mux_codec::MAX_MUX_LINE_BYTES.saturating_sub(1)
+        {
             return Err(crate::mux_codec::MuxCodecError::LineTooLarge(line.len()).into());
         }
         let Some(lane) = tracker.classify_server_line(&line) else {

--- a/cmux-tui/crates/cmux-remote/src/services.rs
+++ b/cmux-tui/crates/cmux-remote/src/services.rs
@@ -1410,7 +1410,10 @@ where
         }
     };
     let download = async move {
-        let mut assembler = crate::mux_codec::MuxLineAssembler::<Option<StreamBudget>>::default();
+        let mut assembler =
+            crate::mux_codec::MuxLineAssembler::<Option<StreamBudget>>::with_maximum(
+                crate::mux_codec::MAX_MUX_DOWNLOAD_LINE_BYTES,
+            );
         while let Some(mut chunk) = remote.receive().await? {
             if !chunk.payload.is_empty() {
                 if let Some(input) = crate::mux_input::decode_packet(&chunk.payload)? {

--- a/cmux-tui/crates/cmux-tui-core/src/lib.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/lib.rs
@@ -89,7 +89,7 @@ pub use workspace_registry::{
     SessionJournalRecord, UnsupportedWorkspaceRegistrySchema, WorkspaceMutation, WorkspaceRegistry,
 };
 
-pub use cmux_remote_protocol::REMOTE_SESSION_MESSAGE_MAX_BYTES;
+pub use cmux_remote_protocol::{REMOTE_CLIENT_MESSAGE_MAX_BYTES, REMOTE_SESSION_MESSAGE_MAX_BYTES};
 pub use cmux_tui_cdp::BrowserMode;
 pub use ghostty_vt::{CursorShape, Rgb};
 

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -82,7 +82,7 @@ use crate::{
 
 pub const ATTACH_INITIAL_SIZE_CAPABILITY: &str = "attach-initial-size";
 /// Maximum JSON payload accepted on the Unix JSON-lines control socket.
-const MAX_JSON_LINE_BYTES: usize = 16 * 1024 * 1024;
+const MAX_JSON_LINE_BYTES: usize = crate::REMOTE_CLIENT_MESSAGE_MAX_BYTES;
 const WORKSPACE_REGISTRY_CAPABILITY: &str = "workspace-registry-v1";
 pub const GUARDED_BROWSER_POINTER_CAPABILITY: &str = "browser-pointer-frame-guard-v1";
 pub const DAEMON_HANDOFF_FORCE_CAPABILITY: &str = "daemon-handoff-force-v1";

--- a/cmux-tui/spec/transports.md
+++ b/cmux-tui/spec/transports.md
@@ -141,11 +141,15 @@ The Unix socket does not use the WebSocket auth preamble. Its filesystem permiss
 
 `CMUX_TUI_SOCKET` and `CMUX_MUX_SOCKET` inherited by a child are ambient full-session capabilities. Untrusted child processes must not inherit them.
 
-### Implemented v10 limits
+### Implemented transport message limits
 
-WebSocket protocol messages are limited to 4 MiB. Unix JSON-lines readers and relay readers currently have no equivalent application limit and may buffer an unterminated line. SDK readers also differ. This is a v10 security limitation, not permission to send unbounded messages.
-
-vNext applies a 4,194,304-byte client-to-server UTF-8 message limit on every transport and a 16,777,216-byte server-to-client limit. The JSON-lines delimiter is excluded. A receiver closes on an oversized message or invalid UTF-8. WebSocket limits apply after reassembly, and an oversized WebSocket closes with code `1009`.
+WebSocket messages are limited to 4 MiB on inbound connections. Unix
+JSON-lines and relay mux uploads accept at most 16,777,216 UTF-8 payload bytes;
+the JSON-lines delimiter is excluded. Relay framing may split a line across
+carrier frames, but it does not raise this Unix ingress limit. Server-to-client
+remote session messages, including render attach and VT replay responses, may
+use the separate 33,554,432-byte budget. Receivers reject an oversized message
+before decoding or allocating its payload.
 
 ## Relay Stdio
 


### PR DESCRIPTION
## Summary
- define separate 16 MiB client-ingress and 32 MiB server-egress remote message budgets
- enforce the client budget in relay mux line framing and Unix JSON-line handling
- add exact-limit and oversized-before-packet-allocation codec contracts
- document directional limits and relay framing behavior

## Checks
- `git diff --check`
- `rustfmt --edition 2024 --check` on changed Rust files
- Cargo, rustc, and tests not run per task constraint

## Residual risk
Hosted Rust tests are still required. Clients that attempted 16-32 MiB Unix-bound lines now fail in the relay before transmission, matching the Unix server rejection.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10939"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790405168&installation_model_id=21920&pr_number=10939&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10939&signature=d3f3794c176aac06e1b84a59e6c7fe6c8dd72b36ac35969a16eb1e91ff5e60e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the relay mux upload line limit with the Unix JSON-lines 16 MiB ingress so oversized client messages fail at the relay before reaching the Unix server. Previously the relay allowed 32 MiB lines, matching the server-to-client budget.

- Defines a separate `REMOTE_CLIENT_MESSAGE_MAX_BYTES` (16 MiB) constant used by relay line framing and Unix JSON-lines handling; server-to-client responses keep the 32 MiB budget.
- Enforces the 16 MiB budget before packet allocation and again on the reassembled line, treating the trailing LF as framing.
- Adds codec tests for the exact limit, oversized rejection, and download egress.
- Documents the directional limits in the transport spec.

<sup>Written for commit 63805ab765f88419b5c87a63068c79e05948506e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added distinct size limits for incoming client messages and outgoing session messages.
  - Relay transfers now support separate upload and download budgets, including large payloads split across frames.
  - Oversized messages are rejected before decoding or allocation.

- **Documentation**
  - Updated transport documentation with implemented WebSocket, Unix socket, relay, and session message limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->