### PR TITLE
Fix remote CLI routing with leading global options

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/cli.rs
+++ b/cmux-tui/crates/cmux-tui/src/cli.rs
@@ -50,6 +50,22 @@ const REMOTE_COMMANDS: &[&str] = &[
     "install-self",
 ];
 
+/// Maps the actions accepted after the `remote` noun to their direct command
+/// aliases. Keeping this mapping with the remote command grammar prevents
+/// startup normalization from drifting from the public CLI parser.
+pub(super) fn remote_action_command(action: &str) -> Option<&'static str> {
+    match action {
+        "connect" => Some("connect"),
+        "ssh" => Some("ssh"),
+        "forward" => Some("forward"),
+        "rpc" => Some("rpc"),
+        "enroll" => Some("enroll"),
+        "known-daemons" => Some("known-daemons"),
+        "stop" => Some("remote-stop"),
+        _ => None,
+    }
+}
+
 /// Returns whether argv selects the remote command family.
 ///
 /// Keeping this classifier next to the public CLI grammar prevents startup

--- a/cmux-tui/crates/cmux-tui/src/cli.rs
+++ b/cmux-tui/crates/cmux-tui/src/cli.rs
@@ -61,9 +61,13 @@ pub(super) fn is_remote_invocation(args: &[String]) -> bool {
             "--" => return false,
             "--socket" | "--session" | "--machine" => index += 2,
             "--json" | "--jsonl" | "--quiet" => index += 1,
-            value if value.starts_with("--socket=")
-                || value.starts_with("--session=")
-                || value.starts_with("--machine=") => index += 1,
+            value
+                if value.starts_with("--socket=")
+                    || value.starts_with("--session=")
+                    || value.starts_with("--machine=") =>
+            {
+                index += 1
+            }
             value if value.starts_with('-') => return false,
             value => return REMOTE_COMMANDS.contains(&value),
         }

--- a/cmux-tui/crates/cmux-tui/src/cli.rs
+++ b/cmux-tui/crates/cmux-tui/src/cli.rs
@@ -817,4 +817,11 @@ mod tests {
         ])));
         assert!(!is_remote_invocation(&strings(&["--session", "remote", "workspace", "list"])));
     }
+
+    #[test]
+    fn remote_invocation_rejects_missing_global_option_values_and_terminator() {
+        assert!(!is_remote_invocation(&strings(&["--session"])));
+        assert!(!is_remote_invocation(&strings(&["--socket"])));
+        assert!(!is_remote_invocation(&strings(&["--", "remote", "connect"])));
+    }
 }

--- a/cmux-tui/crates/cmux-tui/src/cli.rs
+++ b/cmux-tui/crates/cmux-tui/src/cli.rs
@@ -55,7 +55,20 @@ const REMOTE_COMMANDS: &[&str] = &[
 /// Keeping this classifier next to the public CLI grammar prevents startup
 /// routing and the Unix remote implementation from maintaining separate lists.
 pub(super) fn is_remote_invocation(args: &[String]) -> bool {
-    args.first().is_some_and(|argument| REMOTE_COMMANDS.contains(&argument.as_str()))
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--" => return false,
+            "--socket" | "--session" | "--machine" => index += 2,
+            "--json" | "--jsonl" | "--quiet" => index += 1,
+            value if value.starts_with("--socket=")
+                || value.starts_with("--session=")
+                || value.starts_with("--machine=") => index += 1,
+            value if value.starts_with('-') => return false,
+            value => return REMOTE_COMMANDS.contains(&value),
+        }
+    }
+    false
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]

--- a/cmux-tui/crates/cmux-tui/src/cli.rs
+++ b/cmux-tui/crates/cmux-tui/src/cli.rs
@@ -769,4 +769,19 @@ mod tests {
             ParsedCommand::Help(Some(scope)) if scope == "start"
         ));
     }
