### PR TITLE
Add granular Codex tool-hook opt-out [codex][gpt-5.6-sol]

### DIFF
--- a/CLI/CMUXCLI+CodexFireAndForgetHooks.swift
+++ b/CLI/CMUXCLI+CodexFireAndForgetHooks.swift
@@ -23,9 +23,16 @@ extension CMUXCLI {
             throw CLIError(message: "Codex hook integration is unavailable.")
         }
         let usesPersistentChannel = reconcileCodexPersistentHooksForWrapper()
-        let eventsToInject = usesPersistentChannel
-            ? []
-            : CodexHookInjectionSchema.current.events(toolHooksDisabled: Self.codexToolHooksDisabled)
+        if usesPersistentChannel {
+            if Self.codexToolHooksDisabled,
+               let stateOverride = Self.codexPersistentToolHookDisableStateOverride(for: codexDef) {
+                Self.writeNULTerminatedArguments(["-c", stateOverride])
+            }
+            return
+        }
+        let eventsToInject = CodexHookInjectionSchema.current.events(
+            toolHooksDisabled: Self.codexToolHooksDisabled
+        )
         // Prefer a #!/bin/sh SCRIPT FILE as the hook command over an inline shell
         // snippet. Some codex-compatible runtimes (subrouters, proxies) exec the
         // `command` string directly as a program instead of via a shell, so an
