### PR TITLE
Unbreak macOS compile on Xcode 26.2: pin withCurrentBinding result type in gitRemoteVFallback

### DIFF
--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Refs/GitMetadataService+ReferenceSnapshot.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Refs/GitMetadataService+ReferenceSnapshot.swift
@@ -21,7 +21,10 @@ extension GitMetadataService {
         let output = await withTaskCancellationHandler {
             await withCheckedContinuation { continuation in
                 Self.blockingStatusQueue.async {
-                    let output = cancellationSignal.withCurrentBinding {
+                    // Explicit result type: inferring String? across the
+                    // `return output` / `return nil` join fails on newer
+                    // Swift toolchains (Xcode 26.2) and broke the build.
+                    let output = cancellationSignal.withCurrentBinding { () -> String? in
                         let selector = GitReferenceRunnerSelector(wallTimeLimit: wallTimeLimit)
                         let deadline = effectiveDeadline
                         for runner in selector.candidateRunners {


### PR DESCRIPTION
Fleet slots running Xcode 26.2 fail to compile the macOS app target at `Packages/macOS/CmuxGit/Sources/CmuxGit/Refs/GitMetadataService+ReferenceSnapshot.swift`:

```
GitMetadataService+ReferenceSnapshot.swift:22:19: error: generic parameter 'T' could not be inferred
GitMetadataService+ReferenceSnapshot.swift:48:32: error: 'nil' is not compatible with closure result type 'String'
```

`gitRemoteVFallback`'s `withCurrentBinding` closure returns `String` on success and `nil` when every runner is exhausted. Older Swift toolchains joined those returns to `String?`; the Swift in Xcode 26.2 infers `String` from the first return and rejects the `nil`, which also cascades into the `withCheckedContinuation` inference failure. Pinning the closure's result type to `() -> String?` compiles on both toolchains. No behavior change.

Nothing in CmuxGit changed recently; this only shows up on slots with the newer Xcode, so the PR lane (which has no macOS compile gate) never caught it. Found while building an unrelated tagged branch on `cmux-aws-m4pro`.

Dictionary:
- fleet slot: one isolated build session on a shared Mac from the team's build fleet.
- PR lane: the set of GitHub checks that run on pull requests, which currently does not compile the macOS app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the macOS app target failing to compile under Xcode 26.2 by pinning `gitRemoteVFallback`'s `withCurrentBinding` closure result type to `() -> String?`. No behavior change.

- The Swift in Xcode 26.2 infers `String` from the `return output` and rejects the `return nil`, while older toolchains joined them to `String?`.
- The PR lane has no macOS compile gate, so the break only appears on fleet slots running the newer Xcode.

<sup>Written for commit 3449cefcc43db0a38e4e2e7bafae0dc704549379. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11090?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a build issue affecting newer Swift toolchains.
  * Preserved existing behavior when resolving Git remote information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->