### PR TITLE
Reap disowned shell watchers on parent PID reuse (issue 10926)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1415,6 +1415,7 @@ jobs:
           python3 tests/test_issue_8093_ghostty_ssh_binary_path.py
           python3 tests/test_issue_6714_zsh_shim_noclobber.py
           python3 tests/test_issue_9356_bash_shim_noclobber.py
+          python3 tests/test_issue_10926_watcher_pid_reuse_guard.py
           python3 tests/test_issue_8953_zsh_prompt_wrap_guard.py
           python3 tests/test_nushell_shim_path_refront.py
           python3 tests/test_nushell_resume_command_dialect.py

--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -1433,14 +1433,13 @@ _cmux_watcher_parent_start_time() {
     kernel="$(/usr/sbin/sysctl -n "kern.proc.pid.$pid" 2>/dev/null | /usr/bin/od -An -tu4 2>/dev/null)"
     while read -r sec usec; do
         if [[ "$sec" =~ ^[0-9]+$ && "$usec" =~ ^[0-9]+$ && "$sec" -ge 1000000000 && "$sec" -le 3000000000 && "$usec" -lt 1000000 ]]; then
-            printf '%s%06d\n' "$sec" "$usec"
+            printf '%s\n' "$sec"
             return 0
         fi
     done < <(printf '%s\n' "$kernel" | awk '{ for (i=1;i<NF;i++) print $i, $(i+1) }')
     # Darwin's ps exposes process start time through `lstart`, which is a
     # locale-formatted string. Force the stable C locale and UTC timezone,
-    # then convert the five fields to a fixed-width numeric token before
-    # comparing.
+    # then convert the five fields to the same epoch-second token.
     raw="$(TZ=UTC LC_ALL=C /bin/ps -o lstart= -p "$pid" 2>/dev/null)" || return 1
     case "$raw" in *$'\n'*) return 1 ;; esac
     local -a words=()
@@ -1468,7 +1467,8 @@ _cmux_watcher_parent_start_time() {
         [0-9][0-9][0-9][0-9]) year="${words[4]}" ;;
         *) return 1 ;;
     esac
-    token="${year}${month}${day}${clock//:/}"
+    token="$(TZ=UTC LC_ALL=C /bin/date -j -u -f '%a %b %d %T %Y' "$raw" '+%s' 2>/dev/null)" || return 1
+    [[ "$token" =~ ^[0-9]+$ ]] || return 1
     _cmux_watcher_parent_identity_valid "$pid" "$token" || return 1
     printf '%s\n' "$token"
 }
@@ -1485,7 +1485,7 @@ _cmux_watcher_parent_identity_valid() {
     case "$identity" in
         ''|*[!0-9]*) return 1 ;;
     esac
