### PR TITLE
irx: namespace transport state per bundle and broker host

### DIFF
--- a/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/IrxDiskCache.swift
+++ b/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/IrxDiskCache.swift
@@ -19,9 +19,14 @@ public struct IrxDiskCache<Value: Codable & Sendable>: Sendable {
         guard let data = try? JSONEncoder().encode(value) else { return }
         try? FileManager.default.createDirectory(
             at: fileURL.deletingLastPathComponent(),
-            withIntermediateDirectories: true
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
         )
         try? data.write(to: fileURL, options: .atomic)
+        // Cached bindings, grants, and relay passes are for this app alone;
+        // atomic replacement writes a fresh inode, so re-apply owner-only.
+        try? FileManager.default.setAttributes(
+            [.posixPermissions: 0o600], ofItemAtPath: fileURL.path)
     }
 
     public func clear() {

--- a/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/IrxStateLocation.swift
+++ b/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/IrxStateLocation.swift
@@ -1,0 +1,56 @@
+public import Foundation
+
+/// Resolves the transport's on-disk state directory.
+///
+/// Multiple cmux builds share one macOS user Library (Mac apps are not
+/// sandboxed), and dev builds speak to staging while release builds speak to
+/// production. A single shared folder lets one build's staging trust keys
+/// poison another build's production grant verification, and exposes one
+/// build's cached state to every other (08-27 invisible-Mac incident).
+/// Namespacing by bundle identifier AND broker host makes cross-build and
+/// cross-environment reuse structurally impossible.
+public enum IrxStateLocation {
+    /// The pre-namespacing shared folder name; removed on sight because it
+    /// held a plaintext identity key readable by every build.
+    static let legacySharedFolderName = "cmux-irx"
+
+    public static func directory(
+        base: URL,
+        bundleIdentifier: String?,
+        brokerHost: String?
+    ) -> URL {
+        base
+            .appendingPathComponent("cmux-transport", isDirectory: true)
+            .appendingPathComponent(
+                sanitized(bundleIdentifier, fallback: "unknown-bundle"),
+                isDirectory: true
+            )
+            .appendingPathComponent(
+                sanitized(brokerHost, fallback: "unknown-broker"),
+                isDirectory: true
+            )
+    }
+
+    /// Best-effort removal of the legacy shared directory. Running builds
+    /// that still use it re-register on their next launch (cheap, and the
+    /// namespaced path takes over), while the plaintext identity file stops
+    /// existing immediately.
+    public static func removeLegacySharedDirectory(base: URL) {
+        try? FileManager.default.removeItem(
+            at: base.appendingPathComponent(
+                legacySharedFolderName, isDirectory: true)
+        )
+    }
+
+    static func sanitized(_ raw: String?, fallback: String) -> String {
+        guard let raw, !raw.isEmpty else { return fallback }
+        let cleaned = raw.lowercased().map { character in
+            (character.isASCII && (character.isLetter || character.isNumber))
+                || character == "." || character == "-" || character == "_"
+                ? String(character) : "-"
+        }.joined()
+        // An all-dots component ("." / "..") is a path traversal, not a name.
+        guard cleaned.contains(where: { $0 != "." }) else { return fallback }
+        return String(cleaned.prefix(128))
+    }
+}

--- a/Packages/Shared/CmuxIrxTransport/Tests/CmuxIrxTransportTests/IrxStateLocationTests.swift
+++ b/Packages/Shared/CmuxIrxTransport/Tests/CmuxIrxTransportTests/IrxStateLocationTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Testing
+
+@testable import CmuxIrxTransport
+
+/// State isolation regression (08-27 invisible-Mac incident): two builds or
+/// two backends must never resolve the same state directory, and cache files
+/// must be owner-only.
+@Suite("state location")
+struct IrxStateLocationTests {
+    let base = URL(fileURLWithPath: "/tmp/base")
+
+    @Test("different bundles and different brokers never share a directory")
+    func isolation() {
+        let nightlyProd = IrxStateLocation.directory(
+            base: base, bundleIdentifier: "dev.cmux.app.nightly", brokerHost: "cmux.com")
+        let devStaging = IrxStateLocation.directory(
+            base: base, bundleIdentifier: "dev.cmux.app.debug.irx",
+            brokerHost: "cmux-staging.vercel.app")
+        let nightlyStaging = IrxStateLocation.directory(
+            base: base, bundleIdentifier: "dev.cmux.app.nightly",
+            brokerHost: "cmux-staging.vercel.app")
+        #expect(nightlyProd != devStaging)
+        #expect(nightlyProd != nightlyStaging)
+        #expect(devStaging != nightlyStaging)
+    }
+
+    @Test("hostile identifiers sanitize without collapsing to a shared path")
+    func sanitization() {
+        #expect(IrxStateLocation.sanitized("../../etc", fallback: "x") == "..-..-etc")
+        #expect(IrxStateLocation.sanitized("..", fallback: "x") == "x")
+        #expect(IrxStateLocation.sanitized(".", fallback: "x") == "x")
+        #expect(IrxStateLocation.sanitized(nil, fallback: "unknown-bundle") == "unknown-bundle")
+        #expect(IrxStateLocation.sanitized("", fallback: "f") == "f")
+        #expect(IrxStateLocation.sanitized("Dev.Cmux.App", fallback: "f") == "dev.cmux.app")
+    }
+
+    @Test("cache writes are owner-only for files and directories")
+    func cachePermissions() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("irx-perms-\(UUID().uuidString)", isDirectory: true)
+        let cache = IrxDiskCache<[String: String]>(
+            fileURL: dir.appendingPathComponent("secrets.json"))
+        cache.save(["token": "sensitive"])
+        let filePerms = try FileManager.default.attributesOfItem(
+            atPath: dir.appendingPathComponent("secrets.json").path
+        )[.posixPermissions] as? Int
+        let dirPerms = try FileManager.default.attributesOfItem(
+            atPath: dir.path)[.posixPermissions] as? Int
+        #expect(filePerms == 0o600)
+        #expect(dirPerms == 0o700)
+    }
+
+    @Test("legacy shared directory is removed on sight")
+    func legacyCleanup() throws {
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("irx-legacy-\(UUID().uuidString)", isDirectory: true)
+        let legacy = base.appendingPathComponent("cmux-irx", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: legacy, withIntermediateDirectories: true)
+        try Data("secret".utf8).write(to: legacy.appendingPathComponent("identity.json"))
+        IrxStateLocation.removeLegacySharedDirectory(base: base)
+        #expect(!FileManager.default.fileExists(atPath: legacy.path))
+    }
+}

