### PR TITLE
fix(tui): bound provider response channels

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/machine_provider_client.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_client.rs
@@ -362,7 +362,7 @@ struct ProviderClientInner {
     writer: Mutex<Box<dyn Write + Send>>,
     control_guard: ProviderIoGuard,
     streams: Arc<dyn MachineStreamConnector>,
-    pending: Mutex<HashMap<String, Sender<PendingResponse>>>,
+    pending: Mutex<HashMap<String, SyncSender<PendingResponse>>>,
     events: Mutex<ProviderEventHubState>,
     snapshot_subscribers: Mutex<Vec<SyncSender<u64>>>,
     next_request_id: AtomicU64,
@@ -381,7 +381,7 @@ impl ProviderClientInner {
             return;
         };
         for (_, response) in pending.drain() {
-            let _ = response.send(Err(failure.clone()));
+            let _ = response.try_send(Err(failure.clone()));
         }
     }
 
@@ -1117,7 +1117,9 @@ impl ProviderClient {
             .map_err(|error| ProviderClientError::Protocol(error.to_string()))?;
         let id_key = id.as_str().to_string();
         let envelope = RequestEnvelope::new(id.clone(), request);
-        let (sender, receiver) = mpsc::channel();
+        // A request has exactly one response. Keep one slot so a late or
+        // duplicated response cannot accumulate memory after cancellation.
+        let (sender, receiver) = mpsc::sync_channel(1);
         {
             let mut pending = self
                 .inner
@@ -1303,10 +1305,10 @@ fn dispatch_control_frame(
                 .remove(&id);
             zeroize_json_strings(&mut value);
             if let Some(response) = response {
-                if let Err(error) = response.send(Ok(frame))
-                    && let Ok(mut frame) = error.0
-                {
-                    frame.zeroize();
+                if let Err(error) = response.try_send(Ok(frame)) {
+                    if let Ok(mut frame) = error.into_inner() {
+                        frame.zeroize();
+                    }
                 }
             } else {
                 frame.zeroize();

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_client.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_client.rs
@@ -1305,10 +1305,11 @@ fn dispatch_control_frame(
                 .remove(&id);
             zeroize_json_strings(&mut value);
             if let Some(response) = response {
-                if let Err(error) = response.try_send(Ok(frame)) {
-                    if let Ok(mut frame) = error.into_inner() {
-                        frame.zeroize();
-                    }
+                match response.try_send(Ok(frame)) {
+                    Ok(()) => {}
+                    Err(TrySendError::Full(Ok(mut frame)))
+                    | Err(TrySendError::Disconnected(Ok(mut frame))) => frame.zeroize(),
+                    Err(TrySendError::Full(Err(_))) | Err(TrySendError::Disconnected(Err(_))) => {}
                 }
             } else {
                 frame.zeroize();

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_client.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_client.rs
@@ -19,7 +19,7 @@ use std::path::Path;
 #[cfg(unix)]
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 #[cfg(unix)]
-use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender, SyncSender, TrySendError};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError, SyncSender, TrySendError};
 #[cfg(unix)]
 use std::sync::{Arc, Condvar, Mutex, Weak};
 #[cfg(unix)]


### PR DESCRIPTION
Use a bounded one-slot response channel for each machine provider request. Cancellation and disconnect paths remove pending entries; late or duplicate replies are dropped without retaining an unbounded queue.\n\nChecks: cargo fmt --all -- --check; git diff --check. Local Cargo tests intentionally not run per policy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790426272&installation_model_id=21920&pr_number=10973&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10973&signature=9943a02c7d7185625d05f98fe2d4df2ea1fe5804df85eea213b490f93ca3dfe4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the TUI's provider response channels so a late or duplicate reply can't grow an unbounded queue after a request is cancelled.

- Each request now uses a one-slot synchronous channel.
- Cancellation and disconnect paths drop pending entries; replies dropped on full or disconnected channels are zeroized.

<sup>Written for commit ed9497e9f00fdbb12ff7b412468d6ef9db8635b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of delayed or duplicate provider responses.
  * Prevented unbounded memory growth when requests are canceled or responses arrive late.
  * Ensured canceled responses are safely discarded when no longer needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->