### PR TITLE
cloud VM: surface operator-fault provisioning errors in Sentry and PostHog

### DIFF
--- a/web/app/api/vm/base/open/route.ts
+++ b/web/app/api/vm/base/open/route.ts
@@ -1,6 +1,7 @@
 import {
   withAuthedVmApiRoute,
 } from "../../../../../services/vms/routeHelpers";
+import { captureVmProvisionOutcome } from "../../../../../services/vms/observability";
 import { VmTimingRecorder } from "../../../../../services/vms/timings";
 import { runBaseRoute } from "../routeShared";
 
@@ -14,7 +15,10 @@ export async function POST(request: Request): Promise<Response> {
     async ({ user, span, authDurationMs, routeStartedAtMs, setResponseFinalizer }) => {
       const timing = new VmTimingRecorder(span, "base.open", { startedAt: routeStartedAtMs });
       timing.record("auth", authDurationMs);
-      setResponseFinalizer((response) => timing.finish({ status: response.status }));
+      setResponseFinalizer((response) => {
+        timing.finish({ status: response.status });
+        captureVmProvisionOutcome({ userId: user.id, operation: "base_open", response });
+      });
       return await runBaseRoute({ request, user, operation: "open", timing });
     },
   );

--- a/web/app/api/vm/base/reset/route.ts
+++ b/web/app/api/vm/base/reset/route.ts
@@ -1,6 +1,7 @@
 import {
   withAuthedVmApiRoute,
 } from "../../../../../services/vms/routeHelpers";
+import { captureVmProvisionOutcome } from "../../../../../services/vms/observability";
 import { VmTimingRecorder } from "../../../../../services/vms/timings";
 import { runBaseRoute } from "../routeShared";
 
@@ -14,7 +15,10 @@ export async function POST(request: Request): Promise<Response> {
     async ({ user, span, authDurationMs, routeStartedAtMs, setResponseFinalizer }) => {
       const timing = new VmTimingRecorder(span, "base.reset", { startedAt: routeStartedAtMs });
       timing.record("auth", authDurationMs);
-      setResponseFinalizer((response) => timing.finish({ status: response.status }));
+      setResponseFinalizer((response) => {
+        timing.finish({ status: response.status });
+        captureVmProvisionOutcome({ userId: user.id, operation: "base_reset", response });
+      });
       return await runBaseRoute({ request, user, operation: "reset", timing });
     },
   );

--- a/web/app/api/vm/base/routeShared.ts
+++ b/web/app/api/vm/base/routeShared.ts
@@ -87,6 +87,12 @@ export async function runBaseRoute(input: {
         action: "Retry in a moment. If it keeps failing, contact support so we can check the Cloud VM image configuration.",
         reason: "Cloud VM image configuration is unavailable.",
         details: { imageRequested: err.image !== undefined },
+        diagnostics: {
+          provider,
+          image: err.image,
+          envVar: err.envVar,
+          configReason: err.reason,
+        },
         phase: "create",
         retryable: true,
       });

--- a/web/app/api/vm/route.ts
+++ b/web/app/api/vm/route.ts
@@ -43,6 +43,7 @@ import {
   vmActiveLimitExceededResponse,
   vmRequiresProResponse,
 } from "../../../services/vms/routeHelpers";
