### PR TITLE
cmux-tui: abort detached local forward task on drop

### DIFF
--- a/cmux-tui/crates/cmux-remote/src/bridge.rs
+++ b/cmux-tui/crates/cmux-remote/src/bridge.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use bytes::Bytes;
 use cmux_remote_protocol::{MUX_INPUT_V1_FEATURE, RouteId, Service, ServiceControl};
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio::sync::{Semaphore, oneshot};
+use tokio::sync::{Mutex, Semaphore, oneshot, watch};
 
 use crate::mux_codec::{MAX_MUX_DOWNLOAD_LINE_BYTES, MAX_MUX_LINE_BYTES, mux_line_payload_len};
 use crate::service::{ServiceError, ServiceMultiplexer, ServiceStream};
@@ -14,10 +14,39 @@ use crate::services::ServicesError;
 
 pub const DEFAULT_MAX_FORWARD_CONNECTIONS: usize = 128;
 
+struct ForwardConnections {
+    tasks: Mutex<tokio::task::JoinSet<()>>,
+}
+
+impl ForwardConnections {
+    fn new() -> Arc<Self> {
+        Arc::new(Self { tasks: Mutex::new(tokio::task::JoinSet::new()) })
+    }
+
+    async fn reap_finished(&self) {
+        let mut tasks = self.tasks.lock().await;
+        while tasks.try_join_next().is_some() {}
+    }
+
+    async fn shutdown(&self) {
+        let mut tasks = self.tasks.lock().await;
+        tasks.abort_all();
+        while tasks.join_next().await.is_some() {}
+    }
+
+    fn abort_all(&self) {
+        if let Ok(tasks) = self.tasks.try_lock() {
+            tasks.abort_all();
+        }
+    }
+}
+
 pub struct LocalPortForward {
     local_addr: SocketAddr,
     shutdown: Option<oneshot::Sender<()>>,
     task: Option<tokio::task::JoinHandle<()>>,
+    connections: Arc<ForwardConnections>,
+    cancellation: watch::Sender<bool>,
 }
 
 impl LocalPortForward {
@@ -45,10 +74,13 @@ impl LocalPortForward {
         let local_addr = listener.local_addr()?;
         let permits = Arc::new(Semaphore::new(maximum_connections));
         let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
+        let connections = ForwardConnections::new();
+        let task_connections = connections.clone();
+        let (cancellation, _) = watch::channel(false);
+        let task_cancellation = cancellation.clone();
         let task = tokio::spawn(async move {
-            let mut connections = tokio::task::JoinSet::new();
             loop {
-                while connections.try_join_next().is_some() {}
+                task_connections.reap_finished().await;
                 let permit = tokio::select! {
                     _ = &mut shutdown_rx => break,
                     permit = permits.clone().acquire_owned() => {
@@ -65,24 +97,37 @@ impl LocalPortForward {
                     continue;
                 }
                 let multiplexer = multiplexer.clone();
-                connections.spawn(async move {
-                    let _permit = permit;
-                    let mut metadata = BTreeMap::new();
-                    metadata.insert("route".into(), route.0.to_string());
-                    let Ok(stream) = multiplexer.open(Service::TcpTunnel, metadata).await else {
-                        return;
+                let mut cancellation = task_cancellation.subscribe();
+                task_connections.tasks.lock().await.spawn(async move {
+                    let handler = async move {
+                        let _permit = permit;
+                        let mut metadata = BTreeMap::new();
+                        metadata.insert("route".into(), route.0.to_string());
+                        let Ok(stream) = multiplexer.open(Service::TcpTunnel, metadata).await
+                        else {
+                            return;
+                        };
+                        if await_opened(&stream).await.is_err() {
+                            return;
+                        }
+                        let (reader, writer) = socket.into_split();
+                        let _ = pump_client(Arc::new(stream), reader, writer).await;
                     };
-                    if await_opened(&stream).await.is_err() {
-                        return;
+                    tokio::select! {
+                        _ = cancellation.changed() => {}
+                        _ = handler => {}
                     }
-                    let (reader, writer) = socket.into_split();
-                    let _ = pump_client(Arc::new(stream), reader, writer).await;
                 });
             }
-            connections.abort_all();
-            while connections.join_next().await.is_some() {}
+            task_connections.shutdown().await;
         });
-        Ok(Self { local_addr, shutdown: Some(shutdown_tx), task: Some(task) })
+        Ok(Self {
+            local_addr,
+            shutdown: Some(shutdown_tx),
+            task: Some(task),
+            connections,
+            cancellation,
+        })
     }
 
     pub fn local_addr(&self) -> SocketAddr {
@@ -97,6 +142,7 @@ impl LocalPortForward {
     }
 
     pub async fn shutdown(mut self) {
+        self.cancellation.send_replace(true);
         if let Some(shutdown) = self.shutdown.take() {
             let _ = shutdown.send(());
         }
@@ -112,12 +158,14 @@ fn configure_forward_socket(socket: &tokio::net::TcpStream) -> std::io::Result<(
 
 impl Drop for LocalPortForward {
     fn drop(&mut self) {
+        self.cancellation.send_replace(true);
+        self.connections.abort_all();
         if let Some(shutdown) = self.shutdown.take() {
             let _ = shutdown.send(());
         }
-        // A dropped JoinHandle detaches the accept loop. Request cancellation
-        // here so the listener and in-flight tunnel tasks cannot run forever
-        // after the forward's owner is gone.
+        // A dropped JoinHandle detaches the accept loop. Abort it after the
+        // shared cancellation signal and child-task abort request so Drop does
+        // not leave either owner or tunnel handlers running indefinitely.
         if let Some(task) = self.task.take() {
             task.abort();
         }
@@ -462,7 +510,7 @@ impl From<crate::mux_input::MuxInputError> for BridgeError {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
     use async_trait::async_trait;
     use cmux_remote_protocol::{FrameFlags, Lane};
@@ -954,6 +1002,37 @@ mod tests {
         drop(first_socket);
         drop(second_socket);
         forward.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn emergency_forward_cleanup_aborts_active_tunnel_handlers() {
+        struct DropFlag(Arc<AtomicBool>);
+
+        impl Drop for DropFlag {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::Release);
+            }
+        }
+
+        let connections = ForwardConnections::new();
+        let dropped = Arc::new(AtomicBool::new(false));
+        connections.tasks.lock().await.spawn({
+            let dropped = dropped.clone();
+            async move {
+                let _flag = DropFlag(dropped);
+                std::future::pending::<()>().await;
+            }
+        });
+
+        connections.abort_all();
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while !dropped.load(Ordering::Acquire) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("emergency cleanup did not abort the active tunnel handler");
+        connections.shutdown().await;
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/cmux-remote/src/bridge.rs
+++ b/cmux-tui/crates/cmux-remote/src/bridge.rs
@@ -35,7 +35,7 @@ impl ForwardConnections {
     }
 
     fn abort_all(&self) {
-        if let Ok(tasks) = self.tasks.try_lock() {
+        if let Ok(mut tasks) = self.tasks.try_lock() {
             tasks.abort_all();
         }
     }

--- a/cmux-tui/crates/cmux-remote/src/bridge.rs
+++ b/cmux-tui/crates/cmux-remote/src/bridge.rs
@@ -515,7 +515,7 @@ mod tests {
     use async_trait::async_trait;
     use cmux_remote_protocol::{FrameFlags, Lane};
     use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader, split};
-    use tokio::sync::{Mutex, mpsc, watch};
+    use tokio::sync::{Mutex, mpsc, oneshot, watch};
 
     use super::*;
     use crate::service::{EndpointRole, SessionEndpoint};
@@ -1016,23 +1016,20 @@ mod tests {
 
         let connections = ForwardConnections::new();
         let dropped = Arc::new(AtomicBool::new(false));
+        let (started_tx, started_rx) = oneshot::channel();
         connections.tasks.lock().await.spawn({
             let dropped = dropped.clone();
             async move {
                 let _flag = DropFlag(dropped);
+                let _ = started_tx.send(());
                 std::future::pending::<()>().await;
             }
         });
 
+        started_rx.await.unwrap();
         connections.abort_all();
-        tokio::time::timeout(std::time::Duration::from_secs(1), async {
-            while !dropped.load(Ordering::Acquire) {
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("emergency cleanup did not abort the active tunnel handler");
         connections.shutdown().await;
+        assert!(dropped.load(Ordering::Acquire));
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/cmux-remote/src/bridge.rs
+++ b/cmux-tui/crates/cmux-remote/src/bridge.rs
@@ -115,6 +115,12 @@ impl Drop for LocalPortForward {
         if let Some(shutdown) = self.shutdown.take() {
             let _ = shutdown.send(());
         }
+        // A dropped JoinHandle detaches the accept loop. Request cancellation
+        // here so the listener and in-flight tunnel tasks cannot run forever
+        // after the forward's owner is gone.
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
     }
 }
 


### PR DESCRIPTION
LocalPortForward::drop sent shutdown to its accept-loop task, then dropped the JoinHandle. Tokio documents that dropping a JoinHandle detaches the task, so the listener and in-flight tunnel tasks could outlive the owning forward until the runtime happened to poll shutdown.

Abort the task handle during Drop after signaling shutdown. The explicit async shutdown path still sends shutdown and awaits the task. This keeps Drop synchronous and prevents detached forwarding work from retaining sockets after ownership ends.

Checks: rustfmt --edition 2024 --check cmux-tui/crates/cmux-remote/src/bridge.rs; git diff --check. Hosted cmux-tui tests were not run locally per repository instructions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10982"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790436621&installation_model_id=21920&pr_number=10982&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10982&signature=08915c0659213e25700cdc88e413586ce49a8c4bd8c50ac9f26ea6579d41ad52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a resource leak in `LocalPortForward` where dropping the forward detached the accept-loop task, leaving the listener and in-flight tunnel handlers running until the runtime polled shutdown. `Drop` now aborts the accept loop and any tracked tunnel tasks, so cleanup stays synchronous and sockets don't outlive ownership.

- Tracks child tunnel tasks in a shared `ForwardConnections` `JoinSet` that both the accept loop and `Drop` coordinate on.
- Signals handlers through a watch channel so `Drop` stays synchronous while still interrupting active tunnels.
- The async `shutdown` path sends the same cancellation signal and awaits all tasks.
- Adds a regression test verifying active tunnel handlers are torn down on emergency cleanup.

<sup>Written for commit 1e0c3eefaf43e733c967131199361d587f56a34b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Local port forwarding now shuts down promptly when a forward is closed.
  * Active tunnel connections and listeners are reliably stopped and released during shutdown.
  * Improved cleanup when connections close unexpectedly, preventing forwarding activity from continuing in the background.
  * Added safeguards to ensure cleanup also completes when forwarding is dropped or terminated abruptly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->