### PR TITLE
Integrate Escape passthrough fix from PR #9810

### DIFF
--- a/Sources/AgentHibernation/AgentHibernationLifecycleState.swift
+++ b/Sources/AgentHibernation/AgentHibernationLifecycleState.swift
@@ -25,6 +25,55 @@ enum AgentHibernationLifecycleState: String, Codable, Sendable, Equatable, CaseI
         parse(rawValue)
     }
 
+    static func aggregate(
+        statusKeyedStates: [String: AgentHibernationLifecycleState],
+        fallback: AgentHibernationLifecycleState?
+    ) -> AgentHibernationLifecycleState {
+        let states = statusKeyedStates
+            .filter { !AgentHibernationLifecycleStatusKeys.isManualKey($0.key) }
+            .map(\.value)
+        guard !states.isEmpty else {
+            return fallback ?? .unknown
+        }
+        if states.contains(.running) { return .running }
+        if states.contains(.needsInput) { return .needsInput }
+        if states.contains(.unknown) { return .unknown }
+        if states.contains(.idle) { return .idle }
+        return fallback ?? .unknown
+    }
+
+    /// Restricts TextBox Escape authorization to the fixed built-in agent set.
+    /// Custom Vault and manual lifecycle keys remain valid for hibernation state,
+    /// but must not authorize a control key to an arbitrary process.
+    static func aggregateForTextBoxEscape(
+        statusKeyedStates: [String: AgentHibernationLifecycleState]
+    ) -> AgentHibernationLifecycleState {
+        var hasNeedsInput = false
+        var hasUnknown = false
+        var hasIdle = false
+
+        // Iterate the fixed allowlist instead of filtering the unbounded runtime
+        // map. This keeps the Escape authorization lookup bounded by built-ins.
+        for key in AgentHibernationLifecycleStatusKeys.allowedStatusKeys {
+            guard let state = statusKeyedStates[key] else { continue }
+            switch state {
+            case .running:
+                return .running
+            case .needsInput:
+                hasNeedsInput = true
+            case .unknown:
+                hasUnknown = true
+            case .idle:
+                hasIdle = true
+            }
+        }
+
+        if hasNeedsInput { return .needsInput }
+        if hasUnknown { return .unknown }
+        if hasIdle { return .idle }
+        return .unknown
+    }
+
     private static func parse(_ rawValue: String) -> AgentHibernationLifecycleState? {
         let normalized = rawValue
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -60,6 +109,7 @@ enum AgentHibernationLifecycleStatusKeys {
     static let allowedStatusKeys: Set<String> = [
         "amp",
         "antigravity",
+        "campfire",
         "claude_code",
         "codebuddy",
         "codex",

--- a/Sources/DockSplitStore+RestoredAgentLifecycle.swift
+++ b/Sources/DockSplitStore+RestoredAgentLifecycle.swift
@@ -299,6 +299,22 @@ extension DockSplitStore {
         }
     }
 
+    func agentHibernationLifecycleState(
+        panelId: UUID,
+        fallback: AgentHibernationLifecycleState?
+    ) -> AgentHibernationLifecycleState {
+        AgentHibernationLifecycleState.aggregate(
+            statusKeyedStates: agentRuntimeByPanelId[panelId]?.agentLifecycleStates ?? [:],
+            fallback: fallback
+        )
+    }
+
+    func agentLifecycleStateForTextBoxEscape(panelId: UUID) -> AgentHibernationLifecycleState {
+        AgentHibernationLifecycleState.aggregateForTextBoxEscape(
+            statusKeyedStates: agentRuntimeByPanelId[panelId]?.agentLifecycleStates ?? [:]
+        )
+    }
+
     @discardableResult
     func clearAgentLifecycle(key: String, panelId: UUID) -> Bool {
         var didClear = false

--- a/Sources/Panels/TerminalPanel.swift
+++ b/Sources/Panels/TerminalPanel.swift
@@ -340,12 +340,23 @@ final class TerminalPanel: Panel, ObservableObject {
     }
 
     func handleTextBoxEscape() {
+        if containerAgentLifecycleStateForTextBoxEscape == .running {
+            _ = sendNamedKeyResult(TextBoxTerminalKey.escape.rawValue)
+        }
         let hadTextBoxView = textBoxInputView != nil
         let didFocusTerminal = focusTerminalSurface(
             respectForeignFirstResponder: false,
             clearTextBoxHideArm: false
         )
         shouldHideTextBoxOnNextEscape = isTextBoxActive && (hadTextBoxView || didFocusTerminal)
+    }
+
+    private var containerAgentLifecycleStateForTextBoxEscape: AgentHibernationLifecycleState {
+        if let dock = DockSplitStore.liveStore(containingPanel: id) {
+            return dock.agentLifecycleStateForTextBoxEscape(panelId: id)
+        }
+        return surface.owningWorkspace()?
+            .agentLifecycleStateForTextBoxEscape(panelId: id) ?? .unknown
     }
 
     @discardableResult

--- a/Sources/Workspace+AgentLifecycle.swift
+++ b/Sources/Workspace+AgentLifecycle.swift
@@ -944,17 +944,16 @@ extension Workspace {
         panelId: UUID,
         fallback: AgentHibernationLifecycleState?
     ) -> AgentHibernationLifecycleState {
-        let states = (agentLifecycleStatesByPanelId[panelId] ?? [:])
-            .filter { !AgentHibernationLifecycleStatusKeys.isManualKey($0.key) }
-            .map(\.value)
-        guard !states.isEmpty else {
-            return fallback ?? .unknown
-        }
-        if states.contains(.running) { return .running }
-        if states.contains(.needsInput) { return .needsInput }
-        if states.contains(.unknown) { return .unknown }
-        if states.contains(.idle) { return .idle }
-        return fallback ?? .unknown
+        AgentHibernationLifecycleState.aggregate(
+            statusKeyedStates: agentLifecycleStatesByPanelId[panelId] ?? [:],
+            fallback: fallback
+        )
+    }
+
+    func agentLifecycleStateForTextBoxEscape(panelId: UUID) -> AgentHibernationLifecycleState {
+        AgentHibernationLifecycleState.aggregateForTextBoxEscape(
+            statusKeyedStates: agentLifecycleStatesByPanelId[panelId] ?? [:]
+        )
     }
 
     private func recordAgentLifecycleChange(panelId: UUID) {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2563,6 +2563,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		B7758A020000000000000001 /* TerminationWatchdogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7758A020000000000000002 /* TerminationWatchdogTests.swift */; };
 		C0DE7B330000000000000001 /* TextBoxAgentDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7B330000000000000002 /* TextBoxAgentDetection.swift */; };
 		B8835100000000000000000D /* TextBoxAttachment+PreparedPaste.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8835100000000000000000E /* TextBoxAttachment+PreparedPaste.swift */; };
+		970400000000000000000001 /* TextBoxEscapePassthroughTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 970400000000000000000002 /* TextBoxEscapePassthroughTests.swift */; };
 		7898A0020000000000000001 /* TextBoxGitIgnoreProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7898A0020000000000000002 /* TextBoxGitIgnoreProbe.swift */; };
 		C0DE86250000000000000001 /* TextBoxIMECompositionLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE86250000000000000002 /* TextBoxIMECompositionLayoutTests.swift */; };
 		5330B0715330B0715330B071 /* TextBoxInlineAttachmentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5330B0725330B0725330B072 /* TextBoxInlineAttachmentCell.swift */; };
