### PR TITLE
perf(cmux-tui): replay durable notices without a temporary vec

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/machine_provider_client.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_client.rs
@@ -553,7 +553,8 @@ impl ProviderClientInner {
         }
         events.acknowledged_sequence = sequence;
         events.durable_subscription = DurableSubscriptionState::Active;
-        for event in events.retained_durable.iter().cloned().collect::<Vec<_>>() {
+        for index in 0..events.retained_durable.len() {
+            let event = events.retained_durable[index].clone();
             Self::publish_to_event_subscribers(&mut events, event)?;
         }
         Ok(())

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_client.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_client.rs
@@ -1878,16 +1878,18 @@ mod tests {
                     ref consumer_id
                 }) if consumer_id == &id("cmux-process-1")
             ));
-            write_test_frame(
-                &mut stream,
-                &EventEnvelope::with_delivery(
-                    ProviderEvent::Notice(ProviderNotice {
-                        level: NoticeLevel::Warning,
-                        message: "trial has ten minutes remaining".into(),
-                    }),
-                    NoticeDelivery { notice_id: id("usage-warning-90"), sequence: 42 },
-                ),
-            );
+            for (notice_id, sequence) in [("usage-warning-90", 42), ("usage-warning-91", 43)] {
+                write_test_frame(
+                    &mut stream,
+                    &EventEnvelope::with_delivery(
+                        ProviderEvent::Notice(ProviderNotice {
+                            level: NoticeLevel::Warning,
+                            message: format!("trial warning {sequence}"),
+                        }),
+                        NoticeDelivery { notice_id: id(notice_id), sequence },
+                    ),
+                );
+            }
             write_test_frame(
                 &mut stream,
                 &ResponseEnvelope::success(subscribe.id, SubscribeNoticesResult { sequence: 41 }),
@@ -1907,13 +1909,28 @@ mod tests {
         );
         assert!(provider.is_live(), "valid replay closed the provider connection");
         let events = provider.subscribe_events().expect("subscribe to retained events");
+        let first = events
+            .recv_timeout(Duration::from_secs(2))
+            .expect("receive first replay after cursor initialization");
         assert_eq!(
-            events
-                .recv_timeout(Duration::from_secs(2))
-                .expect("receive replay after cursor initialization")
-                .delivery,
+            first.delivery,
             Some(NoticeDelivery { notice_id: id("usage-warning-90"), sequence: 42 })
         );
+        assert!(matches!(
+            first.event,
+            ProviderEvent::Notice(ProviderNotice { ref message, .. }) if message == "trial warning 42"
+        ));
+        let second = events
+            .recv_timeout(Duration::from_secs(2))
+            .expect("receive second replay after cursor initialization");
+        assert_eq!(
+            second.delivery,
+            Some(NoticeDelivery { notice_id: id("usage-warning-91"), sequence: 43 })
+        );
+        assert!(matches!(
+            second.event,
+            ProviderEvent::Notice(ProviderNotice { ref message, .. }) if message == "trial warning 43"
+        ));
 
         finish.send(()).expect("finish provider server");
         drop(provider);

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_client.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_client.rs
@@ -1904,12 +1904,14 @@ mod tests {
             client_descriptor(),
         )
         .expect("authenticate provider");
+        // Install the receiver before the cursor response so this assertion
+        // exercises complete_notice_subscription's ordered replay path.
+        let events = provider.subscribe_events().expect("subscribe to replay events");
         assert_eq!(
             provider.subscribe_notices(id("cmux-process-1")).expect("resume durable subscription"),
             SubscribeNoticesResult { sequence: 41 }
         );
         assert!(provider.is_live(), "valid replay closed the provider connection");
-        let events = provider.subscribe_events().expect("subscribe to retained events");
         let first = events
             .recv_timeout(Duration::from_secs(2))
             .expect("receive first replay after cursor initialization");


### PR DESCRIPTION
## Summary
- replay retained durable notices by index, cloning one event at a time
- preserve queue contents and front-to-back delivery order
- cover ordered multi-notice replay in the existing subscription test

The previous implementation collected the entire bounded retained queue into a temporary Vec only to release the iterator borrow before publishing. The new loop keeps the queue intact and avoids that allocation. The queue is capped at 64 events.

Validation: rustfmt check and git diff check passed locally. Hosted focused verification is required because local cmux-tui cargo builds are not allowed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replays `cmux-tui` durable notices by index instead of collecting them into a temporary `Vec`, avoiding an allocation while preserving queue contents and front-to-back delivery order.

- The subscription test now sends two notices and verifies they replay in sequence.
- Hosted focused verification is required because local `cmux-tui` cargo builds are not allowed.

<sup>Written for commit cd55ac6e3cda48f0660d1c3a93923b551341464f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11026?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved delivery of retained durable notices when resuming a subscription.
  * Ensured consecutive notices are replayed correctly and in sequence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->