### PR TITLE
CLI Sentry: per-failure-class fingerprints, mute Not-connected race, throttle timeouts

### DIFF
--- a/CLI/CLISocketSentryTelemetry.swift
+++ b/CLI/CLISocketSentryTelemetry.swift
@@ -140,6 +140,12 @@ final class CLISocketSentryTelemetry {
         ) else {
             return
         }
+        let fingerprintKind = Self.fingerprintKind(for: error, message: errorDescription)
+        if let fingerprintKind,
+           CLISentryErrorFingerprint.throttledKinds.contains(fingerprintKind),
+           !claimThrottledCaptureSlot(stage: stage, kind: fingerprintKind) {
+            return
+        }
 #if DEBUG
         recordCaptureProbe(stage: stage, error: error)
 #endif
@@ -161,6 +167,7 @@ final class CLISocketSentryTelemetry {
             context: context,
             command: command,
             subcommand: subcommand,
+            fingerprint: ["cmux-cli", stage, fingerprintKind ?? "{{ default }}"],
             breadcrumbs: pendingBreadcrumbs.map { pending in
                 makeBreadcrumb(message: pending.message, data: pending.data)
             }
@@ -179,13 +186,44 @@ final class CLISocketSentryTelemetry {
         // coordination path. The app's Sentry client will pick up the cached
         // envelope on its next transport pass.
 #if DEBUG
-        recordStoreProbe(eventId: scrubbedEvent.eventId.sentryIdString)
+        recordStoreProbe(
+            eventId: scrubbedEvent.eventId.sentryIdString,
+            fingerprint: scrubbedEvent.fingerprint ?? []
+        )
 #endif
 #endif
     }
 
     private var shouldEmit: Bool {
         !disabledByEnv
+    }
+
+    /// Chooses the stable fingerprint kind for a CLI failure: the structured
+    /// v2 protocol error code when the app replied with one, else the known
+    /// transport failure class of the rendered message, else `nil` so the
+    /// event keeps Sentry's default grouping within its stage.
+    private static func fingerprintKind(for error: Error, message: String) -> String? {
+        if let v2Code = (error as? CLIError)?.v2Code?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased(),
+           !v2Code.isEmpty {
+            return "v2-\(v2Code)"
+        }
+        return CLISentryErrorFingerprint().kind(forMessage: message)
+    }
+
+    /// One durable capture per (stage, kind) per throttle interval for
+    /// expected-but-reportable volume states like command timeouts, which
+    /// otherwise fire once per agent hook invocation while the app is wedged.
+    /// Backed by the same locked state file the agent hook failure reporter
+    /// uses; a claim error fails closed (skips the capture) like that reporter.
+    private func claimThrottledCaptureSlot(stage: String, kind: String) -> Bool {
+        let store = ClaudeHookSessionStore(processEnv: processEnv)
+        return (try? store.claimAgentHookFailureReport(
+            agentName: "cli-sentry",
+            stage: stage,
+            sessionId: kind
+        )) == true
     }
 
 #if DEBUG
@@ -199,12 +237,12 @@ final class CLISocketSentryTelemetry {
     }
 
 #if canImport(Sentry)
-    private func recordStoreProbe(eventId: String) {
+    private func recordStoreProbe(eventId: String, fingerprint: [String]) {
         guard let path = processEnv["CMUX_CLI_SENTRY_STORE_PROBE_PATH"]?.trimmingCharacters(in: .whitespacesAndNewlines),
               !path.isEmpty else {
             return
         }
-        let payload = "event_id=\(eventId)\n"
+        let payload = "event_id=\(eventId)\nfingerprint=\(fingerprint.joined(separator: "|"))\n"
         try? payload.write(toFile: NSString(string: path).expandingTildeInPath, atomically: true, encoding: .utf8)
     }
 #endif
@@ -216,12 +254,19 @@ final class CLISocketSentryTelemetry {
         context: [String: Any],
         command: String,
         subcommand: String,
+        fingerprint: [String],
         breadcrumbs: [Breadcrumb]
     ) -> Event {
         let nsError = error as NSError
         let event = Event(error: nsError)
         event.exceptions = errorChain(for: nsError).reversed().map(Self.makeException)
         event.level = .error
+        // Every CLI error shares one NSError domain+code with system-only
+        // frames, so default grouping folds all failure classes into a single
+        // issue. Group by stage plus normalized error kind instead;
+        // "{{ default }}" keeps default grouping inside the stage for
+        // unclassified errors.
+        event.fingerprint = fingerprint
         event.releaseName = currentSentryReleaseName()
 #if DEBUG
         event.environment = "development-cli"

--- a/CLI/CLISocketSentryTelemetry.swift
+++ b/CLI/CLISocketSentryTelemetry.swift
@@ -219,10 +219,14 @@ final class CLISocketSentryTelemetry {
     /// uses; a claim error fails closed (skips the capture) like that reporter.
     private func claimThrottledCaptureSlot(stage: String, kind: String) -> Bool {
         let store = ClaudeHookSessionStore(processEnv: processEnv)
+        // Bounded lock wait: the CLI is already on an error path, so a
+        // contended/stuck state lock must skip the capture (fail closed)
+        // instead of blocking the command's exit.
         return (try? store.claimAgentHookFailureReport(
             agentName: "cli-sentry",
             stage: stage,
-            sessionId: kind
+            sessionId: kind,
+            deadline: Date.now.addingTimeInterval(0.25)
         )) == true
     }
 

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -2422,6 +2422,13 @@ final class ClaudeHookSessionStore {
         _ body: (inout ClaudeHookSessionStoreFile) throws -> T
     ) throws -> T {
         let lockPath = statePath + ".lock"
+        // The lock file is opened before the state is ever saved, so the first
+        // store access on a fresh HOME must create the state directory itself.
+        try fileManager.createDirectory(
+            at: URL(fileURLWithPath: lockPath).deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: NSNumber(value: Int16(0o700))]
+        )
         let fd = open(lockPath, O_CREAT | O_RDWR, mode_t(S_IRUSR | S_IWUSR))
         if fd < 0 {
             throw CLIError(message: "Failed to open Claude hook state lock: \(lockPath)")

--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/CLISentryErrorFingerprint.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/CLISentryErrorFingerprint.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Maps rendered CLI socket failure text onto a stable fingerprint kind so
+/// each failure class groups as its own Sentry issue. Without this, every CLI
+/// error bridges to the same `cmux_cli.CLIError` NSError (domain + code 1)
+/// with system-only frames, and Sentry folds all distinct messages into one
+/// mega-issue (https://manaflow.sentry.io/issues/7290136228/).
+public struct CLISentryErrorFingerprint: Sendable {
+    /// Fingerprint kinds that are expected-but-reportable volume states: worth
+    /// one Sentry event per user per throttle window as an app-responsiveness
+    /// signal, but not one event per agent hook invocation.
+    public static let throttledKinds: Set<String> = ["command-timed-out"]
+
+    public init() {}
+
+    /// Returns a stable kind slug for a known CLI socket failure message, or
+    /// `nil` when the message has no dedicated class and should keep Sentry's
+    /// default grouping within its stage.
+    public func kind(forMessage text: String) -> String? {
+        let t = text.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if t == "command timed out" { return "command-timed-out" }
+        if t == "not connected" { return "not-connected" }
+        if t == "socket read error" { return "socket-read-error" }
+        if t.hasPrefix("socket not found at") { return "socket-not-found" }
+        if t.hasPrefix("failed to connect to socket") { return "socket-connect-failed" }
+        if t.hasPrefix("failed to write to socket") { return "socket-write-failed" }
+        if t.hasPrefix("socket closed before") { return "socket-closed-before-reply" }
+        return nil
+    }
+}

--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SentryNoiseFilter.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SentryNoiseFilter.swift
@@ -26,6 +26,7 @@ public struct SentryNoiseFilter: Sendable {
             return false
         }
         return isExpectedCLISocketTransportMessage(message) ||
+            isExpectedCLISocketLifecycleRaceMessage(message) ||
             (allowSandboxPolicyDenial && isSocketConnectPolicyDenial(message))
     }
 
@@ -60,6 +61,16 @@ public struct SentryNoiseFilter: Sendable {
             containsErrno(2, in: t) ||           // ENOENT
             t.contains("connection refused") ||
             containsErrno(61, in: t)              // ECONNREFUSED
+    }
+
+    /// Matches the CLI's bare "Not connected" failure: the app's socket went
+    /// away between a successful connect and the request write, typically the
+    /// app quitting or restarting mid-hook. The same lifecycle race as the
+    /// muted broken-pipe/ENOENT cases, but its rendered message carries no
+    /// socket wording, so it is matched exactly and, via the guard above, only
+    /// inside a proven CLI socket transport context.
+    private func isExpectedCLISocketLifecycleRaceMessage(_ text: String) -> Bool {
+        text.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "not connected"
     }
 
     private func isSocketConnectPolicyDenial(_ text: String) -> Bool {

--- a/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/CLISentryErrorFingerprintTests.swift
+++ b/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/CLISentryErrorFingerprintTests.swift
@@ -1,0 +1,27 @@
+import Testing
+@testable import CmuxFoundation
+
+@Suite struct CLISentryErrorFingerprintTests {
+    private let fingerprint = CLISentryErrorFingerprint()
+
+    @Test func classifiesKnownTransportFailures() {
+        #expect(fingerprint.kind(forMessage: "Command timed out") == "command-timed-out")
+        #expect(fingerprint.kind(forMessage: "Not connected") == "not-connected")
+        #expect(fingerprint.kind(forMessage: "Socket read error") == "socket-read-error")
+        #expect(fingerprint.kind(forMessage: "Socket not found at /tmp/cmux.sock") == "socket-not-found")
+        #expect(fingerprint.kind(
+            forMessage: "Failed to connect to socket at /tmp/cmux.sock (Connection refused, errno 61)"
+        ) == "socket-connect-failed")
+        #expect(fingerprint.kind(
+            forMessage: "Failed to write to socket (Broken pipe, errno 32)"
+        ) == "socket-write-failed")
+        #expect(fingerprint.kind(forMessage: "Socket closed before reply") == "socket-closed-before-reply")
+        #expect(fingerprint.kind(forMessage: "Socket closed before complete reply") == "socket-closed-before-reply")
+    }
+
+    @Test func unknownMessagesKeepDefaultGrouping() {
+        #expect(fingerprint.kind(forMessage: "Missing relay auth metadata") == nil)
+        #expect(fingerprint.kind(forMessage: "Server reports peer not connected") == nil)
+        #expect(fingerprint.kind(forMessage: "") == nil)
+    }
+}

--- a/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SentryNoiseFilterTests.swift
+++ b/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SentryNoiseFilterTests.swift
@@ -70,6 +70,34 @@ import Testing
         ))
     }
 
