### PR TITLE
irx: arm binding-proof signing offline from the cached binding

### DIFF
--- a/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/IrxBrokerService.swift
+++ b/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/IrxBrokerService.swift
@@ -139,13 +139,35 @@ public actor IrxBrokerService {
                 refreshToken: pair.refresh
             )
         })
+        let dir = configuration.cacheDirectory
+        bindingCache = IrxDiskCache(fileURL: dir.appendingPathComponent("binding.json"))
+        // Warm launches skip register() for speed, but register() is what
+        // arms per-request binding-proof signing; an unarmed client sends
+        // proofless mints that the broker 403s (binding_request_proof_required)
+        // - the 08-27 INTERNAL wedge. Reconstruct the authorization offline
+        // from the cached binding and the identity key, so every request is
+        // signed from the first call regardless of registration order.
+        var retainedAuthorization: CmxIrohBindingRequestAuthorization?
+        if let snapshot = bindingCache.load(),
+            snapshot.endpointIDHex == identity.endpointIDHex,
+            let secretKey = try? CmxIrohSecretKey(bytes: identity.privateKeyData),
+            let material = try? CmxIrohIdentityMaterial(
+                secretKey: secretKey, generation: configuration.identityGeneration),
+            let endpointID = try? CmxIrohPeerIdentity(endpointID: identity.endpointIDHex)
+        {
+            retainedAuthorization = try? CmxIrohBindingRequestAuthorization(
+                bindingID: snapshot.bindingID,
+                clientNamespace: configuration.clientNamespace,
+                identity: material,
+                endpointID: endpointID
+            )
+        }
         client = try CmxIrohTrustBrokerClient(
             baseURL: configuration.baseURL,
             tokenSource: tokenSource,
-            clientNamespace: configuration.clientNamespace
+            clientNamespace: configuration.clientNamespace,
+            bindingAuthorization: retainedAuthorization
         )
-        let dir = configuration.cacheDirectory
-        bindingCache = IrxDiskCache(fileURL: dir.appendingPathComponent("binding.json"))
         trustCache = IrxDiskCache(fileURL: dir.appendingPathComponent("trust.json"))
         credentialCache = IrxDiskCache(fileURL: dir.appendingPathComponent("relay-credentials.json"))
         grantCache = IrxDiskCache(fileURL: dir.appendingPathComponent("grants.json"))
@@ -318,13 +340,36 @@ public actor IrxBrokerService {
         return snapshot.usable(at: Date())
     }
 
