### PR TITLE
perf(cmux-tui): avoid temporary graphics area vector

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -13303,14 +13303,12 @@ impl App {
         let context_changed = self.graphics_scene_cache.context.as_ref() != Some(&context);
         let full_scan = !dirty_only || context_changed;
         self.mark_graphics_clean((!full_scan).then_some(&dirty_surfaces));
-        let areas = self
-            .pane_areas
-            .iter()
-            .copied()
-            .filter(|area| full_scan || dirty_surfaces.contains(&area.surface))
-            .collect::<Vec<_>>();
         let mut updates = Vec::new();
-        for area in areas {
+        for index in 0..self.pane_areas.len() {
+            let area = self.pane_areas[index];
+            if !full_scan && !dirty_surfaces.contains(&area.surface) {
+                continue;
+            }
             let surface = self.session.surface(area.surface);
             let key = self.graphics_pane_scene_key(area, surface.as_ref());
             let unchanged = !context_changed


### PR DESCRIPTION
Remove the temporary per-emission PaneArea allocation in emit_graphics_with_scope. Iterate the Copy areas by index, preserving source order and dirty filtering while keeping mutable self access borrow-safe.

Validation: rustfmt --edition 2024 --check; git diff --check. Rust tests were not run on the Mac per cmux-tui policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the temporary pane area vector in `emit_graphics_with_scope` to cut allocation overhead in `cmux-tui`. Iterates the `Copy` areas by index instead, preserving source order and dirty filtering with no behavior change.

- Rust tests were not run on the Mac per `cmux-tui` policy.

<sup>Written for commit 9487a6cc5ac141b270cf2235a9638b750baf0124. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal pane-area update processing without changing visible behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->