### PR TITLE
fix(cmux-tui): scrub provider capability secrets

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/machine_provider_transport.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_transport.rs
@@ -505,6 +505,7 @@ fn spawn_command(
     command
         .args(arguments)
         .env_remove("CMUX_MACHINE_PROVIDER_TOKEN")
+        .env_remove("CMUX_PROVIDER_WORKSPACE_AUTHORITY")
         .process_group(0)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -859,8 +860,10 @@ mod tests {
         wait_for_file(&complete);
         let recorded_environment = fs::read_to_string(environment).expect("read environment");
         assert!(!recorded_environment.contains("CMUX_MACHINE_PROVIDER_TOKEN=provider-token-test"));
-        assert!(!recorded_environment
-            .contains("CMUX_PROVIDER_WORKSPACE_AUTHORITY=provider-authority-test"));
+        assert!(
+            !recorded_environment
+                .contains("CMUX_PROVIDER_WORKSPACE_AUTHORITY=provider-authority-test")
+        );
         drop(control);
         unsafe {
             std::env::remove_var("CMUX_MACHINE_PROVIDER_TOKEN");

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_transport.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_transport.rs
@@ -746,7 +746,6 @@ mod tests {
     use super::*;
 
     static NEXT_TEST_DIRECTORY: AtomicU64 = AtomicU64::new(1);
-    static TEST_ENV_LOCK: Mutex<()> = Mutex::new(());
 
     struct TestDirectory {
         path: PathBuf,
@@ -837,38 +836,62 @@ mod tests {
 
     #[test]
     fn command_connector_does_not_inherit_provider_capability_secrets() {
-        let _env_lock = TEST_ENV_LOCK.lock().expect("lock provider test environment");
-        let directory = TestDirectory::new();
-        let environment = directory.path.join("environment");
-        let complete = directory.path.join("complete");
-        let script = directory.script(
-            "record-environment",
-            "environment=$1; complete=$2; env > \"$environment.tmp\"; mv \"$environment.tmp\" \"$environment\"; printf 'done\\n' > \"$complete\"; while IFS= read -r _line; do :; done",
-        );
-        unsafe {
-            std::env::set_var("CMUX_MACHINE_PROVIDER_TOKEN", "provider-token-test");
-            std::env::set_var("CMUX_PROVIDER_WORKSPACE_AUTHORITY", "provider-authority-test");
+        const CHILD_MARKER: &str = "CMUX_PROVIDER_ENV_TEST_CHILD";
+        if std::env::var_os(CHILD_MARKER).is_some() {
+            let directory = TestDirectory::new();
+            let environment = directory.path.join("environment");
+            let complete = directory.path.join("complete");
+            let script = directory.script(
+                "record-environment",
+                "environment=$1; complete=$2; env > \"$environment.tmp\"; mv \"$environment.tmp\" \"$environment\"; printf 'done\\n' > \"$complete\"; while IFS= read -r _line; do :; done",
+            );
+            let connector = CommandProviderConnector::new([
+                script.into_os_string(),
+                environment.clone().into_os_string(),
+                complete.clone().into_os_string(),
+            ])
+            .expect("create command connector");
+            let connection = connector.connect().expect("open command control");
+            let (_, control, _) = connection.into_parts();
+            wait_for_file(&complete);
+            let recorded_environment = fs::read_to_string(environment).expect("read environment");
+            assert!(
+                !recorded_environment
+                    .lines()
+                    .any(|line| line.starts_with("CMUX_MACHINE_PROVIDER_TOKEN=")),
+                "machine provider token reached child environment"
+            );
+            assert!(
+                !recorded_environment
+                    .lines()
+                    .any(|line| line.starts_with("CMUX_PROVIDER_WORKSPACE_AUTHORITY=")),
+                "provider workspace authority reached child environment"
+            );
+            drop(control);
+            return;
         }
-        let connector = CommandProviderConnector::new([
-            script.into_os_string(),
-            environment.clone().into_os_string(),
-            complete.clone().into_os_string(),
-        ])
-        .expect("create command connector");
-        let connection = connector.connect().expect("open command control");
-        let (_, control, _) = connection.into_parts();
-        wait_for_file(&complete);
-        let recorded_environment = fs::read_to_string(environment).expect("read environment");
-        assert!(!recorded_environment.contains("CMUX_MACHINE_PROVIDER_TOKEN=provider-token-test"));
+
+        let helper_test = format!(
+            "{}::command_connector_does_not_inherit_provider_capability_secrets",
+            module_path!()
+        );
+        let output = std::process::Command::new(
+            std::env::current_exe().expect("locate provider environment test binary"),
+        )
+        .arg("--exact")
+        .arg(&helper_test)
+        .arg("--nocapture")
+        .env(CHILD_MARKER, "1")
+        .env("CMUX_MACHINE_PROVIDER_TOKEN", "provider-token-test")
+        .env("CMUX_PROVIDER_WORKSPACE_AUTHORITY", "provider-authority-test")
+        .output()
+        .expect("run provider environment test helper");
         assert!(
-            !recorded_environment
-                .contains("CMUX_PROVIDER_WORKSPACE_AUTHORITY=provider-authority-test")
+            output.status.success(),
+            "provider environment test helper failed:\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
         );
-        drop(control);
-        unsafe {
-            std::env::remove_var("CMUX_MACHINE_PROVIDER_TOKEN");
-            std::env::remove_var("CMUX_PROVIDER_WORKSPACE_AUTHORITY");
-        }
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_transport.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_transport.rs
@@ -745,6 +745,7 @@ mod tests {
     use super::*;
 
     static NEXT_TEST_DIRECTORY: AtomicU64 = AtomicU64::new(1);
+    static TEST_ENV_LOCK: Mutex<()> = Mutex::new(());
 
     struct TestDirectory {
         path: PathBuf,
@@ -831,6 +832,40 @@ mod tests {
         assert!(!recorded_arguments.contains(token.expose()));
         assert!(!recorded_environment.contains(token.expose()));
         drop(control);
+    }
+
+    #[test]
+    fn command_connector_does_not_inherit_provider_capability_secrets() {
+        let _env_lock = TEST_ENV_LOCK.lock().expect("lock provider test environment");
+        let directory = TestDirectory::new();
+        let environment = directory.path.join("environment");
+        let complete = directory.path.join("complete");
+        let script = directory.script(
+            "record-environment",
+            "environment=$1; complete=$2; env > \"$environment.tmp\"; mv \"$environment.tmp\" \"$environment\"; printf 'done\\n' > \"$complete\"; while IFS= read -r _line; do :; done",
+        );
+        unsafe {
+            std::env::set_var("CMUX_MACHINE_PROVIDER_TOKEN", "provider-token-test");
+            std::env::set_var("CMUX_PROVIDER_WORKSPACE_AUTHORITY", "provider-authority-test");
+        }
+        let connector = CommandProviderConnector::new([
+            script.into_os_string(),
+            environment.clone().into_os_string(),
+            complete.clone().into_os_string(),
+        ])
+        .expect("create command connector");
+        let connection = connector.connect().expect("open command control");
+        let (_, control, _) = connection.into_parts();
+        wait_for_file(&complete);
+        let recorded_environment = fs::read_to_string(environment).expect("read environment");
+        assert!(!recorded_environment.contains("CMUX_MACHINE_PROVIDER_TOKEN=provider-token-test"));
+        assert!(!recorded_environment
+            .contains("CMUX_PROVIDER_WORKSPACE_AUTHORITY=provider-authority-test"));
+        drop(control);
+        unsafe {
+            std::env::remove_var("CMUX_MACHINE_PROVIDER_TOKEN");
+            std::env::remove_var("CMUX_PROVIDER_WORKSPACE_AUTHORITY");
+        }
     }
 
     #[test]


### PR DESCRIPTION
Summary:
- add a behavior test proving provider commands cannot inherit capability secrets
- remove CMUX_PROVIDER_WORKSPACE_AUTHORITY from provider child environments

Security: provider commands already scrub CMUX_MACHINE_PROVIDER_TOKEN. This closes the matching authority leak.

Commits intentionally separate the failing test and fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10997"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790455688&installation_model_id=21920&pr_number=10997&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10997&signature=aa5fc0858ad4d22487dec6d3c9afa60e0546172c2467d9784460e508a49429e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Provider commands no longer inherit `CMUX_PROVIDER_WORKSPACE_AUTHORITY`, closing the capability authority leak alongside the existing `CMUX_MACHINE_PROVIDER_TOKEN` scrub.

- Adds a behavior test proving provider commands cannot inherit either capability secret.

<sup>Written for commit dd5b16c77472e7b785aba3a710a3b4bff740a7f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10997?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security by preventing provider commands from inheriting sensitive capability credentials.
  * Ensures both provider authentication and workspace authority secrets are excluded from spawned processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->