### PR TITLE
otel: keep all Cloud VM traces, head-sample everything else at 2%

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -184,6 +184,9 @@ CMUX_VAULT_MAX_USER_BYTES=53687091200
 OTEL_EXPORTER_OTLP_ENDPOINT=
 OTEL_EXPORTER_OTLP_HEADERS=
 OTEL_SERVICE_NAME=
+# Head-sampling ratio for non-Cloud-VM traces (0..1). Cloud VM API traces
+# (/api/vm*) are always kept; everything else defaults to 2%.
+CMUX_OTEL_BASE_SAMPLE_RATIO=
 
 # cmux-tui remote daemon on Blaxel machines (docs/cloud-cmux-tui-daemon.md) — the only
 # session daemon there; nothing to enable. The build and its sha256 come from the

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -16,6 +16,7 @@
         "@effect/sql": "0.48.6",
         "@effect/sql-pg": "0.49.7",
         "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/sdk-trace-base": "^2.9.0",
         "@orpc/client": "^1.14.7",
         "@orpc/openapi": "^1.14.7",
         "@orpc/server": "^1.14.7",
@@ -54,6 +55,7 @@
       },
       "devDependencies": {
         "@next/playwright": "16.3.0",
+        "@opentelemetry/context-async-hooks": "^2.7.1",
         "@playwright/test": "1.62.1",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
@@ -451,7 +453,7 @@
 
     "@opentelemetry/context-async-hooks": ["@opentelemetry/context-async-hooks@2.7.1", "", { "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ=="],
 
-    "@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+    "@opentelemetry/core": ["@opentelemetry/core@2.9.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw=="],
 
     "@opentelemetry/exporter-logs-otlp-grpc": ["@opentelemetry/exporter-logs-otlp-grpc@0.217.0", "", { "dependencies": { "@grpc/grpc-js": "^1.14.3", "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-exporter-base": "0.217.0", "@opentelemetry/otlp-grpc-exporter-base": "0.217.0", "@opentelemetry/otlp-transformer": "0.217.0", "@opentelemetry/sdk-logs": "0.217.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-vC5S0Dc+noxD86CVtNu1+awCHPA5Kewi1Sg23ps+9lh4YifwsKXh3pe4XTNEKtUJiAcjpJ5dqStGakLbrSE+YQ=="],
 
@@ -2285,27 +2287,69 @@
 
     "@img/sharp-webcontainers-wasm32/@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.3", "", { "dependencies": { "@emnapi/runtime": "^1.11.1" } }, "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w=="],
 
+    "@opentelemetry/configuration/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+
+    "@opentelemetry/exporter-logs-otlp-grpc/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+
+    "@opentelemetry/exporter-logs-otlp-http/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+
+    "@opentelemetry/exporter-logs-otlp-proto/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+
     "@opentelemetry/exporter-logs-otlp-proto/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw=="],
+
+    "@opentelemetry/exporter-metrics-otlp-grpc/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+
+    "@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+
+    "@opentelemetry/exporter-metrics-otlp-proto/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+
+    "@opentelemetry/exporter-prometheus/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+
+    "@opentelemetry/exporter-trace-otlp-grpc/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
 
     "@opentelemetry/exporter-trace-otlp-grpc/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw=="],
 
+    "@opentelemetry/exporter-trace-otlp-http/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+
     "@opentelemetry/exporter-trace-otlp-http/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw=="],
+
+    "@opentelemetry/exporter-trace-otlp-proto/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
 
     "@opentelemetry/exporter-trace-otlp-proto/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw=="],
 
+    "@opentelemetry/exporter-zipkin/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+
     "@opentelemetry/exporter-zipkin/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw=="],
+
+    "@opentelemetry/instrumentation-http/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+
+    "@opentelemetry/otlp-exporter-base/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+
+    "@opentelemetry/otlp-grpc-exporter-base/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+
+    "@opentelemetry/otlp-transformer/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
 
     "@opentelemetry/otlp-transformer/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw=="],
 
-    "@opentelemetry/sdk-node/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw=="],
+    "@opentelemetry/propagator-b3/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
 
