### PR TITLE
refactor(tui): retain collapsed sidebar specs once

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -7956,12 +7956,13 @@ fn sidebar_layout_for_state(
                 break;
             }
             specs[candidate_index].collapsed = true;
+            collapsed_count += 1;
             candidate_index += 1;
             retained_count -= 1;
         }
     }
 
-    if collapsed_count > 0 || needs_hysteresis_collapse {
+    if collapsed_count > 0 {
         specs.sort_unstable_by_key(|spec| spec.view_index);
         specs.retain(|spec| !spec.collapsed);
     }

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -26294,7 +26294,8 @@ mod tests {
             view.collapse_priority = 10;
         }
 
-        // 50 columns cannot fit three minimum rails and the content area.
+        // 60 columns cannot fit three minimum rails and the content area,
+        // but can fit the two rails that remain after the first collapse.
         // Equal priorities must collapse the first configured rail, matching
         // the previous `min_by_key` plus `remove(index)` behavior.
         let layout = sidebar_layout_for(
@@ -26302,7 +26303,7 @@ mod tests {
             true,
             false,
             true,
-            (50, 30),
+            (60, 30),
             SidebarWidthOverrides::default(),
         );
         assert_eq!(layout.machine, None);

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -7901,34 +7901,56 @@ fn sidebar_layout_for_state(
         })
         .collect::<Vec<_>>();
 
+    // Mark collapsed entries first, then retain once. Repeated `remove(index)`
+    // calls shift every later entry and make narrow layouts unnecessarily
+    // quadratic. `min_by_key` still chooses the first entry on equal priority,
+    // so the configured order remains the tie breaker.
+    let mut retained = vec![true; specs.len()];
+    let mut retained_count = specs.len();
     while width
-        < MIN_CONTENT_WIDTH.saturating_add(MIN_RAIL_WIDTH.saturating_mul(specs.len() as u16))
+        < MIN_CONTENT_WIDTH.saturating_add(MIN_RAIL_WIDTH.saturating_mul(retained_count as u16))
     {
-        let Some((index, _)) = specs.iter().enumerate().min_by_key(|(_, spec)| spec.priority)
+        let Some((index, _)) = specs
+            .iter()
+            .enumerate()
+            .filter(|(index, _)| retained[*index])
+            .min_by_key(|(_, spec)| spec.priority)
         else {
             break;
         };
-        specs.remove(index);
+        retained[index] = false;
+        retained_count -= 1;
     }
 
     if let Some(previous) = previous {
-        while specs.iter().any(|spec| previous.rail(spec.kind).is_none())
+        while specs
+            .iter()
+            .enumerate()
+            .any(|(index, spec)| retained[index] && previous.rail(spec.kind).is_none())
             && width
                 < MIN_CONTENT_WIDTH
-                    .saturating_add(MIN_RAIL_WIDTH.saturating_mul(specs.len() as u16))
+                    .saturating_add(MIN_RAIL_WIDTH.saturating_mul(retained_count as u16))
                     .saturating_add(RAIL_REVEAL_HYSTERESIS)
         {
             let Some((index, _)) = specs
                 .iter()
                 .enumerate()
-                .filter(|(_, spec)| previous.rail(spec.kind).is_none())
+                .filter(|(index, spec)| retained[*index] && previous.rail(spec.kind).is_none())
                 .min_by_key(|(_, spec)| spec.priority)
             else {
                 break;
             };
-            specs.remove(index);
+            retained[index] = false;
+            retained_count -= 1;
         }
     }
+
+    let mut index = 0;
+    specs.retain(|_| {
+        let keep = retained[index];
+        index += 1;
+        keep
+    });
 
     let mut layout = SidebarLayout::default();
     let mut x = 0u16;
@@ -26257,6 +26279,37 @@ mod tests {
         assert_eq!(narrow.tabs, None);
         assert_eq!(narrow.workspace.map(|rect| rect.width), Some(10));
         assert_eq!(narrow.content.width, 40);
+    }
+
+    #[test]
+    fn sidebar_collapse_equal_priorities_keep_first_configured_rail() {
+        let mut config = Config::default();
+        config.sidebar.views_explicit = true;
+        config.sidebar.views = vec![
+            SidebarViewSpec::legacy(SidebarColumnKind::Machines, 18, 0),
+            SidebarViewSpec::legacy(SidebarColumnKind::Workspaces, 22, 0),
+            SidebarViewSpec::legacy(SidebarColumnKind::Tabs, 24, 0),
+        ];
+        for view in &mut config.sidebar.views {
+            view.collapse_priority = 10;
+        }
+
+        // 50 columns cannot fit three minimum rails and the content area.
+        // Equal priorities must collapse the first configured rail, matching
+        // the previous `min_by_key` plus `remove(index)` behavior.
+        let layout = sidebar_layout_for(
+            &config,
+            true,
+            false,
+            true,
+            (50, 30),
+            SidebarWidthOverrides::default(),
+        );
+        assert_eq!(layout.machine, None);
+        assert_eq!(
+            layout.ordered.iter().map(|placement| placement.kind).collect::<Vec<_>>(),
+            vec![RailKind::Workspace, RailKind::Tabs]
+        );
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -7848,6 +7848,7 @@ fn sidebar_layout_for_state(
         desired: u16,
         max_width: u16,
         priority: u16,
+        collapsed: bool,
     }
 
     let mut specs = config
@@ -7897,60 +7898,73 @@ fn sidebar_layout_for_state(
                     RailKind::Tabs | RailKind::Projection(_) => view.max_width,
                 }
             };
-            Some(Spec { kind, view_index, desired, max_width, priority: view.collapse_priority })
+            Some(Spec {
+                kind,
+                view_index,
+                desired,
+                max_width,
+                priority: view.collapse_priority,
+                collapsed: false,
+            })
         })
         .collect::<Vec<_>>();
 
