### PR TITLE
Fix cmux-browser skill surface command sync

### DIFF
--- a/.github/workflows/cmux-skill-contract.yml
+++ b/.github/workflows/cmux-skill-contract.yml
@@ -1,0 +1,43 @@
+name: cmux skill contracts
+
+on:
+  pull_request:
+    paths:
+      - "skills/cmux-browser/**"
+      - "skills/cmux-cli/**"
+      - "skills.sh"
+      - "scripts/validate-cmux-browser-skill.py"
+      - "tests/test_cmux_browser_skill.py"
+      - ".github/workflows/cmux-skill-contract.yml"
+  push:
+    branches: [main]
+    paths:
+      - "skills/cmux-browser/**"
+      - "skills/cmux-cli/**"
+      - "skills.sh"
+      - "scripts/validate-cmux-browser-skill.py"
+      - "tests/test_cmux_browser_skill.py"
+      - ".github/workflows/cmux-skill-contract.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cmux-skill-contract-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  browser-skill:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Validate browser skill documentation contract
+        run: python3 scripts/validate-cmux-browser-skill.py --no-cli
+
+      - name: Exercise browser skill regression guard
+        run: python3 tests/test_cmux_browser_skill.py

--- a/.github/workflows/cmux-skill-contract.yml
+++ b/.github/workflows/cmux-skill-contract.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - "skills/cmux-browser/**"
       - "skills/cmux-cli/**"
+      - ".agents/skills"
+      - ".claude/skills/**"
       - "skills.sh"
       - "scripts/validate-cmux-browser-skill.py"
       - "tests/test_cmux_browser_skill.py"
@@ -14,6 +16,8 @@ on:
     paths:
       - "skills/cmux-browser/**"
       - "skills/cmux-cli/**"
+      - ".agents/skills"
+      - ".claude/skills/**"
       - "skills.sh"
       - "scripts/validate-cmux-browser-skill.py"
       - "tests/test_cmux_browser_skill.py"

--- a/.github/workflows/cmux-skill-contract.yml
+++ b/.github/workflows/cmux-skill-contract.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     paths:
       - "skills/cmux-browser/**"
-      - "skills/cmux-cli/**"
       - ".agents/skills"
       - ".claude/skills/**"
       - "skills.sh"
@@ -15,7 +14,6 @@ on:
     branches: [main]
     paths:
       - "skills/cmux-browser/**"
-      - "skills/cmux-cli/**"
       - ".agents/skills"
       - ".claude/skills/**"
       - "skills.sh"

--- a/scripts/validate-cmux-browser-skill.py
+++ b/scripts/validate-cmux-browser-skill.py
@@ -167,11 +167,17 @@ def _fenced_shell_blocks(path: Path, text: str) -> Iterator[tuple[int, str]]:
         match = re.match(r"^\s*(`{3,}|~{3,})\s*([^\s`]*)", line)
         if opening is None:
             if match and match.group(2).lower() in {"bash", "sh", "shell", "zsh"}:
-                opening = (match.group(1)[0], index + 1)
+                opening = (match.group(1), index + 1)
                 body = []
             continue
 
-        if re.match(rf"^\s*{re.escape(opening[0])}{{{len(opening[0])},}}\s*$", line):
+        fence_run = opening[0]
+        stripped = line.strip()
+        if (
+            len(stripped) >= len(fence_run)
+            and stripped
+            and all(character == fence_run[0] for character in stripped)
+        ):
             yield opening[1], "\n".join(body)
             opening = None
             body = []
@@ -261,6 +267,97 @@ def _tokenize(line: str) -> list[str]:
     return shlex.split(line, comments=True, posix=True)
 
 
+def _substitution_bodies(text: str) -> Iterator[str]:
+    """Yield command bodies inside ``$(...)`` and backtick substitutions."""
+
+    index = 0
+    while index < len(text):
+        if text.startswith("$(", index):
+            start = index + 2
+            depth = 1
+            quote: str | None = None
+            escaped = False
+            cursor = start
+            while cursor < len(text):
+                character = text[cursor]
+                if escaped:
+                    escaped = False
+                elif character == "\\":
+                    escaped = True
+                elif quote:
+                    if character == quote:
+                        quote = None
+                elif character in {"'", '"'}:
+                    quote = character
+                elif text.startswith("$(", cursor):
+                    depth += 1
+                    cursor += 1
+                elif character == ")":
+                    depth -= 1
+                    if depth == 0:
+                        yield text[start:cursor]
+                        index = cursor + 1
+                        break
+                cursor += 1
+            else:
+                index += 2
+                continue
+            continue
+
+        if text[index] == "`":
+            start = index + 1
+            cursor = start
+            escaped = False
+            while cursor < len(text):
+                character = text[cursor]
+                if escaped:
+                    escaped = False
+                elif character == "\\":
+                    escaped = True
+                elif character == "`":
+                    yield text[start:cursor]
+                    index = cursor + 1
+                    break
+                cursor += 1
+            else:
+                index += 1
+                continue
+            continue
+
+        index += 1
+
+
+def _commands_from_tokens(
+    example: ShellExample,
+    tokens: Sequence[str],
+    raw: str,
+) -> list[BrowserCommand]:
+    commands: list[BrowserCommand] = []
+    for index, token in enumerate(tokens):
+        if token != "cmux":
+            continue
+        end = len(tokens)
+        for cursor in range(index + 1, len(tokens)):
+            if tokens[cursor] in SHELL_OPERATORS:
+                end = cursor
+                break
+        browser_index = next(
+            (cursor for cursor in range(index + 1, end) if tokens[cursor] == "browser"),
+            None,
+        )
+        if browser_index is None:
+            continue
+        commands.append(
+            BrowserCommand(
+                example.path,
+                example.line,
+                raw,
+                tuple(tokens[index:end]),
+            )
+        )
+    return commands
+
+
 def browser_commands(examples: Iterable[ShellExample]) -> tuple[list[BrowserCommand], list[str]]:
     commands: list[BrowserCommand] = []
     errors: list[str] = []
