### PR TITLE
refactor(tui): share startup option scanning

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -1162,6 +1162,9 @@ fn rewrite_server_start(args: &mut Vec<String>) {
     while index < args.len() {
         match args[index].as_str() {
             "--socket" | "--session" | "--machine" => {
+                if args.get(index + 1).is_none() {
+                    return;
+                }
                 index = startup_option_value_end(args, index).unwrap_or(args.len());
             }
             "--json" | "--jsonl" | "--quiet" => {
@@ -1222,7 +1225,7 @@ const STARTUP_VALUE_OPTIONS: &[&str] = &[
 fn startup_option_value_end(args: &[String], index: usize) -> Option<usize> {
     let option = args.get(index)?.as_str();
     if STARTUP_VALUE_OPTIONS.contains(&option) {
-        return Some(index + 2);
+        return args.get(index + 1).map(|_| index + 2);
     }
     if option == "--machine-provider-command" {
         let mut end = index + 1;
@@ -2818,6 +2821,20 @@ mod tests {
                 .map(str::to_string)
         ));
         assert!(server_start_has_cli_routing_flag(&["--json"].map(str::to_string)));
+    }
+
+    #[test]
+    fn startup_value_scanner_rejects_missing_values() {
+        for option in STARTUP_VALUE_OPTIONS.iter().copied() {
+            let args = [option].map(str::to_string);
+            assert_eq!(startup_option_value_end(&args, 0), None, "{option} accepted no value");
+        }
+
+        for option in ["--socket", "--session", "--machine"] {
+            let mut args = [option].map(str::to_string).to_vec();
+            rewrite_server_start(&mut args);
+            assert_eq!(args, [option].map(str::to_string));
+        }
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -1162,10 +1162,7 @@ fn rewrite_server_start(args: &mut Vec<String>) {
     while index < args.len() {
         match args[index].as_str() {
             "--socket" | "--session" | "--machine" => {
-                if args.get(index + 1).is_none() {
-                    return;
-                }
-                index += 2;
+                index = startup_option_value_end(args, index).unwrap_or(args.len());
             }
             "--json" | "--jsonl" | "--quiet" => {
                 output_mode = true;
@@ -1188,53 +1185,79 @@ fn rewrite_server_start(args: &mut Vec<String>) {
     }
 }
 
+const STARTUP_VALUE_OPTIONS: &[&str] = &[
+    "--socket",
+    "--session",
+    "--machine",
+    "--terminal",
+    "--state",
+    "--machine-provider",
+    "--cloud-host",
+    "--cloud-user",
+    "--cloud-port",
+    "--cloud-identity",
+    "--ws",
+    "--ws-token",
+    "--remote-ws",
+    "--remote-http",
+    "--remote-state-dir",
+    "--remote-link-socket",
+    "--remote-admin-socket",
+    "--remote-resume-lease-seconds",
+    "--relay",
+    "--relay-slot",
+    "--relay-ticket",
+    "--relay-ticket-file",
+    "--relay-ticket-command",
+    "--relay-ticket-command-arg",
+    "--advertise",
+    "--term",
+];
+
+/// Return the first argument after a startup option and its value.
+///
+/// Startup routing, relay-ticket protection, and lifecycle rewriting all need
+/// to skip the same value-bearing options. Keeping the spans in one helper
+/// prevents a new startup option from being handled by only one scanner.
+fn startup_option_value_end(args: &[String], index: usize) -> Option<usize> {
+    let option = args.get(index)?.as_str();
+    if STARTUP_VALUE_OPTIONS.contains(&option) {
+        return Some(index + 2);
+    }
+    if option == "--machine-provider-command" {
+        let mut end = index + 1;
+        while end < args.len() && args[end] != "--" {
+            end += 1;
+        }
+        return Some(end + 1);
+    }
+    None
+}
+
+fn is_inline_relay_ticket(value: &str) -> bool {
+    value == "--relay-ticket" || value.starts_with("--relay-ticket=")
+}
+
 fn has_inline_relay_ticket_argument(args: &[String]) -> bool {
     let mut index = 0;
     while index < args.len() {
-        match args[index].as_str() {
-            option if option == "--relay-ticket" || option.starts_with("--relay-ticket=") => {
+        let option = args[index].as_str();
+        if is_inline_relay_ticket(option) {
+            return true;
+        }
+        if let Some(end) = startup_option_value_end(args, index) {
+            // A helper argument or provider command may intentionally contain
+            // the literal `--relay-ticket`; those payloads are not startup
+            // credentials and must remain untouched.
+            if option != "--relay-ticket-command-arg"
+                && option != "--machine-provider-command"
+                && args.get(index + 1).is_some_and(|value| is_inline_relay_ticket(value))
+            {
                 return true;
             }
-            "--session"
-            | "--socket"
-            | "--machine"
-            | "--terminal"
-            | "--state"
-            | "--machine-provider"
-            | "--cloud-host"
-            | "--cloud-user"
-            | "--cloud-port"
-            | "--cloud-identity"
-            | "--ws"
-            | "--ws-token"
-            | "--remote-ws"
-            | "--remote-http"
-            | "--remote-state-dir"
-            | "--remote-link-socket"
-            | "--remote-admin-socket"
-            | "--remote-resume-lease-seconds"
-            | "--relay"
-            | "--relay-slot"
-            | "--relay-ticket-file"
-            | "--relay-ticket-command"
-            | "--advertise"
-            | "--term" => {
-                if args.get(index + 1).is_some_and(|value| {
-                    value == "--relay-ticket" || value.starts_with("--relay-ticket=")
-                }) {
-                    return true;
-                }
-                index += 2;
-            }
-            "--relay-ticket-command-arg" => index += 2,
-            "--machine-provider-command" => {
-                index += 1;
-                while index < args.len() && args[index] != "--" {
-                    index += 1;
-                }
-                index += 1;
-            }
-            _ => index += 1,
+            index = end;
+        } else {
+            index += 1;
         }
     }
     false
@@ -1247,40 +1270,8 @@ fn server_start_has_cli_routing_flag(args: &[String]) -> bool {
     let mut index = 0;
     while index < args.len() {
         match args[index].as_str() {
-            "--session"
-            | "--socket"
-            | "--machine"
-            | "--terminal"
-            | "--state"
-            | "--machine-provider"
-            | "--cloud-host"
-            | "--cloud-user"
-            | "--cloud-port"
-            | "--cloud-identity"
-            | "--ws"
-            | "--ws-token"
-            | "--remote-ws"
-            | "--remote-http"
-            | "--remote-state-dir"
-            | "--remote-link-socket"
-            | "--remote-admin-socket"
-            | "--remote-resume-lease-seconds"
-            | "--relay"
-            | "--relay-slot"
-            | "--relay-ticket-file"
-            | "--relay-ticket-command"
-            | "--relay-ticket-command-arg"
-            | "--advertise"
-            | "--term" => index += 2,
-            "--machine-provider-command" => {
-                index += 1;
-                while index < args.len() && args[index] != "--" {
-                    index += 1;
-                }
-                index += 1;
-            }
             "-h" | "--help" | "--json" | "--jsonl" | "--quiet" => return true,
-            _ => index += 1,
+            _ => index = startup_option_value_end(args, index).unwrap_or(index + 1),
         }
     }
     false
@@ -1294,33 +1285,11 @@ fn is_cli_invocation(args: &[String]) -> bool {
     }
     let mut index = 0;
     while index < args.len() {
-        match args[index].as_str() {
-            "--socket"
-            | "--session"
-            | "--machine"
-            | "--terminal"
-            | "--state"
-            | "--machine-provider"
-            | "--cloud-host"
-            | "--cloud-user"
-            | "--cloud-port"
-            | "--cloud-identity"
-            | "--ws"
-            | "--ws-token"
-            | "--remote-ws"
-            | "--remote-http"
-            | "--remote-state-dir"
-            | "--remote-link-socket"
-            | "--remote-admin-socket"
-            | "--remote-resume-lease-seconds"
-            | "--relay"
-            | "--relay-slot"
-            | "--relay-ticket"
-            | "--relay-ticket-file"
-            | "--relay-ticket-command"
-            | "--relay-ticket-command-arg"
-            | "--advertise"
-            | "--term" => index += 2,
+        let value = args[index].as_str();
+        if value == "--machine-provider-command" {
+            return false;
+        }
+        match value {
             "--json" | "--jsonl" | "--quiet" => index += 1,
             "--ephemeral"
             | "--cloud"
@@ -1329,15 +1298,22 @@ fn is_cli_invocation(args: &[String]) -> bool {
             | "--remote"
             | "--remote-ws-insecure-bind"
             | "--iroh" => index += 1,
-            "--machine-provider-command" => return false,
             "-h" | "--help" | "help" => return true,
             "attach" => return false,
             value if cli::is_public_scope(value) => return true,
-            value if value.starts_with('-') => index += 1,
-            // Session startup has no positional arguments. Route unknown
-            // top-level words through the public parser so typos cannot fall
-            // into the unrelated legacy startup help.
-            _ => return true,
+            _ => {
+                if let Some(end) = startup_option_value_end(args, index) {
+                    index = end;
+                } else if value.starts_with('-') {
+                    index += 1;
+                } else {
+                    // Session startup has no positional arguments. Route
+                    // unknown top-level words through the public parser so
+                    // typos cannot fall into the unrelated legacy startup
+                    // help.
+                    return true;
+                }
+            }
         }
     }
     false
@@ -2819,6 +2795,29 @@ mod tests {
         let mut quiet = ["server", "start", "--quiet"].map(str::to_string).to_vec();
         rewrite_server_start(&mut quiet);
         assert_eq!(quiet, ["server", "start", "--quiet"]);
+    }
+
+    #[test]
+    fn startup_scanners_share_option_value_boundaries() {
+        for option in STARTUP_VALUE_OPTIONS
+            .iter()
+            .copied()
+            .filter(|option| !matches!(*option, "--relay-ticket" | "--relay-ticket-command-arg"))
+        {
+            let args = [option, "--help"].map(str::to_string);
+            assert!(!is_cli_invocation(&args), "{option} consumed a value boundary");
+            assert!(!server_start_has_cli_routing_flag(&args), "{option} routed its value");
+        }
+
+        assert!(!has_inline_relay_ticket_argument(
+            &["--relay-ticket-command", "helper", "--relay-ticket-command-arg", "--relay-ticket",]
+                .map(str::to_string)
+        ));
+        assert!(!has_inline_relay_ticket_argument(
+            &["--machine-provider-command", "provider", "--relay-ticket", "--",]
+                .map(str::to_string)
+        ));
+        assert!(server_start_has_cli_routing_flag(&["--json"].map(str::to_string)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- share startup value-option spans across lifecycle rewrite, routing, and relay-ticket scans
- preserve opaque helper and provider command payloads
- add behavior coverage for option value boundaries

## Verification
- rustfmt --edition 2024 --check cmux-tui/crates/cmux-tui/src/main.rs
- git diff --check
- hosted verification dispatched with `--filter startup_scanners_share_option_value_boundaries`

No merge requested.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790411543&installation_model_id=21920&pr_number=10951&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10951&signature=0d230938a00a2d0511e548a31a28adc50d6d3528fb5b412eca5178e3fea1b4dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shares startup option scanning across lifecycle rewrite, CLI routing, and relay-ticket detection so all three skip the same value-bearing options, and stops panicking when a value option is the last argument.

**Refactors**
- Adds `STARTUP_VALUE_OPTIONS` and `startup_option_value_end` as the single source of truth for value-bearing startup options.
- Replaces duplicated option lists in `has_inline_relay_ticket_argument`, `server_start_has_cli_routing_flag`, and `is_cli_invocation`.
- Keeps relay-ticket detection excluding `--relay-ticket-command-arg` and `--machine-provider-command` payloads.

**Fixes**
- `startup_option_value_end` returns `None` when a value option lacks a value, and `rewrite_server_start` bounds its scan so a trailing value option no longer panics.
- Adds tests for option value boundaries, protected payloads, missing values, and incomplete rewrites.

<sup>Written for commit 978655f95b56351c9d554d2bdd1be9ad6ec2c551. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup argument handling for commands that include values or provider command payloads.
  * Preserved relay-ticket values when passed within command arguments.
  * Ensured unknown positional startup arguments continue to route correctly through the public CLI.
  * Improved consistency across startup processing, command routing, and inline relay-ticket detection.
  * Prevented command payloads from being misinterpreted as startup options, improving reliability for advanced command-line workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->