+    @Test func dropsNotConnectedLifecycleRaceOnlyInTransportContext() {
+        // The app quit or restarted between a successful hook connect and the
+        // request write. Proven transport context via structured data keys.
+        #expect(filter.isExpectedCLISocketTransportFailure(
+            stage: "hooks_claude_dispatch",
+            message: "Not connected",
+            dataKeys: ["socket_operation", "socket_phase"]
+        ))
+        // Proven transport context via the stage itself.
+        #expect(filter.isExpectedCLISocketTransportFailure(
+            stage: "socket_command",
+            message: "Not connected"
+        ))
+        // No transport context: keep it reportable.
+        #expect(!filter.isExpectedCLISocketTransportFailure(
+            stage: "hooks_claude_dispatch",
+            message: "Not connected"
+        ))
+        // Only the exact rendered failure counts, not embedded phrases.
+        #expect(!filter.isExpectedCLISocketTransportFailure(
+            stage: "socket_command",
+            message: "Server reports peer not connected"
+        ))
+        // The context-free message gate stays narrow so app-side beforeSend
+        // filtering cannot drop unrelated events that merely contain the text.
+        #expect(!filter.isExpectedCLISocketTransportMessage("Not connected"))
+    }
+
     @Test func keepsRawSignalAndNonSocketMessages() {
         #expect(!filter.isExpectedCLISocketTransportMessage("SIGPIPE: Signal 13, Code 0"))
         #expect(!filter.isExpectedCLISocketTransportFailure(

--- a/cmuxTests/CMUXCLISentryTelemetryRegressionTests.swift
+++ b/cmuxTests/CMUXCLISentryTelemetryRegressionTests.swift
@@ -99,6 +99,75 @@ private final class CMUXCLISentryTelemetryBundleToken {}
         )
     }
 
