### PR TITLE
ci: restore Codex test target compilation

### DIFF
--- a/cmuxTests/RestorableAgentSessionIndexCodexWeakRecordTests.swift
+++ b/cmuxTests/RestorableAgentSessionIndexCodexWeakRecordTests.swift
@@ -1,3 +1,4 @@
+import CMUXAgentLaunch
 import Foundation
 import SQLite3
 import Testing


### PR DESCRIPTION
## Summary
- Add the missing explicit `CMUXAgentLaunch` import to the Codex restore regression test.
- Restore compilation of the `cmuxTests` target without changing production restore behavior.

## Testing
- Confirmed the `cmuxTests` target already links `CMUXAgentLaunch` and the test file is wired in `project.pbxproj`.
- `git diff --check` and focused source/wiring checks pass.
- The two exact-head E2E runs that exposed the issue failed only at compile time with `Cannot find 'CodexSessionResumeVerificationLimits' in scope`: [33122581420](https://github.com/manaflow-ai/cmux/actions/runs/33122581420), [33122581468](https://github.com/manaflow-ai/cmux/actions/runs/33122581468).

## Issues
- Fixes https://github.com/manaflow-ai/cmux/issues/11011


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the `cmuxTests` target compilation by adding the missing `CMUXAgentLaunch` import to the Codex restore regression test. The test target previously failed to compile with `Cannot find 'CodexSessionResumeVerificationLimits' in scope`; production restore behavior is unchanged. Fixes #11011.

<sup>Written for commit 2e4eb00e2ac608e2fe219dba796f875b76722efb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Codex session restoration tests to include the required agent launch module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->