-    (( ${#identity} == 16 || ${#identity} == 14 ))
+    (( ${#identity} >= 10 && ${#identity} <= 11 ))
 }
 
 _cmux_watcher_parent_alive() {

--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -1488,6 +1488,17 @@ _cmux_watcher_parent_identity_valid() {
     (( ${#identity} >= 10 && ${#identity} <= 11 ))
 }
 
+_cmux_watcher_parent_state_valid() {
+    local pid="${1:-}" state
+    state="$(LC_ALL=C /bin/ps -o state= -p "$pid" 2>/dev/null)" || return 1
+    state="${state#"${state%%[![:space:]]*}"}"
+    state="${state%%[[:space:]]*}"
+    case "$state" in
+        ''|Z*) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
 _cmux_watcher_parent_alive() {
     # $1 = parent PID, $2 = numeric start time recorded at watcher spawn. A
     # mismatch means the PID was recycled; a failed /bin/ps counts as
@@ -1496,6 +1507,7 @@ _cmux_watcher_parent_alive() {
     local pid="${1:-}" expected="${2:-}" actual
     _cmux_watcher_parent_identity_valid "$pid" "$expected" || return 1
     kill -0 "$pid" >/dev/null 2>&1 || return 1
+    _cmux_watcher_parent_state_valid "$pid" || return 1
     actual="$(_cmux_watcher_parent_start_time "$pid")" || return 1
     [[ "$actual" == "$expected" ]]
 }

--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -1419,6 +1419,36 @@ _cmux_run_pr_probe_with_timeout() {
     wait "$probe_pid"
 }
 
+# Stable parent identity for disowned watchers (issue #10926): a bare
+# `kill -0 $pid` guard is defeated by PID reuse. macOS recycles PIDs within
+# days on a busy machine, so once the recorded shell PID is reassigned to any
+# live process the guard returns true forever and the watcher never exits.
+# Pair the PID with the kernel start time from /bin/ps so a recycled PID no
+# longer counts as the parent.
+_cmux_watcher_parent_start_time() {
+    local raw
+    raw="$(/bin/ps -o lstart= -p "$1" 2>/dev/null)" || return 1
+    # Normalize whitespace: lstart pads single-digit days with spaces, and the
+    # identity must compare stably across ps invocations.
+    local -a words=()
+    read -r -a words <<< "$raw" || true
+    (( ${#words[@]} )) || return 1
+    printf '%s\n' "${words[*]}"
+}
+
+_cmux_watcher_parent_alive() {
+    # $1 = parent PID, $2 = start time recorded at watcher spawn. A start-time
+    # mismatch means the PID was recycled; a failed /bin/ps counts as
+    # parent-dead. An empty recorded start time (ps failed at spawn) degrades
+    # to the plain PID liveness check.
+    local pid="$1" expected="$2" actual
+    [[ -n "$pid" ]] || return 1
+    kill -0 "$pid" >/dev/null 2>&1 || return 1
+    [[ -n "$expected" ]] || return 0
+    actual="$(_cmux_watcher_parent_start_time "$pid")" || return 1
+    [[ "$actual" == "$expected" ]]
+}
+
 _cmux_halt_pr_poll_loop() {
     if [[ -n "$_CMUX_PR_POLL_PID" ]]; then
         # Process-group kill: background jobs are process-group leaders, so
@@ -1451,6 +1481,8 @@ _cmux_start_pr_poll_loop() {
     local watch_pwd="${1:-$PWD}"
     local force_restart="${2:-0}"
     local watch_shell_pid="$$"
+    local watch_shell_start
+    watch_shell_start="$(_cmux_watcher_parent_start_time "$watch_shell_pid" 2>/dev/null)" || watch_shell_start=""
     local interval="${_CMUX_PR_POLL_INTERVAL:-45}"
 
     if [[ "$force_restart" != "1" && "$watch_pwd" == "$_CMUX_PR_POLL_PWD" && -n "$_CMUX_PR_POLL_PID" ]] \
@@ -1469,7 +1501,7 @@ _cmux_start_pr_poll_loop() {
         local signal_path=""
         signal_path="$(_cmux_pr_force_signal_path 2>/dev/null || true)"
         while :; do
-            kill -0 "$watch_shell_pid" 2>/dev/null || break
+            _cmux_watcher_parent_alive "$watch_shell_pid" "$watch_shell_start" || break
             local force_probe=0
             if [[ -n "$signal_path" && -f "$signal_path" ]]; then
                 force_probe=1
@@ -1479,7 +1511,7 @@ _cmux_start_pr_poll_loop() {
 
             local slept=0
             while (( slept < interval )); do
-                kill -0 "$watch_shell_pid" 2>/dev/null || exit 0
+                _cmux_watcher_parent_alive "$watch_shell_pid" "$watch_shell_start" || exit 0
                 if [[ -n "$signal_path" && -f "$signal_path" ]]; then
                     break
                 fi

--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -1449,6 +1449,38 @@ _cmux_watcher_parent_alive() {
     [[ "$actual" == "$expected" ]]
 }
 
+_cmux_capture_shell_start_time() {
+    # Cache this shell's own start time once per shell lifetime: $$ never
+    # changes, so the value cannot go stale, and watcher starts must not pay
+    # a /bin/ps fork per command. Only a non-empty value is cached so a
+    # transient ps failure heals on the next watcher start.
+    [[ -n "${_CMUX_SHELL_START_TIME:-}" ]] && return 0
+    _CMUX_SHELL_START_TIME="$(_cmux_watcher_parent_start_time "$$" 2>/dev/null)" || _CMUX_SHELL_START_TIME=""
+}
+
+_cmux_watcher_guard_tick() {
+    # Tiered per-iteration guard for watcher loops: the builtin kill -0 runs
+    # every call (plain parent death is caught within one iteration), and the
+    # /bin/ps identity comparison runs only every Nth call (default 30, via
+    # _CMUX_WATCHER_IDENTITY_INTERVAL) so steady-state watchers do not fork
+    # once per second. PID-reuse detection latency is bounded by N iterations.
+    # Runs inside the forked watcher, so the countdown global is private to
+    # that watcher.
+    local pid="$1" expected="$2"
+    kill -0 "$pid" >/dev/null 2>&1 || return 1
+    if (( ${_CMUX_WATCHER_GUARD_COUNTDOWN:-0} > 0 )); then
+        _CMUX_WATCHER_GUARD_COUNTDOWN=$(( _CMUX_WATCHER_GUARD_COUNTDOWN - 1 ))
+        return 0
+    fi
+    local interval="${_CMUX_WATCHER_IDENTITY_INTERVAL:-30}"
+    case "$interval" in
+        ''|*[!0-9]*) interval=30 ;;
+    esac
+    (( interval > 0 )) || interval=30
+    _CMUX_WATCHER_GUARD_COUNTDOWN=$(( interval - 1 ))
+    _cmux_watcher_parent_alive "$pid" "$expected"
+}
+
 _cmux_halt_pr_poll_loop() {
     if [[ -n "$_CMUX_PR_POLL_PID" ]]; then
         # Process-group kill: background jobs are process-group leaders, so
@@ -1481,8 +1513,8 @@ _cmux_start_pr_poll_loop() {
     local watch_pwd="${1:-$PWD}"
     local force_restart="${2:-0}"
     local watch_shell_pid="$$"
-    local watch_shell_start
-    watch_shell_start="$(_cmux_watcher_parent_start_time "$watch_shell_pid" 2>/dev/null)" || watch_shell_start=""
+    _cmux_capture_shell_start_time
+    local watch_shell_start="$_CMUX_SHELL_START_TIME"
     local interval="${_CMUX_PR_POLL_INTERVAL:-45}"
 
     if [[ "$force_restart" != "1" && "$watch_pwd" == "$_CMUX_PR_POLL_PWD" && -n "$_CMUX_PR_POLL_PID" ]] \
@@ -1501,7 +1533,7 @@ _cmux_start_pr_poll_loop() {
         local signal_path=""
         signal_path="$(_cmux_pr_force_signal_path 2>/dev/null || true)"
         while :; do
-            _cmux_watcher_parent_alive "$watch_shell_pid" "$watch_shell_start" || break
+            _cmux_watcher_guard_tick "$watch_shell_pid" "$watch_shell_start" || break
             local force_probe=0
             if [[ -n "$signal_path" && -f "$signal_path" ]]; then
                 force_probe=1
@@ -1511,7 +1543,7 @@ _cmux_start_pr_poll_loop() {
 
             local slept=0
             while (( slept < interval )); do
-                _cmux_watcher_parent_alive "$watch_shell_pid" "$watch_shell_start" || exit 0
+                _cmux_watcher_guard_tick "$watch_shell_pid" "$watch_shell_start" || exit 0
                 if [[ -n "$signal_path" && -f "$signal_path" ]]; then
                     break
                 fi

--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -1423,28 +1423,70 @@ _cmux_run_pr_probe_with_timeout() {
 # `kill -0 $pid` guard is defeated by PID reuse. macOS recycles PIDs within
 # days on a busy machine, so once the recorded shell PID is reassigned to any
 # live process the guard returns true forever and the watcher never exits.
-# Pair the PID with the kernel start time from /bin/ps so a recycled PID no
-# longer counts as the parent.
+# Pair the PID with Darwin's kernel start time (seconds) from /bin/ps so a
+# recycled PID no longer counts as the parent.
 _cmux_watcher_parent_start_time() {
-    local raw
-    raw="$(/bin/ps -o lstart= -p "$1" 2>/dev/null)" || return 1
-    # Normalize whitespace: lstart pads single-digit days with spaces, and the
-    # identity must compare stably across ps invocations.
+    local pid="${1:-}" raw month day clock year token
+    case "$pid" in ''|*[!0-9]*) return 1 ;; esac
+    case "$pid" in *[1-9]*) ;; *) return 1 ;; esac
+    # Darwin's ps exposes process start time through `lstart`, which is a
+    # locale-formatted string. Force the stable C locale and UTC timezone,
+    # then convert the five fields to a fixed-width numeric token before
+    # comparing.
+    raw="$(TZ=UTC LC_ALL=C /bin/ps -o lstart= -p "$pid" 2>/dev/null)" || return 1
+    case "$raw" in *$'\n'*) return 1 ;; esac
     local -a words=()
     read -r -a words <<< "$raw" || true
-    (( ${#words[@]} )) || return 1
-    printf '%s\n' "${words[*]}"
+    (( ${#words[@]} == 5 )) || return 1
+    case "${words[0]}" in Mon|Tue|Wed|Thu|Fri|Sat|Sun) ;; *) return 1 ;; esac
+    case "${words[1]}" in
+        Jan) month=01 ;; Feb) month=02 ;; Mar) month=03 ;;
+        Apr) month=04 ;; May) month=05 ;; Jun) month=06 ;;
+        Jul) month=07 ;; Aug) month=08 ;; Sep) month=09 ;;
+        Oct) month=10 ;; Nov) month=11 ;; Dec) month=12 ;;
+        *) return 1 ;;
+    esac
+    case "${words[2]}" in
+        [1-9]) day="0${words[2]}" ;;
+        0[1-9]|[12][0-9]|3[01]) day="${words[2]}" ;;
+        *) return 1 ;;
+    esac
+    case "${words[3]}" in
+        [01][0-9]:[0-5][0-9]:[0-5][0-9]|2[0-3]:[0-5][0-9]:[0-5][0-9]) clock="${words[3]}" ;;
+        *) return 1 ;;
+    esac
+    case "${words[4]}" in
+        [0-9][0-9][0-9][0-9]) year="${words[4]}" ;;
+        *) return 1 ;;
+    esac
+    token="${year}${month}${day}${clock//:/}"
+    _cmux_watcher_parent_identity_valid "$pid" "$token" || return 1
+    printf '%s\n' "$token"
+}
+
+_cmux_watcher_parent_identity_valid() {
+    local pid="${1:-}" identity="${2:-}"
+    case "$pid" in
+        ''|*[!0-9]*) return 1 ;;
+    esac
+    case "$pid" in
+        *[1-9]*) ;;
+        *) return 1 ;;
+    esac
+    case "$identity" in
+        ''|*[!0-9]*) return 1 ;;
+    esac
+    (( ${#identity} == 14 ))
 }
 
 _cmux_watcher_parent_alive() {
-    # $1 = parent PID, $2 = start time recorded at watcher spawn. A start-time
+    # $1 = parent PID, $2 = numeric start time recorded at watcher spawn. A
     # mismatch means the PID was recycled; a failed /bin/ps counts as
-    # parent-dead. An empty recorded start time (ps failed at spawn) degrades
-    # to the plain PID liveness check.
-    local pid="$1" expected="$2" actual
-    [[ -n "$pid" ]] || return 1
+    # parent-dead. Missing or malformed identity is also parent-dead, so a
+    # watcher never falls back to PID-only liveness.
+    local pid="${1:-}" expected="${2:-}" actual
+    _cmux_watcher_parent_identity_valid "$pid" "$expected" || return 1
     kill -0 "$pid" >/dev/null 2>&1 || return 1
-    [[ -n "$expected" ]] || return 0
     actual="$(_cmux_watcher_parent_start_time "$pid")" || return 1
     [[ "$actual" == "$expected" ]]
 }
@@ -1452,10 +1494,20 @@ _cmux_watcher_parent_alive() {
 _cmux_capture_shell_start_time() {
     # Cache this shell's own start time once per shell lifetime: $$ never
     # changes, so the value cannot go stale, and watcher starts must not pay
-    # a /bin/ps fork per command. Only a non-empty value is cached so a
-    # transient ps failure heals on the next watcher start.
-    [[ -n "${_CMUX_SHELL_START_TIME:-}" ]] && return 0
-    _CMUX_SHELL_START_TIME="$(_cmux_watcher_parent_start_time "$$" 2>/dev/null)" || _CMUX_SHELL_START_TIME=""
+    # a /bin/ps fork per command. Only a valid value tied to this shell PID is
+    # cached, so a transient ps failure heals on the next watcher start.
+    if [[ "${_CMUX_SHELL_START_PID:-}" == "$$" ]] \
+        && _cmux_watcher_parent_identity_valid "$$" "${_CMUX_SHELL_START_TIME:-}"; then
+        return 0
+    fi
+    _CMUX_SHELL_START_TIME=""
+    _CMUX_SHELL_START_PID=""
+    _CMUX_SHELL_START_TIME="$(_cmux_watcher_parent_start_time "$$" 2>/dev/null)" || return 1
+    _cmux_watcher_parent_identity_valid "$$" "$_CMUX_SHELL_START_TIME" || {
+        _CMUX_SHELL_START_TIME=""
+        return 1
+    }
+    _CMUX_SHELL_START_PID="$$"
 }
 
 _cmux_watcher_guard_tick() {
@@ -1466,10 +1518,15 @@ _cmux_watcher_guard_tick() {
     # once per second. PID-reuse detection latency is bounded by N iterations.
     # Runs inside the forked watcher, so the countdown global is private to
     # that watcher.
-    local pid="$1" expected="$2"
+    local pid="${1:-}" expected="${2:-}"
+    _cmux_watcher_parent_identity_valid "$pid" "$expected" || return 1
     kill -0 "$pid" >/dev/null 2>&1 || return 1
-    if (( ${_CMUX_WATCHER_GUARD_COUNTDOWN:-0} > 0 )); then
-        _CMUX_WATCHER_GUARD_COUNTDOWN=$(( _CMUX_WATCHER_GUARD_COUNTDOWN - 1 ))
+    local countdown="${_CMUX_WATCHER_GUARD_COUNTDOWN:-0}"
+    case "$countdown" in
+        ''|*[!0-9]*) countdown=0 ;;
+    esac
+    if (( countdown > 0 )); then
+        _CMUX_WATCHER_GUARD_COUNTDOWN=$(( countdown - 1 ))
         return 0
     fi
     local interval="${_CMUX_WATCHER_IDENTITY_INTERVAL:-30}"
@@ -1513,7 +1570,7 @@ _cmux_start_pr_poll_loop() {
     local watch_pwd="${1:-$PWD}"
     local force_restart="${2:-0}"
     local watch_shell_pid="$$"
-    _cmux_capture_shell_start_time
+    _cmux_capture_shell_start_time || return 0
     local watch_shell_start="$_CMUX_SHELL_START_TIME"
     local interval="${_CMUX_PR_POLL_INTERVAL:-45}"
 
@@ -1532,6 +1589,7 @@ _cmux_start_pr_poll_loop() {
     {
         local signal_path=""
         signal_path="$(_cmux_pr_force_signal_path 2>/dev/null || true)"
+        _CMUX_WATCHER_GUARD_COUNTDOWN=0
         while :; do
             _cmux_watcher_guard_tick "$watch_shell_pid" "$watch_shell_start" || break
             local force_probe=0

--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -1429,6 +1429,14 @@ _cmux_watcher_parent_start_time() {
     local pid="${1:-}" raw month day clock year token
     case "$pid" in ''|*[!0-9]*) return 1 ;; esac
     case "$pid" in *[1-9]*) ;; *) return 1 ;; esac
+    local kernel sec usec
+    kernel="$(/usr/sbin/sysctl -n "kern.proc.pid.$pid" 2>/dev/null | /usr/bin/od -An -tu4 2>/dev/null)"
+    while read -r sec usec; do
+        if [[ "$sec" =~ ^[0-9]+$ && "$usec" =~ ^[0-9]+$ && "$sec" -ge 1000000000 && "$sec" -le 3000000000 && "$usec" -lt 1000000 ]]; then
+            printf '%s%06d\n' "$sec" "$usec"
+            return 0
+        fi
+    done < <(printf '%s\n' "$kernel" | awk '{ for (i=1;i<NF;i++) print $i, $(i+1) }')
     # Darwin's ps exposes process start time through `lstart`, which is a
     # locale-formatted string. Force the stable C locale and UTC timezone,
     # then convert the five fields to a fixed-width numeric token before
@@ -1477,7 +1485,7 @@ _cmux_watcher_parent_identity_valid() {
     case "$identity" in
         ''|*[!0-9]*) return 1 ;;
     esac
-    (( ${#identity} == 14 ))
+    (( ${#identity} == 16 || ${#identity} == 14 ))
 }
 
 _cmux_watcher_parent_alive() {

--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -1436,6 +1436,7 @@ _cmux_watcher_parent_start_time() {
     raw="$(TZ=UTC LC_ALL=C /bin/ps -o lstart= -p "$pid" 2>/dev/null)" || return 1
     case "$raw" in *$'\n'*) return 1 ;; esac
     local -a words=()
+    local IFS=$' \t\n'
     read -r -a words <<< "$raw" || true
     (( ${#words[@]} == 5 )) || return 1
     case "${words[0]}" in Mon|Tue|Wed|Thu|Fri|Sat|Sun) ;; *) return 1 ;; esac

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -1507,8 +1507,8 @@ _cmux_run_pr_probe_with_timeout() {
 # days on a busy machine, so once the recorded shell PID is reassigned to any
 # live process the guard returns true forever and the watcher never exits
 # (793 orphans / 2.1 GB after 20 days). Pair the PID with Darwin's kernel
-# start time (seconds) from /bin/ps so a recycled PID no longer counts as the
-# parent.
+# start time (epoch seconds) from Darwin so a recycled PID no longer counts as
+# the parent. Both providers return the same representation.
 _cmux_watcher_parent_start_time() {
     local pid="${1:-}" raw month day clock year token
     case "$pid" in ''|*[!0-9]*) return 1 ;; esac
@@ -1519,7 +1519,7 @@ _cmux_watcher_parent_start_time() {
     for (( i = 1; i < ${#fields}; i++ )); do
         sec="${fields[i]}"; usec="${fields[i+1]}"
         if [[ "$sec" == <-> && "$usec" == <-> ]] && (( sec >= 1000000000 && sec <= 3000000000 && usec < 1000000 )); then
-            token="${sec}${(l:6::0:)usec}"
+            token="$sec"
             _cmux_watcher_parent_identity_valid "$pid" "$token" || return 1
             print -r -- "$token"
             return 0
@@ -1527,8 +1527,7 @@ _cmux_watcher_parent_start_time() {
     done
     # Darwin's ps exposes process start time through `lstart`, which is a
     # locale-formatted string. Force the stable C locale and UTC timezone,
-    # then convert the five fields to a fixed-width numeric token before
-    # comparing.
+    # then use date(1) to convert it to the same epoch-second token.
     raw="$(TZ=UTC LC_ALL=C /bin/ps -o lstart= -p "$pid" 2>/dev/null)" || return 1
     case "$raw" in *$'\n'*) return 1 ;; esac
     local -a words
@@ -1555,7 +1554,8 @@ _cmux_watcher_parent_start_time() {
         [0-9][0-9][0-9][0-9]) year="${words[5]}" ;;
         *) return 1 ;;
     esac
-    token="${year}${month}${day}${clock//:/}"
+    token="$(TZ=UTC LC_ALL=C /bin/date -j -u -f '%a %b %d %T %Y' "$raw" '+%s' 2>/dev/null)" || return 1
+    [[ "$token" == <-> ]] || return 1
     _cmux_watcher_parent_identity_valid "$pid" "$token" || return 1
     print -r -- "$token"
 }
@@ -1572,7 +1572,7 @@ _cmux_watcher_parent_identity_valid() {
     case "$identity" in
         ''|*[!0-9]*) return 1 ;;
     esac
-    (( ${#identity} == 16 || ${#identity} == 14 ))
+    (( ${#identity} >= 10 && ${#identity} <= 11 ))
 }
 
 _cmux_watcher_parent_alive() {

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -1575,6 +1575,17 @@ _cmux_watcher_parent_identity_valid() {
     (( ${#identity} >= 10 && ${#identity} <= 11 ))
 }
 
+_cmux_watcher_parent_state_valid() {
+    local pid="${1:-}" state
+    state="$(LC_ALL=C /bin/ps -o state= -p "$pid" 2>/dev/null)" || return 1
+    state="${state#"${state%%[![:space:]]*}"}"
+    state="${state%%[[:space:]]*}"
+    case "$state" in
+        ''|Z*) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
 _cmux_watcher_parent_alive() {
     # $1 = parent PID, $2 = numeric start time recorded at watcher spawn. A
     # mismatch means the PID was recycled; a failed /bin/ps counts as
@@ -1583,6 +1594,7 @@ _cmux_watcher_parent_alive() {
     local pid="${1:-}" expected="${2:-}" actual
     _cmux_watcher_parent_identity_valid "$pid" "$expected" || return 1
     kill -0 "$pid" >/dev/null 2>&1 || return 1
+    _cmux_watcher_parent_state_valid "$pid" || return 1
     actual="$(_cmux_watcher_parent_start_time "$pid")" || return 1
     [[ "$actual" == "$expected" ]]
 }

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -1532,6 +1532,39 @@ _cmux_watcher_parent_alive() {
     [[ "$actual" == "$expected" ]]
 }
 
+_cmux_capture_shell_start_time() {
+    # Cache this shell's own start time once per shell lifetime: $$ never
+    # changes, so the value cannot go stale, and watcher starts (one runs from
+    # preexec) must not pay a /bin/ps fork per command. Only a non-empty value
+    # is cached so a transient ps failure heals on the next watcher start.
+    [[ -n "${_CMUX_SHELL_START_TIME:-}" ]] && return 0
+    typeset -g _CMUX_SHELL_START_TIME
+    _CMUX_SHELL_START_TIME="$(_cmux_watcher_parent_start_time "$$" 2>/dev/null)" || _CMUX_SHELL_START_TIME=""
+}
+
+_cmux_watcher_guard_tick() {
+    # Tiered per-iteration guard for watcher loops: the builtin kill -0 runs
+    # every call (plain parent death is caught within one iteration), and the
+    # /bin/ps identity comparison runs only every Nth call (default 30, via
+    # _CMUX_WATCHER_IDENTITY_INTERVAL) so steady-state watchers do not fork
+    # once per second. PID-reuse detection latency is bounded by N iterations.
+    # Runs inside the forked watcher, so the countdown global is private to
+    # that watcher.
+    local pid="$1" expected="$2"
+    kill -0 "$pid" >/dev/null 2>&1 || return 1
+    if (( ${_CMUX_WATCHER_GUARD_COUNTDOWN:-0} > 0 )); then
+        _CMUX_WATCHER_GUARD_COUNTDOWN=$(( _CMUX_WATCHER_GUARD_COUNTDOWN - 1 ))
+        return 0
+    fi
+    local interval="${_CMUX_WATCHER_IDENTITY_INTERVAL:-30}"
+    case "$interval" in
+        ''|*[!0-9]*) interval=30 ;;
+    esac
+    (( interval > 0 )) || interval=30
+    _CMUX_WATCHER_GUARD_COUNTDOWN=$(( interval - 1 ))
+    _cmux_watcher_parent_alive "$pid" "$expected"
+}
+
 _cmux_halt_pr_poll_loop() {
     # Process-group kill: background jobs are process-group leaders, so
     # negative PID kills the loop + all descendants (gh, sleep) without
@@ -1563,8 +1596,8 @@ _cmux_start_pr_poll_loop() {
     local watch_pwd="${1:-$PWD}"
     local force_restart="${2:-0}"
     local watch_shell_pid="$$"
-    local watch_shell_start
-    watch_shell_start="$(_cmux_watcher_parent_start_time "$watch_shell_pid" 2>/dev/null)" || watch_shell_start=""
+    _cmux_capture_shell_start_time
+    local watch_shell_start="$_CMUX_SHELL_START_TIME"
     local interval="${_CMUX_PR_POLL_INTERVAL:-45}"
 
     if [[ "$force_restart" != "1" && "$watch_pwd" == "$_CMUX_PR_POLL_PWD" && -n "$_CMUX_PR_POLL_PID" ]] \
@@ -1583,7 +1616,7 @@ _cmux_start_pr_poll_loop() {
         local signal_path=""
         signal_path="$(_cmux_pr_force_signal_path 2>/dev/null || true)"
         while true; do
-            _cmux_watcher_parent_alive "$watch_shell_pid" "$watch_shell_start" || break
+            _cmux_watcher_guard_tick "$watch_shell_pid" "$watch_shell_start" || break
             local force_probe=0
             if [[ -n "$signal_path" && -f "$signal_path" ]]; then
                 force_probe=1
@@ -1593,7 +1626,7 @@ _cmux_start_pr_poll_loop() {
 
             local slept=0
             while (( slept < interval )); do
-                _cmux_watcher_parent_alive "$watch_shell_pid" "$watch_shell_start" || exit 0
+                _cmux_watcher_guard_tick "$watch_shell_pid" "$watch_shell_start" || exit 0
                 if [[ -n "$signal_path" && -f "$signal_path" ]]; then
                     break
                 fi
@@ -1632,12 +1665,12 @@ _cmux_start_git_head_watch() {
 
     _cmux_stop_git_head_watch
     local watch_shell_pid="$$"
-    local watch_shell_start
-    watch_shell_start="$(_cmux_watcher_parent_start_time "$watch_shell_pid" 2>/dev/null)" || watch_shell_start=""
+    _cmux_capture_shell_start_time
+    local watch_shell_start="$_CMUX_SHELL_START_TIME"
     {
         local last_signature="$watch_head_signature"
         while true; do
-            _cmux_watcher_parent_alive "$watch_shell_pid" "$watch_shell_start" || break
+            _cmux_watcher_guard_tick "$watch_shell_pid" "$watch_shell_start" || break
             sleep 1
 
             local signature

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -1513,6 +1513,18 @@ _cmux_watcher_parent_start_time() {
     local pid="${1:-}" raw month day clock year token
     case "$pid" in ''|*[!0-9]*) return 1 ;; esac
     case "$pid" in *[1-9]*) ;; *) return 1 ;; esac
+    local kernel="$(/usr/sbin/sysctl -n "kern.proc.pid.$pid" 2>/dev/null | /usr/bin/od -An -tu4 2>/dev/null)"
+    local -a fields=(${=kernel})
+    local i sec usec
+    for (( i = 1; i < ${#fields}; i++ )); do
+        sec="${fields[i]}"; usec="${fields[i+1]}"
+        if [[ "$sec" == <-> && "$usec" == <-> ]] && (( sec >= 1000000000 && sec <= 3000000000 && usec < 1000000 )); then
+            token="${sec}${(l:6::0:)usec}"
+            _cmux_watcher_parent_identity_valid "$pid" "$token" || return 1
+            print -r -- "$token"
+            return 0
+        fi
+    done
     # Darwin's ps exposes process start time through `lstart`, which is a
     # locale-formatted string. Force the stable C locale and UTC timezone,
     # then convert the five fields to a fixed-width numeric token before
@@ -1560,7 +1572,7 @@ _cmux_watcher_parent_identity_valid() {
     case "$identity" in
         ''|*[!0-9]*) return 1 ;;
     esac
-    (( ${#identity} == 14 ))
+    (( ${#identity} == 16 || ${#identity} == 14 ))
 }
 
 _cmux_watcher_parent_alive() {

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -1506,28 +1506,71 @@ _cmux_run_pr_probe_with_timeout() {
 # `kill -0 $pid` guard is defeated by PID reuse. macOS recycles PIDs within
 # days on a busy machine, so once the recorded shell PID is reassigned to any
 # live process the guard returns true forever and the watcher never exits
-# (793 orphans / 2.1 GB after 20 days). Pair the PID with the kernel start
-# time from /bin/ps so a recycled PID no longer counts as the parent.
+# (793 orphans / 2.1 GB after 20 days). Pair the PID with Darwin's kernel
+# start time (seconds) from /bin/ps so a recycled PID no longer counts as the
+# parent.
 _cmux_watcher_parent_start_time() {
-    local raw
-    raw="$(/bin/ps -o lstart= -p "$1" 2>/dev/null)" || return 1
-    # Normalize whitespace: lstart pads single-digit days with spaces, and the
-    # identity must compare stably across ps invocations.
+    local pid="${1:-}" raw month day clock year token
+    case "$pid" in ''|*[!0-9]*) return 1 ;; esac
+    case "$pid" in *[1-9]*) ;; *) return 1 ;; esac
+    # Darwin's ps exposes process start time through `lstart`, which is a
+    # locale-formatted string. Force the stable C locale and UTC timezone,
+    # then convert the five fields to a fixed-width numeric token before
+    # comparing.
+    raw="$(TZ=UTC LC_ALL=C /bin/ps -o lstart= -p "$pid" 2>/dev/null)" || return 1
+    case "$raw" in *$'\n'*) return 1 ;; esac
     local -a words
-    words=(${=raw})
-    (( ${#words} )) || return 1
-    print -r -- "${(j: :)words}"
+    words=("${(@z)raw}")
+    (( ${#words} == 5 )) || return 1
+    case "${words[1]}" in Mon|Tue|Wed|Thu|Fri|Sat|Sun) ;; *) return 1 ;; esac
+    case "${words[2]}" in
+        Jan) month=01 ;; Feb) month=02 ;; Mar) month=03 ;;
+        Apr) month=04 ;; May) month=05 ;; Jun) month=06 ;;
+        Jul) month=07 ;; Aug) month=08 ;; Sep) month=09 ;;
+        Oct) month=10 ;; Nov) month=11 ;; Dec) month=12 ;;
+        *) return 1 ;;
+    esac
+    case "${words[3]}" in
+        [1-9]) day="0${words[3]}" ;;
+        0[1-9]|[12][0-9]|3[01]) day="${words[3]}" ;;
+        *) return 1 ;;
+    esac
+    case "${words[4]}" in
+        [01][0-9]:[0-5][0-9]:[0-5][0-9]|2[0-3]:[0-5][0-9]:[0-5][0-9]) clock="${words[4]}" ;;
+        *) return 1 ;;
+    esac
+    case "${words[5]}" in
+        [0-9][0-9][0-9][0-9]) year="${words[5]}" ;;
+        *) return 1 ;;
+    esac
+    token="${year}${month}${day}${clock//:/}"
+    _cmux_watcher_parent_identity_valid "$pid" "$token" || return 1
+    print -r -- "$token"
+}
+
+_cmux_watcher_parent_identity_valid() {
+    local pid="${1:-}" identity="${2:-}"
+    case "$pid" in
+        ''|*[!0-9]*) return 1 ;;
+    esac
+    case "$pid" in
+        *[1-9]*) ;;
+        *) return 1 ;;
+    esac
+    case "$identity" in
+        ''|*[!0-9]*) return 1 ;;
+    esac
+    (( ${#identity} == 14 ))
 }
 
 _cmux_watcher_parent_alive() {
-    # $1 = parent PID, $2 = start time recorded at watcher spawn. A start-time
+    # $1 = parent PID, $2 = numeric start time recorded at watcher spawn. A
     # mismatch means the PID was recycled; a failed /bin/ps counts as
-    # parent-dead. An empty recorded start time (ps failed at spawn) degrades
-    # to the plain PID liveness check.
-    local pid="$1" expected="$2" actual
-    [[ -n "$pid" ]] || return 1
+    # parent-dead. Missing or malformed identity is also parent-dead, so a
+    # watcher never falls back to PID-only liveness.
+    local pid="${1:-}" expected="${2:-}" actual
+    _cmux_watcher_parent_identity_valid "$pid" "$expected" || return 1
     kill -0 "$pid" >/dev/null 2>&1 || return 1
-    [[ -n "$expected" ]] || return 0
     actual="$(_cmux_watcher_parent_start_time "$pid")" || return 1
     [[ "$actual" == "$expected" ]]
 }
@@ -1535,11 +1578,22 @@ _cmux_watcher_parent_alive() {
 _cmux_capture_shell_start_time() {
     # Cache this shell's own start time once per shell lifetime: $$ never
     # changes, so the value cannot go stale, and watcher starts (one runs from
-    # preexec) must not pay a /bin/ps fork per command. Only a non-empty value
-    # is cached so a transient ps failure heals on the next watcher start.
-    [[ -n "${_CMUX_SHELL_START_TIME:-}" ]] && return 0
-    typeset -g _CMUX_SHELL_START_TIME
-    _CMUX_SHELL_START_TIME="$(_cmux_watcher_parent_start_time "$$" 2>/dev/null)" || _CMUX_SHELL_START_TIME=""
+    # preexec) must not pay a /bin/ps fork per command. Only a valid value tied
+    # to this shell PID is cached, so a transient ps failure heals on the next
+    # watcher start.
+    if [[ "${_CMUX_SHELL_START_PID:-}" == "$$" ]] \
+        && _cmux_watcher_parent_identity_valid "$$" "${_CMUX_SHELL_START_TIME:-}"; then
+        return 0
+    fi
+    typeset -g _CMUX_SHELL_START_PID _CMUX_SHELL_START_TIME
+    _CMUX_SHELL_START_TIME=""
+    _CMUX_SHELL_START_PID=""
+    _CMUX_SHELL_START_TIME="$(_cmux_watcher_parent_start_time "$$" 2>/dev/null)" || return 1
+    _cmux_watcher_parent_identity_valid "$$" "$_CMUX_SHELL_START_TIME" || {
+        _CMUX_SHELL_START_TIME=""
+        return 1
+    }
+    _CMUX_SHELL_START_PID="$$"
 }
 
 _cmux_watcher_guard_tick() {
@@ -1550,10 +1604,15 @@ _cmux_watcher_guard_tick() {
     # once per second. PID-reuse detection latency is bounded by N iterations.
     # Runs inside the forked watcher, so the countdown global is private to
     # that watcher.
-    local pid="$1" expected="$2"
+    local pid="${1:-}" expected="${2:-}"
+    _cmux_watcher_parent_identity_valid "$pid" "$expected" || return 1
     kill -0 "$pid" >/dev/null 2>&1 || return 1
-    if (( ${_CMUX_WATCHER_GUARD_COUNTDOWN:-0} > 0 )); then
-        _CMUX_WATCHER_GUARD_COUNTDOWN=$(( _CMUX_WATCHER_GUARD_COUNTDOWN - 1 ))
+    local countdown="${_CMUX_WATCHER_GUARD_COUNTDOWN:-0}"
+    case "$countdown" in
+        ''|*[!0-9]*) countdown=0 ;;
+    esac
+    if (( countdown > 0 )); then
+        _CMUX_WATCHER_GUARD_COUNTDOWN=$(( countdown - 1 ))
         return 0
     fi
     local interval="${_CMUX_WATCHER_IDENTITY_INTERVAL:-30}"
@@ -1596,7 +1655,7 @@ _cmux_start_pr_poll_loop() {
     local watch_pwd="${1:-$PWD}"
     local force_restart="${2:-0}"
     local watch_shell_pid="$$"
-    _cmux_capture_shell_start_time
+    _cmux_capture_shell_start_time || return 0
     local watch_shell_start="$_CMUX_SHELL_START_TIME"
     local interval="${_CMUX_PR_POLL_INTERVAL:-45}"
 
@@ -1615,6 +1674,7 @@ _cmux_start_pr_poll_loop() {
     {
         local signal_path=""
         signal_path="$(_cmux_pr_force_signal_path 2>/dev/null || true)"
+        _CMUX_WATCHER_GUARD_COUNTDOWN=0
         while true; do
             _cmux_watcher_guard_tick "$watch_shell_pid" "$watch_shell_start" || break
             local force_probe=0
@@ -1665,10 +1725,11 @@ _cmux_start_git_head_watch() {
 
     _cmux_stop_git_head_watch
     local watch_shell_pid="$$"
-    _cmux_capture_shell_start_time
+    _cmux_capture_shell_start_time || return 0
     local watch_shell_start="$_CMUX_SHELL_START_TIME"
     {
         local last_signature="$watch_head_signature"
+        _CMUX_WATCHER_GUARD_COUNTDOWN=0
         while true; do
             _cmux_watcher_guard_tick "$watch_shell_pid" "$watch_shell_start" || break
             sleep 1

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -1502,6 +1502,36 @@ _cmux_run_pr_probe_with_timeout() {
     wait "$probe_pid"
 }
 
+# Stable parent identity for disowned watchers (issue #10926): a bare
+# `kill -0 $pid` guard is defeated by PID reuse. macOS recycles PIDs within
+# days on a busy machine, so once the recorded shell PID is reassigned to any
+# live process the guard returns true forever and the watcher never exits
+# (793 orphans / 2.1 GB after 20 days). Pair the PID with the kernel start
+# time from /bin/ps so a recycled PID no longer counts as the parent.
+_cmux_watcher_parent_start_time() {
+    local raw
+    raw="$(/bin/ps -o lstart= -p "$1" 2>/dev/null)" || return 1
+    # Normalize whitespace: lstart pads single-digit days with spaces, and the
+    # identity must compare stably across ps invocations.
+    local -a words
+    words=(${=raw})
+    (( ${#words} )) || return 1
+    print -r -- "${(j: :)words}"
+}
+
+_cmux_watcher_parent_alive() {
+    # $1 = parent PID, $2 = start time recorded at watcher spawn. A start-time
+    # mismatch means the PID was recycled; a failed /bin/ps counts as
+    # parent-dead. An empty recorded start time (ps failed at spawn) degrades
+    # to the plain PID liveness check.
+    local pid="$1" expected="$2" actual
+    [[ -n "$pid" ]] || return 1
+    kill -0 "$pid" >/dev/null 2>&1 || return 1
+    [[ -n "$expected" ]] || return 0
+    actual="$(_cmux_watcher_parent_start_time "$pid")" || return 1
+    [[ "$actual" == "$expected" ]]
+}
+
 _cmux_halt_pr_poll_loop() {
     # Process-group kill: background jobs are process-group leaders, so
     # negative PID kills the loop + all descendants (gh, sleep) without
@@ -1533,6 +1563,8 @@ _cmux_start_pr_poll_loop() {
     local watch_pwd="${1:-$PWD}"
     local force_restart="${2:-0}"
     local watch_shell_pid="$$"
+    local watch_shell_start
+    watch_shell_start="$(_cmux_watcher_parent_start_time "$watch_shell_pid" 2>/dev/null)" || watch_shell_start=""
     local interval="${_CMUX_PR_POLL_INTERVAL:-45}"
 
     if [[ "$force_restart" != "1" && "$watch_pwd" == "$_CMUX_PR_POLL_PWD" && -n "$_CMUX_PR_POLL_PID" ]] \
@@ -1551,7 +1583,7 @@ _cmux_start_pr_poll_loop() {
         local signal_path=""
         signal_path="$(_cmux_pr_force_signal_path 2>/dev/null || true)"
         while true; do
-            kill -0 "$watch_shell_pid" >/dev/null 2>&1 || break
+            _cmux_watcher_parent_alive "$watch_shell_pid" "$watch_shell_start" || break
             local force_probe=0
             if [[ -n "$signal_path" && -f "$signal_path" ]]; then
                 force_probe=1
@@ -1561,7 +1593,7 @@ _cmux_start_pr_poll_loop() {
 
             local slept=0
             while (( slept < interval )); do
-                kill -0 "$watch_shell_pid" >/dev/null 2>&1 || exit 0
+                _cmux_watcher_parent_alive "$watch_shell_pid" "$watch_shell_start" || exit 0
                 if [[ -n "$signal_path" && -f "$signal_path" ]]; then
                     break
                 fi
@@ -1600,10 +1632,12 @@ _cmux_start_git_head_watch() {
 
     _cmux_stop_git_head_watch
     local watch_shell_pid="$$"
+    local watch_shell_start
+    watch_shell_start="$(_cmux_watcher_parent_start_time "$watch_shell_pid" 2>/dev/null)" || watch_shell_start=""
     {
         local last_signature="$watch_head_signature"
         while true; do
-            kill -0 "$watch_shell_pid" >/dev/null 2>&1 || break
+            _cmux_watcher_parent_alive "$watch_shell_pid" "$watch_shell_start" || break
             sleep 1
 
             local signature

--- a/tests/test_issue_10926_watcher_pid_reuse_guard.py
+++ b/tests/test_issue_10926_watcher_pid_reuse_guard.py
@@ -143,6 +143,18 @@ def ps_epoch_start_time(pid: int, env: dict[str, str]) -> str:
     return str(int(started.timestamp()))
 
 
+def process_state(pid: int, env: dict[str, str]) -> str:
+    """Read the symbolic macOS process state without reaping the process."""
+    proc = subprocess.run(
+        ["/bin/ps", "-o", "state=", "-p", str(pid)],
+        env={**env, "LC_ALL": "C"},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return proc.stdout.strip() if proc.returncode == 0 else ""
+
+
 def check_guard_semantics(name: str, shell_argv: list[str], integration: Path, env: dict[str, str]) -> None:
     # The integration path is $1 in both shells so the scripts stay identical.
     guard_script = (
@@ -245,6 +257,40 @@ def check_guard_semantics(name: str, shell_argv: list[str], integration: Path, e
             f"[{name}] guard treated a dead parent PID as alive "
             f"(stdout={proc.stdout!r} stderr={proc.stderr[-500:]!r})"
         )
+
+    # 4. A zombie still has a PID and start time, but it cannot execute and is
+    #    no longer a live watcher parent. Keep it unreaped while checking the
+    #    shipped guard, then reap it in cleanup.
+    zombie = subprocess.Popen(["/bin/sh", "-c", "read _"], stdin=subprocess.PIPE)
+    try:
+        recorded_start = shell_start_time(shell_argv, integration, env, zombie.pid)
+        assert zombie.stdin is not None
+        zombie.stdin.close()
+        deadline = time.monotonic() + 5.0
+        state = ""
+        while time.monotonic() < deadline:
+            state = process_state(zombie.pid, env)
+            if state.startswith("Z"):
+                break
+            time.sleep(0.05)
+        if not recorded_start or not state.startswith("Z"):
+            fail(f"[{name}] could not create a zombie parent fixture (state={state!r})")
+        else:
+            proc = run_shell(
+                shell_argv,
+                guard_script,
+                [str(integration), str(zombie.pid), recorded_start],
+                env,
+            )
+            if "GUARD:0" in proc.stdout or "GUARD:" not in proc.stdout:
+                fail(
+                    f"[{name}] guard treated a zombie parent as alive "
+                    f"(stdout={proc.stdout!r} stderr={proc.stderr[-500:]!r})"
+                )
+    finally:
+        if zombie.stdin is not None and not zombie.stdin.closed:
+            zombie.stdin.close()
+        zombie.wait(timeout=5)
 
 
 def check_tiered_cadence(name: str, shell_argv: list[str], integration: Path, env: dict[str, str]) -> None:

--- a/tests/test_issue_10926_watcher_pid_reuse_guard.py
+++ b/tests/test_issue_10926_watcher_pid_reuse_guard.py
@@ -9,10 +9,10 @@ defeated by PID reuse: once macOS recycles the recorded PID onto any live
 process, the guard returns true forever and the watcher never exits
 (793 orphans / 2.1 GB after 20 days in the issue).
 
-The fix records a stable parent identity at spawn (PID plus /bin/ps lstart
-start time) in `_cmux_watcher_parent_start_time`, and the per-iteration
-guard `_cmux_watcher_parent_alive` treats a start-time mismatch or a
-failed ps as parent-dead.
+The fix records a stable parent identity at spawn (PID plus a numeric UTC
+`/bin/ps` lstart token) in `_cmux_watcher_parent_start_time`, and the
+per-iteration guard `_cmux_watcher_parent_alive` treats a start-time mismatch
+or a failed ps as parent-dead.
 
 This test never touches a running cmux instance or /tmp/cmux-debug.sock:
 it builds its own scratch HOME, its own unix socket, and unique panel ids.
@@ -21,6 +21,7 @@ it builds its own scratch HOME, its own unix socket, and unique panel ids.
 from __future__ import annotations
 
 import os
+import select
 import shutil
 import signal
 import socket
@@ -33,7 +34,7 @@ ROOT = Path(__file__).resolve().parents[1]
 ZSH_INTEGRATION = ROOT / "Resources" / "shell-integration" / "cmux-zsh-integration.zsh"
 BASH_INTEGRATION = ROOT / "Resources" / "shell-integration" / "cmux-bash-integration.bash"
 
-FAKE_START_TIME = "Thu Jan  1 00:00:00 1970"
+FAKE_START_TIME = "19700101000000"
 
 FAILURES: list[str] = []
 
@@ -53,13 +54,21 @@ def base_env(tmp: Path) -> dict[str, str]:
     }
 
 
-def run_shell(shell_argv: list[str], script: str, args: list[str], env: dict[str, str], timeout: float = 15.0) -> subprocess.CompletedProcess:
+def run_shell(
+    shell_argv: list[str],
+    script: str,
+    args: list[str],
+    env: dict[str, str],
+    timeout: float = 15.0,
+    pass_fds: tuple[int, ...] = (),
+) -> subprocess.CompletedProcess:
     return subprocess.run(
         [*shell_argv, "-c", script, "cmux-test", *args],
         env=env,
         capture_output=True,
         text=True,
         timeout=timeout,
+        pass_fds=pass_fds,
     )
 
 
@@ -82,13 +91,33 @@ def wait_pid_gone(pid: int, deadline_s: float) -> bool:
     return not pid_alive(pid)
 
 
-def ps_lstart(pid: int) -> str:
-    out = subprocess.run(
-        ["/bin/ps", "-o", "lstart=", "-p", str(pid)],
-        capture_output=True,
-        text=True,
-    ).stdout
-    return " ".join(out.split())
+def wait_ready(read_fd: int, expected: int = 1, timeout_s: float = 5.0) -> bool:
+    """Wait for explicit watcher-ready records without a timing sleep."""
+    data = b""
+    deadline = time.monotonic() + timeout_s
+    while data.count(b"READY\n") < expected:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return False
+        readable, _, _ = select.select([read_fd], [], [], remaining)
+        if not readable:
+            return False
+        chunk = os.read(read_fd, 4096)
+        if not chunk:
+            return False
+        data += chunk
+    return True
+
+
+def shell_start_time(shell_argv: list[str], integration: Path, env: dict[str, str], pid: int) -> str:
+    """Read the identity token through the shipped shell helper."""
+    proc = run_shell(
+        shell_argv,
+        'source "$1"; _cmux_watcher_parent_start_time "$2"',
+        [str(integration), str(pid)],
+        env,
+    )
+    return proc.stdout.strip() if proc.returncode == 0 else ""
 
 
 def check_guard_semantics(name: str, shell_argv: list[str], integration: Path, env: dict[str, str]) -> None:
@@ -101,6 +130,9 @@ def check_guard_semantics(name: str, shell_argv: list[str], integration: Path, e
     self_script = (
         'source "$1"; '
         'start="$(_cmux_watcher_parent_start_time $$)" || { printf "NOSTART\\n"; exit 1; }; '
+        'repeat="$(_cmux_watcher_parent_start_time $$)" || { printf "NOREPEAT\\n"; exit 1; }; '
+        '_cmux_watcher_parent_identity_valid $$ "$start" || { printf "NONNUMERIC\\n"; exit 1; }; '
+        '[[ "$start" == "$repeat" ]] || { printf "UNSTABLE\\n"; exit 1; }; '
         "_cmux_watcher_parent_alive $$ \"$start\"; "
         'printf \'GUARD:%s\\n\' "$?"'
     )
@@ -110,6 +142,49 @@ def check_guard_semantics(name: str, shell_argv: list[str], integration: Path, e
     if "GUARD:0" not in proc.stdout:
         fail(
             f"[{name}] guard rejected a live parent with its own recorded start time "
+            f"(stdout={proc.stdout!r} stderr={proc.stderr[-500:]!r})"
+        )
+
+    # Locale and timezone must not change the identity token. Darwin's ps uses
+    # both when formatting `lstart`, while the helper pins C/UTC before parsing.
+    localized_env = dict(env)
+    localized_env["LC_ALL"] = "ja_JP.UTF-8"
+    localized_env["TZ"] = "Asia/Tokyo"
+    proc = run_shell(shell_argv, self_script, [str(integration)], localized_env)
+    if "GUARD:0" not in proc.stdout:
+        fail(
+            f"[{name}] locale-sensitive start-time identity rejected a live parent "
+            f"(stdout={proc.stdout!r} stderr={proc.stderr[-500:]!r})"
+        )
+
+    # Missing identity must fail closed even when the PID is alive. A failed
+    # start-time capture cannot safely fall back to PID-only liveness.
+    empty_script = (
+        'source "$1"; '
+        '_cmux_watcher_parent_alive "$$" ""; '
+        'printf \'GUARD:%s\\n\' "$?"'
+    )
+    proc = run_shell(shell_argv, empty_script, [str(integration)], env)
+    if "GUARD:0" in proc.stdout or "GUARD:" not in proc.stdout:
+        fail(
+            f"[{name}] guard accepted an empty recorded start time "
+            f"(stdout={proc.stdout!r} stderr={proc.stderr[-500:]!r})"
+        )
+
+    # Identity lookup failure must also fail closed. Override the helper only
+    # in this throwaway shell to model a /bin/ps failure without touching the
+    # host process table.
+    ps_failure_script = (
+        'source "$1"; '
+        '_cmux_watcher_parent_start_time() { return 1; }; '
+        '_cmux_watcher_parent_alive "$$" "19700101000000"; '
+        'printf \'GUARD:%s\\n\' "$?"; '
+        '_cmux_capture_shell_start_time; printf \'CAPTURE:%s\\n\' "$?"'
+    )
+    proc = run_shell(shell_argv, ps_failure_script, [str(integration)], env)
+    if "GUARD:0" in proc.stdout or "GUARD:" not in proc.stdout or "CAPTURE:1" not in proc.stdout:
+        fail(
+            f"[{name}] guard accepted a failed start-time lookup "
             f"(stdout={proc.stdout!r} stderr={proc.stderr[-500:]!r})"
         )
 
@@ -128,9 +203,12 @@ def check_guard_semantics(name: str, shell_argv: list[str], integration: Path, e
         decoy.wait()
 
     # 3. Parent dead, PID not reused: guard must report parent-dead.
-    short = subprocess.Popen(["/bin/sleep", "0.05"])
-    recorded_start = ps_lstart(short.pid)
-    short.wait()
+    short = subprocess.Popen(["/bin/sleep", "60"])
+    try:
+        recorded_start = shell_start_time(shell_argv, integration, env, short.pid)
+    finally:
+        short.kill()
+        short.wait()
     proc = run_shell(shell_argv, guard_script, [str(integration), str(short.pid), recorded_start or FAKE_START_TIME], env)
     if "GUARD:0" in proc.stdout or "GUARD:" not in proc.stdout:
         fail(
@@ -151,9 +229,9 @@ def check_tiered_cadence(name: str, shell_argv: list[str], integration: Path, en
         "_CMUX_WATCHER_IDENTITY_INTERVAL=3; "
         'start="$(_cmux_watcher_parent_start_time $$)" || exit 9; '
         "_cmux_watcher_guard_tick $$ \"$start\"; printf 'T1:%s\\n' \"$?\"; "
-        "_cmux_watcher_guard_tick $$ \"not-the-start-time\"; printf 'T2:%s\\n' \"$?\"; "
-        "_cmux_watcher_guard_tick $$ \"not-the-start-time\"; printf 'T3:%s\\n' \"$?\"; "
-        "_cmux_watcher_guard_tick $$ \"not-the-start-time\"; printf 'T4:%s\\n' \"$?\""
+        f"_cmux_watcher_guard_tick $$ \"{FAKE_START_TIME}\"; printf 'T2:%s\\n' \"$?\"; "
+        f"_cmux_watcher_guard_tick $$ \"{FAKE_START_TIME}\"; printf 'T3:%s\\n' \"$?\"; "
+        f"_cmux_watcher_guard_tick $$ \"{FAKE_START_TIME}\"; printf 'T4:%s\\n' \"$?\""
     )
     proc = run_shell(shell_argv, script, [str(integration)], env)
     expected = ["T1:0", "T2:0", "T3:0"]
@@ -171,52 +249,67 @@ def check_injected_watcher_loop(name: str, shell_argv: list[str], integration: P
     # forks, which would push the reuse-detection bound past this test's.
     env = dict(env)
     env["_CMUX_WATCHER_IDENTITY_INTERVAL"] = "1"
-    if name == "zsh":
-        loop_script = (
-            'source "$1"; '
-            "{ while true; do _cmux_watcher_guard_tick \"$2\" \"$3\" || exit 0; sleep 0.2; done } >/dev/null 2>&1 &!; "
-            'printf \'LOOP:%s\\n\' "$!"'
-        )
-    else:
-        loop_script = (
-            'source "$1"; '
-            "{ while true; do _cmux_watcher_guard_tick \"$2\" \"$3\" || exit 0; sleep 0.2; done } >/dev/null 2>&1 & "
-            "disown; "
-            'printf \'LOOP:%s\\n\' "$!"'
-        )
 
-    def spawn_loop(pid: int, expected: str) -> int | None:
-        proc = run_shell(shell_argv, loop_script, [str(integration), str(pid), expected], env)
-        for line in proc.stdout.splitlines():
-            if line.startswith("LOOP:"):
-                try:
-                    return int(line.split(":", 1)[1])
-                except ValueError:
-                    return None
-        return None
+    def spawn_loop(pid: int, expected: str) -> tuple[int | None, int, bool]:
+        read_fd, write_fd = os.pipe()
+        try:
+            ready_command = (
+                f"print -r -- READY >&{write_fd}" if name == "zsh" else f"printf 'READY\\n' >&{write_fd}"
+            )
+            launch_suffix = "&!;" if name == "zsh" else "& disown;"
+            loop_script = (
+                'source "$1"; '
+                f"{{ _cmux_watcher_guard_tick \"$2\" \"$3\" || exit 0; {ready_command}; "
+                "while true; do sleep 0.2; _cmux_watcher_guard_tick \"$2\" \"$3\" || exit 0; done; } >/dev/null 2>&1 "
+                f"{launch_suffix} "
+                'printf \'LOOP:%s\\n\' "$!"'
+            )
+            proc = run_shell(
+                shell_argv,
+                loop_script,
+                [str(integration), str(pid), expected],
+                env,
+                pass_fds=(write_fd,),
+            )
+            loop_pid = None
+            for line in proc.stdout.splitlines():
+                if line.startswith("LOOP:"):
+                    try:
+                        loop_pid = int(line.split(":", 1)[1])
+                    except ValueError:
+                        loop_pid = None
+                    break
+            return loop_pid, read_fd, wait_ready(read_fd)
+        finally:
+            os.close(write_fd)
 
     decoy = subprocess.Popen(["/bin/sleep", "120"])
     try:
         # Normal path: recorded identity matches the live decoy. Watcher keeps running.
-        true_start = ps_lstart(decoy.pid)
-        loop_pid = spawn_loop(decoy.pid, true_start)
+        true_start = shell_start_time(shell_argv, integration, env, decoy.pid)
+        loop_pid, ready_fd, ready = spawn_loop(decoy.pid, true_start)
         if loop_pid is None:
             fail(f"[{name}] injected watcher loop did not report a PID")
+        elif not ready:
+            fail(f"[{name}] injected watcher loop did not report its first identity check")
         else:
-            time.sleep(2.0)
             if not pid_alive(loop_pid):
                 fail(f"[{name}] watcher loop exited although the recorded parent identity is alive and matching")
             else:
                 os.kill(loop_pid, signal.SIGKILL)
+        os.close(ready_fd)
 
         # PID reuse: same live PID, mismatched recorded start time. Watcher must
         # exit within a bounded time.
-        loop_pid = spawn_loop(decoy.pid, FAKE_START_TIME)
+        loop_pid, ready_fd, ready = spawn_loop(decoy.pid, FAKE_START_TIME)
         if loop_pid is None:
             fail(f"[{name}] injected reuse watcher loop did not report a PID")
         elif not wait_pid_gone(loop_pid, 5.0):
             fail(f"[{name}] watcher loop survived PID reuse (live PID, mismatched start time) beyond 5s")
             os.kill(loop_pid, signal.SIGKILL)
+        if ready:
+            fail(f"[{name}] injected reuse watcher reported ready despite a mismatched identity")
+        os.close(ready_fd)
     finally:
         decoy.kill()
         decoy.wait()
@@ -251,9 +344,21 @@ def check_real_loops(name: str, shell_argv: list[str], integration: Path, tmp: P
         }
     )
 
+    ready_read, ready_write = os.pipe()
     if name == "zsh":
         parent_script = f"""
 source "$1"
+functions[_cmux_test_guard_tick_impl]="${{functions[_cmux_watcher_guard_tick]}}"
+typeset -g _CMUX_TEST_READY_SENT=0
+_cmux_watcher_guard_tick() {{
+    _cmux_test_guard_tick_impl "$@"
+    local guard_status=$?
+    if (( guard_status == 0 && _CMUX_TEST_READY_SENT == 0 )); then
+        print -r -- READY >&{ready_write}
+        _CMUX_TEST_READY_SENT=1
+    fi
+    return "$guard_status"
+}}
 _cmux_run_pr_probe_with_timeout() {{ true; }}
 _cmux_pr_force_signal_path() {{ print -r -- {str(tmp / 'pr-force')!r}; }}
 _cmux_git_resolve_head_path() {{ print -r -- {str(head_file)!r}; }}
@@ -268,6 +373,17 @@ sleep 300
     else:
         parent_script = f"""
 source "$1"
+eval "$(declare -f _cmux_watcher_guard_tick | sed 's/_cmux_watcher_guard_tick/_cmux_test_guard_tick_impl/g')"
+_CMUX_TEST_READY_SENT=0
+_cmux_watcher_guard_tick() {{
+    _cmux_test_guard_tick_impl "$@"
+    local guard_status=$?
+    if [[ "$guard_status" == "0" && "${{_CMUX_TEST_READY_SENT:-0}}" != "1" ]]; then
+        printf 'READY\\n' >&{ready_write}
+        _CMUX_TEST_READY_SENT=1
+    fi
+    return "$guard_status"
+}}
 _cmux_run_pr_probe_with_timeout() {{ true; }}
 _cmux_pr_force_signal_path() {{ printf '%s\\n' {str(tmp / 'pr-force')!r}; }}
 _CMUX_PR_POLL_INTERVAL=1
@@ -283,13 +399,21 @@ sleep 300
         stderr=subprocess.PIPE,
         text=True,
         start_new_session=True,
+        pass_fds=(ready_write,),
     )
+    os.close(ready_write)
     watcher_pids: list[int] = []
     try:
-        deadline = time.time() + 10
+        deadline = time.monotonic() + 10
         line = ""
-        while time.time() < deadline:
+        while time.monotonic() < deadline:
+            remaining = deadline - time.monotonic()
+            readable, _, _ = select.select([parent.stdout], [], [], remaining)
+            if not readable:
+                break
             line = parent.stdout.readline()
+            if not line:
+                break
             if line.startswith("WATCHERS:"):
                 break
         if not line.startswith("WATCHERS:"):
@@ -302,7 +426,9 @@ sleep 300
             fail(f"[{name}] real-loop parent reported no watcher PIDs")
             return
 
-        time.sleep(2.5)
+        expected_ready = 2 if name == "zsh" else 1
+        if not wait_ready(ready_read, expected=expected_ready):
+            fail(f"[{name}] real-loop watchers did not report their first identity checks")
         for pid in watcher_pids:
             if not pid_alive(pid):
                 fail(f"[{name}] shipped watcher {pid} exited while its parent shell was still alive")
@@ -318,6 +444,7 @@ sleep 300
                 except ProcessLookupError:
                     pass
     finally:
+        os.close(ready_read)
         srv.close()
         if parent.poll() is None:
             try:

--- a/tests/test_issue_10926_watcher_pid_reuse_guard.py
+++ b/tests/test_issue_10926_watcher_pid_reuse_guard.py
@@ -28,6 +28,7 @@ import socket
 import subprocess
 import tempfile
 import time
+from datetime import UTC, datetime
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -121,6 +122,27 @@ def shell_start_time(shell_argv: list[str], integration: Path, env: dict[str, st
     return proc.stdout.strip() if proc.returncode == 0 else ""
 
 
+def ps_epoch_start_time(pid: int, env: dict[str, str]) -> str:
+    """Read macOS ps(1) lstart and convert it to canonical epoch seconds."""
+    proc = subprocess.run(
+        ["/bin/ps", "-o", "lstart=", "-p", str(pid)],
+        env={**env, "LC_ALL": "C", "TZ": "UTC"},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return ""
+    words = proc.stdout.split()
+    if len(words) != 5:
+        return ""
+    try:
+        started = datetime.strptime(" ".join(words), "%a %b %d %H:%M:%S %Y").replace(tzinfo=UTC)
+    except ValueError:
+        return ""
+    return str(int(started.timestamp()))
+
+
 def check_guard_semantics(name: str, shell_argv: list[str], integration: Path, env: dict[str, str]) -> None:
     # The integration path is $1 in both shells so the scripts stay identical.
     guard_script = (
@@ -193,6 +215,13 @@ def check_guard_semantics(name: str, shell_argv: list[str], integration: Path, e
     #    original parent (start time differs). Guard must report parent-dead.
     decoy = subprocess.Popen(["/bin/sleep", "60"])
     try:
+        helper_start = shell_start_time(shell_argv, integration, env, decoy.pid)
+        canonical_start = ps_epoch_start_time(decoy.pid, env)
+        if not canonical_start or helper_start != canonical_start:
+            fail(
+                f"[{name}] helper start identity is not canonical epoch seconds "
+                f"(helper={helper_start!r} ps={canonical_start!r})"
+            )
         proc = run_shell(shell_argv, guard_script, [str(integration), str(decoy.pid), FAKE_START_TIME], env)
         if "GUARD:0" in proc.stdout or "GUARD:" not in proc.stdout:
             fail(

--- a/tests/test_issue_10926_watcher_pid_reuse_guard.py
+++ b/tests/test_issue_10926_watcher_pid_reuse_guard.py
@@ -368,7 +368,7 @@ _CMUX_PR_POLL_INTERVAL=1
 _cmux_start_pr_poll_loop "$PWD" 1
 _cmux_start_git_head_watch
 print -r -- "WATCHERS:$_CMUX_PR_POLL_PID:$_CMUX_GIT_HEAD_WATCH_PID"
-sleep 300
+exec sleep 300
 """
     else:
         parent_script = f"""
@@ -389,7 +389,7 @@ _cmux_pr_force_signal_path() {{ printf '%s\\n' {str(tmp / 'pr-force')!r}; }}
 _CMUX_PR_POLL_INTERVAL=1
 _cmux_start_pr_poll_loop "$PWD" 1
 printf 'WATCHERS:%s:\\n' "$_CMUX_PR_POLL_PID"
-sleep 300
+exec sleep 300
 """
 
     parent = subprocess.Popen(
@@ -433,7 +433,7 @@ sleep 300
             if not pid_alive(pid):
                 fail(f"[{name}] shipped watcher {pid} exited while its parent shell was still alive")
 
-        os.killpg(parent.pid, signal.SIGKILL)
+        os.kill(parent.pid, signal.SIGKILL)
         parent.wait(timeout=5)
 
         for pid in watcher_pids:

--- a/tests/test_issue_10926_watcher_pid_reuse_guard.py
+++ b/tests/test_issue_10926_watcher_pid_reuse_guard.py
@@ -128,7 +128,7 @@ def check_guard_semantics(name: str, shell_argv: list[str], integration: Path, e
         'printf \'GUARD:%s\\n\' "$?"'
     )
     self_script = (
-        'source "$1"; '
+        'source "$1"; IFS=:; '
         'start="$(_cmux_watcher_parent_start_time $$)" || { printf "NOSTART\\n"; exit 1; }; '
         'repeat="$(_cmux_watcher_parent_start_time $$)" || { printf "NOREPEAT\\n"; exit 1; }; '
         '_cmux_watcher_parent_identity_valid $$ "$start" || { printf "NONNUMERIC\\n"; exit 1; }; '

--- a/tests/test_issue_10926_watcher_pid_reuse_guard.py
+++ b/tests/test_issue_10926_watcher_pid_reuse_guard.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""
+Regression for https://github.com/manaflow-ai/cmux/issues/10926.
+
+The zsh integration spawns two disowned watcher loops per pane (PR poll,
+git HEAD watch); the bash integration spawns one (PR poll). Each loop
+guarded parent liveness with a bare `kill -0 $watch_shell_pid`, which is
+defeated by PID reuse: once macOS recycles the recorded PID onto any live
+process, the guard returns true forever and the watcher never exits
+(793 orphans / 2.1 GB after 20 days in the issue).
+
+The fix records a stable parent identity at spawn (PID plus /bin/ps lstart
+start time) in `_cmux_watcher_parent_start_time`, and the per-iteration
+guard `_cmux_watcher_parent_alive` treats a start-time mismatch or a
+failed ps as parent-dead.
+
+This test never touches a running cmux instance or /tmp/cmux-debug.sock:
+it builds its own scratch HOME, its own unix socket, and unique panel ids.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import signal
+import socket
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ZSH_INTEGRATION = ROOT / "Resources" / "shell-integration" / "cmux-zsh-integration.zsh"
+BASH_INTEGRATION = ROOT / "Resources" / "shell-integration" / "cmux-bash-integration.bash"
+
+FAKE_START_TIME = "Thu Jan  1 00:00:00 1970"
+
+FAILURES: list[str] = []
+
+
+def fail(msg: str) -> None:
+    print(f"FAIL: {msg}")
+    FAILURES.append(msg)
+
+
+def base_env(tmp: Path) -> dict[str, str]:
+    return {
+        "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+        "HOME": str(tmp / "home"),
+        "TMPDIR": str(tmp),
+        "TERM": "dumb",
+        "LC_ALL": "C",
+    }
+
+
+def run_shell(shell_argv: list[str], script: str, args: list[str], env: dict[str, str], timeout: float = 15.0) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [*shell_argv, "-c", script, "cmux-test", *args],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+
+def wait_pid_gone(pid: int, deadline_s: float) -> bool:
+    deadline = time.time() + deadline_s
+    while time.time() < deadline:
+        if not pid_alive(pid):
+            return True
+        time.sleep(0.2)
+    return not pid_alive(pid)
+
+
+def ps_lstart(pid: int) -> str:
+    out = subprocess.run(
+        ["/bin/ps", "-o", "lstart=", "-p", str(pid)],
+        capture_output=True,
+        text=True,
+    ).stdout
+    return " ".join(out.split())
+
+
+def check_guard_semantics(name: str, shell_argv: list[str], integration: Path, env: dict[str, str]) -> None:
+    # The integration path is $1 in both shells so the scripts stay identical.
+    guard_script = (
+        'source "$1"; pid="$2"; expected="$3"; '
+        "_cmux_watcher_parent_alive \"$pid\" \"$expected\"; "
+        'printf \'GUARD:%s\\n\' "$?"'
+    )
+    self_script = (
+        'source "$1"; '
+        'start="$(_cmux_watcher_parent_start_time $$)" || { printf "NOSTART\\n"; exit 1; }; '
+        "_cmux_watcher_parent_alive $$ \"$start\"; "
+        'printf \'GUARD:%s\\n\' "$?"'
+    )
+
+    # 1. Parent alive, identity captured through the shipped helper: guard passes.
+    proc = run_shell(shell_argv, self_script, [str(integration)], env)
+    if "GUARD:0" not in proc.stdout:
+        fail(
+            f"[{name}] guard rejected a live parent with its own recorded start time "
+            f"(stdout={proc.stdout!r} stderr={proc.stderr[-500:]!r})"
+        )
+
+    # 2. PID reuse: recorded PID points at a live process that is NOT the
+    #    original parent (start time differs). Guard must report parent-dead.
+    decoy = subprocess.Popen(["/bin/sleep", "60"])
+    try:
+        proc = run_shell(shell_argv, guard_script, [str(integration), str(decoy.pid), FAKE_START_TIME], env)
+        if "GUARD:0" in proc.stdout or "GUARD:" not in proc.stdout:
+            fail(
+                f"[{name}] guard treated a recycled PID (live process, mismatched start time) as the live parent "
+                f"(stdout={proc.stdout!r} stderr={proc.stderr[-500:]!r})"
+            )
+    finally:
+        decoy.kill()
+        decoy.wait()
+
+    # 3. Parent dead, PID not reused: guard must report parent-dead.
+    short = subprocess.Popen(["/bin/sleep", "0.05"])
+    recorded_start = ps_lstart(short.pid)
+    short.wait()
+    proc = run_shell(shell_argv, guard_script, [str(integration), str(short.pid), recorded_start or FAKE_START_TIME], env)
+    if "GUARD:0" in proc.stdout or "GUARD:" not in proc.stdout:
+        fail(
+            f"[{name}] guard treated a dead parent PID as alive "
+            f"(stdout={proc.stdout!r} stderr={proc.stderr[-500:]!r})"
+        )
+
+
+def check_injected_watcher_loop(name: str, shell_argv: list[str], integration: Path, env: dict[str, str]) -> None:
+    if name == "zsh":
+        loop_script = (
+            'source "$1"; '
+            "{ while true; do _cmux_watcher_parent_alive \"$2\" \"$3\" || exit 0; sleep 0.2; done } >/dev/null 2>&1 &!; "
+            'printf \'LOOP:%s\\n\' "$!"'
+        )
+    else:
+        loop_script = (
+            'source "$1"; '
+            "{ while true; do _cmux_watcher_parent_alive \"$2\" \"$3\" || exit 0; sleep 0.2; done } >/dev/null 2>&1 & "
+            "disown; "
+            'printf \'LOOP:%s\\n\' "$!"'
+        )
+
+    def spawn_loop(pid: int, expected: str) -> int | None:
+        proc = run_shell(shell_argv, loop_script, [str(integration), str(pid), expected], env)
+        for line in proc.stdout.splitlines():
+            if line.startswith("LOOP:"):
+                try:
+                    return int(line.split(":", 1)[1])
+                except ValueError:
+                    return None
+        return None
+
+    decoy = subprocess.Popen(["/bin/sleep", "120"])
+    try:
+        # Normal path: recorded identity matches the live decoy. Watcher keeps running.
+        true_start = ps_lstart(decoy.pid)
+        loop_pid = spawn_loop(decoy.pid, true_start)
+        if loop_pid is None:
+            fail(f"[{name}] injected watcher loop did not report a PID")
+        else:
+            time.sleep(2.0)
+            if not pid_alive(loop_pid):
+                fail(f"[{name}] watcher loop exited although the recorded parent identity is alive and matching")
+            else:
+                os.kill(loop_pid, signal.SIGKILL)
+
+        # PID reuse: same live PID, mismatched recorded start time. Watcher must
+        # exit within a bounded time.
+        loop_pid = spawn_loop(decoy.pid, FAKE_START_TIME)
+        if loop_pid is None:
+            fail(f"[{name}] injected reuse watcher loop did not report a PID")
+        elif not wait_pid_gone(loop_pid, 5.0):
+            fail(f"[{name}] watcher loop survived PID reuse (live PID, mismatched start time) beyond 5s")
+            os.kill(loop_pid, signal.SIGKILL)
+    finally:
+        decoy.kill()
+        decoy.wait()
+
+
+def make_socket(path: Path) -> socket.socket:
+    srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    srv.bind(str(path))
+    srv.listen(8)
+    return srv
+
+
+def check_real_loops(name: str, shell_argv: list[str], integration: Path, tmp: Path) -> None:
+    """Drive the shipped _cmux_start_* functions from a throwaway parent shell.
+
+    Parent alive: watchers keep running. Parent killed (SIGKILL, so no exit
+    hooks run, matching the SIGHUP-less pane-close path): watchers exit within
+    a bounded time because the recorded PID is dead and not reused.
+    """
+    sock_path = tmp / f"watch-{name}.sock"
+    srv = make_socket(sock_path)
+    head_file = tmp / "fake-head"
+    head_file.write_text("ref: refs/heads/main\n", encoding="utf-8")
+
+    env = base_env(tmp)
+    env.update(
+        {
+            "CMUX_SOCKET_PATH": str(sock_path),
+            "CMUX_TAB_ID": "tab-test-10926",
+            "CMUX_PANEL_ID": f"panel-test-10926-{name}-{os.getpid()}",
+        }
+    )
+
+    if name == "zsh":
+        parent_script = f"""
+source "$1"
+_cmux_run_pr_probe_with_timeout() {{ true; }}
+_cmux_pr_force_signal_path() {{ print -r -- {str(tmp / 'pr-force')!r}; }}
+_cmux_git_resolve_head_path() {{ print -r -- {str(head_file)!r}; }}
+_cmux_git_head_signature() {{ print -r -- "sig"; }}
+_cmux_report_git_branch_for_path() {{ true; }}
+_CMUX_PR_POLL_INTERVAL=1
+_cmux_start_pr_poll_loop "$PWD" 1
+_cmux_start_git_head_watch
+print -r -- "WATCHERS:$_CMUX_PR_POLL_PID:$_CMUX_GIT_HEAD_WATCH_PID"
+sleep 300
+"""
+    else:
+        parent_script = f"""
+source "$1"
+_cmux_run_pr_probe_with_timeout() {{ true; }}
+_cmux_pr_force_signal_path() {{ printf '%s\\n' {str(tmp / 'pr-force')!r}; }}
+_CMUX_PR_POLL_INTERVAL=1
+_cmux_start_pr_poll_loop "$PWD" 1
+printf 'WATCHERS:%s:\\n' "$_CMUX_PR_POLL_PID"
+sleep 300
+"""
+
+    parent = subprocess.Popen(
+        [*shell_argv, "-c", parent_script, "cmux-test-parent", str(integration)],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+    watcher_pids: list[int] = []
+    try:
+        deadline = time.time() + 10
+        line = ""
+        while time.time() < deadline:
+            line = parent.stdout.readline()
+            if line.startswith("WATCHERS:"):
+                break
+        if not line.startswith("WATCHERS:"):
+            fail(f"[{name}] real-loop parent never reported watcher PIDs")
+            return
+        for token in line.strip().split(":")[1:]:
+            if token:
+                watcher_pids.append(int(token))
+        if not watcher_pids:
+            fail(f"[{name}] real-loop parent reported no watcher PIDs")
+            return
+
+        time.sleep(2.5)
+        for pid in watcher_pids:
+            if not pid_alive(pid):
+                fail(f"[{name}] shipped watcher {pid} exited while its parent shell was still alive")
+
+        os.killpg(parent.pid, signal.SIGKILL)
+        parent.wait(timeout=5)
+
+        for pid in watcher_pids:
+            if not wait_pid_gone(pid, 12.0):
+                fail(f"[{name}] shipped watcher {pid} survived >12s after its parent shell died")
+                try:
+                    os.kill(pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+    finally:
+        srv.close()
+        if parent.poll() is None:
+            try:
+                os.killpg(parent.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            parent.wait(timeout=5)
+        for pid in watcher_pids:
+            if pid_alive(pid):
+                try:
+                    os.kill(pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+
+
+def main() -> int:
+    if not ZSH_INTEGRATION.exists() or not BASH_INTEGRATION.exists():
+        print("SKIP: shell integration resources not found")
+        return 0
+    zsh = shutil.which("zsh")
+    bash = shutil.which("bash")
+    if zsh is None or bash is None:
+        print("SKIP: zsh or bash not installed")
+        return 0
+
+    tmp = Path(tempfile.mkdtemp(prefix="cmux_10926_"))
+    (tmp / "home").mkdir()
+    try:
+        shells = [
+            ("zsh", [zsh, "-f"], ZSH_INTEGRATION),
+            ("bash", [bash, "--norc"], BASH_INTEGRATION),
+        ]
+        for name, argv, integration in shells:
+            env = base_env(tmp)
+            check_guard_semantics(name, argv, integration, env)
+            check_injected_watcher_loop(name, argv, integration, env)
+            check_real_loops(name, argv, integration, tmp)
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+    if FAILURES:
+        print(f"FAILED: {len(FAILURES)} assertion(s)")
+        return 1
+    print("PASS: watcher parent-identity guard holds under PID reuse for zsh and bash")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_issue_10926_watcher_pid_reuse_guard.py
+++ b/tests/test_issue_10926_watcher_pid_reuse_guard.py
@@ -34,7 +34,8 @@ ROOT = Path(__file__).resolve().parents[1]
 ZSH_INTEGRATION = ROOT / "Resources" / "shell-integration" / "cmux-zsh-integration.zsh"
 BASH_INTEGRATION = ROOT / "Resources" / "shell-integration" / "cmux-bash-integration.bash"
 
-FAKE_START_TIME = "19700101000000"
+# Start identities are epoch seconds from both Darwin providers.
+FAKE_START_TIME = "1000000000"
 
 FAILURES: list[str] = []
 

--- a/tests/test_issue_10926_watcher_pid_reuse_guard.py
+++ b/tests/test_issue_10926_watcher_pid_reuse_guard.py
@@ -139,17 +139,48 @@ def check_guard_semantics(name: str, shell_argv: list[str], integration: Path, e
         )
 
 
+def check_tiered_cadence(name: str, shell_argv: list[str], integration: Path, env: dict[str, str]) -> None:
+    """The guard tick must run the ps identity comparison only every Nth call.
+
+    With interval 3: call 1 does the full check (passes, matching identity),
+    calls 2 and 3 take the cheap kill -0 path even though the recorded
+    identity is now wrong, call 4 does the full check again and fails.
+    """
+    script = (
+        'source "$1"; '
+        "_CMUX_WATCHER_IDENTITY_INTERVAL=3; "
+        'start="$(_cmux_watcher_parent_start_time $$)" || exit 9; '
+        "_cmux_watcher_guard_tick $$ \"$start\"; printf 'T1:%s\\n' \"$?\"; "
+        "_cmux_watcher_guard_tick $$ \"not-the-start-time\"; printf 'T2:%s\\n' \"$?\"; "
+        "_cmux_watcher_guard_tick $$ \"not-the-start-time\"; printf 'T3:%s\\n' \"$?\"; "
+        "_cmux_watcher_guard_tick $$ \"not-the-start-time\"; printf 'T4:%s\\n' \"$?\""
+    )
+    proc = run_shell(shell_argv, script, [str(integration)], env)
+    expected = ["T1:0", "T2:0", "T3:0"]
+    got = proc.stdout.split()
+    if got[:3] != expected or not got[3:4] or got[3] == "T4:0" or not got[3].startswith("T4:"):
+        fail(
+            f"[{name}] tiered guard cadence wrong (expected T1:0 T2:0 T3:0 T4:nonzero, "
+            f"stdout={proc.stdout!r} stderr={proc.stderr[-500:]!r})"
+        )
+
+
 def check_injected_watcher_loop(name: str, shell_argv: list[str], integration: Path, env: dict[str, str]) -> None:
+    # Pin the identity-check cadence to every iteration: the shipped default
+    # runs the ps comparison only every Nth iteration to avoid steady-state
+    # forks, which would push the reuse-detection bound past this test's.
+    env = dict(env)
+    env["_CMUX_WATCHER_IDENTITY_INTERVAL"] = "1"
     if name == "zsh":
         loop_script = (
             'source "$1"; '
-            "{ while true; do _cmux_watcher_parent_alive \"$2\" \"$3\" || exit 0; sleep 0.2; done } >/dev/null 2>&1 &!; "
+            "{ while true; do _cmux_watcher_guard_tick \"$2\" \"$3\" || exit 0; sleep 0.2; done } >/dev/null 2>&1 &!; "
             'printf \'LOOP:%s\\n\' "$!"'
         )
     else:
         loop_script = (
             'source "$1"; '
-            "{ while true; do _cmux_watcher_parent_alive \"$2\" \"$3\" || exit 0; sleep 0.2; done } >/dev/null 2>&1 & "
+            "{ while true; do _cmux_watcher_guard_tick \"$2\" \"$3\" || exit 0; sleep 0.2; done } >/dev/null 2>&1 & "
             "disown; "
             'printf \'LOOP:%s\\n\' "$!"'
         )
@@ -216,6 +247,7 @@ def check_real_loops(name: str, shell_argv: list[str], integration: Path, tmp: P
             "CMUX_SOCKET_PATH": str(sock_path),
             "CMUX_TAB_ID": "tab-test-10926",
             "CMUX_PANEL_ID": f"panel-test-10926-{name}-{os.getpid()}",
+            "_CMUX_WATCHER_IDENTITY_INTERVAL": "1",
         }
     )
 
@@ -321,6 +353,7 @@ def main() -> int:
         for name, argv, integration in shells:
             env = base_env(tmp)
             check_guard_semantics(name, argv, integration, env)
+            check_tiered_cadence(name, argv, integration, env)
             check_injected_watcher_loop(name, argv, integration, env)
             check_real_loops(name, argv, integration, tmp)
     finally:


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/10926.

The disowned watcher loops (zsh PR poll, zsh git HEAD watch, bash PR poll) guard parent liveness with a bare `kill -0 $watch_shell_pid`. macOS recycles PIDs within days on a busy machine, so once the recorded shell PID is reassigned to any live process the guard returns true forever and the watcher never exits. Combined with zshexit hooks not running on the untrapped-SIGHUP pane-close path, this accumulated 793 orphaned watchers holding 2.1 GB and spawning up to 208 concurrent `gh` processes over 20 days.

The fix is principled: it replaces the raw PID with a stable process identity. `_cmux_watcher_parent_start_time` records the parent's `/bin/ps -o lstart=` start time at watcher spawn (whitespace-normalized, since lstart pads single-digit days), and the shared per-iteration guard `_cmux_watcher_parent_alive` requires both PID liveness and a matching start time. A mismatch means the PID was recycled and the watcher exits; a failed ps also counts as parent-dead. Cost is one `/bin/ps` per second per watcher, the same subprocess cadence the loops already have. Residual risk: lstart granularity is 1 second, so a recycled PID whose new process has an identical start time string could still fool the guard; that requires the exact PID to be recycled within the same wall-clock second the original shell started, which is far outside observed reuse timescales.

The bash integration had the same pattern in its PR poll loop and gets the same helpers; its git probe is a one-shot, not a loop. The fish and nushell integrations have no disowned-watcher pattern and are unchanged. Commit 1 adds the failing regression test (`tests/test_issue_10926_watcher_pid_reuse_guard.py`, red without the helpers), commit 2 adds the fix (green); the test injects a live not-the-parent PID with a mismatched start time and asserts bounded-time exit, plus the parent-alive and parent-dead-unreused paths, for both shells, without touching any running cmux or `/tmp/cmux-debug.sock`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #10926 by pairing each disowned watcher's PID with the parent shell's start time, so a recycled PID no longer keeps the watcher alive — previously watchers accumulated (793 orphans / 2.1 GB after 20 days). Watchers now fail closed: a missing, malformed, or mismatched start time counts as parent-dead, and a watcher skips starting if the start time can't be captured.

**Bug Fixes**

- The identity comes from Darwin's kernel start time (via `sysctl kern.proc.pid.X`), falling back to a locale-independent `lstart` token, so an identically-timed PID recycle is effectively impossible.
- The `kill -0` liveness check runs every iteration; the start-time identity check runs every 30 iterations by default (`_CMUX_WATCHER_IDENTITY_INTERVAL`), adding no steady-state forks.
- The parent's start time is captured and cached once per shell lifetime, so a transient `ps` failure heals on the next watcher start.
- Applies to the zsh PR poll, zsh git HEAD watch, and bash PR poll; fish and nushell are unchanged.
- Regression tests — now wired into CI — cover parent-alive, parent-dead-unreused, recycled-PID, deferred-cadence, fail-closed, and locale-isolation paths against a scratch HOME and private socket, never a running cmux; existing orphans from before this fix are not cleaned up.

<sup>Written for commit b968841f72c69b4477463c109f7a2c91f842acc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background watcher reliability by detecting when a process ID has been reused.
  * Watchers now stop correctly when their original parent process exits or is replaced.
  * Improved watcher performance through periodic process-identity checks and frequent liveness checks.
  * Applied these safeguards consistently across Bash and Zsh integrations.

* **Tests**
  * Added regression coverage for live, terminated, and recycled parent processes across Bash and Zsh integrations.
  * Added the regression test to continuous integration checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->