--- a/Sources/Mobile/MobileHostIrxRuntime.swift
+++ b/Sources/Mobile/MobileHostIrxRuntime.swift
@@ -58,6 +58,7 @@ final class MobileHostIrxRuntime {
     /// Changes on every (de)activation; per-connection supervisors compare it.
     private var generationToken = UUID()
 
+    private var stateDirectory: URL?
     private var brokerService: IrxBrokerService?
     private var endpointSupervisor: IrxEndpointSupervisor?
     private var autopilot: IrxRelayCredentialAutopilot?
@@ -108,9 +109,19 @@ final class MobileHostIrxRuntime {
             Self.journal.record("host-runtime", "activation-failed", ["reason": "environment"])
             return
         }
-        let stateDir = FileManager.default.urls(
+        let appSupport = FileManager.default.urls(
             for: .applicationSupportDirectory, in: .userDomainMask
-        )[0].appendingPathComponent("cmux-irx", isDirectory: true)
+        )[0]
+        // Per-bundle, per-backend state: another build (or another
+        // environment's) caches must never be readable here, or staging
+        // trust keys reject production grants at admission.
+        let stateDir = IrxStateLocation.directory(
+            base: appSupport,
+            bundleIdentifier: Bundle.main.bundleIdentifier,
+            brokerHost: brokerBaseURL.host
+        )
+        IrxStateLocation.removeLegacySharedDirectory(base: appSupport)
+        stateDirectory = stateDir
         do {
             // IDENTITY ADOPTION: reuse the legacy stack's identity, device
             // ID, and app-instance scope, so the EndpointID, binding slot,
@@ -288,11 +299,12 @@ final class MobileHostIrxRuntime {
         }
         // Admission reads the persisted trust snapshot synchronously; it
         // never awaits the broker (steady-state independence).
+        guard let stateDirectory else { return }
         let judge = IrxGrantJudge(
             acceptor: acceptor,
-            trustProvider: { IrxDiskCacheTrustReader.read() }
+            trustProvider: { IrxDiskCacheTrustReader.read(stateDirectory: stateDirectory) }
         )
-        let trustSnapshot = { IrxDiskCacheTrustReader.read() }
+        let trustSnapshot = { IrxDiskCacheTrustReader.read(stateDirectory: stateDirectory) }
         let brokerClient = brokerService.hostBrokerClient
         acceptLoop = Task { [weak self] in
             journal.record("host-runtime", "accept-loop-started")
@@ -490,9 +502,19 @@ final class MobileHostIrxRuntime {
 /// no network): reads the JSON the broker service persists.
 enum IrxDiskCacheTrustReader {
     nonisolated static func read() -> IrxTrustSnapshot? {
-        let stateDir = FileManager.default.urls(
+        let appSupport = FileManager.default.urls(
             for: .applicationSupportDirectory, in: .userDomainMask
-        )[0].appendingPathComponent("cmux-irx", isDirectory: true)
+        )[0]
+        // Per-bundle, per-backend state: another build (or another
+        // environment's) caches must never be readable here, or staging
+        // trust keys reject production grants at admission.
+        let stateDir = IrxStateLocation.directory(
+            base: appSupport,
+            bundleIdentifier: Bundle.main.bundleIdentifier,
+            brokerHost: brokerBaseURL.host
+        )
+        IrxStateLocation.removeLegacySharedDirectory(base: appSupport)
+        stateDirectory = stateDir
         return IrxDiskCache<IrxTrustSnapshot>(
             fileURL: stateDir.appendingPathComponent("trust.json")
         ).load()

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrxRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrxRuntimeComposition.swift
@@ -114,9 +114,15 @@ public actor MobileIrxRuntimeComposition {
                 || ["-", ".", ":", "_"].contains(character)
                 ? String(character) : "-"
         }.joined()
-        stateDirectory = FileManager.default.urls(
+        let appSupport = FileManager.default.urls(
             for: .applicationSupportDirectory, in: .userDomainMask
-        )[0].appendingPathComponent("cmux-irx", isDirectory: true)
+        )[0]
+        stateDirectory = IrxStateLocation.directory(
+            base: appSupport,
+            bundleIdentifier: bundleIdentifier,
+            brokerHost: brokerBaseURL?.host()
+        )
+        IrxStateLocation.removeLegacySharedDirectory(base: appSupport)
     }
 
     /// irx mints its own durable device UUID (persisted beside the identity),


### PR DESCRIPTION
Second bug from the 08-27 incident: all cmux builds on one Mac shared \`~/Library/Application Support/cmux-irx/\` (Mac apps are unsandboxed). Dev builds speak to staging and kept overwriting the shared trust file, so a production NIGHTLY verified phones' production-signed pair grants against **staging keys** and denied them \`invalid-grant\` — the Mac disappears from the phone. Confirmed live on a dogfood machine: the shared folder held a binding for dev tag \`unrct\` and \`staging-2026-07-13-1\` keys while the NIGHTLY denied the phone at admission. The folder also held the device identity's **plaintext private key**, world-readable.

Fix: state moves to \`cmux-transport/<bundle-id>/<broker-host>/\` (sanitized, traversal-safe), the legacy shared folder is removed on sight (plaintext key gone; older builds re-register once, self-healing), and \`IrxDiskCache\` writes 0600 files in 0700 directories. Applied on macOS and iOS (iOS is sandboxed but gains staging/prod separation within an app).

Tests: isolation across bundles/brokers, hostile-identifier sanitization incl. \`..\`, file/dir permission assertions, legacy-folder cleanup. Full \`CmuxIrxTransport\` suite passes (20).

Follow-up (separate PR): identity private key into the Keychain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the 08-27 incident where shared state on Mac caused staging trust keys to deny production grants, making the Mac disappear from phones.

State now lives in `cmux-transport/<bundle-id>/<broker-host>/` instead of a shared `cmux-irx` folder, so dev and production builds never read each other's trust material. The legacy shared folder is removed on sight (which also deletes a world-readable plaintext identity key), and `IrxDiskCache` writes 0600 files in 0700 directories. iOS is sandboxed already but gains staging/prod separation within an app.

**Bug Fixes**
- Sanitizes bundle and broker identifiers with path-traversal-safe rules, falling back to placeholders for hostile or empty values.
- Re-registers once on next launch after legacy cleanup, so older builds self-heal.
- Follow-up PR will move the identity private key into the Keychain.

<sup>Written for commit 73199b36436843c7a420cf86027cf363ee9e36db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Restricted stored transport state so only the app owner can access its files and directories.
  - Improved protection against unsafe or malformed identifiers used in state paths.

- **Bug Fixes**
  - Prevented separate app instances or backend connections from sharing state unexpectedly.
  - Automatically removes obsolete shared state locations when detected.

- **Reliability**
  - Trust and connection state now consistently use the correct isolated storage location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->