### PR TITLE
sentry: allow cloud VM subsystem events through the shared-project filter

### DIFF
--- a/web/services/sentry.ts
+++ b/web/services/sentry.ts
@@ -27,6 +27,12 @@ export function shouldSendCoderouterSentryEvent(event: Event): boolean {
   if (event.tags?.subsystem === "coderouter") return true;
   const cmux = event.contexts?.cmux as Record<string, unknown> | undefined;
   if (cmux?.service === "coderouter") return true;
+  // Cloud VM operator-fault errors and their Slack-alert failures report
+  // through the same shared project (services/vms/observability.ts,
+  // services/observability/alerts.ts). Before this branch, beforeSend
+  // silently dropped them, which is how a two-day provisioning outage
+  // produced zero Sentry events.
+  if (typeof cmux?.subsystem === "string" && cmux.subsystem.startsWith("cloud_vm")) return true;
   const message =
     event.message ??
     event.exception?.values?.map((value) => value.value ?? "").join(" ") ??

--- a/web/tests/coderouter-sentry.test.ts
+++ b/web/tests/coderouter-sentry.test.ts
@@ -30,6 +30,26 @@ describe("coderouter Sentry privacy", () => {
     ).toBe(false);
   });
 
+  test("cloud VM operator-fault reports pass the filter", () => {
+    expect(
+      shouldSendCoderouterSentryEvent({
+        contexts: { cmux: { subsystem: "cloud_vm_api", code: "vm_image_config_error" } },
+      }),
+    ).toBe(true);
+    expect(
+      shouldSendCoderouterSentryEvent({
+        contexts: { cmux: { subsystem: "cloud_vm_alerts" } },
+      }),
+    ).toBe(true);
+    // Other cmux-context reports (billing reconcile etc.) stay isolated until
+    // deliberately allowlisted.
+    expect(
+      shouldSendCoderouterSentryEvent({
+        contexts: { cmux: { subsystem: "billing" } },
+      }),
+    ).toBe(false);
+  });
+
   test("removes request bodies, auth headers, route tokens, JWTs, and PII", () => {
     const event = scrubSentryEvent({
       message:


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/cmux/pull/10955. The shared Sentry project's beforeSend (shouldSendCoderouterSentryEvent) drops everything that is not coderouter-shaped, so the new cloud VM operator-fault reports, and the pre-existing reportError calls in services/observability/alerts.ts, were silently discarded. Verified live: a deliberate vm_image_config_error drill against production produced the cloud_vm_provision PostHog event but no Sentry issue.

Events whose `contexts.cmux.subsystem` starts with `cloud_vm` now pass the filter and receive the same scrubSentryEvent treatment. Billing and other cmux-context reports stay isolated until deliberately allowlisted (covered by a test).

Tests: `bun test tests/coderouter-sentry.test.ts`, `bun run typecheck` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10968"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790423082&installation_model_id=21920&pr_number=10968&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10968&signature=812742948d54b3e996bfd6f9692dcba7b00aa17815b92a5e34feae7954633c57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the shared Sentry project's `beforeSend` filter so cloud VM subsystem events reach Sentry. Previously `shouldSendCoderouterSentryEvent` dropped all non-coderouter events, silently discarding cloud VM operator-fault reports and Slack alert failures. Events with `contexts.cmux.subsystem` starting with `cloud_vm` now pass and get standard scrubbing; other cmux-context reports stay isolated until allowlisted. Adds tests covering the new filter behavior.

<sup>Written for commit 48931df40074f858c2bf118470ce6e684d9b23de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for cloud VM issues, including image configuration failures and alert delivery problems.
  * Ensured relevant cloud VM failures are captured while unrelated billing events remain excluded.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->