### PR TITLE
test(relay): align the pooled arm-coalescing pin with the #11034 deferral rule

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/journal_forwarder.rs
+++ b/cmux-tui/crates/chatmux-relay/src/journal_forwarder.rs
@@ -1916,7 +1916,7 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn pooled_arm_wakes_are_coalesced_while_the_flusher_is_busy() {
+    async fn pooled_arm_wakes_defer_while_the_flusher_is_busy_and_coalesce_after() {
         let (root, path) = cursor_test_path("pool-arm-coalesce").await;
         let (shared, wake) = test_shared(String::from("http://127.0.0.1:9"), path);
         let generation = Some(String::from("gen_a"));
@@ -1934,9 +1934,32 @@ mod tests {
             );
         }
 
+        // While a POST is in flight, below-threshold arms never wake: the
+        // completion path re-arms the debounce from the leftover total under
+        // the same lock that clears `flushing` (the #11034 deferral rule —
+        // this pin and the pooled_threshold deferral pin share it).
+        assert!(
+            tokio::time::timeout(Duration::from_millis(10), wake.notified()).await.is_err(),
+            "arms during an in-flight POST must defer to the completion re-arm"
+        );
+
+        // After the POST settles, arm wakes flow again — and coalesce.
+        {
+            let mut pool = shared.pool.lock().expect("lock pool");
+            pool.flushing = false;
+        }
+        for sequence in 4..=6 {
+            enqueue_pending(
+                &shared,
+                "alpha",
+                "alpha",
+                &generation,
+                record("gen_a", &sequence.to_string()),
+            );
+        }
         tokio::time::timeout(Duration::from_millis(100), wake.notified())
             .await
-            .expect("arm request must wake the flusher");
+            .expect("an idle-flusher arm request must wake the flusher");
         assert!(
             tokio::time::timeout(Duration::from_millis(10), wake.notified()).await.is_err(),
             "repeated arm requests must use one pending wake"


### PR DESCRIPTION
Unbreak main, part 2. #11034 fixed `pooled_threshold_drains_an_exact_batch_and_defers_while_posting` but its merge gate ran only that test; the sibling pin `pooled_arm_wakes_are_coalesced_while_the_flusher_is_busy` demands the OPPOSITE behavior for the same machine state and now fails on main (both platforms; feat-relay-tunnel-terminal run 33135675946 is the evidence).

The two pins were formally contradictory — identical state (`flushing = true`, zero stored permits) and identical inputs (below-threshold enqueues), one asserting ≥1 wake and the other asserting 0. They were never green together: #10989 and #11034 each gated with a one-test filter.

The code rule that survives is #11034's (reviewed twice: enqueue-under-flushing and completion serialize on the pool lock; the completion path re-arms the debounce from the leftover total, so a wake during a POST is spurious and nothing is stranded). This PR rewrites the sibling pin to that rule and keeps its original purpose: arms DEFER while a POST is in flight, then wake and COALESCE once the flusher is idle. Renamed to `pooled_arm_wakes_defer_while_the_flusher_is_busy_and_coalesce_after`.

Gate: hosted `--filter pooled_` (substring selects BOTH pooled pins — the narrow-filter mistake is what let this contradiction merge twice).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the pooled arm-coalescing test with the `#11034` deferral rule, which the sibling threshold test already follows. The two tests previously demanded opposite wake behavior for the same state (`flushing = true`, zero stored permits, below-threshold enqueues), so they could never pass together. Arms now defer while a POST is in flight, then wake and coalesce once the flusher is idle; the test is renamed to `pooled_arm_wakes_defer_while_the_flusher_is_busy_and_coalesce_after`.

<sup>Written for commit e92bc952ebfba1720bae00fdcc7fb74bee99576b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

