### PR TITLE
ios: attribute terminal-output latency to queue wait vs actor hop

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalOutputDelivery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalOutputDelivery.swift
@@ -447,6 +447,19 @@ extension MobileShellComposite {
                 "terminal.output.pending surface=\(surfaceID) depth=\(pendingCount)"
             )
         }
+        #if DEBUG
+        // Splits the measured gate→ap.yield latency into its two owners: a
+        // chunk that enqueues behind an unfinished in-flight chunk (imm=0)
+        // waits for that apply plus a main-actor turn, while an immediately
+        // yielded chunk (imm=1) waits only for the consumer's next main-actor
+        // turn. `q` is the backlog depth left after this enqueue.
+        MobileLatencyTrace.stamp(
+            "dq",
+            "s=\(surfaceID.prefix(8).lowercased()) " +
+                "seq=\(delivery.sourceRenderGridFrame?.stateSeq ?? delivery.endSequence ?? 0) " +
+                "imm=\(immediate == nil ? 0 : 1) q=\(pendingCount)"
+        )
+        #endif
         if let immediate {
             continuation.yield(
                 MobileTerminalOutputChunk(
@@ -560,6 +573,16 @@ extension MobileShellComposite {
               terminalOutputStreamTokensBySurfaceID[surfaceID] == streamToken else {
             return
         }
+        #if DEBUG
+        // The queued chunk leaves the delivery queue only now, after its
+        // predecessor's apply completed; its own gate→ap.yield span therefore
+        // contains that entire wait. dq.next→ap.yield is the pure hop.
+        MobileLatencyTrace.stamp(
+            "dq.next",
+            "s=\(surfaceID.prefix(8).lowercased()) " +
+                "seq=\(next.sourceRenderGridFrame?.stateSeq ?? next.endSequence ?? 0)"
+        )
+        #endif
         continuation.yield(MobileTerminalOutputChunk(
             data: next.bytes,
             streamToken: streamToken,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -9140,9 +9140,14 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             #if DEBUG
             rawTerminalInputLatencyBatchNumber &+= 1
             let latencyBatchNumber = rawTerminalInputLatencyBatchNumber
+            // `route` makes transport attribution part of the trace itself: a
+            // probe run can prove which path (iroh / websocket relay /
+            // tailscale) produced its numbers instead of inferring it from
+            // the connection-method setting at analysis time.
             MobileLatencyTrace.stamp(
                 "in.send",
-                "n=\(latencyBatchNumber) bytes=\(chunk.text.utf8.count)"
+                "n=\(latencyBatchNumber) bytes=\(chunk.text.utf8.count) " +
+                    "route=\(activeRoute?.kind.rawValue ?? "none")"
             )
             let latencyBatchNumberForSend: UInt64? = latencyBatchNumber
             #else


### PR DESCRIPTION
Physical-iPhone latency traces (scripts/mobile-latency-trace on the relay branch) put gate→ap.yield at 123 ms p50, the largest stage in the 243 ms visible-echo median. That one span mixes two owners with different fixes: waiting in the one-in-flight `TerminalOutputDeliveryQueue` behind the previous chunk's apply, and waiting for the `Task { @MainActor }` consumer to get a main-actor turn.

Two DEBUG-only trace stamps split it:

- `dq` at enqueue, with `imm=` (yielded immediately vs queued) and `q=` (backlog depth after the enqueue).
- `dq.next` when `completeInFlight` promotes a queued chunk, so `dq.next→ap.yield` measures the pure actor hop for queued chunks.

`in.send` additionally records `route=<kind>` so a probe run proves which transport (iroh / websocket relay / tailscale) produced its numbers; the previous run could not attribute its results to a route from the log alone.

No runtime behavior change (all stamps compile only in DEBUG). `swift build` and the full `TerminalRawInputOrderingTests` suite pass for `Packages/iOS/CmuxMobileShell` (11/11).

Follow-up planned once a probe runs with these stamps: move VT apply off the main actor if the split shows actor starvation dominates, or coalesce/pipeline delivery if queue wait dominates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Splits the gate→ap.yield span into two DEBUG-only stamps so the 123 ms p50 can be attributed to queue wait behind the previous chunk's apply versus waiting for a main-actor turn. Adds `route=` to the `in.send` trace so a probe run can prove which transport produced its numbers instead of inferring it from the connection setting.

**Changes**
- `dq` stamps at enqueue with `imm=` (yielded or queued) and `q=` backlog depth.
- `dq.next` stamps when `completeInFlight` promotes a queued chunk, so `dq.next→ap.yield` is the pure actor hop.
- `in.send` now records `route=<kind>` (iroh / websocket relay / tailscale).
- All stamps compile only in DEBUG; no runtime behavior change. `swift build` and `TerminalRawInputOrderingTests` pass (11/11).

<sup>Written for commit 8c3bb260504f50b622158b5ce884f573ddf1c6f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Diagnostics**
  * Improved debug latency tracing for terminal output delivery, including queue depth and delivery timing.
  * Added active transport route details to input latency diagnostics for more accurate performance analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->