### PR TITLE
cmux-tui: wake headless snapshot loop on runtime finish

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/remote_cli.rs
+++ b/cmux-tui/crates/cmux-tui/src/remote_cli.rs
@@ -510,6 +510,7 @@ fn connect_with_flags(flags: ConnectFlags) -> anyhow::Result<()> {
             let runtime = tokio_runtime()?;
             runtime.block_on(async {
                 let mut previous = None;
+                let mut finished = connected.runtime.subscribe_finished();
                 while !crate::shutdown_requested() && !connected.runtime.is_finished() {
                     let snapshot = connected.runtime.connection_snapshot().await;
                     let mut topology = snapshot.clone();
@@ -528,7 +529,10 @@ fn connect_with_flags(flags: ConnectFlags) -> anyhow::Result<()> {
                         io::stdout().flush()?;
                         previous = Some(topology);
                     }
-                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    tokio::select! {
+                        _ = finished.changed() => {},
+                        _ = tokio::time::sleep(Duration::from_millis(100)) => {},
+                    }
                 }
                 Ok::<_, io::Error>(())
             })?;


### PR DESCRIPTION
The headless JSON connect loop polled runtime completion every 100 ms. Subscribe to the existing finished watch channel and select on completion or the bounded shutdown poll, so runtime termination is observed immediately.

Validation: git diff --check. Hosted cmux-tui verification requested; local Cargo tests are prohibited by cmux-tui instructions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790434787&installation_model_id=21920&pr_number=10979&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10979&signature=c479e699f48af87c6d22351441343e6f79d9402231ad5f4ce9adaade54a69124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wakes the headless snapshot loop immediately when the runtime finishes, instead of polling every 100 ms. This removes the up-to-100 ms delay between runtime termination and the loop exiting.

<sup>Written for commit 3fd06370f55f7704f6da90700f4a17c0117ed284. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved headless JSON connection output so it stops waiting as soon as the session finishes, instead of always delaying by a fixed interval.
  * Made snapshot printing more responsive while still preserving the existing fallback wait behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->