### PR TITLE
Add production telemetry to the cloud machine link path

### DIFF
--- a/Sources/Cloud/CloudLinkTelemetry.swift
+++ b/Sources/Cloud/CloudLinkTelemetry.swift
@@ -1,0 +1,210 @@
+import Foundation
+import OSLog
+
+/// Production diagnostics for the sidebar's cloud machine links. This path previously
+/// had no non-DEBUG signal at all: `cmuxDebugLog` compiles out of release builds,
+/// app-side PostHog only counted active users, and the control plane's Axiom spans end
+/// at the attach-endpoint response — so a machine stuck on "Connecting…" in a nightly
+/// or stable build was undiagnosable in the field.
+///
+/// Two sinks:
+/// - os.log (subsystem `com.cmuxterm.app`, category `CloudLink`): every lifecycle
+///   transition, readable from release builds via Console or
+///   `log show --predicate 'subsystem == "com.cmuxterm.app" AND category == "CloudLink"'`.
+///   Interpolations are `.public` only after `redactSecrets` strips token values,
+///   because link routes carry preview tokens in query strings.
+/// - PostHog event `cmux_cloud_link_error`: failures only, matching the server's
+///   `cloud_vm_provision` errors-only split, throttled per machine+stage so the 45 s
+///   sidebar refresh loop cannot flood the project while a machine stays broken.
+enum CloudLinkTelemetry {
+    static let logger = Logger(subsystem: "com.cmuxterm.app", category: "CloudLink")
+
+    static let eventName = "cmux_cloud_link_error"
+
+    /// One capture per machine+stage per interval; os.log still records every occurrence.
+    private static let captureThrottle = CloudLinkCaptureThrottle(interval: 5 * 60)
+
+    // MARK: - Lifecycle logs
+
+    static func connectStarted(machineID: String) {
+        logger.info("connect start machine=\(machineID, privacy: .public)")
+    }
+
+    static func attachEndpointResolved(machineID: String, durationMs: Int) {
+        logger.info("attach-endpoint resolved machine=\(machineID, privacy: .public) duration_ms=\(durationMs, privacy: .public)")
+    }
+
+    static func connected(machineID: String, socketPath: String, durationMs: Int) {
+        logger.info("connected machine=\(machineID, privacy: .public) socket=\(socketPath, privacy: .public) duration_ms=\(durationMs, privacy: .public)")
+    }
+
+    static func connectFailed(machineID: String, error: Error, durationMs: Int) {
+        let stage = Self.stage(for: error)
+        let text = redactSecrets(CloudMachineLink.errorText(error))
+        logger.error("connect failed machine=\(machineID, privacy: .public) stage=\(stage, privacy: .public) duration_ms=\(durationMs, privacy: .public) error=\(text, privacy: .public)")
+        // A backoff rejection re-reports the failure that armed it; capturing it again
+        // would double-count one incident.
+        guard stage != "retry_backoff" else { return }
+        capture(machineID: machineID, stage: stage, error: error, extra: ["duration_ms": durationMs])
+    }
+
+    static func linkExited(machineID: String, status: Int32, wasConnected: Bool, stderrTail: String) {
+        let tail = redactSecrets(stderrTail)
+        logger.error("link exited machine=\(machineID, privacy: .public) status=\(status, privacy: .public) was_connected=\(wasConnected, privacy: .public) stderr=\(tail, privacy: .public)")
+        guard status != 0 else { return }
+        capture(
+            machineID: machineID,
+            stage: "link_exit",
+            errorClass: "exited",
+            errorText: tail,
+            extra: ["exit_status": Int(status), "was_connected": wasConnected]
+        )
+    }
+
+    /// The registry's machine-list read failed, so no provider refreshes ran this cycle.
+    /// This was a silent `try?` before: under a sustained failure (rate limiting, auth,
+    /// backend outage) the whole cloud tree froze in its last state with no trace.
+    static func machineListFailed(error: Error) {
+        let text = redactSecrets(CloudMachineLink.errorText(error))
+        logger.error("machine list refresh failed error=\(text, privacy: .public)")
+        capture(machineID: "all", stage: "list_machines", error: error)
+    }
+
+    static func providerRefreshFailed(machineID: String, state: SurfaceLinkState, error: Error) {
+        let text = redactSecrets(CloudMachineLink.errorText(error))
+        logger.error("provider refresh failed machine=\(machineID, privacy: .public) link_state=\(state.rawValue, privacy: .public) error=\(text, privacy: .public)")
+        // `connecting` here means another attempt is already in flight and will report
+        // its own outcome; only a settled error state is a new incident.
+        guard state == .error else { return }
+        capture(machineID: machineID, stage: "provider_refresh", error: error, extra: ["link_state": state.rawValue])
+    }
+
+    static func linkStateChanged(machineID: String, from: SurfaceLinkState, to: SurfaceLinkState) {
+        guard from != to else { return }
+        logger.info("link state machine=\(machineID, privacy: .public) \(from.rawValue, privacy: .public) -> \(to.rawValue, privacy: .public)")
+    }
+
+    // MARK: - Classification
+
+    /// Which step of the connect pipeline an error came from, derived from its type so
+    /// the pipeline code does not thread a stage variable through every await.
+    static func stage(for error: Error) -> String {
+        switch error {
+        case is VMClientError:
+            return "attach_endpoint"
+        case CloudMachineLink.LinkError.spawnFailed:
+            return "spawn"
+        case CloudMachineLink.LinkError.timedOut:
+            return "socket_wait"
+        case CloudMachineLink.LinkError.exited:
+            return "link_exit"
+        case CloudMachineLink.LinkError.clientMissing,
+             CloudMachineLinkManager.ManagerError.clientMissing:
+            return "client_missing"
+        case CloudMachineLinkManager.ManagerError.retryLater:
+            return "retry_backoff"
+        default:
+            return "other"
+        }
+    }
+
+    /// A short grouping key for PostHog insights, coarser than the error text.
+    static func errorClass(for error: Error) -> String {
+        switch error {
+        case VMClientError.notSignedIn:
+            return "not_signed_in"
+        case VMClientError.sessionRefreshFailed:
+            return "session_refresh_failed"
+        case VMClientError.backendUnreachable:
+            return "backend_unreachable"
+        case VMClientError.httpStatus(let code, _):
+            return "http_\(code)"
+        case VMClientError.malformedResponse:
+            return "malformed_response"
+        case CloudMachineLink.LinkError.spawnFailed:
+            return "spawn_failed"
+        case CloudMachineLink.LinkError.timedOut:
+            return "timeout"
+        case CloudMachineLink.LinkError.exited:
+            return "exited"
+        case CloudMachineLink.LinkError.clientMissing,
+             CloudMachineLinkManager.ManagerError.clientMissing:
+            return "client_missing"
+        case CloudMachineLinkManager.ManagerError.retryLater:
+            return "retry_backoff"
+        case is CancellationError:
+            return "cancelled"
+        default:
+            return "other"
+        }
+    }
+
+    /// Strips secret query values (`bl_preview_token=…`, any `*token*=` parameter) from
+    /// text that may embed a link route, so it is safe to log publicly and send to
+    /// PostHog. Routes appear in child-process stderr and in error descriptions.
+    static func redactSecrets(_ text: String) -> String {
+        text.replacingOccurrences(
+            of: #"([?&][A-Za-z0-9_-]*token[A-Za-z0-9_-]*=)[^&\s"'\\]+"#,
+            with: "$1REDACTED",
+            options: [.regularExpression, .caseInsensitive]
+        )
+    }
+
+    // MARK: - Capture
+
+    private static func capture(
+        machineID: String,
+        stage: String,
+        error: Error,
+        extra: [String: Any] = [:]
+    ) {
+        capture(
+            machineID: machineID,
+            stage: stage,
+            errorClass: errorClass(for: error),
+            errorText: redactSecrets(CloudMachineLink.errorText(error)),
+            extra: extra
+        )
+    }
+
+    private static func capture(
+        machineID: String,
+        stage: String,
+        errorClass: String,
+        errorText: String,
+        extra: [String: Any]
+    ) {
+        guard captureThrottle.shouldSend(key: "\(machineID)|\(stage)") else { return }
+        var properties: [String: Any] = [
+            "machine_id": machineID,
+            "stage": stage,
+            "error_class": errorClass,
+            "error": String(errorText.prefix(500)),
+            "schema_version": 1,
+        ]
+        properties.merge(extra) { _, new in new }
+        PostHogAnalytics.shared.captureDiagnostic(event: eventName, properties: properties)
+    }
+}
+
+/// Allows one send per key per interval. Lock-guarded because failures surface from
+/// actors, detached tasks, and the main actor alike.
+final class CloudLinkCaptureThrottle: @unchecked Sendable {
+    private let interval: TimeInterval
+    private let lock = NSLock()
+    private var lastSent: [String: Date] = [:]
+
+    init(interval: TimeInterval) {
+        self.interval = interval
+    }
+
+    func shouldSend(key: String, now: Date = Date()) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        if let last = lastSent[key], now.timeIntervalSince(last) < interval {
+            return false
+        }
+        lastSent[key] = now
+        return true
+    }
+}