+    /// A broker proof rejection means the retained binding or its signing
+    /// authorization is stale server-side. Drop the cached binding so the
+    /// next provisioning attempt takes the full register() path (which
+    /// re-arms signing on this client) instead of retrying into the same
+    /// rejection forever.
+    private func invalidateBindingOnProofRejection(_ error: any Error) {
+        guard case let .rejected(statusCode, code)? = error as? CmxIrohTrustBrokerClientError,
+            statusCode == 403,
+            code == "binding_request_proof_required" || code == "invalid_binding_request_proof"
+        else { return }
+        bindingCache.clear()
+        journal.record(
+            "broker", "binding-invalidated-on-proof-rejection",
+            ["code": code ?? "-"]
+        )
+    }
+
     /// Mints fresh endpoint-bound relay credentials. Only relay URLs present
     /// in the authenticated discovery fleet are accepted, so a corrupted
     /// credential response can never point the endpoint at a foreign relay.
     public func mintRelayCredentials() async throws -> [IrxRelayCredential] {
         let startedAt = DispatchTime.now()
         let endpointID = try CmxIrohPeerIdentity(endpointID: identity.endpointIDHex)
-        let bootstrap = try await client.issueRelayBootstrap(endpointID: endpointID)
+        let bootstrap: CmxIrohRelayBootstrapResponse
+        do {
+            bootstrap = try await client.issueRelayBootstrap(endpointID: endpointID)
+        } catch {
+            invalidateBindingOnProofRejection(error)
+            throw error
+        }
         guard let tokenResponse = bootstrap.relayToken else {
             journal.record("broker", "relay-mint-empty")
             throw IrxBrokerServiceError.noCredentialsIssued
@@ -408,10 +453,16 @@ public actor IrxBrokerService {
         guard let binding = cachedBinding() else {
             throw IrxBrokerServiceError.notRegistered
         }
-        let response = try await client.issuePairGrant(
-            initiatorBindingID: binding.bindingID,
-            acceptorBindingID: acceptorBindingID
-        )
+        let response: CmxIrohPairGrantResponse
+        do {
+            response = try await client.issuePairGrant(
+                initiatorBindingID: binding.bindingID,
+                acceptorBindingID: acceptorBindingID
+            )
+        } catch {
+            invalidateBindingOnProofRejection(error)
+            throw error
+        }
         let iso = ISO8601DateFormatter()
         let fractional = ISO8601DateFormatter()
         fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]

--- a/Packages/Shared/CmuxIrxTransport/Tests/CmuxIrxTransportTests/IrxBrokerArmingTests.swift
+++ b/Packages/Shared/CmuxIrxTransport/Tests/CmuxIrxTransportTests/IrxBrokerArmingTests.swift
@@ -1,0 +1,100 @@
+import CmuxIrohTransport
+import Foundation
+import Testing
+
+@testable import CmuxIrxTransport
+
+/// Warm-launch signing regression (08-27 INTERNAL wedge): a service built on
+/// a cached binding must arm the broker client's per-request binding-proof
+/// signing WITHOUT a network register(). An unarmed client sends proofless
+/// mints that production 403s (binding_request_proof_required), permanently
+/// wedging the phone until a cold registration.
+enum IrxBrokerArmingSupport {
+    static func makeService(
+        identity: IrxIdentity,
+        cacheDirectory: URL
+    ) throws -> IrxBrokerService {
+        try IrxBrokerService(
+            configuration: .init(
+                baseURL: URL(string: "https://example.invalid")!,
+                clientNamespace: "test.cmux.arming",
+                tag: "test",
+                platform: .ios,
+                displayName: nil,
+                cacheDirectory: cacheDirectory
+            ),
+            identity: identity,
+            accessTokenPair: { nil },
+            journal: IrxJournal(subsystem: "dev.cmux.tests", category: "irx-arming")
+        )
+    }
+
+    static func identity() -> IrxIdentity {
+        var seed = Data(count: 32)
+        for index in 0..<32 { seed[index] = UInt8.random(in: 0...255) }
+        return IrxIdentity(
+            privateKeyData: seed,
+            deviceID: "d-arming-test",
+            appInstanceID: "a-arming-test"
+        )
+    }
+
+    static func seedBinding(
+        endpointIDHex: String,
+        in directory: URL
+    ) {
+        IrxDiskCache<IrxBindingSnapshot>(
+            fileURL: directory.appendingPathComponent("binding.json")
+        ).save(
+            IrxBindingSnapshot(
+                bindingID: "b-cached-arming",
+                deviceID: "d-arming-test",
+                tag: "test",
+                endpointIDHex: endpointIDHex,
+                identityGeneration: 1,
+                registeredAt: Date()
+            )
+        )
+    }
+
+    static func temporaryDirectory() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("irx-arming-\(UUID().uuidString)", isDirectory: true)
+    }
+}
+
+@Suite("broker signing arming")
+struct IrxBrokerArmingTests {
+    @Test("a cached binding arms request signing at init, before any register()")
+    func cachedBindingArmsSigning() async throws {
+        let identity = IrxBrokerArmingSupport.identity()
+        let dir = IrxBrokerArmingSupport.temporaryDirectory()
+        IrxBrokerArmingSupport.seedBinding(
+            endpointIDHex: identity.endpointIDHex, in: dir)
+        let service = try IrxBrokerArmingSupport.makeService(
+            identity: identity, cacheDirectory: dir)
+        #expect(
+            await service.hostBrokerClient.bindingAuthorizationID() == "b-cached-arming",
+            "warm launch left the broker client unsigned; every mint will 403"
+        )
+    }
+
+    @Test("a foreign endpoint's cached binding never arms signing")
+    func foreignBindingDoesNotArm() async throws {
+        let identity = IrxBrokerArmingSupport.identity()
+        let dir = IrxBrokerArmingSupport.temporaryDirectory()
+        IrxBrokerArmingSupport.seedBinding(
+            endpointIDHex: String(repeating: "ab", count: 32), in: dir)
+        let service = try IrxBrokerArmingSupport.makeService(
+            identity: identity, cacheDirectory: dir)
+        #expect(await service.hostBrokerClient.bindingAuthorizationID() == nil)
+    }
+
+    @Test("no cached binding leaves signing to register(), unarmed at init")
+    func emptyCacheDoesNotArm() async throws {
+        let service = try IrxBrokerArmingSupport.makeService(
+            identity: IrxBrokerArmingSupport.identity(),
+            cacheDirectory: IrxBrokerArmingSupport.temporaryDirectory())
+        #expect(await service.hostBrokerClient.bindingAuthorizationID() == nil)
+    }
+}


