### PR TITLE
browser: keep local file URLs available with URL allowlists

### DIFF
--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/BrowserCatalogSection.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/BrowserCatalogSection.swift
@@ -92,9 +92,10 @@ public struct BrowserCatalogSection: SettingCatalogSection {
     /// User/team URL restrictions for every remote embedded-browser navigation.
     /// One host or URL pattern per line; Settings shows loopback development
     /// entries as a suggested starting list. Local absolute `file:` documents
-    /// remain available while this web-origin restriction is active. The
-    /// restriction becomes active when a custom value is saved, unless the MDM
-    /// key ``BrowserURLAllowlistPolicy/managedDefaultsKey`` is forced.
+    /// opened through cmux's trusted app-owned navigation path remain available
+    /// while this web-origin restriction is active. The restriction becomes
+    /// active when a custom value is saved, unless the MDM key
+    /// ``BrowserURLAllowlistPolicy/managedDefaultsKey`` is forced.
     public let urlAllowlist = DefaultsKey<String>(
         id: "browser.urlAllowlist",
         defaultValue: BrowserURLAllowlistPolicy.defaultAllowlistText,

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/BrowserCatalogSection.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/BrowserCatalogSection.swift
@@ -89,11 +89,12 @@ public struct BrowserCatalogSection: SettingCatalogSection {
         userDefaultsKey: "browserInsecureHTTPAllowlist"
     )
 
-    /// User/team URL restrictions for every embedded-browser navigation. One
-    /// host or URL pattern per line; Settings shows loopback development
-    /// entries as a suggested starting list. The restriction becomes active
-    /// when a custom value is saved, unless the MDM key
-    /// ``BrowserURLAllowlistPolicy/managedDefaultsKey`` is forced.
+    /// User/team URL restrictions for every remote embedded-browser navigation.
+    /// One host or URL pattern per line; Settings shows loopback development
+    /// entries as a suggested starting list. Local absolute `file:` documents
+    /// remain available while this web-origin restriction is active. The
+    /// restriction becomes active when a custom value is saved, unless the MDM
+    /// key ``BrowserURLAllowlistPolicy/managedDefaultsKey`` is forced.
     public let urlAllowlist = DefaultsKey<String>(
         id: "browser.urlAllowlist",
         defaultValue: BrowserURLAllowlistPolicy.defaultAllowlistText,

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Policies/BrowserURLAllowlistPolicy.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Policies/BrowserURLAllowlistPolicy.swift
@@ -305,7 +305,7 @@ public struct BrowserURLAllowlistPolicy: Equatable, Sendable {
     public func allowsTrustedInternalURL(_ url: URL) -> Bool {
         guard isActive else { return true }
         guard let scheme = url.scheme?.lowercased() else { return false }
-        if scheme == "file" { return Self.isLocalFileURL(url) }
+        if scheme == "file" { return isLocalFileURL(url) }
         return Self.trustedInternalSchemes.contains(scheme) || allows(url)
     }
 
@@ -314,7 +314,7 @@ public struct BrowserURLAllowlistPolicy: Equatable, Sendable {
         return values.compactMap { BrowserURLAllowlistPattern($0) }.filter { seen.insert($0).inserted }
     }
 
-    private static func isLocalFileURL(_ url: URL) -> Bool {
+    private func isLocalFileURL(_ url: URL) -> Bool {
         guard url.isFileURL,
               url.path.hasPrefix("/"),
               url.user == nil,

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Policies/BrowserURLAllowlistPolicy.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Policies/BrowserURLAllowlistPolicy.swift
@@ -2,6 +2,9 @@ import CmuxCore
 import Foundation
 
 /// A single host-based rule for the embedded-browser URL allowlist.
+///
+/// Local `file:` URLs are a policy-level exemption and are not represented by
+/// this host-based grammar.
 public struct BrowserURLAllowlistPattern: Equatable, Hashable, Sendable {
     /// The normalized rule text used for diagnostics and persistence.
     public let rawValue: String
@@ -202,9 +205,10 @@ public struct BrowserURLAllowlistPolicy: Equatable, Sendable {
         case managed
     }
 
-    /// Schemes that app-owned loads may use without an origin rule. Page-
-    /// initiated navigations to these schemes still go through ``allows(_:)``
-    /// and are denied while a managed list is active.
+    /// Schemes that app-owned loads may use without an origin rule. Local
+    /// absolute `file:` URLs are also exempt in ``allows(_:)`` because they are
+    /// documents rather than remote web origins; the other schemes here remain
+    /// restricted to app-owned loads while a managed list is active.
     public static let trustedInternalSchemes: Set<String> = [
         "about", "applewebdata", "blob", "cmux-browser-action", "cmux-diff-viewer",
         "data", "file", "javascript"
@@ -287,9 +291,15 @@ public struct BrowserURLAllowlistPolicy: Equatable, Sendable {
     }
 
     /// Whether a URL may be loaded in the embedded browser.
+    ///
+    /// A local absolute `file:` URL (with no host or with the `localhost` host)
+    /// is always allowed while the web-origin list is active. Network-host and
+    /// relative `file:` URLs still fail closed, as do non-HTTP(S) schemes that
+    /// are not cmux-owned document URLs.
     public func allows(_ url: URL) -> Bool {
         guard isActive else { return true }
         guard let scheme = url.scheme?.lowercased() else { return false }
+        if scheme == "file", Self.isLocalFileURL(url) { return true }
         if Self.alwaysAllowedDocumentSchemes.contains(scheme) { return true }
         return patterns.contains { $0.matches(url) }
     }
@@ -309,6 +319,12 @@ public struct BrowserURLAllowlistPolicy: Equatable, Sendable {
     private static func patterns(from values: [String]) -> [BrowserURLAllowlistPattern] {
         var seen = Set<BrowserURLAllowlistPattern>()
         return values.compactMap { BrowserURLAllowlistPattern($0) }.filter { seen.insert($0).inserted }
+    }
+
+    private static func isLocalFileURL(_ url: URL) -> Bool {
+        guard url.isFileURL, url.path.hasPrefix("/") else { return false }
+        guard let host = url.host?.lowercased() else { return true }
+        return host.isEmpty || host == "localhost"
     }
 
     private static func stringValues(from rawValue: Any?) -> [String] {

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Policies/BrowserURLAllowlistPolicy.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Policies/BrowserURLAllowlistPolicy.swift
@@ -299,8 +299,9 @@ public struct BrowserURLAllowlistPolicy: Equatable, Sendable {
     /// Callers must use this only for a navigation they initiated themselves;
     /// WebKit delegate callbacks use ``allows(_:)`` so page scripts cannot
     /// turn `file:`, `data:`, `blob:`, or `javascript:` into an origin-policy
-    /// bypass. Local file URLs must be absolute and hostless (or use the
-    /// `localhost` host); network-host and relative file URLs remain denied.
+    /// bypass. Local file URLs must be absolute, have no credentials or port,
+    /// and be hostless (or use the `localhost` host); network-host and relative
+    /// file URLs remain denied.
     public func allowsTrustedInternalURL(_ url: URL) -> Bool {
         guard isActive else { return true }
         guard let scheme = url.scheme?.lowercased() else { return false }
@@ -314,7 +315,13 @@ public struct BrowserURLAllowlistPolicy: Equatable, Sendable {
     }
 
     private static func isLocalFileURL(_ url: URL) -> Bool {
-        guard url.isFileURL, url.path.hasPrefix("/") else { return false }
+        guard url.isFileURL,
+              url.path.hasPrefix("/"),
+              url.user == nil,
+              url.password == nil,
+              url.port == nil else {
+            return false
+        }
         guard let host = url.host?.lowercased() else { return true }
         return host.isEmpty || host == "localhost"
     }

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Policies/BrowserURLAllowlistPolicy.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Policies/BrowserURLAllowlistPolicy.swift
@@ -303,7 +303,7 @@ public struct BrowserURLAllowlistPolicy: Equatable, Sendable {
     /// and be hostless (or use the `localhost` host); network-host and relative
     /// file URLs remain denied.
     public func allowsTrustedInternalURL(_ url: URL) -> Bool {
-        guard let scheme = url.scheme?.lowercased() else { return false }
+        guard let scheme = url.scheme?.lowercased() else { return !isActive }
         if scheme == "file" { return isLocalFileURL(url) }
         guard isActive else { return true }
         return Self.trustedInternalSchemes.contains(scheme) || allows(url)

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Policies/BrowserURLAllowlistPolicy.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Policies/BrowserURLAllowlistPolicy.swift
@@ -303,9 +303,9 @@ public struct BrowserURLAllowlistPolicy: Equatable, Sendable {
     /// and be hostless (or use the `localhost` host); network-host and relative
     /// file URLs remain denied.
     public func allowsTrustedInternalURL(_ url: URL) -> Bool {
-        guard isActive else { return true }
         guard let scheme = url.scheme?.lowercased() else { return false }
         if scheme == "file" { return isLocalFileURL(url) }
+        guard isActive else { return true }
         return Self.trustedInternalSchemes.contains(scheme) || allows(url)
     }
 

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Policies/BrowserURLAllowlistPolicy.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Policies/BrowserURLAllowlistPolicy.swift
@@ -2,9 +2,6 @@ import CmuxCore
 import Foundation
 
 /// A single host-based rule for the embedded-browser URL allowlist.
-///
-/// Local `file:` URLs are a policy-level exemption and are not represented by
-/// this host-based grammar.
 public struct BrowserURLAllowlistPattern: Equatable, Hashable, Sendable {
     /// The normalized rule text used for diagnostics and persistence.
     public let rawValue: String
@@ -205,10 +202,9 @@ public struct BrowserURLAllowlistPolicy: Equatable, Sendable {
         case managed
     }
 
-    /// Schemes that app-owned loads may use without an origin rule. Local
-    /// absolute `file:` URLs are also exempt in ``allows(_:)`` because they are
-    /// documents rather than remote web origins; the other schemes here remain
-    /// restricted to app-owned loads while a managed list is active.
+    /// Schemes that app-owned loads may use without an origin rule. Page-
+    /// initiated navigations to these schemes still go through ``allows(_:)``
+    /// and are denied while a managed list is active.
     public static let trustedInternalSchemes: Set<String> = [
         "about", "applewebdata", "blob", "cmux-browser-action", "cmux-diff-viewer",
         "data", "file", "javascript"
@@ -291,15 +287,9 @@ public struct BrowserURLAllowlistPolicy: Equatable, Sendable {
     }
 
     /// Whether a URL may be loaded in the embedded browser.
-    ///
-    /// A local absolute `file:` URL (with no host or with the `localhost` host)
-    /// is always allowed while the web-origin list is active. Network-host and
-    /// relative `file:` URLs still fail closed, as do non-HTTP(S) schemes that
-    /// are not cmux-owned document URLs.
     public func allows(_ url: URL) -> Bool {
         guard isActive else { return true }
         guard let scheme = url.scheme?.lowercased() else { return false }
-        if scheme == "file", Self.isLocalFileURL(url) { return true }
         if Self.alwaysAllowedDocumentSchemes.contains(scheme) { return true }
         return patterns.contains { $0.matches(url) }
     }
@@ -309,10 +299,12 @@ public struct BrowserURLAllowlistPolicy: Equatable, Sendable {
     /// Callers must use this only for a navigation they initiated themselves;
     /// WebKit delegate callbacks use ``allows(_:)`` so page scripts cannot
     /// turn `file:`, `data:`, `blob:`, or `javascript:` into an origin-policy
-    /// bypass.
+    /// bypass. Local file URLs must be absolute and hostless (or use the
+    /// `localhost` host); network-host and relative file URLs remain denied.
     public func allowsTrustedInternalURL(_ url: URL) -> Bool {
         guard isActive else { return true }
         guard let scheme = url.scheme?.lowercased() else { return false }
+        if scheme == "file" { return Self.isLocalFileURL(url) }
         return Self.trustedInternalSchemes.contains(scheme) || allows(url)
     }
 

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Policies/ManagedDevicePolicyKey.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Policies/ManagedDevicePolicyKey.swift
@@ -21,7 +21,8 @@ public enum ManagedDevicePolicyKey: String, CaseIterable, Sendable {
     case disableRemoteControl = "DisableRemoteControl"
 
     /// Restricts embedded-browser top-level navigations to the administrator's
-    /// URL patterns. An empty forced array denies every external URL while
-    /// preserving cmux-owned internal documents.
+    /// URL patterns. An empty forced array denies every external web origin
+    /// while preserving local `file:` documents and cmux-owned internal
+    /// documents.
     case browserURLAllowlist = "BrowserURLAllowlist"
 }

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Policies/ManagedDevicePolicyKey.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Policies/ManagedDevicePolicyKey.swift
@@ -22,7 +22,7 @@ public enum ManagedDevicePolicyKey: String, CaseIterable, Sendable {
 
     /// Restricts embedded-browser top-level navigations to the administrator's
     /// URL patterns. An empty forced array denies every external web origin
-    /// while preserving local `file:` documents and cmux-owned internal
-    /// documents.
+    /// while preserving local `file:` documents opened through cmux's trusted
+    /// app-owned path and cmux-owned internal documents.
     case browserURLAllowlist = "BrowserURLAllowlist"
 }

--- a/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/BrowserURLAllowlistFileURLTests.swift
+++ b/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/BrowserURLAllowlistFileURLTests.swift
@@ -46,11 +46,13 @@ import Testing
         let localhostFileURL = try #require(URL(string: "file://localhost/tmp/cmux-report.html"))
         let networkFileURL = try #require(URL(string: "file://build-host/tmp/cmux-report.html"))
         let relativeFileURL = try #require(URL(string: "file:relative-report.html"))
+        let credentialedFileURL = try #require(URL(string: "file://user:password@localhost/tmp/cmux-report.html"))
 
         #expect(!policy.allows(localhostFileURL))
         #expect(policy.allowsTrustedInternalURL(localhostFileURL))
         #expect(!policy.allowsTrustedInternalURL(networkFileURL))
         #expect(!policy.allowsTrustedInternalURL(relativeFileURL))
+        #expect(!policy.allowsTrustedInternalURL(credentialedFileURL))
     }
 
     @Test(arguments: ["file://", "file://*", "file:///*", "file:*", "*"])

--- a/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/BrowserURLAllowlistFileURLTests.swift
+++ b/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/BrowserURLAllowlistFileURLTests.swift
@@ -12,7 +12,10 @@ import Testing
 
         #expect(policy.source == .user)
         #expect(policy.isActive)
-        #expect(policy.allows(fileURL))
+        // `allows` is the page/delegate path; app-owned loads use the trusted
+        // seam so a local report can open without allowing page file access.
+        #expect(!policy.allows(fileURL))
+        #expect(policy.allowsTrustedInternalURL(fileURL))
     }
 
     @Test func localFileURLsRemainAvailableForManagedAllowlist() throws {
@@ -21,30 +24,33 @@ import Testing
 
         #expect(policy.isManaged)
         #expect(policy.isActive)
-        #expect(policy.allows(fileURL))
+        #expect(!policy.allows(fileURL))
+        #expect(policy.allowsTrustedInternalURL(fileURL))
         #expect(!policy.allows(try #require(URL(string: "https://outside.example"))))
     }
 
-    @Test func emptyManagedAllowlistStillAllowsLocalDocumentsButBlocksRemoteOrigins() throws {
+    @Test func emptyManagedAllowlistAllowsLocalDocumentsThroughTrustedPath() throws {
         let policy = BrowserURLAllowlistPolicy(managedPatterns: [])
         let fileURL = try #require(URL(string: "file:///tmp/cmux-report.html"))
         let remoteURL = try #require(URL(string: "https://outside.example"))
 
         #expect(policy.isManaged)
         #expect(policy.isActive)
-        #expect(policy.allows(fileURL))
+        #expect(!policy.allows(fileURL))
+        #expect(policy.allowsTrustedInternalURL(fileURL))
         #expect(!policy.allows(remoteURL))
     }
 
-    @Test func onlyLocalFileURLsUseTheExemption() throws {
+    @Test func onlyLocalFileURLsUseTheTrustedExemption() throws {
         let policy = BrowserURLAllowlistPolicy(managedPatterns: ["reports.example.com"])
         let localhostFileURL = try #require(URL(string: "file://localhost/tmp/cmux-report.html"))
         let networkFileURL = try #require(URL(string: "file://build-host/tmp/cmux-report.html"))
         let relativeFileURL = try #require(URL(string: "file:relative-report.html"))
 
-        #expect(policy.allows(localhostFileURL))
-        #expect(!policy.allows(networkFileURL))
-        #expect(!policy.allows(relativeFileURL))
+        #expect(!policy.allows(localhostFileURL))
+        #expect(policy.allowsTrustedInternalURL(localhostFileURL))
+        #expect(!policy.allowsTrustedInternalURL(networkFileURL))
+        #expect(!policy.allowsTrustedInternalURL(relativeFileURL))
     }
 
     @Test(arguments: ["file://", "file://*", "file:///*", "file:*", "*"])
@@ -68,7 +74,8 @@ import Testing
 
         #expect(policy.isActive)
         #expect(policy.patterns.isEmpty)
-        #expect(policy.allows(fileURL))
+        #expect(!policy.allows(fileURL))
+        #expect(policy.allowsTrustedInternalURL(fileURL))
         #expect(!policy.allows(remoteURL))
     }
 }

--- a/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/BrowserURLAllowlistFileURLTests.swift
+++ b/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/BrowserURLAllowlistFileURLTests.swift
@@ -1,0 +1,74 @@
+import CmuxSettings
+import Foundation
+import Testing
+
+@Suite struct BrowserURLAllowlistFileURLTests {
+    @Test func localFileURLsRemainAvailableForUserAllowlist() throws {
+        let policy = BrowserURLAllowlistPolicy(
+            managedPatterns: nil,
+            userPatterns: ["reports.example.com"]
+        )
+        let fileURL = try #require(URL(string: "file:///tmp/cmux-report.html"))
+
+        #expect(policy.source == .user)
+        #expect(policy.isActive)
+        #expect(policy.allows(fileURL))
+    }
+
+    @Test func localFileURLsRemainAvailableForManagedAllowlist() throws {
+        let policy = BrowserURLAllowlistPolicy(managedPatterns: ["reports.example.com"])
+        let fileURL = try #require(URL(string: "file:///tmp/cmux-report.html"))
+
+        #expect(policy.isManaged)
+        #expect(policy.isActive)
+        #expect(policy.allows(fileURL))
+        #expect(!policy.allows(try #require(URL(string: "https://outside.example"))))
+    }
+
+    @Test func emptyManagedAllowlistStillAllowsLocalDocumentsButBlocksRemoteOrigins() throws {
+        let policy = BrowserURLAllowlistPolicy(managedPatterns: [])
+        let fileURL = try #require(URL(string: "file:///tmp/cmux-report.html"))
+        let remoteURL = try #require(URL(string: "https://outside.example"))
+
+        #expect(policy.isManaged)
+        #expect(policy.isActive)
+        #expect(policy.allows(fileURL))
+        #expect(!policy.allows(remoteURL))
+    }
+
+    @Test func onlyLocalFileURLsUseTheExemption() throws {
+        let policy = BrowserURLAllowlistPolicy(managedPatterns: ["reports.example.com"])
+        let localhostFileURL = try #require(URL(string: "file://localhost/tmp/cmux-report.html"))
+        let networkFileURL = try #require(URL(string: "file://build-host/tmp/cmux-report.html"))
+        let relativeFileURL = try #require(URL(string: "file:relative-report.html"))
+
+        #expect(policy.allows(localhostFileURL))
+        #expect(!policy.allows(networkFileURL))
+        #expect(!policy.allows(relativeFileURL))
+    }
+
+    @Test(arguments: ["file://", "file://*", "file:///*", "file:*", "*"])
+    func malformedFileAndWildcardEntriesRemainNonRules(_ entry: String) {
+        #expect(BrowserURLAllowlistPattern(entry) == nil)
+    }
+
+    @Test func bareFileEntryRemainsAnHTTPHostRuleOnly() throws {
+        let pattern = try #require(BrowserURLAllowlistPattern("file"))
+        let httpURL = try #require(URL(string: "https://file/status"))
+        let fileURL = try #require(URL(string: "file:///tmp/cmux-report.html"))
+
+        #expect(pattern.matches(httpURL))
+        #expect(!pattern.matches(fileURL))
+    }
+
+    @Test func wildcardDoesNotAllowRemoteOrigins() throws {
+        let policy = BrowserURLAllowlistPolicy(managedPatterns: ["*"])
+        let fileURL = try #require(URL(string: "file:///tmp/cmux-report.html"))
+        let remoteURL = try #require(URL(string: "https://outside.example"))
+
+        #expect(policy.isActive)
+        #expect(policy.patterns.isEmpty)
+        #expect(policy.allows(fileURL))
+        #expect(!policy.allows(remoteURL))
+    }
+}

--- a/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/BrowserURLAllowlistPolicyTests.swift
+++ b/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/BrowserURLAllowlistPolicyTests.swift
@@ -52,7 +52,7 @@ struct BrowserURLAllowlistPolicyTests {
         let policy = BrowserURLAllowlistPolicy(managedPatterns: [])
         #expect(policy.isManaged)
         #expect(!policy.allows(try #require(URL(string: "https://example.com"))))
-        #expect(policy.allows(try #require(URL(string: "file:///tmp/index.html"))))
+        #expect(!policy.allows(try #require(URL(string: "file:///tmp/index.html"))))
         #expect(!policy.allows(try #require(URL(string: "data:text/html,blocked"))))
         #expect(policy.allowsTrustedInternalURL(try #require(URL(string: "file:///tmp/index.html"))))
     }

--- a/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/BrowserURLAllowlistPolicyTests.swift
+++ b/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/BrowserURLAllowlistPolicyTests.swift
@@ -48,11 +48,11 @@ struct BrowserURLAllowlistPolicyTests {
         #expect(!policy.allows(try #require(URL(string: "https://outside.example"))))
     }
 
-    @Test func anEmptyManagedArrayFailsClosed() throws {
+    @Test func anEmptyManagedArrayFailsClosedForRemoteOrigins() throws {
         let policy = BrowserURLAllowlistPolicy(managedPatterns: [])
         #expect(policy.isManaged)
         #expect(!policy.allows(try #require(URL(string: "https://example.com"))))
-        #expect(!policy.allows(try #require(URL(string: "file:///tmp/index.html"))))
+        #expect(policy.allows(try #require(URL(string: "file:///tmp/index.html"))))
         #expect(!policy.allows(try #require(URL(string: "data:text/html,blocked"))))
         #expect(policy.allowsTrustedInternalURL(try #require(URL(string: "file:///tmp/index.html"))))
     }

--- a/Sources/Panels/BrowserNavigationDelegate.swift
+++ b/Sources/Panels/BrowserNavigationDelegate.swift
@@ -329,7 +329,6 @@ import WebKit
             let isTrustedInternal = trustedInternalNavigation(for: url, in: webView)
             if isMainFrame, !isTrustedInternal {
                 (webView as? CmuxWebView)?.clearTrustedInternalNavigationGrants()
-                owner?.clearTrustedLocalFileDocumentIfNeeded(for: url)
             }
             let isTrustedDocument = isMainFrame && url.isFileURL
                 && owner?.isTrustedLocalFileDocument(url) == true
@@ -754,7 +753,6 @@ import WebKit
             let isTrustedInternal = trustedInternalNavigation(for: url, in: webView)
             if isMainFrame, !isTrustedInternal {
                 (webView as? CmuxWebView)?.clearTrustedInternalNavigationGrants()
-                owner?.clearTrustedLocalFileDocumentIfNeeded(for: url)
             }
             let isTrustedDocument = isMainFrame && url.isFileURL
                 && owner?.isTrustedLocalFileDocument(url) == true
@@ -881,7 +879,11 @@ import WebKit
               cmuxWebView.consumeTrustedInternalNavigation(url) else {
             return false
         }
-        owner?.beginTrustedLocalFileNavigation(url)
+        if url.isFileURL {
+            owner?.beginTrustedLocalFileNavigation(url)
+        } else {
+            owner?.clearTrustedLocalFileDocumentIfNeeded(for: url)
+        }
         trustedInternalNavigationURL = url
         return true
     }

--- a/Sources/Panels/BrowserNavigationDelegate.swift
+++ b/Sources/Panels/BrowserNavigationDelegate.swift
@@ -122,15 +122,12 @@ import WebKit
             clearAttemptedRequest(discardPendingBypasses: true)
         }
         didCommit?(webView, navigation)
-        if isCurrentNavigation, let cmuxWebView = webView as? CmuxWebView {
-            if let committedURL = webView.url {
-                // The response callback consumes the one-shot delegate
-                // marker before commit; the WebView keeps the pending marker
-                // until this point so the document trust survives lifecycle
-                // callbacks.
-                cmuxWebView.commitTrustedInternalDocument(committedURL)
-                cmuxWebView.clearTrustedInternalDocumentIfNeeded(for: committedURL)
-            }
+        if isCurrentNavigation, let committedURL = webView.url {
+            // The response callback consumes the one-shot delegate marker
+            // before commit; the panel keeps the pending marker until this
+            // point so document trust survives WebView replacement.
+            owner?.commitTrustedLocalFileNavigation(committedURL)
+            owner?.clearTrustedLocalFileDocumentIfNeeded(for: committedURL)
         }
         if isCurrentNavigation {
             trustedInternalNavigationURL = nil
@@ -141,11 +138,9 @@ import WebKit
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         let isCurrentNavigation = isCurrentMainFrameNavigation(navigation)
         didFinish?(webView)
-        if isCurrentNavigation,
-           let cmuxWebView = webView as? CmuxWebView,
-           let finishedURL = webView.url {
-            cmuxWebView.commitTrustedInternalDocument(finishedURL)
-            cmuxWebView.clearTrustedInternalDocumentIfNeeded(for: finishedURL)
+        if isCurrentNavigation, let finishedURL = webView.url {
+            owner?.commitTrustedLocalFileNavigation(finishedURL)
+            owner?.clearTrustedLocalFileDocumentIfNeeded(for: finishedURL)
         }
         if isCurrentNavigation {
             trustedInternalNavigationURL = nil
@@ -165,7 +160,7 @@ import WebKit
         let failedURL = webView.url?.absoluteString ?? ""
         didFailNavigation?(webView, failedURL, error.localizedDescription, navigation)
         if isCurrentNavigation {
-            (webView as? CmuxWebView)?.failTrustedInternalNavigation()
+            owner?.failTrustedLocalFileNavigation()
             trustedInternalNavigationURL = nil
         }
         clearActiveMainFrameNavigation(ifMatching: navigation)
@@ -175,7 +170,7 @@ import WebKit
         let isCurrentNavigation = isCurrentMainFrameNavigation(navigation)
         if isCurrentNavigation {
             trustedInternalNavigationURL = nil
-            (webView as? CmuxWebView)?.failTrustedInternalNavigation()
+            owner?.failTrustedLocalFileNavigation()
         }
         let nsError = error as NSError
         NSLog("BrowserPanel provisional navigation failed: %@", error.localizedDescription)
@@ -329,12 +324,11 @@ import WebKit
         if let url = navigationAction.request.url {
             let isMainFrame = navigationAction.targetFrame?.isMainFrame != false
             let isTrustedInternal = trustedInternalNavigation(for: url, in: webView)
-            let cmuxWebView = webView as? CmuxWebView
             if isMainFrame, !isTrustedInternal {
-                cmuxWebView?.clearTrustedInternalDocumentIfNeeded(for: url)
+                owner?.clearTrustedLocalFileDocumentIfNeeded(for: url)
             }
             let isTrustedDocument = isMainFrame && url.isFileURL
-                && cmuxWebView?.isTrustedInternalDocument(url) == true
+                && owner?.isTrustedLocalFileDocument(url) == true
             if !isTrustedInternal,
                !isTrustedDocument,
                url.scheme?.lowercased() != AuthEnvironment.callbackScheme.lowercased(),
@@ -754,12 +748,11 @@ import WebKit
         if let url = navigationResponse.response.url {
             let isMainFrame = navigationResponse.isForMainFrame
             let isTrustedInternal = trustedInternalNavigation(for: url, in: webView)
-            let cmuxWebView = webView as? CmuxWebView
             if isMainFrame, !isTrustedInternal {
-                cmuxWebView?.clearTrustedInternalDocumentIfNeeded(for: url)
+                owner?.clearTrustedLocalFileDocumentIfNeeded(for: url)
             }
             let isTrustedDocument = isMainFrame && url.isFileURL
-                && cmuxWebView?.isTrustedInternalDocument(url) == true
+                && owner?.isTrustedLocalFileDocument(url) == true
             if !isTrustedInternal,
                !isTrustedDocument,
                !BrowserURLAllowlistPolicy(defaults: .standard).allows(url) {
@@ -883,8 +876,14 @@ import WebKit
               cmuxWebView.consumeTrustedInternalNavigation(url) else {
             return false
         }
+        owner?.beginTrustedLocalFileNavigation(url)
         trustedInternalNavigationURL = url
         return true
+    }
+
+    func resetTrustedInternalNavigationState() {
+        trustedInternalNavigationURL = nil
+        activeMainFrameNavigation = nil
     }
 
     /// Applies a newly changed policy to the currently displayed document.
@@ -892,9 +891,9 @@ import WebKit
         guard let url = displayURL ?? webView.url else { return }
         let policy = BrowserURLAllowlistPolicy(defaults: .standard)
         if policy.allows(url) { return }
-        if let cmuxWebView = webView as? CmuxWebView,
+        if let owner,
            url.isFileURL,
-           cmuxWebView.isTrustedInternalDocument(url),
+           owner.isTrustedLocalFileDocument(url),
            policy.allowsTrustedInternalURL(url) {
             return
         }

--- a/Sources/Panels/BrowserNavigationDelegate.swift
+++ b/Sources/Panels/BrowserNavigationDelegate.swift
@@ -121,12 +121,27 @@ import WebKit
             clearAttemptedRequest(discardPendingBypasses: true)
         }
         didCommit?(webView, navigation)
+        if let cmuxWebView = webView as? CmuxWebView {
+            if let committedURL = webView.url {
+                // The response callback consumes the one-shot delegate
+                // marker before commit; the WebView keeps the pending marker
+                // until this point so the document trust survives lifecycle
+                // callbacks.
+                cmuxWebView.commitTrustedInternalDocument(committedURL)
+                cmuxWebView.clearTrustedInternalDocumentIfNeeded(for: committedURL)
+            }
+        }
         trustedInternalNavigationURL = nil
         clearActiveMainFrameNavigation(ifMatching: navigation)
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         didFinish?(webView)
+        if let cmuxWebView = webView as? CmuxWebView,
+           let finishedURL = webView.url {
+            cmuxWebView.commitTrustedInternalDocument(finishedURL)
+            cmuxWebView.clearTrustedInternalDocumentIfNeeded(for: finishedURL)
+        }
         trustedInternalNavigationURL = nil
         clearActiveMainFrameNavigation(ifMatching: navigation)
         if shouldPrintAfterCurrentNavigationFinishes {
@@ -141,12 +156,14 @@ import WebKit
         // stale favicon/title state from the prior page gets cleared.
         let failedURL = webView.url?.absoluteString ?? ""
         didFailNavigation?(webView, failedURL, error.localizedDescription, navigation)
+        (webView as? CmuxWebView)?.failTrustedInternalNavigation()
         trustedInternalNavigationURL = nil
         clearActiveMainFrameNavigation(ifMatching: navigation)
     }
 
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
         trustedInternalNavigationURL = nil
+        (webView as? CmuxWebView)?.failTrustedInternalNavigation()
         let nsError = error as NSError
         NSLog("BrowserPanel provisional navigation failed: %@", error.localizedDescription)
 
@@ -297,9 +314,16 @@ import WebKit
         }
 
         if let url = navigationAction.request.url {
-            let isTrustedInternal = trustedInternalNavigation(for: url, in: webView)
             let isMainFrame = navigationAction.targetFrame?.isMainFrame != false
+            let isTrustedInternal = trustedInternalNavigation(for: url, in: webView)
+            let cmuxWebView = webView as? CmuxWebView
+            if isMainFrame, !isTrustedInternal {
+                cmuxWebView?.clearTrustedInternalDocumentIfNeeded(for: url)
+            }
+            let isTrustedDocument = isMainFrame && url.isFileURL
+                && cmuxWebView?.isTrustedInternalDocument(url) == true
             if !isTrustedInternal,
+               !isTrustedDocument,
                url.scheme?.lowercased() != AuthEnvironment.callbackScheme.lowercased(),
                !BrowserURLAllowlistPolicy(defaults: .standard).allows(url) {
                 decisionHandler(.cancel)
@@ -715,8 +739,16 @@ import WebKit
         ).closure
 
         if let url = navigationResponse.response.url {
+            let isMainFrame = navigationResponse.isForMainFrame
             let isTrustedInternal = trustedInternalNavigation(for: url, in: webView)
+            let cmuxWebView = webView as? CmuxWebView
+            if isMainFrame, !isTrustedInternal {
+                cmuxWebView?.clearTrustedInternalDocumentIfNeeded(for: url)
+            }
+            let isTrustedDocument = isMainFrame && url.isFileURL
+                && cmuxWebView?.isTrustedInternalDocument(url) == true
             if !isTrustedInternal,
+               !isTrustedDocument,
                !BrowserURLAllowlistPolicy(defaults: .standard).allows(url) {
                 decisionHandler(.cancel)
                 if navigationResponse.isForMainFrame {
@@ -844,8 +876,13 @@ import WebKit
 
     /// Applies a newly changed policy to the currently displayed document.
     func enforceURLAllowlistPolicy(in webView: WKWebView, displayURL: URL? = nil) {
-        guard let url = displayURL ?? webView.url,
-              !BrowserURLAllowlistPolicy(defaults: .standard).allows(url) else {
+        guard let url = displayURL ?? webView.url else { return }
+        let policy = BrowserURLAllowlistPolicy(defaults: .standard)
+        if policy.allows(url) { return }
+        if let cmuxWebView = webView as? CmuxWebView,
+           url.isFileURL,
+           cmuxWebView.isTrustedInternalDocument(url),
+           policy.allowsTrustedInternalURL(url) {
             return
         }
         blockURLAllowlistNavigation(url, in: webView)

--- a/Sources/Panels/BrowserNavigationDelegate.swift
+++ b/Sources/Panels/BrowserNavigationDelegate.swift
@@ -117,11 +117,12 @@ import WebKit
     }
 
     func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
+        let isCurrentNavigation = isCurrentMainFrameNavigation(navigation)
         if activeSSLTrustBypassReplayRequest != nil || activeSSLTrustBypassErrorPageRetryRequest != nil {
             clearAttemptedRequest(discardPendingBypasses: true)
         }
         didCommit?(webView, navigation)
-        if let cmuxWebView = webView as? CmuxWebView {
+        if isCurrentNavigation, let cmuxWebView = webView as? CmuxWebView {
             if let committedURL = webView.url {
                 // The response callback consumes the one-shot delegate
                 // marker before commit; the WebView keeps the pending marker
@@ -131,18 +132,24 @@ import WebKit
                 cmuxWebView.clearTrustedInternalDocumentIfNeeded(for: committedURL)
             }
         }
-        trustedInternalNavigationURL = nil
+        if isCurrentNavigation {
+            trustedInternalNavigationURL = nil
+        }
         clearActiveMainFrameNavigation(ifMatching: navigation)
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        let isCurrentNavigation = isCurrentMainFrameNavigation(navigation)
         didFinish?(webView)
-        if let cmuxWebView = webView as? CmuxWebView,
+        if isCurrentNavigation,
+           let cmuxWebView = webView as? CmuxWebView,
            let finishedURL = webView.url {
             cmuxWebView.commitTrustedInternalDocument(finishedURL)
             cmuxWebView.clearTrustedInternalDocumentIfNeeded(for: finishedURL)
         }
-        trustedInternalNavigationURL = nil
+        if isCurrentNavigation {
+            trustedInternalNavigationURL = nil
+        }
         clearActiveMainFrameNavigation(ifMatching: navigation)
         if shouldPrintAfterCurrentNavigationFinishes {
             shouldPrintAfterCurrentNavigationFinishes = false
@@ -151,19 +158,25 @@ import WebKit
     }
 
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        let isCurrentNavigation = isCurrentMainFrameNavigation(navigation)
         NSLog("BrowserPanel navigation failed: %@", error.localizedDescription)
         // Treat committed-navigation failures the same as provisional ones so
         // stale favicon/title state from the prior page gets cleared.
         let failedURL = webView.url?.absoluteString ?? ""
         didFailNavigation?(webView, failedURL, error.localizedDescription, navigation)
-        (webView as? CmuxWebView)?.failTrustedInternalNavigation()
-        trustedInternalNavigationURL = nil
+        if isCurrentNavigation {
+            (webView as? CmuxWebView)?.failTrustedInternalNavigation()
+            trustedInternalNavigationURL = nil
+        }
         clearActiveMainFrameNavigation(ifMatching: navigation)
     }
 
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
-        trustedInternalNavigationURL = nil
-        (webView as? CmuxWebView)?.failTrustedInternalNavigation()
+        let isCurrentNavigation = isCurrentMainFrameNavigation(navigation)
+        if isCurrentNavigation {
+            trustedInternalNavigationURL = nil
+            (webView as? CmuxWebView)?.failTrustedInternalNavigation()
+        }
         let nsError = error as NSError
         NSLog("BrowserPanel provisional navigation failed: %@", error.localizedDescription)
 
@@ -910,6 +923,12 @@ import WebKit
     private func clearActiveMainFrameNavigation(ifMatching navigation: WKNavigation?) {
         guard activeMainFrameNavigation === navigation else { return }
         activeMainFrameNavigation = nil
+    }
+
+    private func isCurrentMainFrameNavigation(_ navigation: WKNavigation?) -> Bool {
+        guard let navigation else { return true }
+        guard let activeMainFrameNavigation else { return false }
+        return activeMainFrameNavigation === navigation
     }
 
     func webView(_ webView: WKWebView, navigationAction: WKNavigationAction, didBecome download: WKDownload) {

--- a/Sources/Panels/BrowserNavigationDelegate.swift
+++ b/Sources/Panels/BrowserNavigationDelegate.swift
@@ -110,6 +110,7 @@ import WebKit
 
     func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
         activeMainFrameNavigation = navigation
+        (webView as? CmuxWebView)?.clearTrustedInternalNavigationGrants()
         lastAttemptedURL = lastAttemptedURL ?? webView.url ?? lastAttemptedRequest?.url
         shouldPrintAfterCurrentNavigationFinishes = false
         didClearPDFDocument?()
@@ -161,6 +162,7 @@ import WebKit
         didFailNavigation?(webView, failedURL, error.localizedDescription, navigation)
         if isCurrentNavigation {
             owner?.failTrustedLocalFileNavigation()
+            (webView as? CmuxWebView)?.clearTrustedInternalNavigationGrants()
             trustedInternalNavigationURL = nil
         }
         clearActiveMainFrameNavigation(ifMatching: navigation)
@@ -171,6 +173,7 @@ import WebKit
         if isCurrentNavigation {
             trustedInternalNavigationURL = nil
             owner?.failTrustedLocalFileNavigation()
+            (webView as? CmuxWebView)?.clearTrustedInternalNavigationGrants()
         }
         let nsError = error as NSError
         NSLog("BrowserPanel provisional navigation failed: %@", error.localizedDescription)
@@ -325,6 +328,7 @@ import WebKit
             let isMainFrame = navigationAction.targetFrame?.isMainFrame != false
             let isTrustedInternal = trustedInternalNavigation(for: url, in: webView)
             if isMainFrame, !isTrustedInternal {
+                (webView as? CmuxWebView)?.clearTrustedInternalNavigationGrants()
                 owner?.clearTrustedLocalFileDocumentIfNeeded(for: url)
             }
             let isTrustedDocument = isMainFrame && url.isFileURL
@@ -749,6 +753,7 @@ import WebKit
             let isMainFrame = navigationResponse.isForMainFrame
             let isTrustedInternal = trustedInternalNavigation(for: url, in: webView)
             if isMainFrame, !isTrustedInternal {
+                (webView as? CmuxWebView)?.clearTrustedInternalNavigationGrants()
                 owner?.clearTrustedLocalFileDocumentIfNeeded(for: url)
             }
             let isTrustedDocument = isMainFrame && url.isFileURL

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2307,6 +2307,8 @@ final class BrowserPanel: Panel, ObservableObject {
     private var lockedPortalHost: PortalHostLock?
     private var webViewCancellables = Set<AnyCancellable>()
     private(set) var navigationDelegate: BrowserNavigationDelegate?
+    private var trustedLocalFileURL: URL?
+    private var pendingTrustedLocalFileURL: URL?
     private var uiDelegate: BrowserUIDelegate?
     var downloadDelegate: BrowserDownloadDelegate?
     private let webAuthnCoordinator = BrowserWebAuthnCoordinator()
@@ -3064,7 +3066,9 @@ final class BrowserPanel: Panel, ObservableObject {
         webView.onContextMenuOpenLinkInNewTab = { [weak self] url in
             self?.openLinkInNewTab(url: url)
         }
-        configureMoveTabToNewWorkspaceContextMenu(for: webView); configureNavigationDelegateCallbacks()
+        configureMoveTabToNewWorkspaceContextMenu(for: webView)
+        navigationDelegate?.resetTrustedInternalNavigationState()
+        configureNavigationDelegateCallbacks()
         automationDocumentReadiness.bind(to: webViewInstanceID, hasCommittedDocument: webView.backForwardList.currentItem != nil)
         automationNavigationCoordinator.bind(to: webViewInstanceID)
         webView.cmuxDownloadDelegate = downloadDelegate
@@ -4969,6 +4973,8 @@ final class BrowserPanel: Panel, ObservableObject {
     func close() {
         cancelHiddenWebViewDiscard()
         isClosingWebViewLifecycle = true
+        trustedLocalFileURL = nil
+        pendingTrustedLocalFileURL = nil
         automationNavigationCoordinator.invalidate()
         navigationDelegate?.cancelPendingAuthenticationPrompts()
         mobileBrowserDialogBroker.resolveAll()
@@ -5396,6 +5402,7 @@ final class BrowserPanel: Panel, ObservableObject {
     ) -> WKNavigation? {
         let request = URLRequest(url: url)
         let policy = BrowserURLAllowlistPolicy(defaults: .standard)
+        beginTrustedLocalFileNavigation(url)
         if !policy.allowsTrustedInternalURL(url) {
             navigationDelegate?.blockURLAllowlistNavigation(url, in: webView)
             onNavigationStarted?(nil)
@@ -5450,6 +5457,9 @@ final class BrowserPanel: Panel, ObservableObject {
         }
         cancelHiddenWebViewDiscard()
         let policy = BrowserURLAllowlistPolicy(defaults: .standard)
+        if trustedInternalNavigation {
+            beginTrustedLocalFileNavigation(url)
+        }
         let policyAllowsURL = trustedInternalNavigation
             ? policy.allowsTrustedInternalURL(url)
             : policy.allows(url)
@@ -5532,12 +5542,18 @@ final class BrowserPanel: Panel, ObservableObject {
         }
         noteDiscardedWebViewRestoreNavigationStarted()
         userStoppedLoadSinceWebViewReplacement = false
+        let trustedInternalNavigation = BrowserURLAllowlistPolicy
+            .trustedInternalSchemes
+            .contains(originalURL.scheme?.lowercased() ?? "")
+        if trustedInternalNavigation {
+            beginTrustedLocalFileNavigation(originalURL)
+        } else {
+            clearTrustedLocalFileDocumentIfNeeded(for: originalURL)
+        }
         let startedNavigation = browserLoadRequest(
             effectiveRequest,
             in: webView,
-            trustedInternalNavigation: BrowserURLAllowlistPolicy
-                .trustedInternalSchemes
-                .contains(originalURL.scheme?.lowercased() ?? "")
+            trustedInternalNavigation: trustedInternalNavigation
         )
         if startedNavigation == nil {
             noteDiscardedWebViewRestoreNavigationDidNotCommit(reason: "navigation_not_started")
@@ -5978,6 +5994,8 @@ extension BrowserPanel {
 
         pageTitle = ""
         currentURL = nil
+        trustedLocalFileURL = nil
+        pendingTrustedLocalFileURL = nil
         renderedPDFDocumentURL = nil
         hiddenWebViewDiscardManager.updateRestoredSessionRenderIntent(nil)
         faviconPNGData = nil
@@ -6038,6 +6056,52 @@ func resolveBrowserNavigableURL(_ input: String) -> URL? {
 }
 
 extension BrowserPanel {
+    func beginTrustedLocalFileNavigation(_ url: URL) {
+        guard url.isFileURL,
+              url.scheme?.lowercased() == "file",
+              BrowserURLAllowlistPolicy(defaults: .standard).allowsTrustedInternalURL(url) else {
+            pendingTrustedLocalFileURL = nil
+            trustedLocalFileURL = nil
+            return
+        }
+        pendingTrustedLocalFileURL = url
+    }
+
+    func commitTrustedLocalFileNavigation(_ url: URL) {
+        guard pendingTrustedLocalFileURL != nil else { return }
+        pendingTrustedLocalFileURL = nil
+        trustedLocalFileURL = url.isFileURL
+            && url.scheme?.lowercased() == "file"
+            && BrowserURLAllowlistPolicy(defaults: .standard).allowsTrustedInternalURL(url)
+            ? url
+            : nil
+    }
+
+    func failTrustedLocalFileNavigation() {
+        pendingTrustedLocalFileURL = nil
+    }
+
+    func isTrustedLocalFileDocument(_ url: URL) -> Bool {
+        guard let trustedURL = trustedLocalFileURL ?? pendingTrustedLocalFileURL else { return false }
+        return trustedURL.isFileURL
+            && url.isFileURL
+            && trustedURL.scheme?.lowercased() == url.scheme?.lowercased()
+            && trustedURL.host?.lowercased() == url.host?.lowercased()
+            && trustedURL.port == url.port
+            && trustedURL.user == url.user
+            && trustedURL.password == url.password
+            && trustedURL.path == url.path
+            && url.scheme?.lowercased() == "file"
+    }
+
+    func clearTrustedLocalFileDocumentIfNeeded(for url: URL) {
+        guard isTrustedLocalFileDocument(url) else {
+            pendingTrustedLocalFileURL = nil
+            trustedLocalFileURL = nil
+            return
+        }
+    }
+
     private func cancelInFlightNavigationBeforeHistoryTraversal() {
         guard webView.isLoading || isMainFrameProvisionalNavigationActive else { return }
         webView.stopLoading()
@@ -6051,6 +6115,7 @@ extension BrowserPanel {
               BrowserURLAllowlistPolicy(defaults: .standard).allowsTrustedInternalURL(url) else {
             return
         }
+        beginTrustedLocalFileNavigation(url)
         (webView as? CmuxWebView)?.markTrustedInternalNavigation(url)
     }
 

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2307,6 +2307,7 @@ final class BrowserPanel: Panel, ObservableObject {
     private var lockedPortalHost: PortalHostLock?
     private var webViewCancellables = Set<AnyCancellable>()
     private(set) var navigationDelegate: BrowserNavigationDelegate?
+    /// Provenance for an app-owned local document, retained across WebView replacement.
     private var trustedLocalFileURL: URL?
     private var pendingTrustedLocalFileURL: URL?
     private var uiDelegate: BrowserUIDelegate?
@@ -5402,7 +5403,7 @@ final class BrowserPanel: Panel, ObservableObject {
     ) -> WKNavigation? {
         let request = URLRequest(url: url)
         let policy = BrowserURLAllowlistPolicy(defaults: .standard)
-        beginTrustedLocalFileNavigation(url)
+        (webView as? CmuxWebView)?.clearTrustedInternalNavigationGrants()
         if !policy.allowsTrustedInternalURL(url) {
             navigationDelegate?.blockURLAllowlistNavigation(url, in: webView)
             onNavigationStarted?(nil)
@@ -5433,6 +5434,7 @@ final class BrowserPanel: Panel, ObservableObject {
         cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy,
         onNavigationStarted: ((WKNavigation?) -> Void)? = nil
     ) -> WKNavigation? {
+        (webView as? CmuxWebView)?.clearTrustedInternalNavigationGrants()
         let request = URLRequest(url: url, cachePolicy: cachePolicy)
         return navigateWithoutInsecureHTTPPrompt(
             request: request,
@@ -5457,9 +5459,6 @@ final class BrowserPanel: Panel, ObservableObject {
         }
         cancelHiddenWebViewDiscard()
         let policy = BrowserURLAllowlistPolicy(defaults: .standard)
-        if trustedInternalNavigation {
-            beginTrustedLocalFileNavigation(url)
-        }
         let policyAllowsURL = trustedInternalNavigation
             ? policy.allowsTrustedInternalURL(url)
             : policy.allows(url)
@@ -5467,6 +5466,9 @@ final class BrowserPanel: Panel, ObservableObject {
             onNavigationStarted?(nil)
             navigationDelegate?.blockURLAllowlistNavigation(url, in: webView)
             return nil
+        }
+        if trustedInternalNavigation {
+            beginTrustedLocalFileNavigation(url)
         }
         if usesRemoteWorkspaceProxy, remoteProxyEndpoint == nil {
             pendingRemoteNavigation?.onNavigationStarted?(nil)
@@ -5542,6 +5544,7 @@ final class BrowserPanel: Panel, ObservableObject {
         }
         noteDiscardedWebViewRestoreNavigationStarted()
         userStoppedLoadSinceWebViewReplacement = false
+        (webView as? CmuxWebView)?.clearTrustedInternalNavigationGrants()
         let trustedInternalNavigation = BrowserURLAllowlistPolicy
             .trustedInternalSchemes
             .contains(originalURL.scheme?.lowercased() ?? "")
@@ -6056,17 +6059,15 @@ func resolveBrowserNavigableURL(_ input: String) -> URL? {
 }
 
 extension BrowserPanel {
+    /// Records a local file navigation started by cmux itself.
     func beginTrustedLocalFileNavigation(_ url: URL) {
         guard url.isFileURL,
               url.scheme?.lowercased() == "file",
-              BrowserURLAllowlistPolicy(defaults: .standard).allowsTrustedInternalURL(url) else {
-            pendingTrustedLocalFileURL = nil
-            trustedLocalFileURL = nil
-            return
-        }
+              BrowserURLAllowlistPolicy(defaults: .standard).allowsTrustedInternalURL(url) else { return }
         pendingTrustedLocalFileURL = url
     }
 
+    /// Promotes the pending local file navigation to the current document.
     func commitTrustedLocalFileNavigation(_ url: URL) {
         guard pendingTrustedLocalFileURL != nil else { return }
         pendingTrustedLocalFileURL = nil
@@ -6077,10 +6078,12 @@ extension BrowserPanel {
             : nil
     }
 
+    /// Drops a pending local file navigation after it fails or is superseded.
     func failTrustedLocalFileNavigation() {
         pendingTrustedLocalFileURL = nil
     }
 
+    /// Returns whether `url` is the app-owned local document for this panel.
     func isTrustedLocalFileDocument(_ url: URL) -> Bool {
         guard let trustedURL = trustedLocalFileURL ?? pendingTrustedLocalFileURL else { return false }
         return trustedURL.isFileURL
@@ -6094,6 +6097,7 @@ extension BrowserPanel {
             && url.scheme?.lowercased() == "file"
     }
 
+    /// Clears local-file provenance when a different main-frame URL takes over.
     func clearTrustedLocalFileDocumentIfNeeded(for url: URL) {
         guard isTrustedLocalFileDocument(url) else {
             pendingTrustedLocalFileURL = nil
@@ -6109,6 +6113,7 @@ extension BrowserPanel {
     }
 
     private func markTrustedInternalNavigationIfNeeded(for url: URL?) {
+        (webView as? CmuxWebView)?.clearTrustedInternalNavigationGrants()
         guard let url,
               let scheme = url.scheme?.lowercased(),
               BrowserURLAllowlistPolicy.trustedInternalSchemes.contains(scheme),

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -3256,6 +3256,8 @@ final class BrowserPanel: Panel, ObservableObject {
         navigationDelegate.didChooseMainFrameDownloadPolicy = { [weak self] webView, navigation in
             MainActor.assumeIsolated {
                 guard let self, self.isCurrentWebView(webView, instanceID: boundWebViewInstanceID) else { return }
+                self.failTrustedLocalFileNavigation()
+                (webView as? CmuxWebView)?.clearTrustedInternalNavigationGrants()
                 self.automationNavigationCoordinator.didChooseDownloadPolicy(
                     instanceID: boundWebViewInstanceID,
                     navigationID: navigation.map { ObjectIdentifier($0) }
@@ -3284,6 +3286,8 @@ final class BrowserPanel: Panel, ObservableObject {
                       self.isCurrentWebView(webView, instanceID: boundWebViewInstanceID) else {
                     return
                 }
+                self.failTrustedLocalFileNavigation()
+                (webView as? CmuxWebView)?.clearTrustedInternalNavigationGrants()
                 guard let restoreAttemptID,
                       restoreAttemptID == self.currentDiscardRestoreAttemptID else {
                     return
@@ -5468,7 +5472,11 @@ final class BrowserPanel: Panel, ObservableObject {
             return nil
         }
         if trustedInternalNavigation {
-            beginTrustedLocalFileNavigation(url)
+            if url.isFileURL {
+                beginTrustedLocalFileNavigation(url)
+            } else {
+                clearTrustedLocalFileDocumentIfNeeded(for: url)
+            }
         }
         if usesRemoteWorkspaceProxy, remoteProxyEndpoint == nil {
             pendingRemoteNavigation?.onNavigationStarted?(nil)
@@ -5548,7 +5556,7 @@ final class BrowserPanel: Panel, ObservableObject {
         let trustedInternalNavigation = BrowserURLAllowlistPolicy
             .trustedInternalSchemes
             .contains(originalURL.scheme?.lowercased() ?? "")
-        if trustedInternalNavigation {
+        if trustedInternalNavigation, originalURL.isFileURL {
             beginTrustedLocalFileNavigation(originalURL)
         } else {
             clearTrustedLocalFileDocumentIfNeeded(for: originalURL)

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -5395,7 +5395,8 @@ final class BrowserPanel: Panel, ObservableObject {
         onNavigationStarted: ((WKNavigation?) -> Void)? = nil
     ) -> WKNavigation? {
         let request = URLRequest(url: url)
-        if !BrowserURLAllowlistPolicy(defaults: .standard).allows(url) {
+        let policy = BrowserURLAllowlistPolicy(defaults: .standard)
+        if !policy.allowsTrustedInternalURL(url) {
             navigationDelegate?.blockURLAllowlistNavigation(url, in: webView)
             onNavigationStarted?(nil)
             return nil
@@ -5412,6 +5413,7 @@ final class BrowserPanel: Panel, ObservableObject {
         return navigateWithoutInsecureHTTPPrompt(
             request: request,
             recordTypedNavigation: recordTypedNavigation,
+            trustedInternalNavigation: true,
             onNavigationStarted: onNavigationStarted
         )
     }
@@ -5429,6 +5431,7 @@ final class BrowserPanel: Panel, ObservableObject {
             request: request,
             recordTypedNavigation: recordTypedNavigation,
             preserveRestoredSessionHistory: preserveRestoredSessionHistory,
+            trustedInternalNavigation: true,
             onNavigationStarted: onNavigationStarted
         )
     }
@@ -5438,6 +5441,7 @@ final class BrowserPanel: Panel, ObservableObject {
         request: URLRequest,
         recordTypedNavigation: Bool,
         preserveRestoredSessionHistory: Bool = false,
+        trustedInternalNavigation: Bool = false,
         onNavigationStarted: ((WKNavigation?) -> Void)? = nil
     ) -> WKNavigation? {
         guard let url = request.url else {
@@ -5445,7 +5449,11 @@ final class BrowserPanel: Panel, ObservableObject {
             return nil
         }
         cancelHiddenWebViewDiscard()
-        guard BrowserURLAllowlistPolicy(defaults: .standard).allows(url) else {
+        let policy = BrowserURLAllowlistPolicy(defaults: .standard)
+        let policyAllowsURL = trustedInternalNavigation
+            ? policy.allowsTrustedInternalURL(url)
+            : policy.allows(url)
+        guard policyAllowsURL else {
             onNavigationStarted?(nil)
             navigationDelegate?.blockURLAllowlistNavigation(url, in: webView)
             return nil

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -6044,6 +6044,16 @@ extension BrowserPanel {
         isMainFrameProvisionalNavigationActive = false
     }
 
+    private func markTrustedInternalNavigationIfNeeded(for url: URL?) {
+        guard let url,
+              let scheme = url.scheme?.lowercased(),
+              BrowserURLAllowlistPolicy.trustedInternalSchemes.contains(scheme),
+              BrowserURLAllowlistPolicy(defaults: .standard).allowsTrustedInternalURL(url) else {
+            return
+        }
+        (webView as? CmuxWebView)?.markTrustedInternalNavigation(url)
+    }
+
     @discardableResult
     func setMuted(_ muted: Bool) -> Bool {
         let applied = applyMuteState(muted, to: webView, reason: "setMuted")
@@ -6081,7 +6091,9 @@ extension BrowserPanel {
                     preserveRestoredSessionHistory: true
                 )
             case .nativeGoBack:
-                webView.applyBrowserUserAgentPolicy(for: webView.backForwardList.backItem?.url)
+                let targetURL = webView.backForwardList.backItem?.url
+                markTrustedInternalNavigationIfNeeded(for: targetURL)
+                webView.applyBrowserUserAgentPolicy(for: targetURL)
                 webView.goBack()
             case .nativeGoForward, .refreshOnly:
                 refreshNavigationAvailability()
@@ -6089,7 +6101,9 @@ extension BrowserPanel {
             return
         }
 
-        webView.applyBrowserUserAgentPolicy(for: webView.backForwardList.backItem?.url)
+        let targetURL = webView.backForwardList.backItem?.url
+        markTrustedInternalNavigationIfNeeded(for: targetURL)
+        webView.applyBrowserUserAgentPolicy(for: targetURL)
         webView.goBack()
     }
 
@@ -6107,7 +6121,9 @@ extension BrowserPanel {
             )
             switch decision {
             case .nativeGoForward:
-                webView.applyBrowserUserAgentPolicy(for: webView.backForwardList.forwardItem?.url)
+                let targetURL = webView.backForwardList.forwardItem?.url
+                markTrustedInternalNavigationIfNeeded(for: targetURL)
+                webView.applyBrowserUserAgentPolicy(for: targetURL)
                 webView.goForward()
             case .navigate(let targetURL):
                 refreshNavigationAvailability()
@@ -6122,7 +6138,9 @@ extension BrowserPanel {
             return
         }
 
-        webView.applyBrowserUserAgentPolicy(for: webView.backForwardList.forwardItem?.url)
+        let targetURL = webView.backForwardList.forwardItem?.url
+        markTrustedInternalNavigationIfNeeded(for: targetURL)
+        webView.applyBrowserUserAgentPolicy(for: targetURL)
         webView.goForward()
     }
 
@@ -6252,6 +6270,7 @@ extension BrowserPanel {
         if prepareForReload(reason: "reload", mode: .soft) {
             return nil
         }
+        markTrustedInternalNavigationIfNeeded(for: webView.url ?? currentURL)
         return webView.reload()
     }
 
@@ -6260,6 +6279,7 @@ extension BrowserPanel {
         if prepareForReload(reason: "hardReload", mode: .hard) {
             return
         }
+        markTrustedInternalNavigationIfNeeded(for: webView.url ?? currentURL)
         webView.reloadFromOrigin()
     }
 

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -59,7 +59,11 @@ final class CmuxWebView: WKWebView {
         if trustedURL.isFileURL || url.isFileURL {
             return trustedURL.isFileURL
                 && url.isFileURL
+                && trustedURL.scheme?.lowercased() == url.scheme?.lowercased()
                 && trustedURL.host?.lowercased() == url.host?.lowercased()
+                && trustedURL.port == url.port
+                && trustedURL.user == url.user
+                && trustedURL.password == url.password
                 && trustedURL.path == url.path
         }
         return trustedURL.absoluteString == url.absoluteString

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -47,6 +47,7 @@ final class CmuxWebView: WKWebView {
 
     @MainActor
     func failTrustedInternalNavigation() {
+        trustedInternalNavigationURLs.removeAll()
         pendingTrustedInternalDocumentURL = nil
     }
 
@@ -67,6 +68,7 @@ final class CmuxWebView: WKWebView {
     @MainActor
     func clearTrustedInternalDocumentIfNeeded(for url: URL) {
         guard !isTrustedInternalDocument(url) else { return }
+        trustedInternalNavigationURLs.removeAll()
         pendingTrustedInternalDocumentURL = nil
         trustedInternalDocumentURL = nil
     }

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -17,12 +17,6 @@ final class CmuxWebView: WKWebView {
     /// must pass the browser URL policy's trusted-load seam. Page callbacks
     /// never add to this set.
     private var trustedInternalNavigationURLs: Set<String> = []
-    /// The currently committed document that was loaded through that seam.
-    /// Keeping only the current document preserves reload/history and live
-    /// policy enforcement without granting page scripts a scheme-wide bypass.
-    private var trustedInternalDocumentURL: URL?
-    /// A trusted navigation that has started but has not committed yet.
-    private var pendingTrustedInternalDocumentURL: URL?
 
     @MainActor
     func markTrustedInternalNavigation(_ url: URL) {
@@ -31,50 +25,12 @@ final class CmuxWebView: WKWebView {
 
     @MainActor
     func consumeTrustedInternalNavigation(_ url: URL) -> Bool {
-        guard trustedInternalNavigationURLs.remove(url.absoluteString) != nil else {
-            return false
-        }
-        pendingTrustedInternalDocumentURL = url
-        return true
+        trustedInternalNavigationURLs.remove(url.absoluteString) != nil
     }
 
     @MainActor
-    func commitTrustedInternalDocument(_ url: URL) {
-        guard pendingTrustedInternalDocumentURL != nil else { return }
-        trustedInternalDocumentURL = url
-        pendingTrustedInternalDocumentURL = nil
-    }
-
-    @MainActor
-    func failTrustedInternalNavigation() {
+    func resetTrustedInternalNavigationState() {
         trustedInternalNavigationURLs.removeAll()
-        pendingTrustedInternalDocumentURL = nil
-    }
-
-    @MainActor
-    func isTrustedInternalDocument(_ url: URL) -> Bool {
-        guard let trustedURL = trustedInternalDocumentURL ?? pendingTrustedInternalDocumentURL else {
-            return false
-        }
-        if trustedURL.isFileURL || url.isFileURL {
-            return trustedURL.isFileURL
-                && url.isFileURL
-                && trustedURL.scheme?.lowercased() == url.scheme?.lowercased()
-                && trustedURL.host?.lowercased() == url.host?.lowercased()
-                && trustedURL.port == url.port
-                && trustedURL.user == url.user
-                && trustedURL.password == url.password
-                && trustedURL.path == url.path
-        }
-        return trustedURL.absoluteString == url.absoluteString
-    }
-
-    @MainActor
-    func clearTrustedInternalDocumentIfNeeded(for url: URL) {
-        guard !isTrustedInternalDocument(url) else { return }
-        trustedInternalNavigationURLs.removeAll()
-        pendingTrustedInternalDocumentURL = nil
-        trustedInternalDocumentURL = nil
     }
 
     // WebKit registers web-content edit commands on the view's `undoManager`;

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -29,8 +29,13 @@ final class CmuxWebView: WKWebView {
     }
 
     @MainActor
-    func resetTrustedInternalNavigationState() {
+    func clearTrustedInternalNavigationGrants() {
         trustedInternalNavigationURLs.removeAll()
+    }
+
+    @MainActor
+    func resetTrustedInternalNavigationState() {
+        clearTrustedInternalNavigationGrants()
     }
 
     // WebKit registers web-content edit commands on the view's `undoManager`;

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -17,6 +17,12 @@ final class CmuxWebView: WKWebView {
     /// must pass the browser URL policy's trusted-load seam. Page callbacks
     /// never add to this set.
     private var trustedInternalNavigationURLs: Set<String> = []
+    /// The currently committed document that was loaded through that seam.
+    /// Keeping only the current document preserves reload/history and live
+    /// policy enforcement without granting page scripts a scheme-wide bypass.
+    private var trustedInternalDocumentURL: URL?
+    /// A trusted navigation that has started but has not committed yet.
+    private var pendingTrustedInternalDocumentURL: URL?
 
     @MainActor
     func markTrustedInternalNavigation(_ url: URL) {
@@ -25,7 +31,44 @@ final class CmuxWebView: WKWebView {
 
     @MainActor
     func consumeTrustedInternalNavigation(_ url: URL) -> Bool {
-        trustedInternalNavigationURLs.remove(url.absoluteString) != nil
+        guard trustedInternalNavigationURLs.remove(url.absoluteString) != nil else {
+            return false
+        }
+        pendingTrustedInternalDocumentURL = url
+        return true
+    }
+
+    @MainActor
+    func commitTrustedInternalDocument(_ url: URL) {
+        guard pendingTrustedInternalDocumentURL != nil else { return }
+        trustedInternalDocumentURL = url
+        pendingTrustedInternalDocumentURL = nil
+    }
+
+    @MainActor
+    func failTrustedInternalNavigation() {
+        pendingTrustedInternalDocumentURL = nil
+    }
+
+    @MainActor
+    func isTrustedInternalDocument(_ url: URL) -> Bool {
+        guard let trustedURL = trustedInternalDocumentURL ?? pendingTrustedInternalDocumentURL else {
+            return false
+        }
+        if trustedURL.isFileURL || url.isFileURL {
+            return trustedURL.isFileURL
+                && url.isFileURL
+                && trustedURL.host?.lowercased() == url.host?.lowercased()
+                && trustedURL.path == url.path
+        }
+        return trustedURL.absoluteString == url.absoluteString
+    }
+
+    @MainActor
+    func clearTrustedInternalDocumentIfNeeded(for url: URL) {
+        guard !isTrustedInternalDocument(url) else { return }
+        pendingTrustedInternalDocumentURL = nil
+        trustedInternalDocumentURL = nil
     }
 
     // WebKit registers web-content edit commands on the view's `undoManager`;

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -7083,10 +7083,13 @@ class TerminalController {
 
     private nonisolated func v2BrowserURLAllowlistFailure(for url: URL) -> V2CallResult? {
         let policy = BrowserURLAllowlistPolicy(defaults: .standard)
-        // Socket/CLI commands are app-owned navigation requests. Keep page
-        // callbacks on ``allows(_:)`` while allowing local documents through
-        // the policy's trusted internal-load seam.
-        guard !policy.allowsTrustedInternalURL(url) else { return nil }
+        // Only local file documents use the trusted seam here. Other
+        // user-supplied schemes (including data/blob/javascript) stay on the
+        // ordinary allowlist path; cmux-owned document schemes already pass it.
+        let allowsURL = url.isFileURL
+            ? policy.allowsTrustedInternalURL(url)
+            : policy.allows(url)
+        guard !allowsURL else { return nil }
         return .err(
             code: "browser_url_blocked",
             message: String(
@@ -7112,12 +7115,18 @@ class TerminalController {
         policy: BrowserURLAllowlistPolicy
     ) -> URL? {
         if let resolvedURL {
-            return policy.allowsTrustedInternalURL(resolvedURL) ? nil : resolvedURL
+            let allowsURL = resolvedURL.isFileURL
+                ? policy.allowsTrustedInternalURL(resolvedURL)
+                : policy.allows(resolvedURL)
+            return allowsURL ? nil : resolvedURL
         }
         guard let parsedURL = URL(string: rawInput), parsedURL.scheme != nil else {
             return nil
         }
-        return policy.allowsTrustedInternalURL(parsedURL) ? nil : parsedURL
+        let allowsURL = parsedURL.isFileURL
+            ? policy.allowsTrustedInternalURL(parsedURL)
+            : policy.allows(parsedURL)
+        return allowsURL ? nil : parsedURL
     }
 
     /// Resolves the URL accepted by `browser.tab.new`, including host-like

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -7083,7 +7083,10 @@ class TerminalController {
 
     private nonisolated func v2BrowserURLAllowlistFailure(for url: URL) -> V2CallResult? {
         let policy = BrowserURLAllowlistPolicy(defaults: .standard)
-        guard !policy.allows(url) else { return nil }
+        // Socket/CLI commands are app-owned navigation requests. Keep page
+        // callbacks on ``allows(_:)`` while allowing local documents through
+        // the policy's trusted internal-load seam.
+        guard !policy.allowsTrustedInternalURL(url) else { return nil }
         return .err(
             code: "browser_url_blocked",
             message: String(
@@ -7109,12 +7112,12 @@ class TerminalController {
         policy: BrowserURLAllowlistPolicy
     ) -> URL? {
         if let resolvedURL {
-            return policy.allows(resolvedURL) ? nil : resolvedURL
+            return policy.allowsTrustedInternalURL(resolvedURL) ? nil : resolvedURL
         }
         guard let parsedURL = URL(string: rawInput), parsedURL.scheme != nil else {
             return nil
         }
-        return policy.allows(parsedURL) ? nil : parsedURL
+        return policy.allowsTrustedInternalURL(parsedURL) ? nil : parsedURL
     }
 
     /// Resolves the URL accepted by `browser.tab.new`, including host-like

--- a/cmuxTests/BrowserNavigableURLPasteTests.swift
+++ b/cmuxTests/BrowserNavigableURLPasteTests.swift
@@ -75,6 +75,22 @@ import Testing
         )
     }
 
+    @Test func localFileBrowserAutomationUsesTheTrustedAllowlistPath() throws {
+        let fileURL = try #require(URL(string: "file:///tmp/cmux-report.html"))
+        let policy = BrowserURLAllowlistPolicy(
+            managedPatterns: nil,
+            userPatterns: ["localhost"]
+        )
+
+        #expect(
+            TerminalController.browserURLAllowlistBlockedURL(
+                rawInput: fileURL.absoluteString,
+                resolvedURL: fileURL,
+                policy: policy
+            ) == nil
+        )
+    }
+
     @Test func browserTabAutomationResolvesHostLikeLocalhostInput() throws {
         let resolved = try #require(
             TerminalController.browserAutomationURL(from: " localhost:3000 ")

--- a/cmuxTests/BrowserNavigableURLPasteTests.swift
+++ b/cmuxTests/BrowserNavigableURLPasteTests.swift
@@ -91,6 +91,19 @@ import Testing
         )
     }
 
+    @Test func automationAllowlistKeepsArbitraryDataURLsBlocked() throws {
+        let dataURL = try #require(URL(string: "data:text/html,not-a-cmux-document"))
+        let policy = BrowserURLAllowlistPolicy(managedPatterns: [])
+
+        #expect(
+            TerminalController.browserURLAllowlistBlockedURL(
+                rawInput: dataURL.absoluteString,
+                resolvedURL: dataURL,
+                policy: policy
+            )?.absoluteString == dataURL.absoluteString
+        )
+    }
+
     @Test func browserTabAutomationResolvesHostLikeLocalhostInput() throws {
         let resolved = try #require(
             TerminalController.browserAutomationURL(from: " localhost:3000 ")


### PR DESCRIPTION
## Summary

- Keep absolute local `file:` URLs (hostless or `localhost`) available whenever the embedded-browser URL allowlist is active.
- Keep network-host/relative `file:` URLs fail-closed, and leave HTTP(S) host/scheme/port matching, wildcard handling, invalid-rule behavior, and managed-policy precedence unchanged.
- Add focused user/managed/empty-policy regression coverage, with the failing test and fix in separate commits.

## Reproduction addressed

With this configuration:

```jsonc
// ~/.config/cmux/cmux.json
"browser": {
  "urlAllowlist": ["localhost", "file", "file://"]
}
```

and:

```sh
$ cmux reload-config
OK Reloaded config

$ printf '<h1>hello</h1>' > /tmp/t.html
$ cmux browser new "file:///tmp/t.html"
```

`file:///tmp/t.html` is now allowed instead of returning `browser_url_blocked`. The allowlist remains a remote-origin restriction; `file`, `file://`, `file://*`, `file:///*`, `file:*`, and `*` are not scheme-wide pattern escape hatches (bare `file` remains an ordinary HTTP host rule).

Fixes https://github.com/manaflow-ai/cmux/issues/10933

## Testing

- `swift test --package-path Packages/macOS/CmuxSettings --disable-sandbox --filter BrowserURLAllowlistFileURLTests` (passes)
- `swift test --package-path Packages/macOS/CmuxSettings --disable-sandbox --filter BrowserURLAllowlistPolicyTests` (passes)
- `swift test --package-path Packages/macOS/CmuxSettings --disable-sandbox` (300 tests passed)
- `git diff --check origin/main...HEAD`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10947"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790407493&installation_model_id=21920&pr_number=10947&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10947&signature=46d78931854204b555271ca027c5b7011113b7ea20d024ef02a3ef2678142dc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps absolute local `file:` URLs (hostless or `localhost`) available through app-initiated navigation, including socket/CLI browser commands, while the embedded-browser URL allowlist is active. Trusted documents now survive WebKit lifecycle callbacks, reloads, back/forward navigation, and webview replacement; stale grants are cleared only when the active main-frame load fails or the page moves elsewhere, so page scripts still cannot bypass the policy.

Network-host, relative, credentialed, or ported `file:` URLs still fail closed. HTTP(S) host/scheme/port matching, wildcard handling, invalid-rule behavior, managed-policy precedence, and empty-allowlist remote blocking are unchanged.

<sup>Written for commit aaed9bfcca6fd2d20a9c3845321ffbb013e59426. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Local absolute `file:` documents remain accessible through trusted app navigation when a browser web-origin allowlist is active.
  - Local file access is limited to local paths, including `localhost`; remote and relative file URLs remain blocked.
  - Trusted local documents remain recognized during browser navigation, reloads, and history actions.

- **Bug Fixes**
  - Empty managed allowlists now correctly block remote web origins while preserving trusted local documents and internal app content.

- **Documentation**
  - Clarified policy descriptions for local file URL exemptions and empty-allowlist behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->