### PR TITLE
iOS: manual simulator pane refresh from the phone

### DIFF
--- a/Packages/Shared/CmuxSimulatorStreamKit/Sources/CmuxSimulatorStreamKit/SimStreamViewerLifecycle.swift
+++ b/Packages/Shared/CmuxSimulatorStreamKit/Sources/CmuxSimulatorStreamKit/SimStreamViewerLifecycle.swift
@@ -34,6 +34,8 @@ public struct SimStreamViewerLifecycle: Sendable, Equatable {
         case framePresented
         /// Decoder gave up (repeated failures) or watchdog saw no progress.
         case streamWedged(reason: String)
+        /// The user explicitly asked for a fresh session (pane refresh).
+        case refreshRequested
         case hostEnded(status: SimStreamHostStatus, detail: String)
         case retryDelayElapsed
         case appBackgrounded
@@ -111,6 +113,19 @@ public struct SimStreamViewerLifecycle: Sendable, Equatable {
         case (.waitingForTransport, .transportLost),
             (.retrying, .transportLost):
             return .none
+
+        // Explicit user refresh: drop everything and go back through the one
+        // reattach path right away. Deliberate intent pays no backoff penalty
+        // and escapes even host-declared endings, because the user may have
+        // just fixed the Mac side (reopened the pane, recovered the worker).
+        case (.waitingForTransport, .refreshRequested),
+            (.starting, .refreshRequested),
+            (.streaming, .refreshRequested),
+            (.retrying, .refreshRequested),
+            (.unavailable, .refreshRequested):
+            backoff.reset()
+            phase = .waitingForTransport
+            return .teardown
 
         // Host-declared endings are terminal until reactivated; retrying
         // into a closed panel would loop forever.

--- a/Packages/Shared/CmuxSimulatorStreamKit/Tests/CmuxSimulatorStreamKitTests/SimStreamPolicyTests.swift
+++ b/Packages/Shared/CmuxSimulatorStreamKit/Tests/CmuxSimulatorStreamKitTests/SimStreamPolicyTests.swift
@@ -288,4 +288,70 @@ struct SimStreamViewerLifecycleTests {
         #expect(lifecycle.phase == .stopped)
         #expect(lifecycle.handle(.deactivate) == .none)
     }
+
+    @Test
+    func refreshRequestedRestartsAStreamingSession() {
+        var lifecycle = SimStreamViewerLifecycle()
+        _ = lifecycle.handle(.activate)
+        _ = lifecycle.handle(.transportReady)
+        _ = lifecycle.handle(.startSucceeded)
+        #expect(lifecycle.handle(.refreshRequested) == .teardown)
+        #expect(lifecycle.phase == .waitingForTransport)
+        #expect(lifecycle.handle(.transportReady) == .openLaneAndStart)
+    }
+
+    @Test
+    func refreshRequestedEscapesHostEndedUnavailable() {
+        var lifecycle = SimStreamViewerLifecycle()
+        _ = lifecycle.handle(.activate)
+        _ = lifecycle.handle(.transportReady)
+        _ = lifecycle.handle(.startSucceeded)
+        _ = lifecycle.handle(.hostEnded(status: .closed, detail: "superseded"))
+        #expect(lifecycle.phase == .unavailable(reason: "superseded"))
+        #expect(lifecycle.handle(.refreshRequested) == .teardown)
+        #expect(lifecycle.phase == .waitingForTransport)
+        #expect(lifecycle.handle(.transportReady) == .openLaneAndStart)
+    }
+
+    @Test
+    func refreshRequestedSkipsPendingRetryDelayAndResetsBackoff() {
+        var lifecycle = SimStreamViewerLifecycle()
+        _ = lifecycle.handle(.activate)
+        _ = lifecycle.handle(.transportReady)
+        _ = lifecycle.handle(.startSucceeded)
+        // Grow the backoff past its base.
+        _ = lifecycle.handle(.streamWedged(reason: "x"))
+        _ = lifecycle.handle(.retryDelayElapsed)
+        _ = lifecycle.handle(.transportReady)
+        guard case .teardownAndRetry = lifecycle.handle(.streamWedged(reason: "x")) else {
+            Issue.record("expected retry")
+            return
+        }
+        // Refresh escapes the pending delay immediately...
+        #expect(lifecycle.handle(.refreshRequested) == .teardown)
+        #expect(lifecycle.phase == .waitingForTransport)
+        #expect(lifecycle.handle(.transportReady) == .openLaneAndStart)
+        // ...and the next wedge pays base backoff again, not the grown one.
+        guard case .teardownAndRetry(let delay) = lifecycle.handle(.transportLost) else {
+            Issue.record("expected retry")
+            return
+        }
+        #expect(delay == 0.25)
+    }
+
+    @Test
+    func refreshRequestedIgnoredWhileInactive() {
+        var lifecycle = SimStreamViewerLifecycle()
+        #expect(lifecycle.handle(.refreshRequested) == .none)
+        #expect(lifecycle.phase == .idle)
+        _ = lifecycle.handle(.activate)
+        _ = lifecycle.handle(.transportReady)
+        _ = lifecycle.handle(.appBackgrounded)
+        #expect(lifecycle.handle(.refreshRequested) == .none)
+        #expect(lifecycle.phase == .backgrounded)
+        _ = lifecycle.handle(.appForegrounded)
+        _ = lifecycle.handle(.deactivate)
+        #expect(lifecycle.handle(.refreshRequested) == .none)
+        #expect(lifecycle.phase == .stopped)
+    }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SimulatorStreamV2Pane.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SimulatorStreamV2Pane.swift
@@ -28,6 +28,7 @@ struct SimulatorStreamV2Pane: View {
     @State private var pendingText = ""
     @State private var devices: [MobileSimulatorDeviceDescriptor] = []
     @State private var deviceFetchTask: Task<Void, Never>?
+    @State private var refreshTask: Task<Void, Never>?
     @AppStorage("cmux.simulatorStream.quality")
     private var qualityRaw = SimStreamQualityPreset.default.rawValue
     @FocusState private var textFocused: Bool
@@ -73,6 +74,8 @@ struct SimulatorStreamV2Pane: View {
         .onDisappear {
             deviceFetchTask?.cancel()
             deviceFetchTask = nil
+            refreshTask?.cancel()
+            refreshTask = nil
         }
         .onChange(of: qualityRaw) { _, _ in
             store?.setQuality(maximumLongSidePixels: quality.maximumLongSidePixels)
@@ -148,15 +151,17 @@ struct SimulatorStreamV2Pane: View {
     /// One shared refresh path for every entrypoint (menu item, overlay
     /// buttons, recovery overlay): ask the Mac to recover the worker first
     /// when the host reports it dead, then rebuild the local session through
-    /// the store's single reattach flow.
+    /// the store's single reattach flow. Single-flight: extra taps while a
+    /// refresh is in flight are dropped, so recover RPCs never overlap.
     private func refreshStream() {
-        guard let store else { return }
+        guard let store, refreshTask == nil else { return }
         let needsHostRecovery = hostNeedsRecovery(store.hostStatus)
-        Task {
+        refreshTask = Task {
             if supportsRecover, needsHostRecovery {
                 _ = await recover()
             }
             store.refresh()
+            refreshTask = nil
         }
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SimulatorStreamV2Pane.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SimulatorStreamV2Pane.swift
@@ -44,7 +44,7 @@ struct SimulatorStreamV2Pane: View {
                 if let store {
                     SimStreamDisplayRepresentable(store: store)
                         .accessibilityIdentifier("SimulatorStreamV2Video")
-                    if store.hostStatus == .workerCrashed || store.hostStatus == .failed {
+                    if hostNeedsRecovery(store.hostStatus) {
                         recoveryOverlay
                     } else {
                         overlay(for: store.phase)
@@ -107,7 +107,8 @@ struct SimulatorStreamV2Pane: View {
                 detail: L10n.string(
                     "mobile.simulatorStream.waitingDetail",
                     defaultValue: "The first frame will appear when the Mac is ready."),
-                symbol: "iphone"
+                symbol: "iphone",
+                refresh: .afterStall
             )
             .accessibilityIdentifier("SimulatorStreamV2Placeholder")
         case .reconnecting:
@@ -117,19 +118,45 @@ struct SimulatorStreamV2Pane: View {
                 detail: L10n.string(
                     "mobile.simulatorStream.stalledDetail",
                     defaultValue: "The video feed stalled. Restoring the stream."),
-                symbol: "arrow.triangle.2.circlepath"
+                symbol: "arrow.triangle.2.circlepath",
+                refresh: .afterStall
             )
             .accessibilityIdentifier("SimulatorStreamV2ReconnectingOverlay")
         case .unavailable(let detail):
+            // Refresh reattaches the stream, which cannot help while the Mac
+            // has simulator panes disabled, so that one state stays inert.
             statusOverlay(
                 title: L10n.string(
                     "mobile.simulatorStream.unavailable", defaultValue: "Simulator Unavailable"),
                 detail: Self.unavailableDetailText(detail),
-                symbol: "iphone.slash"
+                symbol: "iphone.slash",
+                refresh: detail == "simulator_disabled" ? .hidden : .immediate
             )
             .accessibilityIdentifier("SimulatorStreamV2UnavailableOverlay")
         case .streaming, .stopped:
             EmptyView()
+        }
+    }
+
+    /// Mirrors the Mac pane's Reconnect states: a crash-fused worker, a
+    /// failed session, or a vanished device never self-heals, so the frozen
+    /// frame needs a host-side recover, not another lane retry.
+    private func hostNeedsRecovery(_ status: SimStreamHostStatus?) -> Bool {
+        status == .workerCrashed || status == .failed || status == .deviceUnavailable
+    }
+
+    /// One shared refresh path for every entrypoint (menu item, overlay
+    /// buttons, recovery overlay): ask the Mac to recover the worker first
+    /// when the host reports it dead, then rebuild the local session through
+    /// the store's single reattach flow.
+    private func refreshStream() {
+        guard let store else { return }
+        let needsHostRecovery = hostNeedsRecovery(store.hostStatus)
+        Task {
+            if supportsRecover, needsHostRecovery {
+                _ = await recover()
+            }
+            store.refresh()
         }
     }
 
@@ -158,7 +185,7 @@ struct SimulatorStreamV2Pane: View {
                 .multilineTextAlignment(.center)
                 if supportsRecover {
                     Button {
-                        Task { _ = await recover() }
+                        refreshStream()
                     } label: {
                         Text(
                             L10n.string(
@@ -202,18 +229,57 @@ struct SimulatorStreamV2Pane: View {
         }
     }
 
-    private func statusOverlay(title: String, detail: String, symbol: String) -> some View {
+    /// How a status overlay offers the manual refresh escape hatch.
+    private enum OverlayRefresh {
+        /// No refresh affordance (refreshing cannot change the state).
+        case hidden
+        /// Refresh is available right away (terminal states).
+        case immediate
+        /// Refresh appears only once the wait has clearly stalled, so the
+        /// routine sub-second connect never flashes a button.
+        case afterStall
+    }
+
+    private func statusOverlay(
+        title: String, detail: String, symbol: String, refresh: OverlayRefresh
+    ) -> some View {
         ZStack {
             Color.black.opacity(0.72)
             VStack(spacing: 12) {
                 Image(systemName: symbol).font(.system(size: 36))
                 Text(title).font(.headline)
                 Text(detail).font(.subheadline).multilineTextAlignment(.center)
+                switch refresh {
+                case .hidden:
+                    EmptyView()
+                case .immediate:
+                    overlayRefreshButton
+                case .afterStall:
+                    StalledRefreshReveal {
+                        overlayRefreshButton
+                    }
+                }
             }
             .foregroundStyle(.white)
             .padding(28)
         }
-        .allowsHitTesting(false)
+        // A dead stream has nothing useful under the overlay, so swallowing
+        // touches costs nothing and keeps the refresh button tappable.
+        .allowsHitTesting(refresh != .hidden)
+    }
+
+    private var overlayRefreshButton: some View {
+        Button {
+            refreshStream()
+        } label: {
+            Text(L10n.string("mobile.simulatorStream.refresh", defaultValue: "Refresh"))
+                .font(.subheadline.weight(.semibold))
+                .padding(.horizontal, 18)
+                .padding(.vertical, 8)
+        }
+        .buttonStyle(.bordered)
+        .tint(.white)
+        .accessibilityIdentifier("SimulatorStreamV2RefreshButton")
     }
 
     private var bottomBar: some View {
@@ -265,6 +331,19 @@ struct SimulatorStreamV2Pane: View {
                 menuButton(
                     .siri, systemImage: "waveform",
                     label: L10n.string("mobile.simulatorStream.siri", defaultValue: "Siri"))
+                // Manual escape hatch in every state, including a frozen
+                // frame the phase machine still believes is streaming.
+                Button {
+                    refreshStream()
+                } label: {
+                    Label(
+                        L10n.string(
+                            "mobile.simulatorStream.refreshSimulator",
+                            defaultValue: "Refresh Simulator"),
+                        systemImage: "arrow.clockwise"
+                    )
+                }
+                .accessibilityIdentifier("SimulatorStreamV2RefreshMenuItem")
                 qualityMenu
                 if supportsDeviceSwitching, !devices.isEmpty {
                     deviceMenu
@@ -416,6 +495,31 @@ struct SimulatorStreamV2Pane: View {
         let text = pendingText
         pendingText = ""
         store?.sendText(text)
+    }
+}
+
+/// Reveals its content after the stream has visibly stalled. The delay is an
+/// intentional bounded progressive-disclosure timer whose cancellation is
+/// wired to the view lifecycle via `.task`; it sits past the lifecycle's
+/// backoff ceiling (4s), so an overlay that outlives it is genuinely stuck,
+/// not mid-retry.
+private struct StalledRefreshReveal<Content: View>: View {
+    @ViewBuilder let content: () -> Content
+    @State private var revealed = false
+
+    private static var stallDelay: Duration { .seconds(5) }
+
+    var body: some View {
+        ZStack {
+            if revealed {
+                content()
+            }
+        }
+        .task {
+            try? await Task.sleep(for: Self.stallDelay)
+            guard !Task.isCancelled else { return }
+            revealed = true
+        }
     }
 }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SimulatorStreamV2Pane.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SimulatorStreamV2Pane.swift
@@ -149,15 +149,19 @@ struct SimulatorStreamV2Pane: View {
     }
 
     /// One shared refresh path for every entrypoint (menu item, overlay
-    /// buttons, recovery overlay): ask the Mac to recover the worker first
-    /// when the host reports it dead, then rebuild the local session through
-    /// the store's single reattach flow. Single-flight: extra taps while a
+    /// buttons, recovery overlay): the exact equivalent of the Mac pane's
+    /// Reconnect button. Always asks the Mac to recover the session
+    /// (`mobile.simulator.recover` runs the same `recover()` that button
+    /// does), then rebuilds the local viewer through the store's single
+    /// reattach flow. Unconditional on purpose: the phone cannot always see
+    /// which Mac-side state wedged the pane (renderer stopped, stale
+    /// worker), and refresh is an explicit user action, so a brief restart
+    /// of a healthy stream is acceptable. Single-flight: extra taps while a
     /// refresh is in flight are dropped, so recover RPCs never overlap.
     private func refreshStream() {
         guard let store, refreshTask == nil else { return }
-        let needsHostRecovery = hostNeedsRecovery(store.hostStatus)
         refreshTask = Task {
-            if supportsRecover, needsHostRecovery {
+            if supportsRecover {
                 _ = await recover()
             }
             store.refresh()

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SimulatorStreamV2Pane.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SimulatorStreamV2Pane.swift
@@ -29,6 +29,12 @@ struct SimulatorStreamV2Pane: View {
     @State private var devices: [MobileSimulatorDeviceDescriptor] = []
     @State private var deviceFetchTask: Task<Void, Never>?
     @State private var refreshTask: Task<Void, Never>?
+    /// Pane-level stall timer: the connecting/reconnecting overlays swap
+    /// every retry cycle, so a per-overlay timer would reset on each flip
+    /// and the refresh escape hatch would never appear. Tracked here, it
+    /// survives phase churn and reveals once the wait has genuinely stalled.
+    @State private var stallRevealTask: Task<Void, Never>?
+    @State private var stallRevealed = false
     @AppStorage("cmux.simulatorStream.quality")
     private var qualityRaw = SimStreamQualityPreset.default.rawValue
     @FocusState private var textFocused: Bool
@@ -76,6 +82,25 @@ struct SimulatorStreamV2Pane: View {
             deviceFetchTask = nil
             refreshTask?.cancel()
             refreshTask = nil
+            stallRevealTask?.cancel()
+            stallRevealTask = nil
+        }
+        .onChange(of: isStalled, initial: true) { _, stalled in
+            if stalled {
+                guard stallRevealTask == nil else { return }
+                stallRevealTask = Task {
+                    // Intentional bounded progressive-disclosure delay past
+                    // the lifecycle's 4s backoff ceiling; cancellation is
+                    // wired to leaving the stalled state and to disappear.
+                    try? await Task.sleep(for: .seconds(5))
+                    guard !Task.isCancelled else { return }
+                    stallRevealed = true
+                }
+            } else {
+                stallRevealTask?.cancel()
+                stallRevealTask = nil
+                stallRevealed = false
+            }
         }
         .onChange(of: qualityRaw) { _, _ in
             store?.setQuality(maximumLongSidePixels: quality.maximumLongSidePixels)
@@ -146,6 +171,18 @@ struct SimulatorStreamV2Pane: View {
     /// frame needs a host-side recover, not another lane retry.
     private func hostNeedsRecovery(_ status: SimStreamHostStatus?) -> Bool {
         status == .workerCrashed || status == .failed || status == .deviceUnavailable
+    }
+
+    /// Whether the viewer is waiting on frames with no terminal verdict:
+    /// the states whose overlays earn the delayed refresh escape hatch.
+    private var isStalled: Bool {
+        guard let store, !hostNeedsRecovery(store.hostStatus) else { return false }
+        switch store.phase {
+        case .idle, .connecting, .reconnecting:
+            return true
+        case .streaming, .unavailable, .stopped:
+            return false
+        }
     }
 
     /// One shared refresh path for every entrypoint (menu item, overlay
@@ -244,8 +281,9 @@ struct SimulatorStreamV2Pane: View {
         case hidden
         /// Refresh is available right away (terminal states).
         case immediate
-        /// Refresh appears only once the wait has clearly stalled, so the
-        /// routine sub-second connect never flashes a button.
+        /// Refresh appears only once the wait has clearly stalled (the
+        /// pane-level `stallRevealed` timer), so the routine sub-second
+        /// connect never flashes a button.
         case afterStall
     }
 
@@ -264,7 +302,7 @@ struct SimulatorStreamV2Pane: View {
                 case .immediate:
                     overlayRefreshButton
                 case .afterStall:
-                    StalledRefreshReveal {
+                    if stallRevealed {
                         overlayRefreshButton
                     }
                 }
@@ -504,31 +542,6 @@ struct SimulatorStreamV2Pane: View {
         let text = pendingText
         pendingText = ""
         store?.sendText(text)
-    }
-}
-
-/// Reveals its content after the stream has visibly stalled. The delay is an
-/// intentional bounded progressive-disclosure timer whose cancellation is
-/// wired to the view lifecycle via `.task`; it sits past the lifecycle's
-/// backoff ceiling (4s), so an overlay that outlives it is genuinely stuck,
-/// not mid-retry.
-private struct StalledRefreshReveal<Content: View>: View {
-    @ViewBuilder let content: () -> Content
-    @State private var revealed = false
-
-    private static var stallDelay: Duration { .seconds(5) }
-
-    var body: some View {
-        ZStack {
-            if revealed {
-                content()
-            }
-        }
-        .task {
-            try? await Task.sleep(for: Self.stallDelay)
-            guard !Task.isCancelled else { return }
-            revealed = true
-        }
     }
 }
 

--- a/Packages/iOS/CmuxMobileSimulatorStream/Sources/CmuxMobileSimulatorStream/SimulatorStreamV2Store.swift
+++ b/Packages/iOS/CmuxMobileSimulatorStream/Sources/CmuxMobileSimulatorStream/SimulatorStreamV2Store.swift
@@ -106,6 +106,21 @@ public final class SimulatorStreamV2Store {
         refreshPhase()
     }
 
+    /// User-requested refresh: tears the session down and reattaches through
+    /// the single lifecycle path, immediately when the transport is ready.
+    /// Clears the last host status so the UI reports the reconnect in
+    /// progress instead of a stale terminal state; a still-broken host
+    /// re-reports through the fresh session's state flow.
+    public func refresh() {
+        hostStatus = nil
+        hostDetail = ""
+        apply(lifecycle.handle(.refreshRequested))
+        if transportReady() {
+            apply(lifecycle.handle(.transportReady))
+        }
+        refreshPhase()
+    }
+
     // MARK: - Input forwarding
 
     public func send(_ event: SimStreamInputEvent) {

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Refs/GitMetadataService+ReferenceSnapshot.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Refs/GitMetadataService+ReferenceSnapshot.swift
@@ -21,7 +21,10 @@ extension GitMetadataService {
         let output = await withTaskCancellationHandler {
             await withCheckedContinuation { continuation in
                 Self.blockingStatusQueue.async {
-                    let output = cancellationSignal.withCurrentBinding {
+                    // Explicit result type: inferring String? across the
+                    // `return output` / `return nil` join fails on newer
+                    // Swift toolchains (Xcode 26.2) and broke the build.
+                    let output = cancellationSignal.withCurrentBinding { () -> String? in
                         let selector = GitReferenceRunnerSelector(wallTimeLimit: wallTimeLimit)
                         let deadline = effectiveDeadline
                         for runner in selector.candidateRunners {

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Refs/GitMetadataService+ReferenceSnapshot.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Refs/GitMetadataService+ReferenceSnapshot.swift
@@ -21,10 +21,7 @@ extension GitMetadataService {
         let output = await withTaskCancellationHandler {
             await withCheckedContinuation { continuation in
                 Self.blockingStatusQueue.async {
-                    // Explicit result type: inferring String? across the
-                    // `return output` / `return nil` join fails on newer
-                    // Swift toolchains (Xcode 26.2) and broke the build.
-                    let output = cancellationSignal.withCurrentBinding { () -> String? in
+                    let output = cancellationSignal.withCurrentBinding {
                         let selector = GitReferenceRunnerSelector(wallTimeLimit: wallTimeLimit)
                         let deadline = effectiveDeadline
                         for runner in selector.candidateRunners {

--- a/Sources/Mobile/MobileHostIrxRuntime.swift
+++ b/Sources/Mobile/MobileHostIrxRuntime.swift
@@ -488,9 +488,31 @@ final class MobileHostIrxRuntime {
                         peer: admittedPeer
                     )
                 }
-            case .control, .events, .simulatorStream:
-                // control arrives only pre-admission; events is server-opened;
-                // simulator streaming is not served by irx v1.
+            case .simulatorStream:
+                guard let resource = try? CmxIrohResourceID(lane.descriptor.resource ?? "")
+                else {
+                    await lane.writer.reset(errorCode: 2)
+                    await lane.reader.stop(errorCode: 2)
+                    continue
+                }
+                // No lane count here: the v2 stream coordinator enforces
+                // last-writer-wins per panel, so a new attach supersedes and
+                // closes the previous session's lane.
+                Task {
+                    let stream = lane.bidirectional()
+                    let handler = MobileHostIrohSimulatorStreamLaneHandler()
+                    let didTakeOwnership = await handler.handleSimulatorStreamLane(
+                        resourceID: resource,
+                        stream: stream,
+                        peer: admittedPeer
+                    )
+                    if !didTakeOwnership {
+                        await stream.sendStream.reset(errorCode: 2)
+                        await stream.receiveStream.stop(errorCode: 2)
+                    }
+                }
+            case .control, .events:
+                // control arrives only pre-admission; events is server-opened.
                 await lane.writer.reset(errorCode: 2)
                 await lane.reader.stop(errorCode: 2)
             }

--- a/docs/ios-simulator-streaming-v2.md
+++ b/docs/ios-simulator-streaming-v2.md
@@ -145,3 +145,11 @@ One state machine on each side, event-driven:
   ring produced no consumable frame for N seconds, restart the worker
   attachment and force a keyframe. If the viewer has credit outstanding and
   no frame for N seconds, it re-sends `start`.
+- Manual refresh: the pane's Refresh Simulator menu item and the refresh
+  buttons on stalled/unavailable overlays feed one `refreshRequested`
+  lifecycle event, which tears down and reattaches through the same single
+  path with backoff reset, escaping even host-`closed` terminal states
+  (e.g. taking back a superseded stream). When the host reports
+  `worker_crashed`/`failed`/`device_unavailable`, the refresh first invokes
+  `mobile.simulator.recover` (capability `simulator.recover.v1`), the same
+  recovery as the Mac pane's Reconnect button, then reattaches.

--- a/docs/ios-simulator-streaming-v2.md
+++ b/docs/ios-simulator-streaming-v2.md
@@ -146,10 +146,12 @@ One state machine on each side, event-driven:
   attachment and force a keyframe. If the viewer has credit outstanding and
   no frame for N seconds, it re-sends `start`.
 - Manual refresh: the pane's Refresh Simulator menu item and the refresh
-  buttons on stalled/unavailable overlays feed one `refreshRequested`
-  lifecycle event, which tears down and reattaches through the same single
-  path with backoff reset, escaping even host-`closed` terminal states
-  (e.g. taking back a superseded stream). When the host reports
-  `worker_crashed`/`failed`/`device_unavailable`, the refresh first invokes
-  `mobile.simulator.recover` (capability `simulator.recover.v1`), the same
-  recovery as the Mac pane's Reconnect button, then reattaches.
+  buttons on stalled/unavailable overlays are the equivalent of the Mac
+  pane's Reconnect button. They always invoke `mobile.simulator.recover`
+  (capability `simulator.recover.v1`, the same `recover()` that button
+  runs), then feed one `refreshRequested` lifecycle event, which tears down
+  and reattaches through the same single path with backoff reset, escaping
+  even host-`closed` terminal states (e.g. taking back a superseded
+  stream). Unconditional because the phone cannot always see which Mac-side
+  state wedged the pane; refresh is explicit user intent, so briefly
+  restarting a healthy stream is acceptable.

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -1412,6 +1412,40 @@
         }
       }
     },
+    "mobile.simulatorStream.refresh": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refresh"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新"
+          }
+        }
+      }
+    },
+    "mobile.simulatorStream.refreshSimulator": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refresh Simulator"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Simulatorを更新"
+          }
+        }
+      }
+    },
     "mobile.simulatorStream.sendText": {
       "extractionState": "manual",
       "localizations": {

--- a/ios/cmux/cmuxApp.swift
+++ b/ios/cmux/cmuxApp.swift
@@ -149,14 +149,15 @@ struct cmuxApp: App {
                 guard let panelUUID = UUID(uuidString: panelID) else {
                     throw MobileIrohSimulatorStreamLaneError.invalidPanelID
                 }
-                guard !irxEnabled else {
-                    // Simulator streaming is not served by irx v1.
-                    throw MobileIrohSimulatorStreamLaneError.closed
-                }
-                return try await iroh.openSimulatorStreamLane(
-                    for: request,
-                    panelID: panelUUID
-                )
+                return irxEnabled
+                    ? try await irx.openSimulatorStreamLane(
+                        for: request,
+                        panelID: panelUUID
+                    )
+                    : try await iroh.openSimulatorStreamLane(
+                        for: request,
+                        panelID: panelUUID
+                    )
             }
         )
 

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrxRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrxRuntimeComposition.swift
@@ -40,7 +40,6 @@ public actor MobileIrxRuntimeComposition {
         case notSignedIn
         case unsupportedRoute
         case peerNotDiscovered
-        case simulatorStreamingUnsupported
     }
 
     /// One journal for every irx component on the phone; the JSONL file lives
@@ -549,10 +548,26 @@ public actor MobileIrxRuntimeComposition {
         return IrxArtifactLane(lane: lane)
     }
 
-    public func simulatorStreamLaneUnavailable() throws -> Never {
-        // Simulator streaming is not served by irx v1; the viewer surfaces
-        // its ordinary unavailable state.
-        throw CompositionError.simulatorStreamingUnsupported
+    public func openSimulatorStreamLane(
+        for request: CmxByteTransportRequest,
+        panelID: UUID
+    ) async throws -> MobileIrohSimulatorStreamLane {
+        let peerHex = try peerTarget(for: request)
+        let session = try await engine(forPeer: peerHex)
+            .ensureSession(trigger: "simulator-stream-lane")
+        // Same legacy resource dialect the terminal lane uses; the Mac's
+        // dialect server routes it to MobileHostIrohSimulatorStreamLaneHandler.
+        let lane = try await session.connection.openLane(
+            IrxLaneDescriptor(
+                lane: .simulatorStream,
+                resource: "simstream:\(panelID.uuidString.lowercased())"
+            )
+        )
+        Self.journal.record(
+            "client-simstream", "lane-opened",
+            ["panel": panelID.uuidString.lowercased()]
+        )
+        return MobileIrohSimulatorStreamLane(stream: lane.bidirectional())
     }
 
     /// The deferred transport the RPC layer connects through. Each RPC client


### PR DESCRIPTION
Refresh the simulator pane from the iPhone. Three parts, driven by dogfood rounds:

**1. Manual refresh, equivalent to the Mac pane's Reconnect (per Aziz).** A **Refresh Simulator** item in the pane's ellipsis menu (every state), a **Refresh** button on the unavailable overlay (immediate; hidden for `simulator_disabled`) and on the waiting/reconnecting overlays (revealed after a genuine 5s stall), and the existing Recover button, all through one path: unconditionally invoke `mobile.simulator.recover` (the same `coordinator.recover()` the Mac's Reconnect runs — the phone cannot always classify Mac-side wedges like "renderer stopped"), then tear down and reattach the local viewer via a new `refreshRequested` lifecycle event (single reattach path, backoff reset, escapes host-`closed` terminal states). Single-flight so recover RPCs never overlap. The stall-reveal timer lives at pane level because the retry loop flips connecting/reconnecting every backoff cycle and a per-overlay timer would reset on each flip.

**2. Simulator-stream v2 lanes over irx (found in round 2).** v2 simulator streaming has been dead phone-side since irx became primary (08-27): the phone's provider threw "not served by irx v1" and the Mac's irx lane loop rejected `.simulatorStream`, so the viewer looped "Reconnecting to Simulator" forever while RPC worked (phone log: instant lane failures after a successful irx connect). Both halves already existed for the legacy dialect; this wires the irx dialect: `MobileIrxRuntimeComposition.openSimulatorStreamLane` (same lane engine and legacy `simstream:<uuid>` resource format as terminal/artifact lanes), `cmuxApp` routes the provider through irx, and `MobileHostIrxRuntime.runLaneLoop` dispatches `.simulatorStream` to `MobileHostIrohSimulatorStreamLaneHandler`. No quota needed: the v2 coordinator's last-writer-wins panel ownership supersedes and closes prior lanes.

**3.** Recovery overlay now also covers `deviceUnavailable`, mirroring the Mac toolbar's Reconnect states.

No new RPC methods or capabilities. Localization audited: `mobile.simulatorStream.refresh` / `.refreshSimulator` added in en and ja. Tests: four new `SimStreamViewerLifecycle` policy tests (restart from streaming, escape from unavailable, skip pending retry delay with backoff reset, ignored while inactive); `swift test` on CmuxSimulatorStreamKit green.

HIG: the dedicated pull-to-refresh page no longer exists; consulted [Loading](https://developer.apple.com/design/human-interface-guidelines/loading) (placeholder content immediately, offer an action when loading stalls) and [Toolbars](https://developer.apple.com/design/human-interface-guidelines/toolbars) (action placement in bars/menus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)