### PR TITLE
test(tui): remove fixed synchronization waits

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/tests/browser_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/tests/browser_runtime.rs
@@ -229,12 +229,12 @@ fn recv_attach_event(reader: &mut BufReader<UnixStream>, event: &str) -> Value {
 }
 
 fn wait_for<T>(mut f: impl FnMut() -> Option<T>, timeout: Duration) -> Option<T> {
-    let start = Instant::now();
+    let deadline = Instant::now() + test_duration(timeout);
     loop {
         if let Some(value) = f() {
             return Some(value);
         }
-        if start.elapsed() > timeout {
+        if Instant::now() >= deadline {
             return None;
         }
         thread::sleep(Duration::from_millis(20));

--- a/cmux-tui/crates/cmux-tui-core/tests/browser_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/tests/browser_runtime.rs
@@ -1537,7 +1537,7 @@ fn browser_capture_scale_applies_to_metrics_screencast_and_input() {
             let frame_seq = surface.browser_frame_seq()?;
             (frame.seq == frame_seq).then_some((frame, frame_seq))
         },
-        test_duration(Duration::from_secs(10)),
+        Duration::from_secs(10),
     )
     .expect("browser produced a pointer-authoritative frame");
     assert_eq!(frame.data_b64, "c2NhbGU=");

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -3613,8 +3613,24 @@ fn assert_subscribe_reports_tree_changed(server: &HeadlessServer) {
         }
     });
     writeln!(writer, r#"{{"id":1,"cmd":"subscribe"}}"#).unwrap();
+    writer.flush().unwrap();
 
-    std::thread::sleep(Duration::from_millis(200));
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let remaining = deadline
+            .checked_duration_since(Instant::now())
+            .expect("server did not acknowledge the tree-change subscription");
+        let line = rx
+            .recv_timeout(remaining)
+            .expect("server did not acknowledge the tree-change subscription");
+        let message: serde_json::Value =
+            serde_json::from_str(&line).expect("subscription returned invalid JSON");
+        if message["id"].as_u64() == Some(1) {
+            assert_eq!(message["ok"], true, "tree-change subscription failed: {message}");
+            break;
+        }
+    }
+
     let tab = json_cli(server, &["tab", "create", "terminal"]);
     if !tab.status.success() {
         let mut lines = Vec::new();

--- a/cmux-tui/crates/cmux-tui/tests/terminal_host_recovery.rs
+++ b/cmux-tui/crates/cmux-tui/tests/terminal_host_recovery.rs
@@ -3807,7 +3807,7 @@ fn wait_for_socket(path: &Path) {
 }
 
 fn wait_for_screen(path: &Path, surface: u64, marker: &str) -> String {
-    let deadline = Instant::now() + Duration::from_secs(10);
+    let deadline = Instant::now() + test_timeout(Duration::from_secs(10));
     let mut last = String::new();
     while Instant::now() < deadline {
         last = request(path, serde_json::json!({"cmd": "read-screen", "surface": surface}))["text"]

--- a/cmux-tui/crates/cmux-tui/tests/terminal_host_recovery.rs
+++ b/cmux-tui/crates/cmux-tui/tests/terminal_host_recovery.rs
@@ -3823,7 +3823,7 @@ fn wait_for_screen(path: &Path, surface: u64, marker: &str) -> String {
 }
 
 fn wait_for_host_records(root: &Path, expected: usize) -> Vec<(PathBuf, TerminalHostRecord)> {
-    let deadline = Instant::now() + Duration::from_secs(10);
+    let deadline = Instant::now() + test_timeout(Duration::from_secs(10));
     loop {
         let records = load_terminal_host_records(root).unwrap();
         if records.len() == expected {
@@ -3835,7 +3835,7 @@ fn wait_for_host_records(root: &Path, expected: usize) -> Vec<(PathBuf, Terminal
 }
 
 fn wait_for_no_host_records(root: &Path) {
-    let deadline = Instant::now() + Duration::from_secs(10);
+    let deadline = Instant::now() + test_timeout(Duration::from_secs(10));
     while Instant::now() < deadline {
         if load_terminal_host_records(root).unwrap().is_empty()
             && load_terminal_host_exit_records(root).unwrap().is_empty()


### PR DESCRIPTION
Summary:
- scale browser and terminal screen polling deadlines with CI timeout helpers
- wait for the subscribe response before creating the tab in the tree-change test

Validation:
- rustfmt --edition 2024 --check on all three changed test files
- git diff --check
- hosted cmux-tui verification pending

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790449438&installation_model_id=21920&pr_number=10988&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10988&signature=6c853700a13016b436552325856873245edc0a88cc3f216ef95733ad976a116b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes fixed synchronization waits in TUI tests so they no longer time out or flake under slow CI.

- Polling deadlines now scale with CI timeout helpers, applied once inside shared wait helpers so callers pass base durations.
- The wait helpers compare against an absolute deadline, stopping promptly at the boundary instead of sleeping past it.
- The tree-change test waits for the server to acknowledge the subscribe request before creating the tab, replacing a fixed 200 ms sleep.
- Terminal host recovery waits for screens and records now scale with the CI timeout.

<sup>Written for commit e12ce402fc760a9d51dceee2faba1331f59855cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved test reliability by waiting for explicit subscription acknowledgements instead of relying on fixed delays.
  - Applied configurable timeout scaling consistently across runtime and terminal recovery checks.
  - Made timeout handling more precise to avoid unnecessary waiting at deadline boundaries.
  - Reduced timing-related flakiness by using deadline-bounded waits and ensuring pending output is flushed before validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->