@@ -73,12 +80,16 @@ extension CMUXCLI {
         // `while IFS= read -r -d '' arg` loop captures every element including
         // the final one — a separator-only stream drops the unterminated last
         // arg at EOF.
-        var out = Data()
-        for arg in args {
-            out.append(Data(arg.utf8))
-            out.append(0)
+        Self.writeNULTerminatedArguments(args)
+    }
+
+    private static func writeNULTerminatedArguments(_ arguments: [String]) {
+        var output = Data()
+        for argument in arguments {
+            output.append(Data(argument.utf8))
+            output.append(0)
         }
-        FileHandle.standardOutput.write(out)
+        FileHandle.standardOutput.write(output)
     }
 
     /// The cmux-owned directory holding the generated codex hook scripts.

--- a/CLI/CMUXCLI+CodexFireAndForgetHooks.swift
+++ b/CLI/CMUXCLI+CodexFireAndForgetHooks.swift
@@ -2,6 +2,10 @@ import CMUXAgentLaunch
 import Foundation
 
 extension CMUXCLI {
+    static var codexToolHooksDisabled: Bool {
+        ProcessInfo.processInfo.environment["CMUX_CODEX_TOOL_HOOKS_DISABLED"] == "1"
+    }
+
     /// Emit, NUL-separated to stdout, the exact codex arg list the wrapper must
     /// splice ahead of the user's args to enable + inject cmux's fire-and-forget
     /// hooks for one codex invocation when no persistent cmux channel is
@@ -19,7 +23,9 @@ extension CMUXCLI {
             throw CLIError(message: "Codex hook integration is unavailable.")
         }
         let usesPersistentChannel = reconcileCodexPersistentHooksForWrapper()
-        let eventsToInject = usesPersistentChannel ? [] : CodexHookInjectionSchema.current.events
+        let eventsToInject = usesPersistentChannel
+            ? []
+            : CodexHookInjectionSchema.current.events(toolHooksDisabled: Self.codexToolHooksDisabled)
         // Prefer a #!/bin/sh SCRIPT FILE as the hook command over an inline shell
         // snippet. Some codex-compatible runtimes (subrouters, proxies) exec the
         // `command` string directly as a program instead of via a shell, so an
@@ -128,7 +134,7 @@ extension CMUXCLI {
 
     /// Names that the current wrapper schema may reference from a live session.
     static func currentCodexWrapperHookScriptFilenames(for def: AgentHookDef) -> Set<String> {
-        Set(CodexHookInjectionSchema.current.events.compactMap { event in
+        Set(CodexHookInjectionSchema.wrapperScriptRetentionEvents.compactMap { event in
             let body = codexFireAndForgetAgentHookShellCommand(
                 "cmux hooks codex \(event.cmuxSubcommand)",
                 for: def

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -31703,10 +31703,7 @@ struct CMUXCLI {
         // timeout; Codex telemetry stays short so it never delays Codex's own
         // approval reviewer. Most nested agents use milliseconds. Codex, Grok,
         // and Antigravity hook schemas use seconds, so normalize before writing.
-        let feedHookEvents = def.name == "codex" && Self.codexToolHooksDisabled
-            ? def.feedHookEvents.filter { !CodexHookInjectionSchema.isToolExecutionEvent($0) }
-            : def.feedHookEvents
-        for agentEvent in feedHookEvents {
+        for agentEvent in def.feedHookEvents {
             let feedCmd = feedHookCommand(for: def, agentEvent: agentEvent)
             let feedTimeoutMs = feedHookTimeoutMs(for: def, agentEvent: agentEvent)
             switch def.format {
@@ -32555,11 +32552,6 @@ export default CMUXSessionRestore;
         }
 
         var hooks = existing["hooks"] as? [String: Any] ?? [:]
-        let codexHookTrustEntriesBeforeReconciliation = Self.codexHookTrustEntries(
-            hooks: hooks,
-            hooksFilePath: filePath,
-            def: def
-        )
         let newHooks = buildHooksDict(for: def)
 
         // Remove existing cmux-owned entries (both the per-agent hook
@@ -32798,6 +32790,28 @@ export default CMUXSessionRestore;
         return hooks.values.contains {
             Self.jsonHookValueContainsCmuxOwnedCommand($0, for: def)
         }
+    }
+
+    static func codexPersistentToolHookDisableStateOverride(for def: AgentHookDef) -> String? {
+        let hooksFilePath = "\(def.resolvedConfigDir())/\(def.configFile)"
+        guard let data = FileManager.default.contents(atPath: hooksFilePath),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let hooks = root["hooks"] as? [String: Any] else {
+            return nil
+        }
+        let entries = codexHookTrustEntries(
+            hooks: hooks,
+            hooksFilePath: hooksFilePath,
+            def: def
+        ).filter {
+            $0.key.contains(":pre_tool_use:") || $0.key.contains(":post_tool_use:")
+        }.sorted { $0.key < $1.key }
+        guard !entries.isEmpty else { return nil }
+
+        let state = entries.map { entry in
+            "\"\(tomlBasicStringContent(entry.key))\"={enabled=false}"
+        }.joined(separator: ",")
+        return "hooks.state={\(state)}"
     }
 
     private func pruneLegacyGrokHookFileIfNeeded(

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -32802,7 +32802,8 @@ export default CMUXSessionRestore;
         let entries = codexLabeledHookTrustEntries(
             hooks: hooks,
             hooksFilePath: hooksFilePath,
-            def: def
+            def: def,
+            includeLegacyOwnedCommands: true
         ).filter {
             $0.eventLabel == "pre_tool_use" || $0.eventLabel == "post_tool_use"
         }.map(\.trustEntry)

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -31703,7 +31703,10 @@ struct CMUXCLI {
         // timeout; Codex telemetry stays short so it never delays Codex's own
         // approval reviewer. Most nested agents use milliseconds. Codex, Grok,
         // and Antigravity hook schemas use seconds, so normalize before writing.
-        for agentEvent in def.feedHookEvents {
+        let feedHookEvents = def.name == "codex" && Self.codexToolHooksDisabled
+            ? def.feedHookEvents.filter { !CodexHookInjectionSchema.isToolExecutionEvent($0) }
+            : def.feedHookEvents
+        for agentEvent in feedHookEvents {
             let feedCmd = feedHookCommand(for: def, agentEvent: agentEvent)
             let feedTimeoutMs = feedHookTimeoutMs(for: def, agentEvent: agentEvent)
             switch def.format {
@@ -32552,6 +32555,11 @@ export default CMUXSessionRestore;
         }
 
         var hooks = existing["hooks"] as? [String: Any] ?? [:]
+        let codexHookTrustEntriesBeforeReconciliation = Self.codexHookTrustEntries(
+            hooks: hooks,
+            hooksFilePath: filePath,
+            def: def
+        )
         let newHooks = buildHooksDict(for: def)
 
         // Remove existing cmux-owned entries (both the per-agent hook

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -32799,7 +32799,7 @@ export default CMUXSessionRestore;
               let hooks = root["hooks"] as? [String: Any] else {
             return nil
         }
-        let entries = codexHookTrustEntries(
+        let entries = codexLabeledHookTrustEntries(
             hooks: hooks,
             hooksFilePath: hooksFilePath,
             def: def
@@ -33029,17 +33029,38 @@ export default CMUXSessionRestore;
 
     typealias CodexHookTrustEntry = CmuxCodexConfigEditor.HookTrustEntry
 
+    private struct LabeledCodexHookTrustEntry {
+        let trustEntry: CodexHookTrustEntry
+        let eventLabel: String
+
+        var key: String { trustEntry.key }
+    }
+
     static func codexHookTrustEntries(
         hooks: [String: Any],
         hooksFilePath: String,
         def: AgentHookDef,
         includeLegacyOwnedCommands: Bool = false
     ) -> [CodexHookTrustEntry] {
+        codexLabeledHookTrustEntries(
+            hooks: hooks,
+            hooksFilePath: hooksFilePath,
+            def: def,
+            includeLegacyOwnedCommands: includeLegacyOwnedCommands
+        ).map(\.trustEntry)
+    }
+
+    private static func codexLabeledHookTrustEntries(
+        hooks: [String: Any],
+        hooksFilePath: String,
+        def: AgentHookDef,
+        includeLegacyOwnedCommands: Bool = false
+    ) -> [LabeledCodexHookTrustEntry] {
         guard def.name == "codex" else { return [] }
         let isOwnedCommand: (String) -> Bool = { command in
             isCmuxOwnedHookCommand(command, for: def, includeLegacy: includeLegacyOwnedCommands)
         }
-        var entries: [CodexHookTrustEntry] = []
+        var entries: [LabeledCodexHookTrustEntry] = []
         let keySource = codexNormalizedHookSourcePath(hooksFilePath)
 
         for eventName in codexHookEventNames {
@@ -33065,7 +33086,10 @@ export default CMUXSessionRestore;
                         timeoutMs: timeoutMs,
                         statusMessage: statusMessage
                     )
-                    entries.append(CodexHookTrustEntry(key: key, trustedHash: trustedHash))
+                    entries.append(LabeledCodexHookTrustEntry(
+                        trustEntry: CodexHookTrustEntry(key: key, trustedHash: trustedHash),
+                        eventLabel: eventLabel
+                    ))
                 }
             }
         }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -32804,7 +32804,7 @@ export default CMUXSessionRestore;
             hooksFilePath: hooksFilePath,
             def: def
         ).filter {
-            $0.key.contains(":pre_tool_use:") || $0.key.contains(":post_tool_use:")
+            $0.eventLabel == "pre_tool_use" || $0.eventLabel == "post_tool_use"
         }.map(\.trustEntry)
         return CmuxCodexConfigEditor().hookStateOverrideDisabling(entries)
     }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -32805,13 +32805,8 @@ export default CMUXSessionRestore;
             def: def
         ).filter {
             $0.key.contains(":pre_tool_use:") || $0.key.contains(":post_tool_use:")
-        }.sorted { $0.key < $1.key }
-        guard !entries.isEmpty else { return nil }
-
-        let state = entries.map { entry in
-            "\"\(tomlBasicStringContent(entry.key))\"={enabled=false}"
-        }.joined(separator: ",")
-        return "hooks.state={\(state)}"
+        }.map(\.trustEntry)
+        return CmuxCodexConfigEditor().hookStateOverrideDisabling(entries)
     }
 
     private func pruneLegacyGrokHookFileIfNeeded(

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexHookInjectionSchema.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexHookInjectionSchema.swift
@@ -22,6 +22,22 @@ public struct CodexHookInjectionSchema: Equatable, Sendable {
         .init(agentEvent: "PermissionRequest", cmuxSubcommand: "notification", timeoutMs: 120000),
     ])
 
+    /// Whether an event runs once per Codex tool invocation.
+    public static func isToolExecutionEvent(_ eventName: String) -> Bool {
+        eventName == "PreToolUse" || eventName == "PostToolUse"
+    }
+
+    /// The current registration schema after applying the granular tool-hook opt-out.
+    public func events(toolHooksDisabled: Bool) -> [CodexHookInjectionEvent] {
+        guard toolHooksDisabled else { return events }
+        return events.filter { !Self.isToolExecutionEvent($0.agentEvent) }
+    }
+
+    /// Every wrapper script a current cmux process may still reference.
+    public static var wrapperScriptRetentionEvents: [CodexHookInjectionEvent] {
+        current.events
+    }
+
     /// Exact older shapes accepted by saved-layout and replay sanitization.
     /// These remain explicit because stored commands can outlive the cmux
     /// version that captured them. Never broaden this to unordered events or

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/CodexHookInjectionStrippingTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/CodexHookInjectionStrippingTests.swift
@@ -5,6 +5,57 @@ import Testing
 struct CodexHookInjectionStrippingTests {
     private let codexExecutable = "/opt/homebrew/lib/node_modules/@openai/codex/bin/codex"
 
+    @Test
+    func codexToolHookOptOutKeepsLifecycleAndApprovalEvents() {
+        let events = CodexHookInjectionSchema.current
+            .events(toolHooksDisabled: true)
+            .map(\.agentEvent)
+
+        #expect(events == [
+            "SessionStart",
+            "UserPromptSubmit",
+            "Stop",
+            "PermissionRequest",
+        ])
+    }
+
+    @Test
+    func codexDefaultHookSelectionKeepsCurrentSchema() {
+        let events = CodexHookInjectionSchema.current
+            .events(toolHooksDisabled: false)
+            .map(\.agentEvent)
+
+        #expect(events == CodexHookInjectionSchema.current.events.map(\.agentEvent))
+    }
+
+    @Test
+    func codexWrapperScriptRetentionIgnoresRegistrationOptOut() {
+        let retained = CodexHookInjectionSchema.wrapperScriptRetentionEvents
+            .map(\.agentEvent)
+
+        #expect(retained == CodexHookInjectionSchema.current.events.map(\.agentEvent))
+        #expect(retained.contains("PreToolUse"))
+        #expect(retained.contains("PostToolUse"))
+        #expect(
+            CodexHookInjectionSchema.current
+                .events(toolHooksDisabled: true)
+                .map(\.agentEvent)
+                .contains("PreToolUse") == false
+        )
+    }
+
+    @Test(arguments: [
+        ("PreToolUse", true),
+        ("PostToolUse", true),
+        ("PermissionRequest", false),
+        ("Stop", false),
+        ("PreCompact", false),
+        ("SubagentStop", false),
+    ])
+    func codexToolExecutionClassification(event: String, expected: Bool) {
+        #expect(CodexHookInjectionSchema.isToolExecutionEvent(event) == expected)
+    }
+
     @Test("Strips realistic cmux-injected Codex hook flags")
     func stripsRealisticCmuxInjectedCodexHookFlags() {
         #expect(

--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/ConfigPaths/CmuxCodexConfigEditor.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/ConfigPaths/CmuxCodexConfigEditor.swift
@@ -45,6 +45,18 @@ public struct CmuxCodexConfigEditor: Sendable {
     /// Creates an editor with no filesystem or process dependencies.
     public init() {}
 
+    /// Builds a process-local Codex config override that disables the supplied hooks.
+    ///
+    /// - Parameter entries: Hook trust entries whose keys should be disabled.
+    /// - Returns: A stable TOML override, or `nil` when no entries are supplied.
+    public func hookStateOverrideDisabling(_ entries: [HookTrustEntry]) -> String? {
+        guard !entries.isEmpty else { return nil }
+        let state = entries.sorted { $0.key < $1.key }.map { entry in
+            "\"\(tomlBasicStringContent(entry.key))\"={enabled=false}"
+        }.joined(separator: ",")
+        return "hooks.state={\(state)}"
+    }
+
     /// Installs the hooks feature and the supplied cmux-owned trust tables.
     ///
     /// Existing cmux blocks and matching trust tables are removed before the

--- a/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/CmuxCodexConfigEditorTests.swift
+++ b/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/CmuxCodexConfigEditorTests.swift
@@ -94,7 +94,7 @@ struct CmuxCodexConfigEditorTests {
     func hookStateOverrideSortsAndEscapesTrustKeys() {
         let entries = [
             CmuxCodexConfigEditor.HookTrustEntry(
-                key: #"/tmp/z\"hook:post_tool_use:0:0"#,
+                key: "/tmp/z\"hook:post_tool_use:0:0",
                 trustedHash: "sha256:z"
             ),
             CmuxCodexConfigEditor.HookTrustEntry(
@@ -107,7 +107,7 @@ struct CmuxCodexConfigEditorTests {
 
         #expect(
             override ==
-                #"hooks.state={\"/tmp/a-hook:pre_tool_use:0:0\"={enabled=false},\"/tmp/z\\\"hook:post_tool_use:0:0\"={enabled=false}}"#
+                #"hooks.state={"/tmp/a-hook:pre_tool_use:0:0"={enabled=false},"/tmp/z\"hook:post_tool_use:0:0"={enabled=false}}"#
         )
     }
 

--- a/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/CmuxCodexConfigEditorTests.swift
+++ b/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/CmuxCodexConfigEditorTests.swift
@@ -90,6 +90,32 @@ struct CmuxCodexConfigEditorTests {
         #expect(result.content.contains(Self.featureBegin))
     }
 
+    @Test("Hook state override sorts and escapes trust keys")
+    func hookStateOverrideSortsAndEscapesTrustKeys() {
+        let entries = [
+            CmuxCodexConfigEditor.HookTrustEntry(
+                key: #"/tmp/z\"hook:post_tool_use:0:0"#,
+                trustedHash: "sha256:z"
+            ),
+            CmuxCodexConfigEditor.HookTrustEntry(
+                key: "/tmp/a-hook:pre_tool_use:0:0",
+                trustedHash: "sha256:a"
+            ),
+        ]
+
+        let override = editor.hookStateOverrideDisabling(entries)
+
+        #expect(
+            override ==
+                #"hooks.state={\"/tmp/a-hook:pre_tool_use:0:0\"={enabled=false},\"/tmp/z\\\"hook:post_tool_use:0:0\"={enabled=false}}"#
+        )
+    }
+
+    @Test("Hook state override is absent without trust entries")
+    func hookStateOverrideIsAbsentWithoutTrustEntries() {
+        #expect(editor.hookStateOverrideDisabling([]) == nil)
+    }
+
     private static func occurrences(of needle: String, in haystack: String) -> Int {
         haystack.components(separatedBy: needle).count - 1
     }

--- a/docs/agent-hooks.md
+++ b/docs/agent-hooks.md
@@ -156,6 +156,8 @@ and browser state. Restored agent terminals stay idle until you resume them manu
 | Factory | none | `CMUX_FACTORY_HOOKS_DISABLED=1` |
 | Qoder | `QODER_CONFIG_DIR` | `CMUX_QODER_HOOKS_DISABLED=1` |
 
+For Codex, `CMUX_CODEX_TOOL_HOOKS_DISABLED=1` disables only the `PreToolUse` and `PostToolUse` cmux hooks for that process. Lifecycle and approval hooks, including `Stop` and `PermissionRequest`, remain enabled. The value must be exactly `1`; other values preserve the default hook set.
+
 Pi uses Pi's extension system, not the legacy Pi hooks API. The installed extension is auto-discovered from `~/.pi/agent/extensions/` or `$PI_CODING_AGENT_DIR/extensions/`.
 
 OMP uses OMP's native extension system. OMP native extension discovery scans `${PI_CODING_AGENT_DIR:-~/${PI_CONFIG_DIR:-.omp}/agent}/extensions/`, so cmux installs OMP's extension with a distinct `cmux-omp-session.ts` filename and does not reuse Pi's `cmux-session.ts`.

--- a/tests/test_codex_feed_hooks.py
+++ b/tests/test_codex_feed_hooks.py
@@ -59,6 +59,12 @@ CMUX_CODEX_FEED_EVENTS = (
     "SubagentStop",
 )
 
+CMUX_CODEX_SCRIPT_SUBCOMMANDS = {
+    *CMUX_CODEX_HOOK_SUBCOMMANDS,
+    *(f"persistent-{subcommand}" for subcommand in CMUX_CODEX_HOOK_SUBCOMMANDS),
+    *(f"persistent-feed-{agent_event}" for agent_event in CMUX_CODEX_FEED_EVENTS),
+}
+
 FAKE_WORKSPACE_ID = "11111111-1111-1111-1111-111111111111"
 FAKE_SURFACE_ID = "22222222-2222-2222-2222-222222222222"
 
@@ -724,7 +730,25 @@ def cmux_codex_feed_command(agent_event: str) -> str:
 def is_cmux_codex_hook_command(command: str) -> bool:
     hook_commands = {cmux_codex_hook_command(subcommand) for subcommand in CMUX_CODEX_HOOK_SUBCOMMANDS}
     feed_commands = {cmux_codex_feed_command(agent_event) for agent_event in CMUX_CODEX_FEED_EVENTS}
-    return command in hook_commands or command in feed_commands
+    if command in hook_commands or command in feed_commands:
+        return True
+
+    path = Path(command)
+    if path.parent.name != "hooks" or path.parent.parent.name != ".cmux":
+        return False
+    prefix = "cmux-codex-hook-"
+    suffix = ".sh"
+    if not path.name.startswith(prefix) or not path.name.endswith(suffix):
+        return False
+    body = path.name[len(prefix) : -len(suffix)]
+    if body in CMUX_CODEX_SCRIPT_SUBCOMMANDS:
+        return True
+    if len(body) <= 17 or body[16] != "-":
+        return False
+    content_id = body[:16]
+    subcommand = body[17:]
+    return all(character in "0123456789abcdef" for character in content_id) \
+        and subcommand in CMUX_CODEX_SCRIPT_SUBCOMMANDS
 
 
 def toml_basic_string_unescape(value: str) -> str:
@@ -828,6 +852,493 @@ def codex_hook_commands(hooks: dict) -> list[str]:
                 if isinstance(command, str):
                     commands.append(command)
     return commands
+
+
+def codex_hook_commands_by_event(hooks: dict) -> dict[str, list[str]]:
+    commands_by_event: dict[str, list[str]] = {}
+    for event_name, groups in hooks.get("hooks", {}).items():
+        commands_by_event[event_name] = [
+            command
+            for group in groups
+            for hook in group.get("hooks", [])
+            if isinstance((command := hook.get("command")), str)
+        ]
+    return commands_by_event
+
+
+def cmux_codex_hook_groups(hooks: dict, event_name: str) -> list[dict]:
+    return [
+        group
+        for group in hooks.get("hooks", {}).get(event_name, [])
+        if any(
+            is_cmux_codex_hook_command(command)
+            for command in [hook.get("command") for hook in group.get("hooks", [])]
+            if isinstance(command, str)
+        )
+    ]
+
+
+def third_party_codex_hook_groups(hooks: dict, event_name: str) -> list[dict]:
+    cmux_groups = cmux_codex_hook_groups(hooks, event_name)
+    return [
+        group
+        for group in hooks.get("hooks", {}).get(event_name, [])
+        if group not in cmux_groups
+    ]
+
+
+def isolated_codex_cli_env(
+    codex_home: Path,
+    *,
+    tool_hooks_disabled_value: str | None,
+) -> dict[str, str]:
+    env = os.environ.copy()
+    env["HOME"] = str(codex_home.parent)
+    env["CFFIXED_USER_HOME"] = str(codex_home.parent)
+    env["CODEX_HOME"] = str(codex_home)
+    env.pop("CMUX_CODEX_HOOKS_DISABLED", None)
+    if tool_hooks_disabled_value is None:
+        env.pop("CMUX_CODEX_TOOL_HOOKS_DISABLED", None)
+    else:
+        env["CMUX_CODEX_TOOL_HOOKS_DISABLED"] = tool_hooks_disabled_value
+    return env
+
+
+def run_codex_cli(
+    cli_path: str,
+    codex_home: Path,
+    arguments: list[str],
+    *,
+    tool_hooks_disabled_value: str | None,
+) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        [cli_path, *arguments],
+        capture_output=True,
+        check=False,
+        env=isolated_codex_cli_env(
+            codex_home,
+            tool_hooks_disabled_value=tool_hooks_disabled_value,
+        ),
+        timeout=20,
+    )
+
+
+def codex_injected_hook_arguments(
+    cli_path: str,
+    codex_home: Path,
+    *,
+    tool_hooks_disabled_value: str | None,
+) -> list[str]:
+    result = run_codex_cli(
+        cli_path,
+        codex_home,
+        ["hooks", "codex", "inject-args"],
+        tool_hooks_disabled_value=tool_hooks_disabled_value,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"inject-args failed exit={result.returncode}: {result.stderr!r}"
+        )
+    return [part.decode() for part in result.stdout.split(b"\0") if part]
+
+
+def codex_injected_hook_events(
+    cli_path: str,
+    codex_home: Path,
+    *,
+    tool_hooks_disabled_value: str | None,
+) -> list[str]:
+    args = codex_injected_hook_arguments(
+        cli_path,
+        codex_home,
+        tool_hooks_disabled_value=tool_hooks_disabled_value,
+    )
+    return [
+        arg.split("=", 1)[0].removeprefix("hooks.")
+        for arg in args
+        if arg.startswith("hooks.")
+    ]
+
+
+def codex_injected_hook_commands(arguments: list[str]) -> dict[str, str]:
+    commands: dict[str, str] = {}
+    command_prefix = "command='''"
+    command_suffix = "''',timeout="
+    for argument in arguments:
+        if not argument.startswith("hooks."):
+            continue
+        event_assignment, separator, value = argument.partition("=")
+        if separator != "=" or command_prefix not in value or command_suffix not in value:
+            raise AssertionError(f"unexpected injected hook argument: {argument!r}")
+        command = value.split(command_prefix, 1)[1].split(command_suffix, 1)[0]
+        commands[event_assignment.removeprefix("hooks.")] = command
+    return commands
+
+
+def assert_persistent_codex_hook_groups(
+    hooks: dict,
+    expected_third_party_groups: dict[str, list[dict]],
+    *,
+    tool_hooks_disabled: bool,
+) -> None:
+    active_events = [
+        "SessionStart",
+        "UserPromptSubmit",
+        "Stop",
+        "PermissionRequest",
+        "PreCompact",
+        "PostCompact",
+        "SubagentStart",
+        "SubagentStop",
+    ]
+    if not tool_hooks_disabled:
+        active_events.extend(["PreToolUse", "PostToolUse"])
+
+    commands_by_event = codex_hook_commands_by_event(hooks)
+    for event_name in active_events:
+        groups = cmux_codex_hook_groups(hooks, event_name)
+        if len(groups) != 1:
+            raise AssertionError(
+                f"expected exactly one active cmux {event_name} group: "
+                f"groups={groups!r} commands={commands_by_event!r}"
+            )
+
+    expected_tool_group_count = 0 if tool_hooks_disabled else 1
+    for event_name in ["PreToolUse", "PostToolUse"]:
+        groups = cmux_codex_hook_groups(hooks, event_name)
+        if len(groups) != expected_tool_group_count:
+            raise AssertionError(
+                f"wrong cmux {event_name} group count: {groups!r}"
+            )
+        third_party_groups = third_party_codex_hook_groups(hooks, event_name)
+        if third_party_groups != expected_third_party_groups[event_name]:
+            raise AssertionError(
+                f"reconciliation changed third-party {event_name} groups: "
+                f"expected={expected_third_party_groups[event_name]!r} "
+                f"actual={third_party_groups!r}"
+            )
+
+
+def codex_third_party_tool_hook_fixture() -> tuple[dict, dict[str, list[dict]]]:
+    hooks = {
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "Read|Write",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "printf third-party-pre-first",
+                            "timeout": 17,
+                        }
+                    ],
+                    "thirdPartyMetadata": {"position": "first"},
+                },
+                {
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "printf third-party-pre-second",
+                            "timeout": 23,
+                        }
+                    ]
+                },
+            ],
+            "PostToolUse": [
+                {
+                    "matcher": "Bash",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "printf third-party-post-first",
+                            "timeout": 29,
+                        }
+                    ],
+                },
+                {
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "printf third-party-post-second",
+                            "timeout": 31,
+                        }
+                    ],
+                    "thirdPartyMetadata": ["kept", "ordered"],
+                },
+            ],
+        }
+    }
+    expected = {
+        event_name: json.loads(json.dumps(groups))
+        for event_name, groups in hooks["hooks"].items()
+    }
+    return hooks, expected
+
+
+def test_codex_tool_hook_opt_out_filters_real_injected_args(
+    cli_path: str, root: Path
+) -> None:
+    codex_home = root / "codex-inject-opt-out" / ".codex"
+    codex_home.mkdir(parents=True)
+
+    hooks_path = codex_home / "hooks.json"
+    if hooks_path.exists():
+        raise AssertionError("wrapper-fallback test requires no persistent hooks file")
+
+    default_events = codex_injected_hook_events(
+        cli_path, codex_home, tool_hooks_disabled_value=None
+    )
+    disabled_events = codex_injected_hook_events(
+        cli_path, codex_home, tool_hooks_disabled_value="1"
+    )
+
+    if "PreToolUse" not in default_events or "PostToolUse" not in default_events:
+        raise AssertionError(f"default tool hooks missing: {default_events!r}")
+    if disabled_events != [
+        "SessionStart",
+        "UserPromptSubmit",
+        "Stop",
+        "PermissionRequest",
+    ]:
+        raise AssertionError(f"wrong filtered events: {disabled_events!r}")
+
+    for value in ["", "0", "true", "01"]:
+        events = codex_injected_hook_events(
+            cli_path,
+            codex_home,
+            tool_hooks_disabled_value=value,
+        )
+        if events != default_events:
+            raise AssertionError(
+                f"non-exact opt-out value {value!r} changed hook events: "
+                f"expected={default_events!r} actual={events!r}"
+            )
+
+
+def test_codex_tool_hook_opt_out_reconciles_persistent_hooks(
+    cli_path: str, root: Path
+) -> None:
+    codex_home = root / "codex-persistent-opt-out" / ".codex"
+    codex_home.mkdir(parents=True)
+    hooks_path = codex_home / "hooks.json"
+    fixture, expected_third_party_groups = codex_third_party_tool_hook_fixture()
+    hooks_path.write_text(json.dumps(fixture, indent=2), encoding="utf-8")
+
+    install = run_codex_cli(
+        cli_path,
+        codex_home,
+        ["hooks", "codex", "install", "--yes"],
+        tool_hooks_disabled_value=None,
+    )
+    if install.returncode != 0:
+        raise AssertionError(
+            f"hooks codex install failed exit={install.returncode}: "
+            f"stdout={install.stdout!r} stderr={install.stderr!r}"
+        )
+
+    installed_hooks = json.loads(hooks_path.read_text(encoding="utf-8"))
+    assert_persistent_codex_hook_groups(
+        installed_hooks,
+        expected_third_party_groups,
+        tool_hooks_disabled=False,
+    )
+    installed_trust = expected_cmux_codex_hook_trust(installed_hooks, hooks_path)
+    stale_tool_trust_keys = {
+        key
+        for key in installed_trust
+        if ":pre_tool_use:" in key or ":post_tool_use:" in key
+    }
+    if not stale_tool_trust_keys:
+        raise AssertionError(f"installed tool-hook trust was missing: {installed_trust!r}")
+
+    disabled = run_codex_cli(
+        cli_path,
+        codex_home,
+        ["hooks", "codex", "inject-args"],
+        tool_hooks_disabled_value="1",
+    )
+    if disabled.returncode != 0 or disabled.stdout != b"":
+        raise AssertionError(
+            "persistent disabled reconciliation must emit an empty byte stream: "
+            f"exit={disabled.returncode} stdout={disabled.stdout!r} "
+            f"stderr={disabled.stderr!r}"
+        )
+
+    disabled_hooks = json.loads(hooks_path.read_text(encoding="utf-8"))
+    assert_persistent_codex_hook_groups(
+        disabled_hooks,
+        expected_third_party_groups,
+        tool_hooks_disabled=True,
+    )
+    disabled_config = (codex_home / "config.toml").read_text(encoding="utf-8")
+    disabled_trust = codex_hook_trust_state(disabled_config)
+    leaked_tool_trust = stale_tool_trust_keys.intersection(disabled_trust)
+    if leaked_tool_trust:
+        raise AssertionError(
+            f"disabled cmux tool-hook trust was retained: {leaked_tool_trust!r}"
+        )
+    expected_disabled_trust = expected_cmux_codex_hook_trust(disabled_hooks, hooks_path)
+    for key, trusted_hash in expected_disabled_trust.items():
+        if disabled_trust.get(key, {}).get("trusted_hash") != trusted_hash:
+            raise AssertionError(
+                f"active cmux hook trust was not preserved for {key}: "
+                f"expected={trusted_hash!r} actual={disabled_trust!r}"
+            )
+
+    restored = run_codex_cli(
+        cli_path,
+        codex_home,
+        ["hooks", "codex", "inject-args"],
+        tool_hooks_disabled_value=None,
+    )
+    if restored.returncode != 0 or restored.stdout != b"":
+        raise AssertionError(
+            "persistent default reconciliation must emit an empty byte stream: "
+            f"exit={restored.returncode} stdout={restored.stdout!r} "
+            f"stderr={restored.stderr!r}"
+        )
+
+    restored_hooks = json.loads(hooks_path.read_text(encoding="utf-8"))
+    assert_persistent_codex_hook_groups(
+        restored_hooks,
+        expected_third_party_groups,
+        tool_hooks_disabled=False,
+    )
+    restored_config = (codex_home / "config.toml").read_text(encoding="utf-8")
+    restored_trust = codex_hook_trust_state(restored_config)
+    expected_restored_trust = expected_cmux_codex_hook_trust(restored_hooks, hooks_path)
+    for key, trusted_hash in expected_restored_trust.items():
+        if restored_trust.get(key, {}).get("trusted_hash") != trusted_hash:
+            raise AssertionError(
+                f"restored cmux hook trust was missing for {key}: "
+                f"expected={trusted_hash!r} actual={restored_trust!r}"
+            )
+
+
+def test_codex_tool_hook_opt_out_reconciles_concurrent_inject_args(
+    cli_path: str, root: Path
+) -> None:
+    codex_home = root / "codex-concurrent-opt-out" / ".codex"
+    codex_home.mkdir(parents=True)
+    hooks_path = codex_home / "hooks.json"
+    fixture, expected_third_party_groups = codex_third_party_tool_hook_fixture()
+    hooks_path.write_text(json.dumps(fixture, indent=2), encoding="utf-8")
+
+    install = run_codex_cli(
+        cli_path,
+        codex_home,
+        ["hooks", "codex", "install", "--yes"],
+        tool_hooks_disabled_value=None,
+    )
+    if install.returncode != 0:
+        raise AssertionError(
+            f"hooks codex install failed exit={install.returncode}: "
+            f"stdout={install.stdout!r} stderr={install.stderr!r}"
+        )
+
+    env = isolated_codex_cli_env(
+        codex_home,
+        tool_hooks_disabled_value="1",
+    )
+    processes = [
+        subprocess.Popen(
+            [cli_path, "hooks", "codex", "inject-args"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+        )
+        for _ in range(2)
+    ]
+    results: list[tuple[int, bytes, bytes]] = []
+    try:
+        for process in processes:
+            stdout, stderr = process.communicate(timeout=20)
+            results.append((process.returncode, stdout, stderr))
+    except subprocess.TimeoutExpired:
+        for process in processes:
+            process.kill()
+            process.communicate()
+        raise AssertionError("concurrent inject-args reconciliation timed out")
+
+    for returncode, stdout, stderr in results:
+        if returncode != 0 or stdout != b"":
+            raise AssertionError(
+                "concurrent persistent reconciliation failed: "
+                f"exit={returncode} stdout={stdout!r} stderr={stderr!r}"
+            )
+
+    reconciled_hooks = json.loads(hooks_path.read_text(encoding="utf-8"))
+    assert_persistent_codex_hook_groups(
+        reconciled_hooks,
+        expected_third_party_groups,
+        tool_hooks_disabled=True,
+    )
+
+
+def test_codex_tool_hook_opt_out_retains_aged_wrapper_scripts(
+    cli_path: str, root: Path
+) -> None:
+    isolated_root = root / "codex-wrapper-script-retention"
+    codex_home = isolated_root / ".codex"
+    codex_home.mkdir(parents=True)
+    real_home = Path.home().resolve()
+
+    default_arguments = codex_injected_hook_arguments(
+        cli_path,
+        codex_home,
+        tool_hooks_disabled_value=None,
+    )
+    commands = codex_injected_hook_commands(default_arguments)
+    expected_scripts_dir = (isolated_root / ".cmux" / "hooks").resolve()
+    retained_paths: list[Path] = []
+    for event_name in ["PreToolUse", "PostToolUse"]:
+        command = commands.get(event_name)
+        if command is None:
+            raise AssertionError(
+                f"default wrapper arguments omitted {event_name}: {commands!r}"
+            )
+        path = Path(command).resolve()
+        try:
+            path.relative_to(expected_scripts_dir)
+        except ValueError as exc:
+            raise AssertionError(
+                f"{event_name} script escaped isolated hooks directory: {path}"
+            ) from exc
+        try:
+            path.relative_to(real_home)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(
+                f"{event_name} script reached the operator's real home: {path}"
+            )
+        if not path.is_file():
+            raise AssertionError(f"generated {event_name} script is missing: {path}")
+        retained_paths.append(path)
+
+    collectible_timestamp = time.time() - 120
+    for path in retained_paths:
+        os.utime(path, (collectible_timestamp, collectible_timestamp))
+
+    disabled_arguments = codex_injected_hook_arguments(
+        cli_path,
+        codex_home,
+        tool_hooks_disabled_value="1",
+    )
+    disabled_events = [
+        argument.split("=", 1)[0].removeprefix("hooks.")
+        for argument in disabled_arguments
+        if argument.startswith("hooks.")
+    ]
+    if "PreToolUse" in disabled_events or "PostToolUse" in disabled_events:
+        raise AssertionError(
+            f"tool hooks remained in flagged wrapper arguments: {disabled_events!r}"
+        )
+    missing_paths = [path for path in retained_paths if not path.is_file()]
+    if missing_paths:
+        raise AssertionError(
+            f"flagged wrapper collection removed live-session scripts: {missing_paths!r}"
+        )
 
 
 def test_install_adds_codex_permission_request_hook(cli_path: str, root: Path) -> None:
@@ -3997,6 +4508,10 @@ def main() -> int:
             test_codex_prompt_submit_starts_monitor_when_lease_write_fails(cli_path, root)
             test_codex_monitor_exits_when_workspace_has_no_surfaces(cli_path, root)
             test_codex_monitor_survives_transient_owner_rpc_timeout(cli_path, root)
+            test_codex_tool_hook_opt_out_filters_real_injected_args(cli_path, root)
+            test_codex_tool_hook_opt_out_reconciles_persistent_hooks(cli_path, root)
+            test_codex_tool_hook_opt_out_reconciles_concurrent_inject_args(cli_path, root)
+            test_codex_tool_hook_opt_out_retains_aged_wrapper_scripts(cli_path, root)
             test_install_adds_codex_permission_request_hook(cli_path, root)
             test_install_escapes_codex_hook_trust_state_keys(cli_path, root)
             test_install_preserves_codex_hook_position_with_third_party_hooks(cli_path, root)

--- a/tests/test_codex_feed_hooks.py
+++ b/tests/test_codex_feed_hooks.py
@@ -1220,6 +1220,75 @@ def test_codex_tool_hook_opt_out_reconciles_persistent_hooks(
             )
 
 
+def test_codex_tool_hook_opt_out_covers_nonreconcilable_legacy_hooks(
+    cli_path: str, root: Path
+) -> None:
+    codex_home = root / "codex-legacy-opt-out" / ".codex"
+    codex_home.mkdir(parents=True)
+    hooks_path = codex_home / "hooks.json"
+    hooks = {
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "cmux feed-hook --source codex --event PreToolUse",
+                        },
+                        {"type": "command", "command": "printf third-party-pre"},
+                    ]
+                }
+            ],
+            "PostToolUse": [
+                {
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "cmux feed-hook --source codex --event PostToolUse",
+                        },
+                        {"type": "command", "command": "printf third-party-post"},
+                    ]
+                }
+            ],
+            "Stop": [
+                {
+                    "hooks": [
+                        {"type": "command", "command": "cmux codex-hook stop"}
+                    ]
+                }
+            ],
+        }
+    }
+    hooks_path.write_text(json.dumps(hooks, indent=2), encoding="utf-8")
+    original = hooks_path.read_bytes()
+
+    codex_home.chmod(0o555)
+    try:
+        arguments = codex_injected_hook_arguments(
+            cli_path,
+            codex_home,
+            tool_hooks_disabled_value="1",
+        )
+    finally:
+        codex_home.chmod(0o755)
+
+    disabled_state = codex_disabled_hook_state(arguments)
+    key_source = hooks_path.resolve()
+    expected_keys = {
+        f"{key_source}:pre_tool_use:0:0",
+        f"{key_source}:post_tool_use:0:0",
+    }
+    if set(disabled_state) != expected_keys:
+        raise AssertionError(
+            "legacy opt-out targeted the wrong hooks after reconciliation failed: "
+            f"expected={expected_keys!r} actual={disabled_state!r}"
+        )
+    if any(value != {"enabled": False} for value in disabled_state.values()):
+        raise AssertionError(f"invalid legacy disabled hook state: {disabled_state!r}")
+    if hooks_path.read_bytes() != original:
+        raise AssertionError("failed reconciliation changed the persistent hooks file")
+
+
 def test_codex_tool_hook_opt_out_isolates_mixed_concurrent_inject_args(
     cli_path: str, root: Path
 ) -> None:
