### PR TITLE
cmux-tui-cdp: redact ACK overflow diagnostics

### DIFF
--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -10,6 +10,7 @@ use std::sync::mpsc::{
 use std::sync::{Arc, Condvar, Mutex, Weak};
 use std::time::{Duration, Instant};
 
+use anyhow::Context;
 use base64::Engine;
 use serde_json::{Value, json};
 use tungstenite::client::IntoClientRequest;
@@ -39,6 +40,9 @@ pub const CDP_EVENT_QUEUE_MAX_BYTES: usize = 32 * 1024 * 1024;
 /// full, so a blocked reader cannot block the TUI thread indefinitely.
 const CDP_OUTBOUND_QUEUE_CAPACITY: usize = 256;
 const CDP_OUTBOUND_QUEUE_MAX_BYTES: usize = 8 * 1024 * 1024;
+const CDP_CONNECTION_UNAVAILABLE_MESSAGE: &str =
+    "browser connection unavailable; retry the command";
+const CDP_OUTBOUND_QUEUE_BYTE_BUDGET_DETAIL: &str = "CDP outbound queue byte budget exceeded";
 const MAX_ENCODED_FRAME_BYTES: usize = 16 * 1024 * 1024;
 const MAX_DECODED_FRAME_BYTES: usize = 12 * 1024 * 1024;
 const TIMESTAMPLESS_CAPTURE_INTERVAL: Duration = Duration::from_secs(1);
@@ -1418,9 +1422,9 @@ fn reserve_outbound_bytes(inner: &Inner, bytes: usize) -> anyhow::Result<()> {
         let current = inner.outbound_bytes.load(Ordering::Acquire);
         let next = current
             .checked_add(bytes)
-            .ok_or_else(|| anyhow::anyhow!("CDP outbound queue byte budget exceeded"))?;
+            .ok_or_else(outbound_byte_budget_error)?;
         if next > inner.outbound_byte_budget as u64 {
-            anyhow::bail!("CDP outbound queue byte budget exceeded");
+            return Err(outbound_byte_budget_error());
         }
         if inner
             .outbound_bytes
@@ -1430,6 +1434,11 @@ fn reserve_outbound_bytes(inner: &Inner, bytes: usize) -> anyhow::Result<()> {
             return Ok(());
         }
     }
+}
+
+fn outbound_byte_budget_error() -> anyhow::Error {
+    anyhow::anyhow!(CDP_OUTBOUND_QUEUE_BYTE_BUDGET_DETAIL)
+        .context(CDP_CONNECTION_UNAVAILABLE_MESSAGE)
 }
 
 fn outbound_bytes_sub(inner: &Inner, bytes: usize) {
@@ -1841,8 +1850,9 @@ fn ack_screencast_frame(inner: &Arc<Inner>, target_session: &str, frame_session:
         "params": { "sessionId": frame_session },
     });
     let Ok(text) = serde_json::to_string(&msg) else { return };