-    // Mark collapsed entries first, then retain once. Repeated `remove(index)`
-    // calls shift every later entry and make narrow layouts unnecessarily
-    // quadratic. `min_by_key` still chooses the first entry on equal priority,
-    // so the configured order remains the tie breaker.
-    let mut retained = vec![true; specs.len()];
+    // Sort only when a collapse decision is needed. The configured index is a
+    // deterministic tie breaker for equal priorities, then a final in-place
+    // sort restores configured order before the layout is built. This keeps
+    // the normal frame path allocation-free beyond the specs vector itself and
+    // bounds collapse selection to O(n log n).
+    let needs_width_collapse =
+        width < MIN_CONTENT_WIDTH.saturating_add(MIN_RAIL_WIDTH.saturating_mul(specs.len() as u16));
+    let needs_hysteresis_collapse = previous.is_some()
+        && width
+            < MIN_CONTENT_WIDTH
+                .saturating_add(MIN_RAIL_WIDTH.saturating_mul(specs.len() as u16))
+                .saturating_add(RAIL_REVEAL_HYSTERESIS)
+        && previous
+            .is_some_and(|previous| specs.iter().any(|spec| previous.rail(spec.kind).is_none()));
+    let mut collapsed_count = 0;
     let mut retained_count = specs.len();
