### PR TITLE
test(cmux-tui): issue-10431 paste repro harnesses and audit analyzer

### DIFF
--- a/cmux-tui/scripts/analyze-10431-audit.py
+++ b/cmux-tui/scripts/analyze-10431-audit.py
@@ -1,0 +1,172 @@
+# Analyze a CMUX_TUI_INPUT_AUDIT file produced by repro-10431-paste.py.
+#
+# For each paste iteration it reconstructs the byte stream seen at each tap
+# (t1 = crossterm ingress, t2 = app enqueue toward the surface, t3 = bytes
+# written to the child pty) and diffs them against the known 818-byte paste,
+# printing the exact runs that vanished and the layer they vanished in.
+#
+# The taps are NOT compiled into the product: producing an audit file needs
+# an instrumented cmux-tui build. The last full tap implementation lives at
+# commit 67c488b5a85d9aa2d3e46fb15efd33c19c7980ed in the history of
+# https://github.com/manaflow-ai/cmux/pull/11041 - cherry-pick it onto a
+# throwaway branch to re-run the byte accounting. repro-10431-dash-only.py
+# and repro-10431-pure-pty.py run against any build (no taps involved).
+
+import difflib
+import sys
+
+AUDIT = sys.argv[1] if len(sys.argv) > 1 else "audit.log"
+
+inner_osc_query = """python3 - <<'PY'
+import os, select, termios, time, tty
+fd = os.open('/dev/tty', os.O_RDWR)
+old = termios.tcgetattr(fd)
+try:
+    tty.setraw(fd)
+    os.write(fd, b'\\x1b]11;?\\x1b\\\\')
+    data = b''
+    # Generous deadline: the shell may still be consuming the pasted
+    # heredoc and the TUI coalesces frames (this raced at 2s, and 8s
+    # still fails on saturated CI runners).
+    end = time.monotonic() + 30
+    while time.monotonic() < end and not (data.endswith(b'\\x1b\\\\') or data.endswith(b'\\x07')):
+        r, _, _ = select.select([fd], [], [], max(0, end - time.monotonic()))
+        if not r:
+            break
+        data += os.read(fd, 128)
+finally:
+    termios.tcsetattr(fd, termios.TCSADRAIN, old)
+    os.close(fd)
+print(data.decode('ascii', 'ignore').replace('\\x1b', '<ESC>').replace('\\x07', '<BEL>'))
+PY
+"""
+EXPECTED = inner_osc_query.replace("\n", "\r").encode()
+# For capture-mode audits, REPRO_CAPTURE holds the capture file path the
+# repro printed at startup (the path is embedded in the pasted bytes).
+CAPTURE = os.environ.get("REPRO_CAPTURE") if (os := __import__("os")) else None
+if CAPTURE:
+    body = inner_osc_query.split("\n", 1)[1]
+    body = body[: body.rindex("PY\n") + len("PY\n")]
+    tail = "printf 'CAPTURE-%s\\n' done\n"
+    EXPECTED = (f"cat > {CAPTURE} <<'PY'\n" + body + tail).replace("\n", "\r").encode()
+
+
+def parse(path):
+    iterations = []
+    current = None
+    for raw in open(path, "r", encoding="utf-8", errors="replace"):
+        parts = raw.rstrip("\n").split(" ")
+        if len(parts) < 3:
+            continue
+        tag = parts[1]
+        if tag == "harness":
+            marker = parts[2]
+            if marker.endswith("-begin"):
+                current = {"name": marker[:-6].rstrip("-"), "lines": []}
+            elif current is not None:
+                current["result"] = marker.rsplit("-", 1)[-1]
+                iterations.append(current)
+                current = None
+            continue
+        if current is not None:
+            current["lines"].append(parts)
+    return iterations
+
+
+def stream(lines, tag, predicate=lambda parts: True):
+    out = bytearray()
+    for parts in lines:
+        if parts[1] != tag or not predicate(parts):
+            continue
+        hexpart = parts[-1]
+        if hexpart and hexpart != "-":
+            try:
+                out.extend(bytes.fromhex(hexpart))
+            except ValueError:
+                pass
+    return bytes(out)
+
+
+def diff_report(name, got, expected):
+    if got == expected:
+        print(f"  {name}: {len(got)} bytes, exact match")
+        return True
+    print(f"  {name}: {len(got)} bytes (expected {len(expected)})")
+    matcher = difflib.SequenceMatcher(a=expected, b=got, autojunk=False)
+    for op, a0, a1, b0, b1 in matcher.get_opcodes():
+        if op == "equal":
+            continue
+        lost = expected[a0:a1]
+        added = got[b0:b1]
+        print(
+            f"    {op} expected[{a0}:{a1}]={lost!r} got[{b0}:{b1}]={added!r}"
+        )
+    return False
+
+
+def only_paste_window(data, expected):
+    # The tap stream may contain unrelated bytes (probe replies, earlier
+    # commands). Trim to the region from the first byte of the paste prefix.
+    prefix = expected[:16]
+    index = data.find(prefix[:8])
+    return data[index:] if index >= 0 else data
+
+
+def audit_losses(lines):
+    """Audit-writer losses within one iteration: (dropped lines, shed payloads).
+
+    The audit sink drops whole lines under queue pressure (`audit-dropped N`)
+    and sheds large payloads under byte pressure (`payload-bytes=N` in the
+    detail). Either way the tap streams are incomplete, so byte loss must not
+    be attributed to the pipeline from this iteration.
+    """
+    dropped = 0
+    shed = 0
+    for parts in lines:
+        if parts[1] == "audit-dropped":
+            try:
+                dropped += int(parts[2])
+            except (IndexError, ValueError):
+                dropped += 1
+        elif any(part.startswith("payload-bytes=") for part in parts[2:]):
+            shed += 1
+    return dropped, shed
+
+
+iterations = parse(AUDIT)
+print(f"{len(iterations)} iterations in {AUDIT}")
+for iteration in iterations:
+    result = iteration.get("result", "?")
+    print(f"{iteration['name']}: {result}")
+    if result == "ok":
+        continue
+    lines = iteration["lines"]
+    dropped, shed = audit_losses(lines)
+    if dropped or shed:
+        print(
+            f"  INCONCLUSIVE: the audit writer lost data in this iteration"
+            f" ({dropped} dropped lines, {shed} shed payloads); tap streams"
+            " are incomplete, so byte loss cannot be attributed to the"
+            " pipeline. Rerun with less load or a faster audit target."
+        )
+        continue
+    t1 = only_paste_window(stream(lines, "t1-key"), EXPECTED)
+    t2 = only_paste_window(
+        stream(lines, "t2-enqueue", lambda parts: "kind=Ordered" in " ".join(parts)),
+        EXPECTED,
+    )
+    t3 = only_paste_window(
+        stream(lines, "t3-write", lambda parts: "result=ok" in " ".join(parts)),
+        EXPECTED,
+    )
+    ok1 = diff_report("t1 crossterm ingress", t1[: len(EXPECTED)], EXPECTED)
+    ok2 = diff_report("t2 app enqueue     ", t2[: len(EXPECTED)], EXPECTED)
+    ok3 = diff_report("t3 child pty write ", t3[: len(EXPECTED)], EXPECTED)
+    for parts in lines:
+        if parts[1] in ("t2-dropped", "t2-rejected", "t3-canceled", "t3-rejected-exited"):
+            print("    note:", " ".join(parts[1:]))
+    if ok1 and ok2 and ok3:
+        print(
+            "    all taps intact: loss is below the TUI's child-pty write"
+            " (kernel pty input path or the inner shell)"
+        )

