### PR TITLE
Escape uncreatable socket state directory to /tmp; dedupe listener-failure captures per episode

### DIFF
--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Policy/SocketListenerPolicy.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Policy/SocketListenerPolicy.swift
@@ -194,12 +194,19 @@ public struct SocketListenerPolicy: Sendable {
         return currentIdentity == boundIdentity
     }
 
-    /// The fallback socket path after a bind failure at the stable default
-    /// path, or nil when no fallback applies.
+    /// The fallback socket path after a bind failure at a stable path, or nil
+    /// when no fallback applies.
     ///
-    /// Only the shared stable default path falls back (to the user-scoped
-    /// stable path) and only for permission/lock/occupancy failures another
-    /// user's listener can cause. Tagged and explicit paths never fall back.
+    /// Only the stable paths fall back, and only to an alternative that can
+    /// actually succeed. Permission/lock/occupancy failures another user's
+    /// listener can cause move the shared stable default to the user-scoped
+    /// stable path. Failures creating the state directory itself
+    /// (`create_directory`, `create_lock_directory` — e.g. `~/.local/state`
+    /// owned by root after a past `sudo` install, or an I/O-erroring home
+    /// volume) escape both stable paths to the legacy `/tmp` per-user path,
+    /// because the user-scoped path is a sibling inside the same uncreatable
+    /// directory and fails identically. Tagged and explicit paths never fall
+    /// back.
     ///
     /// - Parameters:
     ///   - requestedPath: The path the bind attempted.
