### PR TITLE
fix(cmux-tui): terminal.close retires an exited terminal receipt without a live runtime

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/mux/resource_content.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux/resource_content.rs
@@ -8,7 +8,7 @@ use crate::browser::{BrowserSource, BrowserStatus};
 use crate::model::{Node, State};
 use crate::resource::{
     ContentPublicId, PanePublicId, SplitPublicId, TabPublicId, TabResourceIdentity,
-    WorkspacePublicId,
+    TerminalPublicId, WorkspacePublicId,
 };
 use crate::resource_api::{public_terminal_snapshot, terminal_tab_ids_in_canonical_order};
 use crate::workspace_registry::{
@@ -583,6 +583,64 @@ pub(crate) struct ResourceEffectProjection {
     pub(crate) patch: ResourcePatch,
     pub(crate) changes: Value,
     pub(crate) result: Value,
+}
+
+impl ResourceEffectProjection {
+    /// Explicit terminal close is the only operation that retires an exited
+    /// receipt. Full tree projection cannot infer that intent because exited
+    /// terminals have no runtime or views, so their tombstone and public
+    /// delete never fall out of the detached-tab diff.
+    pub(super) fn ensure_terminal_close(
+        &mut self,
+        terminal_id: &TerminalPublicId,
+        expected_incarnation: Option<&str>,
+    ) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            !self.patch.changes.iter().any(|change| matches!(
+                change,
+                ResourceChange::UpsertTerminal { public_id, .. } if public_id == terminal_id
+            )),
+            "terminal close projection retained {terminal_id}"
+        );
+        if let Some(existing) = self.patch.changes.iter_mut().find_map(|change| match change {
+            ResourceChange::TombstoneTerminal { public_id, expected_incarnation }
+                if public_id == terminal_id =>
+            {
+                Some(expected_incarnation)
+            }
+            _ => None,
+        }) {
+            if existing.is_none() {
+                *existing = expected_incarnation.map(ToOwned::to_owned);
+            }
+        } else {
+            self.patch.changes.push(ResourceChange::TombstoneTerminal {
+                public_id: terminal_id.clone(),
+                expected_incarnation: expected_incarnation.map(ToOwned::to_owned),
+            });
+        }
+
+        let changes = self
+            .changes
+            .as_array_mut()
+            .context("terminal close topology changes are not an array")?;
+        anyhow::ensure!(
+            !changes.iter().any(|change| {
+                change["kind"] == "upsert"
+                    && change["resource"] == "terminal"
+                    && change["id"].as_str() == Some(terminal_id.as_str())
+            }),
+            "terminal close public projection retained {terminal_id}"
+        );
+        if !changes.iter().any(|change| {
+            change["kind"] == "delete"
+                && change["resource"] == "terminal"
+                && change["id"].as_str() == Some(terminal_id.as_str())
+        }) {
+            push_delete_delta(changes, "terminal", terminal_id.as_str());
+        }
+        Ok(())
+    }
 }
 
 impl Mux {

--- a/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
@@ -2181,6 +2181,7 @@ impl Mux {
                     screen: Some(state.workspaces[workspace_index].screens[screen_index].id),
                     pane: Some(pane),
                     tab: Some(surface),
+                    terminal: None,
                 })
             },
         )?;