+import { captureVmProvisionOutcome } from "../../../services/vms/observability";
 import {
   createVm,
   listUserVms,
@@ -149,7 +150,10 @@ export async function POST(request: Request): Promise<Response> {
     async ({ user: initialUser, span, authDurationMs, routeStartedAtMs, setResponseFinalizer }) => {
       const timing = new VmTimingRecorder(span, "create", { startedAt: routeStartedAtMs });
       timing.record("auth", authDurationMs);
-      setResponseFinalizer((response) => timing.finish({ status: response.status }));
+      setResponseFinalizer((response) => {
+        timing.finish({ status: response.status });
+        captureVmProvisionOutcome({ userId: initialUser.id, operation: "create", response });
+      });
       let user: AuthedUser = initialUser;
       {
         // Runtime-validate the payload before we call a paid provider. An invalid `provider`
@@ -286,6 +290,12 @@ export async function POST(request: Request): Promise<Response> {
               action: "Retry without `image` to use the default Cloud VM image, or ask an admin to configure a supported image.",
               reason: "Cloud VM image configuration is unavailable.",
               details: { imageRequested: err.image !== undefined },
+              diagnostics: {
+                provider,
+                image: err.image,
+                envVar: err.envVar,
+                configReason: err.reason,
+              },
             });
           }
           throw err;

--- a/web/services/observability/report.ts
+++ b/web/services/observability/report.ts
@@ -1,6 +1,10 @@
 const SENSITIVE_KEY_PATTERN = /authorization|cookie|credential|dsn|key|password|providerMetadata|secret|token|webhook/i;
 
-export function reportError(error: unknown, context: Record<string, unknown>): void {
+export function reportError(
+  error: unknown,
+  context: Record<string, unknown>,
+  options: { readonly fingerprint?: readonly string[] } = {},
+): void {
   const safeContext = scrubContext(context);
   try {
     // Log a scrubbed summary, never the raw error: provider error messages can
@@ -14,10 +18,17 @@ export function reportError(error: unknown, context: Record<string, unknown>): v
 
   if (!process.env.SENTRY_DSN?.trim()) return;
 
+  const fingerprint = options.fingerprint;
   void import("@sentry/nextjs")
     .then((Sentry) => {
       Sentry.withScope((scope) => {
         scope.setContext("cmux", safeContext);
+        // A stable fingerprint groups every occurrence of one operational
+        // condition (e.g. one misconfigured image env) into one Sentry issue,
+        // so alert rules can fire on "first seen" without per-request noise.
+        if (fingerprint && fingerprint.length > 0) {
+          scope.setFingerprint([...fingerprint]);
+        }
         Sentry.captureException(error);
       });
     })

--- a/web/services/vms/observability.ts
+++ b/web/services/vms/observability.ts
@@ -1,0 +1,115 @@
+import { randomUUID } from "node:crypto";
+import { after } from "next/server";
+
+import { POSTHOG_HOST, POSTHOG_PROJECT_KEY } from "../analytics/iosEventPolicy";
+import { reportError } from "../observability/report";
+import type { VmErrorResponseInput } from "./routeHelpers";
+
+/**
+ * Response header carrying the machine-readable VM error code. Set by
+ * `vmErrorResponse` on every error so response finalizers (analytics,
+ * timing) can classify an outcome without re-parsing the body.
+ */
+export const VM_ERROR_CODE_HEADER = "x-cmux-vm-error";
+
+/**
+ * Error codes that are the operator's fault, never the caller's: a
+ * misconfigured deployment or an unavailable provider. These reach Sentry
+ * even when their HTTP status is not a 5xx, because a user cannot fix them
+ * by changing the request. User-fault errors (limits, credits, validation)
+ * stay out of Sentry; they are product signals, not incidents.
+ */
+const OPERATOR_FAULT_VM_ERROR_CODES: ReadonlySet<string> = new Set([
+  "vm_image_config_error",
+  "vm_create_disabled",
+  "vm_cloud_service_unavailable",
+  "vm_base_create_failed",
+  "vm_create_failed",
+]);
+
+export function isOperatorFaultVmError(input: {
+  readonly error: string;
+  readonly status: number;
+}): boolean {
+  return input.status >= 500 || OPERATOR_FAULT_VM_ERROR_CODES.has(input.error);
+}
+
+/**
+ * Sentry leg of the VM error choke point. Called from `vmErrorResponse` for
+ * every error response; reports only operator-fault errors. The fingerprint
+ * is the error code plus provider, so one misconfiguration is one Sentry
+ * issue no matter how many users hit it, and a "first seen" alert rule can
+ * page without flooding.
+ */
+export function reportVmErrorResponse(input: VmErrorResponseInput): void {
+  if (!isOperatorFaultVmError(input)) return;
+  const diagnostics = input.diagnostics ?? {};
+  const provider = typeof diagnostics.provider === "string" ? diagnostics.provider : undefined;
+  reportError(
+    new Error(`cloud VM ${input.error}: ${input.message}`),
+    {
+      subsystem: "cloud_vm_api",
+      code: input.error,
+      status: input.status,
+      phase: input.phase ?? "unknown",
+      reason: input.reason ?? input.message,
+      ...(input.details ?? {}),
+      ...diagnostics,
+    },
+    { fingerprint: ["cmux-vm-error", input.error, provider ?? "unknown"] },
+  );
+}
+
+export type VmProvisionOperation = "create" | "base_open" | "base_reset";
+
+/**
+ * PostHog leg: one `cloud_vm_provision` event per provisioning attempt,
+ * success or failure, keyed to the requesting user. Feeds the create
+ * success-rate insight and its Slack alert. Reads only the response status
+ * and the `x-cmux-vm-error` header, so it can run as a response finalizer
+ * without touching the body stream.
+ */
+export function captureVmProvisionOutcome(
+  input: {
+    readonly userId: string;
+    readonly operation: VmProvisionOperation;
+    readonly response: Response;
+  },
+  options: {
+    readonly fetch?: typeof fetch;
+    readonly env?: Record<string, string | undefined>;
+  } = {},
+): void {
+  const env = options.env ?? process.env;
+  if (env.VERCEL_ENV !== "production" && env.CMUX_VM_ANALYTICS_FORCE !== "1") return;
+  const status = input.response.status;
+  const code = input.response.headers.get(VM_ERROR_CODE_HEADER) ?? undefined;
+  const properties: Record<string, string | number | boolean> = {
+    operation: input.operation,
+    success: status < 400,
+    status,
+    schema_version: 1,
+    $insert_id: randomUUID(),
+    $geoip_disable: true,
+  };
+  if (code) properties.error_code = code;
+  const body = JSON.stringify({
+    api_key: POSTHOG_PROJECT_KEY,
+    event: "cloud_vm_provision",
+    distinct_id: input.userId,
+    properties,
+    timestamp: new Date().toISOString(),
+  });
+  const fetchImpl = options.fetch ?? fetch;
+  const task = fetchImpl(`${POSTHOG_HOST}/capture/`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body,
+    signal: AbortSignal.timeout(2_000),
+  }).then(() => undefined).catch(() => undefined);
+  try {
+    after(task);
+  } catch {
+    void task;
+  }
+}

--- a/web/services/vms/observability.ts
+++ b/web/services/vms/observability.ts
@@ -108,7 +108,10 @@ export function captureVmProvisionOutcome(
     signal: AbortSignal.timeout(2_000),
   }).then(() => undefined).catch(() => undefined);
   try {
-    after(task);
+    // Callback form keeps the capture inside the request lifecycle; outside a
+    // request scope (tests) `after` throws and the fire-and-forget task above
+    // still runs.
+    after(() => task);
   } catch {
     void task;
   }

--- a/web/services/vms/routeHelpers.ts
+++ b/web/services/vms/routeHelpers.ts
@@ -23,6 +23,7 @@ import {
 } from "./errors";
 import { recordSpanTiming } from "./timings";
 import { authProviderErrorResponse } from "./authErrors";
+import { reportVmErrorResponse, VM_ERROR_CODE_HEADER } from "./observability";
 
 /** Bearer + refresh token pair the mac app stashes in keychain. */
 export type StackBearer = { accessToken: string; refreshToken: string };
@@ -132,6 +133,13 @@ export type VmErrorResponseInput = {
   readonly reason?: string;
   readonly extra?: Record<string, unknown>;
   readonly details?: Record<string, unknown>;
+  /**
+   * Operator-facing context (provider, image id, env var) for Sentry only.
+   * NEVER serialized into the response: VM error payloads deliberately hide
+   * implementation details from callers (see expectNoCloudVmImplementationLeaks
+   * in tests/vm-route-auth.test.ts).
+   */
+  readonly diagnostics?: Record<string, unknown>;
   readonly phase?: VmLifecyclePhase;
   readonly retryable?: boolean;
   readonly retryAfterSeconds?: number;
@@ -185,6 +193,15 @@ export function vmErrorResponse(input: VmErrorResponseInput): Response {
   const headers: Record<string, string> = {};
   if (retryAfterSeconds !== undefined) {
     headers["retry-after"] = String(retryAfterSeconds);
+  }
+  // Every VM error flows through here, so this is the one place operator-fault
+  // errors reach Sentry and the one place the machine-readable code is exposed
+  // for response finalizers. Reporting never changes the response.
+  headers[VM_ERROR_CODE_HEADER] = input.error;
+  try {
+    reportVmErrorResponse(input);
+  } catch {
+    // Reporting must never change the caller's control flow.
   }
   return new Response(JSON.stringify(payload), {
     status: input.status,

--- a/web/tests/vm-observability.test.ts
+++ b/web/tests/vm-observability.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  captureVmProvisionOutcome,
+  isOperatorFaultVmError,
+  VM_ERROR_CODE_HEADER,
+} from "../services/vms/observability";
+import { vmErrorResponse } from "../services/vms/routeHelpers";
+
+describe("vm error choke point", () => {
+  test("every vm error response exposes the machine-readable code header", async () => {
+    const response = vmErrorResponse({
+      error: "vm_image_config_error",
+      status: 503,
+      message: "The Cloud VM image is not available in this environment.",
+      action: "Retry in a moment.",
+      details: { imageRequested: true },
+      diagnostics: { provider: "freestyle", image: "blaxel/xfce-vnc:latest", envVar: "FREESTYLE_SANDBOX_SNAPSHOT" },
+      phase: "create",
+      retryable: true,
+    });
+    expect(response.status).toBe(503);
+    expect(response.headers.get(VM_ERROR_CODE_HEADER)).toBe("vm_image_config_error");
+    const payload = await response.json() as { details: Record<string, unknown> };
+    expect(payload.details.imageRequested).toBe(true);
+  });
+
+  test("diagnostics never leak into the response payload", async () => {
+    const response = vmErrorResponse({
+      error: "vm_image_config_error",
+      status: 503,
+      message: "The Cloud VM image is not available in this environment.",
+      action: "Retry in a moment.",
+      details: { imageRequested: false },
+      diagnostics: {
+        provider: "freestyle",
+        envVar: "FREESTYLE_SANDBOX_SNAPSHOT",
+        image: "sh-17agfasevrc18c8f15nn",
+        configReason: "sh-17agfasevrc18c8f15nn is not listed in the Cloud VM image manifest",
+      },
+      phase: "create",
+    });
+    const raw = JSON.stringify(await response.json());
+    // Mirrors expectNoCloudVmImplementationLeaks in vm-route-auth.test.ts: the
+    // operator context flows to Sentry, never to the caller.
+    expect(raw).not.toMatch(/freestyle|FREESTYLE_|manifest|sh-[a-z0-9]{8,24}|diagnostics/i);
+  });
+
+  test("operator-fault classification: config and 5xx report, user-fault does not", () => {
+    expect(isOperatorFaultVmError({ error: "vm_image_config_error", status: 503 })).toBe(true);
+    expect(isOperatorFaultVmError({ error: "vm_create_disabled", status: 503 })).toBe(true);
+    expect(isOperatorFaultVmError({ error: "vm_base_create_failed", status: 500 })).toBe(true);
+    expect(isOperatorFaultVmError({ error: "anything", status: 500 })).toBe(true);
+    expect(isOperatorFaultVmError({ error: "vm_active_limit_exceeded", status: 402 })).toBe(false);
+    expect(isOperatorFaultVmError({ error: "vm_invalid_request", status: 400 })).toBe(false);
+  });
+});
+
+describe("cloud_vm_provision capture", () => {
+  function captured(response: Response): Record<string, unknown> | null {
+    let body: Record<string, unknown> | null = null;
+    const fakeFetch = ((input: string | URL | Request, init?: RequestInit) => {
+      void input;
+      body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return Promise.resolve(new Response("ok"));
+    }) as typeof fetch;
+    captureVmProvisionOutcome(
+      { userId: "user-1", operation: "base_open", response },
+      { fetch: fakeFetch, env: { CMUX_VM_ANALYTICS_FORCE: "1" } },
+    );
+    return body;
+  }
+
+  test("failure events carry the error code from the response header", () => {
+    const response = vmErrorResponse({
+      error: "vm_image_config_error",
+      status: 503,
+      message: "unavailable",
+      action: "retry",
+      phase: "create",
+    });
+    const body = captured(response);
+    expect(body?.event).toBe("cloud_vm_provision");
+    expect(body?.distinct_id).toBe("user-1");
+    const properties = body?.properties as Record<string, unknown>;
+    expect(properties.success).toBe(false);
+    expect(properties.status).toBe(503);
+    expect(properties.error_code).toBe("vm_image_config_error");
+    expect(properties.operation).toBe("base_open");
+  });
+
+  test("success events carry no error code", () => {
+    const body = captured(new Response("{}", { status: 200 }));
+    const properties = body?.properties as Record<string, unknown>;
+    expect(properties.success).toBe(true);
+    expect(properties.status).toBe(200);
+    expect(properties.error_code).toBeUndefined();
+  });
+
+  test("capture is disabled outside production unless forced", () => {
+    let called = false;
+    const fakeFetch = (() => {
+      called = true;
+      return Promise.resolve(new Response("ok"));
+    }) as typeof fetch;
+    captureVmProvisionOutcome(
+      { userId: "user-1", operation: "create", response: new Response("{}") },
+      { fetch: fakeFetch, env: {} },
+    );
+    expect(called).toBe(false);
+  });
+});


### PR DESCRIPTION
On 2026-08-26 every Cloud VM create in production failed with HTTP 503 vm_image_config_error for two days of nightlies: prod still had CMUX_VM_DEFAULT_PROVIDER=freestyle while the CLI (since #10478) sends explicit Blaxel image ids. Nothing surfaced it. The failure happens before a cloud_vms row exists, so the cron DB alerts cannot see it, and the VM routes report nothing to Sentry or PostHog.

This PR instruments the existing choke point instead of adding per-route logging:

- vmErrorResponse reports operator-fault errors (any 5xx, plus config-class codes: vm_image_config_error, vm_create_disabled, vm_cloud_service_unavailable, vm_base_create_failed, vm_create_failed) to Sentry via the existing scrubbed reportError, fingerprinted by code + provider so one misconfiguration groups into one issue and a first-seen alert rule can page without noise. User-fault 4xx (limits, credits, validation) stays out of Sentry.
- Routes pass a new non-serialized `diagnostics` field (provider, image id, env var, resolver reason) that reaches Sentry only. Response payloads stay unchanged: the vm-route-auth leak tests forbid provider/env/manifest details in caller-visible errors, and this PR keeps that contract.
- Every VM error response now carries `x-cmux-vm-error: <code>`, and the create / base open / base reset response finalizers emit one `cloud_vm_provision` PostHog event per attempt (operation, success, status, error_code, distinct_id = user id) for a success-rate insight and Slack alert.
- reportError gains an optional Sentry fingerprint parameter.

Tests: `bun test tests/vm-observability.test.ts tests/vm-route-auth.test.ts` (59 pass), `bun run typecheck` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790414859&installation_model_id=21920&pr_number=10955&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10955&signature=075e802c36725115bc1bfd3c7918931ce4710f522d646d4c9252f6869436f70b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces Cloud VM provisioning failures in Sentry and PostHog so operator misconfigurations stop failing silently for days. Previously, any error that never reached a `cloud_vms` row was invisible to the cron DB alerts, and the VM routes reported nothing to Sentry or PostHog.

**Sentry**
- Operator-fault errors (any 5xx plus config-class codes like `vm_image_config_error`) now flow through the existing scrubbed `reportError`, fingerprinted by code and provider so one misconfiguration is one issue and a first-seen alert can page without noise.
- Non-serialized diagnostics (provider, image, env var, resolver reason) reach Sentry only; caller-visible error payloads stay unchanged per the leak-protection tests.
- User-fault 4xx errors (limits, credits, validation) stay out of Sentry, and `reportError` gains an optional Sentry fingerprint.

**PostHog**
- Every VM error response now carries an `x-cmux-vm-error` header, and the create and base open/reset response finalizers emit one `cloud_vm_provision` event per attempt (operation, success, status, error code, user id).

<sup>Written for commit e65136f2dc014f6be28a3009e779e4de28ae8e01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer diagnostic details to VM image configuration errors.
  - Added machine-readable VM error codes to responses.
  - Added monitoring for VM creation, opening, and reset outcomes.

- **Bug Fixes**
  - Improved grouping of recurring VM operational errors in error monitoring.
  - Ensured diagnostic information is available for troubleshooting without being exposed in response content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->