### PR TITLE
irx: fix trust-reader compile break from #11047

### DIFF
--- a/Sources/Mobile/MobileHostIrxRuntime.swift
+++ b/Sources/Mobile/MobileHostIrxRuntime.swift
@@ -499,24 +499,14 @@ final class MobileHostIrxRuntime {
 }
 
 /// Synchronous trust-snapshot reader for the admission path (no actor hop,
-/// no network): reads the JSON the broker service persists.
+/// no network): reads the JSON the broker service persists. The caller
+/// passes the runtime's activation-resolved state directory (per-bundle,
+/// per-broker; see `activate(accountID:)`), so another build's or another
+/// environment's caches are never readable here.
 enum IrxDiskCacheTrustReader {
-    nonisolated static func read() -> IrxTrustSnapshot? {
-        let appSupport = FileManager.default.urls(
-            for: .applicationSupportDirectory, in: .userDomainMask
-        )[0]
-        // Per-bundle, per-backend state: another build (or another
-        // environment's) caches must never be readable here, or staging
-        // trust keys reject production grants at admission.
-        let stateDir = IrxStateLocation.directory(
-            base: appSupport,
-            bundleIdentifier: Bundle.main.bundleIdentifier,
-            brokerHost: brokerBaseURL.host
-        )
-        IrxStateLocation.removeLegacySharedDirectory(base: appSupport)
-        stateDirectory = stateDir
-        return IrxDiskCache<IrxTrustSnapshot>(
-            fileURL: stateDir.appendingPathComponent("trust.json")
+    nonisolated static func read(stateDirectory: URL) -> IrxTrustSnapshot? {
+        IrxDiskCache<IrxTrustSnapshot>(
+            fileURL: stateDirectory.appendingPathComponent("trust.json")
         ).load()
     }
 }


### PR DESCRIPTION
Main's app target has not compiled since https://github.com/manaflow-ai/cmux/pull/11047: `IrxDiskCacheTrustReader.read()` references `brokerBaseURL` and assigns `stateDirectory` inside a static enum where neither exists, and both call sites in the accept path call `read(stateDirectory:)`. The reader now takes the activation-resolved state directory (`activate(accountID:)` remains the single place that computes and persists it, including legacy-directory cleanup). Repro: `xcodebuild -scheme cmux ... build` on main fails with the four errors at MobileHostIrxRuntime.swift:305/307/514/517; with this change the same build succeeds (verified on the feat-sidebar-runtime-v2 merge of main).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the compile break on `main` from #11047: `IrxDiskCacheTrustReader.read()` now takes the activation-resolved state directory as a parameter instead of recomputing it inside the static enum, where `brokerBaseURL` and `stateDirectory` don't exist. The two call sites in the accept path already pass `read(stateDirectory:)`, and `activate(accountID:)` remains the single place that computes and persists the directory, including legacy cleanup. The app target builds again.

<sup>Written for commit 20a259160353df20c23d08fac6959eb59934e84c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

