### PR TITLE
iOS: reconnecting never exits the user's workspace or invalidates their current task

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+WorkspaceListRecovery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+WorkspaceListRecovery.swift
@@ -123,10 +123,10 @@ extension MobileShellComposite {
             return
         }
         // Failed dials run their own cleanup with the default non-preserving
-        // teardown, dropping the secondary subscriptions preserved above (the
-        // foreground id is already nil, so that filter keeps only the
-        // anonymous key). Rebuild them so a failed foreground redial cannot
-        // strand healthy secondary Macs.
+        // teardown, cancelling the secondary subscriptions preserved above
+        // (their last-known rows stay, downgraded to unavailable). Rebuild the
+        // subscriptions so a failed foreground redial cannot strand healthy
+        // secondary Macs on stale rows.
         await refreshSecondaryMacWorkspaces()
     }
 

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -10234,8 +10234,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         connectionAttemptGeneration = UUID()
         // Capture the tagged foreground key BEFORE the identity clears below:
         // `foregroundMacKey` derives from `activeMacInstanceTag`, which
-        // `clearActiveConnectionContext()` nils, and the offline retention
-        // filter must keep the exact tagged entry.
+        // `clearActiveConnectionContext()` nils, and the offline status
+        // downgrade must hit the exact tagged entry.
         let offlineForegroundKey = foregroundMacKey
         focusedHandoffPreparedGenerations.removeAll()
         cancelRemoteOperationTasks()
@@ -10257,23 +10257,26 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         replaceRemoteClient(with: nil)
         foregroundMacDeviceID = nil
         if !preservingOtherMacWorkspaceState {
-            // Cancel the live secondary subscriptions (slice 3) and keep only the
-            // now-offline foreground Mac's last-known workspaces for the offline
-            // view; the derived list recomputes to just the offline Mac's rows.
+            // Cancel the live secondary subscriptions (slice 3). Their rows STAY:
+            // teardown is a transport event, and transport events never remove
+            // user-visible workspace state. Rows are removed only by authoritative
+            // events (a healthy list reconcile, unpair/hide, sign-out, team
+            // change). Removing them here popped the mounted workspace detail the
+            // moment a reconnect began: dropping secondary entries flips multi-Mac
+            // row-id scoping (re-keying the selection and every pushed navigation
+            // route), and a failed first dial re-entered this teardown with
+            // `foregroundMacDeviceID` already nil, so a retention filter keyed on
+            // the anonymous sentinel wiped the whole list.
             teardownSecondaryMacSubscriptions()
-            workspacesByMac = workspacesByMac.filter { $0.key == offlineForegroundKey }
         }
