### PR TITLE
Unbreak the macOS build: pass the namespaced state directory into IrxDiskCacheTrustReader

### DIFF
--- a/Sources/Mobile/MobileHostIrxRuntime.swift
+++ b/Sources/Mobile/MobileHostIrxRuntime.swift
@@ -499,24 +499,13 @@ final class MobileHostIrxRuntime {
 }
 
 /// Synchronous trust-snapshot reader for the admission path (no actor hop,
-/// no network): reads the JSON the broker service persists.
+/// no network): reads the JSON the broker service persists. The caller passes
+/// the per-bundle, per-broker state directory computed at activation so
+/// admission never reads another build's (or another environment's) cache.
 enum IrxDiskCacheTrustReader {
-    nonisolated static func read() -> IrxTrustSnapshot? {
-        let appSupport = FileManager.default.urls(
-            for: .applicationSupportDirectory, in: .userDomainMask
-        )[0]
-        // Per-bundle, per-backend state: another build (or another
-        // environment's) caches must never be readable here, or staging
-        // trust keys reject production grants at admission.
-        let stateDir = IrxStateLocation.directory(
-            base: appSupport,
-            bundleIdentifier: Bundle.main.bundleIdentifier,
-            brokerHost: brokerBaseURL.host
-        )
-        IrxStateLocation.removeLegacySharedDirectory(base: appSupport)
-        stateDirectory = stateDir
-        return IrxDiskCache<IrxTrustSnapshot>(
-            fileURL: stateDir.appendingPathComponent("trust.json")
+    nonisolated static func read(stateDirectory: URL) -> IrxTrustSnapshot? {
+        IrxDiskCache<IrxTrustSnapshot>(
+            fileURL: stateDirectory.appendingPathComponent("trust.json")
         ).load()
     }
 }


### PR DESCRIPTION
https://github.com/manaflow-ai/cmux/pull/11047 changed the macOS call sites in `Sources/Mobile/MobileHostIrxRuntime.swift` to `IrxDiskCacheTrustReader.read(stateDirectory:)` but left the reader declared as `read()`, and its new body references `brokerBaseURL` and `stateDirectory`, which only exist on `MobileHostIrxRuntime`. The macOS app target has not compiled since that merge: every nightly since https://github.com/manaflow-ai/cmux/commit/aa7c9221ac576d01e033a23f9f3f46b9afec22cb fails in `build-nightly-app` with these four errors (see https://github.com/manaflow-ai/cmux/actions/runs/33144378644).

The reader now takes the state directory as a parameter. Activation already computes the per-bundle, per-broker directory, stores it, and both call sites already pass it, so the namespacing intent of #11047 is preserved and the out-of-scope path computation is deleted. Legacy shared-directory cleanup still happens in `activate()`.

No test added: the defect is a compile error in the app target, and compilation in CI is the behavior-level check. #11047 merged with only Socket/cubic/CodeRabbit/testbox checks, so no macOS compile gate ever saw it; that required-check gap is worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the macOS build by making `IrxDiskCacheTrustReader.read` accept the state directory as a parameter, resolving a signature mismatch that left the app target uncompilable since #11047.

- The reader now uses the per-bundle, per-broker state directory that activation already computes and passes at both call sites, preserving the original namespacing intent.
- Removes the out-of-scope path computation from the reader; legacy shared-directory cleanup still happens in `activate()`.
- No test added: the defect is a compile error, and CI compilation is the behavior-level check.

<sup>Written for commit 553f1a471d8451eb695d4a6e414d68eaba550c6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11066?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trust-state loading for mobile connections by using the correct per-bundle, per-broker state directory.
  * Ensured connection admission consistently reads the latest stored trust information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->