### PR DESCRIPTION
Fixes the 08-27 cmux INTERNAL outage: phones were hard-down all day with every relay-token mint rejected 403 \`binding_request_proof_required\`.

Root cause: the warm-launch fast path skips \`register()\`, which is the only place the broker client gains its binding-proof signer. The client then sends every mint unsigned, production (correctly, post-#9183 bundle isolation) rejects them all, and the retry loop re-registers a different instance while spamming account-wide route revisions every ~2s. Relaunches never heal because the fast path re-skips register each time.

Fix: reconstruct \`CmxIrohBindingRequestAuthorization\` offline from the cached binding plus the on-disk identity key in \`IrxBrokerService.init\` (the reconstruct initializer already existed for exactly this) and pass it to the client's initializer. Every request is signed from the first call, with the zero-register launch speed kept. A 403 proof rejection now also clears the cached binding so provisioning re-registers instead of looping.

Two commits: the regression test alone (red), then the fix (green). Verified red-without-fix locally. Full \`CmuxIrxTransport\` suite passes (16 tests incl. live QUIC).

Complements https://github.com/manaflow-ai/cmux/pull/10945 (provisioning backoff + register-before-mint ordering): that narrows the unsigned window, this removes the unsigned state entirely. Different files, no conflict.

Evidence: phone journal shows healthy pongs until 06:13Z, first 403 at 06:08:19Z (first renewal after a runtime recreation), then an all-day register→discover→403 loop bumping the account route revision past 36k.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11009"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790461745&installation_model_id=21920&pr_number=11009&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11009&signature=4a755c384653f24f86893cd61d1c2a693217897b11971d00b69714cf0e28ca68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the 08-27 outage where every relay-token mint was rejected 403 `binding_request_proof_required`, leaving phones hard-down all day.

Warm launches skipped `register()`, the only place the broker client gained its binding-proof signer, so all mints went out unsigned and relaunches never healed. `IrxBrokerService.init` now reconstructs `CmxIrohBindingRequestAuthorization` from the cached binding and the on-disk identity key, signing every request from the first call while preserving the zero-register launch speed. A 403 proof rejection now clears the cached binding so provisioning re-registers instead of looping.

- Adds `IrxBrokerArmingTests` covering cached, foreign, and absent bindings.
- Complements #10945 (provisioning backoff + register-before-mint ordering); that PR narrows the unsigned window, this removes it entirely.

<sup>Written for commit 167dd4f80b0b10307eefb07ebf60ae3b2595d541. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved broker startup behavior so cached binding credentials are available immediately, including before registration.
  * Prevented cached credentials for unrelated endpoints from being used.
  * Automatically clears invalid cached binding information when the broker rejects a request.

* **Tests**
  * Added coverage for startup signing behavior with valid, unrelated, and missing cached bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->