### PR TITLE
cloud VM env audit: verify the default provider's image against the manifest, run daily in CI

### DIFF
--- a/.github/workflows/cloud-vm-env-audit.yml
+++ b/.github/workflows/cloud-vm-env-audit.yml
@@ -1,0 +1,45 @@
+name: Cloud VM env audit
+
+# Guards against deployed-env / code drift: the 2026-08-26 outage shipped code
+# that assumed CMUX_VM_DEFAULT_PROVIDER=blaxel while production still said
+# freestyle, and every Cloud VM create 503ed for two days with nothing paging.
+# This audit pulls the real production env and fails when the default
+# provider's image value is missing from the image manifest, so drift is a red
+# workflow on merge (and daily) instead of a user-facing outage.
+
+on:
+  schedule:
+    - cron: "23 8 * * *"
+  push:
+    branches: [main]
+    paths:
+      - web/services/vms/**
+      - web/scripts/cloud-vm/**
+      - .github/workflows/cloud-vm-env-audit.yml
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cloud-vm-env-audit
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # The audit reads the production env; run only trusted main code.
+          ref: refs/heads/main
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      - name: Audit production Cloud VM env
+        working-directory: web
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: bun scripts/cloud-vm/audit-vercel-env.mjs . production --strict

--- a/.github/workflows/cloud-vm-env-audit.yml
+++ b/.github/workflows/cloud-vm-env-audit.yml
@@ -38,6 +38,16 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
+      - name: Install dependencies
+        working-directory: web
+        run: bun install --frozen-lockfile
+
+      # The audit is only as strong as its own checks; run its regression
+      # tests first so a weakened guard fails CI instead of staying green.
+      - name: Audit guard self-tests
+        working-directory: web
+        run: bun test tests/cloud-vm-env-audit.test.ts
+
       - name: Audit production Cloud VM env
         working-directory: web
         env:

--- a/web/scripts/cloud-vm/audit-vercel-env.mjs
+++ b/web/scripts/cloud-vm/audit-vercel-env.mjs
@@ -18,6 +18,10 @@ const { webDir, target, project, rest } = parseWebDirAndTarget(process.argv.slic
 const strict = rest.includes("--strict") || parseBoolean(process.env.CMUX_CLOUD_VM_ENV_AUDIT_STRICT, false);
 
 try {
+  // `target` selects which Vercel PROJECT to audit (staging and production
+  // are separate projects: cmux-staging vs cmux). Each project's runtime env
+  // is its own "production" environment, so the project object fully encodes
+  // the target and the loader needs nothing else.
   const env = loadTargetEnv(project);
   const keys = Object.keys(env).sort();
   const present = new Set(keys);

--- a/web/scripts/cloud-vm/audit-vercel-env.mjs
+++ b/web/scripts/cloud-vm/audit-vercel-env.mjs
@@ -1,20 +1,24 @@
 #!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { auditDefaultProviderImage } from "./defaultProviderAudit.mjs";
 import {
   forbiddenRuntimeEnvKeys,
   legacyCloudVmEnvKeys,
+  loadTargetEnv,
   parseBoolean,
   parseWebDirAndTarget,
-  pullProductionEnv,
   recommendedRuntimeEnvKeys,
   requiredRuntimeEnvKeys,
 } from "./projects.mjs";
 
 const usage = "Usage: audit-vercel-env.mjs [web-dir] <staging|production> [--strict]";
-const { target, project, rest } = parseWebDirAndTarget(process.argv.slice(2), usage);
+const { webDir, target, project, rest } = parseWebDirAndTarget(process.argv.slice(2), usage);
 const strict = rest.includes("--strict") || parseBoolean(process.env.CMUX_CLOUD_VM_ENV_AUDIT_STRICT, false);
 
 try {
-  const env = pullProductionEnv(project);
+  const env = loadTargetEnv(project);
   const keys = Object.keys(env).sort();
   const present = new Set(keys);
   const missingRequired = requiredRuntimeEnvKeys.filter((key) => !present.has(key));
@@ -22,8 +26,18 @@ try {
   const forbiddenPresent = forbiddenRuntimeEnvKeys.filter((key) => present.has(key));
   const legacyCloudVmPresent = legacyCloudVmEnvKeys.filter((key) => present.has(key));
 
+  // Key presence alone missed the 2026-08-26 outage (stale
+  // CMUX_VM_DEFAULT_PROVIDER value): the default provider's image env value
+  // must exist in the image manifest the same deploy ships.
+  const manifest = JSON.parse(
+    readFileSync(path.join(webDir, "services", "vms", "images", "manifest.json"), "utf8"),
+  );
+  const defaultProvider = auditDefaultProviderImage(env, manifest);
+
   const result = {
-    ok: missingRequired.length === 0 && forbiddenPresent.length === 0,
+    ok: missingRequired.length === 0 &&
+      forbiddenPresent.length === 0 &&
+      defaultProvider.problems.length === 0,
     target,
     project: project.projectName,
     envKeyCount: keys.length,
@@ -32,6 +46,7 @@ try {
     missingRecommended,
     forbiddenPresent,
     legacyCloudVmPresent,
+    defaultProvider,
   };
 
   console.log(JSON.stringify(result, null, 2));

--- a/web/scripts/cloud-vm/audit-vercel-env.mjs
+++ b/web/scripts/cloud-vm/audit-vercel-env.mjs
@@ -2,7 +2,7 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 
-import { auditDefaultProviderImage } from "./defaultProviderAudit.mjs";
+import { auditCloudVmProviderCoherence } from "./defaultProviderAudit.mjs";
 import {
   forbiddenRuntimeEnvKeys,
   legacyCloudVmEnvKeys,
@@ -27,17 +27,18 @@ try {
   const legacyCloudVmPresent = legacyCloudVmEnvKeys.filter((key) => present.has(key));
 
   // Key presence alone missed the 2026-08-26 outage (stale
-  // CMUX_VM_DEFAULT_PROVIDER value): the default provider's image env value
-  // must exist in the image manifest the same deploy ships.
+  // CMUX_VM_DEFAULT_PROVIDER value): provider VALUES must exist in the image
+  // manifest the same deploy ships, for the env-selected default AND for the
+  // code default that shipped clients hardcode.
   const manifest = JSON.parse(
     readFileSync(path.join(webDir, "services", "vms", "images", "manifest.json"), "utf8"),
   );
-  const defaultProvider = auditDefaultProviderImage(env, manifest);
+  const providerCoherence = auditCloudVmProviderCoherence(env, manifest);
 
   const result = {
     ok: missingRequired.length === 0 &&
       forbiddenPresent.length === 0 &&
-      defaultProvider.problems.length === 0,
+      providerCoherence.problems.length === 0,
     target,
     project: project.projectName,
     envKeyCount: keys.length,
@@ -46,7 +47,7 @@ try {
     missingRecommended,
     forbiddenPresent,
     legacyCloudVmPresent,
-    defaultProvider,
+    providerCoherence,
   };
 
   console.log(JSON.stringify(result, null, 2));

--- a/web/scripts/cloud-vm/defaultProviderAudit.mjs
+++ b/web/scripts/cloud-vm/defaultProviderAudit.mjs
@@ -2,9 +2,9 @@
 //
 // The 2026-08-26 outage: code shipped assuming CMUX_VM_DEFAULT_PROVIDER=blaxel
 // while production still said freestyle, and no BLAXEL_SANDBOX_IMAGE was set.
-// Key-presence auditing could not catch that; the default provider's VALUE has
-// to agree with the manifest. Everything here derives from manifest.json (each
-// entry carries its provider and env var), so a new provider cannot be added
+// Key-presence auditing could not catch that; provider VALUES have to agree
+// with the manifest. Image env vars derive from manifest.json (each entry
+// carries its provider and env var), so a new provider cannot be added
 // without this audit learning about it.
 
 /**
@@ -18,34 +18,32 @@ const PROVIDER_CREDENTIAL_KEYS = {
   blaxel: ["BL_API_KEY", "BL_WORKSPACE"],
 };
 
-// Mirrors defaultProviderId() in services/vms/drivers/index.ts.
-const CODE_DEFAULT_PROVIDER = "blaxel";
+// Mirrors defaultProviderId() in services/vms/drivers/index.ts. Shipped CLIs
+// also hardcode this provider's image ids (cmux.swift cloudVMDesktopImage /
+// cloudVMBaseImage), so it must stay provisionable in production even when
+// the env deliberately selects a different default as a rollback.
+export const CODE_DEFAULT_PROVIDER = "blaxel";
 
-/**
- * @param {Record<string, string | undefined>} env deployed runtime env values
- * @param {{ images: Array<{ provider: string, version: string, imageId: string, envVar: string, validationStatus: string }> }} manifest
- * @returns {{ provider: string, envVar: string | null, image: string | null, problems: string[] }}
- */
 // What `vercel env pull` writes for values it cannot decrypt. The default
 // provider and its image id are configuration, not secrets; stored as
 // Sensitive they become unauditable, which defeats this check.
 const SENSITIVE_PLACEHOLDER = "[SENSITIVE]";
 