-    while width
-        < MIN_CONTENT_WIDTH.saturating_add(MIN_RAIL_WIDTH.saturating_mul(retained_count as u16))
-    {
-        let Some((index, _)) = specs
-            .iter()
-            .enumerate()
-            .filter(|(index, _)| retained[*index])
-            .min_by_key(|(_, spec)| spec.priority)
-        else {
-            break;
-        };
-        retained[index] = false;
-        retained_count -= 1;
-    }
+    if needs_width_collapse || needs_hysteresis_collapse {
+        specs.sort_unstable_by_key(|spec| (spec.priority, spec.view_index));
 
-    if let Some(previous) = previous {
-        while specs
-            .iter()
-            .enumerate()
-            .any(|(index, spec)| retained[index] && previous.rail(spec.kind).is_none())
+        while retained_count > 0
             && width
                 < MIN_CONTENT_WIDTH
                     .saturating_add(MIN_RAIL_WIDTH.saturating_mul(retained_count as u16))
-                    .saturating_add(RAIL_REVEAL_HYSTERESIS)
         {
-            let Some((index, _)) = specs
-                .iter()
-                .enumerate()
-                .filter(|(index, spec)| retained[*index] && previous.rail(spec.kind).is_none())
-                .min_by_key(|(_, spec)| spec.priority)
-            else {
-                break;
-            };
-            retained[index] = false;
+            specs[collapsed_count].collapsed = true;
+            collapsed_count += 1;
             retained_count -= 1;
         }
     }
 
-    let mut index = 0;
-    specs.retain(|_| {
-        let keep = retained[index];
-        index += 1;
-        keep
-    });
+    if let Some(previous) = previous {
+        let mut candidate_index = collapsed_count;
+        while width
+            < MIN_CONTENT_WIDTH
+                .saturating_add(MIN_RAIL_WIDTH.saturating_mul(retained_count as u16))
+                .saturating_add(RAIL_REVEAL_HYSTERESIS)
+        {
+            while candidate_index < specs.len()
+                && (specs[candidate_index].collapsed
+                    || previous.rail(specs[candidate_index].kind).is_some())
+            {
+                candidate_index += 1;
+            }
+            if candidate_index == specs.len() {
+                break;
+            }
+            specs[candidate_index].collapsed = true;
+            candidate_index += 1;
+            retained_count -= 1;
+        }
+    }
+
+    if collapsed_count > 0 || needs_hysteresis_collapse {
+        specs.sort_unstable_by_key(|spec| spec.view_index);
+        specs.retain(|spec| !spec.collapsed);
+    }
 
     let mut layout = SidebarLayout::default();
     let mut x = 0u16;

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -26404,6 +26404,21 @@ mod tests {
         );
         assert!(collapsed.machine.is_none());
 
+        let without_previous = sidebar_layout_for_state(
+            &config,
+            true,
+            false,
+            true,
+            (70, 30),
+            None,
+            None,
+            None,
+            &overrides,
+            &HashSet::new(),
+            None,
+        );
+        assert!(without_previous.machine.is_some());
+
         let at_boundary = sidebar_layout_for_state(
             &config,
             true,
@@ -26418,6 +26433,10 @@ mod tests {
             Some(&collapsed),
         );
         assert!(at_boundary.machine.is_none());
+        assert_eq!(
+            at_boundary.ordered.iter().map(|placement| placement.kind).collect::<Vec<_>>(),
+            vec![RailKind::Workspace, RailKind::Tabs]
+        );
         let revealed = sidebar_layout_for_state(
             &config,
             true,


### PR DESCRIPTION
Replace repeated Vec::remove(index) calls during sidebar rail collapse with a stable retain pass. This preserves min_by_key tie ordering and hysteresis behavior while avoiding repeated element shifts. Add coverage for equal-priority collapse ordering.

Checks: rustfmt --edition 2024 --check; git diff --check. Full Rust tests require hosted verification per cmux-tui instructions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10994"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790452123&installation_model_id=21920&pr_number=10994&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10994&signature=14aa312a0f18305aefad4f2fc595ce9a8e674c9ba9ec6a209693213c155bd80b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces repeated `Vec::remove` calls during sidebar rail collapse with a single sort-and-retain pass, avoiding quadratic element shifts and keeping the normal frame path allocation-free. Preserves the previous `min_by_key` tie-breaking (first configured rail collapses on equal priority) and fixes hysteresis collapse counting so rails aren't dropped across repeated layout updates. Adds tests for equal-priority collapse ordering and hysteresis-only collapse, including a corrected fixture width.

<sup>Written for commit 15121a79e558f908baa718f3efe25cceb99d4e7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar rail collapsing for more reliable behavior.
  * Preserved the configured order of sidebar entries with equal priorities.
  * Fixed layout reveal behavior to consistently respect the previous layout.
  * Ensured equal-priority sidebar rails collapse in the expected order.
  * Prevented entries from being removed repeatedly during sidebar updates.
  * Improved consistency when restoring and updating sidebar layouts.
  * Reduced unexpected sidebar changes during repeated layout updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->