### PR TITLE
iOS: cap the toolbar title at a fixed maximum width

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileLeadingToolbarTitleWidth.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileLeadingToolbarTitleWidth.swift
@@ -62,7 +62,14 @@ struct MobileLeadingToolbarTitleWidth {
     /// dynamic reserves below still shrink the cap for safety at narrow
     /// widths, but they can no longer stretch it), so the pill is fixed-max
     /// and leftover bar width deliberately stays empty.
-    static let maximumMeasuredCap: CGFloat = unmeasuredFallback
+    ///
+    /// 180 never touches the smallest supported iPhones: the dynamic
+    /// first-pass reserve is `width - 252`, so a 320pt zoomed SE caps at
+    /// 68pt and the 375pt iOS-18 floor (XS/SE/mini) at 123pt, well under
+    /// the ceiling. It binds only at roughly 400pt-and-wider bars, where
+    /// the reserve math (dogfood-proven at 402pt and 440pt) still guards
+    /// over-commit independently.
+    static let maximumMeasuredCap: CGFloat = 180
     static let floor: CGFloat = 96
 
     init(

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileLeadingToolbarTitleWidth.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileLeadingToolbarTitleWidth.swift
@@ -4,8 +4,9 @@ import CoreGraphics
 ///
 /// The workspace title belongs beside the back button, not in the centered
 /// principal slot. Reserve the trailing toolbar cluster and the leading back
-/// control so the title truncates before it can underlap native toolbar items;
-/// beyond those reserves the title may use all remaining bar width.
+/// control so the title truncates before it can underlap native toolbar items.
+/// The title is fixed-max (`maximumMeasuredCap`): the reserves below only ever
+/// shrink it further at narrow widths; free bar width never stretches it.
 ///
 /// iOS overflows toolbar items into a trailing More menu whenever the bar's
 /// contents do not fit, and below iOS 27 there is no public priority to keep
@@ -56,6 +57,12 @@ struct MobileLeadingToolbarTitleWidth {
     /// than the original constants and the bar un-collapses.
     static let collapseRecoveryReserve: CGFloat = 28
     static let unmeasuredFallback: CGFloat = 140
+    /// Hard ceiling: the title never grows into free bar width. A flexible
+    /// title was the destabilizing input behind every More-menu fold (the
+    /// dynamic reserves below still shrink the cap for safety at narrow
+    /// widths, but they can no longer stretch it), so the pill is fixed-max
+    /// and leftover bar width deliberately stays empty.
+    static let maximumMeasuredCap: CGFloat = unmeasuredFallback
     static let floor: CGFloat = 96
 
     init(
@@ -80,7 +87,10 @@ struct MobileLeadingToolbarTitleWidth {
         guard contentWidth > 0 else { return Self.unmeasuredFallback }
         let leading = hasBackButton ? Self.backButtonReserve : 0
         let recovery = hadTrailingCollapse ? Self.collapseRecoveryReserve : 0
-        return max(0, contentWidth - leading - trailingReserve - Self.barMarginsAndSpacing - recovery)
+        return min(
+            Self.maximumMeasuredCap,
+            max(0, contentWidth - leading - trailingReserve - Self.barMarginsAndSpacing - recovery)
+        )
     }
 
     private var trailingReserve: CGFloat {

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileLeadingToolbarTitleWidthTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileLeadingToolbarTitleWidthTests.swift
@@ -20,10 +20,13 @@ import Testing
     }
 
     @Test func leadingTitleReservesBackAndTrailingControls() {
-        let expected = 393
+        let expected = min(
+            MobileLeadingToolbarTitleWidth.maximumMeasuredCap,
+            393
             - MobileLeadingToolbarTitleWidth.backButtonReserve
             - MobileLeadingToolbarTitleWidth.trailingReserveBase
             - MobileLeadingToolbarTitleWidth.barMarginsAndSpacing
+        )
 
         #expect(cap(393) == expected)
     }
@@ -35,20 +38,22 @@ import Testing
     @Test func noTrailingClusterReservesOnlyBackAndMargins() {
         let contentWidth: CGFloat = 220
         let withoutTrailing = cap(contentWidth, hasTrailingCluster: false)
-        let expected = contentWidth
+        let expected = min(
+            MobileLeadingToolbarTitleWidth.maximumMeasuredCap,
+            contentWidth
             - MobileLeadingToolbarTitleWidth.backButtonReserve
             - MobileLeadingToolbarTitleWidth.barMarginsAndSpacing
+        )
 
         #expect(withoutTrailing == expected)
     }
 
-    @Test func measuredWidthUsesAllRemainingSpace() {
-        let expected: CGFloat = 800
-            - MobileLeadingToolbarTitleWidth.backButtonReserve
-            - MobileLeadingToolbarTitleWidth.trailingReserveBase
-            - MobileLeadingToolbarTitleWidth.barMarginsAndSpacing
-
-        #expect(cap(800) == expected)
+    @Test func wideBarsNeverExpandTheTitlePastTheMaximumCap() {
+        // The title is fixed-max by design: free bar width stays empty
+        // instead of stretching the pill (a flexible title was the
+        // destabilizing input behind the More-menu folds).
+        #expect(cap(800) == MobileLeadingToolbarTitleWidth.maximumMeasuredCap)
+        #expect(cap(1200) == MobileLeadingToolbarTitleWidth.maximumMeasuredCap)
     }
 
     @Test func measuredTrailingItemsReplaceTheConstantEstimate() {

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileLeadingToolbarTitleWidthTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileLeadingToolbarTitleWidthTests.swift
@@ -97,14 +97,16 @@ import Testing
         // menu; a collapse born on the first pass never produces the
         // attach-then-detach signature the recovery ratchet watches, so it
         // sticks until the next remount.
+        // 300pt keeps both caps below maximumMeasuredCap so the reserve
+        // delta is observable rather than flattened by the ceiling.
         let clusterOnly = MobileLeadingToolbarTitleWidth(
-            contentWidth: 402,
+            contentWidth: 300,
             hasBackButton: true,
             hasTrailingCluster: true,
             trailingItemCount: 1
         )
         let clusterPlusChip = MobileLeadingToolbarTitleWidth(
-            contentWidth: 402,
+            contentWidth: 300,
             hasBackButton: true,
             hasTrailingCluster: true,
             trailingItemCount: 2


### PR DESCRIPTION
Per dogfood direction: stop trading More-menu risk for a flexible title. The leading title pill gets a hard 140pt ceiling (`maximumMeasuredCap`, the clamp https://github.com/manaflow-ai/cmux/pull/10376 removed): free bar width stays empty instead of stretching the pill, and the dynamic reserves, first-pass structural fallback, and collapse-recovery ratchet remain purely as shrink-for-safety mechanisms at narrow widths. A flexible title has been the destabilizing input behind every More-menu fold; with a fixed maximum the title can no longer provoke one.

Tests updated: wide bars pin at the ceiling instead of consuming remaining space; narrow-width expectations gain the clamp.

HIG note: could not fetch the HIG page from this session (network tool unavailable); the change follows the standard navigation-bar pattern of short, tail-truncated titles that never displace controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps the iOS toolbar title at a fixed 180pt maximum so it can no longer trigger More-menu folds.

- The title previously stretched into free bar width, which was the destabilizing input behind every fold; leftover bar width now stays empty.
- The dynamic reserves, first-pass structural fallback, and collapse-recovery ratchet remain only as shrink-for-safety mechanisms at narrow widths.
- Updated tests: wide bars pin at the ceiling, and the first-pass reserve test moved from 402pt to 300pt so the reserve delta stays observable below the clamp.

<sup>Written for commit 58009a1300caa83f0c88c8e27707d7d11fbaa703. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mobile toolbar title sizing so titles no longer expand to fill all available toolbar space.
  * Added a fixed maximum width for calculated titles, leaving excess toolbar space empty when appropriate.
  * Preserved existing spacing and recovery behavior while applying the width limit.

* **Tests**
  * Updated coverage to verify title widths remain within the fixed maximum on wide toolbars.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->