### PR TITLE
Cloud tree: right-click verbs with confirmations, D13 workspace double-click, drag gating, visual polish

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -59744,23 +59744,6 @@
         }
       }
     },
-    "cloudTree.menu.closeWorkspace": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Close Workspace"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ワークスペースを閉じる"
-          }
-        }
-      }
-    },
     "cloudTree.menu.copyPort": {
       "extractionState": "manual",
       "localizations": {
@@ -59842,6 +59825,312 @@
           "stringUnit": {
             "state": "translated",
             "value": "ここに新規ターミナル"
+          }
+        }
+      }
+    },
+    "cloudTree.confirm.cancel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャンセル"
+          }
+        }
+      }
+    },
+    "cloudTree.deleteWorkspace.confirm": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "削除"
+          }
+        }
+      }
+    },
+    "cloudTree.deleteWorkspace.message.empty": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The workspace closes on the machine."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "マシン上のワークスペースが閉じます。"
+          }
+        }
+      }
+    },
+    "cloudTree.deleteWorkspace.message.one": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Its terminal is killed with it. To keep it, use “Close Workspace” instead — it moves to the Terminals pool."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中のターミナルも一緒に終了します。残す場合は「ワークスペースを閉じる」を使ってください。ターミナルはプールに移動します。"
+          }
+        }
+      }
+    },
+    "cloudTree.deleteWorkspace.message.other": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Its %d terminals are killed with it. To keep them, use “Close Workspace” instead — they move to the Terminals pool."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中の%d個のターミナルも一緒に終了します。残す場合は「ワークスペースを閉じる」を使ってください。ターミナルはプールに移動します。"
+          }
+        }
+      }
+    },
+    "cloudTree.deleteWorkspace.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete workspace “%@”?"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペース「%@」を削除しますか？"
+          }
+        }
+      }
+    },
+    "cloudTree.killTerminal.confirm": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kill"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "強制終了"
+          }
+        }
+      }
+    },
+    "cloudTree.killTerminal.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The process ends on the machine, everywhere it is shown. Panes keep their scrollback."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "マシン上のプロセスが終了し、表示中のすべての場所に反映されます。ペインのスクロールバックは残ります。"
+          }
+        }
+      }
+    },
+    "cloudTree.killTerminal.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kill terminal “%@”?"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナル「%@」を強制終了しますか？"
+          }
+        }
+      }
+    },
+    "cloudTree.menu.closeWorkspace": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close Workspace (Keep Terminals)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースを閉じる（ターミナルを保持）"
+          }
+        }
+      }
+    },
+    "cloudTree.menu.deleteWorkspace": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete Workspace and Terminals…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースとターミナルを削除…"
+          }
+        }
+      }
+    },
+    "cloudTree.menu.killTerminal": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kill Terminal…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナルを強制終了…"
+          }
+        }
+      }
+    },
+    "cloudTree.menu.openWorkspace": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Workspace"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースを開く"
+          }
+        }
+      }
+    },
+    "cloudTree.menu.renameWorkspace": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rename…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "名称変更…"
+          }
+        }
+      }
+    },
+    "cloudTree.operation.deleteWorkspace": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deleting %@…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ を削除しています…"
+          }
+        }
+      }
+    },
+    "cloudTree.operation.renameWorkspace": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renaming %@…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ の名称を変更しています…"
+          }
+        }
+      }
+    },
+    "cloudTree.rename.confirm": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rename"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "名称変更"
+          }
+        }
+      }
+    },
+    "cloudTree.renameWorkspace.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rename “%@”"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "「%@」の名称変更"
           }
         }
       }
@@ -60369,23 +60658,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "メモリ %@/%@ GB"
-          }
-        }
-      }
-    },
-    "cloudTree.terminal.open": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open in a pane"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ペインで開いています"
           }
         }
       }

--- a/Sources/Cloud/CloudTreeCellView.swift
+++ b/Sources/Cloud/CloudTreeCellView.swift
@@ -138,7 +138,9 @@ final class CloudTreeRowView: NSTableRowView {
         guard isSelected else { return }
         let insetRect = bounds.insetBy(dx: 6, dy: 1)
         let path = NSBezierPath(roundedRect: insetRect, xRadius: 4, yRadius: 4)
-        (isKeyboardFocusActive ? NSColor.controlAccentColor.withAlphaComponent(0.20) : NSColor.labelColor.withAlphaComponent(0.08)).setFill()
+        // Gray in both focus states (no accent blue); keyboard focus reads as a
+        // slightly stronger shade.
+        NSColor.labelColor.withAlphaComponent(isKeyboardFocusActive ? 0.12 : 0.07).setFill()
         path.fill()
     }
 
@@ -154,6 +156,8 @@ final class CloudTreeRowView: NSTableRowView {
     }
 
     override var interiorBackgroundStyle: NSView.BackgroundStyle {
-        isSelected && isKeyboardFocusActive ? .emphasized : .normal
+        // The gray highlight keeps normal label colors; .emphasized would flip
+        // the text to white as if on an accent fill.
+        .normal
     }
 }

--- a/Sources/Cloud/CloudTreeNode.swift
+++ b/Sources/Cloud/CloudTreeNode.swift
@@ -141,6 +141,16 @@ final class CloudTreeNode: NSObject {
         return dragResource.map { SurfaceResourceGroup(single: $0) }
     }
 
