### PR TITLE
Cloud tree: workspaces lead; New Display verb on workspace and display menus

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -59511,6 +59511,23 @@
         }
       }
     },
+    "cloudTree.menu.newDisplay": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Display"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新規ディスプレイ"
+          }
+        }
+      }
+    },
     "cloudTree.menu.newTerminal": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/Cloud/CloudTreeNode.swift
+++ b/Sources/Cloud/CloudTreeNode.swift
@@ -401,16 +401,11 @@ enum CloudTreeNodeBuilder {
             children.append(placeholder(machine, text: String(localized: "cloudTree.placeholder.unavailable", defaultValue: "Sessions unavailable on this machine"), style: .dimmed))
             if let displaysNode { children.append(displaysNode) }
         case .connected, .notApplicable:
-            // The pool: one row per terminal identity the machine owns, badge = views.
-            children.append(CloudTreeNode(
-                id: nodeID(terminalsPool: machine),
-                kind: .terminalsPool(machine: machine, count: terminals.count),
-                children: terminals.map { terminalNode($0, snapshot: snapshot, viewBadge: $0.remoteViews?.count) }
-            ))
-            if let displaysNode { children.append(displaysNode) }
-            // Workspaces are pointer lists: a terminal shows under every workspace that
-            // has a view of it; a zero-view terminal shows only in the pool. Empty
-            // workspaces come from the machine info, so they still get a row.
+            // Workspaces lead (they are what you work in); the pools follow as
+            // the machine's inventory. Workspaces are pointer lists: a terminal
+            // shows under every workspace that has a view of it; a zero-view
+            // terminal shows only in the pool. Empty workspaces come from the
+            // machine info, so they still get a row.
             var byWorkspace: [String: (SurfaceRemoteWorkspace, [SurfaceResource])] = [:]
             for workspace in info.remoteWorkspaces ?? [] {
                 byWorkspace[workspace.id] = (workspace, [])
@@ -446,6 +441,13 @@ enum CloudTreeNodeBuilder {
                     children: workspaceNodes
                 ))
             }
+            // The pool: one row per terminal identity the machine owns, badge = views.
+            children.append(CloudTreeNode(
+                id: nodeID(terminalsPool: machine),
+                kind: .terminalsPool(machine: machine, count: terminals.count),
+                children: terminals.map { terminalNode($0, snapshot: snapshot, viewBadge: $0.remoteViews?.count) }
+            ))
+            if let displaysNode { children.append(displaysNode) }
         }
         // Ports are out of the tree for now (still in the catalog: the CLI and
         // `cmux vm open <id>:port/<n>` keep working); the rows return with the

--- a/Sources/Cloud/CloudTreeOutlineView.swift
+++ b/Sources/Cloud/CloudTreeOutlineView.swift
@@ -405,15 +405,14 @@ struct CloudTreeOutlineView: NSViewRepresentable {
                 ]
             case .displaysPool(let machine, _):
                 return [
-                    item(String(localized: "machines.menu.openDesktop", defaultValue: "Open Desktop")) { [nodeActions] in
-                        nodeActions.project(SurfaceResourceID(machine: machine, kind: .display, key: SurfaceResourceID.desktopDisplayKey), .split, true)
-                    },
+                    newDisplayItem(machine),
                     item(String(localized: "cloudTree.menu.refresh", defaultValue: "Refresh")) { [nodeActions] in nodeActions.refresh() },
                 ]
             case .workspacesGroup(let machine):
                 return [
                     item(String(localized: "cloudTree.menu.newWorkspace", defaultValue: "New Workspace")) { [nodeActions] in nodeActions.newWorkspace(machine) },
                     item(String(localized: "cloudTree.menu.newTerminal", defaultValue: "New Terminal")) { [nodeActions] in nodeActions.newTerminal(machine, nil) },
+                    newDisplayItem(machine),
                     item(String(localized: "cloudTree.menu.refresh", defaultValue: "Refresh")) { [nodeActions] in nodeActions.refresh() },
                 ]
             case .workspace(let machine, let workspace, _):