--- a/cmux-tui/scripts/repro-10431-dash-only.py
+++ b/cmux-tui/scripts/repro-10431-dash-only.py
@@ -1,0 +1,149 @@
+# cmux-free control for issue 10431: pty.fork straight into /bin/sh, paste
+# the same heredoc the smoke test used (optionally as 1-byte writes with a
+# slow echo drain), and diff the capture file. If this loses bytes, the loss
+# is in the kernel pty/line-discipline path plus dash, with no cmux code
+# anywhere in the picture.
+#
+# Env: REPRO_ITERS (30), REPRO_LOAD (cpu count), REPRO_WRITE_CHUNK (1),
+#      REPRO_ECHO_DELAY (0), REPRO_ECHO_READ (65536)
+
+import difflib
+import multiprocessing
+import os
+import pty
+import select
+import signal
+import sys
+import time
+
+import tempfile
+
+ITERS = int(os.environ.get("REPRO_ITERS", "30"))
+LOAD = int(os.environ.get("REPRO_LOAD", str(os.cpu_count() or 4)))
+WRITE_CHUNK = int(os.environ.get("REPRO_WRITE_CHUNK", "1"))
+ECHO_DELAY = float(os.environ.get("REPRO_ECHO_DELAY", "0"))
+ECHO_READ = int(os.environ.get("REPRO_ECHO_READ", "65536"))
+# Fresh private directory: never write through a predictable /tmp path.
+CAPTURE = os.path.join(tempfile.mkdtemp(prefix="repro10431-dash-"), "paste-cap.txt")
+
+inner_osc_query = """python3 - <<'PY'
+import os, select, termios, time, tty
+fd = os.open('/dev/tty', os.O_RDWR)
+old = termios.tcgetattr(fd)
+try:
+    tty.setraw(fd)
+    os.write(fd, b'\\x1b]11;?\\x1b\\\\')
+    data = b''
+    # Generous deadline: the shell may still be consuming the pasted
+    # heredoc and the TUI coalesces frames (this raced at 2s, and 8s
+    # still fails on saturated CI runners).
+    end = time.monotonic() + 30
+    while time.monotonic() < end and not (data.endswith(b'\\x1b\\\\') or data.endswith(b'\\x07')):
+        r, _, _ = select.select([fd], [], [], max(0, end - time.monotonic()))
+        if not r:
+            break
+        data += os.read(fd, 128)
+finally:
+    termios.tcsetattr(fd, termios.TCSADRAIN, old)
+    os.close(fd)
+print(data.decode('ascii', 'ignore').replace('\\x1b', '<ESC>').replace('\\x07', '<BEL>'))
+PY
+"""
+body = inner_osc_query.split("\n", 1)[1]
+body = body[: body.rindex("PY\n") + len("PY\n")]
+tail = "printf 'CAPTURE-%s\\n' done\n"
+PASTE = (f"cat > {CAPTURE} <<'PY'\n" + body + tail).replace("\n", "\r").encode()
+EXPECT_BODY = body[: body.rindex("PY\n")]
+
+
+def spin_worker():
+    x = 0
+    while True:
+        x = (x * 1103515245 + 12345) & 0xFFFFFFFF
+
+
+for _ in range(LOAD):
+    multiprocessing.Process(target=spin_worker, daemon=True).start()
+print(f"load: {LOAD}; chunk={WRITE_CHUNK}; echo_delay={ECHO_DELAY}; echo_read={ECHO_READ}")
+
+pid, fd = pty.fork()
+if pid == 0:
+    os.environ["TERM"] = "xterm-256color"
+    os.execv("/bin/sh", ["/bin/sh", "-i"])
+
+import fcntl
+import struct
+import termios
+
+fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", 30, 100, 0, 0))
+
+output = b""
+
+
+def drain(seconds):
+    global output
+    end = time.monotonic() + seconds
+    while time.monotonic() < end:
+        r, _, _ = select.select([fd], [], [], 0.1)
+        if r:
+            try:
+                chunk = os.read(fd, ECHO_READ)
+            except OSError:
+                return
+            output += chunk
+            if ECHO_DELAY:
+                time.sleep(ECHO_DELAY)
+
+
+def write_all_chunked(data):
+    view = memoryview(data)
+    while view:
+        n = os.write(fd, view[:WRITE_CHUNK])
+        view = view[n:]
+
+
+drain(1.0)
+failures = 0
+for iteration in range(1, ITERS + 1):
+    if os.path.exists(CAPTURE):
+        os.unlink(CAPTURE)
+    write_all_chunked(PASTE)
+    deadline = time.monotonic() + 45
+    done = False
+    while time.monotonic() < deadline:
+        drain(0.2)
+        if b"CAPTURE-done" in output:
+            done = True
+            break
+    got = None
+    if done:
+        try:
+            got = open(CAPTURE, "r", encoding="utf-8", errors="replace").read()
+        except OSError:
+            got = "<missing>"
+    if got == EXPECT_BODY:
+        print(f"iteration {iteration}: ok")
+    else:
+        failures += 1
+        print(f"iteration {iteration}: FAILURE (done={done})")
+        if got is not None:
+            for line in difflib.unified_diff(
+                EXPECT_BODY.splitlines(), got.splitlines(), "expected", "received", lineterm=""
+            ):
+                print(line)
+        else:
+            print("---- raw pty tail ----")
+            print(repr(output[-2000:]))
+        write_all_chunked(b"\x03")
+        drain(0.5)
+    output = b""
+    write_all_chunked(b"clear\r")
+    drain(0.4)
+    sys.stdout.flush()
+
+try:
+    os.kill(pid, signal.SIGTERM)
+except ProcessLookupError:
+    pass
+print(f"{failures} failures / {ITERS} iterations")
+sys.exit(2 if failures else 0)

