### PR TITLE
relay: name the rate-limit enforcement layer in responses and journals

### DIFF
--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohBrokerBackpressureGate.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohBrokerBackpressureGate.swift
@@ -285,8 +285,12 @@ public actor CmxIrohBrokerBackpressureGate {
         let remaining = Self.remainingSeconds(floor: floor, now: now())
         switch floor.errorKind {
         case let .brokerRateLimit(code):
+            // "cooldown:" marks a LOCAL fail-fast waiting out a prior 429;
+            // without it these are indistinguishable from real server
+            // rejections in journals (08-27: hundreds of countdown lines
+            // read as a server hammer that never happened).
             throw CmxIrohTrustBrokerClientError.rateLimited(
-                code: code,
+                code: "cooldown:" + (code ?? "rate_limited"),
                 retryAfterSeconds: remaining
             )
         case .cooldown:

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerClient.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerClient.swift
@@ -279,7 +279,13 @@ public actor CmxIrohTrustBrokerClient: CmxIrohRelayPolicyServing {
             case lanRendezvousRotated = "lan_rendezvous_rotated"
         }
     }
-    private struct BrokerError: Decodable { let error: String }
+    private struct BrokerError: Decodable {
+        let error: String
+        /// Which enforcement layer produced a 429 (ingress_ip,
+        /// device_budget, auth_provider); diagnosing rate limits without it
+        /// takes hours of elimination.
+        let source: String?
+    }
 
     private let baseURL: URL
     private let tokenSource: CmxIrohBrokerTokenSource
@@ -934,7 +940,10 @@ public actor CmxIrohTrustBrokerClient: CmxIrohRelayPolicyServing {
             throw CmxIrohTrustBrokerClientError.invalidResponse
         }
         guard (200 ... 299).contains(http.statusCode) else {
-            let code = try? JSONDecoder().decode(BrokerError.self, from: data).error
+            let body = try? JSONDecoder().decode(BrokerError.self, from: data)
+            let code = body.map { payload in
+                payload.source.map { "\(payload.error):\($0)" } ?? payload.error
+            }
             if http.statusCode == 429,
                let retryAfterSeconds = Self.retryAfterSeconds(
                    http.value(forHTTPHeaderField: "Retry-After")

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerClient.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerClient.swift
@@ -300,17 +300,11 @@ public actor CmxIrohTrustBrokerClient: CmxIrohRelayPolicyServing {
         init(from decoder: any Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             error = try container.decode(String.self, forKey: .error)
-            if let rawSource = try container.decodeIfPresent(
-                String.self,
-                forKey: .source
-            ) {
-                // Keep the coarse error code when an untrusted or newer
-                // server sends an unknown source. Do not interpolate that
-                // value into the journal.
-                source = BrokerErrorSource(rawValue: rawSource)
-            } else {
-                source = nil
-            }
+            // Keep the coarse error code when an untrusted or newer server
+            // sends an unknown or malformed source. Do not interpolate that
+            // value into the journal.
+            source = (try? container.decode(String.self, forKey: .source))
+                .flatMap(BrokerErrorSource.init(rawValue:))
         }
     }
 

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerClient.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerClient.swift
@@ -279,12 +279,39 @@ public actor CmxIrohTrustBrokerClient: CmxIrohRelayPolicyServing {
             case lanRendezvousRotated = "lan_rendezvous_rotated"
         }
     }
+    private enum BrokerErrorSource: String, Decodable {
+        case ingressIP = "ingress_ip"
+        case deviceBudget = "device_budget"
+        case authProvider = "auth_provider"
+    }
+
     private struct BrokerError: Decodable {
         let error: String
         /// Which enforcement layer produced a 429 (ingress_ip,
         /// device_budget, auth_provider); diagnosing rate limits without it
         /// takes hours of elimination.
-        let source: String?
+        let source: BrokerErrorSource?
+
+        private enum CodingKeys: String, CodingKey {
+            case error
+            case source
+        }
+
+        init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            error = try container.decode(String.self, forKey: .error)
+            if let rawSource = try container.decodeIfPresent(
+                String.self,
+                forKey: .source
+            ) {
+                // Keep the coarse error code when an untrusted or newer
+                // server sends an unknown source. Do not interpolate that
+                // value into the journal.
+                source = BrokerErrorSource(rawValue: rawSource)
+            } else {
+                source = nil
+            }
+        }
     }
 
     private let baseURL: URL
@@ -942,7 +969,7 @@ public actor CmxIrohTrustBrokerClient: CmxIrohRelayPolicyServing {
         guard (200 ... 299).contains(http.statusCode) else {
             let body = try? JSONDecoder().decode(BrokerError.self, from: data)
             let code = body.map { payload in
-                payload.source.map { "\(payload.error):\($0)" } ?? payload.error
+                payload.source.map { "\(payload.error):\($0.rawValue)" } ?? payload.error
             }
             if http.statusCode == 429,
                let retryAfterSeconds = Self.retryAfterSeconds(

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerClient.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerClient.swift
@@ -279,35 +279,6 @@ public actor CmxIrohTrustBrokerClient: CmxIrohRelayPolicyServing {
             case lanRendezvousRotated = "lan_rendezvous_rotated"
         }
     }
-    private enum BrokerErrorSource: String, Decodable {
-        case ingressIP = "ingress_ip"
-        case deviceBudget = "device_budget"
-        case authProvider = "auth_provider"
-    }
-
-    private struct BrokerError: Decodable {
-        let error: String
-        /// Which enforcement layer produced a 429 (ingress_ip,
-        /// device_budget, auth_provider); diagnosing rate limits without it
-        /// takes hours of elimination.
-        let source: BrokerErrorSource?
-
-        private enum CodingKeys: String, CodingKey {
-            case error
-            case source
-        }
-
-        init(from decoder: any Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            error = try container.decode(String.self, forKey: .error)
-            // Keep the coarse error code when an untrusted or newer server
-            // sends an unknown or malformed source. Do not interpolate that
-            // value into the journal.
-            source = (try? container.decode(String.self, forKey: .source))
-                .flatMap(BrokerErrorSource.init(rawValue:))
-        }
-    }
-
     private let baseURL: URL
     private let tokenSource: CmxIrohBrokerTokenSource
     private let transport: any CmxIrohHTTPTransport
@@ -961,7 +932,7 @@ public actor CmxIrohTrustBrokerClient: CmxIrohRelayPolicyServing {
             throw CmxIrohTrustBrokerClientError.invalidResponse
         }
         guard (200 ... 299).contains(http.statusCode) else {
-            let body = try? JSONDecoder().decode(BrokerError.self, from: data)
+            let body = try? JSONDecoder().decode(CmxIrohTrustBrokerError.self, from: data)
             let code = body.map { payload in
                 payload.source.map { "\(payload.error):\($0.rawValue)" } ?? payload.error
             }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerError.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerError.swift
@@ -2,15 +2,9 @@ import Foundation
 
 /// Structured error returned by the Iroh trust broker.
 struct CmxIrohTrustBrokerError: Decodable {
-    enum Source: String, Decodable {
-        case ingressIP = "ingress_ip"
-        case deviceBudget = "device_budget"
-        case authProvider = "auth_provider"
-    }
-
     let error: String
     /// Which enforcement layer produced a 429.
-    let source: Source?
+    let source: CmxIrohTrustBrokerErrorSource?
 
     private enum CodingKeys: String, CodingKey {
         case error
@@ -23,6 +17,6 @@ struct CmxIrohTrustBrokerError: Decodable {
         // Keep the coarse error code when an untrusted or newer server sends
         // an unknown or malformed source.
         source = (try? container.decode(String.self, forKey: .source))
-            .flatMap(Source.init(rawValue:))
+            .flatMap(CmxIrohTrustBrokerErrorSource.init(rawValue:))
     }
 }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerError.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerError.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Structured error returned by the Iroh trust broker.
+struct CmxIrohTrustBrokerError: Decodable {
+    enum Source: String, Decodable {
+        case ingressIP = "ingress_ip"
+        case deviceBudget = "device_budget"
+        case authProvider = "auth_provider"
+    }
+
+    let error: String
+    /// Which enforcement layer produced a 429.
+    let source: Source?
+
+    private enum CodingKeys: String, CodingKey {
+        case error
+        case source
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        error = try container.decode(String.self, forKey: .error)
+        // Keep the coarse error code when an untrusted or newer server sends
+        // an unknown or malformed source.
+        source = (try? container.decode(String.self, forKey: .source))
+            .flatMap(Source.init(rawValue:))
+    }
+}

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerErrorSource.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerErrorSource.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+enum CmxIrohTrustBrokerErrorSource: String, Decodable {
+    case ingressIP = "ingress_ip"
+    case accountBudget = "account_budget"
+    case deviceBudget = "device_budget"
+    case authProvider = "auth_provider"
+}

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohBackpressuredHostBrokerTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohBackpressuredHostBrokerTests.swift
@@ -70,7 +70,11 @@ struct CmxIrohBackpressuredHostBrokerTests {
             operation: .relayCredential
         ) == 600)
 
-        await #expect(throws: relayLimit) {
+        // The gate's local fail-fast is marked "cooldown:"; only genuine
+        // server responses carry the bare code.
+        await #expect(throws: CmxIrohTrustBrokerClientError.rateLimited(
+            code: "cooldown:relay_rate_limited", retryAfterSeconds: 600)
+        ) {
             _ = try await relayPolicy.issueRelayBootstrap(endpointID: endpointID)
         }
         #expect(await probe.calls() == BackpressuredHostBrokerProbeCalls(

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohTrustBrokerClientNetworkTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohTrustBrokerClientNetworkTests.swift
@@ -154,7 +154,7 @@ extension CmxIrohTrustBrokerClientTests {
         try await client.revoke(bindingID: "binding-1")
 
         await #expect(throws: CmxIrohTrustBrokerClientError.rateLimited(
-            code: "rate_limited",
+            code: "cooldown:rate_limited",
             retryAfterSeconds: 600
         )) {
             _ = try await client.discover()

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohTrustBrokerClientNetworkTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohTrustBrokerClientNetworkTests.swift
@@ -43,6 +43,46 @@ extension CmxIrohTrustBrokerClientTests {
     }
 
     @Test
+    func rateLimitSourceUsesOnlyCanonicalValues() async throws {
+        let cases = [
+            (
+                #"{"error":"rate_limited","source":"ingress_ip"}"#,
+                "rate_limited:ingress_ip"
+            ),
+            (
+                #"{"error":"rate_limited","source":"device_budget"}"#,
+                "rate_limited:device_budget"
+            ),
+            (
+                #"{"error":"rate_limited","source":"auth_provider"}"#,
+                "rate_limited:auth_provider"
+            ),
+            (
+                #"{"error":"rate_limited","source":"attacker\nforged"}"#,
+                "rate_limited"
+            ),
+        ]
+
+        for (body, expectedCode) in cases {
+            let transport = RecordingBrokerTransport(responses: [
+                .json(
+                    status: 429,
+                    body: body,
+                    headers: ["Retry-After": "60"]
+                ),
+            ])
+            let client = try makeNetworkClient(transport: transport)
+
+            await #expect(throws: CmxIrohTrustBrokerClientError.rateLimited(
+                code: expectedCode,
+                retryAfterSeconds: 60
+            )) {
+                _ = try await client.discover()
+            }
+        }
+    }
+
+    @Test
     func rateLimitSuppressesConcurrentSameRouteRequestsWithoutBlockingOtherRoutes() async throws {
         let transport = RouteRecordingBrokerTransport(responsesByPath: [
             "/api/devices/iroh": [

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohTrustBrokerClientNetworkTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohTrustBrokerClientNetworkTests.swift
@@ -61,6 +61,14 @@ extension CmxIrohTrustBrokerClientTests {
                 #"{"error":"rate_limited","source":"attacker\nforged"}"#,
                 "rate_limited"
             ),
+            (
+                #"{"error":"rate_limited","source":42}"#,
+                "rate_limited"
+            ),
+            (
+                #"{"error":"rate_limited","source":{"layer":"ingress_ip"}}"#,
+                "rate_limited"
+            ),
         ]
 
         for (body, expectedCode) in cases {

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohTrustBrokerClientNetworkTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohTrustBrokerClientNetworkTests.swift
@@ -54,6 +54,10 @@ extension CmxIrohTrustBrokerClientTests {
                 "rate_limited:device_budget"
             ),
             (
+                #"{"error":"rate_limited","source":"account_budget"}"#,
+                "rate_limited:account_budget"
+            ),
+            (
                 #"{"error":"rate_limited","source":"auth_provider"}"#,
                 "rate_limited:auth_provider"
             ),

--- a/web/services/relay/errors.ts
+++ b/web/services/relay/errors.ts
@@ -65,7 +65,11 @@ export class RelayAuthenticationError extends Data.TaggedError(
 
 /** Which enforcement layer produced a 429; diagnosing the 08-27 incident
  * required hours of elimination because all three were indistinguishable. */
-export type RelayRateLimitSource = "ingress_ip" | "device_budget" | "auth_provider";
+export type RelayRateLimitSource =
+  | "ingress_ip"
+  | "account_budget"
+  | "device_budget"
+  | "auth_provider";
 
 
 export class RelaySigningError extends Data.TaggedError("RelaySigningError")<{

--- a/web/services/relay/errors.ts
+++ b/web/services/relay/errors.ts
@@ -52,6 +52,7 @@ export class RelayAccountDeletionBlockedError extends Data.TaggedError(
 export class RelayRateLimitError extends Data.TaggedError("RelayRateLimitError")<{
   readonly code: "rate_limited" | "rate_limit_unavailable";
   readonly retryAfterSeconds?: number;
+  readonly source?: RelayRateLimitSource;
 }> {}
 
 export class RelayAuthenticationError extends Data.TaggedError(
@@ -61,6 +62,11 @@ export class RelayAuthenticationError extends Data.TaggedError(
   readonly cause: unknown;
   readonly retryAfterSeconds?: number;
 }> {}
+
+/** Which enforcement layer produced a 429; diagnosing the 08-27 incident
+ * required hours of elimination because all three were indistinguishable. */
+export type RelayRateLimitSource = "ingress_ip" | "device_budget" | "auth_provider";
+
 
 export class RelaySigningError extends Data.TaggedError("RelaySigningError")<{
   readonly cause: unknown;
@@ -77,6 +83,9 @@ const MAX_AUTH_ERROR_METADATA_DEPTH = 8;
  */
 export function relayAuthenticationError(cause: unknown): RelayAuthenticationError {
   const rateLimited = hasRateLimitSignal(cause);
+  if (rateLimited) {
+    console.warn("relay.rate_limited", { source: "auth_provider" });
+  }
   return new RelayAuthenticationError({
     code: rateLimited ? "rate_limited" : "unavailable",
     cause,

--- a/web/services/relay/http.ts
+++ b/web/services/relay/http.ts
@@ -4,6 +4,7 @@ import {
   RelayAuthenticationError,
   RelayConfigurationError,
   RelayRateLimitError,
+  type RelayRateLimitSource,
   type RelayServiceError,
 } from "./errors";
 
@@ -63,9 +64,14 @@ export function enforceRelayRateLimit(input: {
   }).pipe(
     Effect.flatMap(({ rateLimited, error }) => {
       if (rateLimited || error === "blocked") {
+        const source: RelayRateLimitSource = input.rateLimitKey === null
+          ? "ingress_ip"
+          : "device_budget";
+        console.warn("relay.rate_limited", { source });
         const retryAfterSeconds = input.retryAfterSeconds;
         return Effect.fail(new RelayRateLimitError({
           code: "rate_limited",
+          source,
           ...(retryAfterSeconds !== undefined &&
           Number.isSafeInteger(retryAfterSeconds) &&
           retryAfterSeconds >= 1 &&
@@ -97,9 +103,10 @@ export function relayErrorResponse(error: unknown): Response {
   if (tag === "RelayAuthenticationError") {
     const typed = error as RelayAuthenticationError;
     const rateLimited = typed.code === "rate_limited";
+    const source = rateLimited ? { source: "auth_provider" } : {};
     console.error("relay.auth.unavailable", { reason: typed.code });
     return jsonResponse(
-      { error: rateLimited ? "rate_limited" : "authentication_unavailable" },
+      { error: rateLimited ? "rate_limited" : "authentication_unavailable", ...source },
       rateLimited ? 429 : 503,
       typed.retryAfterSeconds === undefined
         ? undefined
@@ -108,8 +115,9 @@ export function relayErrorResponse(error: unknown): Response {
   }
   if (tag === "RelayRateLimitError") {
     const code = (error as RelayRateLimitError).code;
+    const limitSource = (error as RelayRateLimitError).source;
     return jsonResponse(
-      { error: code },
+      { error: code, ...(limitSource ? { source: limitSource } : {}) },
       code === "rate_limited" ? 429 : 503,
       code === "rate_limited" &&
       (error as RelayRateLimitError).retryAfterSeconds !== undefined

--- a/web/services/relay/http.ts
+++ b/web/services/relay/http.ts
@@ -66,7 +66,9 @@ export function enforceRelayRateLimit(input: {
       if (rateLimited || error === "blocked") {
         const source: RelayRateLimitSource = input.rateLimitKey === null
           ? "ingress_ip"
-          : "device_budget";
+          : input.devicePartition
+            ? "device_budget"
+            : "account_budget";
         console.warn("relay.rate_limited", { source });
         const retryAfterSeconds = input.retryAfterSeconds;
         return Effect.fail(new RelayRateLimitError({

--- a/web/tests/relay-preferences-route.test.ts
+++ b/web/tests/relay-preferences-route.test.ts
@@ -157,6 +157,7 @@ describe("/api/relay/preferences", () => {
       checkRateLimit: async () => ({ rateLimited: true }),
     }));
     expect(limited.status).toBe(429);
+    expect(await limited.json()).toEqual({ error: "rate_limited", source: "account_budget" });
   });
 
   test("rejects unauthenticated callers", async () => {

--- a/web/tests/relay-token-route.test.ts
+++ b/web/tests/relay-token-route.test.ts
@@ -416,7 +416,10 @@ describe("POST /api/relay/token", () => {
 
     expect(response.status).toBe(429);
     expect(response.headers.get("retry-after")).toBe("60");
-    expect(await response.json()).toEqual({ error: "rate_limited" });
+    expect(await response.json()).toEqual({
+      error: "rate_limited",
+      source: "auth_provider",
+    });
 
     const statusLimited = await handleRelayTokenRequest(
       request({ endpointId: ENDPOINT_ID }),
@@ -463,6 +466,10 @@ describe("POST /api/relay/token", () => {
 
     expect(response.status).toBe(429);
     expect(response.headers.get("retry-after")).toBe("60");
+    expect(await response.json()).toEqual({
+      error: "rate_limited",
+      source: "ingress_ip",
+    });
     expect(authCalls).toBe(0);
   });
 
@@ -483,6 +490,9 @@ describe("POST /api/relay/token", () => {
       }),
     );
     expect(limited.status).toBe(429);
+    expect(await limited.clone().json()).toEqual(
+      expect.objectContaining({ error: "rate_limited", source: "device_budget" }),
+    );
     // Partitioned per device, protocol phase, and minute: a storming endpoint
     // starves only its duplicate work, never bootstrap, renewal, or another
     // phone, simulator, or tagged build.


### PR DESCRIPTION
Diagnosing the 08-27 incident took hours of elimination because a journaled \`rateLimited(code: rate_limited, retryAfterSeconds: 60)\` could be any of four things: the per-IP ingress gate, the per-device budget, a Stack Auth throttle passthrough, or the client's own local cooldown counting down a prior 429.

Now: the 429 body carries \`source\` (\`ingress_ip\` | \`device_budget\` | \`auth_provider\`), the server logs \`relay.rate_limited {source}\` on each, the Swift client folds source into the journaled code (\`rate_limited:auth_provider\`), and the client gate prefixes local fail-fasts with \`cooldown:\`. One journal line now names the layer.

Tests: route tests assert the source per layer (ingress, device, auth), gate test pins the \`cooldown:\` marker. \`tsgo --noEmit\` clean, \`bun test\` relay suites green, Swift backpressure suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11060"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790487411&installation_model_id=21920&pr_number=11060&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11060&signature=804d575e931336abb68175282e9423f1fab1dab16c0f9475c66a76712ae529f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Names the rate-limit enforcement layer in every 429 response and journal line so incidents are diagnosable without elimination. Previously `rateLimited` errors from the ingress gate, account/device budgets, auth provider, and local cooldowns were indistinguishable.

- The 429 body now carries `source` (`ingress_ip`, `account_budget`, `device_budget`, or `auth_provider`); server logs `relay.rate_limited` with it.
- The Swift client decodes the body into a dedicated error type, folds `source` into the journaled code (e.g. `rate_limited:auth_provider`), falls back to the bare code on unknown or malformed sources, and prefixes local fail-fasts with `cooldown:`.
- Route, client, and gate tests pin the per-layer source, the malformed-source fallback, and the `cooldown:` marker.

<sup>Written for commit c4c6d46db5e0f3f8b97b4c503f0d0e8ff45a05bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rate-limit responses now identify the enforcement source, including ingress IP, account budget, device budget, or authentication provider.
  * Error codes distinguish local cooldowns from direct server rate-limit rejections.

* **Bug Fixes**
  * Improved rate-limit reporting and diagnostics across relay and broker interactions.
  * Retry timing information is preserved while error details are clearer.
  * Invalid or unrecognized enforcement sources are safely omitted without disrupting error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->