### PR TITLE
Fix immediate cmux TUI redraws after visible input changes

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -36236,28 +36236,26 @@ mod tests {
             }
             terminal.vt_write(b"bottom");
         });
-        surface.scroll_delta(-5).unwrap();
-        let offset =
-            surface.with_terminal(|terminal| terminal.scrollbar().unwrap().offset).unwrap();
-        assert!(offset > 0);
-
         let mut app = test_app(Session::Local(mux.clone()));
         app.sidebar_visible = false;
         app.replace_tree(app.session.tree());
         app.status_message = Some("old failure".to_string());
+        let mut terminal = Terminal::new(TestBackend::new(100, 12)).unwrap();
+        app.render_action(&mut terminal, RenderAction::Draw).unwrap();
+        surface.scroll_delta(-5).unwrap();
+        let offset =
+            surface.with_terminal(|terminal| terminal.scrollbar().unwrap().offset).unwrap();
+        assert!(offset > 0);
         app.replace_selection(Some(Selection {
             surface: surface.id,
             anchor: (0, offset),
             head: (4, offset),
         }));
-        let mut terminal = Terminal::new(TestBackend::new(100, 12)).unwrap();
         app.render_action(&mut terminal, RenderAction::Draw).unwrap();
-        let selected_cell = (app.pane_areas[0].content.x, app.pane_areas[0].content.y);
-        assert!(buffer_text(terminal.backend().buffer()).contains("old failure"));
         assert_eq!(
-            terminal.backend().buffer()[selected_cell].style().bg,
-            Some(app.config.theme.selection_bg),
-            "the setup frame must contain the painted terminal selection"
+            app.rendered_status_message.as_ref().map(|message| message.text.as_str()),
+            Some("old failure"),
+            "the setup frame must retain the semantic status message"
         );
 
         let action = app
@@ -36276,11 +36274,9 @@ mod tests {
             "ordinary PTY input must return a scrolled viewport to the live bottom"
         );
         app.render_action(&mut terminal, action).unwrap();