--- a/Sources/Cloud/CloudMachineLink.swift
+++ b/Sources/Cloud/CloudMachineLink.swift
@@ -259,6 +259,7 @@ actor CloudMachineLink {
     }
 
     private func linkProcessDidExit(status: Int32) {
+        let wasConnected = connected != nil
         eventsProcess?.terminate()
         eventsProcess = nil
         process = nil
@@ -267,6 +268,14 @@ actor CloudMachineLink {
         if state != .unavailable {
             state = status == 0 ? .unavailable : .error
             lastError = status == 0 ? nil : LinkError.exited(status: status, output: stderrTail.joined(separator: "\n")).errorDescription
+            // A deliberate `disconnect` already set .unavailable; anything else is the
+            // link dying underneath the sidebar and worth a trace in release builds.
+            CloudLinkTelemetry.linkExited(
+                machineID: machineID,
+                status: status,
+                wasConnected: wasConnected,
+                stderrTail: stderrTail.suffix(5).joined(separator: " · ")
+            )
         }
         changesContinuation.yield()
         changesContinuation.finish()

--- a/Sources/Cloud/CloudMachineLinkManager.swift
+++ b/Sources/Cloud/CloudMachineLinkManager.swift
@@ -63,6 +63,8 @@ actor CloudMachineLinkManager {
         #if DEBUG
         cmuxDebugLog("cloud.link.connect machine=\(machineID)")
         #endif
+        let startedAt = Date()
+        CloudLinkTelemetry.connectStarted(machineID: machineID)
         let task = Task<CloudMachineLink.Connected, Error> { [paths] in
             let link = CloudMachineLink(machineID: machineID, clientURL: clientURL, paths: paths)
             self.store(link: link, for: machineID)
@@ -74,6 +76,10 @@ actor CloudMachineLinkManager {
                 id: machineID,
                 deviceFingerprint: paths.deviceFingerprint(for: machineID),
                 clientCapabilities: Self.clientCapabilities(clientURL: clientURL)
+            )
+            CloudLinkTelemetry.attachEndpointResolved(
+                machineID: machineID,
+                durationMs: Int(Date().timeIntervalSince(startedAt) * 1000)
             )
             var approval: Task<Void, Never>?
             if let invitation = endpoint.invitation {
@@ -92,6 +98,11 @@ actor CloudMachineLinkManager {
         do {
             let connected = try await task.value
             lastFailure[machineID] = nil
+            CloudLinkTelemetry.connected(
+                machineID: machineID,
+                socketPath: connected.socketPath,
+                durationMs: Int(Date().timeIntervalSince(startedAt) * 1000)
+            )
             #if DEBUG
             cmuxDebugLog("cloud.link.connected machine=\(machineID) socket=\(connected.socketPath)")
             #endif
@@ -100,6 +111,11 @@ actor CloudMachineLinkManager {
             let text = CloudMachineLink.errorText(error)
             lastFailure[machineID] = (Date(), text)
             links[machineID] = nil
+            CloudLinkTelemetry.connectFailed(
+                machineID: machineID,
+                error: error,
+                durationMs: Int(Date().timeIntervalSince(startedAt) * 1000)
+            )
             #if DEBUG
             cmuxDebugLog("cloud.link.failed machine=\(machineID) error=\(String(reflecting: error)) text=\(text)")
             #endif

--- a/Sources/PostHogAnalytics.swift
+++ b/Sources/PostHogAnalytics.swift
@@ -113,6 +113,18 @@ final class PostHogAnalytics: @unchecked Sendable {
         }
     }
 
+    /// Captures a low-volume diagnostic event (errors-only paths such as
+    /// ``CloudLinkTelemetry``). Callers own deduplication and throttling; this only
+    /// gates on the telemetry opt-out and SDK startup, like the active-user events.
+    func captureDiagnostic(event: String, properties: [String: Any]) {
+        dispatchAsyncOnWorkQueue { [weak self] in
+            guard let self else { return }
+            self.startIfNeededOnWorkQueue()
+            guard self.didStart else { return }
+            self.capturePostHog(event, properties)
+        }
+    }
+
     private func startIfNeededOnWorkQueue() {
         guard !didStart else { return }
         guard isEnabled else { return }

--- a/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
+++ b/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
@@ -87,7 +87,17 @@ final class CmuxTuiSurfaceProviderRegistry {
 
     private func performRefresh(force: Bool) async {
         guard let catalog, let client = VMClient.shared else { return }
-        guard let page = try? await client.listPage() else { return }
+        let page: VMListPage
+        do {
+            page = try await client.listPage()
+        } catch {
+            // Without the list no provider refreshes run this cycle, so the whole cloud
+            // tree keeps its last state (a machine created as "Connecting…" stays a
+            // spinner). Swallowing this silently made sustained rate limiting or auth
+            // outages look like a UI hang; the telemetry names the cause.
+            CloudLinkTelemetry.machineListFailed(error: error)
+            return
+        }
         let seen = Set(page.vms.map(\.id))
         for id in providers.keys where !seen.contains(id) {
             providers[id]?.stop()
@@ -210,6 +220,7 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
             resources.append(CmuxTuiSnapshotParser.display(machine: machine))
         }
         guard isAwake, let client = VMClient.shared else {
+            CloudLinkTelemetry.linkStateChanged(machineID: machineID, from: info.linkState, to: .asleep)
             info = Self.info(from: summary, linkState: .asleep, linkError: nil, stats: nil)
             catalog.replaceResources(resources, on: machine, info: info)
             return
@@ -244,10 +255,12 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
             let status = await links.status(machineID: machineID)
             linkState = status?.state ?? .error
             linkError = status?.error ?? CloudMachineLink.errorText(error)
+            CloudLinkTelemetry.providerRefreshFailed(machineID: machineID, state: linkState, error: error)
             #if DEBUG
             cmuxDebugLog("cloud.provider.refreshFailed machine=\(machineID) state=\(linkState) error=\(String(reflecting: error))")
             #endif
         }
+        CloudLinkTelemetry.linkStateChanged(machineID: machineID, from: info.linkState, to: linkState)
         info = Self.info(from: summary, linkState: linkState, linkError: linkError, stats: await stats, remoteWorkspaces: remoteWorkspaces)
         catalog.replaceResources(resources, on: machine, info: info)
         reprojectRestoredPanes()

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -611,6 +611,8 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		EAEF1B227CA5A458005D2EAD /* CloudAgentSkillLauncher+LauncherError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0110525EA7A8A51561759317 /* CloudAgentSkillLauncher+LauncherError.swift */; };
 		68B60071A7049D7CD9C2CFD7 /* CloudAgentSkillLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7BA0E69E17F61ECF69C9025 /* CloudAgentSkillLauncher.swift */; };
 		C6D4C5A38097BB05AB98E460 /* CloudAgentSkillLauncherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 763D217526D3832668F47568 /* CloudAgentSkillLauncherTests.swift */; };
+		E977503E8B8046B097237FFD /* CloudLinkTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = B178A93A7C7B414BAD3EC1DE /* CloudLinkTelemetry.swift */; };
+		012E0AE48A6D451A83E28F4B /* CloudLinkTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B359639AD68340E3AE557F22 /* CloudLinkTelemetryTests.swift */; };
 		E0C1BF3A1CF2C22FF100B77B /* CloudMachineLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DC04B459E0132708ACD366 /* CloudMachineLink.swift */; };
 		5C6CEB17F0A6776F357BAF09 /* CloudMachineLinkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874061DC8AD0C4E7297BF267 /* CloudMachineLinkManager.swift */; };
 		0F5C2DDC1A39436E867D28BB /* CloudMachinesFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9143D900F124494A55F859F /* CloudMachinesFeature.swift */; };
@@ -3590,6 +3592,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		0110525EA7A8A51561759317 /* CloudAgentSkillLauncher+LauncherError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "CloudAgentSkillLauncher+LauncherError.swift"; sourceTree = "<group>"; };
 		A7BA0E69E17F61ECF69C9025 /* CloudAgentSkillLauncher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudAgentSkillLauncher.swift; sourceTree = "<group>"; };
 		763D217526D3832668F47568 /* CloudAgentSkillLauncherTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudAgentSkillLauncherTests.swift; sourceTree = "<group>"; };
+		B178A93A7C7B414BAD3EC1DE /* CloudLinkTelemetry.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudLinkTelemetry.swift; sourceTree = "<group>"; };
+		B359639AD68340E3AE557F22 /* CloudLinkTelemetryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudLinkTelemetryTests.swift; sourceTree = "<group>"; };
 		49DC04B459E0132708ACD366 /* CloudMachineLink.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudMachineLink.swift; sourceTree = "<group>"; };
 		874061DC8AD0C4E7297BF267 /* CloudMachineLinkManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudMachineLinkManager.swift; sourceTree = "<group>"; };
 		D9143D900F124494A55F859F /* CloudMachinesFeature.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudMachinesFeature.swift; sourceTree = "<group>"; };
@@ -6221,6 +6225,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				68672B3C63D4E348AFA4DEF7 /* MachinesPanelViewModel.swift */,
 				874061DC8AD0C4E7297BF267 /* CloudMachineLinkManager.swift */,
 				49DC04B459E0132708ACD366 /* CloudMachineLink.swift */,
+				B178A93A7C7B414BAD3EC1DE /* CloudLinkTelemetry.swift */,
 				47DA953E018A1329DF8C0255 /* CloudTuiCommandLine.swift */,
 				8C4E59490776669AA7257527 /* CloudTuiClientPaths.swift */,
 				48A1307BCCDB493F49179E0B /* SurfaceResourceDragPayload.swift */,
@@ -8548,6 +8553,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C3408A000000000000000004 /* RightSidebarCommandPaletteTests.swift */,
 				78F49DA9F80DC43173341410 /* MachinesPanelModelTests.swift */,
 				763D217526D3832668F47568 /* CloudAgentSkillLauncherTests.swift */,
+				B359639AD68340E3AE557F22 /* CloudLinkTelemetryTests.swift */,
 				5130177E80C2A18E09DBBBC4 /* NewMachineModelTests.swift */,
 				64C68B378B6071B213B4AA57 /* LocalSurfaceProviderTests.swift */,
 				BC427A4C642EBC36E600FA7F /* CmuxTuiSurfaceProviderTests.swift */,
@@ -9729,6 +9735,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C62A16251EC09E72A897A2A3 /* CloudAgentSkillLauncher+CodingAgent.swift in Sources */,
 				EAEF1B227CA5A458005D2EAD /* CloudAgentSkillLauncher+LauncherError.swift in Sources */,
 				68B60071A7049D7CD9C2CFD7 /* CloudAgentSkillLauncher.swift in Sources */,
+				E977503E8B8046B097237FFD /* CloudLinkTelemetry.swift in Sources */,
 				E0C1BF3A1CF2C22FF100B77B /* CloudMachineLink.swift in Sources */,
 				5C6CEB17F0A6776F357BAF09 /* CloudMachineLinkManager.swift in Sources */,
 				0F5C2DDC1A39436E867D28BB /* CloudMachinesFeature.swift in Sources */,
@@ -11612,6 +11619,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 					799100000000000000000003 /* CLIWorkspaceStableIDTests.swift in Sources */,
 				7375A0037375A0037375A003 /* ClosedMainWindowRoutingTests.swift in Sources */,
 				C6D4C5A38097BB05AB98E460 /* CloudAgentSkillLauncherTests.swift in Sources */,
+				012E0AE48A6D451A83E28F4B /* CloudLinkTelemetryTests.swift in Sources */,
 				C75740010000000000000001 /* CloudVMMenuItemMetricsTests.swift in Sources */,
 				C0DE43000000000000000009 /* CmuxAgentChatConfigTests.swift in Sources */,
 				8295A0058295A0058295A005 /* CmuxAlertContentTests.swift in Sources */,

--- a/cmuxTests/CloudLinkTelemetryTests.swift
+++ b/cmuxTests/CloudLinkTelemetryTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+
+struct CloudLinkTelemetryTests {
+    @Test("token query values are redacted from routes and stderr text")
+    func redactsTokenQueryValues() {
+        let route = "wss://happy-fox-cmux.preview.bl.run/v1/link?bl_preview_token=dbbfe6ecdcb6cde040f0ec3c9cddc536"
+        #expect(CloudLinkTelemetry.redactSecrets(route)
+            == "wss://happy-fox-cmux.preview.bl.run/v1/link?bl_preview_token=REDACTED")
+
+        let stderr = "connect failed for wss://h/v1/link?bl_preview_token=abc123&x=1 · retrying"
+        let redacted = CloudLinkTelemetry.redactSecrets(stderr)
+        #expect(!redacted.contains("abc123"))
+        #expect(redacted.contains("&x=1"))
+
+        let mixedCase = "https://h/p?Access_Token=secret&plain=keep"
+        let mixedRedacted = CloudLinkTelemetry.redactSecrets(mixedCase)
+        #expect(!mixedRedacted.contains("secret"))
+        #expect(mixedRedacted.contains("plain=keep"))
+
+        #expect(CloudLinkTelemetry.redactSecrets("no secrets here") == "no secrets here")
+    }
+
+    @Test("errors map to the pipeline stage they came from")
+    func stagesFollowErrorTypes() {
+        #expect(CloudLinkTelemetry.stage(for: VMClientError.httpStatus(429, "rate_limited")) == "attach_endpoint")
+        #expect(CloudLinkTelemetry.stage(for: CloudMachineLink.LinkError.timedOut) == "socket_wait")
+        #expect(CloudLinkTelemetry.stage(for: CloudMachineLink.LinkError.spawnFailed("nope")) == "spawn")
+        #expect(CloudLinkTelemetry.stage(for: CloudMachineLink.LinkError.exited(status: 1, output: "boom")) == "link_exit")
+        #expect(CloudLinkTelemetry.stage(for: CloudMachineLinkManager.ManagerError.clientMissing) == "client_missing")
+        #expect(CloudLinkTelemetry.stage(for: CloudMachineLinkManager.ManagerError.retryLater("backing off")) == "retry_backoff")
+        #expect(CloudLinkTelemetry.stage(for: CocoaError(.fileNoSuchFile)) == "other")
+    }
+
+    @Test("error classes group HTTP statuses and typed failures")
+    func errorClassesGroupFailures() {
+        #expect(CloudLinkTelemetry.errorClass(for: VMClientError.httpStatus(429, "rate_limited")) == "http_429")
+        #expect(CloudLinkTelemetry.errorClass(for: VMClientError.notSignedIn) == "not_signed_in")
+        #expect(CloudLinkTelemetry.errorClass(for: VMClientError.backendUnreachable(url: "http://x", detail: "d")) == "backend_unreachable")
+        #expect(CloudLinkTelemetry.errorClass(for: CloudMachineLink.LinkError.timedOut) == "timeout")
+        #expect(CloudLinkTelemetry.errorClass(for: CancellationError()) == "cancelled")
+    }
+
+    @Test("capture throttle allows one send per key per interval")
+    func throttleAllowsOneSendPerInterval() {
+        let throttle = CloudLinkCaptureThrottle(interval: 300)
+        let start = Date(timeIntervalSince1970: 1_000_000)
+        #expect(throttle.shouldSend(key: "vm-1|socket_wait", now: start))
+        #expect(!throttle.shouldSend(key: "vm-1|socket_wait", now: start.addingTimeInterval(299)))
+        #expect(throttle.shouldSend(key: "vm-1|attach_endpoint", now: start))
+        #expect(throttle.shouldSend(key: "vm-2|socket_wait", now: start))
+        #expect(throttle.shouldSend(key: "vm-1|socket_wait", now: start.addingTimeInterval(301)))
+        #expect(!throttle.shouldSend(key: "vm-1|socket_wait", now: start.addingTimeInterval(302)))
+    }
+}
+#endif


### PR DESCRIPTION
A machine can sit on "Connecting…" in the Cloud tree indefinitely with no trace anywhere: `cmuxDebugLog` compiles out of release builds, app-side PostHog only counts active users, and the control plane's Axiom spans end at the attach-endpoint response. Diagnosing a live spinner (happy-fox, 2026-08-27) required process-table archaeology on the user's Mac.

Two silent failure modes make it worse. `CmuxTuiSurfaceProviderRegistry.performRefresh` swallowed `listPage` errors with `try?`, so a sustained 429 (which the account was serving during the incident) or auth outage freezes the whole tree in its last rendered state, spinner included, with zero signal. And a link process dying or timing out leaves nothing behind in nightly or stable builds.

`CloudLinkTelemetry` adds two sinks. Every link lifecycle transition (connect start, attach-endpoint resolved, socket resolved, connect failed, link exited, machine-list refresh failed, link state changes) logs to os.log subsystem `com.cmuxterm.app` category `CloudLink`, readable from release builds via `log show`. Failures only are captured to PostHog as `cmux_cloud_link_error` (schema_version 1) with `machine_id`, `stage` (attach_endpoint / spawn / socket_wait / link_exit / provider_refresh / list_machines / client_missing), `error_class`, redacted error text, and duration, matching the server's `cloud_vm_provision` errors-only split. Captures are throttled to one per machine+stage per 5 minutes so the 45 s refresh loop cannot flood the project. `redactSecrets` strips token query values (`bl_preview_token`) before any text leaves the process, since link routes embed preview tokens and child stderr can echo them.

Tests cover redaction, stage and error-class mapping, and the capture throttle.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds production telemetry to the cloud machine link path so a spinner stuck on "Connecting…" is diagnosable in release builds, and stops silently swallowing machine-list refresh failures that froze the whole cloud tree.

**New Features**
- Logs every link lifecycle transition to os.log under subsystem `com.cmuxterm.app` category `CloudLink`, readable from release builds via `log show`.
- Captures failures only to PostHog as `cmux_cloud_link_error`, with machine ID, pipeline stage, error class, and duration.
- Throttles PostHog captures to one per machine and stage per 5 minutes so the 45-second refresh loop can't flood the project, while os.log still records every occurrence.
- Redacts preview-token query values before any text leaves the process, and gates captures on the telemetry opt-out.
- Adds tests for redaction, stage and error-class mapping, and the capture throttle.

**Bug Fixes**
- Machine-list refresh errors are no longer swallowed by `try?`; a sustained 429 or auth outage previously left the tree frozen in its last rendered state with zero signal.

<sup>Written for commit b0090d75bc613fce6d5f3cd99af87aacfb254ff8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added diagnostic reporting for cloud machine link connection stages, failures, exits, and state changes.
  * Added privacy-conscious redaction for sensitive connection details.
  * Added throttling to reduce duplicate diagnostic events.
  * Added opt-out-aware diagnostic event capture.

* **Bug Fixes**
  * Cloud machine list and provider refresh failures are now surfaced in diagnostics instead of being silently ignored.

* **Tests**
  * Added coverage for redaction, error classification, lifecycle stages, and diagnostic throttling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->