### PR TITLE
cloud VM: explicit manifest images resolve their own provider; list blaxel/base-image

### DIFF
--- a/web/app/api/vm/base/routeShared.ts
+++ b/web/app/api/vm/base/routeShared.ts
@@ -16,6 +16,7 @@ import {
 } from "../../../../services/vms/errors";
 import {
   imageUsesBakedFreestyleSignedAdmin,
+  inferVmProviderForImage,
   resolveVmImage,
 } from "../../../../services/vms/images/resolver";
 import {
@@ -62,7 +63,9 @@ export async function runBaseRoute(input: {
     return vmRequiresProResponse();
   }
 
-  const provider = parsed.body.provider ?? defaultProviderId();
+  // Same provider inference as POST /api/vm: an explicit manifest image
+  // names its own provider even when the deployment default disagrees.
+  const provider = parsed.body.provider ?? inferVmProviderForImage(parsed.body.image) ?? defaultProviderId();
   let imageSelection;
   try {
     assertVmCreateEnabled(provider);

--- a/web/app/api/vm/route.ts
+++ b/web/app/api/vm/route.ts
@@ -30,6 +30,7 @@ import {
 } from "../../../services/vms/entitlements";
 import {
   imageUsesBakedFreestyleSignedAdmin,
+  inferVmProviderForImage,
   resolveVmImage,
 } from "../../../services/vms/images/resolver";
 import { reconcileProPlanMetadata } from "../../../services/billing/pro";
@@ -263,7 +264,10 @@ export async function POST(request: Request): Promise<Response> {
           provider: candidate.provider as ProviderId | undefined,
           billingTeamId: typeof bodyBillingTeamId === "string" ? bodyBillingTeamId.trim() : undefined,
         };
-        const provider = body.provider ?? defaultProviderId();
+        // An explicit manifest image names its own provider: the CLI sends
+        // provider-specific image ids without a provider field, and the
+        // deployment default must not reroute them under the wrong provider.
+        const provider = body.provider ?? inferVmProviderForImage(body.image) ?? defaultProviderId();
         let imageSelection;
         try {
           assertVmCreateEnabled(provider);

--- a/web/services/vms/images/manifest.json
+++ b/web/services/vms/images/manifest.json
@@ -178,6 +178,18 @@
       "builderScriptVersion": "bootstrap-on-create",
       "validationStatus": "passed",
       "notes": "Stock Blaxel xfce + TigerVNC/noVNC image (a machine comes with its screen; `cmux vm new --base` picks blaxel/base-image:latest explicitly). No cmuxd-remote: at create time the sandbox installs the pinned cmux-tui build from the artifacts manifest onto its persistent home volume and the supervisor runs `cmux-tui server start --remote-ws 0.0.0.0:1337`, so no baked template is required. Validated cmux-remote attach (route + enrollment), exec, private preview URL + minted preview token, and standby/wake process preservation in us-pdx-1."
+    },
+    {
+      "provider": "blaxel",
+      "version": "blaxel-base-bootstrap-20260824a",
+      "imageId": "blaxel/base-image:latest",
+      "envVar": "BLAXEL_SANDBOX_IMAGE",
+      "defaultForLocalDev": false,
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "builtAt": "2026-08-24T23:07:01.000Z",
+      "builderScriptVersion": "bootstrap-on-create",
+      "validationStatus": "passed",
+      "notes": "Stock Blaxel Alpine shell image, no desktop; `cmux vm new --base` and `vm run` pool provisioning send this id explicitly. Nothing is baked: the driver bootstraps every image at create time, installing the pinned cmux-tui build onto the persistent home volume (the installer adds curl via apk first, since the stock image ships without it). Validated live in #10478 in us-pdx-1: create + bootstrap, cmux-remote attach (route + enrollment), exec, and standby/wake process preservation. Listed so deployed runtimes accept the id the CLI sends; it was missing from the manifest between #10478 and this entry, so `vm new --base` failed closed in production."
     }
   ]
 }

--- a/web/services/vms/images/resolver.ts
+++ b/web/services/vms/images/resolver.ts
@@ -51,6 +51,28 @@ export function listVmImageManifestEntries(): readonly VmImageManifestEntry[] {
   return typedManifest.images;
 }
 
+/**
+ * The provider that owns an explicitly requested image, when the manifest
+ * answers that unambiguously. Clients (the CLI since #10478) send provider
+ * image ids without a provider field and rely on the deployment's default
+ * provider matching; when the two disagree, the image is looked up under the
+ * wrong provider and provisioning fails closed even though the image is a
+ * known-good manifest entry (the 2026-08-26 outage). An image id or version
+ * that appears under exactly one provider names that provider; anything
+ * ambiguous or unknown returns null and leaves the caller's default in force.
+ */
+export function inferVmProviderForImage(requestedImage: string | undefined): ProviderId | null {
+  const requested = requestedImage?.trim();
+  if (!requested) return null;
+  const providers = new Set(
+    typedManifest.images
+      .filter((entry) => entry.imageId === requested || entry.version === requested)
+      .map((entry) => entry.provider),
+  );
+  if (providers.size !== 1) return null;
+  return [...providers][0] ?? null;
+}
+
 export function imageUsesBakedFreestyleSignedAdmin(provider: ProviderId, imageId: string): boolean {
   const entry = typedManifest.images.find((candidate) =>
     candidate.provider === provider && candidate.imageId === imageId

--- a/web/tests/vm-image-resolver.test.ts
+++ b/web/tests/vm-image-resolver.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   imageUsesBakedFreestyleSignedAdmin,
+  inferVmProviderForImage,
   resolveVmImage,
 } from "../services/vms/images/resolver";
 import { VmImageConfigError } from "../services/vms/errors";
@@ -110,22 +111,19 @@ describe("VM image resolver", () => {
 });
 
 describe("provider inference from explicit images", () => {
-  test("a manifest image id uniquely owned by one provider infers that provider", async () => {
-    const { inferVmProviderForImage } = await import("../services/vms/images/resolver");
+  test("a manifest image id uniquely owned by one provider infers that provider", () => {
     expect(inferVmProviderForImage("blaxel/xfce-vnc:latest")).toBe("blaxel");
     expect(inferVmProviderForImage("sandbox/cmux-devbox:latest")).toBe("blaxel");
     expect(inferVmProviderForImage("sh-6ch5p9k23xrcx24056n8")).toBe("freestyle");
     expect(inferVmProviderForImage("cmuxd-ws:tooling-20260509f")).toBe("e2b");
   });
 
-  test("manifest versions infer their provider too", async () => {
-    const { inferVmProviderForImage } = await import("../services/vms/images/resolver");
+  test("manifest versions infer their provider too", () => {
     expect(inferVmProviderForImage("blaxel-bootstrap-20260820a")).toBe("blaxel");
     expect(inferVmProviderForImage("freestyle-rpclease-20260502a")).toBe("freestyle");
   });
 
-  test("unknown or absent images infer nothing", async () => {
-    const { inferVmProviderForImage } = await import("../services/vms/images/resolver");
+  test("unknown or absent images infer nothing", () => {
     expect(inferVmProviderForImage("not-in-the-manifest")).toBeNull();
     expect(inferVmProviderForImage(undefined)).toBeNull();
     expect(inferVmProviderForImage("   ")).toBeNull();

--- a/web/tests/vm-image-resolver.test.ts
+++ b/web/tests/vm-image-resolver.test.ts
@@ -108,3 +108,26 @@ describe("VM image resolver", () => {
     });
   });
 });
+
+describe("provider inference from explicit images", () => {
+  test("a manifest image id uniquely owned by one provider infers that provider", async () => {
+    const { inferVmProviderForImage } = await import("../services/vms/images/resolver");
+    expect(inferVmProviderForImage("blaxel/xfce-vnc:latest")).toBe("blaxel");
+    expect(inferVmProviderForImage("sandbox/cmux-devbox:latest")).toBe("blaxel");
+    expect(inferVmProviderForImage("sh-6ch5p9k23xrcx24056n8")).toBe("freestyle");
+    expect(inferVmProviderForImage("cmuxd-ws:tooling-20260509f")).toBe("e2b");
+  });
+
+  test("manifest versions infer their provider too", async () => {
+    const { inferVmProviderForImage } = await import("../services/vms/images/resolver");
+    expect(inferVmProviderForImage("blaxel-bootstrap-20260820a")).toBe("blaxel");
+    expect(inferVmProviderForImage("freestyle-rpclease-20260502a")).toBe("freestyle");
+  });
+
+  test("unknown or absent images infer nothing", async () => {
+    const { inferVmProviderForImage } = await import("../services/vms/images/resolver");
+    expect(inferVmProviderForImage("not-in-the-manifest")).toBeNull();
+    expect(inferVmProviderForImage(undefined)).toBeNull();
+    expect(inferVmProviderForImage("   ")).toBeNull();
+  });
+});

--- a/web/tests/vm-route-auth.test.ts
+++ b/web/tests/vm-route-auth.test.ts
@@ -35,6 +35,7 @@ const VM_ENV_KEYS = [
   "CMUX_VM_PLAN_PRO_MAX_MEMORY_MB",
   "CMUX_VM_PLAN_PRO_DEFAULT_MEMORY_MB",
   "CMUX_VM_REQUIRE_PRO",
+  "CMUX_VM_DEFAULT_PROVIDER",
   "VERCEL",
   "VERCEL_ENV",
 ] as const;
@@ -1766,6 +1767,67 @@ describe("VM REST auth", () => {
     expect(createVm).toHaveBeenCalledWith(expect.objectContaining({
       image: "sh-6ch5p9k23xrcx24056n8",
       imageVersion: "freestyle-rpclease-20260502a",
+    }));
+  });
+
+  test("explicit manifest image resolves its own provider when the deployment default disagrees", async () => {
+    // Regression for the 2026-08-26 outage: the CLI sends Blaxel image ids with
+    // no provider override, and prod still had CMUX_VM_DEFAULT_PROVIDER=freestyle,
+    // so the image was looked up under freestyle and every create 503ed.
+    process.env.VERCEL = "1";
+    process.env.VERCEL_ENV = "preview";
+    process.env.CMUX_VM_DEFAULT_PROVIDER = "freestyle";
+    process.env.FREESTYLE_SANDBOX_SNAPSHOT = "sh-6ch5p9k23xrcx24056n8";
+    getUser.mockResolvedValue(authedStackUser());
+    runVmWorkflow.mockResolvedValue({
+      providerVmId: "provider-vm-blaxel",
+      provider: "blaxel",
+      image: "blaxel/xfce-vnc:latest",
+      imageVersion: "blaxel-bootstrap-20260820a",
+      createdAt: 1_777_000_000_000,
+    });
+
+    const response = await POST(
+      new Request("https://cmux.test/api/vm", {
+        method: "POST",
+        headers: { origin: "https://cmux.test" },
+        body: JSON.stringify({ image: "blaxel/xfce-vnc:latest" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(createVm).toHaveBeenCalledWith(expect.objectContaining({
+      provider: "blaxel",
+      image: "blaxel/xfce-vnc:latest",
+      imageVersion: "blaxel-bootstrap-20260820a",
+    }));
+  });
+
+  test("the shell-only base image the CLI sends for `vm new --base` is manifest-listed", async () => {
+    process.env.VERCEL = "1";
+    process.env.VERCEL_ENV = "preview";
+    process.env.CMUX_VM_DEFAULT_PROVIDER = "freestyle";
+    getUser.mockResolvedValue(authedStackUser());
+    runVmWorkflow.mockResolvedValue({
+      providerVmId: "provider-vm-blaxel-base",
+      provider: "blaxel",
+      image: "blaxel/base-image:latest",
+      imageVersion: "blaxel-base-bootstrap-20260824a",
+      createdAt: 1_777_000_000_000,
+    });
+
+    const response = await POST(
+      new Request("https://cmux.test/api/vm", {
+        method: "POST",
+        headers: { origin: "https://cmux.test" },
+        body: JSON.stringify({ image: "blaxel/base-image:latest" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(createVm).toHaveBeenCalledWith(expect.objectContaining({
+      provider: "blaxel",
+      image: "blaxel/base-image:latest",
     }));
   });
 });


### PR DESCRIPTION
Root-cause fix for the 2026-08-26 outage (every `cmux vm new` 503ed with vm_image_config_error). Since #10478 the CLI sends explicit Blaxel image ids with no provider field, trusting the deployment's CMUX_VM_DEFAULT_PROVIDER; prod still said freestyle, so the server looked the Blaxel id up under freestyle, found no manifest entry, and failed closed.

The fix makes the request self-consistent server-side, so every already-shipped nightly is fixed the moment this deploys and the CLI keeps sending no provider (deliberate: the backend keeps rollback control for imageless requests):

- `inferVmProviderForImage(image)`: an image id or version owned by exactly one provider in the manifest names that provider. Ambiguous or unknown ids return null.
- POST /api/vm and the base open/reset routes resolve `body.provider ?? inferVmProviderForImage(body.image) ?? defaultProviderId()`.
- `blaxel/base-image:latest` (sent by `cmux vm new --base` and `vm run` pool provisioning, validated in #10478) gets its missing manifest entry; deployed runtimes fail closed on unmanifested ids, so it still 503ed even under a blaxel default.

Two commits so CI proves the tests catch it: commit 1 adds failing regression tests (route-level repro of the outage plus resolver inference), commit 2 the fix.

Tests: `bun test tests/vm-image-resolver.test.ts tests/vm-route-auth.test.ts tests/vm-blaxel-image.test.ts tests/build-cloud-vm-images.test.ts` (101 pass), `bun run typecheck` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10957"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790415500&installation_model_id=21920&pr_number=10957&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10957&signature=fd662b04407bdd81e7d3113e64bdb511387036cfdbc8cec122907b0b23cf4924"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the 2026-08-26 outage where `cmux vm new` 503ed with `vm_image_config_error`: the CLI sends explicit Blaxel image ids without a provider field, and prod's default provider (freestyle) rerouted them under the wrong provider until the server failed closed. Explicit manifest images now resolve their own provider; the CLI keeps omitting the provider field so the backend retains rollback control.

- `inferVmProviderForImage` maps an image id or version to the single provider that owns it in the manifest; ambiguous or unknown images fall back to the deployment default.
- POST /api/vm and the base open/reset routes consult it before `CMUX_VM_DEFAULT_PROVIDER`.
- Lists `blaxel/base-image:latest` in the manifest; it was missing, so `vm new --base` and pool provisioning failed closed even under a blaxel default.
- Regression tests reproduce the outage at the route level and cover the resolver and the new manifest entry.

<sup>Written for commit 1bddc1bac37818f5e8e12e4fbcdc313b749eb563. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