+    @Test func commandTimeoutTelemetryIsFingerprintedAndThrottledPerStage() throws {
+        let cliPath = try bundledCLIPath()
+        let root = URL(
+            fileURLWithPath: "/tmp/cmux-st-\(UUID().uuidString.prefix(8))",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        // A bound, listening socket that never accepts or replies: connect and
+        // write succeed, the response read times out.
+        let socketPath = root.appendingPathComponent("cmux.sock", isDirectory: false).path
+        let listenerFD = try muteListeningSocketDescriptor(at: socketPath)
+        defer {
+            close(listenerFD)
+            unlink(socketPath)
+        }
+
+        func runPing(captureProbePath: String, storeProbePath: String) -> ProcessRunResult {
+            var environment = sentryProbeEnvironment(socketPath: socketPath, probePath: captureProbePath)
+            environment["CMUX_CLI_SENTRY_STORE_PROBE_PATH"] = storeProbePath
+            // The throttle claim state defaults to the real user home
+            // (expandingTildeInPath ignores the HOME override), so pin it
+            // inside the test root: both runs must share one state file
+            // without touching or depending on the machine's own state.
+            environment["CMUX_CLAUDE_HOOK_STATE_PATH"] = root
+                .appendingPathComponent("claude-hook-sessions.json", isDirectory: false).path
+            return runProcess(
+                executablePath: cliPath,
+                arguments: ["ping"],
+                environment: environment,
+                timeout: 10
+            )
+        }
+
+        let firstCaptureProbe = root.appendingPathComponent("capture-1.txt", isDirectory: false).path
+        let firstStoreProbe = root.appendingPathComponent("store-1.txt", isDirectory: false).path
+        let first = runPing(captureProbePath: firstCaptureProbe, storeProbePath: firstStoreProbe)
+
+        #expect(!first.timedOut, Comment(rawValue: first.stdout))
+        #expect(first.status != 0, Comment(rawValue: first.stdout))
+        #expect(first.stdout.contains("Command timed out"), Comment(rawValue: first.stdout))
+        #expect(
+            FileManager.default.fileExists(atPath: firstCaptureProbe),
+            Comment(rawValue: "The first timed-out command per stage must stay reportable. Output: \(first.stdout)")
+        )
+        let firstStorePayload = (try? String(contentsOfFile: firstStoreProbe, encoding: .utf8)) ?? "<missing>"
+        #expect(
+            firstStorePayload.contains("fingerprint=cmux-cli|socket_command|command-timed-out"),
+            Comment(rawValue: "Timed-out commands need their own stage-scoped Sentry fingerprint. Store probe: \(firstStorePayload)")
+        )
+
+        let secondCaptureProbe = root.appendingPathComponent("capture-2.txt", isDirectory: false).path
+        let secondStoreProbe = root.appendingPathComponent("store-2.txt", isDirectory: false).path
+        let second = runPing(captureProbePath: secondCaptureProbe, storeProbePath: secondStoreProbe)
+
+        #expect(!second.timedOut, Comment(rawValue: second.stdout))
+        #expect(second.status != 0, Comment(rawValue: second.stdout))
+        #expect(second.stdout.contains("Command timed out"), Comment(rawValue: second.stdout))
+        #expect(
+            !FileManager.default.fileExists(atPath: secondCaptureProbe),
+            Comment(rawValue: "A repeat timed-out command inside the throttle window must be deduplicated, not re-captured. Output: \(second.stdout)")
+        )
+        #expect(
+            !FileManager.default.fileExists(atPath: secondStoreProbe),
+            Comment(rawValue: "A throttled timed-out command must not store a Sentry envelope. Output: \(second.stdout)")
+        )
+    }
+
     private func bundledCLIPath() throws -> String {
         try BundledCLITestSupport.bundledCLIPath(for: CMUXCLISentryTelemetryBundleToken.self)
     }
