### PR TITLE
mac auth: release builds use cmux.com as the account API origin (api.cmux.sh is the retired Render service)

### DIFF
--- a/Sources/Auth/AuthEnvironment.swift
+++ b/Sources/Auth/AuthEnvironment.swift
@@ -457,7 +457,9 @@ enum AuthEnvironment {
         if isDebugBuild {
             return "http://localhost:\(resolvedCmuxPort(environment: environment))"
         }
-        return "https://api.cmux.sh"
+        // Same origin as the VM API and the website; api.cmux.sh is the retired manaflow
+        // Render service (maintenance mode) and never served these routes.
+        return "https://cmux.com"
     }
 
     static var stackBaseURL: URL {

--- a/Sources/Auth/AuthEnvironment.swift
+++ b/Sources/Auth/AuthEnvironment.swift
@@ -438,16 +438,26 @@ enum AuthEnvironment {
     }
 
     private static var defaultAPIBaseURL: String {
-        if let url = ProcessInfo.processInfo.environment["CMUX_API_BASE_URL"]?
+        #if DEBUG
+        let isDebugBuild = true
+        #else
+        let isDebugBuild = false
+        #endif
+        return resolvedDefaultAPIBaseURL(environment: ProcessInfo.processInfo.environment, isDebugBuild: isDebugBuild)
+    }
+
+    /// The account API origin (billing plan, client config, devices, auth recovery):
+    /// `CMUX_API_BASE_URL` when set, else the dev web server in Debug builds.
+    static func resolvedDefaultAPIBaseURL(environment: [String: String], isDebugBuild: Bool) -> String {
+        if let url = environment["CMUX_API_BASE_URL"]?
             .trimmingCharacters(in: .whitespacesAndNewlines),
            !url.isEmpty {
             return url
         }
-        #if DEBUG
-        return "http://localhost:\(cmuxPort)"
-        #else
+        if isDebugBuild {
+            return "http://localhost:\(resolvedCmuxPort(environment: environment))"
+        }
         return "https://api.cmux.sh"
-        #endif
     }
 
     static var stackBaseURL: URL {

--- a/cmuxTests/AuthEnvironmentTests.swift
+++ b/cmuxTests/AuthEnvironmentTests.swift
@@ -586,4 +586,16 @@ private func isLocalePathSegment(_ segment: String) -> Bool {
     return parts.dropFirst().allSatisfy { subtag in
         (2...4).contains(subtag.count) && subtag.allSatisfy(\.isLetter)
     }
+
+    @Test("release builds use cmux.com for the account API, the same origin as the VM API")
+    func releaseAPIBaseIsCmuxCom() {
+        // api.cmux.sh points at the retired manaflow Render service (maintenance mode
+        // since 2026-08): billing/plan, client-config, devices all live on cmux.com now,
+        // where iOS and CmuxAuthRuntime already go.
+        #expect(AuthEnvironment.resolvedDefaultAPIBaseURL(environment: [:], isDebugBuild: false) == "https://cmux.com")
+        #expect(AuthEnvironment.resolvedDefaultAPIBaseURL(environment: ["CMUX_API_BASE_URL": " https://cmux-staging.vercel.app "], isDebugBuild: false)
+                == "https://cmux-staging.vercel.app")
+        #expect(AuthEnvironment.resolvedDefaultAPIBaseURL(environment: ["CMUX_API_BASE_URL": ""], isDebugBuild: false) == "https://cmux.com")
+        #expect(AuthEnvironment.resolvedDefaultAPIBaseURL(environment: ["CMUX_PORT": "3777"], isDebugBuild: true) == "http://localhost:3777")
+    }
 }


### PR DESCRIPTION
## Why

Nightly/release Macs show "Cloud is unreachable"-class failures around billing and config: `AuthEnvironment.defaultAPIBaseURL` has pointed at **https://api.cmux.sh** since April. That hostname is the custom domain of the Render service `cmux-server` (built from `manaflow-ai/manaflow`), which has been in **maintenance mode since 2026-08** — Cloudflare answers 503 "Under Maintenance" on every path — and that server never had `/api/billing/plan`, `/api/client-config` or `/api/devices` anyway. So the plan fetch fails (`isProActive=false`), client config falls back to defaults, and device registration fails on every install.

## What

Release builds now use **https://cmux.com** for the account API — the same origin as the VM API and the website, and what iOS and `CmuxAuthRuntime` already default to. Verified cmux.com serves every route the Mac app calls on this base (`/api/billing/plan`, `/api/client-config`, `/api/devices`, `/api/auth/email-verification`). `CMUX_API_BASE_URL` still overrides (dev/staging lanes).

Two commits: the test (red) pins the release default; the fix (green) changes the one line. The resolver is now a pure `resolvedDefaultAPIBaseURL(environment:isDebugBuild:)`.

## Follow-ups (ops, not in this PR)
- Existing installs keep calling api.cmux.sh until they update; pointing that DNS name at the Vercel `cmux` project (Cloudflare CNAME → `cname.vercel-dns.com`, then `vercel domains add api.cmux.sh`) would heal them without a release.
- The Render service can stay in maintenance mode (or be deleted) — nothing current depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release Mac builds now default the account API to `cmux.com` instead of the retired `api.cmux.sh`, fixing plan fetch, client config, and device registration failures on every install. `CMUX_API_BASE_URL` still overrides for dev/staging, and a new test pins the release default.

**Follow-up**
- Existing installs keep hitting `api.cmux.sh` until they update; pointing that DNS name at the Vercel `cmux` project would heal them without a release.

<sup>Written for commit dcce0170fd7051b225b610669e34777bafe22230. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated default connection routing for release builds to use `https://cmux.com`.
  * Added support for configuring a custom API base URL through environment settings.
  * Debug builds continue to connect to the locally configured port.

* **Bug Fixes**
  * Removed reliance on the retired `api.cmux.sh` service endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->