### PR TITLE
cloud-vm smoke: allow blaxel and the no-provider default create path

### DIFF
--- a/web/scripts/cloud-vm/smoke-vm-api.mjs
+++ b/web/scripts/cloud-vm/smoke-vm-api.mjs
@@ -13,7 +13,7 @@ import {
   requireEnvKeys,
 } from "./projects.mjs";
 
-const usage = "Usage: smoke-vm-api.mjs [web-dir] <staging|production> [--create] [--provider e2b|freestyle|daytona] [--url https://preview.example] [--vercel-curl] [--skip-attach]";
+const usage = "Usage: smoke-vm-api.mjs [web-dir] <staging|production> [--create] [--provider e2b|freestyle|daytona|blaxel|default] [--url https://preview.example] [--vercel-curl] [--skip-attach]";
 const args = process.argv.slice(2);
 const { webDir, target, project, rest } = parseWebDirAndTarget(args, usage);
 const shouldCreate = rest.includes("--create");
@@ -23,8 +23,17 @@ const provider = optionValue(rest, "--provider") ?? "e2b";
 const targetUrl = optionValue(rest, "--url") ?? project.url;
 const REQUEST_TIMEOUT_MS = 45_000;
 
-if (shouldCreate && provider !== "e2b" && provider !== "freestyle" && provider !== "daytona") {
-  console.error("--provider must be e2b, freestyle, or daytona");
+// "default" omits the provider from the create body, exercising the same
+// server-side default-provider path real clients (CLI, Mac app) use.
+if (
+  shouldCreate &&
+  provider !== "e2b" &&
+  provider !== "freestyle" &&
+  provider !== "daytona" &&
+  provider !== "blaxel" &&
+  provider !== "default"
+) {
+  console.error("--provider must be e2b, freestyle, daytona, blaxel, or default");
   process.exit(2);
 }
 
@@ -153,14 +162,14 @@ try {
     const create = await fetchWithTimeout(`${targetUrl}/api/vm`, {
       method: "POST",
       headers: { ...authHeaders, "content-type": "application/json", "idempotency-key": `smoke-${suffix}` },
-      body: JSON.stringify({ provider }),
+      body: JSON.stringify(provider === "default" ? {} : { provider }),
     });
     const createDurationMs = Math.round(performance.now() - createStartedAt);
     const createText = await create.text();
     if (create.status !== 200) throw new Error(`POST /api/vm expected 200, got ${create.status}: ${createText}`);
     const created = JSON.parse(createText);
     if (!created.id) throw new Error("create response missing id");
-    if (created.provider !== provider) {
+    if (provider !== "default" && created.provider !== provider) {
       throw new Error(`POST /api/vm returned provider ${created.provider}, expected ${provider}`);
     }
     vmId = created.id;


### PR DESCRIPTION
The `--provider` allowlist in `web/scripts/cloud-vm/smoke-vm-api.mjs` predates the Blaxel rollout, so the production smoke could not exercise the provider production now defaults to. `--provider default` omits the provider field from the create body, which is the same server-side default-provider path real clients (CLI, Mac app) hit. `--provider blaxel` is also accepted explicitly.

Verified against production while investigating today's PostHog `cloud_vm_provision` alert: the default create resolved to blaxel (`blaxel-cmux-devbox-20260826a`, 19s), attach over `cmux-remote` (2s), destroy clean. That run is the `success: true` event at 23:21 UTC in the insight.

Operator script only; no runtime behavior change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Broadens the smoke script's `--provider` allowlist to include `blaxel` and `default`, so the production smoke can exercise the provider production now defaults to.

- `--provider default` omits the provider field from the create body, hitting the same server-side default-provider path real clients (CLI, Mac app) use.
- `--provider blaxel` is accepted explicitly.
- Verified against production: default create resolved to blaxel (19s), attach over `cmux-remote` (2s), destroy clean.
- Operator script only; no runtime behavior change.

<sup>Written for commit d86368aa9d462de1b6469beadbdf94efceff2fc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