@@ -155,17 +224,31 @@ private final class CMUXCLISentryTelemetryBundleToken {}
     }
 
     private func createStaleSocketFile(at path: String) throws {
+        close(try boundUnixSocketDescriptor(at: path))
+    }
+
+    private func muteListeningSocketDescriptor(at path: String) throws -> Int32 {
+        let fd = try boundUnixSocketDescriptor(at: path)
+        guard listen(fd, 8) == 0 else {
+            let error = posixError("listen failed")
+            close(fd)
+            throw error
+        }
+        return fd
+    }
+
+    private func boundUnixSocketDescriptor(at path: String) throws -> Int32 {
         unlink(path)
         let fd = socket(AF_UNIX, SOCK_STREAM, 0)
         guard fd >= 0 else {
             throw posixError("socket failed")
         }
-        defer { close(fd) }
 
         var address = sockaddr_un()
         address.sun_family = sa_family_t(AF_UNIX)
         let maxLength = MemoryLayout.size(ofValue: address.sun_path)
         guard path.utf8.count < maxLength else {
+            close(fd)
             throw NSError(
                 domain: NSPOSIXErrorDomain,
                 code: Int(ENAMETOOLONG),
@@ -185,8 +268,11 @@ private final class CMUXCLISentryTelemetryBundleToken {}
             }
         }
         guard bindResult == 0 else {
-            throw posixError("bind failed")
+            let error = posixError("bind failed")
+            close(fd)
+            throw error
         }
+        return fd
     }
 
     private func posixError(_ message: String) -> NSError {


### PR DESCRIPTION
Fixes the 64.7M-event, 100k-user CLI mega-issue https://manaflow.sentry.io/issues/7290136228/ (CMUXTERM-MACOS-DW).

Prior-bad: every CLI failure bridged to the same NSError (`cmux_cli.CLIError`, code 1) with system-only frames, so Sentry folded every distinct message ("TabManager not available", "Broken pipe", "Socket not found", "Not connected", "Command timed out") into one issue, and agent hooks captured one event per tool-use invocation on live releases ("Not connected" and "Command timed out" pass the noise filter today).

Now:
- CLI events carry `fingerprint = [cmux-cli, <stage>, <kind>]` via a new `CLISentryErrorFingerprint` classifier in CmuxFoundation (structured v2 error codes become `v2-<code>`; unknown messages keep `{{ default }}` grouping inside their stage), so each failure class is its own issue and future CLI errors cannot re-inflate this bucket.
- `SentryNoiseFilter` mutes the bare "Not connected" write race (app quit/restarted between hook connect and write) as an expected lifecycle disconnect, matched exactly and only in a proven CLI socket transport context (stage or `socket_operation`/`socket_phase` data keys), the same class as the already-muted broken-pipe/ENOENT cases.
- "Command timed out" stays reportable (a connected app not answering for 15s is an app-responsiveness signal) but the reporter dedupes it per (stage, kind) through the existing durable `claimAgentHookFailureReport` claim state instead of capturing per hook invocation.
- `ClaudeHookSessionStore.withLockedState` now creates its state directory before opening the lock, so the first claim on a fresh HOME cannot fail closed.

Commit 1 adds the failing regression tests (noise-filter classification, plus an end-to-end bundled-CLI test that proves the timed-out fingerprint and the per-stage throttle through the DEBUG capture/store probes); commit 2 adds the fix.

The already-dead "unavailable: TabManager not available" variant (only emitted by pre-gate release 0.62.2) is separately hardened by https://github.com/manaflow-ai/cmux/pull/10550, which this PR does not overlap.

Principled: grouping and deduplication are fixed in the one shared reporter path with a stateful durable claim, not per-call-site flags; the only judgment call is the 15-minute per-stage throttle window inherited from the existing hook-failure claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CLI Sentry mega-issue where every CLI failure was folded into one shared issue, and cuts event volume from the "Not connected" race and repeated "Command timed out" captures.

**Bug Fixes**
- CLI errors now group by a per-class fingerprint `[cmux-cli, stage, kind]` instead of one shared NSError; structured v2 codes become `v2-<code>`, and unknown messages keep default grouping within their stage.
- `SentryNoiseFilter` mutes the bare "Not connected" lifecycle race only in proven CLI socket transport contexts (stage or `socket_operation`/`socket_phase` data keys).
- "Command timed out" stays reportable as an app-responsiveness signal but is throttled to one durable capture per (stage, kind) per 15-minute window, with a bounded lock wait so a stuck state lock skips the capture rather than blocking the CLI's exit.
- `ClaudeHookSessionStore.withLockedState` now creates its state directory before opening the lock, so the first claim on a fresh HOME cannot fail closed.

<sup>Written for commit 7e2436b0a552e35cfd415bed92c47c42f7f117a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error grouping for CLI connection failures using consistent failure categories.
  * Reduced duplicate telemetry for repeated timeout and transport errors.
  * Prevented expected “Not connected” socket lifecycle messages from generating unnecessary reports.
  * Ensured telemetry state initializes correctly in fresh environments, including first use.
  * Preserved reporting for similarly worded errors outside the expected socket context.

* **Tests**
  * Added coverage for error classification, filtering, throttling, and timeout reporting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->