@@ -4534,6 +4603,7 @@ def main() -> int:
             test_codex_monitor_survives_transient_owner_rpc_timeout(cli_path, root)
             test_codex_tool_hook_opt_out_filters_real_injected_args(cli_path, root)
             test_codex_tool_hook_opt_out_reconciles_persistent_hooks(cli_path, root)
+            test_codex_tool_hook_opt_out_covers_nonreconcilable_legacy_hooks(cli_path, root)
             test_codex_tool_hook_opt_out_isolates_mixed_concurrent_inject_args(cli_path, root)
             test_codex_tool_hook_opt_out_retains_aged_wrapper_scripts(cli_path, root)
             test_install_adds_codex_permission_request_hook(cli_path, root)

--- a/tests/test_codex_feed_hooks.py
+++ b/tests/test_codex_feed_hooks.py
@@ -14,6 +14,7 @@ import subprocess
 import tempfile
 import threading
 import time
+import tomllib
 from pathlib import Path
 
 from claude_teams_test_utils import resolve_cmux_cli
@@ -975,11 +976,25 @@ def codex_injected_hook_commands(arguments: list[str]) -> dict[str, str]:
     return commands
 
 
+def codex_disabled_hook_state(arguments: list[str]) -> dict[str, dict[str, bool]]:
+    if len(arguments) != 2 or arguments[0] != "-c":
+        raise AssertionError(
+            f"expected one session-scoped hook-state override: {arguments!r}"
+        )
+    assignment = arguments[1]
+    prefix = "hooks.state="
+    if not assignment.startswith(prefix):
+        raise AssertionError(f"unexpected hook-state override: {assignment!r}")
+    parsed = tomllib.loads(f"state={assignment.removeprefix(prefix)}")
+    state = parsed.get("state")
+    if not isinstance(state, dict):
+        raise AssertionError(f"hook-state override was not a TOML table: {parsed!r}")
+    return state
+
+
 def assert_persistent_codex_hook_groups(
     hooks: dict,
     expected_third_party_groups: dict[str, list[dict]],
-    *,
-    tool_hooks_disabled: bool,
 ) -> None:
     active_events = [
         "SessionStart",
@@ -991,8 +1006,7 @@ def assert_persistent_codex_hook_groups(
         "SubagentStart",
         "SubagentStop",
     ]
-    if not tool_hooks_disabled:
-        active_events.extend(["PreToolUse", "PostToolUse"])
+    active_events.extend(["PreToolUse", "PostToolUse"])
 
     commands_by_event = codex_hook_commands_by_event(hooks)
     for event_name in active_events:
@@ -1003,10 +1017,9 @@ def assert_persistent_codex_hook_groups(
                 f"groups={groups!r} commands={commands_by_event!r}"
             )
 
-    expected_tool_group_count = 0 if tool_hooks_disabled else 1
     for event_name in ["PreToolUse", "PostToolUse"]:
         groups = cmux_codex_hook_groups(hooks, event_name)
-        if len(groups) != expected_tool_group_count:
+        if len(groups) != 1:
             raise AssertionError(
                 f"wrong cmux {event_name} group count: {groups!r}"
             )
@@ -1140,7 +1153,6 @@ def test_codex_tool_hook_opt_out_reconciles_persistent_hooks(
     assert_persistent_codex_hook_groups(
         installed_hooks,
         expected_third_party_groups,
-        tool_hooks_disabled=False,
     )
     installed_trust = expected_cmux_codex_hook_trust(installed_hooks, hooks_path)
     stale_tool_trust_keys = {
@@ -1151,32 +1163,26 @@ def test_codex_tool_hook_opt_out_reconciles_persistent_hooks(
     if not stale_tool_trust_keys:
         raise AssertionError(f"installed tool-hook trust was missing: {installed_trust!r}")
 
-    disabled = run_codex_cli(
-        cli_path,
-        codex_home,
-        ["hooks", "codex", "inject-args"],
-        tool_hooks_disabled_value="1",
+    disabled_arguments = codex_injected_hook_arguments(
+        cli_path, codex_home, tool_hooks_disabled_value="1"
     )
-    if disabled.returncode != 0 or disabled.stdout != b"":
+    disabled_state = codex_disabled_hook_state(disabled_arguments)
+    expected_disabled_keys = stale_tool_trust_keys
+    if set(disabled_state) != expected_disabled_keys:
         raise AssertionError(
-            "persistent disabled reconciliation must emit an empty byte stream: "
-            f"exit={disabled.returncode} stdout={disabled.stdout!r} "
-            f"stderr={disabled.stderr!r}"
+            "session override targeted the wrong persistent hooks: "
+            f"expected={expected_disabled_keys!r} actual={disabled_state!r}"
         )
+    if any(value != {"enabled": False} for value in disabled_state.values()):
+        raise AssertionError(f"invalid disabled hook state: {disabled_state!r}")
 
     disabled_hooks = json.loads(hooks_path.read_text(encoding="utf-8"))
     assert_persistent_codex_hook_groups(
         disabled_hooks,
         expected_third_party_groups,
-        tool_hooks_disabled=True,
     )
     disabled_config = (codex_home / "config.toml").read_text(encoding="utf-8")
     disabled_trust = codex_hook_trust_state(disabled_config)
-    leaked_tool_trust = stale_tool_trust_keys.intersection(disabled_trust)
-    if leaked_tool_trust:
-        raise AssertionError(
-            f"disabled cmux tool-hook trust was retained: {leaked_tool_trust!r}"
-        )
     expected_disabled_trust = expected_cmux_codex_hook_trust(disabled_hooks, hooks_path)
     for key, trusted_hash in expected_disabled_trust.items():
         if disabled_trust.get(key, {}).get("trusted_hash") != trusted_hash:
@@ -1202,7 +1208,6 @@ def test_codex_tool_hook_opt_out_reconciles_persistent_hooks(
     assert_persistent_codex_hook_groups(
         restored_hooks,
         expected_third_party_groups,
-        tool_hooks_disabled=False,
     )
     restored_config = (codex_home / "config.toml").read_text(encoding="utf-8")
     restored_trust = codex_hook_trust_state(restored_config)
@@ -1215,7 +1220,7 @@ def test_codex_tool_hook_opt_out_reconciles_persistent_hooks(
             )
 
 
-def test_codex_tool_hook_opt_out_reconciles_concurrent_inject_args(
+def test_codex_tool_hook_opt_out_isolates_mixed_concurrent_inject_args(
     cli_path: str, root: Path
 ) -> None:
     codex_home = root / "codex-concurrent-opt-out" / ".codex"
@@ -1236,10 +1241,17 @@ def test_codex_tool_hook_opt_out_reconciles_concurrent_inject_args(
             f"stdout={install.stdout!r} stderr={install.stderr!r}"
         )
 
-    env = isolated_codex_cli_env(
-        codex_home,
-        tool_hooks_disabled_value="1",
-    )
+    expected_tool_keys = {
+        key
+        for key in expected_cmux_codex_hook_trust(
+            json.loads(hooks_path.read_text(encoding="utf-8")), hooks_path
+        )
+        if ":pre_tool_use:" in key or ":post_tool_use:" in key
+    }
+    environments = [
+        isolated_codex_cli_env(codex_home, tool_hooks_disabled_value="1"),
+        isolated_codex_cli_env(codex_home, tool_hooks_disabled_value=None),
+    ]
     processes = [
         subprocess.Popen(
             [cli_path, "hooks", "codex", "inject-args"],
@@ -1247,7 +1259,7 @@ def test_codex_tool_hook_opt_out_reconciles_concurrent_inject_args(
             stderr=subprocess.PIPE,
             env=env,
         )
-        for _ in range(2)
+        for env in environments
     ]
     results: list[tuple[int, bytes, bytes]] = []
     try:
@@ -1260,18 +1272,30 @@ def test_codex_tool_hook_opt_out_reconciles_concurrent_inject_args(
             process.communicate()
         raise AssertionError("concurrent inject-args reconciliation timed out")
 
-    for returncode, stdout, stderr in results:
-        if returncode != 0 or stdout != b"":
+    disabled_result, default_result = results
+    for returncode, _, stderr in results:
+        if returncode != 0:
             raise AssertionError(
-                "concurrent persistent reconciliation failed: "
-                f"exit={returncode} stdout={stdout!r} stderr={stderr!r}"
+                "mixed concurrent persistent reconciliation failed: "
+                f"exit={returncode} stderr={stderr!r}"
             )
+    disabled_arguments = [
+        part.decode() for part in disabled_result[1].split(b"\0") if part
+    ]
+    disabled_state = codex_disabled_hook_state(disabled_arguments)
+    if set(disabled_state) != expected_tool_keys:
+        raise AssertionError(
+            f"flagged launch disabled the wrong hooks: {disabled_state!r}"
+        )
+    if default_result[1] != b"":
+        raise AssertionError(
+            f"default persistent launch unexpectedly emitted args: {default_result[1]!r}"
+        )
 
     reconciled_hooks = json.loads(hooks_path.read_text(encoding="utf-8"))
     assert_persistent_codex_hook_groups(
         reconciled_hooks,
         expected_third_party_groups,
-        tool_hooks_disabled=True,
     )
 
 
@@ -4510,7 +4534,7 @@ def main() -> int:
             test_codex_monitor_survives_transient_owner_rpc_timeout(cli_path, root)
             test_codex_tool_hook_opt_out_filters_real_injected_args(cli_path, root)
             test_codex_tool_hook_opt_out_reconciles_persistent_hooks(cli_path, root)
-            test_codex_tool_hook_opt_out_reconciles_concurrent_inject_args(cli_path, root)
+            test_codex_tool_hook_opt_out_isolates_mixed_concurrent_inject_args(cli_path, root)
             test_codex_tool_hook_opt_out_retains_aged_wrapper_scripts(cli_path, root)
             test_install_adds_codex_permission_request_hook(cli_path, root)
             test_install_escapes_codex_hook_trust_state_keys(cli_path, root)

--- a/tests/test_codex_feed_hooks.py
+++ b/tests/test_codex_feed_hooks.py
@@ -1131,7 +1131,7 @@ def test_codex_tool_hook_opt_out_filters_real_injected_args(
 def test_codex_tool_hook_opt_out_reconciles_persistent_hooks(
     cli_path: str, root: Path
 ) -> None:
-    codex_home = root / "codex-persistent-opt-out" / ".codex"
+    codex_home = root / "codex:pre_tool_use:persistent-opt-out" / ".codex"
     codex_home.mkdir(parents=True)
     hooks_path = codex_home / "hooks.json"
     fixture, expected_third_party_groups = codex_third_party_tool_hook_fixture()
@@ -1158,7 +1158,7 @@ def test_codex_tool_hook_opt_out_reconciles_persistent_hooks(
     stale_tool_trust_keys = {
         key
         for key in installed_trust
-        if ":pre_tool_use:" in key or ":post_tool_use:" in key
+        if key.rsplit(":", 3)[1] in {"pre_tool_use", "post_tool_use"}
     }
     if not stale_tool_trust_keys:
         raise AssertionError(f"installed tool-hook trust was missing: {installed_trust!r}")

--- a/tests/test_codex_permission_prompt_notification.py
+++ b/tests/test_codex_permission_prompt_notification.py
@@ -166,7 +166,11 @@ def run_codex_start_stop_capture(
         "cwd": str(state_dir.parent),
     }
 
-    with FakeCmuxSocket(socket_path, None) as fake:
+    with FakeCmuxSocket(
+        socket_path,
+        None,
+        surface_delivery_target=(FAKE_WORKSPACE_ID, FAKE_SURFACE_ID),
+    ) as fake:
         for subcommand in ("session-start", "stop"):
             result = subprocess.run(
                 [

--- a/tests/test_codex_permission_prompt_notification.py
+++ b/tests/test_codex_permission_prompt_notification.py
@@ -64,16 +64,25 @@ def run_feed_hook_capture(
     surface_delivery_target: tuple[str, str] | None = None,
     method_delays: dict[str, float] | None = None,
     settle_seconds: float = 0,
+    extra_env: dict[str, str] | None = None,
 ) -> tuple[dict, list, float]:
     """Runs `cmux hooks feed --source codex` and returns (stdout JSON,
     ordered received frames, elapsed seconds)."""
     env = os.environ.copy()
-    for key in ("CMUX_SOCKET", "CMUX_SOCKET_CAPABILITY", "CMUX_SOCKET_PATH", "CMUX_SOCKET_PASSWORD"):
+    for key in (
+        "CMUX_SOCKET",
+        "CMUX_SOCKET_CAPABILITY",
+        "CMUX_SOCKET_PATH",
+        "CMUX_SOCKET_PASSWORD",
+        "CMUX_CODEX_HOOKS_DISABLED",
+    ):
         env.pop(key, None)
     env["CMUX_SURFACE_ID"] = FAKE_SURFACE_ID
     env["CMUX_WORKSPACE_ID"] = FAKE_WORKSPACE_ID
     if socket_password is not None:
         env["CMUX_SOCKET_PASSWORD"] = socket_password
+    if extra_env:
+        env.update(extra_env)
     with FakeCmuxSocket(
         socket_path,
         None,
@@ -128,6 +137,61 @@ def raw_commands(frames: list) -> list[str]:
     ]
 
 
+def run_codex_start_stop_capture(
+    cli_path: str,
+    socket_path: Path,
+    state_dir: Path,
+    extra_env: dict[str, str] | None = None,
+) -> list:
+    """Run real Codex lifecycle hooks and return the ordered socket frames."""
+    state_dir.mkdir()
+    env = os.environ.copy()
+    for key in (
+        "CMUX_SOCKET",
+        "CMUX_SOCKET_CAPABILITY",
+        "CMUX_SOCKET_PATH",
+        "CMUX_SOCKET_PASSWORD",
+        "CMUX_CODEX_HOOKS_DISABLED",
+    ):
+        env.pop(key, None)
+    env["CMUX_SURFACE_ID"] = FAKE_SURFACE_ID
+    env["CMUX_WORKSPACE_ID"] = FAKE_WORKSPACE_ID
+    env["CMUX_AGENT_HOOK_STATE_DIR"] = str(state_dir)
+    if extra_env:
+        env.update(extra_env)
+
+    session_id = "codex-tool-hook-opt-out-notification"
+    payload = {
+        "session_id": session_id,
+        "cwd": str(state_dir.parent),
+    }
+
+    with FakeCmuxSocket(socket_path, None) as fake:
+        for subcommand in ("session-start", "stop"):
+            result = subprocess.run(
+                [
+                    cli_path,
+                    "--socket",
+                    str(socket_path),
+                    "hooks",
+                    "codex",
+                    subcommand,
+                ],
+                input=json.dumps(payload),
+                capture_output=True,
+                text=True,
+                check=False,
+                env=env,
+                timeout=15,
+            )
+            if result.returncode != 0:
+                raise AssertionError(
+                    f"hooks codex {subcommand} failed exit={result.returncode}\n"
+                    f"stdout={result.stdout}\nstderr={result.stderr}"
+                )
+        return list(fake.frames)
+
+
 def frame_index(frames: list, predicate) -> int:
     for index, frame in enumerate(frames):
         if predicate(frame):
@@ -160,6 +224,46 @@ def test_permission_request_sends_gated_notification_before_feed_push(
         raise AssertionError(
             f"notification must precede telemetry (notify at {notify_index}, "
             f"feed.push at {feed_index}): {frames!r}"
+        )
+
+
+def test_tool_hook_opt_out_preserves_permission_request_notification(
+    cli_path: str, root: Path
+) -> None:
+    stdout, frames, _ = run_feed_hook_capture(
+        cli_path,
+        root / "cmux-flagged-permission.sock",
+        "PermissionRequest",
+        extra_env={"CMUX_CODEX_TOOL_HOOKS_DISABLED": "1"},
+    )
+    if stdout != {}:
+        raise AssertionError(f"PermissionRequest must stay non-blocking: {stdout!r}")
+    if EXPECTED_NOTIFY_COMMAND not in raw_commands(frames):
+        raise AssertionError(
+            f"tool-hook opt-out lost permission notification: {frames!r}"
+        )
+
+
+def test_tool_hook_opt_out_preserves_stop_completion_notification(
+    cli_path: str, root: Path
+) -> None:
+    frames = run_codex_start_stop_capture(
+        cli_path,
+        root / "cmux-stop-notify.sock",
+        root / "codex-stop-hook-state",
+        extra_env={"CMUX_CODEX_TOOL_HOOKS_DISABLED": "1"},
+    )
+    commands = raw_commands(frames)
+    expected_prefix = (
+        f"notify_target_async {FAKE_WORKSPACE_ID} {FAKE_SURFACE_ID} Codex|"
+    )
+    if not any(command.startswith(expected_prefix) for command in commands):
+        raise AssertionError(
+            f"tool-hook opt-out lost Stop completion notification: {commands!r}"
+        )
+    if not any(command.startswith("set_status codex ") for command in commands):
+        raise AssertionError(
+            f"tool-hook opt-out lost Stop status transition: {commands!r}"
         )
 
 
@@ -326,6 +430,8 @@ def main() -> int:
         root = Path(td)
         try:
             test_permission_request_sends_gated_notification_before_feed_push(cli_path, root)
+            test_tool_hook_opt_out_preserves_permission_request_notification(cli_path, root)
+            test_tool_hook_opt_out_preserves_stop_completion_notification(cli_path, root)
             test_post_tool_use_clears_pane_before_feed_push(cli_path, root)
             test_pre_tool_use_sends_no_attention_command(cli_path, root)
             test_permission_notification_is_acknowledged_before_hook_returns(cli_path, root)


### PR DESCRIPTION
## Summary

- add a process-local `CMUX_CODEX_TOOL_HOOKS_DISABLED=1` opt-out for cmux-owned Codex `PreToolUse` and `PostToolUse` hooks
- preserve lifecycle and notification hooks, including `PermissionRequest`, `Stop`, `SessionStart`, and `UserPromptSubmit`
- use Codex's native per-launch `hooks.state` override instead of rewriting shared hook configuration
- preserve third-party hooks and retain wrapper scripts needed by already-running Codex processes

## Why

High-frequency Codex tool hooks can produce avoidable cmux CLI/socket traffic in busy multi-agent sessions. The existing coarse `CMUX_CODEX_HOOKS_DISABLED=1` switch also removes completion and permission notifications. This change disables only cmux-owned tool-execution hooks for the flagged launch.

## Verification

- real Codex `app-server hooks/list` A/B probe against an isolated built cmux CLI:
  - cmux-owned enabled tool handlers per call: `2 -> 0` (100% eligibility reduction)
  - `PermissionRequest`: `1 -> 1`
  - `Stop`: `1 -> 1`
  - shared `hooks.json` SHA-256 unchanged before/after
- fake-socket integration captured both the permission notification and Stop completion notification commands with the flag enabled
- 5 focused granular opt-out integration tests passed, including concurrent flagged/default launches, a `:pre_tool_use:` path-delimiter collision, and a non-writable legacy-config fallback
- `CMUXAgentLaunch` package: 361 tests passed
- `CmuxCodexConfigEditorTests`: 6 tests passed
- isolated compile-only `cmux-cli` Xcode build passed with code signing disabled

No app was installed, launched, or restarted during verification.

## Notes

The full `CmuxFoundation` package currently has unrelated failures in `SidebarDropPlannerPackageTests`; this branch does not modify that code. Its `CommandRunnerTests` timeout failures under suite load pass when run alone.

Related fork validation: jleechanorg/cmux#10


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-out setting, `CMUX_CODEX_TOOL_HOOKS_DISABLED=1`, that disables Codex tool-execution hooks while preserving lifecycle and approval notifications.
  * Added support for safely reconciling persistent hook settings, including third-party hooks.
* **Bug Fixes**
  * Improved hook handling for persistent sessions and retained generated wrapper scripts.
* **Documentation**
  * Documented the new Codex environment override and its exact-value behavior.
* **Tests**
  * Added regression coverage for opt-out behavior, persistent hooks, notifications, and concurrent launches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->