### PR TITLE
docs(tui): reconcile boards after synchronization merge

### DIFF
--- a/cmux-tui/docs/CURRENT-STATE.md
+++ b/cmux-tui/docs/CURRENT-STATE.md
@@ -1,0 +1,20 @@
+# cmux-tui current state
+
+## Wave 92 authoritative snapshot
+
+Snapshot: 2026-08-28T14:10:26Z. Current `main`: `87e71b229ca8337f86d0c67e5761413abacc6a34`.
+
+Merged TUI work:
+
+| PR | Source head | Merge commit | Merged at |
+| --- | --- | --- | --- |
+| [#11030](https://github.com/manaflow-ai/cmux/pull/11030) | `4295e446dcdc2b0c52e0084dd5a1ec31c35d0f25` | `0ba31a2883577f1dea06957627c0c753955d0e8d` | 2026-08-28T02:55:15Z |
+| [#11055](https://github.com/manaflow-ai/cmux/pull/11055) | `9487a6cc5ac141b270cf2235a9638b750baf0124` | `6dc9dea996585cde55bdba8209146e0908ce8526` | 2026-08-28T11:38:07Z |
+| [#11025](https://github.com/manaflow-ai/cmux/pull/11025) | `478a6f96084738e699d94afabbd96041beee4778` | `e45af147e9677e844c611e83b1a32cbda7711ebd` | 2026-08-28T12:11:04Z |
+| [#11113](https://github.com/manaflow-ai/cmux/pull/11113) | `ba9a5581cf8a57dae070531ac27a151b7b780c38` | `495477e5716bfda23acfb424867cfd4d2ff7e863` | 2026-08-28T12:54:21Z |
+| [#11028](https://github.com/manaflow-ai/cmux/pull/11028) | `a703004f4eb714f7a9ecdda774bf54beb1304c0c` | `b91d338727659adc55465b989babd076cdaa3baf` | 2026-08-28T13:36:34Z |
+| [#10993](https://github.com/manaflow-ai/cmux/pull/10993) | `87974b03cf311c481a37b5ce41f32cb2f24abfb0` | `87e71b229ca8337f86d0c67e5761413abacc6a34` | 2026-08-28T14:04:34Z |
+
+Current candidate heads and deferred work are listed in `PR-INTENT-BOARD.md`. Session total is `unknown`. This snapshot uses sanitized evidence IDs; local receipt details are intentionally omitted.
+
+Rollback rule: run `git rev-list --parents -n 1 <sha>` first. One parent uses `git revert <sha>`; two parents use `git revert -m 1 <sha>`. Run focused checks before merging the revert.

--- a/cmux-tui/docs/PR-INTENT-BOARD.md
+++ b/cmux-tui/docs/PR-INTENT-BOARD.md
@@ -1,5 +1,27 @@
 # cmux TUI PR intent and merge board
 
+## Wave 92 authoritative snapshot
+
+Snapshot: 2026-08-28T14:10:26Z. Current `main`: `87e71b229ca8337f86d0c67e5761413abacc6a34`. Use this section for current state; sections below are historical archive.
+
+| PR | State | Exact head | Next action |
+| --- | --- | --- | --- |
+| [#11112](https://github.com/manaflow-ai/cmux/pull/11112) | Open | `3d9433469544a463dc94b573492f8230a66394c3` | Verify close cancellation for reconnect and heartbeat waits. |
+| [#11024](https://github.com/manaflow-ai/cmux/pull/11024) | Open | `c897b40a93c7f9085e903ae40a1d96540f951f0d` | Run restart, stale-hook, and public-snapshot checks. |
+| [#11013](https://github.com/manaflow-ai/cmux/pull/11013) | Open | `b8470b455e0bdf73b4d29030f4d322e3a6e34c61` | Verify bounded CDP queue and safe public errors. |
+| [#11078](https://github.com/manaflow-ai/cmux/pull/11078) | Open, stacked | `46fe5348e2631769c4e9482e1127ad0c75a8dbff` | Retarget after #11013 and verify overflow redaction. |
+| [#11068](https://github.com/manaflow-ai/cmux/pull/11068) | Open | `b3eca00fd03dd76763bd5273066df2779c236abc` | Resolve identity and parity findings. |
+| [#11002](https://github.com/manaflow-ai/cmux/pull/11002) | Open | `8da5643df4d89ecf4b3a0abad5809241c57e6b1d` | Resolve journal cursor, tombstone, and recovery design. |
+| [#11063](https://github.com/manaflow-ai/cmux/pull/11063) | Open, stacked | `bd5d47b03facb3e20eff1b8aba8d697f1f96c9d6` | Publish the hierarchical tree follow-up. |
+| [#10994](https://github.com/manaflow-ai/cmux/pull/10994) | Open | `15121a79e558f908baa718f3efe25cceb99d4e7d` | Verify collapsed-sidebar retention. |
+| [#10969](https://github.com/manaflow-ai/cmux/pull/10969) | Open | `2e8024606f650c26124adc9e0b71e8d1fb9509ea` | Complete preview-input checks. |
+| [#10966](https://github.com/manaflow-ai/cmux/pull/10966) | Open | `3885306fb27853a60732dbbbf79fe44d172f2949` | Cover agent lifecycle and attention events. |
+| [#10401](https://github.com/manaflow-ai/cmux/pull/10401) | Open | `46590bacaed87fba46d4ceb5cdacadcafad07833` | Rebase drag-into-terminal work and reject text insertion. |
+
+Merged in this snapshot: #11025 (`478a6f96084738e699d94afabbd96041beee4778` -> `e45af147e9677e844c611e83b1a32cbda7711ebd`), #11113 (`ba9a5581cf8a57dae070531ac27a151b7b780c38` -> `495477e5716bfda23acfb424867cfd4d2ff7e863`), #11028 (`a703004f4eb714f7a9ecdda774bf54beb1304c0c` -> `b91d338727659adc55465b989babd076cdaa3baf`), and #10993 (`87974b03cf311c481a37b5ce41f32cb2f24abfb0` -> `87e71b229ca8337f86d0c67e5761413abacc6a34`). Closed duplicate fixes: #11058 head `710e93df3dad1cd3afb9b6c7ee3c45d23e1f807` and #11064 head `20a259160353df20c23d08fac6959eb59934e84c`.
+
+Rollback rule: inspect `git rev-list --parents -n 1 <sha>` first. One parent uses `git revert <sha>`; two parents use `git revert -m 1 <sha>`.
+
 ## Current reconciliation: main `af31628f7b0b2f6c34e184049254fa2fe91f285d`
 
 Audit basis: 2026-08-27T19:39:39Z. Main currently includes the following

--- a/cmux-tui/docs/TECH-DEBT-BOARD.md
+++ b/cmux-tui/docs/TECH-DEBT-BOARD.md
@@ -1,5 +1,22 @@
 # cmux-tui technical-debt board
 
+## Wave 92 authoritative snapshot
+
+Snapshot: 2026-08-28T14:10:26Z. Current `main`: `87e71b229ca8337f86d0c67e5761413abacc6a34`. Use this section for current state; sections below are historical archive.
+
+| Debt | Current PR head | Exit condition |
+| --- | --- | --- |
+| Reconnect and heartbeat shutdown | [#11112](https://github.com/manaflow-ai/cmux/pull/11112), `3d9433469544a463dc94b573492f8230a66394c3` | Close cancels waits without leaks or late writes. |
+| Hook ordering and terminal tombstones | [#11024](https://github.com/manaflow-ai/cmux/pull/11024), `c897b40a93c7f9085e903ae40a1d96540f951f0d` | Restart, stale-hook, and public-snapshot tests pass. |
+| CDP queue and diagnostic privacy | [#11013](https://github.com/manaflow-ai/cmux/pull/11013), `b8470b455e0bdf73b4d29030f4d322e3a6e34c61`; stacked [#11078](https://github.com/manaflow-ai/cmux/pull/11078), `46fe5348e2631769c4e9482e1127ad0c75a8dbff` | Byte cap and safe public errors are proven. |
+| Journal identity and screen parity | [#11002](https://github.com/manaflow-ai/cmux/pull/11002), `8da5643df4d89ecf4b3a0abad5809241c57e6b1d`; [#11068](https://github.com/manaflow-ai/cmux/pull/11068), `b3eca00fd03dd76763bd5273066df2779c236abc` | Cursor, tombstone, identity, and parity tests pass. |
+| External session tree and manual I/O | [#11063](https://github.com/manaflow-ai/cmux/pull/11063), `bd5d47b03facb3e20eff1b8aba8d697f1f96c9d6` | Attach, reconnect, drag, and raw/echo cleanup are proven. |
+| Sidebar retention, preview input, and agent drag | [#10994](https://github.com/manaflow-ai/cmux/pull/10994), `15121a79e558f908baa718f3efe25cceb99d4e7d`; [#10969](https://github.com/manaflow-ai/cmux/pull/10969), `2e8024606f650c26124adc9e0b71e8d1fb9509ea`; [#10401](https://github.com/manaflow-ai/cmux/pull/10401), `46590bacaed87fba46d4ceb5cdacadcafad07833` | Collapse, focus, routing, and no-text-injection tests pass. |
+
+Closed duplicate trust-reader fixes: #11058 (`710e93df3dad1cd3afb9b6c7ee3c45d23e1f807`) and #11064 (`20a259160353df20c23d08fac6959eb59934e84c`) are not active debt rows. The #10993 remote-global-options fix is merged in current main.
+
+Rollback rule: inspect `git rev-list --parents -n 1 <sha>` first. One parent uses `git revert <sha>`; two parents use `git revert -m 1 <sha>`.
+
 ## Current reconciliation: main `af31628f7b0b2f6c34e184049254fa2fe91f285d`
 
 Audit basis: 2026-08-27T19:39:39Z. Current merged log: [#10984](https://github.com/manaflow-ai/cmux/pull/10984)

--- a/cmux-tui/docs/TECH-DEBT-CHANGELOG.md
+++ b/cmux-tui/docs/TECH-DEBT-CHANGELOG.md
@@ -1,5 +1,18 @@
 # cmux-tui aggregate change log
 
+## Wave 92 authoritative snapshot, 2026-08-28T14:10:26Z
+
+Current `main`: `87e71b229ca8337f86d0c67e5761413abacc6a34`. The rows below are the latest merged records; the existing rows later in this file remain the historical archive.
+
+| PR | Source head | Merge commit | Merged at | Rollback |
+| --- | --- | --- | --- | --- |
+| [#11025](https://github.com/manaflow-ai/cmux/pull/11025) | `478a6f96084738e699d94afabbd96041beee4778` | `e45af147e9677e844c611e83b1a32cbda7711ebd` | 2026-08-28T12:11:04Z | `git revert e45af147e9677e844c611e83b1a32cbda7711ebd` |
+| [#11113](https://github.com/manaflow-ai/cmux/pull/11113) | `ba9a5581cf8a57dae070531ac27a151b7b780c38` | `495477e5716bfda23acfb424867cfd4d2ff7e863` | 2026-08-28T12:54:21Z | `git revert 495477e5716bfda23acfb424867cfd4d2ff7e863` |
+| [#11028](https://github.com/manaflow-ai/cmux/pull/11028) | `a703004f4eb714f7a9ecdda774bf54beb1304c0c` | `b91d338727659adc55465b989babd076cdaa3baf` | 2026-08-28T13:36:34Z | `git revert b91d338727659adc55465b989babd076cdaa3baf` |
+| [#10993](https://github.com/manaflow-ai/cmux/pull/10993) | `87974b03cf311c481a37b5ce41f32cb2f24abfb0` | `87e71b229ca8337f86d0c67e5761413abacc6a34` | 2026-08-28T14:04:34Z | `git revert 87e71b229ca8337f86d0c67e5761413abacc6a34` |
+
+Before any rollback, run `git rev-list --parents -n 1 <sha>`. Use plain `git revert <sha>` for one parent and `git revert -m 1 <sha>` for two parents, then run focused checks.
+
 ## Current reconciliation: main `af31628f7b0b2f6c34e184049254fa2fe91f285d`
 
 Audit basis: 2026-08-27T19:39:39Z. The current merged cmux-tui log is

--- a/cmux-tui/docs/USER-INTENT-BOARD.md
+++ b/cmux-tui/docs/USER-INTENT-BOARD.md
@@ -1,5 +1,24 @@
 # cmux-tui user-intent board
 
+## Wave 92 authoritative snapshot
+
+Snapshot: 2026-08-28T14:10:26Z. Current `main`: `87e71b229ca8337f86d0c67e5761413abacc6a34`. Use this section for current state; later sections are historical archive. New evidence references use sanitized IDs.
+
+| User intent | Current PR or status | Exact head / evidence | Acceptance condition |
+| --- | --- | --- | --- |
+| Cancel reconnect and heartbeat waits on close. | [#11112](https://github.com/manaflow-ai/cmux/pull/11112) open | `3d9433469544a463dc94b573492f8230a66394c3` | Close cancels waits and prevents late writes. |
+| Order hook records and suppress done restores. | [#11024](https://github.com/manaflow-ai/cmux/pull/11024) open | `c897b40a93c7f9085e903ae40a1d96540f951f0d` | Restart and stale-hook tests pass. |
+| Bound CDP output and redact diagnostics. | [#11013](https://github.com/manaflow-ai/cmux/pull/11013) and stacked [#11078](https://github.com/manaflow-ai/cmux/pull/11078) | `b8470b455e0bdf73b4d29030f4d322e3a6e34c61`, `46fe5348e2631769c4e9482e1127ad0c75a8dbff` | Byte-cap and safe public-error tests pass. |
+| Give sessions one durable identity and a hierarchical tree. | [#11002](https://github.com/manaflow-ai/cmux/pull/11002), [#11068](https://github.com/manaflow-ai/cmux/pull/11068), [#11063](https://github.com/manaflow-ai/cmux/pull/11063) | `evidence-record:session-catalog` | Attach, reconnect, reorder, and detach preserve one identity. |
+| Keep sidebar state and preview input stable. | [#10994](https://github.com/manaflow-ai/cmux/pull/10994), [#10969](https://github.com/manaflow-ai/cmux/pull/10969) | `evidence-record:sidebar-state` | Collapse, focus, and routing stay deterministic. |
+| Drag an agent into a terminal without text injection. | [#10401](https://github.com/manaflow-ai/cmux/pull/10401) | `46590bacaed87fba46d4ceb5cdacadcafad07833` | A drop opens the target session and never types its label. |
+| Keep account-scoped discovery and pairing authorized. | Deferred | `evidence-record:account-pairing` | Device scope, expiry, and reconnect authorization have behavior tests. |
+| Enforce sandbox capability authorization. | Deferred | `evidence-record:sandbox-capability` | Every capability request is scoped, denied by default, and audited. |
+| Preserve cloud resource lifecycle and restore safety. | Deferred | `evidence-record:cloud-lifecycle` | Create, attach, detach, restore, and delete transitions are explicit and recoverable. |
+| Keep direct manual I/O cloud-only. | Deferred | `evidence-record:manual-io-policy` | Local creation is unchanged; cloud attach has bounded reconnect and error states. |
+
+Merged in this snapshot: #11025, #11113, #11028, and #10993. Closed duplicate fixes #11058 and #11064 are not active intents. These rows are requests and acceptance criteria, not completion claims.
+
 ## Current reconciliation: main `af31628f7b0b2f6c34e184049254fa2fe91f285d`
 
 Audit basis: 2026-08-27T19:39:39Z. Main's current cmux-tui merge log is

--- a/cmux-tui/docs/USER-REQUEST-BOARD.md
+++ b/cmux-tui/docs/USER-REQUEST-BOARD.md
@@ -1,5 +1,24 @@
 # cmux-tui user request board
 
+## Wave 92 authoritative snapshot
+
+Snapshot: 2026-08-28T14:10:26Z. Current `main`: `87e71b229ca8337f86d0c67e5761413abacc6a34`. Use this section for current state; later sections are historical archive. New evidence references use sanitized IDs.
+
+| Request | PR and exact head | State | Required proof |
+| --- | --- | --- | --- |
+| Cancel reconnect and heartbeat waits on close. | [#11112](https://github.com/manaflow-ai/cmux/pull/11112), `3d9433469544a463dc94b573492f8230a66394c3` | Open | Close, cancellation, and late-write tests. |
+| Order hook records and suppress done restores. | [#11024](https://github.com/manaflow-ai/cmux/pull/11024), `c897b40a93c7f9085e903ae40a1d96540f951f0d` | Open | Restart and stale-hook tests. |
+| Bound CDP outbound bytes and redact overflow details. | [#11013](https://github.com/manaflow-ai/cmux/pull/11013), `b8470b455e0bdf73b4d29030f4d322e3a6e34c61`; [#11078](https://github.com/manaflow-ai/cmux/pull/11078), `46fe5348e2631769c4e9482e1127ad0c75a8dbff` | Open, stacked | Byte-cap, overflow, and public-error tests. |
+| Derive agent state from a durable journal. | [#11002](https://github.com/manaflow-ai/cmux/pull/11002), `8da5643df4d89ecf4b3a0abad5809241c57e6b1d`; [#11068](https://github.com/manaflow-ai/cmux/pull/11068), `b3eca00fd03dd76763bd5273066df2779c236abc` | Open | Cursor, tombstone, identity, and parity tests. |
+| Attach external sessions through a hierarchical tree. | [#11063](https://github.com/manaflow-ai/cmux/pull/11063), `bd5d47b03facb3e20eff1b8aba8d697f1f96c9d6` | Open, stacked | Attach, reconnect, drag, and raw/echo cleanup proof. |
+| Retain collapsed sidebar specs and simplify preview input. | [#10994](https://github.com/manaflow-ai/cmux/pull/10994), `15121a79e558f908baa718f3efe25cceb99d4e7d`; [#10969](https://github.com/manaflow-ai/cmux/pull/10969), `2e8024606f650c26124adc9e0b71e8d1fb9509ea` | Open | Collapse, focus, and routing tests. |
+| Drop an agent into a terminal without text injection. | [#10401](https://github.com/manaflow-ai/cmux/pull/10401), `46590bacaed87fba46d4ceb5cdacadcafad07833` | Open | Session payload and terminal-drop behavior tests. |
+| Preserve Unicode glyph invariants. | [#11028](https://github.com/manaflow-ai/cmux/pull/11028), source `a703004f4eb714f7a9ecdda774bf54beb1304c0c`, merge `b91d338727659adc55465b989babd076cdaa3baf` | Merged | Hosted verification status is not recorded in this board. |
+
+Closed duplicate fixes: [#11058](https://github.com/manaflow-ai/cmux/pull/11058), head `710e93df3dad1cd3afb9b6c7ee3c45d23e1f807`, and [#11064](https://github.com/manaflow-ai/cmux/pull/11064), head `20a259160353df20c23d08fac6959eb59934e84c`, are closed. These rows are requests and acceptance criteria, not completion claims.
+
+Merged in this snapshot: #11025, #11113, #11028, and #10993. The #11028 hosted verification status remains unrecorded here.
+
 ## Current reconciliation: main `af31628f7b0b2f6c34e184049254fa2fe91f285d`
 
 Audit basis: 2026-08-27T19:39:39Z. Current merged log: [#10984](https://github.com/manaflow-ai/cmux/pull/10984)


### PR DESCRIPTION
Refresh the durable cmux-tui intent and technical-debt ledgers after merged PRs #10987 and #10988.

- pin current main at `e7584a4c4a25b2e4fe400b67ab19b7c7ec3a5f11`
- record both merged PRs, source heads, merge SHAs, and rollback commands
- state the strict session evidence as 0 confirmed turns with total unknown
- retain five documented owner workstreams as the practical evidence floor
- preserve prior count claims in historical sections
- add the current aggregate change-log row

Verification: `git diff --check`. Documentation only, so no runtime build or test ran.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790455233&installation_model_id=21920&pr_number=10996&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10996&signature=639049f0fbd58892a157df26a0bd228bbf8ec14e2f961c5bd9ba78de1a2c27a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Wave 92 authoritative snapshot to the cmux-tui documentation boards, pinning main at `87e71b229ca8337f86d0c67e5761413abacc6a34` and adding `CURRENT-STATE.md`.

- Records merged PRs #11030, #11055, #11025, #11113, #11028, and #10993 with source heads, merge SHAs, and rollback commands; lists open candidate PRs and closed duplicates.
- Keeps the session total as `unknown` and uses sanitized evidence IDs only.
- Documentation only, verified with `git diff --check`.

<sup>Written for commit 551d4a65d56f01ec1c87559f915d62f843cdcd50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a current-state snapshot for the TUI project, including merged work, open gates, blockers, revert references, and session accounting.
  * Expanded intent, request, technical-debt, and reconciliation boards with Waves 83–85 updates, acceptance evidence, open work, and audit references.
  * Updated reconciliation records to reflect the latest project state and merged changes.
  * Added a Wave 85 changelog entry with completed work, deferred items, and recovery guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->