--- a/cmux-tui/scripts/repro-10431-kernel.bt
+++ b/cmux-tui/scripts/repro-10431-kernel.bt
@@ -1,0 +1,70 @@
+// Kernel byte accounting for issue 10431 (run with: sudo bpftrace this.bt)
+// Compares bytes accepted by pty master writes against bytes the slave's
+// line discipline actually received, and flags every discard path.
+
+kprobe:pty_write
+{
+    @w_req[((struct tty_struct *)arg0)->name] = sum(arg2);
+    @w_tty[tid] = ((struct tty_struct *)arg0)->name;
+}
+
+kretprobe:pty_write
+/@w_tty[tid] != ""/
+{
+    if ((int64)retval > 0) {
+        @w_acc[@w_tty[tid]] = sum(retval);
+    } else {
+        printf("pty_write ret=%d tty=%s comm=%s\n", retval, @w_tty[tid], comm);
+    }
+    delete(@w_tty[tid]);
+}
+
+kprobe:n_tty_receive_buf2
+{
+    @r_req[((struct tty_struct *)arg0)->name] = sum(arg3);
+    @r_tty[tid] = ((struct tty_struct *)arg0)->name;
+    @r_cnt[tid] = arg3;
+}
+
+kretprobe:n_tty_receive_buf2
+/@r_tty[tid] != ""/
+{
+    @r_acc[@r_tty[tid]] = sum(retval);
+    if ((uint64)retval != @r_cnt[tid]) {
+        printf("%d ms n_tty_receive_buf2 SHORT tty=%s req=%d rcvd=%d\n",
+               elapsed / 1000000, @r_tty[tid], @r_cnt[tid], retval);
+    }
+    delete(@r_tty[tid]);
+    delete(@r_cnt[tid]);
+}
+
+kprobe:n_tty_receive_char_flagged
+{
+    printf("%d ms receive_char_flagged tty=%s c=%x flag=%d comm=%s\n",
+           elapsed / 1000000, ((struct tty_struct *)arg0)->name, arg1, arg2, comm);
+    @flagged[((struct tty_struct *)arg0)->name] = count();
+}
+
+kprobe:n_tty_lookahead_flow_ctrl
+{
+    @lookahead[((struct tty_struct *)arg0)->name] = sum(arg3);
+}
+
+kprobe:tty_buffer_flush
+{
+    printf("%d ms tty_buffer_flush tty=%s comm=%s\n%s\n",
+           elapsed / 1000000, ((struct tty_struct *)arg0)->name, comm, kstack(6));
+}
+
+kprobe:n_tty_flush_buffer
+{
+    printf("%d ms n_tty_flush_buffer tty=%s comm=%s\n%s\n",
+           elapsed / 1000000, ((struct tty_struct *)arg0)->name, comm, kstack(6));
+}
+
+END
+{
+    clear(@w_tty);
+    clear(@r_tty);
+    clear(@r_cnt);
+}

