### PR TITLE
cmux-tui: resolve startup config once

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -8714,6 +8714,7 @@ pub fn run_with_machine_updates(
     owner_mux: Option<Arc<Mux>>,
     machine_ui: Option<MachineUiState>,
     machine_controller: Option<Box<dyn MachineController>>,
+    startup_config: crate::config::StartupConfigSnapshot,
 ) -> anyhow::Result<RunOutcome> {
     type PanicHook = dyn for<'a> Fn(&std::panic::PanicHookInfo<'a>) + Send + Sync + 'static;
     let previous_panic_hook: Arc<PanicHook> = Arc::from(std::panic::take_hook());
@@ -8737,6 +8738,7 @@ pub fn run_with_machine_updates(
             owner_mux,
             machine_ui,
             machine_controller,
+            startup_config,
         )
     }));
     let _ = std::panic::take_hook();
@@ -8761,6 +8763,7 @@ fn run_with_machine_updates_inner(
     owner_mux: Option<Arc<Mux>>,
     machine_ui: Option<MachineUiState>,
     machine_controller: Option<Box<dyn MachineController>>,
+    startup_config: crate::config::StartupConfigSnapshot,
 ) -> anyhow::Result<RunOutcome> {
     if let Session::Local(mux) = &session {
         install_mux_diagnostic_logger(mux);
@@ -8768,7 +8771,7 @@ fn run_with_machine_updates_inner(
     if let Some(mux) = owner_mux.as_ref() {
         install_mux_diagnostic_logger(mux);
     }
-    let mut config = crate::config::load();
+    let mut config = startup_config.into_config();
     let chrome = ChromeTheme::for_defaults(config.chrome, default_colors);
     config.apply_chrome_defaults(chrome);
     let session_available = machine_ui.as_ref().is_none_or(|machine| machine.session_available);

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -129,6 +129,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::io::{Read, Write};
+use std::ops::Deref;
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
@@ -3035,6 +3036,35 @@ pub struct Config {
     pub commands: Vec<UserCommandConfig>,
 }
 
+/// Configuration resolved once for the process startup path.
+///
+/// The snapshot is consumed by the selected startup mode. Interactive reloads
+/// intentionally call [`load`] again after startup and replace the app state.
+#[derive(Debug)]
+pub(crate) struct StartupConfigSnapshot(Config);
+
+impl StartupConfigSnapshot {
+    pub(crate) fn load() -> Self {
+        Self::from_loader(load)
+    }
+
+    fn from_loader(loader: impl FnOnce() -> Config) -> Self {
+        Self(loader())
+    }
+
+    pub(crate) fn into_config(self) -> Config {
+        self.0
+    }
+}
+
+impl Deref for StartupConfigSnapshot {
+    type Target = Config;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 /// The maximum configurable pane padding, in cells per side.
 pub const MAX_PANE_PADDING: u16 = 4;
 
@@ -5367,6 +5397,7 @@ fn overlay_ghostty_defaults(defaults: &mut DefaultColors, overrides: DefaultColo
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::Cell;
 
     #[test]
     fn config_diagnostics_do_not_echo_parser_details() {
@@ -5382,6 +5413,20 @@ mod tests {
     /// Config env vars are process-global state; tests that set them must not
     /// run concurrently with each other.
     static CONFIG_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn startup_snapshot_invokes_loader_once() {
+        let loads = Cell::new(0);
+        let snapshot = StartupConfigSnapshot::from_loader(|| {
+            loads.set(loads.get() + 1);
+            Config::default()
+        });
+
+        assert!(snapshot.server.detached_owner);
+        assert!(snapshot.server.detached_owner);
+        let _config = snapshot.into_config();
+        assert_eq!(loads.get(), 1);
+    }
     static NEXT_TEST_DIRECTORY: AtomicU64 = AtomicU64::new(0);
 
     struct TestDirectory {

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -41,7 +41,11 @@ mod remote_cli {
         crate::cli::is_remote_invocation(args)
     }
 
-    pub fn run(_: &[String], _: &str) -> i32 {
+    pub fn run(
+        _: &[String],
+        _: &str,
+        _: impl FnOnce() -> crate::config::StartupConfigSnapshot,
+    ) -> i32 {
         crate::client_log::stderr_log!(
             "startup",
             "cmux-tui: remote daemon commands require Unix sockets and are unsupported on {}",
@@ -1466,7 +1470,7 @@ fn run_main() {
     }
     if remote_cli::is_remote_invocation(&raw_args) {
         discard_provider_secret_environment();
-        client_log::exit(remote_cli::run(&raw_args, &usage()));
+        client_log::exit(remote_cli::run(&raw_args, &usage(), config::StartupConfigSnapshot::load));
     }
     if raw_args.first().map(|arg| arg.as_str()) == Some("relay") {
         let args = parse_args(raw_args.into_iter().skip(1));
@@ -1505,7 +1509,7 @@ fn run_main() {
     #[cfg(unix)]
     let provider_token = CapturedProviderToken::capture();
     let provider_workspace_authority = CapturedProviderWorkspaceAuthority::capture();
-    let config = config::load();
+    let config = config::StartupConfigSnapshot::load();
     let provider = resolve_provider_launch(&args, &config)
         .unwrap_or_else(|error| usage_exit(&error.to_string()));
     #[cfg(unix)]
@@ -1538,16 +1542,16 @@ fn run_main() {
     #[cfg(unix)]
     let result = match provider {
         Some((provider, local_machines, connect_external)) => {
-            run_provider_machine_client(provider, local_machines, connect_external)
+            run_provider_machine_client(provider, local_machines, connect_external, config)
         }
-        None if args.attach => run_attach(args),
-        None => run_server(args, provider_workspace_authority),
+        None if args.attach => run_attach(args, config),
+        None => run_server(args, provider_workspace_authority, config),
     };
     #[cfg(not(unix))]
     let result = match provider {
         Some(_) => Err(anyhow::anyhow!("dynamic machine providers require Unix")),
-        None if args.attach => run_attach(args),
-        None => run_server(args, provider_workspace_authority),
+        None if args.attach => run_attach(args, config),
+        None => run_server(args, provider_workspace_authority, config),
     };
     if let Err(e) = result {
         crate::client_log::stderr_log!("startup", "cmux-tui: {e}");
@@ -1564,12 +1568,11 @@ fn run_terminal_host_process(args: &[String]) -> anyhow::Result<()> {
     cmux_tui_core::terminal_host_runtime::serve_terminal_host_stdio(args, &mut reader, &mut writer)
 }
 
-fn run_attach(args: Args) -> anyhow::Result<()> {
+fn run_attach(args: Args, config: config::StartupConfigSnapshot) -> anyhow::Result<()> {
     let socket_path = match args.socket {
         Some(path) => path,
         None => cmux_tui_core::server::try_default_socket_path(&args.session)?,
     };
-    let config = config::load();
     let messages = &localization::catalog().attach;
     let terminal = args
         .terminal
@@ -1822,6 +1825,7 @@ impl Drop for LocalOwnerEventLoop {
 fn run_server(
     args: Args,
     provider_workspace_authority: Option<ProviderWorkspaceAuthority>,
+    config: config::StartupConfigSnapshot,
 ) -> anyhow::Result<()> {
     #[cfg(not(unix))]
     reject_unsupported_remote_options(&args)?;
@@ -1837,7 +1841,6 @@ fn run_server(
             "provider workspace authority cannot use both environment and management socket"
         );
     }
-    let config = config::load();
     let ws_addr = args.ws.clone().or(config.server.ws.clone());
     let ws_token = args.ws_token.clone().or(config.server.ws_token.clone());
     // Compute the socket path up front so a normal interactive launch can
@@ -2100,14 +2103,18 @@ fn run_server(
             run_headless(&mux, &socket_path, || false)
         }
     } else if let Some(runtime) = machine_runtime {
-        run_machine_client(runtime, mux.clone())
+        run_machine_client(runtime, mux.clone(), config)
     } else {
         match RemoteSession::connect(&socket_path)
             .context("connect the interactive client to its session server")
         {
-            Ok(remote) => {
-                run_tui_with_owner(Session::Remote(remote), args.session, None, Some(mux.clone()))
-            }
+            Ok(remote) => run_tui_with_owner(
+                Session::Remote(remote),
+                args.session,
+                None,
+                Some(mux.clone()),
+                config,
+            ),
             Err(error) => Err(error),
         }
     };
@@ -2227,8 +2234,9 @@ fn run_tui(
     session: Session,
     session_label: String,
     surface_only: Option<cmux_tui_core::SurfaceId>,
+    config: config::StartupConfigSnapshot,
 ) -> anyhow::Result<()> {
-    run_tui_with_owner(session, session_label, surface_only, None)
+    run_tui_with_owner(session, session_label, surface_only, None, config)
 }
 
 fn run_tui_with_owner(
@@ -2236,8 +2244,9 @@ fn run_tui_with_owner(
     session_label: String,
     surface_only: Option<cmux_tui_core::SurfaceId>,
     owner_mux: Option<Arc<Mux>>,
+    config: config::StartupConfigSnapshot,
 ) -> anyhow::Result<()> {
-    match run_tui_once(session, session_label, surface_only, owner_mux, None, None)? {
+    match run_tui_once(session, session_label, surface_only, owner_mux, None, None, config)? {
         app::RunOutcome::Quit => Ok(()),
         app::RunOutcome::Machine(_) => {
             anyhow::bail!("machine request returned without a machine runtime")
@@ -2293,7 +2302,7 @@ fn detached_owner_launch_applicable(
 
 fn start_detached_owner_session(
     args: Args,
-    config: config::Config,
+    config: config::StartupConfigSnapshot,
     socket_path: PathBuf,
 ) -> anyhow::Result<()> {
     let messages = &localization::catalog().local_server;
@@ -2331,43 +2340,48 @@ fn start_detached_owner_session(
 fn run_connected_session_client(
     socket_path: PathBuf,
     session_label: String,
-    config: config::Config,
+    config: config::StartupConfigSnapshot,
     session: Session,
     surface_only: Option<cmux_tui_core::SurfaceId>,
 ) -> anyhow::Result<()> {
     if surface_only.is_some() {
-        return run_tui(session, session_label, surface_only);
+        return run_tui(session, session_label, surface_only, config);
     }
     match session_client_mode(&config) {
-        SessionClientMode::Plain => run_tui(session, session_label, None),
+        SessionClientMode::Plain => run_tui(session, session_label, None, config),
         SessionClientMode::Machines => {
             let runtime = MachineRuntime::with_creation_sources(
                 socket_path,
-                config.machines,
-                config.machine_sidebar.create_sources,
+                config.machines.clone(),
+                config.machine_sidebar.create_sources.clone(),
             );
-            run_machine_client_with_initial(runtime, session, None)
+            run_machine_client_with_initial(runtime, session, None, config)
         }
     }
 }
 
-fn run_machine_client(runtime: MachineRuntime, owner_mux: Arc<Mux>) -> anyhow::Result<()> {
+fn run_machine_client(
+    runtime: MachineRuntime,
+    owner_mux: Arc<Mux>,
+    config: config::StartupConfigSnapshot,
+) -> anyhow::Result<()> {
     let active = runtime.initial_key();
     let connections = MachineConnectionHub::new(runtime.connection_connectors());
     let session = connections.connect(active)?;
-    run_machine_client_with_hub(runtime, session, connections, Some(owner_mux))
+    run_machine_client_with_hub(runtime, session, connections, Some(owner_mux), config)
 }
 
 fn run_machine_client_with_initial(
     runtime: MachineRuntime,
     session: Session,
     active_lease: Option<Box<dyn MachineConnectionLease>>,
+    config: config::StartupConfigSnapshot,
 ) -> anyhow::Result<()> {
     let active = runtime.initial_key();
     let connections = MachineConnectionHub::new(runtime.connection_connectors());
     connections
         .insert_ready(active, MachineConnection { session: session.clone(), _lease: active_lease });
-    run_machine_client_with_hub(runtime, session, connections, None)
+    run_machine_client_with_hub(runtime, session, connections, None, config)
 }
 
 fn run_machine_client_with_hub(
@@ -2375,6 +2389,7 @@ fn run_machine_client_with_hub(
     session: Session,
     connections: MachineConnectionHub,
     owner_mux: Option<Arc<Mux>>,
+    config: config::StartupConfigSnapshot,
 ) -> anyhow::Result<()> {
     let active = runtime.initial_key();
     let label = runtime.name(active).unwrap_or("machine").to_string();
@@ -2383,7 +2398,8 @@ fn run_machine_client_with_hub(
     connections.note_presented(Some(active));
     let controller: Box<dyn MachineController> =
         Box::new(StaticMachineController { runtime, active, connections, pending: None });
-    match run_tui_once(session, label, None, owner_mux, Some(machine_ui), Some(controller))? {
+    match run_tui_once(session, label, None, owner_mux, Some(machine_ui), Some(controller), config)?
+    {
         app::RunOutcome::Quit => Ok(()),
         app::RunOutcome::Machine(_) => {
             anyhow::bail!("machine request escaped its in-place controller")
@@ -2507,6 +2523,7 @@ fn run_provider_machine_client(
     connector: Arc<dyn MachineProviderConnector>,
     local_machines: Vec<config::MachineConfig>,
     connect_external: bool,
+    config: config::StartupConfigSnapshot,
 ) -> anyhow::Result<()> {
     let state_root = cmux_tui_core::platform::workspace_state_dir();
     let mut runtime = ProviderMachineController::connect_with(
@@ -2525,7 +2542,7 @@ fn run_provider_machine_client(
     };
     runtime.sync_connections();
     let controller: Box<dyn MachineController> = Box::new(runtime);
-    match run_tui_once(session, label, None, None, Some(machine_ui), Some(controller))? {
+    match run_tui_once(session, label, None, None, Some(machine_ui), Some(controller), config)? {
         app::RunOutcome::Quit => Ok(()),
         app::RunOutcome::Machine(_) => {
             anyhow::bail!("provider request escaped its in-place controller")
@@ -2567,9 +2584,9 @@ fn run_tui_once(
     owner_mux: Option<Arc<Mux>>,
     machine_ui: Option<MachineUiState>,
     machine_controller: Option<Box<dyn MachineController>>,
+    config: config::StartupConfigSnapshot,
 ) -> anyhow::Result<app::RunOutcome> {
     crossterm::terminal::enable_raw_mode()?;
-    let config = config::load();
     let mut colors = config.terminal_defaults;
     let host_colors = host_colors::probe_default_colors();
     if host_colors.fg.is_some() {
@@ -2592,6 +2609,7 @@ fn run_tui_once(
         owner_mux,
         machine_ui,
         machine_controller,
+        config,
     )
 }
 

--- a/cmux-tui/crates/cmux-tui/src/remote_cli.rs
+++ b/cmux-tui/crates/cmux-tui/src/remote_cli.rs
@@ -64,8 +64,12 @@ pub fn is_remote_invocation(args: &[String]) -> bool {
     crate::cli::is_remote_invocation(args)
 }
 
-pub fn run(args: &[String], usage: &str) -> i32 {
-    match run_inner(args, usage) {
+pub fn run(
+    args: &[String],
+    usage: &str,
+    load_config: impl FnOnce() -> crate::config::StartupConfigSnapshot,
+) -> i32 {
+    match run_inner(args, usage, load_config) {
         Ok(()) => 0,
         Err(error) => {
             crate::client_log::stderr_log!("remote", "cmux-tui: {error:#}");
@@ -74,17 +78,21 @@ pub fn run(args: &[String], usage: &str) -> i32 {
     }
 }
 
-fn run_inner(args: &[String], usage: &str) -> anyhow::Result<()> {
+fn run_inner(
+    args: &[String],
+    usage: &str,
+    load_config: impl FnOnce() -> crate::config::StartupConfigSnapshot,
+) -> anyhow::Result<()> {
     if remote_help_requested(&args[1..]) {
         print!("{}", remote_help(args.first().map(String::as_str)));
         return Ok(());
     }
     match args.first().map(String::as_str) {
-        Some("connect") => run_connect(&args[1..], None),
-        Some("ssh") => run_ssh(&args[1..]),
+        Some("connect") => run_connect(&args[1..], None, load_config),
+        Some("ssh") => run_ssh(&args[1..], load_config),
         Some("forward") => run_forward(&args[1..]),
         Some("rpc") => run_rpc(&args[1..]),
-        Some("enroll") => run_enroll(&args[1..]),
+        Some("enroll") => run_enroll(&args[1..], load_config),
         Some("known-daemons") => run_known_daemons(&args[1..]),
         Some("remote-probe") => run_probe(&args[1..]),
         Some("remote-link") => run_remote_link(&args[1..]),
@@ -493,15 +501,22 @@ fn set_invitation_arg(
     Ok(())
 }
 
-fn run_connect(args: &[String], preset_route: Option<String>) -> anyhow::Result<()> {
+fn run_connect(
+    args: &[String],
+    preset_route: Option<String>,
+    load_config: impl FnOnce() -> crate::config::StartupConfigSnapshot,
+) -> anyhow::Result<()> {
     let mut flags = parse_connect_flags(args)?;
     if preset_route.is_some() {
         flags.route = preset_route;
     }
-    connect_with_flags(flags)
+    connect_with_flags(flags, load_config)
 }
 
-fn connect_with_flags(flags: ConnectFlags) -> anyhow::Result<()> {
+fn connect_with_flags(
+    flags: ConnectFlags,
+    load_config: impl FnOnce() -> crate::config::StartupConfigSnapshot,
+) -> anyhow::Result<()> {
     let headless = flags.headless;
     let json = flags.json;
     let connected = start_connected(flags)?;
@@ -546,7 +561,8 @@ fn connect_with_flags(flags: ConnectFlags) -> anyhow::Result<()> {
     }
 
     let remote = RemoteSession::connect(&connected.runtime.info().local_socket)?;
-    let result = crate::run_tui(Session::Remote(remote), connected.route, None);
+    let config = load_config();
+    let result = crate::run_tui(Session::Remote(remote), connected.route, None, config);
     let shutdown = connected.runtime.shutdown();
     result.and(shutdown)
 }
@@ -1100,8 +1116,11 @@ fn run_rpc(args: &[String]) -> anyhow::Result<()> {
     result.and(shutdown)
 }
 
-fn run_ssh(args: &[String]) -> anyhow::Result<()> {
-    connect_with_flags(direct_ssh_flags(args)?)
+fn run_ssh(
+    args: &[String],
+    load_config: impl FnOnce() -> crate::config::StartupConfigSnapshot,
+) -> anyhow::Result<()> {
+    connect_with_flags(direct_ssh_flags(args)?, load_config)
 }
 
 fn direct_ssh_flags(args: &[String]) -> anyhow::Result<ConnectFlags> {
@@ -1403,9 +1422,12 @@ fn strict_option_value(args: &[String], index: &mut usize, option: &str) -> anyh
     Ok(value)
 }
 
-fn run_enroll(args: &[String]) -> anyhow::Result<()> {
+fn run_enroll(
+    args: &[String],
+    load_config: impl FnOnce() -> crate::config::StartupConfigSnapshot,
+) -> anyhow::Result<()> {
     if args.first().is_some_and(|action| action == "connect") {
-        return run_connect(&args[1..], None);
+        return run_connect(&args[1..], None, load_config);
     }
     let parsed = parse_enroll_admin_args(args)?;
     let admin_socket = parsed.admin_socket.clone().unwrap_or_else(|| {
@@ -2528,6 +2550,29 @@ fn expand_home(path: String) -> anyhow::Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     #[test]
+    fn startup_config_loader_stays_lazy_for_help_and_parse_errors() {
+        let load_count = std::cell::Cell::new(0);
+        let help_args = ["connect", "--help"].map(str::to_string);
+        assert!(
+            super::run_inner(&help_args, "usage", || {
+                load_count.set(load_count.get() + 1);
+                panic!("remote help must not load startup config");
+            })
+            .is_ok()
+        );
+
+        let invalid_args = ["ssh", "--unknown"].map(str::to_string);
+        assert!(
+            super::run_inner(&invalid_args, "usage", || {
+                load_count.set(load_count.get() + 1);
+                panic!("remote parse errors must not load startup config");
+            })
+            .is_err()
+        );
+        assert_eq!(load_count.get(), 0);
+    }
+
+    #[test]
     fn probe_capabilities_include_direct_ws_user_agent() {
         assert!(super::PROBE_CAPABILITIES.contains(&"direct-ws-user-agent"));
     }
@@ -2993,7 +3038,10 @@ mod tests {
     fn every_remote_subcommand_help_exits_without_running_the_command() {
         for command in ["connect", "ssh", "forward", "rpc", "enroll", "remote-probe"] {
             let args = [command.to_string(), "--help".to_string()];
-            assert!(run_inner(&args, "unused").is_ok(), "{command}");
+            assert!(
+                run_inner(&args, "unused", || panic!("help must not load TUI config")).is_ok(),
+                "{command}"
+            );
             assert!(remote_help(Some(command)).starts_with("USAGE:"));
         }
     }
@@ -3541,7 +3589,11 @@ mod tests {
                 parse_connect_flags(&args).err().expect("invalid connect arguments were accepted");
             assert_japanese(&error.to_string());
         }
-        assert_japanese(&run_ssh(&[]).unwrap_err().to_string());
+        assert_japanese(
+            &run_ssh(&[], || panic!("invalid SSH arguments must not load TUI config"))
+                .unwrap_err()
+                .to_string(),
+        );
         assert_japanese(&ssh_url("invalid destination").unwrap_err().to_string());
         assert_japanese(&run_forward(&[]).unwrap_err().to_string());
         assert_japanese(&run_rpc(&["--request".into()]).unwrap_err().to_string());


### PR DESCRIPTION
## Summary
- Resolve one non-cloneable StartupConfigSnapshot for each interactive process startup.
- Pass the snapshot through server, attach, machine, remote, and TUI startup paths.
- Keep explicit runtime config reloads on config::load().
- Avoid unrelated input polling, CLI parsing, and benchmark changes from https://github.com/manaflow-ai/cmux/pull/9933.

## Testing
- rustfmt --edition 2024 --check on changed Rust files
- git diff --check
- Hosted verifier pending, selector: cmux-tui startup/config focused test or narrow supported selector

## Issues
- Related: https://github.com/manaflow-ai/cmux/pull/9933

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10986"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790441868&installation_model_id=21920&pr_number=10986&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10986&signature=adb578056a7c36f52605a6b353efd98e6235d86a5817bdabef5de1cccf98c738"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves the startup configuration once per interactive process instead of calling `config::load()` on each TUI startup path, so all startup consumers see the same config snapshot.

**Refactors**
- Passes a `StartupConfigSnapshot` through server, attach, machine, provider, remote, and TUI startup paths.
- Keeps explicit runtime config reloads via `config::load()`.
- Remote help and invalid SSH argument paths no longer load the config unless needed.

<sup>Written for commit cab795c82437d503443abbc832d2061f4228512c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup reliability by loading configuration once and applying it consistently across local, remote, server, client, and TUI workflows.
  * Prevented unnecessary configuration loading when displaying help or rejecting invalid remote command arguments.
  * Ensured startup settings remain consistent throughout remote connections and interactive sessions.
  * Added safeguards to avoid repeated configuration loading during application startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->