### PR TITLE
fix(tui): accept unknown remote capabilities

### DIFF
--- a/cmux-tui/crates/cmux-remote-protocol/src/rpc.rs
+++ b/cmux-tui/crates/cmux-remote-protocol/src/rpc.rs
@@ -1203,6 +1203,34 @@ mod tests {
     }
 
     #[test]
+    fn remote_capabilities_round_trip_known_and_unknown_wire_values() {
+        let known: RemoteCapability =
+            serde_json::from_value(serde_json::json!("process-catalog-v1")).unwrap();
+        assert_eq!(known, RemoteCapability::ProcessCatalogV1);
+        assert_eq!(serde_json::to_value(known).unwrap(), "process-catalog-v1");
+
+        let unknown_wire_value = "workspace-files-v99";
+        let unknown: RemoteCapability =
+            serde_json::from_value(serde_json::json!(unknown_wire_value)).unwrap();
+        assert_eq!(unknown, RemoteCapability::Unknown(unknown_wire_value.to_owned()));
+        assert_eq!(serde_json::to_value(unknown).unwrap(), unknown_wire_value);
+
+        let response: WorkspaceResponse = serde_json::from_value(serde_json::json!({
+            "type": "capabilities",
+            "capabilities": ["process-catalog-v1", unknown_wire_value]
+        }))
+        .unwrap();
+        assert!(matches!(
+            response,
+            WorkspaceResponse::Capabilities { capabilities }
+                if capabilities == vec![
+                    RemoteCapability::ProcessCatalogV1,
+                    RemoteCapability::Unknown(unknown_wire_value.to_owned())
+                ]
+        ));
+    }
+
+    #[test]
     fn request_ids_are_uuid_json_strings() {
         const ENCODED: &str = "\"018f47a2-17d6-4c16-a8b1-7b3d5d998271\"";
         let request: RequestId =

--- a/cmux-tui/crates/cmux-remote-protocol/src/rpc.rs
+++ b/cmux-tui/crates/cmux-remote-protocol/src/rpc.rs
@@ -128,7 +128,7 @@ pub enum ServiceControl {
     Rejected { code: String, message: String },
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum RemoteCapability {
     MuxControlV9,
@@ -151,6 +151,13 @@ pub enum RemoteCapability {
     ProcessTerminalSnapshotV1,
     RequestControlV1,
     ComputerUseV1,
+    /// A capability introduced by a newer peer.
+    ///
+    /// Capabilities are versioned wire strings, so clients must be able to
+    /// retain values they do not understand yet instead of rejecting the
+    /// complete capabilities response.
+    #[serde(untagged)]
+    Unknown(String),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
Remote capability names are extensible strings, but the protocol enum rejected values introduced by newer peers. Add an untagged `Unknown(String)` fallback so known kebab-case names keep their wire values and unknown names deserialize and round-trip without rejecting the response.

Tests: hosted cmux-tui verification (Linux and macOS), including `remote_capabilities_round_trip_known_and_unknown_wire_values`; local rustfmt and diff checks passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10941"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790405468&installation_model_id=21920&pr_number=10941&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10941&signature=9d15d27a3922bfc90aedf9516dd1cf337af50a79e520bb1a175fe7ef5c7edcba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the TUI remote protocol so unknown capability names from newer peers no longer cause the capabilities response to be rejected.

Remote capability names are versioned wire strings, so `RemoteCapability` now includes an untagged `Unknown(String)` fallback. Known kebab-case names keep their wire values, and unknown names deserialize and round-trip without error.

<sup>Written for commit 122a4ff210c50dea21e12846c276849047b16357. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with unrecognized remote capability values.
  * Capability responses now preserve unknown values instead of rejecting them.
  * Added support for correctly handling both known and unknown capabilities in workspace responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->