### PR TITLE
Fix macOS build: IrxDiskCacheTrustReader.read signature left behind by #11047

### DIFF
--- a/Sources/Mobile/MobileHostIrxRuntime.swift
+++ b/Sources/Mobile/MobileHostIrxRuntime.swift
@@ -499,24 +499,13 @@ final class MobileHostIrxRuntime {
 }
 
 /// Synchronous trust-snapshot reader for the admission path (no actor hop,
-/// no network): reads the JSON the broker service persists.
+/// no network): reads the JSON the broker service persists. The caller passes
+/// the per-bundle, per-broker state directory `activate(accountID:)` resolved,
+/// so this reader never re-derives the location (and cannot drift from it).
 enum IrxDiskCacheTrustReader {
-    nonisolated static func read() -> IrxTrustSnapshot? {
-        let appSupport = FileManager.default.urls(
-            for: .applicationSupportDirectory, in: .userDomainMask
-        )[0]
-        // Per-bundle, per-backend state: another build (or another
-        // environment's) caches must never be readable here, or staging
-        // trust keys reject production grants at admission.
-        let stateDir = IrxStateLocation.directory(
-            base: appSupport,
-            bundleIdentifier: Bundle.main.bundleIdentifier,
-            brokerHost: brokerBaseURL.host
-        )
-        IrxStateLocation.removeLegacySharedDirectory(base: appSupport)
-        stateDirectory = stateDir
-        return IrxDiskCache<IrxTrustSnapshot>(
-            fileURL: stateDir.appendingPathComponent("trust.json")
+    nonisolated static func read(stateDirectory: URL) -> IrxTrustSnapshot? {
+        IrxDiskCache<IrxTrustSnapshot>(
+            fileURL: stateDirectory.appendingPathComponent("trust.json")
         ).load()
     }
 }


### PR DESCRIPTION
https://github.com/manaflow-ai/cmux/pull/11047 updated both call sites in `MobileHostIrxRuntime.swift` to `IrxDiskCacheTrustReader.read(stateDirectory:)` but left the enum's `read()` argument-less and pasted the caller's directory-resolution block into it, where `brokerBaseURL` and `stateDirectory` do not exist in scope. Every macOS app build of `main` since that merge fails to compile (verified on both the Blacksmith reload runner and an aws-m4pro fleet builder; the same errors, `argument passed to call that takes no arguments` at the two call sites and `cannot find 'brokerBaseURL' in scope`).

The reader now takes the state directory that `activate(accountID:)` resolved and only loads `trust.json` from it. Directory resolution and `removeLegacySharedDirectory` cleanup stay at the single call site that owns them, so the per-bundle/per-broker isolation #11047 introduced is unchanged.

Verified by building the tagged macOS Debug app from this branch on the cloud builder.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the macOS build break from #11047, where `IrxDiskCacheTrustReader.read()` was called with an argument but still declared without one, leaving both call sites unable to compile.

- Updates the reader to accept the state directory that `activate(accountID:)` already resolved, instead of re-deriving it.
- Moves directory resolution and `removeLegacySharedDirectory` cleanup back to the single call site that owns them.
- Keeps the per-bundle, per-broker isolation from #11047 intact.

<sup>Written for commit 710e93df3dad1cd3afb9b6c7ee3c45d23e1f8072. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