@@ -5421,6 +5422,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		B7758A020000000000000002 /* TerminationWatchdogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminationWatchdogTests.swift; sourceTree = "<group>"; };
 		C0DE7B330000000000000002 /* TextBoxAgentDetection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxAgentDetection.swift; sourceTree = "<group>"; };
 		B8835100000000000000000E /* TextBoxAttachment+PreparedPaste.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TextBoxAttachment+PreparedPaste.swift"; sourceTree = "<group>"; };
+		970400000000000000000002 /* TextBoxEscapePassthroughTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxEscapePassthroughTests.swift; sourceTree = "<group>"; };
 		7898A0020000000000000002 /* TextBoxGitIgnoreProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxGitIgnoreProbe.swift; sourceTree = "<group>"; };
 		C0DE86250000000000000002 /* TextBoxIMECompositionLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxIMECompositionLayoutTests.swift; sourceTree = "<group>"; };
 		5330B0725330B0725330B072 /* TextBoxInlineAttachmentCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxInlineAttachmentCell.swift; sourceTree = "<group>"; };
@@ -8189,6 +8191,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				5330A0025330A0025330A002 /* TextBoxInlineAttachmentRenderingTests.swift */,
 				C0DE7B300000000000000002 /* TextBoxMentionCompletionTests.swift */,
 				C0DE86250000000000000002 /* TextBoxIMECompositionLayoutTests.swift */,
+				970400000000000000000002 /* TextBoxEscapePassthroughTests.swift */,
 				9005A0010000000000000002 /* TextBoxSelectionReplacementTests.swift */,
 				7898A0010000000000000002 /* TextBoxMentionGitIgnoreProbeTests.swift */,
 				C1713005C1713005C1713005 /* CommandPaletteShortcutCustomizationTests.swift */,