-    if reserve_outbound_bytes(inner, text.len()).is_err() {
-        close_inner(inner, "CDP outbound queue byte budget exceeded");
+    if let Err(error) = reserve_outbound_bytes(inner, text.len()) {
+        eprintln!("cmux-tui-cdp: screencast acknowledgment rejected: {error:#}");
+        close_inner(inner, CDP_CONNECTION_UNAVAILABLE_MESSAGE);
         return;
     }
     if let Err(error) = inner.outbound.try_send(Outbound::Message(text)) {

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -1420,9 +1420,7 @@ fn reserve_outbound_bytes(inner: &Inner, bytes: usize) -> anyhow::Result<()> {
     let bytes = u64::try_from(bytes).unwrap_or(u64::MAX);
     loop {
         let current = inner.outbound_bytes.load(Ordering::Acquire);
-        let next = current
-            .checked_add(bytes)
-            .ok_or_else(outbound_byte_budget_error)?;
+        let next = current.checked_add(bytes).ok_or_else(outbound_byte_budget_error)?;
         if next > inner.outbound_byte_budget as u64 {
             return Err(outbound_byte_budget_error());
         }
@@ -1580,7 +1578,9 @@ fn handle_text(inner: &Arc<Inner>, text: &str) {
                 let Some(ack_id) = params.get("sessionId").and_then(|value| value.as_u64()) else {
                     return;
                 };
-                ack_screencast_frame(inner, target_session, ack_id);
+                ack_screencast_frame(inner, target_session, ack_id, |message| {
+                    eprintln!("{message}");
+                });
                 let (
                     frame_epoch,
                     navigation_epoch,
@@ -1841,7 +1841,14 @@ fn dispatch_event(inner: &Arc<Inner>, event: CdpEvent) {
     }
 }
 
-fn ack_screencast_frame(inner: &Arc<Inner>, target_session: &str, frame_session: u64) {
+const CDP_ACK_REJECTED_DIAGNOSTIC: &str = "cmux-tui-cdp: screencast acknowledgment rejected";
+
+fn ack_screencast_frame(
+    inner: &Arc<Inner>,
+    target_session: &str,
+    frame_session: u64,
+    report: impl FnOnce(&str),
+) {
     let id = inner.next_id.fetch_add(1, Ordering::Relaxed);
     let msg = json!({
         "id": id,
@@ -1850,8 +1857,10 @@ fn ack_screencast_frame(inner: &Arc<Inner>, target_session: &str, frame_session:
         "params": { "sessionId": frame_session },
     });
     let Ok(text) = serde_json::to_string(&msg) else { return };
-    if let Err(error) = reserve_outbound_bytes(inner, text.len()) {
-        eprintln!("cmux-tui-cdp: screencast acknowledgment rejected: {error:#}");
+    if reserve_outbound_bytes(inner, text.len()).is_err() {
+        // Keep queue and protocol details out of stderr. The close event
+        // carries the stable recovery message to callers.
+        report(CDP_ACK_REJECTED_DIAGNOSTIC);
         close_inner(inner, CDP_CONNECTION_UNAVAILABLE_MESSAGE);
         return;
     }
@@ -2178,7 +2187,10 @@ mod tests {
         let client = CdpClient { inner };
 
         let error = client.send_value(&json!({"payload": "0123456789"})).unwrap_err();
-        assert_eq!(error.to_string(), "browser connection unavailable; retry the command");
+        let public = error.to_string();
+        assert_eq!(public, "browser connection unavailable; retry the command");
+        assert!(!public.contains("ws://"));
+        assert!(!public.contains("CDP outbound queue byte budget exceeded"));
         assert!(format!("{error:#}").contains("CDP outbound queue byte budget exceeded"));
     }
 
@@ -2223,7 +2235,10 @@ mod tests {
     #[test]
     fn screencast_ack_byte_budget_closure_hides_internal_reason() {
         let (inner, _outbound_rx) = test_inner_with_limits(1, 1);
-        ack_screencast_frame(&inner, "session-1", 7);
+        let mut diagnostics = Vec::new();
+        ack_screencast_frame(&inner, "session-1", 7, |message| {
+            diagnostics.push(message.to_string());
+        });
 
         let (event_tx, event_rx) = sync_channel(1);
         inner.events.drain_into(&event_tx).unwrap();
@@ -2232,6 +2247,9 @@ mod tests {
         };
         assert_eq!(reason, "browser connection unavailable; retry the command");
         assert!(!reason.contains("CDP"));
+        assert_eq!(diagnostics, vec![CDP_ACK_REJECTED_DIAGNOSTIC.to_string()]);
+        assert!(!diagnostics[0].contains("ws://"));
+        assert!(!diagnostics[0].contains("queue byte budget"));
     }
 
     #[test]
@@ -2258,7 +2276,7 @@ mod tests {
     #[test]
     fn screencast_ack_queue_overflow_closes_the_connection() {
         let (inner, _outbound_rx) = test_inner_with_capacity(0);
-        ack_screencast_frame(&inner, "session-1", 7);
+        ack_screencast_frame(&inner, "session-1", 7, |_| {});
         assert!(inner.closed.load(Ordering::Acquire));
     }
 

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -1521,8 +1521,16 @@ fn drain_outbound<W: OutboundWriter>(
     loop {
         match outbound.try_recv() {
             Ok(Outbound::Message(text)) => {
-                outbound_bytes_sub(inner, text.len());
-                ws.send_text(text)?;
+                let bytes = text.len();
+                // Keep the reservation while the socket write is in progress.
+                // Release it only after the write returns, including errors.
+                match ws.send_text(text) {
+                    Ok(()) => outbound_bytes_sub(inner, bytes),
+                    Err(error) => {
+                        outbound_bytes_sub(inner, bytes);
+                        return Err(error);
+                    }
+                }
             }
             Ok(Outbound::Flush(done)) => {
                 let _ = done.send(());

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -2085,6 +2085,15 @@ mod tests {
     }
 
     #[test]
+    fn outbound_commands_fail_fast_at_the_byte_bound() {
+        let (inner, _outbound_rx) = test_inner_with_capacity(8);
+        let client = CdpClient { inner };
+
+        let error = client.send_value(&json!({"payload": "0123456789"})).unwrap_err();
+        assert!(error.to_string().contains("outbound queue byte budget"));
+    }
+
+    #[test]
     fn outbound_commands_fail_fast_at_the_queue_bound() {
         let (inner, _outbound_rx) = test_inner_with_capacity(1);
         let client = CdpClient { inner };

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -1502,16 +1502,27 @@ fn reader_loop(
     }
 }
 
-fn drain_outbound(
+trait OutboundWriter {
+    fn send_text(&mut self, text: String) -> anyhow::Result<()>;
+}
+
+impl OutboundWriter for WebSocket<TcpStream> {
+    fn send_text(&mut self, text: String) -> anyhow::Result<()> {
+        self.send(Message::Text(text.into()))?;
+        Ok(())
+    }
+}
+
+fn drain_outbound<W: OutboundWriter>(
     inner: &Arc<Inner>,
-    ws: &mut WebSocket<TcpStream>,
+    ws: &mut W,
     outbound: &Receiver<Outbound>,
 ) -> anyhow::Result<()> {
     loop {
         match outbound.try_recv() {
             Ok(Outbound::Message(text)) => {
                 outbound_bytes_sub(inner, text.len());
-                ws.send(Message::Text(text.into()))?
+                ws.send_text(text)?;
             }
             Ok(Outbound::Flush(done)) => {
                 let _ = done.send(());
@@ -2150,6 +2161,43 @@ mod tests {
 
         let error = client.send_value(&json!({"payload": "0123456789"})).unwrap_err();
         assert!(error.to_string().contains("outbound queue byte budget"));
+    }
+
+    struct BlockingOutboundWriter {
+        started: Arc<Barrier>,
+        release: Arc<Barrier>,
+    }
+
+    impl OutboundWriter for BlockingOutboundWriter {
+        fn send_text(&mut self, _text: String) -> anyhow::Result<()> {
+            self.started.wait();
+            self.release.wait();
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn outbound_bytes_remain_reserved_while_write_is_in_flight() {
+        let value = json!({"payload": "0123456789"});
+        let message_bytes = serde_json::to_string(&value).unwrap().len();
+        let (inner, outbound_rx) = test_inner_with_limits(2, message_bytes);
+        let client = CdpClient { inner: inner.clone() };
+        client.send_value(&value).unwrap();
+
+        let started = Arc::new(Barrier::new(2));
+        let release = Arc::new(Barrier::new(2));
+        let writer = BlockingOutboundWriter { started: started.clone(), release: release.clone() };
+        let drain_inner = inner.clone();
+        let drain = thread::spawn(move || {
+            let mut writer = writer;
+            drain_outbound(&drain_inner, &mut writer, &outbound_rx).unwrap();
+        });
+
+        started.wait();
+        let error = client.send_value(&value).unwrap_err();
+        assert!(error.to_string().contains("outbound queue byte budget"));
+        release.wait();
+        drain.join().unwrap();
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -38,6 +38,7 @@ pub const CDP_EVENT_QUEUE_MAX_BYTES: usize = 32 * 1024 * 1024;
 /// unbounded number of JSON messages. Callers fail fast when the queue is
 /// full, so a blocked reader cannot block the TUI thread indefinitely.
 const CDP_OUTBOUND_QUEUE_CAPACITY: usize = 256;
+const CDP_OUTBOUND_QUEUE_MAX_BYTES: usize = 8 * 1024 * 1024;
 const MAX_ENCODED_FRAME_BYTES: usize = 16 * 1024 * 1024;
 const MAX_DECODED_FRAME_BYTES: usize = 12 * 1024 * 1024;
 const TIMESTAMPLESS_CAPTURE_INTERVAL: Duration = Duration::from_secs(1);
@@ -282,6 +283,8 @@ pub struct CdpClient {
 
 struct Inner {
     outbound: SyncSender<Outbound>,
+    outbound_bytes: AtomicU64,
+    outbound_byte_budget: usize,
     pending: Mutex<HashMap<u64, PendingCall>>,
     events: Arc<EventQueue>,
     frame_epochs: Mutex<HashMap<String, FrameSession>>,
@@ -578,6 +581,8 @@ impl CdpClient {
         let client = CdpClient {
             inner: Arc::new(Inner {
                 outbound: outbound_tx,
+                outbound_bytes: AtomicU64::new(0),
+                outbound_byte_budget: CDP_OUTBOUND_QUEUE_MAX_BYTES,
                 pending: Mutex::new(HashMap::new()),
                 events: event_queue,
                 frame_epochs: Mutex::new(HashMap::new()),
@@ -1383,8 +1388,20 @@ impl CdpClient {
         if cdp_debug() {
             eprintln!("cdp-> {text}");
         }
-        self.inner.outbound.try_send(Outbound::Message(text)).map_err(outbound_send_error)?;
+        reserve_outbound_bytes(&self.inner, text.len())?;
+        if let Err(error) = self.inner.outbound.try_send(Outbound::Message(text)) {
+            outbound_bytes_sub(&self.inner, outbound_bytes(&error));
+            return Err(outbound_send_error(error));
+        }
         Ok(())
+    }
+}
+
+fn outbound_bytes(error: &TrySendError<Outbound>) -> usize {
+    match error {
+        TrySendError::Full(Outbound::Message(text))
+        | TrySendError::Disconnected(Outbound::Message(text)) => text.len(),
+        _ => 0,
     }
 }
 
@@ -1393,6 +1410,30 @@ fn outbound_send_error(error: TrySendError<Outbound>) -> anyhow::Error {
         TrySendError::Full(_) => anyhow::anyhow!("CDP outbound queue is full"),
         TrySendError::Disconnected(_) => anyhow::anyhow!("CDP connection is closed"),
     }
+}
+
+fn reserve_outbound_bytes(inner: &Inner, bytes: usize) -> anyhow::Result<()> {
+    let bytes = u64::try_from(bytes).unwrap_or(u64::MAX);
+    loop {
+        let current = inner.outbound_bytes.load(Ordering::Acquire);
+        let next = current
+            .checked_add(bytes)
+            .ok_or_else(|| anyhow::anyhow!("CDP outbound queue byte budget exceeded"))?;
+        if next > inner.outbound_byte_budget as u64 {
+            anyhow::bail!("CDP outbound queue byte budget exceeded");
+        }
+        if inner
+            .outbound_bytes
+            .compare_exchange(current, next, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            return Ok(());
+        }
+    }
+}
+
+fn outbound_bytes_sub(inner: &Inner, bytes: usize) {
+    inner.outbound_bytes.fetch_sub(bytes as u64, Ordering::AcqRel);
 }
 
 pub fn resolve_browser_ws_url(input: &str) -> anyhow::Result<String> {
@@ -1426,7 +1467,7 @@ fn reader_loop(
         if inner.closed.load(Ordering::Acquire) {
             break;
         }
-        if let Err(err) = drain_outbound(&mut ws, outbound) {
+        if let Err(err) = drain_outbound(&inner, &mut ws, outbound) {
             close_inner(&inner, &format!("CDP socket error: {err}"));
             break;
         }
@@ -1462,12 +1503,16 @@ fn reader_loop(
 }
 
 fn drain_outbound(
+    inner: &Arc<Inner>,
     ws: &mut WebSocket<TcpStream>,
     outbound: &Receiver<Outbound>,
 ) -> anyhow::Result<()> {
     loop {
         match outbound.try_recv() {
-            Ok(Outbound::Message(text)) => ws.send(Message::Text(text.into()))?,
+            Ok(Outbound::Message(text)) => {
+                outbound_bytes_sub(inner, text.len());
+                ws.send(Message::Text(text.into()))?
+            }
             Ok(Outbound::Flush(done)) => {
                 let _ = done.send(());
             }
@@ -1777,7 +1822,12 @@ fn ack_screencast_frame(inner: &Arc<Inner>, target_session: &str, frame_session:
         "params": { "sessionId": frame_session },
     });
     let Ok(text) = serde_json::to_string(&msg) else { return };
+    if reserve_outbound_bytes(inner, text.len()).is_err() {
+        close_inner(inner, "CDP outbound queue byte budget exceeded");
+        return;
+    }
     if let Err(error) = inner.outbound.try_send(Outbound::Message(text)) {
+        outbound_bytes_sub(inner, outbound_bytes(&error));
         let reason = match error {
             TrySendError::Full(_) => "CDP outbound queue overflow",
             TrySendError::Disconnected(_) => "CDP connection is closed",
@@ -2063,14 +2113,23 @@ mod tests {
     use super::*;
 
     fn test_inner() -> (Arc<Inner>, Receiver<Outbound>) {
-        test_inner_with_capacity(256)
+        test_inner_with_limits(256, CDP_OUTBOUND_QUEUE_MAX_BYTES)
     }
 
     fn test_inner_with_capacity(capacity: usize) -> (Arc<Inner>, Receiver<Outbound>) {
+        test_inner_with_limits(capacity, CDP_OUTBOUND_QUEUE_MAX_BYTES)
+    }
+
+    fn test_inner_with_limits(
+        capacity: usize,
+        outbound_byte_budget: usize,
+    ) -> (Arc<Inner>, Receiver<Outbound>) {
         let (outbound, outbound_rx) = std::sync::mpsc::sync_channel(capacity);
         (
             Arc::new(Inner {
                 outbound,
+                outbound_bytes: AtomicU64::new(0),
+                outbound_byte_budget,
                 pending: Mutex::new(HashMap::new()),
                 events: Arc::new(EventQueue::new()),
                 frame_epochs: Mutex::new(HashMap::new()),
@@ -2086,7 +2145,7 @@ mod tests {
 
     #[test]
     fn outbound_commands_fail_fast_at_the_byte_bound() {
-        let (inner, _outbound_rx) = test_inner_with_capacity(8);
+        let (inner, _outbound_rx) = test_inner_with_limits(8, 16);
         let client = CdpClient { inner };
 
         let error = client.send_value(&json!({"payload": "0123456789"})).unwrap_err();

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -2168,7 +2168,8 @@ mod tests {
         let client = CdpClient { inner };
 
         let error = client.send_value(&json!({"payload": "0123456789"})).unwrap_err();
-        assert!(error.to_string().contains("outbound queue byte budget"));
+        assert_eq!(error.to_string(), "browser connection unavailable; retry the command");
+        assert!(format!("{error:#}").contains("CDP outbound queue byte budget exceeded"));
     }
 
     struct BlockingOutboundWriter {
@@ -2203,9 +2204,24 @@ mod tests {
 
         started.wait();
         let error = client.send_value(&value).unwrap_err();
-        assert!(error.to_string().contains("outbound queue byte budget"));
+        assert_eq!(error.to_string(), "browser connection unavailable; retry the command");
+        assert!(format!("{error:#}").contains("CDP outbound queue byte budget exceeded"));
         release.wait();
         drain.join().unwrap();
+    }
+
+    #[test]
+    fn screencast_ack_byte_budget_closure_hides_internal_reason() {
+        let (inner, _outbound_rx) = test_inner_with_limits(1, 1);
+        ack_screencast_frame(&inner, "session-1", 7);
+
+        let (event_tx, event_rx) = sync_channel(1);
+        inner.events.drain_into(&event_tx).unwrap();
+        let CdpEvent::Closed(reason) = event_rx.recv().unwrap() else {
+            panic!("expected a close event");
+        };
+        assert_eq!(reason, "browser connection unavailable; retry the command");
+        assert!(!reason.contains("CDP"));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -8828,7 +8828,8 @@ fn run_with_machine_updates_inner(
             let _ = browser_failure_tx.send(AppEvent::BrowserResizeFailed(failure));
         },
         move |error| {
-            let message = localization::catalog().browser.control_failed(&error);
+            crate::client_log::error("browser-control", &error);
+            let message = localization::catalog().browser.control_unavailable();
             let _ = browser_control_tx.send(AppEvent::Mux(MuxEvent::Status(message)));
         },
     )?;

--- a/cmux-tui/crates/cmux-tui/src/localization.rs
+++ b/cmux-tui/crates/cmux-tui/src/localization.rs
@@ -249,6 +249,7 @@ pub(crate) struct ShortcutMessages {
 pub(crate) struct BrowserMessages {
     failed_prefix: &'static str,
     control_failed: &'static str,
+    control_unavailable: &'static str,
     not_responding: &'static str,
     resize_recovery: &'static str,
     new_page_verification_prefix: &'static str,
@@ -267,6 +268,10 @@ pub(crate) struct BrowserMessages {
 impl BrowserMessages {
     pub(crate) fn control_failed(&self, error: &str) -> String {
         self.control_failed.replace("{error}", error)
+    }
+
+    pub(crate) fn control_unavailable(&self) -> String {
+        self.control_failed.replace("{error}", self.control_unavailable)
     }
 
     pub(crate) fn loading(&self, url: &str) -> String {
@@ -1333,6 +1338,7 @@ edits shell files. Authenticate with the configured host before retrying.
     browser: BrowserMessages {
         failed_prefix: "browser failed: ",
         control_failed: "browser command failed: {error}",
+        control_unavailable: "browser connection unavailable; retry the command",
         not_responding: "browser failed: browser is not responding",
         resize_recovery: "browser failed: browser resize recovery failed; reload to retry",
         new_page_verification_prefix: "browser failed: could not verify new page pixels: ",
@@ -1978,6 +1984,7 @@ cmux machine-agent - ローカルの cmux セッションをリモートサー�
     browser: BrowserMessages {
         failed_prefix: "ブラウザでエラーが発生しました: ",
         control_failed: "ブラウザ操作に失敗しました: {error}",
+        control_unavailable: "ブラウザ接続を利用できません。コマンドを再試行してください",
         not_responding: "ブラウザが応答していません",
         resize_recovery: "ブラウザのサイズ変更を復旧できませんでした。再読み込みして再試行してください",
         new_page_verification_prefix: "新しいページの表示を確認できませんでした: ",


### PR DESCRIPTION
Stacked on [#11013](https://github.com/manaflow-ai/cmux/pull/11013).

This keeps the existing fail-closed ACK overflow behavior, but removes the raw anyhow pretty-format from stderr. Queue and protocol details stay out of the user-facing diagnostic stream. The close event still carries the stable recovery message.

The existing byte-budget behavior test now asserts that public text contains neither endpoint-like `ws://` data nor the internal queue-budget detail. The internal pretty format remains available to tests and trusted diagnostics where needed.

Static checks:
- `git diff --check`
- `rustup run 1.95.0 rustfmt --edition 2024 --check cmux-tui/crates/cmux-tui-cdp/src/client.rs`

No local Cargo tests or builds were run, per `cmux-tui/AGENTS.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the fail-closed CDP outbound behavior but redacts internal details from user-facing diagnostics. The outbound queue is byte-capped and bytes are held through socket writes, while ack-overflow and transport errors no longer expose endpoints or queue-budget internals. The close event still carries the stable recovery message. The byte-budget test now asserts public text contains neither endpoint-like `ws://` data nor queue-budget details; the internal pretty format remains available to tests and trusted diagnostics.

<sup>Written for commit 46fe5348e2631769c4e9482e1127ad0c75a8dbff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

