### PR TITLE
fix: redact Blaxel provider error details

### DIFF
--- a/web/services/vms/drivers/blaxel.ts
+++ b/web/services/vms/drivers/blaxel.ts
@@ -346,9 +346,25 @@ async function blaxelFetch<T>(
   });
   const text = await response.text();
   if (!response.ok) {
-    throw new ProviderError("blaxel", `${method} ${url} -> ${response.status}: ${text.slice(0, 500)}`);
+    // Blaxel private previews use `bl_preview_token` in the URL. Provider error
+    // messages are persisted and returned to clients, so never include query,
+    // fragment, credentials, or an upstream response body in them.
+    throw new ProviderError("blaxel", `${method} ${safeProviderUrl(url)} -> ${response.status}`);
   }
   return (text ? JSON.parse(text) : undefined) as T;
+}
+
+function safeProviderUrl(value: string): string {
+  try {
+    const parsed = new URL(value);
+    parsed.username = "";
+    parsed.password = "";
+    parsed.search = "";
+    parsed.hash = "";
+    return parsed.toString().replace(/\/$/, "");
+  } catch {
+    return "[invalid URL]";
+  }
 }
 
 export type CmuxTuiSource = { url: string; sha256: string; commit: string; builtAt: string | null };

--- a/web/tests/vm-blaxel-provider.test.ts
+++ b/web/tests/vm-blaxel-provider.test.ts
@@ -158,6 +158,43 @@ describe("BlaxelProvider SSH surface", () => {
 });
 
 describe("BlaxelProvider configuration errors", () => {
+  test("provider failures do not expose tokenized sandbox URLs or response bodies", async () => {
+    const previousKey = process.env.BL_API_KEY;
+    const previousWorkspace = process.env.BL_WORKSPACE;
+    process.env.BL_API_KEY = "test-key";
+    process.env.BL_WORKSPACE = "cmux";
+    const originalFetch = globalThis.fetch;
+    const urlSecret = "url-secret-marker";
+    const bodySecret = "body-secret-marker";
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (url.endsWith("/sandboxes/machine-a")) {
+        return new Response(JSON.stringify({
+          metadata: { url: `https://sandbox-api.test?bl_preview_token=${urlSecret}` },
+        }), { status: 200 });
+      }
+      return new Response(JSON.stringify({
+        error: "upstream request failed",
+        token: bodySecret,
+      }), { status: 502 });
+    }) as typeof fetch;
+    try {
+      const error = await new BlaxelProvider()
+        .revokeEndpointLeases("machine-a")
+        .then(() => "unexpected success", (failure: unknown) => String(failure));
+      expect(error).toContain("POST https://sandbox-api.test -> 502");
+      expect(error).not.toContain(urlSecret);
+      expect(error).not.toContain(bodySecret);
+      expect(error).not.toContain("bl_preview_token");
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (previousKey === undefined) delete process.env.BL_API_KEY;
+      else process.env.BL_API_KEY = previousKey;
+      if (previousWorkspace === undefined) delete process.env.BL_WORKSPACE;
+      else process.env.BL_WORKSPACE = previousWorkspace;
+    }
+  });
+
   test("create fails with a clear error when BL_API_KEY is missing", async () => {
     const prevKey = process.env.BL_API_KEY;
     const prevWs = process.env.BL_WORKSPACE;


### PR DESCRIPTION
Redact sandbox URLs and upstream response bodies from Blaxel ProviderError messages.

Regression test first commit, fix second commit.

Tests: bun test web/tests/vm-blaxel-provider.test.ts; bun run typecheck (web).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10976"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790428339&installation_model_id=21920&pr_number=10976&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10976&signature=dd965d6b21527246f5e85cce3fe68935b5e57df7ad0178801edf4501e3dd619b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts Blaxel ProviderError messages so sandbox URLs no longer leak preview tokens and upstream response bodies are no longer exposed. Previously these messages included the full request URL with query strings and up to 500 characters of the response body; now they include only the method, a sanitized URL (credentials, query, and fragment stripped), and the status code. Adds a regression test covering the redaction.

<sup>Written for commit f1e213e1a5fd7df4a1fe607a26e3c5310b329cb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved provider error messages by removing sensitive URL credentials, query parameters, fragments, and response-body content.
  - Error messages now retain the request method and status code while protecting tokenized URLs and upstream secrets.
- **Tests**
  - Added coverage confirming sensitive sandbox tokens and error-response data are not exposed during endpoint lease revocation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->