@@ -214,19 +221,26 @@ public struct SocketListenerPolicy: Sendable {
         errnoCode: Int32,
         currentUserID: uid_t = getuid()
     ) -> String? {
-        guard requestedPath == SocketControlSettings.stableDefaultSocketPath else {
+        let userScopedPath = SocketControlSettings.userScopedStableSocketPath(
+            currentUserID: currentUserID
+        )
+        let isStableDefaultPath = requestedPath == SocketControlSettings.stableDefaultSocketPath
+        guard isStableDefaultPath || requestedPath == userScopedPath else {
             return nil
         }
 
         switch stage {
-        case "unlink" where errnoCode == EACCES || errnoCode == EPERM:
-            return SocketControlSettings.userScopedStableSocketPath(currentUserID: currentUserID)
-        case "create_lock_directory", "open_lock", "lock":
-            return SocketControlSettings.userScopedStableSocketPath(currentUserID: currentUserID)
-        case "existing_path", "stat_existing_path":
-            return SocketControlSettings.userScopedStableSocketPath(currentUserID: currentUserID)
-        case "bind" where errnoCode == EACCES || errnoCode == EPERM || errnoCode == EADDRINUSE:
-            return SocketControlSettings.userScopedStableSocketPath(currentUserID: currentUserID)
+        case "create_directory", "create_lock_directory":
+            return SocketControlSettings.legacyUserScopedStableSocketPath(
+                currentUserID: currentUserID
+            )
+        case "unlink" where isStableDefaultPath && (errnoCode == EACCES || errnoCode == EPERM):
+            return userScopedPath
+        case "open_lock", "lock", "existing_path", "stat_existing_path":
+            return isStableDefaultPath ? userScopedPath : nil
+        case "bind" where isStableDefaultPath
+            && (errnoCode == EACCES || errnoCode == EPERM || errnoCode == EADDRINUSE):
+            return userScopedPath
         default:
             return nil
         }

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Server/SocketControlServerEvents.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Server/SocketControlServerEvents.swift
@@ -17,7 +17,8 @@ public struct SocketControlServerEvents: Sendable {
     public let breadcrumb: @Sendable (_ message: String, _ data: [String: any Sendable]) -> Void
 
     /// Reports a listener failure. The host decides whether to escalate the
-    /// breadcrumb to a captured error (the app applies a per-key cooldown).
+    /// breadcrumb to a captured error (the app dedupes through
+    /// ``SocketListenerFailureCaptureGate``).
     /// `data` already contains the listener-state snapshot fields plus
     /// `stage`/`errno` entries; `stage` and `errnoCode` are passed discretely
     /// so the host can build its dedupe key without re-parsing the dictionary.

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Server/SocketListenerFailureCaptureGate.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Server/SocketListenerFailureCaptureGate.swift
@@ -1,0 +1,66 @@
+internal import os
+
+/// Decides which listener failures escalate from a breadcrumb to a captured
+/// Sentry error.
+///
+/// A permanently wedged machine restarts its listener on every wake and
+/// activation, so a time-based cooldown still produces an unbounded event
+/// stream (a 60s cooldown yielded ~1400 events/day per machine on
+/// CMUXTERM-MACOS-2MHE). Instead, each distinct failure key
+/// (message|stage|path|errno) is captured once per failure episode: the seen
+/// set clears when the listener starts successfully, so a recovered listener
+/// that later fails again reports the new episode, while a listener that
+/// never recovers reports each distinct failure exactly once per app session.
+///
+/// `socket.listener.path.missing` can additionally be demoted to
+/// breadcrumb-only: on debug builds, cleanup scripts routinely delete `/tmp`
+/// dev sockets and the path monitor self-heals by restarting the listener,
+/// so that state is expected rather than an error (CMUXTERM-MACOS-KBT).
+///
+/// Thread-safe; the failure seam is invoked from the main actor and the
+/// listener queue.
+public final class SocketListenerFailureCaptureGate: Sendable {
+    /// The failure message the path monitor reports for a deleted socket file.
+    public static let pathMissingMessage = "socket.listener.path.missing"
+
+    private let capturesPathMissingFailures: Bool
+    private let capturedKeys = OSAllocatedUnfairLock<Set<String>>(initialState: [])
+
+    /// Creates a gate.
+    ///
+    /// - Parameter capturesPathMissingFailures: Whether
+    ///   ``pathMissingMessage`` failures may be captured at all. Pass `false`
+    ///   for debug-like bundle identifiers, where deleted dev sockets are
+    ///   expected and the monitor self-heals.
+    public init(capturesPathMissingFailures: Bool = true) {
+        self.capturesPathMissingFailures = capturesPathMissingFailures
+    }
+
+    /// Whether this failure should be captured (the breadcrumb is always
+    /// recorded by the caller). True at most once per distinct key per
+    /// failure episode.
+    ///
+    /// - Parameters:
+    ///   - message: The failure message (e.g. `socket.listener.start.failed`).
+    ///   - stage: The failing stage.
+    ///   - path: The socket path involved.
+    ///   - errnoCode: The failing `errno`, when known.
+    public func shouldCapture(
+        message: String,
+        stage: String,
+        path: String,
+        errnoCode: Int32?
+    ) -> Bool {
+        if message == Self.pathMissingMessage, !capturesPathMissingFailures {
+            return false
+        }
+        let key = "\(message)|\(stage)|\(path)|\(errnoCode.map(String.init) ?? "none")"
+        return capturedKeys.withLock { $0.insert(key).inserted }
+    }
+
+    /// Marks the end of a failure episode: the listener started successfully,
+    /// so any later failure is a new incident worth one capture.
+    public func listenerDidStart() {
+        capturedKeys.withLock { $0.removeAll() }
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Transport/SocketTransport+Bind.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Transport/SocketTransport+Bind.swift
@@ -107,12 +107,27 @@ extension SocketTransport {
                 attributes: [.posixPermissions: 0o700]
             )
             return nil
-        } catch let error as NSError {
-            if error.domain == NSPOSIXErrorDomain {
-                return Int32(error.code)
-            }
-            return EIO
+        } catch {
+            return Self.posixErrnoCode(from: error as NSError) ?? EIO
         }
+    }
+
+    /// The underlying POSIX `errno` in an error's `NSUnderlyingErrorKey`
+    /// chain, or nil when none exists. `FileManager` wraps `mkdir(2)`
+    /// failures in Cocoa-domain errors; unwrapping keeps the real errno
+    /// (EACCES vs ENOENT vs EIO) visible in bind-failure telemetry instead of
+    /// collapsing every wrapped failure to EIO.
+    private static func posixErrnoCode(from error: NSError) -> Int32? {
+        var current: NSError? = error
+        var remainingDepth = 8
+        while let nsError = current, remainingDepth > 0 {
+            if nsError.domain == NSPOSIXErrorDomain {
+                return Int32(nsError.code)
+            }
+            current = nsError.userInfo[NSUnderlyingErrorKey] as? NSError
+            remainingDepth -= 1
+        }
+        return nil
     }
 
     /// Raw `bind(2)`; nil when the path does not fit in `sockaddr_un`.

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/SocketListenerFailureCaptureGateTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/SocketListenerFailureCaptureGateTests.swift
@@ -1,0 +1,110 @@
+import Darwin
+import Testing
+
+@testable import CmuxControlSocket
+
+@Suite struct SocketListenerFailureCaptureGateTests {
+    @Test func capturesEachDistinctKeyOncePerEpisode() {
+        let gate = SocketListenerFailureCaptureGate()
+        #expect(gate.shouldCapture(
+            message: "socket.listener.start.failed",
+            stage: "create_lock_directory",
+            path: "/tmp/a.sock",
+            errnoCode: EIO
+        ))
+        // A wedged machine retries the identical failure on every wake; the
+        // second and later identical failures stay breadcrumb-only.
+        #expect(!gate.shouldCapture(
+            message: "socket.listener.start.failed",
+            stage: "create_lock_directory",
+            path: "/tmp/a.sock",
+            errnoCode: EIO
+        ))
+        // A different stage, path, or errno is a distinct failure.
+        #expect(gate.shouldCapture(
+            message: "socket.listener.start.failed",
+            stage: "bind",
+            path: "/tmp/a.sock",
+            errnoCode: EIO
+        ))
+        #expect(gate.shouldCapture(
+            message: "socket.listener.start.failed",
+            stage: "create_lock_directory",
+            path: "/tmp/b.sock",
+            errnoCode: EIO
+        ))
+        #expect(gate.shouldCapture(
+            message: "socket.listener.start.failed",
+            stage: "create_lock_directory",
+            path: "/tmp/a.sock",
+            errnoCode: EACCES
+        ))
+        #expect(gate.shouldCapture(
+            message: "socket.listener.start.failed",
+            stage: "create_lock_directory",
+            path: "/tmp/a.sock",
+            errnoCode: nil
+        ))
+    }
+
+    @Test func successfulListenerStartOpensANewEpisode() {
+        let gate = SocketListenerFailureCaptureGate()
+        #expect(gate.shouldCapture(
+            message: "socket.listener.start.failed",
+            stage: "bind",
+            path: "/tmp/a.sock",
+            errnoCode: EADDRINUSE
+        ))
+        #expect(!gate.shouldCapture(
+            message: "socket.listener.start.failed",
+            stage: "bind",
+            path: "/tmp/a.sock",
+            errnoCode: EADDRINUSE
+        ))
+
+        gate.listenerDidStart()
+
+        // The listener recovered; a later identical failure is a new incident.
+        #expect(gate.shouldCapture(
+            message: "socket.listener.start.failed",
+            stage: "bind",
+            path: "/tmp/a.sock",
+            errnoCode: EADDRINUSE
+        ))
+    }
+
+    @Test func pathMissingIsBreadcrumbOnlyWhenSuppressed() {
+        let gate = SocketListenerFailureCaptureGate(capturesPathMissingFailures: false)
+        // Dev-machine cleanup scripts delete /tmp debug sockets and the path
+        // monitor self-heals; that expected state never escalates to a capture.
+        #expect(!gate.shouldCapture(
+            message: SocketListenerFailureCaptureGate.pathMissingMessage,
+            stage: "path_monitor",
+            path: "/tmp/cmux-debug-main.sock",
+            errnoCode: nil
+        ))
+        // Other failures still capture on debug builds.
+        #expect(gate.shouldCapture(
+            message: "socket.listener.start.failed",
+            stage: "bind",
+            path: "/tmp/cmux-debug-main.sock",
+            errnoCode: EADDRINUSE
+        ))
+    }
+
+    @Test func pathMissingCapturesOncePerEpisodeWhenNotSuppressed() {
+        let gate = SocketListenerFailureCaptureGate()
+        #expect(gate.shouldCapture(
+            message: SocketListenerFailureCaptureGate.pathMissingMessage,
+            stage: "path_monitor",
+            path: "/tmp/a.sock",
+            errnoCode: nil
+        ))
+        #expect(!gate.shouldCapture(
+            message: SocketListenerFailureCaptureGate.pathMissingMessage,
+            stage: "path_monitor",
+            path: "/tmp/a.sock",
+            errnoCode: nil
+        ))
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/SocketListenerPolicyTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/SocketListenerPolicyTests.swift
@@ -208,7 +208,6 @@ import Testing
     }
 
     @Test(arguments: [
-        ("create_lock_directory", EACCES),
         ("open_lock", EACCES),
         ("open_lock", ELOOP),
         ("open_lock", EINVAL),
@@ -224,6 +223,80 @@ import Testing
                 errnoCode: errnoCode,
                 currentUserID: 501
             ) == SocketControlSettings.userScopedStableSocketPath(currentUserID: 501)
+        )
+    }
+
+    // The user-scoped stable socket is a sibling of the stable default inside
+    // the same state directory. When that directory itself cannot be created
+    // (root-owned ~/.local/state after a past `sudo` install, or an
+    // I/O-erroring home volume), every sibling fails identically, so both
+    // stable paths must escape to the legacy /tmp per-user path.
+    @Test(arguments: [
+        ("create_directory", EACCES),
+        ("create_directory", EPERM),
+        ("create_directory", EIO),
+        ("create_lock_directory", EACCES),
+        ("create_lock_directory", EPERM),
+        ("create_lock_directory", EIO),
+    ] as [(String, Int32)])
+    func stableSocketStateDirectoryCreationFailuresFallBackToLegacyTmpSocket(
+        stage: String,
+        errnoCode: Int32
+    ) {
+        #expect(
+            policy.fallbackSocketPathAfterBindFailure(
+                requestedPath: SocketControlSettings.stableDefaultSocketPath,
+                stage: stage,
+                errnoCode: errnoCode,
+                currentUserID: 501
+            ) == SocketControlSettings.legacyUserScopedStableSocketPath(currentUserID: 501)
+        )
+    }
+
+    // Wedged machines whose stable-default probe reports inaccessible resolve
+    // the user-scoped path directly, before any bind attempt, so the fallback
+    // must also fire when the user-scoped path itself is the requested path
+    // (CMUXTERM-MACOS-2MHE: wake-driven create_lock_directory loop at
+    // ~/.local/state/cmux/cmux-501.sock with no fallback breadcrumb).
+    @Test(arguments: [
+        ("create_directory", EIO),
+        ("create_directory", EACCES),
+        ("create_lock_directory", EIO),
+        ("create_lock_directory", EACCES),
+    ] as [(String, Int32)])
+    func userScopedSocketStateDirectoryCreationFailuresFallBackToLegacyTmpSocket(
+        stage: String,
+        errnoCode: Int32
+    ) {
+        #expect(
+            policy.fallbackSocketPathAfterBindFailure(
+                requestedPath: SocketControlSettings.userScopedStableSocketPath(currentUserID: 501),
+                stage: stage,
+                errnoCode: errnoCode,
+                currentUserID: 501
+            ) == SocketControlSettings.legacyUserScopedStableSocketPath(currentUserID: 501)
+        )
+    }
+
+    // Only the shared stable default may fall back for lock/occupancy stages;
+    // those failures at the user-scoped path mean a same-user listener owns
+    // it, which is not a path problem the fallback should route around.
+    @Test(arguments: [
+        ("lock", EWOULDBLOCK),
+        ("open_lock", EACCES),
+        ("existing_path", EEXIST),
+        ("stat_existing_path", EACCES),
+        ("unlink", EACCES),
+        ("bind", EADDRINUSE),
+    ] as [(String, Int32)])
+    func userScopedSocketNonDirectoryFailuresDoNotFallBack(stage: String, errnoCode: Int32) {
+        #expect(
+            policy.fallbackSocketPathAfterBindFailure(
+                requestedPath: SocketControlSettings.userScopedStableSocketPath(currentUserID: 501),
+                stage: stage,
+                errnoCode: errnoCode,
+                currentUserID: 501
+            ) == nil
         )
     }
 

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/SocketTransportPathTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/SocketTransportPathTests.swift
@@ -352,3 +352,48 @@ import Testing
         #expect(!transport.removeSocketPathLockIfAvailable(for: path))
     }
 }
