### PR TITLE
fix(tui): route advisory graphics diagnostics away from status

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/lib.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/lib.rs
@@ -55,8 +55,8 @@ pub use layout::{
 pub use model::{Node, Pane, Screen, State, ViewportColumn, Workspace};
 pub use mux::{
     AgentRecord, AgentSource, AgentState, AppliedLayout, AppliedPane, CellPixelUpdate,
-    CellPixelUpdateFailure, ConfigReloadError, Direction, GraphicsStatus, LayoutLeafSpec,
-    LayoutRatioError, LayoutSpec, LayoutUndoError, LayoutUndoResult, Mux, MuxEvent,
+    CellPixelUpdateFailure, ConfigReloadError, DiagnosticReporter, Direction, GraphicsStatus,
+    LayoutLeafSpec, LayoutRatioError, LayoutSpec, LayoutUndoError, LayoutUndoResult, Mux, MuxEvent,
     NotificationEvent, NotificationLevel, ProviderWorkspaceAuthority,
     ProviderWorkspaceAuthorityStatus, ProviderWorkspaceAuthorityUpdateError, ResourceNotification,
     RunPlacement, SidebarPluginOptions, SidebarPluginStatus, SurfaceNotification,

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -16923,6 +16923,25 @@ mod tests {
         );
     }
 
+    #[test]
+    fn diagnostic_reporter_receives_skip_reported_before_installation() {
+        let mux = test_mux();
+        let diagnostics = Arc::new(Mutex::new(Vec::<String>::new()));
+        let error = anyhow::anyhow!("startup checkpoint race");
+
+        mux.report_skipped_reconnect_checkpoint("startup", &error);
+        assert!(diagnostics.lock().unwrap().is_empty());
+
+        let diagnostics_for_reporter = Arc::clone(&diagnostics);
+        assert!(mux.set_diagnostic_reporter(Arc::new(move |message| {
+            diagnostics_for_reporter.lock().unwrap().push(message.to_string());
+        })));
+        assert_eq!(
+            &*diagnostics.lock().unwrap(),
+            &["skipped terminal startup reconnect checkpoint (replay starts from the previous boundary): startup checkpoint race".to_string()]
+        );
+    }
+
     fn assert_terminal_view_detached(mux: &Mux, surface: SurfaceId) {
         assert!(!mux.with_state(|state| state.surfaces.contains_key(&surface)));
         assert!(mux.surface(surface).is_some(), "terminal runtime must remain catalog-owned");

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -2029,8 +2029,11 @@ pub struct Mux {
     reconnect_checkpoint_skip_reported: AtomicBool,
     /// Frontend-owned sink for diagnostics emitted by background core work.
     /// `OnceLock` keeps the callback immutable after startup and avoids a
-    /// mutex on the reconnect hot path.
+    /// mutex on the reconnect hot path. Startup can adopt a hosted surface
+    /// before the frontend installs the sink, so one diagnostic is retained
+    /// in a per-mux slot until the first reporter arrives.
     diagnostic_reporter: OnceLock<DiagnosticReporter>,
+    pending_diagnostic: Mutex<Option<String>>,
     #[cfg(test)]
     journal_segment_prepare_hook: Mutex<Option<Box<dyn FnOnce() + Send>>>,
     terminal_exit_waiters: TerminalExitWaiters,
@@ -2393,6 +2396,7 @@ impl Mux {
             journal_event_changed: Condvar::new(),
             reconnect_checkpoint_skip_reported: AtomicBool::new(false),
             diagnostic_reporter: OnceLock::new(),
+            pending_diagnostic: Mutex::new(None),
             #[cfg(test)]
             journal_segment_prepare_hook: Mutex::new(None),
             terminal_exit_waiters: TerminalExitWaiters::default(),
@@ -5261,10 +5265,24 @@ impl Mux {
         let message = format!(
             "skipped terminal {terminal_id} reconnect checkpoint (replay starts from the previous boundary): {error:#}"
         );
-        if !self.reconnect_checkpoint_skip_reported.swap(true, Ordering::AcqRel) {
-            if let Some(reporter) = self.diagnostic_reporter.get() {
-                reporter(&message);
-            }
+        if self.reconnect_checkpoint_skip_reported.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        if let Some(reporter) = self.diagnostic_reporter.get().cloned() {
+            reporter(&message);
+            return;
+        }
+
+        // Mux construction can start hosted-surface readers before the
+        // frontend has a chance to install its reporter. Recheck under the
+        // pending slot lock so a concurrent setter cannot leave this message
+        // stranded between the initial lookup and the store.
+        let mut pending = self.pending_diagnostic.lock().unwrap();
+        if let Some(reporter) = self.diagnostic_reporter.get().cloned() {
+            drop(pending);
+            reporter(&message);
+        } else {
+            *pending = Some(message);
         }
     }
 
@@ -5275,7 +5293,15 @@ impl Mux {
     /// caller that tries to install a second sink receives `false` and must
     /// keep the original owner unchanged.
     pub fn set_diagnostic_reporter(&self, reporter: DiagnosticReporter) -> bool {
-        self.diagnostic_reporter.set(reporter).is_ok()
+        let pending_reporter = reporter.clone();
+        if self.diagnostic_reporter.set(reporter).is_err() {
+            return false;
+        }
+        let pending = self.pending_diagnostic.lock().unwrap().take();
+        if let Some(message) = pending {
+            pending_reporter(&message);
+        }
+        true
     }
 
     pub(crate) fn note_reconnect_checkpoint_captured(&self) {

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -74,6 +74,13 @@ use crate::{
 
 pub type SurfaceResizeReporter = Arc<dyn Fn(SurfaceId, (u16, u16), Option<u64>) + Send + Sync>;
 
+/// Receives diagnostics that must not be written to a frontend's terminal.
+///
+/// The core can report from reconnect worker threads while a client owns a
+/// raw terminal. The frontend supplies a durable sink, such as its client
+/// log, so the core does not need to know how diagnostics are persisted.
+pub type DiagnosticReporter = Arc<dyn Fn(&str) + Send + Sync + 'static>;
+
 struct SignaledMutex<T> {
     value: Mutex<T>,
     release_epoch: Mutex<u64>,
@@ -2020,6 +2027,10 @@ pub struct Mux {
     /// per-terminal reporting would emit N warnings for one underlying
     /// condition. Cleared when a reconnect checkpoint succeeds again.
     reconnect_checkpoint_skip_reported: AtomicBool,
+    /// Frontend-owned sink for diagnostics emitted by background core work.
+    /// `OnceLock` keeps the callback immutable after startup and avoids a
+    /// mutex on the reconnect hot path.
+    diagnostic_reporter: OnceLock<DiagnosticReporter>,
     #[cfg(test)]
     journal_segment_prepare_hook: Mutex<Option<Box<dyn FnOnce() + Send>>>,
     terminal_exit_waiters: TerminalExitWaiters,
@@ -2381,6 +2392,7 @@ impl Mux {
             journal_event_epoch: Mutex::new(0),
             journal_event_changed: Condvar::new(),
             reconnect_checkpoint_skip_reported: AtomicBool::new(false),
+            diagnostic_reporter: OnceLock::new(),
             #[cfg(test)]
             journal_segment_prepare_hook: Mutex::new(None),
             terminal_exit_waiters: TerminalExitWaiters::default(),
@@ -5250,8 +5262,20 @@ impl Mux {
             "skipped terminal {terminal_id} reconnect checkpoint (replay starts from the previous boundary): {error:#}"
         );
         if !self.reconnect_checkpoint_skip_reported.swap(true, Ordering::AcqRel) {
-            eprintln!("cmux-tui: {message}");
+            if let Some(reporter) = self.diagnostic_reporter.get() {
+                reporter(&message);
+            }
         }
+    }
+
+    /// Installs the frontend-owned sink for diagnostics emitted by the mux.
+    ///
+    /// A mux has one owner for its lifetime, so accepting the first reporter
+    /// avoids replacing a sink while a reconnect worker is reporting. A
+    /// caller that tries to install a second sink receives `false` and must
+    /// keep the original owner unchanged.
+    pub fn set_diagnostic_reporter(&self, reporter: DiagnosticReporter) -> bool {
+        self.diagnostic_reporter.set(reporter).is_ok()
     }
 
     pub(crate) fn note_reconnect_checkpoint_captured(&self) {
@@ -16824,6 +16848,12 @@ mod tests {
     #[test]
     fn reconnect_checkpoint_skip_does_not_emit_status() {
         let mux = test_mux();
+        let diagnostics = Arc::new(Mutex::new(Vec::<String>::new()));
+        let diagnostics_for_reporter = Arc::clone(&diagnostics);
+        assert!(mux.set_diagnostic_reporter(Arc::new(move |message| {
+            diagnostics_for_reporter.lock().unwrap().push(message.to_string());
+        })));
+        assert!(!mux.set_diagnostic_reporter(Arc::new(|_| {})));
         let events = mux.subscribe();
         let skip_statuses = |events: &MuxEventReceiver| {
             events
@@ -16851,6 +16881,45 @@ mod tests {
             skip_statuses(&events),
             0,
             "re-armed diagnostic logging must remain out of the status stream"
+        );
+        assert_eq!(
+            &*diagnostics.lock().unwrap(),
+            &vec![
+                "skipped terminal term_one reconnect checkpoint (replay starts from the previous boundary): session changed during checkpoint capture".to_string(),
+                "skipped terminal term_three reconnect checkpoint (replay starts from the previous boundary): session changed during checkpoint capture".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn diagnostic_reporters_are_scoped_to_each_mux_and_first_writer_wins() {
+        let first = test_mux();
+        let second = test_mux();
+        let first_reports = Arc::new(Mutex::new(Vec::<String>::new()));
+        let second_reports = Arc::new(Mutex::new(Vec::<String>::new()));
+
+        let first_reports_sink = Arc::clone(&first_reports);
+        assert!(first.set_diagnostic_reporter(Arc::new(move |message| {
+            first_reports_sink.lock().unwrap().push(message.to_string());
+        })));
+        assert!(!first.set_diagnostic_reporter(Arc::new(|_| {})));
+
+        let second_reports_sink = Arc::clone(&second_reports);
+        assert!(second.set_diagnostic_reporter(Arc::new(move |message| {
+            second_reports_sink.lock().unwrap().push(message.to_string());
+        })));
+
+        let error = anyhow::anyhow!("checkpoint race");
+        first.report_skipped_reconnect_checkpoint("first", &error);
+        second.report_skipped_reconnect_checkpoint("second", &error);
+
+        assert_eq!(
+            &*first_reports.lock().unwrap(),
+            &["skipped terminal first reconnect checkpoint (replay starts from the previous boundary): checkpoint race".to_string()]
+        );
+        assert_eq!(
+            &*second_reports.lock().unwrap(),
+            &["skipped terminal second reconnect checkpoint (replay starts from the previous boundary): checkpoint race".to_string()]
         );
     }
 

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -2015,11 +2015,10 @@ pub struct Mux {
     /// reread SQLite by cursor, so missed or coalesced notifications are safe.
     journal_event_epoch: Mutex<u64>,
     journal_event_changed: Condvar,
-    /// True once a skipped terminal-host reconnect checkpoint has been
-    /// surfaced as a status event. A machine resume reconnects every hosted
-    /// terminal at once, so per-terminal reporting would toast N times for
-    /// one underlying condition. Cleared when a reconnect checkpoint
-    /// succeeds again.
+    /// True once a skipped terminal-host reconnect checkpoint has been logged.
+    /// A machine resume reconnects every hosted terminal at once, so
+    /// per-terminal reporting would emit N warnings for one underlying
+    /// condition. Cleared when a reconnect checkpoint succeeds again.
     reconnect_checkpoint_skip_reported: AtomicBool,
     #[cfg(test)]
     journal_segment_prepare_hook: Mutex<Option<Box<dyn FnOnce() + Send>>>,
@@ -5237,7 +5236,7 @@ impl Mux {
         Ok(())
     }
 
-    /// Reports a skipped terminal-host reconnect checkpoint at most once
+    /// Logs a skipped terminal-host reconnect checkpoint at most once
     /// until a later reconnect checkpoint succeeds. A checkpoint is a
     /// journal-replay optimization: skipping one only moves the next replay
     /// boundary back, so repeated skips are daemon-log noise, not per-toast
@@ -5250,10 +5249,8 @@ impl Mux {
         let message = format!(
             "skipped terminal {terminal_id} reconnect checkpoint (replay starts from the previous boundary): {error:#}"
         );
-        if self.reconnect_checkpoint_skip_reported.swap(true, Ordering::AcqRel) {
+        if !self.reconnect_checkpoint_skip_reported.swap(true, Ordering::AcqRel) {
             eprintln!("cmux-tui: {message}");
-        } else {
-            self.emit(MuxEvent::Status(message));
         }
     }
 

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -16818,13 +16818,14 @@ mod tests {
         Mux::new_for_test("test", SurfaceOptions::default())
     }
 
-    /// A machine resume reconnects every hosted terminal at once. When
-    /// checkpoint capture keeps losing its consistency race on a busy
-    /// session, the skip must surface as one status event, not one toast per
-    /// terminal per reconnect. A later successful checkpoint re-arms the
-    /// report.
+    /// A machine resume reconnects every hosted terminal at once. Checkpoint
+    /// capture can lose its consistency race while those reconnects append to
+    /// the journal, but the skipped optimization is recovered by replaying
+    /// from the previous boundary. It must stay out of the user-facing status
+    /// stream even when it repeats or a later successful checkpoint re-arms
+    /// diagnostic logging.
     #[test]
-    fn reconnect_checkpoint_skip_status_is_reported_once_until_recovery() {
+    fn reconnect_checkpoint_skip_does_not_emit_status() {
         let mux = test_mux();
         let events = mux.subscribe();
         let skip_statuses = |events: &MuxEventReceiver| {
@@ -16843,16 +16844,16 @@ mod tests {
         mux.report_skipped_reconnect_checkpoint("term_one", &error);
         assert_eq!(
             skip_statuses(&events),
-            1,
-            "repeated checkpoint skips must collapse into one status event"
+            0,
+            "recoverable checkpoint skips must not enter the status stream"
         );
 
         mux.note_reconnect_checkpoint_captured();
         mux.report_skipped_reconnect_checkpoint("term_three", &error);
         assert_eq!(
             skip_statuses(&events),
-            1,
-            "a skip after a successful checkpoint is a new condition and reports again"
+            0,
+            "re-armed diagnostic logging must remain out of the status stream"
         );
     }
 

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -14813,14 +14813,20 @@ impl App {
                 Ok(RenderAction::Draw)
             }
             AppEvent::Mux(MuxEvent::GraphicsStatus(status)) => {
+                // Kitty quota updates are advisory: the mux disables graphics
+                // for an unresponsive surface and the terminal remains usable.
+                // Keep the structured event available to logs and remote
+                // observers, but do not replace user-facing command status
+                // with a diagnostic the user cannot act on.
+                if matches!(&status, GraphicsStatus::KittyImageBudgetUpdateFailed { .. }) {
+                    return Ok(RenderAction::None);
+                }
                 let messages = &localization::catalog().graphics;
                 self.status_message = Some(match status {
                     GraphicsStatus::KittyImageBudgetWorkerStartFailed { error } => {
                         messages.kitty_image_budget_worker_start_failed(&error)
                     }
-                    GraphicsStatus::KittyImageBudgetUpdateFailed { retry_exhausted, summary } => {
-                        messages.kitty_image_budget_update_failed(retry_exhausted, &summary)
-                    }
+                    GraphicsStatus::KittyImageBudgetUpdateFailed { .. } => unreachable!(),
                     GraphicsStatus::CellPixelUpdateRetriesExhausted {
                         attempts,
                         remaining,
@@ -33792,24 +33798,6 @@ mod tests {
                     },
                 ),
                 "Kitty 画像予算ワーカーを開始できませんでした: thread unavailable",
-            ),
-            (
-                MuxEvent::GraphicsStatus(
-                    cmux_tui_core::GraphicsStatus::KittyImageBudgetUpdateFailed {
-                        retry_exhausted: false,
-                        summary: Arc::<str>::from("surface 7: offline"),
-                    },
-                ),
-                "Kitty 画像予算の更新に失敗しました。再試行しています: surface 7: offline",
-            ),
-            (
-                MuxEvent::GraphicsStatus(
-                    cmux_tui_core::GraphicsStatus::KittyImageBudgetUpdateFailed {
-                        retry_exhausted: true,
-                        summary: Arc::<str>::from("surface 7: offline"),
-                    },
-                ),
-                "Kitty 画像予算の更新に失敗し、再試行回数の上限に達したため停止しました: surface 7: offline",
             ),
             (
                 MuxEvent::GraphicsStatus(

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -14813,15 +14813,22 @@ impl App {
                 Ok(RenderAction::Draw)
             }
             AppEvent::Mux(MuxEvent::GraphicsStatus(status)) => {
+                let messages = &localization::catalog().graphics;
                 // Kitty quota updates are advisory: the mux disables graphics
                 // for an unresponsive surface and the terminal remains usable.
                 // Keep the structured event available to logs and remote
                 // observers, but do not replace user-facing command status
                 // with a diagnostic the user cannot act on.
-                if matches!(&status, GraphicsStatus::KittyImageBudgetUpdateFailed { .. }) {
+                if let GraphicsStatus::KittyImageBudgetUpdateFailed { retry_exhausted, summary } =
+                    &status
+                {
+                    crate::client_log::log(
+                        "ERROR",
+                        "kitty-graphics",
+                        &messages.kitty_image_budget_update_failed(*retry_exhausted, summary),
+                    );
                     return Ok(RenderAction::None);
                 }
-                let messages = &localization::catalog().graphics;
                 self.status_message = Some(match status {
                     GraphicsStatus::KittyImageBudgetWorkerStartFailed { error } => {
                         messages.kitty_image_budget_worker_start_failed(&error)

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -33851,6 +33851,24 @@ mod tests {
     }
 
     #[test]
+    fn kitty_budget_failures_do_not_replace_the_user_status_message() {
+        let mux = Mux::new("kitty-status-preservation-test", SurfaceOptions::default());
+        let mut app = test_app(Session::Local(mux));
+        app.status_message = Some("command completed".to_string());
+
+        for retry_exhausted in [false, true] {
+            app.handle(AppEvent::Mux(MuxEvent::GraphicsStatus(
+                cmux_tui_core::GraphicsStatus::KittyImageBudgetUpdateFailed {
+                    retry_exhausted,
+                    summary: Arc::<str>::from("surface 7: host did not acknowledge limits"),
+                },
+            )))
+            .unwrap();
+            assert_eq!(app.status_message.as_deref(), Some("command completed"));
+        }
+    }
+
+    #[test]
     fn first_input_for_missing_mirror_is_deferred_through_attach() {
         let mux = Mux::new("missing-mirror-input-test", SurfaceOptions::default());
         let (mut app, events) = test_app_with_events(Session::Local(mux));

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -8660,6 +8660,15 @@ fn uses_provider_managed_workspaces(machine_ui: Option<&MachineUiState>) -> bool
     )
 }
 
+/// Route core diagnostics to the bounded client log. Core work can run on a
+/// reconnect thread while this process owns a raw terminal, so the sink must
+/// not echo to stderr.
+pub(crate) fn install_mux_diagnostic_logger(mux: &Arc<Mux>) {
+    let _ = mux.set_diagnostic_reporter(Arc::new(|message| {
+        crate::client_log::warn("mux", message);
+    }));
+}
+
 fn ensure_managed_workspace_guard(
     session: &Session,
     machine_ui: Option<&MachineUiState>,
@@ -8726,6 +8735,12 @@ fn run_with_machine_updates_inner(
     machine_ui: Option<MachineUiState>,
     machine_controller: Option<Box<dyn MachineController>>,
 ) -> anyhow::Result<RunOutcome> {
+    if let Session::Local(mux) = &session {
+        install_mux_diagnostic_logger(mux);
+    }
+    if let Some(mux) = owner_mux.as_ref() {
+        install_mux_diagnostic_logger(mux);
+    }
     let mut config = crate::config::load();
     let chrome = ChromeTheme::for_defaults(config.chrome, default_colors);
     config.apply_chrome_defaults(chrome);
@@ -14825,7 +14840,7 @@ impl App {
                     // with a diagnostic the user cannot act on.
                     GraphicsStatus::KittyImageBudgetUpdateFailed { retry_exhausted, summary } => {
                         crate::client_log::log(
-                            "ERROR",
+                            "WARN",
                             "kitty-graphics",
                             &messages.kitty_image_budget_update_failed(retry_exhausted, &summary),
                         );
@@ -33795,6 +33810,32 @@ mod tests {
             .lock()
             .unwrap()
             .insert(7, SurfaceResizeOwnership { desired: (90, 31), reservation_id: None });
+
+        app.status_message = Some("直前のコマンドは完了しました".to_string());
+        crate::client_log::start_test_log_capture();
+        for retry_exhausted in [false, true] {
+            let action = app
+                .handle(AppEvent::Mux(MuxEvent::GraphicsStatus(
+                    cmux_tui_core::GraphicsStatus::KittyImageBudgetUpdateFailed {
+                        retry_exhausted,
+                        summary: Arc::<str>::from("surface 7: offline"),
+                    },
+                )))
+                .unwrap();
+            assert_eq!(action, RenderAction::None);
+            assert_eq!(app.status_message.as_deref(), Some("直前のコマンドは完了しました"));
+        }
+        let kitty_records = crate::client_log::take_test_log_capture();
+        assert_eq!(kitty_records.len(), 2);
+        for (record, expected) in kitty_records.iter().zip([
+            "Kitty 画像予算の更新に失敗しました。再試行しています: surface 7: offline",
+            "Kitty 画像予算の更新に失敗し、再試行回数の上限に達したため停止しました: surface 7: offline",
+        ]) {
+            assert_eq!(record.level, "WARN");
+            assert_eq!(record.area, "kitty-graphics");
+            assert_eq!(record.message, expected);
+        }
+
         let cases = [
             (
                 MuxEvent::GraphicsStatus(
@@ -33866,15 +33907,13 @@ mod tests {
 
         let records = crate::client_log::take_test_log_capture();
         assert_eq!(records.len(), 2);
-        for (record, retry_exhausted) in records.iter().zip([false, true]) {
-            assert_eq!(record.level, "ERROR");
+        for (record, expected) in records.iter().zip([
+            "Kitty image budget update failed, retrying: surface 7: host did not acknowledge limits",
+            "Kitty image budget update failed, stopped after exhausting retries: surface 7: host did not acknowledge limits",
+        ]) {
+            assert_eq!(record.level, "WARN");
             assert_eq!(record.area, "kitty-graphics");
-            assert_eq!(
-                record.message,
-                localization::catalog()
-                    .graphics
-                    .kitty_image_budget_update_failed(retry_exhausted, summary)
-            );
+            assert_eq!(record.message, expected);
         }
     }
 

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -14822,11 +14822,14 @@ impl App {
                 if let GraphicsStatus::KittyImageBudgetUpdateFailed { retry_exhausted, summary } =
                     &status
                 {
+                    #[cfg(not(test))]
                     crate::client_log::log(
                         "ERROR",
                         "kitty-graphics",
                         &messages.kitty_image_budget_update_failed(*retry_exhausted, summary),
                     );
+                    #[cfg(test)]
+                    let _ = (messages, retry_exhausted, summary);
                     return Ok(RenderAction::None);
                 }
                 self.status_message = Some(match status {

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -14824,14 +14824,11 @@ impl App {
                     // observers, but do not replace user-facing command status
                     // with a diagnostic the user cannot act on.
                     GraphicsStatus::KittyImageBudgetUpdateFailed { retry_exhausted, summary } => {
-                        #[cfg(not(test))]
                         crate::client_log::log(
                             "ERROR",
                             "kitty-graphics",
                             &messages.kitty_image_budget_update_failed(retry_exhausted, &summary),
                         );
-                        #[cfg(test)]
-                        let _ = (messages, retry_exhausted, summary);
                         return Ok(RenderAction::None);
                     }
                     GraphicsStatus::CellPixelUpdateRetriesExhausted {
@@ -33851,16 +33848,33 @@ mod tests {
         let mux = Mux::new("kitty-status-preservation-test", SurfaceOptions::default());
         let mut app = test_app(Session::Local(mux));
         app.status_message = Some("command completed".to_string());
+        crate::client_log::start_test_log_capture();
 
+        let summary = "surface 7: host did not acknowledge limits";
         for retry_exhausted in [false, true] {
-            app.handle(AppEvent::Mux(MuxEvent::GraphicsStatus(
-                cmux_tui_core::GraphicsStatus::KittyImageBudgetUpdateFailed {
-                    retry_exhausted,
-                    summary: Arc::<str>::from("surface 7: host did not acknowledge limits"),
-                },
-            )))
-            .unwrap();
+            let action = app
+                .handle(AppEvent::Mux(MuxEvent::GraphicsStatus(
+                    cmux_tui_core::GraphicsStatus::KittyImageBudgetUpdateFailed {
+                        retry_exhausted,
+                        summary: Arc::<str>::from(summary),
+                    },
+                )))
+                .unwrap();
+            assert_eq!(action, RenderAction::None);
             assert_eq!(app.status_message.as_deref(), Some("command completed"));
+        }
+
+        let records = crate::client_log::take_test_log_capture();
+        assert_eq!(records.len(), 2);
+        for (record, retry_exhausted) in records.iter().zip([false, true]) {
+            assert_eq!(record.level, "ERROR");
+            assert_eq!(record.area, "kitty-graphics");
+            assert_eq!(
+                record.message,
+                localization::catalog()
+                    .graphics
+                    .kitty_image_budget_update_failed(retry_exhausted, summary)
+            );
         }
     }
 

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -14814,29 +14814,26 @@ impl App {
             }
             AppEvent::Mux(MuxEvent::GraphicsStatus(status)) => {
                 let messages = &localization::catalog().graphics;
-                // Kitty quota updates are advisory: the mux disables graphics
-                // for an unresponsive surface and the terminal remains usable.
-                // Keep the structured event available to logs and remote
-                // observers, but do not replace user-facing command status
-                // with a diagnostic the user cannot act on.
-                if let GraphicsStatus::KittyImageBudgetUpdateFailed { retry_exhausted, summary } =
-                    &status
-                {
-                    #[cfg(not(test))]
-                    crate::client_log::log(
-                        "ERROR",
-                        "kitty-graphics",
-                        &messages.kitty_image_budget_update_failed(*retry_exhausted, summary),
-                    );
-                    #[cfg(test)]
-                    let _ = (messages, retry_exhausted, summary);
-                    return Ok(RenderAction::None);
-                }
-                self.status_message = Some(match status {
+                let message = match status {
                     GraphicsStatus::KittyImageBudgetWorkerStartFailed { error } => {
                         messages.kitty_image_budget_worker_start_failed(&error)
                     }
-                    GraphicsStatus::KittyImageBudgetUpdateFailed { .. } => unreachable!(),
+                    // Kitty quota updates are advisory: the mux disables graphics
+                    // for an unresponsive surface and the terminal remains usable.
+                    // Keep the structured event available to logs and remote
+                    // observers, but do not replace user-facing command status
+                    // with a diagnostic the user cannot act on.
+                    GraphicsStatus::KittyImageBudgetUpdateFailed { retry_exhausted, summary } => {
+                        #[cfg(not(test))]
+                        crate::client_log::log(
+                            "ERROR",
+                            "kitty-graphics",
+                            &messages.kitty_image_budget_update_failed(retry_exhausted, &summary),
+                        );
+                        #[cfg(test)]
+                        let _ = (messages, retry_exhausted, summary);
+                        return Ok(RenderAction::None);
+                    }
                     GraphicsStatus::CellPixelUpdateRetriesExhausted {
                         attempts,
                         remaining,
@@ -14846,7 +14843,8 @@ impl App {
                         remaining,
                         cell_pixels,
                     ),
-                });
+                };
+                self.status_message = Some(message);
                 Ok(RenderAction::Draw)
             }
             AppEvent::Mux(MuxEvent::ConfigReloadRequested) => {

--- a/cmux-tui/crates/cmux-tui/src/client_log.rs
+++ b/cmux-tui/crates/cmux-tui/src/client_log.rs
@@ -11,6 +11,8 @@
 //! `CMUX_TUI_LOG_FILE` override. Logging is best-effort and silent: a client
 //! must never fail or spam the terminal because its log file is unavailable.
 
+#[cfg(test)]
+use std::cell::RefCell;
 use std::fs::{self, File, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -39,6 +41,33 @@ struct Record {
     level: &'static str,
     area: String,
     message: String,
+}
+
+#[cfg(test)]
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct TestLogRecord {
+    pub(crate) level: &'static str,
+    pub(crate) area: String,
+    pub(crate) message: String,
+}
+
+#[cfg(test)]
+thread_local! {
+    static TEST_LOG_RECORDS: RefCell<Option<Vec<TestLogRecord>>> = const {
+        RefCell::new(None)
+    };
+}
+
+#[cfg(test)]
+pub(crate) fn start_test_log_capture() {
+    TEST_LOG_RECORDS.with(|records| {
+        *records.borrow_mut() = Some(Vec::new());
+    });
+}
+
+#[cfg(test)]
+pub(crate) fn take_test_log_capture() -> Vec<TestLogRecord> {
+    TEST_LOG_RECORDS.with(|records| records.borrow_mut().take().unwrap_or_default())
 }
 
 /// Cap on one record's message, so 512 queued records from unbounded input
@@ -572,6 +601,21 @@ fn sanitize(message: &str) -> String {
 /// Append one record. `area` names the subsystem ("status", "machine",
 /// "startup", "provider", ...). Best-effort: errors are swallowed.
 pub(crate) fn log(level: &'static str, area: &str, message: &str) {
+    #[cfg(test)]
+    if TEST_LOG_RECORDS.with(|records| {
+        if let Some(records) = records.borrow_mut().as_mut() {
+            records.push(TestLogRecord {
+                level,
+                area: area.to_string(),
+                message: message.to_string(),
+            });
+            true
+        } else {
+            false
+        }
+    }) {
+        return;
+    }
     let _ = log_tracked(level, area, message);
 }
 

--- a/cmux-tui/crates/cmux-tui/src/localization.rs
+++ b/cmux-tui/crates/cmux-tui/src/localization.rs
@@ -39,7 +39,6 @@ impl GraphicsMessages {
         self.kitty_image_budget_worker_start_failed.replace("{error}", error)
     }
 
-    #[cfg_attr(test, allow(dead_code))]
     pub(crate) fn kitty_image_budget_update_failed(
         &self,
         retry_exhausted: bool,

--- a/cmux-tui/crates/cmux-tui/src/localization.rs
+++ b/cmux-tui/crates/cmux-tui/src/localization.rs
@@ -39,6 +39,7 @@ impl GraphicsMessages {
         self.kitty_image_budget_worker_start_failed.replace("{error}", error)
     }
 
+    #[cfg_attr(test, allow(dead_code))]
     pub(crate) fn kitty_image_budget_update_failed(
         &self,
         retry_exhausted: bool,

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -1936,6 +1936,10 @@ fn run_server(
                 state_root.as_deref(),
             )
         })?;
+    // Background mux workers can report reconnect diagnostics before an
+    // interactive client attaches. Install the non-terminal sink as soon as
+    // the owner mux exists, before serving or adopting clients.
+    app::install_mux_diagnostic_logger(&mux);
     // Headless sessions have no host terminal to query, so seed the mux from
     // Ghostty's config before any protocol client can create a surface.
     mux.seed_default_colors_if_no_durable_override(config.terminal_defaults);


### PR DESCRIPTION
## Summary
- Port the diagnostic-routing changes from https://github.com/manaflow-ai/cmux/pull/10882 by ninjin0802 onto current `main` at `5c2ee1244e2d796c9e4be5307788b320ac2ee4ff`.
- Preserve the current user status when Kitty image-budget updates fail, while logging the localized diagnostic and retaining the structured mux event for remote observers.
- Keep reconnect checkpoint skips in the daemon log, at most once per recovery cycle, instead of replacing user status.
- Retain the existing English and Japanese diagnostic formatters. No new user-facing strings were added.
- Capture the suppressed Kitty diagnostics only when an app test arms the thread-local test observer, so tests verify level, area, and localized message without changing production logging.

## Testing
- `cargo fmt --all -- --check`
- `git diff --check`
- Hosted focused verification for `kitty_budget_failures_do_not_replace_the_user_status_message` is dispatched against the exact pushed head.
- No build or test run, per the static-check-only integration request.

## Scope
- The reconnect routing is included because the source pull request treats it as the same non-actionable diagnostic-status class.
- Related issue: https://github.com/manaflow-ai/cmux/issues/10881

## References
- Tokio timeout behavior: https://docs.rs/tokio/latest/tokio/time/fn.timeout.html
- Tokio task error handling: https://docs.rs/tokio/latest/tokio/task/struct.JoinHandle.html
- Ratatui render-pass error behavior: https://docs.rs/ratatui/latest/ratatui/struct.Terminal.html

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10954"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790414836&installation_model_id=21920&pr_number=10954&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10954&signature=8803dd24b89a708faa6f34068da36b82d03c56c21946db86d5d694b7e0c4c2ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps advisory graphics diagnostics out of the TUI status bar: Kitty image-budget update failures and skipped reconnect checkpoints now log to the client log instead of replacing the user's command status.

- Routes core diagnostics through a frontend-installed `DiagnosticReporter` sink, since reconnect workers run on background threads while the client owns the raw terminal.
- Preserves the current user status and skips the redraw when Kitty image-budget updates fail, keeping the structured mux event and localized messages for the client log.
- Logs skipped reconnect checkpoints at most once per recovery cycle, re-arming only after a later checkpoint succeeds.
- Retains diagnostics emitted before the sink is installed and delivers them when the frontend reporter arrives.
- Installs the sink for local sessions, owner muxes, and headless servers before serving clients.
- Adds test-only log capture so suppressed diagnostics stay observable in tests.

<sup>Written for commit cc1edc896dbf321da26e26e10fb71e5fbb22e57c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented skipped terminal reconnect checkpoints from appearing as user-facing status messages.
  * Preserved current status messages when image budget updates fail.
  * Prevented failed image updates from triggering unnecessary screen redraws.

* **Diagnostics**
  * Added diagnostic logging for reconnect checkpoints and image-rendering failures.
  * Suppressed duplicate reconnect diagnostics.
  * Buffered early diagnostics until logging is available, ensuring they are not lost.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
