### PR TITLE
fix(cmux-tui): keep config replacement files private

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -4152,24 +4152,43 @@ fn write_config_value_atomic_with_sync(
     sync_parent: &dyn Fn(&Path) -> anyhow::Result<ConfigParentSyncOutcome>,
 ) -> anyhow::Result<ConfigWriteOutcome> {
     let parent = config_parent_directory(path);
-    let created_directories = ensure_config_parent_directory(parent)?;
     let file_name = path.file_name().and_then(|name| name.to_str()).unwrap_or("cmux-tui.json");
     let stamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_nanos();
-    let tmp_path = parent.join(format!(".{file_name}.{}.{}.tmp", std::process::id(), stamp));
-    let result = (|| -> anyhow::Result<()> {
-        let mut options = OpenOptions::new();
-        options.write(true).create_new(true);
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::OpenOptionsExt;
+    let process_id = std::process::id();
+    let staging_path = move |parent: &Path, attempt: usize| {
+        let suffix = if attempt == 0 {
+            format!(".{file_name}.{process_id}.{stamp}.tmp")
+        } else {
+            format!(".{file_name}.{process_id}.{stamp}.{attempt}.tmp")
+        };
+        parent.join(suffix)
+    };
+    write_config_value_atomic_with_sync_and_staging(path, value, sync_parent, &staging_path)
+}
 
-            // The config can contain the server authentication token. Create
-            // the staging file private from the start, independent of umask,
-            // and reject a pre-existing symlink if a concurrent writer races
-            // with this process before open(2).
-            options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
-        }
-        let mut file = options.open(&tmp_path)?;
+fn write_config_value_atomic_with_sync_and_staging(
+    path: &Path,
+    value: &Value,
+    sync_parent: &dyn Fn(&Path) -> anyhow::Result<ConfigParentSyncOutcome>,
+    staging_path: &dyn Fn(&Path, usize) -> PathBuf,
+) -> anyhow::Result<ConfigWriteOutcome> {
+    let parent = config_parent_directory(path);
+    let created_directories = ensure_config_parent_directory(parent)?;
+    let tmp_path = staging_path(parent, 0);
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+
+        // The config can contain the server authentication token. Create
+        // the staging file private from the start, independent of umask,
+        // and reject a pre-existing symlink if a concurrent writer races
+        // with this process before open(2).
+        options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+    }
+    let mut file = options.open(&tmp_path)?;
+    let result = (|| -> anyhow::Result<()> {
         serde_json::to_writer_pretty(&mut file, value)?;
         file.write_all(b"\n")?;
         file.sync_all()?;
@@ -9011,6 +9030,32 @@ mod tests {
         let entries = std::fs::read_dir(&dir.path).unwrap().collect::<Result<Vec<_>, _>>().unwrap();
         assert_eq!(entries.len(), 1, "failed writes must remove their staging file");
         assert_eq!(entries[0].path(), path);
+    }
+
+    #[test]
+    fn config_write_collision_preserves_existing_staging_file() {
+        let dir = TestDirectory::new("staging-collision");
+        let path = dir.path.join("cmux-tui.json");
+        let collision = dir.path.join("collision.tmp");
+        let replacement = dir.path.join("replacement.tmp");
+        std::fs::write(&collision, b"owned by another writer").unwrap();
+        let staging_paths = [collision.clone(), replacement.clone()];
+        let staging_path = |_: &Path, attempt: usize| staging_paths[attempt].clone();
+        let sync_parent = |_parent: &Path| -> anyhow::Result<ConfigParentSyncOutcome> {
+            Ok(ConfigParentSyncOutcome::Synced)
+        };
+
+        assert_committed(
+            write_config_value_atomic_with_sync_and_staging(
+                &path,
+                &json!({"server": {"ws_token": "secret"}}),
+                &sync_parent,
+                &staging_path,
+            )
+            .expect("a colliding staging path should be retried"),
+        );
+        assert_eq!(std::fs::read(&collision).unwrap(), b"owned by another writer");
+        assert!(!replacement.exists(), "the successful staging file must be renamed");
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -9074,6 +9074,17 @@ mod tests {
     }
 
     #[test]
+    fn config_parent_creation_handles_absolute_path_syntax() {
+        let dir = TestDirectory::new("absolute-parent");
+        let parent = dir.path.join("nested").join("config");
+
+        let created = ensure_config_parent_directory(&parent).unwrap();
+
+        assert!(parent.is_dir());
+        assert!(created.iter().any(|directory| directory == &parent));
+    }
+
+    #[test]
     fn config_parent_directory_normalizes_relative_path() {
         assert_eq!(config_parent_directory(Path::new("cmux-tui.json")), Path::new("."));
         assert_eq!(config_parent_directory(Path::new("nested/cmux-tui.json")), Path::new("nested"));

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -133,7 +133,7 @@ use std::io::{Read, Write};
 use std::ops::Deref;
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::process::Child;
 use std::process::Command;
 use std::process::Stdio;
@@ -4238,6 +4238,11 @@ fn ensure_config_parent_directory(parent: &Path) -> anyhow::Result<Vec<PathBuf>>
     let mut current = PathBuf::new();
     for component in parent.components() {
         current.push(component.as_os_str());
+        // Prefix, root, and navigation components establish path syntax;
+        // only normal components identify directory entries to create.
+        if !matches!(component, Component::Normal(_)) {
+            continue;
+        }
         match std::fs::create_dir(&current) {
             Ok(()) => created_directories.push(current.clone()),
             Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -8837,7 +8837,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn sidebar_plugin_write_replaces_config_with_private_permissions() {
-        use std::os::unix::fs::{PermissionsExt, OpenOptionsExt};
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
         let dir = TestDirectory::new("private-permissions");
         let path = dir.path.join("cmux-tui.json");

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -4107,6 +4107,8 @@ fn read_config_value(path: &Path) -> anyhow::Result<Value> {
     }
 }
 
+/// Serializes a config value to a private staging file before atomically
+/// replacing the destination and durably syncing its parent directory.
 fn write_config_value_atomic(path: &Path, value: &Value) -> anyhow::Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -4131,10 +4131,10 @@ fn read_config_value(path: &Path) -> anyhow::Result<Value> {
 }
 
 /// Serializes a config value to a private staging file before atomically
-/// replacing the destination and durably syncing its parent directory. An
+/// replacing the destination and durably syncing its parent directories. An
 /// `Err` means that replacement did not commit. A
 /// [`ConfigWriteOutcome::CommittedButUnsynced`] value means the rename did
-/// commit, but the parent directory sync failed.
+/// commit, but a directory sync failed.
 fn write_config_value_atomic(path: &Path, value: &Value) -> anyhow::Result<ConfigWriteOutcome> {
     write_config_value_atomic_with_sync(path, value, &sync_config_parent_directory)
 }
@@ -4186,8 +4186,24 @@ fn write_config_value_atomic_with_sync(
 }
 
 fn ensure_config_parent_directory(parent: &Path) -> anyhow::Result<Vec<PathBuf>> {
-    std::fs::create_dir_all(parent)?;
-    Ok(Vec::new())
+    let mut created_directories = Vec::new();
+    let mut current = PathBuf::new();
+    for component in parent.components() {
+        current.push(component.as_os_str());
+        match std::fs::create_dir(&current) {
+            Ok(()) => created_directories.push(current.clone()),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                if !std::fs::metadata(&current)?.is_dir() {
+                    anyhow::bail!(
+                        "config parent component {} is not a directory",
+                        current.display()
+                    );
+                }
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Ok(created_directories)
 }
 
 #[cfg(unix)]
@@ -4204,10 +4220,14 @@ fn sync_config_parent_directory(_parent: &Path) -> anyhow::Result<()> {
 #[cfg(unix)]
 fn sync_config_parent_directories(
     parent: &Path,
-    _created_directories: &[PathBuf],
+    created_directories: &[PathBuf],
     sync_parent: &dyn Fn(&Path) -> anyhow::Result<()>,
 ) -> anyhow::Result<()> {
-    sync_parent(parent)
+    sync_parent(parent)?;
+    for directory in created_directories.iter().rev() {
+        sync_parent(config_parent_directory(directory))?;
+    }
+    Ok(())
 }
 
 fn config_parent_directory(path: &Path) -> &Path {

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -155,7 +155,7 @@ use wait_timeout::ChildExt;
 
 use crate::localization::catalog;
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 std::thread_local! {
     static FAIL_CONFIG_PARENT_SYNC: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
@@ -4074,6 +4074,8 @@ pub(crate) enum ConfigWriteOutcome {
 }
 
 impl ConfigWriteOutcome {
+    /// Takes the parent-sync error, if the replacement committed without a
+    /// durability confirmation.
     pub(crate) fn into_unsynced_error(self) -> Option<anyhow::Error> {
         match self {
             Self::Committed => None,
@@ -4082,6 +4084,7 @@ impl ConfigWriteOutcome {
     }
 }
 
+/// Writes the sidebar plugin selection to the configured path.
 pub(crate) fn write_sidebar_plugin(
     plugin: Option<&SidebarPluginConfig>,
 ) -> anyhow::Result<ConfigWriteOutcome> {
@@ -4089,6 +4092,7 @@ pub(crate) fn write_sidebar_plugin(
     write_sidebar_plugin_at_path(&path, plugin)
 }
 
+/// Writes the sidebar plugin selection to an explicit path.
 pub(crate) fn write_sidebar_plugin_at_path(
     path: &Path,
     plugin: Option<&SidebarPluginConfig>,

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -155,6 +155,11 @@ use wait_timeout::ChildExt;
 
 use crate::localization::catalog;
 
+#[cfg(test)]
+std::thread_local! {
+    static FAIL_CONFIG_PARENT_SYNC: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
 /// For a field typed `Option<Option<T>>`: makes an explicit `null` in the
 /// input deserialize to `Some(None)` rather than the `None` an absent key
 /// also produces, so callers can tell "not set" from "set to null".
@@ -4146,6 +4151,10 @@ fn write_config_value_atomic(path: &Path, value: &Value) -> anyhow::Result<()> {
 
 #[cfg(unix)]
 fn sync_config_parent_directory(parent: &Path) -> anyhow::Result<()> {
+    #[cfg(test)]
+    if FAIL_CONFIG_PARENT_SYNC.with(|fail| fail.replace(false)) {
+        return Err(std::io::Error::other("injected parent directory sync failure").into());
+    }
     let result = std::fs::File::open(parent).and_then(|directory| directory.sync_all());
     #[cfg(target_os = "macos")]
     if let Err(error) = &result {
@@ -8904,6 +8913,20 @@ mod tests {
         write_config_value_atomic(&path, &json!({"server": {"ws_token": "secret"}})).unwrap();
 
         let value: Value = serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
+        assert_eq!(value["server"]["ws_token"], json!("secret"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn config_write_does_not_report_failure_after_parent_sync_error() {
+        let dir = TestDirectory::new("parent-sync-failure");
+        let path = dir.path.join("cmux-tui.json");
+        FAIL_CONFIG_PARENT_SYNC.with(|fail| fail.set(true));
+
+        let result = write_config_value_atomic(&path, &json!({"server": {"ws_token": "secret"}}));
+
+        assert!(result.is_ok(), "a committed rename must not be reported as a write failure");
+        let value: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(value["server"]["ws_token"], json!("secret"));
     }
 }

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -4064,16 +4064,35 @@ pub fn config_path() -> anyhow::Result<PathBuf> {
     platform::config_path().ok_or_else(|| anyhow::anyhow!("could not resolve mux config path"))
 }
 
-pub fn write_sidebar_plugin(plugin: Option<&SidebarPluginConfig>) -> anyhow::Result<PathBuf> {
-    let path = config_path()?;
-    write_sidebar_plugin_at_path(&path, plugin)?;
-    Ok(path)
+/// The result of replacing the config file. A committed replacement is a
+/// successful operation even when the parent directory could not be synced.
+#[must_use = "inspect config durability after a committed write"]
+#[derive(Debug)]
+pub(crate) enum ConfigWriteOutcome {
+    Committed,
+    CommittedButUnsynced { error: anyhow::Error },
 }
 
-pub fn write_sidebar_plugin_at_path(
+impl ConfigWriteOutcome {
+    pub(crate) fn into_unsynced_error(self) -> Option<anyhow::Error> {
+        match self {
+            Self::Committed => None,
+            Self::CommittedButUnsynced { error } => Some(error),
+        }
+    }
+}
+
+pub(crate) fn write_sidebar_plugin(
+    plugin: Option<&SidebarPluginConfig>,
+) -> anyhow::Result<ConfigWriteOutcome> {
+    let path = config_path()?;
+    write_sidebar_plugin_at_path(&path, plugin)
+}
+
+pub(crate) fn write_sidebar_plugin_at_path(
     path: &Path,
     plugin: Option<&SidebarPluginConfig>,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<ConfigWriteOutcome> {
     let mut root = read_config_value(path)?;
     let Some(root_object) = root.as_object_mut() else {
         anyhow::bail!("{} must contain a JSON object", path.display());
@@ -4113,8 +4132,11 @@ fn read_config_value(path: &Path) -> anyhow::Result<Value> {
 }
 
 /// Serializes a config value to a private staging file before atomically
-/// replacing the destination and durably syncing its parent directory.
-fn write_config_value_atomic(path: &Path, value: &Value) -> anyhow::Result<()> {
+/// replacing the destination and durably syncing its parent directory. An
+/// `Err` means that replacement did not commit. A
+/// [`ConfigWriteOutcome::CommittedButUnsynced`] value means the rename did
+/// commit, but the parent directory sync failed.
+fn write_config_value_atomic(path: &Path, value: &Value) -> anyhow::Result<ConfigWriteOutcome> {
     let parent = config_parent_directory(path);
     std::fs::create_dir_all(parent)?;
     let file_name = path.file_name().and_then(|name| name.to_str()).unwrap_or("cmux-tui.json");
@@ -4139,14 +4161,19 @@ fn write_config_value_atomic(path: &Path, value: &Value) -> anyhow::Result<()> {
         file.sync_all()?;
         drop(file);
         std::fs::rename(&tmp_path, path)?;
-        #[cfg(unix)]
-        sync_config_parent_directory(parent)?;
         Ok(())
     })();
-    if result.is_err() {
+    if let Err(error) = result {
         let _ = std::fs::remove_file(&tmp_path);
+        return Err(error);
     }
-    result
+
+    #[cfg(unix)]
+    if let Err(error) = sync_config_parent_directory(parent) {
+        return Ok(ConfigWriteOutcome::CommittedButUnsynced { error });
+    }
+
+    Ok(ConfigWriteOutcome::Committed)
 }
 
 #[cfg(unix)]
@@ -8840,14 +8867,21 @@ mod tests {
         )
         .unwrap();
 
-        write_sidebar_plugin_at_path(
-            &path,
-            Some(&SidebarPluginConfig {
-                command: vec!["/tmp/plugin".to_string(), "--mode".to_string(), "test".to_string()],
-                cwd: Some("/tmp".to_string()),
-            }),
-        )
-        .unwrap();
+        assert!(matches!(
+            write_sidebar_plugin_at_path(
+                &path,
+                Some(&SidebarPluginConfig {
+                    command: vec![
+                        "/tmp/plugin".to_string(),
+                        "--mode".to_string(),
+                        "test".to_string()
+                    ],
+                    cwd: Some("/tmp".to_string()),
+                }),
+            )
+            .unwrap(),
+            ConfigWriteOutcome::Committed
+        ));
         let value: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(value["theme"]["sidebar_rail"], json!(42));
         assert_eq!(value["sidebar"]["width"], json!(31));
@@ -8855,7 +8889,10 @@ mod tests {
         assert_eq!(value["sidebar"]["plugin"]["command"][0], json!("/tmp/plugin"));
         assert_eq!(value["sidebar"]["plugin"]["cwd"], json!("/tmp"));
 
-        write_sidebar_plugin_at_path(&path, None).unwrap();
+        assert!(matches!(
+            write_sidebar_plugin_at_path(&path, None).unwrap(),
+            ConfigWriteOutcome::Committed
+        ));
         let value: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(value["sidebar"]["width"], json!(31));
         assert!(value["sidebar"].get("plugin").is_none());
@@ -8875,11 +8912,14 @@ mod tests {
         let file = options.open(&path).unwrap();
         drop(file);
 
-        write_sidebar_plugin_at_path(
-            &path,
-            Some(&SidebarPluginConfig { command: vec!["/tmp/plugin".to_string()], cwd: None }),
-        )
-        .unwrap();
+        assert!(matches!(
+            write_sidebar_plugin_at_path(
+                &path,
+                Some(&SidebarPluginConfig { command: vec!["/tmp/plugin".to_string()], cwd: None }),
+            )
+            .unwrap(),
+            ConfigWriteOutcome::Committed
+        ));
 
         let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o600, "config permissions must not expose server.ws_token");
@@ -8910,7 +8950,10 @@ mod tests {
     fn config_write_succeeds_after_parent_directory_sync() {
         let dir = TestDirectory::new("parent-sync");
         let path = dir.path.join("cmux-tui.json");
-        write_config_value_atomic(&path, &json!({"server": {"ws_token": "secret"}})).unwrap();
+        assert!(matches!(
+            write_config_value_atomic(&path, &json!({"server": {"ws_token": "secret"}})).unwrap(),
+            ConfigWriteOutcome::Committed
+        ));
 
         let value: Value = serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
         assert_eq!(value["server"]["ws_token"], json!("secret"));
@@ -8925,7 +8968,10 @@ mod tests {
 
         let result = write_config_value_atomic(&path, &json!({"server": {"ws_token": "secret"}}));
 
-        assert!(result.is_ok(), "a committed rename must not be reported as a write failure");
+        assert!(matches!(
+            result.expect("a committed rename must not be reported as a write failure"),
+            ConfigWriteOutcome::CommittedButUnsynced { .. }
+        ));
         let value: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(value["server"]["ws_token"], json!("secret"));
     }

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -155,11 +155,6 @@ use wait_timeout::ChildExt;
 
 use crate::localization::catalog;
 
-#[cfg(all(test, unix))]
-std::thread_local! {
-    static FAIL_CONFIG_PARENT_SYNC: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
-}
-
 /// For a field typed `Option<Option<T>>`: makes an explicit `null` in the
 /// input deserialize to `Some(None)` rather than the `None` an absent key
 /// also produces, so callers can tell "not set" from "set to null".
@@ -4141,8 +4136,16 @@ fn read_config_value(path: &Path) -> anyhow::Result<Value> {
 /// [`ConfigWriteOutcome::CommittedButUnsynced`] value means the rename did
 /// commit, but the parent directory sync failed.
 fn write_config_value_atomic(path: &Path, value: &Value) -> anyhow::Result<ConfigWriteOutcome> {
+    write_config_value_atomic_with_sync(path, value, &sync_config_parent_directory)
+}
+
+fn write_config_value_atomic_with_sync(
+    path: &Path,
+    value: &Value,
+    sync_parent: &dyn Fn(&Path) -> anyhow::Result<()>,
+) -> anyhow::Result<ConfigWriteOutcome> {
     let parent = config_parent_directory(path);
-    std::fs::create_dir_all(parent)?;
+    let created_directories = ensure_config_parent_directory(parent)?;
     let file_name = path.file_name().and_then(|name| name.to_str()).unwrap_or("cmux-tui.json");
     let stamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_nanos();
     let tmp_path = parent.join(format!(".{file_name}.{}.{}.tmp", std::process::id(), stamp));
@@ -4173,31 +4176,38 @@ fn write_config_value_atomic(path: &Path, value: &Value) -> anyhow::Result<Confi
     }
 
     #[cfg(unix)]
-    if let Err(error) = sync_config_parent_directory(parent) {
+    if let Err(error) = sync_config_parent_directories(parent, &created_directories, sync_parent) {
         return Ok(ConfigWriteOutcome::CommittedButUnsynced { error });
     }
+    #[cfg(not(unix))]
+    let _ = created_directories;
 
     Ok(ConfigWriteOutcome::Committed)
 }
 
+fn ensure_config_parent_directory(parent: &Path) -> anyhow::Result<Vec<PathBuf>> {
+    std::fs::create_dir_all(parent)?;
+    Ok(Vec::new())
+}
+
 #[cfg(unix)]
 fn sync_config_parent_directory(parent: &Path) -> anyhow::Result<()> {
-    #[cfg(test)]
-    if FAIL_CONFIG_PARENT_SYNC.with(|fail| fail.replace(false)) {
-        return Err(std::io::Error::other("injected parent directory sync failure").into());
-    }
-    let result = std::fs::File::open(parent).and_then(|directory| directory.sync_all());
-    #[cfg(target_os = "macos")]
-    if let Err(error) = &result {
-        if matches!(error.raw_os_error(), Some(code) if code == libc::EINVAL || code == libc::ENOTSUP)
-        {
-            // macOS filesystems may not support fsync on a directory. The file
-            // itself is already durable, and the rename has completed, so this
-            // unsupported directory operation must not report a false failure.
-            return Ok(());
-        }
-    }
-    result.map_err(Into::into)
+    std::fs::File::open(parent)?.sync_all()?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn sync_config_parent_directory(_parent: &Path) -> anyhow::Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn sync_config_parent_directories(
+    parent: &Path,
+    _created_directories: &[PathBuf],
+    sync_parent: &dyn Fn(&Path) -> anyhow::Result<()>,
+) -> anyhow::Result<()> {
+    sync_parent(parent)
 }
 
 fn config_parent_directory(path: &Path) -> &Path {
@@ -5472,7 +5482,7 @@ fn overlay_ghostty_defaults(defaults: &mut DefaultColors, overrides: DefaultColo
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::cell::Cell;
+    use std::cell::{Cell, RefCell};
 
     #[test]
     fn config_diagnostics_do_not_echo_parser_details() {
@@ -5535,6 +5545,13 @@ mod tests {
             Some(value) => unsafe { std::env::set_var(key, value) },
             None => unsafe { std::env::remove_var(key) },
         }
+    }
+
+    fn assert_committed(outcome: ConfigWriteOutcome) {
+        assert!(matches!(
+            outcome,
+            ConfigWriteOutcome::Committed | ConfigWriteOutcome::CommittedButUnsynced { .. }
+        ));
     }
 
     #[test]
@@ -8871,21 +8888,20 @@ mod tests {
         )
         .unwrap();
 
-        assert!(matches!(
+        assert_committed(
             write_sidebar_plugin_at_path(
                 &path,
                 Some(&SidebarPluginConfig {
                     command: vec![
                         "/tmp/plugin".to_string(),
                         "--mode".to_string(),
-                        "test".to_string()
+                        "test".to_string(),
                     ],
                     cwd: Some("/tmp".to_string()),
                 }),
             )
             .unwrap(),
-            ConfigWriteOutcome::Committed
-        ));
+        );
         let value: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(value["theme"]["sidebar_rail"], json!(42));
         assert_eq!(value["sidebar"]["width"], json!(31));
@@ -8893,10 +8909,7 @@ mod tests {
         assert_eq!(value["sidebar"]["plugin"]["command"][0], json!("/tmp/plugin"));
         assert_eq!(value["sidebar"]["plugin"]["cwd"], json!("/tmp"));
 
-        assert!(matches!(
-            write_sidebar_plugin_at_path(&path, None).unwrap(),
-            ConfigWriteOutcome::Committed
-        ));
+        assert_committed(write_sidebar_plugin_at_path(&path, None).unwrap());
         let value: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(value["sidebar"]["width"], json!(31));
         assert!(value["sidebar"].get("plugin").is_none());
@@ -8916,14 +8929,13 @@ mod tests {
         let file = options.open(&path).unwrap();
         drop(file);
 
-        assert!(matches!(
+        assert_committed(
             write_sidebar_plugin_at_path(
                 &path,
                 Some(&SidebarPluginConfig { command: vec!["/tmp/plugin".to_string()], cwd: None }),
             )
             .unwrap(),
-            ConfigWriteOutcome::Committed
-        ));
+        );
 
         let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o600, "config permissions must not expose server.ws_token");
@@ -8954,10 +8966,9 @@ mod tests {
     fn config_write_succeeds_after_parent_directory_sync() {
         let dir = TestDirectory::new("parent-sync");
         let path = dir.path.join("cmux-tui.json");
-        assert!(matches!(
+        assert_committed(
             write_config_value_atomic(&path, &json!({"server": {"ws_token": "secret"}})).unwrap(),
-            ConfigWriteOutcome::Committed
-        ));
+        );
 
         let value: Value = serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
         assert_eq!(value["server"]["ws_token"], json!("secret"));
@@ -8968,9 +8979,14 @@ mod tests {
     fn config_write_does_not_report_failure_after_parent_sync_error() {
         let dir = TestDirectory::new("parent-sync-failure");
         let path = dir.path.join("cmux-tui.json");
-        FAIL_CONFIG_PARENT_SYNC.with(|fail| fail.set(true));
+        let sync_parent =
+            |_parent: &Path| Err(anyhow::anyhow!("injected parent directory sync failure"));
 
-        let result = write_config_value_atomic(&path, &json!({"server": {"ws_token": "secret"}}));
+        let result = write_config_value_atomic_with_sync(
+            &path,
+            &json!({"server": {"ws_token": "secret"}}),
+            &sync_parent,
+        );
 
         assert!(matches!(
             result.expect("a committed rename must not be reported as a write failure"),
@@ -8978,5 +8994,31 @@ mod tests {
         ));
         let value: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(value["server"]["ws_token"], json!("secret"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn config_write_syncs_parents_of_new_directories() {
+        let dir = TestDirectory::new("created-parent-sync");
+        let parent = dir.path.join("new").join("nested");
+        let path = parent.join("cmux-tui.json");
+        let synced = RefCell::new(Vec::new());
+        let sync_parent = |directory: &Path| {
+            synced.borrow_mut().push(directory.to_path_buf());
+            Ok(())
+        };
+
+        assert_committed(
+            write_config_value_atomic_with_sync(
+                &path,
+                &json!({"server": {"ws_token": "secret"}}),
+                &sync_parent,
+            )
+            .unwrap(),
+        );
+
+        let synced = synced.into_inner();
+        assert!(synced.iter().any(|directory| directory == &parent));
+        assert!(synced.iter().any(|directory| directory == &dir.path));
     }
 }

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -4064,7 +4064,12 @@ pub fn config_path() -> anyhow::Result<PathBuf> {
 #[must_use = "inspect config durability after a committed write"]
 #[derive(Debug)]
 pub(crate) enum ConfigWriteOutcome {
+    /// The replacement and all relevant directory entries were synced.
     Committed,
+    /// The replacement committed, but this platform does not support syncing
+    /// directory entries. The staged file itself was synced before rename.
+    CommittedWithoutDirectorySync,
+    /// The replacement committed, but a supported directory sync failed.
     CommittedButUnsynced { error: anyhow::Error },
 }
 
@@ -4073,7 +4078,7 @@ impl ConfigWriteOutcome {
     /// durability confirmation.
     pub(crate) fn into_unsynced_error(self) -> Option<anyhow::Error> {
         match self {
-            Self::Committed => None,
+            Self::Committed | Self::CommittedWithoutDirectorySync => None,
             Self::CommittedButUnsynced { error } => Some(error),
         }
     }
@@ -4133,8 +4138,10 @@ fn read_config_value(path: &Path) -> anyhow::Result<Value> {
 /// Serializes a config value to a private staging file before atomically
 /// replacing the destination and durably syncing its parent directories. An
 /// `Err` means that replacement did not commit. A
-/// [`ConfigWriteOutcome::CommittedButUnsynced`] value means the rename did
-/// commit, but a directory sync failed.
+/// [`ConfigWriteOutcome::CommittedWithoutDirectorySync`] means the rename
+/// committed on a platform without directory-sync support. A
+/// [`ConfigWriteOutcome::CommittedButUnsynced`] value means a supported
+/// directory sync failed.
 fn write_config_value_atomic(path: &Path, value: &Value) -> anyhow::Result<ConfigWriteOutcome> {
     write_config_value_atomic_with_sync(path, value, &sync_config_parent_directory)
 }
@@ -4142,7 +4149,7 @@ fn write_config_value_atomic(path: &Path, value: &Value) -> anyhow::Result<Confi
 fn write_config_value_atomic_with_sync(
     path: &Path,
     value: &Value,
-    sync_parent: &dyn Fn(&Path) -> anyhow::Result<()>,
+    sync_parent: &dyn Fn(&Path) -> anyhow::Result<ConfigParentSyncOutcome>,
 ) -> anyhow::Result<ConfigWriteOutcome> {
     let parent = config_parent_directory(path);
     let created_directories = ensure_config_parent_directory(parent)?;
@@ -4176,13 +4183,20 @@ fn write_config_value_atomic_with_sync(
     }
 
     #[cfg(unix)]
-    if let Err(error) = sync_config_parent_directories(parent, &created_directories, sync_parent) {
-        return Ok(ConfigWriteOutcome::CommittedButUnsynced { error });
+    {
+        Ok(match sync_config_parent_directories(parent, &created_directories, sync_parent) {
+            Ok(ConfigParentSyncOutcome::Synced) => ConfigWriteOutcome::Committed,
+            Ok(ConfigParentSyncOutcome::Unsupported) => {
+                ConfigWriteOutcome::CommittedWithoutDirectorySync
+            }
+            Err(error) => ConfigWriteOutcome::CommittedButUnsynced { error },
+        })
     }
     #[cfg(not(unix))]
-    let _ = created_directories;
-
-    Ok(ConfigWriteOutcome::Committed)
+    {
+        let _ = (created_directories, sync_parent);
+        Ok(ConfigWriteOutcome::CommittedWithoutDirectorySync)
+    }
 }
 
 fn ensure_config_parent_directory(parent: &Path) -> anyhow::Result<Vec<PathBuf>> {
@@ -4206,28 +4220,49 @@ fn ensure_config_parent_directory(parent: &Path) -> anyhow::Result<Vec<PathBuf>>
     Ok(created_directories)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConfigParentSyncOutcome {
+    Synced,
+    Unsupported,
+}
+
 #[cfg(unix)]
-fn sync_config_parent_directory(parent: &Path) -> anyhow::Result<()> {
-    std::fs::File::open(parent)?.sync_all()?;
-    Ok(())
+fn sync_config_parent_directory(parent: &Path) -> anyhow::Result<ConfigParentSyncOutcome> {
+    let result = std::fs::File::open(parent).and_then(|directory| directory.sync_all());
+    #[cfg(target_os = "macos")]
+    if let Err(error) = &result {
+        if matches!(error.raw_os_error(), Some(code) if code == libc::EINVAL || code == libc::ENOTSUP)
+        {
+            return Ok(ConfigParentSyncOutcome::Unsupported);
+        }
+    }
+    result.map(|()| ConfigParentSyncOutcome::Synced).map_err(Into::into)
 }
 
 #[cfg(not(unix))]
-fn sync_config_parent_directory(_parent: &Path) -> anyhow::Result<()> {
-    Ok(())
+fn sync_config_parent_directory(_parent: &Path) -> anyhow::Result<ConfigParentSyncOutcome> {
+    Ok(ConfigParentSyncOutcome::Unsupported)
 }
 
 #[cfg(unix)]
 fn sync_config_parent_directories(
     parent: &Path,
     created_directories: &[PathBuf],
-    sync_parent: &dyn Fn(&Path) -> anyhow::Result<()>,
-) -> anyhow::Result<()> {
-    sync_parent(parent)?;
-    for directory in created_directories.iter().rev() {
-        sync_parent(config_parent_directory(directory))?;
+    sync_parent: &dyn Fn(&Path) -> anyhow::Result<ConfigParentSyncOutcome>,
+) -> anyhow::Result<ConfigParentSyncOutcome> {
+    let mut unsupported = false;
+    for directory in std::iter::once(parent)
+        .chain(created_directories.iter().rev().map(|directory| config_parent_directory(directory)))
+    {
+        if matches!(sync_parent(directory)?, ConfigParentSyncOutcome::Unsupported) {
+            unsupported = true;
+        }
     }
-    Ok(())
+    Ok(if unsupported {
+        ConfigParentSyncOutcome::Unsupported
+    } else {
+        ConfigParentSyncOutcome::Synced
+    })
 }
 
 fn config_parent_directory(path: &Path) -> &Path {
@@ -5570,7 +5605,9 @@ mod tests {
     fn assert_committed(outcome: ConfigWriteOutcome) {
         assert!(matches!(
             outcome,
-            ConfigWriteOutcome::Committed | ConfigWriteOutcome::CommittedButUnsynced { .. }
+            ConfigWriteOutcome::Committed
+                | ConfigWriteOutcome::CommittedWithoutDirectorySync
+                | ConfigWriteOutcome::CommittedButUnsynced { .. }
         ));
     }
 
@@ -8999,8 +9036,9 @@ mod tests {
     fn config_write_does_not_report_failure_after_parent_sync_error() {
         let dir = TestDirectory::new("parent-sync-failure");
         let path = dir.path.join("cmux-tui.json");
-        let sync_parent =
-            |_parent: &Path| Err(anyhow::anyhow!("injected parent directory sync failure"));
+        let sync_parent = |_parent: &Path| -> anyhow::Result<ConfigParentSyncOutcome> {
+            Err(anyhow::anyhow!("injected parent directory sync failure"))
+        };
 
         let result = write_config_value_atomic_with_sync(
             &path,
@@ -9021,8 +9059,8 @@ mod tests {
     fn config_write_does_not_warn_for_unsupported_parent_sync() {
         let dir = TestDirectory::new("unsupported-parent-sync");
         let path = dir.path.join("cmux-tui.json");
-        let sync_parent = |_parent: &Path| {
-            Err(anyhow::Error::new(std::io::Error::from_raw_os_error(libc::EINVAL)))
+        let sync_parent = |_parent: &Path| -> anyhow::Result<ConfigParentSyncOutcome> {
+            Ok(ConfigParentSyncOutcome::Unsupported)
         };
 
         let outcome = write_config_value_atomic_with_sync(
@@ -9031,6 +9069,7 @@ mod tests {
             &sync_parent,
         )
         .expect("a committed rename must not be reported as a write failure");
+        assert!(matches!(&outcome, ConfigWriteOutcome::CommittedWithoutDirectorySync));
         assert!(outcome.into_unsynced_error().is_none());
     }
 
@@ -9041,9 +9080,9 @@ mod tests {
         let parent = dir.path.join("new").join("nested");
         let path = parent.join("cmux-tui.json");
         let synced = RefCell::new(Vec::new());
-        let sync_parent = |directory: &Path| {
+        let sync_parent = |directory: &Path| -> anyhow::Result<ConfigParentSyncOutcome> {
             synced.borrow_mut().push(directory.to_path_buf());
-            Ok(())
+            Ok(ConfigParentSyncOutcome::Synced)
         };
 
         assert_committed(

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -9016,6 +9016,24 @@ mod tests {
         assert_eq!(value["server"]["ws_token"], json!("secret"));
     }
 
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn config_write_does_not_warn_for_unsupported_parent_sync() {
+        let dir = TestDirectory::new("unsupported-parent-sync");
+        let path = dir.path.join("cmux-tui.json");
+        let sync_parent = |_parent: &Path| {
+            Err(anyhow::Error::new(std::io::Error::from_raw_os_error(libc::EINVAL)))
+        };
+
+        let outcome = write_config_value_atomic_with_sync(
+            &path,
+            &json!({"server": {"ws_token": "secret"}}),
+            &sync_parent,
+        )
+        .expect("a committed rename must not be reported as a write failure");
+        assert!(outcome.into_unsynced_error().is_none());
+    }
+
     #[cfg(unix)]
     #[test]
     fn config_write_syncs_parents_of_new_directories() {

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -128,6 +128,7 @@
 //! keys.
 
 use std::collections::{HashMap, HashSet};
+use std::fs::OpenOptions;
 use std::io::{Read, Write};
 use std::ops::Deref;
 #[cfg(unix)]
@@ -4115,12 +4116,26 @@ fn write_config_value_atomic(path: &Path, value: &Value) -> anyhow::Result<()> {
     let stamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_nanos();
     let tmp_path = parent.join(format!(".{file_name}.{}.{}.tmp", std::process::id(), stamp));
     let result = (|| -> anyhow::Result<()> {
-        let mut file = std::fs::File::create(&tmp_path)?;
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+
+            // The config can contain the server authentication token. Create
+            // the staging file private from the start, independent of umask,
+            // and reject a pre-existing symlink if a concurrent writer races
+            // with this process before open(2).
+            options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+        }
+        let mut file = options.open(&tmp_path)?;
         serde_json::to_writer_pretty(&mut file, value)?;
         file.write_all(b"\n")?;
         file.sync_all()?;
         drop(file);
         std::fs::rename(&tmp_path, path)?;
+        #[cfg(unix)]
+        std::fs::File::open(parent)?.sync_all()?;
         Ok(())
     })();
     if result.is_err() {

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -4110,10 +4110,8 @@ fn read_config_value(path: &Path) -> anyhow::Result<Value> {
 /// Serializes a config value to a private staging file before atomically
 /// replacing the destination and durably syncing its parent directory.
 fn write_config_value_atomic(path: &Path, value: &Value) -> anyhow::Result<()> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let parent = config_parent_directory(path);
+    std::fs::create_dir_all(parent)?;
     let file_name = path.file_name().and_then(|name| name.to_str()).unwrap_or("cmux-tui.json");
     let stamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_nanos();
     let tmp_path = parent.join(format!(".{file_name}.{}.{}.tmp", std::process::id(), stamp));
@@ -4137,13 +4135,33 @@ fn write_config_value_atomic(path: &Path, value: &Value) -> anyhow::Result<()> {
         drop(file);
         std::fs::rename(&tmp_path, path)?;
         #[cfg(unix)]
-        std::fs::File::open(parent)?.sync_all()?;
+        sync_config_parent_directory(parent)?;
         Ok(())
     })();
     if result.is_err() {
         let _ = std::fs::remove_file(&tmp_path);
     }
     result
+}
+
+#[cfg(unix)]
+fn sync_config_parent_directory(parent: &Path) -> anyhow::Result<()> {
+    let result = std::fs::File::open(parent).and_then(|directory| directory.sync_all());
+    #[cfg(target_os = "macos")]
+    if let Err(error) = &result {
+        if matches!(error.raw_os_error(), Some(code) if code == libc::EINVAL || code == libc::ENOTSUP)
+        {
+            // macOS filesystems may not support fsync on a directory. The file
+            // itself is already durable, and the rename has completed, so this
+            // unsupported directory operation must not report a false failure.
+            return Ok(());
+        }
+    }
+    result.map_err(Into::into)
+}
+
+fn config_parent_directory(path: &Path) -> &Path {
+    path.parent().filter(|parent| !parent.as_os_str().is_empty()).unwrap_or_else(|| Path::new("."))
 }
 
 /// `#rrggbb`, `#rgb`, or an xterm-256 index in a string.
@@ -8871,5 +8889,21 @@ mod tests {
         let entries = std::fs::read_dir(&dir.path).unwrap().collect::<Result<Vec<_>, _>>().unwrap();
         assert_eq!(entries.len(), 1, "failed writes must remove their staging file");
         assert_eq!(entries[0].path(), path);
+    }
+
+    #[test]
+    fn config_parent_directory_normalizes_relative_path() {
+        assert_eq!(config_parent_directory(Path::new("cmux-tui.json")), Path::new("."));
+        assert_eq!(config_parent_directory(Path::new("nested/cmux-tui.json")), Path::new("nested"));
+    }
+
+    #[test]
+    fn config_write_succeeds_after_parent_directory_sync() {
+        let dir = TestDirectory::new("parent-sync");
+        let path = dir.path.join("cmux-tui.json");
+        write_config_value_atomic(&path, &json!({"server": {"ws_token": "secret"}})).unwrap();
+
+        let value: Value = serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
+        assert_eq!(value["server"]["ws_token"], json!("secret"));
     }
 }

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -8818,4 +8818,41 @@ mod tests {
         assert_eq!(value["future"]["unknown"], json!(true));
         let _ = std::fs::remove_dir_all(&dir);
     }
+
+    #[cfg(unix)]
+    #[test]
+    fn sidebar_plugin_write_replaces_config_with_private_permissions() {
+        use std::os::unix::fs::{PermissionsExt, OpenOptionsExt};
+
+        let dir = TestDirectory::new("private-permissions");
+        let path = dir.path.join("cmux-tui.json");
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true).mode(0o644);
+        let file = options.open(&path).unwrap();
+        drop(file);
+
+        write_sidebar_plugin_at_path(
+            &path,
+            Some(&SidebarPluginConfig { command: vec!["/tmp/plugin".to_string()], cwd: None }),
+        )
+        .unwrap();
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "config permissions must not expose server.ws_token");
+    }
+
+    #[test]
+    fn config_write_failure_cleans_staging_file() {
+        let dir = TestDirectory::new("failure-cleanup");
+        let path = dir.path.join("cmux-tui.json");
+        std::fs::create_dir(&path).unwrap();
+
+        let error = write_config_value_atomic(&path, &json!({"server": {"ws_token": "secret"}}))
+            .expect_err("replacing a directory must fail");
+        assert!(!error.to_string().is_empty());
+
+        let entries = std::fs::read_dir(&dir.path).unwrap().collect::<Result<Vec<_>, _>>().unwrap();
+        assert_eq!(entries.len(), 1, "failed writes must remove their staging file");
+        assert_eq!(entries[0].path(), path);
+    }
 }

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -4166,6 +4166,8 @@ fn write_config_value_atomic_with_sync(
     write_config_value_atomic_with_sync_and_staging(path, value, sync_parent, &staging_path)
 }
 
+const CONFIG_STAGING_ATTEMPTS: usize = 16;
+
 fn write_config_value_atomic_with_sync_and_staging(
     path: &Path,
     value: &Value,
@@ -4174,20 +4176,33 @@ fn write_config_value_atomic_with_sync_and_staging(
 ) -> anyhow::Result<ConfigWriteOutcome> {
     let parent = config_parent_directory(path);
     let created_directories = ensure_config_parent_directory(parent)?;
-    let tmp_path = staging_path(parent, 0);
-    let mut options = OpenOptions::new();
-    options.write(true).create_new(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
+    let mut staged = None;
+    for attempt in 0..CONFIG_STAGING_ATTEMPTS {
+        let tmp_path = staging_path(parent, attempt);
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
 
-        // The config can contain the server authentication token. Create
-        // the staging file private from the start, independent of umask,
-        // and reject a pre-existing symlink if a concurrent writer races
-        // with this process before open(2).
-        options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+            // The config can contain the server authentication token. Create
+            // the staging file private from the start, independent of umask,
+            // and reject a pre-existing symlink if a concurrent writer races
+            // with this process before open(2).
+            options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+        }
+        match options.open(&tmp_path) {
+            Ok(file) => {
+                staged = Some((tmp_path, file));
+                break;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error.into()),
+        }
     }
-    let mut file = options.open(&tmp_path)?;
+    let Some((tmp_path, mut file)) = staged else {
+        anyhow::bail!("could not create a unique config staging file")
+    };
     let result = (|| -> anyhow::Result<()> {
         serde_json::to_writer_pretty(&mut file, value)?;
         file.write_all(b"\n")?;

--- a/cmux-tui/crates/cmux-tui/src/localization.rs
+++ b/cmux-tui/crates/cmux-tui/src/localization.rs
@@ -700,6 +700,7 @@ pub(crate) struct ConfigMessages {
     invalid_section: &'static str,
     unknown_field: &'static str,
     invalid_root: &'static str,
+    write_durability_warning: &'static str,
 }
 
 impl ConfigMessages {
@@ -714,6 +715,9 @@ impl ConfigMessages {
     }
     pub(crate) fn invalid_root(&self) -> &'static str {
         self.invalid_root
+    }
+    pub(crate) fn write_durability_warning(&self, error: &str) -> String {
+        self.write_durability_warning.replace("{error}", error)
     }
 }
 
@@ -1615,6 +1619,7 @@ OPTIONS:
         invalid_section: "cmux-tui: ignoring invalid config section {section}",
         unknown_field: "cmux-tui: ignoring unknown config field {field}",
         invalid_root: "cmux-tui: ignoring config because the root value is not an object",
+        write_durability_warning: "cmux-tui: config write committed, but parent directory durability is unconfirmed: {error}",
     },
     attach: AttachMessages {
         filtered_subscription_unavailable: "single-terminal attach requires a newer cmux-tui server; restart the session",
@@ -2257,6 +2262,7 @@ ID とセッション:
         invalid_section: "cmux-tui: 無効な設定セクション {section} を無視します",
         unknown_field: "cmux-tui: 不明な設定フィールド {field} を無視します",
         invalid_root: "cmux-tui: ルート値がオブジェクトではないため設定を無視します",
+        write_durability_warning: "cmux-tui: 設定の書き込みは完了しましたが、親ディレクトリの永続性を確認できません: {error}",
     },
     attach: AttachMessages {
         filtered_subscription_unavailable: "単一ターミナルへの接続には新しい cmux-tui サーバーが必要です。セッションを再起動してください",

--- a/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
+++ b/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
@@ -290,7 +290,8 @@ fn persist_sidebar_plugin(plugin: Option<&SidebarPluginConfig>) -> Result<(), Ma
     if let Some(error) = config::write_sidebar_plugin(plugin)?.into_unsynced_error() {
         crate::client_log::stderr_log!(
             "config",
-            "config write committed, but parent directory durability is unconfirmed: {error}"
+            "{}",
+            crate::localization::catalog().config.write_durability_warning(&error.to_string())
         );
     }
     Ok(())

--- a/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
+++ b/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
@@ -186,7 +186,7 @@ fn install_command(positionals: &[String], options: &CliOptions) -> Result<Value
         if selected {
             let command = resolved_run_command(&manifest, &target)?;
             let cwd = canonical_path(&target)?;
-            config::write_sidebar_plugin(Some(&SidebarPluginConfig {
+            persist_sidebar_plugin(Some(&SidebarPluginConfig {
                 command,
                 cwd: Some(cwd.display().to_string()),
             }))?;
@@ -230,7 +230,7 @@ fn use_command(positionals: &[String], options: &CliOptions) -> Result<Value, Ma
     let command = resolved_run_command(&plugin.manifest, &plugin.dir)?;
     verify_executable(&command[0])?;
     let cwd = canonical_path(&plugin.dir)?;
-    config::write_sidebar_plugin(Some(&SidebarPluginConfig {
+    persist_sidebar_plugin(Some(&SidebarPluginConfig {
         command,
         cwd: Some(cwd.display().to_string()),
     }))?;
@@ -253,7 +253,7 @@ fn update_command(positionals: &[String], options: &CliOptions) -> Result<Value,
     verify_executable(&command[0])?;
     if plugin.selected {
         let cwd = canonical_path(&plugin.dir)?;
-        config::write_sidebar_plugin(Some(&SidebarPluginConfig {
+        persist_sidebar_plugin(Some(&SidebarPluginConfig {
             command,
             cwd: Some(cwd.display().to_string()),
         }))?;
@@ -271,7 +271,7 @@ fn remove_command(positionals: &[String], options: &CliOptions) -> Result<Value,
     let installed = resolve_installed_plugin(&positionals[1])?;
     let mut plugin = plugin_json(&installed);
     if installed.selected {
-        config::write_sidebar_plugin(None)?;
+        persist_sidebar_plugin(None)?;
     }
     fs::remove_dir_all(&installed.dir)?;
     remove_registry_metadata(&install_root()?, &installed.name)?;
@@ -281,9 +281,19 @@ fn remove_command(positionals: &[String], options: &CliOptions) -> Result<Value,
 }
 
 fn write_builtin_config(_options: &CliOptions) -> Result<Value, ManagerError> {
-    config::write_sidebar_plugin(None)?;
+    persist_sidebar_plugin(None)?;
     let plugins = installed_plugins()?;
     Ok(json!({"plugins": plugins.iter().map(plugin_json).collect::<Vec<_>>()}))
+}
+
+fn persist_sidebar_plugin(plugin: Option<&SidebarPluginConfig>) -> Result<(), ManagerError> {
+    if let Some(error) = config::write_sidebar_plugin(plugin)?.into_unsynced_error() {
+        crate::client_log::stderr_log!(
+            "config",
+            "config write committed, but parent directory durability is unconfirmed: {error}"
+        );
+    }
+    Ok(())
 }
 
 fn reject_plugin_flags(


### PR DESCRIPTION
Creates cmux-tui config replacement files with owner-only permissions and atomically replaces the destination.

The temporary file uses create_new and O_NOFOLLOW on Unix, syncs file contents before rename, and syncs the parent directory after rename. Failed replacements remove the staging file.

Regression commits:
- test(config): cover private atomic config writes
- fix(config): keep atomic writes private and durable

Focused hosted verification: config_write_failure_cleans_staging_file

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10990"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790449747&installation_model_id=21920&pr_number=10990&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10990&signature=df652d280dd949283136776544e7024d930900d4bac382cd83afa0993ea88f34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`cmux-tui` config writes are now private and durable: configs are staged with `0o600` and `O_NOFOLLOW` (the config can contain the server auth token), synced before an atomic rename, and committed writes now warn instead of failing when a supported parent directory sync fails.

**Bug Fixes**
- Staging file collisions are retried, and failed writes clean up the staging file.
- Unsupported macOS directory sync passes without a warning.
- Parent directories are created component-wise so Windows prefixes and relative paths work, and newly created parents are synced.
- Durability warnings are localized in English and Japanese.

<sup>Written for commit 2608c8ca279f26c188723e95f31e6ac287439423. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration saving to prevent unintended access by other users.
  * Prevented unsafe links from being overwritten during updates.
  * Ensured temporary files are cleaned up when saves fail or naming conflicts occur.
  * Improved reliability when creating configuration directories and saving across supported operating systems.
  * Added safeguards for safer, more complete configuration updates.
  * Added clearer warnings when a configuration is saved but its durability cannot be fully confirmed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->