### PR TITLE
test(cmux-remote): hang the fake ssh without spawning a second process

### DIFF
--- a/cmux-tui/crates/cmux-remote/src/ssh_bootstrap.rs
+++ b/cmux-tui/crates/cmux-remote/src/ssh_bootstrap.rs
@@ -794,6 +794,21 @@ impl BootstrapError {
 mod tests {
     use super::*;
 
+    /// A FIFO no writer ever opens. A fake ssh that ends in `exec < fifo`
+    /// blocks in the shell's own open() forever, so the hang needs no second
+    /// process; `exec /bin/sleep` here used to fail under full-suite fork
+    /// pressure, exit the fake early, and turn the expected error into a
+    /// different variant (issue #10384).
+    #[cfg(unix)]
+    fn make_blocking_fifo(directory: &Path) -> String {
+        use std::os::unix::ffi::OsStrExt;
+
+        let fifo = directory.join("block");
+        let path = std::ffi::CString::new(fifo.as_os_str().as_bytes()).unwrap();
+        assert_eq!(unsafe { libc::mkfifo(path.as_ptr(), 0o600) }, 0);
+        fifo.to_string_lossy().into_owned()
+    }
+
     #[test]
     fn upload_command_writes_only_after_exclusive_directory_creation() {
         let command = upload_command(
@@ -1215,9 +1230,10 @@ mod tests {
         let script = directory.path().join("ssh");
         let pid_file = directory.path().join("pid");
         let pid_file_path = pid_file.display();
+        let fifo_path = make_blocking_fifo(directory.path());
         fs::write(
             &script,
-            format!("#!/bin/sh\nprintf '%s' \"$$\" > '{pid_file_path}'\nexec /bin/sleep 30\n"),
+            format!("#!/bin/sh\nprintf '%s' \"$$\" > '{pid_file_path}'\nexec < '{fifo_path}'\n"),
         )
         .unwrap();
         fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
@@ -1226,7 +1242,10 @@ mod tests {
         config.ssh_binary = script.to_string_lossy().into_owned();
         config.timeout = Duration::from_secs(5);
         let error = SshBootstrapper::new(config).unwrap().probe().await.unwrap_err();
-        assert!(matches!(error, BootstrapError::Timeout));
+        assert!(
+            matches!(error, BootstrapError::Timeout),
+            "a hung ssh must surface BootstrapError::Timeout, got {error:?}"
+        );
 
         let pid = fs::read_to_string(pid_file).unwrap().parse::<libc::pid_t>().unwrap();
         assert_eq!(unsafe { libc::kill(pid, 0) }, -1);
@@ -1247,10 +1266,11 @@ mod tests {
             "stderr" => " >&2",
             _ => panic!("unsupported test stream {stream}"),
         };
+        let fifo_path = make_blocking_fifo(directory.path());
         fs::write(
             &script,
             format!(
-                "#!/bin/sh\nprintf '%s' \"$$\" > '{pid_file_path}'\ni=0\nwhile [ \"$i\" -lt 4097 ]; do\n  printf x{redirect}\n  i=$((i + 1))\ndone\nexec /bin/sleep 30\n"
+                "#!/bin/sh\nprintf '%s' \"$$\" > '{pid_file_path}'\ni=0\nwhile [ \"$i\" -lt 4097 ]; do\n  printf x{redirect}\n  i=$((i + 1))\ndone\nexec < '{fifo_path}'\n"
             ),
         )
         .unwrap();


### PR DESCRIPTION
The flake in `timeout_kills_and_reaps_the_ssh_process` had two mechanisms. The I/O half is already closed on main: `run_child_with_timeout` maps a pipe error that races the expired budget to `BootstrapError::Timeout` (landed 2026-08-23; the stale branch `issue-10384-tui` duplicates that change and can be deleted). The remaining half is load-sensitive process spawning: the fake ssh ended in `exec /bin/sleep 30`, and under full-suite fork pressure that exec can fail, so the fake exits quickly with a nonzero status and `probe()` correctly returns `Remote{..}` instead of `Timeout`.

This makes the fake hang without a second process: the script ends in `exec < fifo` on a FIFO that never gets a writer, so the shell blocks in its own open() regardless of fork/exec pressure. The assertion now prints the actual error variant, so any future recurrence identifies itself instead of printing `false`. The oversized-output fakes shared the `exec /bin/sleep` pattern and get the same treatment.

Principled: it removes the test's dependency on resources the scenario never needed, rather than widening timeouts or retrying. Test-only change, so no red/green commit split applies.

Fixes https://github.com/manaflow-ai/cmux/issues/10384

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the flake in the `timeout_kills_and_reaps_the_ssh_process` test from issue #10384 by making the fake ssh hang on a FIFO without spawning a second process. This removes the dependency on fork/exec pressure, and the assertion now prints the actual error variant so any future recurrence identifies itself.

<sup>Written for commit 37bde229bf7b6705a2c5e3a58f1ec7e69d4b9123. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for SSH timeout handling and oversized-output scenarios.
  * Added more deterministic test conditions for blocked input streams.
  * Enhanced timeout diagnostics to make test failures easier to understand.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->