### PR TITLE
cmux-tui: await remote runtime finish signal

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -230,7 +230,9 @@ pub(crate) async fn wait_for_shutdown_signal_async() {
 }
 
 #[cfg(not(unix))]
-pub(crate) async fn wait_for_shutdown_signal_async() {}
+pub(crate) async fn wait_for_shutdown_signal_async() {
+    std::future::pending::<()>().await;
+}
 
 // No POSIX signals on Windows; Ctrl-C arrives as console input and the
 // TUI's normal quit path handles shutdown.

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -193,45 +193,40 @@ pub(crate) fn wait_for_shutdown_signal() {
 }
 
 #[cfg(unix)]
-pub(crate) async fn wait_for_shutdown_signal_async() {
+pub(crate) async fn wait_for_shutdown_signal_async() -> bool {
     if shutdown_requested() {
-        return;
+        return true;
     }
     let reader = SIGNAL_WAKE_READER.load(Ordering::Acquire);
     if reader < 0 {
-        return;
+        return std::future::pending::<bool>().await;
     }
     let duplicate = unsafe { libc::dup(reader) };
     if duplicate < 0 {
-        return;
+        return std::future::pending::<bool>().await;
     }
     let stream = unsafe { UnixStream::from_raw_fd(duplicate) };
     if stream.set_nonblocking(true).is_err() {
-        return;
+        return std::future::pending::<bool>().await;
     }
     let stream = match tokio::net::UnixStream::from_std(stream) {
         Ok(stream) => stream,
-        Err(_) => return,
+        Err(_) => return std::future::pending::<bool>().await,
     };
     loop {
         if shutdown_requested() {
-            return;
+            return true;
         }
         if stream.readable().await.is_err() {
-            return;
+            return std::future::pending::<bool>().await;
         }
         let mut byte = [0_u8; 1];
         match stream.try_read(&mut byte) {
-            Ok(_) => return,
+            Ok(_) => return true,
             Err(error) if error.kind() == io::ErrorKind::WouldBlock => continue,
-            Err(_) => return,
+            Err(_) => return std::future::pending::<bool>().await,
         }
     }
-}
-
-#[cfg(not(unix))]
-pub(crate) async fn wait_for_shutdown_signal_async() {
-    std::future::pending::<()>().await;
 }
 
 // No POSIX signals on Windows; Ctrl-C arrives as console input and the

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -190,16 +190,9 @@ pub(crate) fn wait_for_shutdown_signal() {
             continue;
         }
         if result < 0 && io::Error::last_os_error().kind() == io::ErrorKind::WouldBlock {
-            let mut pollfd = libc::pollfd {
-                fd: reader,
-                events: libc::POLLIN,
-                revents: 0,
-            };
+            let mut pollfd = libc::pollfd { fd: reader, events: libc::POLLIN, revents: 0 };
             let polled = unsafe { libc::poll(&mut pollfd, 1, -1) };
-            if polled > 0
-                || (polled < 0
-                    && io::Error::last_os_error().kind() == io::ErrorKind::Interrupted)
-            {
+            if polled > 0 || (polled < 0 && io::Error::last_os_error().kind() == io::ErrorKind::Interrupted) {
                 continue;
             }
         }

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -237,6 +237,16 @@ pub(crate) async fn wait_for_shutdown_signal_async() -> io::Result<()> {
     }
 }
 
+#[cfg(not(unix))]
+pub(crate) async fn wait_for_shutdown_signal_async() -> io::Result<()> {
+    if shutdown_requested() {
+        return Ok(());
+    }
+    tokio::signal::ctrl_c().await?;
+    SHUTDOWN_REQUESTED.store(true, Ordering::Release);
+    Ok(())
+}
+
 // No POSIX signals on Windows; Ctrl-C arrives as console input and the
 // TUI's normal quit path handles shutdown.
 #[cfg(not(unix))]

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -63,7 +63,7 @@ use std::ffi::OsString;
 use std::io::{self, BufRead, BufReader, IsTerminal, Read, Write};
 use std::net::Shutdown;
 #[cfg(unix)]
-use std::os::fd::AsRawFd;
+use std::os::fd::{AsRawFd, FromRawFd};
 #[cfg(unix)]
 use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
@@ -189,6 +189,44 @@ pub(crate) fn wait_for_shutdown_signal() {
             continue;
         }
         return;
+    }
+}
+
+#[cfg(unix)]
+pub(crate) async fn wait_for_shutdown_signal_async() {
+    if shutdown_requested() {
+        return;
+    }
+    let reader = SIGNAL_WAKE_READER.load(Ordering::Acquire);
+    if reader < 0 {
+        return;
+    }
+    let duplicate = unsafe { libc::dup(reader) };
+    if duplicate < 0 {
+        return;
+    }
+    let stream = unsafe { UnixStream::from_raw_fd(duplicate) };
+    if stream.set_nonblocking(true).is_err() {
+        return;
+    }
+    let stream = match tokio::net::UnixStream::from_std(stream) {
+        Ok(stream) => stream,
+        Err(_) => return,
+    };
+    loop {
+        if shutdown_requested() {
+            return;
+        }
+        let ready = match stream.readable().await {
+            Ok(ready) => ready,
+            Err(_) => return,
+        };
+        let mut byte = [0_u8; 1];
+        match ready.try_read(&mut byte) {
+            Ok(_) => return,
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => continue,
+            Err(_) => return,
+        }
     }
 }
 

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -192,7 +192,9 @@ pub(crate) fn wait_for_shutdown_signal() {
         if result < 0 && io::Error::last_os_error().kind() == io::ErrorKind::WouldBlock {
             let mut pollfd = libc::pollfd { fd: reader, events: libc::POLLIN, revents: 0 };
             let polled = unsafe { libc::poll(&mut pollfd, 1, -1) };
-            if polled > 0 || (polled < 0 && io::Error::last_os_error().kind() == io::ErrorKind::Interrupted) {
+            if polled > 0
+                || (polled < 0 && io::Error::last_os_error().kind() == io::ErrorKind::Interrupted)
+            {
                 continue;
             }
         }

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -229,6 +229,9 @@ pub(crate) async fn wait_for_shutdown_signal_async() {
     }
 }
 
+#[cfg(not(unix))]
+pub(crate) async fn wait_for_shutdown_signal_async() {}
+
 // No POSIX signals on Windows; Ctrl-C arrives as console input and the
 // TUI's normal quit path handles shutdown.
 #[cfg(not(unix))]

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -217,12 +217,11 @@ pub(crate) async fn wait_for_shutdown_signal_async() {
         if shutdown_requested() {
             return;
         }
-        let ready = match stream.readable().await {
-            Ok(ready) => ready,
-            Err(_) => return,
-        };
+        if stream.readable().await.is_err() {
+            return;
+        }
         let mut byte = [0_u8; 1];
-        match ready.try_read(&mut byte) {
+        match stream.try_read(&mut byte) {
             Ok(_) => return,
             Err(error) if error.kind() == io::ErrorKind::WouldBlock => continue,
             Err(_) => return,

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -138,6 +138,7 @@ fn install_signal_handlers() -> io::Result<()> {
             return Err(io::Error::last_os_error());
         }
     }
+    wake_reader.set_nonblocking(true)?;
     wake_writer.set_nonblocking(true)?;
     SIGNAL_WAKE_READER.store(wake_reader.as_raw_fd(), Ordering::Release);
     SIGNAL_WAKE_WRITER.store(wake_writer.as_raw_fd(), Ordering::Release);
@@ -188,43 +189,55 @@ pub(crate) fn wait_for_shutdown_signal() {
         if result < 0 && io::Error::last_os_error().kind() == io::ErrorKind::Interrupted {
             continue;
         }
+        if result < 0 && io::Error::last_os_error().kind() == io::ErrorKind::WouldBlock {
+            let mut pollfd = libc::pollfd {
+                fd: reader,
+                events: libc::POLLIN,
+                revents: 0,
+            };
+            let polled = unsafe { libc::poll(&mut pollfd, 1, -1) };
+            if polled > 0
+                || (polled < 0
+                    && io::Error::last_os_error().kind() == io::ErrorKind::Interrupted)
+            {
+                continue;
+            }
+        }
         return;
     }
 }
 
 #[cfg(unix)]
-pub(crate) async fn wait_for_shutdown_signal_async() -> bool {
+pub(crate) async fn wait_for_shutdown_signal_async() -> io::Result<()> {
     if shutdown_requested() {
-        return true;
+        return Ok(());
     }
     let reader = SIGNAL_WAKE_READER.load(Ordering::Acquire);
     if reader < 0 {
-        return std::future::pending::<bool>().await;
+        return Err(io::Error::new(
+            io::ErrorKind::NotConnected,
+            "shutdown wake reader unavailable",
+        ));
     }
     let duplicate = unsafe { libc::dup(reader) };
     if duplicate < 0 {
-        return std::future::pending::<bool>().await;
+        return Err(io::Error::last_os_error());
     }
     let stream = unsafe { UnixStream::from_raw_fd(duplicate) };
-    if stream.set_nonblocking(true).is_err() {
-        return std::future::pending::<bool>().await;
-    }
     let stream = match tokio::net::UnixStream::from_std(stream) {
         Ok(stream) => stream,
-        Err(_) => return std::future::pending::<bool>().await,
+        Err(error) => return Err(error),
     };
     loop {
         if shutdown_requested() {
-            return true;
+            return Ok(());
         }
-        if stream.readable().await.is_err() {
-            return std::future::pending::<bool>().await;
-        }
+        stream.readable().await?;
         let mut byte = [0_u8; 1];
         match stream.try_read(&mut byte) {
-            Ok(_) => return true,
+            Ok(_) => return Ok(()),
             Err(error) if error.kind() == io::ErrorKind::WouldBlock => continue,
-            Err(_) => return std::future::pending::<bool>().await,
+            Err(error) => return Err(error),
         }
     }
 }

--- a/cmux-tui/crates/cmux-tui/src/remote_cli.rs
+++ b/cmux-tui/crates/cmux-tui/src/remote_cli.rs
@@ -953,9 +953,11 @@ fn run_forward(args: &[String]) -> anyhow::Result<()> {
             LocalPortForward::bind(connected.runtime.multiplexer().clone(), route, listen).await?;
         println!("{}", forward.webview_url(&scheme)?);
         let mut finished = connected.runtime.subscribe_finished();
-        while !crate::shutdown_requested() && !*finished.borrow() {
-            if finished.changed().await.is_err() {
-                break;
+        if !crate::shutdown_requested() && !*finished.borrow() {
+            tokio::select! {
+                biased;
+                _ = crate::wait_for_shutdown_signal_async() => {}
+                _ = finished.changed() => {}
             }
         }
         forward.shutdown().await;

--- a/cmux-tui/crates/cmux-tui/src/remote_cli.rs
+++ b/cmux-tui/crates/cmux-tui/src/remote_cli.rs
@@ -954,10 +954,19 @@ fn run_forward(args: &[String]) -> anyhow::Result<()> {
         println!("{}", forward.webview_url(&scheme)?);
         let mut finished = connected.runtime.subscribe_finished();
         if !crate::shutdown_requested() && !*finished.borrow() {
+            #[cfg(unix)]
             tokio::select! {
                 biased;
-                _ = crate::wait_for_shutdown_signal_async() => {}
+                shutdown = crate::wait_for_shutdown_signal_async() => {
+                    if shutdown.is_err() {
+                        let _ = finished.changed().await;
+                    }
+                }
                 _ = finished.changed() => {}
+            }
+            #[cfg(not(unix))]
+            {
+                let _ = finished.changed().await;
             }
         }
         forward.shutdown().await;

--- a/cmux-tui/crates/cmux-tui/src/remote_cli.rs
+++ b/cmux-tui/crates/cmux-tui/src/remote_cli.rs
@@ -955,7 +955,6 @@ fn run_forward(args: &[String]) -> anyhow::Result<()> {
         let mut finished = connected.runtime.subscribe_finished();
         let mut wait_error = None;
         if !crate::shutdown_requested() && !*finished.borrow() {
-            #[cfg(unix)]
             tokio::select! {
                 biased;
                 shutdown = crate::wait_for_shutdown_signal_async() => {
@@ -964,10 +963,6 @@ fn run_forward(args: &[String]) -> anyhow::Result<()> {
                     }
                 }
                 _ = finished.changed() => {}
-            }
-            #[cfg(not(unix))]
-            {
-                let _ = finished.changed().await;
             }
         }
         forward.shutdown().await;

--- a/cmux-tui/crates/cmux-tui/src/remote_cli.rs
+++ b/cmux-tui/crates/cmux-tui/src/remote_cli.rs
@@ -953,18 +953,14 @@ fn run_forward(args: &[String]) -> anyhow::Result<()> {
             LocalPortForward::bind(connected.runtime.multiplexer().clone(), route, listen).await?;
         println!("{}", forward.webview_url(&scheme)?);
         let mut finished = connected.runtime.subscribe_finished();
+        let mut wait_error = None;
         if !crate::shutdown_requested() && !*finished.borrow() {
             #[cfg(unix)]
             tokio::select! {
                 biased;
                 shutdown = crate::wait_for_shutdown_signal_async() => {
                     if shutdown.is_err() {
-                        let signal_wait =
-                            tokio::task::spawn_blocking(crate::wait_for_shutdown_signal);
-                        tokio::select! {
-                            _ = signal_wait => {}
-                            _ = finished.changed() => {}
-                        }
+                        wait_error = shutdown.err();
                     }
                 }
                 _ = finished.changed() => {}
@@ -976,6 +972,9 @@ fn run_forward(args: &[String]) -> anyhow::Result<()> {
         }
         forward.shutdown().await;
         let _ = client.request(WorkspaceRequest::CloseRoute { route }).await;
+        if let Some(error) = wait_error {
+            return Err(error.into());
+        }
         Ok::<_, anyhow::Error>(())
     });
     let shutdown = connected.runtime.shutdown();

--- a/cmux-tui/crates/cmux-tui/src/remote_cli.rs
+++ b/cmux-tui/crates/cmux-tui/src/remote_cli.rs
@@ -952,8 +952,11 @@ fn run_forward(args: &[String]) -> anyhow::Result<()> {
         let forward =
             LocalPortForward::bind(connected.runtime.multiplexer().clone(), route, listen).await?;
         println!("{}", forward.webview_url(&scheme)?);
-        while !crate::shutdown_requested() && !connected.runtime.is_finished() {
-            tokio::time::sleep(Duration::from_millis(100)).await;
+        let mut finished = connected.runtime.subscribe_finished();
+        while !crate::shutdown_requested() && !*finished.borrow() {
+            if finished.changed().await.is_err() {
+                break;
+            }
         }
         forward.shutdown().await;
         let _ = client.request(WorkspaceRequest::CloseRoute { route }).await;

--- a/cmux-tui/crates/cmux-tui/src/remote_cli.rs
+++ b/cmux-tui/crates/cmux-tui/src/remote_cli.rs
@@ -959,7 +959,12 @@ fn run_forward(args: &[String]) -> anyhow::Result<()> {
                 biased;
                 shutdown = crate::wait_for_shutdown_signal_async() => {
                     if shutdown.is_err() {
-                        let _ = finished.changed().await;
+                        let signal_wait =
+                            tokio::task::spawn_blocking(crate::wait_for_shutdown_signal);
+                        tokio::select! {
+                            _ = signal_wait => {}
+                            _ = finished.changed() => {}
+                        }
                     }
                 }
                 _ = finished.changed() => {}


### PR DESCRIPTION
Replace polling with the remote runtime finish watch signal in port-forward mode. This lets shutdown wake immediately when the runtime exits while preserving the global shutdown request path.

Verifier: ./scripts/verify-cmux-tui-hosted.sh --filter remote_cli

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10975"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790427859&installation_model_id=21920&pr_number=10975&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10975&signature=a989e611cbc7180b7765b68567c4f54baf374f3e992f92caf275483d3ed965cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Awaits the remote runtime finish signal instead of polling in port-forward mode, so shutdown wakes immediately when the remote runtime exits or the global shutdown signal fires. The async shutdown waiter duplicates the signal wake fd into a non-blocking `UnixStream`; wake setup errors are reported but stay non-terminal. On non-Unix targets, the async shutdown waiter awaits Ctrl-C.

Verifier: `./scripts/verify-cmux-tui-hosted.sh --filter remote_cli`

<sup>Written for commit f1b824e241b394edcc8e43a8d9433a613bd14e0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved port-forwarding responsiveness when a remote runtime shuts down.
  * Active port forwards now react promptly to shutdown signals.
  * Reduced unnecessary background activity while maintaining active connections.
  * Improved reliability when remote sessions finish or the application is closing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->