### PR TITLE
observability: defer and flush Sentry sends so they survive the serverless freeze

### DIFF
--- a/web/services/observability/report.ts
+++ b/web/services/observability/report.ts
@@ -1,3 +1,5 @@
+import { after } from "next/server";
+
 const SENSITIVE_KEY_PATTERN = /authorization|cookie|credential|dsn|key|password|providerMetadata|secret|token|webhook/i;
 
 export function reportError(
@@ -19,22 +21,36 @@ export function reportError(
   if (!process.env.SENTRY_DSN?.trim()) return;
 
   const fingerprint = options.fingerprint;
-  void import("@sentry/nextjs")
-    .then((Sentry) => {
-      Sentry.withScope((scope) => {
-        scope.setContext("cmux", safeContext);
-        // A stable fingerprint groups every occurrence of one operational
-        // condition (e.g. one misconfigured image env) into one Sentry issue,
-        // so alert rules can fire on "first seen" without per-request noise.
-        if (fingerprint && fingerprint.length > 0) {
-          scope.setFingerprint([...fingerprint]);
-        }
-        Sentry.captureException(error);
+  const send = () =>
+    import("@sentry/nextjs")
+      .then(async (Sentry) => {
+        Sentry.withScope((scope) => {
+          scope.setContext("cmux", safeContext);
+          // A stable fingerprint groups every occurrence of one operational
+          // condition (e.g. one misconfigured image env) into one Sentry issue,
+          // so alert rules can fire on "first seen" without per-request noise.
+          if (fingerprint && fingerprint.length > 0) {
+            scope.setFingerprint([...fingerprint]);
+          }
+          Sentry.captureException(error);
+        });
+        // The SDK queues events; without an explicit flush the serverless
+        // function freezes right after the response and the envelope never
+        // leaves the process. Zero events reached Sentry between 2026-08-06
+        // and 2026-08-27 because of this.
+        await Sentry.flush(2_000);
+      })
+      .catch(() => {
+        // Reporting must never change the caller's control flow.
       });
-    })
-    .catch(() => {
-      // Reporting must never change the caller's control flow.
-    });
+  try {
+    // Inside a request, defer past the response so the flush cannot add
+    // user-visible latency; outside one (cron bootstrap, tests) `after`
+    // throws and the send runs fire-and-forget.
+    after(send);
+  } catch {
+    void send();
+  }
 }
 
 function scrubContext(context: Record<string, unknown>): Record<string, unknown> {


### PR DESCRIPTION
Live drills against production (deliberate vm_image_config_error after #10955 and #10968 deployed) produced the PostHog event but never a Sentry event. The project's event stream shows zero events since the manual sanity checks on 2026-08-06, across every reportError caller (coderouter, cloud VM, billing reconcile, vm-alerts webhook failures): the send was a floating promise with no flush, and the Vercel function freezes right after the response, so the SDK's queued envelope never left the process.

reportError now wraps the send in next/server `after()` (deferred past the response, so the flush costs no user-visible latency; fire-and-forget fallback where no request scope exists) and awaits `Sentry.flush(2000)`.

Tests: `bun test tests/vm-observability.test.ts tests/coderouter-sentry.test.ts`, `bun run typecheck` clean. Will verify live with another drill once deployed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10972"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790425158&installation_model_id=21920&pr_number=10972&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10972&signature=1eb69c16d968ac134cb5b310e806391171b7bddbaf803a3a152746d085b94db5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Sentry error reporting in serverless functions so events reach Sentry instead of being dropped when the function freezes after the response. `reportError` now defers the send with `after()` and awaits `Sentry.flush(2000)`; previously the send was a floating promise with no flush, so the Vercel function froze before the queued envelope left the process.

**Bug Fixes**
- The send runs inside `after()` from `next/server`, so the 2s flush adds no user-visible latency within a request; outside a request scope it falls back to fire-and-forget.
- The flush is awaited, ensuring the event leaves the process before the function freezes.

<sup>Written for commit d41cac100d2488c41cbabff7c236166186b9deb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10972?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting reliability during requests by ensuring events are sent after request processing completes.
  * Added a brief delivery window for reporting events while preventing reporting failures from affecting the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->