@@ -2191,25 +2192,28 @@ impl Mux {
 
     pub(crate) fn commit_resource_terminal_close_effect(
         &self,
-        surface: SurfaceId,
+        terminal_id: &TerminalPublicId,
         idempotency_key: &str,
         operation_name: &str,
         fingerprint: &Value,
     ) -> anyhow::Result<ResourcePatchCommit> {
         let _creation_handoff = self.resource_creation_handoff.lock().unwrap();
         let _creation_fence = self.resource_creation_execution.lock().unwrap();
+        let terminal_id = terminal_id.clone();
         let committed = self.commit_resource_close_with(
             ResourceOperation::TerminalClose,
             None,
             idempotency_key,
             operation_name,
             fingerprint,
-            move |state| {
-                anyhow::ensure!(
-                    state.terminal_runtime_by_id(surface).is_some(),
-                    "terminal disappeared"
-                );
-                Ok(EffectSlots { workspace: None, screen: None, pane: None, tab: Some(surface) })
+            move |_| {
+                Ok(EffectSlots {
+                    workspace: None,
+                    screen: None,
+                    pane: None,
+                    tab: None,
+                    terminal: Some(terminal_id),
+                })
             },
         )?;
         drop(_creation_fence);
@@ -2259,48 +2263,53 @@ impl Mux {
             return Err(terminal_close_state_error("terminal resource changed hosts"));
         }
         let content_id = ContentPublicId::Terminal(public_id.clone());
-        let (target, mut plan) = if let Some(runtime) =
-            state.terminal_catalog.get(&public_id).cloned()
-        {
-            let host = self.resource_terminal_host_identity(&runtime).ok_or_else(|| {
-                terminal_close_state_error("terminal runtime omitted its durable host identity")
-            })?;
-            if host.terminal_id != terminal_id {
-                return Err(terminal_close_state_error("terminal resource changed hosts"));
-            }
-            if let Some(expected) = expected_incarnation {
-                anyhow::ensure!(host.incarnation == expected, "terminal_incarnation_mismatch");
-            }
-            let target = state.placements_of_content(&content_id).first().copied();
-            let plan = self.resource_close_plan_locked(
-                ResourceOperation::TerminalClose,
-                EffectSlots { workspace: None, screen: None, pane: None, tab: Some(runtime.id) },
-                &registry,
-                &state,
-                &notifications,
-            )?;
-            (target, plan)
-        } else {
-            if !state.placements_of_content(&content_id).is_empty() {
-                return Err(terminal_close_state_error(format!(
-                    "live terminal resource {public_id} has views but no runtime owner"
-                )));
-            }
-            (
-                None,
-                ResourceClosePlan {
-                    state: state.clone(),
-                    removed: Vec::new(),
-                    terminal_runtime: None,
-                    closed_terminal_public_id: Some(public_id.clone()),
-                    terminal_batch: Vec::new(),
-                    workspace_close: None,
-                    delta: None,
-                    changed_screens: Vec::new(),
-                    selection_resync: false,
-                },
-            )
-        };
+        let (target, mut plan) =
+            if let Some(runtime) = state.terminal_catalog.get(&public_id).cloned() {
+                let host = self.resource_terminal_host_identity(&runtime).ok_or_else(|| {
+                    terminal_close_state_error("terminal runtime omitted its durable host identity")
+                })?;
+                if host.terminal_id != terminal_id {
+                    return Err(terminal_close_state_error("terminal resource changed hosts"));
+                }
+                if let Some(expected) = expected_incarnation {
+                    anyhow::ensure!(host.incarnation == expected, "terminal_incarnation_mismatch");
+                }
+                let target = state.placements_of_content(&content_id).first().copied();
+                let plan = self.resource_close_plan_locked(
+                    ResourceOperation::TerminalClose,
+                    EffectSlots {
+                        workspace: None,
+                        screen: None,
+                        pane: None,
+                        tab: None,
+                        terminal: Some(public_id.clone()),
+                    },
+                    &registry,
+                    &state,
+                    &notifications,
+                )?;
+                (target, plan)
+            } else {
+                if !state.placements_of_content(&content_id).is_empty() {
+                    return Err(terminal_close_state_error(format!(
+                        "live terminal resource {public_id} has views but no runtime owner"
+                    )));
+                }
+                (
+                    None,
+                    ResourceClosePlan {
+                        state: state.clone(),
+                        removed: Vec::new(),
+                        terminal_runtime: None,
+                        closed_terminal_public_id: Some(public_id.clone()),
+                        terminal_batch: Vec::new(),
+                        workspace_close: None,
+                        delta: None,
+                        changed_screens: Vec::new(),
+                        selection_resync: false,
+                    },
+                )
+            };
         let mut projection =
             self.resource_effect_projection_locked(&registry, &mut plan.state, json!({}))?;
         if !projection.patch.changes.iter().any(|change| {
@@ -2628,8 +2637,16 @@ impl Mux {
         }
         let mut plan =
             self.resource_close_plan_locked(operation, slots, &registry, &state, &notifications)?;
-        let projection =
+        let mut projection =
             self.resource_effect_projection_locked(&registry, &mut plan.state, json!({}))?;
+        // Full projection derives terminal tombstones from detached tabs, but
+        // an exited terminal receipt has zero tabs. Explicit close must still
+        // retire that receipt.
+        if let Some(terminal_id) = plan.closed_terminal_public_id.as_ref() {
+            let expected_incarnation =
+                plan.terminal_batch.first().and_then(|(_, incarnation)| incarnation.as_deref());
+            projection.ensure_terminal_close(terminal_id, expected_incarnation)?;
+        }
         #[cfg(test)]
         if let Some(hook) = self.resource_projection_before_commit.lock().unwrap().clone() {
             hook();
@@ -2715,7 +2732,7 @@ impl Mux {
         &self,
         operation: ResourceOperation,
         slots: EffectSlots,
-        _registry: &WorkspaceRegistry,
+        registry: &WorkspaceRegistry,
         state: &State,
         notifications: &HashMap<SurfaceId, SurfaceNotification>,
     ) -> anyhow::Result<ResourceClosePlan> {
@@ -2803,29 +2820,40 @@ impl Mux {
                 }
             }
             ResourceOperation::TerminalClose => {
-                let surface = slots.tab.context("terminal disappeared")?;
-                let runtime = state
-                    .terminal_runtime_by_id(surface)
-                    .cloned()
-                    .context("terminal disappeared")?;
-                let public_id = runtime
-                    .terminal_public_id()
-                    .cloned()
-                    .context("terminal catalog entry omitted its public identity")?;
-                let host = self
-                    .resource_terminal_host_identity(&runtime)
-                    .context("terminal omitted its durable host identity")?;
+                let public_id = slots.terminal.clone().context("terminal disappeared")?;
+                let host_id = registry
+                    .terminal_host_id(&public_id)?
+                    .with_context(|| format!("terminal {public_id} has no durable host"))?;
+                let terminal = registry
+                    .terminal_record(&host_id)?
+                    .with_context(|| format!("terminal {public_id} has no durable receipt"))?;
+                // An exited terminal is a durable receipt with no runtime and
+                // no views; explicit close is the one operation that retires
+                // it. A live terminal still requires its catalog runtime.
+                let runtime = state.terminal_catalog.get(&public_id).cloned();
+                if let Some(runtime) = runtime.as_ref() {
+                    let host = self
+                        .resource_terminal_host_identity(runtime)
+                        .context("terminal omitted its durable host identity")?;
+                    anyhow::ensure!(host.terminal_id == host_id, "terminal changed durable hosts");
+                }
                 let placements = state
                     .placements_of_content(&ContentPublicId::Terminal(public_id.clone()))
                     .to_vec();
+                if runtime.is_none() {
+                    anyhow::ensure!(
+                        placements.is_empty(),
+                        "live terminal resource {public_id} has views but no runtime owner"
+                    );
+                }
                 let screens = unique_screen_ids(
                     placements.iter().filter_map(|surface| surface_screen_id(state, *surface)),
                 );
                 ResourceCloseInputs {
                     surface_ids: placements,
                     changed_screens: screens,
-                    terminal_runtime: Some(runtime),
-                    terminal_batch: vec![(host.terminal_id, Some(host.incarnation))],
+                    terminal_runtime: runtime,
+                    terminal_batch: vec![(host_id, terminal.incarnation)],
                     terminal_public_id: Some(public_id),
                     ..Default::default()
                 }
@@ -2838,13 +2866,14 @@ impl Mux {
         if let Some(public_id) = &terminal_public_id {
             let (removed_runtime, terminal_views, changed) =
                 remove_terminal_content_from_state(self, &mut projected, public_id);
-            anyhow::ensure!(
-                removed_runtime
-                    .as_ref()
-                    .zip(terminal_runtime.as_ref())
-                    .is_some_and(|(removed, planned)| removed.shares_terminal_runtime(planned)),
-                "terminal close lost its catalog runtime"
-            );
+            match (removed_runtime.as_ref(), terminal_runtime.as_ref()) {
+                (Some(removed), Some(planned)) => anyhow::ensure!(
+                    removed.shares_terminal_runtime(planned),
+                    "terminal close changed its catalog runtime"
+                ),
+                (None, None) => {}
+                _ => anyhow::bail!("terminal close lost its catalog runtime"),
+            }
             removed = terminal_views;
             split_index_changed = changed;
             for surface in surface_ids {
@@ -3850,7 +3879,7 @@ impl Mux {
                     .with_context(|| format!("tab {id} disappeared"))
             })
             .transpose()?;
-        Ok(EffectSlots { workspace, screen, pane, tab })
+        Ok(EffectSlots { workspace, screen, pane, tab, terminal: path.terminal.clone() })
     }
 
     pub(super) fn created_resource_path(&self, surface: SurfaceId) -> anyhow::Result<Value> {
@@ -4414,12 +4443,13 @@ impl Mux {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 struct EffectSlots {
     workspace: Option<WorkspaceId>,
     screen: Option<ScreenId>,
     pane: Option<PaneId>,
     tab: Option<SurfaceId>,
+    terminal: Option<TerminalPublicId>,
 }
 
 enum ResourceCreationEvidence {

--- a/cmux-tui/crates/cmux-tui-core/src/resource_router/content.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/resource_router/content.rs
@@ -345,7 +345,16 @@ fn terminal_effect(mux: &Arc<Mux>, request: ParsedResourceRequest) -> Result<Val
     validate_terminal_effect_fields(&request)?;
     let fields = request.fields.clone();
     let preparation = effects::prepare(mux, &request, || {
-        let (terminal_id, _) = resolve_terminal_surface(mux, &request.selectors)?;
+        // Explicit close is the only terminal effect that must keep working
+        // after the runtime is gone: an exited terminal survives as a durable
+        // receipt with zero views, and close is the one operation that
+        // retires that receipt. Resolve it like `terminal.wait_exit` instead
+        // of demanding a live surface.
+        let terminal_id = if request.envelope.operation == ResourceOperation::TerminalClose {
+            resolve_terminal_wait_exit_id(mux, &request.selectors)?
+        } else {
+            resolve_terminal_surface(mux, &request.selectors)?.0
+        };
         Ok(json!({"terminal_id":terminal_id,"fields":fields}))
     })?;
     match preparation {
@@ -371,6 +380,16 @@ fn execute_terminal_effect(
         Ok(fields) => fields.clone(),
         Err(error) => return effects::commit_known_failure(mux, prepared, error),
     };
+    if prepared.operation == "terminal.close" {
+        let commit = mux.commit_resource_terminal_close_effect(
+            &terminal_id,
+            &prepared.idempotency_key,
+            &prepared.operation,
+            &prepared.fingerprint,
+        );
+        return finish_projection_commit(mux, prepared, commit);
+    }
+
     let Some(surface_id) = mux.resource_surface_for_terminal(&terminal_id) else {
         return effects::commit_known_failure(
             mux,
@@ -402,7 +421,6 @@ fn execute_terminal_effect(
             surface.clear_history().map_err(|error| ActionFailure::Indeterminate(error.to_string()))
         }
         "terminal.viewport.scroll" => terminal_scroll_viewport(mux, &surface, &fields),
-        "terminal.close" => Ok(()),
         operation => Err(ActionFailure::Known(ResourceError::operation_failed(
             operation,
             "stored terminal effect operation is invalid",
@@ -411,16 +429,6 @@ fn execute_terminal_effect(
     };
     if let Err(failure) = action {
         return finish_action_failure(mux, prepared, failure);
-    }
-
-    if prepared.operation == "terminal.close" {
-        let commit = mux.commit_resource_terminal_close_effect(
-            surface_id,
-            &prepared.idempotency_key,
-            &prepared.operation,
-            &prepared.fingerprint,
-        );
-        return finish_projection_commit(mux, prepared, commit);
     }
 
     debug_assert!(effects::receipt_only_operation(&prepared.operation));

--- a/cmux-tui/crates/cmux-tui-core/src/resource_router/content.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/resource_router/content.rs
@@ -2067,6 +2067,56 @@ mod tests {
         assert!(mux.surface(surface.id).is_none());
     }
 
+    #[test]
+    fn terminal_close_tombstones_an_exited_receipt_without_a_live_runtime() {
+        let (mux, _surface, selectors) = terminal_fixture(Some(vec!["fake-shell".into()]));
+        let public_id = TerminalPublicId::parse(selectors.terminal.as_deref().unwrap()).unwrap();
+        let host_id = mux
+            .terminal_registry_snapshot()
+            .unwrap()
+            .terminals
+            .into_iter()
+            .next()
+            .unwrap()
+            .terminal_id;
+        let exit = crate::terminal_host_protocol::TerminalExit {
+            outcome: crate::terminal_host_protocol::TerminalExitOutcome::Exit { code: 17 },
+            exited_at_ms: 4_567_890,
+        };
+        assert!(mux.persist_terminal_exit_for_test(&public_id, &exit).unwrap());
+        assert!(
+            mux.resource_surface_for_terminal(&public_id).is_none(),
+            "exit detach must retire the terminal runtime"
+        );
+
+        let closed = dispatch(
+            &mux,
+            parsed_request(
+                "terminal.close",
+                &selectors,
+                json!({}),
+                Some("close-exited-terminal-receipt"),
+            ),
+        )
+        .expect("terminal.close must retire an exited receipt without a live runtime");
+
+        assert_eq!(closed["replayed"], false);
+        assert!(
+            public_session_snapshot(&mux).unwrap()["terminals"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .all(|terminal| terminal["id"] != public_id.as_str()),
+            "a closed exited receipt must leave the public session snapshot"
+        );
+        let tombstone = mux.resolve_terminal(&host_id).unwrap().unwrap();
+        assert_eq!(
+            tombstone.terminal.lifecycle,
+            crate::workspace_registry::TerminalLifecycle::Tombstoned
+        );
+        mux.shutdown();
+    }
+
     #[cfg(unix)]
     #[test]
     fn terminal_wait_exit_resolves_detached_id_after_exit_upsert() {


### PR DESCRIPTION
Recut of one still-missing behavioral invariant from https://github.com/manaflow-ai/cmux/pull/9903, per https://github.com/manaflow-ai/cmux/issues/10998. The full TerminalResource/Surface rewrite is intentionally not carried over.

## Audit: behavioral invariants in #9903 vs current main

| Invariant enforced by #9903 | On current main |
| --- | --- |
| Terminal survives with zero views, addressable by public id | Covered by #9387: catalog owns the runtime, `Mux::surface` falls back to `terminal_runtime_by_id` |
| Runtime events (output/title/bell/resize/scroll) fan out to every materialized view | Covered: `terminal_event_placements` + test `terminal_runtime_events_fan_out_only_to_materialized_views` |
| Host connection-lost/reconnect accepted in the spawn/adopt publication gap, including after lifecycle committed Running | Covered: `pending_terminal_host_callback_matches` accepts Launching/Adopting/Running; test `pending_topology_accepts_running_host_before_surface_publication` |
| Exit persists lifecycle before topology detach, with retry ownership | Covered: `mark_hosted_surface_exited` + `schedule_exited_terminal_detach` |
| Terminal exit preserves the durable exited receipt in projections | Covered: exit-detach projection strips its own tombstone; test `terminal_wait_exit_latches_one_public_event_without_host_identity` asserts the receipt stays publicly addressable |
| Exited receipt survives unrelated later projections | Covered: full projection derives terminal tombstones only from detached tabs, and patches are change lists, so a zero-tab receipt is never swept |
| One explicit client/placement geometry authority per terminal | Covered: `claim_terminal_geometry` / `release_terminal_geometry` + tests |
| Closed view's SurfaceId retired; runtime gets its own id; kitty budgets/cell-pixels/sizing keyed by that runtime id; `set_terminal_client_size_participation`; retained-state snapshot (`emit_terminal_view_snapshot`) for late views | Rewrite-bound: these presuppose the TerminalResource/Surface identity split that #10998 forbids carrying over |
| `pty_input` shutdown drain waits for failure/completion callback settlement | Missing, but a narrow shutdown-only race with no API-visible contract; not chosen |
| Failed session-reset deletion restores the staged child | Missing, error-path hardening needing failure injection; not chosen |
| **Explicit `terminal.close` retires an exited terminal's durable receipt even with no live runtime** | **Missing — fixed here** |

## Chosen invariant and why

An exited terminal is deliberately kept as a durable receipt: zero views, no runtime, still shown in every `session.get` snapshot with `lifecycle: "exited"` so the exit stays observable. Explicit close is the only operation that may retire that receipt. But `terminal.close` resolved its target through a live runtime surface, so it returned `selector.not_found` for exactly these terminals: the receipt was permanently undismissable through the resource API (SDKs/CLI). Only the legacy host-id socket command could tombstone it. This is independently valuable, independent of the #9903 rewrite, and user-visible.

Red commit: the new test fails on main with `selector.not_found` on both hosted platforms.

## Mechanism of the fix

- `terminal.close` now resolves its target with `resolve_terminal_wait_exit_id`, the existing durable-receipt resolver used by `terminal.wait_exit` and `terminal.output.read` (nested workspace/screen/pane/tab selectors still scope-check; tombstoned ids still return not_found).
- `commit_resource_terminal_close_effect` takes the public terminal id. The close plan resolves the durable host and record through the registry, keeps the live-runtime path unchanged, and accepts a missing catalog runtime only when the terminal has zero placements.
- Full-tree projection derives terminal tombstones from detached tabs, which an exited receipt does not have, so the close commit now explicitly ensures the `TombstoneTerminal` change and the public `delete` delta (`ResourceEffectProjection::ensure_terminal_close`), and asserts the projection did not retain an upsert for the closed terminal.

Principled: it routes the receipt close through the same idempotent close-effect commit as a live close and reuses the established wait-exit resolver, instead of special-casing a second close path. Residual risk: the live-close terminal batch now carries the registry record's incarnation instead of the runtime host identity's; those match for adopted/running terminals, and a launching record without an incarnation now closes without an incarnation fence instead of failing.

## Verification

Two commits so CI shows red then green:

- Red (test only, `54661b0539`): hosted verify failed on Linux and macOS with `selector.not_found` — https://github.com/manaflow-ai/cmux/actions/runs/33125950006
- Green (fix, `3ec9433d83`): hosted verify with filter `terminal_close` (new test plus the neighboring close-path tests) — https://github.com/manaflow-ai/cmux/actions/runs/33136734795 (test (linux) and test (macos) both green; filter selects the new test plus terminal_close_runs_runtime_cleanup_outside_creation_fence, terminal_close_tombstones_before_kill_and_retries_safely, terminal_wait_exit_wakes_when_a_concurrent_terminal_close_tombstones_it, batch_terminal_close_rolls_back_every_tab_on_mid_transaction_failure, and concurrent_terminal_close_settles_unbounded_connection_wait_exit)

Part of https://github.com/manaflow-ai/cmux/issues/10998


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`terminal.close` now retires an exited terminal's durable receipt even when no live runtime exists, so exited terminals no longer get stuck in session snapshots.

- Resolves close targets with the same durable-receipt resolver as `terminal.wait_exit`, so an exited receipt with zero views is now closeable.
- Routes the close through the existing idempotent close-effect commit and explicitly tombstones the terminal in the projection, since full-tree projection only derives tombstones from detached tabs.
- Preserves the live-runtime close path unchanged; only receipt-only terminals are affected, and the live-close incarnation fence now uses the registry record's incarnation, which matches for adopted/running terminals.

Part of #10998.

<sup>Written for commit 3ec9433d83ced9daafe575235828dd528ab9efca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal closing to work reliably even after the terminal has exited.
  * Ensured closed terminal records are properly retired when no active runtime or view remains.
  * Prevented incomplete close operations by validating associated terminal state and deletion records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->