### PR TITLE
cloud VM telemetry: PostHog errors only, full outcome and error context on Axiom spans

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -176,7 +176,11 @@ CMUX_VAULT_MAX_UPLOAD_BYTES=536870912
 # Per-user cap on total committed compressed Vault bytes. Defaults to 50 GiB.
 CMUX_VAULT_MAX_USER_BYTES=53687091200
 
-# OpenTelemetry/Axiom.
+# OpenTelemetry/Axiom. The generic endpoint must be the BASE url (the SDK
+# appends /v1/traces): https://api.axiom.co, NOT https://api.axiom.co/v1/traces.
+# A suffixed value posts to /v1/traces/v1/traces and every span is dropped
+# silently (this broke production export until 2026-08-27). Headers:
+# Authorization=Bearer <ingest token>,X-Axiom-Dataset=<dataset>.
 OTEL_EXPORTER_OTLP_ENDPOINT=
 OTEL_EXPORTER_OTLP_HEADERS=
 OTEL_SERVICE_NAME=

--- a/web/app/api/vm/base/open/route.ts
+++ b/web/app/api/vm/base/open/route.ts
@@ -17,7 +17,7 @@ export async function POST(request: Request): Promise<Response> {
       timing.record("auth", authDurationMs);
       setResponseFinalizer((response) => {
         timing.finish({ status: response.status });
-        captureVmProvisionOutcome({ userId: user.id, operation: "base_open", response });
+        captureVmProvisionOutcome({ userId: user.id, operation: "base_open", response, span });
       });
       return await runBaseRoute({ request, user, operation: "open", timing });
     },

--- a/web/app/api/vm/base/reset/route.ts
+++ b/web/app/api/vm/base/reset/route.ts
@@ -17,7 +17,7 @@ export async function POST(request: Request): Promise<Response> {
       timing.record("auth", authDurationMs);
       setResponseFinalizer((response) => {
         timing.finish({ status: response.status });
-        captureVmProvisionOutcome({ userId: user.id, operation: "base_reset", response });
+        captureVmProvisionOutcome({ userId: user.id, operation: "base_reset", response, span });
       });
       return await runBaseRoute({ request, user, operation: "reset", timing });
     },