+
+    #[test]
+    fn remote_invocation_allows_leading_global_options() {
+        assert!(is_remote_invocation(&strings(&["remote", "connect"])));
+        assert!(is_remote_invocation(&strings(&["--json", "remote", "connect"])));
+        assert!(is_remote_invocation(&strings(&[
+            "--session",
+            "dev",
+            "--socket",
+            "/tmp/cmux.sock",
+            "remote",
+            "rpc",
+        ])));
+        assert!(!is_remote_invocation(&strings(&["--session", "remote", "workspace", "list"])));
+    }
 }

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -1433,14 +1433,10 @@ fn normalize_remote_resource_args(raw_args: &mut Vec<String>) -> Result<(), Stri
             }
         }
         if let Some(action) = raw_args.get(action_index).cloned() {
-            let recognized = matches!(
-                action.as_str(),
-                "connect" | "ssh" | "forward" | "rpc" | "enroll" | "known-daemons" | "stop"
-            );
             raw_args.remove(action_index);
-            if recognized {
+            if let Some(command) = crate::cli::remote_action_command(&action) {
                 raw_args.remove(0);
-                raw_args.insert(0, if action == "stop" { "remote-stop".into() } else { action });
+                raw_args.insert(0, command.to_string());
                 return Ok(());
             } else {
                 raw_args.insert(1, action);

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -2945,6 +2945,17 @@ mod tests {
     }
 
     #[test]
+    fn remote_normalization_leaves_missing_global_values_and_terminator_untouched() {
+        let mut missing = ["--session"].map(str::to_string).to_vec();
+        normalize_remote_resource_args(&mut missing).unwrap();
+        assert_eq!(missing, ["--session"]);
+
+        let mut terminated = ["--", "remote", "connect"].map(str::to_string).to_vec();
+        normalize_remote_resource_args(&mut terminated).unwrap();
+        assert_eq!(terminated, ["--", "remote", "connect"]);
+    }
+
+    #[test]
     fn server_start_routing_skips_private_process_option_values() {
         for value in ["--help", "--json", "--jsonl", "--quiet"] {
             let mut values = [

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -1382,8 +1382,64 @@ fn is_cli_invocation(args: &[String]) -> bool {
 }
 
 fn normalize_remote_resource_args(raw_args: &mut Vec<String>) -> Result<(), String> {
-    if raw_args.first().map(String::as_str) != Some("remote") {
+    let mut index = 0;
+    let mut leading = Vec::new();
+    while index < raw_args.len() {
+        match raw_args[index].as_str() {
+            "--socket" | "--session" | "--machine" => {
+                leading.extend(raw_args[index..].iter().take(2).cloned());
+                index += 2;
+            }
+            value if value.starts_with("--socket=")
+                || value.starts_with("--session=")
+                || value.starts_with("--machine=") => {
+                leading.push(raw_args[index].clone());
+                index += 1;
+            }
+            "--json" | "--jsonl" | "--quiet" => {
+                leading.push(raw_args[index].clone());
+                index += 1;
+            }
+            _ => break,
+        }
+    }
+    let Some(command) = raw_args.get(index).cloned() else {
         return Ok(());
+    };
+    if !crate::cli::is_remote_invocation(raw_args) {
+        return Ok(());
+    }
+    let rest = raw_args[index + 1..].to_vec();
+    *raw_args = std::iter::once(command.clone()).chain(leading).chain(rest).collect();
+    if command != "remote" {
+        return Ok(());
+    }
+    if command == "remote" {
+        let mut action_index = 1;
+        while action_index < raw_args.len() {
+            match raw_args[action_index].as_str() {
+                "--socket" | "--session" | "--machine" => action_index += 2,
+                "--json" | "--jsonl" | "--quiet" => action_index += 1,
+                value if value.starts_with("--socket=")
+                    || value.starts_with("--session=")
+                    || value.starts_with("--machine=") => action_index += 1,
+                _ => break,
+            }
+        }
+        if let Some(action) = raw_args.get(action_index).cloned() {
+            let recognized = matches!(
+                action.as_str(),
+                "connect" | "ssh" | "forward" | "rpc" | "enroll" | "known-daemons" | "stop"
+            );
+            raw_args.remove(action_index);
+            if recognized {
+                raw_args.remove(0);
+                raw_args.insert(0, if action == "stop" { "remote-stop".into() } else { action });
+            } else {
+                raw_args.insert(1, action);
+            }
+            return Ok(());
+        }
     }
     match raw_args.get(1).map(String::as_str) {
         Some("stop") => {

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -1390,9 +1390,11 @@ fn normalize_remote_resource_args(raw_args: &mut Vec<String>) -> Result<(), Stri
                 leading.extend(raw_args[index..].iter().take(2).cloned());
                 index += 2;
             }
-            value if value.starts_with("--socket=")
-                || value.starts_with("--session=")
-                || value.starts_with("--machine=") => {
+            value
+                if value.starts_with("--socket=")
+                    || value.starts_with("--session=")
+                    || value.starts_with("--machine=") =>
+            {
                 leading.push(raw_args[index].clone());
                 index += 1;
             }
@@ -1420,9 +1422,13 @@ fn normalize_remote_resource_args(raw_args: &mut Vec<String>) -> Result<(), Stri
             match raw_args[action_index].as_str() {
                 "--socket" | "--session" | "--machine" => action_index += 2,
                 "--json" | "--jsonl" | "--quiet" => action_index += 1,
-                value if value.starts_with("--socket=")
-                    || value.starts_with("--session=")
-                    || value.starts_with("--machine=") => action_index += 1,
+                value
+                    if value.starts_with("--socket=")
+                        || value.starts_with("--session=")
+                        || value.starts_with("--machine=") =>
+                {
+                    action_index += 1
+                }
                 _ => break,
             }
         }
@@ -2923,18 +2929,14 @@ mod tests {
         normalize_remote_resource_args(&mut json_connect).unwrap();
         assert_eq!(json_connect, ["connect", "--json"]);
 
-        let mut session_stop = ["--session", "dev", "remote-stop"]
-            .map(str::to_string)
-            .to_vec();
+        let mut session_stop = ["--session", "dev", "remote-stop"].map(str::to_string).to_vec();
         normalize_remote_resource_args(&mut session_stop).unwrap();
         assert_eq!(session_stop, ["remote-stop", "--session", "dev"]);
     }
 
     #[test]
     fn remote_normalization_handles_inline_globals_and_unknown_actions() {
-        let mut inline_nested = ["--session=dev", "remote", "connect"]
-            .map(str::to_string)
-            .to_vec();
+        let mut inline_nested = ["--session=dev", "remote", "connect"].map(str::to_string).to_vec();
         normalize_remote_resource_args(&mut inline_nested).unwrap();
         assert_eq!(inline_nested, ["connect", "--session=dev"]);
 

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -1435,10 +1435,10 @@ fn normalize_remote_resource_args(raw_args: &mut Vec<String>) -> Result<(), Stri
             if recognized {
                 raw_args.remove(0);
                 raw_args.insert(0, if action == "stop" { "remote-stop".into() } else { action });
+                return Ok(());
             } else {
                 raw_args.insert(1, action);
             }
-            return Ok(());
         }
     }
     match raw_args.get(1).map(String::as_str) {

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -2918,6 +2918,35 @@ mod tests {
     }
 
     #[test]
+    fn remote_normalization_preserves_leading_globals_for_direct_commands() {
+        let mut json_connect = ["--json", "connect"].map(str::to_string).to_vec();
+        normalize_remote_resource_args(&mut json_connect).unwrap();
+        assert_eq!(json_connect, ["connect", "--json"]);
+
+        let mut session_stop = ["--session", "dev", "remote-stop"]
+            .map(str::to_string)
+            .to_vec();
+        normalize_remote_resource_args(&mut session_stop).unwrap();
+        assert_eq!(session_stop, ["remote-stop", "--session", "dev"]);
+    }
+
+    #[test]
+    fn remote_normalization_handles_inline_globals_and_unknown_actions() {
+        let mut inline_nested = ["--session=dev", "remote", "connect"]
+            .map(str::to_string)
+            .to_vec();
+        normalize_remote_resource_args(&mut inline_nested).unwrap();
+        assert_eq!(inline_nested, ["connect", "--session=dev"]);
+
+        let mut unknown = ["--json", "remote", "frobnicate"].map(str::to_string).to_vec();
+        let error = normalize_remote_resource_args(&mut unknown).unwrap_err();
+        assert_eq!(
+            error,
+            localization::catalog().remote_client.unknown_action("remote", "frobnicate")
+        );
+    }
+
+    #[test]
     fn server_start_routing_skips_private_process_option_values() {
         for value in ["--help", "--json", "--jsonl", "--quiet"] {
             let mut values = [


### PR DESCRIPTION
The CLI specification permits shared global options before the resource scope. Remote dispatch checked argv[0] only, so leading --json, --session, --socket, or --machine prevented remote routing.

This adds a shared classifier that skips supported global options and normalizes the remote noun to argv[0]. Tests cover valid leading globals and avoid treating a consumed option value as a command.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790452086&installation_model_id=21920&pr_number=10993&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10993&signature=c5fbfcabdb7d000c2b500b36ff85e91795893ce7fb3e8c1dbbbf3a3b9f0e3d50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes remote CLI routing so leading global options no longer fall through; `--json`, `--jsonl`, `--quiet`, `--session`, `--socket`, and `--machine` (including `--option=value` forms) now dispatch to the remote handler and are reordered alongside the resolved command.

- Adds a shared classifier that skips supported global options, handles inline and separated values, and rejects `--` or unknown leading flags.
- Reorders the command first (globals after) and resolves remote actions through a shared mapping, so `remote stop` becomes `remote-stop` and unknown actions surface as errors.
- Tests cover valid leading globals, malformed args like missing values or `--`, and ensure consumed option values aren't mistaken for commands.

<sup>Written for commit 87974b03cf311c481a37b5ce41f32cb2f24abfb0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Remote commands now work correctly when preceded by supported global options.
  * Improved handling of separated and inline option values.
  * Added support for JSON, quiet, help, and argument-separator flags during remote command detection.
  * Remote stop commands are normalized consistently for reliable execution.
  * Remote command options are preserved while actions are correctly identified and executed.
  * Invalid or incomplete options no longer trigger incorrect remote command handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->