### PR TITLE
fix: make window-chrome separators visible in light mode

### DIFF
--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/WindowChrome/Color/WindowChromeColorResolver.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/WindowChrome/Color/WindowChromeColorResolver.swift
@@ -16,7 +16,10 @@ public struct WindowChromeColorResolver: Sendable {
         srgb.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
         let luminance = 0.299 * red + 0.587 * green + 0.114 * blue
         let isLight = luminance > 0.5
-        let amount: CGFloat = isLight ? -0.12 : 0.16
+        // Asymmetric because sRGB gamma compresses a fixed RGB step far more
+        // near white than near black. These deltas put both sides at CIE
+        // dL* ~7 against their own background once composited.
+        let amount: CGFloat = isLight ? -0.30 : 0.16
         let separatorAlpha: CGFloat = isLight ? 0.26 : 0.36
         return NSColor(
             red: min(1.0, max(0.0, red + amount)),

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -1415,7 +1415,7 @@ final class WorkspaceChromeThemeTests: XCTestCase {
         XCTAssertEqual(colors.tabBarBackgroundHex, "#FDF6E3")
         XCTAssertEqual(colors.splitButtonBackdropHex, "#FDF6E3")
         XCTAssertEqual(colors.paneBackgroundHex, "#00000000")
-        XCTAssertEqual(colors.borderHex, "#DED7C442")
+        XCTAssertEqual(colors.borderHex, "#B0A99642")
     }
 
     func testResolvedChromeColorsUsesDarkGhosttyBackground() {
@@ -1484,8 +1484,10 @@ final class WorkspaceChromeThemeTests: XCTestCase {
     }
 }
 
+// Bonsplit carries an equivalent fallback, but cmux always supplies
+// `borderHex`, so this resolver is the formula that actually runs.
 final class WindowChromeSeparatorColorTests: XCTestCase {
-    func testDarkChromeSeparatorMatchesBonsplitDerivation() {
+    func testDarkChromeSeparatorDerivation() {
         guard let backgroundColor = NSColor(hex: "#272822") else {
             XCTFail("Expected valid test color")
             return
@@ -1500,7 +1502,7 @@ final class WindowChromeSeparatorColorTests: XCTestCase {
         XCTAssertEqual(rgba.alpha, CGFloat(0.36), accuracy: 0.0001)
     }
 
-    func testLightChromeSeparatorMatchesBonsplitDerivation() {
+    func testLightChromeSeparatorDerivation() {
         guard let backgroundColor = NSColor(hex: "#FDF6E3") else {
             XCTFail("Expected valid test color")
             return
@@ -1509,10 +1511,44 @@ final class WindowChromeSeparatorColorTests: XCTestCase {
         let color = WindowChromeColorResolver().separatorColor(forChromeBackground: backgroundColor)
         let rgba = rgbaComponents(color)
 
-        XCTAssertEqual(rgba.red, CGFloat(253.0 / 255.0) - CGFloat(0.12), accuracy: 0.0001)
-        XCTAssertEqual(rgba.green, CGFloat(246.0 / 255.0) - CGFloat(0.12), accuracy: 0.0001)
-        XCTAssertEqual(rgba.blue, CGFloat(227.0 / 255.0) - CGFloat(0.12), accuracy: 0.0001)
+        XCTAssertEqual(rgba.red, CGFloat(253.0 / 255.0) - CGFloat(0.30), accuracy: 0.0001)
+        XCTAssertEqual(rgba.green, CGFloat(246.0 / 255.0) - CGFloat(0.30), accuracy: 0.0001)
+        XCTAssertEqual(rgba.blue, CGFloat(227.0 / 255.0) - CGFloat(0.30), accuracy: 0.0001)
         XCTAssertEqual(rgba.alpha, CGFloat(0.26), accuracy: 0.0001)
+    }
+
+    func testLightChromeSeparatorStaysPerceptible() {
+        let background = NSColor.white
+        let resolver = WindowChromeColorResolver()
+        let composited = resolver.compositedColor(
+            resolver.separatorColor(forChromeBackground: background),
+            over: background
+        )
+        // The separator is translucent, so only the composite is visible, and
+        // sRGB gamma nearly erases a small delta near white. Dark chrome
+        // measures ~7; light must not compress below this floor.
+        XCTAssertGreaterThanOrEqual(
+            lightness(background) - lightness(composited),
+            4.0
+        )
+    }
+
+    /// CIE L* of a color, the scale perceived separation is asserted in.
+    private func lightness(_ color: NSColor) -> CGFloat {
+        let rgba = rgbaComponents(color)
+
+        func linearized(_ component: CGFloat) -> CGFloat {
+            component <= 0.03928
+                ? component / 12.92
+                : CGFloat(pow(Double((component + 0.055) / 1.055), 2.4))
+        }
+
+        let luminance = 0.2126 * linearized(rgba.red)
+            + 0.7152 * linearized(rgba.green)
+            + 0.0722 * linearized(rgba.blue)
+        return luminance > 0.008856
+            ? 116 * CGFloat(pow(Double(luminance), 1.0 / 3.0)) - 16
+            : 903.3 * luminance
     }
 
     private func rgbaComponents(_ color: NSColor) -> (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat) {


### PR DESCRIPTION
The sidebar trailing edge, the titlebar/tab-bar underline, and the Bonsplit tab and pane borders all come from
WindowChromeColorResolver.separatorColor(forChromeBackground:), which shifts the chrome background by a fixed RGB amount before applying alpha.

sRGB gamma compresses that step to almost nothing near white: light chrome measured CIE dL* ~2.8 against its own background where dark measured ~6.1. With "Match Terminal Background" on there is no tonal step between sidebar and terminal to fall back on, so light mode lost every chrome line while dark kept them.

Darken light chrome by 0.30 instead of 0.12, putting it at dL* ~6.9 to match dark. The line still lands softer than NSColor.separatorColor does on white. Dark chrome is unchanged.

before / after:

<img width="850" height="778" alt="image" src="https://github.com/user-attachments/assets/216d6747-034c-47d5-a664-ab5d979a2d01" />


## Summary

- What changed?
- Why?

## Testing

- How did you test this change?
- What did you verify manually?

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment:

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10967"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790422093&installation_model_id=21920&pr_number=10967&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10967&signature=ee632ed03ced2eeac2b498e674ad93eea006cf07f9457a78ed445921572c4095"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes window-chrome separator lines (sidebar edge, titlebar underline, and Bonsplit borders) visible in light mode. Light chrome was previously shifted by -0.12 RGB, but sRGB gamma compressed that near white to ~2.8 CIE L* contrast; it now uses -0.30 to reach ~6.9, matching dark chrome. Dark chrome is unchanged, and the change updates tests and adds a perceptual contrast regression.

<sup>Written for commit 11a775b9b4482811349a88a84a2cd4fb3d8b2a74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved window chrome separator contrast on light backgrounds for better visual clarity.
  - Maintained appropriate separator brightness on dark backgrounds.

- **Tests**
  - Added coverage to verify perceptual lightness and RGB adjustments.
  - Updated separator color expectations to reflect the improved contrast behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->