### PR TITLE
cmux-tui: sidebar split columns and all-scope agents view

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -84,6 +84,7 @@ use crate::session::{
 use crate::sidebar_files::{FileBrowser, FileCommand, file_url, shell_single_quote};
 use crate::sidebar_projection::{
     ProjectionBranch, ProjectionRailState, ProjectionRow, ProjectionTarget,
+    selected_workspace_cache_key,
 };
 use crate::ui::graphics::{
     GraphicPlacement, GraphicSourceRect, kitty_graphic_image, kitty_graphic_placement,
@@ -100,6 +101,11 @@ use crate::ui::{
 
 const DEFERRED_INPUT_CAPACITY: usize = 512;
 const MAX_PROJECTION_ROWS_CACHE_ENTRIES: usize = 8;
+
+/// Session-local divider shares, keyed by split group and stable child id.
+/// Child ids keep a drag ratio attached to its rail when visibility pruning
+/// or layout reordering changes the current child vector.
+type SidebarSplitFractions = HashMap<String, HashMap<String, f32>>;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 struct ProjectionFocusKey {
@@ -143,14 +149,14 @@ struct ProjectionRowsCache {
     workspace_revision: u64,
     pane_revision: Option<u64>,
     invalidation_revision: u64,
-    selected_workspace: usize,
+    selected_workspace: Option<usize>,
     focus: ProjectionFocusKey,
     /// All surfaces that can contribute an agent row to this snapshot. This
     /// includes currently hidden/filtered rows so an agent state transition
     /// cannot leave an old empty snapshot cached.
-    agent_surfaces: HashSet<SurfaceId>,
+    agent_surfaces: Arc<HashSet<SurfaceId>>,
     /// Surfaces whose title can affect a visible row in this snapshot.
-    title_surfaces: HashSet<SurfaceId>,
+    title_surfaces: Arc<HashSet<SurfaceId>>,
     rows: Arc<[ProjectionRow]>,
 }
 
@@ -7074,6 +7080,11 @@ pub struct App {
     /// retired surface cannot accumulate or trigger future fanout.
     projection_agent_surfaces: HashSet<SurfaceId>,
     projection_title_surfaces: HashSet<SurfaceId>,
+    /// Dependencies are retained per active view, not only in a global union.
+    /// This lets hidden views be removed without losing dependencies for a
+    /// visible view whose bounded row snapshot was evicted.
+    projection_agent_surfaces_by_view: HashMap<String, Arc<HashSet<SurfaceId>>>,
+    projection_title_surfaces_by_view: HashMap<String, Arc<HashSet<SurfaceId>>>,
     /// Coalesce surface updates until the next successful rendered frame.
     projection_paint_pending: bool,
     pub(crate) machine_rail_follow_selection: bool,
@@ -7094,9 +7105,10 @@ pub struct App {
     tabs_sidebar_width_override: Option<u16>,
     projection_sidebar_width_overrides: HashMap<String, u16>,
     /// Session-local divider drags inside sidebar split groups for the active
-    /// profile. A profile switch clears these values so a reused group id
-    /// cannot apply another profile's geometry.
-    sidebar_split_fractions: HashMap<String, Vec<f32>>,
+    /// profile. Values are keyed by stable child id, and a profile switch
+    /// clears them so a reused group id cannot apply another profile's
+    /// geometry.
+    sidebar_split_fractions: SidebarSplitFractions,
     /// Session-local visibility overrides, keyed by profile and stable view id.
     hidden_sidebar_views: HashMap<String, HashSet<String>>,
     /// Pane region of the current frame (screen minus sidebar/status).
@@ -8087,7 +8099,7 @@ fn place_sidebar_column_node(
     node: &SidebarColumnNode,
     rect: Rect,
     layout: &mut SidebarLayout,
-    split_fractions: &HashMap<String, Vec<f32>>,
+    split_fractions: &SidebarSplitFractions,
 ) {
     use crate::config::SidebarSplitDir;
     if rect.width == 0 || rect.height == 0 {
@@ -8133,15 +8145,21 @@ fn place_sidebar_column_node(
                 return;
             }
             // A committed divider drag overrides the configured weights while
-            // the same children remain visible.
-            let shares: Vec<f32> = split_fractions
-                .get(id)
-                .filter(|fractions| {
-                    fractions.len() == kept.len()
-                        && fractions.iter().all(|value| value.is_finite() && *value > 0.0)
+            // each child keeps its own stable share. A newly visible child
+            // falls back to its configured weight, while a hidden child does
+            // not force every surviving ratio back to defaults.
+            let child_keys =
+                kept.iter().map(|(_, child)| child.key().to_owned()).collect::<Vec<_>>();
+            let shares: Vec<f32> = kept
+                .iter()
+                .map(|(weight, child)| {
+                    split_fractions
+                        .get(id)
+                        .and_then(|fractions| fractions.get(child.key()).copied())
+                        .filter(|value| value.is_finite() && *value > 0.0)
+                        .unwrap_or_else(|| f32::from(*weight))
                 })
-                .cloned()
-                .unwrap_or_else(|| kept.iter().map(|(weight, _)| f32::from(*weight)).collect());
+                .collect();
             let sum: f32 = shares.iter().sum();
             let mut sizes: Vec<u16> = shares
                 .iter()
@@ -8174,7 +8192,7 @@ fn place_sidebar_column_node(
                 id: id.clone(),
                 dir: *dir,
                 children: Vec::new(),
-                child_keys: Vec::new(),
+                child_keys,
             });
             let mut offset = 0u16;
             for (child_index, (_, child)) in kept.iter().enumerate() {
@@ -8193,7 +8211,6 @@ fn place_sidebar_column_node(
                     },
                 };
                 layout.split_groups[group_index].children.push(child_rect);
-                layout.split_groups[group_index].child_keys.push(child.key().to_string());
                 place_sidebar_column_node(child, child_rect, layout, split_fractions);
                 offset = offset.saturating_add(sizes[child_index]);
                 if child_index + 1 < kept.len() {
@@ -8240,7 +8257,7 @@ fn sidebar_layout_for_state(
     machine_override: Option<u16>,
     tabs_override: Option<u16>,
     projection_overrides: &HashMap<String, u16>,
-    split_fractions: &HashMap<String, Vec<f32>>,
+    split_fractions: &SidebarSplitFractions,
     hidden_views: &HashSet<String>,
     previous: Option<&SidebarLayout>,
 ) -> SidebarLayout {
@@ -9586,6 +9603,8 @@ fn run_with_machine_updates_inner(
         projection_rows_revision: 0,
         projection_agent_surfaces: HashSet::new(),
         projection_title_surfaces: HashSet::new(),
+        projection_agent_surfaces_by_view: HashMap::new(),
+        projection_title_surfaces_by_view: HashMap::new(),
         projection_paint_pending: false,
         machine_rail_follow_selection: true,
         workspace_rail_follow_selection: true,
@@ -10345,6 +10364,8 @@ impl App {
             .map(|state| state.collapsed.clone())
             .unwrap_or_default();
         let selected_workspace = self.sidebar_workspace_selection;
+        let selected_workspace_key = selected_workspace_cache_key(&spec, selected_workspace)
+            .map(|selected| selected.min(self.tree.workspaces.len().saturating_sub(1)));
         let workspace_revision = self.tree.workspace_revision;
         let pane_revision = self.tree.pane_revision;
         let invalidation_revision = self.projection_rows_revision;
@@ -10354,7 +10375,7 @@ impl App {
                 && cache.workspace_revision == workspace_revision
                 && cache.pane_revision == pane_revision
                 && cache.invalidation_revision == invalidation_revision
-                && cache.selected_workspace == selected_workspace
+                && cache.selected_workspace == selected_workspace_key
                 && cache.focus == focus
         });
         let rows = if let Some(cache_index) = cache_index {
@@ -10362,8 +10383,11 @@ impl App {
                 .projection_rows_cache
                 .remove(cache_index)
                 .expect("projection cache index came from the cache");
-            self.projection_agent_surfaces.extend(cache.agent_surfaces.iter().copied());
-            self.projection_title_surfaces.extend(cache.title_surfaces.iter().copied());
+            self.set_projection_surface_dependencies(
+                &cache.view_id,
+                cache.agent_surfaces.clone(),
+                cache.title_surfaces.clone(),
+            );
             let rows = cache.rows.clone();
             self.projection_rows_cache.push_front(cache);
             rows
@@ -10395,21 +10419,22 @@ impl App {
             );
             let (agent_surfaces, title_surfaces) =
                 projection_cache_dependencies(&spec, &self.tree, &rows, selected_workspace);
+            let agent_surfaces = Arc::new(agent_surfaces);
+            let title_surfaces = Arc::new(title_surfaces);
             let rows: Arc<[ProjectionRow]> = Arc::from(rows);
-            self.projection_agent_surfaces.extend(agent_surfaces.iter().copied());
-            self.projection_title_surfaces.extend(title_surfaces.iter().copied());
             self.projection_rows_cache.push_front(ProjectionRowsCache {
                 view_id: spec.id.clone(),
                 workspace_revision,
                 pane_revision,
                 invalidation_revision,
-                selected_workspace,
+                selected_workspace: selected_workspace_key,
                 focus,
-                agent_surfaces,
-                title_surfaces,
+                agent_surfaces: agent_surfaces.clone(),
+                title_surfaces: title_surfaces.clone(),
                 rows: rows.clone(),
             });
             self.projection_rows_cache.truncate(MAX_PROJECTION_ROWS_CACHE_ENTRIES);
+            self.set_projection_surface_dependencies(&spec.id, agent_surfaces, title_surfaces);
             rows
         };
         self.projection_rail_state_mut(index).reconcile_selection(&rows);
@@ -10421,17 +10446,131 @@ impl App {
         self.projection_rows_cache.clear();
         self.projection_agent_surfaces.clear();
         self.projection_title_surfaces.clear();
+        self.projection_agent_surfaces_by_view.clear();
+        self.projection_title_surfaces_by_view.clear();
         self.projection_paint_pending = false;
     }
 
-    fn prune_projection_surface_indexes(&mut self) {
-        let live_surfaces = &self.tab_locations;
-        for cache in &mut self.projection_rows_cache {
-            cache.agent_surfaces.retain(|surface| live_surfaces.contains_key(surface));
-            cache.title_surfaces.retain(|surface| live_surfaces.contains_key(surface));
+    fn projection_view_is_visible(&self, view_id: &str) -> bool {
+        if !self.sidebar_visible || self.surface_only.is_some() {
+            return false;
         }
-        self.projection_agent_surfaces.retain(|surface| live_surfaces.contains_key(surface));
-        self.projection_title_surfaces.retain(|surface| live_surfaces.contains_key(surface));
+        if self
+            .hidden_sidebar_views
+            .get(&self.config.sidebar.active_profile)
+            .is_some_and(|hidden| hidden.contains(view_id))
+        {
+            return false;
+        }
+        // Before the first frame there is no layout yet, but direct input and
+        // tests may still build a projection snapshot. Treat active views as
+        // visible until the first concrete layout is available.
+        if self.outer_size == (0, 0) {
+            return self.config.sidebar.views.iter().any(|view| view.id == view_id);
+        }
+        let Some(index) = self.config.sidebar.views.iter().position(|view| view.id == view_id)
+        else {
+            return false;
+        };
+        self.sidebar_layout
+            .ordered
+            .iter()
+            .any(|placement| placement.kind == RailKind::Projection(index))
+    }
+
+    /// Replace one view's dependency snapshot and rebuild the global wake
+    /// union only when that snapshot changes. Per-view storage prevents a
+    /// hidden view from keeping a retired dependency alive while retaining
+    /// wake coverage for visible views whose LRU row snapshot was evicted.
+    fn set_projection_surface_dependencies(
+        &mut self,
+        view_id: &str,
+        agent_surfaces: Arc<HashSet<SurfaceId>>,
+        title_surfaces: Arc<HashSet<SurfaceId>>,
+    ) {
+        if !self.projection_view_is_visible(view_id) {
+            return;
+        }
+        let agent_changed = self
+            .projection_agent_surfaces_by_view
+            .get(view_id)
+            .is_none_or(|previous| !Arc::ptr_eq(previous, &agent_surfaces));
+        let title_changed = self
+            .projection_title_surfaces_by_view
+            .get(view_id)
+            .is_none_or(|previous| !Arc::ptr_eq(previous, &title_surfaces));
+        self.projection_agent_surfaces_by_view.insert(view_id.to_owned(), agent_surfaces);
+        self.projection_title_surfaces_by_view.insert(view_id.to_owned(), title_surfaces);
+        if agent_changed || title_changed {
+            self.rebuild_projection_surface_indexes();
+        }
+    }
+
+    /// Keep wake indexes bounded to active, visible view ids and live tab
+    /// surfaces. The operation touches only the small per-view dependency
+    /// maps, never the workspace tree.
+    fn rebuild_projection_surface_indexes(&mut self) {
+        let visible_view_ids = self
+            .config
+            .sidebar
+            .views
+            .iter()
+            .map(|view| view.id.clone())
+            .filter(|view_id| self.projection_view_is_visible(view_id))
+            .collect::<HashSet<_>>();
+        self.projection_agent_surfaces_by_view
+            .retain(|view_id, _| visible_view_ids.contains(view_id));
+        self.projection_title_surfaces_by_view
+            .retain(|view_id, _| visible_view_ids.contains(view_id));
+
+        let live_surfaces = &self.tab_locations;
+        self.projection_agent_surfaces = self
+            .projection_agent_surfaces_by_view
+            .values()
+            .flat_map(|dependencies| {
+                dependencies.iter().filter(|surface| live_surfaces.contains_key(surface)).copied()
+            })
+            .collect();
+        self.projection_title_surfaces = self
+            .projection_title_surfaces_by_view
+            .values()
+            .flat_map(|dependencies| {
+                dependencies.iter().filter(|surface| live_surfaces.contains_key(surface)).copied()
+            })
+            .collect();
+    }
+
+    fn prune_projection_surface_indexes(&mut self) {
+        {
+            let live_surfaces = &self.tab_locations;
+            for cache in &mut self.projection_rows_cache {
+                Arc::make_mut(&mut cache.agent_surfaces)
+                    .retain(|surface| live_surfaces.contains_key(surface));
+                Arc::make_mut(&mut cache.title_surfaces)
+                    .retain(|surface| live_surfaces.contains_key(surface));
+            }
+            for dependencies in self.projection_agent_surfaces_by_view.values_mut() {
+                let filtered = dependencies
+                    .iter()
+                    .filter(|surface| live_surfaces.contains_key(surface))
+                    .copied()
+                    .collect::<HashSet<_>>();
+                if filtered.len() != dependencies.len() {
+                    *dependencies = Arc::new(filtered);
+                }
+            }
+            for dependencies in self.projection_title_surfaces_by_view.values_mut() {
+                let filtered = dependencies
+                    .iter()
+                    .filter(|surface| live_surfaces.contains_key(surface))
+                    .copied()
+                    .collect::<HashSet<_>>();
+                if filtered.len() != dependencies.len() {
+                    *dependencies = Arc::new(filtered);
+                }
+            }
+        }
+        self.rebuild_projection_surface_indexes();
     }
 
     fn invalidate_projection_rows_if_sidebar_spec_changed(
@@ -10485,9 +10624,12 @@ impl App {
         surface: SurfaceId,
         change: ProjectionSurfaceChange,
     ) -> bool {
-        let was_affected = self.projection_rows_cache.iter().any(|cache| match change {
-            ProjectionSurfaceChange::Agent => cache.agent_surfaces.contains(&surface),
-            ProjectionSurfaceChange::Title => cache.title_surfaces.contains(&surface),
+        let was_affected = self.projection_rows_cache.iter().any(|cache| {
+            self.projection_view_is_visible(&cache.view_id)
+                && match change {
+                    ProjectionSurfaceChange::Agent => cache.agent_surfaces.contains(&surface),
+                    ProjectionSurfaceChange::Title => cache.title_surfaces.contains(&surface),
+                }
         });
         self.projection_rows_cache.retain(|cache| match change {
             ProjectionSurfaceChange::Agent => !cache.agent_surfaces.contains(&surface),
@@ -22829,8 +22971,13 @@ impl App {
             return true;
         }
         let id = placement.id.clone();
-        let fractions = sizes.iter().map(|size| f32::from(*size) / total).collect();
-        self.sidebar_split_fractions.insert(id, fractions);
+        let child_keys = placement.child_keys.clone();
+        let fractions = child_keys
+            .into_iter()
+            .zip(sizes)
+            .map(|(child, size)| (child, f32::from(size) / total))
+            .collect::<HashMap<_, _>>();
+        self.sidebar_split_fractions.entry(id).or_default().extend(fractions);
         true
     }
 
@@ -23517,19 +23664,22 @@ impl App {
         let Some(view) = self.config.sidebar.views.get(index) else { return };
         let view_id = view.id.clone();
         let hides_focused = !visible && self.focused_sidebar_view_id().as_deref() == Some(&view_id);
-        let hidden = self
-            .hidden_sidebar_views
-            .entry(self.config.sidebar.active_profile.clone())
-            .or_default();
-        if visible {
-            hidden.remove(&view_id);
-            self.sidebar_visible = true;
-        } else {
-            hidden.insert(view_id);
-            if hides_focused {
-                self.focus = FocusTarget::Pane;
+        {
+            let hidden = self
+                .hidden_sidebar_views
+                .entry(self.config.sidebar.active_profile.clone())
+                .or_default();
+            if visible {
+                hidden.remove(&view_id);
+                self.sidebar_visible = true;
+            } else {
+                hidden.insert(view_id);
+                if hides_focused {
+                    self.focus = FocusTarget::Pane;
+                }
             }
         }
+        self.rebuild_projection_surface_indexes();
     }
 
     fn activate_sidebar_profile(&mut self, index: usize) {
@@ -27245,7 +27395,10 @@ mod tests {
 
         let mut app = test_app(Session::Local(mux));
         app.config = first;
-        app.sidebar_split_fractions.insert("left".into(), vec![0.8, 0.2]);
+        app.sidebar_split_fractions.insert(
+            "left".into(),
+            HashMap::from([("workspaces".to_string(), 0.8), ("all-agents".to_string(), 0.2)]),
+        );
         app.sync_layout((120, 31));
         assert_eq!(app.sidebar_layout.ordered[0].rect.height, 24);
         app.projection_sidebar_width_overrides.insert("left".into(), 50);
@@ -27427,7 +27580,10 @@ mod tests {
     fn split_fraction_overrides_replace_configured_weights() {
         let config = split_sidebar_config();
         let mut fractions = HashMap::new();
-        fractions.insert("left".to_string(), vec![0.2f32, 0.8f32]);
+        fractions.insert(
+            "left".to_string(),
+            HashMap::from([("workspaces".to_string(), 0.2f32), ("all-agents".to_string(), 0.8f32)]),
+        );
         let layout = sidebar_layout_for_state(
             &config,
             true,
@@ -27446,6 +27602,95 @@ mod tests {
         let bottom = layout.ordered[1].rect;
         assert_eq!(top.height, 6, "0.2 of the 30 shared rows");
         assert_eq!(bottom.height, 24);
+    }
+
+    #[test]
+    fn split_fraction_overrides_follow_child_ids_after_reordering() {
+        let mut config = split_sidebar_config();
+        if let Some(crate::config::SidebarLayoutNode::Split(split)) =
+            config.sidebar.layout.first_mut()
+        {
+            split.children.reverse();
+            split.weights.reverse();
+        }
+        let mut fractions = HashMap::new();
+        fractions.insert(
+            "left".to_string(),
+            HashMap::from([("workspaces".to_string(), 0.2f32), ("all-agents".to_string(), 0.8f32)]),
+        );
+        let layout = sidebar_layout_for_state(
+            &config,
+            true,
+            false,
+            false,
+            (120, 31),
+            None,
+            None,
+            None,
+            &HashMap::new(),
+            &fractions,
+            &HashSet::new(),
+            None,
+        );
+
+        assert_eq!(layout.rail(RailKind::Workspace).unwrap().height, 6);
+        assert_eq!(layout.rail(RailKind::Projection(1)).unwrap().height, 24);
+    }
+
+    #[test]
+    fn split_fraction_overrides_keep_surviving_child_ratios_after_pruning() {
+        use crate::config::{SidebarLayoutNode, SidebarSplitDir, SidebarSplitSpec};
+
+        let mut config = split_sidebar_config();
+        let mut third = config.sidebar.views[1].clone();
+        third.id = "third".into();
+        config.sidebar.views.push(third);
+        config.sidebar.views[0].collapse_priority = 1;
+        config.sidebar.views[1].collapse_priority = 20;
+        config.sidebar.views[2].collapse_priority = 30;
+        config.sidebar.layout = vec![SidebarLayoutNode::Split(SidebarSplitSpec {
+            id: "left".into(),
+            dir: SidebarSplitDir::Vertical,
+            weights: vec![1, 1, 1],
+            children: vec![
+                SidebarLayoutNode::Leaf(0),
+                SidebarLayoutNode::Leaf(1),
+                SidebarLayoutNode::Leaf(2),
+            ],
+            width: 26,
+            max_width: 0,
+            collapse_priority: 30,
+        })];
+        let mut fractions = HashMap::new();
+        fractions.insert(
+            "left".to_string(),
+            HashMap::from([
+                ("workspaces".to_string(), 0.2f32),
+                ("all-agents".to_string(), 0.6f32),
+                ("third".to_string(), 0.2f32),
+            ]),
+        );
+
+        // The first child is pruned at this height. The two surviving
+        // children retain their 3:1 saved ratio instead of falling back to
+        // equal configured weights.
+        let layout = sidebar_layout_for_state(
+            &config,
+            true,
+            false,
+            false,
+            (120, 16),
+            None,
+            None,
+            None,
+            &HashMap::new(),
+            &fractions,
+            &HashSet::new(),
+            None,
+        );
+        assert_eq!(layout.split_groups[0].child_keys, vec!["all-agents", "third"]);
+        assert_eq!(layout.rail(RailKind::Projection(1)).unwrap().height, 10);
+        assert_eq!(layout.rail(RailKind::Projection(2)).unwrap().height, 5);
     }
 
     #[test]
@@ -27522,6 +27767,9 @@ mod tests {
 
         assert!(app.sidebar_split_fractions.contains_key("left"));
         assert!(!app.sidebar_split_fractions.contains_key("other"));
+        let fractions = app.sidebar_split_fractions.get("left").unwrap();
+        assert!(fractions.contains_key("first"));
+        assert!(fractions.contains_key("second"));
     }
 
     #[test]
@@ -42800,6 +43048,37 @@ mod tests {
     }
 
     #[test]
+    fn all_scope_projection_cache_ignores_workspace_highlight_moves() {
+        let (mux, first) = test_mux("projection-all-scope-selection-cache-test", None);
+        let second = mux.new_workspace(Some("second".into()), Some((20, 8))).unwrap();
+        let mut app = test_app(Session::Local(mux.clone()));
+        app.config.sidebar.columns.clear();
+        app.config.sidebar.views = vec![SidebarViewSpec {
+            id: "all-agents".into(),
+            levels: vec![SidebarResourceKind::Agents],
+            actions: Vec::new(),
+            actions_position: crate::config::ActionsPosition::Bottom,
+            width: 40,
+            max_width: 0,
+            collapse_priority: 30,
+            scope: crate::config::SidebarViewScope::All,
+        }];
+        app.config.sidebar.views_explicit = true;
+        app.replace_tree(app.session.tree());
+
+        app.sidebar_workspace_selection = 0;
+        let first_rows = app.projection_rows(0);
+        app.sidebar_workspace_selection = 1;
+        let second_rows = app.projection_rows(0);
+
+        assert!(Arc::ptr_eq(&first_rows, &second_rows));
+        assert_eq!(app.projection_rows_cache.len(), 1);
+
+        mux.close_surface(first.id).unwrap();
+        mux.close_surface(second.id).unwrap();
+    }
+
+    #[test]
     fn projection_title_update_keeps_an_unrelated_workspace_cache() {
         let (mux, first) = test_mux("projection-title-cache-scope-test", None);
         let second = mux.new_workspace(Some("second".into()), Some((20, 8))).unwrap();
@@ -42892,6 +43171,44 @@ mod tests {
         // topology refresh. It must not reintroduce the retired id.
         app.projection_rows(0);
         assert!(!app.projection_agent_surfaces.contains(&surface.id));
+    }
+
+    #[test]
+    fn hidden_projection_view_drops_wake_dependencies() {
+        let (mux, surface) = test_mux("projection-hidden-view-wake-test", None);
+        let mut app = test_app(Session::Local(mux.clone()));
+        app.config.sidebar.columns.clear();
+        app.config.sidebar.views = vec![SidebarViewSpec {
+            id: "agents".into(),
+            levels: vec![SidebarResourceKind::Agents],
+            actions: Vec::new(),
+            actions_position: crate::config::ActionsPosition::Bottom,
+            width: 40,
+            max_width: 0,
+            collapse_priority: 30,
+            scope: crate::config::SidebarViewScope::Workspace,
+        }];
+        app.config.sidebar.views_explicit = true;
+        app.replace_tree(app.session.tree());
+        app.projection_rows(0);
+        assert!(app.projection_agent_surfaces.contains(&surface.id));
+
+        app.set_sidebar_view_visible(0, false);
+        assert!(!app.projection_agent_surfaces.contains(&surface.id));
+        assert_eq!(
+            app.handle(AppEvent::Mux(MuxEvent::AgentChanged {
+                surface: surface.id,
+                state: "working".into(),
+                source: "hook".into(),
+                session: None,
+                updated_at_ms: 1,
+            }))
+            .unwrap(),
+            RenderAction::None,
+            "updates for a hidden projection must not schedule a paint"
+        );
+
+        mux.close_surface(surface.id).unwrap();
     }
 
     #[test]
@@ -45200,6 +45517,8 @@ mod tests {
             projection_rows_revision: 0,
             projection_agent_surfaces: HashSet::new(),
             projection_title_surfaces: HashSet::new(),
+            projection_agent_surfaces_by_view: HashMap::new(),
+            projection_title_surfaces_by_view: HashMap::new(),
             projection_paint_pending: false,
             machine_rail_follow_selection: true,
             workspace_rail_follow_selection: true,

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -3935,6 +3935,11 @@ pub enum Hit {
     RailPad(RailKind),
     /// A rail's right border.
     RailResize(RailKind),
+    /// A draggable divider between two panes of a sidebar split group.
+    SidebarSplitDivider {
+        group: usize,
+        index: usize,
+    },
     /// Pane border resize handle.
     PaneResize {
         horizontal: Option<(PaneId, PaneEdge)>,
@@ -4033,12 +4038,49 @@ pub struct RailPlacement {
     pub rect: Rect,
 }
 
+/// One top-level sidebar column. A column holds one rail, or a split group
+/// of rails; width drag and the packing solver operate on columns.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SidebarColumnPlacement {
+    /// Width-override key: the leaf view id, or the split group id.
+    pub key: String,
+    pub rect: Rect,
+    pub max_width: u16,
+    /// Rails inside this column, tree order.
+    pub rails: Vec<RailKind>,
+}
+
+/// A rendered split group: the region its children partition. Divider drags
+/// convert pointer positions into new child fractions through this record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SidebarSplitGroupPlacement {
+    pub id: String,
+    pub dir: crate::config::SidebarSplitDir,
+    pub children: Vec<Rect>,
+}
+
+/// A draggable boundary between two children of a split group. A vertical
+/// split renders its divider as a dedicated row; a horizontal split reuses
+/// the left child's border column.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SidebarDividerPlacement {
+    /// Index into `SidebarLayout::split_groups`.
+    pub group: usize,
+    /// The divider sits between child `index` and child `index + 1`.
+    pub index: usize,
+    pub rect: Rect,
+    pub dir: crate::config::SidebarSplitDir,
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct SidebarLayout {
     pub machine: Option<Rect>,
     pub workspace: Option<Rect>,
     pub tabs: Option<Rect>,
     pub ordered: Vec<RailPlacement>,
+    pub columns: Vec<SidebarColumnPlacement>,
+    pub split_groups: Vec<SidebarSplitGroupPlacement>,
+    pub dividers: Vec<SidebarDividerPlacement>,
     pub content: Rect,
 }
 
@@ -5490,6 +5532,8 @@ enum Drag {
     },
     /// Independent rail width override drag.
     RailResize(RailKind),
+    /// Sidebar split-group divider drag: re-shares the group's children.
+    SidebarSplit { group: usize, index: usize },
     /// Pane split resize drag.
     ResizeSplit { horizontal: Option<PaneResizeDragTarget>, vertical: Option<PaneResizeDragTarget> },
 }
@@ -6935,6 +6979,9 @@ pub struct App {
     machine_sidebar_width_override: Option<u16>,
     tabs_sidebar_width_override: Option<u16>,
     projection_sidebar_width_overrides: HashMap<String, u16>,
+    /// Session-local divider drags inside sidebar split groups, keyed by
+    /// group id: each child's share of the group, in child order.
+    sidebar_split_fractions: HashMap<String, Vec<f32>>,
     /// Session-local visibility overrides, keyed by profile and stable view id.
     hidden_sidebar_views: HashMap<String, HashSet<String>>,
     /// Pane region of the current frame (screen minus sidebar/status).
@@ -7140,6 +7187,9 @@ fn preserve_client_view(previous: &TreeView, next: &mut TreeView) {
 
 const MIN_RAIL_WIDTH: u16 = 10;
 const MIN_CONTENT_WIDTH: u16 = 40;
+/// Minimum rows for a rail stacked inside a vertical sidebar split: the top
+/// pad, one full entry, and a row of slack so the list stays usable.
+const MIN_SPLIT_RAIL_HEIGHT: u16 = 4;
 const MIN_TABBED_PANE_HEIGHT: u16 = 3;
 const RAIL_REVEAL_HYSTERESIS: u16 = 4;
 
@@ -7811,9 +7861,253 @@ fn sidebar_layout_for(
         overrides.machine,
         overrides.tabs,
         &HashMap::new(),
+        &HashMap::new(),
         &HashSet::new(),
         None,
     )
+}
+
+/// One top-level sidebar column after visibility pruning: hidden views and
+/// an absent machine provider drop leaves, empty splits collapse away.
+#[derive(Clone)]
+enum SidebarColumnNode {
+    Leaf { view_index: usize, kind: RailKind, priority: u16 },
+    Split {
+        id: String,
+        dir: crate::config::SidebarSplitDir,
+        priority: u16,
+        children: Vec<(u16, SidebarColumnNode)>,
+    },
+}
+
+impl SidebarColumnNode {
+    fn priority(&self) -> u16 {
+        match self {
+            SidebarColumnNode::Leaf { priority, .. }
+            | SidebarColumnNode::Split { priority, .. } => *priority,
+        }
+    }
+
+    fn first_kind(&self) -> RailKind {
+        match self {
+            SidebarColumnNode::Leaf { kind, .. } => *kind,
+            SidebarColumnNode::Split { children, .. } => children[0].1.first_kind(),
+        }
+    }
+
+    fn collect_rails(&self, rails: &mut Vec<RailKind>) {
+        match self {
+            SidebarColumnNode::Leaf { kind, .. } => rails.push(*kind),
+            SidebarColumnNode::Split { children, .. } => {
+                for (_, child) in children {
+                    child.collect_rails(rails);
+                }
+            }
+        }
+    }
+}
+
+fn prune_sidebar_layout_node(
+    node: &crate::config::SidebarLayoutNode,
+    views: &[SidebarViewSpec],
+    hidden_views: &HashSet<String>,
+    machine_visible: bool,
+) -> Option<SidebarColumnNode> {
+    use crate::config::SidebarLayoutNode;
+    match node {
+        SidebarLayoutNode::Leaf(view_index) => {
+            let view = views.get(*view_index)?;
+            if hidden_views.contains(&view.id) {
+                return None;
+            }
+            if view.includes(SidebarResourceKind::Machines) && !machine_visible {
+                return None;
+            }
+            let kind = match view.legacy_kind() {
+                Some(SidebarColumnKind::Machines) => RailKind::Machine,
+                Some(SidebarColumnKind::Workspaces) => RailKind::Workspace,
+                Some(SidebarColumnKind::Tabs) => RailKind::Tabs,
+                None => RailKind::Projection(*view_index),
+            };
+            Some(SidebarColumnNode::Leaf {
+                view_index: *view_index,
+                kind,
+                priority: view.collapse_priority,
+            })
+        }
+        SidebarLayoutNode::Split(split) => {
+            let children: Vec<(u16, SidebarColumnNode)> = split
+                .children
+                .iter()
+                .enumerate()
+                .filter_map(|(index, child)| {
+                    prune_sidebar_layout_node(child, views, hidden_views, machine_visible).map(
+                        |node| (split.weights.get(index).copied().unwrap_or(1).max(1), node),
+                    )
+                })
+                .collect();
+            match children.len() {
+                0 => None,
+                1 => children.into_iter().next().map(|(_, child)| child),
+                _ => Some(SidebarColumnNode::Split {
+                    id: split.id.clone(),
+                    dir: split.dir,
+                    priority: split.collapse_priority,
+                    children,
+                }),
+            }
+        }
+    }
+}
+
+/// Lay out one pruned column node inside `rect`, appending rail placements,
+/// split-group records, and divider handles. Children that no longer fit at
+/// their minimum size collapse away lowest-priority-first, exactly like
+/// columns do when the terminal narrows.
+fn place_sidebar_column_node(
+    node: &SidebarColumnNode,
+    rect: Rect,
+    layout: &mut SidebarLayout,
+    split_fractions: &HashMap<String, Vec<f32>>,
+) {
+    use crate::config::SidebarSplitDir;
+    if rect.width == 0 || rect.height == 0 {
+        return;
+    }
+    match node {
+        SidebarColumnNode::Leaf { view_index, kind, .. } => {
+            match kind {
+                RailKind::Machine => layout.machine = Some(rect),
+                RailKind::Workspace => layout.workspace = Some(rect),
+                RailKind::Tabs => layout.tabs = Some(rect),
+                RailKind::Projection(_) => {}
+            }
+            layout.ordered.push(RailPlacement { kind: *kind, view_index: *view_index, rect });
+        }
+        SidebarColumnNode::Split { id, dir, children, .. } => {
+            let (total, min_each, divider_size) = match dir {
+                SidebarSplitDir::Vertical => (rect.height, MIN_SPLIT_RAIL_HEIGHT, 1u16),
+                SidebarSplitDir::Horizontal => (rect.width, MIN_RAIL_WIDTH, 0u16),
+            };
+            let mut kept: Vec<&(u16, SidebarColumnNode)> = children.iter().collect();
+            while kept.len() > 1 {
+                let dividers = divider_size.saturating_mul(kept.len().saturating_sub(1) as u16);
+                let needed =
+                    min_each.saturating_mul(kept.len() as u16).saturating_add(dividers);
+                if total >= needed {
+                    break;
+                }
+                let Some((drop_index, _)) = kept
+                    .iter()
+                    .enumerate()
+                    .min_by_key(|(_, (_, child))| child.priority())
+                else {
+                    break;
+                };
+                kept.remove(drop_index);
+            }
+            if kept.len() == 1 {
+                place_sidebar_column_node(&kept[0].1, rect, layout, split_fractions);
+                return;
+            }
+            let dividers = divider_size.saturating_mul(kept.len().saturating_sub(1) as u16);
+            let available = total.saturating_sub(dividers);
+            if available < min_each.saturating_mul(kept.len() as u16) {
+                place_sidebar_column_node(&kept[0].1, rect, layout, split_fractions);
+                return;
+            }
+            // A committed divider drag overrides the configured weights while
+            // the same children remain visible.
+            let shares: Vec<f32> = split_fractions
+                .get(id)
+                .filter(|fractions| {
+                    fractions.len() == kept.len()
+                        && fractions.iter().all(|value| value.is_finite() && *value > 0.0)
+                })
+                .cloned()
+                .unwrap_or_else(|| kept.iter().map(|(weight, _)| f32::from(*weight)).collect());
+            let sum: f32 = shares.iter().sum();
+            let mut sizes: Vec<u16> = shares
+                .iter()
+                .map(|share| {
+                    (((share / sum) * f32::from(available)) as u16).clamp(min_each, available)
+                })
+                .collect();
+            let mut used: u16 = sizes.iter().fold(0, |sum, size| sum.saturating_add(*size));
+            while used > available {
+                let Some((largest, _)) = sizes
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, size)| **size > min_each)
+                    .max_by_key(|(_, size)| **size)
+                else {
+                    break;
+                };
+                sizes[largest] -= 1;
+                used -= 1;
+            }
+            let mut round_robin = 0usize;
+            while used < available {
+                sizes[round_robin % sizes.len()] += 1;
+                used += 1;
+                round_robin += 1;
+            }
+            let group_index = layout.split_groups.len();
+            layout.split_groups.push(SidebarSplitGroupPlacement {
+                id: id.clone(),
+                dir: *dir,
+                children: Vec::new(),
+            });
+            let mut offset = 0u16;
+            for (child_index, (_, child)) in kept.iter().enumerate() {
+                let child_rect = match dir {
+                    SidebarSplitDir::Vertical => Rect {
+                        x: rect.x,
+                        y: rect.y + offset,
+                        width: rect.width,
+                        height: sizes[child_index],
+                    },
+                    SidebarSplitDir::Horizontal => Rect {
+                        x: rect.x + offset,
+                        y: rect.y,
+                        width: sizes[child_index],
+                        height: rect.height,
+                    },
+                };
+                layout.split_groups[group_index].children.push(child_rect);
+                place_sidebar_column_node(child, child_rect, layout, split_fractions);
+                offset = offset.saturating_add(sizes[child_index]);
+                if child_index + 1 < kept.len() {
+                    let divider_rect = match dir {
+                        SidebarSplitDir::Vertical => {
+                            let divider = Rect {
+                                x: rect.x,
+                                y: rect.y + offset,
+                                width: rect.width,
+                                height: 1,
+                            };
+                            offset = offset.saturating_add(1);
+                            divider
+                        }
+                        // The horizontal handle overlays the left child's
+                        // border column; no extra cell is carved out.
+                        SidebarSplitDir::Horizontal => Rect {
+                            x: (rect.x + offset).saturating_sub(1),
+                            y: rect.y,
+                            width: 1,
+                            height: rect.height,
+                        },
+                    };
+                    layout.dividers.push(SidebarDividerPlacement {
+                        group: group_index,
+                        index: child_index,
+                        rect: divider_rect,
+                        dir: *dir,
+                    });
+                }
+            }
+        }
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -7827,6 +8121,7 @@ fn sidebar_layout_for_state(
     machine_override: Option<u16>,
     tabs_override: Option<u16>,
     projection_overrides: &HashMap<String, u16>,
+    split_fractions: &HashMap<String, Vec<f32>>,
     hidden_views: &HashSet<String>,
     previous: Option<&SidebarLayout>,
 ) -> SidebarLayout {
@@ -7841,63 +8136,89 @@ fn sidebar_layout_for_state(
         };
     }
 
-    #[derive(Clone, Copy)]
     struct Spec {
-        kind: RailKind,
-        view_index: usize,
+        node: SidebarColumnNode,
+        key: String,
+        first_kind: RailKind,
         desired: u16,
         max_width: u16,
         priority: u16,
     }
 
-    let mut specs = config
-        .sidebar
-        .views
+    let views = &config.sidebar.views;
+    // The resolved layout always covers every view exactly once. Anything
+    // else means `views` was replaced without its layout (tests and older
+    // call sites do this), so fall back to one column per view.
+    let identity: Vec<crate::config::SidebarLayoutNode>;
+    let layout_nodes: &[crate::config::SidebarLayoutNode] = {
+        let mut leaves: Vec<usize> =
+            config.sidebar.layout.iter().flat_map(|node| node.leaves()).collect();
+        leaves.sort_unstable();
+        if leaves == (0..views.len()).collect::<Vec<_>>() {
+            &config.sidebar.layout
+        } else {
+            identity = crate::config::sidebar_layout_of_columns(views);
+            &identity
+        }
+    };
+    let mut specs = layout_nodes
         .iter()
-        .enumerate()
-        .filter_map(|(view_index, view)| {
-            if hidden_views.contains(&view.id) {
-                return None;
-            }
-            if view.includes(SidebarResourceKind::Machines) && !machine_visible {
-                return None;
-            }
-            let kind = match view.legacy_kind() {
-                Some(SidebarColumnKind::Machines) => RailKind::Machine,
-                Some(SidebarColumnKind::Workspaces) => RailKind::Workspace,
-                Some(SidebarColumnKind::Tabs) => RailKind::Tabs,
-                None => RailKind::Projection(view_index),
-            };
-            let width_override = match kind {
-                RailKind::Machine => machine_override,
-                RailKind::Workspace => workspace_override,
-                RailKind::Tabs => tabs_override,
-                RailKind::Projection(_) => projection_overrides.get(&view.id).copied(),
-            };
-            let legacy_width = match kind {
-                RailKind::Machine => config.machine_sidebar.width,
-                RailKind::Workspace => config.sidebar.width,
-                RailKind::Tabs | RailKind::Projection(_) => view.width,
-            };
-            let desired = if compact && kind == RailKind::Workspace {
-                config.sidebar.compact_width
-            } else {
-                width_override.unwrap_or(if config.sidebar.views_explicit {
-                    view.width
-                } else {
-                    legacy_width
-                })
-            };
-            let max_width = if config.sidebar.views_explicit {
-                view.max_width
-            } else {
-                match kind {
-                    RailKind::Machine => config.machine_sidebar.max_width,
-                    RailKind::Workspace => config.sidebar.max_width,
-                    RailKind::Tabs | RailKind::Projection(_) => view.max_width,
+        .filter_map(|layout_node| {
+            let node =
+                prune_sidebar_layout_node(layout_node, views, hidden_views, machine_visible)?;
+            let (key, first_kind, desired, max_width, priority) = match &node {
+                SidebarColumnNode::Leaf { view_index, kind, priority } => {
+                    let view = views.get(*view_index)?;
+                    let width_override = match kind {
+                        RailKind::Machine => machine_override,
+                        RailKind::Workspace => workspace_override,
+                        RailKind::Tabs => tabs_override,
+                        RailKind::Projection(_) => projection_overrides.get(&view.id).copied(),
+                    };
+                    let legacy_width = match kind {
+                        RailKind::Machine => config.machine_sidebar.width,
+                        RailKind::Workspace => config.sidebar.width,
+                        RailKind::Tabs | RailKind::Projection(_) => view.width,
+                    };
+                    let desired = if compact && *kind == RailKind::Workspace {
+                        config.sidebar.compact_width
+                    } else {
+                        width_override.unwrap_or(if config.sidebar.views_explicit {
+                            view.width
+                        } else {
+                            legacy_width
+                        })
+                    };
+                    let max_width = if config.sidebar.views_explicit {
+                        view.max_width
+                    } else {
+                        match kind {
+                            RailKind::Machine => config.machine_sidebar.max_width,
+                            RailKind::Workspace => config.sidebar.max_width,
+                            RailKind::Tabs | RailKind::Projection(_) => view.max_width,
+                        }
+                    };
+                    (view.id.clone(), *kind, desired, max_width, *priority)
+                }
+                SidebarColumnNode::Split { id, priority, .. } => {
+                    // A pruned single-child split resolves as a leaf above,
+                    // so this arm always covers a real multi-pane column.
+                    let split = sidebar_split_spec(&config.sidebar.layout, id);
+                    let desired = projection_overrides
+                        .get(id)
+                        .copied()
+                        .or(split.map(|split| split.width))
+                        .unwrap_or(22);
+                    (
+                        id.clone(),
+                        node.first_kind(),
+                        desired,
+                        split.map_or(0, |split| split.max_width),
+                        *priority,
+                    )
                 }
             };
-            Some(Spec { kind, view_index, desired, max_width, priority: view.collapse_priority })
+            Some(Spec { node, key, first_kind, desired, max_width, priority })
         })
         .collect::<Vec<_>>();
 
@@ -7912,7 +8233,7 @@ fn sidebar_layout_for_state(
     }
 
     if let Some(previous) = previous {
-        while specs.iter().any(|spec| previous.rail(spec.kind).is_none())
+        while specs.iter().any(|spec| previous.rail(spec.first_kind).is_none())
             && width
                 < MIN_CONTENT_WIDTH
                     .saturating_add(MIN_RAIL_WIDTH.saturating_mul(specs.len() as u16))
@@ -7921,7 +8242,7 @@ fn sidebar_layout_for_state(
             let Some((index, _)) = specs
                 .iter()
                 .enumerate()
-                .filter(|(_, spec)| previous.rail(spec.kind).is_none())
+                .filter(|(_, spec)| previous.rail(spec.first_kind).is_none())
                 .min_by_key(|(_, spec)| spec.priority)
             else {
                 break;
@@ -7942,42 +8263,88 @@ fn sidebar_layout_for_state(
             continue;
         };
         let rect = Rect { x, y: 0, width: rail_width, height };
-        match spec.kind {
-            RailKind::Machine => layout.machine = Some(rect),
-            RailKind::Workspace => layout.workspace = Some(rect),
-            RailKind::Tabs => layout.tabs = Some(rect),
-            RailKind::Projection(_) => {}
-        }
-        layout.ordered.push(RailPlacement { kind: spec.kind, view_index: spec.view_index, rect });
+        let mut rails = Vec::new();
+        spec.node.collect_rails(&mut rails);
+        layout.columns.push(SidebarColumnPlacement {
+            key: spec.key.clone(),
+            rect,
+            max_width: spec.max_width,
+            rails,
+        });
+        place_sidebar_column_node(&spec.node, rect, &mut layout, split_fractions);
         x = x.saturating_add(rail_width);
     }
     layout.content = Rect { x, y: 0, width: width.saturating_sub(x), height: content_height };
     layout
 }
 
+/// Ids of every split group in the layout forest, depth first.
+fn collect_sidebar_split_ids(nodes: &[crate::config::SidebarLayoutNode], ids: &mut Vec<String>) {
+    use crate::config::SidebarLayoutNode;
+    for node in nodes {
+        if let SidebarLayoutNode::Split(split) = node {
+            ids.push(split.id.clone());
+            collect_sidebar_split_ids(&split.children, ids);
+        }
+    }
+}
+
+/// Find a split group's config spec by id anywhere in the layout forest.
+fn sidebar_split_spec<'a>(
+    nodes: &'a [crate::config::SidebarLayoutNode],
+    id: &str,
+) -> Option<&'a crate::config::SidebarSplitSpec> {
+    use crate::config::SidebarLayoutNode;
+    for node in nodes {
+        if let SidebarLayoutNode::Split(split) = node {
+            if split.id == id {
+                return Some(split);
+            }
+            if let Some(found) = sidebar_split_spec(&split.children, id) {
+                return Some(found);
+            }
+        }
+    }
+    None
+}
+
+/// A rail's width drag resizes its whole column: stacked rails share their
+/// column's width, so the drag target is the column, not the one rail.
 fn rail_drag_width(config: &Config, layout: &SidebarLayout, kind: RailKind, x: u16) -> Option<u16> {
-    let rail = layout.rail(kind)?;
+    let column_index = sidebar_column_for_rail(layout, kind)?;
+    let column = &layout.columns[column_index];
     let terminal_width = layout.content.x.saturating_add(layout.content.width);
     let other_width = layout
-        .ordered
+        .columns
         .iter()
-        .filter(|placement| placement.kind != kind)
-        .map(|placement| placement.rect.width)
+        .enumerate()
+        .filter(|(index, _)| *index != column_index)
+        .map(|(_, column)| column.rect.width)
         .fold(0u16, u16::saturating_add);
     let available = terminal_width.saturating_sub(MIN_CONTENT_WIDTH).saturating_sub(other_width);
-    let view_index = layout.ordered.iter().find(|placement| placement.kind == kind)?.view_index;
-    let view = config.sidebar.views.get(view_index)?;
-    let configured_max = if config.sidebar.views_explicit {
-        view.max_width
+    let configured_max = if column.rails.len() > 1 {
+        column.max_width
     } else {
-        match kind {
-            RailKind::Machine => config.machine_sidebar.max_width,
-            RailKind::Workspace => config.sidebar.max_width,
-            RailKind::Tabs | RailKind::Projection(_) => view.max_width,
+        let view_index =
+            layout.ordered.iter().find(|placement| placement.kind == kind)?.view_index;
+        let view = config.sidebar.views.get(view_index)?;
+        if config.sidebar.views_explicit {
+            view.max_width
+        } else {
+            match kind {
+                RailKind::Machine => config.machine_sidebar.max_width,
+                RailKind::Workspace => config.sidebar.max_width,
+                RailKind::Tabs | RailKind::Projection(_) => view.max_width,
+            }
         }
     };
-    let desired = x.saturating_sub(rail.x).saturating_add(1);
+    let desired = x.saturating_sub(column.rect.x).saturating_add(1);
     clamp_rail_width(desired, configured_max, available)
+}
+
+/// The index of the column holding `kind`, in `layout.columns`.
+fn sidebar_column_for_rail(layout: &SidebarLayout, kind: RailKind) -> Option<usize> {
+    layout.columns.iter().position(|column| column.rails.contains(&kind))
 }
 
 fn content_size_for_rect(
@@ -9120,6 +9487,7 @@ fn run_with_machine_updates_inner(
         machine_sidebar_width_override: None,
         tabs_sidebar_width_override: None,
         projection_sidebar_width_overrides: HashMap::new(),
+        sidebar_split_fractions: HashMap::new(),
         hidden_sidebar_views: HashMap::new(),
         content_area: Rect::default(),
         hits: Vec::new(),
@@ -9856,10 +10224,17 @@ impl App {
         let agents = if spec.includes(SidebarResourceKind::Agents) {
             // Finished reports are historical records, not active agents.
             // Otherwise detached "surface..." rows remain forever after exit.
+            // An `all`-scoped view is a chronological status board, so it
+            // keeps done agents; unknown stays out everywhere.
+            let keep_done = spec.scope == crate::config::SidebarViewScope::All;
             self.session
                 .agents()
                 .into_iter()
-                .filter(|agent| !matches!(agent.state.as_str(), "done" | "unknown"))
+                .filter(|agent| match agent.state.as_str() {
+                    "unknown" => false,
+                    "done" => keep_done,
+                    _ => true,
+                })
                 .collect::<Vec<_>>()
         } else {
             Vec::new()
@@ -10141,6 +10516,7 @@ impl App {
             self.machine_sidebar_width_override,
             self.tabs_sidebar_width_override,
             &self.projection_sidebar_width_overrides,
+            &self.sidebar_split_fractions,
             &hidden_views,
             None,
         )
@@ -10190,16 +10566,59 @@ impl App {
     }
 
     fn focus_adjacent_rail(&mut self, kind: RailKind, delta: isize) -> bool {
-        let order = self.visible_rail_order();
-        let Some(index) = order.iter().position(|candidate| *candidate == kind) else {
+        let direction = if delta < 0 { Direction::Left } else { Direction::Right };
+        let Some(next) = self.adjacent_rail(kind, direction) else {
             return false;
         };
-        let next = index as isize + delta;
-        let Some(next) = usize::try_from(next).ok().filter(|next| *next < order.len()) else {
-            return false;
-        };
-        self.focus_rail(order[next]);
+        self.focus_rail(next);
         true
+    }
+
+    /// The rail geometrically next to `kind`. With stacked rails, left and
+    /// right mean the neighboring column (preferring the vertically closest
+    /// rail there), and up and down move within the column.
+    fn adjacent_rail(&self, kind: RailKind, direction: Direction) -> Option<RailKind> {
+        let placements = &self.sidebar_layout.ordered;
+        let rect = placements.iter().find(|placement| placement.kind == kind)?.rect;
+        let overlap = |low_a: u16, len_a: u16, low_b: u16, len_b: u16| -> u16 {
+            let high = (low_a.saturating_add(len_a)).min(low_b.saturating_add(len_b));
+            let low = low_a.max(low_b);
+            high.saturating_sub(low)
+        };
+        placements
+            .iter()
+            .filter(|placement| placement.kind != kind)
+            .filter_map(|placement| {
+                let candidate = placement.rect;
+                let (distance, alignment) = match direction {
+                    Direction::Left if candidate.x.saturating_add(candidate.width) <= rect.x => (
+                        rect.x - candidate.x.saturating_add(candidate.width),
+                        overlap(rect.y, rect.height, candidate.y, candidate.height),
+                    ),
+                    Direction::Right if candidate.x >= rect.x.saturating_add(rect.width) => (
+                        candidate.x - rect.x.saturating_add(rect.width),
+                        overlap(rect.y, rect.height, candidate.y, candidate.height),
+                    ),
+                    Direction::Up
+                        if candidate.y.saturating_add(candidate.height) <= rect.y
+                            && overlap(rect.x, rect.width, candidate.x, candidate.width) > 0 =>
+                    (
+                        rect.y - candidate.y.saturating_add(candidate.height),
+                        overlap(rect.x, rect.width, candidate.x, candidate.width),
+                    ),
+                    Direction::Down
+                        if candidate.y >= rect.y.saturating_add(rect.height)
+                            && overlap(rect.x, rect.width, candidate.x, candidate.width) > 0 =>
+                    (
+                        candidate.y - rect.y.saturating_add(rect.height),
+                        overlap(rect.x, rect.width, candidate.x, candidate.width),
+                    ),
+                    _ => return None,
+                };
+                Some((distance, std::cmp::Reverse(alignment), placement.kind))
+            })
+            .min_by_key(|(distance, alignment, _)| (*distance, *alignment))
+            .map(|(_, _, kind)| kind)
     }
 
     fn move_focus_between_sidebar_rails(&mut self, direction: Direction) -> bool {
@@ -10215,8 +10634,28 @@ impl App {
                 }
                 true
             }
-            Direction::Up | Direction::Down => false,
+            Direction::Up | Direction::Down => {
+                if let Some(next) = self.adjacent_rail(kind, direction) {
+                    self.focus_rail(next);
+                    true
+                } else {
+                    false
+                }
+            }
         }
+    }
+
+    /// At a rail's first or last row, Up/Down continues into the stacked
+    /// neighbor rail. Returns whether focus moved.
+    fn continue_past_rail_boundary(&mut self, kind: RailKind, key: &KeyEvent) -> bool {
+        let direction = match key.code {
+            KeyCode::Up | KeyCode::Char('k') => Direction::Up,
+            KeyCode::Down | KeyCode::Char('j') => Direction::Down,
+            _ => return false,
+        };
+        let Some(next) = self.adjacent_rail(kind, direction) else { return false };
+        self.focus_rail(next);
+        true
     }
 
     fn focus_rightmost_sidebar_rail(&mut self) -> bool {
@@ -11921,6 +12360,7 @@ impl App {
             | Hit::HorizontalScrollbar { .. }
             | Hit::WorkspaceScrollbar { .. }
             | Hit::RailResize(_)
+            | Hit::SidebarSplitDivider { .. }
             | Hit::PaneResize { .. }
             | Hit::TabScroll { .. } => None,
         }
@@ -13673,9 +14113,14 @@ impl App {
         self.session.apply_config(config.clone());
         self.sidebar_view = config.sidebar.view;
         self.config = config;
-        let valid_view_ids =
+        let mut valid_view_ids =
             self.config.sidebar.views.iter().map(|view| view.id.clone()).collect::<HashSet<_>>();
         self.projection_rails.retain(|id, _| valid_view_ids.contains(id));
+        let mut group_ids = Vec::new();
+        collect_sidebar_split_ids(&self.config.sidebar.layout, &mut group_ids);
+        self.sidebar_split_fractions.retain(|id, _| group_ids.contains(id));
+        // Split-group column widths share the projection override map.
+        valid_view_ids.extend(group_ids);
         self.projection_sidebar_width_overrides.retain(|id, _| valid_view_ids.contains(id));
         if let Some(id) = focused_projection_id {
             if let Some((index, view)) =
@@ -14079,6 +14524,7 @@ impl App {
                 self.machine_sidebar_width_override,
                 self.tabs_sidebar_width_override,
                 &self.projection_sidebar_width_overrides,
+                &self.sidebar_split_fractions,
                 &hidden_views,
                 previous,
             )
@@ -17805,6 +18251,11 @@ impl App {
             .projection_sidebar_area(view_index)
             .map_or(1, |area| usize::from(area.height.saturating_sub(2)).max(1));
         if let Some(next) = rail_navigation_index(key, current, selectable_rows, page) {
+            if next == current
+                && self.continue_past_rail_boundary(RailKind::Projection(view_index), key)
+            {
+                return Ok(RenderAction::Draw);
+            }
             let state = self.projection_rail_state_mut(view_index);
             if next < rows.len() {
                 state.selected = next;
@@ -18218,6 +18669,11 @@ impl App {
                     .unwrap_or_default();
                 let page = rail_page_size(self.sidebar_layout.workspace);
                 if let Some(next) = rail_navigation_index(key, current, targets.len(), page) {
+                    if next == current
+                        && self.continue_past_rail_boundary(RailKind::Workspace, key)
+                    {
+                        return Ok(RenderAction::Draw);
+                    }
                     if let Some(target) = targets.get(next).cloned() {
                         self.select_workspace_rail_target(target);
                     }
@@ -18279,6 +18735,11 @@ impl App {
         if let Some(next) =
             rail_navigation_index(key, self.tabs_rail_selection, targets.len(), page)
         {
+            if next == self.tabs_rail_selection
+                && self.continue_past_rail_boundary(RailKind::Tabs, key)
+            {
+                return Ok(RenderAction::Draw);
+            }
             self.tabs_rail_selection = next;
         } else if key.code == KeyCode::Enter
             && let Some(target) = targets.get(self.tabs_rail_selection)
@@ -20778,7 +21239,8 @@ impl App {
                 | Drag::Scrollbar { .. }
                 | Drag::HorizontalScrollbar { .. }
                 | Drag::WorkspaceScrollbar { .. }
-                | Drag::RailResize(_),
+                | Drag::RailResize(_)
+                | Drag::SidebarSplit { .. },
             )
             | None => {}
             Some(Drag::PtyMouse { .. }) => unreachable!("PTY drag returned before take"),
@@ -21737,7 +22199,24 @@ impl App {
                     self.start_workspace_scrollbar_drag(track, total_rows, visible_rows, y);
                 }
                 Hit::RailResize(kind) => {
-                    self.drag = Some(Drag::RailResize(kind));
+                    // A horizontal split divider shares the left child's
+                    // border column; a press there re-shares the split
+                    // instead of resizing the whole column.
+                    if let Some(divider) = self
+                        .sidebar_layout
+                        .dividers
+                        .iter()
+                        .find(|divider| divider.rect.contains(x, y))
+                        .copied()
+                    {
+                        self.drag =
+                            Some(Drag::SidebarSplit { group: divider.group, index: divider.index });
+                    } else {
+                        self.drag = Some(Drag::RailResize(kind));
+                    }
+                }
+                Hit::SidebarSplitDivider { group, index } => {
+                    self.drag = Some(Drag::SidebarSplit { group, index });
                 }
                 Hit::PaneResize { horizontal, vertical } => {
                     let horizontal = horizontal
@@ -21980,22 +22459,37 @@ impl App {
             Some(Drag::RailResize(kind)) => {
                 let kind = *kind;
                 if let Some(width) = rail_drag_width(&self.config, &self.sidebar_layout, kind, x) {
-                    match kind {
-                        RailKind::Machine => self.machine_sidebar_width_override = Some(width),
-                        RailKind::Workspace => {
-                            self.sidebar_compact = false;
-                            self.sidebar_width_override = Some(width);
-                        }
-                        RailKind::Tabs => self.tabs_sidebar_width_override = Some(width),
-                        RailKind::Projection(index) => {
-                            if let Some(id) =
-                                self.config.sidebar.views.get(index).map(|view| view.id.clone())
-                            {
-                                self.projection_sidebar_width_overrides.insert(id, width);
+                    // Stacked rails share their column's width, so the drag
+                    // commits to the column key instead of the one rail.
+                    let shared_column = sidebar_column_for_rail(&self.sidebar_layout, kind)
+                        .map(|index| &self.sidebar_layout.columns[index])
+                        .filter(|column| column.rails.len() > 1)
+                        .map(|column| column.key.clone());
+                    if let Some(key) = shared_column {
+                        self.projection_sidebar_width_overrides.insert(key, width);
+                    } else {
+                        match kind {
+                            RailKind::Machine => self.machine_sidebar_width_override = Some(width),
+                            RailKind::Workspace => {
+                                self.sidebar_compact = false;
+                                self.sidebar_width_override = Some(width);
+                            }
+                            RailKind::Tabs => self.tabs_sidebar_width_override = Some(width),
+                            RailKind::Projection(index) => {
+                                if let Some(id) =
+                                    self.config.sidebar.views.get(index).map(|view| view.id.clone())
+                                {
+                                    self.projection_sidebar_width_overrides.insert(id, width);
+                                }
                             }
                         }
                     }
                 }
+                Ok(RenderAction::Draw)
+            }
+            Some(Drag::SidebarSplit { group, index }) => {
+                let (group, index) = (*group, *index);
+                self.drag_sidebar_split_divider(group, index, x, y);
                 Ok(RenderAction::Draw)
             }
             Some(Drag::ResizeSplit { horizontal, vertical }) => {
@@ -22010,6 +22504,53 @@ impl App {
             }
             None => Ok(RenderAction::None),
         }
+    }
+
+    /// Convert a divider drag into new share fractions for its split group.
+    /// Only the two children flanking the divider change; the rest keep
+    /// their rendered sizes.
+    fn drag_sidebar_split_divider(&mut self, group: usize, index: usize, x: u16, y: u16) {
+        use crate::config::SidebarSplitDir;
+        let Some(placement) = self.sidebar_layout.split_groups.get(group) else { return };
+        let Some(first) = placement.children.get(index).copied() else { return };
+        let Some(second) = placement.children.get(index + 1).copied() else { return };
+        let mut sizes: Vec<u16> = placement
+            .children
+            .iter()
+            .map(|child| match placement.dir {
+                SidebarSplitDir::Vertical => child.height,
+                SidebarSplitDir::Horizontal => child.width,
+            })
+            .collect();
+        let (combined, min_each, desired_first) = match placement.dir {
+            SidebarSplitDir::Vertical => (
+                first.height.saturating_add(second.height),
+                MIN_SPLIT_RAIL_HEIGHT,
+                // The divider row sits below the first child, so the row
+                // under the pointer becomes the first child's height.
+                y.saturating_sub(first.y),
+            ),
+            SidebarSplitDir::Horizontal => (
+                first.width.saturating_add(second.width),
+                MIN_RAIL_WIDTH,
+                // The border column belongs to the first child, matching
+                // column-width drags.
+                x.saturating_sub(first.x).saturating_add(1),
+            ),
+        };
+        if combined < min_each.saturating_mul(2) {
+            return;
+        }
+        let desired_first = desired_first.clamp(min_each, combined - min_each);
+        sizes[index] = desired_first;
+        sizes[index + 1] = combined - desired_first;
+        let total: f32 = sizes.iter().map(|size| f32::from(*size)).sum();
+        if total <= 0.0 {
+            return;
+        }
+        let id = placement.id.clone();
+        let fractions = sizes.iter().map(|size| f32::from(*size) / total).collect();
+        self.sidebar_split_fractions.insert(id, fractions);
     }
 
     fn handle_left_up(&mut self, x: u16, y: u16) -> anyhow::Result<RenderAction> {
@@ -22715,6 +23256,7 @@ impl App {
         let focused_view = self.focused_sidebar_view_id();
         self.config.sidebar.active_profile = profile.id;
         self.config.sidebar.views = profile.views;
+        self.config.sidebar.layout = profile.layout;
         self.config.sidebar.columns = self
             .config
             .sidebar
@@ -26275,12 +26817,19 @@ mod tests {
             width: 30,
             max_width: 0,
             collapse_priority: 30,
+            scope: crate::config::SidebarViewScope::Workspace,
         }];
         app.config.sidebar.profiles = vec![
-            SidebarProfileSpec { id: "full".into(), name: "Full".into(), views: full.clone() },
+            SidebarProfileSpec {
+                id: "full".into(),
+                name: "Full".into(),
+                layout: crate::config::sidebar_layout_of_columns(&full),
+                views: full.clone(),
+            },
             SidebarProfileSpec {
                 id: "focused".into(),
                 name: "Focused".into(),
+                layout: crate::config::sidebar_layout_of_columns(&focused),
                 views: focused.clone(),
             },
         ];
@@ -26331,6 +26880,7 @@ mod tests {
             None,
             None,
             &overrides,
+            &HashMap::new(),
             &HashSet::new(),
             None,
         );
@@ -26346,6 +26896,7 @@ mod tests {
             None,
             None,
             &overrides,
+            &HashMap::new(),
             &HashSet::new(),
             Some(&collapsed),
         );
@@ -26360,10 +26911,191 @@ mod tests {
             None,
             None,
             &overrides,
+            &HashMap::new(),
             &HashSet::new(),
             Some(&at_boundary),
         );
         assert!(revealed.machine.is_some());
+    }
+
+    fn split_sidebar_config() -> Config {
+        use crate::config::{
+            SidebarLayoutNode, SidebarSplitDir, SidebarSplitSpec, SidebarViewScope,
+        };
+        let mut config = Config::default();
+        config.sidebar.views = vec![
+            SidebarViewSpec::legacy(SidebarColumnKind::Workspaces, 26, 0),
+            SidebarViewSpec {
+                id: "all-agents".into(),
+                levels: vec![SidebarResourceKind::Agents],
+                actions: Vec::new(),
+                actions_position: crate::config::ActionsPosition::Bottom,
+                width: 26,
+                max_width: 0,
+                collapse_priority: 20,
+                scope: SidebarViewScope::All,
+            },
+        ];
+        config.sidebar.views_explicit = true;
+        config.sidebar.layout = vec![SidebarLayoutNode::Split(SidebarSplitSpec {
+            id: "left".into(),
+            dir: SidebarSplitDir::Vertical,
+            weights: vec![1, 1],
+            children: vec![SidebarLayoutNode::Leaf(0), SidebarLayoutNode::Leaf(1)],
+            width: 26,
+            max_width: 0,
+            collapse_priority: 30,
+        })];
+        config
+    }
+
+    #[test]
+    fn vertical_split_column_stacks_rails_around_a_divider_row() {
+        let config = split_sidebar_config();
+        let layout = sidebar_layout_for_state(
+            &config,
+            true,
+            false,
+            false,
+            (120, 31),
+            None,
+            None,
+            None,
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashSet::new(),
+            None,
+        );
+        assert_eq!(layout.columns.len(), 1);
+        assert_eq!(layout.ordered.len(), 2);
+        let top = layout.ordered[0].rect;
+        let bottom = layout.ordered[1].rect;
+        assert_eq!(layout.workspace, Some(top));
+        assert_eq!(layout.ordered[1].kind, RailKind::Projection(1));
+        assert_eq!((top.x, bottom.x), (0, 0));
+        assert_eq!(top.width, bottom.width);
+        assert_eq!(layout.dividers.len(), 1);
+        let divider = layout.dividers[0];
+        assert_eq!(divider.rect.y, top.y + top.height);
+        assert_eq!(bottom.y, divider.rect.y + 1);
+        assert_eq!(top.height + bottom.height + 1, 31, "children partition the full column");
+        assert_eq!(layout.content.x, top.width, "one column, one column width");
+    }
+
+    #[test]
+    fn split_fraction_overrides_replace_configured_weights() {
+        let config = split_sidebar_config();
+        let mut fractions = HashMap::new();
+        fractions.insert("left".to_string(), vec![0.2f32, 0.8f32]);
+        let layout = sidebar_layout_for_state(
+            &config,
+            true,
+            false,
+            false,
+            (120, 31),
+            None,
+            None,
+            None,
+            &HashMap::new(),
+            &fractions,
+            &HashSet::new(),
+            None,
+        );
+        let top = layout.ordered[0].rect;
+        let bottom = layout.ordered[1].rect;
+        assert_eq!(top.height, 6, "0.2 of the 30 shared rows");
+        assert_eq!(bottom.height, 24);
+    }
+
+    #[test]
+    fn hidden_split_pane_gives_the_column_to_the_remaining_rail() {
+        let config = split_sidebar_config();
+        let mut hidden = HashSet::new();
+        hidden.insert("all-agents".to_string());
+        let layout = sidebar_layout_for_state(
+            &config,
+            true,
+            false,
+            false,
+            (120, 31),
+            None,
+            None,
+            None,
+            &HashMap::new(),
+            &HashMap::new(),
+            &hidden,
+            None,
+        );
+        assert_eq!(layout.ordered.len(), 1);
+        assert!(layout.dividers.is_empty());
+        assert_eq!(layout.ordered[0].rect.height, 31);
+    }
+
+    #[test]
+    fn sidebar_split_divider_drag_re_shares_the_column() {
+        let mux = Mux::new("sidebar-split-drag-test", SurfaceOptions::default());
+        let mut app = test_app(Session::Local(mux));
+        app.config = split_sidebar_config();
+        app.sync_layout((120, 31));
+        assert_eq!(app.sidebar_layout.dividers.len(), 1);
+
+        app.drag_sidebar_split_divider(0, 0, 0, 9);
+        app.sync_layout((120, 31));
+        let top = app.sidebar_layout.ordered[0].rect;
+        let bottom = app.sidebar_layout.ordered[1].rect;
+        assert_eq!(top.height, 9, "the dragged divider row becomes the boundary");
+        assert_eq!(top.height + bottom.height, 30);
+
+        // The two rails clamp at their minimum height.
+        app.drag_sidebar_split_divider(0, 0, 0, 0);
+        app.sync_layout((120, 31));
+        assert_eq!(app.sidebar_layout.ordered[0].rect.height, MIN_SPLIT_RAIL_HEIGHT);
+    }
+
+    #[test]
+    fn focus_moves_vertically_between_stacked_rails() {
+        let mux = Mux::new("sidebar-split-focus-test", SurfaceOptions::default());
+        let mut app = test_app(Session::Local(mux));
+        app.config = split_sidebar_config();
+        app.sync_layout((120, 31));
+
+        app.focus = FocusTarget::WorkspaceRail;
+        assert!(app.move_focus_between_sidebar_rails(Direction::Down));
+        assert_eq!(app.focus, FocusTarget::ProjectionRail(1));
+        assert!(app.move_focus_between_sidebar_rails(Direction::Up));
+        assert_eq!(app.focus, FocusTarget::WorkspaceRail);
+        assert!(
+            !app.move_focus_between_sidebar_rails(Direction::Up),
+            "no rail above the top of the column"
+        );
+    }
+
+    #[test]
+    fn rail_width_drag_on_a_stacked_rail_resizes_the_whole_column() {
+        let mux = Mux::new("sidebar-split-width-test", SurfaceOptions::default());
+        let mut app = test_app(Session::Local(mux));
+        app.config = split_sidebar_config();
+        app.sync_layout((120, 31));
+
+        app.drag = Some(Drag::RailResize(RailKind::Projection(1)));
+        app.handle_mouse(MouseEvent {
+            kind: MouseEventKind::Drag(MouseButton::Left),
+            column: 33,
+            row: 25,
+            modifiers: KeyModifiers::NONE,
+        })
+        .unwrap();
+        app.sync_layout((120, 31));
+        assert_eq!(
+            app.projection_sidebar_width_overrides.get("left").copied(),
+            Some(34),
+            "the override commits under the split group id"
+        );
+        let top = app.sidebar_layout.ordered[0].rect;
+        let bottom = app.sidebar_layout.ordered[1].rect;
+        assert_eq!(top.width, 34);
+        assert_eq!(bottom.width, 34);
+        app.drag = None;
     }
 
     #[test]
@@ -41607,6 +42339,7 @@ mod tests {
             width: 40,
             max_width: 0,
             collapse_priority: 30,
+            scope: crate::config::SidebarViewScope::Workspace,
         }];
         app.config.sidebar.views_explicit = true;
         app.replace_tree(app.session.tree());
@@ -41685,6 +42418,7 @@ mod tests {
             width: 40,
             max_width: 0,
             collapse_priority: 30,
+            scope: crate::config::SidebarViewScope::Workspace,
         }];
         app.config.sidebar.views_explicit = true;
         app.replace_tree(app.session.tree());
@@ -41720,6 +42454,7 @@ mod tests {
             width: 40,
             max_width: 0,
             collapse_priority: 30,
+            scope: crate::config::SidebarViewScope::Workspace,
         }];
         app.config.sidebar.views_explicit = true;
         app.replace_tree(app.session.tree());
@@ -41758,6 +42493,7 @@ mod tests {
             width: 40,
             max_width: 0,
             collapse_priority: 30,
+            scope: crate::config::SidebarViewScope::Workspace,
         }];
         app.config.sidebar.views_explicit = true;
         app.replace_tree(app.session.tree());
@@ -41909,6 +42645,7 @@ mod tests {
             width: 40,
             max_width: 0,
             collapse_priority: 30,
+            scope: crate::config::SidebarViewScope::Workspace,
         }];
         app.config.sidebar.views_explicit = true;
         app.replace_tree(app.session.tree());
@@ -42008,6 +42745,7 @@ mod tests {
             width: 40,
             max_width: 0,
             collapse_priority: 30,
+            scope: crate::config::SidebarViewScope::Workspace,
         }];
         app.config.sidebar.views_explicit = true;
         app.sync_layout((100, 12));
@@ -43929,6 +44667,7 @@ mod tests {
             machine_sidebar_width_override: None,
             tabs_sidebar_width_override: None,
             projection_sidebar_width_overrides: HashMap::new(),
+            sidebar_split_fractions: HashMap::new(),
             hidden_sidebar_views: HashMap::new(),
             content_area: Rect::default(),
             hits: Vec::new(),

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -56,7 +56,7 @@ use crate::browser_input::{
 };
 use crate::config::{
     Action, ChromeTheme, Config, ScrollbarPosition, SidebarColumn, SidebarColumnKind,
-    SidebarResourceKind, SidebarView, SidebarViewScope, SidebarViewSpec,
+    SidebarLayoutNode, SidebarResourceKind, SidebarView, SidebarViewScope, SidebarViewSpec,
 };
 use crate::keys;
 use crate::localization;
@@ -114,6 +114,27 @@ struct ProjectionFocusKey {
 enum ProjectionSurfaceChange {
     Agent,
     Title,
+}
+
+/// The part of the sidebar configuration that changes the meaning of cached
+/// projection rows. Keep this identity separate from the full config so a
+/// profile switch cannot reuse rows for a view with the same id but a new
+/// level or action definition.
+#[derive(Clone, PartialEq, Eq)]
+struct SidebarProjectionSpec {
+    profile_id: String,
+    views: Vec<SidebarViewSpec>,
+    layout: Vec<SidebarLayoutNode>,
+}
+
+impl SidebarProjectionSpec {
+    fn from_config(config: &Config) -> Self {
+        Self {
+            profile_id: config.sidebar.active_profile.clone(),
+            views: config.sidebar.views.clone(),
+            layout: config.sidebar.layout.clone(),
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -10396,6 +10417,31 @@ impl App {
         self.projection_paint_pending = false;
     }
 
+    fn invalidate_projection_rows_if_sidebar_spec_changed(
+        &mut self,
+        previous: SidebarProjectionSpec,
+    ) {
+        if previous != SidebarProjectionSpec::from_config(&self.config) {
+            self.invalidate_projection_rows_cache();
+        }
+    }
+
+    /// Replace the active profile's projection specification and invalidate
+    /// snapshots in one place. View ids are profile-local, so a reused id may
+    /// describe a different resource tree after the replacement.
+    fn replace_sidebar_projection(
+        &mut self,
+        profile_id: String,
+        views: Vec<SidebarViewSpec>,
+        layout: Vec<SidebarLayoutNode>,
+    ) {
+        let previous = SidebarProjectionSpec::from_config(&self.config);
+        self.config.sidebar.active_profile = profile_id;
+        self.config.sidebar.views = views;
+        self.config.sidebar.layout = layout;
+        self.invalidate_projection_rows_if_sidebar_spec_changed(previous);
+    }
+
     /// Drop only snapshots that depend on the changed surface. The event
     /// stream can deliver several updates before the next frame, so return
     /// whether this surface needs to schedule the first paint boundary.
@@ -14217,6 +14263,7 @@ impl App {
         {
             self.config_reload_applications += 1;
         }
+        let previous_projection = SidebarProjectionSpec::from_config(&self.config);
         let focused_projection_id = match self.focus {
             FocusTarget::ProjectionRail(index) => {
                 self.config.sidebar.views.get(index).map(|view| view.id.clone())
@@ -14235,7 +14282,7 @@ impl App {
         self.session.apply_config(config.clone());
         self.sidebar_view = config.sidebar.view;
         self.config = config;
-        self.invalidate_projection_rows_cache();
+        self.invalidate_projection_rows_if_sidebar_spec_changed(previous_projection);
         let mut valid_view_ids =
             self.config.sidebar.views.iter().map(|view| view.id.clone()).collect::<HashSet<_>>();
         self.projection_rails.retain(|id, _| valid_view_ids.contains(id));
@@ -23397,9 +23444,7 @@ impl App {
     fn activate_sidebar_profile(&mut self, index: usize) {
         let Some(profile) = self.config.sidebar.profiles.get(index).cloned() else { return };
         let focused_view = self.focused_sidebar_view_id();
-        self.config.sidebar.active_profile = profile.id;
-        self.config.sidebar.views = profile.views;
-        self.config.sidebar.layout = profile.layout;
+        self.replace_sidebar_projection(profile.id, profile.views, profile.layout);
         self.config.sidebar.columns = self
             .config
             .sidebar
@@ -27002,6 +27047,75 @@ mod tests {
         app.activate_sidebar_profile(0);
         app.sync_layout((120, 20));
         assert!(app.sidebar_layout.tabs.is_none());
+    }
+
+    #[test]
+    fn profile_switch_rebuilds_projection_when_view_id_is_reused() {
+        let (mux, surface) = test_mux("sidebar-profile-projection-cache-test", None);
+        mux.report_agent(
+            surface.id,
+            AgentState::Working,
+            AgentSource::Hook,
+            Some("agent-session".into()),
+        )
+        .unwrap();
+
+        let tabs_view = SidebarViewSpec {
+            id: "shared-view".into(),
+            levels: vec![SidebarResourceKind::Tabs],
+            actions: Vec::new(),
+            actions_position: crate::config::ActionsPosition::Bottom,
+            width: 30,
+            max_width: 0,
+            collapse_priority: 30,
+            scope: crate::config::SidebarViewScope::Workspace,
+        };
+        let agents_view = SidebarViewSpec {
+            id: "shared-view".into(),
+            levels: vec![SidebarResourceKind::Agents],
+            actions: vec![crate::config::SidebarActionSpec::plain(Action::NewWorkspace)],
+            actions_position: crate::config::ActionsPosition::Bottom,
+            width: 30,
+            max_width: 0,
+            collapse_priority: 30,
+            scope: crate::config::SidebarViewScope::Workspace,
+        };
+        let tabs_profile = SidebarProfileSpec {
+            id: "tabs".into(),
+            name: "Tabs".into(),
+            layout: crate::config::sidebar_layout_of_columns(std::slice::from_ref(&tabs_view)),
+            views: vec![tabs_view],
+        };
+        let agents_profile = SidebarProfileSpec {
+            id: "agents".into(),
+            name: "Agents".into(),
+            layout: crate::config::sidebar_layout_of_columns(std::slice::from_ref(&agents_view)),
+            views: vec![agents_view],
+        };
+
+        let mut app = test_app(Session::Local(mux.clone()));
+        app.config.sidebar.columns.clear();
+        app.config.sidebar.profiles = vec![tabs_profile.clone(), agents_profile.clone()];
+        app.config.sidebar.active_profile = tabs_profile.id.clone();
+        app.config.sidebar.views = tabs_profile.views.clone();
+        app.config.sidebar.layout = tabs_profile.layout.clone();
+        app.config.sidebar.views_explicit = true;
+        app.replace_tree(app.session.tree());
+
+        let tabs_rows = app.projection_rows(0);
+        assert!(tabs_rows.iter().any(|row| row.resource == SidebarResourceKind::Tabs));
+
+        app.activate_sidebar_profile(1);
+
+        let agent_rows = app.projection_rows(0);
+        assert!(agent_rows.iter().any(|row| row.resource == SidebarResourceKind::Agents));
+        assert!(
+            app.sidebar_action_rows(0)
+                .iter()
+                .any(|row| row.target == SidebarActionTarget::CreateWorkspace(None))
+        );
+
+        mux.close_surface(surface.id).unwrap();
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -2420,6 +2420,12 @@ impl OrderedSession {
         self.inner.daemon_shutdown_requested()
     }
 
+    /// The first reason recorded when a remote transport reader stopped, or
+    /// `None` for local sessions and deliberate local disconnects.
+    fn transport_disconnect_reason(&self) -> Option<String> {
+        self.inner.transport_disconnect_reason()
+    }
+
     fn attach_surface(&self, id: SurfaceId, size: Option<(u16, u16)>) {
         if self.remote
             && let Some(size) = size
@@ -12434,34 +12440,41 @@ impl App {
         self.encode_buf.clear();
     }
 
-    fn request_current_machine_session(&mut self) -> bool {
+    /// A machine that is sleeping or stopped lost its stream BECAUSE it was
+    /// paused; reconnecting would start it right back up and make pause
+    /// impossible. Present it as asleep instead - the user's next input (or
+    /// a rail click) wakes it through the normal switch path.
+    fn present_machine_as_asleep_after_stream_loss(&mut self) -> bool {
         let Some(machine) = self.machine_ui.as_mut() else { return false };
-        // A machine that is sleeping or stopped lost its stream BECAUSE it
-        // was paused; reconnecting would start it right back up and make
-        // pause impossible. Present it as asleep instead - the user's next
-        // input (or a rail click) wakes it through the normal switch path.
-        if let Some(active) = machine.snapshot.active
-            && machine.snapshot.machines.iter().any(|descriptor| {
-                descriptor.key == active
-                    && matches!(
-                        descriptor.status,
-                        crate::machine::MachineStatus::Sleeping
-                            | crate::machine::MachineStatus::Stopped
-                    )
-            })
-        {
-            crate::client_log::info(
-                "machine",
-                &format!("stream lost for sleeping machine {}; presenting as asleep", active.0),
-            );
-            machine.session_available = false;
-            machine.set_connection_phase(active, MachineConnectionPhase::Disconnected);
-            // The previous open's narration is stale now; a later wake
-            // reuses the same selection intent, so select_machine_intent
-            // will not clear it.
-            machine.clear_connection_progress(active);
+        let Some(active) = machine.snapshot.active else { return false };
+        if !machine.snapshot.machines.iter().any(|descriptor| {
+            descriptor.key == active
+                && matches!(
+                    descriptor.status,
+                    crate::machine::MachineStatus::Sleeping
+                        | crate::machine::MachineStatus::Stopped
+                )
+        }) {
+            return false;
+        }
+        crate::client_log::info(
+            "machine",
+            &format!("stream lost for sleeping machine {}; presenting as asleep", active.0),
+        );
+        machine.session_available = false;
+        machine.set_connection_phase(active, MachineConnectionPhase::Disconnected);
+        // The previous open's narration is stale now; a later wake
+        // reuses the same selection intent, so select_machine_intent
+        // will not clear it.
+        machine.clear_connection_progress(active);
+        true
+    }
+
+    fn request_current_machine_session(&mut self) -> bool {
+        if self.present_machine_as_asleep_after_stream_loss() {
             return true;
         }
+        let Some(machine) = self.machine_ui.as_mut() else { return false };
         if machine.request.is_none() {
             let request = machine
                 .snapshot
@@ -15720,6 +15733,26 @@ impl App {
                 Ok(self.apply_machine_controller_completion(*completion))
             }
             AppEvent::Mux(MuxEvent::Empty) => {
+                // A genuinely emptied workspace list and a dead event
+                // transport both end the event stream with this event, but
+                // only the former is a clean exit. The remote reader records
+                // why it stopped; consult that BEFORE any machine-session
+                // request so a machine or provider surface cannot swallow the
+                // dead transport into a stuck reconnect (issue 11042). A
+                // deliberate local disconnect records no reason. The one
+                // machine response that outranks the error is a sleeping or
+                // stopped machine, whose stream loss is the designed result
+                // of pausing it.
+                if let Some(reason) = self.session.transport_disconnect_reason() {
+                    if self.present_machine_as_asleep_after_stream_loss() {
+                        return Ok(RenderAction::Draw);
+                    }
+                    crate::client_log::error(
+                        "session",
+                        &format!("remote event transport lost: {reason}"),
+                    );
+                    anyhow::bail!(localization::catalog().runtime.session_transport_lost());
+                }
                 if self.request_current_machine_session() {
                     return Ok(RenderAction::Draw);
                 }
@@ -24862,7 +24895,7 @@ mod tests {
         ClientInfo, ClientSizeInfo, RemoteSession, Session, SidebarPluginSurface, SurfaceAttach,
         SurfaceHandle, TreeView, test_remote_session_with_deferred_attach,
         test_remote_session_with_deferred_attach_and_first_resize_failure,
-        test_remote_session_with_deferred_sized_attach,
+        test_remote_session_with_deferred_sized_attach, test_remote_session_with_lost_transport,
     };
 
     #[test]
@@ -44942,6 +44975,80 @@ mod tests {
         assert_eq!(app.session_generation, 2);
         assert!(app.machine_ui.as_ref().unwrap().request.is_none());
         assert!(!app.quit);
+    }
+
+    /// Regression test for issue 11042: when a remote event transport dies,
+    /// the reader thread records the reason and synthesizes `MuxEvent::Empty`.
+    /// That must surface the transport failure as an error, never the "session
+    /// has no workspaces" clean quit (exit code 0) it produces today.
+    #[test]
+    fn transport_loss_empty_event_is_an_error_not_a_clean_quit() {
+        let reason = "the daemon closed the connection";
+        let mut app = test_app(test_remote_session_with_lost_transport(reason));
+
+        let result = app.handle(AppEvent::Mux(MuxEvent::Empty));
+
+        let error = result.expect_err("a lost event transport must not report an empty session");
+        assert_eq!(error.to_string(), "session connection lost. Reconnect and retry.");
+        assert!(!error.to_string().contains(reason));
+        assert!(!app.quit, "a lost transport must not use the clean-quit path");
+    }
+
+    /// The transport check must run BEFORE any machine-session request: with
+    /// machine/provider authority present, `request_current_machine_session`
+    /// returns true and would otherwise swallow the dead transport into a
+    /// stuck reconnect state.
+    #[test]
+    fn transport_loss_outranks_a_machine_session_request() {
+        let reason = "the daemon closed the connection";
+        let mut app = test_app(test_remote_session_with_lost_transport(reason));
+        app.machine_ui = Some(provider_machine_ui());
+
+        let result = app.handle(AppEvent::Mux(MuxEvent::Empty));
+
+        let error = result.expect_err("machine authority must not hide a lost transport");
+        assert_eq!(error.to_string(), "session connection lost. Reconnect and retry.");
+        assert!(!error.to_string().contains(reason));
+        assert!(!app.quit);
+        let machine = app.machine_ui.as_ref().unwrap();
+        assert!(
+            machine.request.is_none(),
+            "no reconnect request may be queued for a dead transport"
+        );
+    }
+
+    /// A sleeping or stopped machine loses its stream because it was paused;
+    /// that deliberate loss keeps presenting the machine as asleep instead of
+    /// failing the client, even though a transport reason is recorded.
+    #[test]
+    fn sleeping_machine_stream_loss_still_presents_as_asleep() {
+        let mut app =
+            test_app(test_remote_session_with_lost_transport("the daemon closed the connection"));
+        let mut ui = provider_machine_ui();
+        ui.snapshot.machines[0].status = MachineStatus::Sleeping;
+        app.machine_ui = Some(ui);
+
+        let action = app.handle(AppEvent::Mux(MuxEvent::Empty)).unwrap();
+
+        assert_eq!(action, RenderAction::Draw);
+        assert!(!app.quit);
+        let machine = app.machine_ui.as_ref().unwrap();
+        assert!(!machine.session_available);
+        assert!(machine.request.is_none());
+    }
+
+    /// A genuinely emptied session (all workspaces closed) still exits
+    /// cleanly: `MuxEvent::Empty` without a recorded transport failure keeps
+    /// the quiet quit path.
+    #[test]
+    fn empty_session_without_transport_loss_still_quits_cleanly() {
+        let mux = Mux::new("empty-clean-quit-test", SurfaceOptions::default());
+        let mut app = test_app(Session::Local(mux));
+
+        let action = app.handle(AppEvent::Mux(MuxEvent::Empty)).unwrap();
+
+        assert_eq!(action, RenderAction::None);
+        assert!(app.quit);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -56,7 +56,7 @@ use crate::browser_input::{
 };
 use crate::config::{
     Action, ChromeTheme, Config, ScrollbarPosition, SidebarColumn, SidebarColumnKind,
-    SidebarResourceKind, SidebarView, SidebarViewSpec,
+    SidebarResourceKind, SidebarView, SidebarViewScope, SidebarViewSpec,
 };
 use crate::keys;
 use crate::localization;
@@ -101,15 +101,112 @@ use crate::ui::{
 const DEFERRED_INPUT_CAPACITY: usize = 512;
 const MAX_PROJECTION_ROWS_CACHE_ENTRIES: usize = 8;
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct ProjectionFocusKey {
+    workspace_id: Option<WorkspaceId>,
+    screen_id: Option<ScreenId>,
+    pane_id: Option<PaneId>,
+    tab_index: Option<usize>,
+    surface_id: Option<SurfaceId>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ProjectionSurfaceChange {
+    Agent,
+    Title,
+}
+
 #[derive(Clone)]
 struct ProjectionRowsCache {
     view_id: String,
     workspace_revision: u64,
     pane_revision: Option<u64>,
-    agent_revision: u64,
     invalidation_revision: u64,
     selected_workspace: usize,
+    focus: ProjectionFocusKey,
+    /// All surfaces that can contribute an agent row to this snapshot. This
+    /// includes currently hidden/filtered rows so an agent state transition
+    /// cannot leave an old empty snapshot cached.
+    agent_surfaces: HashSet<SurfaceId>,
+    /// Surfaces whose title can affect a visible row in this snapshot.
+    title_surfaces: HashSet<SurfaceId>,
     rows: Vec<ProjectionRow>,
+}
+
+fn projection_focus_key(tree: &TreeView) -> ProjectionFocusKey {
+    let Some(workspace) = tree.active_workspace() else { return ProjectionFocusKey::default() };
+    let Some(screen) = workspace.active_screen_ref() else {
+        return ProjectionFocusKey {
+            workspace_id: Some(workspace.id),
+            ..ProjectionFocusKey::default()
+        };
+    };
+    let pane = screen.pane(screen.active_pane);
+    ProjectionFocusKey {
+        workspace_id: Some(workspace.id),
+        screen_id: Some(screen.id),
+        pane_id: Some(screen.active_pane),
+        tab_index: pane.map(|pane| pane.active_tab),
+        surface_id: pane.and_then(|pane| pane.active_surface()),
+    }
+}
+
+fn projection_cache_dependencies(
+    spec: &SidebarViewSpec,
+    tree: &TreeView,
+    rows: &[ProjectionRow],
+    selected_workspace: usize,
+) -> (HashSet<SurfaceId>, HashSet<SurfaceId>) {
+    let selected_workspace = selected_workspace.min(tree.workspaces.len().saturating_sub(1));
+    let mut agent_surfaces = HashSet::new();
+    if spec.includes(SidebarResourceKind::Agents) {
+        // A nested agent level below Workspaces contributes rows from every
+        // workspace. A flat workspace-scoped level follows the selected one.
+        let agent_depth = spec.levels.iter().position(|kind| *kind == SidebarResourceKind::Agents);
+        let all_workspaces = spec.scope == SidebarViewScope::All
+            || agent_depth.is_some_and(|depth| {
+                spec.levels[..depth].contains(&SidebarResourceKind::Workspaces)
+            });
+        for (workspace_index, workspace) in tree.workspaces.iter().enumerate() {
+            if !all_workspaces && workspace_index != selected_workspace {
+                continue;
+            }
+            for screen in &workspace.screens {
+                for pane in &screen.panes {
+                    agent_surfaces.extend(pane.tabs.iter().map(|tab| tab.surface));
+                }
+            }
+        }
+    }
+
+    let active_surfaces_by_pane = if spec.includes(SidebarResourceKind::Panes) {
+        tree.workspaces
+            .iter()
+            .flat_map(|workspace| workspace.screens.iter())
+            .flat_map(|screen| screen.panes.iter())
+            .filter_map(|pane| pane.active_surface().map(|surface| (pane.id, surface)))
+            .collect::<HashMap<_, _>>()
+    } else {
+        HashMap::new()
+    };
+    let mut title_surfaces = HashSet::new();
+    for row in rows {
+        match (row.resource, row.target) {
+            (
+                SidebarResourceKind::Tabs | SidebarResourceKind::Agents,
+                ProjectionTarget::Surface { surface, .. },
+            ) => {
+                title_surfaces.insert(surface);
+            }
+            (SidebarResourceKind::Panes, ProjectionTarget::Pane { pane, .. }) => {
+                if let Some(surface) = active_surfaces_by_pane.get(&pane) {
+                    title_surfaces.insert(*surface);
+                }
+            }
+            _ => {}
+        }
+    }
+    (agent_surfaces, title_surfaces)
 }
 
 // Projection rows are a render snapshot. Keep only the most recently used
@@ -6942,7 +7039,13 @@ pub struct App {
     projection_rails: HashMap<String, ProjectionRailState>,
     projection_rows_cache: VecDeque<ProjectionRowsCache>,
     projection_rows_revision: u64,
-    projection_agent_revision: u64,
+    /// Projection surfaces seen by the most recent rendered snapshots. These
+    /// sets cover caches evicted by the bounded LRU, so an update still wakes
+    /// a visible rail even when its snapshot is not retained.
+    projection_agent_surfaces: HashSet<SurfaceId>,
+    projection_title_surfaces: HashSet<SurfaceId>,
+    /// Coalesce surface updates until the next successful rendered frame.
+    projection_paint_pending: bool,
     pub(crate) machine_rail_follow_selection: bool,
     pub(crate) workspace_rail_follow_selection: bool,
     pub(crate) tabs_rail_follow_selection: bool,
@@ -9454,7 +9557,9 @@ fn run_with_machine_updates_inner(
         projection_rails: HashMap::new(),
         projection_rows_cache: VecDeque::new(),
         projection_rows_revision: 0,
-        projection_agent_revision: 0,
+        projection_agent_surfaces: HashSet::new(),
+        projection_title_surfaces: HashSet::new(),
+        projection_paint_pending: false,
         machine_rail_follow_selection: true,
         workspace_rail_follow_selection: true,
         tabs_rail_follow_selection: true,
@@ -10212,46 +10317,48 @@ impl App {
             .get(&spec.id)
             .map(|state| state.collapsed.clone())
             .unwrap_or_default();
-        let agents = if spec.includes(SidebarResourceKind::Agents) {
-            // Finished reports are historical records, not active agents.
-            // Otherwise detached "surface..." rows remain forever after exit.
-            // An `all`-scoped view is a chronological status board, so it
-            // keeps done agents; unknown stays out everywhere.
-            let keep_done = spec.scope == crate::config::SidebarViewScope::All;
-            self.session
-                .agents()
-                .into_iter()
-                .filter(|agent| match agent.state.as_str() {
-                    "unknown" => false,
-                    "done" => keep_done,
-                    _ => true,
-                })
-                .collect::<Vec<_>>()
-        } else {
-            Vec::new()
-        };
         let selected_workspace = self.sidebar_workspace_selection;
         let workspace_revision = self.tree.workspace_revision;
         let pane_revision = self.tree.pane_revision;
-        let agent_revision = self.projection_agent_revision;
         let invalidation_revision = self.projection_rows_revision;
+        let focus = projection_focus_key(&self.tree);
         let cache_index = self.projection_rows_cache.iter().position(|cache| {
             cache.view_id == spec.id
                 && cache.workspace_revision == workspace_revision
                 && cache.pane_revision == pane_revision
-                && cache.agent_revision == agent_revision
                 && cache.invalidation_revision == invalidation_revision
                 && cache.selected_workspace == selected_workspace
+                && cache.focus == focus
         });
         let rows = if let Some(cache_index) = cache_index {
             let cache = self
                 .projection_rows_cache
                 .remove(cache_index)
                 .expect("projection cache index came from the cache");
+            self.projection_agent_surfaces.extend(cache.agent_surfaces.iter().copied());
+            self.projection_title_surfaces.extend(cache.title_surfaces.iter().copied());
             let rows = cache.rows.clone();
             self.projection_rows_cache.push_front(cache);
             rows
         } else {
+            let agents = if spec.includes(SidebarResourceKind::Agents) {
+                // Finished reports are historical records, not active agents.
+                // Otherwise detached "surface..." rows remain forever after exit.
+                // An `all`-scoped view is a chronological status board, so it
+                // keeps done agents; unknown stays out everywhere.
+                let keep_done = spec.scope == crate::config::SidebarViewScope::All;
+                self.session
+                    .agents()
+                    .into_iter()
+                    .filter(|agent| match agent.state.as_str() {
+                        "unknown" => false,
+                        "done" => keep_done,
+                        _ => true,
+                    })
+                    .collect::<Vec<_>>()
+            } else {
+                Vec::new()
+            };
             let rows = crate::sidebar_projection::rows(
                 &spec,
                 &self.tree,
@@ -10259,13 +10366,19 @@ impl App {
                 selected_workspace,
                 &collapsed,
             );
+            let (agent_surfaces, title_surfaces) =
+                projection_cache_dependencies(&spec, &self.tree, &rows, selected_workspace);
+            self.projection_agent_surfaces.extend(agent_surfaces.iter().copied());
+            self.projection_title_surfaces.extend(title_surfaces.iter().copied());
             self.projection_rows_cache.push_front(ProjectionRowsCache {
                 view_id: spec.id.clone(),
                 workspace_revision,
                 pane_revision,
-                agent_revision,
                 invalidation_revision,
                 selected_workspace,
+                focus,
+                agent_surfaces,
+                title_surfaces,
                 rows: rows.clone(),
             });
             self.projection_rows_cache.truncate(MAX_PROJECTION_ROWS_CACHE_ENTRIES);
@@ -10278,11 +10391,48 @@ impl App {
     fn invalidate_projection_rows_cache(&mut self) {
         self.projection_rows_revision = self.projection_rows_revision.wrapping_add(1);
         self.projection_rows_cache.clear();
+        self.projection_agent_surfaces.clear();
+        self.projection_title_surfaces.clear();
+        self.projection_paint_pending = false;
     }
 
-    fn invalidate_agent_projection_rows_cache(&mut self) {
-        self.projection_agent_revision = self.projection_agent_revision.wrapping_add(1);
-        self.invalidate_projection_rows_cache();
+    /// Drop only snapshots that depend on the changed surface. The event
+    /// stream can deliver several updates before the next frame, so return
+    /// whether this surface needs to schedule the first paint boundary.
+    fn invalidate_projection_rows_for_surface(
+        &mut self,
+        surface: SurfaceId,
+        change: ProjectionSurfaceChange,
+    ) -> bool {
+        let was_affected = self.projection_rows_cache.iter().any(|cache| match change {
+            ProjectionSurfaceChange::Agent => cache.agent_surfaces.contains(&surface),
+            ProjectionSurfaceChange::Title => cache.title_surfaces.contains(&surface),
+        });
+        self.projection_rows_cache.retain(|cache| match change {
+            ProjectionSurfaceChange::Agent => !cache.agent_surfaces.contains(&surface),
+            ProjectionSurfaceChange::Title => !cache.title_surfaces.contains(&surface),
+        });
+        let visible = match change {
+            ProjectionSurfaceChange::Agent => self.projection_agent_surfaces.contains(&surface),
+            ProjectionSurfaceChange::Title => self.projection_title_surfaces.contains(&surface),
+        };
+        if !(was_affected || visible) || self.projection_paint_pending {
+            return false;
+        }
+        self.projection_paint_pending = true;
+        true
+    }
+
+    fn schedule_projection_paint(&mut self) -> bool {
+        if self.projection_paint_pending {
+            return false;
+        }
+        self.projection_paint_pending = true;
+        true
+    }
+
+    fn clear_pending_projection_paint(&mut self) {
+        self.projection_paint_pending = false;
     }
 
     pub(crate) fn sidebar_action_rows(&self, index: usize) -> Vec<SidebarActionRow> {
@@ -13160,21 +13310,21 @@ impl App {
         RenderAction::Draw
     }
 
-    fn apply_mux_titles(&mut self) -> bool {
+    fn apply_mux_titles(&mut self) -> HashSet<SurfaceId> {
         let titles = self.mux_titles.take_dirty();
         self.apply_mux_title_snapshot(titles)
     }
 
     fn reapply_mux_titles(&mut self) -> bool {
         let titles = self.mux_titles.snapshot();
-        self.apply_mux_title_snapshot(titles)
+        !self.apply_mux_title_snapshot(titles).is_empty()
     }
 
-    fn apply_mux_title_snapshot(&mut self, titles: HashMap<SurfaceId, Arc<str>>) -> bool {
-        if titles.is_empty() {
-            return false;
-        }
-        let mut changed = false;
+    fn apply_mux_title_snapshot(
+        &mut self,
+        titles: HashMap<SurfaceId, Arc<str>>,
+    ) -> HashSet<SurfaceId> {
+        let mut changed = HashSet::new();
         for (surface, title) in titles {
             let Some([workspace, screen, pane, tab]) = self.tab_locations.get(&surface).copied()
             else {
@@ -13192,7 +13342,7 @@ impl App {
             };
             if tab.title.as_str() != title.as_ref() {
                 tab.title = title.to_string();
-                changed = true;
+                changed.insert(surface);
             }
         }
         changed
@@ -13465,6 +13615,7 @@ impl App {
                 crate::ui::draw(self, frame);
             })
         })??;
+        self.clear_pending_projection_paint();
         if self.graphics_host_scene_reset_pending {
             if let Some(writer) = &self.graphics_writer {
                 writer.invalidate_host_scene();
@@ -15215,10 +15366,18 @@ impl App {
             AppEvent::GraphicsWriterReady => Ok(self.apply_graphics_completion()),
             AppEvent::MuxTitlesReady => {
                 let changed = self.apply_mux_titles();
-                if changed {
-                    self.invalidate_projection_rows_cache();
+                let changed_any = !changed.is_empty();
+                for surface in changed {
+                    self.invalidate_projection_rows_for_surface(
+                        surface,
+                        ProjectionSurfaceChange::Title,
+                    );
                 }
-                Ok(if changed { RenderAction::Paint } else { RenderAction::None })
+                Ok(if changed_any && self.schedule_projection_paint() {
+                    RenderAction::Paint
+                } else {
+                    RenderAction::None
+                })
             }
             AppEvent::StatusCommandsUpdated => {
                 self.status_poke_pending.store(false, Ordering::Release);
@@ -15429,14 +15588,24 @@ impl App {
                     Ok(RenderAction::Paint)
                 }
             }
-            AppEvent::Mux(MuxEvent::AgentChanged { .. }) => {
-                self.invalidate_agent_projection_rows_cache();
-                Ok(RenderAction::Draw)
-            }
-            AppEvent::Mux(MuxEvent::TitleChanged { .. }) => {
-                self.invalidate_projection_rows_cache();
-                Ok(RenderAction::Draw)
-            }
+            AppEvent::Mux(MuxEvent::AgentChanged { surface, .. }) => Ok(
+                if self
+                    .invalidate_projection_rows_for_surface(surface, ProjectionSurfaceChange::Agent)
+                {
+                    RenderAction::Paint
+                } else {
+                    RenderAction::None
+                },
+            ),
+            AppEvent::Mux(MuxEvent::TitleChanged { surface, .. }) => Ok(
+                if self
+                    .invalidate_projection_rows_for_surface(surface, ProjectionSurfaceChange::Title)
+                {
+                    RenderAction::Paint
+                } else {
+                    RenderAction::None
+                },
+            ),
             AppEvent::Mux(MuxEvent::PairingRequested(challenge)) => {
                 let duplicate = self
                     .pairing_dialog
@@ -42190,6 +42359,216 @@ mod tests {
     }
 
     #[test]
+    fn projection_agent_update_keeps_an_unrelated_workspace_cache() {
+        let (mux, first) = test_mux("projection-agent-cache-scope-test", None);
+        let second = mux.new_workspace(Some("second".into()), Some((20, 8))).unwrap();
+        let mut app = test_app(Session::Local(mux.clone()));
+        app.config.sidebar.columns.clear();
+        app.config.sidebar.views = vec![
+            SidebarViewSpec {
+                id: "agents-first".into(),
+                levels: vec![SidebarResourceKind::Agents],
+                actions: Vec::new(),
+                actions_position: crate::config::ActionsPosition::Bottom,
+                width: 40,
+                max_width: 0,
+                collapse_priority: 30,
+                scope: crate::config::SidebarViewScope::Workspace,
+            },
+            SidebarViewSpec {
+                id: "agents-second".into(),
+                levels: vec![SidebarResourceKind::Agents],
+                actions: Vec::new(),
+                actions_position: crate::config::ActionsPosition::Bottom,
+                width: 40,
+                max_width: 0,
+                collapse_priority: 30,
+                scope: crate::config::SidebarViewScope::Workspace,
+            },
+        ];
+        app.config.sidebar.views_explicit = true;
+        app.replace_tree(app.session.tree());
+        app.sidebar_workspace_selection = 0;
+        app.projection_rows(0);
+        app.sidebar_workspace_selection = 1;
+        app.projection_rows(1);
+
+        assert_eq!(
+            app.handle(AppEvent::Mux(MuxEvent::AgentChanged {
+                surface: SurfaceId::MAX,
+                state: "working".into(),
+                source: "hook".into(),
+                session: None,
+                updated_at_ms: 1,
+            }))
+            .unwrap(),
+            RenderAction::None,
+            "an agent outside every projected scope must not schedule a paint"
+        );
+        assert_eq!(app.projection_rows_cache.len(), 2);
+
+        let action = app
+            .handle(AppEvent::Mux(MuxEvent::AgentChanged {
+                surface: first.id,
+                state: "working".into(),
+                source: "hook".into(),
+                session: None,
+                updated_at_ms: 1,
+            }))
+            .unwrap();
+        assert_eq!(action, RenderAction::Paint);
+        assert_eq!(
+            app.projection_rows_cache
+                .iter()
+                .map(|cache| cache.view_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["agents-second"],
+            "an agent update must retain caches for other workspace scopes"
+        );
+        assert_eq!(
+            app.handle(AppEvent::Mux(MuxEvent::AgentChanged {
+                surface: first.id,
+                state: "working".into(),
+                source: "hook".into(),
+                session: None,
+                updated_at_ms: 2,
+            }))
+            .unwrap(),
+            RenderAction::None,
+            "repeated updates for one surface share one paint boundary"
+        );
+
+        mux.close_surface(first.id).unwrap();
+        mux.close_surface(second.id).unwrap();
+    }
+
+    #[test]
+    fn projection_title_update_keeps_an_unrelated_workspace_cache() {
+        let (mux, first) = test_mux("projection-title-cache-scope-test", None);
+        let second = mux.new_workspace(Some("second".into()), Some((20, 8))).unwrap();
+        let mut app = test_app(Session::Local(mux.clone()));
+        app.config.sidebar.columns.clear();
+        app.config.sidebar.views = vec![
+            SidebarViewSpec {
+                id: "tabs-first".into(),
+                levels: vec![SidebarResourceKind::Tabs],
+                actions: Vec::new(),
+                actions_position: crate::config::ActionsPosition::Bottom,
+                width: 40,
+                max_width: 0,
+                collapse_priority: 30,
+                scope: crate::config::SidebarViewScope::Workspace,
+            },
+            SidebarViewSpec {
+                id: "tabs-second".into(),
+                levels: vec![SidebarResourceKind::Tabs],
+                actions: Vec::new(),
+                actions_position: crate::config::ActionsPosition::Bottom,
+                width: 40,
+                max_width: 0,
+                collapse_priority: 30,
+                scope: crate::config::SidebarViewScope::Workspace,
+            },
+        ];
+        app.config.sidebar.views_explicit = true;
+        app.replace_tree(app.session.tree());
+        app.sidebar_workspace_selection = 0;
+        app.projection_rows(0);
+        app.sidebar_workspace_selection = 1;
+        app.projection_rows(1);
+
+        assert_eq!(
+            app.handle(AppEvent::Mux(MuxEvent::TitleChanged {
+                surface: SurfaceId::MAX,
+                title: "unrelated".into(),
+            }))
+            .unwrap(),
+            RenderAction::None,
+            "a title outside every projected scope must not schedule a paint"
+        );
+        assert_eq!(app.projection_rows_cache.len(), 2);
+
+        let action = app
+            .handle(AppEvent::Mux(MuxEvent::TitleChanged {
+                surface: first.id,
+                title: "renamed".into(),
+            }))
+            .unwrap();
+        assert_eq!(action, RenderAction::Paint);
+        assert_eq!(
+            app.projection_rows_cache
+                .iter()
+                .map(|cache| cache.view_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["tabs-second"],
+            "a title update must retain caches for other workspace scopes"
+        );
+
+        mux.close_surface(first.id).unwrap();
+        mux.close_surface(second.id).unwrap();
+    }
+
+    #[test]
+    fn projection_cache_refreshes_active_tab_after_focus_changes() {
+        let (mux, first) = test_mux("projection-active-focus-cache-test", None);
+        let pane = mux.with_state(|state| state.pane_of(first.id).unwrap());
+        let second = mux.new_tab(Some(pane), None, Some((20, 8))).unwrap();
+        let mut app = test_app(Session::Local(mux.clone()));
+        app.config.sidebar.columns.clear();
+        app.config.sidebar.views = vec![SidebarViewSpec {
+            id: "tabs".into(),
+            levels: vec![SidebarResourceKind::Tabs],
+            actions: Vec::new(),
+            actions_position: crate::config::ActionsPosition::Bottom,
+            width: 40,
+            max_width: 0,
+            collapse_priority: 30,
+            scope: crate::config::SidebarViewScope::Workspace,
+        }];
+        app.config.sidebar.views_explicit = true;
+        app.replace_tree(app.session.tree());
+
+        let before = app.projection_rows(0);
+        let before_active = app.tree.active_surface().unwrap();
+        let after_active = if before_active == first.id { second.id } else { first.id };
+        let after_index = app
+            .tree
+            .pane(pane)
+            .unwrap()
+            .tabs
+            .iter()
+            .position(|tab| tab.surface == after_active)
+            .unwrap();
+        app.select_tab_for_client(Some(pane), Some(after_index), None);
+        let after = app.projection_rows(0);
+
+        assert!(before.iter().any(|row| {
+            matches!(
+                row.target,
+                crate::sidebar_projection::ProjectionTarget::Surface { surface, .. }
+                    if surface == before_active && row.active
+            )
+        }));
+        assert!(after.iter().any(|row| {
+            matches!(
+                row.target,
+                crate::sidebar_projection::ProjectionTarget::Surface { surface, .. }
+                    if surface == after_active && row.active
+            )
+        }));
+        assert!(after.iter().any(|row| {
+            matches!(
+                row.target,
+                crate::sidebar_projection::ProjectionTarget::Surface { surface, .. }
+                    if surface == before_active && !row.active
+            )
+        }));
+
+        mux.close_surface(first.id).unwrap();
+        mux.close_surface(second.id).unwrap();
+    }
+
+    #[test]
     fn projection_stale_action_selection_does_not_retarget_resource_row() {
         let (mux, surface) = test_mux("projection-stale-action-selection-test", None);
         mux.report_agent(
@@ -44334,7 +44713,9 @@ mod tests {
             projection_rails: HashMap::new(),
             projection_rows_cache: VecDeque::new(),
             projection_rows_revision: 0,
-            projection_agent_revision: 0,
+            projection_agent_surfaces: HashSet::new(),
+            projection_title_surfaces: HashSet::new(),
+            projection_paint_pending: false,
             machine_rail_follow_selection: true,
             workspace_rail_follow_selection: true,
             tabs_rail_follow_selection: true,

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -42658,7 +42658,7 @@ mod tests {
         app.replace_tree(app.session.tree());
         app.projection_rows(0);
 
-        assert!(app.mux_titles.push(surface.id, "renamed".into()));
+        assert!(app.mux_titles.push(surface.id, "renamed"));
         assert_eq!(app.handle(AppEvent::MuxTitlesReady).unwrap(), RenderAction::Paint);
         assert_eq!(
             app.tree

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -16148,6 +16148,7 @@ impl App {
                 Ok(RenderAction::Draw)
             }
             TerminalInput::FocusLost => {
+                self.prefix_armed = false;
                 let action = if self.cancel_pointer_interaction() {
                     RenderAction::Draw
                 } else {
@@ -25278,6 +25279,17 @@ mod tests {
         assert!(!app.prefix_armed);
         assert!(!app.quit);
         assert!(app.pty_input.shutdown(Duration::from_secs(1)));
+    }
+
+    #[test]
+    fn focus_loss_clears_a_pending_prefix() {
+        let mux = Mux::new("focus-loss-prefix-reset", SurfaceOptions::default());
+        let mut app = test_app(Session::Local(mux));
+        app.prefix_armed = true;
+
+        app.handle(AppEvent::Input(Event::FocusLost)).unwrap();
+
+        assert!(!app.prefix_armed);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -7871,7 +7871,11 @@ fn sidebar_layout_for(
 /// an absent machine provider drop leaves, empty splits collapse away.
 #[derive(Clone)]
 enum SidebarColumnNode {
-    Leaf { view_index: usize, kind: RailKind, priority: u16 },
+    Leaf {
+        view_index: usize,
+        kind: RailKind,
+        priority: u16,
+    },
     Split {
         id: String,
         dir: crate::config::SidebarSplitDir,
@@ -7941,9 +7945,8 @@ fn prune_sidebar_layout_node(
                 .iter()
                 .enumerate()
                 .filter_map(|(index, child)| {
-                    prune_sidebar_layout_node(child, views, hidden_views, machine_visible).map(
-                        |node| (split.weights.get(index).copied().unwrap_or(1).max(1), node),
-                    )
+                    prune_sidebar_layout_node(child, views, hidden_views, machine_visible)
+                        .map(|node| (split.weights.get(index).copied().unwrap_or(1).max(1), node))
                 })
                 .collect();
             match children.len() {
@@ -7992,15 +7995,12 @@ fn place_sidebar_column_node(
             let mut kept: Vec<&(u16, SidebarColumnNode)> = children.iter().collect();
             while kept.len() > 1 {
                 let dividers = divider_size.saturating_mul(kept.len().saturating_sub(1) as u16);
-                let needed =
-                    min_each.saturating_mul(kept.len() as u16).saturating_add(dividers);
+                let needed = min_each.saturating_mul(kept.len() as u16).saturating_add(dividers);
                 if total >= needed {
                     break;
                 }
-                let Some((drop_index, _)) = kept
-                    .iter()
-                    .enumerate()
-                    .min_by_key(|(_, (_, child))| child.priority())
+                let Some((drop_index, _)) =
+                    kept.iter().enumerate().min_by_key(|(_, (_, child))| child.priority())
                 else {
                     break;
                 };
@@ -8326,8 +8326,7 @@ fn rail_drag_width(config: &Config, layout: &SidebarLayout, kind: RailKind, x: u
     let configured_max = if column.rails.len() > 1 {
         column.max_width
     } else {
-        let view_index =
-            layout.ordered.iter().find(|placement| placement.kind == kind)?.view_index;
+        let view_index = layout.ordered.iter().find(|placement| placement.kind == kind)?.view_index;
         let view = config.sidebar.views.get(view_index)?;
         if config.sidebar.views_explicit {
             view.max_width
@@ -10603,17 +10602,21 @@ impl App {
                     Direction::Up
                         if candidate.y.saturating_add(candidate.height) <= rect.y
                             && overlap(rect.x, rect.width, candidate.x, candidate.width) > 0 =>
-                    (
-                        rect.y - candidate.y.saturating_add(candidate.height),
-                        overlap(rect.x, rect.width, candidate.x, candidate.width),
-                    ),
+                    {
+                        (
+                            rect.y - candidate.y.saturating_add(candidate.height),
+                            overlap(rect.x, rect.width, candidate.x, candidate.width),
+                        )
+                    }
                     Direction::Down
                         if candidate.y >= rect.y.saturating_add(rect.height)
                             && overlap(rect.x, rect.width, candidate.x, candidate.width) > 0 =>
-                    (
-                        candidate.y - rect.y.saturating_add(rect.height),
-                        overlap(rect.x, rect.width, candidate.x, candidate.width),
-                    ),
+                    {
+                        (
+                            candidate.y - rect.y.saturating_add(rect.height),
+                            overlap(rect.x, rect.width, candidate.x, candidate.width),
+                        )
+                    }
                     _ => return None,
                 };
                 Some((distance, std::cmp::Reverse(alignment), placement.kind))
@@ -18670,8 +18673,7 @@ impl App {
                     .unwrap_or_default();
                 let page = rail_page_size(self.sidebar_layout.workspace);
                 if let Some(next) = rail_navigation_index(key, current, targets.len(), page) {
-                    if next == current
-                        && self.continue_past_rail_boundary(RailKind::Workspace, key)
+                    if next == current && self.continue_past_rail_boundary(RailKind::Workspace, key)
                     {
                         return Ok(RenderAction::Draw);
                     }

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -2280,12 +2280,6 @@ impl OrderedSession {
         self.inner.daemon_shutdown_requested()
     }
 
-    /// The first reason recorded when a remote transport reader stopped, or
-    /// `None` for local sessions and deliberate local disconnects.
-    fn transport_disconnect_reason(&self) -> Option<String> {
-        self.inner.transport_disconnect_reason()
-    }
-
     fn attach_surface(&self, id: SurfaceId, size: Option<(u16, u16)>) {
         if self.remote
             && let Some(size) = size
@@ -5533,7 +5527,8 @@ enum Drag {
     /// Independent rail width override drag.
     RailResize(RailKind),
     /// Sidebar split-group divider drag: re-shares the group's children.
-    SidebarSplit { group: usize, index: usize },
+    /// The stable config id survives layout pruning and reordering.
+    SidebarSplit { group: String, index: usize },
     /// Pane split resize drag.
     ResizeSplit { horizontal: Option<PaneResizeDragTarget>, vertical: Option<PaneResizeDragTarget> },
 }
@@ -5811,26 +5806,6 @@ impl PointerRouteIdentity {
             _ => None,
         }
     }
-
-    /// A press that opens the cmux-owned context menu never enters the pane's
-    /// application, so the surface's content generation and encoder semantics
-    /// are not part of that press's route identity. Only the geometry (which
-    /// pane, which region) decides where the menu opens.
-    fn normalized_for_cmux_menu(mut self) -> Self {
-        if let Self::Pane { region, .. } = &mut self {
-            match region {
-                PanePointerRegion::TerminalCell { semantics, content_generation, .. } => {
-                    *semantics = None;
-                    *content_generation = None;
-                }
-                PanePointerRegion::BrowserCell { content_generation, .. } => {
-                    *content_generation = None;
-                }
-                PanePointerRegion::ContentPadding | PanePointerRegion::Chrome => {}
-            }
-        }
-        self
-    }
 }
 
 #[derive(Clone, Default)]
@@ -5843,7 +5818,6 @@ struct RenderedPointerFrame {
     machine_rail: Option<Rect>,
     workspace_rail: Option<Rect>,
     tabs_rail: Option<Rect>,
-    projection_rails: Arc<[(RailKind, Rect)]>,
     hits: Arc<[RenderedHitRoute]>,
     panes: Arc<[RenderedPaneRoute]>,
     terminal_pointer_semantics: Arc<HashMap<SurfaceId, TerminalPointerSemanticSnapshot>>,
@@ -5952,18 +5926,6 @@ impl RenderedPointerFrame {
             (RailKind::Tabs, self.tabs_rail),
         ] {
             if let Some(rect) = rect.filter(|rect| rect.contains(x, y)) {
-                return PointerRouteIdentity::Rail {
-                    kind,
-                    rect,
-                    column: x.saturating_sub(rect.x),
-                    row: y.saturating_sub(rect.y),
-                };
-            }
-        }
-        if let Some((kind, rect)) =
-            self.projection_rails.iter().copied().find(|(_, rect)| rect.contains(x, y))
-        {
-            if !self.panes.iter().any(|pane| pane.content.contains(x, y)) {
                 return PointerRouteIdentity::Rail {
                     kind,
                     rect,
@@ -7052,7 +7014,7 @@ pub struct App {
     active_pointer_buttons: HashSet<MouseButton>,
     ignored_pty_mouse_buttons: HashSet<MouseButton>,
     #[cfg(test)]
-    timeout_drain_hook: Option<Box<dyn FnOnce(&mut Self) + Send>>,
+    timeout_drain_hook: Option<Box<dyn FnOnce() + Send>>,
     encoder: KeyEncoder,
     encode_buf: Vec<u8>,
     quit: bool,
@@ -9559,7 +9521,14 @@ fn run_with_machine_updates_inner(
     }
 
     if let Err(error) = app.restart_machine_updates() {
-        app.shutdown_runtime_components();
+        app.shutdown_background_workers();
+        app.cancel_pointer_interaction();
+        app.session.begin_shutdown();
+        let _ = app.pty_input.shutdown(Duration::from_secs(3));
+        if let Some(writer) = app.graphics_writer.as_mut() {
+            writer.shutdown(Duration::from_millis(200));
+        }
+        let _ = std::panic::take_hook();
         return Err(terminal_restore.restore_after_error(error));
     }
 
@@ -9568,7 +9537,14 @@ fn run_with_machine_updates_inner(
     }
 
     let result = app.event_loop(&mut terminal, rx);
-    app.shutdown_runtime_components();
+    app.shutdown_background_workers();
+    app.cancel_pointer_interaction();
+    app.session.begin_shutdown();
+    let _ = app.pty_input.shutdown(Duration::from_secs(3));
+    if let Some(writer) = app.graphics_writer.as_mut() {
+        writer.shutdown(Duration::from_millis(200));
+    }
+    let _ = std::panic::take_hook();
     let restore_result = terminal_restore.restore();
     match (result, restore_result) {
         (Ok(()), Ok(())) => {}
@@ -9930,14 +9906,6 @@ fn should_claim_clear_history_shortcut(
     supports_atomic_fallback: bool,
 ) -> bool {
     surface_kind == SurfaceKind::Pty && supports_atomic_fallback
-}
-
-fn adjust_active_tab_after_removal(pane: &mut PaneView, removed_tab_index: usize) {
-    if pane.active_tab > removed_tab_index {
-        pane.active_tab -= 1;
-    } else if pane.active_tab >= pane.tabs.len() {
-        pane.active_tab = pane.tabs.len().saturating_sub(1);
-    }
 }
 
 impl App {
@@ -10783,7 +10751,6 @@ impl App {
                 Duration::from_millis(250)
             };
             let timeout = terminal_paints.wait_timeout(timeout, Instant::now());
-            let mut toast_expired_on_timeout = false;
             let first = match rx.recv_timeout(timeout) {
                 Ok(event) => Some(event),
                 Err(crossbeam_channel::RecvTimeoutError::Timeout) => {
@@ -10794,7 +10761,6 @@ impl App {
                         action = action.merge(RenderAction::Draw);
                     }
                     if self.expire_toast() {
-                        toast_expired_on_timeout = true;
                         action = action.merge(RenderAction::Draw);
                     }
                     if self.tick_sidebar_files() {
@@ -10817,7 +10783,7 @@ impl App {
             if first.is_none()
                 && let Some(hook) = self.timeout_drain_hook.take()
             {
-                hook(self);
+                hook();
             }
             if let Some(event) = first {
                 action = self.handle_event_and_process_machine_requests(event, action)?;
@@ -10847,8 +10813,7 @@ impl App {
             if self.quit {
                 break;
             }
-            // Keep a toast reintroduced by the timeout drain hook alive for one iteration.
-            if !toast_expired_on_timeout && self.expire_toast() {
+            if self.expire_toast() {
                 action = action.merge(RenderAction::Draw);
             }
             action = action.merge(self.advance_viewport_animation(Instant::now()));
@@ -10946,17 +10911,6 @@ impl App {
         if let Some(mut owner_reload) = self.owner_reload_worker.take() {
             owner_reload.stop_and_join();
         }
-    }
-
-    fn shutdown_runtime_components(&mut self) {
-        self.shutdown_background_workers();
-        self.cancel_pointer_interaction();
-        self.session.begin_shutdown();
-        let _ = self.pty_input.shutdown(Duration::from_secs(3));
-        if let Some(writer) = self.graphics_writer.as_mut() {
-            writer.shutdown(Duration::from_millis(200));
-        }
-        let _ = std::panic::take_hook();
     }
 
     fn process_machine_requests(&mut self) -> RenderAction {
@@ -12025,41 +11979,34 @@ impl App {
         self.encode_buf.clear();
     }
 
-    /// A machine that is sleeping or stopped lost its stream BECAUSE it was
-    /// paused; reconnecting would start it right back up and make pause
-    /// impossible. Present it as asleep instead - the user's next input (or
-    /// a rail click) wakes it through the normal switch path.
-    fn present_machine_as_asleep_after_stream_loss(&mut self) -> bool {
-        let Some(machine) = self.machine_ui.as_mut() else { return false };
-        let Some(active) = machine.snapshot.active else { return false };
-        if !machine.snapshot.machines.iter().any(|descriptor| {
-            descriptor.key == active
-                && matches!(
-                    descriptor.status,
-                    crate::machine::MachineStatus::Sleeping
-                        | crate::machine::MachineStatus::Stopped
-                )
-        }) {
-            return false;
-        }
-        crate::client_log::info(
-            "machine",
-            &format!("stream lost for sleeping machine {}; presenting as asleep", active.0),
-        );
-        machine.session_available = false;
-        machine.set_connection_phase(active, MachineConnectionPhase::Disconnected);
-        // The previous open's narration is stale now; a later wake
-        // reuses the same selection intent, so select_machine_intent
-        // will not clear it.
-        machine.clear_connection_progress(active);
-        true
-    }
-
     fn request_current_machine_session(&mut self) -> bool {
-        if self.present_machine_as_asleep_after_stream_loss() {
+        let Some(machine) = self.machine_ui.as_mut() else { return false };
+        // A machine that is sleeping or stopped lost its stream BECAUSE it
+        // was paused; reconnecting would start it right back up and make
+        // pause impossible. Present it as asleep instead - the user's next
+        // input (or a rail click) wakes it through the normal switch path.
+        if let Some(active) = machine.snapshot.active
+            && machine.snapshot.machines.iter().any(|descriptor| {
+                descriptor.key == active
+                    && matches!(
+                        descriptor.status,
+                        crate::machine::MachineStatus::Sleeping
+                            | crate::machine::MachineStatus::Stopped
+                    )
+            })
+        {
+            crate::client_log::info(
+                "machine",
+                &format!("stream lost for sleeping machine {}; presenting as asleep", active.0),
+            );
+            machine.session_available = false;
+            machine.set_connection_phase(active, MachineConnectionPhase::Disconnected);
+            // The previous open's narration is stale now; a later wake
+            // reuses the same selection intent, so select_machine_intent
+            // will not clear it.
+            machine.clear_connection_progress(active);
             return true;
         }
-        let Some(machine) = self.machine_ui.as_mut() else { return false };
         if machine.request.is_none() {
             let request = machine
                 .snapshot
@@ -12519,16 +12466,6 @@ impl App {
         let machine_rail = self.sidebar_layout.machine;
         let workspace_rail = self.sidebar_layout.workspace;
         let tabs_rail = self.sidebar_layout.tabs;
-        let projection_rails = self
-            .sidebar_layout
-            .ordered
-            .iter()
-            .filter_map(|placement| match placement.kind {
-                RailKind::Projection(_) => Some((placement.kind, placement.rect)),
-                _ => None,
-            })
-            .collect::<Vec<_>>()
-            .into();
         let pointer_map_generation = self.session.pointer_map_generation();
         let reuse_owners = action == RenderAction::Paint
             && self.rendered_pointer_frame.pointer_map_generation == pointer_map_generation;
@@ -12612,7 +12549,6 @@ impl App {
             machine_rail,
             workspace_rail,
             tabs_rail,
-            projection_rails,
             hits,
             panes,
             terminal_pointer_semantics,
@@ -12861,12 +12797,6 @@ impl App {
         if self.pointer_route_is_globally_stale() {
             return true;
         }
-        if Self::mouse_opens_cmux_context_menu(mouse) {
-            // The menu is owned by cmux rather than the browser bitmap or a
-            // graphics scene. Keep global and layout barriers above, but do
-            // not wait for content admission this press never enters.
-            return false;
-        }
         if self.pending_graphics_changes_cell(mouse.column, mouse.row) {
             return true;
         }
@@ -12874,6 +12804,12 @@ impl App {
             self.pointer_route_phase,
             PointerRoutePhase::GraphicsRenderPending | PointerRoutePhase::GraphicsProcessingPending
         ) {
+            return false;
+        }
+        if Self::mouse_opens_cmux_context_menu(mouse) {
+            // The menu is owned by cmux rather than the browser bitmap. Keep
+            // geometry barriers above, but do not wait for browser content
+            // admission that this press never enters.
             return false;
         }
         let route = self.rendered_pointer_frame.route_for_mouse(mouse);
@@ -13355,52 +13291,6 @@ impl App {
     /// topology refresh arrives. The backend projection still owns parent
     /// pane, screen, and workspace collapse.
     fn remove_surface_from_cached_tree(&mut self, surface: SurfaceId) {
-        let Some([workspace_index, screen_index, pane_index, tab_index]) =
-            self.tab_locations.get(&surface).copied()
-        else {
-            self.remove_surface_from_cached_tree_scan_and_rebuild_locations(surface);
-            return;
-        };
-
-        let location_is_current = self
-            .tree
-            .workspaces
-            .get(workspace_index)
-            .and_then(|workspace| workspace.screens.get(screen_index))
-            .and_then(|screen| screen.panes.get(pane_index))
-            .and_then(|pane| pane.tabs.get(tab_index))
-            .is_some_and(|tab| tab.surface == surface);
-        if !location_is_current {
-            self.remove_surface_from_cached_tree_scan_and_rebuild_locations(surface);
-            return;
-        }
-
-        let shifted_tabs = {
-            let pane =
-                &mut self.tree.workspaces[workspace_index].screens[screen_index].panes[pane_index];
-            pane.tabs.remove(tab_index);
-            adjust_active_tab_after_removal(pane, tab_index);
-            pane.tabs
-                .iter()
-                .enumerate()
-                .skip(tab_index)
-                .map(|(tab_index, tab)| (tab.surface, tab_index))
-                .collect::<Vec<_>>()
-        };
-
-        self.tab_locations.remove(&surface);
-        for (shifted_surface, shifted_index) in shifted_tabs {
-            self.tab_locations.insert(
-                shifted_surface,
-                [workspace_index, screen_index, pane_index, shifted_index],
-            );
-        }
-    }
-
-    /// Repair the cache from the tree and rebuild `tab_locations` if the index was missing or stale.
-    /// This path is defensive only. Normal surface exits use the indexed path
-    /// above and touch one pane instead of scanning the entire topology.
-    fn remove_surface_from_cached_tree_scan_and_rebuild_locations(&mut self, surface: SurfaceId) {
         for workspace in &mut self.tree.workspaces {
             for screen in &mut workspace.screens {
                 for pane in &mut screen.panes {
@@ -13409,7 +13299,11 @@ impl App {
                         continue;
                     };
                     pane.tabs.remove(index);
-                    adjust_active_tab_after_removal(pane, index);
+                    if pane.active_tab > index {
+                        pane.active_tab -= 1;
+                    } else if pane.active_tab >= pane.tabs.len() {
+                        pane.active_tab = pane.tabs.len().saturating_sub(1);
+                    }
                 }
             }
         }
@@ -13771,12 +13665,14 @@ impl App {
         let context_changed = self.graphics_scene_cache.context.as_ref() != Some(&context);
         let full_scan = !dirty_only || context_changed;
         self.mark_graphics_clean((!full_scan).then_some(&dirty_surfaces));
+        let areas = self
+            .pane_areas
+            .iter()
+            .copied()
+            .filter(|area| full_scan || dirty_surfaces.contains(&area.surface))
+            .collect::<Vec<_>>();
         let mut updates = Vec::new();
-        for index in 0..self.pane_areas.len() {
-            let area = self.pane_areas[index];
-            if !full_scan && !dirty_surfaces.contains(&area.surface) {
-                continue;
-            }
+        for area in areas {
             let surface = self.session.surface(area.surface);
             let key = self.graphics_pane_scene_key(area, surface.as_ref());
             let unchanged = !context_changed
@@ -15064,7 +14960,7 @@ impl App {
             if let TerminalInput::Mouse(mouse) = input
                 && !pointer_has_capture
             {
-                let rendered_route = self.rendered_pointer_route_for_mouse(mouse);
+                let rendered_route = self.rendered_pointer_frame.route_for_mouse(mouse);
                 let replayed_route_changed = replay_context
                     .as_ref()
                     .and_then(|context| context.pointer.as_ref())
@@ -15343,26 +15239,6 @@ impl App {
                 Ok(self.apply_machine_controller_completion(*completion))
             }
             AppEvent::Mux(MuxEvent::Empty) => {
-                // A genuinely emptied workspace list and a dead event
-                // transport both end the event stream with this event, but
-                // only the former is a clean exit. The remote reader records
-                // why it stopped; consult that BEFORE any machine-session
-                // request so a machine or provider surface cannot swallow the
-                // dead transport into a stuck reconnect (issue 11042). A
-                // deliberate local disconnect records no reason. The one
-                // machine response that outranks the error is a sleeping or
-                // stopped machine, whose stream loss is the designed result
-                // of pausing it.
-                if let Some(reason) = self.session.transport_disconnect_reason() {
-                    if self.present_machine_as_asleep_after_stream_loss() {
-                        return Ok(RenderAction::Draw);
-                    }
-                    crate::client_log::error(
-                        "session",
-                        &format!("remote event transport lost: {reason}"),
-                    );
-                    anyhow::bail!(localization::catalog().runtime.session_transport_lost());
-                }
                 if self.request_current_machine_session() {
                     return Ok(RenderAction::Draw);
                 }
@@ -16276,7 +16152,7 @@ impl App {
                 focus_generation: self.pointer_focus_generation,
                 pointer_map_generation: self.rendered_pointer_frame.pointer_map_generation,
                 route: Self::mouse_requires_rendered_route(mouse.kind)
-                    .then(|| self.rendered_pointer_route_for_mouse(mouse)),
+                    .then(|| self.rendered_pointer_frame.route_for_mouse(mouse)),
             })
         } else {
             None
@@ -16456,17 +16332,6 @@ impl App {
             && mouse.modifiers.contains(KeyModifiers::SHIFT)
     }
 
-    fn rendered_pointer_route_for_mouse(&self, mouse: &MouseEvent) -> PointerRouteIdentity {
-        let route = self.rendered_pointer_frame.route_for_mouse(mouse);
-        if Self::mouse_opens_cmux_context_menu(mouse) {
-            // The menu press never enters the pane's application; async output
-            // must not change its recorded route.
-            route.normalized_for_cmux_menu()
-        } else {
-            route
-        }
-    }
-
     fn pointer_has_capture(&self, kind: MouseEventKind) -> bool {
         match kind {
             MouseEventKind::Drag(button) | MouseEventKind::Up(button) => {
@@ -16511,14 +16376,6 @@ impl App {
         mouse: &MouseEvent,
         missing_surface: Option<SurfaceId>,
     ) -> TerminalPointerAdmissionResult {
-        if Self::mouse_opens_cmux_context_menu(mouse) {
-            // The menu is owned by cmux rather than the terminal
-            // application: the press never forwards bytes, so encoder
-            // semantics and content-generation admission cannot gate it.
-            // Geometry barriers (pending paints, pointer-map mutations)
-            // still defer it through the route staleness checks.
-            return TerminalPointerAdmissionResult::NotTerminal;
-        }
         let Some((surface, input_rect, expected_snapshot)) =
             rendered_route.terminal_pointer_snapshot()
         else {
@@ -18101,6 +17958,7 @@ impl App {
             self.machine_rail_follow_selection = true;
         }
         let page = rail_page_size(self.sidebar_layout.machine);
+        let mut continue_past_boundary = false;
         let command = {
             let Some(machine) = self.machine_ui.as_mut() else {
                 self.focus = FocusTarget::Pane;
@@ -18121,6 +17979,8 @@ impl App {
                 // j, k, h, l, or an arrow key.
                 Some(MachineRailCommand::ProviderMenu)
             } else if let Some(next) = rail_navigation_index(key, current, targets.len(), page) {
+                continue_past_boundary = next == current
+                    && matches!(key.code, KeyCode::Up | KeyCode::Down | KeyCode::Char('j' | 'k'));
                 if let Some(target) = targets.get(next).copied() {
                     machine.select_rail_target(target);
                 }
@@ -18177,6 +18037,9 @@ impl App {
                 None
             }
         };
+        if continue_past_boundary && self.continue_past_rail_boundary(RailKind::Machine, key) {
+            return RenderAction::Draw;
+        }
         match command {
             Some(MachineRailCommand::Activate(machine)) => {
                 self.activate_machine(machine);
@@ -22212,14 +22075,24 @@ impl App {
                         .find(|divider| divider.rect.contains(x, y))
                         .copied()
                     {
-                        self.drag =
-                            Some(Drag::SidebarSplit { group: divider.group, index: divider.index });
+                        if let Some(group) = self
+                            .sidebar_layout
+                            .split_groups
+                            .get(divider.group)
+                            .map(|group| group.id.clone())
+                        {
+                            self.drag = Some(Drag::SidebarSplit { group, index: divider.index });
+                        }
                     } else {
                         self.drag = Some(Drag::RailResize(kind));
                     }
                 }
                 Hit::SidebarSplitDivider { group, index } => {
-                    self.drag = Some(Drag::SidebarSplit { group, index });
+                    if let Some(group) =
+                        self.sidebar_layout.split_groups.get(group).map(|group| group.id.clone())
+                    {
+                        self.drag = Some(Drag::SidebarSplit { group, index });
+                    }
                 }
                 Hit::PaneResize { horizontal, vertical } => {
                     let horizontal = horizontal
@@ -22491,8 +22364,8 @@ impl App {
                 Ok(RenderAction::Draw)
             }
             Some(Drag::SidebarSplit { group, index }) => {
-                let (group, index) = (*group, *index);
-                self.drag_sidebar_split_divider(group, index, x, y);
+                let group = group.clone();
+                self.drag_sidebar_split_divider(&group, *index, x, y);
                 Ok(RenderAction::Draw)
             }
             Some(Drag::ResizeSplit { horizontal, vertical }) => {
@@ -22512,9 +22385,13 @@ impl App {
     /// Convert a divider drag into new share fractions for its split group.
     /// Only the two children flanking the divider change; the rest keep
     /// their rendered sizes.
-    fn drag_sidebar_split_divider(&mut self, group: usize, index: usize, x: u16, y: u16) {
+    fn drag_sidebar_split_divider(&mut self, group: &str, index: usize, x: u16, y: u16) {
         use crate::config::SidebarSplitDir;
-        let Some(placement) = self.sidebar_layout.split_groups.get(group) else { return };
+        let Some(placement) =
+            self.sidebar_layout.split_groups.iter().find(|placement| placement.id == group)
+        else {
+            return;
+        };
         let Some(first) = placement.children.get(index).copied() else { return };
         let Some(second) = placement.children.get(index + 1).copied() else { return };
         let mut sizes: Vec<u16> = placement
@@ -24356,17 +24233,18 @@ mod tests {
         Prompt, PromptTarget, PtyFailureIngress, PtyMousePressResult, RailKind, RenderAction,
         RenderedMenuLevel, RenderedPaneRoute, RenderedPointerFrame, Selection, SessionCompletion,
         SessionCompletionAction, SessionEventSender, ShortcutHelp, SidebarActionTarget,
-        SidebarLayout, SidebarPluginSyncClaim, SidebarPluginSyncState, SidebarWidthOverrides,
-        StatusTemplateValues, StatusWorkerStop, StdoutLock, SurfaceAttachClaimState,
-        SurfaceResizeDecision, SurfaceResizeOwnership, TERMINAL_PAINT_CADENCE, TerminalInput,
-        TerminalPaintPacer, TerminalPointerAdmission, TerminalPointerAdmissionResult,
-        TerminalPointerEncoding, TextInput, Toast, VIEWPORT_ANIMATION_DURATION, ViewportMotion,
-        ViewportPaneAreaProjection, WorkspaceRailSelection, action_available_in_mode,
-        browser_content_size_for_rect, browser_frame_source_crop, browser_hover_forward_allowed,
-        browser_source_crop, canonical_terminal_content, catch_renderer_panic,
-        clamp_split_ratio_for_tab_bars, client_menu_item, clip_horizontal_rect,
-        content_size_for_rect, disable_host_keyboard_protocol, enable_host_keyboard_protocol,
-        expand_status_tokens, forward_host_input, forward_mux_event, forward_mux_events,
+        SidebarLayout, SidebarPluginSyncClaim, SidebarPluginSyncState, SidebarSplitGroupPlacement,
+        SidebarWidthOverrides, StatusTemplateValues, StatusWorkerStop, StdoutLock,
+        SurfaceAttachClaimState, SurfaceResizeDecision, SurfaceResizeOwnership,
+        TERMINAL_PAINT_CADENCE, TerminalInput, TerminalPaintPacer, TerminalPointerAdmission,
+        TerminalPointerAdmissionResult, TerminalPointerEncoding, TextInput,
+        VIEWPORT_ANIMATION_DURATION, ViewportMotion, ViewportPaneAreaProjection,
+        WorkspaceRailSelection, action_available_in_mode, browser_content_size_for_rect,
+        browser_frame_source_crop, browser_hover_forward_allowed, browser_source_crop,
+        canonical_terminal_content, catch_renderer_panic, clamp_split_ratio_for_tab_bars,
+        client_menu_item, clip_horizontal_rect, content_size_for_rect,
+        disable_host_keyboard_protocol, enable_host_keyboard_protocol, expand_status_tokens,
+        forward_host_input, forward_mux_event, forward_mux_events,
         host_mouse_capture_escape_if_changed, host_startup_input_modes,
         initial_applied_outer_cursor, initial_host_mouse_capture, keyboard_protocol_accepts,
         layout_undo_error_completion, negotiate_host_keyboard_protocol_with, outer_cursor_escape,
@@ -24412,7 +24290,7 @@ mod tests {
     use crate::browser_input::{BrowserInputDispatcher, BrowserInputEvent, BrowserInputKind};
     use crate::config::{
         Action, ChromeTheme, Config, ScrollbarPosition, SidebarColumnKind, SidebarProfileSpec,
-        SidebarResourceKind, SidebarView, SidebarViewSpec, action_definitions,
+        SidebarResourceKind, SidebarSplitDir, SidebarView, SidebarViewSpec, action_definitions,
     };
     use crate::localization;
     use crate::machine::{
@@ -24435,7 +24313,7 @@ mod tests {
         ClientInfo, ClientSizeInfo, RemoteSession, Session, SidebarPluginSurface, SurfaceAttach,
         SurfaceHandle, TreeView, test_remote_session_with_deferred_attach,
         test_remote_session_with_deferred_attach_and_first_resize_failure,
-        test_remote_session_with_deferred_sized_attach, test_remote_session_with_lost_transport,
+        test_remote_session_with_deferred_sized_attach,
     };
 
     #[test]
@@ -27042,7 +26920,7 @@ mod tests {
         app.sync_layout((120, 31));
         assert_eq!(app.sidebar_layout.dividers.len(), 1);
 
-        app.drag_sidebar_split_divider(0, 0, 0, 9);
+        app.drag_sidebar_split_divider("left", 0, 0, 9);
         app.sync_layout((120, 31));
         let top = app.sidebar_layout.ordered[0].rect;
         let bottom = app.sidebar_layout.ordered[1].rect;
@@ -27050,9 +26928,38 @@ mod tests {
         assert_eq!(top.height + bottom.height, 30);
 
         // The two rails clamp at their minimum height.
-        app.drag_sidebar_split_divider(0, 0, 0, 0);
+        app.drag_sidebar_split_divider("left", 0, 0, 0);
         app.sync_layout((120, 31));
         assert_eq!(app.sidebar_layout.ordered[0].rect.height, super::MIN_SPLIT_RAIL_HEIGHT);
+    }
+
+    #[test]
+    fn sidebar_split_divider_drag_resolves_group_by_stable_id() {
+        let mux = Mux::new("sidebar-split-stable-id-test", SurfaceOptions::default());
+        let mut app = test_app(Session::Local(mux));
+        app.sidebar_layout.split_groups = vec![
+            SidebarSplitGroupPlacement {
+                id: "other".into(),
+                dir: SidebarSplitDir::Vertical,
+                children: vec![
+                    Rect { x: 0, y: 0, width: 20, height: 10 },
+                    Rect { x: 0, y: 11, width: 20, height: 10 },
+                ],
+            },
+            SidebarSplitGroupPlacement {
+                id: "left".into(),
+                dir: SidebarSplitDir::Vertical,
+                children: vec![
+                    Rect { x: 0, y: 0, width: 20, height: 10 },
+                    Rect { x: 0, y: 11, width: 20, height: 10 },
+                ],
+            },
+        ];
+
+        app.drag_sidebar_split_divider("left", 0, 0, 9);
+
+        assert!(app.sidebar_split_fractions.contains_key("left"));
+        assert!(!app.sidebar_split_fractions.contains_key("other"));
     }
 
     #[test]
@@ -27596,20 +27503,6 @@ mod tests {
         assert_eq!(app.status_message.as_deref(), Some("SSH connection failed"));
         app.run_action(Action::ToggleSidebarCompact).unwrap();
         assert_eq!(app.status_message.as_deref(), Some("SSH connection failed"));
-    }
-
-    #[test]
-    fn expired_toast_is_consumed_once() {
-        let mux = Mux::new("expired-toast-once-test", SurfaceOptions::default());
-        let mut app = test_app(Session::Local(mux));
-        app.toast = Some(Toast {
-            text: "expired".to_string(),
-            deadline: Instant::now() - Duration::from_millis(1),
-        });
-
-        assert!(app.expire_toast());
-        assert!(!app.expire_toast());
-        assert!(app.toast.is_none());
     }
 
     #[test]
@@ -31241,100 +31134,6 @@ mod tests {
     }
 
     #[test]
-    fn immediate_menu_press_survives_content_changed_before_surface_output() {
-        let (mux, surface) = test_mux("immediate-menu-content-test", None);
-        surface.with_terminal(|terminal| {
-            for index in 0..100 {
-                terminal.vt_write(format!("line {index}\r\n").as_bytes());
-            }
-        });
-        let (mut app, events) = test_app_with_events(Session::Local(mux.clone()));
-        app.replace_tree(app.session.tree());
-        app.sidebar_visible = false;
-        app.sync_layout((40, 15));
-        while app.session.has_pending_mutations() {
-            app.handle(events.recv_timeout(Duration::from_secs(1)).unwrap()).unwrap();
-        }
-        let mut terminal = Terminal::new(TestBackend::new(40, 15)).unwrap();
-        app.render_action(&mut terminal, RenderAction::Draw).unwrap();
-        let content = app.pane_areas[0].content;
-        assert_eq!(app.pointer_route_phase, PointerRoutePhase::Fresh);
-
-        // Terminal content moves after the frame committed, exactly like PTY
-        // output landing between a paint and the user's press.
-        surface.scroll_delta(-3).unwrap();
-        assert_eq!(
-            app.pointer_route_phase,
-            PointerRoutePhase::Fresh,
-            "the queued output event has not marked the rendered route stale yet"
-        );
-
-        app.handle(AppEvent::Input(Event::Mouse(MouseEvent {
-            kind: MouseEventKind::Down(MouseButton::Right),
-            column: content.x + 4,
-            row: content.y + 2,
-            modifiers: KeyModifiers::SHIFT,
-        })))
-        .unwrap();
-
-        assert!(
-            app.menu.is_some(),
-            "a cmux-owned context menu press must not be swallowed by terminal content \
-             admission: it never forwards bytes to the terminal application"
-        );
-        assert!(app.deferred_input.is_empty());
-        mux.close_surface(surface.id).unwrap();
-    }
-
-    #[test]
-    fn deferred_menu_press_survives_content_repaint_before_replay() {
-        let (mux, surface) = test_mux("deferred-menu-content-test", None);
-        surface.with_terminal(|terminal| {
-            for index in 0..100 {
-                terminal.vt_write(format!("line {index}\r\n").as_bytes());
-            }
-        });
-        let (mut app, events) = test_app_with_events(Session::Local(mux.clone()));
-        app.replace_tree(app.session.tree());
-        app.sidebar_visible = false;
-        app.sync_layout((40, 15));
-        while app.session.has_pending_mutations() {
-            app.handle(events.recv_timeout(Duration::from_secs(1)).unwrap()).unwrap();
-        }
-        let mut terminal = Terminal::new(TestBackend::new(40, 15)).unwrap();
-        app.render_action(&mut terminal, RenderAction::Draw).unwrap();
-        let content = app.pane_areas[0].content;
-
-        app.pointer_route_phase = PointerRoutePhase::DrawPending;
-        app.handle(AppEvent::Input(Event::Mouse(MouseEvent {
-            kind: MouseEventKind::Down(MouseButton::Right),
-            column: content.x + 4,
-            row: content.y + 2,
-            modifiers: KeyModifiers::SHIFT,
-        })))
-        .unwrap();
-        assert_eq!(app.deferred_input.len(), 1);
-        assert!(app.menu.is_none());
-
-        // Content changes while the press waits for its paint, so the
-        // repainted frame carries a newer terminal content generation than
-        // the one recorded when the press was deferred.
-        surface.scroll_delta(-3).unwrap();
-        let repaint = app.handle(AppEvent::Mux(MuxEvent::SurfaceOutput(surface.id))).unwrap();
-        app.render_action(&mut terminal, repaint).unwrap();
-        assert_eq!(app.pointer_route_phase, PointerRoutePhase::Fresh);
-        app.replay_deferred_input().unwrap();
-
-        assert!(app.deferred_input.is_empty());
-        assert!(
-            app.menu.is_some(),
-            "a replayed cmux-owned context menu press must not be dropped because terminal \
-             content changed under it while it waited for the paint"
-        );
-        mux.close_surface(surface.id).unwrap();
-    }
-
-    #[test]
     fn immediate_untracked_wheel_fails_closed_before_surface_output_marks_route_stale() {
         let (mux, surface) = test_mux("immediate-wheel-semantics-test", None);
         let (mut app, events) = test_app_with_events(Session::Local(mux.clone()));
@@ -31645,49 +31444,6 @@ mod tests {
     }
 
     #[test]
-    fn pointer_routes_projection_rail_padding_to_projection_rail() {
-        let rect = Rect { x: 4, y: 0, width: 20, height: 10 };
-        let pane = PaneArea {
-            pane: 7,
-            surface: 9,
-            rect,
-            bar: None,
-            omnibar: None,
-            content: Rect { x: 5, y: 1, width: 18, height: 8 },
-            track: None,
-            viewport: None,
-        };
-        let mux = Mux::new("projection-rail-pointer-frame-test", SurfaceOptions::default());
-        let mut app = test_app(Session::Local(mux));
-        app.outer_size = (40, 10);
-        app.sidebar_layout.ordered =
-            vec![super::RailPlacement { kind: RailKind::Projection(0), view_index: 0, rect }];
-        app.pane_areas = vec![pane];
-        app.commit_rendered_pointer_frame();
-
-        let padding_route = app.rendered_pointer_frame.route_for_mouse(&MouseEvent {
-            kind: MouseEventKind::Down(MouseButton::Left),
-            column: rect.x + rect.width - 1,
-            row: rect.y + rect.height - 1,
-            modifiers: KeyModifiers::NONE,
-        });
-        assert!(matches!(
-            padding_route,
-            PointerRouteIdentity::Rail { kind: RailKind::Projection(0), .. }
-        ));
-
-        let content_route = app.rendered_pointer_frame.route_for_mouse(&MouseEvent {
-            kind: MouseEventKind::Down(MouseButton::Left),
-            column: pane.content.x,
-            row: pane.content.y,
-            modifiers: KeyModifiers::NONE,
-        });
-        assert!(
-            matches!(content_route, PointerRouteIdentity::Pane { pane: routed, .. } if routed.pane == pane.pane)
-        );
-    }
-
-    #[test]
     fn graphics_only_repaint_is_a_pointer_replay_barrier() {
         assert_eq!(
             PointerRoutePhase::Fresh.with_action(RenderAction::Graphics),
@@ -31785,15 +31541,6 @@ mod tests {
         assert!(
             app.pointer_route_is_stale_for_mouse(&covered),
             "the old browser image still owns this cell until deletion is processed"
-        );
-        let menu = MouseEvent {
-            kind: MouseEventKind::Down(MouseButton::Right),
-            modifiers: KeyModifiers::SHIFT,
-            ..covered
-        };
-        assert!(
-            !app.pointer_route_is_stale_for_mouse(&menu),
-            "a cmux-owned menu press must not wait for a graphics image it never enters"
         );
 
         app.pending_graphics_snapshot = Some(vec![GraphicIdentity {
@@ -34015,68 +33762,6 @@ mod tests {
         assert!(!app.render_states.contains_key(&42));
         assert!(!app.tab_locations.contains_key(&42));
         assert!(!app.mux_titles.snapshot().contains_key(&42));
-    }
-
-    #[test]
-    fn cached_surface_exit_updates_tab_index_without_rebuilding_unrelated_tabs() {
-        let mux = Mux::new("cached-surface-exit-index-test", SurfaceOptions::default());
-        let mut app = test_app(Session::Local(mux));
-        let mut tree = notify_tree(41, false);
-        let pane = &mut tree.workspaces[0].screens[0].panes[0];
-        let mut second = pane.tabs[0].clone();
-        second.surface = 41;
-        let mut third = pane.tabs[0].clone();
-        third.surface = 43;
-        pane.tabs[0].surface = 40;
-        pane.tabs.push(second);
-        pane.tabs.push(third);
-        pane.active_tab = 1;
-        app.replace_tree(tree);
-
-        app.remove_surface_from_cached_tree(40);
-
-        let pane = &app.tree.workspaces[0].screens[0].panes[0];
-        assert_eq!(pane.tabs.iter().map(|tab| tab.surface).collect::<Vec<_>>(), vec![41, 43]);
-        assert_eq!(pane.active_tab, 0);
-        assert!(!app.tab_locations.contains_key(&40));
-        assert_eq!(app.tab_locations.get(&41), Some(&[0, 0, 0, 0]));
-        assert_eq!(app.tab_locations.get(&43), Some(&[0, 0, 0, 1]));
-    }
-
-    #[test]
-    fn stale_surface_exit_index_falls_back_to_tree_scan_and_rebuilds_locations() {
-        let mux = Mux::new("stale-surface-exit-index-test", SurfaceOptions::default());
-        let mut app = test_app(Session::Local(mux));
-        let mut tree = notify_tree(41, false);
-        let pane = &mut tree.workspaces[0].screens[0].panes[0];
-        let mut second = pane.tabs[0].clone();
-        second.surface = 41;
-        let mut third = pane.tabs[0].clone();
-        third.surface = 43;
-        pane.tabs[0].surface = 40;
-        pane.tabs.push(second);
-        pane.tabs.push(third);
-        pane.active_tab = 2;
-        app.replace_tree(tree);
-
-        // Force the defensive dispatch path by making the cached location stale.
-        app.tab_locations.insert(40, [0, 0, 0, 1]);
-        app.remove_surface_from_cached_tree(40);
-
-        let pane = &app.tree.workspaces[0].screens[0].panes[0];
-        assert_eq!(pane.tabs.iter().map(|tab| tab.surface).collect::<Vec<_>>(), vec![41, 43]);
-        assert_eq!(pane.active_tab, 1);
-        assert_eq!(app.tab_locations.get(&41), Some(&[0, 0, 0, 0]));
-        assert_eq!(app.tab_locations.get(&43), Some(&[0, 0, 0, 1]));
-        assert!(!app.tab_locations.contains_key(&40));
-
-        // The fallback must repair the index so the next exit uses the
-        // indexed path instead of scanning the whole tree again.
-        app.remove_surface_from_cached_tree(41);
-        let pane = &app.tree.workspaces[0].screens[0].panes[0];
-        assert_eq!(pane.tabs.iter().map(|tab| tab.surface).collect::<Vec<_>>(), vec![43]);
-        assert_eq!(app.tab_locations.get(&43), Some(&[0, 0, 0, 0]));
-        assert!(!app.tab_locations.contains_key(&41));
     }
 
     #[test]
@@ -37412,7 +37097,7 @@ mod tests {
         app.shake_frames = 2;
         let (timeout_started_tx, timeout_started_rx) = std::sync::mpsc::channel();
         let (pointer_queued_tx, pointer_queued_rx) = std::sync::mpsc::channel();
-        app.timeout_drain_hook = Some(Box::new(move |_| {
+        app.timeout_drain_hook = Some(Box::new(move || {
             timeout_started_tx.send(()).unwrap();
             pointer_queued_rx.recv().unwrap();
         }));
@@ -37438,33 +37123,6 @@ mod tests {
             app.deferred_input_sequence, 1,
             "pointer input drained after a timeout-triggered draw must cross the rendered-frame barrier"
         );
-    }
-
-    #[test]
-    fn event_loop_expires_toast_on_idle_timeout() {
-        let mux = Mux::new("toast-timeout-test", SurfaceOptions::default());
-        let mut app = test_app(Session::Local(mux));
-        app.toast = Some(Toast {
-            text: "expired".to_string(),
-            deadline: Instant::now() - Duration::from_millis(1),
-        });
-        let timeout_seen = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let timeout_seen_in_hook = timeout_seen.clone();
-        let (events, receiver) = crossbeam_channel::unbounded();
-        app.timeout_drain_hook = Some(Box::new(move |app| {
-            timeout_seen_in_hook.store(true, std::sync::atomic::Ordering::Relaxed);
-            app.toast = Some(Toast {
-                text: "reintroduced".to_string(),
-                deadline: Instant::now() - Duration::from_millis(1),
-            });
-            drop(events);
-        }));
-        let mut terminal = Terminal::new(TestBackend::new(100, 20)).unwrap();
-
-        app.event_loop(&mut terminal, receiver).unwrap();
-
-        assert!(timeout_seen.load(std::sync::atomic::Ordering::Relaxed));
-        assert_eq!(app.toast.as_ref().map(|toast| toast.text.as_str()), Some("reintroduced"));
     }
 
     #[test]
@@ -44009,80 +43667,6 @@ mod tests {
         assert_eq!(app.session_generation, 2);
         assert!(app.machine_ui.as_ref().unwrap().request.is_none());
         assert!(!app.quit);
-    }
-
-    /// Regression test for issue 11042: when a remote event transport dies,
-    /// the reader thread records the reason and synthesizes `MuxEvent::Empty`.
-    /// That must surface the transport failure as an error, never the "session
-    /// has no workspaces" clean quit (exit code 0) it produces today.
-    #[test]
-    fn transport_loss_empty_event_is_an_error_not_a_clean_quit() {
-        let reason = "the daemon closed the connection";
-        let mut app = test_app(test_remote_session_with_lost_transport(reason));
-
-        let result = app.handle(AppEvent::Mux(MuxEvent::Empty));
-
-        let error = result.expect_err("a lost event transport must not report an empty session");
-        assert_eq!(error.to_string(), "session connection lost. Reconnect and retry.");
-        assert!(!error.to_string().contains(reason));
-        assert!(!app.quit, "a lost transport must not use the clean-quit path");
-    }
-
-    /// The transport check must run BEFORE any machine-session request: with
-    /// machine/provider authority present, `request_current_machine_session`
-    /// returns true and would otherwise swallow the dead transport into a
-    /// stuck reconnect state.
-    #[test]
-    fn transport_loss_outranks_a_machine_session_request() {
-        let reason = "the daemon closed the connection";
-        let mut app = test_app(test_remote_session_with_lost_transport(reason));
-        app.machine_ui = Some(provider_machine_ui());
-
-        let result = app.handle(AppEvent::Mux(MuxEvent::Empty));
-
-        let error = result.expect_err("machine authority must not hide a lost transport");
-        assert_eq!(error.to_string(), "session connection lost. Reconnect and retry.");
-        assert!(!error.to_string().contains(reason));
-        assert!(!app.quit);
-        let machine = app.machine_ui.as_ref().unwrap();
-        assert!(
-            machine.request.is_none(),
-            "no reconnect request may be queued for a dead transport"
-        );
-    }
-
-    /// A sleeping or stopped machine loses its stream because it was paused;
-    /// that deliberate loss keeps presenting the machine as asleep instead of
-    /// failing the client, even though a transport reason is recorded.
-    #[test]
-    fn sleeping_machine_stream_loss_still_presents_as_asleep() {
-        let mut app =
-            test_app(test_remote_session_with_lost_transport("the daemon closed the connection"));
-        let mut ui = provider_machine_ui();
-        ui.snapshot.machines[0].status = MachineStatus::Sleeping;
-        app.machine_ui = Some(ui);
-
-        let action = app.handle(AppEvent::Mux(MuxEvent::Empty)).unwrap();
-
-        assert_eq!(action, RenderAction::Draw);
-        assert!(!app.quit);
-        let machine = app.machine_ui.as_ref().unwrap();
-        assert!(!machine.session_available);
-        assert!(machine.request.is_none());
-    }
-
-    /// A genuinely emptied session (all workspaces closed) still exits
-    /// cleanly: `MuxEvent::Empty` without a recorded transport failure keeps
-    /// the quiet quit path.
-    #[test]
-    fn empty_session_without_transport_loss_still_quits_cleanly() {
-        let mux = Mux::new("empty-clean-quit-test", SurfaceOptions::default());
-        let mut app = test_app(Session::Local(mux));
-
-        let action = app.handle(AppEvent::Mux(MuxEvent::Empty)).unwrap();
-
-        assert_eq!(action, RenderAction::None);
-        assert!(app.quit);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -99,6 +99,22 @@ use crate::ui::{
 };
 
 const DEFERRED_INPUT_CAPACITY: usize = 512;
+const MAX_PROJECTION_ROWS_CACHE_ENTRIES: usize = 8;
+
+#[derive(Clone)]
+struct ProjectionRowsCache {
+    view_id: String,
+    workspace_revision: u64,
+    pane_revision: Option<u64>,
+    agent_revision: u64,
+    invalidation_revision: u64,
+    selected_workspace: usize,
+    rows: Vec<ProjectionRow>,
+}
+
+// Projection rows are a render snapshot. Keep only the most recently used
+// view snapshots so a large all-workspaces projection cannot retain unbounded
+// memory when configuration contains many views.
 
 fn read_crossterm_event(
     timeout: Option<Duration>,
@@ -6924,6 +6940,9 @@ pub struct App {
     pub(crate) tabs_rail_scroll: usize,
     pub(crate) tabs_footer_scroll: usize,
     projection_rails: HashMap<String, ProjectionRailState>,
+    projection_rows_cache: VecDeque<ProjectionRowsCache>,
+    projection_rows_revision: u64,
+    projection_agent_revision: u64,
     pub(crate) machine_rail_follow_selection: bool,
     pub(crate) workspace_rail_follow_selection: bool,
     pub(crate) tabs_rail_follow_selection: bool,
@@ -9433,6 +9452,9 @@ fn run_with_machine_updates_inner(
         tabs_rail_scroll: 0,
         tabs_footer_scroll: 0,
         projection_rails: HashMap::new(),
+        projection_rows_cache: VecDeque::new(),
+        projection_rows_revision: 0,
+        projection_agent_revision: 0,
         machine_rail_follow_selection: true,
         workspace_rail_follow_selection: true,
         tabs_rail_follow_selection: true,
@@ -10181,14 +10203,15 @@ impl App {
         self.focus == FocusTarget::ProjectionRail(index)
     }
 
-    pub(crate) fn projection_rows(&self, index: usize) -> Vec<ProjectionRow> {
-        let Some(spec) = self.config.sidebar.views.get(index) else { return Vec::new() };
-        let empty_collapsed = HashSet::new();
+    pub(crate) fn projection_rows(&mut self, index: usize) -> Vec<ProjectionRow> {
+        let Some(spec) = self.config.sidebar.views.get(index).cloned() else {
+            return Vec::new();
+        };
         let collapsed = self
             .projection_rails
             .get(&spec.id)
-            .map(|state| &state.collapsed)
-            .unwrap_or(&empty_collapsed);
+            .map(|state| state.collapsed.clone())
+            .unwrap_or_default();
         let agents = if spec.includes(SidebarResourceKind::Agents) {
             // Finished reports are historical records, not active agents.
             // Otherwise detached "surface..." rows remain forever after exit.
@@ -10207,13 +10230,59 @@ impl App {
         } else {
             Vec::new()
         };
-        crate::sidebar_projection::rows(
-            spec,
-            &self.tree,
-            &agents,
-            self.sidebar_workspace_selection,
-            collapsed,
-        )
+        let selected_workspace = self.sidebar_workspace_selection;
+        let workspace_revision = self.tree.workspace_revision;
+        let pane_revision = self.tree.pane_revision;
+        let agent_revision = self.projection_agent_revision;
+        let invalidation_revision = self.projection_rows_revision;
+        let cache_index = self.projection_rows_cache.iter().position(|cache| {
+            cache.view_id == spec.id
+                && cache.workspace_revision == workspace_revision
+                && cache.pane_revision == pane_revision
+                && cache.agent_revision == agent_revision
+                && cache.invalidation_revision == invalidation_revision
+                && cache.selected_workspace == selected_workspace
+        });
+        let rows = if let Some(cache_index) = cache_index {
+            let cache = self
+                .projection_rows_cache
+                .remove(cache_index)
+                .expect("projection cache index came from the cache");
+            let rows = cache.rows.clone();
+            self.projection_rows_cache.push_front(cache);
+            rows
+        } else {
+            let rows = crate::sidebar_projection::rows(
+                &spec,
+                &self.tree,
+                &agents,
+                selected_workspace,
+                &collapsed,
+            );
+            self.projection_rows_cache.push_front(ProjectionRowsCache {
+                view_id: spec.id.clone(),
+                workspace_revision,
+                pane_revision,
+                agent_revision,
+                invalidation_revision,
+                selected_workspace,
+                rows: rows.clone(),
+            });
+            self.projection_rows_cache.truncate(MAX_PROJECTION_ROWS_CACHE_ENTRIES);
+            rows
+        };
+        self.projection_rail_state_mut(index).reconcile_selection(&rows);
+        rows
+    }
+
+    fn invalidate_projection_rows_cache(&mut self) {
+        self.projection_rows_revision = self.projection_rows_revision.wrapping_add(1);
+        self.projection_rows_cache.clear();
+    }
+
+    fn invalidate_agent_projection_rows_cache(&mut self) {
+        self.projection_agent_revision = self.projection_agent_revision.wrapping_add(1);
+        self.invalidate_projection_rows_cache();
     }
 
     pub(crate) fn sidebar_action_rows(&self, index: usize) -> Vec<SidebarActionRow> {
@@ -11903,6 +11972,7 @@ impl App {
             self.browser_input.forget_surface(surface);
         }
         self.tree = tree;
+        self.invalidate_projection_rows_cache();
         self.tab_locations.clear();
         self.rebuild_tab_locations();
         self.render_states.clear();
@@ -13182,6 +13252,7 @@ impl App {
         self.viewport_states.retain(|screen, _| live_screens.contains(screen));
         self.pane_focus_history.sync_membership(&tree);
         self.tree = tree;
+        self.invalidate_projection_rows_cache();
         self.sidebar_workspace_selection = selected_workspace
             .and_then(|selected| {
                 self.tree.workspaces.iter().position(|workspace| workspace.id == selected)
@@ -14013,6 +14084,7 @@ impl App {
         self.session.apply_config(config.clone());
         self.sidebar_view = config.sidebar.view;
         self.config = config;
+        self.invalidate_projection_rows_cache();
         let mut valid_view_ids =
             self.config.sidebar.views.iter().map(|view| view.id.clone()).collect::<HashSet<_>>();
         self.projection_rails.retain(|id, _| valid_view_ids.contains(id));
@@ -15142,7 +15214,11 @@ impl App {
             AppEvent::HostInputReady => Ok(RenderAction::None),
             AppEvent::GraphicsWriterReady => Ok(self.apply_graphics_completion()),
             AppEvent::MuxTitlesReady => {
-                Ok(if self.apply_mux_titles() { RenderAction::Paint } else { RenderAction::None })
+                let changed = self.apply_mux_titles();
+                if changed {
+                    self.invalidate_projection_rows_cache();
+                }
+                Ok(if changed { RenderAction::Paint } else { RenderAction::None })
             }
             AppEvent::StatusCommandsUpdated => {
                 self.status_poke_pending.store(false, Ordering::Release);
@@ -15352,6 +15428,14 @@ impl App {
                 } else {
                     Ok(RenderAction::Paint)
                 }
+            }
+            AppEvent::Mux(MuxEvent::AgentChanged { .. }) => {
+                self.invalidate_agent_projection_rows_cache();
+                Ok(RenderAction::Draw)
+            }
+            AppEvent::Mux(MuxEvent::TitleChanged { .. }) => {
+                self.invalidate_projection_rows_cache();
+                Ok(RenderAction::Draw)
             }
             AppEvent::Mux(MuxEvent::PairingRequested(challenge)) => {
                 let duplicate = self
@@ -18098,6 +18182,7 @@ impl App {
                 && selected.as_ref().is_some_and(|row| row.expanded)
             {
                 self.projection_rail_state_mut(view_index).collapsed.insert(branch);
+                self.invalidate_projection_rows_cache();
             } else {
                 self.focus_adjacent_rail(RailKind::Projection(view_index), -1);
             }
@@ -18109,6 +18194,7 @@ impl App {
                 && selected.as_ref().is_some_and(|row| !row.expanded)
             {
                 self.projection_rail_state_mut(view_index).collapsed.remove(&branch);
+                self.invalidate_projection_rows_cache();
             } else if !self.focus_adjacent_rail(RailKind::Projection(view_index), 1) {
                 self.focus = FocusTarget::Pane;
             }
@@ -18126,6 +18212,7 @@ impl App {
             let state = self.projection_rail_state_mut(view_index);
             if next < rows.len() {
                 state.selected = next;
+                state.selected_target = rows.get(next).map(|row| row.target);
                 state.selected_action = None;
             } else {
                 state.selected_action = Some(next.saturating_sub(rows.len()));
@@ -18136,10 +18223,13 @@ impl App {
         if matches!(key.code, KeyCode::Char(' '))
             && let Some(branch) = selected.as_ref().and_then(|row| row.branch)
         {
-            let state = self.projection_rail_state_mut(view_index);
-            if !state.collapsed.remove(&branch) {
-                state.collapsed.insert(branch);
+            {
+                let state = self.projection_rail_state_mut(view_index);
+                if !state.collapsed.remove(&branch) {
+                    state.collapsed.insert(branch);
+                }
             }
+            self.invalidate_projection_rows_cache();
             return Ok(RenderAction::Draw);
         }
         if key.code == KeyCode::Enter {
@@ -21944,14 +22034,18 @@ impl App {
                     }
                 }
                 Hit::ProjectionToggle { view, branch } => {
-                    let state = self.projection_rail_state_mut(view);
-                    if !state.collapsed.remove(&branch) {
-                        state.collapsed.insert(branch);
+                    {
+                        let state = self.projection_rail_state_mut(view);
+                        if !state.collapsed.remove(&branch) {
+                            state.collapsed.insert(branch);
+                        }
                     }
+                    self.invalidate_projection_rows_cache();
                 }
                 Hit::ProjectionRow { view, row, target } => {
                     let state = self.projection_rail_state_mut(view);
                     state.selected = row;
+                    state.selected_target = Some(target);
                     state.selected_action = None;
                     state.follow_selection = true;
                     self.activate_projection_target(target)?;
@@ -44238,6 +44332,9 @@ mod tests {
             tabs_rail_scroll: 0,
             tabs_footer_scroll: 0,
             projection_rails: HashMap::new(),
+            projection_rows_cache: VecDeque::new(),
+            projection_rows_revision: 0,
+            projection_agent_revision: 0,
             machine_rail_follow_selection: true,
             workspace_rail_follow_selection: true,
             tabs_rail_follow_selection: true,

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -15414,17 +15414,22 @@ impl App {
             AppEvent::MuxTitlesReady => {
                 let changed = self.apply_mux_titles();
                 let changed_any = !changed.is_empty();
+                let mut projection_paint_requested = false;
                 for surface in changed {
-                    self.invalidate_projection_rows_for_surface(
+                    projection_paint_requested |= self.invalidate_projection_rows_for_surface(
                         surface,
                         ProjectionSurfaceChange::Title,
                     );
                 }
-                Ok(if changed_any && self.schedule_projection_paint() {
-                    RenderAction::Paint
-                } else {
-                    RenderAction::None
-                })
+                Ok(
+                    if changed_any
+                        && (projection_paint_requested || self.schedule_projection_paint())
+                    {
+                        RenderAction::Paint
+                    } else {
+                        RenderAction::None
+                    },
+                )
             }
             AppEvent::StatusCommandsUpdated => {
                 self.status_poke_pending.store(false, Ordering::Release);
@@ -42632,6 +42637,42 @@ mod tests {
 
         mux.close_surface(first.id).unwrap();
         mux.close_surface(second.id).unwrap();
+    }
+
+    #[test]
+    fn projection_title_wake_paints_after_invalidating_cached_rows() {
+        let (mux, surface) = test_mux("projection-title-paint-test", None);
+        let mut app = test_app(Session::Local(mux.clone()));
+        app.config.sidebar.columns.clear();
+        app.config.sidebar.views = vec![SidebarViewSpec {
+            id: "tabs".into(),
+            levels: vec![SidebarResourceKind::Tabs],
+            actions: Vec::new(),
+            actions_position: crate::config::ActionsPosition::Bottom,
+            width: 40,
+            max_width: 0,
+            collapse_priority: 30,
+            scope: crate::config::SidebarViewScope::Workspace,
+        }];
+        app.config.sidebar.views_explicit = true;
+        app.replace_tree(app.session.tree());
+        app.projection_rows(0);
+
+        assert!(app.mux_titles.push(surface.id, "renamed".into()));
+        assert_eq!(app.handle(AppEvent::MuxTitlesReady).unwrap(), RenderAction::Paint);
+        assert_eq!(
+            app.tree
+                .workspaces
+                .iter()
+                .flat_map(|workspace| workspace.screens.iter())
+                .flat_map(|screen| screen.panes.iter())
+                .flat_map(|pane| pane.tabs.iter())
+                .find(|tab| tab.surface == surface.id)
+                .map(|tab| tab.title.as_str()),
+            Some("renamed")
+        );
+
+        mux.close_surface(surface.id).unwrap();
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -4185,6 +4185,9 @@ pub struct SidebarSplitGroupPlacement {
     pub id: String,
     pub dir: crate::config::SidebarSplitDir,
     pub children: Vec<Rect>,
+    /// Stable child ids in the same order as `children`. Drag state uses
+    /// these ids so a layout refresh cannot retarget a divider by index.
+    pub child_keys: Vec<String>,
 }
 
 /// A draggable boundary between two children of a split group. A vertical
@@ -5665,8 +5668,8 @@ enum Drag {
     /// Independent rail width override drag.
     RailResize(RailKind),
     /// Sidebar split-group divider drag: re-shares the group's children.
-    /// The stable config id survives layout pruning and reordering.
-    SidebarSplit { group: String, index: usize },
+    /// Stable group and child ids survive layout pruning and reordering.
+    SidebarSplit { group: String, first_child: String, second_child: String },
     /// Pane split resize drag.
     ResizeSplit { horizontal: Option<PaneResizeDragTarget>, vertical: Option<PaneResizeDragTarget> },
 }
@@ -7986,6 +7989,7 @@ enum SidebarColumnNode {
     Leaf {
         view_index: usize,
         kind: RailKind,
+        key: String,
         priority: u16,
     },
     Split {
@@ -7997,6 +8001,12 @@ enum SidebarColumnNode {
 }
 
 impl SidebarColumnNode {
+    fn key(&self) -> &str {
+        match self {
+            SidebarColumnNode::Leaf { key, .. } | SidebarColumnNode::Split { id: key, .. } => key,
+        }
+    }
+
     fn priority(&self) -> u16 {
         match self {
             SidebarColumnNode::Leaf { priority, .. }
@@ -8041,6 +8051,7 @@ fn prune_sidebar_layout_node(
             Some(SidebarColumnNode::Leaf {
                 view_index: *view_index,
                 kind,
+                key: view.id.clone(),
                 priority: view.collapse_priority,
             })
         }
@@ -8163,6 +8174,7 @@ fn place_sidebar_column_node(
                 id: id.clone(),
                 dir: *dir,
                 children: Vec::new(),
+                child_keys: Vec::new(),
             });
             let mut offset = 0u16;
             for (child_index, (_, child)) in kept.iter().enumerate() {
@@ -8181,6 +8193,7 @@ fn place_sidebar_column_node(
                     },
                 };
                 layout.split_groups[group_index].children.push(child_rect);
+                layout.split_groups[group_index].child_keys.push(child.key().to_string());
                 place_sidebar_column_node(child, child_rect, layout, split_fractions);
                 offset = offset.saturating_add(sizes[child_index]);
                 if child_index + 1 < kept.len() {
@@ -8272,7 +8285,7 @@ fn sidebar_layout_for_state(
             let node =
                 prune_sidebar_layout_node(layout_node, views, hidden_views, machine_visible)?;
             let (key, desired, max_width, priority) = match &node {
-                SidebarColumnNode::Leaf { view_index, kind, priority } => {
+                SidebarColumnNode::Leaf { view_index, kind, priority, .. } => {
                     let view = views.get(*view_index)?;
                     let width_override = match kind {
                         RailKind::Machine => machine_override,
@@ -10427,6 +10440,13 @@ impl App {
     ) {
         if previous != SidebarProjectionSpec::from_config(&self.config) {
             self.invalidate_projection_rows_cache();
+            self.cancel_sidebar_layout_drag();
+        }
+    }
+
+    fn cancel_sidebar_layout_drag(&mut self) {
+        if matches!(self.drag, Some(Drag::RailResize(_) | Drag::SidebarSplit { .. })) {
+            self.drag = None;
         }
     }
 
@@ -22423,23 +22443,21 @@ impl App {
                         .find(|divider| divider.rect.contains(x, y))
                         .copied()
                     {
-                        if let Some(group) = self
-                            .sidebar_layout
-                            .split_groups
-                            .get(divider.group)
-                            .map(|group| group.id.clone())
+                        if let Some((group, first_child, second_child)) =
+                            self.sidebar_split_drag_target(divider.group, divider.index)
                         {
-                            self.drag = Some(Drag::SidebarSplit { group, index: divider.index });
+                            self.drag =
+                                Some(Drag::SidebarSplit { group, first_child, second_child });
                         }
                     } else {
                         self.drag = Some(Drag::RailResize(kind));
                     }
                 }
                 Hit::SidebarSplitDivider { group, index } => {
-                    if let Some(group) =
-                        self.sidebar_layout.split_groups.get(group).map(|group| group.id.clone())
+                    if let Some((group, first_child, second_child)) =
+                        self.sidebar_split_drag_target(group, index)
                     {
-                        self.drag = Some(Drag::SidebarSplit { group, index });
+                        self.drag = Some(Drag::SidebarSplit { group, first_child, second_child });
                     }
                 }
                 Hit::PaneResize { horizontal, vertical } => {
@@ -22711,9 +22729,14 @@ impl App {
                 }
                 Ok(RenderAction::Draw)
             }
-            Some(Drag::SidebarSplit { group, index }) => {
-                let group = group.clone();
-                self.drag_sidebar_split_divider(&group, *index, x, y);
+            Some(Drag::SidebarSplit { group, first_child, second_child }) => {
+                let (group, first_child, second_child) =
+                    (group.clone(), first_child.clone(), second_child.clone());
+                if !self.drag_sidebar_split_divider(&group, &first_child, &second_child, x, y) {
+                    // The split topology changed while the pointer was down.
+                    // Do not apply the old divider to a new child pair.
+                    self.drag = None;
+                }
                 Ok(RenderAction::Draw)
             }
             Some(Drag::ResizeSplit { horizontal, vertical }) => {
@@ -22730,18 +22753,47 @@ impl App {
         }
     }
 
+    /// Capture stable ids for the two children flanking a divider.
+    fn sidebar_split_drag_target(
+        &self,
+        group_index: usize,
+        child_index: usize,
+    ) -> Option<(String, String, String)> {
+        let group = self.sidebar_layout.split_groups.get(group_index)?;
+        let first_child = group.child_keys.get(child_index)?.clone();
+        let second_child = group.child_keys.get(child_index + 1)?.clone();
+        Some((group.id.clone(), first_child, second_child))
+    }
+
     /// Convert a divider drag into new share fractions for its split group.
-    /// Only the two children flanking the divider change; the rest keep
-    /// their rendered sizes.
-    fn drag_sidebar_split_divider(&mut self, group: &str, index: usize, x: u16, y: u16) {
+    /// Return false when the split topology no longer contains the same
+    /// adjacent child pair captured at mouse-down.
+    fn drag_sidebar_split_divider(
+        &mut self,
+        group: &str,
+        first_child: &str,
+        second_child: &str,
+        x: u16,
+        y: u16,
+    ) -> bool {
         use crate::config::SidebarSplitDir;
         let Some(placement) =
             self.sidebar_layout.split_groups.iter().find(|placement| placement.id == group)
         else {
-            return;
+            return false;
         };
-        let Some(first) = placement.children.get(index).copied() else { return };
-        let Some(second) = placement.children.get(index + 1).copied() else { return };
+        let Some(index) = placement.child_keys.iter().position(|key| key == first_child) else {
+            return false;
+        };
+        let Some(second_index) = placement.child_keys.iter().position(|key| key == second_child)
+        else {
+            return false;
+        };
+        if second_index != index + 1 {
+            return false;
+        }
+        let Some(first) = placement.children.get(index).copied() else { return false };
+        let Some(second) = placement.children.get(second_index).copied() else { return false };
         let mut sizes: Vec<u16> = placement
             .children
             .iter()
@@ -22767,18 +22819,19 @@ impl App {
             ),
         };
         if combined < min_each.saturating_mul(2) {
-            return;
+            return true;
         }
         let desired_first = desired_first.clamp(min_each, combined - min_each);
         sizes[index] = desired_first;
         sizes[index + 1] = combined - desired_first;
         let total: f32 = sizes.iter().map(|size| f32::from(*size)).sum();
         if total <= 0.0 {
-            return;
+            return true;
         }
         let id = placement.id.clone();
         let fractions = sizes.iter().map(|size| f32::from(*size) / total).collect();
         self.sidebar_split_fractions.insert(id, fractions);
+        true
     }
 
     fn handle_left_up(&mut self, x: u16, y: u16) -> anyhow::Result<RenderAction> {
@@ -27427,7 +27480,7 @@ mod tests {
         app.sync_layout((120, 31));
         assert_eq!(app.sidebar_layout.dividers.len(), 1);
 
-        app.drag_sidebar_split_divider("left", 0, 0, 9);
+        app.drag_sidebar_split_divider("left", "workspaces", "all-agents", 0, 9);
         app.sync_layout((120, 31));
         let top = app.sidebar_layout.ordered[0].rect;
         let bottom = app.sidebar_layout.ordered[1].rect;
@@ -27435,7 +27488,7 @@ mod tests {
         assert_eq!(top.height + bottom.height, 30);
 
         // The two rails clamp at their minimum height.
-        app.drag_sidebar_split_divider("left", 0, 0, 0);
+        app.drag_sidebar_split_divider("left", "workspaces", "all-agents", 0, 0);
         app.sync_layout((120, 31));
         assert_eq!(app.sidebar_layout.ordered[0].rect.height, super::MIN_SPLIT_RAIL_HEIGHT);
     }
@@ -27452,6 +27505,7 @@ mod tests {
                     Rect { x: 0, y: 0, width: 20, height: 10 },
                     Rect { x: 0, y: 11, width: 20, height: 10 },
                 ],
+                child_keys: vec!["other-first".into(), "other-second".into()],
             },
             SidebarSplitGroupPlacement {
                 id: "left".into(),
@@ -27460,13 +27514,72 @@ mod tests {
                     Rect { x: 0, y: 0, width: 20, height: 10 },
                     Rect { x: 0, y: 11, width: 20, height: 10 },
                 ],
+                child_keys: vec!["first".into(), "second".into()],
             },
         ];
 
-        app.drag_sidebar_split_divider("left", 0, 0, 9);
+        app.drag_sidebar_split_divider("left", "first", "second", 0, 9);
 
         assert!(app.sidebar_split_fractions.contains_key("left"));
         assert!(!app.sidebar_split_fractions.contains_key("other"));
+    }
+
+    #[test]
+    fn sidebar_split_drag_keeps_the_same_children_after_layout_pruning() {
+        use crate::config::{SidebarLayoutNode, SidebarSplitDir, SidebarSplitSpec};
+
+        let mux = Mux::new("sidebar-split-drag-pruning-test", SurfaceOptions::default());
+        let mut app = test_app(Session::Local(mux));
+        let mut config = split_sidebar_config();
+        let mut third = config.sidebar.views[1].clone();
+        third.id = "third".into();
+        let mut fourth = third.clone();
+        fourth.id = "fourth".into();
+        config.sidebar.views.extend([third, fourth]);
+        config.sidebar.views[0].collapse_priority = 1;
+        config.sidebar.views[1].collapse_priority = 20;
+        config.sidebar.views[2].collapse_priority = 30;
+        config.sidebar.views[3].collapse_priority = 40;
+        config.sidebar.layout = vec![SidebarLayoutNode::Split(SidebarSplitSpec {
+            id: "left".into(),
+            dir: SidebarSplitDir::Vertical,
+            weights: vec![1; 4],
+            children: (0..4).map(SidebarLayoutNode::Leaf).collect(),
+            width: 26,
+            max_width: 0,
+            collapse_priority: 30,
+        })];
+        config.sidebar.views_explicit = true;
+        app.config = config;
+
+        // Capture the divider between the second and third children while all
+        // four children fit.
+        app.sync_layout((120, 23));
+        let (group, first_child, second_child) =
+            app.sidebar_split_drag_target(0, 1).expect("second split divider exists");
+        assert_eq!((first_child.as_str(), second_child.as_str()), ("all-agents", "third"));
+        app.drag = Some(Drag::SidebarSplit { group, first_child, second_child });
+
+        // A shorter frame prunes only the first child. The captured pair is
+        // now at indexes 0 and 1, so an index-only drag would target the wrong
+        // pair (or fail when the old index is out of range).
+        app.sync_layout((120, 18));
+        assert_eq!(
+            app.sidebar_layout.split_groups[0].child_keys,
+            vec!["all-agents", "third", "fourth"]
+        );
+        app.handle_left_drag(0, 6).unwrap();
+        app.sync_layout((120, 18));
+
+        let fourth_height = app
+            .sidebar_layout
+            .ordered
+            .iter()
+            .find(|placement| placement.kind == RailKind::Projection(3))
+            .map(|placement| placement.rect.height)
+            .expect("fourth child remains visible");
+        assert_eq!(fourth_height, 5, "the captured pair, not the stale index, was resized");
+        assert!(matches!(app.drag, Some(Drag::SidebarSplit { .. })));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -7062,7 +7062,9 @@ pub struct App {
     projection_rows_revision: u64,
     /// Projection surfaces seen by the most recent rendered snapshots. These
     /// sets cover caches evicted by the bounded LRU, so an update still wakes
-    /// a visible rail even when its snapshot is not retained.
+    /// a visible rail even when its snapshot is not retained. They are pruned
+    /// against the current tab locations after every cache/index update, so a
+    /// retired surface cannot accumulate or trigger future fanout.
     projection_agent_surfaces: HashSet<SurfaceId>,
     projection_title_surfaces: HashSet<SurfaceId>,
     /// Coalesce surface updates until the next successful rendered frame.
@@ -10360,6 +10362,7 @@ impl App {
             self.projection_title_surfaces.extend(cache.title_surfaces.iter().copied());
             let rows = cache.rows.clone();
             self.projection_rows_cache.push_front(cache);
+            self.prune_projection_surface_indexes();
             rows
         } else {
             let agents = if spec.includes(SidebarResourceKind::Agents) {
@@ -10403,6 +10406,7 @@ impl App {
                 rows: rows.clone(),
             });
             self.projection_rows_cache.truncate(MAX_PROJECTION_ROWS_CACHE_ENTRIES);
+            self.prune_projection_surface_indexes();
             rows
         };
         self.projection_rail_state_mut(index).reconcile_selection(&rows);
@@ -10415,6 +10419,16 @@ impl App {
         self.projection_agent_surfaces.clear();
         self.projection_title_surfaces.clear();
         self.projection_paint_pending = false;
+    }
+
+    fn prune_projection_surface_indexes(&mut self) {
+        let live_surfaces = &self.tab_locations;
+        for cache in &mut self.projection_rows_cache {
+            cache.agent_surfaces.retain(|surface| live_surfaces.contains_key(surface));
+            cache.title_surfaces.retain(|surface| live_surfaces.contains_key(surface));
+        }
+        self.projection_agent_surfaces.retain(|surface| live_surfaces.contains_key(surface));
+        self.projection_title_surfaces.retain(|surface| live_surfaces.contains_key(surface));
     }
 
     fn invalidate_projection_rows_if_sidebar_spec_changed(
@@ -10450,6 +10464,7 @@ impl App {
         surface: SurfaceId,
         change: ProjectionSurfaceChange,
     ) -> bool {
+        self.prune_projection_surface_indexes();
         let was_affected = self.projection_rows_cache.iter().any(|cache| match change {
             ProjectionSurfaceChange::Agent => cache.agent_surfaces.contains(&surface),
             ProjectionSurfaceChange::Title => cache.title_surfaces.contains(&surface),
@@ -10479,6 +10494,18 @@ impl App {
 
     fn clear_pending_projection_paint(&mut self) {
         self.projection_paint_pending = false;
+    }
+
+    fn invalidate_projection_rows_for_surfaces(
+        &mut self,
+        surfaces: impl IntoIterator<Item = SurfaceId>,
+        change: ProjectionSurfaceChange,
+    ) -> bool {
+        let mut paint_requested = false;
+        for surface in surfaces {
+            paint_requested |= self.invalidate_projection_rows_for_surface(surface, change);
+        }
+        paint_requested
     }
 
     pub(crate) fn sidebar_action_rows(&self, index: usize) -> Vec<SidebarActionRow> {
@@ -13356,14 +13383,22 @@ impl App {
         RenderAction::Draw
     }
 
-    fn apply_mux_titles(&mut self) -> HashSet<SurfaceId> {
+    fn apply_mux_titles(&mut self) -> (bool, bool) {
         let titles = self.mux_titles.take_dirty();
-        self.apply_mux_title_snapshot(titles)
+        let changed = self.apply_mux_title_snapshot(titles);
+        let changed_any = !changed.is_empty();
+        let projection_paint_requested =
+            self.invalidate_projection_rows_for_surfaces(changed, ProjectionSurfaceChange::Title);
+        (changed_any, projection_paint_requested)
     }
 
-    fn reapply_mux_titles(&mut self) -> bool {
+    fn reapply_mux_titles(&mut self) -> (bool, bool) {
         let titles = self.mux_titles.snapshot();
-        !self.apply_mux_title_snapshot(titles).is_empty()
+        let changed = self.apply_mux_title_snapshot(titles);
+        let changed_any = !changed.is_empty();
+        let projection_paint_requested =
+            self.invalidate_projection_rows_for_surfaces(changed, ProjectionSurfaceChange::Title);
+        (changed_any, projection_paint_requested)
     }
 
     fn apply_mux_title_snapshot(
@@ -13575,6 +13610,7 @@ impl App {
             }
         }
         self.rebuild_tab_locations();
+        self.prune_projection_surface_indexes();
     }
 
     fn apply_session_completions_through(&mut self, authoritative_generation: u64) -> bool {
@@ -15412,15 +15448,7 @@ impl App {
             AppEvent::HostInputReady => Ok(RenderAction::None),
             AppEvent::GraphicsWriterReady => Ok(self.apply_graphics_completion()),
             AppEvent::MuxTitlesReady => {
-                let changed = self.apply_mux_titles();
-                let changed_any = !changed.is_empty();
-                let mut projection_paint_requested = false;
-                for surface in changed {
-                    projection_paint_requested |= self.invalidate_projection_rows_for_surface(
-                        surface,
-                        ProjectionSurfaceChange::Title,
-                    );
-                }
+                let (changed_any, projection_paint_requested) = self.apply_mux_titles();
                 Ok(
                     if changed_any
                         && (projection_paint_requested || self.schedule_projection_paint())
@@ -42640,6 +42668,35 @@ mod tests {
     }
 
     #[test]
+    fn projection_surface_indexes_drop_retired_surfaces() {
+        let (mux, surface) = test_mux("projection-surface-index-prune-test", None);
+        let mut app = test_app(Session::Local(mux.clone()));
+        app.config.sidebar.columns.clear();
+        app.config.sidebar.views = vec![SidebarViewSpec {
+            id: "agents".into(),
+            levels: vec![SidebarResourceKind::Agents],
+            actions: Vec::new(),
+            actions_position: crate::config::ActionsPosition::Bottom,
+            width: 40,
+            max_width: 0,
+            collapse_priority: 30,
+            scope: crate::config::SidebarViewScope::Workspace,
+        }];
+        app.config.sidebar.views_explicit = true;
+        app.replace_tree(app.session.tree());
+        app.projection_rows(0);
+
+        assert!(app.projection_agent_surfaces.contains(&surface.id));
+        app.handle(AppEvent::Mux(MuxEvent::SurfaceExited(surface.id))).unwrap();
+        assert!(!app.projection_agent_surfaces.contains(&surface.id));
+
+        // A retained cache entry may still be hit before the authoritative
+        // topology refresh. It must not reintroduce the retired id.
+        app.projection_rows(0);
+        assert!(!app.projection_agent_surfaces.contains(&surface.id));
+    }
+
+    #[test]
     fn projection_title_wake_paints_after_invalidating_cached_rows() {
         let (mux, surface) = test_mux("projection-title-paint-test", None);
         let mut app = test_app(Session::Local(mux.clone()));
@@ -42671,6 +42728,44 @@ mod tests {
                 .map(|tab| tab.title.as_str()),
             Some("renamed")
         );
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
+    fn reapply_mux_titles_invalidates_cached_projection_rows() {
+        let (mux, surface) = test_mux("projection-title-reapply-cache-test", None);
+        let mut app = test_app(Session::Local(mux.clone()));
+        app.config.sidebar.columns.clear();
+        app.config.sidebar.views = vec![SidebarViewSpec {
+            id: "tabs".into(),
+            levels: vec![SidebarResourceKind::Tabs],
+            actions: Vec::new(),
+            actions_position: crate::config::ActionsPosition::Bottom,
+            width: 40,
+            max_width: 0,
+            collapse_priority: 30,
+            scope: crate::config::SidebarViewScope::Workspace,
+        }];
+        app.config.sidebar.views_explicit = true;
+        app.replace_tree(app.session.tree());
+        app.projection_rows(0);
+        assert_eq!(app.projection_rows_cache.len(), 1);
+
+        assert!(app.mux_titles.push(surface.id, "reapplied"));
+        let (changed, projection_paint_requested) = app.reapply_mux_titles();
+        assert!(changed);
+        assert!(projection_paint_requested);
+        assert!(app.projection_rows_cache.is_empty());
+
+        let rows = app.projection_rows(0);
+        assert!(rows.iter().any(|row| {
+            matches!(
+                row.target,
+                crate::sidebar_projection::ProjectionTarget::Surface { surface: id, .. }
+                    if id == surface.id
+            ) && row.name == "reapplied"
+        }));
 
         mux.close_surface(surface.id).unwrap();
     }

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -4217,6 +4217,10 @@ impl SidebarLayout {
         self.content.x
     }
 
+    fn has_column(&self, key: &str) -> bool {
+        self.columns.iter().any(|column| column.key == key)
+    }
+
     pub fn rail(&self, kind: RailKind) -> Option<Rect> {
         match kind {
             RailKind::Machine => self.machine,
@@ -8000,13 +8004,6 @@ impl SidebarColumnNode {
         }
     }
 
-    fn first_kind(&self) -> RailKind {
-        match self {
-            SidebarColumnNode::Leaf { kind, .. } => *kind,
-            SidebarColumnNode::Split { children, .. } => children[0].1.first_kind(),
-        }
-    }
-
     fn collect_rails(&self, rails: &mut Vec<RailKind>) {
         match self {
             SidebarColumnNode::Leaf { kind, .. } => rails.push(*kind),
@@ -8248,7 +8245,6 @@ fn sidebar_layout_for_state(
     struct Spec {
         node: SidebarColumnNode,
         key: String,
-        first_kind: RailKind,
         desired: u16,
         max_width: u16,
         priority: u16,
@@ -8275,7 +8271,7 @@ fn sidebar_layout_for_state(
         .filter_map(|layout_node| {
             let node =
                 prune_sidebar_layout_node(layout_node, views, hidden_views, machine_visible)?;
-            let (key, first_kind, desired, max_width, priority) = match &node {
+            let (key, desired, max_width, priority) = match &node {
                 SidebarColumnNode::Leaf { view_index, kind, priority } => {
                     let view = views.get(*view_index)?;
                     let width_override = match kind {
@@ -8307,7 +8303,7 @@ fn sidebar_layout_for_state(
                             RailKind::Tabs | RailKind::Projection(_) => view.max_width,
                         }
                     };
-                    (view.id.clone(), *kind, desired, max_width, *priority)
+                    (view.id.clone(), desired, max_width, *priority)
                 }
                 SidebarColumnNode::Split { id, priority, .. } => {
                     // A pruned single-child split resolves as a leaf above,
@@ -8318,16 +8314,10 @@ fn sidebar_layout_for_state(
                         .copied()
                         .or(split.map(|split| split.width))
                         .unwrap_or(22);
-                    (
-                        id.clone(),
-                        node.first_kind(),
-                        desired,
-                        split.map_or(0, |split| split.max_width),
-                        *priority,
-                    )
+                    (id.clone(), desired, split.map_or(0, |split| split.max_width), *priority)
                 }
             };
-            Some(Spec { node, key, first_kind, desired, max_width, priority })
+            Some(Spec { node, key, desired, max_width, priority })
         })
         .collect::<Vec<_>>();
 
@@ -8342,7 +8332,7 @@ fn sidebar_layout_for_state(
     }
 
     if let Some(previous) = previous {
-        while specs.iter().any(|spec| previous.rail(spec.first_kind).is_none())
+        while specs.iter().any(|spec| !previous.has_column(&spec.key))
             && width
                 < MIN_CONTENT_WIDTH
                     .saturating_add(MIN_RAIL_WIDTH.saturating_mul(specs.len() as u16))
@@ -8351,7 +8341,7 @@ fn sidebar_layout_for_state(
             let Some((index, _)) = specs
                 .iter()
                 .enumerate()
-                .filter(|(_, spec)| previous.rail(spec.first_kind).is_none())
+                .filter(|(_, spec)| !previous.has_column(&spec.key))
                 .min_by_key(|(_, spec)| spec.priority)
             else {
                 break;
@@ -10440,6 +10430,13 @@ impl App {
         }
     }
 
+    /// Width and divider overrides are local to the active profile. Drop both
+    /// maps together whenever a profile replacement changes that owner.
+    fn clear_profile_sidebar_geometry(&mut self) {
+        self.projection_sidebar_width_overrides.clear();
+        self.sidebar_split_fractions.clear();
+    }
+
     /// Replace the active profile's projection specification and invalidate
     /// snapshots in one place. View ids are profile-local, so a reused id may
     /// describe a different resource tree after the replacement.
@@ -10455,7 +10452,7 @@ impl App {
         self.config.sidebar.views = views;
         self.config.sidebar.layout = layout;
         if profile_changed {
-            self.sidebar_split_fractions.clear();
+            self.clear_profile_sidebar_geometry();
         }
         self.invalidate_projection_rows_if_sidebar_spec_changed(previous);
     }
@@ -14323,7 +14320,7 @@ impl App {
         self.sidebar_view = config.sidebar.view;
         self.config = config;
         if previous_profile != self.config.sidebar.active_profile {
-            self.sidebar_split_fractions.clear();
+            self.clear_profile_sidebar_geometry();
         }
         self.invalidate_projection_rows_if_sidebar_spec_changed(previous_projection);
         let mut valid_view_ids =
@@ -27198,9 +27195,11 @@ mod tests {
         app.sidebar_split_fractions.insert("left".into(), vec![0.8, 0.2]);
         app.sync_layout((120, 31));
         assert_eq!(app.sidebar_layout.ordered[0].rect.height, 24);
+        app.projection_sidebar_width_overrides.insert("left".into(), 50);
 
         app.activate_sidebar_profile(1);
         assert!(app.sidebar_split_fractions.is_empty());
+        assert!(app.projection_sidebar_width_overrides.is_empty());
         app.sync_layout((120, 31));
         assert_eq!(app.sidebar_layout.ordered[0].rect.height, 23);
     }
@@ -27261,6 +27260,50 @@ mod tests {
             Some(&at_boundary),
         );
         assert!(revealed.machine.is_some());
+    }
+
+    #[test]
+    fn split_hysteresis_tracks_column_after_inner_child_pruning() {
+        let mut config = split_sidebar_config();
+        // The first child is pruned by the split's minimum height, while the
+        // top-level split column itself remains rendered.
+        config.sidebar.views[0].collapse_priority = 10;
+        config.sidebar.views[1].collapse_priority = 20;
+
+        let previous = sidebar_layout_for_state(
+            &config,
+            true,
+            false,
+            false,
+            (50, 8),
+            None,
+            None,
+            None,
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashSet::new(),
+            None,
+        );
+        assert!(previous.has_column("left"));
+        assert!(previous.rail(RailKind::Workspace).is_none());
+        assert!(previous.rail(RailKind::Projection(1)).is_some());
+
+        let current = sidebar_layout_for_state(
+            &config,
+            true,
+            false,
+            false,
+            (50, 8),
+            None,
+            None,
+            None,
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashSet::new(),
+            Some(&previous),
+        );
+        assert!(current.has_column("left"));
+        assert!(current.rail(RailKind::Projection(1)).is_some());
     }
 
     fn split_sidebar_config() -> Config {

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -56,7 +56,7 @@ use crate::browser_input::{
 };
 use crate::config::{
     Action, ChromeTheme, Config, ScrollbarPosition, SidebarColumn, SidebarColumnKind,
-    SidebarResourceKind, SidebarView,
+    SidebarResourceKind, SidebarView, SidebarViewSpec,
 };
 use crate::keys;
 use crate::localization;
@@ -8047,8 +8047,9 @@ fn place_sidebar_column_node(
                 used -= 1;
             }
             let mut round_robin = 0usize;
+            let share_count = sizes.len();
             while used < available {
-                sizes[round_robin % sizes.len()] += 1;
+                sizes[round_robin % share_count] += 1;
                 used += 1;
                 round_robin += 1;
             }
@@ -27049,7 +27050,7 @@ mod tests {
         // The two rails clamp at their minimum height.
         app.drag_sidebar_split_divider(0, 0, 0, 0);
         app.sync_layout((120, 31));
-        assert_eq!(app.sidebar_layout.ordered[0].rect.height, MIN_SPLIT_RAIL_HEIGHT);
+        assert_eq!(app.sidebar_layout.ordered[0].rect.height, super::MIN_SPLIT_RAIL_HEIGHT);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -151,7 +151,7 @@ struct ProjectionRowsCache {
     agent_surfaces: HashSet<SurfaceId>,
     /// Surfaces whose title can affect a visible row in this snapshot.
     title_surfaces: HashSet<SurfaceId>,
-    rows: Vec<ProjectionRow>,
+    rows: Arc<[ProjectionRow]>,
 }
 
 fn projection_focus_key(tree: &TreeView) -> ProjectionFocusKey {
@@ -7086,8 +7086,9 @@ pub struct App {
     machine_sidebar_width_override: Option<u16>,
     tabs_sidebar_width_override: Option<u16>,
     projection_sidebar_width_overrides: HashMap<String, u16>,
-    /// Session-local divider drags inside sidebar split groups, keyed by
-    /// group id: each child's share of the group, in child order.
+    /// Session-local divider drags inside sidebar split groups for the active
+    /// profile. A profile switch clears these values so a reused group id
+    /// cannot apply another profile's geometry.
     sidebar_split_fractions: HashMap<String, Vec<f32>>,
     /// Session-local visibility overrides, keyed by profile and stable view id.
     hidden_sidebar_views: HashMap<String, HashSet<String>>,
@@ -10331,9 +10332,9 @@ impl App {
         self.focus == FocusTarget::ProjectionRail(index)
     }
 
-    pub(crate) fn projection_rows(&mut self, index: usize) -> Vec<ProjectionRow> {
+    pub(crate) fn projection_rows(&mut self, index: usize) -> Arc<[ProjectionRow]> {
         let Some(spec) = self.config.sidebar.views.get(index).cloned() else {
-            return Vec::new();
+            return Arc::<[ProjectionRow]>::from(Vec::new());
         };
         let collapsed = self
             .projection_rails
@@ -10362,7 +10363,6 @@ impl App {
             self.projection_title_surfaces.extend(cache.title_surfaces.iter().copied());
             let rows = cache.rows.clone();
             self.projection_rows_cache.push_front(cache);
-            self.prune_projection_surface_indexes();
             rows
         } else {
             let agents = if spec.includes(SidebarResourceKind::Agents) {
@@ -10392,6 +10392,7 @@ impl App {
             );
             let (agent_surfaces, title_surfaces) =
                 projection_cache_dependencies(&spec, &self.tree, &rows, selected_workspace);
+            let rows: Arc<[ProjectionRow]> = Arc::from(rows);
             self.projection_agent_surfaces.extend(agent_surfaces.iter().copied());
             self.projection_title_surfaces.extend(title_surfaces.iter().copied());
             self.projection_rows_cache.push_front(ProjectionRowsCache {
@@ -10406,7 +10407,6 @@ impl App {
                 rows: rows.clone(),
             });
             self.projection_rows_cache.truncate(MAX_PROJECTION_ROWS_CACHE_ENTRIES);
-            self.prune_projection_surface_indexes();
             rows
         };
         self.projection_rail_state_mut(index).reconcile_selection(&rows);
@@ -10450,9 +10450,13 @@ impl App {
         layout: Vec<SidebarLayoutNode>,
     ) {
         let previous = SidebarProjectionSpec::from_config(&self.config);
+        let profile_changed = self.config.sidebar.active_profile != profile_id;
         self.config.sidebar.active_profile = profile_id;
         self.config.sidebar.views = views;
         self.config.sidebar.layout = layout;
+        if profile_changed {
+            self.sidebar_split_fractions.clear();
+        }
         self.invalidate_projection_rows_if_sidebar_spec_changed(previous);
     }
 
@@ -10464,7 +10468,6 @@ impl App {
         surface: SurfaceId,
         change: ProjectionSurfaceChange,
     ) -> bool {
-        self.prune_projection_surface_indexes();
         let was_affected = self.projection_rows_cache.iter().any(|cache| match change {
             ProjectionSurfaceChange::Agent => cache.agent_surfaces.contains(&surface),
             ProjectionSurfaceChange::Title => cache.title_surfaces.contains(&surface),
@@ -13587,6 +13590,7 @@ impl App {
                 }
             }
         }
+        self.prune_projection_surface_indexes();
     }
 
     /// Remove a retired view from the client cache before the authoritative
@@ -13610,7 +13614,6 @@ impl App {
             }
         }
         self.rebuild_tab_locations();
-        self.prune_projection_surface_indexes();
     }
 
     fn apply_session_completions_through(&mut self, authoritative_generation: u64) -> bool {
@@ -14300,6 +14303,7 @@ impl App {
             self.config_reload_applications += 1;
         }
         let previous_projection = SidebarProjectionSpec::from_config(&self.config);
+        let previous_profile = self.config.sidebar.active_profile.clone();
         let focused_projection_id = match self.focus {
             FocusTarget::ProjectionRail(index) => {
                 self.config.sidebar.views.get(index).map(|view| view.id.clone())
@@ -14318,6 +14322,9 @@ impl App {
         self.session.apply_config(config.clone());
         self.sidebar_view = config.sidebar.view;
         self.config = config;
+        if previous_profile != self.config.sidebar.active_profile {
+            self.sidebar_split_fractions.clear();
+        }
         self.invalidate_projection_rows_if_sidebar_spec_changed(previous_projection);
         let mut valid_view_ids =
             self.config.sidebar.views.iter().map(|view| view.id.clone()).collect::<HashSet<_>>();
@@ -27161,6 +27168,41 @@ mod tests {
         );
 
         mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
+    fn profile_switch_does_not_reuse_split_fractions_for_a_reused_group() {
+        let mux = Mux::new("sidebar-profile-split-fractions-test", SurfaceOptions::default());
+        let mut first = split_sidebar_config();
+        let mut second_layout = first.sidebar.layout.clone();
+        if let Some(crate::config::SidebarLayoutNode::Split(split)) = second_layout.first_mut() {
+            split.weights = vec![3, 1];
+        }
+        let first_profile = SidebarProfileSpec {
+            id: "first".into(),
+            name: "First".into(),
+            views: first.sidebar.views.clone(),
+            layout: first.sidebar.layout.clone(),
+        };
+        let second_profile = SidebarProfileSpec {
+            id: "second".into(),
+            name: "Second".into(),
+            views: first.sidebar.views.clone(),
+            layout: second_layout,
+        };
+        first.sidebar.profiles = vec![first_profile.clone(), second_profile];
+        first.sidebar.active_profile = first_profile.id.clone();
+
+        let mut app = test_app(Session::Local(mux));
+        app.config = first;
+        app.sidebar_split_fractions.insert("left".into(), vec![0.8, 0.2]);
+        app.sync_layout((120, 31));
+        assert_eq!(app.sidebar_layout.ordered[0].rect.height, 24);
+
+        app.activate_sidebar_profile(1);
+        assert!(app.sidebar_split_fractions.is_empty());
+        app.sync_layout((120, 31));
+        assert_eq!(app.sidebar_layout.ordered[0].rect.height, 23);
     }
 
     #[test]
@@ -42728,6 +42770,31 @@ mod tests {
                 .map(|tab| tab.title.as_str()),
             Some("renamed")
         );
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
+    fn projection_cache_hit_reuses_a_shared_rows_snapshot() {
+        let (mux, surface) = test_mux("projection-shared-rows-cache-test", None);
+        let mut app = test_app(Session::Local(mux.clone()));
+        app.config.sidebar.columns.clear();
+        app.config.sidebar.views = vec![SidebarViewSpec {
+            id: "tabs".into(),
+            levels: vec![SidebarResourceKind::Tabs],
+            actions: Vec::new(),
+            actions_position: crate::config::ActionsPosition::Bottom,
+            width: 40,
+            max_width: 0,
+            collapse_priority: 30,
+            scope: crate::config::SidebarViewScope::Workspace,
+        }];
+        app.config.sidebar.views_explicit = true;
+        app.replace_tree(app.session.tree());
+
+        let first = app.projection_rows(0);
+        let second = app.projection_rows(0);
+        assert!(Arc::ptr_eq(&first, &second));
 
         mux.close_surface(surface.id).unwrap();
     }

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -1551,9 +1551,9 @@ struct SidebarViewResolution<'a> {
 /// Column sizing of a resolved node, for bottom-up split-group defaults.
 fn sidebar_node_metrics(node: &SidebarLayoutNode, views: &[SidebarViewSpec]) -> (u16, u16) {
     match node {
-        SidebarLayoutNode::Leaf(index) => views
-            .get(*index)
-            .map_or((22, 20), |view| (view.width, view.collapse_priority)),
+        SidebarLayoutNode::Leaf(index) => {
+            views.get(*index).map_or((22, 20), |view| (view.width, view.collapse_priority))
+        }
         SidebarLayoutNode::Split(split) => (split.width, split.collapse_priority),
     }
 }
@@ -1745,7 +1745,10 @@ fn resolve_sidebar_leaf_view(
         }
     }
     if let Err(reason) = validate_sidebar_levels(&levels) {
-        crate::client_log::stderr_log!("config", "cmux-tui: ignoring {owner} view {id:?}: {reason}");
+        crate::client_log::stderr_log!(
+            "config",
+            "cmux-tui: ignoring {owner} view {id:?}: {reason}"
+        );
         return None;
     }
     let scope = match view.scope.as_deref().map(str::trim) {

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -1552,12 +1552,13 @@ struct SidebarViewResolution<'a> {
 }
 
 /// Column sizing of a resolved node, for bottom-up split-group defaults.
-fn sidebar_node_metrics(node: &SidebarLayoutNode, views: &[SidebarViewSpec]) -> (u16, u16) {
+/// A zero maximum means that the node is unbounded.
+fn sidebar_node_metrics(node: &SidebarLayoutNode, views: &[SidebarViewSpec]) -> (u16, u16, u16) {
     match node {
-        SidebarLayoutNode::Leaf(index) => {
-            views.get(*index).map_or((22, 20), |view| (view.width, view.collapse_priority))
-        }
-        SidebarLayoutNode::Split(split) => (split.width, split.collapse_priority),
+        SidebarLayoutNode::Leaf(index) => views
+            .get(*index)
+            .map_or((22, 0, 20), |view| (view.width, view.max_width, view.collapse_priority)),
+        SidebarLayoutNode::Split(split) => (split.width, split.max_width, split.collapse_priority),
     }
 }
 
@@ -1649,19 +1650,31 @@ fn resolve_sidebar_view_entry(
                 children.pop()
             }
             _ => {
-                let (default_width, default_priority) = children
-                    .iter()
-                    .map(|child| sidebar_node_metrics(child, &state.views))
-                    .fold((10u16, 0u16), |(width, priority), (child_width, child_priority)| {
-                        (width.max(child_width), priority.max(child_priority))
-                    });
+                let mut default_width = 10u16;
+                let mut default_max_width = 0u16;
+                let mut has_unlimited_child = false;
+                let mut default_priority = 0u16;
+                for child in &children {
+                    let (child_width, child_max_width, child_priority) =
+                        sidebar_node_metrics(child, &state.views);
+                    default_width = default_width.max(child_width);
+                    default_priority = default_priority.max(child_priority);
+                    if child_max_width == 0 {
+                        has_unlimited_child = true;
+                    } else {
+                        default_max_width = default_max_width.max(child_max_width);
+                    }
+                }
+                if has_unlimited_child {
+                    default_max_width = 0;
+                }
                 Some(SidebarLayoutNode::Split(SidebarSplitSpec {
                     id,
                     dir,
                     weights,
                     children,
                     width: view.width.map_or(default_width, |width| width.clamp(10, 60)),
-                    max_width: view.max_width.unwrap_or(0),
+                    max_width: view.max_width.unwrap_or(default_max_width),
                     collapse_priority: view.collapse_priority.unwrap_or(default_priority),
                 }))
             }
@@ -1679,12 +1692,16 @@ fn resolve_sidebar_view_entry(
 }
 
 fn collect_sidebar_view_ids(views: &[RawSidebarView], ids: &mut HashSet<String>) {
-    for view in views {
+    let mut pending = views.iter().map(|view| (view, 0usize)).collect::<Vec<_>>();
+    while let Some((view, depth)) = pending.pop() {
         if let Some(id) = view.id.as_deref().map(str::trim).filter(|id| !id.is_empty()) {
             ids.insert(id.to_string());
         }
+        if depth >= MAX_SIDEBAR_SPLIT_DEPTH {
+            continue;
+        }
         if let Some(panes) = view.panes.as_deref() {
-            collect_sidebar_view_ids(panes, ids);
+            pending.extend(panes.iter().rev().map(|pane| (pane, depth + 1)));
         }
     }
 }
@@ -9033,6 +9050,7 @@ mod tests {
                     vec![SidebarLayoutNode::Leaf(0), SidebarLayoutNode::Leaf(1)]
                 );
                 assert_eq!(split.width, 22, "defaults to the widest pane");
+                assert_eq!(split.max_width, 0, "an unbounded pane keeps the group unbounded");
                 assert_eq!(split.collapse_priority, 30, "defaults to the highest pane priority");
             }
             node => panic!("expected a split column, got {node:?}"),
@@ -9109,6 +9127,43 @@ mod tests {
         group.panes = Some(vec![raw_leaf("ws", &["workspaces"]), raw_leaf("ag", &["agents"])]);
         let resolved = resolve_sidebar_view_specs(&[group], 22, 0, 22, 0, "sidebar", &[]);
         assert!(resolved.views.is_empty());
+    }
+
+    #[test]
+    fn split_group_defaults_max_width_to_largest_finite_child() {
+        let mut narrow = raw_leaf("narrow", &["workspaces"]);
+        narrow.max_width = Some(31);
+        let mut wide = raw_leaf("wide", &["agents"]);
+        wide.max_width = Some(47);
+        let mut group = raw_leaf("group", &[]);
+        group.levels = None;
+        group.split = Some("horizontal".to_string());
+        group.panes = Some(vec![narrow, wide]);
+
+        let resolved = resolve_sidebar_view_specs(&[group], 22, 0, 22, 0, "sidebar", &[]);
+        match &resolved.layout[0] {
+            SidebarLayoutNode::Split(split) => assert_eq!(split.max_width, 47),
+            node => panic!("expected a split column, got {node:?}"),
+        }
+    }
+
+    #[test]
+    fn sidebar_view_id_prepass_stops_at_the_split_depth_limit() {
+        let mut nested = raw_leaf("leaf-too-deep", &["tabs"]);
+        for depth in (0..=MAX_SIDEBAR_SPLIT_DEPTH).rev() {
+            let mut group = raw_leaf(&format!("split-{depth}"), &[]);
+            group.levels = None;
+            group.split = Some("vertical".to_string());
+            group.panes = Some(vec![nested]);
+            nested = group;
+        }
+
+        let mut ids = HashSet::new();
+        collect_sidebar_view_ids(&[nested], &mut ids);
+        for depth in 0..=MAX_SIDEBAR_SPLIT_DEPTH {
+            assert!(ids.contains(&format!("split-{depth}")));
+        }
+        assert!(!ids.contains("leaf-too-deep"));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -1537,6 +1537,9 @@ fn parse_sidebar_view_scope(value: &str) -> Result<SidebarViewScope, String> {
 /// flat leaf list the layout tree indexes into.
 struct SidebarViewResolution<'a> {
     ids: HashSet<String>,
+    /// Explicit IDs in the complete raw tree. Generated split IDs must avoid
+    /// these even when the user entry appears later in configuration order.
+    reserved_ids: HashSet<String>,
     legacy_kinds: HashSet<SidebarColumnKind>,
     views: Vec<SidebarViewSpec>,
     split_counter: usize,
@@ -1606,7 +1609,7 @@ fn resolve_sidebar_view_entry(
             _ => loop {
                 state.split_counter += 1;
                 let candidate = format!("split-{}", state.split_counter);
-                if !state.ids.contains(&candidate) {
+                if !state.ids.contains(&candidate) && !state.reserved_ids.contains(&candidate) {
                     break candidate;
                 }
             },
@@ -1675,6 +1678,17 @@ fn resolve_sidebar_view_entry(
     }
 }
 
+fn collect_sidebar_view_ids(views: &[RawSidebarView], ids: &mut HashSet<String>) {
+    for view in views {
+        if let Some(id) = view.id.as_deref().map(str::trim).filter(|id| !id.is_empty()) {
+            ids.insert(id.to_string());
+        }
+        if let Some(panes) = view.panes.as_deref() {
+            collect_sidebar_view_ids(panes, ids);
+        }
+    }
+}
+
 fn resolve_sidebar_view_specs(
     views: &[RawSidebarView],
     machine_width: u16,
@@ -1684,8 +1698,11 @@ fn resolve_sidebar_view_specs(
     owner: &str,
     command_ids: &[String],
 ) -> ResolvedSidebarViews {
+    let mut reserved_ids = HashSet::new();
+    collect_sidebar_view_ids(views, &mut reserved_ids);
     let mut state = SidebarViewResolution {
         ids: HashSet::new(),
+        reserved_ids,
         legacy_kinds: HashSet::new(),
         views: Vec::new(),
         split_counter: 0,
@@ -9040,6 +9057,24 @@ mod tests {
         assert_eq!(views.len(), 1);
         assert_eq!(views[0].split.as_deref(), Some("vertical"));
         assert_eq!(views[0].panes.as_ref().map(Vec::len), Some(2));
+    }
+
+    #[test]
+    fn generated_split_ids_reserve_explicit_ids_from_later_entries() {
+        let mut group = raw_leaf("", &[]);
+        group.levels = None;
+        group.split = Some("vertical".to_string());
+        group.panes = Some(vec![raw_leaf("ws", &["workspaces"]), raw_leaf("ag", &["agents"])]);
+        let later = raw_leaf("split-1", &["tabs"]);
+        let resolved = resolve_sidebar_view_specs(&[group, later], 22, 0, 22, 0, "sidebar", &[]);
+
+        assert_eq!(resolved.views.len(), 3);
+        match &resolved.layout[0] {
+            SidebarLayoutNode::Split(split) => assert_eq!(split.id, "split-2"),
+            node => panic!("expected generated split, got {node:?}"),
+        }
+        assert_eq!(resolved.layout[1], SidebarLayoutNode::Leaf(2));
+        assert_eq!(resolved.views[2].id, "split-1");
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -548,13 +548,25 @@ struct RawSidebarProfile {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct RawSidebarView {
-    id: String,
-    levels: Vec<String>,
+    id: Option<String>,
+    levels: Option<Vec<String>>,
     actions: Option<Vec<RawSidebarAction>>,
     actions_position: Option<ActionsPosition>,
     width: Option<u16>,
     max_width: Option<u16>,
     collapse_priority: Option<u16>,
+    /// Resource scope for flat tabs/agents views: `"workspace"` (default)
+    /// follows the selected workspace; `"all"` lists every workspace, and
+    /// agents order chronologically by their last status change.
+    scope: Option<String>,
+    /// Turns this entry into a split group instead of a leaf view:
+    /// `"vertical"` stacks `panes` top to bottom, `"horizontal"` places them
+    /// side by side. Split groups nest.
+    split: Option<String>,
+    /// Child entries of a split group, each a view or another split.
+    panes: Option<Vec<RawSidebarView>>,
+    /// Relative share of the parent split (default 1).
+    weight: Option<u16>,
 }
 
 /// One pinned action: an action name, or an object that also renames its
@@ -1012,6 +1024,9 @@ pub struct Sidebar {
     /// list behavior; multiple levels render as one native tree column.
     pub views: Vec<SidebarViewSpec>,
     pub views_explicit: bool,
+    /// Column arrangement over `views`: one node per top-level column, where
+    /// a node is a leaf view or a nested split group.
+    pub layout: Vec<SidebarLayoutNode>,
     /// Named native layouts. `views` is always the currently selected
     /// profile's resolved rail list so older consumers remain compatible.
     pub profiles: Vec<SidebarProfileSpec>,
@@ -1043,11 +1058,13 @@ impl Default for Sidebar {
                 SidebarColumn { kind: SidebarColumnKind::Workspaces, width: 22, max_width: 0 },
             ],
             columns_explicit: false,
+            layout: sidebar_layout_of_columns(&views),
             views: views.clone(),
             views_explicit: false,
             profiles: vec![SidebarProfileSpec {
                 id: "default".to_string(),
                 name: "Default".to_string(),
+                layout: sidebar_layout_of_columns(&views),
                 views,
             }],
             active_profile: "default".to_string(),
@@ -1065,6 +1082,7 @@ pub struct SidebarProfileSpec {
     pub id: String,
     pub name: String,
     pub views: Vec<SidebarViewSpec>,
+    pub layout: Vec<SidebarLayoutNode>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -1103,6 +1121,74 @@ pub struct SidebarViewSpec {
     pub max_width: u16,
     /// Lower values collapse first when pane space becomes constrained.
     pub collapse_priority: u16,
+    /// Resource scope for flat tabs/agents views. `All` lists every
+    /// workspace; agents then order chronologically by last status change.
+    pub scope: SidebarViewScope,
+}
+
+/// Which workspaces feed a flat tabs/agents view.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SidebarViewScope {
+    /// Follow the selected workspace (the historical behavior).
+    #[default]
+    Workspace,
+    /// Every workspace in the session.
+    All,
+}
+
+/// Split orientation for a sidebar split group. `Vertical` stacks children
+/// top to bottom (a vertical arrangement), `Horizontal` places them side by
+/// side, matching tmux's `-v`/`-h` convention.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SidebarSplitDir {
+    Vertical,
+    Horizontal,
+}
+
+/// One top-level sidebar column, or a node inside a split group: either a
+/// leaf view (an index into the resolved flat view list) or a nested split.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SidebarLayoutNode {
+    Leaf(usize),
+    Split(SidebarSplitSpec),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SidebarSplitSpec {
+    pub id: String,
+    pub dir: SidebarSplitDir,
+    /// Relative share per child; same length as `children`.
+    pub weights: Vec<u16>,
+    pub children: Vec<SidebarLayoutNode>,
+    /// Column sizing when this split is a top-level entry.
+    pub width: u16,
+    pub max_width: u16,
+    pub collapse_priority: u16,
+}
+
+impl SidebarLayoutNode {
+    /// Leaf view indices in tree order.
+    pub fn leaves(&self) -> Vec<usize> {
+        let mut leaves = Vec::new();
+        self.collect_leaves(&mut leaves);
+        leaves
+    }
+
+    fn collect_leaves(&self, leaves: &mut Vec<usize>) {
+        match self {
+            SidebarLayoutNode::Leaf(index) => leaves.push(*index),
+            SidebarLayoutNode::Split(split) => {
+                for child in &split.children {
+                    child.collect_leaves(leaves);
+                }
+            }
+        }
+    }
+}
+
+/// The identity layout for a flat view list: one top-level column per view.
+pub fn sidebar_layout_of_columns(views: &[SidebarViewSpec]) -> Vec<SidebarLayoutNode> {
+    (0..views.len()).map(SidebarLayoutNode::Leaf).collect()
 }
 
 /// One pinned sidebar action and its optional label override.
@@ -1192,10 +1278,17 @@ impl SidebarViewSpec {
             width,
             max_width,
             collapse_priority,
+            scope: SidebarViewScope::Workspace,
         }
     }
 
     pub fn legacy_kind(&self) -> Option<SidebarColumnKind> {
+        // An `all`-scoped view never maps to a legacy rail: the legacy
+        // renderers follow the selected workspace, so scope must route
+        // through the projection path.
+        if self.scope != SidebarViewScope::Workspace {
+            return None;
+        }
         match self.levels.as_slice() {
             [SidebarResourceKind::Machines] => Some(SidebarColumnKind::Machines),
             [SidebarResourceKind::Workspaces] => Some(SidebarColumnKind::Workspaces),
@@ -1408,6 +1501,180 @@ fn parse_sidebar_action(value: &str, command_ids: &[String]) -> Result<Action, S
         .ok_or_else(|| format!("cmux-tui: ignoring unknown sidebar action {value:?}"))
 }
 
+/// Flat view list plus the column/split arrangement over it.
+#[derive(Debug, Default)]
+struct ResolvedSidebarViews {
+    views: Vec<SidebarViewSpec>,
+    layout: Vec<SidebarLayoutNode>,
+}
+
+/// The deepest allowed split nesting. Splits inside splits inside splits
+/// cover every practical arrangement; deeper trees are almost certainly a
+/// config mistake and each level costs a validation pass per frame.
+const MAX_SIDEBAR_SPLIT_DEPTH: usize = 3;
+
+fn parse_sidebar_split_dir(value: &str) -> Result<SidebarSplitDir, String> {
+    match value {
+        "vertical" => Ok(SidebarSplitDir::Vertical),
+        "horizontal" => Ok(SidebarSplitDir::Horizontal),
+        _ => Err(format!(
+            "cmux-tui: ignoring unknown sidebar split {value:?}; expected \"vertical\" (top/bottom) or \"horizontal\" (side by side)"
+        )),
+    }
+}
+
+fn parse_sidebar_view_scope(value: &str) -> Result<SidebarViewScope, String> {
+    match value {
+        "workspace" => Ok(SidebarViewScope::Workspace),
+        "all" => Ok(SidebarViewScope::All),
+        _ => Err(format!(
+            "cmux-tui: ignoring unknown sidebar view scope {value:?}; expected \"workspace\" or \"all\""
+        )),
+    }
+}
+
+/// Shared mutable state across one resolution pass: id/legacy dedup and the
+/// flat leaf list the layout tree indexes into.
+struct SidebarViewResolution<'a> {
+    ids: HashSet<String>,
+    legacy_kinds: HashSet<SidebarColumnKind>,
+    views: Vec<SidebarViewSpec>,
+    split_counter: usize,
+    machine_width: u16,
+    machine_max_width: u16,
+    workspace_width: u16,
+    workspace_max_width: u16,
+    owner: &'a str,
+    command_ids: &'a [String],
+}
+
+/// Column sizing of a resolved node, for bottom-up split-group defaults.
+fn sidebar_node_metrics(node: &SidebarLayoutNode, views: &[SidebarViewSpec]) -> (u16, u16) {
+    match node {
+        SidebarLayoutNode::Leaf(index) => views
+            .get(*index)
+            .map_or((22, 20), |view| (view.width, view.collapse_priority)),
+        SidebarLayoutNode::Split(split) => (split.width, split.collapse_priority),
+    }
+}
+
+fn resolve_sidebar_view_entry(
+    view: &RawSidebarView,
+    depth: usize,
+    state: &mut SidebarViewResolution<'_>,
+) -> Option<SidebarLayoutNode> {
+    let owner = state.owner;
+    if let Some(split) = view.split.as_deref() {
+        let dir = match parse_sidebar_split_dir(split.trim()) {
+            Ok(dir) => dir,
+            Err(warning) => {
+                crate::client_log::stderr_log!("config", "{warning} in {owner}");
+                return None;
+            }
+        };
+        if view.levels.is_some() {
+            crate::client_log::stderr_log!(
+                "config",
+                "cmux-tui: ignoring {owner} split group with levels; a split holds panes, not resources"
+            );
+            return None;
+        }
+        if depth >= MAX_SIDEBAR_SPLIT_DEPTH {
+            crate::client_log::stderr_log!(
+                "config",
+                "cmux-tui: ignoring {owner} split group nested deeper than {MAX_SIDEBAR_SPLIT_DEPTH} levels"
+            );
+            return None;
+        }
+        if view.actions.is_some() || view.actions_position.is_some() || view.scope.is_some() {
+            crate::client_log::stderr_log!(
+                "config",
+                "cmux-tui: ignoring actions/scope on an {owner} split group; set them on its panes"
+            );
+        }
+        let id = match view.id.as_deref().map(str::trim) {
+            Some(id) if !id.is_empty() => {
+                if state.ids.contains(id) {
+                    crate::client_log::stderr_log!(
+                        "config",
+                        "cmux-tui: ignoring {owner} split group with a duplicate id"
+                    );
+                    return None;
+                }
+                id.to_string()
+            }
+            _ => loop {
+                state.split_counter += 1;
+                let candidate = format!("split-{}", state.split_counter);
+                if !state.ids.contains(&candidate) {
+                    break candidate;
+                }
+            },
+        };
+        let panes = view.panes.as_deref().unwrap_or_default();
+        if panes.is_empty() {
+            crate::client_log::stderr_log!(
+                "config",
+                "cmux-tui: ignoring {owner} split group without panes"
+            );
+            return None;
+        }
+        state.ids.insert(id.clone());
+        let mut children = Vec::new();
+        let mut weights = Vec::new();
+        for pane in panes {
+            if let Some(child) = resolve_sidebar_view_entry(pane, depth + 1, state) {
+                weights.push(pane.weight.unwrap_or(1).max(1));
+                children.push(child);
+            }
+        }
+        match children.len() {
+            0 => {
+                state.ids.remove(&id);
+                crate::client_log::stderr_log!(
+                    "config",
+                    "cmux-tui: ignoring {owner} split group with no usable panes"
+                );
+                None
+            }
+            1 => {
+                state.ids.remove(&id);
+                crate::client_log::stderr_log!(
+                    "config",
+                    "cmux-tui: {owner} split group has one usable pane; using it directly"
+                );
+                children.pop()
+            }
+            _ => {
+                let (default_width, default_priority) = children
+                    .iter()
+                    .map(|child| sidebar_node_metrics(child, &state.views))
+                    .fold((10u16, 0u16), |(width, priority), (child_width, child_priority)| {
+                        (width.max(child_width), priority.max(child_priority))
+                    });
+                Some(SidebarLayoutNode::Split(SidebarSplitSpec {
+                    id,
+                    dir,
+                    weights,
+                    children,
+                    width: view.width.map_or(default_width, |width| width.clamp(10, 60)),
+                    max_width: view.max_width.unwrap_or(0),
+                    collapse_priority: view.collapse_priority.unwrap_or(default_priority),
+                }))
+            }
+        }
+    } else {
+        if view.panes.is_some() {
+            crate::client_log::stderr_log!(
+                "config",
+                "cmux-tui: ignoring {owner} view with panes but no split direction"
+            );
+            return None;
+        }
+        resolve_sidebar_leaf_view(view, state).map(SidebarLayoutNode::Leaf)
+    }
+}
+
 fn resolve_sidebar_view_specs(
     views: &[RawSidebarView],
     machine_width: u16,
@@ -1416,116 +1683,167 @@ fn resolve_sidebar_view_specs(
     workspace_max_width: u16,
     owner: &str,
     command_ids: &[String],
-) -> Vec<SidebarViewSpec> {
-    let mut ids = HashSet::new();
-    let mut legacy_kinds = HashSet::new();
-    let mut resolved = Vec::new();
+) -> ResolvedSidebarViews {
+    let mut state = SidebarViewResolution {
+        ids: HashSet::new(),
+        legacy_kinds: HashSet::new(),
+        views: Vec::new(),
+        split_counter: 0,
+        machine_width,
+        machine_max_width,
+        workspace_width,
+        workspace_max_width,
+        owner,
+        command_ids,
+    };
+    let mut layout = Vec::new();
     for view in views {
-        let id = view.id.trim();
-        if id.is_empty() || ids.contains(id) {
+        if view.weight.is_some() {
             crate::client_log::stderr_log!(
                 "config",
-                "cmux-tui: ignoring {owner} view with an empty or duplicate id"
+                "cmux-tui: ignoring weight on a top-level {owner} entry; weights apply inside a split group"
             );
-            continue;
         }
-        let mut levels = Vec::with_capacity(view.levels.len());
-        let mut valid = true;
-        for level in &view.levels {
-            match parse_sidebar_resource_kind(level.trim()) {
-                Ok(level) => levels.push(level),
-                Err(warning) => {
-                    crate::client_log::stderr_log!("config", "{warning}");
-                    valid = false;
-                    break;
-                }
+        if let Some(node) = resolve_sidebar_view_entry(view, 0, &mut state) {
+            layout.push(node);
+        }
+    }
+    ResolvedSidebarViews { views: state.views, layout }
+}
+
+fn resolve_sidebar_leaf_view(
+    view: &RawSidebarView,
+    state: &mut SidebarViewResolution<'_>,
+) -> Option<usize> {
+    let owner = state.owner;
+    let (machine_width, machine_max_width) = (state.machine_width, state.machine_max_width);
+    let (workspace_width, workspace_max_width) = (state.workspace_width, state.workspace_max_width);
+    let command_ids = state.command_ids;
+    let id = view.id.as_deref().map(str::trim).unwrap_or_default();
+    if id.is_empty() || state.ids.contains(id) {
+        crate::client_log::stderr_log!(
+            "config",
+            "cmux-tui: ignoring {owner} view with an empty or duplicate id"
+        );
+        return None;
+    }
+    let Some(raw_levels) = view.levels.as_ref() else {
+        crate::client_log::stderr_log!(
+            "config",
+            "cmux-tui: ignoring {owner} view {id:?} without levels"
+        );
+        return None;
+    };
+    let mut levels = Vec::with_capacity(raw_levels.len());
+    for level in raw_levels {
+        match parse_sidebar_resource_kind(level.trim()) {
+            Ok(level) => levels.push(level),
+            Err(warning) => {
+                crate::client_log::stderr_log!("config", "{warning}");
+                return None;
             }
         }
-        if !valid {
-            continue;
-        }
-        if let Err(reason) = validate_sidebar_levels(&levels) {
-            crate::client_log::stderr_log!(
-                "config",
-                "cmux-tui: ignoring {owner} view {id:?}: {reason}"
-            );
-            continue;
-        }
-        let legacy_kind = SidebarViewSpec {
-            id: id.to_string(),
-            levels: levels.clone(),
-            actions: Vec::new(),
-            actions_position: ActionsPosition::Bottom,
-            width: 0,
-            max_width: 0,
-            collapse_priority: 0,
-        }
-        .legacy_kind();
-        if legacy_kind.is_some_and(|kind| !legacy_kinds.insert(kind)) {
-            crate::client_log::stderr_log!(
-                "config",
-                "cmux-tui: ignoring {owner} view {id:?}: a one-level view for that resource already exists"
-            );
-            continue;
-        }
-        ids.insert(id.to_string());
-        let (default_width, default_max_width) = match legacy_kind {
-            Some(SidebarColumnKind::Machines) => (machine_width, machine_max_width),
-            Some(SidebarColumnKind::Workspaces) => (workspace_width, workspace_max_width),
-            Some(SidebarColumnKind::Tabs) | None => (22, 0),
-        };
-        let actions = if levels == [SidebarResourceKind::Machines]
-            && view.actions.as_ref().is_some_and(|actions| !actions.is_empty())
-        {
-            crate::client_log::stderr_log!(
-                "config",
-                "cmux-tui: ignoring sidebar actions in {owner} machine view {id:?}; machine actions come from provider capabilities"
-            );
-            Vec::new()
-        } else if let Some(raw_actions) = view.actions.as_ref() {
-            let mut seen = HashSet::new();
-            raw_actions
-                .iter()
-                .filter_map(|raw_action| {
-                    match parse_sidebar_action(raw_action.action().trim(), command_ids) {
-                        Ok(action) if seen.insert(action) => Some(SidebarActionSpec {
-                            action,
-                            label: raw_action
-                                .label()
-                                .map(str::trim)
-                                .filter(|label| !label.is_empty())
-                                .map(str::to_string),
-                        }),
-                        Ok(_) => {
-                            crate::client_log::stderr_log!("config", 
-                                "cmux-tui: ignoring duplicate sidebar action {:?} in {owner} view {id:?}",
-                                raw_action.action().trim()
-                            );
-                            None
-                        }
-                        Err(warning) => {
-                            crate::client_log::stderr_log!("config", "{warning} in {owner} view {id:?}");
-                            None
-                        }
-                    }
-                })
-                .collect()
-        } else {
-            default_sidebar_actions(&levels)
-        };
-        resolved.push(SidebarViewSpec {
-            id: id.to_string(),
-            collapse_priority: view
-                .collapse_priority
-                .unwrap_or_else(|| default_sidebar_collapse_priority(&levels)),
-            levels,
-            actions,
-            actions_position: view.actions_position.unwrap_or_default(),
-            width: view.width.unwrap_or(default_width).clamp(10, 60),
-            max_width: view.max_width.unwrap_or(default_max_width),
-        });
     }
-    resolved
+    if let Err(reason) = validate_sidebar_levels(&levels) {
+        crate::client_log::stderr_log!("config", "cmux-tui: ignoring {owner} view {id:?}: {reason}");
+        return None;
+    }
+    let scope = match view.scope.as_deref().map(str::trim) {
+        None | Some("") => SidebarViewScope::Workspace,
+        Some(value) => match parse_sidebar_view_scope(value) {
+            Ok(SidebarViewScope::All)
+                if levels != [SidebarResourceKind::Tabs]
+                    && levels != [SidebarResourceKind::Agents] =>
+            {
+                crate::client_log::stderr_log!(
+                    "config",
+                    "cmux-tui: ignoring scope \"all\" in {owner} view {id:?}; it applies to one-level tabs or agents views"
+                );
+                SidebarViewScope::Workspace
+            }
+            Ok(scope) => scope,
+            Err(warning) => {
+                crate::client_log::stderr_log!("config", "{warning} in {owner} view {id:?}");
+                SidebarViewScope::Workspace
+            }
+        },
+    };
+    let legacy_kind = SidebarViewSpec {
+        id: id.to_string(),
+        levels: levels.clone(),
+        actions: Vec::new(),
+        actions_position: ActionsPosition::Bottom,
+        width: 0,
+        max_width: 0,
+        collapse_priority: 0,
+        scope,
+    }
+    .legacy_kind();
+    if legacy_kind.is_some_and(|kind| !state.legacy_kinds.insert(kind)) {
+        crate::client_log::stderr_log!(
+            "config",
+            "cmux-tui: ignoring {owner} view {id:?}: a one-level view for that resource already exists"
+        );
+        return None;
+    }
+    state.ids.insert(id.to_string());
+    let (default_width, default_max_width) = match legacy_kind {
+        Some(SidebarColumnKind::Machines) => (machine_width, machine_max_width),
+        Some(SidebarColumnKind::Workspaces) => (workspace_width, workspace_max_width),
+        Some(SidebarColumnKind::Tabs) | None => (22, 0),
+    };
+    let actions = if levels == [SidebarResourceKind::Machines]
+        && view.actions.as_ref().is_some_and(|actions| !actions.is_empty())
+    {
+        crate::client_log::stderr_log!(
+            "config",
+            "cmux-tui: ignoring sidebar actions in {owner} machine view {id:?}; machine actions come from provider capabilities"
+        );
+        Vec::new()
+    } else if let Some(raw_actions) = view.actions.as_ref() {
+        let mut seen = HashSet::new();
+        raw_actions
+            .iter()
+            .filter_map(|raw_action| {
+                match parse_sidebar_action(raw_action.action().trim(), command_ids) {
+                    Ok(action) if seen.insert(action) => Some(SidebarActionSpec {
+                        action,
+                        label: raw_action
+                            .label()
+                            .map(str::trim)
+                            .filter(|label| !label.is_empty())
+                            .map(str::to_string),
+                    }),
+                    Ok(_) => {
+                        crate::client_log::stderr_log!("config",
+                            "cmux-tui: ignoring duplicate sidebar action {:?} in {owner} view {id:?}",
+                            raw_action.action().trim()
+                        );
+                        None
+                    }
+                    Err(warning) => {
+                        crate::client_log::stderr_log!("config", "{warning} in {owner} view {id:?}");
+                        None
+                    }
+                }
+            })
+            .collect()
+    } else {
+        default_sidebar_actions(&levels)
+    };
+    state.views.push(SidebarViewSpec {
+        id: id.to_string(),
+        collapse_priority: view
+            .collapse_priority
+            .unwrap_or_else(|| default_sidebar_collapse_priority(&levels)),
+        levels,
+        actions,
+        actions_position: view.actions_position.unwrap_or_default(),
+        width: view.width.unwrap_or(default_width).clamp(10, 60),
+        max_width: view.max_width.unwrap_or(default_max_width),
+        scope,
+    });
+    Some(state.views.len() - 1)
 }
 
 #[derive(Debug, Clone)]
@@ -3493,6 +3811,7 @@ pub fn load() -> Config {
         .iter()
         .map(|column| SidebarViewSpec::legacy(column.kind, column.width, column.max_width))
         .collect();
+    config.sidebar.layout = sidebar_layout_of_columns(&config.sidebar.views);
     config.sidebar.views_explicit = config.sidebar.columns_explicit;
     // User commands resolve before sidebar views so pinned buttons can
     // reference them as `command:<id>`; their chords bind after `keys`.
@@ -3520,13 +3839,14 @@ pub fn load() -> Config {
             "sidebar",
             &command_ids,
         );
-        if resolved.is_empty() {
+        if resolved.views.is_empty() {
             crate::client_log::stderr_log!(
                 "config",
                 "cmux-tui: sidebar.views had no usable entries; keeping defaults"
             );
         } else {
             config.sidebar.columns = resolved
+                .views
                 .iter()
                 .filter_map(|view| {
                     view.legacy_kind().map(|kind| SidebarColumn {
@@ -3536,12 +3856,14 @@ pub fn load() -> Config {
                     })
                 })
                 .collect();
-            config.sidebar.views = resolved;
+            config.sidebar.views = resolved.views;
+            config.sidebar.layout = resolved.layout;
             config.sidebar.columns_explicit = false;
             config.sidebar.views_explicit = true;
         }
     }
     config.sidebar.profiles[0].views.clone_from(&config.sidebar.views);
+    config.sidebar.profiles[0].layout.clone_from(&config.sidebar.layout);
     if let Some(raw_profiles) = raw.sidebar.profiles.as_ref() {
         if raw.sidebar.views.is_some() || raw.sidebar.columns.is_some() {
             crate::client_log::stderr_log!(
@@ -3561,7 +3883,7 @@ pub fn load() -> Config {
                 continue;
             }
             let owner = format!("sidebar profile {id:?}");
-            let views = resolve_sidebar_view_specs(
+            let resolved = resolve_sidebar_view_specs(
                 &raw_profile.views,
                 config.machine_sidebar.width,
                 config.machine_sidebar.max_width,
@@ -3570,7 +3892,7 @@ pub fn load() -> Config {
                 &owner,
                 &command_ids,
             );
-            if views.is_empty() {
+            if resolved.views.is_empty() {
                 crate::client_log::stderr_log!(
                     "config",
                     "cmux-tui: ignoring sidebar profile {id:?} with no usable views"
@@ -3584,7 +3906,12 @@ pub fn load() -> Config {
                 .filter(|name| !name.is_empty())
                 .unwrap_or(id)
                 .to_string();
-            profiles.push(SidebarProfileSpec { id: id.to_string(), name, views });
+            profiles.push(SidebarProfileSpec {
+                id: id.to_string(),
+                name,
+                views: resolved.views,
+                layout: resolved.layout,
+            });
         }
         if profiles.is_empty() {
             crate::client_log::stderr_log!(
@@ -3606,6 +3933,7 @@ pub fn load() -> Config {
                 });
             config.sidebar.active_profile = profiles[selected].id.clone();
             config.sidebar.views = profiles[selected].views.clone();
+            config.sidebar.layout = profiles[selected].layout.clone();
             config.sidebar.columns = config
                 .sidebar
                 .views
@@ -8605,8 +8933,8 @@ mod tests {
     #[test]
     fn sidebar_buttons_accept_labels_positions_and_command_references() {
         let views = vec![RawSidebarView {
-            id: "ws".to_string(),
-            levels: vec!["workspaces".to_string()],
+            id: Some("ws".to_string()),
+            levels: Some(vec!["workspaces".to_string()]),
             actions: Some(vec![
                 RawSidebarAction::Detailed {
                     action: "new-workspace".to_string(),
@@ -8620,9 +8948,14 @@ mod tests {
             width: None,
             max_width: None,
             collapse_priority: None,
+            scope: None,
+            split: None,
+            panes: None,
+            weight: None,
         }];
         let command_ids = vec!["lazygit".to_string()];
-        let resolved = resolve_sidebar_view_specs(&views, 22, 0, 22, 0, "sidebar", &command_ids);
+        let resolved =
+            resolve_sidebar_view_specs(&views, 22, 0, 22, 0, "sidebar", &command_ids).views;
         assert_eq!(resolved.len(), 1);
         assert_eq!(resolved[0].actions_position, ActionsPosition::Top);
         assert_eq!(
@@ -8634,6 +8967,119 @@ mod tests {
             ],
             "unknown command references drop, known ones bind by id"
         );
+    }
+
+    fn raw_leaf(id: &str, levels: &[&str]) -> RawSidebarView {
+        RawSidebarView {
+            id: Some(id.to_string()),
+            levels: Some(levels.iter().map(|level| level.to_string()).collect()),
+            actions: None,
+            actions_position: None,
+            width: None,
+            max_width: None,
+            collapse_priority: None,
+            scope: None,
+            split: None,
+            panes: None,
+            weight: None,
+        }
+    }
+
+    #[test]
+    fn sidebar_split_groups_resolve_scope_weights_and_layout() {
+        let mut agents = raw_leaf("all-agents", &["agents"]);
+        agents.scope = Some("all".to_string());
+        agents.weight = Some(2);
+        let mut group = raw_leaf("left", &[]);
+        group.levels = None;
+        group.split = Some("vertical".to_string());
+        group.panes = Some(vec![raw_leaf("ws", &["workspaces"]), agents]);
+        let views = vec![group, raw_leaf("tabs", &["tabs"])];
+        let resolved = resolve_sidebar_view_specs(&views, 22, 0, 22, 0, "sidebar", &[]);
+
+        assert_eq!(resolved.views.len(), 3);
+        assert_eq!(resolved.views[0].id, "ws");
+        assert_eq!(resolved.views[1].id, "all-agents");
+        assert_eq!(resolved.views[1].scope, SidebarViewScope::All);
+        assert_eq!(resolved.views[2].scope, SidebarViewScope::Workspace);
+        assert_eq!(resolved.layout.len(), 2);
+        match &resolved.layout[0] {
+            SidebarLayoutNode::Split(split) => {
+                assert_eq!(split.id, "left");
+                assert_eq!(split.dir, SidebarSplitDir::Vertical);
+                assert_eq!(split.weights, vec![1, 2]);
+                assert_eq!(
+                    split.children,
+                    vec![SidebarLayoutNode::Leaf(0), SidebarLayoutNode::Leaf(1)]
+                );
+                assert_eq!(split.width, 22, "defaults to the widest pane");
+                assert_eq!(split.collapse_priority, 30, "defaults to the highest pane priority");
+            }
+            node => panic!("expected a split column, got {node:?}"),
+        }
+        assert_eq!(resolved.layout[1], SidebarLayoutNode::Leaf(2));
+    }
+
+    #[test]
+    fn sidebar_split_grammar_parses_from_json() {
+        let raw: RawConfig = serde_json::from_value(json!({
+            "sidebar": {
+                "views": [
+                    {"id": "left", "split": "vertical", "panes": [
+                        {"id": "ws", "levels": ["workspaces"]},
+                        {"id": "all-agents", "levels": ["agents"], "scope": "all"}
+                    ]}
+                ]
+            }
+        }))
+        .unwrap();
+        let views = raw.sidebar.views.unwrap();
+        assert_eq!(views.len(), 1);
+        assert_eq!(views[0].split.as_deref(), Some("vertical"));
+        assert_eq!(views[0].panes.as_ref().map(Vec::len), Some(2));
+    }
+
+    #[test]
+    fn sidebar_split_rejects_bad_shapes_and_unwraps_single_panes() {
+        // scope "all" needs a flat tabs/agents view.
+        let mut scoped = raw_leaf("tree", &["workspaces", "agents"]);
+        scoped.scope = Some("all".to_string());
+        let resolved = resolve_sidebar_view_specs(&[scoped], 22, 0, 22, 0, "sidebar", &[]);
+        assert_eq!(resolved.views[0].scope, SidebarViewScope::Workspace);
+
+        // A split with one usable pane flattens to that pane.
+        let mut group = raw_leaf("left", &[]);
+        group.levels = None;
+        group.split = Some("vertical".to_string());
+        group.panes = Some(vec![raw_leaf("ws", &["workspaces"]), raw_leaf("", &["agents"])]);
+        let resolved = resolve_sidebar_view_specs(&[group], 22, 0, 22, 0, "sidebar", &[]);
+        assert_eq!(resolved.views.len(), 1);
+        assert_eq!(resolved.layout, vec![SidebarLayoutNode::Leaf(0)]);
+
+        // An unknown split direction drops the group and its panes.
+        let mut group = raw_leaf("left", &[]);
+        group.levels = None;
+        group.split = Some("diagonal".to_string());
+        group.panes = Some(vec![raw_leaf("ws", &["workspaces"]), raw_leaf("ag", &["agents"])]);
+        let resolved = resolve_sidebar_view_specs(&[group], 22, 0, 22, 0, "sidebar", &[]);
+        assert!(resolved.views.is_empty());
+        assert!(resolved.layout.is_empty());
+
+        // A split group with levels is ambiguous and drops.
+        let mut group = raw_leaf("left", &["workspaces"]);
+        group.split = Some("vertical".to_string());
+        group.panes = Some(vec![raw_leaf("ws", &["workspaces"]), raw_leaf("ag", &["agents"])]);
+        let resolved = resolve_sidebar_view_specs(&[group], 22, 0, 22, 0, "sidebar", &[]);
+        assert!(resolved.views.is_empty());
+    }
+
+    #[test]
+    fn all_scoped_tabs_view_never_maps_to_the_legacy_tabs_rail() {
+        let mut tabs = raw_leaf("tabs-everywhere", &["tabs"]);
+        tabs.scope = Some("all".to_string());
+        let resolved = resolve_sidebar_view_specs(&[tabs], 22, 0, 22, 0, "sidebar", &[]);
+        assert_eq!(resolved.views[0].scope, SidebarViewScope::All);
+        assert_eq!(resolved.views[0].legacy_kind(), None);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
@@ -34,6 +34,22 @@ pub(crate) enum ProjectionTarget {
     },
 }
 
+impl ProjectionTarget {
+    /// Compare the projected resource identity while ignoring positions that
+    /// can change when a fresh tree snapshot is rebuilt.
+    pub(crate) fn same_resource(self, other: Self) -> bool {
+        match (self, other) {
+            (Self::Workspace { id: left, .. }, Self::Workspace { id: right, .. }) => left == right,
+            (Self::Pane { pane: left, .. }, Self::Pane { pane: right, .. }) => left == right,
+            (
+                Self::Surface { surface: left, agent: left_agent, .. },
+                Self::Surface { surface: right, agent: right_agent, .. },
+            ) => left == right && left_agent == right_agent,
+            _ => false,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ProjectionRow {
     pub resource: SidebarResourceKind,
@@ -52,6 +68,8 @@ pub(crate) struct ProjectionRailState {
     /// Selected resource-row index. Action selection is tracked separately so
     /// live resource insertions cannot retarget a pinned action.
     pub selected: usize,
+    /// Stable resource identity for preserving selection when rows reorder.
+    pub selected_target: Option<ProjectionTarget>,
     pub selected_action: Option<usize>,
     pub scroll: usize,
     pub footer_scroll: usize,
@@ -63,12 +81,31 @@ impl Default for ProjectionRailState {
     fn default() -> Self {
         Self {
             selected: 0,
+            selected_target: None,
             selected_action: None,
             scroll: 0,
             footer_scroll: 0,
             follow_selection: true,
             collapsed: HashSet::new(),
         }
+    }
+
+    pub(crate) fn reconcile_selection(&mut self, rows: &[ProjectionRow]) {
+        if rows.is_empty() {
+            self.selected = 0;
+            self.selected_target = None;
+            return;
+        }
+        if let Some(target) = self.selected_target
+            && let Some((index, row)) =
+                rows.iter().enumerate().find(|(_, row)| row.target.same_resource(target))
+        {
+            self.selected = index;
+            self.selected_target = Some(row.target);
+            return;
+        }
+        self.selected = self.selected.min(rows.len().saturating_sub(1));
+        self.selected_target = rows.get(self.selected).map(|row| row.target);
     }
 }
 
@@ -610,5 +647,53 @@ mod tests {
             rows(&spec(vec![SidebarResourceKind::Agents]), &tree, &agents, 1, &HashSet::new());
         assert_eq!(rows.len(), 1);
         assert!(matches!(rows[0].target, ProjectionTarget::Surface { surface: 22, .. }));
+    }
+
+    #[test]
+    fn selection_reconciles_by_surface_when_agent_recency_reorders_rows() {
+        let tree = TreeView {
+            workspaces: vec![
+                workspace(1, "alpha", 10, [11, 12]),
+                workspace(2, "beta", 20, [21, 22]),
+            ],
+            workspace_revision: 1,
+            pane_revision: Some(1),
+            active_workspace: 0,
+        };
+        let mut all_spec = spec(vec![SidebarResourceKind::Agents]);
+        all_spec.scope = SidebarViewScope::All;
+        let initial_agents = vec![
+            AgentInfo {
+                surface: 11,
+                state: "working".into(),
+                source: "hook".into(),
+                session: None,
+                updated_at_ms: 100,
+            },
+            AgentInfo {
+                surface: 22,
+                state: "working".into(),
+                source: "hook".into(),
+                session: None,
+                updated_at_ms: 900,
+            },
+        ];
+        let initial = rows(&all_spec, &tree, &initial_agents, 0, &HashSet::new());
+        let selected_target = initial[1].target;
+        let mut state = ProjectionRailState {
+            selected: 1,
+            selected_target: Some(selected_target),
+            ..ProjectionRailState::default()
+        };
+
+        let updated_agents = vec![
+            AgentInfo { updated_at_ms: 1_000, ..initial_agents[0].clone() },
+            initial_agents[1].clone(),
+        ];
+        let reordered = rows(&all_spec, &tree, &updated_agents, 0, &HashSet::new());
+        assert_ne!(reordered[1].target, selected_target);
+        state.reconcile_selection(&reordered);
+        assert_eq!(state.selected_target, Some(selected_target));
+        assert_eq!(reordered[state.selected].target, selected_target);
     }
 }

--- a/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
@@ -282,6 +282,11 @@ fn append_level(
                 vec![context.map_or(selected_workspace, |context| context.workspace)]
             };
             let order_by_recency = all_workspaces && agent_only;
+            // Complexity note: this is the only O(A log A) projection path,
+            // where A is the all-scope agent-row count. The sort preserves the
+            // user-visible updated_at order; every other path appends in O(A).
+            // The ignored 1000-workspace fixture below is the measurement hook
+            // for this intentional tradeoff, without claiming a local timing.
             // (last status change, insertion order) so an `all`-scoped agents
             // view reads chronologically, newest first. `u64::MAX - ...`
             // inverts recency while the tree-order index breaks ties.
@@ -384,6 +389,7 @@ fn append_level(
 mod tests {
     use super::*;
     use cmux_tui_core::{Node, SurfaceKind};
+    use std::time::Instant;
 
     use crate::session::tree::{PaneView, ScreenView, TabView, WorkspaceView};
 
@@ -752,5 +758,48 @@ mod tests {
         state.reconcile_selection(&reordered);
         assert_eq!(state.selected_target, Some(selected_target));
         assert_eq!(reordered[state.selected].target, selected_target);
+    }
+
+    /// Manual performance fixture for the intentional all-scope agent sort.
+    /// Run with `--ignored --nocapture` when a hosted or local timing sample is
+    /// needed. This test records no threshold and makes no timing claim.
+    #[test]
+    #[ignore = "manual projection performance measurement"]
+    fn benchmark_all_scope_agents_at_thousand_workspaces() {
+        let tree = TreeView {
+            workspaces: (0..1_000)
+                .map(|index| {
+                    workspace(
+                        index as WorkspaceId + 1,
+                        "workspace",
+                        index as PaneId + 10,
+                        [index as SurfaceId + 100, index as SurfaceId + 10_100],
+                    )
+                })
+                .collect(),
+            workspace_revision: 1,
+            pane_revision: Some(1),
+            active_workspace: 0,
+        };
+        let agents = (0..1_000)
+            .map(|index| AgentInfo {
+                surface: index as SurfaceId + 100,
+                state: "working".into(),
+                source: "fixture".into(),
+                session: None,
+                updated_at_ms: index as u64,
+            })
+            .collect::<Vec<_>>();
+        let mut all_spec = spec(vec![SidebarResourceKind::Agents]);
+        all_spec.scope = SidebarViewScope::All;
+
+        let started = Instant::now();
+        let projected = rows(&all_spec, &tree, &agents, 0, &HashSet::new());
+        eprintln!(
+            "all-scope agent projection: {} rows in {:?}",
+            projected.len(),
+            started.elapsed()
+        );
+        assert_eq!(projected.len(), 1_000);
     }
 }

--- a/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
@@ -89,7 +89,9 @@ impl Default for ProjectionRailState {
             collapsed: HashSet::new(),
         }
     }
+}
 
+impl ProjectionRailState {
     pub(crate) fn reconcile_selection(&mut self, rows: &[ProjectionRow]) {
         if rows.is_empty() {
             self.selected = 0;

--- a/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
@@ -4,7 +4,7 @@ use std::collections::{HashMap, HashSet};
 
 use cmux_tui_core::{PaneId, SurfaceId, WorkspaceId};
 
-use crate::config::{SidebarResourceKind, SidebarViewSpec};
+use crate::config::{SidebarResourceKind, SidebarViewScope, SidebarViewSpec};
 use crate::session::{AgentInfo, TreeView};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -95,6 +95,7 @@ pub(crate) fn rows(
     append_level(
         &mut rows,
         &spec.levels,
+        spec.scope,
         0,
         None,
         tree,
@@ -109,6 +110,7 @@ pub(crate) fn rows(
 fn append_level(
     output: &mut Vec<ProjectionRow>,
     levels: &[SidebarResourceKind],
+    scope: SidebarViewScope,
     depth: usize,
     context: Option<ProjectionContext>,
     tree: &TreeView,
@@ -142,6 +144,7 @@ fn append_level(
                     append_level(
                         output,
                         levels,
+                        scope,
                         depth + 1,
                         Some(ProjectionContext {
                             workspace: workspace_index,
@@ -193,6 +196,7 @@ fn append_level(
                         append_level(
                             output,
                             levels,
+                            scope,
                             depth + 1,
                             Some(ProjectionContext {
                                 workspace: workspace_index,
@@ -210,68 +214,102 @@ fn append_level(
         }
         SidebarResourceKind::Tabs | SidebarResourceKind::Agents => {
             let agent_only = resource == SidebarResourceKind::Agents;
-            let workspace_index = context.map_or(selected_workspace, |context| context.workspace);
-            let Some(workspace) = tree.workspaces.get(workspace_index) else { return };
-            for (screen_index, screen) in workspace.screens.iter().enumerate() {
-                if context.is_some_and(|context| {
-                    context.screen.is_some_and(|candidate| candidate != screen_index)
-                }) {
-                    continue;
-                }
-                for pane in &screen.panes {
+            // A flat `all`-scoped view sweeps every workspace; the historical
+            // behavior scopes the flat view to the selected workspace and a
+            // nested view to its parent context.
+            let all_workspaces = context.is_none() && scope == SidebarViewScope::All;
+            let workspace_indices: Vec<usize> = if all_workspaces {
+                (0..tree.workspaces.len()).collect()
+            } else {
+                vec![context.map_or(selected_workspace, |context| context.workspace)]
+            };
+            // (last status change, insertion order) so an `all`-scoped agents
+            // view reads chronologically, newest first. `u64::MAX - ...`
+            // inverts recency while the tree-order index breaks ties.
+            let mut entries: Vec<((u64, usize), ProjectionRow)> = Vec::new();
+            for workspace_index in workspace_indices {
+                let Some(workspace) = tree.workspaces.get(workspace_index) else { continue };
+                for (screen_index, screen) in workspace.screens.iter().enumerate() {
                     if context.is_some_and(|context| {
-                        context.pane.is_some_and(|candidate| candidate != pane.id)
+                        context.screen.is_some_and(|candidate| candidate != screen_index)
                     }) {
                         continue;
                     }
-                    for (tab_index, tab) in pane.tabs.iter().enumerate() {
-                        let agent = agents.get(&tab.surface).copied();
-                        if agent_only && agent.is_none() {
+                    for pane in &screen.panes {
+                        if context.is_some_and(|context| {
+                            context.pane.is_some_and(|candidate| candidate != pane.id)
+                        }) {
                             continue;
                         }
-                        let name = tab
-                            .name
-                            .as_deref()
-                            .filter(|name| !name.is_empty())
-                            .or_else(|| (!tab.title.is_empty()).then_some(tab.title.as_str()))
-                            .unwrap_or(tab.short_id.as_str())
-                            .to_string();
-                        let subtitle = if let Some(agent) = agent.filter(|_| agent_only) {
-                            agent
-                                .session
+                        for (tab_index, tab) in pane.tabs.iter().enumerate() {
+                            let agent = agents.get(&tab.surface).copied();
+                            if agent_only && agent.is_none() {
+                                continue;
+                            }
+                            let name = tab
+                                .name
                                 .as_deref()
-                                .filter(|session| !session.is_empty())
-                                .unwrap_or(pane.short_id.as_str())
-                                .to_string()
-                        } else {
-                            pane.short_id.clone()
-                        };
-                        output.push(ProjectionRow {
-                            resource,
-                            depth: depth as u16,
-                            name,
-                            subtitle,
-                            agent_state: agent
-                                .filter(|_| agent_only)
-                                .map(|agent| agent.state.clone()),
-                            active: workspace_index == tree.active_workspace
-                                && screen_index == workspace.active_screen
-                                && pane.id == screen.active_pane
-                                && pane.active_tab == tab_index,
-                            branch: None,
-                            expanded: false,
-                            target: ProjectionTarget::Surface {
-                                workspace: workspace_index,
-                                screen: screen_index,
-                                pane: pane.id,
-                                index: tab_index,
-                                surface: tab.surface,
-                                agent: agent_only,
-                            },
-                        });
+                                .filter(|name| !name.is_empty())
+                                .or_else(|| (!tab.title.is_empty()).then_some(tab.title.as_str()))
+                                .unwrap_or(tab.short_id.as_str())
+                                .to_string();
+                            let subtitle = if let Some(agent) = agent.filter(|_| agent_only) {
+                                agent
+                                    .session
+                                    .as_deref()
+                                    .filter(|session| !session.is_empty())
+                                    .unwrap_or_else(|| {
+                                        // In an all-workspaces sweep the
+                                        // workspace locates the agent better
+                                        // than a pane short id.
+                                        if all_workspaces {
+                                            workspace.name.as_str()
+                                        } else {
+                                            pane.short_id.as_str()
+                                        }
+                                    })
+                                    .to_string()
+                            } else {
+                                pane.short_id.clone()
+                            };
+                            let recency = if all_workspaces && agent_only {
+                                u64::MAX
+                                    - agent.map(|agent| agent.updated_at_ms).unwrap_or_default()
+                            } else {
+                                0
+                            };
+                            entries.push((
+                                (recency, entries.len()),
+                                ProjectionRow {
+                                    resource,
+                                    depth: depth as u16,
+                                    name,
+                                    subtitle,
+                                    agent_state: agent
+                                        .filter(|_| agent_only)
+                                        .map(|agent| agent.state.clone()),
+                                    active: workspace_index == tree.active_workspace
+                                        && screen_index == workspace.active_screen
+                                        && pane.id == screen.active_pane
+                                        && pane.active_tab == tab_index,
+                                    branch: None,
+                                    expanded: false,
+                                    target: ProjectionTarget::Surface {
+                                        workspace: workspace_index,
+                                        screen: screen_index,
+                                        pane: pane.id,
+                                        index: tab_index,
+                                        surface: tab.surface,
+                                        agent: agent_only,
+                                    },
+                                },
+                            ));
+                        }
                     }
                 }
             }
+            entries.sort_by_key(|(key, _)| *key);
+            output.extend(entries.into_iter().map(|(_, row)| row));
         }
     }
 }
@@ -345,6 +383,7 @@ mod tests {
             width: 22,
             max_width: 0,
             collapse_priority: 20,
+            scope: SidebarViewScope::Workspace,
         }
     }
 
@@ -429,5 +468,124 @@ mod tests {
     fn flat_agent_view_is_empty_when_no_agents_are_running() {
         let rows = rows(&spec(vec![SidebarResourceKind::Agents]), &tree(), &[], 0, &HashSet::new());
         assert!(rows.is_empty());
+    }
+
+    fn workspace(id: WorkspaceId, name: &str, pane: PaneId, surfaces: [SurfaceId; 2]) -> WorkspaceView {
+        WorkspaceView {
+            id,
+            resource_id: None,
+            key: format!("workspace-{id}"),
+            short_id: format!("w{id}"),
+            name: name.into(),
+            screens: vec![ScreenView {
+                id: id + 100,
+                resource_id: None,
+                short_id: format!("s{id}"),
+                name: None,
+                layout: Node::Leaf(pane),
+                active_pane: pane,
+                zoomed_pane: None,
+                viewport_base_width: None,
+                viewport_splits: Default::default(),
+                panes: vec![PaneView {
+                    id: pane,
+                    resource_id: None,
+                    short_id: format!("p{pane}"),
+                    name: None,
+                    tabs: vec![tab(surfaces[0], "claude"), tab(surfaces[1], "codex")],
+                    active_tab: 0,
+                    focused_at: 0,
+                }],
+            }],
+            active_screen: 0,
+        }
+    }
+
+    #[test]
+    fn all_scope_agents_sweep_workspaces_newest_first() {
+        let tree = TreeView {
+            workspaces: vec![
+                workspace(1, "alpha", 10, [11, 12]),
+                workspace(2, "beta", 20, [21, 22]),
+            ],
+            workspace_revision: 1,
+            pane_revision: Some(1),
+            active_workspace: 0,
+        };
+        let agents = vec![
+            AgentInfo {
+                surface: 11,
+                state: "idle".into(),
+                source: "hook".into(),
+                session: Some("older task".into()),
+                updated_at_ms: 100,
+            },
+            AgentInfo {
+                surface: 22,
+                state: "working".into(),
+                source: "hook".into(),
+                session: None,
+                updated_at_ms: 900,
+            },
+            AgentInfo {
+                surface: 12,
+                state: "done".into(),
+                source: "hook".into(),
+                session: Some("finished task".into()),
+                updated_at_ms: 500,
+            },
+        ];
+        let mut all_spec = spec(vec![SidebarResourceKind::Agents]);
+        all_spec.scope = SidebarViewScope::All;
+        // The selected workspace must not scope the sweep.
+        let rows = rows(&all_spec, &tree, &agents, 1, &HashSet::new());
+
+        assert_eq!(rows.len(), 3, "agents from every workspace appear");
+        let order: Vec<u64> = rows
+            .iter()
+            .map(|row| match row.target {
+                ProjectionTarget::Surface { surface, .. } => surface,
+                _ => panic!("agent rows target surfaces"),
+            })
+            .collect();
+        assert_eq!(order, vec![22, 12, 11], "newest status change first");
+        assert_eq!(rows[0].agent_state.as_deref(), Some("working"));
+        assert_eq!(
+            rows[0].subtitle, "beta",
+            "a session-less agent names its workspace in an all sweep"
+        );
+        assert_eq!(rows[1].agent_state.as_deref(), Some("done"));
+    }
+
+    #[test]
+    fn workspace_scope_keeps_the_selected_workspace_filter() {
+        let tree = TreeView {
+            workspaces: vec![
+                workspace(1, "alpha", 10, [11, 12]),
+                workspace(2, "beta", 20, [21, 22]),
+            ],
+            workspace_revision: 1,
+            pane_revision: Some(1),
+            active_workspace: 0,
+        };
+        let agents = vec![
+            AgentInfo {
+                surface: 11,
+                state: "working".into(),
+                source: "hook".into(),
+                session: None,
+                updated_at_ms: 100,
+            },
+            AgentInfo {
+                surface: 22,
+                state: "working".into(),
+                source: "hook".into(),
+                session: None,
+                updated_at_ms: 900,
+            },
+        ];
+        let rows = rows(&spec(vec![SidebarResourceKind::Agents]), &tree, &agents, 1, &HashSet::new());
+        assert_eq!(rows.len(), 1);
+        assert!(matches!(rows[0].target, ProjectionTarget::Surface { surface: 22, .. }));
     }
 }

--- a/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
@@ -111,6 +111,25 @@ impl ProjectionRailState {
     }
 }
 
+/// Return the workspace-selection component that can affect this projection.
+/// Flat all-scoped tab/agent views enumerate every workspace themselves, and
+/// workspace rows do the same. Keeping those views independent of the current
+/// highlight lets their snapshots survive a highlight-only move.
+pub(crate) fn selected_workspace_cache_key(
+    spec: &SidebarViewSpec,
+    selected_workspace: usize,
+) -> Option<usize> {
+    match spec.levels.first().copied() {
+        Some(SidebarResourceKind::Panes) => Some(selected_workspace),
+        Some(SidebarResourceKind::Tabs | SidebarResourceKind::Agents)
+            if spec.scope != SidebarViewScope::All =>
+        {
+            Some(selected_workspace)
+        }
+        _ => None,
+    }
+}
+
 #[derive(Clone, Copy)]
 struct ProjectionContext {
     workspace: usize,
@@ -262,6 +281,7 @@ fn append_level(
             } else {
                 vec![context.map_or(selected_workspace, |context| context.workspace)]
             };
+            let order_by_recency = all_workspaces && agent_only;
             // (last status change, insertion order) so an `all`-scoped agents
             // view reads chronologically, newest first. `u64::MAX - ...`
             // inverts recency while the tree-order index breaks ties.
@@ -314,44 +334,48 @@ fn append_level(
                             } else {
                                 pane.short_id.clone()
                             };
-                            let recency = if all_workspaces && agent_only {
+                            let recency = if order_by_recency {
                                 u64::MAX
                                     - agent.map(|agent| agent.updated_at_ms).unwrap_or_default()
                             } else {
                                 0
                             };
-                            entries.push((
-                                (recency, entries.len()),
-                                ProjectionRow {
-                                    resource,
-                                    depth: depth as u16,
-                                    name,
-                                    subtitle,
-                                    agent_state: agent
-                                        .filter(|_| agent_only)
-                                        .map(|agent| agent.state.clone()),
-                                    active: workspace_index == tree.active_workspace
-                                        && screen_index == workspace.active_screen
-                                        && pane.id == screen.active_pane
-                                        && pane.active_tab == tab_index,
-                                    branch: None,
-                                    expanded: false,
-                                    target: ProjectionTarget::Surface {
-                                        workspace: workspace_index,
-                                        screen: screen_index,
-                                        pane: pane.id,
-                                        index: tab_index,
-                                        surface: tab.surface,
-                                        agent: agent_only,
-                                    },
+                            let row = ProjectionRow {
+                                resource,
+                                depth: depth as u16,
+                                name,
+                                subtitle,
+                                agent_state: agent
+                                    .filter(|_| agent_only)
+                                    .map(|agent| agent.state.clone()),
+                                active: workspace_index == tree.active_workspace
+                                    && screen_index == workspace.active_screen
+                                    && pane.id == screen.active_pane
+                                    && pane.active_tab == tab_index,
+                                branch: None,
+                                expanded: false,
+                                target: ProjectionTarget::Surface {
+                                    workspace: workspace_index,
+                                    screen: screen_index,
+                                    pane: pane.id,
+                                    index: tab_index,
+                                    surface: tab.surface,
+                                    agent: agent_only,
                                 },
-                            ));
+                            };
+                            if order_by_recency {
+                                entries.push(((recency, entries.len()), row));
+                            } else {
+                                output.push(row);
+                            }
                         }
                     }
                 }
             }
-            entries.sort_by_key(|(key, _)| *key);
-            output.extend(entries.into_iter().map(|(_, row)| row));
+            if order_by_recency {
+                entries.sort_by_key(|(key, _)| *key);
+                output.extend(entries.into_iter().map(|(_, row)| row));
+            }
         }
     }
 }
@@ -649,6 +673,37 @@ mod tests {
             rows(&spec(vec![SidebarResourceKind::Agents]), &tree, &agents, 1, &HashSet::new());
         assert_eq!(rows.len(), 1);
         assert!(matches!(rows[0].target, ProjectionTarget::Surface { surface: 22, .. }));
+    }
+
+    #[test]
+    fn workspace_scoped_agents_keep_tree_order() {
+        let tree = tree();
+        let agents = vec![
+            AgentInfo {
+                surface: 4,
+                state: "working".into(),
+                source: "hook".into(),
+                session: None,
+                updated_at_ms: 900,
+            },
+            AgentInfo {
+                surface: 5,
+                state: "working".into(),
+                source: "hook".into(),
+                session: None,
+                updated_at_ms: 100,
+            },
+        ];
+        let rows =
+            rows(&spec(vec![SidebarResourceKind::Agents]), &tree, &agents, 0, &HashSet::new());
+        let surfaces = rows
+            .iter()
+            .map(|row| match row.target {
+                ProjectionTarget::Surface { surface, .. } => surface,
+                _ => panic!("agent rows target surfaces"),
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(surfaces, vec![4, 5]);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
@@ -470,7 +470,12 @@ mod tests {
         assert!(rows.is_empty());
     }
 
-    fn workspace(id: WorkspaceId, name: &str, pane: PaneId, surfaces: [SurfaceId; 2]) -> WorkspaceView {
+    fn workspace(
+        id: WorkspaceId,
+        name: &str,
+        pane: PaneId,
+        surfaces: [SurfaceId; 2],
+    ) -> WorkspaceView {
         WorkspaceView {
             id,
             resource_id: None,
@@ -584,7 +589,8 @@ mod tests {
                 updated_at_ms: 900,
             },
         ];
-        let rows = rows(&spec(vec![SidebarResourceKind::Agents]), &tree, &agents, 1, &HashSet::new());
+        let rows =
+            rows(&spec(vec![SidebarResourceKind::Agents]), &tree, &agents, 1, &HashSet::new());
         assert_eq!(rows.len(), 1);
         assert!(matches!(rows[0].target, ProjectionTarget::Surface { surface: 22, .. }));
     }

--- a/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
@@ -243,7 +243,10 @@ fn append_level(
                         }
                         for (tab_index, tab) in pane.tabs.iter().enumerate() {
                             let agent = agents.get(&tab.surface).copied();
-                            if agent_only && agent.is_none() {
+                            if agent_only
+                                && (agent.is_none()
+                                    || agent.is_some_and(|agent| agent.state == "unknown"))
+                            {
                                 continue;
                             }
                             let name = tab
@@ -467,6 +470,20 @@ mod tests {
     #[test]
     fn flat_agent_view_is_empty_when_no_agents_are_running() {
         let rows = rows(&spec(vec![SidebarResourceKind::Agents]), &tree(), &[], 0, &HashSet::new());
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn agent_projection_hides_unknown_records_at_its_boundary() {
+        let agents = vec![AgentInfo {
+            surface: 5,
+            state: "unknown".into(),
+            source: "hook".into(),
+            session: None,
+            updated_at_ms: 1,
+        }];
+        let rows =
+            rows(&spec(vec![SidebarResourceKind::Agents]), &tree(), &agents, 0, &HashSet::new());
         assert!(rows.is_empty());
     }
 

--- a/cmux-tui/crates/cmux-tui/src/ui/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/mod.rs
@@ -133,6 +133,7 @@ pub fn draw(app: &mut App, frame: &mut Frame) {
                 RailKind::Projection(index) => sidebar::draw_projection(app, frame, index),
             }
         }
+        sidebar::draw_split_dividers(app, frame);
     }
 
     let pane_cursors = if draw_machine_transition(app, frame) {

--- a/cmux-tui/crates/cmux-tui/src/ui/sidebar.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/sidebar.rs
@@ -409,6 +409,35 @@ pub fn draw_projection(app: &mut App, frame: &mut Frame, view_index: usize) {
     app.hits.push((rail::divider(area), Hit::RailResize(RailKind::Projection(view_index))));
 }
 
+/// Draw the horizontal rule of every vertical split divider and register
+/// its drag handle. Horizontal splits need no extra drawing: their handle
+/// is the left child's border column, rerouted at press time.
+pub fn draw_split_dividers(app: &mut App, frame: &mut Frame) {
+    if app.sidebar_layout.dividers.is_empty() {
+        return;
+    }
+    let palette = rail::RailPalette::for_app(app, false);
+    for divider in app.sidebar_layout.dividers.clone() {
+        if divider.dir != crate::config::SidebarSplitDir::Vertical || divider.rect.width == 0 {
+            continue;
+        }
+        {
+            let buf = frame.buffer_mut();
+            let y = divider.rect.y;
+            let last = divider.rect.x + divider.rect.width - 1;
+            for x in divider.rect.x..last {
+                buf[(x, y)].set_symbol("─").set_style(palette.border);
+            }
+            // The rail border column stays continuous through the divider.
+            buf[(last, y)].set_symbol(palette.border_symbol).set_style(palette.border);
+        }
+        app.hits.push((
+            divider.rect,
+            Hit::SidebarSplitDivider { group: divider.group, index: divider.index },
+        ));
+    }
+}
+
 fn draw_plugin(app: &mut App, frame: &mut Frame) {
     let Some(area) = app.workspace_sidebar_area(frame.area().height) else { return };
     let width = area.width;

--- a/cmux-tui/docs/configuration.md
+++ b/cmux-tui/docs/configuration.md
@@ -70,7 +70,22 @@ The built-in sidebar defaults to the workspace list. Set `"sidebar": {"view": "f
 
 Actions use the same stable IDs and execution path as keyboard commands, including `new-workspace`, `new-tab`, and `new-pane-smart`. An entry may also be an object `{"action": "new-workspace", "label": "new"}` to rename its button, and `"command:<id>"` pins a user command from the top-level `commands` section as a button. `actions_position: "top"` mounts the buttons at the view's top instead of the bottom edge. A view rooted at `workspaces` inherits `new-workspace`, including provider-specific isolated and shared choices. Set `"actions": []` to hide every pinned action, or provide an ordered list to replace the preset. Machine creation and connection actions remain capability-driven by the selected provider.
 
-Every view has an independent width and drag handle. Lower `collapse_priority` values hide first when the terminal must preserve 40 pane columns. A hidden view needs four additional columns before it returns, which prevents resize-boundary flicker. `sidebar.columns` remains a compatibility alias for one-level machine, workspace, and tab views; `sidebar.views` wins when both are present.
+A top-level entry can also be a split group instead of a view: `{"id": "left", "split": "vertical", "panes": [ ... ]}` stacks its panes top to bottom in one column, `"split": "horizontal"` places them side by side, and groups nest up to three levels. Each pane is a view (same schema) or another split, with an optional `weight` (default `1`) setting its share. The divider between stacked panes drags with the mouse; from a rail's first or last row, `Up`/`Down` (or `k`/`j`) moves focus into the stacked neighbor. A split column keeps one width: the group's `width`, `max_width`, and `collapse_priority` default to the largest among its panes, and a width drag on any of its rails resizes the whole column.
+
+Flat one-level `tabs` and `agents` views accept `"scope": "all"`. An `all`-scoped view sweeps every workspace instead of following the highlighted one; agents then order chronologically by their last status change, newest first, keep `done` agents visible, and show their workspace name when the agent has no session title. This is how a status board like *workspaces on top, all agents below* is built:
+
+```json
+"sidebar": {
+  "views": [
+    {"id": "left", "split": "vertical", "panes": [
+      {"id": "workspaces", "levels": ["workspaces"]},
+      {"id": "all-agents", "levels": ["agents"], "scope": "all", "weight": 2}
+    ]}
+  ]
+}
+```
+
+Every view has an independent width and drag handle. Lower `collapse_priority` values hide first when the terminal must preserve 40 pane columns. A hidden view needs four additional columns before it returns, which prevents resize-boundary flicker. Panes of a split behave the same way vertically: when a column gets too short, its lowest-priority panes hide until space returns. `sidebar.columns` remains a compatibility alias for one-level machine, workspace, and tab views; `sidebar.views` wins when both are present.
 
 | Key | Type | Default | Effect |
 | --- | --- | --- | --- |
@@ -91,6 +106,10 @@ Every view has an independent width and drag handle. Lower `collapse_priority` v
 | `sidebar.views[].max_width` | integer | `0` | Maximum live drag width; `0` means no configured maximum |
 | `sidebar.views[].collapse_priority` | integer | resource default | Lower priorities hide first on narrow terminals |
 | `sidebar.views[].actions_position` | `"top"` or `"bottom"` | `"bottom"` | Where the view's pinned action buttons render |
+| `sidebar.views[].scope` | `"workspace"` or `"all"` | `"workspace"` | For flat `tabs`/`agents` views: follow the highlighted workspace, or sweep all workspaces (agents order newest status change first) |
+| `sidebar.views[].split` | `"vertical"` or `"horizontal"` | unset | Turns the entry into a split group of `panes` instead of a leaf view |
+| `sidebar.views[].panes` | array of entries | required with `split` | Child views or nested splits of a split group |
+| `sidebar.views[].panes[].weight` | integer | `1` | Relative share of the parent split |
 | `sidebar.row_height` | `1` or `2` | `2` | Rows per rail entry; `1` drops the subtitle line |
 | `sidebar.row_gap` | integer | `1` | Blank rows between rail entries, `0` through `2` |
 | `sidebar.rail_glyph` | string | `"▎"` | Accent glyph on active rail rows; `"none"` removes it |

--- a/cmux-tui/docs/configuration.md
+++ b/cmux-tui/docs/configuration.md
@@ -72,7 +72,7 @@ Actions use the same stable IDs and execution path as keyboard commands, includi
 
 A top-level entry can also be a split group instead of a view: `{"id": "left", "split": "vertical", "panes": [ ... ]}` stacks its panes top to bottom in one column, `"split": "horizontal"` places them side by side, and groups nest up to three levels. Each pane is a view (same schema) or another split, with an optional `weight` (default `1`) setting its share. The divider between stacked panes drags with the mouse; from a rail's first or last row, `Up`/`Down` (or `k`/`j`) moves focus into the stacked neighbor. A split column keeps one width: the group's `width`, `max_width`, and `collapse_priority` default to the largest among its panes, and a width drag on any of its rails resizes the whole column.
 
-Flat one-level `tabs` and `agents` views accept `"scope": "all"`. An `all`-scoped view sweeps every workspace instead of following the highlighted one; agents then order chronologically by their last status change, newest first, keep `done` agents visible, and show their workspace name when the agent has no session title. This is how a status board like *workspaces on top, all agents below* is built:
+Flat one-level `tabs` and `agents` views accept `"scope": "all"`. An `all`-scoped view sweeps every workspace instead of following the highlighted one; agents hide `unknown` records, order chronologically by their last status change, newest first, keep `done` agents visible, and show their workspace name when the agent has no session title. This is how a status board like *workspaces on top, all agents below* is built:
 
 ```json
 "sidebar": {

--- a/cmux-tui/examples/sidebar-splits.json
+++ b/cmux-tui/examples/sidebar-splits.json
@@ -1,0 +1,14 @@
+{
+  "sidebar": {
+    "views": [
+      {
+        "id": "left",
+        "split": "vertical",
+        "panes": [
+          { "id": "workspaces", "levels": ["workspaces"] },
+          { "id": "all-agents", "levels": ["agents"], "scope": "all", "weight": 2 }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
The TUI sidebar gains a split primitive: a `sidebar.views` entry can now be a split group instead of a leaf view. `{"split": "vertical", "panes": [...]}` stacks panes top to bottom inside one column, `"horizontal"` places them side by side, groups nest up to three levels, and each pane takes an optional `weight`. The motivating layout ships as `cmux-tui/examples/sidebar-splits.json`: workspaces on top, all agents below.

```json
"sidebar": { "views": [
  {"id": "left", "split": "vertical", "panes": [
    {"id": "workspaces", "levels": ["workspaces"]},
    {"id": "all-agents", "levels": ["agents"], "scope": "all", "weight": 2}
  ]}
]}
```

Mechanism. Config resolution now produces the flat view list plus a layout forest (`SidebarLayoutNode::Leaf|Split`); every existing consumer of `sidebar.views` is untouched. The column solver (`sidebar_layout_for_state`) packs top-level nodes exactly as it packed views before (same collapse priorities, minimum widths, reveal hysteresis), then recursively partitions each column's rect: vertical splits carve a one-row divider between children, horizontal splits share the width, and children that no longer fit at minimum size hide lowest-collapse-priority first, mirroring column behavior. If `views` is replaced without a matching layout (tests, older paths), the solver falls back to one column per view, so the old behavior is the degenerate case.

Interaction. Dividers drag with the mouse (`Hit::SidebarSplitDivider` for vertical dividers; a horizontal split reuses the left child's border column and the press handler reroutes it), committing session-local share fractions. A width drag on any stacked rail resizes the whole column under the split group's id. Rail focus is now geometric: Left/Right pick the nearest column with the best vertical overlap, Up/Down move within a column, and pressing Up/Down at a rail's first/last row continues into the stacked neighbor (workspaces, tabs, and projection rails).

`scope: "all"` on flat `tabs`/`agents` views sweeps every workspace instead of following the selected one. All-scoped agents order by `updated_at_ms` newest first, keep `done` agents visible (it is a status board, not an active-agent list; `unknown` stays hidden), and show the workspace name as subtitle when the agent has no session title. `all`-scoped `tabs` views never map to the legacy selected-workspace tabs rail.

Sidebar layout state stays frontend-local per `spec/native-frontend.md`: fractions and width overrides are session-only, config is the durable source.

Tests: split grammar resolution (weights, scope validation, single-pane unwrap, bad-direction/ambiguous-group rejection, JSON parse), solver geometry (stacking, divider rects, fraction overrides, hidden-pane collapse), divider drag re-sharing with min clamps, column-wide width drag, vertical focus movement, and all-scope projection ordering across workspaces.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10966"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790421777&installation_model_id=21920&pr_number=10966&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10966&signature=4b4eee07c1f08c4d0c1a56de996dd341017c46a32ae9efc8af45aab4a46d6c2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sidebar columns previously held one view tied to the selected workspace; they can now contain nested split panes and views that span all workspaces. Remote transport loss previously looked like an empty session and exited quietly; it now surfaces a localized nonzero error, while genuinely empty sessions retain the quiet exit.

**Sidebar**
- `sidebar.views` entries support vertical or horizontal `panes`, nesting up to three levels with optional weights; documentation and an example config are included.
- Split dividers are draggable, keyboard focus moves between stacked panes, and low-priority panes collapse first when space runs out.
- `scope: "all"` makes flat `tabs` and `agents` views enumerate every workspace; agents hide `unknown`, retain `done`, sort by latest status change, and use the workspace name when no session title exists.
- Profile changes restore configured layouts, while bounded projection caching preserves selection by resource identity.

**Transport handling**
- Empty-session events attempt machine-session reconnects before reporting the recorded transport failure.
- Deliberate local disconnects remain quiet, and transport errors include recovery guidance.
- Fixes #11042.

<sup>Written for commit 79ffd93866754498f86abca190f6faadce9047ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10966?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable nested sidebar split groups with vertical or horizontal panes.
  * Resize stacked panes by dragging dividers, with shared column widths and persisted layout settings.
  * Navigate focus across stacked sidebar sections using keyboard controls.
  * Added “all workspaces” views for tabs and agents, with chronological ordering and workspace context.
  * Completed agents remain visible in all-workspace views, while unknown agents are filtered out.
  * Profile switching restores the configured sidebar layout.
  * Preserve selection when sidebar resources are reordered.

* **Documentation**
  * Added sidebar split and resource-scope configuration guidance, plus an example layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->