-    "@opentelemetry/sdk-trace/@opentelemetry/core": ["@opentelemetry/core@2.9.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw=="],
+    "@opentelemetry/propagator-jaeger/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+
+    "@opentelemetry/resources/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+
+    "@opentelemetry/sdk-logs/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+
+    "@opentelemetry/sdk-metrics/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+
+    "@opentelemetry/sdk-node/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+
+    "@opentelemetry/sdk-node/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw=="],
 
     "@opentelemetry/sdk-trace/@opentelemetry/resources": ["@opentelemetry/resources@2.9.0", "", { "dependencies": { "@opentelemetry/core": "2.9.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg=="],
 
-    "@opentelemetry/sdk-trace-base/@opentelemetry/core": ["@opentelemetry/core@2.9.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw=="],
-
     "@opentelemetry/sdk-trace-base/@opentelemetry/resources": ["@opentelemetry/resources@2.9.0", "", { "dependencies": { "@opentelemetry/core": "2.9.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg=="],
+
+    "@opentelemetry/sdk-trace-node/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
 
     "@opentelemetry/sdk-trace-node/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw=="],
 

--- a/web/instrumentation.ts
+++ b/web/instrumentation.ts
@@ -1,11 +1,17 @@
 import { registerOTel } from "@vercel/otel";
+import { buildCmuxTraceSampler } from "./services/observability/sampler";
 import {
   scrubSentryEvent,
   shouldSendCoderouterSentryEvent,
 } from "./services/sentry";
 
 export async function register() {
-  registerOTel({ serviceName: process.env.OTEL_SERVICE_NAME ?? "cmux-web" });
+  registerOTel({
+    serviceName: process.env.OTEL_SERVICE_NAME ?? "cmux-web",
+    // Keep 100% of Cloud VM traces, sample the rest (CMUX_OTEL_BASE_SAMPLE_RATIO,
+    // default 2%). The unsampled firehose measured ~4M spans/15min in production.
+    traceSampler: buildCmuxTraceSampler(),
+  });
   if (process.env.NEXT_RUNTIME === "nodejs" && process.env.SENTRY_DSN) {
     const Sentry = await import("@sentry/nextjs");
     Sentry.init({

--- a/web/package.json
+++ b/web/package.json
@@ -49,6 +49,7 @@
     "@effect/sql": "0.48.6",
     "@effect/sql-pg": "0.49.7",
     "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/sdk-trace-base": "^2.9.0",
     "@orpc/client": "^1.14.7",
     "@orpc/openapi": "^1.14.7",
     "@orpc/server": "^1.14.7",
@@ -87,6 +88,7 @@
   },
   "devDependencies": {
     "@next/playwright": "16.3.0",
+    "@opentelemetry/context-async-hooks": "^2.7.1",
     "@playwright/test": "1.62.1",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",

--- a/web/services/observability/sampler.ts
+++ b/web/services/observability/sampler.ts
@@ -72,7 +72,16 @@ export function buildCmuxTraceSampler(
 ): Sampler {
   const ratio = baseSampleRatio(env);
   const base = ratio >= 1 ? new AlwaysOnSampler() : new TraceIdRatioBasedSampler(ratio);
-  return new ParentBasedSampler({ root: new VmPriorityRootSampler(base) });
+  const root = new VmPriorityRootSampler(base);
+  // Remote parents come from untrusted clients: a caller can send a W3C
+  // traceparent with the sampled flag set and would otherwise get the
+  // ParentBased default (AlwaysOn), bypassing the ratio entirely. Ignore the
+  // remote flag in both directions and make a fresh root decision instead.
+  return new ParentBasedSampler({
+    root,
+    remoteParentSampled: root,
+    remoteParentNotSampled: root,
+  });
 }
 
 const DEFAULT_BASE_SAMPLE_RATIO = 0.02;

--- a/web/services/observability/sampler.ts
+++ b/web/services/observability/sampler.ts
@@ -1,0 +1,86 @@
+import type { Attributes } from "@opentelemetry/api";
+import {
+  AlwaysOnSampler,
+  ParentBasedSampler,
+  SamplingDecision,
+  TraceIdRatioBasedSampler,
+  type Sampler,
+} from "@opentelemetry/sdk-trace-base";
+
+/**
+ * Cloud VM API traffic is the traffic Axiom traces exist for: it is rare
+ * (creates, base opens, attaches) and every attempt matters. Everything
+ * else on the shared app (presence heartbeats, device polls, page loads)
+ * arrives at thousands of spans per second and is only needed as a sample.
+ * When the export endpoint was fixed on 2026-08-27 the unsampled firehose
+ * measured ~4M spans per 15 minutes, almost all pg.query/fetch noise.
+ */
+export const VM_PRIORITY_PATH_PREFIX = "/api/vm";
+
+const PRIORITY_PATH_ATTRIBUTE_KEYS = ["http.route", "url.path", "http.target"] as const;
+
+/**
+ * Whether a root span, judged only by what is available at creation time,
+ * belongs to Cloud VM work. Matches the request path when the runtime
+ * provides it at start, the span name when it embeds the route, and the
+ * `cmux.subsystem` attribute that `withApiRouteSpan` stamps on re-rooted
+ * VM spans (the guaranteed signal: we control it).
+ */
+export function isVmPrioritySpan(spanName: string, attributes: Attributes): boolean {
+  if (attributes["cmux.subsystem"] === "vm-cloud") return true;
+  for (const key of PRIORITY_PATH_ATTRIBUTE_KEYS) {
+    const value = attributes[key];
+    if (typeof value === "string" && isVmPriorityPath(value)) return true;
+  }
+  return (
+    spanName.endsWith(` ${VM_PRIORITY_PATH_PREFIX}`) ||
+    spanName.includes(` ${VM_PRIORITY_PATH_PREFIX}/`)
+  );
+}
+
+/** Path-segment-aware prefix match: /api/vm and /api/vm/..., never /api/vmstats. */
+export function isVmPriorityPath(path: string): boolean {
+  if (!path.startsWith(VM_PRIORITY_PATH_PREFIX)) return false;
+  const next = path.charAt(VM_PRIORITY_PATH_PREFIX.length);
+  return next === "" || next === "/" || next === "?";
+}
+
+class VmPriorityRootSampler implements Sampler {
+  constructor(private readonly base: Sampler) {}
+
+  shouldSample(...args: Parameters<Sampler["shouldSample"]>): ReturnType<Sampler["shouldSample"]> {
+    const [, , spanName, , attributes] = args;
+    if (isVmPrioritySpan(spanName, attributes)) {
+      return { decision: SamplingDecision.RECORD_AND_SAMPLED };
+    }
+    return this.base.shouldSample(...args);
+  }
+
+  toString(): string {
+    return `VmPriorityRootSampler(${this.base.toString()})`;
+  }
+}
+
+/**
+ * The app-wide trace sampler: keep 100% of Cloud VM traces, head-sample
+ * everything else at `CMUX_OTEL_BASE_SAMPLE_RATIO` (default 2%). Children
+ * follow their root's decision, so a kept VM trace keeps its pg/fetch/
+ * provider child spans and a dropped page-load trace drops all of its own.
+ */
+export function buildCmuxTraceSampler(
+  env: Record<string, string | undefined> = process.env,
+): Sampler {
+  const ratio = baseSampleRatio(env);
+  const base = ratio >= 1 ? new AlwaysOnSampler() : new TraceIdRatioBasedSampler(ratio);
+  return new ParentBasedSampler({ root: new VmPriorityRootSampler(base) });
+}
+
+const DEFAULT_BASE_SAMPLE_RATIO = 0.02;
+
+function baseSampleRatio(env: Record<string, string | undefined>): number {
+  const raw = env.CMUX_OTEL_BASE_SAMPLE_RATIO?.trim();
+  if (!raw) return DEFAULT_BASE_SAMPLE_RATIO;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return DEFAULT_BASE_SAMPLE_RATIO;
+  return parsed;
+}

--- a/web/services/telemetry.ts
+++ b/web/services/telemetry.ts
@@ -1,9 +1,16 @@
 import {
+  context as otelContext,
+  ROOT_CONTEXT,
   SpanStatusCode,
   trace,
+  TraceFlags,
   type Attributes,
+  type Context,
+  type Link,
   type Span,
 } from "@opentelemetry/api";
+
+import { isVmPriorityPath } from "./observability/sampler";
 
 type AttributeValue = string | number | boolean;
 export type MaybeAttributes = Record<string, AttributeValue | null | undefined>;
@@ -14,20 +21,26 @@ export async function withSpan<T>(
   name: string,
   attributes: MaybeAttributes,
   fn: SpanCallback<T>,
+  options: { readonly context?: Context; readonly links?: Link[] } = {},
 ): Promise<T> {
   const tracer = trace.getTracer(tracerName);
-  return tracer.startActiveSpan(name, { attributes: cleanAttributes(attributes) }, async (span) => {
-    const start = performance.now();
-    try {
-      return await fn(span);
-    } catch (err) {
-      recordSpanError(span, err);
-      throw err;
-    } finally {
-      span.setAttribute("cmux.duration_ms", Math.round((performance.now() - start) * 100) / 100);
-      span.end();
-    }
-  });
+  return tracer.startActiveSpan(
+    name,
+    { attributes: cleanAttributes(attributes), links: options.links },
+    options.context ?? otelContext.active(),
+    async (span) => {
+      const start = performance.now();
+      try {
+        return await fn(span);
+      } catch (err) {
+        recordSpanError(span, err);
+        throw err;
+      } finally {
+        span.setAttribute("cmux.duration_ms", Math.round((performance.now() - start) * 100) / 100);
+        span.end();
+      }
+    },
+  );
 }
 
 export async function withApiRouteSpan<T extends Response>(
@@ -37,6 +50,16 @@ export async function withApiRouteSpan<T extends Response>(
   fn: SpanCallback<T>,
 ): Promise<T> {
   const path = requestPath(request);
+  // Cloud VM API spans must survive head sampling even when the surrounding
+  // Next.js request trace was dropped: re-root them into their own trace
+  // (linked back to the dropped one) so the priority sampler sees the
+  // vm-cloud attributes on a root span and keeps the whole VM subtree.
+  const parent = trace.getSpanContext(otelContext.active());
+  const reRoot =
+    isVmPriorityPath(route) &&
+    parent !== undefined &&
+    (parent.traceFlags & TraceFlags.SAMPLED) === 0;
+  const links = reRoot && trace.isSpanContextValid(parent) ? [{ context: parent }] : undefined;
   return withSpan(
     "cmux-api",
     `cmux.api.${request.method} ${route}`,
@@ -57,6 +80,7 @@ export async function withApiRouteSpan<T extends Response>(
       }
       return response;
     },
+    { context: reRoot ? ROOT_CONTEXT : undefined, links },
   );
 }
 

--- a/web/services/telemetry.ts
+++ b/web/services/telemetry.ts
@@ -1,6 +1,5 @@
 import {
   context as otelContext,
-  ROOT_CONTEXT,
   SpanStatusCode,
   trace,
   TraceFlags,
@@ -80,7 +79,9 @@ export async function withApiRouteSpan<T extends Response>(
       }
       return response;
     },
-    { context: reRoot ? ROOT_CONTEXT : undefined, links },
+    // deleteSpan, not ROOT_CONTEXT: only the dropped parent span leaves the
+    // context; baggage and other context values stay with the request.
+    { context: reRoot ? trace.deleteSpan(otelContext.active()) : undefined, links },
   );
 }
 

--- a/web/services/vms/observability.ts
+++ b/web/services/vms/observability.ts
@@ -132,7 +132,9 @@ export function captureVmProvisionOutcome(
     operation: input.operation,
     success,
     status,
-    operator_fault: code !== undefined && isOperatorFaultVmError({ error: code, status }),
+    // A missing code on a 5xx (a response that bypassed vmErrorResponse) is
+    // still an operator fault; isOperatorFaultVmError treats every 5xx as one.
+    operator_fault: isOperatorFaultVmError({ error: code ?? "", status }),
     schema_version: 2,
     $insert_id: randomUUID(),
     $geoip_disable: true,

--- a/web/tests/telemetry-sampler.test.ts
+++ b/web/tests/telemetry-sampler.test.ts
@@ -35,6 +35,35 @@ describe("buildCmuxTraceSampler", () => {
     );
   });
 
+  test("a client-sent sampled traceparent cannot bypass the ratio", () => {
+    const remoteSampled = trace.setSpanContext(root, {
+      traceId: "2af7651916cd43dd8448eb211c80319c",
+      spanId: "c7ad6b7169203331",
+      traceFlags: TraceFlags.SAMPLED,
+      isRemote: true,
+    });
+    expect(
+      neverSample.shouldSample(
+        remoteSampled,
+        "2af7651916cd43dd8448eb211c80319c",
+        "GET /",
+        1,
+        { "http.route": "/" },
+        [],
+      ).decision,
+    ).toBe(SamplingDecision.NOT_RECORD);
+    expect(
+      neverSample.shouldSample(
+        remoteSampled,
+        "2af7651916cd43dd8448eb211c80319c",
+        "POST /api/vm",
+        1,
+        { "http.route": "/api/vm" },
+        [],
+      ).decision,
+    ).toBe(SamplingDecision.RECORD_AND_SAMPLED);
+  });
+
   test("everything else follows the base ratio", () => {
     expect(decideRoot("GET /", { "http.route": "/" })).toBe(SamplingDecision.NOT_RECORD);
     expect(decideRoot("GET /api/devices", { "http.route": "/api/devices" })).toBe(

--- a/web/tests/telemetry-sampler.test.ts
+++ b/web/tests/telemetry-sampler.test.ts
@@ -1,0 +1,141 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { context as otelContext, trace, TraceFlags } from "@opentelemetry/api";
+import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks";
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SamplingDecision,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+
+import { buildCmuxTraceSampler, isVmPrioritySpan } from "../services/observability/sampler";
+import { withApiRouteSpan } from "../services/telemetry";
+
+describe("buildCmuxTraceSampler", () => {
+  const neverSample = buildCmuxTraceSampler({ CMUX_OTEL_BASE_SAMPLE_RATIO: "0" });
+  const root = otelContext.active();
+
+  function decideRoot(name: string, attributes: Record<string, string>): SamplingDecision {
+    return neverSample.shouldSample(root, "0af7651916cd43dd8448eb211c80319c", name, 1, attributes, [])
+      .decision;
+  }
+
+  test("vm routes are always kept, judged by creation-time signals", () => {
+    expect(decideRoot("POST /api/vm", { "http.route": "/api/vm" })).toBe(
+      SamplingDecision.RECORD_AND_SAMPLED,
+    );
+    expect(decideRoot("POST", { "http.target": "/api/vm/abc/attach-endpoint" })).toBe(
+      SamplingDecision.RECORD_AND_SAMPLED,
+    );
+    expect(decideRoot("cmux.api.POST /api/vm/base/open", {})).toBe(
+      SamplingDecision.RECORD_AND_SAMPLED,
+    );
+    expect(decideRoot("anything", { "cmux.subsystem": "vm-cloud" })).toBe(
+      SamplingDecision.RECORD_AND_SAMPLED,
+    );
+  });
+
+  test("everything else follows the base ratio", () => {
+    expect(decideRoot("GET /", { "http.route": "/" })).toBe(SamplingDecision.NOT_RECORD);
+    expect(decideRoot("GET /api/devices", { "http.route": "/api/devices" })).toBe(
+      SamplingDecision.NOT_RECORD,
+    );
+    const alwaysSample = buildCmuxTraceSampler({ CMUX_OTEL_BASE_SAMPLE_RATIO: "1" });
+    expect(
+      alwaysSample.shouldSample(root, "0af7651916cd43dd8448eb211c80319c", "GET /", 1, {}, [])
+        .decision,
+    ).toBe(SamplingDecision.RECORD_AND_SAMPLED);
+  });
+
+  test("invalid or missing ratios fall back to the default without throwing", () => {
+    for (const raw of [undefined, "", "nan", "-1", "7"]) {
+      expect(() => buildCmuxTraceSampler({ CMUX_OTEL_BASE_SAMPLE_RATIO: raw })).not.toThrow();
+    }
+  });
+
+  test("isVmPrioritySpan does not match unrelated paths", () => {
+    expect(isVmPrioritySpan("GET /api/vmstats-lookalike", {})).toBe(false);
+    expect(isVmPrioritySpan("GET", { "url.path": "/api/devices" })).toBe(false);
+    // Prefix semantics are intentional: /api/vm/... and /api/vm itself.
+    expect(isVmPrioritySpan("GET", { "url.path": "/api/vm" })).toBe(true);
+  });
+});
+
+describe("withApiRouteSpan re-rooting under head sampling", () => {
+  const exporter = new InMemorySpanExporter();
+  const provider = new BasicTracerProvider({
+    sampler: buildCmuxTraceSampler({ CMUX_OTEL_BASE_SAMPLE_RATIO: "0" }),
+    spanProcessors: [new SimpleSpanProcessor(exporter)],
+  });
+  trace.setGlobalTracerProvider(provider);
+  // The API's default context manager is a no-op (`context.with` does not
+  // propagate); production gets a real one from @vercel/otel's registerOTel.
+  const contextManager = new AsyncLocalStorageContextManager().enable();
+  otelContext.setGlobalContextManager(contextManager);
+
+  afterAll(async () => {
+    await provider.shutdown();
+    trace.disable();
+    otelContext.disable();
+  });
+
+  function unsampledParentContext() {
+    return trace.setSpanContext(otelContext.active(), {
+      traceId: "1af7651916cd43dd8448eb211c80319c",
+      spanId: "b7ad6b7169203331",
+      traceFlags: TraceFlags.NONE,
+    });
+  }
+
+  test("a vm route under a dropped trace re-roots and is exported with a link", async () => {
+    exporter.reset();
+    await otelContext.with(unsampledParentContext(), () =>
+      withApiRouteSpan(
+        new Request("https://cmux.com/api/vm", { method: "POST" }),
+        "/api/vm",
+        { "cmux.subsystem": "vm-cloud" },
+        async () => new Response("{}", { status: 200 }),
+      ));
+    const spans = exporter.getFinishedSpans();
+    expect(spans.length).toBe(1);
+    const span = spans[0]!;
+    expect(span.name).toBe("cmux.api.POST /api/vm");
+    // New trace, not the dropped parent's.
+    expect(span.spanContext().traceId).not.toBe("1af7651916cd43dd8448eb211c80319c");
+    expect(span.parentSpanContext).toBeUndefined();
+    expect(span.links.length).toBe(1);
+    expect(span.links[0]?.context.traceId).toBe("1af7651916cd43dd8448eb211c80319c");
+  });
+
+  test("a non-vm route under a dropped trace stays dropped", async () => {
+    exporter.reset();
+    await otelContext.with(unsampledParentContext(), () =>
+      withApiRouteSpan(
+        new Request("https://cmux.com/api/devices", { method: "GET" }),
+        "/api/devices",
+        {},
+        async () => new Response("{}", { status: 200 }),
+      ));
+    expect(exporter.getFinishedSpans().length).toBe(0);
+  });
+
+  test("a vm route inside a sampled trace nests normally", async () => {
+    exporter.reset();
+    const tracer = trace.getTracer("test");
+    await tracer.startActiveSpan("POST /api/vm", { attributes: { "http.route": "/api/vm" } }, async (parent) => {
+      await withApiRouteSpan(
+        new Request("https://cmux.com/api/vm", { method: "POST" }),
+        "/api/vm",
+        { "cmux.subsystem": "vm-cloud" },
+        async () => new Response("{}", { status: 200 }),
+      );
+      parent.end();
+    });
+    const spans = exporter.getFinishedSpans();
+    expect(spans.length).toBe(2);
+    const child = spans.find((s) => s.name === "cmux.api.POST /api/vm");
+    const parent = spans.find((s) => s.name === "POST /api/vm");
+    expect(child?.parentSpanContext?.spanId).toBe(parent?.spanContext().spanId);
+    expect(child?.links.length ?? 0).toBe(0);
+  });
+});

--- a/web/tests/vm-observability.test.ts
+++ b/web/tests/vm-observability.test.ts
@@ -181,6 +181,14 @@ describe("cloud_vm_provision capture", () => {
     expect(attributes["cmux.vm.provision_error_code"]).toBe("vm_create_disabled");
   });
 
+  test("a 5xx without the error header still counts as operator fault", () => {
+    const { body } = captured(new Response("boom", { status: 500 }));
+    const properties = body?.properties as Record<string, unknown>;
+    expect(properties.status).toBe(500);
+    expect(properties.error_code).toBeUndefined();
+    expect(properties.operator_fault).toBe(true);
+  });
+
   test("capture is disabled outside production unless forced", () => {
     let called = false;
     const fakeFetch = (() => {


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/cmux/pull/11031. Fixing the production OTLP endpoint turned on an unsampled firehose: about 4M spans per 15 minutes (roughly 380M spans/day), dominated by pg.query, fetch, and Stack spans from high-frequency routes. That volume is an Axiom cost problem and buries the Cloud VM traces the export exists for.

- New `buildCmuxTraceSampler` (`web/services/observability/sampler.ts`): keeps 100% of Cloud VM traces, samples all other roots at `CMUX_OTEL_BASE_SAMPLE_RATIO` (default 2%), children follow their root (`ParentBasedSampler`).
- Priority detection uses creation-time signals only: path-segment-aware `/api/vm` match on `http.route` / `url.path` / `http.target`, the span name, or the `cmux.subsystem=vm-cloud` attribute (`/api/vmstats` would not match).
- Next.js attaches the matched route to its request span only after routing, so a VM request whose root got sampled away would lose its subtree. `withApiRouteSpan` now re-roots Cloud VM API spans into their own trace, linked back to the dropped one, whenever the active parent is unsampled. The whole VM subtree (provider driver, pg, fetch spans) survives deterministically.
- `@opentelemetry/sdk-trace-base` becomes a direct dependency (already in the tree transitively); `@opentelemetry/context-async-hooks` is a devDependency for the test context manager.

Tests: `tests/telemetry-sampler.test.ts` (sampler decisions, lookalike paths, re-rooting with link, normal nesting under a sampled parent), plus `vm-observability` and `vm-route-auth` suites; `bun run typecheck`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the unsampled OTLP firehose by head-sampling all traces at 2% while always keeping Cloud VM traces, and splits VM provisioning telemetry so PostHog gets only failures while spans carry full error detail.

**Sampling and re-rooting**
- New `buildCmuxTraceSampler` keeps roots matched by `/api/vm` path segments, span name, or the `cmux.subsystem=vm-cloud` attribute; all other roots sample at `CMUX_OTEL_BASE_SAMPLE_RATIO` (default 2%) and children follow their root.
- Remote traceparents with the sampled flag no longer bypass the base ratio; remote parents get the same fresh priority-or-ratio decision.
- VM API spans under a dropped trace re-root into a new trace linked back to the dropped parent, so the VM subtree survives deterministically.
- Re-rooting deletes only the dropped parent span, so baggage and other context values still propagate.
- `@opentelemetry/sdk-trace-base` becomes a direct dependency; `@opentelemetry/context-async-hooks` is a devDependency for tests.

**Provisioning telemetry split**
- PostHog `cloud_vm_provision` events now fire only on provisioning failure, with `operator_fault` and `schema_version: 2`; a 5xx without a `x-cmux-vm-error` header still counts as an operator fault.
- Every provisioning attempt and VM error annotates the active span with `cmux.vm.*` attributes, including operator context scrubbed from response bodies.
- `.env.example` documents that `OTEL_EXPORTER_OTLP_ENDPOINT` must be the base URL; a suffixed `/v1/traces` value silently drops every span.

<sup>Written for commit 3d93c5bf4c2441e2c51c6f700648513b28ac04f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Observability**
  - Improved VM request tracing so Cloud VM API activity is consistently retained for troubleshooting.
  - Added configurable sampling for other telemetry, with a safe 2% default.
  - Improved VM error and provisioning telemetry, including clearer operator-fault classification and richer error context.
  - Reduced unnecessary success events while preserving failure reporting.

- **Documentation**
  - Clarified telemetry endpoint configuration requirements and sampling options in the environment configuration example.

- **Tests**
  - Added coverage for priority sampling, trace behavior, and VM error classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->