### PR TITLE
cmux-tui: avoid cloning unchanged projection subtitles

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/ui/sidebar.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/sidebar.rs
@@ -6,6 +6,7 @@
 use cmux_tui_core::Rect;
 use ratatui::Frame;
 use ratatui::style::{Color, Modifier, Style};
+use std::borrow::Cow;
 
 use super::{
     ScrollbarState, ScrollbarStyle, middle_truncate, rail, truncate, viewport_thumb_geometry,
@@ -26,8 +27,8 @@ fn projection_empty_label(resource: SidebarResourceKind) -> &'static str {
     }
 }
 
-fn projection_detail(row: &crate::sidebar_projection::ProjectionRow) -> String {
-    let Some(state) = row.agent_state.as_deref() else { return row.subtitle.clone() };
+fn projection_detail<'a>(row: &'a crate::sidebar_projection::ProjectionRow) -> Cow<'a, str> {
+    let Some(state) = row.agent_state.as_deref() else { return Cow::Borrowed(&row.subtitle) };
     let messages = &localization::catalog().sidebar;
     let state = match state {
         "working" => messages.working,
@@ -36,7 +37,11 @@ fn projection_detail(row: &crate::sidebar_projection::ProjectionRow) -> String {
         "done" => messages.done,
         _ => messages.unknown,
     };
-    if row.subtitle.is_empty() { state.to_string() } else { format!("{state} · {}", row.subtitle) }
+    if row.subtitle.is_empty() {
+        Cow::Borrowed(state)
+    } else {
+        Cow::Owned(format!("{state} · {}", row.subtitle))
+    }
 }
 
 /// The color of a workspace's unread indicator, or `None` when nothing is


### PR DESCRIPTION
## Summary
- return borrowed projection subtitles when no agent state is present
- return localized state labels by borrow and allocate only for combined detail

## Verification
- Hosted cmux-tui focused verification dispatched: https://github.com/manaflow-ai/cmux/actions/runs/33123966856
- Rust `Cow` reference: https://doc.rust-lang.org/std/borrow/enum.Cow.html

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces sidebar rendering allocations in cmux-tui by returning borrowed `Cow<str>` values from `projection_detail` where possible, instead of cloning the subtitle unconditionally. Subtitles without agent state and standalone state labels are now borrowed; an owned string is allocated only when combining a state with a non-empty subtitle. Sidebar appearance is unchanged.

<sup>Written for commit 8d118f410fa32fbff94b34e3317719015c56d3b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved sidebar rendering efficiency by reducing unnecessary text allocations.
  * Preserved the existing appearance and behavior of sidebar details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->