### PR TITLE
cmux-tui: preserve projection rail pointer routing

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -30910,8 +30910,22 @@ mod tests {
     #[test]
     fn pointer_routes_projection_rail_padding_to_projection_rail() {
         let rect = Rect { x: 4, y: 0, width: 20, height: 10 };
+        let pane = RenderedPaneRoute {
+            pane: 7,
+            surface: 9,
+            kind: Some(SurfaceKind::Pty),
+            rect,
+            bar: None,
+            omnibar: None,
+            omnibar_source_x: 0,
+            content: Rect { x: 5, y: 1, width: 18, height: 8 },
+            content_source_x: 0,
+            track: None,
+            terminal_input: None,
+        };
         let frame = RenderedPointerFrame {
             projection_rails: vec![(RailKind::Projection(0), rect)].into(),
+            panes: vec![pane].into(),
             ..Default::default()
         };
         let route = frame.route_for_mouse(&MouseEvent {

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -5916,9 +5916,10 @@ impl RenderedPointerFrame {
                 };
             }
         }
-        let pane_content_owns_cell = self.panes.iter().any(|pane| pane.content.contains(x, y));
-        for (kind, rect) in self.projection_rails.iter().copied() {
-            if !pane_content_owns_cell && rect.contains(x, y) {
+        if let Some((kind, rect)) =
+            self.projection_rails.iter().copied().find(|(_, rect)| rect.contains(x, y))
+        {
+            if !self.panes.iter().any(|pane| pane.content.contains(x, y)) {
                 return PointerRouteIdentity::Rail {
                     kind,
                     rect,
@@ -12079,7 +12080,7 @@ impl App {
             .ordered
             .iter()
             .filter_map(|placement| match placement.kind {
-                RailKind::Projection(index) => Some((placement.kind, placement.rect)),
+                RailKind::Projection(_) => Some((placement.kind, placement.rect)),
                 _ => None,
             })
             .collect::<Vec<_>>()
@@ -30911,25 +30912,25 @@ mod tests {
     #[test]
     fn pointer_routes_projection_rail_padding_to_projection_rail() {
         let rect = Rect { x: 4, y: 0, width: 20, height: 10 };
-        let pane = RenderedPaneRoute {
+        let pane = PaneArea {
             pane: 7,
             surface: 9,
-            kind: Some(SurfaceKind::Pty),
             rect,
             bar: None,
             omnibar: None,
-            omnibar_source_x: 0,
             content: Rect { x: 5, y: 1, width: 18, height: 8 },
-            content_source_x: 0,
             track: None,
-            terminal_input: None,
+            viewport: None,
         };
-        let frame = RenderedPointerFrame {
-            projection_rails: vec![(RailKind::Projection(0), rect)].into(),
-            panes: vec![pane].into(),
-            ..Default::default()
-        };
-        let padding_route = frame.route_for_mouse(&MouseEvent {
+        let mux = Mux::new("projection-rail-pointer-frame-test", SurfaceOptions::default());
+        let mut app = test_app(Session::Local(mux));
+        app.outer_size = (40, 10);
+        app.sidebar_layout.ordered =
+            vec![super::RailPlacement { kind: RailKind::Projection(0), view_index: 0, rect }];
+        app.pane_areas = vec![pane];
+        app.commit_rendered_pointer_frame();
+
+        let padding_route = app.rendered_pointer_frame.route_for_mouse(&MouseEvent {
             kind: MouseEventKind::Down(MouseButton::Left),
             column: rect.x + rect.width - 1,
             row: rect.y + rect.height - 1,
@@ -30940,14 +30941,14 @@ mod tests {
             PointerRouteIdentity::Rail { kind: RailKind::Projection(0), .. }
         ));
 
-        let content_route = frame.route_for_mouse(&MouseEvent {
+        let content_route = app.rendered_pointer_frame.route_for_mouse(&MouseEvent {
             kind: MouseEventKind::Down(MouseButton::Left),
             column: pane.content.x,
             row: pane.content.y,
             modifiers: KeyModifiers::NONE,
         });
         assert!(
-            matches!(content_route, PointerRouteIdentity::Pane { pane: routed, .. } if routed == pane)
+            matches!(content_route, PointerRouteIdentity::Pane { pane: routed, .. } if routed.pane == pane.pane)
         );
     }
 

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -5916,8 +5916,9 @@ impl RenderedPointerFrame {
                 };
             }
         }
+        let pane_content_owns_cell = self.panes.iter().any(|pane| pane.content.contains(x, y));
         for (kind, rect) in self.projection_rails.iter().copied() {
-            if rect.contains(x, y) {
+            if !pane_content_owns_cell && rect.contains(x, y) {
                 return PointerRouteIdentity::Rail {
                     kind,
                     rect,
@@ -30928,13 +30929,26 @@ mod tests {
             panes: vec![pane].into(),
             ..Default::default()
         };
-        let route = frame.route_for_mouse(&MouseEvent {
+        let padding_route = frame.route_for_mouse(&MouseEvent {
             kind: MouseEventKind::Down(MouseButton::Left),
             column: rect.x + rect.width - 1,
             row: rect.y + rect.height - 1,
             modifiers: KeyModifiers::NONE,
         });
-        assert!(matches!(route, PointerRouteIdentity::Rail { kind: RailKind::Projection(0), .. }));
+        assert!(matches!(
+            padding_route,
+            PointerRouteIdentity::Rail { kind: RailKind::Projection(0), .. }
+        ));
+
+        let content_route = frame.route_for_mouse(&MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: pane.content.x,
+            row: pane.content.y,
+            modifiers: KeyModifiers::NONE,
+        });
+        assert!(
+            matches!(content_route, PointerRouteIdentity::Pane { pane: routed, .. } if routed == pane)
+        );
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -5799,6 +5799,7 @@ struct RenderedPointerFrame {
     machine_rail: Option<Rect>,
     workspace_rail: Option<Rect>,
     tabs_rail: Option<Rect>,
+    projection_rails: Arc<[(RailKind, Rect)]>,
     hits: Arc<[RenderedHitRoute]>,
     panes: Arc<[RenderedPaneRoute]>,
     terminal_pointer_semantics: Arc<HashMap<SurfaceId, TerminalPointerSemanticSnapshot>>,
@@ -5907,6 +5908,16 @@ impl RenderedPointerFrame {
             (RailKind::Tabs, self.tabs_rail),
         ] {
             if let Some(rect) = rect.filter(|rect| rect.contains(x, y)) {
+                return PointerRouteIdentity::Rail {
+                    kind,
+                    rect,
+                    column: x.saturating_sub(rect.x),
+                    row: y.saturating_sub(rect.y),
+                };
+            }
+        }
+        for (kind, rect) in self.projection_rails.iter().copied() {
+            if rect.contains(x, y) {
                 return PointerRouteIdentity::Rail {
                     kind,
                     rect,
@@ -12062,6 +12073,16 @@ impl App {
         let machine_rail = self.sidebar_layout.machine;
         let workspace_rail = self.sidebar_layout.workspace;
         let tabs_rail = self.sidebar_layout.tabs;
+        let projection_rails = self
+            .sidebar_layout
+            .ordered
+            .iter()
+            .filter_map(|placement| match placement.kind {
+                RailKind::Projection(index) => Some((placement.kind, placement.rect)),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .into();
         let pointer_map_generation = self.session.pointer_map_generation();
         let reuse_owners = action == RenderAction::Paint
             && self.rendered_pointer_frame.pointer_map_generation == pointer_map_generation;
@@ -12145,6 +12166,7 @@ impl App {
             machine_rail,
             workspace_rail,
             tabs_rail,
+            projection_rails,
             hits,
             panes,
             terminal_pointer_semantics,
@@ -30883,6 +30905,22 @@ mod tests {
             Arc::ptr_eq(&levels, &routed),
             "motion routing must clone only the Arc, not menu items"
         );
+    }
+
+    #[test]
+    fn pointer_routes_projection_rail_padding_to_projection_rail() {
+        let rect = Rect { x: 4, y: 0, width: 20, height: 10 };
+        let frame = RenderedPointerFrame {
+            projection_rails: vec![(RailKind::Projection(0), rect)].into(),
+            ..Default::default()
+        };
+        let route = frame.route_for_mouse(&MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: rect.x + rect.width - 1,
+            row: rect.y + rect.height - 1,
+            modifiers: KeyModifiers::NONE,
+        });
+        assert!(matches!(route, PointerRouteIdentity::Rail { kind: RailKind::Projection(0), .. }));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Preserve projection rail geometry in the committed pointer frame.
- Route clicks in projection rail padding to the projection rail, matching machine, workspace, and tab rails.
- Add a focused behavioral regression test.

## Testing
- Hosted filter: pointer_routes_projection_rail_padding_to_projection_rail

## Issues
- Related: https://github.com/manaflow-ai/cmux/issues/11012

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pointer routing so clicks in projection rail padding target the rail instead of falling through to panes beneath, while clicks on pane content still route to that pane.

- Projection rails now preserve their geometry in the committed pointer frame, matching machine, workspace, and tab rail behavior.
- Rail routing checks only pane content for overlap, so clicks on pane content keep their pane ownership instead of being captured by the rail.
- Adds a regression test covering both rail padding and pane content routing.
- Related to [#11012](https://github.com/manaflow-ai/cmux/issues/11012).

<sup>Written for commit 478a6f96084738e699d94afabbd96041beee4778. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11025?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mouse interaction with projection rails in the sidebar.
  * Clicks on projection rail areas, including their edges and padding, are now routed correctly instead of being assigned to an underlying pane.
  * Mouse clicks within pane content continue to be handled by the pane, ensuring accurate interaction across adjacent rail and pane areas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->