+    /// Whether this row may start a native drag. Only terminals and displays
+    /// leave the tree by drag; workspaces, browsers, ports, machines, and
+    /// headers do not (their `dragGroup` still feeds open verbs and menus).
+    var isDragSource: Bool {
+        switch kind {
+        case .terminal, .display: return true
+        default: return false
+        }
+    }
+
     /// The single resource a leaf row stands for; nil for workspace rows and headers.
     var dragResource: SurfaceResource? {
         switch kind {

--- a/Sources/Cloud/CloudTreeNodeActions.swift
+++ b/Sources/Cloud/CloudTreeNodeActions.swift
@@ -158,7 +158,14 @@ struct CloudTreeNodeActions {
                 guard confirmDestructive(title: title, message: message, verb: String(localized: "cloudTree.deleteWorkspace.confirm", defaultValue: "Delete")) else { return }
                 run(String(format: String(localized: "cloudTree.operation.deleteWorkspace", defaultValue: "Deleting %@\u{2026}"), workspace.name)) { catalog in
                     guard let provider = catalog.provider(for: machine) else { throw SurfaceCatalogError.noProvider(machine) }
-                    for terminal in terminals {
+                    // Re-sync and re-enumerate AT operation time: the pre-confirm list
+                    // above only words the dialog. A terminal created while the dialog
+                    // was up must die with the workspace too, not detach into the pool.
+                    await provider.refresh()
+                    let doomed = catalog.snapshot.resources(on: machine).filter { resource in
+                        resource.kind == .terminal && resource.remoteWorkspaces.contains { $0.id == workspace.id }
+                    }
+                    for terminal in doomed {
                         try await provider.closeTerminal(terminal.id)
                     }
                     try await provider.closeRemoteWorkspace(id: workspace.id)

--- a/Sources/Cloud/CloudTreeNodeActions.swift
+++ b/Sources/Cloud/CloudTreeNodeActions.swift
@@ -23,8 +23,13 @@ struct CloudTreeNodeActions {
     let newWorkspace: @MainActor (_ machine: SurfaceMachineID) -> Void
     /// End a terminal on its machine (the process and its remote tab).
     let closeTerminal: @MainActor (_ resource: SurfaceResourceID) -> Void
-    /// Close a workspace on its machine and every terminal in it.
+    /// Close a workspace on its machine; its terminals detach into the pool
+    /// (only `terminal close` kills content).
     let closeWorkspace: @MainActor (_ machine: SurfaceMachineID, _ remoteWorkspaceID: String) -> Void
+    /// Delete a workspace AND kill every terminal in it. Confirms first.
+    let deleteWorkspace: @MainActor (_ machine: SurfaceMachineID, _ workspace: SurfaceRemoteWorkspace) -> Void
+    /// Rename a remote workspace via a text prompt.
+    let renameWorkspace: @MainActor (_ machine: SurfaceMachineID, _ workspace: SurfaceRemoteWorkspace) -> Void
     /// Select a local workspace.
     let selectLocalWorkspace: @MainActor (_ workspaceID: UUID) -> Void
     let copyToPasteboard: @MainActor (_ text: String) -> Void
@@ -120,6 +125,11 @@ struct CloudTreeNodeActions {
                 }
             },
             closeTerminal: { resource in
+                guard confirmDestructive(
+                    title: String(format: String(localized: "cloudTree.killTerminal.title", defaultValue: "Kill terminal \u{201C}%@\u{201D}?"), resource.key),
+                    message: String(localized: "cloudTree.killTerminal.message", defaultValue: "The process ends on the machine, everywhere it is shown. Panes keep their scrollback."),
+                    verb: String(localized: "cloudTree.killTerminal.confirm", defaultValue: "Kill")
+                ) else { return }
                 run(String(format: String(localized: "cloudTree.operation.close", defaultValue: "Closing on %@\u{2026}"), machineName(resource.machine))) { catalog in
                     guard let provider = catalog.provider(for: resource.machine) else { throw SurfaceCatalogError.noProvider(resource.machine) }
                     try await provider.closeTerminal(resource)
@@ -129,6 +139,39 @@ struct CloudTreeNodeActions {
                 run(String(format: String(localized: "cloudTree.operation.close", defaultValue: "Closing on %@\u{2026}"), machineName(machine))) { catalog in
                     guard let provider = catalog.provider(for: machine) else { throw SurfaceCatalogError.noProvider(machine) }
                     try await provider.closeRemoteWorkspace(id: remoteWorkspaceID)
+                }
+            },
+            deleteWorkspace: { machine, workspace in
+                let terminals = catalog().snapshot.resources(on: machine).filter { resource in
+                    resource.kind == .terminal && resource.remoteWorkspaces.contains { $0.id == workspace.id }
+                }
+                let title = String(format: String(localized: "cloudTree.deleteWorkspace.title", defaultValue: "Delete workspace \u{201C}%@\u{201D}?"), workspace.name)
+                let message: String
+                switch terminals.count {
+                case 0:
+                    message = String(localized: "cloudTree.deleteWorkspace.message.empty", defaultValue: "The workspace closes on the machine.")
+                case 1:
+                    message = String(localized: "cloudTree.deleteWorkspace.message.one", defaultValue: "Its terminal is killed with it. To keep it, use \u{201C}Close Workspace\u{201D} instead — it moves to the Terminals pool.")
+                default:
+                    message = String(format: String(localized: "cloudTree.deleteWorkspace.message.other", defaultValue: "Its %d terminals are killed with it. To keep them, use \u{201C}Close Workspace\u{201D} instead — they move to the Terminals pool."), terminals.count)
+                }
+                guard confirmDestructive(title: title, message: message, verb: String(localized: "cloudTree.deleteWorkspace.confirm", defaultValue: "Delete")) else { return }
+                run(String(format: String(localized: "cloudTree.operation.deleteWorkspace", defaultValue: "Deleting %@\u{2026}"), workspace.name)) { catalog in
+                    guard let provider = catalog.provider(for: machine) else { throw SurfaceCatalogError.noProvider(machine) }
+                    for terminal in terminals {
+                        try await provider.closeTerminal(terminal.id)
+                    }
+                    try await provider.closeRemoteWorkspace(id: workspace.id)
+                }
+            },
+            renameWorkspace: { machine, workspace in
+                guard let name = promptForName(
+                    title: String(format: String(localized: "cloudTree.renameWorkspace.title", defaultValue: "Rename \u{201C}%@\u{201D}"), workspace.name),
+                    current: workspace.name
+                ), name != workspace.name else { return }
+                run(String(format: String(localized: "cloudTree.operation.renameWorkspace", defaultValue: "Renaming %@\u{2026}"), workspace.name)) { catalog in
+                    guard let provider = catalog.provider(for: machine) else { throw SurfaceCatalogError.noProvider(machine) }
+                    try await provider.renameRemoteWorkspace(id: workspace.id, name: name)
                 }
             },
             selectLocalWorkspace: selectLocalWorkspace,
@@ -184,5 +227,34 @@ struct CloudTreeNodeActions {
             host: .app
         )
         return (workspace, terminal, opened)
+    }
+
+    /// The house destructive-confirm shape (`NSAlert`, warning style, verb first).
+    @MainActor
+    private static func confirmDestructive(title: String, message: String, verb: String) -> Bool {
+        let alert = NSAlert()
+        alert.messageText = title
+        alert.informativeText = message
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: verb)
+        alert.addButton(withTitle: String(localized: "cloudTree.confirm.cancel", defaultValue: "Cancel"))
+        return alert.runModal() == .alertFirstButtonReturn
+    }
+
+    /// A one-field rename prompt. Returns the trimmed name, or nil on cancel/empty.
+    @MainActor
+    private static func promptForName(title: String, current: String) -> String? {
+        let alert = NSAlert()
+        alert.messageText = title
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: String(localized: "cloudTree.rename.confirm", defaultValue: "Rename"))
+        alert.addButton(withTitle: String(localized: "cloudTree.confirm.cancel", defaultValue: "Cancel"))
+        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 240, height: 24))
+        field.stringValue = current
+        alert.accessoryView = field
+        alert.window.initialFirstResponder = field
+        guard alert.runModal() == .alertFirstButtonReturn else { return nil }
+        let name = field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        return name.isEmpty ? nil : name
     }
 }

--- a/Sources/Cloud/CloudTreeOutlineView.swift
+++ b/Sources/Cloud/CloudTreeOutlineView.swift
@@ -441,11 +441,12 @@ struct CloudTreeOutlineView: NSViewRepresentable {
                     item(String(localized: "cloudTree.menu.refresh", defaultValue: "Refresh")) { [nodeActions] in nodeActions.refresh() },
                 ]
             case .workspace(let machine, let workspace, _):
-                let group = node.dragGroup ?? SurfaceResourceGroup(title: workspace.name, resources: [])
                 return [
-                    // One open verb, same as double-click: the remote workspace gets
-                    // its own local workspace (remote and local never intermingle, D13).
-                    item(String(localized: "cloudTree.menu.openWorkspace", defaultValue: "Open Workspace")) { [nodeActions] in nodeActions.openGroupAsWorkspace(machine, group, workspace.id) },
+                    // One open verb, THE SAME PATH as double-click and Return (`open`):
+                    // focus the pane already showing the workspace instead of opening a
+                    // duplicate, refuse an empty group, else open as an own local
+                    // workspace (remote and local never intermingle, D13).
+                    item(String(localized: "cloudTree.menu.openWorkspace", defaultValue: "Open Workspace")) { [weak self] in self?.open(node) },
                     item(String(localized: "cloudTree.menu.newTerminalHere", defaultValue: "New Terminal Here")) { [nodeActions] in nodeActions.newTerminal(machine, workspace.id) },
                     .separator(),
                     item(String(localized: "cloudTree.menu.renameWorkspace", defaultValue: "Rename\u{2026}")) { [nodeActions] in nodeActions.renameWorkspace(machine, workspace) },

--- a/Sources/Cloud/CloudTreeOutlineView.swift
+++ b/Sources/Cloud/CloudTreeOutlineView.swift
@@ -247,7 +247,10 @@ struct CloudTreeOutlineView: NSViewRepresentable {
 
         /// One click means open (D9): a click on any row carries the intent to
         /// open it. The second click of a double-click is ignored so machine and
-        /// group rows don't toggle twice.
+        /// group rows don't toggle twice. Workspace rows are the exception
+        /// (lawrence, 2026-08-27): one click only toggles the container;
+        /// double-click opens the remote workspace as its own local workspace,
+        /// or focuses it when a pane already shows one of its terminals.
         @objc func handleSingleClick(_ sender: Any?) {
             guard let outlineView, NSApp.currentEvent.map({ $0.clickCount <= 1 }) ?? true else { return }
             let row = outlineView.clickedRow >= 0 ? outlineView.clickedRow : outlineView.selectedRow
@@ -255,6 +258,20 @@ struct CloudTreeOutlineView: NSViewRepresentable {
 #if DEBUG
             cmuxDebugLog("cloudTree.click row=\(row) kind=\(node.structureTag) clicks=\(NSApp.currentEvent?.clickCount ?? -1)")
 #endif
+            if case .workspace = node.kind {
+                toggle(node)
+                return
+            }
+            open(node)
+        }
+
+        /// Double-click matters only on workspace rows; every other row already
+        /// acted on the first click.
+        @objc func handleDoubleClick(_ sender: Any?) {
+            guard let outlineView else { return }
+            let row = outlineView.clickedRow >= 0 ? outlineView.clickedRow : outlineView.selectedRow
+            guard row >= 0, let node = outlineView.item(atRow: row) as? CloudTreeNode,
+                  case .workspace = node.kind else { return }
             open(node)
         }
 
@@ -281,10 +298,17 @@ struct CloudTreeOutlineView: NSViewRepresentable {
             case .localMachine, .terminalsPool, .displaysPool, .workspacesGroup, .portsGroup, .browsersGroup:
                 toggle(node)
             case .workspace(let machine, let workspace, _):
-                // A remote workspace opens as its own local workspace, panes and all.
-                // D9: open never creates — an empty workspace row opens nothing here;
-                // its "+" and menu own creation.
-                if let group = node.dragGroup, !group.isEmpty {
+                // Open-or-focus (D13). Already showing in a pane -> focus that pane.
+                // Otherwise the remote workspace opens as its OWN local workspace —
+                // remote and local workspaces never intermingle. D9: open never
+                // creates — an empty workspace row opens nothing here; its "+" and
+                // menu own creation.
+                if let shown = node.children.first(where: { child in
+                    if case .terminal(let row) = child.kind { return row.isOpen }
+                    return false
+                }), case .terminal(let openRow) = shown.kind {
+                    nodeActions.project(openRow.resource.id, .split, true)
+                } else if let group = node.dragGroup, !group.isEmpty {
                     nodeActions.openGroupAsWorkspace(machine, group, workspace.id)
                 }
             case .localWorkspace(let row):
@@ -419,13 +443,16 @@ struct CloudTreeOutlineView: NSViewRepresentable {
             case .workspace(let machine, let workspace, _):
                 let group = node.dragGroup ?? SurfaceResourceGroup(title: workspace.name, resources: [])
                 return [
-                    item(String(localized: "cloudTree.menu.openAsNewWorkspace", defaultValue: "Open as New Workspace")) { [nodeActions] in nodeActions.openGroupAsWorkspace(machine, group, workspace.id) },
-                    item(String(localized: "cloudTree.menu.openAllHere", defaultValue: "Open All Here")) { [nodeActions] in nodeActions.openGroup(machine, group, .split, workspace.id) },
-                    item(String(localized: "cloudTree.menu.openAllInNewTabs", defaultValue: "Open All in New Tabs")) { [nodeActions] in nodeActions.openGroup(machine, group, .tab, workspace.id) },
+                    // One open verb, same as double-click: the remote workspace gets
+                    // its own local workspace (remote and local never intermingle, D13).
+                    item(String(localized: "cloudTree.menu.openWorkspace", defaultValue: "Open Workspace")) { [nodeActions] in nodeActions.openGroupAsWorkspace(machine, group, workspace.id) },
                     item(String(localized: "cloudTree.menu.newTerminalHere", defaultValue: "New Terminal Here")) { [nodeActions] in nodeActions.newTerminal(machine, workspace.id) },
                     .separator(),
-                    item(String(localized: "cloudTree.menu.closeWorkspace", defaultValue: "Close Workspace")) { [nodeActions] in nodeActions.closeWorkspace(machine, workspace.id) },
+                    item(String(localized: "cloudTree.menu.renameWorkspace", defaultValue: "Rename\u{2026}")) { [nodeActions] in nodeActions.renameWorkspace(machine, workspace) },
                     item(String(localized: "cloudTree.menu.copyWorkspaceID", defaultValue: "Copy Workspace ID")) { [nodeActions] in nodeActions.copyToPasteboard(workspace.id) },
+                    .separator(),
+                    item(String(localized: "cloudTree.menu.closeWorkspace", defaultValue: "Close Workspace (Keep Terminals)")) { [nodeActions] in nodeActions.closeWorkspace(machine, workspace.id) },
+                    item(String(localized: "cloudTree.menu.deleteWorkspace", defaultValue: "Delete Workspace and Terminals\u{2026}")) { [nodeActions] in nodeActions.deleteWorkspace(machine, workspace) },
                 ]
             case .localWorkspace(let row):
                 var items = [
@@ -440,7 +467,7 @@ struct CloudTreeOutlineView: NSViewRepresentable {
                 var items = resourceMenuItems(row.resource, isLocal: row.resource.machine.isLocal)
                 if !row.resource.machine.isLocal {
                     items.append(.separator())
-                    items.append(item(String(localized: "cloudTree.menu.closeTerminal", defaultValue: "Close Terminal")) { [nodeActions] in nodeActions.closeTerminal(row.resource.id) })
+                    items.append(item(String(localized: "cloudTree.menu.killTerminal", defaultValue: "Kill Terminal\u{2026}")) { [nodeActions] in nodeActions.closeTerminal(row.resource.id) })
                 }
                 return items
             case .browser(let row):
@@ -513,7 +540,11 @@ struct CloudTreeOutlineView: NSViewRepresentable {
         // MARK: Drag source
 
         func outlineView(_ outlineView: NSOutlineView, pasteboardWriterForItem item: Any) -> NSPasteboardWriting? {
-            guard let node = item as? CloudTreeNode, let group = node.dragGroup, let lead = group.resources.first,
+            // Only terminals and displays leave the tree by drag (lawrence,
+            // 2026-08-27). Workspaces are containers (their drag becomes the D2
+            // mirror later); browsers and ports open in place.
+            guard let node = item as? CloudTreeNode, node.isDragSource,
+                  let group = node.dragGroup, let lead = group.resources.first,
                   let transferRegistry = tabDragTransferRegistry() else { return nil }
             let dragID = SurfaceResourceDragRegistry.shared.register(group)
             guard let registration = SurfaceResourceDragPayload(group: group, leadKind: lead.kind, dragID: dragID)
@@ -593,13 +624,20 @@ final class CloudTreeContainerView: NSView {
         column.resizingMask = .autoresizingMask
         outlineView.addTableColumn(column)
         outlineView.outlineTableColumn = column
+        // The one column's width is derived from the live bounds on EVERY layout
+        // pass (see `layout()`), never left to resize notifications: a width set
+        // only during live-resize events is exactly the "row content is wrong
+        // until I drag the divider" class of bug.
+        outlineView.columnAutoresizingStyle = .firstColumnOnlyAutoresizingStyle
 
         outlineView.dataSource = coordinator
         outlineView.delegate = coordinator
         outlineView.target = coordinator
-        // D9: one click opens. No doubleAction — the handler ignores the second
-        // click of a double-click, so a habitual double-click acts once.
+        // D9: one click opens; the single-click handler ignores the second click
+        // of a double-click, so a habitual double-click acts once. The double
+        // action exists solely for workspace rows (open-or-focus, D13).
         outlineView.action = #selector(CloudTreeOutlineView.Coordinator.handleSingleClick(_:))
+        outlineView.doubleAction = #selector(CloudTreeOutlineView.Coordinator.handleDoubleClick(_:))
         outlineView.setDraggingSourceOperationMask(.move, forLocal: true)
         outlineView.onOpenSelection = { [weak coordinator] in coordinator?.openSelection() }
         outlineView.onMoveSelection = { [weak coordinator] delta in coordinator?.moveSelection(by: delta) }
@@ -636,5 +674,13 @@ final class CloudTreeContainerView: NSView {
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    /// Width is a pure function of the current bounds, recomputed on every layout
+    /// pass. Rows are correct on first display, on sidebar show, and on any
+    /// programmatic resize — not only after a live divider drag.
+    override func layout() {
+        super.layout()
+        outlineView.sizeLastColumnToFit()
     }
 }

--- a/Sources/Cloud/CloudTreeRowContentView.swift
+++ b/Sources/Cloud/CloudTreeRowContentView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 enum CloudTreeRowGrid {
     /// Width of the outline's disclosure slot; content starts `disclosureGap` after it.
     static let disclosureSlot: CGFloat = 16
-    static let disclosureGap: CGFloat = 6
+    static let disclosureGap: CGFloat = 10
     /// Machine rows: the status dot has its own slot, never adjacent to the chevron.
     static let dotSlot: CGFloat = 10
     static let dotGap: CGFloat = 8
@@ -111,8 +111,7 @@ struct CloudTreeRowContentView: View {
                 icon: "globe",
                 tint: CloudTreeIconPalette.browser,
                 title: row.resource.title.isEmpty ? String(localized: "cloudTree.browser.untitled", defaultValue: "browser") : row.resource.title,
-                detail: CloudTreeBrowserDetail.text(for: row),
-                showsOpenMark: row.isOpen
+                detail: CloudTreeBrowserDetail.text(for: row)
             )
         case .portsGroup:
             groupRow(title: String(localized: "cloudTree.group.ports", defaultValue: "Ports"))
@@ -125,7 +124,7 @@ struct CloudTreeRowContentView: View {
                 detail: resource.detail?.isEmpty == false ? resource.detail : nil
             )
         case .placeholder(_, let placeholder):
-            HStack(alignment: .firstTextBaseline, spacing: style.iconGap) {
+            HStack(alignment: .center, spacing: style.iconGap) {
                 Group {
                     switch placeholder.style {
                     case .connecting:
@@ -157,7 +156,7 @@ struct CloudTreeRowContentView: View {
     /// stays narrow; child titles indent past it naturally. `.uppercased`
     /// styles speak in tracked mini-caps.
     private func groupRow(title: String, count: Int? = nil) -> some View {
-        HStack(alignment: .firstTextBaseline, spacing: style.iconGap) {
+        HStack(alignment: .center, spacing: style.iconGap) {
             HStack(alignment: .firstTextBaseline, spacing: CloudTreeRowGrid.detailGap) {
                 Text(style.groupLabelStyle == .uppercased ? title.uppercased() : title)
                     .tracking(style.groupLabelStyle == .uppercased ? 0.8 : 0)
@@ -228,7 +227,6 @@ struct CloudTreeLeafRow<Accessories: View>: View {
     var titleWeight: Font.Weight = .regular
     var titleDimmed: Bool = false
     var detail: String?
-    var showsOpenMark: Bool = false
     @ViewBuilder var accessories: () -> Accessories
 
     init(
@@ -239,7 +237,6 @@ struct CloudTreeLeafRow<Accessories: View>: View {
         titleWeight: Font.Weight = .regular,
         titleDimmed: Bool = false,
         detail: String? = nil,
-        showsOpenMark: Bool = false,
         @ViewBuilder accessories: @escaping () -> Accessories
     ) {
         self.style = style
@@ -249,12 +246,11 @@ struct CloudTreeLeafRow<Accessories: View>: View {
         self.titleWeight = titleWeight
         self.titleDimmed = titleDimmed
         self.detail = detail
-        self.showsOpenMark = showsOpenMark
         self.accessories = accessories
     }
 
     var body: some View {
-        HStack(alignment: style.leafLayout == .twoLine ? .center : .firstTextBaseline, spacing: style.iconGap) {
+        HStack(alignment: .center, spacing: style.iconGap) {
             if style.iconSlot > 0 {
                 CloudTreeRowIcon(style: style, systemName: icon, tint: tint, dimmed: titleDimmed)
             }
@@ -287,15 +283,6 @@ struct CloudTreeLeafRow<Accessories: View>: View {
                 }
             }
             accessories()
-            if showsOpenMark {
-                // "eye": a pane on this Mac is showing it. (Not
-                // rectangle.on.rectangle, which reads as a copy button.)
-                Image(systemName: "eye")
-                    .font(.system(size: 9.5, weight: .regular))
-                    .foregroundStyle(.tertiary)
-                    .frame(width: CloudTreeRowGrid.trailingSlot, alignment: .center)
-                    .help(String(localized: "cloudTree.terminal.open", defaultValue: "Open in a pane"))
-            }
         }
         .padding(.trailing, CloudTreeRowGrid.trailingPadding)
     }
@@ -325,8 +312,7 @@ extension CloudTreeLeafRow where Accessories == EmptyView {
         title: String,
         titleWeight: Font.Weight = .regular,
         titleDimmed: Bool = false,
-        detail: String? = nil,
-        showsOpenMark: Bool = false
+        detail: String? = nil
     ) {
         self.init(
             style: style,
@@ -336,7 +322,6 @@ extension CloudTreeLeafRow where Accessories == EmptyView {
             titleWeight: titleWeight,
             titleDimmed: titleDimmed,
             detail: detail,
-            showsOpenMark: showsOpenMark,
             accessories: { EmptyView() }
         )
     }
@@ -358,8 +343,7 @@ struct CloudTreeTerminalRowContent: View {
             tint: CloudTreeIconPalette.terminal,
             title: terminal.title.isEmpty ? String(localized: "cloudTree.terminal.untitled", defaultValue: "terminal") : terminal.title,
             titleDimmed: terminal.lifecycle == .exited,
-            detail: terminal.detail.flatMap { $0.isEmpty ? nil : Self.abbreviated($0) },
-            showsOpenMark: row.isOpen
+            detail: terminal.detail.flatMap { $0.isEmpty ? nil : Self.abbreviated($0) }
         ) {
             if let agent = agentLabel {
                 Image(systemName: "sparkle")
@@ -453,7 +437,7 @@ struct CloudTreeLocalMachineRowContent: View {
         switch style.machineRowLayout {
         case .singleLine:
             CloudTreeMachineBand(style: style) {
-                HStack(alignment: .firstTextBaseline, spacing: CloudTreeRowGrid.dotGap) {
+                HStack(alignment: .center, spacing: CloudTreeRowGrid.dotGap) {
                     Image(systemName: "laptopcomputer")
                         .font(.system(size: max(style.iconSize, 9), weight: .regular))
                         .foregroundStyle(style.iconTreatment == .monochrome ? AnyShapeStyle(.secondary) : AnyShapeStyle(CloudTreeIconPalette.machine))
@@ -547,9 +531,16 @@ struct CloudTreeMachineRowContent: View {
             // Finder-like: dot, name, one dim inline fact. Everything else is
             // in the tooltip and the context menu.
             CloudTreeMachineBand(style: style) {
-                HStack(alignment: .firstTextBaseline, spacing: CloudTreeRowGrid.dotGap) {
-                    activityDot
-                        .frame(width: CloudTreeRowGrid.dotSlot, alignment: .center)
+                // No status dot (lawrence, 2026-08-27): the name starts right after
+                // the chevron. A locked (free-window-expired) machine keeps a lock
+                // glyph — that one changes what a click does.
+                HStack(alignment: .center, spacing: CloudTreeRowGrid.dotGap) {
+                    if machine.freeAccess == .expired {
+                        Image(systemName: "lock.fill")
+                            .font(.system(size: 8, weight: .semibold))
+                            .foregroundStyle(.secondary)
+                            .frame(width: CloudTreeRowGrid.dotSlot, alignment: .center)
+                    }
                     Text(machine.displayName)
                         .cmuxFont(size: style.machineNameSize, weight: style.machineBand ? .semibold : .medium, design: style.fontDesign)
                         .foregroundStyle(.primary)
@@ -568,11 +559,16 @@ struct CloudTreeMachineRowContent: View {
             .accessibilityElement(children: .combine)
             .accessibilityLabel("\(machine.displayName), \(machine.activityLabel)")
         case .twoLine:
-            // Top-aligned: the dot and the outline's chevron both sit on the name line
-            // (see `CloudTreeNSOutlineView.frameOfOutlineCell`), not on the row's middle.
+            // Top-aligned: the chevron sits on the name line (see
+            // `CloudTreeNSOutlineView.frameOfOutlineCell`), not on the row's middle.
+            // No status dot; only the expired lock earns the leading slot.
             HStack(alignment: .top, spacing: CloudTreeRowGrid.dotGap) {
-                activityDot
-                    .frame(width: CloudTreeRowGrid.dotSlot, height: style.machineNameLineHeight, alignment: .center)
+                if machine.freeAccess == .expired {
+                    Image(systemName: "lock.fill")
+                        .font(.system(size: 8, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                        .frame(width: CloudTreeRowGrid.dotSlot, height: style.machineNameLineHeight, alignment: .center)
+                }
                 VStack(alignment: .leading, spacing: CloudTreeRowGrid.machineLineSpacing) {
                     Text(machine.displayName)
                         .cmuxFont(size: style.machineNameSize, weight: .medium, design: style.fontDesign)
@@ -603,30 +599,6 @@ struct CloudTreeMachineRowContent: View {
             .padding(.trailing, CloudTreeRowGrid.trailingPadding)
             .accessibilityElement(children: .combine)
             .accessibilityLabel("\(machine.displayName), \(machine.activityLabel)")
-        }
-    }
-
-    @ViewBuilder
-    private var activityDot: some View {
-        if machine.freeAccess == .expired {
-            Image(systemName: "lock.fill")
-                .font(.system(size: 8, weight: .semibold))
-                .foregroundStyle(.secondary)
-        } else {
-            Circle()
-                .fill(dotColor)
-                .frame(width: 7, height: 7)
-        }
-    }
-
-    /// The one colored element in the monochrome trees: the sidebar's semantic
-    /// status colors (running, pending, needs attention), so a glance still
-    /// answers "is it up".
-    private var dotColor: Color {
-        switch machine.activity {
-        case .ready: return Color.green.opacity(0.85)
-        case .pending: return Color.orange.opacity(0.9)
-        case .attention: return Color.red.opacity(0.85)
         }
     }
 
@@ -742,7 +714,7 @@ struct CloudTreeRowHoverButtons: View {
             }
         case .terminal(let row):
             if !row.resource.machine.isLocal {
-                xmark(String(localized: "cloudTree.row.closeTerminal", defaultValue: "Close Terminal")) {
+                xmark(String(localized: "cloudTree.menu.killTerminal", defaultValue: "Kill Terminal\u{2026}")) {
                     nodeActions.closeTerminal(row.resource.id)
                 }
             }

--- a/Sources/Cloud/CloudTreeStyle.swift
+++ b/Sources/Cloud/CloudTreeStyle.swift
@@ -96,15 +96,17 @@ struct CloudTreeStyle: Equatable, Identifiable, Sendable {
 
     // MARK: Presets
 
-    /// The default: quiet Finder-like single lines, monochrome glyphs, tight.
+    /// The default: quiet Finder-like single lines, monochrome glyphs. Sized like
+    /// the system sidebar (13pt titles; lawrence, 2026-08-27: the old 11.5 read
+    /// too small next to the Files tree).
     static let compact = CloudTreeStyle(
         id: "compact", name: "Compact",
-        rowHeight: 20, machineRowLayout: .singleLine, leafLayout: .singleLine,
+        rowHeight: 24, machineRowLayout: .singleLine, leafLayout: .singleLine,
         iconTreatment: .monochrome, groupLabelStyle: .plain, metaPlacement: .inline,
         machineBand: false, monospacedText: false, rowSeparators: false,
-        indentPerLevel: 11,
-        machineNameSize: 12, titleSize: 11.5, detailSize: 10, groupLabelSize: 10.5,
-        iconSize: 9.5, iconSlot: 14, iconGap: 6,
+        indentPerLevel: 12,
+        machineNameSize: 13, titleSize: 13, detailSize: 11, groupLabelSize: 11.5,
+        iconSize: 11, iconSlot: 16, iconGap: 7,
         showsGroupCounts: true, showsViewBadges: true, showsMachineStats: false,
         machineVerticalPadding: 3
     )

--- a/Sources/Cloud/CloudTuiCommandLine.swift
+++ b/Sources/Cloud/CloudTuiCommandLine.swift
@@ -52,9 +52,17 @@ struct CloudTuiCommandLine: Sendable {
         ["--socket", socketPath, "--json", "tab", tabID, "close"]
     }
 
-    /// `workspace <ws_id> close`: close a cmux-tui workspace and everything in it.
+    /// `workspace <ws_id> close`: remove the workspace view. Its terminals detach
+    /// (alive, zero views) rather than die (`spec/cli.md`) — close them first for
+    /// a full delete.
     static func closeWorkspaceArguments(socketPath: String, workspaceID: String) -> [String] {
         ["--socket", socketPath, "--json", "workspace", workspaceID, "close"]
+    }
+
+    /// `workspace <ws_id> rename --name <name>` (verified live: the positional
+    /// form is `usage.invalid`; the name rides the `--name` flag).
+    static func renameWorkspaceArguments(socketPath: String, workspaceID: String, name: String) -> [String] {
+        ["--socket", socketPath, "--json", "workspace", workspaceID, "rename", "--name", name]
     }
 
     /// `attach --terminal <term_id>`: render exactly one remote terminal into this tty.

--- a/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
+++ b/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
@@ -398,6 +398,19 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
         return workspace
     }
 
+    func renameRemoteWorkspace(id: String, name: String) async throws {
+        let connected = try await links.connected(machineID: machineID)
+        guard let link = await links.link(machineID: machineID) else { throw ProviderError.machineAsleep(machineID) }
+        _ = try await link.run(arguments: CloudTuiCommandLine.renameWorkspaceArguments(socketPath: connected.socketPath, workspaceID: id, name: name))
+        info.remoteWorkspaces = info.remoteWorkspaces?.map { workspace in
+            var renamed = workspace
+            if workspace.id == id { renamed.name = name }
+            return renamed
+        }
+        catalog.updateMachine(info)
+        scheduleRefresh()
+    }
+
     /// The terminal lives in the machine's session; only the local pane went away.
     func projectionDidEnd(_ projection: SurfaceProjection) {
         materializedPanels.remove(projection.panelID)

--- a/Sources/Surfaces/SurfaceCatalog.swift
+++ b/Sources/Surfaces/SurfaceCatalog.swift
@@ -25,8 +25,12 @@ protocol SurfaceProvider: AnyObject {
     /// Create a new, empty workspace on this machine, directly (not as a side effect of
     /// creating a terminal). Providers without remote workspaces refuse.
     func createRemoteWorkspace(name: String?) async throws -> SurfaceRemoteWorkspace
-    /// Close a workspace on this machine and every terminal in it.
+    /// Close a workspace view on this machine. Its terminals detach into the pool
+    /// (`spec/cli.md`: only `terminal close` kills); callers wanting a full delete
+    /// close each terminal first.
     func closeRemoteWorkspace(id: String) async throws
+    /// Rename a remote workspace.
+    func renameRemoteWorkspace(id: String, name: String) async throws
     /// Close a projection's pane: a materialization that lost a race with an existing
     /// projection, or a URL-backed pane whose machine was unregistered. The default
     /// implementation handles providers that use the shared pane factory; providers may
@@ -45,6 +49,9 @@ extension SurfaceProvider {
     }
     func closeRemoteWorkspace(id: String) async throws {
         throw SurfaceCatalogError.unsupported("closing workspaces on \(machine)")
+    }
+    func renameRemoteWorkspace(id: String, name: String) async throws {
+        throw SurfaceCatalogError.unsupported("workspaces on \(machine)")
     }
     @discardableResult
     func discardMaterialization(_ projection: SurfaceProjection) -> Bool {

--- a/cmuxTests/CmuxTuiSurfaceProviderTests.swift
+++ b/cmuxTests/CmuxTuiSurfaceProviderTests.swift
@@ -229,6 +229,9 @@ import Testing
         #expect(CloudTuiCommandLine.commandStartingIn(cwd: nil, command: ["bash", "-l"]) == ["bash", "-l"])
         #expect(CloudTuiCommandLine.commandStartingIn(cwd: "/root/work/my app", command: ["codex", "exec", "it's"]) ==
             ["sh", "-lc", "cd '/root/work/my app' && exec codex exec 'it'\\''s'"])
+        // Rename takes the name via --name (verified live; positional is usage.invalid).
+        #expect(CloudTuiCommandLine.renameWorkspaceArguments(socketPath: "/k.sock", workspaceID: "ws_main", name: "backend work") ==
+            ["--socket", "/k.sock", "--json", "workspace", "ws_main", "rename", "--name", "backend work"])
     }
 
     @Test func clientPathsMirrorTheCLI() throws {

--- a/cmuxTests/MachinesPanelModelTests.swift
+++ b/cmuxTests/MachinesPanelModelTests.swift
@@ -457,6 +457,16 @@ final class MachinesPanelModelTests: XCTestCase {
         XCTAssertTrue(flattened[0].isMachineRow)
         XCTAssertTrue(flattened[3].isMachineRow)
         XCTAssertEqual(flattened[3].machine, .cloud("vivid-newt"))
+        // Only terminals and displays leave the tree by drag; workspaces,
+        // browsers, machines, and headers do not.
+        for node in flattened {
+            switch node.kind {
+            case .terminal, .display:
+                XCTAssertTrue(node.isDragSource, "\(node.id) should drag")
+            default:
+                XCTAssertFalse(node.isDragSource, "\(node.id) should not drag")
+            }
+        }
     }
 
     func testCloudTreeLocalBrowsersGroupAndEmptyLocalPlaceholder() {


### PR DESCRIPTION
Re-lands the post-#10916 cloud-tree round on current main. The old shared wave-0 branch went stale against the #10948 squash; this PR carries the reconciled delta only (12 files), with the stale branch's unrelated regressions excluded.

**Verbs.** Workspace rows: Rename… (`workspace <id> rename --name`, verified against a live daemon — the positional form is `usage.invalid`), Close Workspace (Keep Terminals) — the daemon's `workspace close` only detaches (`spec/cli.md`) — and Delete Workspace and Terminals… (confirmed; closes each terminal first). Terminal rows: Kill Terminal… with a confirm; panes keep their scrollback. New provider seam `renameRemoteWorkspace`; close paths reuse #10948's `closeTerminal`/`closeRemoteWorkspace`.

**Click semantics (D13).** Remote and local workspaces never intermingle. A workspace row toggles on single click; double-click and Return open it as its own local workspace (`openGroupAsWorkspace`), or focus the pane already showing one of its terminals. One "Open Workspace" menu verb replaces open-all-here/new-tabs.

**Drag.** Only terminal and display rows write a drag payload (`isDragSource` gates the pasteboard writer); workspace, browser, and port rows refuse.

**Visuals.** 13pt system-sidebar type on 24pt rows; no activity dot (the expired lock stays); no open-eye marker; `.center` row stacks so dots/badges/spinners stop hanging off the text baseline; chevron gap 6→10; gray selection in both focus states with `.normal` interior text; and the outline column width recomputed from bounds on every `layout()` pass, eliminating the wrong-until-divider-drag width class.

Strings localized (en/ja); orphaned keys removed. Focused tests updated (`CmuxTuiSurfaceProviderTests` argv grammar, `MachinesPanelModelTests` drag-source sweep).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-lands the post-#10916 cloud-tree round on current main, adding confirmed context-menu verbs, D13 workspace double-click behavior, drag gating to terminals and displays, and sidebar-matched row styling.

**Context-menu verbs**
- Workspace rows gain Rename…, Close Workspace (Keep Terminals), and Delete Workspace and Terminals…; all strings are localized.
- Delete kills each terminal first because the daemon's `workspace close` only detaches them, and re-enumerates the terminal list at operation time so a terminal created while the confirm dialog was up dies too.
- Kill Terminal… confirms and leaves panes' scrollback in place.
- Adds a `renameRemoteWorkspace` seam to `SurfaceProvider`; rename passes the name via `--name`.

**Clicks, drag, and visuals**
- Workspace rows toggle on single click; double-click opens them as their own local workspace or focuses a pane already showing one of their terminals.
- The open-all-here and open-all-in-new-tabs entries merge into one Open Workspace verb that rides the same focus-if-open path as double-click.
- Only terminal and display rows write drag payloads; workspace, browser, and port rows have none.
- Rows switch to 13pt type at 24pt height, drop the activity dot and open-eye marker, and restack on center alignment.
- Column width is recomputed from bounds on each layout pass, fixing the wrong width until a divider drag.

<sup>Written for commit d9646e350bcd5db20458899ff66f4a19df9d0a14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workspace renaming and deletion with confirmation dialogs.
  * Added destructive confirmation before killing terminals.
  * Simplified workspace opening across clicks, double-clicks, Return, and menus.
  * Limited cloud-tree dragging to terminals and displays.
* **Bug Fixes**
  * Closing a workspace now keeps its terminals available.
  * Refined selection highlights, row layout, access-status indicators, and compact display sizing.
* **Localization**
  * Added English and Japanese translations for workspace and terminal management dialogs, actions, and progress messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->