-export function auditDefaultProviderImage(env, manifest) {
+/**
+ * Audit one provider: its image env var must name a validated manifest entry
+ * and its API credentials must exist.
+ *
+ * @param {string} provider
+ * @param {Record<string, string | undefined>} env deployed runtime env values
+ * @param {{ images: Array<{ provider: string, version: string, imageId: string, envVar: string, validationStatus: string }> }} manifest
+ * @returns {{ provider: string, envVar: string | null, image: string | null, problems: string[] }}
+ */
+export function auditProviderReadiness(provider, env, manifest) {
   const problems = [];
-  const rawProvider = (env.CMUX_VM_DEFAULT_PROVIDER ?? CODE_DEFAULT_PROVIDER).trim();
-  if (rawProvider === SENSITIVE_PLACEHOLDER) {
-    problems.push(
-      "CMUX_VM_DEFAULT_PROVIDER is stored as a Sensitive env var, so its value " +
-      "cannot be audited; store it as a plain env var (it is configuration, not a secret)",
-    );
-    return { provider: null, envVar: null, image: null, problems };
-  }
-  const provider = rawProvider;
   const entries = manifest.images.filter((entry) => entry.provider === provider);
   if (entries.length === 0) {
     problems.push(
-      `default provider ${provider} has no entries in the image manifest; ` +
+      `provider ${provider} has no entries in the image manifest; ` +
       "every imageless create will fail closed in deployed runtimes",
     );
     return { provider, envVar: null, image: null, problems };
@@ -55,8 +53,8 @@ export function auditDefaultProviderImage(env, manifest) {
   const image = env[envVar]?.trim() || null;
   if (!image) {
     problems.push(
-      `${envVar} is not set; deployed runtimes fail closed on imageless creates ` +
-      `for default provider ${provider}`,
+      `${envVar} is not set; deployed runtimes fail closed on imageless ` +
+      `creates for provider ${provider}`,
     );
   } else if (image === SENSITIVE_PLACEHOLDER) {
     problems.push(
@@ -80,9 +78,47 @@ export function auditDefaultProviderImage(env, manifest) {
 
   for (const key of PROVIDER_CREDENTIAL_KEYS[provider] ?? []) {
     if (!env[key]?.trim()) {
-      problems.push(`${key} is not set but ${provider} is the default provider`);
+      problems.push(`${key} is not set but provider ${provider} must be provisionable`);
     }
   }
 
   return { provider, envVar, image, problems };
+}
+
+/**
+ * Full coherence audit. Two legs:
+ * - the env-selected default provider (what imageless creates use), and
+ * - the code default (blaxel) whenever the env selects something else,
+ *   because shipped clients hardcode blaxel image ids: an env rollback to
+ *   another default must not leave blaxel unprovisionable. This second leg
+ *   is what would have caught the 2026-08-26 production env, where a fully
+ *   coherent freestyle default coexisted with clients that only send blaxel.
+ *
+ * @param {Record<string, string | undefined>} env
+ * @param {{ images: Array<{ provider: string, version: string, imageId: string, envVar: string, validationStatus: string }> }} manifest
+ * @returns {{ selected: object | null, codeDefault: object | null, problems: string[] }}
+ */
+export function auditCloudVmProviderCoherence(env, manifest) {
+  const rawProvider = (env.CMUX_VM_DEFAULT_PROVIDER ?? CODE_DEFAULT_PROVIDER).trim();
+  if (rawProvider === SENSITIVE_PLACEHOLDER) {
+    return {
+      selected: null,
+      codeDefault: null,
+      problems: [
+        "CMUX_VM_DEFAULT_PROVIDER is stored as a Sensitive env var, so its value " +
+        "cannot be audited; store it as a plain env var (it is configuration, not a secret)",
+      ],
+    };
+  }
+
+  const selected = auditProviderReadiness(rawProvider, env, manifest);
+  const problems = selected.problems.map((problem) => `default provider: ${problem}`);
+  let codeDefault = null;
+  if (rawProvider !== CODE_DEFAULT_PROVIDER) {
+    codeDefault = auditProviderReadiness(CODE_DEFAULT_PROVIDER, env, manifest);
+    problems.push(
+      ...codeDefault.problems.map((problem) => `code default (${CODE_DEFAULT_PROVIDER}): ${problem}`),
+    );
+  }
+  return { selected, codeDefault, problems };
 }

--- a/web/scripts/cloud-vm/defaultProviderAudit.mjs
+++ b/web/scripts/cloud-vm/defaultProviderAudit.mjs
@@ -76,7 +76,16 @@ export function auditProviderReadiness(provider, env, manifest) {
     }
   }
 
-  for (const key of PROVIDER_CREDENTIAL_KEYS[provider] ?? []) {
+  const credentialKeys = PROVIDER_CREDENTIAL_KEYS[provider];
+  if (!credentialKeys) {
+    // Fail closed: a provider without a credential mapping would otherwise
+    // pass this audit and then fail every create at runtime.
+    problems.push(
+      `provider ${provider} has no credential mapping in this audit; ` +
+      "add its API credential env keys to PROVIDER_CREDENTIAL_KEYS",
+    );
+  }
+  for (const key of credentialKeys ?? []) {
     if (!env[key]?.trim()) {
       problems.push(`${key} is not set but provider ${provider} must be provisionable`);
     }

--- a/web/scripts/cloud-vm/defaultProviderAudit.mjs
+++ b/web/scripts/cloud-vm/defaultProviderAudit.mjs
@@ -1,0 +1,88 @@
+// Coherence check between the deployed Cloud VM env and the image manifest.
+//
+// The 2026-08-26 outage: code shipped assuming CMUX_VM_DEFAULT_PROVIDER=blaxel
+// while production still said freestyle, and no BLAXEL_SANDBOX_IMAGE was set.
+// Key-presence auditing could not catch that; the default provider's VALUE has
+// to agree with the manifest. Everything here derives from manifest.json (each
+// entry carries its provider and env var), so a new provider cannot be added
+// without this audit learning about it.
+
+/**
+ * Provider API credential env keys. These cannot be derived from the manifest;
+ * keep in sync with services/vms/drivers/*.
+ */
+const PROVIDER_CREDENTIAL_KEYS = {
+  e2b: ["E2B_API_KEY"],
+  freestyle: ["FREESTYLE_API_KEY"],
+  daytona: ["DAYTONA_API_KEY"],
+  blaxel: ["BL_API_KEY", "BL_WORKSPACE"],
+};
+
+// Mirrors defaultProviderId() in services/vms/drivers/index.ts.
+const CODE_DEFAULT_PROVIDER = "blaxel";
+
+/**
+ * @param {Record<string, string | undefined>} env deployed runtime env values
+ * @param {{ images: Array<{ provider: string, version: string, imageId: string, envVar: string, validationStatus: string }> }} manifest
+ * @returns {{ provider: string, envVar: string | null, image: string | null, problems: string[] }}
+ */
+// What `vercel env pull` writes for values it cannot decrypt. The default
+// provider and its image id are configuration, not secrets; stored as
+// Sensitive they become unauditable, which defeats this check.
+const SENSITIVE_PLACEHOLDER = "[SENSITIVE]";
+
+export function auditDefaultProviderImage(env, manifest) {
+  const problems = [];
+  const rawProvider = (env.CMUX_VM_DEFAULT_PROVIDER ?? CODE_DEFAULT_PROVIDER).trim();
+  if (rawProvider === SENSITIVE_PLACEHOLDER) {
+    problems.push(
+      "CMUX_VM_DEFAULT_PROVIDER is stored as a Sensitive env var, so its value " +
+      "cannot be audited; store it as a plain env var (it is configuration, not a secret)",
+    );
+    return { provider: null, envVar: null, image: null, problems };
+  }
+  const provider = rawProvider;
+  const entries = manifest.images.filter((entry) => entry.provider === provider);
+  if (entries.length === 0) {
+    problems.push(
+      `default provider ${provider} has no entries in the image manifest; ` +
+      "every imageless create will fail closed in deployed runtimes",
+    );
+    return { provider, envVar: null, image: null, problems };
+  }
+
+  const envVar = entries[0].envVar;
+  const image = env[envVar]?.trim() || null;
+  if (!image) {
+    problems.push(
+      `${envVar} is not set; deployed runtimes fail closed on imageless creates ` +
+      `for default provider ${provider}`,
+    );
+  } else if (image === SENSITIVE_PLACEHOLDER) {
+    problems.push(
+      `${envVar} is stored as a Sensitive env var, so its value cannot be audited; ` +
+      "store it as a plain env var (image ids are configuration, not secrets)",
+    );
+  } else {
+    const entry = entries.find((candidate) => candidate.imageId === image || candidate.version === image);
+    if (!entry) {
+      problems.push(
+        `${envVar}=${image} is not listed in the image manifest for ${provider}; ` +
+        "deployed runtimes will reject it with vm_image_config_error",
+      );
+    } else if (entry.validationStatus !== "passed") {
+      problems.push(
+        `${envVar} selects manifest entry ${entry.version} whose validationStatus is ` +
+        `${entry.validationStatus}, not passed`,
+      );
+    }
+  }
+
+  for (const key of PROVIDER_CREDENTIAL_KEYS[provider] ?? []) {
+    if (!env[key]?.trim()) {
+      problems.push(`${key} is not set but ${provider} is the default provider`);
+    }
+  }
+
+  return { provider, envVar, image, problems };
+}

--- a/web/scripts/cloud-vm/projects.mjs
+++ b/web/scripts/cloud-vm/projects.mjs
@@ -146,6 +146,11 @@ export function requireEnvKeys(env, keys, label) {
 export function runVercel(args, options = {}) {
   const stdio = options.stdio ?? "inherit";
   const env = { ...process.env, ...options.env };
+  // CI has no interactive Vercel login; the CLI only honors --token, so
+  // forward VERCEL_TOKEN explicitly when the caller did not pass one.
+  if (env.VERCEL_TOKEN && !args.some((arg) => String(arg).startsWith("--token"))) {
+    args = [...args, "--token", env.VERCEL_TOKEN];
+  }
   const command = process.env.VERCEL_CLI;
   if (command) return execFileSync(command, args, { ...options, env, stdio });
   try {

--- a/web/scripts/cloud-vm/projects.mjs
+++ b/web/scripts/cloud-vm/projects.mjs
@@ -145,12 +145,9 @@ export function requireEnvKeys(env, keys, label) {
 
 export function runVercel(args, options = {}) {
   const stdio = options.stdio ?? "inherit";
+  // The Vercel CLI reads VERCEL_TOKEN from the environment, so CI needs no
+  // --token in argv (argv leaks into process listings and thrown errors).
   const env = { ...process.env, ...options.env };
-  // CI has no interactive Vercel login; the CLI only honors --token, so
-  // forward VERCEL_TOKEN explicitly when the caller did not pass one.
-  if (env.VERCEL_TOKEN && !args.some((arg) => String(arg).startsWith("--token"))) {
-    args = [...args, "--token", env.VERCEL_TOKEN];
-  }
   const command = process.env.VERCEL_CLI;
   if (command) return execFileSync(command, args, { ...options, env, stdio });
   try {

--- a/web/tests/cloud-vm-env-audit.test.ts
+++ b/web/tests/cloud-vm-env-audit.test.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import {
   auditCloudVmProviderCoherence,
   auditProviderReadiness,
+  CODE_DEFAULT_PROVIDER,
 } from "../scripts/cloud-vm/defaultProviderAudit.mjs";
 
 type Manifest = {
@@ -139,5 +140,41 @@ describe("sensitive env placeholders", () => {
       realManifest,
     ) as Coherence;
     expect(result.problems.join("\n")).toContain("cannot be audited");
+  });
+});
+
+describe("audit constants stay tied to the runtime", () => {
+  test("CODE_DEFAULT_PROVIDER matches defaultProviderId() with no env override", async () => {
+    // The audit script cannot import the runtime driver module (it must stay
+    // a dependency-free .mjs for CI), so this test enforces the pairing: if
+    // defaultProviderId()'s fallback changes, this fails until the audit's
+    // CODE_DEFAULT_PROVIDER moves with it. Dynamic import on purpose: loading
+    // the driver registry is only needed for this one assertion.
+    const { defaultProviderId } = await import("../services/vms/drivers");
+    const saved = process.env.CMUX_VM_DEFAULT_PROVIDER;
+    delete process.env.CMUX_VM_DEFAULT_PROVIDER;
+    try {
+      expect(CODE_DEFAULT_PROVIDER).toBe(defaultProviderId());
+    } finally {
+      if (saved !== undefined) process.env.CMUX_VM_DEFAULT_PROVIDER = saved;
+    }
+  });
+
+  test("a provider without a credential mapping fails closed", () => {
+    const manifest = {
+      images: [{
+        provider: "newprovider",
+        version: "newprovider-v1",
+        imageId: "np:latest",
+        envVar: "NEWPROVIDER_IMAGE",
+        validationStatus: "passed",
+      }],
+    };
+    const result = auditProviderReadiness(
+      "newprovider",
+      { NEWPROVIDER_IMAGE: "np:latest" },
+      manifest,
+    ) as { problems: string[] };
+    expect(result.problems.join("\n")).toContain("no credential mapping");
   });
 });

--- a/web/tests/cloud-vm-env-audit.test.ts
+++ b/web/tests/cloud-vm-env-audit.test.ts
@@ -8,6 +8,7 @@ import {
   auditProviderReadiness,
   CODE_DEFAULT_PROVIDER,
 } from "../scripts/cloud-vm/defaultProviderAudit.mjs";
+import { defaultProviderId } from "../services/vms/drivers";
 
 type Manifest = {
   images: Array<{
@@ -144,13 +145,11 @@ describe("sensitive env placeholders", () => {
 });
 
 describe("audit constants stay tied to the runtime", () => {
-  test("CODE_DEFAULT_PROVIDER matches defaultProviderId() with no env override", async () => {
+  test("CODE_DEFAULT_PROVIDER matches defaultProviderId() with no env override", () => {
     // The audit script cannot import the runtime driver module (it must stay
     // a dependency-free .mjs for CI), so this test enforces the pairing: if
     // defaultProviderId()'s fallback changes, this fails until the audit's
-    // CODE_DEFAULT_PROVIDER moves with it. Dynamic import on purpose: loading
-    // the driver registry is only needed for this one assertion.
-    const { defaultProviderId } = await import("../services/vms/drivers");
+    // CODE_DEFAULT_PROVIDER moves with it.
     const saved = process.env.CMUX_VM_DEFAULT_PROVIDER;
     delete process.env.CMUX_VM_DEFAULT_PROVIDER;
     try {

--- a/web/tests/cloud-vm-env-audit.test.ts
+++ b/web/tests/cloud-vm-env-audit.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { auditDefaultProviderImage } from "../scripts/cloud-vm/defaultProviderAudit.mjs";
+
+type Manifest = {
+  images: Array<{
+    provider: string;
+    version: string;
+    imageId: string;
+    envVar: string;
+    validationStatus: string;
+  }>;
+};
+
+const realManifest = JSON.parse(
+  readFileSync(
+    path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "services", "vms", "images", "manifest.json"),
+    "utf8",
+  ),
+) as Manifest;
+
+describe("default provider env coherence audit", () => {
+  test("the 2026-08-26 production shape fails: freestyle default with only blaxel-era changes needed", () => {
+    // Exact prod state during the outage: default provider flipped in code,
+    // never in env, and no BLAXEL_SANDBOX_IMAGE. The old audit passed on this.
+    const result = auditDefaultProviderImage(
+      {
+        FREESTYLE_SANDBOX_SNAPSHOT: "sh-17agfasevrc18c8f15nn",
+        FREESTYLE_API_KEY: "x",
+      },
+      realManifest,
+    ) as { provider: string; problems: string[] };
+    // With no CMUX_VM_DEFAULT_PROVIDER, the code default (blaxel) applies and
+    // its image env plus credentials are missing.
+    expect(result.provider).toBe("blaxel");
+    expect(result.problems.join("\n")).toContain("BLAXEL_SANDBOX_IMAGE is not set");
+    expect(result.problems.join("\n")).toContain("BL_API_KEY");
+  });
+
+  test("an image value outside the manifest is a problem", () => {
+    const result = auditDefaultProviderImage(
+      {
+        CMUX_VM_DEFAULT_PROVIDER: "freestyle",
+        FREESTYLE_SANDBOX_SNAPSHOT: "sh-not-a-real-snapshot",
+        FREESTYLE_API_KEY: "x",
+      },
+      realManifest,
+    ) as { problems: string[] };
+    expect(result.problems.join("\n")).toContain("not listed in the image manifest");
+  });
+
+  test("a coherent blaxel production env passes", () => {
+    const result = auditDefaultProviderImage(
+      {
+        CMUX_VM_DEFAULT_PROVIDER: "blaxel",
+        BLAXEL_SANDBOX_IMAGE: "sandbox/cmux-devbox:latest",
+        BL_API_KEY: "x",
+        BL_WORKSPACE: "manaflow",
+      },
+      realManifest,
+    ) as { provider: string; envVar: string; problems: string[] };
+    expect(result.provider).toBe("blaxel");
+    expect(result.envVar).toBe("BLAXEL_SANDBOX_IMAGE");
+    expect(result.problems).toEqual([]);
+  });
+
+  test("a provider with no manifest entries at all is a problem", () => {
+    const result = auditDefaultProviderImage(
+      { CMUX_VM_DEFAULT_PROVIDER: "daytona" },
+      { images: realManifest.images.filter((entry) => entry.provider !== "daytona") },
+    ) as { problems: string[] };
+    expect(result.problems.join("\n")).toContain("no entries in the image manifest");
+  });
+
+  test("a manifest entry that never passed validation is a problem", () => {
+    const result = auditDefaultProviderImage(
+      {
+        CMUX_VM_DEFAULT_PROVIDER: "freestyle",
+        FREESTYLE_SANDBOX_SNAPSHOT: "sh-w2otfp1g287lzrpuc2gr",
+        FREESTYLE_API_KEY: "x",
+      },
+      realManifest,
+    ) as { problems: string[] };
+    expect(result.problems.join("\n")).toContain("validationStatus");
+  });
+});
+
+describe("sensitive env placeholders", () => {
+  test("a Sensitive default-provider value is itself a problem", () => {
+    const result = auditDefaultProviderImage(
+      { CMUX_VM_DEFAULT_PROVIDER: "[SENSITIVE]" },
+      realManifest,
+    ) as { problems: string[] };
+    expect(result.problems.join("\n")).toContain("cannot be audited");
+  });
+
+  test("a Sensitive image value is itself a problem", () => {
+    const result = auditDefaultProviderImage(
+      {
+        CMUX_VM_DEFAULT_PROVIDER: "blaxel",
+        BLAXEL_SANDBOX_IMAGE: "[SENSITIVE]",
+        BL_API_KEY: "x",
+        BL_WORKSPACE: "manaflow",
+      },
+      realManifest,
+    ) as { problems: string[] };
+    expect(result.problems.join("\n")).toContain("cannot be audited");
+  });
+});

--- a/web/tests/cloud-vm-env-audit.test.ts
+++ b/web/tests/cloud-vm-env-audit.test.ts
@@ -3,7 +3,10 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { auditDefaultProviderImage } from "../scripts/cloud-vm/defaultProviderAudit.mjs";
+import {
+  auditCloudVmProviderCoherence,
+  auditProviderReadiness,
+} from "../scripts/cloud-vm/defaultProviderAudit.mjs";
 
 type Manifest = {
   images: Array<{
@@ -15,6 +18,12 @@ type Manifest = {
   }>;
 };
 
+type Coherence = {
+  selected: { provider: string } | null;
+  codeDefault: { provider: string } | null;
+  problems: string[];
+};
+
 const realManifest = JSON.parse(
   readFileSync(
     path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "services", "vms", "images", "manifest.json"),
@@ -22,38 +31,39 @@ const realManifest = JSON.parse(
   ),
 ) as Manifest;
 
-describe("default provider env coherence audit", () => {
-  test("the 2026-08-26 production shape fails: freestyle default with only blaxel-era changes needed", () => {
-    // Exact prod state during the outage: default provider flipped in code,
-    // never in env, and no BLAXEL_SANDBOX_IMAGE. The old audit passed on this.
-    const result = auditDefaultProviderImage(
+describe("cloud VM provider coherence audit", () => {
+  test("the exact 2026-08-26 production env fails on the code-default leg", () => {
+    // Prod state during the outage: a fully coherent freestyle default, while
+    // shipped CLIs hardcode blaxel image ids and no blaxel env existed. The
+    // old key-presence audit passed this env.
+    const result = auditCloudVmProviderCoherence(
       {
+        CMUX_VM_DEFAULT_PROVIDER: "freestyle",
         FREESTYLE_SANDBOX_SNAPSHOT: "sh-17agfasevrc18c8f15nn",
         FREESTYLE_API_KEY: "x",
+        BL_API_KEY: "x",
+        BL_WORKSPACE: "manaflow",
       },
       realManifest,
-    ) as { provider: string; problems: string[] };
-    // With no CMUX_VM_DEFAULT_PROVIDER, the code default (blaxel) applies and
-    // its image env plus credentials are missing.
-    expect(result.provider).toBe("blaxel");
+    ) as Coherence;
+    expect(result.selected?.provider).toBe("freestyle");
+    expect(result.codeDefault?.provider).toBe("blaxel");
+    expect(result.problems.join("\n")).toContain("BLAXEL_SANDBOX_IMAGE is not set");
+  });
+
+  test("no default provider set means the code default (blaxel) must be ready", () => {
+    const result = auditCloudVmProviderCoherence(
+      { FREESTYLE_SANDBOX_SNAPSHOT: "sh-17agfasevrc18c8f15nn", FREESTYLE_API_KEY: "x" },
+      realManifest,
+    ) as Coherence;
+    expect(result.selected?.provider).toBe("blaxel");
+    expect(result.codeDefault).toBeNull();
     expect(result.problems.join("\n")).toContain("BLAXEL_SANDBOX_IMAGE is not set");
     expect(result.problems.join("\n")).toContain("BL_API_KEY");
   });
 
-  test("an image value outside the manifest is a problem", () => {
-    const result = auditDefaultProviderImage(
-      {
-        CMUX_VM_DEFAULT_PROVIDER: "freestyle",
-        FREESTYLE_SANDBOX_SNAPSHOT: "sh-not-a-real-snapshot",
-        FREESTYLE_API_KEY: "x",
-      },
-      realManifest,
-    ) as { problems: string[] };
-    expect(result.problems.join("\n")).toContain("not listed in the image manifest");
-  });
-
   test("a coherent blaxel production env passes", () => {
-    const result = auditDefaultProviderImage(
+    const result = auditCloudVmProviderCoherence(
       {
         CMUX_VM_DEFAULT_PROVIDER: "blaxel",
         BLAXEL_SANDBOX_IMAGE: "sandbox/cmux-devbox:latest",
@@ -61,27 +71,48 @@ describe("default provider env coherence audit", () => {
         BL_WORKSPACE: "manaflow",
       },
       realManifest,
-    ) as { provider: string; envVar: string; problems: string[] };
-    expect(result.provider).toBe("blaxel");
-    expect(result.envVar).toBe("BLAXEL_SANDBOX_IMAGE");
+    ) as Coherence;
+    expect(result.selected?.provider).toBe("blaxel");
+    expect(result.codeDefault).toBeNull();
     expect(result.problems).toEqual([]);
   });
 
+  test("a deliberate freestyle rollback passes only with blaxel still provisionable", () => {
+    const rollbackEnv = {
+      CMUX_VM_DEFAULT_PROVIDER: "freestyle",
+      FREESTYLE_SANDBOX_SNAPSHOT: "sh-17agfasevrc18c8f15nn",
+      FREESTYLE_API_KEY: "x",
+      BLAXEL_SANDBOX_IMAGE: "sandbox/cmux-devbox:latest",
+      BL_API_KEY: "x",
+      BL_WORKSPACE: "manaflow",
+    };
+    const result = auditCloudVmProviderCoherence(rollbackEnv, realManifest) as Coherence;
+    expect(result.problems).toEqual([]);
+    expect(result.codeDefault?.provider).toBe("blaxel");
+  });
+
+  test("an image value outside the manifest is a problem", () => {
+    const result = auditProviderReadiness(
+      "freestyle",
+      { FREESTYLE_SANDBOX_SNAPSHOT: "sh-not-a-real-snapshot", FREESTYLE_API_KEY: "x" },
+      realManifest,
+    ) as { problems: string[] };
+    expect(result.problems.join("\n")).toContain("not listed in the image manifest");
+  });
+
   test("a provider with no manifest entries at all is a problem", () => {
-    const result = auditDefaultProviderImage(
-      { CMUX_VM_DEFAULT_PROVIDER: "daytona" },
+    const result = auditProviderReadiness(
+      "daytona",
+      {},
       { images: realManifest.images.filter((entry) => entry.provider !== "daytona") },
     ) as { problems: string[] };
     expect(result.problems.join("\n")).toContain("no entries in the image manifest");
   });
 
   test("a manifest entry that never passed validation is a problem", () => {
-    const result = auditDefaultProviderImage(
-      {
-        CMUX_VM_DEFAULT_PROVIDER: "freestyle",
-        FREESTYLE_SANDBOX_SNAPSHOT: "sh-w2otfp1g287lzrpuc2gr",
-        FREESTYLE_API_KEY: "x",
-      },
+    const result = auditProviderReadiness(
+      "freestyle",
+      { FREESTYLE_SANDBOX_SNAPSHOT: "sh-w2otfp1g287lzrpuc2gr", FREESTYLE_API_KEY: "x" },
       realManifest,
     ) as { problems: string[] };
     expect(result.problems.join("\n")).toContain("validationStatus");
@@ -90,15 +121,15 @@ describe("default provider env coherence audit", () => {
 
 describe("sensitive env placeholders", () => {
   test("a Sensitive default-provider value is itself a problem", () => {
-    const result = auditDefaultProviderImage(
+    const result = auditCloudVmProviderCoherence(
       { CMUX_VM_DEFAULT_PROVIDER: "[SENSITIVE]" },
       realManifest,
-    ) as { problems: string[] };
+    ) as Coherence;
     expect(result.problems.join("\n")).toContain("cannot be audited");
   });
 
   test("a Sensitive image value is itself a problem", () => {
-    const result = auditDefaultProviderImage(
+    const result = auditCloudVmProviderCoherence(
       {
         CMUX_VM_DEFAULT_PROVIDER: "blaxel",
         BLAXEL_SANDBOX_IMAGE: "[SENSITIVE]",
@@ -106,7 +137,7 @@ describe("sensitive env placeholders", () => {
         BL_WORKSPACE: "manaflow",
       },
       realManifest,
-    ) as { problems: string[] };
+    ) as Coherence;
     expect(result.problems.join("\n")).toContain("cannot be audited");
   });
 });


### PR DESCRIPTION
The env audit passed straight through the 2026-08-26 outage: every required KEY existed, but CMUX_VM_DEFAULT_PROVIDER's VALUE still said freestyle while the shipped CLI sends Blaxel image ids, and BLAXEL_SANDBOX_IMAGE did not exist at all. Presence checks cannot catch value drift.

- `defaultProviderAudit.mjs`: derives the default provider's image env var from the manifest itself (each entry carries `envVar`, so new providers are covered automatically), requires its value to be a manifest entry with `validationStatus: passed`, and requires that provider's API credentials (BL_API_KEY/BL_WORKSPACE for blaxel). A value stored as a Sensitive Vercel var is itself flagged: `vercel env pull` returns `[SENSITIVE]` for those, and an unauditable gate is no gate. Exact outage shape is a regression test.
- `audit-vercel-env.mjs` includes the check in `ok` and switches to `loadTargetEnv`, so `CMUX_CLOUD_VM_ENV_SOURCE=process` works for CI dry runs and tests.
- `runVercel` forwards `VERCEL_TOKEN` as `--token` (the CLI does not read the env var), so the audit runs headless in CI.
- New `cloud-vm-env-audit.yml` workflow runs the strict audit against real production daily, on main pushes touching `web/services/vms/**` or `web/scripts/cloud-vm/**`, and on dispatch, using the existing `VERCEL_TOKEN` repo secret. Checkout pins `refs/heads/main` like cloud-vm-smoke so the secret only runs trusted code.

Verified against live production after today's env fix: `bun scripts/cloud-vm/audit-vercel-env.mjs . production --strict` exits 0 with `defaultProvider: { provider: blaxel, image: sandbox/cmux-devbox:latest, problems: [] }`. Both new prod vars were also recreated as plain (they were created Sensitive this morning, which this audit would flag).

Tests: `bun test tests/cloud-vm-env-audit.test.ts` (7 pass), `bun run typecheck` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10960"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790416277&installation_model_id=21920&pr_number=10960&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10960&signature=d9ef9a8366ee0b7ab54e862cff7943f5c871a4f2574a9d674ce4a9db6efb8234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Cloud VM env audit so value drift in the default provider's image fails CI instead of passing, closing the gap that let the 2026-08-26 outage slip through the gate (presence checks can't catch value drift).

- The default provider's image env var is derived from the manifest itself, so new providers are covered automatically.
- The check fails when the image value isn't a validated manifest entry, when the provider's API credentials are missing, or when a required value is stored as a Sensitive Vercel var and pulls as `[SENSITIVE]`.
- A provider with no credential mapping in the audit also fails closed rather than silently passing.
- When the env selects a non-blaxel default, the audit also verifies blaxel stays provisionable, since shipped CLIs hardcode blaxel image ids; this catches the exact 2026-08-26 env.
- A test asserts the audit's `CODE_DEFAULT_PROVIDER` matches the runtime driver's default, so the constant can't drift.
- The script supports `CMUX_CLOUD_VM_ENV_SOURCE=process` and relies on the Vercel CLI reading `VERCEL_TOKEN` from the environment, so the audit runs headless without putting the token in argv.
- A new CI workflow runs the strict audit against production daily, on main pushes touching Cloud VM files or scripts, and on dispatch, using the existing `VERCEL_TOKEN` secret.
- The workflow runs the audit's regression tests before the production audit, so weakening the guard fails CI instead of staying green.
- Regression tests cover the exact outage shape, values outside the manifest, failed validation status, and Sensitive placeholders.

<sup>Written for commit ad84cf7b8261badd1c4e7e4c270afade65607be4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scheduled, on-demand, and change-triggered production Cloud VM environment audits.
  * Added validation for configured providers, image manifests, validation status, required credentials, and sensitive placeholder values.
  * Added fallback checks for the default provider when no provider is explicitly configured.
  * Audits now report provider and image configuration coherence.

* **Bug Fixes**
  * Audits fail when provider or image configuration is missing, invalid, unvalidated, or incomplete.

* **Tests**
  * Added coverage for valid configurations, provider rollbacks, and common audit failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->