+
+@Suite struct SocketParentDirectoryCreationErrnoTests {
+    let transport = SocketTransport()
+
+    // FileManager wraps mkdir failures in Cocoa-domain errors; the transport
+    // must surface the underlying POSIX errno (EACCES for a read-only parent)
+    // instead of collapsing every non-POSIX-domain error to EIO, which made
+    // Sentry events show a misleading "Input/output error" for permission
+    // problems (CMUXTERM-MACOS-2MHE).
+    @Test func readOnlyParentReportsUnderlyingPosixErrno() throws {
+        let base = URL(
+            fileURLWithPath: "/tmp/cmux-ctlsock-mkdir-\(UUID().uuidString.lowercased().prefix(8))",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        defer {
+            chmod(base.path, 0o700)
+            try? FileManager.default.removeItem(at: base)
+        }
+        #expect(chmod(base.path, 0o500) == 0)
+
+        let socketPath = base
+            .appendingPathComponent("state", isDirectory: true)
+            .appendingPathComponent("cmux.sock", isDirectory: false)
+            .path
+        let errnoCode = transport.ensureSocketParentDirectoryExists(path: socketPath)
+        #expect(errnoCode == EACCES)
+    }
+
+    @Test func creatableParentReportsNoError() throws {
+        let base = URL(
+            fileURLWithPath: "/tmp/cmux-ctlsock-mkdir-\(UUID().uuidString.lowercased().prefix(8))",
+            isDirectory: true
+        )
+        defer { try? FileManager.default.removeItem(at: base) }
+
+        let socketPath = base
+            .appendingPathComponent("state", isDirectory: true)
+            .appendingPathComponent("cmux.sock", isDirectory: false)
+            .path
+        #expect(transport.ensureSocketParentDirectoryExists(path: socketPath) == nil)
+        var st = stat()
+        #expect(stat((socketPath as NSString).deletingLastPathComponent, &st) == 0)
+    }
+}

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -233,12 +233,9 @@ class TerminalController {
     private nonisolated static var socketMainHopSignpostingActive: Bool {
         socketMainHopSignposter.isEnabled
     }
-    private nonisolated static let socketListenerFailureCaptureCooldown: TimeInterval = 60
     private nonisolated static let v2BrowserDownloadWaitDefaultTimeoutMs = 10_000
     private nonisolated static let v2BrowserDownloadWaitMaxTimeoutMs = 120_000
     private nonisolated static let v2ConsumedBrowserDownloadIDLimit = 128
-    private nonisolated static let socketListenerFailureCaptureLock = NSLock()
-    private nonisolated(unsafe) static var socketListenerFailureLastCapturedAt: [String: Date] = [:]
     private struct MobileViewportReport {
         var columns: Int; var rows: Int; var updatedAt: Date; var generation: UInt64? = nil
         /// Sticky reports come from the dedicated `mobile.terminal.viewport`
@@ -514,7 +511,15 @@ class TerminalController {
             authorizationChangeSignals: socketPasswordFileWatcher?.events,
             events: Self.makeSocketServerEvents(
                 target: serverEventTarget,
-                markerStore: socketPathMarkerStore
+                markerStore: socketPathMarkerStore,
+                failureCaptureGate: SocketListenerFailureCaptureGate(
+                    // Deleted /tmp dev sockets are routine on dev machines
+                    // (cleanup scripts) and the path monitor self-heals, so
+                    // debug builds keep path.missing as breadcrumbs only.
+                    capturesPathMissingFailures: !SocketControlSettings.isDebugLikeBundleIdentifier(
+                        socketMarkerBundleIdentifier
+                    )
+                )
             )
         )
         self.socketServer = socketServer
@@ -913,29 +918,12 @@ class TerminalController {
         transport.isProcessDescendant(pid, of: myPid)
     }
 
-    private nonisolated static func shouldCaptureSocketListenerFailure(
-        message: String,
-        stage: String,
-        path: String,
-        errnoCode: Int32?
-    ) -> Bool {
-        let key = "\(message)|\(stage)|\(path)|\(errnoCode.map(String.init) ?? "none")"
-        let now = Date()
-        socketListenerFailureCaptureLock.lock()
-        defer { socketListenerFailureCaptureLock.unlock() }
-        if let lastCapturedAt = socketListenerFailureLastCapturedAt[key],
-           now.timeIntervalSince(lastCapturedAt) < socketListenerFailureCaptureCooldown {
-            return false
-        }
-        socketListenerFailureLastCapturedAt[key] = now
-        return true
-    }
-
     /// Builds the package server's host-callback seam. `target` is filled in
     /// at the end of `init`; no listener event can fire before `start`.
     private nonisolated static func makeSocketServerEvents(
         target: ServerEventTarget,
-        markerStore: SocketPathMarkerStore
+        markerStore: SocketPathMarkerStore,
+        failureCaptureGate: SocketListenerFailureCaptureGate
     ) -> SocketControlServerEvents {
         SocketControlServerEvents(
             breadcrumb: { message, data in
@@ -943,7 +931,7 @@ class TerminalController {
             },
             failure: { message, stage, errnoCode, data in
                 sentryBreadcrumb(message, category: "socket", data: data)
-                guard shouldCaptureSocketListenerFailure(
+                guard failureCaptureGate.shouldCapture(
                     message: message,
                     stage: stage,
                     path: data["path"] as? String ?? "",
@@ -955,6 +943,7 @@ class TerminalController {
             },
             listenerDidStart: { path, _ in
                 // @MainActor closure, invoked synchronously inside start().
+                failureCaptureGate.listenerDidStart()
                 target.controller?.socketListenerDidStart(path: path)
             },
             recordLastSocketPath: { path in


### PR DESCRIPTION
Fixes the live `socket.listener.start.failed` loop. Prior-bad: a machine whose `~/.local/state/cmux` cannot be created (root-owned after a past `sudo` install, or an I/O-erroring home volume) never got a listener. The bind fallback moved the shared stable path to the user-scoped sibling inside the same uncreatable directory, and applied no fallback at all when path resolution had already selected the user-scoped path (the wedged machines' breadcrumbs show wake restarts at `cmux-<uid>.sock` with zero fallback crumbs). Every `workspace.didWake` restart re-failed at stage `create_lock_directory` and re-captured after each 60s cooldown window, ~1400 events/day per machine forever.

Now: `SocketListenerPolicy.fallbackSocketPathAfterBindFailure` accepts both stable paths as the requested path and routes `create_directory`/`create_lock_directory` failures to the legacy `/tmp/cmux-<uid>.sock`, which `CLISocketPathResolver` already lists as an implicit candidate, so the listener starts and the wake loop ends. `ensureSocketParentDirectoryExists` unwraps the `NSUnderlyingErrorKey` chain to report the real POSIX errno instead of collapsing Cocoa-domain mkdir errors to EIO (the events showed a misleading "errno 5"). Listener-failure capture dedup moves from a 60s per-key cooldown to a stateful `SocketListenerFailureCaptureGate`: one capture per `(message|stage|path|errno)` key per failure episode, reset on successful listener start, and `socket.listener.path.missing` stays breadcrumb-only on debug-like bundle ids because dev cleanup scripts routinely delete `/tmp` dev sockets and the path monitor self-heals.

Commit 1 adds the failing policy and errno tests (CI red), commit 2 the fix (green). Supersedes the policy half of https://github.com/manaflow-ai/cmux/pull/9228 (same `/tmp` escape for the stable default) and extends it to the user-scoped path that PR left uncovered.

Sentry issues addressed:
- https://manaflow.sentry.io/issues/7315971398/ (6ER start.failed)
- https://manaflow.sentry.io/issues/7532514473/ (15EV start.failed)
- https://manaflow.sentry.io/issues/7648847316/ (2MHE start.failed, current release)
- https://manaflow.sentry.io/issues/7620536124/ (2FVF start.failed)
- https://manaflow.sentry.io/issues/7610087288/ (25PE start.failed)
- https://manaflow.sentry.io/issues/7523093625/ (KBT path.missing, debug builds)
- https://manaflow.sentry.io/issues/7329336809/ (9B8 bind EADDRINUSE, already fixed by the lock/replace-refused bind path; the episode gate bounds any recurrence)
- https://manaflow.sentry.io/issues/7280271584/ (53 unhealthy, emitter already deleted in 832426af56; 0.62.x residue only)

Principled: the fallback targets the one path family the failing mechanism cannot poison, telemetry reports true errnos, and rate limiting is a single stateful reporter keyed to listener lifecycle rather than a timer. Residual risk: a machine where `/tmp` is also unusable still fails, now captured once per session instead of continuously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11050"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790484212&installation_model_id=21920&pr_number=11050&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11050&signature=9ee5397b22674092499f56509171df9c948388aa444c341c3e4e79c2d7e993a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the infinite `socket.listener.start.failed` loop on machines whose socket state directory (`~/.local/state/cmux`) can't be created (root-owned after a past `sudo` install, or an I/O-erroring home volume): both stable paths now fall back to the legacy `/tmp/cmux-<uid>.sock`, so the listener starts and the wake loop ends. Listener-failure captures are now deduped per failure episode instead of on a 60-second cooldown, cutting ~1,400 events/day per wedged machine down to one per distinct failure.

**Bug Fixes**
- `fallbackSocketPathAfterBindFailure` now also accepts the user-scoped stable path and routes `create_directory`/`create_lock_directory` failures to the legacy `/tmp` per-user path, which `CLISocketPathResolver` already lists as a candidate.
- `ensureSocketParentDirectoryExists` unwraps `NSUnderlyingErrorKey` chains so telemetry reports the real POSIX errno instead of collapsing Cocoa-domain mkdir errors to EIO.
- New `SocketListenerFailureCaptureGate` captures once per `(message|stage|path|errno)` key per episode, resets on successful listener start, and keeps `socket.listener.path.missing` breadcrumb-only on debug-like bundle ids since dev cleanup deletes `/tmp` dev sockets and the path monitor self-heals.
- Residual risk: a machine where `/tmp` is also unusable still fails, now captured once per session instead of continuously.

<sup>Written for commit e33c834a8bd1b8019e8bedc685b1e7a385a3a915. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved socket listener error reporting by preventing duplicate error captures during the same failure episode.
  * Missing socket paths can now be reported according to the app’s configuration.

* **Bug Fixes**
  * Improved socket path fallback behavior when directories cannot be created or accessed.
  * Preserved more specific permission errors instead of reporting generic failures.
  * Clarified listener failure handling and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->