--- a/web/app/api/vm/route.ts
+++ b/web/app/api/vm/route.ts
@@ -154,7 +154,7 @@ export async function POST(request: Request): Promise<Response> {
       timing.record("auth", authDurationMs);
       setResponseFinalizer((response) => {
         timing.finish({ status: response.status });
-        captureVmProvisionOutcome({ userId: initialUser.id, operation: "create", response });
+        captureVmProvisionOutcome({ userId: initialUser.id, operation: "create", response, span });
       });
       let user: AuthedUser = initialUser;
       {

--- a/web/services/vms/observability.ts
+++ b/web/services/vms/observability.ts
@@ -1,8 +1,10 @@
 import { randomUUID } from "node:crypto";
 import { after } from "next/server";
+import { trace, type Span } from "@opentelemetry/api";
 
 import { POSTHOG_HOST, POSTHOG_PROJECT_KEY } from "../analytics/iosEventPolicy";
 import { reportError } from "../observability/report";
+import { setSpanAttributes } from "../telemetry";
 import type { VmErrorResponseInput } from "./routeHelpers";
 
 /**
@@ -14,10 +16,11 @@ export const VM_ERROR_CODE_HEADER = "x-cmux-vm-error";
 
 /**
  * Error codes that are the operator's fault, never the caller's: a
- * misconfigured deployment or an unavailable provider. These reach Sentry
- * even when their HTTP status is not a 5xx, because a user cannot fix them
- * by changing the request. User-fault errors (limits, credits, validation)
- * stay out of Sentry; they are product signals, not incidents.
+ * misconfigured deployment or an unavailable provider. A user cannot fix
+ * these by changing the request. User-fault errors (limits, credits,
+ * validation) are product signals, not incidents; alerting should filter
+ * on the `cmux.vm.error_operator_fault` span attribute or the PostHog
+ * `operator_fault` property.
  */
 const OPERATOR_FAULT_VM_ERROR_CODES: ReadonlySet<string> = new Set([
   "vm_image_config_error",
@@ -35,13 +38,37 @@ export function isOperatorFaultVmError(input: {
 }
 
 /**
- * Sentry leg of the VM error choke point. Called from `vmErrorResponse` for
- * every error response; reports only operator-fault errors. The fingerprint
- * is the error code plus provider, so one misconfiguration is one Sentry
- * issue no matter how many users hit it, and a "first seen" alert rule can
- * page without flooding.
+ * Span leg of the VM error choke point: every VM error annotates the active
+ * request span with the machine-readable code and the operator-context that
+ * must never reach the response body (provider, image, env var name,
+ * reason). Axiom is the operator-facing sink for these details; the caller
+ * only ever sees the scrubbed payload from `vmErrorResponse`.
+ */
+export function annotateVmErrorSpan(span: Span, input: VmErrorResponseInput): void {
+  const diagnostics = input.diagnostics ?? {};
+  setSpanAttributes(span, {
+    "cmux.vm.error_code": input.error,
+    "cmux.vm.error_status": input.status,
+    "cmux.vm.error_phase": input.phase ?? "unknown",
+    "cmux.vm.error_operator_fault": isOperatorFaultVmError(input),
+    "cmux.vm.error_reason": input.reason ?? input.message,
+    "cmux.vm.error_provider": stringOrUndefined(diagnostics.provider),
+    "cmux.vm.error_image": stringOrUndefined(diagnostics.image),
+    "cmux.vm.error_env_var": stringOrUndefined(diagnostics.envVar),
+  });
+}
+
+/**
+ * Log leg of the VM error choke point. Called from `vmErrorResponse` for
+ * every error response; emits a scrubbed structured log line for
+ * operator-fault errors (Vercel runtime logs) and annotates the active
+ * span so the full error context reaches Axiom. The Sentry delivery inside
+ * `reportError` is intentionally inert for this app: `instrumentation.ts`
+ * filters the shared Sentry project to coderouter events only.
  */
 export function reportVmErrorResponse(input: VmErrorResponseInput): void {
+  const activeSpan = trace.getActiveSpan();
+  if (activeSpan) annotateVmErrorSpan(activeSpan, input);
   if (!isOperatorFaultVmError(input)) return;
   const diagnostics = input.diagnostics ?? {};
   const provider = typeof diagnostics.provider === "string" ? diagnostics.provider : undefined;
@@ -63,32 +90,50 @@ export function reportVmErrorResponse(input: VmErrorResponseInput): void {
 export type VmProvisionOperation = "create" | "base_open" | "base_reset";
 
 /**
- * PostHog leg: one `cloud_vm_provision` event per provisioning attempt,
- * success or failure, keyed to the requesting user. Feeds the create
- * success-rate insight and its Slack alert. Reads only the response status
- * and the `x-cmux-vm-error` header, so it can run as a response finalizer
- * without touching the body stream.
+ * Provisioning outcome choke point, run as a response finalizer. Two legs:
+ *
+ * - Span (Axiom): every attempt, success or failure, annotates the route
+ *   span with the operation, outcome, and error code. Success-rate and
+ *   latency questions are answered from Axiom traces.
+ * - PostHog: failures only. `cloud_vm_provision` is the error signal that
+ *   feeds the provisioning-failures insight and its alert; successes stay
+ *   out of PostHog by design (2026-08-27 telemetry split).
+ *
+ * Reads only the response status and the `x-cmux-vm-error` header, so it
+ * never touches the body stream.
  */
 export function captureVmProvisionOutcome(
   input: {
     readonly userId: string;
     readonly operation: VmProvisionOperation;
     readonly response: Response;
+    readonly span?: Span;
   },
   options: {
     readonly fetch?: typeof fetch;
     readonly env?: Record<string, string | undefined>;
   } = {},
 ): void {
+  const status = input.response.status;
+  const success = status < 400;
+  const code = input.response.headers.get(VM_ERROR_CODE_HEADER) ?? undefined;
+  const span = input.span ?? trace.getActiveSpan();
+  if (span) {
+    setSpanAttributes(span, {
+      "cmux.vm.provision_operation": input.operation,
+      "cmux.vm.provision_success": success,
+      "cmux.vm.provision_error_code": code,
+    });
+  }
+  if (success) return;
   const env = options.env ?? process.env;
   if (env.VERCEL_ENV !== "production" && env.CMUX_VM_ANALYTICS_FORCE !== "1") return;
-  const status = input.response.status;
-  const code = input.response.headers.get(VM_ERROR_CODE_HEADER) ?? undefined;
   const properties: Record<string, string | number | boolean> = {
     operation: input.operation,
-    success: status < 400,
+    success,
     status,
-    schema_version: 1,
+    operator_fault: code !== undefined && isOperatorFaultVmError({ error: code, status }),
+    schema_version: 2,
     $insert_id: randomUUID(),
     $geoip_disable: true,
   };
@@ -115,4 +160,8 @@ export function captureVmProvisionOutcome(
   } catch {
     void task;
   }
+}
+
+function stringOrUndefined(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
 }

--- a/web/tests/vm-observability.test.ts
+++ b/web/tests/vm-observability.test.ts
@@ -1,11 +1,28 @@
 import { describe, expect, test } from "bun:test";
+import type { Span } from "@opentelemetry/api";
 
 import {
+  annotateVmErrorSpan,
   captureVmProvisionOutcome,
   isOperatorFaultVmError,
   VM_ERROR_CODE_HEADER,
 } from "../services/vms/observability";
 import { vmErrorResponse } from "../services/vms/routeHelpers";
+
+function fakeSpan(): { span: Span; attributes: Record<string, unknown> } {
+  const attributes: Record<string, unknown> = {};
+  const span = {
+    setAttributes(values: Record<string, unknown>) {
+      Object.assign(attributes, values);
+      return span;
+    },
+    setAttribute(key: string, value: unknown) {
+      attributes[key] = value;
+      return span;
+    },
+  } as unknown as Span;
+  return { span, attributes };
+}
 
 describe("vm error choke point", () => {
   test("every vm error response exposes the machine-readable code header", async () => {
@@ -42,7 +59,7 @@ describe("vm error choke point", () => {
     });
     const raw = JSON.stringify(await response.json());
     // Mirrors expectNoCloudVmImplementationLeaks in vm-route-auth.test.ts: the
-    // operator context flows to Sentry, never to the caller.
+    // operator context flows to the trace span, never to the caller.
     expect(raw).not.toMatch(/freestyle|FREESTYLE_|manifest|sh-[a-z0-9]{8,24}|diagnostics/i);
   });
 
@@ -54,21 +71,58 @@ describe("vm error choke point", () => {
     expect(isOperatorFaultVmError({ error: "vm_active_limit_exceeded", status: 402 })).toBe(false);
     expect(isOperatorFaultVmError({ error: "vm_invalid_request", status: 400 })).toBe(false);
   });
+
+  test("the span carries the full operator context, user-fault included", () => {
+    const { span, attributes } = fakeSpan();
+    annotateVmErrorSpan(span, {
+      error: "vm_image_config_error",
+      status: 503,
+      message: "The Cloud VM image is not available in this environment.",
+      action: "Retry in a moment.",
+      reason: "sh-17agfasevrc18c8f15nn is not listed in the Cloud VM image manifest",
+      diagnostics: { provider: "freestyle", image: "sh-17agfasevrc18c8f15nn", envVar: "FREESTYLE_SANDBOX_SNAPSHOT" },
+      phase: "create",
+    });
+    expect(attributes["cmux.vm.error_code"]).toBe("vm_image_config_error");
+    expect(attributes["cmux.vm.error_status"]).toBe(503);
+    expect(attributes["cmux.vm.error_phase"]).toBe("create");
+    expect(attributes["cmux.vm.error_operator_fault"]).toBe(true);
+    expect(attributes["cmux.vm.error_provider"]).toBe("freestyle");
+    expect(attributes["cmux.vm.error_image"]).toBe("sh-17agfasevrc18c8f15nn");
+    expect(attributes["cmux.vm.error_env_var"]).toBe("FREESTYLE_SANDBOX_SNAPSHOT");
+    expect(attributes["cmux.vm.error_reason"]).toMatch(/not listed/);
+
+    const userFault = fakeSpan();
+    annotateVmErrorSpan(userFault.span, {
+      error: "vm_billing_team_required",
+      status: 409,
+      message: "Select a team.",
+      action: "Select a team in cmux, then retry.",
+      phase: "billing",
+    });
+    expect(userFault.attributes["cmux.vm.error_code"]).toBe("vm_billing_team_required");
+    expect(userFault.attributes["cmux.vm.error_operator_fault"]).toBe(false);
+  });
 });
 
 describe("cloud_vm_provision capture", () => {
-  function captured(response: Response): Record<string, unknown> | null {
+  function captured(response: Response, span?: Span): {
+    body: Record<string, unknown> | null;
+    posthogCalled: boolean;
+  } {
     let body: Record<string, unknown> | null = null;
+    let posthogCalled = false;
     const fakeFetch = ((input: string | URL | Request, init?: RequestInit) => {
       void input;
+      posthogCalled = true;
       body = JSON.parse(String(init?.body)) as Record<string, unknown>;
       return Promise.resolve(new Response("ok"));
     }) as typeof fetch;
     captureVmProvisionOutcome(
-      { userId: "user-1", operation: "base_open", response },
+      { userId: "user-1", operation: "base_open", response, span },
       { fetch: fakeFetch, env: { CMUX_VM_ANALYTICS_FORCE: "1" } },
     );
-    return body;
+    return { body, posthogCalled };
   }
 
   test("failure events carry the error code from the response header", () => {
@@ -79,22 +133,52 @@ describe("cloud_vm_provision capture", () => {
       action: "retry",
       phase: "create",
     });
-    const body = captured(response);
+    const { body } = captured(response);
     expect(body?.event).toBe("cloud_vm_provision");
     expect(body?.distinct_id).toBe("user-1");
     const properties = body?.properties as Record<string, unknown>;
     expect(properties.success).toBe(false);
     expect(properties.status).toBe(503);
     expect(properties.error_code).toBe("vm_image_config_error");
+    expect(properties.operator_fault).toBe(true);
     expect(properties.operation).toBe("base_open");
   });
 
-  test("success events carry no error code", () => {
-    const body = captured(new Response("{}", { status: 200 }));
+  test("user-fault failures reach PostHog flagged as not operator fault", () => {
+    const response = vmErrorResponse({
+      error: "vm_billing_team_required",
+      status: 409,
+      message: "Select a team.",
+      action: "Select a team in cmux, then retry.",
+      phase: "billing",
+    });
+    const { body } = captured(response);
     const properties = body?.properties as Record<string, unknown>;
-    expect(properties.success).toBe(true);
-    expect(properties.status).toBe(200);
-    expect(properties.error_code).toBeUndefined();
+    expect(properties.error_code).toBe("vm_billing_team_required");
+    expect(properties.operator_fault).toBe(false);
+  });
+
+  test("successes never reach PostHog but still annotate the span", () => {
+    const { span, attributes } = fakeSpan();
+    const { posthogCalled } = captured(new Response("{}", { status: 200 }), span);
+    expect(posthogCalled).toBe(false);
+    expect(attributes["cmux.vm.provision_operation"]).toBe("base_open");
+    expect(attributes["cmux.vm.provision_success"]).toBe(true);
+    expect(attributes["cmux.vm.provision_error_code"]).toBeUndefined();
+  });
+
+  test("failures annotate the span with the error code", () => {
+    const { span, attributes } = fakeSpan();
+    const response = vmErrorResponse({
+      error: "vm_create_disabled",
+      status: 503,
+      message: "disabled",
+      action: "enable",
+      phase: "create",
+    });
+    captured(response, span);
+    expect(attributes["cmux.vm.provision_success"]).toBe(false);
+    expect(attributes["cmux.vm.provision_error_code"]).toBe("vm_create_disabled");
   });
 
   test("capture is disabled outside production unless forced", () => {
@@ -104,7 +188,12 @@ describe("cloud_vm_provision capture", () => {
       return Promise.resolve(new Response("ok"));
     }) as typeof fetch;
     captureVmProvisionOutcome(
-      { userId: "user-1", operation: "create", response: new Response("{}") },
+      { userId: "user-1", operation: "create", response: vmErrorResponse({
+        error: "vm_internal_error",
+        status: 500,
+        message: "boom",
+        action: "retry",
+      }) },
       { fetch: fakeFetch, env: {} },
     );
     expect(called).toBe(false);


### PR DESCRIPTION
Per the telemetry split decision (2026-08-27): PostHog is the Cloud VM error signal, Axiom traces are the operator detail sink.

- `cloud_vm_provision` (PostHog) now fires only on failures, `schema_version` 2, with an `operator_fault` property so the provisioning-failures alert can filter out user-fault errors (for example `vm_billing_team_required` 409 from a multi-team user whose client sent no `X-Cmux-Team-Id`).
- Every provisioning attempt (create, base_open, base_reset), success or failure, annotates the route span with `cmux.vm.provision_operation` / `provision_success` / `provision_error_code`.
- Every VM error response annotates the active span with `cmux.vm.error_*`: code, status, phase, operator-fault flag, provider, image, env var name, and reason. This is the operator context that is deliberately scrubbed from response bodies and that today has no working sink: the shared Sentry project is filtered to coderouter events by `instrumentation.ts`, so VM errors never reach Sentry.
- Documents in `.env.example` why `OTEL_EXPORTER_OTLP_ENDPOINT` must be the base url. Production had the `/v1/traces`-suffixed value; `@vercel/otel` appends `/v1/traces` to the generic endpoint, so every production span posted to `/v1/traces/v1/traces` and was dropped silently. The dataset `cmux-prod-otel-traces` contained zero `cmux-web-production` spans ever. I already fixed the Vercel production env value to `https://api.axiom.co`; it takes effect with the deploy of this merge.

Tests: `bun test tests/vm-observability.test.ts` (9 pass), `tests/vm-route-auth.test.ts` (55 pass), `tests/vm-image-resolver.test.ts`, `bun run typecheck`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Splits Cloud VM telemetry: PostHog now receives `cloud_vm_provision` only on failures (schema_version 2, with an `operator_fault` flag), and every provisioning attempt and every VM error annotates the active Axiom span with operation, outcome, error code, and scrubbed operator context (provider, image, env var, reason). Also fixes the OTLP endpoint so production spans are exported instead of silently dropped.

**Bug Fixes**
- Production `OTEL_EXPORTER_OTLP_ENDPOINT` was set to a `/v1/traces`-suffixed URL; the SDK appends `/v1/traces`, so spans went to `/v1/traces/v1/traces` and were dropped. The Vercel env is corrected to the base URL, and `.env.example` now documents the requirement.

<sup>Written for commit a1a433d56b943a34bd00bb2419d2b9601f8a289e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

