### PR TITLE
fix: bound initial relay connection deadline

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -3108,7 +3108,11 @@ final class SocketClient {
                     guard remaining > 0 else {
                         throw CLIError(message: "Socket connection deadline exceeded")
                     }
-                    try connectOnce(responseTimeout: remaining, deadline: deadline)
+                    try connectOnce(
+                        responseTimeout: remaining,
+                        deadline: deadline,
+                        connectionDeadline: retryDeadline
+                    )
                 } else {
                     // Relay TCP establishment must honor the short retry
                     // budget; relay authentication keeps its normal response

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -3089,8 +3089,8 @@ final class SocketClient {
         try connectWithRetry(deadline: nil)
     }
 
-    /// Connects using the remaining absolute deadline for both the socket
-    /// operation timeout and the existing short retry window.
+    /// Connects with a short establishment retry window and an optional
+    /// absolute deadline for the remaining operation.
     func connect(deadline: Date) throws {
         try connectWithRetry(deadline: deadline)
     }
@@ -3110,7 +3110,10 @@ final class SocketClient {
                     }
                     try connectOnce(responseTimeout: remaining, deadline: deadline)
                 } else {
-                    try connectOnce()
+                    // Relay TCP establishment must honor the short retry
+                    // budget; relay authentication keeps its normal response
+                    // deadline after the connection is established.
+                    try connectOnce(connectionDeadline: retryDeadline)
                 }
                 return
             } catch {
@@ -3331,13 +3334,15 @@ final class SocketClient {
 
     private func connectOnce(
         responseTimeout: TimeInterval? = nil,
-        deadline: Date? = nil
+        deadline: Date? = nil,
+        connectionDeadline: Date? = nil
     ) throws {
         if let relayEndpoint {
             try connectToRelay(
                 endpoint: relayEndpoint,
                 responseTimeout: responseTimeout,
-                deadline: deadline
+                deadline: deadline,
+                connectionDeadline: connectionDeadline
             )
             return
         }
@@ -3497,7 +3502,8 @@ final class SocketClient {
     private func connectToRelay(
         endpoint: RelayEndpoint,
         responseTimeout: TimeInterval? = nil,
-        deadline: Date? = nil
+        deadline: Date? = nil,
+        connectionDeadline: Date? = nil
     ) throws {
         let operationDeadline = deadline
             ?? Date.now.addingTimeInterval(responseTimeout ?? Self.responseTimeoutSeconds)
@@ -3505,6 +3511,10 @@ final class SocketClient {
         let timeout = try remainingSocketTimeout(
             responseTimeout: responseTimeout,
             deadline: operationDeadline
+        )
+        let socketConnectDeadline = min(
+            connectionDeadline ?? operationDeadline,
+            operationDeadline
         )
 
         socketFD = socket(AF_INET, SOCK_STREAM, 0)
@@ -3533,7 +3543,7 @@ final class SocketClient {
             throw CLIError(message: "Invalid relay endpoint \(endpoint.host):\(endpoint.port)")
         }
 
-        let connectErrno = connectSocket(deadline: operationDeadline) {
+        let connectErrno = connectSocket(deadline: socketConnectDeadline) {
             withUnsafePointer(to: &address) { pointer in
                 pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
                     Darwin.connect(socketFD, sockaddrPointer, socklen_t(MemoryLayout<sockaddr_in>.stride))


### PR DESCRIPTION
Follow-up to #11014.

The relay-backed restore path could spend its full 15-second operation deadline inside the initial TCP connect even though `SocketClient.connectWithRetry` owns a 350ms retry window. A bound-but-not-listening relay endpoint therefore prevented the restore startup waiter from starting.

This change passes the existing retry deadline only to raw relay TCP establishment while preserving the normal relay authentication/operation deadline and explicit-socket behavior. The existing delayed-relay Swift Testing regression covers the startup handoff; no production restore behavior beyond the connection deadline is changed.

Fixes #11011

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #11011 by bounding relay TCP establishment to the 350ms retry window, so a bound-but-not-listening relay endpoint no longer spends the full 15-second restore deadline inside the initial connect and blocks the startup waiter. The short deadline now applies to both retry-window and explicit-deadline relay connects, while relay authentication keeps its normal operation deadline and explicit-socket behavior is preserved.

<sup>Written for commit 27c71c00037db5e631ab465ebf2e7155c8c71377. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relay connection reliability by enforcing a short connection retry window.
  * Prevented connection attempts from exceeding their intended time limit.
  * Preserved the normal timeout for relay authentication after a connection is established.
  * Reduced delays when a relay cannot be reached, allowing the connection process to fail or retry promptly.
  * Ensured connection setup and authentication each use appropriate timing limits for a more predictable experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->