--- a/cmux-tui/scripts/repro-10431-paste.py
+++ b/cmux-tui/scripts/repro-10431-paste.py
@@ -1,0 +1,399 @@
+# Repro harness for https://github.com/manaflow-ai/cmux/issues/10431.
+#
+# Restores the smoke step that pasted a ~818-byte python heredoc into the
+# TUI's shell as raw pty keystrokes, loops it under CPU load, and stops at
+# the first iteration where the OSC 11 reply never appears. On failure this
+# script prints the screen and the exact bytes it wrote.
+#
+# The paste loop and capture mode run against ANY cmux-tui build. The
+# CMUX_TUI_INPUT_AUDIT byte-accounting taps that this harness and
+# analyze-10431-audit.py consume are NOT compiled into the product: they
+# need an instrumented build. The last full tap implementation lives at
+# commit 67c488b5a85d9aa2d3e46fb15efd33c19c7980ed in the history of
+# https://github.com/manaflow-ai/cmux/pull/11041 - cherry-pick it onto a
+# throwaway branch to re-run the byte accounting. Against a stock build the
+# audit file only contains this harness's own marker lines.
+#
+# Env:
+#   CMUX_TUI_BIN     path to the cmux-tui binary (default target/debug/cmux-tui)
+#   REPRO_ITERS      paste iterations (default 30)
+#   REPRO_LOAD       busy-spin worker count (default: os.cpu_count())
+#   CMUX_TUI_INPUT_AUDIT  audit file (instrumented builds only, see above)
+
+import json
+import multiprocessing
+import os
+import pty
+import re
+import select
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+
+BIN = os.path.abspath(os.environ.get("CMUX_TUI_BIN", "target/debug/cmux-tui"))
+SESSION = f"repro10431-{os.getpid()}"
+CONTROL_SOCKET_RE = re.compile(r"control socket at (.+)$")
+ITERS = int(os.environ.get("REPRO_ITERS", "30"))
+LOAD = int(os.environ.get("REPRO_LOAD", str(os.cpu_count() or 4)))
+AUDIT = os.environ.get("CMUX_TUI_INPUT_AUDIT")
+
+
+def write_all(fd, data):
+    view = memoryview(data)
+    while view:
+        written = os.write(fd, view)
+        if written <= 0:
+            raise OSError("PTY write made no progress")
+        view = view[written:]
+
+
+def wait_for_control_socket(server, seconds=30):
+    deadline = time.monotonic() + seconds
+    output = []
+    while time.monotonic() < deadline:
+        if server.poll() is not None:
+            rest = server.stdout.read() or ""
+            if rest:
+                output.append(rest)
+            break
+        wait = min(0.1, max(0.0, deadline - time.monotonic()))
+        readable, _, _ = select.select([server.stdout], [], [], wait)
+        if not readable:
+            continue
+        line = server.stdout.readline()
+        if not line:
+            continue
+        output.append(line)
+        match = CONTROL_SOCKET_RE.search(line.strip())
+        if match:
+            path = match.group(1)
+            socket_deadline = time.monotonic() + 5
+            while time.monotonic() < socket_deadline:
+                if os.path.exists(path):
+                    return path
+                if server.poll() is not None:
+                    break
+                time.sleep(0.05)
+            raise AssertionError(f"control socket line found but socket missing at {path}")
+    raise AssertionError("no control socket: " + "".join(output)[-2000:])
+
+
+def stop_process(process):
+    if process.poll() is not None:
+        return
+    process.terminate()
+    try:
+        process.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=10)
+
+
+def discover_socket_path():
+    probe = subprocess.Popen(
+        [BIN, "--headless", "--session", SESSION],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+    path = None
+    try:
+        path = wait_for_control_socket(probe)
+        return path
+    finally:
+        stop_process(probe)
+        if path and os.path.exists(path):
+            os.unlink(path)
+
+
+SOCK = discover_socket_path()
+
+
+def rpc(cmd):
+    s = socket.socket(socket.AF_UNIX)
+    s.settimeout(15)
+    s.connect(SOCK)
+    s.sendall((json.dumps(cmd) + "\n").encode())
+    buf = b""
+    while not buf.endswith(b"\n"):
+        chunk = s.recv(65536)
+        if not chunk:
+            break
+        buf += chunk
+    s.close()
+    return json.loads(buf)
+
+
+def spin_worker():
+    x = 0
+    while True:
+        x = (x * 1103515245 + 12345) & 0xFFFFFFFF
+
+
+load_procs = []
+
+
+def start_load():
+    for _ in range(LOAD):
+        p = multiprocessing.Process(target=spin_worker, daemon=True)
+        p.start()
+        load_procs.append(p)
+    print(f"load: {LOAD} spin workers")
+
+tmpdir = tempfile.TemporaryDirectory(prefix="cmux-tui-repro10431-")
+
+pid, fd = pty.fork()
+if pid == 0:
+    os.chdir(tmpdir.name)
+    os.environ["TERM"] = "xterm-256color"
+    os.environ["SHELL"] = os.environ.get("REPRO_SHELL", "/bin/sh")
+    os.environ["HOME"] = tmpdir.name
+    os.environ["CMUX_MUX_CDP_URL"] = "http://127.0.0.1:1/"
+    os.environ.pop("NO_COLOR", None)
+    os.execv(BIN, [BIN, "--session", SESSION, "--socket", SOCK, "--ephemeral"])
+
+import fcntl
+import struct
+import termios
+
+fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", 30, 100, 0, 0))
+os.kill(pid, signal.SIGWINCH)
+
+output = b""
+probe_pending = b""
+keyboard_probe_answers = 0
+
+
+def answer_host_color_queries(chunk):
+    global probe_pending
+    probe_pending += chunk
+    while True:
+        start = probe_pending.find(b"\x1b]")
+        if start < 0:
+            probe_pending = probe_pending[-1:]
+            return
+        if start > 0:
+            probe_pending = probe_pending[start:]
+        bel = probe_pending.find(b"\x07", 2)
+        st = probe_pending.find(b"\x1b\\", 2)
+        ends = [(bel, b"\x07"), (st, b"\x1b\\")]
+        ends = [e for e in ends if e[0] >= 0]
+        if not ends:
+            probe_pending = probe_pending[-64:]
+            return
+        end, terminator = min(ends, key=lambda e: e[0])
+        seq = probe_pending[:end]
+        if seq == b"\x1b]10;?":
+            write_all(fd, b"\x1b]10;rgb:d8d8/d9d9/dada" + terminator)
+        elif seq == b"\x1b]11;?":
+            write_all(fd, b"\x1b]11;rgb:1313/1414/1515" + terminator)
+        probe_pending = probe_pending[end + len(terminator):]
+
+
+def drain(seconds):
+    global output, keyboard_probe_answers
+    end = time.monotonic() + seconds
+    while time.monotonic() < end:
+        r, _, _ = select.select([fd], [], [], 0.1)
+        if r:
+            try:
+                chunk = os.read(fd, 65536)
+                output += chunk
+                keyboard_queries = output.count(b"\x1b[?u")
+                while keyboard_probe_answers < keyboard_queries:
+                    write_all(fd, b"\x1b[?29u")
+                    keyboard_probe_answers += 1
+                answer_host_color_queries(chunk)
+            except OSError:
+                break
+
+
+def read_screen(surface_id):
+    return rpc({"id": 300, "cmd": "read-screen", "surface": surface_id})["data"]["text"]
+
+
+def wait_screen(surface_id, needle, seconds=45, absent=False):
+    deadline = time.monotonic() + seconds
+    last = ""
+    while time.monotonic() < deadline:
+        drain(0.2)
+        last = read_screen(surface_id)
+        if (needle in last) != absent:
+            return last, True
+    return last, False
+
+
+def first_surface():
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        drain(0.2)
+        workspaces = rpc({"id": 999, "cmd": "list-workspaces"})["data"]["workspaces"]
+        for workspace in workspaces:
+            for screen in workspace["screens"]:
+                for pane in screen["panes"]:
+                    for tab in pane["tabs"]:
+                        return tab["surface"]
+    raise AssertionError("no surface appeared")
+
+
+surface_id = first_surface()
+write_all(fd, b"printf 'ready-%s\\n' ok\r")
+screen, ok = wait_screen(surface_id, "ready-ok")
+assert ok, screen[-500:]
+print("shell ready")
+
+# Optional one-time setup command typed into the shell (e.g. 'stty -ixon'
+# for the kernel IXON-lookahead A/B experiment).
+SETUP = os.environ.get("REPRO_SETUP")
+if SETUP:
+    write_all(fd, SETUP.encode() + b"; printf 'setup-%s\\n' ok\r")
+    screen, ok = wait_screen(surface_id, "setup-ok")
+    assert ok, screen[-500:]
+    print(f"setup ran: {SETUP}")
+
+inner_osc_query = """python3 - <<'PY'
+import os, select, termios, time, tty
+fd = os.open('/dev/tty', os.O_RDWR)
+old = termios.tcgetattr(fd)
+try:
+    tty.setraw(fd)
+    os.write(fd, b'\\x1b]11;?\\x1b\\\\')
+    data = b''
+    # Generous deadline: the shell may still be consuming the pasted
+    # heredoc and the TUI coalesces frames (this raced at 2s, and 8s
+    # still fails on saturated CI runners).
+    end = time.monotonic() + 30
+    while time.monotonic() < end and not (data.endswith(b'\\x1b\\\\') or data.endswith(b'\\x07')):
+        r, _, _ = select.select([fd], [], [], max(0, end - time.monotonic()))
+        if not r:
+            break
+        data += os.read(fd, 128)
+finally:
+    termios.tcsetattr(fd, termios.TCSADRAIN, old)
+    os.close(fd)
+print(data.decode('ascii', 'ignore').replace('\\x1b', '<ESC>').replace('\\x07', '<BEL>'))
+PY
+"""
+PASTE = inner_osc_query.replace("\n", "\r").encode()
+print(f"paste is {len(PASTE)} bytes")
+
+# capture mode (REPRO_CAPTURE=1): same heredoc body, but the shell writes it
+# to a file so the exact bytes the inner shell received (tap T4) can be
+# diffed afterwards. The file lives in a fresh private directory (mkdtemp)
+# so a predictable, symlinkable path is never written through. Pass the
+# printed path to analyze-10431-audit.py via REPRO_CAPTURE.
+CAPTURE = None
+if os.environ.get("REPRO_CAPTURE"):
+    CAPTURE = os.path.join(
+        tempfile.mkdtemp(prefix="repro10431-cap-"), "paste-cap.txt"
+    )
+EXPECT_BODY = None
+if CAPTURE:
+    body = inner_osc_query.split("\n", 1)[1]
+    body = body[: body.rindex("PY\n") + len("PY\n")]
+    tail = "printf 'CAPTURE-%s\\n' done\n"
+    PASTE = (f"cat > {CAPTURE} <<'PY'\n" + body + tail).replace("\n", "\r").encode()
+    EXPECT_BODY = body[: body.rindex("PY\n")]
+    print(f"capture mode: paste is {len(PASTE)} bytes, capture file {CAPTURE}")
+
+
+def audit_mark(marker):
+    # Create 0600 like the TUI's audit writer; the writer refuses an audit
+    # file with group/other permission bits (it captures raw keystrokes).
+    if AUDIT:
+        fd = os.open(AUDIT, os.O_CREAT | os.O_WRONLY | os.O_APPEND, 0o600)
+        try:
+            os.write(fd, f"0 harness {marker} -\n".encode())
+        finally:
+            os.close(fd)
+
+
+SUCCESS_NEEDLE = "CAPTURE-done" if CAPTURE else "1313/1414/1515"
+
+start_load()
+
+
+def dump_tui_death(iteration):
+    print(f"iteration {iteration}: TUI/control socket died mid-iteration")
+    drain(1.0)
+    try:
+        done, status = os.waitpid(pid, os.WNOHANG)
+        if done:
+            print(f"TUI waitpid status: {status:#x} (exited={os.WIFEXITED(status)} "
+                  f"code={os.WEXITSTATUS(status) if os.WIFEXITED(status) else '-'} "
+                  f"signaled={os.WIFSIGNALED(status)} "
+                  f"sig={os.WTERMSIG(status) if os.WIFSIGNALED(status) else '-'})")
+        else:
+            print("TUI process still running; socket alone vanished")
+    except OSError as error:
+        print(f"waitpid failed: {error}")
+    print("---- last pty output (repr, tail 4000) ----")
+    print(repr(output[-4000:]))
+    print("---- end pty output ----")
+
+
+failures = 0
+for iteration in range(1, ITERS + 1):
+    if CAPTURE and os.path.exists(CAPTURE):
+        os.unlink(CAPTURE)
+    audit_mark(f"iter-{iteration}-begin")
+    try:
+        write_all(fd, PASTE)
+        screen, ok = wait_screen(surface_id, SUCCESS_NEEDLE, seconds=45)
+    except (FileNotFoundError, ConnectionRefusedError, OSError) as error:
+        audit_mark(f"iter-{iteration}-DIED")
+        print(f"iteration {iteration}: rpc/pty error: {error!r}")
+        dump_tui_death(iteration)
+        failures += 1
+        break
+    if ok and CAPTURE:
+        try:
+            got = open(CAPTURE, "r", encoding="utf-8", errors="replace").read()
+        except OSError:
+            got = "<missing capture file>"
+        if got != EXPECT_BODY:
+            ok = False
+            print(f"iteration {iteration}: capture file diverges from paste")
+            import difflib
+            for line in difflib.unified_diff(
+                EXPECT_BODY.splitlines(), got.splitlines(), "expected", "received", lineterm=""
+            ):
+                print(line)
+    audit_mark(f"iter-{iteration}-{'ok' if ok else 'FAIL'}")
+    if not ok:
+        failures += 1
+        print(f"iteration {iteration}: FAILURE")
+        print("---- screen ----")
+        print(screen)
+        print("---- end screen ----")
+        sys.stdout.flush()
+        break
+    # Interrupt any half-open heredoc state and clear for the next round.
+    write_all(fd, b"\x03")
+    drain(0.3)
+    write_all(fd, b"clear\r")
+    screen, cleared = wait_screen(surface_id, SUCCESS_NEEDLE, seconds=15, absent=True)
+    if not cleared:
+        print(f"iteration {iteration}: screen did not clear; aborting")
+        print(screen)
+        break
+    print(f"iteration {iteration}: ok")
+    sys.stdout.flush()
+
+write_all(fd, b"\x03")
+drain(0.3)
+rpc({"id": 1, "cmd": "shutdown"}) if False else None
+os.kill(pid, signal.SIGTERM)
+time.sleep(0.5)
+try:
+    os.kill(pid, signal.SIGKILL)
+except ProcessLookupError:
+    pass
+for p in load_procs:
+    p.terminate()
+
+sys.exit(2 if failures else 0)

--- a/cmux-tui/scripts/repro-10431-pure-pty.py
+++ b/cmux-tui/scripts/repro-10431-pure-pty.py
@@ -1,0 +1,191 @@
+# Pure-kernel control experiment for issue 10431: no cmux code involved.
+#
+# Creates a pty pair with the same termios the cmux-tui child shell has
+# (ICANON|ECHO|ICRNL|IXON), forks a reader that consumes canonical lines
+# from the slave (like dash collecting a heredoc), writes the same ~860-byte
+# paste into the master in one write, drains the echo, and compares what the
+# reader received against what was written. Run under CPU load.
+#
+# Env:
+#   REPRO_ITERS  iterations (default 50)
+#   REPRO_LOAD   busy-spin workers (default: cpu count)
+#   REPRO_IXON   1 keeps IXON (default), 0 clears it
+#   REPRO_READER_DELAY  seconds the reader sleeps between line reads (default 0.01)
+
+import multiprocessing
+import os
+import select
+import sys
+import termios
+import time
+
+ITERS = int(os.environ.get("REPRO_ITERS", "50"))
+LOAD = int(os.environ.get("REPRO_LOAD", str(os.cpu_count() or 4)))
+KEEP_IXON = os.environ.get("REPRO_IXON", "1") == "1"
+READER_DELAY = float(os.environ.get("REPRO_READER_DELAY", "0.01"))
+# cmux-tui's pty-input worker delivers a paste as one merged chunk followed
+# by hundreds of 1-byte writes; default mimics that. Set large (e.g. 65536)
+# for a single-write control.
+WRITE_CHUNK = int(os.environ.get("REPRO_WRITE_CHUNK", "1"))
+# Echo backpressure: seconds to wait between master-side echo reads, and the
+# read size. A busy TUI drains the child master slowly; 0 drains eagerly.
+ECHO_DELAY = float(os.environ.get("REPRO_ECHO_DELAY", "0"))
+ECHO_READ = int(os.environ.get("REPRO_ECHO_READ", "65536"))
+
+inner_osc_query = """python3 - <<'PY'
+import os, select, termios, time, tty
+fd = os.open('/dev/tty', os.O_RDWR)
+old = termios.tcgetattr(fd)
+try:
+    tty.setraw(fd)
+    os.write(fd, b'\\x1b]11;?\\x1b\\\\')
+    data = b''
+    # Generous deadline: the shell may still be consuming the pasted
+    # heredoc and the TUI coalesces frames (this raced at 2s, and 8s
+    # still fails on saturated CI runners).
+    end = time.monotonic() + 30
+    while time.monotonic() < end and not (data.endswith(b'\\x1b\\\\') or data.endswith(b'\\x07')):
+        r, _, _ = select.select([fd], [], [], max(0, end - time.monotonic()))
+        if not r:
+            break
+        data += os.read(fd, 128)
+finally:
+    termios.tcsetattr(fd, termios.TCSADRAIN, old)
+    os.close(fd)
+print(data.decode('ascii', 'ignore').replace('\\x1b', '<ESC>').replace('\\x07', '<BEL>'))
+PY
+"""
+PASTE = inner_osc_query.replace("\n", "\r").encode()
+EXPECTED = inner_osc_query.encode()  # after ICRNL, CR arrives as NL
+
+
+def spin_worker():
+    x = 0
+    while True:
+        x = (x * 1103515245 + 12345) & 0xFFFFFFFF
+
+
+for _ in range(LOAD):
+    multiprocessing.Process(target=spin_worker, daemon=True).start()
+print(f"load: {LOAD} spin workers; ixon={KEEP_IXON}; reader delay {READER_DELAY}s")
+
+failures = 0
+for iteration in range(1, ITERS + 1):
+    master, slave = os.openpty()
+    import fcntl
+    import struct
+    fcntl.ioctl(slave, termios.TIOCSWINSZ, struct.pack("HHHH", 30, 100, 0, 0))
+    attrs = termios.tcgetattr(slave)
+    # default openpty termios already has ICANON|ECHO|ICRNL|IXON on Linux;
+    # assert the ones the experiment depends on, and toggle IXON as asked.
+    if KEEP_IXON:
+        attrs[0] |= termios.IXON
+    else:
+        attrs[0] &= ~termios.IXON
+    attrs[0] |= termios.ICRNL
+    attrs[3] |= termios.ICANON | termios.ECHO
+    termios.tcsetattr(slave, termios.TCSANOW, attrs)
+
+    reader_done_r, reader_done_w = os.pipe()
+    ps2 = os.environ.get("REPRO_PS2", "0") == "1"
+    child = os.fork()
+    if child == 0:
+        os.close(master)
+        os.close(reader_done_r)
+        got = bytearray()
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline and len(got) < len(EXPECTED):
+            r, _, _ = select.select([slave], [], [], deadline - time.monotonic())
+            if not r:
+                break
+            chunk = os.read(slave, 8192)
+            if not chunk:
+                break
+            got.extend(chunk)
+            if ps2:
+                # dash writes a "> " continuation prompt to the tty between
+                # canonical line reads while collecting a heredoc.
+                os.write(slave, b"> ")
+            if READER_DELAY:
+                time.sleep(READER_DELAY)
+        os.write(reader_done_w, bytes(got) + b"\x00DONE\x00")
+        os.close(reader_done_w)
+        os._exit(0)
+
+    os.close(slave)
+    os.close(reader_done_w)
+
+    # Echo drainer: a separate thread reads the master like the TUI's reader
+    # thread would, optionally slowly (echo backpressure).
+    import threading
+
+    echoed = bytearray()
+    echo_stop = threading.Event()
+
+    def drain_echo():
+        while not echo_stop.is_set():
+            r, _, _ = select.select([master], [], [], 0.2)
+            if not r:
+                continue
+            try:
+                chunk = os.read(master, ECHO_READ)
+            except OSError:
+                return
+            if not chunk:
+                return
+            echoed.extend(chunk)
+            if ECHO_DELAY:
+                time.sleep(ECHO_DELAY)
+
+    echo_thread = threading.Thread(target=drain_echo, daemon=True)
+    echo_thread.start()
+
+    view = memoryview(PASTE)
+    if WRITE_CHUNK == 0:
+        # cmux-tui's observed paste delivery: one large merged chunk, then
+        # the remainder as rapid 1-byte writes (the corruption in the full
+        # system clusters at exactly this seam).
+        seam = int(os.environ.get("REPRO_SEAM", "512"))
+        n = os.write(master, view[:seam])
+        view = view[n:]
+        while view:
+            n = os.write(master, view[:1])
+            view = view[n:]
+    else:
+        while view:
+            n = os.write(master, view[:WRITE_CHUNK])
+            view = view[n:]
+
+    received = bytearray()
+    deadline = time.monotonic() + 35
+    while time.monotonic() < deadline and not received.endswith(b"\x00DONE\x00"):
+        r, _, _ = select.select([reader_done_r], [], [], 1.0)
+        if reader_done_r in r:
+            chunk = os.read(reader_done_r, 65536)
+            if not chunk:
+                break
+            received.extend(chunk)
+    os.close(reader_done_r)
+    echo_stop.set()
+    os.close(master)
+    echo_thread.join(timeout=5)
+    os.waitpid(child, 0)
+
+    got = bytes(received)
+    if got.endswith(b"\x00DONE\x00"):
+        got = got[: -len(b"\x00DONE\x00")]
+    if got == EXPECTED:
+        print(f"iteration {iteration}: ok")
+    else:
+        failures += 1
+        print(f"iteration {iteration}: FAILURE got {len(got)} expected {len(EXPECTED)}")
+        import difflib
+        m = difflib.SequenceMatcher(a=EXPECTED, b=got, autojunk=False)
+        for op, a0, a1, b0, b1 in m.get_opcodes():
+            if op == "equal":
+                continue
+            print(f"  {op}: expected[{a0}:{a1}]={EXPECTED[a0:a1]!r} got={got[b0:b1]!r}")
+    sys.stdout.flush()
+
+print(f"{failures} failures / {ITERS} iterations")
+sys.exit(2 if failures else 0)


### PR DESCRIPTION
Repro harnesses and the audit analyzer that produced the byte-accounting evidence for https://github.com/manaflow-ai/cmux/issues/10431 (full writeup on the issue). Scripts only; this PR contains no product-code changes.

Under `cmux-tui/scripts/`:

- `repro-10431-paste.py` restores the heredoc paste that #10847 removed from smoke-tui.py and loops it under CPU load against an `--ephemeral` TUI; capture mode (`REPRO_CAPTURE=1`) makes the shell write the heredoc into a file under a fresh `mkdtemp` directory (never a predictable, symlinkable path) so the exact received bytes can be diffed. Runs against any build.
- `analyze-10431-audit.py` diffs each byte-accounting tap stream (`t1` crossterm ingress, `t2` app enqueue, `t3` child-pty write) against the known paste, prints the lost runs per layer, and marks any iteration where the audit writer itself dropped lines or shed payloads INCONCLUSIVE instead of attributing byte loss to the pipeline.
- `repro-10431-dash-only.py` and `repro-10431-pure-pty.py` are the cmux-free kernel control experiments (0 failures in 260+ loaded iterations, which exonerates plain pty usage patterns). They run against any build.
- `repro-10431-kernel.bt` is the bpftrace script comparing pty master write bytes against slave line-discipline receive bytes and flagging every kernel discard path.

The `CMUX_TUI_INPUT_AUDIT` taps that the paste harness and analyzer consume are deliberately NOT product code: they are heavy diagnostics that belong on a throwaway branch, and producing an audit file needs an instrumented build. The last full tap implementation (bounded off-thread writer, byte budget, 0600 regular-file contract, T1/T2/T3 taps plus lifecycle notes) lives at commit 67c488b5a85d9aa2d3e46fb15efd33c19c7980ed in this PR's history; cherry-pick it onto a throwaway branch to re-run the byte accounting. Against a stock build, the audit file carries only the harness's own marker lines.

Result of the accounting (details and evidence on the issue): every paste byte left cmux-tui with a successful `write()` to the child pty master (T1=T2=T3 byte-exact in every audited failure); the corruption happens inside the Linux 6.6.141 tty stack under load, so the harness-side contract from #10847 stands and no product change is made. The investigation also uncovered a separate bug (remote transport loss synthesizes `MuxEvent::Empty`, silently exiting an ephemeral TUI with code 0), fixed in https://github.com/manaflow-ai/cmux/pull/11045.

Hosted verification on this head: https://github.com/manaflow-ai/cmux/actions/runs/33151018414

Part of https://github.com/manaflow-ai/cmux/issues/10431
