### PR TITLE
refactor(tui): share draw and paint render path

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -11602,11 +11602,7 @@ impl App {
         self.ensure_graphics_writer_healthy()?;
         self.mark_pointer_route_for_rebuild(action);
         match action {
-            RenderAction::Draw => {
-                self.draw_terminal(terminal, action)?;
-                self.emit_graphics()?;
-            }
-            RenderAction::Paint => {
+            RenderAction::Draw | RenderAction::Paint => {
                 self.draw_terminal(terminal, action)?;
                 self.emit_graphics()?;
             }


### PR DESCRIPTION
## Summary
- share the identical terminal draw and graphics emission path for Draw and Paint actions
- preserve the action value for layout preparation and pointer snapshot semantics

## Verification
- rustfmt --edition 2024 --check cmux-tui/crates/cmux-tui/src/app.rs
- git diff --check
- hosted focused verification pending

No merge requested.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10970"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790424739&installation_model_id=21920&pr_number=10970&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10970&signature=eb071f37ec5c360e1ca2562fe5c698cdfaa9de5c61f7258f431708f85de30ddf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the `Draw` and `Paint` render paths in the TUI so both actions use the same terminal draw and graphics emission flow. The action value is still passed through to layout preparation and pointer snapshot logic.

<sup>Written for commit 561ddccdc9da7d6389d90940f73e9ea30205fa26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10970?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated equivalent rendering paths without changing visible behavior or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->