@@ -422,6 +421,7 @@ struct CloudTreeOutlineView: NSViewRepresentable {
                     item(String(localized: "cloudTree.menu.openAllHere", defaultValue: "Open All Here")) { [nodeActions] in nodeActions.openGroup(machine, group, .split, workspace.id) },
                     item(String(localized: "cloudTree.menu.openAllInNewTabs", defaultValue: "Open All in New Tabs")) { [nodeActions] in nodeActions.openGroup(machine, group, .tab, workspace.id) },
                     item(String(localized: "cloudTree.menu.newTerminalHere", defaultValue: "New Terminal Here")) { [nodeActions] in nodeActions.newTerminal(machine, workspace.id) },
+                    newDisplayItem(machine),
                     .separator(),
                     item(String(localized: "cloudTree.menu.copyWorkspaceID", defaultValue: "Copy Workspace ID")) { [nodeActions] in nodeActions.copyToPasteboard(workspace.id) },
                 ]
@@ -501,6 +501,15 @@ struct CloudTreeOutlineView: NSViewRepresentable {
             let item = CloudTreeMenuItem(title: title, action: action)
             item.target = item
             return item
+        }
+
+        /// "New Display" opens another view of the machine's one desktop (a new
+        /// pane every time). It becomes a real display creation when the daemon
+        /// can create them (T10).
+        private func newDisplayItem(_ machine: SurfaceMachineID) -> NSMenuItem {
+            item(String(localized: "cloudTree.menu.newDisplay", defaultValue: "New Display")) { [nodeActions] in
+                nodeActions.project(SurfaceResourceID(machine: machine, kind: .display, key: SurfaceResourceID.desktopDisplayKey), .split, false)
+            }
         }
 
         // MARK: Drag source

--- a/Sources/Cloud/CloudTreeRowContentView.swift
+++ b/Sources/Cloud/CloudTreeRowContentView.swift
@@ -713,10 +713,10 @@ struct CloudTreeRowHoverButtons: View {
                 nodeActions.newTerminal(machine, nil)
             }
         case .displaysPool(let machine, _):
-            // The daemon cannot create displays yet (T10); until then "+" shows
-            // the machine's one desktop, reusing a pane that already does.
-            plus(String(localized: "machines.menu.openDesktop", defaultValue: "Open Desktop")) {
-                nodeActions.project(SurfaceResourceID(machine: machine, kind: .display, key: SurfaceResourceID.desktopDisplayKey), .split, true)
+            // The daemon cannot create displays yet (T10); until then "New
+            // Display" opens another pane on the machine's one desktop.
+            plus(String(localized: "cloudTree.menu.newDisplay", defaultValue: "New Display")) {
+                nodeActions.project(SurfaceResourceID(machine: machine, kind: .display, key: SurfaceResourceID.desktopDisplayKey), .split, false)
             }
         case .workspacesGroup(let machine):
             plus(String(localized: "cloudTree.menu.newWorkspace", defaultValue: "New Workspace")) {

--- a/cmuxTests/MachinesPanelModelTests.swift
+++ b/cmuxTests/MachinesPanelModelTests.swift
@@ -450,10 +450,10 @@ final class MachinesPanelModelTests: XCTestCase {
         if case .localWorkspace(let row) = flattened[1].kind { XCTAssertEqual(row.title, "cmux90"); XCTAssertTrue(row.isSelected) } else { XCTFail("expected local workspace") }
         XCTAssertEqual(flattened.compactMap { $0.dragResource?.id.rawValue }, [
             "local/terminal/AAA",
+            "vivid-newt/terminal/term_1", "vivid-newt/terminal/term_1",
             "vivid-newt/terminal/term_1", "vivid-newt/terminal/term_2",
             "vivid-newt/display/display:1",
-            "vivid-newt/terminal/term_1", "vivid-newt/terminal/term_1",
-        ], "pool rows, then one drag resource per pointer row")
+        ], "workspace pointer rows precede pool rows, with one drag resource per visible row")
         XCTAssertTrue(flattened[0].isMachineRow)
         XCTAssertTrue(flattened[3].isMachineRow)
         XCTAssertEqual(flattened[3].machine, .cloud("vivid-newt"))

--- a/cmuxTests/MachinesPanelModelTests.swift
+++ b/cmuxTests/MachinesPanelModelTests.swift
@@ -372,7 +372,7 @@ final class MachinesPanelModelTests: XCTestCase {
         )
     }
 