@@ -11993,6 +11996,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				AA11BB22CC33DD44EE55F002 /* TerminalWindowPortalLayoutPassRefreshTests.swift in Sources */,
 				C95BAC3D37A6111B487582DC /* TerminalWindowPortalLifecycleHiddenRefreshTests.swift in Sources */,
 				B7758A020000000000000001 /* TerminationWatchdogTests.swift in Sources */,
+				970400000000000000000001 /* TextBoxEscapePassthroughTests.swift in Sources */,
 				C0DE86250000000000000001 /* TextBoxIMECompositionLayoutTests.swift in Sources */,
 				5330A0015330A0015330A001 /* TextBoxInlineAttachmentRenderingTests.swift in Sources */,
 				C0DE7B300000000000000001 /* TextBoxMentionCompletionTests.swift in Sources */,

--- a/cmuxTests/TextBoxEscapePassthroughTests.swift
+++ b/cmuxTests/TextBoxEscapePassthroughTests.swift
@@ -1,0 +1,276 @@
+import AppKit
+import CmuxTerminal
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+@Suite("TextBox Escape passthrough", .serialized)
+struct TextBoxEscapePassthroughTests {
+    @Test
+    func runningAgentReceivesEscapeFromTextBox() throws {
+        let fixture = try makeWorkspaceFixture()
+        defer { closeWindow(fixture.windowID) }
+
+        fixture.workspace.setAgentLifecycle(
+            key: "claude_code",
+            panelId: fixture.panel.id,
+            lifecycle: .running
+        )
+        defer {
+            _ = fixture.workspace.clearAgentLifecycle(
+                key: "claude_code",
+                panelId: fixture.panel.id
+            )
+        }
+        let before = fixture.panel.surface.debugPendingSocketInputForTesting()
+
+        fixture.panel.handleTextBoxEscape()
+
+        let after = fixture.panel.surface.debugPendingSocketInputForTesting()
+        #expect(
+            after.keyEvents == before.keyEvents + 1,
+            "Escape from TextBox must reach the PTY while the focused agent turn is running"
+        )
+    }
+
+    @Test
+    func runningCampfireAgentReceivesEscapeFromTextBox() throws {
+        let fixture = try makeWorkspaceFixture()
+        defer { closeWindow(fixture.windowID) }
+
+        fixture.workspace.setAgentLifecycle(
+            key: "campfire",
+            panelId: fixture.panel.id,
+            lifecycle: .running
+        )
+        defer {
+            _ = fixture.workspace.clearAgentLifecycle(
+                key: "campfire",
+                panelId: fixture.panel.id
+            )
+        }
+        let before = fixture.panel.surface.debugPendingSocketInputForTesting()
+
+        fixture.panel.handleTextBoxEscape()
+
+        let after = fixture.panel.surface.debugPendingSocketInputForTesting()
+        #expect(
+            after.keyEvents == before.keyEvents + 1,
+            "Escape from TextBox must reach a running Campfire agent"
+        )
+    }
+
+    @Test
+    func focusedTextBoxKeyDownRoutesOneEscapeToRunningAgent() throws {
+        let fixture = try makeWorkspaceFixture()
+        defer { closeWindow(fixture.windowID) }
+
+        fixture.workspace.setAgentLifecycle(
+            key: "claude_code",
+            panelId: fixture.panel.id,
+            lifecycle: .running
+        )
+        defer {
+            _ = fixture.workspace.clearAgentLifecycle(
+                key: "claude_code",
+                panelId: fixture.panel.id
+            )
+        }
+
+        let windowIdentifier = "cmux.main.\(fixture.windowID.uuidString)"
+        let window = try #require(
+            NSApp.windows.first { $0.identifier?.rawValue == windowIdentifier }
+        )
+        let contentView = try #require(window.contentView)
+        let textView = TextBoxInputTextView(frame: NSRect(x: 0, y: 0, width: 240, height: 30))
+        let scrollView = NSScrollView(frame: textView.frame)
+        scrollView.documentView = textView
+        contentView.addSubview(scrollView)
+        defer { scrollView.removeFromSuperview() }
+
+        textView.onFocusTextBox = { fixture.panel.textBoxDidBecomeFocused() }
+        textView.onEscape = { fixture.panel.handleTextBoxEscape() }
+        fixture.panel.hostedView.setVisibleInUI(true)
+        fixture.panel.hostedView.setActive(true)
+        fixture.panel.hostedView.moveFocus()
+        fixture.panel.registerTextBoxInputView(textView)
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+
+        let sentinelDraft = "unsubmitted sentinel draft"
+        textView.string = sentinelDraft
+        #expect(window.makeFirstResponder(textView))
+        #expect(window.firstResponder === textView)
+
+        let escapeEvent = try #require(
+            NSEvent.keyEvent(
+                with: .keyDown,
+                location: .zero,
+                modifierFlags: [],
+                timestamp: 0,
+                windowNumber: window.windowNumber,
+                context: nil,
+                characters: "\u{1b}",
+                charactersIgnoringModifiers: "\u{1b}",
+                isARepeat: false,
+                keyCode: 53
+            )
+        )
+        let before = fixture.panel.surface.debugPendingSocketInputForTesting()
+
+        textView.keyDown(with: escapeEvent)
+
+        let after = fixture.panel.surface.debugPendingSocketInputForTesting()
+        #expect(
+            after.keyEvents == before.keyEvents + 1,
+            "A physical Escape handled by the focused TextBox must enqueue exactly one PTY key event"
+        )
+        #expect(textView.string == sentinelDraft, "Escape must preserve the unsubmitted TextBox draft")
+        #expect(fixture.panel.isTextBoxActive, "The first Escape must leave TextBox visible")
+        // Terminal first-responder transfer is covered by the existing window-routing suite;
+        // this standalone TextBox fixture focuses on the physical keyDown-to-PTY path.
+    }
+
+    @Test
+    func idleAgentDoesNotReceiveEscapeFromTextBox() throws {
+        let fixture = try makeWorkspaceFixture()
+        defer { closeWindow(fixture.windowID) }
+
+        fixture.workspace.setAgentLifecycle(
+            key: "claude_code",
+            panelId: fixture.panel.id,
+            lifecycle: .idle
+        )
+        defer {
+            _ = fixture.workspace.clearAgentLifecycle(
+                key: "claude_code",
+                panelId: fixture.panel.id
+            )
+        }
+        let before = fixture.panel.surface.debugPendingSocketInputForTesting()
+
+        fixture.panel.handleTextBoxEscape()
+
+        let after = fixture.panel.surface.debugPendingSocketInputForTesting()
+        #expect(
+            after.keyEvents == before.keyEvents,
+            "Escape must retain TextBox focus behavior when the agent is not running"
+        )
+    }
+
+    @Test
+    func unsupportedRunningLifecycleDoesNotReceiveEscapeFromTextBox() throws {
+        let fixture = try makeWorkspaceFixture()
+        defer { closeWindow(fixture.windowID) }
+
+        fixture.workspace.setAgentLifecycle(
+            key: "unsupported-agent",
+            panelId: fixture.panel.id,
+            lifecycle: .running
+        )
+        defer {
+            _ = fixture.workspace.clearAgentLifecycle(
+                key: "unsupported-agent",
+                panelId: fixture.panel.id
+            )
+        }
+        let before = fixture.panel.surface.debugPendingSocketInputForTesting()
+
+        fixture.panel.handleTextBoxEscape()
+
+        let after = fixture.panel.surface.debugPendingSocketInputForTesting()
+        #expect(
+            after.keyEvents == before.keyEvents,
+            "Unsupported lifecycle keys must not authorize PTY Escape passthrough"
+        )
+    }
+
+    @Test
+    func runningDockAgentReceivesEscapeFromTextBox() {
+        let fixture = makeDockFixture()
+        defer { fixture.dock.closeAllPanels() }
+
+        fixture.dock.setAgentLifecycle(
+            key: "claude_code",
+            panelId: fixture.panel.id,
+            lifecycle: .running
+        )
+        let before = fixture.panel.surface.debugPendingSocketInputForTesting()
+
+        fixture.panel.handleTextBoxEscape()
+
+        let after = fixture.panel.surface.debugPendingSocketInputForTesting()
+        #expect(
+            after.keyEvents == before.keyEvents + 1,
+            "Escape passthrough must follow a running agent into the Dock"
+        )
+    }
+
+    @Test
+    func manualDockActivityDoesNotReceiveEscapeFromTextBox() {
+        let fixture = makeDockFixture()
+        defer { fixture.dock.closeAllPanels() }
+
+        fixture.dock.setAgentLifecycle(
+            key: "manual:loader",
+            panelId: fixture.panel.id,
+            lifecycle: .running
+        )
+        let before = fixture.panel.surface.debugPendingSocketInputForTesting()
+
+        fixture.panel.handleTextBoxEscape()
+
+        let after = fixture.panel.surface.debugPendingSocketInputForTesting()
+        #expect(
+            after.keyEvents == before.keyEvents,
+            "Manual loading activity must not be treated as a running agent turn"
+        )
+    }
+
+    private func makeWorkspaceFixture() throws -> (
+        windowID: UUID,
+        workspace: Workspace,
+        panel: TerminalPanel
+    ) {
+        let appDelegate = try #require(AppDelegate.shared)
+        let windowID = appDelegate.createMainWindow()
+        do {
+            let manager = try #require(appDelegate.tabManagerFor(windowId: windowID))
+            let workspace = try #require(manager.selectedWorkspace)
+            let panelID = try #require(workspace.focusedPanelId)
+            let panel = try #require(workspace.terminalPanel(for: panelID))
+
+            panel.showTextBoxInputWhenAvailable()
+            panel.surface.releaseSurfaceForTesting()
+            return (windowID, workspace, panel)
+        } catch {
+            closeWindow(windowID)
+            throw error
+        }
+    }
+
+    private func makeDockFixture() -> (
+        dock: DockSplitStore,
+        panel: TerminalPanel
+    ) {
+        let dock = DockSplitStore(workspaceId: UUID(), baseDirectoryProvider: { nil })
+        let panel = TerminalPanel(
+            workspaceId: dock.workspaceId,
+            runtimeSpawnPolicy: .pacedSessionRestore
+        )
+        dock.panels[panel.id] = panel
+        panel.showTextBoxInputWhenAvailable()
+        panel.surface.releaseSurfaceForTesting()
+        return (dock, panel)
+    }
+
+    private func closeWindow(_ windowID: UUID) {
+        let identifier = "cmux.main.\(windowID.uuidString)"
+        NSApp.windows.first { $0.identifier?.rawValue == identifier }?.performClose(nil)
+    }
+}


