### PR TITLE
irx: register before minting on cached-state launches (mint proof race wedges cold launches)

### DIFF
--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrxRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrxRuntimeComposition.swift
@@ -158,11 +158,17 @@ public actor MobileIrxRuntimeComposition {
         // background at launch, never on the dial path.
         provisioningTask?.cancel()
         provisioningTask = Task { [weak self] in
+            // Capped exponential backoff: a persistent broker-side failure
+            // must degrade to a gentle poll, never a 2s hammer (each failed
+            // attempt can hit registration, and registration writes bump the
+            // account route revision fleet-wide).
+            var delay: Duration = .seconds(2)
             while !Task.isCancelled {
                 if await self?.provisionIfPossible() == true {
                     return
                 }
-                try? await Task.sleep(for: .seconds(2))
+                try? await Task.sleep(for: delay)
+                delay = min(delay * 2, .seconds(30))
             }
         }
     }
@@ -273,13 +279,26 @@ public actor MobileIrxRuntimeComposition {
         // during provisioning so the first dial never pays for it.
         let cachedBinding = await broker.cachedBinding()
         let cachedTrust = await broker.cachedTrust()
+        let cachedCredentials = await broker.cachedRelayCredentials()
         if cachedBinding == nil || cachedTrust == nil {
             // First run for this identity: the full serial path, correctness
             // over speed (registration must precede mint/discovery).
             _ = try await broker.register(pairingEnabled: false, relayURLHint: nil)
             _ = try await pilot.usableCredentials()
             _ = try? await broker.discover()
+        } else if cachedCredentials.isEmpty {
+            // Cached identity but stale relay passes: the mint below MUST
+            // follow a registration on THIS client instance. register() arms
+            // the client's per-request binding proof, and the broker's mint
+            // policy rejects proofless non-legacy mints; a mint racing a
+            // background register 403s (`binding_request_proof_required`)
+            // and wedges provisioning in a retry loop.
+            _ = try await broker.register(pairingEnabled: false, relayURLHint: nil)
+            Task { _ = try? await broker.discover() }
         } else {
+            // Fresh passes on disk: nothing needs the broker before dialing,
+            // so registration + discovery refresh entirely in the background
+            // (the true zero-RTT launch).
             Task {
                 _ = try? await broker.register(pairingEnabled: false, relayURLHint: nil)
                 _ = try? await broker.discover()


### PR DESCRIPTION
Every irx cold launch with stale relay passes (older than the 5-minute TTL, i.e. any launch after minutes away) currently wedges against backends with the hardened mint policy: the launch fast path from https://github.com/manaflow-ai/cmux/pull/10889 runs registration in the background, the mint for fresh passes races ahead of it prooflessly (the trust-broker client only attaches its per-request Ed25519 binding proof after register() arms that client instance), the mint 403s with binding_request_proof_required, and provisioning falls into a 2-second retry loop where every attempt re-registers, bumping the account route revision fleet-wide (observed: +60 revisions in one minute on staging).

Fix, journal-verified on a simulator against staging: launches with fresh cached passes keep the fully-background zero-RTT path (no mint happens, no race exists); launches with stale passes register serially first (~300-600ms) so the mint always carries proof; the provisioning retry loop backs off 2s to 30s so a persistent broker failure degrades to a gentle poll instead of a registration storm.

First run was already serial and stays unchanged. Long-lived processes were never affected (their client is already armed). This should land before the next INTERNAL/nightly cut, since every dev and nightly cold launch hits the broken path.

Related: https://github.com/manaflow-ai/cmux/pull/10930 (mint stale-connection retry), https://github.com/manaflow-ai/cmux/issues/10924.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a cold-start race where stale relay passes caused provisioning to wedge in a retry loop. Previously, the mint raced ahead of registration, got a `binding_request_proof_required` 403, and every retry re-registered (bumping account route revisions fleet-wide). Now, stale passes register serially before minting, fresh passes keep the fully-background path, and the retry loop backs off from 2s to 30s.

<sup>Written for commit d04c1d859b7b174aaf6a8c98d1fca2766814b9d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved background provisioning reliability with progressively spaced retry attempts, reducing unnecessary repeated requests.
  * Enhanced recovery when saved connection credentials are incomplete by securely refreshing required access information before continuing setup.
  * Preserved the existing first-time setup flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->