-    func testCloudTreePoolsThenWorkspacePointerLists() {
+    func testCloudTreeWorkspacesThenPoolsAndPointerLists() {
         let ws0 = SurfaceRemoteWorkspace(id: "ws_main", name: "main", index: 0, focused: true)
         let ws1 = SurfaceRemoteWorkspace(id: "ws_side", name: "side", index: 1, focused: false)
         let wsEmpty = SurfaceRemoteWorkspace(id: "ws_empty", name: "scratch", index: 2, focused: false)
@@ -405,17 +405,17 @@ final class MachinesPanelModelTests: XCTestCase {
             "machine:local/ws/\(local.uuidString)",
             "resource:local/terminal/AAA",
             "machine:vivid-newt",
-            "machine:vivid-newt/terminals",
-            "resource:vivid-newt/terminal/term_1",
-            "resource:vivid-newt/terminal/term_2",
-            "machine:vivid-newt/displays",
-            "resource:vivid-newt/display/display:1",
             "machine:vivid-newt/workspaces",
             "machine:vivid-newt/ws/ws_main",
             "machine:vivid-newt/ws/ws_main/resource:vivid-newt/terminal/term_1",
             "machine:vivid-newt/ws/ws_side",
             "machine:vivid-newt/ws/ws_side/resource:vivid-newt/terminal/term_1",
             "machine:vivid-newt/ws/ws_empty",
+            "machine:vivid-newt/terminals",
+            "resource:vivid-newt/terminal/term_1",
+            "resource:vivid-newt/terminal/term_2",
+            "machine:vivid-newt/displays",
+            "resource:vivid-newt/display/display:1",
         ])
         XCTAssertFalse(ids.contains { $0.contains("port") }, "ports stay out of the tree for now")
         let flattened = CloudTreeNodeBuilder.flattened(nodes)


### PR DESCRIPTION
Follow-ups from the wave-0 dogfood (plan doc D9-D11):

- Workspaces now render above the Terminals and Displays pools under each cloud machine. Workspaces are what you work in; the pools are inventory.
- One shared "New Display" verb (localized en+ja): right-click on a workspace row, the Workspaces group, or the Displays pool, and the Displays pool hover "+". It opens a new pane on the machine's one desktop; it becomes real display creation when the daemon can create displays (T10).

The Displays pool "+" changes from "Open Desktop" (focus existing) to "New Display" (new pane every time); single-clicking the Desktop row keeps the focus-existing behavior.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790458705&installation_model_id=21920&pr_number=11001&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11001&signature=9d59a0835f42cb028cd8319aaa3bd71de68058347f10b934ae57a8ea4c2d385c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reorders the cloud tree so workspaces render above the Terminals and Displays pools under each machine, and replaces "Open Desktop" with a shared "New Display" verb on workspace and display menus.

**Behavior change**

- "New Display" opens a new pane on the machine's existing display; it no longer reuses an already-open pane.
- The action is a no-op when the machine's catalog has no display yet, until the daemon reports one.
- Right-clicking the Displays pool offers "New Display" instead of "Open Desktop" only when the pool has at least one display; single-clicking the Desktop row keeps the focus-existing behavior.
- "New Display" appears on workspace rows, the Workspaces group, and the Displays pool hover "+", localized in English and Japanese.

<sup>Written for commit dddd6cbb4d9c63d7932233bf3749b30c3c3c82f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “New Display” option to cloud machine, workspace, and display menus.
  * New displays now open in a separate pane instead of reusing an existing one.
  * Added Japanese translation for the new menu item.

* **Improvements**
  * Reordered cloud tree items so workspaces appear before terminals and displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->