### PR TITLE
test(tui): add Unicode glyph conformance invariants

### DIFF
--- a/cmux-tui/crates/ghostty-vt/tests/unicode_glyphs.rs
+++ b/cmux-tui/crates/ghostty-vt/tests/unicode_glyphs.rs
@@ -87,7 +87,7 @@ fn unicode_conformance_rows_to_runs_preserve_terminal_columns() {
 
 #[test]
 fn unicode_conformance_utf8_chunking_preserves_rendered_text() {
-    let input = "before λ 🙂 e\u{301} 赤";
+    let input = "\x1b[?2027hbefore λ 🙂 e\u{301} 赤";
     let expected = frame_for(input, 32);
     let mut terminal = Terminal::new(32, 2, 0, Callbacks::default()).unwrap();
     for chunk in input.as_bytes().chunks(1) {

--- a/cmux-tui/crates/ghostty-vt/tests/unicode_glyphs.rs
+++ b/cmux-tui/crates/ghostty-vt/tests/unicode_glyphs.rs
@@ -1,0 +1,69 @@
+use ghostty_vt::{Callbacks, CellWidth, RenderState, Terminal, rows_to_runs};
+
+fn frame_for(input: &str, cols: u16) -> ghostty_vt::RenderFrame {
+    let mut terminal = Terminal::new(cols, 2, 0, Callbacks::default()).unwrap();
+    terminal.vt_write(input.as_bytes());
+    let mut state = RenderState::new().unwrap();
+    state.update(&mut terminal).unwrap();
+    state.build_frame().unwrap()
+}
+
+#[test]
+fn unicode_conformance_preserves_grapheme_clusters_and_cell_roles() {
+    for input in ["e\u{301}", "日本語", "क्ष"] {
+        let frame = frame_for(input, 16);
+        let row = frame.styled_row(0).unwrap();
+        let visible: String = row
+            .iter()
+            .filter(|c| c.width != CellWidth::SpacerTail)
+            .filter_map(|c| (!c.text.is_empty()).then_some(c.text.as_str()))
+            .collect();
+        assert_eq!(visible, input);
+        for (index, cell) in row.iter().enumerate() {
+            if cell.width == CellWidth::Wide {
+                assert!(!cell.text.is_empty());
+                assert_eq!(row.get(index + 1).map(|next| next.width), Some(CellWidth::SpacerTail));
+            }
+            if cell.width == CellWidth::SpacerTail {
+                assert!(cell.text.is_empty());
+                assert!(index > 0 && row[index - 1].width == CellWidth::Wide);
+            }
+        }
+    }
+}
+
+#[test]
+fn unicode_conformance_rows_to_runs_are_width_accounted() {
+    let frame = frame_for("e\u{301} 日本語", 16);
+    let runs = rows_to_runs(frame.styled_rows());
+    assert!(runs.iter().flat_map(|row| row.iter()).all(|run| !run.text.is_empty()));
+    assert_eq!(
+        runs[0]
+            .iter()
+            .map(|run| run.width_hint.unwrap_or_else(|| run.text.chars().count() as u16))
+            .sum::<u16>(),
+        16
+    );
+}
+
+#[test]
+fn unicode_conformance_utf8_chunking_preserves_rendered_text() {
+    let input = "before λ 🙂 e\u{301} 赤";
+    let expected = frame_for(input, 32);
+    let mut terminal = Terminal::new(32, 2, 0, Callbacks::default()).unwrap();
+    for chunk in input.as_bytes().chunks(1) {
+        terminal.vt_write(chunk);
+    }
+    let mut state = RenderState::new().unwrap();
+    state.update(&mut terminal).unwrap();
+    let actual = state.build_frame().unwrap();
+    let text = |frame: &ghostty_vt::RenderFrame| {
+        frame
+            .styled_row(0)
+            .unwrap()
+            .iter()
+            .filter_map(|c| (!c.text.is_empty()).then_some(c.text.as_str()))
+            .collect::<String>()
+    };
+    assert_eq!(text(&actual), text(&expected));
+}

--- a/cmux-tui/crates/ghostty-vt/tests/unicode_glyphs.rs
+++ b/cmux-tui/crates/ghostty-vt/tests/unicode_glyphs.rs
@@ -92,13 +92,13 @@ fn unicode_conformance_utf8_chunking_preserves_rendered_text() {
     let mut state = RenderState::new().unwrap();
     state.update(&mut terminal).unwrap();
     let actual = state.build_frame().unwrap();
-    let text = |frame: &ghostty_vt::RenderFrame| {
+    let cells = |frame: &ghostty_vt::RenderFrame| {
         frame
             .styled_row(0)
             .unwrap()
             .iter()
-            .filter_map(|c| (!c.text.is_empty()).then_some(c.text.as_str()))
-            .collect::<String>()
+            .map(|cell| (cell.text.clone(), cell.width))
+            .collect::<Vec<_>>()
     };
-    assert_eq!(text(&actual), text(&expected));
+    assert_eq!(cells(&actual), cells(&expected));
 }

--- a/cmux-tui/crates/ghostty-vt/tests/unicode_glyphs.rs
+++ b/cmux-tui/crates/ghostty-vt/tests/unicode_glyphs.rs
@@ -10,6 +10,10 @@ fn frame_for(input: &str, cols: u16) -> ghostty_vt::RenderFrame {
     state.build_frame().unwrap()
 }
 
+fn styled_row_cells(frame: &ghostty_vt::RenderFrame) -> Vec<(String, CellWidth)> {
+    frame.styled_row(0).unwrap().iter().map(|cell| (cell.text.clone(), cell.width)).collect()
+}
+
 fn assert_grapheme_cells(input: &str, expected: &[(&str, CellWidth)]) {
     // Mode 2027 uses the terminal's extended grapheme segmentation. UAX #29
     // keeps combining marks and Indic conjuncts in one cluster, while UAX #11
@@ -92,13 +96,13 @@ fn unicode_conformance_utf8_chunking_preserves_rendered_text() {
     let mut state = RenderState::new().unwrap();
     state.update(&mut terminal).unwrap();
     let actual = state.build_frame().unwrap();
-    let cells = |frame: &ghostty_vt::RenderFrame| {
-        frame
-            .styled_row(0)
-            .unwrap()
+    let expected_cells = styled_row_cells(&expected);
+    let actual_cells = styled_row_cells(&actual);
+    assert_eq!(actual_cells, expected_cells);
+    assert!(
+        expected_cells
             .iter()
-            .map(|cell| (cell.text.clone(), cell.width))
-            .collect::<Vec<_>>()
-    };
-    assert_eq!(cells(&actual), cells(&expected));
+            .any(|(text, width)| text.is_empty() && *width == CellWidth::SpacerTail),
+        "expected fixture must retain the empty spacer tail cell"
+    );
 }

--- a/cmux-tui/crates/ghostty-vt/tests/unicode_glyphs.rs
+++ b/cmux-tui/crates/ghostty-vt/tests/unicode_glyphs.rs
@@ -35,15 +35,11 @@ fn unicode_conformance_preserves_grapheme_clusters_and_cell_roles() {
 #[test]
 fn unicode_conformance_rows_to_runs_are_width_accounted() {
     let frame = frame_for("e\u{301} 日本語", 16);
+    let row = frame.styled_row(0).unwrap();
+    assert_eq!(row.len(), usize::from(frame.size.0));
     let runs = rows_to_runs(frame.styled_rows());
     assert!(runs.iter().flat_map(|row| row.iter()).all(|run| !run.text.is_empty()));
-    assert_eq!(
-        runs[0]
-            .iter()
-            .map(|run| run.width_hint.unwrap_or_else(|| run.text.chars().count() as u16))
-            .sum::<u16>(),
-        16
-    );
+    assert!(runs[0].iter().any(|run| run.width_hint.is_some()));
 }
 
 #[test]

--- a/cmux-tui/crates/ghostty-vt/tests/unicode_glyphs.rs
+++ b/cmux-tui/crates/ghostty-vt/tests/unicode_glyphs.rs
@@ -1,5 +1,7 @@
 use ghostty_vt::{Callbacks, CellWidth, RenderState, Terminal, rows_to_runs};
 
+const TEST_COLUMNS: u16 = 16;
+
 fn frame_for(input: &str, cols: u16) -> ghostty_vt::RenderFrame {
     let mut terminal = Terminal::new(cols, 2, 0, Callbacks::default()).unwrap();
     terminal.vt_write(input.as_bytes());
@@ -8,38 +10,75 @@ fn frame_for(input: &str, cols: u16) -> ghostty_vt::RenderFrame {
     state.build_frame().unwrap()
 }
 
-#[test]
-fn unicode_conformance_preserves_grapheme_clusters_and_cell_roles() {
-    for input in ["e\u{301}", "日本語", "क्ष"] {
-        let frame = frame_for(input, 16);
-        let row = frame.styled_row(0).unwrap();
-        let visible: String = row
-            .iter()
-            .filter(|c| c.width != CellWidth::SpacerTail)
-            .filter_map(|c| (!c.text.is_empty()).then_some(c.text.as_str()))
-            .collect();
-        assert_eq!(visible, input);
-        for (index, cell) in row.iter().enumerate() {
-            if cell.width == CellWidth::Wide {
-                assert!(!cell.text.is_empty());
-                assert_eq!(row.get(index + 1).map(|next| next.width), Some(CellWidth::SpacerTail));
+fn assert_grapheme_cells(input: &str, expected: &[(&str, CellWidth)]) {
+    // Mode 2027 uses the terminal's extended grapheme segmentation. UAX #29
+    // keeps combining marks and Indic conjuncts in one cluster, while UAX #11
+    // classifies Han ideographs as wide. Ghostty represents a two-column
+    // cluster with a Wide lead and a SpacerTail.
+    let frame = frame_for(&format!("\x1b[?2027h{input}"), TEST_COLUMNS);
+    let row = frame.styled_row(0).unwrap();
+    assert_eq!(row.len(), usize::from(TEST_COLUMNS), "unexpected viewport width for {input:?}");
+
+    let mut column = 0;
+    for &(expected_text, expected_width) in expected {
+        let cell = row
+            .get(column)
+            .unwrap_or_else(|| panic!("missing lead cell at column {column} for {input:?}"));
+        assert_eq!(cell.text, expected_text, "cluster text at column {column} for {input:?}");
+        assert_eq!(cell.width, expected_width, "cluster width at column {column} for {input:?}");
+
+        match expected_width {
+            CellWidth::Narrow => column += 1,
+            CellWidth::Wide => {
+                let tail = row.get(column + 1).unwrap_or_else(|| {
+                    panic!("missing spacer tail after column {column} for {input:?}")
+                });
+                assert!(tail.text.is_empty(), "spacer tail must not contain text");
+                assert_eq!(tail.width, CellWidth::SpacerTail);
+                column += 2;
             }
-            if cell.width == CellWidth::SpacerTail {
-                assert!(cell.text.is_empty());
-                assert!(index > 0 && row[index - 1].width == CellWidth::Wide);
+            CellWidth::SpacerTail | CellWidth::SpacerHead => {
+                panic!("expected entries must name grapheme lead cells")
             }
         }
     }
+
+    assert!(
+        row[column..].iter().all(|cell| cell.width == CellWidth::Narrow && cell.text.is_empty()),
+        "unexpected occupied cells after column {column} for {input:?}"
+    );
 }
 
 #[test]
-fn unicode_conformance_rows_to_runs_are_width_accounted() {
-    let frame = frame_for("e\u{301} 日本語", 16);
+fn unicode_conformance_preserves_grapheme_clusters_and_cell_roles() {
+    assert_grapheme_cells("e\u{301}", &[("e\u{301}", CellWidth::Narrow)]);
+    assert_grapheme_cells(
+        "日本語",
+        &[("日", CellWidth::Wide), ("本", CellWidth::Wide), ("語", CellWidth::Wide)],
+    );
+    assert_grapheme_cells("क्ष", &[("क्ष", CellWidth::Wide)]);
+}
+
+#[test]
+fn unicode_conformance_rows_to_runs_preserve_terminal_columns() {
+    let frame = frame_for("\x1b[?2027he\u{301} 日本語", TEST_COLUMNS);
     let row = frame.styled_row(0).unwrap();
-    assert_eq!(row.len(), usize::from(frame.size.0));
     let runs = rows_to_runs(frame.styled_rows());
     assert!(runs.iter().flat_map(|row| row.iter()).all(|run| !run.text.is_empty()));
-    assert!(runs[0].iter().any(|run| run.width_hint.is_some()));
+
+    let source_columns: u16 = row
+        .iter()
+        .map(|cell| match cell.width {
+            CellWidth::Wide => 2,
+            CellWidth::SpacerTail => 0,
+            CellWidth::Narrow | CellWidth::SpacerHead => 1,
+        })
+        .sum();
+    assert_eq!(source_columns, TEST_COLUMNS);
+    assert_eq!(frame.size.0, TEST_COLUMNS);
+
+    assert_eq!(runs[0].len(), 1, "default styling should form one maximal run");
+    assert_eq!(runs[0][0].width_hint, Some(TEST_COLUMNS));
 }
 
 #[test]


### PR DESCRIPTION
Adds bounded behavior-level tests for UTF-8 chunking, combining marks, CJK graphemes, wide-cell spacer roles, and protocol run width accounting. No font-sensitive emoji widths are hard-coded.

Focused test: cargo test -p ghostty-vt --test unicode_glyphs (blocked locally because clean worktree Ghostty submodule lacks build.zig).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Unicode conformance tests for `ghostty-vt` that pin down grapheme cluster preservation (combining marks, CJK wide, Indic conjuncts), wide-cell spacer roles, UTF-8 chunking equivalence, and `rows_to_runs` column accounting. The chunked-write test now enables grapheme mode so partial UTF-8 writes render identically to a single write. No font-sensitive emoji widths are hard-coded; run `cargo test -p ghostty-vt --test unicode_glyphs` to execute.

<sup>Written for commit a703004f4eb714f7a9ecdda774bf54beb1304c0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for Unicode grapheme rendering, including combining marks, wide characters, and Indic text.
  * Verified terminal column preservation and consistent rendering across chunked versus single UTF-8 writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->