### PR TITLE
fix(tui): bound CDP outbound commands

### DIFF
--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -2095,6 +2095,17 @@ mod tests {
     }
 
     #[test]
+    fn call_queue_overflow_removes_pending_call() {
+        let (inner, _outbound_rx) = test_inner_with_capacity(0);
+        let client = CdpClient { inner: inner.clone() };
+
+        let error = client.call("Test.method", json!({}), None).unwrap_err();
+
+        assert!(error.to_string().contains("outbound queue is full"));
+        assert!(inner.pending.lock().unwrap().is_empty());
+    }
+
+    #[test]
     fn screencast_ack_queue_overflow_closes_the_connection() {
         let (inner, _outbound_rx) = test_inner_with_capacity(0);
         ack_screencast_frame(&inner, "session-1", 7);

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -3,7 +3,10 @@ use std::io::{Read, Write};
 use std::mem::size_of;
 use std::net::{TcpStream, ToSocketAddrs};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::mpsc::{Receiver, Sender, SyncSender, TryRecvError, TrySendError, channel};
+use std::sync::mpsc::{
+    Receiver, Sender, SyncSender, TryRecvError, TrySendError, channel,
+    sync_channel as bounded_channel,
+};
 use std::sync::{Arc, Condvar, Mutex, Weak};
 use std::time::{Duration, Instant};
 
@@ -29,6 +32,12 @@ const MAIN_FRAME_SNAPSHOT_ATTEMPTS: usize = 8;
 /// arithmetic. It is a queue-enforcement budget, not an exact allocator usage
 /// measurement.
 pub const CDP_EVENT_QUEUE_MAX_BYTES: usize = 32 * 1024 * 1024;
+/// Maximum number of commands waiting for the CDP reader thread.
+///
+/// A bounded command queue keeps a stalled browser from retaining an
+/// unbounded number of JSON messages. Callers fail fast when the queue is
+/// full, so a blocked reader cannot block the TUI thread indefinitely.
+const CDP_OUTBOUND_QUEUE_CAPACITY: usize = 256;
 const MAX_ENCODED_FRAME_BYTES: usize = 16 * 1024 * 1024;
 const MAX_DECODED_FRAME_BYTES: usize = 12 * 1024 * 1024;
 const TIMESTAMPLESS_CAPTURE_INTERVAL: Duration = Duration::from_secs(1);
@@ -564,7 +573,7 @@ impl CdpClient {
         // on the socket itself.
         ws.get_ref().set_read_timeout(Some(Duration::from_millis(20)))?;
         ws.get_ref().set_write_timeout(Some(Duration::from_secs(5)))?;
-        let (outbound_tx, outbound_rx) = channel();
+        let (outbound_tx, outbound_rx) = bounded_channel(CDP_OUTBOUND_QUEUE_CAPACITY);
         let event_queue = Arc::new(EventQueue::new());
         let client = CdpClient {
             inner: Arc::new(Inner {
@@ -780,10 +789,7 @@ impl CdpClient {
             anyhow::bail!("CDP connection is closed");
         }
         let (tx, rx) = channel();
-        self.inner
-            .outbound
-            .send(Outbound::Flush(tx))
-            .map_err(|_| anyhow::anyhow!("CDP connection is closed"))?;
+        self.inner.outbound.try_send(Outbound::Flush(tx)).map_err(outbound_send_error)?;
         rx.recv_timeout(timeout).map_err(|_| anyhow::anyhow!("timed out flushing CDP commands"))
     }
 
@@ -1377,11 +1383,15 @@ impl CdpClient {
         if cdp_debug() {
             eprintln!("cdp-> {text}");
         }
-        self.inner
-            .outbound
-            .send(Outbound::Message(text))
-            .map_err(|_| anyhow::anyhow!("CDP connection is closed"))?;
+        self.inner.outbound.try_send(Outbound::Message(text)).map_err(outbound_send_error)?;
         Ok(())
+    }
+}
+
+fn outbound_send_error(error: TrySendError<Outbound>) -> anyhow::Error {
+    match error {
+        TrySendError::Full(_) => anyhow::anyhow!("CDP outbound queue is full"),
+        TrySendError::Disconnected(_) => anyhow::anyhow!("CDP connection is closed"),
     }
 }
 
@@ -1767,7 +1777,13 @@ fn ack_screencast_frame(inner: &Arc<Inner>, target_session: &str, frame_session:
         "params": { "sessionId": frame_session },
     });
     let Ok(text) = serde_json::to_string(&msg) else { return };
-    let _ = inner.outbound.send(Outbound::Message(text));
+    if let Err(error) = inner.outbound.try_send(Outbound::Message(text)) {
+        let reason = match error {
+            TrySendError::Full(_) => "CDP outbound queue overflow",
+            TrySendError::Disconnected(_) => "CDP connection is closed",
+        };
+        close_inner(inner, reason);
+    }
 }
 
 fn screencast_frame(params: &Value, session_id: &str, frame_epoch: u64) -> Option<ScreencastFrame> {
@@ -2051,8 +2067,7 @@ mod tests {
     }
 
     fn test_inner_with_capacity(capacity: usize) -> (Arc<Inner>, Receiver<Outbound>) {
-        let _ = capacity;
-        let (outbound, outbound_rx) = channel();
+        let (outbound, outbound_rx) = sync_channel(capacity);
         (
             Arc::new(Inner {
                 outbound,

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -2067,7 +2067,7 @@ mod tests {
     }
 
     fn test_inner_with_capacity(capacity: usize) -> (Arc<Inner>, Receiver<Outbound>) {
-        let (outbound, outbound_rx) = sync_channel(capacity);
+        let (outbound, outbound_rx) = bounded_channel(capacity);
         (
             Arc::new(Inner {
                 outbound,

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -281,7 +281,7 @@ pub struct CdpClient {
 }
 
 struct Inner {
-    outbound: Sender<Outbound>,
+    outbound: SyncSender<Outbound>,
     pending: Mutex<HashMap<u64, PendingCall>>,
     events: Arc<EventQueue>,
     frame_epochs: Mutex<HashMap<String, FrameSession>>,

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -2067,7 +2067,7 @@ mod tests {
     }
 
     fn test_inner_with_capacity(capacity: usize) -> (Arc<Inner>, Receiver<Outbound>) {
-        let (outbound, outbound_rx) = bounded_channel(capacity);
+        let (outbound, outbound_rx) = std::sync::mpsc::sync_channel(capacity);
         (
             Arc::new(Inner {
                 outbound,

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -2047,6 +2047,11 @@ mod tests {
     use super::*;
 
     fn test_inner() -> (Arc<Inner>, Receiver<Outbound>) {
+        test_inner_with_capacity(256)
+    }
+
+    fn test_inner_with_capacity(capacity: usize) -> (Arc<Inner>, Receiver<Outbound>) {
+        let _ = capacity;
         let (outbound, outbound_rx) = channel();
         (
             Arc::new(Inner {
@@ -2062,6 +2067,23 @@ mod tests {
             }),
             outbound_rx,
         )
+    }
+
+    #[test]
+    fn outbound_commands_fail_fast_at_the_queue_bound() {
+        let (inner, _outbound_rx) = test_inner_with_capacity(1);
+        let client = CdpClient { inner };
+
+        client.send_value(&json!({"id": 1})).unwrap();
+        let error = client.send_value(&json!({"id": 2})).unwrap_err();
+        assert!(error.to_string().contains("outbound queue is full"));
+    }
+
+    #[test]
+    fn screencast_ack_queue_overflow_closes_the_connection() {
+        let (inner, _outbound_rx) = test_inner_with_capacity(0);
+        ack_screencast_frame(&inner, "session-1", 7);
+        assert!(inner.closed.load(Ordering::Acquire));
     }
 
     #[test]


### PR DESCRIPTION
Bound the synchronous CDP command queue and fail fast when a stalled browser cannot accept more work. Close the connection when a screencast acknowledgement cannot be queued, because dropping acknowledgements stalls the browser.

Static checks: rustfmt --edition 2024 --check; git diff --check. Hosted cmux-tui verification is required.

Official pattern: Rust sync_channel and try_send provide fixed storage and non-blocking overflow handling.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the CDP outbound command queue so a stalled browser can't retain an unbounded number of messages and block the TUI thread.

- Replaces the unbounded channel with a fixed-capacity `sync_channel` (256 commands) and `try_send`, so callers fail fast with an "outbound queue is full" error instead of blocking indefinitely.
- Closes the CDP connection when a screencast acknowledgement can't be queued, since dropping acks stalls the browser.
- Adds tests for the full-queue and closed-connection error paths, including pending call cleanup on overflow.

<sup>Written for commit 42498b8c87c81272271294de00d88febe1d6a08d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10983"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790436897&installation_model_id=21920&pr_number=10983&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10983&signature=9682701d39554916cefb68ff769de9721cf3d71b3dbbca52c9bfc1c92651420f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsiveness during communication congestion by failing fast instead of waiting indefinitely.
  * Added clearer errors when outbound communication is unavailable or overloaded.
  * Screencast frame acknowledgments now properly close unavailable connections instead of silently ignoring failures.
  * Added safeguards to prevent excessive outbound messages from overwhelming the connection.
* **Tests**
  * Added coverage for overloaded, closed, and unavailable communication paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->