-        assert!(!buffer_text(terminal.backend().buffer()).contains("old failure"));
-        assert_ne!(
-            terminal.backend().buffer()[selected_cell].style().bg,
-            Some(app.config.theme.selection_bg),
-            "the input frame must remove the old selection highlight"
+        assert!(
+            app.rendered_status_message.is_none(),
+            "the input frame must remove the semantic status message"
         );
 
         let unchanged = app
@@ -36303,14 +36299,21 @@ mod tests {
         app.status_message = Some("old failure".to_string());
         let mut terminal = Terminal::new(TestBackend::new(100, 12)).unwrap();
         app.render_action(&mut terminal, RenderAction::Draw).unwrap();
-        assert!(buffer_text(terminal.backend().buffer()).contains("old failure"));
+        assert_eq!(
+            app.rendered_status_message.as_ref().map(|message| message.text.as_str()),
+            Some("old failure"),
+            "the setup frame must retain the semantic status message"
+        );
 
         let action = app.handle(AppEvent::Input(Event::Paste("text".to_string()))).unwrap();
 
         assert_eq!(action, RenderAction::Draw, "removing a painted status needs a new frame");
         assert!(app.status_message.is_none());
         app.render_action(&mut terminal, action).unwrap();
-        assert!(!buffer_text(terminal.backend().buffer()).contains("old failure"));
+        assert!(
+            app.rendered_status_message.is_none(),
+            "the paste frame must remove the semantic status message"
+        );
 
         let unchanged = app.handle(AppEvent::Input(Event::Paste("more".to_string()))).unwrap();
         assert_eq!(unchanged, RenderAction::None, "paste with no visible mutation needs no draw");

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -16467,7 +16467,7 @@ impl App {
         let surface = destination.or_else(|| self.active_surface())?;
         (self.tree.surface_kind(surface) == SurfaceKind::Pty).then(|| VisiblePtyInputState {
             surface,
-            selection: self.selection.filter(|selection| selection.surface == surface),
+            selection: self.selection,
             scroll_offset: self.surface_scroll_offset(surface),
         })
     }
@@ -16487,8 +16487,7 @@ impl App {
     fn visible_pty_input_action(&self, before: Option<VisiblePtyInputState>) -> RenderAction {
         let status_action = self.painted_status_message_action();
         let Some(before) = before else { return status_action };
-        let selection = self.selection.filter(|selection| selection.surface == before.surface);
-        let action = if selection != before.selection
+        let action = if self.selection != before.selection
             || self.surface_scroll_offset(before.surface) != before.scroll_offset
         {
             RenderAction::Draw
@@ -36365,6 +36364,40 @@ mod tests {
         );
 
         mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
+    fn visible_state_keyboard_requests_draw_after_selection_clear_on_other_surface() {
+        let mux = Mux::new("visible-state-split-selection-test", SurfaceOptions::default());
+        let first = mux.new_workspace(None, Some((80, 12))).unwrap();
+        let first_pane = mux.with_state(|state| state.pane_of(first.id).unwrap());
+        let second = mux.split(first_pane, SplitDir::Right, Some((40, 12))).unwrap();
+        let (mut app, events) = test_app_with_events(Session::Local(mux.clone()));
+        app.sidebar_visible = false;
+        app.replace_tree(app.session.tree());
+        app.sync_layout((80, 12));
+        while app.session.has_pending_mutations() {
+            app.handle(events.recv_timeout(Duration::from_secs(1)).unwrap()).unwrap();
+        }
+        assert_eq!(app.active_surface(), Some(second.id));
+
+        app.replace_selection(Some(Selection { surface: first.id, anchor: (0, 0), head: (3, 0) }));
+        let mut terminal = Terminal::new(TestBackend::new(80, 12)).unwrap();
+        app.render_action(&mut terminal, RenderAction::Draw).unwrap();
+
+        let action = app.handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE)).unwrap();
+
+        assert_eq!(
+            action,
+            RenderAction::Draw,
+            "typing in the active pane must repaint a selection cleared from another pane"
+        );
+        assert!(app.selection.is_none());
+        app.render_action(&mut terminal, action).unwrap();
+        assert!(app.selection.is_none());
+        assert!(app.pty_input.shutdown(Duration::from_secs(1)));
+        mux.close_surface(first.id).unwrap();
+        mux.close_surface(second.id).unwrap();
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -36342,7 +36342,7 @@ mod tests {
         app.sidebar_visible = false;
         app.replace_tree(app.session.tree());
 
-        let mut terminal = Terminal::new(TestBackend::new(40, 12)).unwrap();
+        let mut terminal = Terminal::new(TestBackend::new(100, 12)).unwrap();
         app.status_message = Some("old failure".to_string());
         app.render_action(&mut terminal, RenderAction::Draw).unwrap();
         assert_eq!(

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -5293,6 +5293,13 @@ pub struct Selection {
     pub head: (u16, u64),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct VisiblePtyInputState {
+    surface: SurfaceId,
+    selection: Option<Selection>,
+    scroll_offset: u64,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct StatusMessageSelection {
     text: String,
@@ -15353,9 +15360,13 @@ impl App {
                 Ok(RenderAction::Draw)
             }
             TerminalInput::FocusLost => {
-                self.cancel_pointer_interaction();
+                let action = if self.cancel_pointer_interaction() {
+                    RenderAction::Draw
+                } else {
+                    RenderAction::None
+                };
                 self.advance_pointer_focus_generation();
-                Ok(RenderAction::None)
+                Ok(action)
             }
             TerminalInput::Resize => {
                 self.reassert_scoped_host_terminal_state();
@@ -15371,6 +15382,15 @@ impl App {
     }
 
     fn handle_paste_to(
+        &mut self,
+        text: String,
+        destination: Option<SurfaceId>,
+    ) -> anyhow::Result<RenderAction> {
+        let action = self.handle_paste_to_inner(text, destination)?;
+        Ok(action.merge(self.painted_status_message_action()))
+    }
+
+    fn handle_paste_to_inner(
         &mut self,
         text: String,
         destination: Option<SurfaceId>,
@@ -16440,6 +16460,43 @@ impl App {
         self.selection = selection;
     }
 
+    fn visible_pty_input_state(
+        &self,
+        destination: Option<SurfaceId>,
+    ) -> Option<VisiblePtyInputState> {
+        let surface = destination.or_else(|| self.active_surface())?;
+        (self.tree.surface_kind(surface) == SurfaceKind::Pty).then(|| VisiblePtyInputState {
+            surface,
+            selection: self.selection.filter(|selection| selection.surface == surface),
+            scroll_offset: self.surface_scroll_offset(surface),
+        })
+    }
+
+    fn painted_status_message_action(&self) -> RenderAction {
+        if self
+            .rendered_status_message
+            .as_ref()
+            .is_some_and(|rendered| self.status_message.as_deref() != Some(rendered.text.as_str()))
+        {
+            RenderAction::Draw
+        } else {
+            RenderAction::None
+        }
+    }
+
+    fn visible_pty_input_action(&self, before: Option<VisiblePtyInputState>) -> RenderAction {
+        let Some(before) = before else { return RenderAction::None };
+        let selection = self.selection.filter(|selection| selection.surface == before.surface);
+        let action = if selection != before.selection
+            || self.surface_scroll_offset(before.surface) != before.scroll_offset
+        {
+            RenderAction::Draw
+        } else {
+            RenderAction::None
+        };
+        action.merge(self.painted_status_message_action())
+    }
+
     pub(crate) fn reset_rendered_status_message(&mut self) {
         // Per-frame render reset. `logged_status_message` deliberately
         // survives it: a message that stays visible across redraws is one
@@ -17276,6 +17333,16 @@ impl App {
     }
 
     fn handle_direct_keyboard_to(
+        &mut self,
+        input: keys::KeyboardInput,
+        destination: Option<SurfaceId>,
+    ) -> anyhow::Result<RenderAction> {
+        let visible_state = self.visible_pty_input_state(destination);
+        let action = self.handle_direct_keyboard_to_inner(input, destination)?;
+        Ok(action.merge(self.visible_pty_input_action(visible_state)))
+    }
+
+    fn handle_direct_keyboard_to_inner(
         &mut self,
         input: keys::KeyboardInput,
         destination: Option<SurfaceId>,
@@ -19554,13 +19621,12 @@ impl App {
             self.tree.surface_kind(surface_id),
             self.session.supports_clear_history_key_fallback(surface_id),
         ) {
+            let visible_state = self.visible_pty_input_state(Some(surface_id));
             self.replace_selection(None);
             self.forward_key_to_surface(input, surface_id);
-            return if self.status_message.is_some() {
-                RenderAction::Draw
-            } else {
-                RenderAction::None
-            };
+            let action =
+                if self.status_message.is_some() { RenderAction::Draw } else { RenderAction::None };
+            return action.merge(self.visible_pty_input_action(visible_state));
         }
         let Some(key_input) = input.into_terminal_input() else {
             return RenderAction::None;
@@ -20420,10 +20486,10 @@ impl App {
         self.handle_pty_enqueue_result(result)
     }
 
-    fn cancel_pointer_interaction(&mut self) {
-        if let Some(menu) = self.menu.as_mut() {
-            menu.finish_scrollbar_drag();
-        }
+    fn cancel_pointer_interaction(&mut self) -> bool {
+        let menu_scrollbar_dragged =
+            self.menu.as_mut().is_some_and(|menu| menu.finish_scrollbar_drag());
+        let pointer_dragged = self.drag.is_some();
         if matches!(self.drag, Some(Drag::PtyMouse { .. })) {
             self.cancel_pty_mouse_drag();
         } else if let Some(Drag::Browser { surface, content, position, frame_seq }) = &self.drag {
@@ -20449,6 +20515,7 @@ impl App {
         }
         self.active_pointer_buttons.clear();
         self.ignored_pty_mouse_buttons.clear();
+        menu_scrollbar_dragged || pointer_dragged
     }
 
     fn cancel_pty_mouse_drag(&mut self) {

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -5294,8 +5294,8 @@ pub struct Selection {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct VisiblePtyInputState {
-    surface: SurfaceId,
+struct VisibleInputState {
+    pty_surface: Option<SurfaceId>,
     selection: Option<Selection>,
     scroll_offset: u64,
 }
@@ -16460,16 +16460,15 @@ impl App {
         self.selection = selection;
     }
 
-    fn visible_pty_input_state(
-        &self,
-        destination: Option<SurfaceId>,
-    ) -> Option<VisiblePtyInputState> {
-        let surface = destination.or_else(|| self.active_surface())?;
-        (self.tree.surface_kind(surface) == SurfaceKind::Pty).then(|| VisiblePtyInputState {
-            surface,
+    fn visible_input_state(&self, destination: Option<SurfaceId>) -> VisibleInputState {
+        let pty_surface = destination
+            .or_else(|| self.active_surface())
+            .filter(|surface| self.tree.surface_kind(*surface) == SurfaceKind::Pty);
+        VisibleInputState {
+            pty_surface,
             selection: self.selection,
-            scroll_offset: self.surface_scroll_offset(surface),
-        })
+            scroll_offset: pty_surface.map_or(0, |surface| self.surface_scroll_offset(surface)),
+        }
     }
 
     fn painted_status_message_action(&self) -> RenderAction {
@@ -16484,11 +16483,12 @@ impl App {
         }
     }
 
-    fn visible_pty_input_action(&self, before: Option<VisiblePtyInputState>) -> RenderAction {
+    fn visible_input_action(&self, before: VisibleInputState) -> RenderAction {
         let status_action = self.painted_status_message_action();
-        let Some(before) = before else { return status_action };
         let action = if self.selection != before.selection
-            || self.surface_scroll_offset(before.surface) != before.scroll_offset
+            || before
+                .pty_surface
+                .is_some_and(|surface| self.surface_scroll_offset(surface) != before.scroll_offset)
         {
             RenderAction::Draw
         } else {
@@ -17337,9 +17337,9 @@ impl App {
         input: keys::KeyboardInput,
         destination: Option<SurfaceId>,
     ) -> anyhow::Result<RenderAction> {
-        let visible_state = self.visible_pty_input_state(destination);
+        let visible_state = self.visible_input_state(destination);
         let action = self.handle_direct_keyboard_to_inner(input, destination)?;
-        Ok(action.merge(self.visible_pty_input_action(visible_state)))
+        Ok(action.merge(self.visible_input_action(visible_state)))
     }
 
     fn handle_direct_keyboard_to_inner(
@@ -19621,12 +19621,12 @@ impl App {
             self.tree.surface_kind(surface_id),
             self.session.supports_clear_history_key_fallback(surface_id),
         ) {
-            let visible_state = self.visible_pty_input_state(Some(surface_id));
+            let visible_state = self.visible_input_state(Some(surface_id));
             self.replace_selection(None);
             self.forward_key_to_surface(input, surface_id);
             let action =
                 if self.status_message.is_some() { RenderAction::Draw } else { RenderAction::None };
-            return action.merge(self.visible_pty_input_action(visible_state));
+            return action.merge(self.visible_input_action(visible_state));
         }
         let Some(key_input) = input.into_terminal_input() else {
             return RenderAction::None;
@@ -36396,6 +36396,45 @@ mod tests {
         app.render_action(&mut terminal, action).unwrap();
         assert!(app.selection.is_none());
         assert!(app.pty_input.shutdown(Duration::from_secs(1)));
+        mux.close_surface(first.id).unwrap();
+        mux.close_surface(second.id).unwrap();
+    }
+
+    #[test]
+    fn visible_state_browser_input_requests_draw_after_selection_clear_on_pty_surface() {
+        let mux = Mux::new("visible-state-browser-selection-test", SurfaceOptions::default());
+        let first = mux.new_workspace(None, Some((80, 12))).unwrap();
+        let first_pane = mux.with_state(|state| state.pane_of(first.id).unwrap());
+        let second = mux.split(first_pane, SplitDir::Right, Some((40, 12))).unwrap();
+        let second_pane = mux.with_state(|state| state.pane_of(second.id).unwrap());
+        let browser = mux
+            .new_browser_tab("about:blank".to_string(), Some(second_pane), Some((40, 12)))
+            .unwrap();
+        let (mut app, events) = test_app_with_events(Session::Local(mux.clone()));
+        app.sidebar_visible = false;
+        app.replace_tree(app.session.tree());
+        app.sync_layout((80, 12));
+        while app.session.has_pending_mutations() {
+            app.handle(events.recv_timeout(Duration::from_secs(1)).unwrap()).unwrap();
+        }
+        assert_eq!(app.active_surface(), Some(browser.id));
+
+        app.replace_selection(Some(Selection { surface: first.id, anchor: (0, 0), head: (3, 0) }));
+        let mut terminal = Terminal::new(TestBackend::new(80, 12)).unwrap();
+        app.render_action(&mut terminal, RenderAction::Draw).unwrap();
+
+        let action = app.handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE)).unwrap();
+
+        assert_eq!(
+            action,
+            RenderAction::Draw,
+            "browser input must repaint a selection cleared from a visible PTY pane"
+        );
+        assert!(app.selection.is_none());
+        app.render_action(&mut terminal, action).unwrap();
+        assert!(app.selection.is_none());
+        assert!(app.pty_input.shutdown(Duration::from_secs(1)));
+        mux.close_surface(browser.id).unwrap();
         mux.close_surface(first.id).unwrap();
         mux.close_surface(second.id).unwrap();
     }

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -36342,13 +36342,12 @@ mod tests {
         app.sidebar_visible = false;
         app.replace_tree(app.session.tree());
 
-        let mut terminal = Terminal::new(TestBackend::new(100, 12)).unwrap();
+        let mut terminal = Terminal::new(TestBackend::new(40, 12)).unwrap();
         app.status_message = Some("old failure".to_string());
         app.render_action(&mut terminal, RenderAction::Draw).unwrap();
-        assert_eq!(
-            app.rendered_status_message.as_ref().map(|message| message.text.as_str()),
-            Some("old failure"),
-            "the setup frame must retain the semantic status message"
+        assert!(
+            app.rendered_status_message.as_ref().is_some_and(|message| !message.text.is_empty()),
+            "the setup frame must retain a visible status message"
         );
 
         let action = app.handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE)).unwrap();

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -36272,10 +36272,15 @@ mod tests {
         assert_eq!(action, RenderAction::Draw, "clearing a painted selection needs a new frame");
         assert!(app.selection.is_none());
         assert!(app.status_message.is_none());
+        let scrollbar = app
+            .session
+            .surface(surface.id)
+            .and_then(|surface| surface.scrollbar())
+            .expect("the visible PTY must expose viewport geometry");
         assert_eq!(
-            app.surface_scroll_offset(surface.id),
-            0,
-            "ordinary PTY input must return a scrolled viewport to the live bottom"
+            scrollbar.offset,
+            scrollbar.total.saturating_sub(scrollbar.len),
+            "ordinary PTY input must return the viewport to the live bottom (offset is absolute)"
         );
         app.render_action(&mut terminal, action).unwrap();
         assert!(

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -36161,6 +36161,156 @@ mod tests {
     }
 
     #[test]
+    fn visible_state_direct_keyboard_requests_draw_after_selection_clear() {
+        let (mux, surface) = test_mux("visible-state-key-selection-test", None);
+        surface.with_terminal(|terminal| {
+            for line in 0..32 {
+                terminal.vt_write(format!("history-{line:02}\r\n").as_bytes());
+            }
+            terminal.vt_write(b"bottom");
+        });
+        surface.scroll_delta(-5).unwrap();
+        let offset =
+            surface.with_terminal(|terminal| terminal.scrollbar().unwrap().offset).unwrap();
+        assert!(offset > 0);
+
+        let mut app = test_app(Session::Local(mux.clone()));
+        app.sidebar_visible = false;
+        app.replace_tree(app.session.tree());
+        app.status_message = Some("old failure".to_string());
+        app.replace_selection(Some(Selection {
+            surface: surface.id,
+            anchor: (0, offset),
+            head: (4, offset),
+        }));
+        let mut terminal = Terminal::new(TestBackend::new(40, 12)).unwrap();
+        app.render_action(&mut terminal, RenderAction::Draw).unwrap();
+        let selected_cell = (app.pane_areas[0].content.x, app.pane_areas[0].content.y);
+        assert!(buffer_text(terminal.backend().buffer()).contains("old failure"));
+        assert_eq!(
+            terminal.backend().buffer()[selected_cell].style().bg,
+            Some(app.config.theme.selection_bg),
+            "the setup frame must contain the painted terminal selection"
+        );
+
+        let action = app
+            .handle(AppEvent::Input(Event::Key(KeyEvent::new(
+                KeyCode::Char('x'),
+                KeyModifiers::NONE,
+            ))))
+            .unwrap();
+
+        assert_eq!(action, RenderAction::Draw, "clearing a painted selection needs a new frame");
+        assert!(app.selection.is_none());
+        assert!(app.status_message.is_none());
+        assert_eq!(
+            surface.with_terminal(|terminal| terminal.scrollbar().unwrap().offset).unwrap(),
+            0,
+            "ordinary PTY input must return a scrolled viewport to the live bottom"
+        );
+        app.render_action(&mut terminal, action).unwrap();
+        assert!(!buffer_text(terminal.backend().buffer()).contains("old failure"));
+        assert_ne!(
+            terminal.backend().buffer()[selected_cell].style().bg,
+            Some(app.config.theme.selection_bg),
+            "the input frame must remove the old selection highlight"
+        );
+
+        let unchanged = app
+            .handle(AppEvent::Input(Event::Key(KeyEvent::new(
+                KeyCode::Char('y'),
+                KeyModifiers::NONE,
+            ))))
+            .unwrap();
+        assert_eq!(unchanged, RenderAction::None, "a key with no visible mutation needs no draw");
+        assert!(app.pty_input.shutdown(Duration::from_secs(1)));
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
+    fn visible_state_paste_requests_draw_after_status_clear() {
+        let (mux, surface) = test_mux("visible-state-paste-status-test", None);
+        let mut app = test_app(Session::Local(mux.clone()));
+        app.sidebar_visible = false;
+        app.replace_tree(app.session.tree());
+        app.status_message = Some("old failure".to_string());
+        let mut terminal = Terminal::new(TestBackend::new(40, 12)).unwrap();
+        app.render_action(&mut terminal, RenderAction::Draw).unwrap();
+        assert!(buffer_text(terminal.backend().buffer()).contains("old failure"));
+
+        let action = app.handle(AppEvent::Input(Event::Paste("text".to_string()))).unwrap();
+
+        assert_eq!(action, RenderAction::Draw, "removing a painted status needs a new frame");
+        assert!(app.status_message.is_none());
+        app.render_action(&mut terminal, action).unwrap();
+        assert!(!buffer_text(terminal.backend().buffer()).contains("old failure"));
+
+        let unchanged = app.handle(AppEvent::Input(Event::Paste("more".to_string()))).unwrap();
+        assert_eq!(unchanged, RenderAction::None, "paste with no visible mutation needs no draw");
+        assert!(app.pty_input.shutdown(Duration::from_secs(1)));
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
+    fn visible_state_clear_history_fallback_requests_draw_after_selection_clear() {
+        let mux = Mux::new("visible-state-clear-history-fallback-test", SurfaceOptions::default());
+        let mut app = test_app(Session::Local(mux));
+        app.tree = notify_tree(11, false);
+        app.replace_selection(Some(Selection { surface: 11, anchor: (1, 1), head: (4, 1) }));
+
+        let action = app.run_clear_history_shortcut(
+            KeyEvent::new(KeyCode::Char('k'), KeyModifiers::SUPER).into(),
+        );
+
+        assert_eq!(
+            action,
+            RenderAction::Draw,
+            "the unclaimed PTY fallback clears the visible selection before forwarding the key"
+        );
+        assert!(app.selection.is_none());
+
+        let unchanged = app.run_clear_history_shortcut(
+            KeyEvent::new(KeyCode::Char('k'), KeyModifiers::SUPER).into(),
+        );
+        assert_eq!(unchanged, RenderAction::None, "fallback with no selection needs no draw");
+    }
+
+    #[test]
+    fn visible_state_focus_loss_requests_draw_after_pointer_cancel() {
+        let mux = Mux::new("visible-state-focus-loss-test", SurfaceOptions::default());
+        let first = mux.new_workspace(None, Some((40, 10))).unwrap();
+        let pane = mux.with_state(|state| state.pane_of(first.id).unwrap());
+        let second = mux.new_tab(Some(pane), None, Some((40, 10))).unwrap();
+        let mut app = test_app(Session::Local(mux.clone()));
+        app.sidebar_visible = false;
+        app.replace_tree(app.session.tree());
+        app.drag = Some(Drag::Tab { surface: second.id, target: Some((pane, 0)) });
+        app.active_pointer_buttons.insert(MouseButton::Left);
+        let mut terminal = Terminal::new(TestBackend::new(40, 12)).unwrap();
+        app.render_action(&mut terminal, RenderAction::Draw).unwrap();
+        assert!(
+            buffer_text(terminal.backend().buffer()).contains('▌'),
+            "the setup frame must contain the tab drop marker"
+        );
+
+        let action = app.handle(AppEvent::Input(Event::FocusLost)).unwrap();
+
+        assert_eq!(action, RenderAction::Draw, "canceling painted pointer state needs a new frame");
+        assert!(app.drag.is_none());
+        assert!(app.active_pointer_buttons.is_empty());
+        app.render_action(&mut terminal, action).unwrap();
+        assert!(
+            !buffer_text(terminal.backend().buffer()).contains('▌'),
+            "the focus-loss frame must remove the old tab drop marker"
+        );
+
+        let unchanged = app.handle(AppEvent::Input(Event::FocusLost)).unwrap();
+        assert_eq!(unchanged, RenderAction::None, "idle focus loss needs no draw");
+        let workspace = mux.with_state(|state| state.workspaces[state.active_workspace].id);
+        mux.close_workspace(workspace);
+    }
+
+    #[test]
     fn focus_loss_settles_an_active_split_resize() {
         let mux = Mux::new("focus-loss-split-settle-test", SurfaceOptions::default());
         let (mut app, _events) = test_app_with_events(Session::Local(mux));

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -16485,7 +16485,8 @@ impl App {
     }
 
     fn visible_pty_input_action(&self, before: Option<VisiblePtyInputState>) -> RenderAction {
-        let Some(before) = before else { return RenderAction::None };
+        let status_action = self.painted_status_message_action();
+        let Some(before) = before else { return status_action };
         let selection = self.selection.filter(|selection| selection.surface == before.surface);
         let action = if selection != before.selection
             || self.surface_scroll_offset(before.surface) != before.scroll_offset
@@ -16494,7 +16495,7 @@ impl App {
         } else {
             RenderAction::None
         };
-        action.merge(self.painted_status_message_action())
+        action.merge(status_action)
     }
 
     pub(crate) fn reset_rendered_status_message(&mut self) {
@@ -36330,6 +36331,40 @@ mod tests {
         let unchanged = app.handle(AppEvent::Input(Event::Paste("more".to_string()))).unwrap();
         assert_eq!(unchanged, RenderAction::None, "paste with no visible mutation needs no draw");
         assert!(app.pty_input.shutdown(Duration::from_secs(1)));
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
+    fn visible_state_keyboard_requests_draw_after_status_clear_for_browser_surface() {
+        let mux = Mux::new("visible-state-browser-status-test", SurfaceOptions::default());
+        let surface = mux.new_browser_tab("about:blank".to_string(), None, Some((40, 8))).unwrap();
+        let mut app = test_app(Session::Local(mux.clone()));
+        app.sidebar_visible = false;
+        app.replace_tree(app.session.tree());
+
+        let mut terminal = Terminal::new(TestBackend::new(40, 12)).unwrap();
+        app.status_message = Some("old failure".to_string());
+        app.render_action(&mut terminal, RenderAction::Draw).unwrap();
+        assert_eq!(
+            app.rendered_status_message.as_ref().map(|message| message.text.as_str()),
+            Some("old failure"),
+            "the setup frame must retain the semantic status message"
+        );
+
+        let action = app.handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE)).unwrap();
+
+        assert_eq!(
+            action,
+            RenderAction::Draw,
+            "a browser key that clears a painted status still needs a new frame"
+        );
+        assert!(app.status_message.is_none());
+        app.render_action(&mut terminal, action).unwrap();
+        assert!(
+            app.rendered_status_message.is_none(),
+            "the input frame must remove the semantic status message"
+        );
+
         mux.close_surface(surface.id).unwrap();
     }
 

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -36236,22 +36236,26 @@ mod tests {
             }
             terminal.vt_write(b"bottom");
         });
-        let mut app = test_app(Session::Local(mux.clone()));
+        let (mut app, events) = test_app_with_events(Session::Local(mux.clone()));
         app.sidebar_visible = false;
-        app.replace_tree(app.session.tree());
+        app.sync_layout((100, 12));
+        while app.session.has_pending_mutations() {
+            app.handle(events.recv_timeout(Duration::from_secs(1)).unwrap()).unwrap();
+        }
         app.status_message = Some("old failure".to_string());
         let mut terminal = Terminal::new(TestBackend::new(100, 12)).unwrap();
-        app.render_action(&mut terminal, RenderAction::Draw).unwrap();
-        surface.scroll_delta(-5).unwrap();
-        let offset =
-            surface.with_terminal(|terminal| terminal.scrollbar().unwrap().offset).unwrap();
+        app.render_action(&mut terminal, RenderAction::Paint).unwrap();
+        let visible = app.session.surface(surface.id).unwrap();
+        assert_eq!(visible.scroll_delta(-5), Some(true));
+        let offset = app.surface_scroll_offset(surface.id);
         assert!(offset > 0);
         app.replace_selection(Some(Selection {
             surface: surface.id,
             anchor: (0, offset),
             head: (4, offset),
         }));
-        app.render_action(&mut terminal, RenderAction::Draw).unwrap();
+        app.render_action(&mut terminal, RenderAction::Paint).unwrap();
+        assert!(app.selection.is_some(), "the setup frame must retain the visible selection");
         assert_eq!(
             app.rendered_status_message.as_ref().map(|message| message.text.as_str()),
             Some("old failure"),
@@ -36269,7 +36273,7 @@ mod tests {
         assert!(app.selection.is_none());
         assert!(app.status_message.is_none());
         assert_eq!(
-            surface.with_terminal(|terminal| terminal.scrollbar().unwrap().offset).unwrap(),
+            app.surface_scroll_offset(surface.id),
             0,
             "ordinary PTY input must return a scrolled viewport to the live bottom"
         );
@@ -36293,12 +36297,15 @@ mod tests {
     #[test]
     fn visible_state_paste_requests_draw_after_status_clear() {
         let (mux, surface) = test_mux("visible-state-paste-status-test", None);
-        let mut app = test_app(Session::Local(mux.clone()));
+        let (mut app, events) = test_app_with_events(Session::Local(mux.clone()));
         app.sidebar_visible = false;
-        app.replace_tree(app.session.tree());
+        app.sync_layout((100, 12));
+        while app.session.has_pending_mutations() {
+            app.handle(events.recv_timeout(Duration::from_secs(1)).unwrap()).unwrap();
+        }
         app.status_message = Some("old failure".to_string());
         let mut terminal = Terminal::new(TestBackend::new(100, 12)).unwrap();
-        app.render_action(&mut terminal, RenderAction::Draw).unwrap();
+        app.render_action(&mut terminal, RenderAction::Paint).unwrap();
         assert_eq!(
             app.rendered_status_message.as_ref().map(|message| message.text.as_str()),
             Some("old failure"),

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -36250,7 +36250,7 @@ mod tests {
             anchor: (0, offset),
             head: (4, offset),
         }));
-        let mut terminal = Terminal::new(TestBackend::new(40, 12)).unwrap();
+        let mut terminal = Terminal::new(TestBackend::new(100, 12)).unwrap();
         app.render_action(&mut terminal, RenderAction::Draw).unwrap();
         let selected_cell = (app.pane_areas[0].content.x, app.pane_areas[0].content.y);
         assert!(buffer_text(terminal.backend().buffer()).contains("old failure"));
@@ -36301,7 +36301,7 @@ mod tests {
         app.sidebar_visible = false;
         app.replace_tree(app.session.tree());
         app.status_message = Some("old failure".to_string());
-        let mut terminal = Terminal::new(TestBackend::new(40, 12)).unwrap();
+        let mut terminal = Terminal::new(TestBackend::new(100, 12)).unwrap();
         app.render_action(&mut terminal, RenderAction::Draw).unwrap();
         assert!(buffer_text(terminal.backend().buffer()).contains("old failure"));
 


### PR DESCRIPTION
## Intent
Integrate [PR #10213](https://github.com/manaflow-ai/cmux/pull/10213), authored by Lawrence Chen (`lawrencecchen`), onto the current main line. Input that changes visible state now requests an immediate redraw.

## Changes
- Add behavior tests for selection, status, scroll, paste, focus, browser input, and no-op paths.
- Return `Draw` when visible selection, status, pointer state, or live-bottom viewport changes.
- Track selection across visible panes and non-PTY destinations.
- Keep the first two commits as test-only then fix, followed by the upstream test hardening and focused fixes.

## Verification
- Base: `d65d6e6ccacf1d7300316451ce2830f05f889e14`
- Head: `c898707d4755043aa08b2e440afec956e0ed8145`
- `rustfmt --edition 2024 --check cmux-tui/crates/cmux-tui/src/app.rs`
- `git diff --check`
- Hosted focused TUI verification is running: https://github.com/manaflow-ai/cmux/actions/runs/33061756807

Residual UI risk: this branch covers state-driven redraw decisions in the TUI reducer. It does not add a GUI frame scheduler, so an unrelated renderer or terminal wakeup failure would remain outside this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10962"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790417686&installation_model_id=21920&pr_number=10962&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10962&signature=ec98fe166feceba6a3110daa66401ffab289ca6d24a6dacd75f5a1ab1ba4bacf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the TUI reducer so input that changes visible state now requests an immediate redraw, preventing stale frames when selection, status message, scroll offset, or pointer drag state changes.

- Direct keyboard, paste, and clear-history fallback paths return `RenderAction::Draw` when visible selection, status message, or viewport offset changes; no-ops still return `None`.
- Selection is tracked across visible panes and non-PTY destinations, and status messages are repainted after non-PTY input and focus loss.
- Added tests covering selection, status, scroll, paste, focus, browser input, and no-op paths.

<sup>Written for commit ff719b6dc4e9f05358d0c77b7f49a9db021f72e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