@@ -273,22 +370,14 @@ def browser_commands(examples: Iterable[ShellExample]) -> tuple[list[BrowserComm
             errors.append(f"{example.path}:{example.line}: invalid shell syntax: {exc}")
             continue
 
-        for index, token in enumerate(tokens):
-            if token != "cmux":
+        commands.extend(_commands_from_tokens(example, tokens, example.text))
+        for body in _substitution_bodies(example.text):
+            try:
+                nested_tokens = _tokenize(body)
+            except ValueError as exc:
+                errors.append(f"{example.path}:{example.line}: invalid nested shell syntax: {exc}")
                 continue
-            end = len(tokens)
-            for cursor in range(index + 1, len(tokens)):
-                if tokens[cursor] in SHELL_OPERATORS:
-                    end = cursor
-                    break
-            browser_index = next(
-                (cursor for cursor in range(index + 1, end) if tokens[cursor] == "browser"),
-                None,
-            )
-            if browser_index is None:
-                continue
-            command_tokens = tuple(tokens[index:end])
-            commands.append(BrowserCommand(example.path, example.line, example.text, command_tokens))
+            commands.extend(_commands_from_tokens(example, nested_tokens, body))
     return commands, errors
 
 
@@ -433,7 +522,12 @@ def _metadata_errors(root: Path) -> list[str]:
 def _template_errors(root: Path) -> list[str]:
     template_root = root / "skills" / "cmux-browser" / "templates"
     errors: list[str] = []
-    for path in sorted(template_root.glob("*.sh")):
+    if not template_root.is_dir():
+        return [f"{template_root}: template directory is missing"]
+    templates = sorted(template_root.glob("*.sh"))
+    if not templates:
+        return [f"{template_root}: no shell templates found"]
+    for path in templates:
         text = path.read_text(encoding="utf-8")
         if re.search(r"SURFACE\s*=\s*[\"']?\$\{[^}]*:-\s*surface:", text):
             errors.append(f"{path}: template must not guess a default surface")
@@ -550,6 +644,9 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv or sys.argv[1:])
+    if args.no_cli and args.require_cli:
+        print("FAIL: --no-cli and --require-cli are mutually exclusive")
+        return 2
     root = args.root.resolve()
     help_text: str | None = None
     cli_warning: str | None = None

--- a/scripts/validate-cmux-browser-skill.py
+++ b/scripts/validate-cmux-browser-skill.py
@@ -1,0 +1,588 @@
+#!/usr/bin/env python3
+"""Validate cmux-browser skill examples against the live CLI contract.
+
+The guard is intentionally an executable docs check, not a grep for a handful
+of strings. When a cmux binary is available it runs ``cmux browser --help`` and
+checks the advertised grammar. It then tokenizes shell examples in the
+canonical skill (and an optional cmux-cli skill) and requires a surface handle
+for every existing-surface browser verb. This catches an old example such as
+an unscoped tab-list invocation even if its wording or whitespace changes.
+
+On Linux documentation-only CI there may be no macOS cmux binary. In that
+case the structural command parser still runs; pass ``--require-cli`` when a
+live help contract is required (for example, from the macOS CLI test lane).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Iterator, Sequence
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# Keep this set aligned with the public ``cmux browser --help`` surface. The
+# validator deliberately rejects an unknown verb so a renamed/removed CLI verb
+# cannot quietly remain in an installed skill.
+SURFACE_REQUIRED_VERBS = frozenset(
+    {
+        "back",
+        "click",
+        "check",
+        "cookies",
+        "console",
+        "dblclick",
+        "download",
+        "errors",
+        "eval",
+        "fill",
+        "find",
+        "focus",
+        "focus-webview",
+        "focus_webview",
+        "forward",
+        "frame",
+        "geolocation",
+        "geo",
+        "get",
+        "get-url",
+        "goto",
+        "highlight",
+        "hover",
+        "input",
+        "input_keyboard",
+        "input_mouse",
+        "input_touch",
+        "is",
+        "is-webview-focused",
+        "is_webview_focused",
+        "key",
+        "keydown",
+        "keyup",
+        "navigate",
+        "network",
+        "offline",
+        "press",
+        "reload",
+        "screenshot",
+        "scroll",
+        "scroll-into-view",
+        "scrollinto",
+        "scrollintoview",
+        "select",
+        "snapshot",
+        "state",
+        "storage",
+        "tab",
+        "trace",
+        "type",
+        "uncheck",
+        "url",
+        "viewport",
+        "wait",
+    }
+)
+
+UNSCOPED_VERBS = frozenset(
+    {
+        "disable",
+        "dev-tools",
+        "devtools",
+        "design-mode",
+        "enable",
+        "focus-mode",
+        "history",
+        "identify",
+        "import",
+        "new",
+        "open",
+        "open-split",
+        "profile",
+        "profiles",
+        "react-grab",
+        "reactgrab",
+        "status",
+        "zoom",
+    }
+)
+
+KNOWN_VERBS = SURFACE_REQUIRED_VERBS | UNSCOPED_VERBS
+
+SHELL_OPERATORS = frozenset(
+    {
+        ";",
+        "|",
+        "||",
+        "&&",
+        ">",
+        ">>",
+        "<",
+        "(",
+        ")",
+        "{",
+        "}",
+    }
+)
+
+HELP_MARKERS = (
+    "Usage: cmux browser [--surface <id|ref|index> | <surface>] <subcommand> [args]",
+    "url|get-url",
+    "snapshot [--interactive|-i]",
+    "get <url|title|text|html|value|attr|count|box|styles>",
+    "tab <new|list|switch|close|<index>>",
+)
+
+
+@dataclass(frozen=True)
+class ShellExample:
+    path: Path
+    line: int
+    text: str
+
+
+@dataclass(frozen=True)
+class BrowserCommand:
+    path: Path
+    line: int
+    raw: str
+    tokens: tuple[str, ...]
+
+
+def _fenced_shell_blocks(path: Path, text: str) -> Iterator[tuple[int, str]]:
+    """Yield (start line, block text) for shell-language Markdown fences."""
+
+    lines = text.splitlines()
+    opening: tuple[str, int] | None = None
+    body: list[str] = []
+    for index, line in enumerate(lines, start=1):
+        match = re.match(r"^\s*(`{3,}|~{3,})\s*([^\s`]*)", line)
+        if opening is None:
+            if match and match.group(2).lower() in {"bash", "sh", "shell", "zsh"}:
+                opening = (match.group(1)[0], index + 1)
+                body = []
+            continue
+
+        if re.match(rf"^\s*{re.escape(opening[0])}{{{len(opening[0])},}}\s*$", line):
+            yield opening[1], "\n".join(body)
+            opening = None
+            body = []
+            continue
+        body.append(line)
+
+
+def shell_examples(paths: Iterable[Path]) -> Iterator[ShellExample]:
+    for path in paths:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if path.suffix == ".md":
+            for start_line, block in _fenced_shell_blocks(path, text):
+                for offset, line in enumerate(block.splitlines(), start=0):
+                    yield ShellExample(path, start_line + offset, line)
+        elif path.suffix == ".sh":
+            for line_number, line in enumerate(text.splitlines(), start=1):
+                yield ShellExample(path, line_number, line)
+
+
+def _logical_examples(examples: Iterable[ShellExample]) -> Iterator[ShellExample]:
+    pending: ShellExample | None = None
+    for example in examples:
+        line = example.text.rstrip()
+        if pending is not None:
+            joined = pending.text + line.lstrip()
+            if joined.endswith("\\"):
+                pending = ShellExample(pending.path, pending.line, joined[:-1] + " ")
+            elif _has_unclosed_quote(joined):
+                pending = ShellExample(pending.path, pending.line, joined + " ")
+            else:
+                yield ShellExample(pending.path, pending.line, joined)
+                pending = None
+            continue
+
+        if line.endswith("\\"):
+            pending = ShellExample(example.path, example.line, line[:-1] + " ")
+        elif _has_unclosed_quote(line):
+            pending = example
+        else:
+            yield example
+    if pending is not None:
+        yield pending
+
+
+def _has_unclosed_quote(text: str) -> bool:
+    """Return whether a shell logical line still has an open quote."""
+
+    lexer = shlex.shlex(text, posix=True)
+    lexer.whitespace_split = True
+    lexer.commenters = "#"
+    try:
+        list(lexer)
+    except ValueError as exc:
+        return "No closing quotation" in str(exc)
+    return False
+
+
+def _split_alternatives(token: str) -> tuple[str, ...]:
+    # Reference docs use compact notation such as ``back|forward|reload``.
+    pieces = tuple(piece for piece in token.split("|") if piece)
+    return pieces or (token,)
+
+
+def _looks_like_surface(token: str) -> bool:
+    normalized = token.strip().lower()
+    if normalized in {"<surface>", "<surface-id>", "<surface-ref>", "$surface", "${surface}"}:
+        return True
+    if normalized.startswith(("surface:", "tab:")):
+        return True
+    if normalized.isdigit():
+        return True
+    if re.fullmatch(
+        r"[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}",
+        normalized,
+    ):
+        return True
+    # Shell variables in examples should name the thing they carry. Accept
+    # ${SURFACE:-...} too, while rejecting arbitrary variables as an implicit
+    # target.
+    return bool(re.fullmatch(r"\$\{?surface(?:[^}]*)\}?", normalized))
+
+
+def _tokenize(line: str) -> list[str]:
+    return shlex.split(line, comments=True, posix=True)
+
+
+def browser_commands(examples: Iterable[ShellExample]) -> tuple[list[BrowserCommand], list[str]]:
+    commands: list[BrowserCommand] = []
+    errors: list[str] = []
+    for example in _logical_examples(examples):
+        if not example.text.strip() or example.text.lstrip().startswith("#"):
+            continue
+        try:
+            tokens = _tokenize(example.text)
+        except ValueError as exc:
+            errors.append(f"{example.path}:{example.line}: invalid shell syntax: {exc}")
+            continue
+
+        for index, token in enumerate(tokens):
+            if token != "cmux":
+                continue
+            end = len(tokens)
+            for cursor in range(index + 1, len(tokens)):
+                if tokens[cursor] in SHELL_OPERATORS:
+                    end = cursor
+                    break
+            browser_index = next(
+                (cursor for cursor in range(index + 1, end) if tokens[cursor] == "browser"),
+                None,
+            )
+            if browser_index is None:
+                continue
+            command_tokens = tuple(tokens[index:end])
+            commands.append(BrowserCommand(example.path, example.line, example.text, command_tokens))
+    return commands, errors
+
+
+def _surface_flag_value(after_browser: Sequence[str]) -> tuple[bool, list[str]]:
+    has_surface = False
+    remaining = list(after_browser)
+    index = 0
+    while index < len(remaining):
+        token = remaining[index]
+        if token == "--surface":
+            has_surface = True
+            if index + 1 >= len(remaining) or remaining[index + 1] in SHELL_OPERATORS:
+                return has_surface, []
+            del remaining[index : index + 2]
+            continue
+        if token.startswith("--surface="):
+            has_surface = bool(token.split("=", 1)[1])
+            del remaining[index]
+            continue
+        index += 1
+    return has_surface, remaining
+
+
+def _verb_candidates(after_browser: Sequence[str]) -> tuple[bool, tuple[str, ...], str | None]:
+    has_surface, remaining = _surface_flag_value(after_browser)
+    if not remaining:
+        return has_surface, (), "missing subcommand"
+
+    # Help is intentionally allowed without a target.
+    if remaining[0] in {"--help", "-h"}:
+        return has_surface, (), None
+
+    positional_surface = _looks_like_surface(remaining[0])
+    if positional_surface:
+        has_surface = True
+        remaining = remaining[1:]
+    while remaining and remaining[0].startswith("--"):
+        # A global display flag before the verb has no value in the current
+        # docs. Skip it so the command parser remains tolerant of --json.
+        remaining = remaining[1:]
+    if not remaining:
+        return has_surface, (), "missing subcommand"
+    return has_surface, _split_alternatives(remaining[0]), None
+
+
+def validate_command(command: BrowserCommand) -> list[str]:
+    tokens = command.tokens
+    browser_index = tokens.index("browser")
+    after_browser = tokens[browser_index + 1 :]
+    has_surface, verbs, parse_error = _verb_candidates(after_browser)
+    if parse_error:
+        return [f"{command.path}:{command.line}: {parse_error}: {command.raw.strip()}"]
+    if not verbs:
+        return []
+
+    errors: list[str] = []
+    for verb in verbs:
+        normalized = verb.lower()
+        if normalized not in KNOWN_VERBS:
+            errors.append(
+                f"{command.path}:{command.line}: unsupported browser verb {verb!r}; "
+                f"refresh `cmux browser --help`: {command.raw.strip()}"
+            )
+            continue
+        if normalized in SURFACE_REQUIRED_VERBS and not has_surface:
+            errors.append(
+                f"{command.path}:{command.line}: browser {verb!r} requires an explicit "
+                f"surface handle (`--surface <surface>` or positional): {command.raw.strip()}"
+            )
+    return errors
+
+
+def _skill_files(root: Path) -> list[Path]:
+    paths: list[Path] = []
+    for base in (root / "skills" / "cmux-browser", root / "skills" / "cmux-cli"):
+        if not base.is_dir():
+            continue
+        paths.extend(sorted(path for path in base.rglob("*.md") if path.is_file()))
+        paths.extend(sorted(path for path in base.rglob("*.sh") if path.is_file()))
+    return paths
+
+
+def _frontmatter_errors(path: Path) -> list[str]:
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        return [f"{path}: unable to read frontmatter: {exc}"]
+    if not lines or lines[0].strip() != "---":
+        return [f"{path}: missing YAML frontmatter"]
+    try:
+        end = next(index for index, line in enumerate(lines[1:], start=1) if line.strip() == "---")
+    except StopIteration:
+        return [f"{path}: unterminated YAML frontmatter"]
+    fields: dict[str, str] = {}
+    for line in lines[1:end]:
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        fields[key.strip()] = value.strip().strip('"').strip("'")
+    errors: list[str] = []
+    for required in ("name", "description"):
+        if not fields.get(required):
+            errors.append(f"{path}: frontmatter requires {required}")
+    return errors
+
+
+def _mirror_errors(root: Path) -> list[str]:
+    canonical = (root / "skills").resolve()
+    errors: list[str] = []
+    mirrors = {
+        Path(".agents/skills"): canonical,
+        Path(".claude/skills/cmux-browser"): canonical / "cmux-browser",
+    }
+    for relative, expected_target in mirrors.items():
+        mirror = root / relative
+        if not mirror.is_symlink():
+            expected = "../skills" if relative == Path(".agents/skills") else "../../skills/cmux-browser"
+            errors.append(f"{mirror}: discovery mirror must remain a symlink to {expected}")
+            continue
+        if mirror.resolve() != expected_target:
+            errors.append(f"{mirror}: resolves to {mirror.resolve()}, expected {expected_target}")
+    return errors
+
+
+def _metadata_errors(root: Path) -> list[str]:
+    skill = root / "skills" / "cmux-browser"
+    errors = _frontmatter_errors(skill / "SKILL.md")
+    metadata = skill / "agents" / "openai.yaml"
+    try:
+        text = metadata.read_text(encoding="utf-8")
+    except OSError as exc:
+        return errors + [f"{metadata}: unable to read: {exc}"]
+    for marker in ("interface:", "default_prompt:", "--help", "surface"):
+        if marker not in text:
+            errors.append(f"{metadata}: registration metadata is missing {marker!r}")
+    agents = skill / "AGENTS.md"
+    if not agents.is_file():
+        errors.append(f"{agents}: Codex agent instructions are missing")
+    return errors
+
+
+def _template_errors(root: Path) -> list[str]:
+    template_root = root / "skills" / "cmux-browser" / "templates"
+    errors: list[str] = []
+    for path in sorted(template_root.glob("*.sh")):
+        text = path.read_text(encoding="utf-8")
+        if re.search(r"SURFACE\s*=\s*[\"']?\$\{[^}]*:-\s*surface:", text):
+            errors.append(f"{path}: template must not guess a default surface")
+    return errors
+
+
+def validate_repository(root: Path, help_text: str | None = None) -> list[str]:
+    errors = _metadata_errors(root) + _mirror_errors(root) + _template_errors(root)
+    files = _skill_files(root)
+    commands, parse_errors = browser_commands(shell_examples(files))
+    errors.extend(parse_errors)
+    for command in commands:
+        errors.extend(validate_command(command))
+
+    if help_text is not None:
+        normalized = " ".join(help_text.split())
+        for marker in HELP_MARKERS:
+            if " ".join(marker.split()) not in normalized:
+                errors.append(f"cmux browser --help: missing contract marker {marker!r}")
+    return errors
+
+
+def resolve_cli(explicit: str | None) -> str | None:
+    candidates = [explicit, os.environ.get("CMUX_CLI_BIN"), os.environ.get("CMUX_CLI")]
+    for candidate in candidates:
+        if candidate and os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    return shutil.which("cmux")
+
+
+def live_help(cli: str) -> tuple[str | None, str | None]:
+    try:
+        result = subprocess.run(
+            [cli, "browser", "--help"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return None, f"unable to run {cli!r}: {exc}"
+    output = f"{result.stdout}\n{result.stderr}".strip()
+    if result.returncode != 0:
+        return None, f"{cli!r} browser --help exited {result.returncode}: {output}"
+    return output, None
+
+
+def live_syntax_errors(cli: str) -> list[str]:
+    """Check representative CLI forms reach the socket parser unambiguously."""
+
+    valid_commands = (
+        ("url", ["browser", "--surface", "surface:1", "url"]),
+        ("get-url", ["browser", "--surface", "surface:1", "get-url"]),
+        ("get url", ["browser", "--surface", "surface:1", "get", "url"]),
+        ("tab list", ["browser", "--surface", "surface:1", "tab", "list"]),
+        ("snapshot", ["browser", "--surface", "surface:1", "snapshot", "--interactive"]),
+        ("click", ["browser", "--surface", "surface:1", "click", "e1"]),
+        ("positional get", ["browser", "surface:1", "get", "title"]),
+    )
+    errors: list[str] = []
+    with tempfile.TemporaryDirectory(prefix="cmux-browser-skill-") as directory:
+        socket_path = str(Path(directory) / "absent.sock")
+        environment = dict(os.environ)
+        for key in (
+            "CMUX_SOCKET",
+            "CMUX_SOCKET_PATH",
+            "CMUX_SOCKET_PASSWORD",
+            "CMUX_WORKSPACE_ID",
+            "CMUX_SURFACE_ID",
+            "CMUX_TAB_ID",
+        ):
+            environment.pop(key, None)
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+        environment["CMUX_CLAUDE_HOOK_SENTRY_DISABLED"] = "1"
+
+        def run(arguments: Sequence[str]) -> str:
+            try:
+                result = subprocess.run(
+                    [cli, "--socket", socket_path, *arguments],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                    env=environment,
+                )
+            except (OSError, subprocess.SubprocessError) as exc:
+                errors.append(f"{' '.join(arguments)}: unable to execute: {exc}")
+                return ""
+            return f"{result.stdout}\n{result.stderr}".strip()
+
+        parser_failure_markers = (
+            "Unsupported browser subcommand",
+            "browser requires a subcommand",
+            "requires a surface handle",
+            "Invalid surface handle",
+        )
+        for label, arguments in valid_commands:
+            output = run(arguments)
+            if any(marker in output for marker in parser_failure_markers):
+                errors.append(
+                    f"{label}: surface-scoped form was rejected before socket dispatch: {output!r}"
+                )
+    return errors
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=ROOT, help="repository root")
+    parser.add_argument("--cmux-bin", help="cmux executable to use for live help")
+    parser.add_argument("--require-cli", action="store_true", help="fail when no live cmux binary is available")
+    parser.add_argument("--no-cli", action="store_true", help="skip live help even when cmux is on PATH")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    root = args.root.resolve()
+    help_text: str | None = None
+    cli_warning: str | None = None
+    if not args.no_cli:
+        cli = resolve_cli(args.cmux_bin)
+        if cli:
+            help_text, cli_warning = live_help(cli)
+            if help_text is not None:
+                cli_syntax_errors = live_syntax_errors(cli)
+                if cli_syntax_errors:
+                    print("FAIL: cmux-browser CLI syntax contract")
+                    for error in cli_syntax_errors:
+                        print(f"- {error}")
+                    return 1
+        elif args.require_cli:
+            cli_warning = "no executable cmux binary found (set CMUX_CLI_BIN)"
+    if cli_warning and args.require_cli:
+        print(f"FAIL: {cli_warning}")
+        return 1
+    errors = validate_repository(root, help_text=help_text)
+    if errors:
+        print("FAIL: cmux-browser skill contract")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    if cli_warning:
+        print(f"INFO: {cli_warning}; structural docs contract used")
+    elif help_text is not None:
+        print("PASS: cmux-browser skill and live cmux browser --help contract")
+    else:
+        print("PASS: cmux-browser skill structural contract (no live CLI requested)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate-cmux-browser-skill.py
+++ b/scripts/validate-cmux-browser-skill.py
@@ -327,6 +327,35 @@ def _substitution_bodies(text: str) -> Iterator[str]:
         index += 1
 
 
+def _nested_browser_commands(
+    example: ShellExample,
+    text: str,
+    depth: int = 0,
+) -> tuple[list[BrowserCommand], list[str]]:
+    """Collect browser commands in a shell line and all nested substitutions."""
+
+    # A malformed or adversarial example must not make the validator recurse
+    # forever. Sixteen levels is far beyond any useful shell example while
+    # still allowing nested command substitutions to be checked completely.
+    if depth > 16:
+        return [], [f"{example.path}:{example.line}: shell substitution nesting is too deep"]
+
+    commands: list[BrowserCommand] = []
+    errors: list[str] = []
+    try:
+        tokens = _tokenize(text)
+    except ValueError as exc:
+        errors.append(f"{example.path}:{example.line}: invalid nested shell syntax: {exc}")
+        return commands, errors
+
+    commands.extend(_commands_from_tokens(example, tokens, text))
+    for body in _substitution_bodies(text):
+        nested_commands, nested_errors = _nested_browser_commands(example, body, depth + 1)
+        commands.extend(nested_commands)
+        errors.extend(nested_errors)
+    return commands, errors
+
+
 def _commands_from_tokens(
     example: ShellExample,
     tokens: Sequence[str],
@@ -364,20 +393,9 @@ def browser_commands(examples: Iterable[ShellExample]) -> tuple[list[BrowserComm
     for example in _logical_examples(examples):
         if not example.text.strip() or example.text.lstrip().startswith("#"):
             continue
-        try:
-            tokens = _tokenize(example.text)
-        except ValueError as exc:
-            errors.append(f"{example.path}:{example.line}: invalid shell syntax: {exc}")
-            continue
-
-        commands.extend(_commands_from_tokens(example, tokens, example.text))
-        for body in _substitution_bodies(example.text):
-            try:
-                nested_tokens = _tokenize(body)
-            except ValueError as exc:
-                errors.append(f"{example.path}:{example.line}: invalid nested shell syntax: {exc}")
-                continue
-            commands.extend(_commands_from_tokens(example, nested_tokens, body))
+        nested_commands, nested_errors = _nested_browser_commands(example, example.text)
+        commands.extend(nested_commands)
+        errors.extend(nested_errors)
     return commands, errors
 
 

--- a/scripts/validate-cmux-browser-skill.py
+++ b/scripts/validate-cmux-browser-skill.py
@@ -310,7 +310,7 @@ def _substitution_bodies(text: str) -> Iterator[str]:
                 character = text[cursor]
                 if escaped:
                     escaped = False
-                elif character == "\\":
+                elif character == "\\" and nested_quote != "'":
                     escaped = True
                 elif nested_quote:
                     if character == nested_quote:

--- a/scripts/validate-cmux-browser-skill.py
+++ b/scripts/validate-cmux-browser-skill.py
@@ -271,11 +271,39 @@ def _substitution_bodies(text: str) -> Iterator[str]:
     """Yield command bodies inside ``$(...)`` and backtick substitutions."""
 
     index = 0
+    quote: str | None = None
+    escaped = False
     while index < len(text):
-        if text.startswith("$(", index):
+        character = text[index]
+        if escaped:
+            escaped = False
+            index += 1
+            continue
+
+        # A backslash is literal inside a single-quoted shell string, but
+        # escapes the next character everywhere else.
+        if character == "\\" and quote != "'":
+            escaped = True
+            index += 1
+            continue
+
+        if quote == "'":
+            if character == "'":
+                quote = None
+            index += 1
+            continue
+
+        if quote is None and character in {"'", '"'}:
+            quote = character
+            index += 1
+            continue
+
+        # Command substitutions are active when unquoted or inside a
+        # double-quoted string; single-quoted/escaped text is literal.
+        if (quote is None or quote == '"') and text.startswith("$(", index):
             start = index + 2
             depth = 1
-            quote: str | None = None
+            nested_quote: str | None = None
             escaped = False
             cursor = start
             while cursor < len(text):
@@ -284,11 +312,11 @@ def _substitution_bodies(text: str) -> Iterator[str]:
                     escaped = False
                 elif character == "\\":
                     escaped = True
-                elif quote:
-                    if character == quote:
-                        quote = None
+                elif nested_quote:
+                    if character == nested_quote:
+                        nested_quote = None
                 elif character in {"'", '"'}:
-                    quote = character
+                    nested_quote = character
                 elif text.startswith("$(", cursor):
                     depth += 1
                     cursor += 1
@@ -304,7 +332,7 @@ def _substitution_bodies(text: str) -> Iterator[str]:
                 continue
             continue
 
-        if text[index] == "`":
+        if (quote is None or quote == '"') and character == "`":
             start = index + 1
             cursor = start
             escaped = False

--- a/scripts/validate-cmux-browser-skill.py
+++ b/scripts/validate-cmux-browser-skill.py
@@ -157,6 +157,10 @@ class BrowserCommand:
     tokens: tuple[str, ...]
 
 
+class ShellSyntaxError(ValueError):
+    """A shell example cannot be parsed into complete command substitutions."""
+
+
 def _fenced_shell_blocks(path: Path, text: str) -> Iterator[tuple[int, str]]:
     """Yield (start line, block text) for shell-language Markdown fences."""
 
@@ -264,7 +268,13 @@ def _looks_like_surface(token: str) -> bool:
 
 
 def _tokenize(line: str) -> list[str]:
-    return shlex.split(line, comments=True, posix=True)
+    # Ask shlex to keep shell operators as standalone tokens so an adjacent
+    # ``;``/``&&`` cannot make one browser invocation consume the next one.
+    # Quoted operator characters remain part of their quoted argument.
+    lexer = shlex.shlex(line, posix=True, punctuation_chars=";&|")
+    lexer.whitespace_split = True
+    lexer.commenters = "#"
+    return list(lexer)
 
 
 def _substitution_bodies(text: str) -> Iterator[str]:
@@ -328,8 +338,7 @@ def _substitution_bodies(text: str) -> Iterator[str]:
                         break
                 cursor += 1
             else:
-                index += 2
-                continue
+                raise ShellSyntaxError("unterminated $() command substitution")
             continue
 
         if (quote is None or quote == '"') and character == "`":
@@ -348,8 +357,7 @@ def _substitution_bodies(text: str) -> Iterator[str]:
                     break
                 cursor += 1
             else:
-                index += 1
-                continue
+                raise ShellSyntaxError("unterminated backtick command substitution")
             continue
 
         index += 1
@@ -377,7 +385,13 @@ def _nested_browser_commands(
         return commands, errors
 
     commands.extend(_commands_from_tokens(example, tokens, text))
-    for body in _substitution_bodies(text):
+    try:
+        substitution_bodies = list(_substitution_bodies(text))
+    except ShellSyntaxError as exc:
+        errors.append(f"{example.path}:{example.line}: {exc}")
+        return commands, errors
+
+    for body in substitution_bodies:
         nested_commands, nested_errors = _nested_browser_commands(example, body, depth + 1)
         commands.extend(nested_commands)
         errors.extend(nested_errors)
@@ -418,11 +432,17 @@ def _commands_from_tokens(
 def browser_commands(examples: Iterable[ShellExample]) -> tuple[list[BrowserCommand], list[str]]:
     commands: list[BrowserCommand] = []
     errors: list[str] = []
+    seen: set[tuple[Path, int, tuple[str, ...]]] = set()
     for example in _logical_examples(examples):
         if not example.text.strip() or example.text.lstrip().startswith("#"):
             continue
         nested_commands, nested_errors = _nested_browser_commands(example, example.text)
-        commands.extend(nested_commands)
+        for command in nested_commands:
+            key = (command.path, command.line, command.tokens)
+            if key in seen:
+                continue
+            seen.add(key)
+            commands.append(command)
         errors.extend(nested_errors)
     return commands, errors
 

--- a/scripts/validate-cmux-browser-skill.py
+++ b/scripts/validate-cmux-browser-skill.py
@@ -35,12 +35,16 @@ ROOT = Path(__file__).resolve().parent.parent
 # cannot quietly remain in an installed skill.
 SURFACE_REQUIRED_VERBS = frozenset(
     {
+        "addinitscript",
+        "addscript",
+        "addstyle",
         "back",
         "click",
         "check",
         "cookies",
         "console",
         "dblclick",
+        "dialog",
         "download",
         "errors",
         "eval",
@@ -79,6 +83,7 @@ SURFACE_REQUIRED_VERBS = frozenset(
         "scrollinto",
         "scrollintoview",
         "select",
+        "screencast",
         "snapshot",
         "state",
         "storage",
@@ -139,6 +144,10 @@ HELP_MARKERS = (
     "snapshot [--interactive|-i]",
     "get <url|title|text|html|value|attr|count|box|styles>",
     "tab <new|list|switch|close|<index>>",
+    "dialog <accept|dismiss>",
+    "addinitscript|addscript",
+    "addstyle",
+    "screencast <start|stop>",
 )
 
 

--- a/skills/cmux-browser/AGENTS.md
+++ b/skills/cmux-browser/AGENTS.md
@@ -1,0 +1,16 @@
+# cmux Browser agent instructions
+
+Read `SKILL.md` before using the cmux browser CLI.
+
+- Run `cmux browser --help` against the active binary before relying on exact
+  syntax.
+- Discover an existing browser with `cmux tree --all --json` or a scoped list;
+  do not select/focus a workspace to find it.
+- Pass `--surface <handle>` (or the positional equivalent) to every operation
+  on an existing browser. Only creation and explicitly global browser verbs may
+  omit the handle.
+- Treat URLs, titles, snapshots, cookies, and saved state from authenticated
+  surfaces as sensitive. Filter output and never commit or paste secrets.
+- Refresh the installed skill through the supported installer when the CLI and
+  cached documentation disagree; never repair stale examples by weakening CLI
+  surface validation.

--- a/skills/cmux-browser/AGENTS.md
+++ b/skills/cmux-browser/AGENTS.md
@@ -6,9 +6,9 @@ Read `SKILL.md` before using the cmux browser CLI.
   syntax.
 - Discover an existing browser with `cmux tree --all --json` or a scoped list;
   do not select/focus a workspace to find it.
-- Pass `--surface <handle>` (or the positional equivalent) to every operation
-  on an existing browser. Only creation and explicitly global browser verbs may
-  omit the handle.
+- Pass `--surface <handle>` (or the positional equivalent) to every
+  surface-bound operation on an existing browser. Only creation and explicitly
+  global browser verbs may omit the handle.
 - Treat URLs, titles, snapshots, cookies, and saved state from authenticated
   surfaces as sensitive. Filter output and never commit or paste secrets.
 - Refresh the installed skill through the supported installer when the CLI and

--- a/skills/cmux-browser/SKILL.md
+++ b/skills/cmux-browser/SKILL.md
@@ -156,16 +156,16 @@ implicit target.
 
 The repository copies are the source of truth: `.claude/skills/cmux-browser`
 and `.agents/skills/cmux-browser` point at `skills/cmux-browser`. Do not edit a
-mirror by hand. The supported Vercel installer refreshes both global Claude
-Code and Codex discovery roots and copies the complete skill (including
-references and templates):
+mirror by hand. The supported Vercel installer (pinned here to the reviewed
+`skills` 1.5.23 release) refreshes both global Claude Code and Codex discovery
+roots and copies the complete skill (including references and templates):
 
 ```bash
 # From this checkout while developing the skill:
-npx skills add . --global --yes --skill cmux-browser --agent claude-code codex --copy
+npx --yes skills@1.5.23 add . --global --yes --skill cmux-browser --agent claude-code codex --copy
 
 # From the published repository after the change is merged:
-npx skills add manaflow-ai/cmux --global --yes --skill cmux-browser --agent claude-code codex --copy
+npx --yes skills@1.5.23 add manaflow-ai/cmux --global --yes --skill cmux-browser --agent claude-code codex --copy
 ```
 
 Restart an agent session after a refresh if it cached the previous document.

--- a/skills/cmux-browser/SKILL.md
+++ b/skills/cmux-browser/SKILL.md
@@ -1,74 +1,190 @@
 ---
 name: cmux-browser
-description: End-user browser automation with cmux. Use when you need to open sites, interact with pages, wait for state changes, and extract data from cmux browser surfaces.
+description: "End-user browser automation with cmux. Use when you need to open sites, inspect or interact with browser surfaces, wait for page state, and extract data without stealing focus."
 ---
 
 # Browser Automation with cmux
 
-## Core workflow
+## Read the CLI contract first
 
-Open or target a browser surface, verify navigation with `get url`, snapshot for fresh element refs, act on refs, wait for the state change, re-snapshot.
+Check the binary that will actually run before giving an exact command:
 
 ```bash
-cmux --json browser open https://example.com     # returns a surface ref, e.g. surface:7
-cmux browser surface:7 get url
-cmux browser surface:7 wait --load-state complete --timeout-ms 15000
-cmux browser surface:7 snapshot --interactive
-cmux browser surface:7 fill e1 "hello"
-cmux --json browser surface:7 click e2 --snapshot-after
-cmux browser surface:7 snapshot --interactive
+cmux browser --help
+cmux --version
 ```
 
-If `get url` is empty or `about:blank`, navigate first instead of waiting on load state. Re-snapshot after navigation, modal open/close, or major DOM changes; refs go stale.
+There are two deliberately different command shapes:
 
-## Surface targeting
+- **Create a browser surface** with `open`, `open-split`, or `new`. These commands may be workspace-scoped and do not need a surface handle.
+- **Use an existing surface** with every navigation, inspection, interaction, tab, state, or diagnostic command. Pass the handle explicitly with `--surface <handle>` or as the first positional token.
 
-`browser open` targets the workspace of the terminal running the command (`CMUX_WORKSPACE_ID`), even when another workspace is focused. Override with `--workspace` / `--window`:
+Prefer the flag form in scripts because it makes the target unmissable:
+
+```bash
+SURFACE="surface:7" # use a ref returned by discovery; do not guess an index
+cmux browser --surface "$SURFACE" get url
+cmux browser --surface "$SURFACE" get-url       # accepted alias
+cmux browser --surface "$SURFACE" snapshot --interactive
+cmux browser --surface "$SURFACE" snapshot -i   # accepted alias
+cmux browser --surface "$SURFACE" url            # accepted alias
+cmux browser --surface "$SURFACE" tab list
+cmux browser --surface "$SURFACE" click e1 --snapshot-after
+```
+
+The positional form is equivalent (`cmux browser "$SURFACE" get url`). `url` and
+`get-url` are accepted URL aliases, and the short interactive snapshot flag is
+accepted when a surface is already present; use `get url` and
+`snapshot --interactive` in new documentation so the target and operation are
+clear. There is no unscoped form for an existing-surface operation.
+
+## Find an existing browser surface without changing focus
+
+`identify`, `tree`, and list commands are read-only and do not select a
+workspace, pane, or browser. Do not infer that the visually focused surface is
+the one the user wants.
+
+First inspect the caller context (useful for the default workspace):
 
 ```bash
 cmux identify --json
-cmux browser open https://example.com --workspace workspace:2 --window window:1 --json
 ```
 
-Output defaults to short refs (`surface:N`, `pane:N`, `workspace:N`, `window:N`); UUIDs are accepted on input, and `--id-format uuids|both` requests them on output. Keep one `surface:N` per task.
+To discover browser surfaces in the caller or another workspace/window, use the
+all-window tree. It includes parent refs, so a browser in a different workspace
+can be targeted directly without selecting that workspace:
+
+```bash
+cmux tree --all --json \
+  | jq -r '
+      .windows[]? as $window
+      | $window.workspaces[]? as $workspace
+      | $workspace.panes[]? as $pane
+      | $pane.surfaces[]?
+      | select(.type == "browser")
+      | [$window.ref, $workspace.ref, $pane.ref, .ref]
+      | @tsv'
+```
+
+The filtered output is `window`, `workspace`, `pane`, and `surface` refs. Keep
+the `surface` ref, then target it explicitly:
+
+```bash
+SURFACE="surface:N" # copied from the filtered tree output
+cmux browser --surface "$SURFACE" get url
+cmux browser --surface "$SURFACE" snapshot --interactive
+```
+
+For one known workspace, `cmux --json list-pane-surfaces --workspace
+<workspace>` is a smaller read-only query. Raw tree/list payloads can contain
+page URLs and titles; filter or redact them before logging or pasting them.
+Never use a focus/select command merely to discover a surface.
+
+## Core workflow
+
+Open (or create) a surface without stealing focus, capture the returned ref,
+then use that ref for every existing-surface operation:
+
+```bash
+OPEN_JSON="$(cmux --json browser open https://example.com --focus false)"
+SURFACE="$(printf '%s' "$OPEN_JSON" | jq -r '.surface_ref // .surface_id // empty')"
+[ -n "$SURFACE" ] || { printf '%s\n' 'browser open did not return a surface ref' >&2; exit 1; }
+cmux browser --surface "$SURFACE" get url
+cmux browser --surface "$SURFACE" wait --load-state complete --timeout-ms 15000
+cmux browser --surface "$SURFACE" snapshot --interactive
+cmux browser --surface "$SURFACE" fill e1 "hello"
+cmux browser --surface "$SURFACE" click e2 --snapshot-after
+cmux browser --surface "$SURFACE" snapshot --interactive
+```
+
+The `open` response contains the new surface ref; in a script, extract it from
+the JSON response instead of printing the full response. If `get url` is empty
+or `about:blank`, navigate first instead of waiting on load state. Re-snapshot
+after navigation, modal open/close, or any major DOM change because refs go
+stale.
 
 ## Wait
 
 ```bash
-cmux browser <surface> wait --selector "#ready" --timeout-ms 10000
-cmux browser <surface> wait --text "Success" --timeout-ms 10000
-cmux browser <surface> wait --url-contains "/dashboard" --timeout-ms 10000
-cmux browser <surface> wait --load-state complete --timeout-ms 15000
-cmux browser <surface> wait --function "document.readyState === 'complete'" --timeout-ms 10000
+cmux browser --surface "$SURFACE" wait --selector "#ready" --timeout-ms 10000
+cmux browser --surface "$SURFACE" wait --text "Success" --timeout-ms 10000
+cmux browser --surface "$SURFACE" wait --url-contains "/dashboard" --timeout-ms 10000
+cmux browser --surface "$SURFACE" wait --load-state complete --timeout-ms 15000
+cmux browser --surface "$SURFACE" wait --function "document.readyState === 'complete'" --timeout-ms 10000
 ```
 
 ## Viewport sizing (WKWebView)
 
-`cmux browser <surface> viewport <width> <height>` sets an exact logical viewport from 1 to 4096 CSS pixels. The page is aspect-fitted inside its existing pane, so pane layout and focus stay unchanged, and screenshots use the requested logical dimensions. `viewport reset` returns to native pane sizing.
+`cmux browser --surface "$SURFACE" viewport <width> <height>` sets an exact
+logical viewport from 1 to 4096 CSS pixels. The page is aspect-fitted inside
+its existing pane, so pane layout and focus stay unchanged, and screenshots use
+the requested logical dimensions. `viewport reset` returns to native pane
+sizing.
 
-Close or detach the browser inspector first: its inspector-managed split layout cannot be combined with viewport emulation, and opening or redocking an attached inspector resets emulation to native sizing. Large viewport and page-zoom combinations are bounded; the command returns structured `maximum_page_zoom` details and leaves the viewport unchanged when the combination exceeds WKWebView render limits.
+Close or detach the browser inspector first: its inspector-managed split layout
+cannot be combined with viewport emulation, and opening or redocking an
+attached inspector resets emulation to native sizing. Large viewport and
+page-zoom combinations are bounded; the command returns structured
+`maximum_page_zoom` details and leaves the viewport unchanged when the
+combination exceeds WKWebView render limits.
 
 ## Limits (WKWebView)
 
-Offline emulation, trace/screencast recording, network route interception/mocking, and low-level raw input injection return `not_supported`; they depend on Chrome/CDP-only APIs. Use `click`, `fill`, `press`, `scroll`, `wait`, `snapshot` instead.
+Offline emulation, trace/screencast recording, network route
+interception/mocking, and low-level raw input injection return `not_supported`;
+they depend on Chrome/CDP-only APIs. Use `click`, `fill`, `press`, `scroll`,
+`wait`, and `snapshot` instead.
 
 ## Troubleshooting `js_error`
 
-Some complex pages reject the JavaScript behind `snapshot --interactive` and `eval`. Recover by checking whether the page actually navigated, then falling back to raw text or HTML:
+Some complex pages reject the JavaScript behind `snapshot --interactive` and
+`eval`. Recover by checking whether the page actually navigated, then fall
+back to raw text or HTML:
 
 ```bash
-cmux browser surface:7 get url
-cmux browser surface:7 get text body
-cmux browser surface:7 get html body
+cmux browser --surface "$SURFACE" get url
+cmux browser --surface "$SURFACE" get text body
+cmux browser --surface "$SURFACE" get html body
 ```
 
-If it still fails, navigate to a simpler intermediate page and retry from there.
+If it still fails, navigate to a simpler intermediate page and retry from
+there. If the CLI and this skill disagree, refresh help (`cmux browser
+--help`) and refresh the installed skill before continuing; do not invent an
+implicit target.
+
+## Skill distribution and refresh
+
+The repository copies are the source of truth: `.claude/skills/cmux-browser`
+and `.agents/skills/cmux-browser` point at `skills/cmux-browser`. Do not edit a
+mirror by hand. The supported Vercel installer refreshes both global Claude
+Code and Codex discovery roots and copies the complete skill (including
+references and templates):
+
+```bash
+# From this checkout while developing the skill:
+npx skills add . --global --yes --skill cmux-browser --agent claude-code codex --copy
+
+# From the published repository after the change is merged:
+npx skills add manaflow-ai/cmux --global --yes --skill cmux-browser --agent claude-code codex --copy
+```
+
+Restart an agent session after a refresh if it cached the previous document.
+The repository's `skills.sh` remains available for a Codex-only destination;
+pass its `--dest` explicitly when that is the installation path:
+
+```bash
+./skills.sh --dest "$HOME/.codex/skills" --skill cmux-browser
+```
+
+Never commit home-directory skill copies, credentials, cookies, or saved browser
+state.
 
 ## Deep-dive references
 
 | Reference | When to Use |
 |-----------|-------------|
-| [references/commands.md](references/commands.md) | Full command mapping, `agent-browser` equivalents, viewport error codes |
+| [references/surface-discovery.md](references/surface-discovery.md) | Find and target an existing browser surface without focus changes |
+| [references/commands.md](references/commands.md) | Full command mapping, aliases, `agent-browser` equivalents, viewport error codes |
 | [references/snapshot-refs.md](references/snapshot-refs.md) | Ref lifecycle and stale-ref troubleshooting |
 | [references/authentication.md](references/authentication.md) | Login/OAuth/2FA patterns and state save/load |
 | [references/session-management.md](references/session-management.md) | Multi-surface isolation and state persistence |
@@ -79,6 +195,6 @@ If it still fails, navigate to a simpler intermediate page and retry from there.
 
 | Template | Description |
 |----------|-------------|
-| [templates/form-automation.sh](templates/form-automation.sh) | Snapshot/ref form fill loop |
-| [templates/authenticated-session.sh](templates/authenticated-session.sh) | Login once, save/load state |
-| [templates/capture-workflow.sh](templates/capture-workflow.sh) | Navigate and capture snapshots/screenshots |
+| [templates/form-automation.sh](templates/form-automation.sh) | Snapshot/ref form fill loop (requires an explicit surface) |
+| [templates/authenticated-session.sh](templates/authenticated-session.sh) | Login once, save/load state (requires an explicit surface) |
+| [templates/capture-workflow.sh](templates/capture-workflow.sh) | Navigate and capture snapshots/screenshots (requires an explicit surface) |

--- a/skills/cmux-browser/SKILL.md
+++ b/skills/cmux-browser/SKILL.md
@@ -75,6 +75,33 @@ cmux browser --surface "$SURFACE" get url
 cmux browser --surface "$SURFACE" snapshot --interactive
 ```
 
+If the user gives a URL or title instead of a workspace/pane, match that
+metadata locally and emit only the unique surface ref. This never prints the
+matched URL or title:
+
+```bash
+MATCH_FIELD="url" # use "title" when matching a page title
+MATCH_VALUE="${BROWSER_URL_OR_TITLE:?set BROWSER_URL_OR_TITLE without logging it}"
+SURFACE="$(
+  cmux tree --all --json |
+    jq -r --arg field "$MATCH_FIELD" --arg value "$MATCH_VALUE" '
+      [
+        .windows[]? as $window
+        | $window.workspaces[]? as $workspace
+        | $workspace.panes[]? as $pane
+        | $pane.surfaces[]?
+        | select(.type == "browser")
+        | select((if $field == "url" then (.url // "") else (.title // "") end) == $value)
+        | .ref
+      ] as $matches
+      | if ($matches | length) == 1 then $matches[0]
+        elif ($matches | length) == 0 then error("no matching browser surface")
+        else error("multiple matches; use workspace/pane context")
+        end'
+)"
+cmux browser --surface "$SURFACE" get url
+```
+
 For one known workspace, `cmux --json list-pane-surfaces --workspace
 <workspace>` is a smaller read-only query. Raw tree/list payloads can contain
 page URLs and titles; filter or redact them before logging or pasting them.

--- a/skills/cmux-browser/SKILL.md
+++ b/skills/cmux-browser/SKILL.md
@@ -17,7 +17,7 @@ cmux --version
 There are two deliberately different command shapes:
 
 - **Create a browser surface** with `open`, `open-split`, or `new`. These commands may be workspace-scoped and do not need a surface handle.
-- **Use an existing surface** with every navigation, inspection, interaction, tab, state, or diagnostic command. Pass the handle explicitly with `--surface <handle>` or as the first positional token.
+- **Use an existing surface** with every surface-bound navigation, inspection, interaction, tab, state, or diagnostic command. Pass the handle explicitly with `--surface <handle>` or as the first positional token.
 
 Prefer the flag form in scripts because it makes the target unmissable:
 
@@ -36,7 +36,12 @@ The positional form is equivalent (`cmux browser "$SURFACE" get url`). `url` and
 `get-url` are accepted URL aliases, and the short interactive snapshot flag is
 accepted when a surface is already present; use `get url` and
 `snapshot --interactive` in new documentation so the target and operation are
-clear. There is no unscoped form for an existing-surface operation.
+clear. Surface-bound operations have no unscoped form. The current CLI's
+explicitly global browser verbs (`open`, `open-split`, `new`, `identify`,
+`import`, `profile`, `profiles`, `react-grab`, `reactgrab`, `devtools`,
+`dev-tools`, `focus-mode`, `design-mode`, `zoom`, and `history`) may omit the
+handle and use caller/workspace routing; do not infer a target from visible
+focus for any other verb.
 
 ## Find an existing browser surface without changing focus
 
@@ -99,6 +104,10 @@ SURFACE="$(
         else error("multiple matches; use workspace/pane context")
         end'
 )"
+if [[ -z "$SURFACE" ]]; then
+  printf '%s\n' 'no uniquely matching browser surface; provide workspace/pane context' >&2
+  exit 1
+fi
 cmux browser --surface "$SURFACE" get url
 ```
 

--- a/skills/cmux-browser/agents/openai.yaml
+++ b/skills/cmux-browser/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "cmux Browser"
-  short_description: "Automate cmux webview surfaces with snapshot/ref workflows."
-  default_prompt: "Use this skill for browser automation via cmux CLI: identify target surface, snapshot interactive refs, perform actions, wait for state changes, and re-snapshot to avoid stale refs."
+  short_description: "Discover and automate explicit cmux browser surfaces without changing focus."
+  default_prompt: "Use this skill for cmux browser automation. Check `cmux browser --help`, discover the intended surface with read-only topology commands (including other workspaces), pass that surface to every existing-surface command, preserve visible focus, and re-snapshot after state changes."

--- a/skills/cmux-browser/references/authentication.md
+++ b/skills/cmux-browser/references/authentication.md
@@ -2,22 +2,25 @@
 
 Login flows, session persistence, OAuth, and 2FA for cmux browser surfaces. Related: [session-management.md](session-management.md), [../SKILL.md](../SKILL.md).
 
+Set `SURFACE` from [surface discovery](surface-discovery.md) or from the JSON
+returned by `browser open`. Never guess a default surface or log credentials.
+
 ## Basic login
 
 ```bash
-cmux browser open https://app.example.com/login --json
-cmux browser surface:7 wait --load-state complete --timeout-ms 15000
-cmux browser surface:7 snapshot --interactive    # e1 email, e2 password, e3 submit
-cmux browser surface:7 fill e1 "user@example.com"
-cmux browser surface:7 fill e2 "$APP_PASSWORD"
-cmux browser surface:7 click e3 --snapshot-after --json
-cmux browser surface:7 wait --url-contains "/dashboard" --timeout-ms 20000
+cmux --json browser open https://app.example.com/login --focus false
+cmux browser --surface "$SURFACE" wait --load-state complete --timeout-ms 15000
+cmux browser --surface "$SURFACE" snapshot --interactive
+cmux browser --surface "$SURFACE" fill e1 "$APP_USERNAME"
+cmux browser --surface "$SURFACE" fill e2 "$APP_PASSWORD"
+cmux browser --surface "$SURFACE" click e3 --snapshot-after --json
+cmux browser --surface "$SURFACE" wait --url-contains "/dashboard" --timeout-ms 20000
 ```
 
 ## Saving authentication state
 
 ```bash
-cmux browser surface:7 state save ./auth-state.json
+cmux browser --surface "$SURFACE" state save ./auth-state.json
 ```
 
 State includes cookies, localStorage, sessionStorage, and open tab metadata for that surface.
@@ -25,10 +28,10 @@ State includes cookies, localStorage, sessionStorage, and open tab metadata for 
 ## Restoring authentication
 
 ```bash
-cmux browser open https://app.example.com --json
-cmux browser surface:8 state load ./auth-state.json
-cmux browser surface:8 goto https://app.example.com/dashboard
-cmux browser surface:8 snapshot --interactive
+cmux --json browser open https://app.example.com --focus false
+cmux browser --surface "$SURFACE" state load ./auth-state.json
+cmux browser --surface "$SURFACE" goto https://app.example.com/dashboard
+cmux browser --surface "$SURFACE" snapshot --interactive
 ```
 
 ## OAuth / SSO
@@ -36,12 +39,12 @@ cmux browser surface:8 snapshot --interactive
 Same shape as basic login, waiting on the provider host and then the return host, with generous timeouts:
 
 ```bash
-cmux browser open https://app.example.com/auth/google --json
-cmux browser surface:7 wait --url-contains "accounts.google.com" --timeout-ms 30000
-cmux browser surface:7 snapshot --interactive
+cmux --json browser open https://app.example.com/auth/provider --focus false
+cmux browser --surface "$SURFACE" wait --url-contains "login.example.com" --timeout-ms 30000
+cmux browser --surface "$SURFACE" snapshot --interactive
 # fill and click the provider's fields
-cmux browser surface:7 wait --url-contains "app.example.com" --timeout-ms 45000
-cmux browser surface:7 state save ./oauth-state.json
+cmux browser --surface "$SURFACE" wait --url-contains "app.example.com" --timeout-ms 45000
+cmux browser --surface "$SURFACE" state save ./oauth-state.json
 ```
 
 ## Two-factor
@@ -51,8 +54,8 @@ Drive the password step, let the user complete 2FA in the webview, then wait wit
 ## Cookie-based auth
 
 ```bash
-cmux browser surface:7 cookies set session_token "abc123xyz"
-cmux browser surface:7 goto https://app.example.com/dashboard
+cmux browser --surface "$SURFACE" cookies set session_cookie "$SESSION_COOKIE"
+cmux browser --surface "$SURFACE" goto https://app.example.com/dashboard
 ```
 
 ## Token refresh
@@ -63,18 +66,18 @@ Load saved state, navigate, and re-login only when the URL bounced to `/login`:
 #!/usr/bin/env bash
 set -euo pipefail
 STATE_FILE="./auth-state.json"
-SURFACE="surface:7"
+: "${SURFACE:?set SURFACE from browser open or surface discovery}"
 
-[ -f "$STATE_FILE" ] && cmux browser "$SURFACE" state load "$STATE_FILE"
-cmux browser "$SURFACE" goto https://app.example.com/dashboard
+[ -f "$STATE_FILE" ] && cmux browser --surface "$SURFACE" state load "$STATE_FILE"
+cmux browser --surface "$SURFACE" goto https://app.example.com/dashboard
 
-if cmux browser "$SURFACE" get url | grep -q '/login'; then
-  cmux browser "$SURFACE" snapshot --interactive
-  cmux browser "$SURFACE" fill e1 "$APP_USERNAME"
-  cmux browser "$SURFACE" fill e2 "$APP_PASSWORD"
-  cmux browser "$SURFACE" click e3
-  cmux browser "$SURFACE" wait --url-contains "/dashboard" --timeout-ms 20000
-  cmux browser "$SURFACE" state save "$STATE_FILE"
+if cmux browser --surface "$SURFACE" get url | grep -q '/login'; then
+  cmux browser --surface "$SURFACE" snapshot --interactive
+  cmux browser --surface "$SURFACE" fill e1 "$APP_USERNAME"
+  cmux browser --surface "$SURFACE" fill e2 "$APP_PASSWORD"
+  cmux browser --surface "$SURFACE" click e3
+  cmux browser --surface "$SURFACE" wait --url-contains "/dashboard" --timeout-ms 20000
+  cmux browser --surface "$SURFACE" state save "$STATE_FILE"
 fi
 ```
 
@@ -83,6 +86,6 @@ fi
 Never commit state files; they contain auth tokens. Take credentials from environment variables. Clear state after sensitive tasks:
 
 ```bash
-cmux browser surface:7 cookies clear --all
+cmux browser --surface "$SURFACE" cookies clear --all
 rm -f ./auth-state.json
 ```

--- a/skills/cmux-browser/references/authentication.md
+++ b/skills/cmux-browser/references/authentication.md
@@ -5,6 +5,17 @@ Login flows, session persistence, OAuth, and 2FA for cmux browser surfaces. Rela
 Set `SURFACE` from [surface discovery](surface-discovery.md) or from the JSON
 returned by `browser open`. Never guess a default surface or log credentials.
 
+Saved browser state contains cookies and storage. Use a private directory with
+restrictive permissions before saving it:
+
+```bash
+STATE_DIR="${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}/cmux-browser-state"
+umask 077
+mkdir -p "$STATE_DIR"
+chmod 700 "$STATE_DIR"
+STATE_FILE="$STATE_DIR/auth-state.json"
+```
+
 ## Basic login
 
 ```bash
@@ -22,7 +33,8 @@ cmux browser --surface "$SURFACE" wait --url-contains "/dashboard" --timeout-ms 
 ## Saving authentication state
 
 ```bash
-cmux browser --surface "$SURFACE" state save ./auth-state.json
+cmux browser --surface "$SURFACE" state save "$STATE_FILE"
+chmod 600 "$STATE_FILE"
 ```
 
 State includes cookies, localStorage, sessionStorage, and open tab metadata for that surface.
@@ -30,10 +42,15 @@ State includes cookies, localStorage, sessionStorage, and open tab metadata for 
 ## Restoring authentication
 
 ```bash
+STATE_DIR="${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}/cmux-browser-state"
+umask 077
+mkdir -p "$STATE_DIR"
+chmod 700 "$STATE_DIR"
+STATE_FILE="$STATE_DIR/auth-state.json"
 OPEN_JSON="$(cmux --json browser open https://app.example.com --focus false)"
 SURFACE="$(printf '%s' "$OPEN_JSON" | jq -r '.surface_ref // .surface_id // empty')"
 [ -n "$SURFACE" ] || { printf '%s\n' 'browser open did not return a surface ref' >&2; exit 1; }
-cmux browser --surface "$SURFACE" state load ./auth-state.json
+cmux browser --surface "$SURFACE" state load "$STATE_FILE"
 cmux browser --surface "$SURFACE" goto https://app.example.com/dashboard
 cmux browser --surface "$SURFACE" snapshot --interactive
 ```
@@ -43,6 +60,11 @@ cmux browser --surface "$SURFACE" snapshot --interactive
 Same shape as basic login, waiting on the provider host and then the return host, with generous timeouts:
 
 ```bash
+OAUTH_STATE_DIR="${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}/cmux-browser-state"
+umask 077
+mkdir -p "$OAUTH_STATE_DIR"
+chmod 700 "$OAUTH_STATE_DIR"
+OAUTH_STATE_FILE="$OAUTH_STATE_DIR/oauth-state.json"
 OPEN_JSON="$(cmux --json browser open https://app.example.com/auth/provider --focus false)"
 SURFACE="$(printf '%s' "$OPEN_JSON" | jq -r '.surface_ref // .surface_id // empty')"
 [ -n "$SURFACE" ] || { printf '%s\n' 'browser open did not return a surface ref' >&2; exit 1; }
@@ -50,7 +72,8 @@ cmux browser --surface "$SURFACE" wait --url-contains "login.example.com" --time
 cmux browser --surface "$SURFACE" snapshot --interactive
 # fill and click the provider's fields
 cmux browser --surface "$SURFACE" wait --url-contains "app.example.com" --timeout-ms 45000
-cmux browser --surface "$SURFACE" state save ./oauth-state.json
+cmux browser --surface "$SURFACE" state save "$OAUTH_STATE_FILE"
+chmod 600 "$OAUTH_STATE_FILE"
 ```
 
 ## Two-factor
@@ -71,7 +94,11 @@ Load saved state, navigate, and re-login only when the URL bounced to `/login`:
 ```bash
 #!/usr/bin/env bash
 set -euo pipefail
-STATE_FILE="./auth-state.json"
+STATE_DIR="${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}/cmux-browser-state"
+umask 077
+mkdir -p "$STATE_DIR"
+chmod 700 "$STATE_DIR"
+STATE_FILE="${STATE_FILE:-$STATE_DIR/auth-state.json}"
 : "${SURFACE:?set SURFACE from browser open or surface discovery}"
 
 [ -f "$STATE_FILE" ] && cmux browser --surface "$SURFACE" state load "$STATE_FILE"
@@ -84,6 +111,7 @@ if cmux browser --surface "$SURFACE" get url | grep -q '/login'; then
   cmux browser --surface "$SURFACE" click e3
   cmux browser --surface "$SURFACE" wait --url-contains "/dashboard" --timeout-ms 20000
   cmux browser --surface "$SURFACE" state save "$STATE_FILE"
+  chmod 600 "$STATE_FILE"
 fi
 ```
 
@@ -93,5 +121,6 @@ Never commit state files; they contain auth tokens. Take credentials from enviro
 
 ```bash
 cmux browser --surface "$SURFACE" cookies clear --all
-rm -f ./auth-state.json ./oauth-state.json
+rm -f "$STATE_FILE"
+[ -n "${OAUTH_STATE_FILE:-}" ] && rm -f "$OAUTH_STATE_FILE"
 ```

--- a/skills/cmux-browser/references/authentication.md
+++ b/skills/cmux-browser/references/authentication.md
@@ -8,7 +8,9 @@ returned by `browser open`. Never guess a default surface or log credentials.
 ## Basic login
 
 ```bash
-cmux --json browser open https://app.example.com/login --focus false
+OPEN_JSON="$(cmux --json browser open https://app.example.com/login --focus false)"
+SURFACE="$(printf '%s' "$OPEN_JSON" | jq -r '.surface_ref // .surface_id // empty')"
+[ -n "$SURFACE" ] || { printf '%s\n' 'browser open did not return a surface ref' >&2; exit 1; }
 cmux browser --surface "$SURFACE" wait --load-state complete --timeout-ms 15000
 cmux browser --surface "$SURFACE" snapshot --interactive
 cmux browser --surface "$SURFACE" fill e1 "$APP_USERNAME"
@@ -28,7 +30,9 @@ State includes cookies, localStorage, sessionStorage, and open tab metadata for 
 ## Restoring authentication
 
 ```bash
-cmux --json browser open https://app.example.com --focus false
+OPEN_JSON="$(cmux --json browser open https://app.example.com --focus false)"
+SURFACE="$(printf '%s' "$OPEN_JSON" | jq -r '.surface_ref // .surface_id // empty')"
+[ -n "$SURFACE" ] || { printf '%s\n' 'browser open did not return a surface ref' >&2; exit 1; }
 cmux browser --surface "$SURFACE" state load ./auth-state.json
 cmux browser --surface "$SURFACE" goto https://app.example.com/dashboard
 cmux browser --surface "$SURFACE" snapshot --interactive
@@ -39,7 +43,9 @@ cmux browser --surface "$SURFACE" snapshot --interactive
 Same shape as basic login, waiting on the provider host and then the return host, with generous timeouts:
 
 ```bash
-cmux --json browser open https://app.example.com/auth/provider --focus false
+OPEN_JSON="$(cmux --json browser open https://app.example.com/auth/provider --focus false)"
+SURFACE="$(printf '%s' "$OPEN_JSON" | jq -r '.surface_ref // .surface_id // empty')"
+[ -n "$SURFACE" ] || { printf '%s\n' 'browser open did not return a surface ref' >&2; exit 1; }
 cmux browser --surface "$SURFACE" wait --url-contains "login.example.com" --timeout-ms 30000
 cmux browser --surface "$SURFACE" snapshot --interactive
 # fill and click the provider's fields
@@ -87,5 +93,5 @@ Never commit state files; they contain auth tokens. Take credentials from enviro
 
 ```bash
 cmux browser --surface "$SURFACE" cookies clear --all
-rm -f ./auth-state.json
+rm -f ./auth-state.json ./oauth-state.json
 ```

--- a/skills/cmux-browser/references/authentication.md
+++ b/skills/cmux-browser/references/authentication.md
@@ -121,6 +121,9 @@ Never commit state files; they contain auth tokens. Take credentials from enviro
 
 ```bash
 cmux browser --surface "$SURFACE" cookies clear --all
+STATE_DIR="${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}/cmux-browser-state"
+STATE_FILE="${STATE_FILE:-$STATE_DIR/auth-state.json}"
+OAUTH_STATE_FILE="${OAUTH_STATE_FILE:-$STATE_DIR/oauth-state.json}"
 rm -f "$STATE_FILE"
-[ -n "${OAUTH_STATE_FILE:-}" ] && rm -f "$OAUTH_STATE_FILE"
+rm -f "$OAUTH_STATE_FILE"
 ```

--- a/skills/cmux-browser/references/commands.md
+++ b/skills/cmux-browser/references/commands.md
@@ -1,81 +1,131 @@
 # Command Reference (cmux Browser)
 
-## agent-browser equivalents
+## Surface contract
 
-`agent-browser <verb>` maps to `cmux browser <surface> <verb>` for `goto`/`navigate`, `click`, `fill`, `type`, `select`, `get text`, `get url`, `get title`. `agent-browser snapshot -i` is `cmux browser <surface> snapshot --interactive`. `agent-browser open <url>` is `cmux browser open <url>` (no surface, since it creates one).
+Run `cmux browser --help` against the installed binary before relying on exact
+syntax. Creation verbs (`open`, `open-split`, `new`) may omit a surface. Every
+command that reads or mutates an existing browser must include one:
+
+```bash
+cmux browser --surface <surface> get url
+cmux browser --surface <surface> snapshot --interactive
+cmux browser --surface <surface> tab list
+cmux browser --surface <surface> click <selector-or-ref>
+```
+
+`cmux browser <surface> <verb> ...` is the equivalent positional form. See
+[surface-discovery.md](surface-discovery.md) before targeting an existing
+authenticated browser or a browser in another workspace.
+
+## Accepted aliases
+
+Use the preferred column in new docs/scripts; every alias still requires the
+same explicit surface.
+
+| Purpose | Preferred | Accepted alias |
+| --- | --- | --- |
+| Read URL | `cmux browser --surface <surface> get url` | `cmux browser --surface <surface> url` or `get-url` |
+| Navigate | `cmux browser --surface <surface> goto <url>` | `navigate` |
+| Interactive snapshot | `cmux browser --surface <surface> snapshot --interactive` | `-i` |
+| Press a key | `cmux browser --surface <surface> press <key>` | `key` |
+
+The upstream `agent-browser` command's implicit page context maps to an
+explicit cmux surface. Its interactive snapshot maps to `snapshot
+--interactive`; its `open` command maps to `cmux browser open` because creation
+returns a new surface.
+
+## Discovery and creation
+
+```bash
+cmux identify --json
+cmux tree --all --json
+cmux browser --surface <surface> identify --json
+
+cmux --json browser open <url> --focus false
+cmux --json browser open <url> --workspace <workspace> --window <window> --focus false
+cmux --json browser open-split <url> --workspace <workspace> --focus false
+```
+
+Creation defaults to the caller's `CMUX_WORKSPACE_ID` when neither
+`--workspace` nor `--window` is supplied, and `--focus` defaults to false. An
+explicit `--workspace` lets an agent create in another workspace without
+selecting it.
 
 ## Navigation
 
 ```bash
-cmux browser open <url>                        # caller's workspace, via CMUX_WORKSPACE_ID
-cmux browser open <url> --workspace <id|ref>
-cmux browser <surface> goto <url>
-cmux browser <surface> back|forward|reload
-cmux browser <surface> get url|title
+cmux browser --surface <surface> goto <url>
+cmux browser --surface <surface> back|forward|reload
+cmux browser --surface <surface> get url|title
 ```
 
 ## Snapshot and inspection
 
 ```bash
-cmux browser <surface> snapshot --interactive
-cmux browser <surface> snapshot --interactive --compact --max-depth 3
-cmux browser <surface> get text body
-cmux browser <surface> get html body
-cmux browser <surface> get value "#email"
-cmux browser <surface> get attr "#email" --attr placeholder
-cmux browser <surface> get count ".row"
-cmux browser <surface> get box "#submit"
-cmux browser <surface> get styles "#submit" --property color
-cmux browser <surface> eval '<js>'
+cmux browser --surface <surface> snapshot --interactive
+cmux browser --surface <surface> snapshot --interactive --compact --max-depth 3
+cmux browser --surface <surface> get text body
+cmux browser --surface <surface> get html body
+cmux browser --surface <surface> get value "#email"
+cmux browser --surface <surface> get attr "#email" --attr placeholder
+cmux browser --surface <surface> get count ".row"
+cmux browser --surface <surface> get box "#submit"
+cmux browser --surface <surface> get styles "#submit" --property color
+cmux browser --surface <surface> eval '<js>'
 ```
 
 ## Interaction
 
 ```bash
-cmux browser <surface> click|dblclick|hover|focus <selector-or-ref>
-cmux browser <surface> fill <selector-or-ref> [text]   # empty text clears
-cmux browser <surface> type <selector-or-ref> <text>
-cmux browser <surface> press|key|keydown|keyup [--key <key> | <key>]
-cmux browser <surface> select <selector-or-ref> <value>
-cmux browser <surface> check|uncheck <selector-or-ref>
-cmux browser <surface> scroll [--selector <css>] [--dx <n>] [--dy <n>]
+cmux browser --surface <surface> click|dblclick|hover|focus <selector-or-ref>
+cmux browser --surface <surface> fill <selector-or-ref> [text]
+cmux browser --surface <surface> type <selector-or-ref> <text>
+cmux browser --surface <surface> press|key|keydown|keyup [--key <key> | <key>]
+cmux browser --surface <surface> select <selector-or-ref> <value>
+cmux browser --surface <surface> check|uncheck <selector-or-ref>
+cmux browser --surface <surface> scroll [--selector <css>] [--dx <n>] [--dy <n>]
 ```
 
-Keyboard names follow Playwright/W3C conventions (`Enter`, `Tab`, `Escape`, `ArrowLeft`, `Space`). `Space`, `Spacebar`, and `space` all emit DOM key `" "` with code `"Space"`; use `--key ' '` to pass the raw DOM key.
+Empty `fill` text clears the field. Keyboard names follow Playwright/W3C
+conventions (`Enter`, `Tab`, `Escape`, `ArrowLeft`, `Space`). `Space`,
+`Spacebar`, and `space` emit DOM key `" "` with code `"Space"`; use `--key ' '`
+to pass the raw DOM key.
 
 ## Wait
 
 ```bash
-cmux browser <surface> wait --selector "#ready" --timeout-ms 10000
-cmux browser <surface> wait --text "Done" --timeout-ms 10000
-cmux browser <surface> wait --url-contains "/dashboard" --timeout-ms 10000
-cmux browser <surface> wait --load-state complete --timeout-ms 15000
-cmux browser <surface> wait --function "document.readyState === 'complete'" --timeout-ms 10000
+cmux browser --surface <surface> wait --selector "#ready" --timeout-ms 10000
+cmux browser --surface <surface> wait --text "Done" --timeout-ms 10000
+cmux browser --surface <surface> wait --url-contains "/dashboard" --timeout-ms 10000
+cmux browser --surface <surface> wait --load-state complete --timeout-ms 15000
+cmux browser --surface <surface> wait --function "document.readyState === 'complete'" --timeout-ms 10000
 ```
 
 ## Design mode
 
 ```bash
-cmux browser design-mode enable|status|disable --surface <surface> [--json]
+cmux browser --surface <surface> design-mode enable|status|disable --json
 ```
 
-Design mode lets a user select page elements and copy their DOM, style, URL, and screenshot context for pasting into an agent. CLI enable/disable never moves application focus or copies context automatically.
+Design mode lets a user select page elements and copy their DOM, style, URL,
+and screenshot context for pasting into an agent. CLI enable/disable never
+moves application focus or copies context automatically.
 
-## Session, state, diagnostics
+## Session, state, and diagnostics
 
 ```bash
-cmux browser <surface> cookies get|set|clear ...
-cmux browser <surface> cookies clear --url https://app.example.com/
-cmux browser <surface> cookies clear --domain app.example.com
-cmux browser <surface> cookies clear --all
-cmux browser <surface> storage local|session get|set|clear ...
-cmux browser <surface> tab list|new|switch|close ...
-cmux browser <surface> state save|load <path>
-cmux browser <surface> console list|clear
-cmux browser <surface> errors list|clear
-cmux browser <surface> highlight <selector>
-cmux browser <surface> screenshot
-cmux browser <surface> download wait --timeout-ms 10000
+cmux browser --surface <surface> cookies get|set|clear ...
+cmux browser --surface <surface> cookies clear --url https://app.example.com/
+cmux browser --surface <surface> cookies clear --domain app.example.com
+cmux browser --surface <surface> cookies clear --all
+cmux browser --surface <surface> storage local|session get|set|clear ...
+cmux browser --surface <surface> tab list|new|switch|close ...
+cmux browser --surface <surface> state save|load <path>
+cmux browser --surface <surface> console list|clear
+cmux browser --surface <surface> errors list|clear
+cmux browser --surface <surface> highlight <selector>
+cmux browser --surface <surface> screenshot
+cmux browser --surface <surface> download wait --timeout-ms 10000
 ```
 
 `cookies clear` requires an explicit scope (`--url`, `--domain`, `--name`,
@@ -85,22 +135,41 @@ responses include the number of removed cookies as `cleared`.
 
 ## Agent reliability
 
-Use `--snapshot-after` on mutating actions to get a fresh post-action snapshot. Re-snapshot after navigation, modal open/close, or major DOM changes. Prefer short handles in output; use `--id-format both` only when a UUID must be logged or exported.
+Use `--snapshot-after` on mutating actions to get a fresh post-action snapshot.
+Re-snapshot after navigation, modal open/close, or major DOM changes. Prefer
+short handles in output; use `--id-format both` only when a UUID must be logged
+or exported. If the handle is stale, rediscover it; never silently retarget the
+focused browser.
 
 ## Viewport emulation
 
 ```bash
-cmux browser surface:7 viewport 1280 720
-cmux browser surface:7 screenshot --out /tmp/desktop.png
-cmux browser surface:7 viewport reset
+cmux browser --surface <surface> viewport 1280 720
+cmux browser --surface <surface> screenshot --out /tmp/desktop.png
+cmux browser --surface <surface> viewport reset
 ```
 
-Dimensions are limited to 1..4096 CSS pixels. cmux changes `window.innerWidth`/`window.innerHeight` and aspect-fits the page inside the existing pane; it does not resize the pane, move other surfaces, or change focus. The JSON result includes logical and displayed dimensions, scale, presentation mode, and whether the pane was resized. Screenshot PNG dimensions are exact CSS pixels on Retina and non-Retina displays.
+Dimensions are limited to 1..4096 CSS pixels. cmux changes
+`window.innerWidth`/`window.innerHeight` and aspect-fits the page inside the
+existing pane; it does not resize the pane, move other surfaces, or change
+focus. Screenshot PNG dimensions are exact CSS pixels on Retina and non-Retina
+displays.
 
-Error cases: an unsupported viewport/page-zoom combination leaves the viewport unchanged and returns `invalid_params` with `reason: viewport_zoom_render_geometry_too_large` plus `maximum_page_zoom`. An attached browser inspector returns `invalid_state` with `reason: attached_browser_inspector`; close or detach it first. Opening or redocking an attached inspector while emulation is active resets the viewport to native sizing.
+An unsupported viewport/page-zoom combination leaves the viewport unchanged
+and returns `invalid_params` with reason
+`viewport_zoom_render_geometry_too_large` plus `maximum_page_zoom`. An attached
+browser inspector returns `invalid_state` with reason
+`attached_browser_inspector`; close or detach it first. Opening or redocking an
+attached inspector while emulation is active resets the viewport to native
+sizing.
 
 ## Known WKWebView gaps (`not_supported`)
 
-`browser.geolocation.set`, `browser.offline.set`, `browser.trace.start|stop`, `browser.network.route|unroute|requests`, `browser.screencast.start|stop`, `browser.input_mouse|input_keyboard|input_touch`.
+`browser.geolocation.set`, `browser.offline.set`, `browser.trace.start|stop`,
+`browser.network.route|unroute|requests`, `browser.screencast.start|stop`, and
+`browser.input_mouse|input_keyboard|input_touch` are not supported by the
+WKWebView engine.
 
-See also [snapshot-refs.md](snapshot-refs.md), [authentication.md](authentication.md), [session-management.md](session-management.md).
+See also [snapshot-refs.md](snapshot-refs.md),
+[authentication.md](authentication.md), and
+[session-management.md](session-management.md).

--- a/skills/cmux-browser/references/commands.md
+++ b/skills/cmux-browser/references/commands.md
@@ -3,7 +3,8 @@
 ## Surface contract
 
 Run `cmux browser --help` against the installed binary before relying on exact
-syntax. Creation verbs (`open`, `open-split`, `new`) may omit a surface. Every
+syntax. Creation verbs (`open`, `open-split`, `new`) and the explicitly global
+browser verbs listed in `SKILL.md` may omit a surface. Every surface-bound
 command that reads or mutates an existing browser must include one:
 
 ```bash

--- a/skills/cmux-browser/references/proxy-support.md
+++ b/skills/cmux-browser/references/proxy-support.md
@@ -7,6 +7,6 @@ There is no `cmux browser proxy ...` command for per-surface routing: WKWebView 
 Verify egress:
 
 ```bash
-cmux browser open https://httpbin.org/ip --json
-cmux browser surface:7 get text body
+cmux --json browser open https://httpbin.org/ip --focus false
+cmux browser --surface "$SURFACE" get text body
 ```

--- a/skills/cmux-browser/references/proxy-support.md
+++ b/skills/cmux-browser/references/proxy-support.md
@@ -7,6 +7,8 @@ There is no `cmux browser proxy ...` command for per-surface routing: WKWebView 
 Verify egress:
 
 ```bash
-cmux --json browser open https://httpbin.org/ip --focus false
+OPEN_JSON="$(cmux --json browser open https://httpbin.org/ip --focus false)"
+SURFACE="$(printf '%s' "$OPEN_JSON" | jq -r '.surface_ref // .surface_id // empty')"
+[ -n "$SURFACE" ] || { printf '%s\n' 'browser open did not return a surface ref' >&2; exit 1; }
 cmux browser --surface "$SURFACE" get text body
 ```

--- a/skills/cmux-browser/references/session-management.md
+++ b/skills/cmux-browser/references/session-management.md
@@ -2,25 +2,30 @@
 
 cmux gives each browser surface its own context. Every surface is an independent session with its own cookies, localStorage/sessionStorage, tab list and active tab, and navigation history. Related: [authentication.md](authentication.md), [../SKILL.md](../SKILL.md).
 
+Keep the handle returned by creation or
+[surface discovery](surface-discovery.md); never use a guessed default.
+
 ## Parallel sessions
 
 Each `cmux browser open` returns a new surface ref; drive them independently.
 
 ```bash
-cmux browser open https://site-a.example --json    # -> surface:11
-cmux browser open https://site-b.example --json    # -> surface:12
+cmux --json browser open https://site-a.example --focus false    # -> surface:11
+cmux --json browser open https://site-b.example --focus false    # -> surface:12
 
-cmux browser surface:11 get text body > /tmp/a.txt
-cmux browser surface:12 get text body > /tmp/b.txt
+cmux browser --surface surface:11 get text body > /tmp/a.txt
+cmux browser --surface surface:12 get text body > /tmp/b.txt
 ```
 
 ## Reusing auth across surfaces
 
 ```bash
-cmux browser surface:7 state save /tmp/auth.json    # after logging in on surface:7
-cmux browser open https://app.example.com --json    # -> surface:8
-cmux browser surface:8 state load /tmp/auth.json
-cmux browser surface:8 goto https://app.example.com/dashboard
+SOURCE_SURFACE="surface:7"       # from discovery
+DESTINATION_SURFACE="surface:8"   # from the second open response
+cmux browser --surface "$SOURCE_SURFACE" state save /tmp/auth.json
+cmux --json browser open https://app.example.com --focus false    # -> surface:8
+cmux browser --surface "$DESTINATION_SURFACE" state load /tmp/auth.json
+cmux browser --surface "$DESTINATION_SURFACE" goto https://app.example.com/dashboard
 ```
 
 ## Cleanup
@@ -32,4 +37,7 @@ rm -f /tmp/auth.json
 
 ## Best practices
 
-Log surface refs in script output so actions stay attributable, keep one task per surface to avoid ref churn, save state after successful auth milestones, and re-snapshot after switching tabs or pages inside a surface.
+Log only the surface refs needed to keep actions attributable (not raw URLs or
+auth payloads), keep one task per surface to avoid ref churn, save state after
+successful auth milestones, and re-snapshot after switching tabs or pages
+inside a surface.

--- a/skills/cmux-browser/references/session-management.md
+++ b/skills/cmux-browser/references/session-management.md
@@ -10,20 +10,24 @@ Keep the handle returned by creation or
 Each `cmux browser open` returns a new surface ref; drive them independently.
 
 ```bash
-cmux --json browser open https://site-a.example --focus false    # -> surface:11
-cmux --json browser open https://site-b.example --focus false    # -> surface:12
+FIRST_JSON="$(cmux --json browser open https://site-a.example --focus false)"
+FIRST_SURFACE="$(printf '%s' "$FIRST_JSON" | jq -r '.surface_ref // .surface_id // empty')"
+SECOND_JSON="$(cmux --json browser open https://site-b.example --focus false)"
+SECOND_SURFACE="$(printf '%s' "$SECOND_JSON" | jq -r '.surface_ref // .surface_id // empty')"
+[ -n "$FIRST_SURFACE" ] && [ -n "$SECOND_SURFACE" ] || exit 1
 
-cmux browser --surface surface:11 get text body > /tmp/a.txt
-cmux browser --surface surface:12 get text body > /tmp/b.txt
+cmux browser --surface "$FIRST_SURFACE" get text body > /tmp/a.txt
+cmux browser --surface "$SECOND_SURFACE" get text body > /tmp/b.txt
 ```
 
 ## Reusing auth across surfaces
 
 ```bash
 SOURCE_SURFACE="surface:7"       # from discovery
-DESTINATION_SURFACE="surface:8"   # from the second open response
 cmux browser --surface "$SOURCE_SURFACE" state save /tmp/auth.json
-cmux --json browser open https://app.example.com --focus false    # -> surface:8
+DESTINATION_JSON="$(cmux --json browser open https://app.example.com --focus false)"
+DESTINATION_SURFACE="$(printf '%s' "$DESTINATION_JSON" | jq -r '.surface_ref // .surface_id // empty')"
+[ -n "$DESTINATION_SURFACE" ] || exit 1
 cmux browser --surface "$DESTINATION_SURFACE" state load /tmp/auth.json
 cmux browser --surface "$DESTINATION_SURFACE" goto https://app.example.com/dashboard
 ```

--- a/skills/cmux-browser/references/session-management.md
+++ b/skills/cmux-browser/references/session-management.md
@@ -16,19 +16,30 @@ SECOND_JSON="$(cmux --json browser open https://site-b.example --focus false)"
 SECOND_SURFACE="$(printf '%s' "$SECOND_JSON" | jq -r '.surface_ref // .surface_id // empty')"
 [ -n "$FIRST_SURFACE" ] && [ -n "$SECOND_SURFACE" ] || exit 1
 
-cmux browser --surface "$FIRST_SURFACE" get text body > /tmp/a.txt
-cmux browser --surface "$SECOND_SURFACE" get text body > /tmp/b.txt
+ARTIFACT_DIR="${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}/cmux-browser-output"
+umask 077
+mkdir -p "$ARTIFACT_DIR"
+chmod 700 "$ARTIFACT_DIR"
+cmux browser --surface "$FIRST_SURFACE" get text body > "$ARTIFACT_DIR/a.txt"
+cmux browser --surface "$SECOND_SURFACE" get text body > "$ARTIFACT_DIR/b.txt"
+chmod 600 "$ARTIFACT_DIR/a.txt" "$ARTIFACT_DIR/b.txt"
 ```
 
 ## Reusing auth across surfaces
 
 ```bash
+STATE_DIR="${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}/cmux-browser-state"
+umask 077
+mkdir -p "$STATE_DIR"
+chmod 700 "$STATE_DIR"
+STATE_FILE="$STATE_DIR/auth.json"
 SOURCE_SURFACE="surface:7"       # from discovery
-cmux browser --surface "$SOURCE_SURFACE" state save /tmp/auth.json
 DESTINATION_JSON="$(cmux --json browser open https://app.example.com --focus false)"
 DESTINATION_SURFACE="$(printf '%s' "$DESTINATION_JSON" | jq -r '.surface_ref // .surface_id // empty')"
 [ -n "$DESTINATION_SURFACE" ] || exit 1
-cmux browser --surface "$DESTINATION_SURFACE" state load /tmp/auth.json
+cmux browser --surface "$SOURCE_SURFACE" state save "$STATE_FILE"
+chmod 600 "$STATE_FILE"
+cmux browser --surface "$DESTINATION_SURFACE" state load "$STATE_FILE"
 cmux browser --surface "$DESTINATION_SURFACE" goto https://app.example.com/dashboard
 ```
 
@@ -36,7 +47,7 @@ cmux browser --surface "$DESTINATION_SURFACE" goto https://app.example.com/dashb
 
 ```bash
 cmux close-surface --surface surface:7
-rm -f /tmp/auth.json
+rm -f "$STATE_FILE"
 ```
 
 ## Best practices

--- a/skills/cmux-browser/references/session-management.md
+++ b/skills/cmux-browser/references/session-management.md
@@ -46,6 +46,8 @@ cmux browser --surface "$DESTINATION_SURFACE" goto https://app.example.com/dashb
 ## Cleanup
 
 ```bash
+STATE_DIR="${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}/cmux-browser-state"
+STATE_FILE="${STATE_FILE:-$STATE_DIR/auth.json}"
 cmux close-surface --surface surface:7
 rm -f "$STATE_FILE"
 ```

--- a/skills/cmux-browser/references/snapshot-refs.md
+++ b/skills/cmux-browser/references/snapshot-refs.md
@@ -2,14 +2,17 @@
 
 Instead of dumping the DOM and guessing selectors, snapshot the page and act on the returned refs (`e1`, `e2`, ...). Related: [commands.md](commands.md), [../SKILL.md](../SKILL.md).
 
-```bash
-cmux browser surface:7 snapshot
-cmux browser surface:7 snapshot --interactive
-cmux browser surface:7 snapshot --interactive --compact --max-depth 3
+Set `SURFACE` from creation or
+[surface discovery](surface-discovery.md) before taking the snapshot.
 
-cmux browser surface:7 fill e10 "user@example.com"
-cmux browser surface:7 fill e11 "password123"
-cmux browser surface:7 click e12
+```bash
+cmux browser --surface "$SURFACE" snapshot
+cmux browser --surface "$SURFACE" snapshot --interactive
+cmux browser --surface "$SURFACE" snapshot --interactive --compact --max-depth 3
+
+cmux browser --surface "$SURFACE" fill e10 "$APP_USERNAME"
+cmux browser --surface "$SURFACE" fill e11 "$APP_PASSWORD"
+cmux browser --surface "$SURFACE" click e12
 ```
 
 ## Ref lifecycle

--- a/skills/cmux-browser/references/surface-discovery.md
+++ b/skills/cmux-browser/references/surface-discovery.md
@@ -1,0 +1,78 @@
+# Browser Surface Discovery
+
+Existing-surface browser commands always need an explicit surface handle. Find
+the handle with read-only topology commands; never select or focus a workspace
+just to make an implicit target work.
+
+## Caller workspace
+
+Start with the context of the terminal that launched the agent:
+
+```bash
+cmux identify --json
+cmux tree --workspace "${CMUX_WORKSPACE_ID:-}" --json
+```
+
+`CMUX_WORKSPACE_ID` is the caller anchor, not necessarily the workspace visible
+on screen. If it is unavailable, use `cmux identify --json` and state that the
+current server context is being used.
+
+For one known workspace, list its panes/surfaces without selecting it:
+
+```bash
+cmux --json list-pane-surfaces --workspace workspace:N
+```
+
+## Browser in any workspace or window
+
+`tree --all --json` is the non-focus-changing global inventory. The following
+filter prints only topology refs, not page titles or URLs:
+
+```bash
+cmux tree --all --json \
+  | jq -r '
+      .windows[]? as $window
+      | $window.workspaces[]? as $workspace
+      | $workspace.panes[]? as $pane
+      | $pane.surfaces[]?
+      | select(.type == "browser")
+      | [$window.ref, $workspace.ref, $pane.ref, .ref]
+      | @tsv'
+```
+
+Pick the surface by the workspace/pane the user named, or by a URL/title only
+when the user supplied enough context to disambiguate it. Do not print or store
+raw authenticated-page metadata unnecessarily.
+
+## Inspect the chosen surface
+
+```bash
+SURFACE="surface:N"
+cmux browser --surface "$SURFACE" get url
+cmux browser --surface "$SURFACE" get title
+cmux browser --surface "$SURFACE" tab list --json
+cmux browser --surface "$SURFACE" snapshot --interactive
+```
+
+These inspection commands do not focus the browser or its workspace. Avoid
+`select-workspace`, `focus-pane`, `focus-panel`, `focus-webview`, and other
+focus-intent verbs unless the user explicitly asked to change visible focus.
+
+## Stale handles and help drift
+
+Surface refs can change when a tab is closed/replaced or a browser is restored.
+If a previously valid handle is rejected, run `cmux tree --all --json` again and
+reselect from the authoritative topology. Never fall back to a focused surface
+or a guessed numeric index.
+
+When installed documentation and the binary disagree, stop and refresh the
+contract before continuing:
+
+```bash
+cmux browser --help
+cmux --version
+npx skills add manaflow-ai/cmux --global --yes --skill cmux-browser --agent claude-code codex --copy
+```
+
+An already-running agent may have cached the old skill; start a fresh session
+after the install when needed.

--- a/skills/cmux-browser/references/surface-discovery.md
+++ b/skills/cmux-browser/references/surface-discovery.md
@@ -10,7 +10,12 @@ Start with the context of the terminal that launched the agent:
 
 ```bash
 cmux identify --json
-cmux tree --workspace "${CMUX_WORKSPACE_ID:-}" --json
+if [[ -n "${CMUX_WORKSPACE_ID:-}" ]]; then
+  cmux tree --workspace "$CMUX_WORKSPACE_ID" --json
+else
+  # With no caller anchor, use the server's current context after identify.
+  cmux tree --json
+fi
 ```
 
 `CMUX_WORKSPACE_ID` is the caller anchor, not necessarily the workspace visible
@@ -66,12 +71,13 @@ reselect from the authoritative topology. Never fall back to a focused surface
 or a guessed numeric index.
 
 When installed documentation and the binary disagree, stop and refresh the
-contract before continuing:
+contract before continuing. The installer is pinned to the reviewed `skills`
+1.5.23 release:
 
 ```bash
 cmux browser --help
 cmux --version
-npx skills add manaflow-ai/cmux --global --yes --skill cmux-browser --agent claude-code codex --copy
+npx --yes skills@1.5.23 add manaflow-ai/cmux --global --yes --skill cmux-browser --agent claude-code codex --copy
 ```
 
 An already-running agent may have cached the old skill; start a fresh session

--- a/skills/cmux-browser/references/surface-discovery.md
+++ b/skills/cmux-browser/references/surface-discovery.md
@@ -46,8 +46,34 @@ cmux tree --all --json \
 ```
 
 Pick the surface by the workspace/pane the user named, or by a URL/title only
-when the user supplied enough context to disambiguate it. Do not print or store
-raw authenticated-page metadata unnecessarily.
+when the user supplied enough context to disambiguate it. For URL/title-only
+context, use this exact-match filter; it emits only the unique surface ref and
+does not print the matched metadata:
+
+```bash
+MATCH_FIELD="url" # use "title" when matching a page title
+MATCH_VALUE="${BROWSER_URL_OR_TITLE:?set BROWSER_URL_OR_TITLE without logging it}"
+SURFACE="$(
+  cmux tree --all --json |
+    jq -r --arg field "$MATCH_FIELD" --arg value "$MATCH_VALUE" '
+      [
+        .windows[]? as $window
+        | $window.workspaces[]? as $workspace
+        | $workspace.panes[]? as $pane
+        | $pane.surfaces[]?
+        | select(.type == "browser")
+        | select((if $field == "url" then (.url // "") else (.title // "") end) == $value)
+        | .ref
+      ] as $matches
+      | if ($matches | length) == 1 then $matches[0]
+        elif ($matches | length) == 0 then error("no matching browser surface")
+        else error("multiple matches; use workspace/pane context")
+        end'
+)"
+cmux browser --surface "$SURFACE" get url
+```
+
+Do not print or store raw authenticated-page metadata unnecessarily.
 
 ## Inspect the chosen surface
 

--- a/skills/cmux-browser/references/surface-discovery.md
+++ b/skills/cmux-browser/references/surface-discovery.md
@@ -1,8 +1,11 @@
 # Browser Surface Discovery
 
-Existing-surface browser commands always need an explicit surface handle. Find
-the handle with read-only topology commands; never select or focus a workspace
-just to make an implicit target work.
+Surface-bound existing-surface browser commands need an explicit surface
+handle. The CLI also has a small, explicit global-verb allowlist (for example
+`identify`, `devtools`, `design-mode`, `zoom`, `history`, and creation/import
+verbs); those commands may omit a handle according to `SKILL.md`. Find a
+surface-bound handle with read-only topology commands; never select or focus a
+workspace just to make an implicit target work.
 
 ## Caller workspace
 
@@ -70,6 +73,10 @@ SURFACE="$(
         else error("multiple matches; use workspace/pane context")
         end'
 )"
+if [[ -z "$SURFACE" ]]; then
+  printf '%s\n' 'no uniquely matching browser surface; provide workspace/pane context' >&2
+  exit 1
+fi
 cmux browser --surface "$SURFACE" get url
 ```
 

--- a/skills/cmux-browser/references/video-recording.md
+++ b/skills/cmux-browser/references/video-recording.md
@@ -5,11 +5,11 @@
 Capture evidence for flaky-automation debugging, CI logs, and release-to-release flow diffs with step screenshots and a snapshot timeline instead:
 
 ```bash
-cmux browser surface:7 screenshot > /tmp/step1.b64
-cmux browser surface:7 snapshot --interactive > /tmp/snap-1.txt
-cmux --json browser surface:7 click e3 --snapshot-after > /tmp/action-1.json
-cmux browser surface:7 screenshot > /tmp/step2.b64
-cmux browser surface:7 snapshot --interactive > /tmp/snap-2.txt
+cmux browser --surface "$SURFACE" screenshot > /tmp/step1.b64
+cmux browser --surface "$SURFACE" snapshot --interactive > /tmp/snap-1.txt
+cmux --json browser --surface "$SURFACE" click e3 --snapshot-after > /tmp/action-1.json
+cmux browser --surface "$SURFACE" screenshot > /tmp/step2.b64
+cmux browser --surface "$SURFACE" snapshot --interactive > /tmp/snap-2.txt
 ```
 
 Capture before and after each mutating action, add `--snapshot-after` on state-changing clicks/fills/types, and group artifacts by timestamp or run id. Use an external screen recorder when full-motion capture is genuinely required.

--- a/skills/cmux-browser/templates/authenticated-session.sh
+++ b/skills/cmux-browser/templates/authenticated-session.sh
@@ -1,18 +1,23 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SURFACE="${1:-surface:1}"
+if [[ -z "${1:-}" ]]; then
+  printf 'Usage: %s <surface> [state-file] [dashboard-url]\n' "${0##*/}" >&2
+  exit 2
+fi
+
+SURFACE="$1"
 STATE_FILE="${2:-./auth-state.json}"
 DASHBOARD_URL="${3:-https://app.example.com/dashboard}"
 
 if [ -f "$STATE_FILE" ]; then
-  cmux browser "$SURFACE" state load "$STATE_FILE"
+  cmux browser --surface "$SURFACE" state load "$STATE_FILE"
 fi
 
-cmux browser "$SURFACE" goto "$DASHBOARD_URL"
-cmux browser "$SURFACE" get url
-cmux browser "$SURFACE" wait --load-state complete --timeout-ms 15000
-cmux browser "$SURFACE" snapshot --interactive
+cmux browser --surface "$SURFACE" goto "$DASHBOARD_URL"
+cmux browser --surface "$SURFACE" get url
+cmux browser --surface "$SURFACE" wait --load-state complete --timeout-ms 15000
+cmux browser --surface "$SURFACE" snapshot --interactive
 
 echo "If redirected to login, complete login flow then run:"
-echo "  cmux browser $SURFACE state save $STATE_FILE"
+printf '  cmux browser --surface %q state save %q\n' "$SURFACE" "$STATE_FILE"

--- a/skills/cmux-browser/templates/capture-workflow.sh
+++ b/skills/cmux-browser/templates/capture-workflow.sh
@@ -1,13 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SURFACE="${1:-surface:1}"
+if [[ -z "${1:-}" ]]; then
+  printf 'Usage: %s <surface> [output-directory]\n' "${0##*/}" >&2
+  exit 2
+fi
+
+SURFACE="$1"
 OUT_DIR="${2:-./browser-artifacts}"
 mkdir -p "$OUT_DIR"
 
 TS="$(date +%Y%m%d-%H%M%S)"
-cmux browser "$SURFACE" snapshot --interactive > "$OUT_DIR/snapshot-$TS.txt"
-cmux browser "$SURFACE" screenshot > "$OUT_DIR/screenshot-$TS.b64"
+cmux browser --surface "$SURFACE" snapshot --interactive > "$OUT_DIR/snapshot-$TS.txt"
+cmux browser --surface "$SURFACE" screenshot > "$OUT_DIR/screenshot-$TS.b64"
 
 echo "Wrote: $OUT_DIR/snapshot-$TS.txt"
 echo "Wrote: $OUT_DIR/screenshot-$TS.b64"

--- a/skills/cmux-browser/templates/form-automation.sh
+++ b/skills/cmux-browser/templates/form-automation.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-URL="${1:-https://example.com/form}"
-SURFACE="${2:-surface:1}"
+if [[ -z "${1:-}" || -z "${2:-}" ]]; then
+  printf 'Usage: %s <url> <surface>\n' "${0##*/}" >&2
+  exit 2
+fi
 
-cmux browser "$SURFACE" goto "$URL"
-cmux browser "$SURFACE" get url
-cmux browser "$SURFACE" wait --load-state complete --timeout-ms 15000
-cmux browser "$SURFACE" snapshot --interactive
+URL="$1"
+SURFACE="$2"
+
+cmux browser --surface "$SURFACE" goto "$URL"
+cmux browser --surface "$SURFACE" get url
+cmux browser --surface "$SURFACE" wait --load-state complete --timeout-ms 15000
+cmux browser --surface "$SURFACE" snapshot --interactive
 
 echo "Now run fill/click commands using refs from the snapshot above."

--- a/tests/test_cmux_browser_skill.py
+++ b/tests/test_cmux_browser_skill.py
@@ -90,6 +90,7 @@ def test_nested_commands_are_checked(validator: ModuleType) -> None:
     fixture = "```bash\n"
     fixture += 'URL="$(' + browser + 'url)"\n'
     fixture += 'TABS="$(' + browser + 'tab list)"\n'
+    fixture += 'NESTED="$(printf "%s" "$(' + browser + 'snapshot -i)")"\n'
     fixture += "```\n"
     examples = [
         validator.ShellExample(Path("nested-fixture.md"), line, text)
@@ -99,7 +100,7 @@ def test_nested_commands_are_checked(validator: ModuleType) -> None:
     if parse_errors:
         raise AssertionError(f"nested fixture parser failed: {parse_errors}")
     errors = [error for command in commands for error in validator.validate_command(command)]
-    if len(errors) != 2 or not all("explicit" in error for error in errors):
+    if len(errors) != 3 or not all("explicit" in error for error in errors):
         raise AssertionError(f"nested unscoped commands were not rejected: {errors}")
 
 

--- a/tests/test_cmux_browser_skill.py
+++ b/tests/test_cmux_browser_skill.py
@@ -10,6 +10,8 @@ any user's browser state.
 
 from __future__ import annotations
 
+import contextlib
+import io
 import importlib.util
 import os
 import subprocess
@@ -83,8 +85,37 @@ cmux browser --surface surface:1 tab list
         raise AssertionError(f"surface-scoped aliases were rejected: {errors}")
 
 
+def test_nested_commands_are_checked(validator: ModuleType) -> None:
+    browser = "cmux browser "
+    fixture = "```bash\n"
+    fixture += 'URL="$(' + browser + 'url)"\n'
+    fixture += 'TABS="$(' + browser + 'tab list)"\n'
+    fixture += "```\n"
+    examples = [
+        validator.ShellExample(Path("nested-fixture.md"), line, text)
+        for line, text in enumerate(fixture.splitlines(), start=1)
+    ]
+    commands, parse_errors = validator.browser_commands(examples)
+    if parse_errors:
+        raise AssertionError(f"nested fixture parser failed: {parse_errors}")
+    errors = [error for command in commands for error in validator.validate_command(command)]
+    if len(errors) != 2 or not all("explicit" in error for error in errors):
+        raise AssertionError(f"nested unscoped commands were not rejected: {errors}")
+
+
+def test_longer_markdown_fences_are_not_closed_early(validator: ModuleType) -> None:
+    fixture = "````bash\ncmux browser --surface surface:1 get url\n```\n"
+    fixture += "cmux browser --surface surface:1 snapshot --interactive\n````\n"
+    blocks = list(validator._fenced_shell_blocks(Path("fence-fixture.md"), fixture))
+    if len(blocks) != 1 or "snapshot --interactive" not in blocks[0][1]:
+        raise AssertionError(f"longer fence was closed before its matching fence: {blocks}")
+
+
 def test_templates_require_a_surface() -> None:
-    for template in sorted((ROOT / "skills" / "cmux-browser" / "templates").glob("*.sh")):
+    templates = sorted((ROOT / "skills" / "cmux-browser" / "templates").glob("*.sh"))
+    if not templates:
+        raise AssertionError("cmux-browser template directory contains no shell templates")
+    for template in templates:
         environment = dict(os.environ)
         environment.pop("CMUX_SURFACE_ID", None)
         result = subprocess.run(
@@ -115,14 +146,25 @@ def test_live_help_when_available(validator: ModuleType) -> None:
         raise AssertionError("live help contract failed:\n- " + "\n- ".join(errors))
 
 
+def test_cli_flags_are_mutually_exclusive(validator: ModuleType) -> None:
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        result = validator.main(["--no-cli", "--require-cli"])
+    if result == 0 or "mutually exclusive" not in output.getvalue():
+        raise AssertionError("--no-cli and --require-cli must not silently pass together")
+
+
 def main() -> int:
     validator = load_validator()
     tests = [
         lambda: test_repository_contract(validator),
         lambda: test_old_unscoped_forms_are_rejected(validator),
         lambda: test_scoped_aliases_are_accepted(validator),
+        lambda: test_nested_commands_are_checked(validator),
+        lambda: test_longer_markdown_fences_are_not_closed_early(validator),
         test_templates_require_a_surface,
         lambda: test_live_help_when_available(validator),
+        lambda: test_cli_flags_are_mutually_exclusive(validator),
     ]
     for test in tests:
         test()

--- a/tests/test_cmux_browser_skill.py
+++ b/tests/test_cmux_browser_skill.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Executable regression coverage for the cmux-browser skill contract.
+
+The repository guard tokenizes the shell examples and, when available, runs
+the real ``cmux browser --help`` command. These tests keep the guard honest by
+proving that the historical unscoped forms fail validation while their
+surface-scoped aliases pass. They do not depend on a live browser or expose
+any user's browser state.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+ROOT = Path(__file__).resolve().parent.parent
+VALIDATOR_PATH = ROOT / "scripts" / "validate-cmux-browser-skill.py"
+
+
+def load_validator() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("cmux_browser_skill_validator", VALIDATOR_PATH)
+    if spec is None or spec.loader is None:
+        raise AssertionError(f"unable to load {VALIDATOR_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_repository_contract(validator: ModuleType) -> None:
+    errors = validator.validate_repository(ROOT)
+    if errors:
+        raise AssertionError("repository contract failed:\n- " + "\n- ".join(errors))
+
+
+def test_old_unscoped_forms_are_rejected(validator: ModuleType) -> None:
+    browser = "cmux browser "
+    fixture = "```bash\n"
+    fixture += browser + "tab list\n"
+    fixture += browser + "url\n"
+    fixture += browser + "snapshot -i\n"
+    fixture += browser + "list\n"
+    fixture += "```\n"
+    examples = [
+        validator.ShellExample(Path("stale-fixture.md"), line, text)
+        for line, text in enumerate(fixture.splitlines(), start=1)
+    ]
+    commands, parse_errors = validator.browser_commands(examples)
+    if parse_errors:
+        raise AssertionError(f"fixture parser failed: {parse_errors}")
+    errors = [error for command in commands for error in validator.validate_command(command)]
+    if len(errors) != 4:
+        raise AssertionError(f"expected all four stale forms to fail, got {errors}")
+    if not all("explicit" in error and "surface" in error for error in errors[:3]):
+        raise AssertionError(f"surface omissions were not diagnosed: {errors}")
+    if "unsupported browser verb 'list'" not in errors[3]:
+        raise AssertionError(f"stale list verb was not diagnosed: {errors}")
+
+
+def test_scoped_aliases_are_accepted(validator: ModuleType) -> None:
+    fixture = """
+```bash
+cmux browser --surface surface:1 get url
+cmux browser surface:1 get-url
+cmux browser surface:1 snapshot -i
+cmux browser --surface surface:1 tab list
+```
+"""
+    examples = [
+        validator.ShellExample(Path("scoped-fixture.md"), line, text)
+        for line, text in enumerate(fixture.splitlines(), start=1)
+    ]
+    commands, parse_errors = validator.browser_commands(examples)
+    if parse_errors:
+        raise AssertionError(f"fixture parser failed: {parse_errors}")
+    errors = [error for command in commands for error in validator.validate_command(command)]
+    if errors:
+        raise AssertionError(f"surface-scoped aliases were rejected: {errors}")
+
+
+def test_templates_require_a_surface() -> None:
+    for template in sorted((ROOT / "skills" / "cmux-browser" / "templates").glob("*.sh")):
+        environment = dict(os.environ)
+        environment.pop("CMUX_SURFACE_ID", None)
+        result = subprocess.run(
+            ["bash", str(template)],
+            cwd=ROOT,
+            env=environment,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+        if result.returncode != 2 or "Usage:" not in result.stderr:
+            raise AssertionError(
+                f"{template} accepted a missing surface: "
+                f"status={result.returncode} stderr={result.stderr!r}"
+            )
+
+
+def test_live_help_when_available(validator: ModuleType) -> None:
+    cli = validator.resolve_cli(os.environ.get("CMUX_CLI_BIN"))
+    if not cli:
+        return
+    help_text, error = validator.live_help(cli)
+    if error or help_text is None:
+        raise AssertionError(error or "cmux browser --help returned no output")
+    errors = validator.validate_repository(ROOT, help_text=help_text)
+    if errors:
+        raise AssertionError("live help contract failed:\n- " + "\n- ".join(errors))
+
+
+def main() -> int:
+    validator = load_validator()
+    tests = [
+        lambda: test_repository_contract(validator),
+        lambda: test_old_unscoped_forms_are_rejected(validator),
+        lambda: test_scoped_aliases_are_accepted(validator),
+        test_templates_require_a_surface,
+        lambda: test_live_help_when_available(validator),
+    ]
+    for test in tests:
+        test()
+    print(f"PASS: {len(tests)} cmux-browser skill contract tests")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cmux_browser_skill.py
+++ b/tests/test_cmux_browser_skill.py
@@ -91,6 +91,7 @@ def test_nested_commands_are_checked(validator: ModuleType) -> None:
     fixture += 'URL="$(' + browser + 'url)"\n'
     fixture += 'TABS="$(' + browser + 'tab list)"\n'
     fixture += 'NESTED="$(printf "%s" "$(' + browser + 'snapshot -i)")"\n'
+    fixture += 'QUOTED="$(printf \'%s\' \'x\\\' "$(' + browser + 'url)")"\n'
     fixture += "```\n"
     examples = [
         validator.ShellExample(Path("nested-fixture.md"), line, text)
@@ -100,7 +101,7 @@ def test_nested_commands_are_checked(validator: ModuleType) -> None:
     if parse_errors:
         raise AssertionError(f"nested fixture parser failed: {parse_errors}")
     errors = [error for command in commands for error in validator.validate_command(command)]
-    if len(errors) != 3 or not all("explicit" in error for error in errors):
+    if len(errors) != 4 or not all("explicit" in error for error in errors):
         raise AssertionError(f"nested unscoped commands were not rejected: {errors}")
 
 

--- a/tests/test_cmux_browser_skill.py
+++ b/tests/test_cmux_browser_skill.py
@@ -104,6 +104,24 @@ def test_nested_commands_are_checked(validator: ModuleType) -> None:
         raise AssertionError(f"nested unscoped commands were not rejected: {errors}")
 
 
+def test_literal_substitution_text_is_ignored(validator: ModuleType) -> None:
+    browser = "cmux browser "
+    fixture = "```bash\n"
+    fixture += "MESSAGE='$(" + browser + "url)'\n"
+    fixture += "MESSAGE=\\$(" + browser + "tab list)\n"
+    fixture += "```\n"
+    examples = [
+        validator.ShellExample(Path("literal-substitution-fixture.md"), line, text)
+        for line, text in enumerate(fixture.splitlines(), start=1)
+    ]
+    commands, parse_errors = validator.browser_commands(examples)
+    if parse_errors or commands:
+        raise AssertionError(
+            f"literal/escaped substitution text was treated as executable: "
+            f"commands={commands} errors={parse_errors}"
+        )
+
+
 def test_longer_markdown_fences_are_not_closed_early(validator: ModuleType) -> None:
     fixture = "````bash\ncmux browser --surface surface:1 get url\n```\n"
     fixture += "cmux browser --surface surface:1 snapshot --interactive\n````\n"
@@ -162,6 +180,7 @@ def main() -> int:
         lambda: test_old_unscoped_forms_are_rejected(validator),
         lambda: test_scoped_aliases_are_accepted(validator),
         lambda: test_nested_commands_are_checked(validator),
+        lambda: test_literal_substitution_text_is_ignored(validator),
         lambda: test_longer_markdown_fences_are_not_closed_early(validator),
         test_templates_require_a_surface,
         lambda: test_live_help_when_available(validator),

--- a/tests/test_cmux_browser_skill.py
+++ b/tests/test_cmux_browser_skill.py
@@ -42,15 +42,15 @@ def test_repository_contract(validator: ModuleType) -> None:
 
 def test_old_unscoped_forms_are_rejected(validator: ModuleType) -> None:
     browser = "cmux browser "
-    fixture = "```bash\n"
-    fixture += browser + "tab list\n"
-    fixture += browser + "url\n"
-    fixture += browser + "snapshot -i\n"
-    fixture += browser + "list\n"
-    fixture += "```\n"
+    fixture = [
+        browser + "tab list",
+        browser + "url",
+        browser + "snapshot -i",
+        browser + "list",
+    ]
     examples = [
         validator.ShellExample(Path("stale-fixture.md"), line, text)
-        for line, text in enumerate(fixture.splitlines(), start=1)
+        for line, text in enumerate(fixture, start=1)
     ]
     commands, parse_errors = validator.browser_commands(examples)
     if parse_errors:
@@ -65,17 +65,15 @@ def test_old_unscoped_forms_are_rejected(validator: ModuleType) -> None:
 
 
 def test_scoped_aliases_are_accepted(validator: ModuleType) -> None:
-    fixture = """
-```bash
-cmux browser --surface surface:1 get url
-cmux browser surface:1 get-url
-cmux browser surface:1 snapshot -i
-cmux browser --surface surface:1 tab list
-```
-"""
+    fixture = [
+        "cmux browser --surface surface:1 get url",
+        "cmux browser surface:1 get-url",
+        "cmux browser surface:1 snapshot -i",
+        "cmux browser --surface surface:1 tab list",
+    ]
     examples = [
         validator.ShellExample(Path("scoped-fixture.md"), line, text)
-        for line, text in enumerate(fixture.splitlines(), start=1)
+        for line, text in enumerate(fixture, start=1)
     ]
     commands, parse_errors = validator.browser_commands(examples)
     if parse_errors:
@@ -87,15 +85,15 @@ cmux browser --surface surface:1 tab list
 
 def test_nested_commands_are_checked(validator: ModuleType) -> None:
     browser = "cmux browser "
-    fixture = "```bash\n"
-    fixture += 'URL="$(' + browser + 'url)"\n'
-    fixture += 'TABS="$(' + browser + 'tab list)"\n'
-    fixture += 'NESTED="$(printf "%s" "$(' + browser + 'snapshot -i)")"\n'
-    fixture += 'QUOTED="$(printf \'%s\' \'x\\\' "$(' + browser + 'url)")"\n'
-    fixture += "```\n"
+    fixture = [
+        'URL="$(' + browser + 'url)"',
+        'TABS="$(' + browser + 'tab list)"',
+        'NESTED="$(printf "%s" "$(' + browser + 'snapshot -i)")"',
+        'QUOTED="$(printf \'%s\' \'x\\\' "$(' + browser + 'url)")"',
+    ]
     examples = [
         validator.ShellExample(Path("nested-fixture.md"), line, text)
-        for line, text in enumerate(fixture.splitlines(), start=1)
+        for line, text in enumerate(fixture, start=1)
     ]
     commands, parse_errors = validator.browser_commands(examples)
     if parse_errors:
@@ -107,19 +105,54 @@ def test_nested_commands_are_checked(validator: ModuleType) -> None:
 
 def test_literal_substitution_text_is_ignored(validator: ModuleType) -> None:
     browser = "cmux browser "
-    fixture = "```bash\n"
-    fixture += "MESSAGE='$(" + browser + "url)'\n"
-    fixture += "MESSAGE=\\$(" + browser + "tab list)\n"
-    fixture += "```\n"
+    fixture = [
+        "MESSAGE='$(" + browser + "url)'",
+        "MESSAGE=\\$(" + browser + "tab list)",
+    ]
     examples = [
         validator.ShellExample(Path("literal-substitution-fixture.md"), line, text)
-        for line, text in enumerate(fixture.splitlines(), start=1)
+        for line, text in enumerate(fixture, start=1)
     ]
     commands, parse_errors = validator.browser_commands(examples)
     if parse_errors or commands:
         raise AssertionError(
             f"literal/escaped substitution text was treated as executable: "
             f"commands={commands} errors={parse_errors}"
+        )
+
+
+def test_adjacent_shell_operators_do_not_cross_scope(validator: ModuleType) -> None:
+    browser = "cmux browser "
+    fixture = [
+        browser + "goto https://example.test;" + browser + "--surface surface:1 get url",
+        browser + "snapshot -i&&" + browser + "--surface surface:1 get title",
+    ]
+    examples = [
+        validator.ShellExample(Path("operator-fixture.md"), line, text)
+        for line, text in enumerate(fixture, start=1)
+    ]
+    commands, parse_errors = validator.browser_commands(examples)
+    if parse_errors:
+        raise AssertionError(f"operator fixture parser failed: {parse_errors}")
+    errors = [error for command in commands for error in validator.validate_command(command)]
+    if len(errors) != 2 or not all("explicit" in error for error in errors):
+        raise AssertionError(f"adjacent operators allowed a later surface to scope an earlier command: {errors}")
+
+
+def test_unterminated_substitutions_fail_closed(validator: ModuleType) -> None:
+    browser = "cmux browser "
+    fixture = [
+        'URL="$(' + browser + 'url"',
+        'URL=`' + browser + 'tab list',
+    ]
+    examples = [
+        validator.ShellExample(Path("unterminated-fixture.md"), line, text)
+        for line, text in enumerate(fixture, start=1)
+    ]
+    commands, parse_errors = validator.browser_commands(examples)
+    if len(parse_errors) != 2 or commands:
+        raise AssertionError(
+            f"unterminated substitutions were not rejected: commands={commands} errors={parse_errors}"
         )
 
 
@@ -182,6 +215,8 @@ def main() -> int:
         lambda: test_scoped_aliases_are_accepted(validator),
         lambda: test_nested_commands_are_checked(validator),
         lambda: test_literal_substitution_text_is_ignored(validator),
+        lambda: test_adjacent_shell_operators_do_not_cross_scope(validator),
+        lambda: test_unterminated_substitutions_fail_closed(validator),
         lambda: test_longer_markdown_fences_are_not_closed_early(validator),
         test_templates_require_a_surface,
         lambda: test_live_help_when_available(validator),

--- a/tests/test_cmux_browser_skill.py
+++ b/tests/test_cmux_browser_skill.py
@@ -47,6 +47,11 @@ def test_old_unscoped_forms_are_rejected(validator: ModuleType) -> None:
         browser + "url",
         browser + "snapshot -i",
         browser + "list",
+        browser + "dialog accept",
+        browser + "addinitscript script",
+        browser + "addscript script",
+        browser + "addstyle css",
+        browser + "screencast start",
     ]
     examples = [
         validator.ShellExample(Path("stale-fixture.md"), line, text)
@@ -56,12 +61,37 @@ def test_old_unscoped_forms_are_rejected(validator: ModuleType) -> None:
     if parse_errors:
         raise AssertionError(f"fixture parser failed: {parse_errors}")
     errors = [error for command in commands for error in validator.validate_command(command)]
-    if len(errors) != 4:
-        raise AssertionError(f"expected all four stale forms to fail, got {errors}")
-    if not all("explicit" in error and "surface" in error for error in errors[:3]):
+    if len(errors) != len(fixture):
+        raise AssertionError(f"expected every stale form to fail, got {errors}")
+    surface_errors = errors[:3] + errors[4:]
+    if not all("explicit" in error and "surface" in error for error in surface_errors):
         raise AssertionError(f"surface omissions were not diagnosed: {errors}")
     if "unsupported browser verb 'list'" not in errors[3]:
         raise AssertionError(f"stale list verb was not diagnosed: {errors}")
+
+
+def test_explicitly_global_verbs_are_allowed_without_surface(validator: ModuleType) -> None:
+    fixture = [
+        "cmux browser identify --json",
+        "cmux browser devtools toggle",
+        "cmux browser design-mode status",
+        "cmux browser zoom in",
+        "cmux browser history clear --force",
+        "cmux browser react-grab toggle",
+        "cmux browser open https://example.test",
+        "cmux browser profiles list",
+        "cmux browser import --non-interactive",
+    ]
+    examples = [
+        validator.ShellExample(Path("global-fixture.md"), line, text)
+        for line, text in enumerate(fixture, start=1)
+    ]
+    commands, parse_errors = validator.browser_commands(examples)
+    if parse_errors:
+        raise AssertionError(f"global fixture parser failed: {parse_errors}")
+    errors = [error for command in commands for error in validator.validate_command(command)]
+    if errors:
+        raise AssertionError(f"explicitly global browser verbs were rejected: {errors}")
 
 
 def test_scoped_aliases_are_accepted(validator: ModuleType) -> None:
@@ -212,6 +242,7 @@ def main() -> int:
     tests = [
         lambda: test_repository_contract(validator),
         lambda: test_old_unscoped_forms_are_rejected(validator),
+        lambda: test_explicitly_global_verbs_are_allowed_without_surface(validator),
         lambda: test_scoped_aliases_are_accepted(validator),
         lambda: test_nested_commands_are_checked(validator),
         lambda: test_literal_substitution_text_is_ignored(validator),


### PR DESCRIPTION
## Summary

The cmux-browser skill and its Claude/Codex distribution copies were teaching stale unscoped browser commands. This updates the authoritative skill, references, templates, and registration metadata to require an explicit surface for existing-surface operations, adds focus-neutral cross-workspace surface discovery, and documents the supported refresh path.

A maintainable executable contract validates shell examples against `cmux browser --help`, rejects unscoped browser verbs/templates, and exercises representative surface-scoped aliases without a live browser. The guard is wired into a dedicated workflow.

## Validation

- `python3 tests/test_cmux_browser_skill.py`
- `CMUX_CLI_BIN=cmux python3 scripts/validate-cmux-browser-skill.py --require-cli`
- `bash -n skills/cmux-browser/templates/*.sh`
- `git diff --check`

The regression guard and fix are intentionally separate commits so CI can prove the guard catches the pre-fix templates.

Fixes #11082

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #11082. Existing-surface `cmux browser` commands previously acted on a focused or guessed target; they now require an explicit `--surface <handle>` or positional handle, while `open`, `open-split`, `new`, and other explicitly global verbs stay unscoped. Auth examples now keep saved state in private, permission-restricted directories, and discovery uses read-only topology so focus never changes.

**Validation**
- Adds an executable validator that tokenizes shell examples, checks them against live `cmux browser --help`, and rejects unscoped and unknown verbs, including nested, quoted/escaped, and operator-split substitutions, aliases, and `--no-cli`/`--require-cli` modes.
- Adds regression tests and wires the validator into `.github/workflows/cmux-skill-contract.yml`.
- Updates templates to fail fast without a surface argument, adds focus-neutral discovery docs (`cmux tree --all --json`), refreshes registration metadata, and pins `skills@1.5.23` refresh instructions.

<sup>Written for commit 5d477d6214e06e639ea7e1190eca3e369b4365e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added safer browser-surface discovery and explicit targeting for browser workflows.
  * Added guidance for stale surface references and protecting sensitive authentication data.
  * Updated templates to require an explicit surface instead of using defaults.
  * Added documentation for supported command aliases and browser-surface workflows.

* **Bug Fixes**
  * Prevented browser commands from unintentionally targeting or changing focus on the wrong surface.

* **Tests**
  * Added automated validation for command syntax, documentation, aliases, and template usage.
  * Added continuous checks for browser skill documentation and command contracts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->