### PR TITLE
cmux-tui: avoid no-op deletion redraws

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/ui/input.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/input.rs
@@ -473,6 +473,7 @@ mod tests {
         assert!(input.buffer.is_empty());
 
         let mut input = text_input("x");
+        input.cursor = 0;
         assert_eq!(
             input.handle_key(&key(KeyCode::Delete, KeyModifiers::NONE)),
             InputEvent::Changed

--- a/cmux-tui/crates/cmux-tui/src/ui/input.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/input.rs
@@ -439,6 +439,40 @@ mod tests {
     }
 
     #[test]
+    fn deletion_reports_changed_only_when_text_was_removed() {
+        let no_op_keys = [
+            key(KeyCode::Backspace, KeyModifiers::NONE),
+            key(KeyCode::Delete, KeyModifiers::NONE),
+            key(KeyCode::Backspace, KeyModifiers::ALT),
+            key(KeyCode::Char('d'), KeyModifiers::CONTROL),
+            key(KeyCode::Char('w'), KeyModifiers::CONTROL),
+            key(KeyCode::Char('d'), KeyModifiers::ALT),
+            key(KeyCode::Char('k'), KeyModifiers::CONTROL),
+            key(KeyCode::Char('u'), KeyModifiers::CONTROL),
+            key(KeyCode::Char('c'), KeyModifiers::CONTROL),
+        ];
+        for key in no_op_keys {
+            let mut input = text_input("");
+            assert_eq!(input.handle_key(&key), InputEvent::None, "{key:?}");
+        }
+
+        let mut input = text_input("x");
+        input.cursor = 1;
+        assert_eq!(
+            input.handle_key(&key(KeyCode::Backspace, KeyModifiers::NONE)),
+            InputEvent::Changed
+        );
+        assert!(input.buffer.is_empty());
+
+        let mut input = text_input("x");
+        assert_eq!(
+            input.handle_key(&key(KeyCode::Delete, KeyModifiers::NONE)),
+            InputEvent::Changed
+        );
+        assert!(input.buffer.is_empty());
+    }
+
+    #[test]
     fn utf8_safe_movement_and_deletion() {
         let mut input = text_input("héllo wörld");
         input.handle_key(&key(KeyCode::Char('a'), KeyModifiers::CONTROL));

--- a/cmux-tui/crates/cmux-tui/src/ui/input.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/input.rs
@@ -76,16 +76,21 @@ impl TextInput {
                 InputEvent::None
             }
             KeyCode::Backspace if key.modifiers.contains(KeyModifiers::ALT) => {
-                self.delete_word_left();
-                InputEvent::Changed
+                if self.delete_word_left() { InputEvent::Changed } else { InputEvent::None }
             }
             KeyCode::Backspace => {
-                self.delete_left();
-                InputEvent::Changed
+                if self.delete_left() {
+                    InputEvent::Changed
+                } else {
+                    InputEvent::None
+                }
             }
             KeyCode::Delete => {
-                self.delete_right();
-                InputEvent::Changed
+                if self.delete_right() {
+                    InputEvent::Changed
+                } else {
+                    InputEvent::None
+                }
             }
             KeyCode::Char(c) if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 self.handle_control(c)
@@ -155,24 +160,23 @@ impl TextInput {
             'a' => self.move_start(),
             'e' => self.move_end(),
             'd' => {
-                self.delete_right();
-                return InputEvent::Changed;
+                return if self.delete_right() { InputEvent::Changed } else { InputEvent::None };
             }
             'w' => {
-                self.delete_word_left();
-                return InputEvent::Changed;
+                return if self.delete_word_left() {
+                    InputEvent::Changed
+                } else {
+                    InputEvent::None
+                };
             }
             'k' => {
-                self.kill_end();
-                return InputEvent::Changed;
+                return if self.kill_end() { InputEvent::Changed } else { InputEvent::None };
             }
             'u' => {
-                self.kill_start();
-                return InputEvent::Changed;
+                return if self.kill_start() { InputEvent::Changed } else { InputEvent::None };
             }
             'c' => {
-                self.clear();
-                return InputEvent::Changed;
+                return if self.clear() { InputEvent::Changed } else { InputEvent::None };
             }
             _ => {}
         }
@@ -184,8 +188,11 @@ impl TextInput {
             'b' => self.move_word_left(),
             'f' => self.move_word_right(),
             'd' => {
-                self.delete_word_right();
-                return InputEvent::Changed;
+                return if self.delete_word_right() {
+                    InputEvent::Changed
+                } else {
+                    InputEvent::None
+                };
             }
             _ => {}
         }
@@ -222,41 +229,42 @@ impl TextInput {
         self.cursor = self.word_right(self.cursor);
     }
 
-    fn delete_left(&mut self) {
+    fn delete_left(&mut self) -> bool {
         let start = self.prev_boundary(self.cursor);
-        self.delete_range(start, self.cursor);
+        self.delete_range(start, self.cursor)
     }
 
-    fn delete_right(&mut self) {
+    fn delete_right(&mut self) -> bool {
         let end = self.next_boundary(self.cursor);
-        self.delete_range(self.cursor, end);
+        self.delete_range(self.cursor, end)
     }
 
-    fn delete_word_left(&mut self) {
+    fn delete_word_left(&mut self) -> bool {
         let start = self.word_left(self.cursor);
-        self.delete_range(start, self.cursor);
+        self.delete_range(start, self.cursor)
     }
 
-    fn delete_word_right(&mut self) {
+    fn delete_word_right(&mut self) -> bool {
         let end = self.word_right(self.cursor);
-        self.delete_range(self.cursor, end);
+        self.delete_range(self.cursor, end)
     }
 
-    fn kill_end(&mut self) {
-        self.delete_range(self.cursor, self.buffer.len());
+    fn kill_end(&mut self) -> bool {
+        self.delete_range(self.cursor, self.buffer.len())
     }
 
-    fn kill_start(&mut self) {
-        self.delete_range(0, self.cursor);
+    fn kill_start(&mut self) -> bool {
+        self.delete_range(0, self.cursor)
     }
 
-    fn delete_range(&mut self, start: usize, end: usize) {
+    fn delete_range(&mut self, start: usize, end: usize) -> bool {
         if start >= end {
-            return;
+            return false;
         }
         self.buffer.replace_range(start..end, "");
         self.cursor = start;
         self.scroll = self.scroll.min(self.cursor);
+        true
     }
 
     fn word_left(&self, from: usize) -> usize {


### PR DESCRIPTION
Summary:
- Return InputEvent::Changed only when deletion or clear changes TextInput state.
- Add behavior coverage for empty-buffer no-op keys and real deletions.

Why:
TextInput previously reported Changed after boundary no-ops, causing unnecessary redraws and downstream mutation handling. Deletion primitives now return whether bytes were removed.

Verification:
- rustfmt on changed file
- git diff --check
- No local Cargo tests/builds per cmux-tui instructions; hosted verification to follow.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10984"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790437102&installation_model_id=21920&pr_number=10984&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10984&signature=a0b69e07a60f519bde32c7980f2019b5f2b94c1ee6fa45a2126f17e997a075c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `cmux-tui` `TextInput` so no-op deletions no longer trigger redraws or downstream mutation handling. Previously, pressing backspace or delete at a boundary reported `InputEvent::Changed`; now it reports `InputEvent::None` when no text was removed.

- Deletion and clear primitives now return whether bytes were removed, and callers map that to `Changed` or `None`.
- Adds tests for no-op keys on an empty buffer and for real backspace and delete deletions.

<sup>Written for commit 91b73f695b61e883b37bb22e314e932275f8743c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text deletion behavior so empty-input or boundary deletion commands no longer report a change when nothing was removed.
  * Backspace and Delete actions now accurately reflect whether text was successfully deleted, helping prevent unnecessary updates when editing.

* **Tests**
  * Added coverage for successful deletions and no-op deletion commands to ensure consistent editing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->