### PR TITLE
Fix plugin force-install rollback

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
+++ b/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use fs4::FileExt;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
@@ -125,13 +126,77 @@ struct PluginRegistryMetadata {
     id: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum InstallJournalPhase {
+    Prepared,
+    Committed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct InstallJournal {
+    #[serde(default = "default_owner_token")]
+    owner_token: String,
+    name: String,
+    target_backup: PathBuf,
+    metadata_backup: PathBuf,
+    temp_dir: PathBuf,
+    metadata_temp: PathBuf,
+    target_existed: bool,
+    metadata_existed: bool,
+    config_snapshot: Option<ConfigSnapshot>,
+    #[serde(default)]
+    expected_sidebar_plugin: Option<Value>,
+    phase: InstallJournalPhase,
+}
+
+fn default_owner_token() -> String {
+    "legacy".to_string()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ConfigSnapshot {
+    path: PathBuf,
+    #[serde(default)]
+    config_existed: bool,
+    #[serde(default)]
+    sidebar_plugin: Option<Value>,
+    #[serde(default)]
+    original_non_object: Option<Value>,
+}
+
+struct PluginOperationLock {
+    _file: fs::File,
+}
+
+fn acquire_plugin_operation_lock() -> anyhow::Result<PluginOperationLock> {
+    let root = install_root()?;
+    fs::create_dir_all(&root)?;
+    let path = root.join(".install.lock");
+    let file = fs::OpenOptions::new().create(true).read(true).write(true).open(path)?;
+    file.lock()?;
+    Ok(PluginOperationLock { _file: file })
+}
+
 pub(crate) fn execute(positionals: &[String], options: CliOptions) -> Result<Value, ManagerError> {
     match positionals.first().map(String::as_str) {
-        Some("install") => install_command(positionals, &options),
+        Some("install") => {
+            let _lock = acquire_plugin_operation_lock().map_err(ManagerError::Failure)?;
+            install_command(positionals, &options)
+        }
         Some("list") => list_command(positionals, &options),
-        Some("use") => use_command(positionals, &options),
-        Some("update") => update_command(positionals, &options),
-        Some("remove") => remove_command(positionals, &options),
+        Some("use") => {
+            let _lock = acquire_plugin_operation_lock().map_err(ManagerError::Failure)?;
+            use_command(positionals, &options)
+        }
+        Some("update") => {
+            let _lock = acquire_plugin_operation_lock().map_err(ManagerError::Failure)?;
+            update_command(positionals, &options)
+        }
+        Some("remove") => {
+            let _lock = acquire_plugin_operation_lock().map_err(ManagerError::Failure)?;
+            remove_command(positionals, &options)
+        }
         Some(other) => Err(ManagerError::Usage(format!("unknown plugin subcommand {other:?}"))),
         None => Err(ManagerError::Usage("plugin subcommand is required".to_string())),
     }
@@ -149,6 +214,7 @@ fn install_command(positionals: &[String], options: &CliOptions) -> Result<Value
     }
     let root = install_root()?;
     fs::create_dir_all(&root)?;
+    reconcile_install_transactions(&root)?;
     let temp_dir = root.join(format!(".install-{}-{}", std::process::id(), now_nanos()));
     let clone_result =
         run_git(["clone", "--depth", "1", positionals[1].as_str()], Some(&temp_dir), None);
@@ -180,16 +246,52 @@ fn install_command(positionals: &[String], options: &CliOptions) -> Result<Value
         let metadata_temp = write_registry_metadata_temp(&root, &name, &metadata)?;
         metadata_temp_path = Some(metadata_temp.clone());
         let id = metadata.id;
-        replace_installed_plugin(&root, &name, &temp_dir, &metadata_temp)?;
         let selected = selected_plugin_cwd()?.is_some_and(|cwd| same_path(&cwd, &target));
-        if selected {
-            let command = resolved_run_command(&manifest, &target)?;
-            let cwd = canonical_path(&target)?;
-            persist_sidebar_plugin(Some(&SidebarPluginConfig {
-                command,
-                cwd: Some(cwd.display().to_string()),
-            }))?;
-        }
+        let config_snapshot = selected.then(capture_config_snapshot).transpose()?;
+        let expected_sidebar_plugin = if selected {
+            let staging_command = resolved_run_command(&manifest, &temp_dir)?;
+            let staging_root = canonical_path(&temp_dir)?;
+            let target_root = canonical_path(&target)?;
+            let expected_command = staging_command
+                .into_iter()
+                .enumerate()
+                .map(|(index, argument)| {
+                    if index == 0 {
+                        let command_path = Path::new(&argument);
+                        if let Ok(relative) = command_path.strip_prefix(&staging_root) {
+                            return target_root.join(relative).display().to_string();
+                        }
+                    }
+                    argument
+                })
+                .collect::<Vec<_>>();
+            let expected_cwd = canonical_path(&target)?;
+            Some(json!({
+                "command": expected_command,
+                "cwd": expected_cwd.display().to_string(),
+            }))
+        } else {
+            None
+        };
+        replace_installed_plugin_with_config(
+            &root,
+            &name,
+            &temp_dir,
+            &metadata_temp,
+            config_snapshot,
+            expected_sidebar_plugin,
+            || {
+                if selected {
+                    let command = resolved_run_command(&manifest, &target)?;
+                    let cwd = canonical_path(&target)?;
+                    config::write_sidebar_plugin(Some(&SidebarPluginConfig {
+                        command,
+                        cwd: Some(cwd.display().to_string()),
+                    }))?;
+                }
+                Ok(())
+            },
+        )?;
         Ok(json!({"plugin": plugin_json(&InstalledPlugin {
             id,
             name,
@@ -234,7 +336,7 @@ fn use_command(positionals: &[String], options: &CliOptions) -> Result<Value, Ma
     let command = resolved_run_command(&plugin.manifest, &plugin.dir)?;
     verify_executable(&command[0])?;
     let cwd = canonical_path(&plugin.dir)?;
-    persist_sidebar_plugin(Some(&SidebarPluginConfig {
+    config::write_sidebar_plugin(Some(&SidebarPluginConfig {
         command,
         cwd: Some(cwd.display().to_string()),
     }))?;
@@ -257,7 +359,7 @@ fn update_command(positionals: &[String], options: &CliOptions) -> Result<Value,
     verify_executable(&command[0])?;
     if plugin.selected {
         let cwd = canonical_path(&plugin.dir)?;
-        persist_sidebar_plugin(Some(&SidebarPluginConfig {
+        config::write_sidebar_plugin(Some(&SidebarPluginConfig {
             command,
             cwd: Some(cwd.display().to_string()),
         }))?;
@@ -275,7 +377,7 @@ fn remove_command(positionals: &[String], options: &CliOptions) -> Result<Value,
     let installed = resolve_installed_plugin(&positionals[1])?;
     let mut plugin = plugin_json(&installed);
     if installed.selected {
-        persist_sidebar_plugin(None)?;
+        config::write_sidebar_plugin(None)?;
     }
     fs::remove_dir_all(&installed.dir)?;
     remove_registry_metadata(&install_root()?, &installed.name)?;
@@ -285,20 +387,9 @@ fn remove_command(positionals: &[String], options: &CliOptions) -> Result<Value,
 }
 
 fn write_builtin_config(_options: &CliOptions) -> Result<Value, ManagerError> {
-    persist_sidebar_plugin(None)?;
+    config::write_sidebar_plugin(None)?;
     let plugins = installed_plugins()?;
     Ok(json!({"plugins": plugins.iter().map(plugin_json).collect::<Vec<_>>()}))
-}
-
-fn persist_sidebar_plugin(plugin: Option<&SidebarPluginConfig>) -> Result<(), ManagerError> {
-    if let Some(error) = config::write_sidebar_plugin(plugin)?.into_unsynced_error() {
-        crate::client_log::stderr_log!(
-            "config",
-            "{}",
-            crate::localization::catalog().config.write_durability_warning(&error.to_string())
-        );
-    }
-    Ok(())
 }
 
 fn reject_plugin_flags(
@@ -321,6 +412,7 @@ fn reject_plugin_flags(
 
 fn installed_plugins() -> anyhow::Result<Vec<InstalledPlugin>> {
     let root = install_root()?;
+    reconcile_install_transactions(&root)?;
     let selected = selected_plugin_cwd()?;
     let mut plugins = Vec::new();
     let entries = match fs::read_dir(&root) {
@@ -620,6 +712,321 @@ fn unique_backup_path(parent: &Path, name: &str, suffix: &str) -> PathBuf {
     }
 }
 
+fn install_journal_path(install_root: &Path, name: &str) -> PathBuf {
+    install_root.join(format!(".{name}.install-journal.json"))
+}
+
+fn install_commit_marker_path(install_root: &Path, name: &str) -> PathBuf {
+    install_root.join(format!(".{name}.install-commit"))
+}
+
+fn write_install_journal(path: &Path, journal: &InstallJournal) -> anyhow::Result<()> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let temp = parent.join(format!(
+        ".{}.{}-journal.tmp",
+        path.file_name().unwrap().to_string_lossy(),
+        now_nanos()
+    ));
+    let encoded = serde_json::to_vec(journal)?;
+    let result = (|| -> anyhow::Result<()> {
+        let mut file = fs::OpenOptions::new().create_new(true).write(true).open(&temp)?;
+        file.write_all(&encoded)?;
+        file.write_all(b"\n")?;
+        file.sync_all()?;
+        drop(file);
+        fs::rename(&temp, path)?;
+        sync_directory(parent)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temp);
+    }
+    result
+}
+
+#[cfg(unix)]
+fn sync_directory(path: &Path) -> anyhow::Result<()> {
+    fs::File::open(path)?.sync_all()?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn sync_directory(_path: &Path) -> anyhow::Result<()> {
+    Ok(())
+}
+
+fn sync_transaction_directories(install_root: &Path) -> anyhow::Result<()> {
+    sync_directory(install_root)?;
+    sync_directory(&install_root.join(".registry"))?;
+    Ok(())
+}
+
+fn write_install_commit_marker(
+    install_root: &Path,
+    name: &str,
+    owner_token: &str,
+) -> anyhow::Result<()> {
+    let path = install_commit_marker_path(install_root, name);
+    let result = (|| -> anyhow::Result<()> {
+        let mut file = fs::OpenOptions::new().create_new(true).write(true).open(&path)?;
+        file.write_all(owner_token.as_bytes())?;
+        file.write_all(b"\n")?;
+        file.sync_all()?;
+        drop(file);
+        sync_directory(install_root)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&path);
+    }
+    result
+}
+
+fn commit_marker_matches(path: &Path, owner_token: &str) -> anyhow::Result<bool> {
+    let contents = match fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error.into()),
+    };
+    Ok(contents.trim() == owner_token)
+}
+
+fn remove_path_if_present(path: &Path) -> anyhow::Result<()> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.into()),
+    };
+    if metadata.is_dir() {
+        fs::remove_dir_all(path)?;
+    } else {
+        fs::remove_file(path)?;
+    }
+    Ok(())
+}
+
+fn path_exists(path: &Path) -> anyhow::Result<bool> {
+    match fs::symlink_metadata(path) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn reconcile_install_transactions(install_root: &Path) -> anyhow::Result<()> {
+    cleanup_orphan_metadata_temps(install_root)?;
+    cleanup_orphan_commit_markers(install_root)?;
+    let entries = match fs::read_dir(install_root) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.into()),
+    };
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|value| value.to_str()) else { continue };
+        if !name.starts_with('.') || !name.ends_with(".install-journal.json") {
+            continue;
+        }
+        let journal: InstallJournal = match serde_json::from_slice(&fs::read(&path)?) {
+            Ok(journal) => journal,
+            Err(_) => continue,
+        };
+        if validate_install_journal(install_root, &journal).is_err() {
+            continue;
+        }
+        if install_journal_path(install_root, &journal.name) != path {
+            continue;
+        }
+        let marker_path = install_commit_marker_path(install_root, &journal.name);
+        let marker_committed = commit_marker_matches(&marker_path, &journal.owner_token)?;
+        if matches!(&journal.phase, InstallJournalPhase::Committed) || marker_committed {
+            remove_path_if_present(&journal.target_backup)?;
+            remove_path_if_present(&journal.metadata_backup)?;
+            remove_path_if_present(&journal.temp_dir)?;
+            remove_path_if_present(&journal.metadata_temp)?;
+            sync_transaction_directories(install_root)?;
+            remove_path_if_present(&path)?;
+            sync_transaction_directories(install_root)?;
+            remove_path_if_present(&marker_path)?;
+            continue;
+        }
+        match journal.phase {
+            InstallJournalPhase::Prepared => {
+                if let Some(snapshot) = &journal.config_snapshot {
+                    restore_config_snapshot(snapshot, journal.expected_sidebar_plugin.as_ref())?;
+                }
+                if journal.target_existed {
+                    if path_exists(&journal.target_backup)? {
+                        remove_path_if_present(&install_root.join(&journal.name))?;
+                        fs::rename(&journal.target_backup, install_root.join(&journal.name))?;
+                    }
+                } else {
+                    remove_path_if_present(&install_root.join(&journal.name))?;
+                }
+                if journal.metadata_existed {
+                    let metadata_path = registry_metadata_path(install_root, &journal.name);
+                    if path_exists(&journal.metadata_backup)? {
+                        remove_path_if_present(&metadata_path)?;
+                        fs::rename(&journal.metadata_backup, metadata_path)?;
+                    }
+                } else {
+                    remove_path_if_present(&registry_metadata_path(install_root, &journal.name))?;
+                }
+                remove_path_if_present(&journal.temp_dir)?;
+                remove_path_if_present(&journal.metadata_temp)?;
+                sync_transaction_directories(install_root)?;
+            }
+            InstallJournalPhase::Committed => unreachable!(),
+        }
+        remove_path_if_present(&path)?;
+        sync_transaction_directories(install_root)?;
+        remove_path_if_present(&marker_path)?;
+    }
+    Ok(())
+}
+
+fn cleanup_orphan_metadata_temps(install_root: &Path) -> anyhow::Result<()> {
+    let registry = install_root.join(".registry");
+    let entries = match fs::read_dir(&registry) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.into()),
+    };
+    for entry in entries {
+        let path = entry?.path();
+        let Some(name) = path.file_name().and_then(|value| value.to_str()) else { continue };
+        if name.starts_with('.') && name.ends_with(".tmp") {
+            remove_path_if_present(&path)?;
+        }
+    }
+    Ok(())
+}
+
+fn cleanup_orphan_commit_markers(install_root: &Path) -> anyhow::Result<()> {
+    let entries = match fs::read_dir(install_root) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.into()),
+    };
+    for entry in entries {
+        let path = entry?.path();
+        let Some(name) = path.file_name().and_then(|value| value.to_str()) else { continue };
+        if !name.starts_with('.') || !name.ends_with(".install-commit") {
+            continue;
+        }
+        let plugin_name = name.trim_start_matches('.').trim_end_matches(".install-commit");
+        if validate_plugin_name(plugin_name).is_err()
+            || !path_exists(&install_journal_path(install_root, plugin_name))?
+        {
+            remove_path_if_present(&path)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_install_journal(install_root: &Path, journal: &InstallJournal) -> anyhow::Result<()> {
+    if journal.owner_token.is_empty() {
+        anyhow::bail!("transaction owner token is missing");
+    }
+    validate_plugin_name(&journal.name)?;
+    let registry = install_root.join(".registry");
+    let expected_target = install_root.join(&journal.name);
+    let expected_metadata = registry_metadata_path(install_root, &journal.name);
+    let paths = [
+        ("target backup", &journal.target_backup, install_root),
+        ("metadata backup", &journal.metadata_backup, &registry),
+        ("staging directory", &journal.temp_dir, install_root),
+        ("metadata staging", &journal.metadata_temp, &registry),
+    ];
+    for (label, path, parent) in paths {
+        if path.parent() != Some(parent) {
+            anyhow::bail!("{label} path escapes its transaction directory");
+        }
+    }
+    if journal.target_backup == expected_target || journal.temp_dir == expected_target {
+        anyhow::bail!("transaction path aliases the live plugin");
+    }
+    if journal.metadata_backup == expected_metadata || journal.metadata_temp == expected_metadata {
+        anyhow::bail!("transaction path aliases live metadata");
+    }
+    Ok(())
+}
+
+fn restore_config_snapshot(
+    snapshot: &ConfigSnapshot,
+    expected_sidebar_plugin: Option<&Value>,
+) -> anyhow::Result<()> {
+    let mut root = match fs::read_to_string(&snapshot.path) {
+        Ok(text) if text.trim().is_empty() => json!({}),
+        Ok(text) => serde_json::from_str(&text)?,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => json!({}),
+        Err(error) => return Err(error.into()),
+    };
+    if let Some(expected) = expected_sidebar_plugin {
+        let current = root.get("sidebar").and_then(|sidebar| sidebar.get("plugin"));
+        if current != Some(expected) {
+            return Ok(());
+        }
+    }
+    let Some(root_object) = root.as_object_mut() else {
+        if let Some(original) = &snapshot.original_non_object {
+            return write_config_value_atomic_local(&snapshot.path, original);
+        }
+        anyhow::bail!("{} must contain a JSON object", snapshot.path.display());
+    };
+    match &snapshot.sidebar_plugin {
+        Some(plugin) => {
+            let sidebar = root_object.entry("sidebar").or_insert_with(|| json!({}));
+            if !sidebar.is_object() {
+                *sidebar = json!({});
+            }
+            sidebar
+                .as_object_mut()
+                .expect("sidebar was just made an object")
+                .insert("plugin".to_string(), plugin.clone());
+        }
+        None => {
+            if let Some(sidebar) = root_object.get_mut("sidebar")
+                && let Some(sidebar_object) = sidebar.as_object_mut()
+            {
+                sidebar_object.remove("plugin");
+            }
+        }
+    }
+    if !snapshot.config_existed && snapshot.sidebar_plugin.is_none() {
+        return match fs::remove_file(&snapshot.path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error.into()),
+        };
+    }
+    write_config_value_atomic_local(&snapshot.path, &root)
+}
+
+fn write_config_value_atomic_local(path: &Path, value: &Value) -> anyhow::Result<()> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent)?;
+    let file_name = path.file_name().and_then(|name| name.to_str()).unwrap_or("cmux-tui.json");
+    let temp =
+        parent.join(format!(".{file_name}.{}.{}-restore.tmp", std::process::id(), now_nanos()));
+    let result = (|| -> anyhow::Result<()> {
+        let mut file = fs::OpenOptions::new().create_new(true).write(true).open(&temp)?;
+        serde_json::to_writer_pretty(&mut file, value)?;
+        file.write_all(b"\n")?;
+        file.sync_all()?;
+        drop(file);
+        fs::rename(&temp, path)?;
+        sync_directory(parent)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temp);
+    }
+    result
+}
+
+#[cfg(test)]
 fn replace_installed_plugin(
     install_root: &Path,
     name: &str,
@@ -632,23 +1039,85 @@ fn replace_installed_plugin(
         name,
         temp_dir,
         metadata_temp,
+        None,
+        None,
+        || Ok(()),
     )
 }
 
-fn replace_installed_plugin_with_fs<F: InstallFilesystem>(
+fn replace_installed_plugin_with_config<C: FnOnce() -> anyhow::Result<()>>(
+    install_root: &Path,
+    name: &str,
+    temp_dir: &Path,
+    metadata_temp: &Path,
+    config_snapshot: Option<ConfigSnapshot>,
+    expected_sidebar_plugin: Option<Value>,
+    after_install: C,
+) -> anyhow::Result<()> {
+    replace_installed_plugin_with_fs(
+        &StandardInstallFilesystem,
+        install_root,
+        name,
+        temp_dir,
+        metadata_temp,
+        config_snapshot,
+        expected_sidebar_plugin,
+        after_install,
+    )
+}
+
+fn capture_config_snapshot() -> anyhow::Result<ConfigSnapshot> {
+    let path = config::config_path()?;
+    let (config_existed, sidebar_plugin, original_non_object) = match fs::read_to_string(&path) {
+        Ok(text) if text.trim().is_empty() => (true, None, None),
+        Ok(text) => {
+            let value: Value = serde_json::from_str(&text)?;
+            let sidebar_plugin = value
+                .as_object()
+                .and_then(|root| root.get("sidebar"))
+                .and_then(|sidebar| sidebar.get("plugin"))
+                .cloned();
+            let original_non_object = (!value.is_object()).then_some(value);
+            (true, sidebar_plugin, original_non_object)
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => (false, None, None),
+        Err(error) => return Err(error.into()),
+    };
+    Ok(ConfigSnapshot { path, config_existed, sidebar_plugin, original_non_object })
+}
+
+fn replace_installed_plugin_with_fs<F: InstallFilesystem, C: FnOnce() -> anyhow::Result<()>>(
     filesystem: &F,
     install_root: &Path,
     name: &str,
     temp_dir: &Path,
     metadata_temp: &Path,
+    config_snapshot: Option<ConfigSnapshot>,
+    expected_sidebar_plugin: Option<Value>,
+    after_install: C,
 ) -> anyhow::Result<()> {
     let target = install_root.join(name);
-    let target_exists = target.exists();
+    let target_exists = path_exists(&target)?;
     let metadata_path = registry_metadata_path(install_root, name);
     let target_backup = unique_backup_path(install_root, name, ".plugin-backup");
     let metadata_backup =
         unique_backup_path(&install_root.join(".registry"), name, ".metadata-backup.json");
-    let metadata_exists = metadata_path.exists();
+    let metadata_exists = path_exists(&metadata_path)?;
+    let journal_path = install_journal_path(install_root, name);
+    let journal = InstallJournal {
+        owner_token: format!("{}-{}", std::process::id(), now_nanos()),
+        name: name.to_string(),
+        target_backup: target_backup.clone(),
+        metadata_backup: metadata_backup.clone(),
+        temp_dir: temp_dir.to_path_buf(),
+        metadata_temp: metadata_temp.to_path_buf(),
+        target_existed: target_exists,
+        metadata_existed: metadata_exists,
+        config_snapshot,
+        expected_sidebar_plugin,
+        phase: InstallJournalPhase::Prepared,
+    };
+    write_install_journal(&journal_path, &journal)?;
     let mut target_backed_up = false;
     let mut metadata_backed_up = false;
     let mut target_installed = false;
@@ -675,27 +1144,67 @@ fn replace_installed_plugin_with_fs<F: InstallFilesystem>(
             anyhow::anyhow!("failed to persist {}: {error}", metadata_path.display())
         })?;
         metadata_installed = true;
+        after_install()?;
+        sync_transaction_directories(install_root)?;
+        write_install_commit_marker(install_root, name, &journal.owner_token)?;
         Ok(())
     })();
 
     if let Err(error) = result {
         let mut rollback_errors = Vec::new();
-        if metadata_installed
-            && let Err(rollback_error) = filesystem.rename(&metadata_path, metadata_temp)
-        {
-            rollback_errors.push(format!("metadata staging: {rollback_error}"));
+        if metadata_installed {
+            if let Err(rollback_error) = filesystem.rename(&metadata_path, metadata_temp) {
+                rollback_errors.push(format!("metadata staging: {rollback_error}"));
+                match filesystem.remove_file(&metadata_path) {
+                    Ok(()) => {}
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(error) => rollback_errors.push(format!("metadata removal: {error}")),
+                }
+            }
         }
-        if metadata_backed_up
-            && let Err(rollback_error) = filesystem.rename(&metadata_backup, &metadata_path)
-        {
-            rollback_errors.push(format!("metadata restore: {rollback_error}"));
+        if metadata_backed_up {
+            if let Err(rollback_error) = filesystem.rename(&metadata_backup, &metadata_path) {
+                rollback_errors.push(format!("metadata restore: {rollback_error}"));
+            }
         }
-        if target_installed && let Err(rollback_error) = filesystem.rename(&target, temp_dir) {
-            rollback_errors.push(format!("plugin staging: {rollback_error}"));
+        if target_installed {
+            if let Err(rollback_error) = filesystem.rename(&target, temp_dir) {
+                rollback_errors.push(format!("plugin staging: {rollback_error}"));
+                match filesystem.remove_dir_all(&target) {
+                    Ok(()) => {}
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(error) => rollback_errors.push(format!("plugin removal: {error}")),
+                }
+            }
         }
-        if target_backed_up && let Err(rollback_error) = filesystem.rename(&target_backup, &target)
+        if target_backed_up {
+            if let Err(rollback_error) = filesystem.rename(&target_backup, &target) {
+                rollback_errors.push(format!("plugin restore: {rollback_error}"));
+            }
+        }
+        if let Some(snapshot) = &journal.config_snapshot
+            && let Err(rollback_error) =
+                restore_config_snapshot(snapshot, journal.expected_sidebar_plugin.as_ref())
         {
-            rollback_errors.push(format!("plugin restore: {rollback_error}"));
+            rollback_errors.push(format!("config restore: {rollback_error}"));
+        }
+        if rollback_errors.is_empty()
+            && let Err(sync_error) = sync_transaction_directories(install_root)
+        {
+            rollback_errors.push(format!("rollback directory sync: {sync_error}"));
+        }
+        if rollback_errors.is_empty() {
+            let marker_path = install_commit_marker_path(install_root, name);
+            if let Err(marker_error) = remove_path_if_present(&marker_path) {
+                rollback_errors.push(format!("commit marker cleanup: {marker_error}"));
+            }
+        }
+        if rollback_errors.is_empty() {
+            if let Err(rollback_error) = filesystem.remove_file(&journal_path)
+                && rollback_error.kind() != std::io::ErrorKind::NotFound
+            {
+                rollback_errors.push(format!("journal cleanup: {rollback_error}"));
+            }
         }
         if !rollback_errors.is_empty() {
             anyhow::bail!("{error}; rollback failed: {}", rollback_errors.join("; "));
@@ -703,11 +1212,31 @@ fn replace_installed_plugin_with_fs<F: InstallFilesystem>(
         return Err(error);
     }
 
-    // The replacement is committed once both new paths are in place. Cleanup is
-    // deliberately best effort: retaining an old same-parent backup is safe and
-    // preserves recovery data if the process loses access after commit.
-    let _ = filesystem.remove_dir_all(&target_backup);
-    let _ = filesystem.remove_file(&metadata_backup);
+    // The replacement is committed once both new paths are in place. Keep the
+    // committed journal until all cleanup succeeds, so a later invocation can
+    // retry cleanup if access is temporarily unavailable.
+    let backup_dir_clean = match filesystem.remove_dir_all(&target_backup) {
+        Ok(()) => true,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => true,
+        Err(_) => false,
+    };
+    let metadata_backup_clean = match filesystem.remove_file(&metadata_backup) {
+        Ok(()) => true,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => true,
+        Err(_) => false,
+    };
+    let marker_path = install_commit_marker_path(install_root, name);
+    if backup_dir_clean
+        && metadata_backup_clean
+        && sync_transaction_directories(install_root).is_ok()
+    {
+        let journal_removed = filesystem.remove_file(&journal_path).is_ok();
+        if journal_removed {
+            let _ = sync_transaction_directories(install_root);
+            let _ = remove_path_if_present(&marker_path);
+            let _ = sync_transaction_directories(install_root);
+        }
+    }
     Ok(())
 }
 
@@ -730,6 +1259,7 @@ fn write_registry_metadata_temp(
     Ok(temp)
 }
 
+#[cfg(test)]
 fn replace_registry_metadata(
     install_root: &Path,
     name: &str,
@@ -963,9 +1493,17 @@ mod tests {
     fn replacement_failure_after_backup_restores_plugin_and_metadata() {
         let (root, target, temp_dir, metadata_temp) = replacement_fixture("rollback");
         let filesystem = FailingRenameFilesystem { fail_at: 2, calls: Cell::new(0) };
-        let error =
-            replace_installed_plugin_with_fs(&filesystem, &root, "demo", &temp_dir, &metadata_temp)
-                .unwrap_err();
+        let error = replace_installed_plugin_with_fs(
+            &filesystem,
+            &root,
+            "demo",
+            &temp_dir,
+            &metadata_temp,
+            None,
+            None,
+            || Ok(()),
+        )
+        .unwrap_err();
         assert!(error.to_string().contains("back up"));
         assert_eq!(fs::read_to_string(target.join("marker")).unwrap(), "old");
         assert_eq!(
@@ -994,6 +1532,129 @@ mod tests {
             .filter(|entry| !entry.file_name().to_string_lossy().starts_with('.'))
             .count();
         assert_eq!(visible_entries, 1);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn reconciliation_restores_an_interrupted_replacement() {
+        let (root, target, temp_dir, metadata_temp) = replacement_fixture("reconcile");
+        let metadata_path = registry_metadata_path(&root, "demo");
+        let target_backup = root.join(".demo.recovery.plugin-backup");
+        let metadata_backup = root.join(".registry/.demo.recovery.metadata-backup.json");
+        fs::rename(&target, &target_backup).unwrap();
+        fs::rename(&metadata_path, &metadata_backup).unwrap();
+        fs::rename(&temp_dir, &target).unwrap();
+        let journal_path = install_journal_path(&root, "demo");
+        write_install_journal(
+            &journal_path,
+            &InstallJournal {
+                owner_token: "test-owner".into(),
+                name: "demo".into(),
+                target_backup: target_backup.clone(),
+                metadata_backup: metadata_backup.clone(),
+                temp_dir: temp_dir.clone(),
+                metadata_temp: metadata_temp.clone(),
+                target_existed: true,
+                metadata_existed: true,
+                config_snapshot: None,
+                expected_sidebar_plugin: None,
+                phase: InstallJournalPhase::Prepared,
+            },
+        )
+        .unwrap();
+
+        reconcile_install_transactions(&root).unwrap();
+        assert_eq!(fs::read_to_string(target.join("marker")).unwrap(), "old");
+        assert_eq!(
+            read_registry_metadata(&root, "demo").unwrap().id,
+            "sidebar_plugin_11111111111111111111111111111111"
+        );
+        assert!(!journal_path.exists());
+        assert!(!target_backup.exists());
+        assert!(!metadata_backup.exists());
+        assert!(!metadata_temp.exists());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn reconciliation_cleans_committed_backups() {
+        let (root, target, temp_dir, metadata_temp) = replacement_fixture("committed-cleanup");
+        let metadata_path = registry_metadata_path(&root, "demo");
+        let target_backup = root.join(".demo.recovery.plugin-backup");
+        let metadata_backup = root.join(".registry/.demo.recovery.metadata-backup.json");
+        fs::rename(&target, &target_backup).unwrap();
+        fs::rename(&metadata_path, &metadata_backup).unwrap();
+        fs::rename(&temp_dir, &target).unwrap();
+        let journal_path = install_journal_path(&root, "demo");
+        write_install_journal(
+            &journal_path,
+            &InstallJournal {
+                owner_token: "test-owner".into(),
+                name: "demo".into(),
+                target_backup: target_backup.clone(),
+                metadata_backup: metadata_backup.clone(),
+                temp_dir,
+                metadata_temp,
+                target_existed: true,
+                metadata_existed: true,
+                config_snapshot: None,
+                expected_sidebar_plugin: None,
+                phase: InstallJournalPhase::Committed,
+            },
+        )
+        .unwrap();
+        write_install_commit_marker(&root, "demo", "test-owner").unwrap();
+        reconcile_install_transactions(&root).unwrap();
+        assert!(target.exists());
+        assert!(!target_backup.exists());
+        assert!(!metadata_backup.exists());
+        assert!(!journal_path.exists());
+        assert!(!install_commit_marker_path(&root, "demo").exists());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn config_callback_failure_rolls_back_filesystem_and_config() {
+        let (root, target, temp_dir, metadata_temp) = replacement_fixture("config-rollback");
+        let config_path = root.join("config.json");
+        fs::write(
+            &config_path,
+            "{\"sidebar\":{\"plugin\":{\"command\":[\"old\"]}},\"theme\":{\"name\":\"keep\"}}\n",
+        )
+        .unwrap();
+        let snapshot = ConfigSnapshot {
+            path: config_path.clone(),
+            config_existed: true,
+            sidebar_plugin: Some(json!({"command": ["old"]})),
+            original_non_object: None,
+        };
+        let error = replace_installed_plugin_with_fs(
+            &StandardInstallFilesystem,
+            &root,
+            "demo",
+            &temp_dir,
+            &metadata_temp,
+            Some(snapshot),
+            Some(json!({"command": ["new"]})),
+            || {
+                fs::write(
+                    &config_path,
+                    "{\"sidebar\":{\"plugin\":{\"command\":[\"new\"]}},\"theme\":{\"name\":\"keep\"}}\n",
+                )?;
+                anyhow::bail!("injected config failure")
+            },
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("injected config failure"));
+        assert_eq!(fs::read_to_string(target.join("marker")).unwrap(), "old");
+        let restored: Value =
+            serde_json::from_str(&fs::read_to_string(config_path).unwrap()).unwrap();
+        assert_eq!(restored["sidebar"]["plugin"]["command"], json!(["old"]));
+        assert_eq!(restored["theme"]["name"], json!("keep"));
+        assert_eq!(
+            read_registry_metadata(&root, "demo").unwrap().id,
+            "sidebar_plugin_11111111111111111111111111111111"
+        );
         fs::remove_dir_all(root).unwrap();
     }
 

--- a/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
+++ b/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
@@ -768,6 +768,105 @@ mod tests {
         fs::remove_dir_all(root).unwrap();
     }
 
+    struct FailingRenameFilesystem {
+        fail_at: usize,
+        calls: Cell<usize>,
+    }
+
+    impl InstallFilesystem for FailingRenameFilesystem {
+        fn rename(&self, from: &Path, to: &Path) -> std::io::Result<()> {
+            let call = self.calls.get() + 1;
+            self.calls.set(call);
+            if call == self.fail_at {
+                return Err(std::io::Error::other("injected rename failure"));
+            }
+            fs::rename(from, to)
+        }
+
+        fn remove_dir_all(&self, path: &Path) -> std::io::Result<()> {
+            fs::remove_dir_all(path)
+        }
+
+        fn remove_file(&self, path: &Path) -> std::io::Result<()> {
+            fs::remove_file(path)
+        }
+    }
+
+    fn replacement_fixture(label: &str) -> (PathBuf, PathBuf, PathBuf, PathBuf) {
+        let root = std::env::temp_dir().join(format!(
+            "cmux-plugin-replacement-test-{label}-{}-{}",
+            std::process::id(),
+            now_nanos()
+        ));
+        let target = root.join("demo");
+        let registry = root.join(".registry");
+        let metadata_path = registry.join("demo.json");
+        let temp_dir = root.join(".install");
+        let metadata_temp = registry.join(".demo.tmp");
+        fs::create_dir_all(target.join("bin")).unwrap();
+        fs::write(target.join("marker"), "old").unwrap();
+        fs::create_dir_all(&registry).unwrap();
+        fs::write(
+            &metadata_path,
+            r#"{"id":"sidebar_plugin_11111111111111111111111111111111"}
+"#,
+        )
+        .unwrap();
+        fs::create_dir_all(temp_dir.join("bin")).unwrap();
+        fs::write(temp_dir.join("marker"), "new").unwrap();
+        fs::write(
+            &metadata_temp,
+            r#"{"id":"sidebar_plugin_22222222222222222222222222222222"}
+"#,
+        )
+        .unwrap();
+        (root, target, temp_dir, metadata_temp)
+    }
+
+    #[test]
+    fn replacement_failure_after_backup_restores_plugin_and_metadata() {
+        let (root, target, temp_dir, metadata_temp) = replacement_fixture("rollback");
+        let filesystem = FailingRenameFilesystem { fail_at: 2, calls: Cell::new(0) };
+        let error = replace_installed_plugin_with_fs(
+            &filesystem,
+            &root,
+            "demo",
+            &temp_dir,
+            &metadata_temp,
+            true,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("back up"));
+        assert_eq!(fs::read_to_string(target.join("marker")).unwrap(), "old");
+        assert_eq!(
+            read_registry_metadata(&root, "demo").unwrap().id,
+            "sidebar_plugin_11111111111111111111111111111111"
+        );
+        assert!(temp_dir.exists());
+        assert!(metadata_temp.exists());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn replacement_commits_new_plugin_and_metadata_together() {
+        let (root, target, temp_dir, metadata_temp) = replacement_fixture("success");
+        replace_installed_plugin(&root, "demo", &temp_dir, &metadata_temp, true).unwrap();
+        assert_eq!(fs::read_to_string(target.join("marker")).unwrap(), "new");
+        assert_eq!(
+            read_registry_metadata(&root, "demo").unwrap().id,
+            "sidebar_plugin_22222222222222222222222222222222"
+        );
+        assert!(!temp_dir.exists());
+        assert!(!metadata_temp.exists());
+        let visible_entries = fs::read_dir(&root)
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|entry| !entry.file_name().to_string_lossy().starts_with('.'))
+            .count();
+        assert_eq!(visible_entries, 1);
+        fs::remove_dir_all(root).unwrap();
+    }
+
     #[test]
     fn plugin_snapshot_matches_the_closed_catalog_shape() {
         let root = std::env::temp_dir().join(format!(

--- a/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
+++ b/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
@@ -157,6 +157,7 @@ fn install_command(positionals: &[String], options: &CliOptions) -> Result<Value
         return Err(error.into());
     }
 
+    let mut metadata_temp_path = None;
     let result = (|| -> Result<Value, ManagerError> {
         let manifest = read_manifest(&temp_dir)
             .map_err(|error| ManagerError::validation(None, error.to_string()))?;
@@ -176,12 +177,10 @@ fn install_command(positionals: &[String], options: &CliOptions) -> Result<Value
         let command = resolved_run_command(&manifest, &temp_dir)?;
         verify_executable(&command[0])?;
         let metadata = PluginRegistryMetadata { id: random_plugin_id()? };
-        replace_registry_metadata(&root, &name, &metadata)?;
+        let metadata_temp = write_registry_metadata_temp(&root, &name, &metadata)?;
+        metadata_temp_path = Some(metadata_temp.clone());
         let id = metadata.id;
-        if target.exists() {
-            fs::remove_dir_all(&target)?;
-        }
-        fs::rename(&temp_dir, &target)?;
+        replace_installed_plugin(&root, &name, &temp_dir, &metadata_temp)?;
         let selected = selected_plugin_cwd()?.is_some_and(|cwd| same_path(&cwd, &target));
         if selected {
             let command = resolved_run_command(&manifest, &target)?;
@@ -199,8 +198,13 @@ fn install_command(positionals: &[String], options: &CliOptions) -> Result<Value
             selected,
         })}))
     })();
-    if result.is_err() && temp_dir.exists() {
-        let _ = fs::remove_dir_all(&temp_dir);
+    if result.is_err() {
+        if temp_dir.exists() {
+            let _ = fs::remove_dir_all(&temp_dir);
+        }
+        if let Some(metadata_temp) = metadata_temp_path {
+            let _ = fs::remove_file(metadata_temp);
+        }
     }
     result
 }
@@ -585,16 +589,137 @@ fn registry_metadata_path(install_root: &Path, name: &str) -> PathBuf {
     install_root.join(".registry").join(format!("{name}.json"))
 }
 
-fn replace_registry_metadata(
+trait InstallFilesystem {
+    fn rename(&self, from: &Path, to: &Path) -> std::io::Result<()>;
+    fn remove_dir_all(&self, path: &Path) -> std::io::Result<()>;
+    fn remove_file(&self, path: &Path) -> std::io::Result<()>;
+}
+
+struct StandardInstallFilesystem;
+
+impl InstallFilesystem for StandardInstallFilesystem {
+    fn rename(&self, from: &Path, to: &Path) -> std::io::Result<()> {
+        fs::rename(from, to)
+    }
+
+    fn remove_dir_all(&self, path: &Path) -> std::io::Result<()> {
+        fs::remove_dir_all(path)
+    }
+
+    fn remove_file(&self, path: &Path) -> std::io::Result<()> {
+        fs::remove_file(path)
+    }
+}
+
+fn unique_backup_path(parent: &Path, name: &str, suffix: &str) -> PathBuf {
+    loop {
+        let path = parent.join(format!(".{name}.{}-{}{suffix}", std::process::id(), now_nanos()));
+        if !path.exists() {
+            return path;
+        }
+    }
+}
+
+fn replace_installed_plugin(
+    install_root: &Path,
+    name: &str,
+    temp_dir: &Path,
+    metadata_temp: &Path,
+) -> anyhow::Result<()> {
+    replace_installed_plugin_with_fs(
+        &StandardInstallFilesystem,
+        install_root,
+        name,
+        temp_dir,
+        metadata_temp,
+    )
+}
+
+fn replace_installed_plugin_with_fs<F: InstallFilesystem>(
+    filesystem: &F,
+    install_root: &Path,
+    name: &str,
+    temp_dir: &Path,
+    metadata_temp: &Path,
+) -> anyhow::Result<()> {
+    let target = install_root.join(name);
+    let target_exists = target.exists();
+    let metadata_path = registry_metadata_path(install_root, name);
+    let target_backup = unique_backup_path(install_root, name, ".plugin-backup");
+    let metadata_backup =
+        unique_backup_path(&install_root.join(".registry"), name, ".metadata-backup.json");
+    let metadata_exists = metadata_path.exists();
+    let mut target_backed_up = false;
+    let mut metadata_backed_up = false;
+    let mut target_installed = false;
+    let mut metadata_installed = false;
+
+    let result = (|| -> anyhow::Result<()> {
+        if target_exists {
+            filesystem.rename(&target, &target_backup).map_err(|error| {
+                anyhow::anyhow!("failed to back up {}: {error}", target.display())
+            })?;
+            target_backed_up = true;
+        }
+        if metadata_exists {
+            filesystem.rename(&metadata_path, &metadata_backup).map_err(|error| {
+                anyhow::anyhow!("failed to back up {}: {error}", metadata_path.display())
+            })?;
+            metadata_backed_up = true;
+        }
+        filesystem
+            .rename(temp_dir, &target)
+            .map_err(|error| anyhow::anyhow!("failed to install {}: {error}", target.display()))?;
+        target_installed = true;
+        filesystem.rename(metadata_temp, &metadata_path).map_err(|error| {
+            anyhow::anyhow!("failed to persist {}: {error}", metadata_path.display())
+        })?;
+        metadata_installed = true;
+        Ok(())
+    })();
+
+    if let Err(error) = result {
+        let mut rollback_errors = Vec::new();
+        if metadata_installed
+            && let Err(rollback_error) = filesystem.rename(&metadata_path, metadata_temp)
+        {
+            rollback_errors.push(format!("metadata staging: {rollback_error}"));
+        }
+        if metadata_backed_up
+            && let Err(rollback_error) = filesystem.rename(&metadata_backup, &metadata_path)
+        {
+            rollback_errors.push(format!("metadata restore: {rollback_error}"));
+        }
+        if target_installed && let Err(rollback_error) = filesystem.rename(&target, temp_dir) {
+            rollback_errors.push(format!("plugin staging: {rollback_error}"));
+        }
+        if target_backed_up && let Err(rollback_error) = filesystem.rename(&target_backup, &target)
+        {
+            rollback_errors.push(format!("plugin restore: {rollback_error}"));
+        }
+        if !rollback_errors.is_empty() {
+            anyhow::bail!("{error}; rollback failed: {}", rollback_errors.join("; "));
+        }
+        return Err(error);
+    }
+
+    // The replacement is committed once both new paths are in place. Cleanup is
+    // deliberately best effort: retaining an old same-parent backup is safe and
+    // preserves recovery data if the process loses access after commit.
+    let _ = filesystem.remove_dir_all(&target_backup);
+    let _ = filesystem.remove_file(&metadata_backup);
+    Ok(())
+}
+
+fn write_registry_metadata_temp(
     install_root: &Path,
     name: &str,
     metadata: &PluginRegistryMetadata,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<PathBuf> {
     validate_plugin_name(name)?;
     validate_plugin_id(&metadata.id)?;
     let registry = install_root.join(".registry");
     fs::create_dir_all(&registry)?;
-    let path = registry_metadata_path(install_root, name);
     let temp = registry.join(format!(".{name}.{}-{}.tmp", std::process::id(), now_nanos()));
     let encoded = serde_json::to_vec(metadata)?;
     let mut file = fs::OpenOptions::new().create_new(true).write(true).open(&temp)?;
@@ -602,6 +727,16 @@ fn replace_registry_metadata(
     file.write_all(b"\n")?;
     file.sync_all()?;
     drop(file);
+    Ok(temp)
+}
+
+fn replace_registry_metadata(
+    install_root: &Path,
+    name: &str,
+    metadata: &PluginRegistryMetadata,
+) -> anyhow::Result<()> {
+    let path = registry_metadata_path(install_root, name);
+    let temp = write_registry_metadata_temp(install_root, name, metadata)?;
     if let Err(error) = fs::rename(&temp, &path) {
         let _ = fs::remove_file(&temp);
         return Err(anyhow::anyhow!("failed to persist {}: {error}", path.display()));
@@ -682,6 +817,7 @@ fn now_nanos() -> u128 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::Cell;
 
     fn manifest_text(name: &str) -> String {
         format!(
@@ -827,15 +963,9 @@ mod tests {
     fn replacement_failure_after_backup_restores_plugin_and_metadata() {
         let (root, target, temp_dir, metadata_temp) = replacement_fixture("rollback");
         let filesystem = FailingRenameFilesystem { fail_at: 2, calls: Cell::new(0) };
-        let error = replace_installed_plugin_with_fs(
-            &filesystem,
-            &root,
-            "demo",
-            &temp_dir,
-            &metadata_temp,
-            true,
-        )
-        .unwrap_err();
+        let error =
+            replace_installed_plugin_with_fs(&filesystem, &root, "demo", &temp_dir, &metadata_temp)
+                .unwrap_err();
         assert!(error.to_string().contains("back up"));
         assert_eq!(fs::read_to_string(target.join("marker")).unwrap(), "old");
         assert_eq!(
@@ -850,7 +980,7 @@ mod tests {
     #[test]
     fn replacement_commits_new_plugin_and_metadata_together() {
         let (root, target, temp_dir, metadata_temp) = replacement_fixture("success");
-        replace_installed_plugin(&root, "demo", &temp_dir, &metadata_temp, true).unwrap();
+        replace_installed_plugin(&root, "demo", &temp_dir, &metadata_temp).unwrap();
         assert_eq!(fs::read_to_string(target.join("marker")).unwrap(), "new");
         assert_eq!(
             read_registry_metadata(&root, "demo").unwrap().id,


### PR DESCRIPTION
Force-install now keeps the existing plugin directory and registry metadata in same-parent backups until the replacement is complete. Any intermediate rename failure restores both paths.

Behavior tests inject a failure after the target backup and cover successful replacement.

Rust fs::rename requires same-mount paths and has stricter existing-directory replacement rules on Unix and Windows, so all transaction renames use unique sibling paths.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10992"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790451015&installation_model_id=21920&pr_number=10992&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10992&signature=481081c54dc7cd2bf965f4a2882a3c9d727a63c2794f8cc213bda55af44e1c70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes plugin force-install so a failed replacement no longer leaves the plugin directory, registry metadata, or sidebar config partially updated, and recovers installs interrupted by a crash.

- Pairs each rename with a same-parent backup so any failure restores the previous directory, metadata, and config.
- Writes a validated install journal before replacing; later commands reconcile it to roll back interrupted installs, and committed journals persist until backup cleanup succeeds.
- Serializes mutating plugin commands with an exclusive `fs4` file lock; read-only commands skip it.
- Runs recovery before changing the sidebar selection so a prepared transaction cannot undo a builtin selection.
- Quarantines malformed or out-of-root journals and preserves dangling symlink entries for the plugin and metadata paths.
- Failure and validation messages are localized and redact internal paths and system details.
- Adds tests for rename failure, mid-replacement crash, config callback failure, and a success case confirming both paths commit together.

<sup>Written for commit 3fc686d29a9358f6a7314d958d3fa9286b96e8b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved plugin installation reliability by preventing partial updates when errors occur.
  - Plugin files, registry information, and related configuration are now restored automatically if an installation fails.
  - Interrupted installations are detected and recovered when viewing or installing plugins.
  - Installation operations are protected from conflicting changes, helping preserve a consistent installed state.
  - Temporary installation changes are finalized safely or fully rolled back when completion is unsuccessful.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->