### PR TITLE
fix(tui): localize browser control failures at UI boundary

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -8760,7 +8760,8 @@ fn run_with_machine_updates_inner(
         move |failure| {
             let _ = browser_failure_tx.send(AppEvent::BrowserResizeFailed(failure));
         },
-        move |message| {
+        move |error| {
+            let message = localization::catalog().browser.control_failed(&error);
             let _ = browser_control_tx.send(AppEvent::Mux(MuxEvent::Status(message)));
         },
     )?;

--- a/cmux-tui/crates/cmux-tui/src/browser_input.rs
+++ b/cmux-tui/crates/cmux-tui/src/browser_input.rs
@@ -958,7 +958,7 @@ fn dispatch_surface_event(
         if event.event.kind.is_control()
             && let Err(error) = result
         {
-            on_control_failure(format!("browser command failed: {error}"));
+            on_control_failure(error.to_string());
         }
         return;
     };

--- a/cmux-tui/crates/cmux-tui/src/browser_input.rs
+++ b/cmux-tui/crates/cmux-tui/src/browser_input.rs
@@ -1378,7 +1378,7 @@ mod tests {
 
         assert!(dispatcher.enqueue(reload_event(1)));
         let message = rx.recv_timeout(Duration::from_secs(1)).unwrap();
-        assert!(message.contains("browser command failed"), "unexpected message: {message}");
+        assert_eq!(message, "browser panes are not supported over attach yet");
 
         // Disposable input never reports, so the worker stays quiet for it.
         assert!(dispatcher.enqueue(move_event(1, 1.0)));

--- a/cmux-tui/crates/cmux-tui/src/localization.rs
+++ b/cmux-tui/crates/cmux-tui/src/localization.rs
@@ -248,6 +248,7 @@ pub(crate) struct ShortcutMessages {
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct BrowserMessages {
     failed_prefix: &'static str,
+    control_failed: &'static str,
     not_responding: &'static str,
     resize_recovery: &'static str,
     new_page_verification_prefix: &'static str,
@@ -264,6 +265,10 @@ pub(crate) struct BrowserMessages {
 }
 
 impl BrowserMessages {
+    pub(crate) fn control_failed(&self, error: &str) -> String {
+        self.control_failed.replace("{error}", error)
+    }
+
     pub(crate) fn loading(&self, url: &str) -> String {
         self.loading.replace("{url}", url)
     }
@@ -1323,6 +1328,7 @@ edits shell files. Authenticate with the configured host before retrying.
     },
     browser: BrowserMessages {
         failed_prefix: "browser failed: ",
+        control_failed: "browser command failed: {error}",
         not_responding: "browser failed: browser is not responding",
         resize_recovery: "browser failed: browser resize recovery failed; reload to retry",
         new_page_verification_prefix: "browser failed: could not verify new page pixels: ",
@@ -1967,6 +1973,7 @@ cmux machine-agent - ローカルの cmux セッションをリモートサー�
     },
     browser: BrowserMessages {
         failed_prefix: "ブラウザでエラーが発生しました: ",
+        control_failed: "ブラウザ操作に失敗しました: {error}",
         not_responding: "ブラウザが応答していません",
         resize_recovery: "ブラウザのサイズ変更を復旧できませんでした。再読み込みして再試行してください",
         new_page_verification_prefix: "新しいページの表示を確認できませんでした: ",
@@ -2858,6 +2865,22 @@ mod tests {
                 japanese
             );
         }
+    }
+
+    #[test]
+    fn browser_control_failures_are_localized_at_the_ui_boundary() {
+        assert_eq!(
+            catalog_for_locale("en_US.UTF-8")
+                .browser
+                .control_failed("browser panes are not supported over attach yet"),
+            "browser command failed: browser panes are not supported over attach yet"
+        );
+        assert_eq!(
+            catalog_for_locale("ja_JP.UTF-8")
+                .browser
+                .control_failed("browser panes are not supported over attach yet"),
+            "ブラウザ操作に失敗しました: browser panes are not supported over attach yet"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary\n\nBrowser control worker errors now carry only the underlying diagnostic. The app formats the status through the English/Japanese browser catalog at the UI boundary. English output remains unchanged; Japanese users no longer see the worker-owned English prefix.\n\n## Verification\n\n- rustfmt --config-path cmux-tui/rustfmt.toml --edition 2024 --check on changed Rust files\n- git diff --check\n- Cargo and rustc tests were not run, per the task constraint and cmux-tui policy\n\nThe first commit is test-only, so the regression contract is visible before the fix commit.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790409389&installation_model_id=21920&pr_number=10949&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10949&signature=698d8bfe48f58d3b85ad4724bf2a4c5881a1408108ec14d839f42d2bb38afc0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localizes browser control failure messages at the UI boundary: worker errors now carry only the underlying diagnostic, and the app wraps it through the English/Japanese browser catalog. English output is unchanged; Japanese users see a localized prefix, though the diagnostic itself remains the worker's English text.

<sup>Written for commit 634f34535681d01a9c51369eee5da21e3f57c3a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser-control failure messages with clearer, consistently formatted feedback.
  * Added localized failure messages in English and Japanese.
  * Updated error display behavior for browser commands used through attached sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->