### PR TITLE
ios: reserve unread badge overflow before the group header chevron

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceGroupHeaderRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceGroupHeaderRow.swift
@@ -32,6 +32,21 @@ struct WorkspaceGroupHeaderRow: View, Equatable {
     @State private var renameDraft = ""
     @State private var pendingDestructiveAction: WorkspaceGroupHeaderPendingDestructiveAction?
 
+    /// Daylight between the unread badge's trailing edge and the chevron's
+    /// hit frame. Internal (not private) so layout tests can assert the
+    /// reservation math against the shipped constant.
+    static let indicatorChevronVisualGap: CGFloat = 3
+
+    /// Width reserved between the unread gutter and the chevron so the badge's
+    /// gutter overflow never reaches the chevron.
+    private var chevronLayoutGap: CGFloat {
+        WorkspaceUnreadDot.layoutGap(
+            afterGutterForDiameter: value.unreadBadgeDiameter,
+            leftShift: value.unreadIndicatorLeftShift,
+            visualGap: Self.indicatorChevronVisualGap
+        )
+    }
+
     /// The leading disclosure chevron. Its own hit target, so tapping it only
     /// collapses/expands and never opens the anchor.
     private var chevron: some View {
@@ -107,7 +122,7 @@ struct WorkspaceGroupHeaderRow: View, Equatable {
     }
 
     var body: some View {
-        HStack(spacing: 6) {
+        HStack(spacing: 0) {
             // Same leading unread gutter as workspace rows (indicator hidden
             // when read) so headers and top-level rows keep their columns
             // aligned.
@@ -116,7 +131,18 @@ struct WorkspaceGroupHeaderRow: View, Equatable {
                 leftShift: value.unreadIndicatorLeftShift,
                 diameter: value.unreadBadgeDiameter
             )
+            // The badge overflows the gutter toward the chevron, so the
+            // chevron must reserve that overflow (exactly as `WorkspaceRow`
+            // reserves it for the rail) or the badge leans on it. The gap is
+            // measured to the chevron's hit frame; its glyph centers ~5pt
+            // inside, so the optical badge-to-glyph gap matches the rows'
+            // 8pt badge-to-rail rhythm. The reservation ignores unread state,
+            // so read and unread headers keep one chevron column.
+            Spacer()
+                .frame(width: chevronLayoutGap)
             chevron
+            Spacer()
+                .frame(width: 6)
             anchorTarget
                 // The indicator itself is accessibility-hidden; VoiceOver hears
                 // the unread state on the anchor target, like workspace rows.

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceRow.swift
@@ -4,7 +4,10 @@ import CmuxMobileSupport
 import SwiftUI
 
 struct WorkspaceRow: View {
-    private static let unreadDotRailVisualGap: CGFloat = 8
+    /// Daylight between the unread badge's trailing edge and the color rail.
+    /// Internal (not private) so layout tests can assert the reservation math
+    /// against the shipped constant.
+    static let unreadDotRailVisualGap: CGFloat = 8
     private static let railTextVisualGap: CGFloat = 10
     private static let railVerticalInset: CGFloat = 5
 
@@ -138,14 +141,12 @@ struct WorkspaceRow: View {
     }
 
     private var unreadDotRailLayoutGap: CGFloat {
-        // Indicators are leading-aligned in the gutter, so the badge ends at
-        // its diameter. Reserving for it keeps the visual gap promise for
-        // badge rows and one uniform rail column for every row.
-        let indicatorTrailing = CGFloat(unreadBadgeDiameter)
-            - CGFloat(unreadIndicatorLeftShift)
-        return max(
-            0,
-            Self.unreadDotRailVisualGap + indicatorTrailing - WorkspaceUnreadDot.gutterWidth
+        // Reserving the badge's gutter overflow keeps the visual gap promise
+        // for badge rows and one uniform rail column for every row.
+        WorkspaceUnreadDot.layoutGap(
+            afterGutterForDiameter: unreadBadgeDiameter,
+            leftShift: unreadIndicatorLeftShift,
+            visualGap: Self.unreadDotRailVisualGap
         )
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceUnreadDot.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceUnreadDot.swift
@@ -17,9 +17,26 @@ struct WorkspaceUnreadDot: View {
     /// list does not drift right. Indicators are LEADING-aligned in it: the
     /// badge is wider than the dot, and anchoring both to the same left edge
     /// keeps the leading margin identical whether a row shows a dot, a badge,
-    /// or nothing. All overflow goes toward the rail, which `WorkspaceRow`'s
-    /// layout math reserves via `badgeDiameter`.
+    /// or nothing. All overflow goes toward the next element, which every
+    /// surface must reserve through ``layoutGap(afterGutterForDiameter:leftShift:visualGap:)``.
     static let gutterWidth: CGFloat = 10
+
+    /// The width a surface must lay out between the gutter and its next
+    /// element so that element keeps `visualGap` points of daylight from the
+    /// badge's trailing edge. The badge is leading-aligned in the gutter and
+    /// wider than it, so its trailing edge lands `diameter - leftShift` from
+    /// the gutter's leading edge — past the gutter itself. `WorkspaceRow`
+    /// (rail column) and `WorkspaceGroupHeaderRow` (disclosure chevron) both
+    /// space off the badge with this one formula; a surface that skips it puts
+    /// its next element inside the badge's overflow.
+    static func layoutGap(
+        afterGutterForDiameter diameter: Double,
+        leftShift: Double,
+        visualGap: CGFloat
+    ) -> CGFloat {
+        let indicatorTrailing = CGFloat(diameter) - CGFloat(leftShift)
+        return max(0, visualGap + indicatorTrailing - gutterWidth)
+    }
     let unread: MobileWorkspaceUnreadState
     var leftShift: Double = MobileDisplaySettings.defaultUnreadIndicatorLeftShift
     var diameter: Double = MobileDisplaySettings.defaultUnreadBadgeDiameter

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceUnreadIndicatorLayoutTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceUnreadIndicatorLayoutTests.swift
@@ -1,0 +1,53 @@
+import CoreGraphics
+import Testing
+@testable import CmuxMobileShellUI
+
+/// The unread badge is leading-aligned in a gutter narrower than itself, so
+/// every element laid out after the gutter must reserve the badge's overflow
+/// through `WorkspaceUnreadDot.layoutGap`. These tests pin that shared math to
+/// the shipped settings for both consumers: the workspace row's color rail and
+/// the group header's disclosure chevron (which the badge used to lean on).
+@MainActor
+@Suite struct WorkspaceUnreadIndicatorLayoutTests {
+    /// Where the badge's trailing edge lands, measured from the gutter's
+    /// leading edge, for the shipped badge geometry.
+    private var shippedBadgeTrailingEdge: CGFloat {
+        CGFloat(MobileDisplaySettings.defaultUnreadBadgeDiameter)
+            - CGFloat(MobileDisplaySettings.defaultUnreadIndicatorLeftShift)
+    }
+
+    private func shippedGap(visualGap: CGFloat) -> CGFloat {
+        WorkspaceUnreadDot.layoutGap(
+            afterGutterForDiameter: MobileDisplaySettings.defaultUnreadBadgeDiameter,
+            leftShift: MobileDisplaySettings.defaultUnreadIndicatorLeftShift,
+            visualGap: visualGap
+        )
+    }
+
+    @Test func groupHeaderChevronClearsBadgeByItsVisualGap() {
+        let gap = shippedGap(visualGap: WorkspaceGroupHeaderRow.indicatorChevronVisualGap)
+        let chevronLeadingEdge = WorkspaceUnreadDot.gutterWidth + gap
+        #expect(
+            chevronLeadingEdge - shippedBadgeTrailingEdge
+                == WorkspaceGroupHeaderRow.indicatorChevronVisualGap
+        )
+    }
+
+    @Test func workspaceRowRailKeepsItsVisualGap() {
+        let gap = shippedGap(visualGap: WorkspaceRow.unreadDotRailVisualGap)
+        let railLeadingEdge = WorkspaceUnreadDot.gutterWidth + gap
+        #expect(railLeadingEdge - shippedBadgeTrailingEdge == WorkspaceRow.unreadDotRailVisualGap)
+    }
+
+    /// The lab's extremes (small badge, maximum left shift) push the badge
+    /// entirely left of the gutter; the reservation clamps at zero instead of
+    /// laying out negative width.
+    @Test func gapClampsToZeroWhenBadgeShiftsPastTheGutter() {
+        let gap = WorkspaceUnreadDot.layoutGap(
+            afterGutterForDiameter: MobileDisplaySettings.unreadBadgeDiameterRange.lowerBound,
+            leftShift: MobileDisplaySettings.unreadIndicatorLeftShiftRange.upperBound,
+            visualGap: WorkspaceGroupHeaderRow.indicatorChevronVisualGap
+        )
+        #expect(gap == 0)
+    }
+}


### PR DESCRIPTION
The iOS unread count badge (20pt, shipped in https://github.com/manaflow-ai/cmux/pull/10791) is leading-aligned in a 10pt gutter, so it overflows 8.5pt past the gutter's trailing edge. `WorkspaceRow` reserves that overflow before its color rail (8pt visual gap), but `WorkspaceGroupHeaderRow` laid its disclosure chevron out just 6pt after the gutter, inside the overflow: the badge overlapped the chevron's 22pt hit frame by 2.5pt and sat ~2.5pt from the glyph.

Fix: centralize the reservation as `WorkspaceUnreadDot.layoutGap(afterGutterForDiameter:leftShift:visualGap:)` and use it from both surfaces. The header keeps 3pt from the badge's trailing edge to the chevron's hit frame (~8pt optical to the glyph, matching the rows' badge-to-rail rhythm). The reservation ignores unread state, so read and unread headers keep one chevron column, and it tracks the Unread Indicator Lab's live diameter/shift values.

Audited scenarios: workspace rows (flat + grouped, SwiftUI List and UIKit table pipelines share `WorkspaceRow`), group header expanded (anchor count) and collapsed (summed count), read headers, selected sidebar anchor, Unread Indicator Lab previews (reuse `WorkspaceRow`). Only the header lacked the reservation. Multi-digit counts: 2 digits fit the 20pt circle without scaling; 3+ digits scale down inside the circle, same behavior as the Mac sidebar row badge (kept for parity, noted as a possible follow-up pill treatment like the Mac group header).

Tests: `WorkspaceUnreadIndicatorLayoutTests` pins the shared math for both consumers at shipped settings plus the lab-extreme zero clamp (runs in the `test-ios` package lane via `cmux.xctestplan`). A red-first regression commit was not constructible: the test asserts through the new shared seam, which does not compile against the old code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the iOS unread badge overlapping the group header's disclosure chevron. The badge overflows its 10pt gutter, so the header now reserves that overflow and keeps 3pt from the badge's trailing edge to the chevron's hit frame (~8pt optical to the glyph, matching the rows' badge-to-rail rhythm).

- Centralizes the reservation as `WorkspaceUnreadDot.layoutGap`, used by both `WorkspaceRow` and `WorkspaceGroupHeaderRow`.
- The reservation ignores unread state, so read and unread headers keep one chevron column.
- Adds `WorkspaceUnreadIndicatorLayoutTests` to pin the shared math for both consumers.

<sup>Written for commit 070fd65f127cb3cd00f8efebf3adbcb99c39f5b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spacing between unread indicators, workspace labels, and disclosure chevrons.
  * Preserved consistent visual alignment across workspace rows and group headers.
* **Tests**
  * Added coverage for unread-indicator spacing, including edge cases where the indicator extends beyond its gutter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->