-        // The retained foreground entry still carries its last-known
-        // `status: .connected`; `macConnectionStatuses` (the Computers screen's
-        // per-Mac dots) derives from these per-Mac states, so without this the
-        // just-disconnected Mac would keep showing a green connected dot. Downgrade
-        // it to `.unavailable` to match the global connection state.
-        let offlineDeviceID = offlineForegroundKey.canonicalMacDeviceID
+        // Retained entries still carry their last-known `status: .connected`;
+        // `macConnectionStatuses` (the Computers screen's per-Mac dots) derives
+        // from these per-Mac states, so without this the just-disconnected Macs
+        // would keep showing a green connected dot. Downgrade the foreground
+        // entry — and every entry whose secondary subscription was torn down
+        // above — to `.unavailable` to match the global connection state.
         let keysToDowngrade = workspacesByMac.keys.filter { key in
-            key == offlineForegroundKey
-                || (!preservingOtherMacWorkspaceState
-                    && offlineForegroundKey != .anonymousForeground
-                    && key.canonicalMacDeviceID == offlineDeviceID)
+            key == offlineForegroundKey || !preservingOtherMacWorkspaceState
         }
         var updatedWorkspacesByMac = workspacesByMac
         for key in keysToDowngrade {

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ConnectionTeardownWorkspaceRetentionTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ConnectionTeardownWorkspaceRetentionTests.swift
@@ -1,0 +1,138 @@
+import CmuxMobileShellModel
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+/// Connection teardown is a transport event: it must never remove user-visible
+/// workspace rows, retarget the selection, or change derived row identity.
+/// Rows are removed only by authoritative events (a healthy workspace list,
+/// unpair/hide, sign-out, team change).
+///
+/// These pin the reconnect regression where a recovery redial tore down the
+/// connection context once (dropping every secondary Mac's rows, which flips
+/// multi-Mac row-id scoping and re-keys the pushed navigation route), and a
+/// failed first dial tore it down again with the foreground identity already
+/// nil — so the retention filter keyed on the anonymous sentinel, wiped
+/// `workspacesByMac` entirely, nilled the selection, and popped the mounted
+/// workspace detail the moment reconnecting began.
+@MainActor
+struct ConnectionTeardownWorkspaceRetentionTests {
+    private static let foregroundKey = MacPairingKey(
+        macDeviceID: "mac-fg",
+        instanceTag: "default"
+    )
+    private static let secondaryKey = MacPairingKey(
+        macDeviceID: "mac-2nd",
+        instanceTag: "default"
+    )
+
+    private func makeTwoMacStore() -> MobileShellComposite {
+        let store = MobileShellComposite(
+            isSignedIn: true,
+            connectionState: .connected,
+            presence: IdlePresence(),
+            identityProvider: StaticIdentityProvider(userID: "user-1"),
+            teamIDProvider: { "team-1" },
+            reachability: AlwaysOnlineReachability(),
+            pendingDismissQueue: PendingNotificationDismissQueue(
+                defaults: UserDefaults(
+                    suiteName: "teardown-retention-\(UUID().uuidString)"
+                )!
+            )
+        )
+        var foregroundWorkspace = MobileWorkspacePreview(
+            id: "ws-fg",
+            macDeviceID: "mac-fg",
+            name: "Foreground Workspace",
+            terminals: []
+        )
+        foregroundWorkspace.macInstanceTag = "default"
+        var secondaryWorkspace = MobileWorkspacePreview(
+            id: "ws-2nd",
+            macDeviceID: "mac-2nd",
+            name: "Secondary Workspace",
+            terminals: []
+        )
+        secondaryWorkspace.macInstanceTag = "default"
+        store.foregroundMacDeviceID = "mac-fg"
+        store.activeMacInstanceTag = "default"
+        store.macConnectionStatus = .connected
+        store.workspacesByMac = [
+            Self.foregroundKey: MacWorkspaceState(
+                macDeviceID: "mac-fg",
+                instanceTag: "default",
+                displayName: "Foreground Mac",
+                workspaces: [foregroundWorkspace],
+                status: .connected
+            ),
+            Self.secondaryKey: MacWorkspaceState(
+                macDeviceID: "mac-2nd",
+                instanceTag: "default",
+                displayName: "Secondary Mac",
+                workspaces: [secondaryWorkspace],
+                status: .connected
+            ),
+        ]
+        return store
+    }
+
+    /// Models the recovery sequence exactly: redial teardown with the
+    /// foreground identity still set, then a failed-dial teardown after that
+    /// identity was nilled by the first.
+    private func runRecoveryTeardownTwice(on store: MobileShellComposite) {
+        store.connectionState = .disconnected
+        store.macConnectionStatus = .unavailable
+        store.clearRemoteConnectionContext()
+        store.clearRemoteConnectionContext()
+    }
+
+    @Test func teardownRetainsEveryMacsRowsAndForegroundSelection() {
+        let store = makeTwoMacStore()
+        let initialRowIDs = Set(store.workspaces.map(\.id))
+        #expect(initialRowIDs.count == 2)
+        let selected = store.workspaces.first { $0.macDeviceID == "mac-fg" }
+        #expect(selected != nil)
+        store.selectedWorkspaceID = selected?.id
+
+        store.connectionState = .disconnected
+        store.macConnectionStatus = .unavailable
+        store.clearRemoteConnectionContext()
+
+        #expect(store.workspacesByMac[Self.foregroundKey] != nil)
+        #expect(store.workspacesByMac[Self.secondaryKey] != nil)
+        #expect(store.workspacesByMac.values.allSatisfy { $0.status == .unavailable })
+        #expect(store.selectedWorkspaceID == selected?.id)
+        #expect(Set(store.workspaces.map(\.id)) == initialRowIDs)
+
+        store.clearRemoteConnectionContext()
+
+        #expect(store.workspacesByMac[Self.foregroundKey] != nil)
+        #expect(store.workspacesByMac[Self.secondaryKey] != nil)
+        #expect(store.selectedWorkspaceID == selected?.id)
+        #expect(Set(store.workspaces.map(\.id)) == initialRowIDs)
+    }
+
+    @Test func teardownKeepsSelectionOnSecondaryMacRow() {
+        let store = makeTwoMacStore()
+        let selected = store.workspaces.first { $0.macDeviceID == "mac-2nd" }
+        #expect(selected != nil)
+        store.selectedWorkspaceID = selected?.id
+
+        runRecoveryTeardownTwice(on: store)
+
+        #expect(store.workspacesByMac[Self.secondaryKey] != nil)
+        #expect(store.selectedWorkspaceID == selected?.id)
+        #expect(store.workspaces.contains { $0.id == selected?.id })
+    }
+
+    @Test func preservingTeardownStillDowngradesOnlyTheForegroundEntry() {
+        let store = makeTwoMacStore()
+
+        store.connectionState = .disconnected
+        store.macConnectionStatus = .unavailable
+        store.clearRemoteConnectionContext(preservingOtherMacWorkspaceState: true)
+
+        #expect(store.workspacesByMac[Self.foregroundKey]?.status == .unavailable)
+        #expect(store.workspacesByMac[Self.secondaryKey]?.status == .connected)
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -232,6 +232,15 @@ struct WorkspaceShellView: View {
         return store.workspaceListConnectionStatus
     }
 
+    /// Whether the workspace list reflects a healthy connection. Compact
+    /// navigation pops a mounted detail only when it does: a reconnecting or
+    /// disconnected state must never exit the user's current workspace, so
+    /// list holes and cleared selections during a degraded connection keep the
+    /// pushed route mounted on its last-known snapshot.
+    private var workspaceListIsAuthoritative: Bool {
+        listConnectionStatus == .connected
+    }
+
     private var canCreateWorkspaceOnForegroundConnection: Bool {
         store.connectionState == .connected
     }
@@ -611,7 +620,8 @@ struct WorkspaceShellView: View {
             compactNavigationPath = compactNavigationPolicy.pathForSelectionChange(
                 currentPath: compactNavigationPath,
                 selectedWorkspaceID: selectedWorkspaceID,
-                visibleWorkspaceIDs: Set(store.workspaces.map(\.id))
+                visibleWorkspaceIDs: Set(store.workspaces.map(\.id)),
+                listIsAuthoritative: workspaceListIsAuthoritative
             )
             autoOpenSelectedWorkspaceForSoakIfNeeded()
         }
@@ -629,7 +639,8 @@ struct WorkspaceShellView: View {
             compactNavigationPath = compactNavigationPolicy.pathForVisibleWorkspaceIDsChange(
                 currentPath: compactNavigationPath,
                 visibleWorkspaceIDs: Set(workspaceIDs),
-                selectedWorkspaceID: store.selectedWorkspaceID
+                selectedWorkspaceID: store.selectedWorkspaceID,
+                listIsAuthoritative: workspaceListIsAuthoritative
             )
             autoOpenSelectedWorkspaceForSoakIfNeeded()
         }

--- a/Packages/iOS/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/WorkspaceShellCompactNavigationPolicy.swift
+++ b/Packages/iOS/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/WorkspaceShellCompactNavigationPolicy.swift
@@ -14,6 +14,11 @@ public struct WorkspaceShellCompactNavigationPolicy {
     /// - Parameters:
     ///   - currentPath: The current navigation path.
     ///   - selectedWorkspaceID: The newly selected workspace, or `nil` to clear.
+    ///   - listIsAuthoritative: Whether the workspace list reflects a healthy
+    ///     connection. A cleared selection pops to the root only when it does;
+    ///     while reconnecting or disconnected the mounted detail stays, because
+    ///     a connection-state change must never exit the user's current
+    ///     workspace.
     /// - Returns: The path to apply. Stays empty when the user is at the root,
     ///   clears when the authoritative selection clears, and retargets when the
     ///   store selects a different workspace. Transient workspace-list omissions
@@ -21,13 +26,14 @@ public struct WorkspaceShellCompactNavigationPolicy {
     public func pathForSelectionChange<ID: Hashable>(
         currentPath: [ID],
         selectedWorkspaceID: ID?,
-        visibleWorkspaceIDs: Set<ID> = []
+        visibleWorkspaceIDs: Set<ID> = [],
+        listIsAuthoritative: Bool = true
     ) -> [ID] {
         guard !currentPath.isEmpty else {
             return currentPath
         }
         guard let selectedWorkspaceID else {
-            return []
+            return listIsAuthoritative ? [] : currentPath
         }
         guard currentPath.last != selectedWorkspaceID else {
             return currentPath
@@ -80,10 +86,16 @@ public struct WorkspaceShellCompactNavigationPolicy {
     /// terminal arrives. If the authoritative selection has moved away, pop or
     /// remap to the selected visible workspace so deleted workspaces do not stay
     /// mounted from a stale route snapshot.
+    /// - Parameter listIsAuthoritative: Whether the workspace list reflects a
+    ///   healthy connection. Routes are dropped only when it does; a list hole
+    ///   opened by a reconnecting or disconnected state keeps the mounted
+    ///   detail, which renders its last-known snapshot until the next healthy
+    ///   list restores the row or confirms the deletion.
     public func pathForVisibleWorkspaceIDsChange<ID: Hashable>(
         currentPath: [ID],
         visibleWorkspaceIDs: Set<ID>,
-        selectedWorkspaceID: ID?
+        selectedWorkspaceID: ID?,
+        listIsAuthoritative: Bool = true
     ) -> [ID] {
         guard let currentDetailID = currentPath.last else {
             return currentPath
@@ -97,6 +109,9 @@ public struct WorkspaceShellCompactNavigationPolicy {
         if let selectedWorkspaceID,
            visibleWorkspaceIDs.contains(selectedWorkspaceID) {
             return [selectedWorkspaceID]
+        }
+        guard listIsAuthoritative else {
+            return currentPath
         }
         return currentPath.filter { visibleWorkspaceIDs.contains($0) }
     }

--- a/Packages/iOS/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/WorkspaceShellCompactNavigationPolicyTests.swift
+++ b/Packages/iOS/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/WorkspaceShellCompactNavigationPolicyTests.swift
@@ -148,4 +148,49 @@ import Testing
 
         #expect(path.isEmpty)
     }
+
+    @Test func clearedSelectionKeepsDetailWhileListIsNotAuthoritative() {
+        let detailID = MobileWorkspacePreview.ID(rawValue: "workspace-a")
+        let path = policy.pathForSelectionChange(
+            currentPath: [detailID],
+            selectedWorkspaceID: nil,
+            listIsAuthoritative: false
+        )
+
+        #expect(path == [detailID])
+    }
+
+    @Test func clearedSelectionStillPopsWhenListIsAuthoritative() {
+        let path = policy.pathForSelectionChange(
+            currentPath: [MobileWorkspacePreview.ID(rawValue: "workspace-a")],
+            selectedWorkspaceID: nil,
+            listIsAuthoritative: true
+        )
+
+        #expect(path.isEmpty)
+    }
+
+    @Test func listHoleKeepsDetailWhileListIsNotAuthoritative() {
+        let detailID = MobileWorkspacePreview.ID(rawValue: "workspace-a")
+        let path = policy.pathForVisibleWorkspaceIDsChange(
+            currentPath: [detailID],
+            visibleWorkspaceIDs: [],
+            selectedWorkspaceID: nil,
+            listIsAuthoritative: false
+        )
+
+        #expect(path == [detailID])
+    }
+
+    @Test func retargetsToVisibleSelectionEvenWhileListIsNotAuthoritative() {
+        let selectedID = MobileWorkspacePreview.ID(rawValue: "workspace-b")
+        let path = policy.pathForVisibleWorkspaceIDsChange(
+            currentPath: [MobileWorkspacePreview.ID(rawValue: "workspace-a")],
+            visibleWorkspaceIDs: [selectedID],
+            selectedWorkspaceID: selectedID,
+            listIsAuthoritative: false
+        )
+
+        #expect(path == [selectedID])
+    }
 }


### PR DESCRIPTION
On iPhone (iroh, latest INTERNAL/NIGHTLY), the moment a reconnect began the mounted workspace detail was exited. Reproduced at the store level by the new regression tests (commit 1, red): recovery's redial teardown dropped every secondary Mac's `workspacesByMac` entry, which flips multi-Mac row-id scoping, changes every derived row id's raw value, remaps the selection, and re-keys the pushed navigation route (destroying the mounted detail); a failed first dial then re-entered the teardown with `foregroundMacDeviceID` already nil, so the retention filter keyed on the anonymous sentinel and wiped the whole list.

The fix is the general invariant the symptom kept violating: **connection state changes never terminate or invalidate the user's current context.**

- **Store:** `clearRemoteConnectionContext` no longer removes workspace rows. Teardown is a transport event; rows are removed only by authoritative events (healthy list reconcile, unpair/hide in the secondary reconcile pass, sign-out, team change), all of which already do their own explicit removal. All retained entries downgrade to `.unavailable` so the Computers dots and list chrome stay truthful, the teardown is idempotent (a second clear is a status no-op), and the per-Mac entry count stays stable so row-id scoping and route identity survive reconnects. The post-reconnect secondary refresh re-syncs the retained rows.
- **Navigation policy (defense-in-depth):** `WorkspaceShellCompactNavigationPolicy` takes `listIsAuthoritative`. While the list is reconnecting/disconnected, a cleared selection or a list hole keeps the mounted detail rendering its last-known snapshot (rename dialogs and sheets survive because the detail view identity survives); deletions confirmed by a healthy list still pop normally.

Commit 1 adds the failing store tests only (CI red); commit 2 adds the fix plus policy tests (CI green). Full `CmuxMobileWorkspace` suite passes (45/45); full `CmuxMobileShell` suite run included in the verification pass.

HIG: [Feedback](https://developer.apple.com/design/human-interface-guidelines/feedback) — status feedback should reach people "without having to take action or leave their current context"; only alerts may deliberately disrupt context. Transient connectivity is status, so it is shown in place (existing title spinner from #10821) instead of ejecting the user.

Follow-up (out of scope): genuine Mac removal while N→1 still flips row-id scoping and re-keys a mounted route; making scoping sticky would remove that last identity change, but it changes persisted-selection semantics and deserves its own pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes iOS reconnects so reconnecting never exits the user's workspace or invalidates their current task. Connection teardown no longer removes workspace rows or retargets the selection, and compact navigation keeps the mounted detail while the list is reconnecting or disconnected.

**Store**

- `clearRemoteConnectionContext` keeps all `workspacesByMac` rows, downgrading their status to `.unavailable` so the Computers dots and list chrome stay truthful.
- Rows are removed only by authoritative events: a healthy list reconcile, unpair/hide, sign-out, or team change.
- Retaining secondary entries means multi-Mac row-id scoping never flips mid-recovery, so derived row ids and the pushed navigation route keep their identity; a second teardown is now a status no-op.
- A genuine Mac removal while N→1 still flips row-id scoping and re-keys a mounted route; making scoping sticky is a follow-up.

**Navigation**

- `WorkspaceShellCompactNavigationPolicy` takes `listIsAuthoritative`; while the list is reconnecting or disconnected, a cleared selection or list hole keeps the mounted detail on its last-known snapshot.
- Deletions confirmed by a healthy list still pop normally.

<sup>Written for commit a0c781bdfca8fc3fadb4f7541cdd525d5a0cc967. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11091?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Workspace rows now remain visible during connection teardown and recovery.
  - Workspace selections and mounted detail views are preserved while reconnecting or disconnected.
  - Workspace statuses are updated to unavailable without removing retained rows.
  - Navigation now avoids popping detail routes until the workspace list is confirmed current.
- **Tests**
  - Added coverage for workspace retention, selection preservation, repeated teardown, and reconnect navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->