### PR TITLE
fix(relay): no pooled-flusher wake for below-threshold records during an in-flight POST

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/journal_forwarder.rs
+++ b/cmux-tui/crates/chatmux-relay/src/journal_forwarder.rs
@@ -987,6 +987,13 @@ fn enqueue_pending(
     }
     let total = pool.pending.iter().map(|entry| entry.records.len()).sum::<usize>();
     if total < MAX_BATCH_RECORDS {
+        // During an in-flight POST the completion path re-arms the debounce
+        // for any leftover pending records (flush_cycle reads the total under
+        // the same lock that clears `flushing`), so waking here would only
+        // store a spurious permit — the exact wake the deferral pin forbids.
+        if pool.flushing {
+            return;
+        }
         drop(pool);
         shared.flush_wake.notify_one();
         return;


### PR DESCRIPTION
Unbreak main: `journal_forwarder::tests::pooled_threshold_drains_an_exact_batch_and_defers_while_posting` fails deterministically on main (Linux + macOS) since #10989 merged — first surfaced by the feat-relay-tunnel-terminal gate (run 33135003977), reproduced on a main-pinned probe branch (verify-main-journal-pool).

#10989 replaced the typed `FlushWake::Arm/Batch` channel with one coalesced `Notify`, and the below-threshold arm lost its distinction: during an in-flight POST every sub-threshold enqueue now stores a wake permit, which the PR's own deferral pin forbids. Fix: skip the wake while `pool.flushing` — the POST completion path already re-arms the debounce for leftover pending records under the same lock that clears `flushing` (`flush_cycle`), so nothing waits and nothing is lost.

Hosted `--filter pooled_threshold` dispatch on this branch is the gate evidence.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the pooled flusher wake in `journal_forwarder` so below-threshold records no longer store a spurious permit during an in-flight POST. The POST completion path already re-arms the debounce for leftover pending records, so the extra wake was causing a deterministic test failure on main since #10989.

<sup>Written for commit 6364b3fe081b80cce3318832dc9df098a0473d0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11034?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

