### PR TITLE
fix(relay): disarm process guard after wait

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -1133,15 +1133,17 @@ async fn run_spec(
                         std::time::Duration::from_millis(250),
                     )));
                 }
-                exited = Some(match status {
-                    Ok(status) => status.code().map(i64::from).unwrap_or(1),
-                    Err(_) => 1,
-                });
-                // `wait` has reaped the leader. Disarm before any subsequent
-                // cancellation can run the guard and target a reused PID.
-                #[cfg(unix)]
-                {
-                    process_group_guard.armed = false;
+                match status {
+                    Ok(status) => {
+                        exited = Some(status.code().map(i64::from).unwrap_or(1));
+                        // `wait` has reaped the leader. Disarm before any
+                        // subsequent cancellation can target a reused PID.
+                        #[cfg(unix)]
+                        {
+                            process_group_guard.armed = false;
+                        }
+                    }
+                    Err(_) => exited = Some(1),
                 }
             }
             () = &mut deadline, if !timed_out => {

--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -1137,6 +1137,12 @@ async fn run_spec(
                     Ok(status) => status.code().map(i64::from).unwrap_or(1),
                     Err(_) => 1,
                 });
+                // `wait` has reaped the leader. Disarm before any subsequent
+                // cancellation can run the guard and target a reused PID.
+                #[cfg(unix)]
+                {
+                    process_group_guard.armed = false;
+                }
             }
             () = &mut deadline, if !timed_out => {
                 timed_out = true;


### PR DESCRIPTION
Disarm the Unix process-group cancellation guard immediately after child.wait reaps the leader. This closes the PID reuse race during later output draining. Focused local static checks only; no local Rust tests per policy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10985"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790441564&installation_model_id=21920&pr_number=10985&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10985&signature=4809b4c76ea4eb58f25cbcc03dd597d262410d8f33cf8a8d284130198c6d2c29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the PID reuse race in the relay by disarming the Unix process-group cancellation guard immediately after `child.wait` reaps the leader. The guard stays armed when `wait` returns an error, since the process may not have been reaped.

<sup>Written for commit f32d788d1cb503fb7cddf50e70fc40d0e067ec4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process cleanup reliability by preventing cancellation handling from signaling a recycled process identifier after the process leader exits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->