### PR DESCRIPTION
Ports the safe app portion of external PR https://github.com/manaflow-ai/cmux/pull/9810 from commit 7391d871d519a191c8e47a833f9aa317e7745050 onto current main 5c2ee1244d.

Changes:
- Forward TextBox Escape to the PTY only for a running built-in agent, using Dock-first then workspace ownership lookup.
- Keep manual and custom Vault lifecycle keys out of Escape authorization.
- Add Campfire to the built-in lifecycle allowlist.
- Centralize existing hibernation aggregation and use a bounded allowlist lookup for Escape.
- Add serialized behavior coverage for workspace, Dock, physical TextBox keyDown, idle, unsupported, and manual states.

This branch intentionally excludes the contributor branch submodule pointer changes. It has two commits, test first then fix.

Static checks passed:
- scripts/check-pbxproj.sh
- scripts/lint-pbxproj-test-wiring.sh
- swiftc -parse on all changed Swift files
- git diff --check

No local Xcode tests or runtime build were run, per task scope.

Apple event references:
- https://developer.apple.com/documentation/appkit/nsresponder/keydown%28with%3A%29
- https://developer.apple.com/documentation/appkit/nsevent/keyevent%28with%3Alocation%3Amodifierflags%3Atimestamp%3Awindownumber%3Acontext%3Acharacters%3Acharactersignoringmodifiers%3Aisarepeat%3Akeycode%3A%29
- https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/EventOverview/HandlingKeyEvents/HandlingKeyEvents.html
- https://docs.swift.org/swift-book/documentation/the-swift-programming-language/concurrency/

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790416220&installation_model_id=21920&pr_number=10959&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10959&signature=56e32a0935a8f6ade9963310139033d24c0b663cee90329a06e7b295debc2186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports the upstream Escape passthrough fix so TextBox Escape reaches the PTY only while a built-in agent is running, instead of forwarding more broadly.

- Escape authorization prefers Dock lookup, then workspace ownership.
- Manual and custom Vault lifecycle keys no longer authorize Escape passthrough.
- Adds `campfire` to the built-in allowlist and centralizes hibernation aggregation.
- Adds serialized tests for workspace, Dock, physical TextBox keyDown, idle, unsupported, and manual states.

<sup>Written for commit 8f74239c78a81352d69e8fe5512a688b0a9d7b7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Escape key presses in text boxes now pass through to active terminal agents.
  * Added support for additional lifecycle statuses, including `campfire`.
  * Text-box drafts remain intact and visible after Escape is forwarded.

* **Bug Fixes**
  * Escape passthrough is limited to supported running agents, preventing unintended terminal input during idle or unsupported states.

* **Tests**
  * Added coverage for workspace and dock-based agents, lifecycle states, and text-box behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->