### PR TITLE
iOS: Keep Mac Awake is per computer — detail toggle, leading swipe action, row indicator

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+Caffeine.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+Caffeine.swift
@@ -1,5 +1,5 @@
 internal import CMUXMobileCore
-internal import CmuxMobileRPC
+public import CmuxMobileRPC
 internal import Foundation
 internal import OSLog
 
@@ -11,9 +11,144 @@ nonisolated private let caffeineLog = Logger(
 extension MobileShellComposite {
     private static let caffeineRequestTimeoutNanoseconds: UInt64 = 5_000_000_000
 
-    /// Reads the current Mac's authoritative cmux-owned keep-awake state.
+    // MARK: - Per-Mac surface
+
+    /// Keep-awake is controlled per Mac: the foreground connection and each
+    /// live control (secondary) connection carry their own state, so every
+    /// read and mutation names the exact pairing it targets.
+    public func caffeineStatus(
+        macDeviceID: String,
+        instanceTag: String?
+    ) -> MobileCaffeineStatus? {
+        let key = MacPairingKey(macDeviceID: macDeviceID, instanceTag: instanceTag)
+        if key == foregroundMacKey { return caffeineStatus }
+        // A dict entry is only trusted while its control connection is live;
+        // retirement paths don't have to chase entries down.
+        guard secondaryMacSubscriptions[key] != nil else { return nil }
+        return secondaryCaffeineStatusesByPairingID[key.pairingID]
+    }
+
+    /// Whether the phone can control keep-awake on this pairing right now:
+    /// a live connection whose host advertises `caffeine.control.v1`.
+    public func supportsCaffeineControl(
+        macDeviceID: String,
+        instanceTag: String?
+    ) -> Bool {
+        let key = MacPairingKey(macDeviceID: macDeviceID, instanceTag: instanceTag)
+        if key == foregroundMacKey { return supportsCaffeineControl }
+        return secondaryMacSubscriptions[key]?
+            .supportedHostCapabilities
+            .contains(Self.caffeineControlCapability) == true
+    }
+
+    /// Whether a keep-awake mutation is awaiting this pairing's Mac.
+    public func isCaffeineMutationInFlight(
+        macDeviceID: String,
+        instanceTag: String?
+    ) -> Bool {
+        let key = MacPairingKey(macDeviceID: macDeviceID, instanceTag: instanceTag)
+        if key == foregroundMacKey { return isCaffeineMutationInFlight }
+        return secondaryCaffeineMutationPairingIDs.contains(key.pairingID)
+    }
+
+    /// Pairing ids with any keep-awake mutation in flight, for row-level busy
+    /// states on the Computers screen.
+    public var caffeineMutatingPairingIDs: Set<String> {
+        var ids = secondaryCaffeineMutationPairingIDs
+        if isCaffeineMutationInFlight {
+            ids.insert(foregroundMacKey.pairingID)
+        }
+        return ids
+    }
+
+    /// Reads the named Mac's authoritative keep-awake state.
     @discardableResult
     public func refreshCaffeineStatus(
+        macDeviceID: String,
+        instanceTag: String?
+    ) async -> Bool {
+        let key = MacPairingKey(macDeviceID: macDeviceID, instanceTag: instanceTag)
+        if key == foregroundMacKey {
+            return await refreshForegroundCaffeineStatus()
+        }
+        return await refreshSecondaryCaffeineStatus(ownerKey: key)
+    }
+
+    /// Changes keep-awake on the named Mac.
+    @discardableResult
+    public func setCaffeineEnabled(
+        _ enabled: Bool,
+        macDeviceID: String,
+        instanceTag: String?
+    ) async -> Bool {
+        let key = MacPairingKey(macDeviceID: macDeviceID, instanceTag: instanceTag)
+        if key == foregroundMacKey {
+            return await setForegroundCaffeineEnabled(enabled)
+        }
+        return await setSecondaryCaffeineEnabled(enabled, ownerKey: key)
+    }
+
+    // MARK: - Seeding
+
+    /// The Computers rows show a keep-awake indicator without any detail view
+    /// open, so the foreground state is read as soon as the host's capability
+    /// snapshot proves the RPC exists.
+    func seedForegroundCaffeineStatusIfSupported() {
+        guard supportsCaffeineControl, caffeineStatus == nil,
+              !isCaffeineMutationInFlight else { return }
+        Task { @MainActor [weak self] in
+            _ = await self?.refreshForegroundCaffeineStatus()
+        }
+    }
+
+    /// Seeds one freshly established control connection's keep-awake state.
+    func seedSecondaryCaffeineStatus(_ subscription: SecondaryMacSubscription) {
+        guard subscription.supportedHostCapabilities.contains(
+            Self.caffeineControlCapability
+        ) else { return }
+        let ownerKey = subscription.ownerKey
+        guard secondaryCaffeineStatusesByPairingID[ownerKey.pairingID] == nil else {
+            return
+        }
+        Task { @MainActor [weak self] in
+            _ = await self?.refreshSecondaryCaffeineStatus(ownerKey: ownerKey)
+        }
+    }
+
+    /// Promotion publishes the control connection's capability snapshot
+    /// directly (no host-status round trip), so the control entry's known
+    /// state moves into the foreground slot instead of waiting for a refresh.
+    func adoptSecondaryCaffeineStatusForPromotedForeground(ownerKey: MacPairingKey) {
+        guard caffeineStatus == nil, !isCaffeineMutationInFlight,
+              let adopted = secondaryCaffeineStatusesByPairingID[ownerKey.pairingID]
+        else { return }
+        secondaryCaffeineStatusesByPairingID[ownerKey.pairingID] = nil
+        caffeineStatus = adopted
+        caffeineStatusRevision &+= 1
+    }
+
+    /// Fills keep-awake state that a promotion, demotion, or failed seed left
+    /// missing on a live connection. Called from the Computers screen's gentle
+    /// refresh cadence; only connections without state are asked.
+    func backfillMissingCaffeineStatuses() {
+        seedForegroundCaffeineStatusIfSupported()
+        for (ownerKey, subscription) in secondaryMacSubscriptions {
+            guard subscription.supportedHostCapabilities.contains(
+                Self.caffeineControlCapability
+            ), secondaryCaffeineStatusesByPairingID[ownerKey.pairingID] == nil,
+                !secondaryCaffeineMutationPairingIDs.contains(ownerKey.pairingID)
+            else { continue }
+            Task { @MainActor [weak self] in
+                _ = await self?.refreshSecondaryCaffeineStatus(ownerKey: ownerKey)
+            }
+        }
+    }
+
+    // MARK: - Foreground connection
+
+    /// Reads the current Mac's authoritative cmux-owned keep-awake state.
+    @discardableResult
+    func refreshForegroundCaffeineStatus(
         preservingRevision expectedRevision: UInt64? = nil
     ) async -> Bool {
         guard supportsCaffeineControl, let client = remoteClient else {
@@ -67,7 +202,7 @@ extension MobileShellComposite {
     /// Optimistically changes keep-awake, then replaces the optimistic value
     /// with the Mac's response or rolls it back on a current-connection error.
     @discardableResult
-    public func setCaffeineEnabled(_ enabled: Bool) async -> Bool {
+    func setForegroundCaffeineEnabled(_ enabled: Bool) async -> Bool {
         guard supportsCaffeineControl,
               !isCaffeineMutationInFlight,
               let client = remoteClient else { return false }
@@ -128,7 +263,7 @@ extension MobileShellComposite {
             caffeineLog.error(
                 "caffeine.set failed error=\(String(describing: error), privacy: .public)"
             )
-            _ = await refreshCaffeineStatus(
+            _ = await refreshForegroundCaffeineStatus(
                 preservingRevision: statusRevision
             )
             return caffeineStatus?.enabled == enabled
@@ -149,5 +284,120 @@ extension MobileShellComposite {
         }
         caffeineStatus = status
         caffeineStatusRevision &+= 1
+    }
+
+    // MARK: - Control (secondary) connections
+
+    func handleSecondaryCaffeineStatusEvent(
+        _ event: MobileEventEnvelope,
+        ownerKey: MacPairingKey
+    ) {
+        guard let payload = event.payloadJSON,
+              let status = try? MobileCaffeineStatus(decoding: payload) else {
+            return
+        }
+        secondaryCaffeineStatusesByPairingID[ownerKey.pairingID] = status
+    }
+
+    private func refreshSecondaryCaffeineStatus(ownerKey: MacPairingKey) async -> Bool {
+        guard let subscription = secondaryMacSubscriptions[ownerKey],
+              subscription.supportedHostCapabilities.contains(
+                Self.caffeineControlCapability
+              ) else {
+            secondaryCaffeineStatusesByPairingID[ownerKey.pairingID] = nil
+            return false
+        }
+        let client = subscription.client
+        do {
+            let data = try await client.sendRequest(
+                MobileCoreRPCClient.requestData(
+                    method: "caffeine.status",
+                    params: [:]
+                ),
+                timeoutNanoseconds: Self.caffeineRequestTimeoutNanoseconds
+            )
+            let status = try MobileCaffeineStatus(decoding: data)
+            guard isCurrentSecondaryCaffeineOperation(
+                ownerKey: ownerKey,
+                client: client
+            ) else { return false }
+            // An in-flight mutation owns the optimistic value; its own
+            // reconciliation lands the authoritative state.
+            guard !secondaryCaffeineMutationPairingIDs.contains(ownerKey.pairingID)
+            else { return true }
+            secondaryCaffeineStatusesByPairingID[ownerKey.pairingID] = status
+            return true
+        } catch {
+            guard isCurrentSecondaryCaffeineOperation(
+                ownerKey: ownerKey,
+                client: client
+            ) else { return false }
+            if !secondaryCaffeineMutationPairingIDs.contains(ownerKey.pairingID) {
+                secondaryCaffeineStatusesByPairingID[ownerKey.pairingID] = nil
+            }
+            caffeineLog.error(
+                "caffeine.status (control) failed mac=\(ownerKey.pairingID, privacy: .public) error=\(String(describing: error), privacy: .public)"
+            )
+            return false
+        }
+    }
+
+    private func setSecondaryCaffeineEnabled(
+        _ enabled: Bool,
+        ownerKey: MacPairingKey
+    ) async -> Bool {
+        let pairingID = ownerKey.pairingID
+        guard !secondaryCaffeineMutationPairingIDs.contains(pairingID),
+              let subscription = secondaryMacSubscriptions[ownerKey],
+              subscription.supportedHostCapabilities.contains(
+                Self.caffeineControlCapability
+              ) else { return false }
+        let client = subscription.client
+        secondaryCaffeineMutationPairingIDs.insert(pairingID)
+        secondaryCaffeineStatusesByPairingID[pairingID] =
+            MobileCaffeineStatus(enabled: enabled)
+        defer { secondaryCaffeineMutationPairingIDs.remove(pairingID) }
+        do {
+            let data = try await client.sendRequest(
+                MobileCoreRPCClient.requestData(
+                    method: "caffeine.set",
+                    params: ["enabled": enabled]
+                ),
+                timeoutNanoseconds: Self.caffeineRequestTimeoutNanoseconds
+            )
+            let status = try MobileCaffeineStatus(decoding: data)
+            guard isCurrentSecondaryCaffeineOperation(
+                ownerKey: ownerKey,
+                client: client
+            ) else { return false }
+            secondaryCaffeineStatusesByPairingID[pairingID] = status
+            return true
+        } catch {
+            guard isCurrentSecondaryCaffeineOperation(
+                ownerKey: ownerKey,
+                client: client
+            ) else { return false }
+            // Same ambiguity as the foreground path: the set may have landed
+            // before the response was lost, so the state is unknown until a
+            // bounded status read confirms it.
+            secondaryCaffeineStatusesByPairingID[pairingID] = nil
+            caffeineLog.error(
+                "caffeine.set (control) failed mac=\(pairingID, privacy: .public) error=\(String(describing: error), privacy: .public)"
+            )
+            secondaryCaffeineMutationPairingIDs.remove(pairingID)
+            _ = await refreshSecondaryCaffeineStatus(ownerKey: ownerKey)
+            return secondaryCaffeineStatusesByPairingID[pairingID]?.enabled == enabled
+        }
+    }
+
+    /// Whether the subscription this request was sent on still owns its pool
+    /// slot; a retired or replaced control connection's stale response must
+    /// not overwrite the replacement's state.
+    private func isCurrentSecondaryCaffeineOperation(
+        ownerKey: MacPairingKey,
+        client: MobileCoreRPCClient
+    ) -> Bool {
+        guard let current = secondaryMacSubscriptions[ownerKey] else { return false }
+        return current.client === client
     }
 }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+Caffeine.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+Caffeine.swift
@@ -13,6 +13,26 @@ extension MobileShellComposite {
 
     // MARK: - Per-Mac surface
 
+    /// Whether the named pairing is the live foreground connection, using the
+    /// SAME device-id + tag correlation the Computers rows and detail use for
+    /// their Connected status (``exactPairingConnectionStatus``). Keying off
+    /// `foregroundMacKey` alone breaks manual/anonymous tickets, whose device
+    /// id settles through the ``connectedMacDeviceID`` fallback chain; caffeine
+    /// routing must agree with the Connected gate the UI renders.
+    private func isForegroundCaffeinePairing(
+        macDeviceID: String,
+        instanceTag: String?
+    ) -> Bool {
+        guard let connectedMacDeviceID else { return false }
+        return Self.exactPairingConnectionStatus(
+            deviceStatus: .connected,
+            connectedMacDeviceID: connectedMacDeviceID,
+            connectedMacInstanceTag: connectedMacInstanceTag,
+            rowMacDeviceID: macDeviceID,
+            rowInstanceTag: instanceTag
+        ) == .connected
+    }
+
     /// Keep-awake is controlled per Mac: the foreground connection and each
     /// live control (secondary) connection carry their own state, so every
     /// read and mutation names the exact pairing it targets.
@@ -20,8 +40,10 @@ extension MobileShellComposite {
         macDeviceID: String,
         instanceTag: String?
     ) -> MobileCaffeineStatus? {
+        if isForegroundCaffeinePairing(macDeviceID: macDeviceID, instanceTag: instanceTag) {
+            return caffeineStatus
+        }
         let key = MacPairingKey(macDeviceID: macDeviceID, instanceTag: instanceTag)
-        if key == foregroundMacKey { return caffeineStatus }
         // A dict entry is only trusted while its control connection is live;
         // retirement paths don't have to chase entries down.
         guard secondaryMacSubscriptions[key] != nil else { return nil }
@@ -34,8 +56,10 @@ extension MobileShellComposite {
         macDeviceID: String,
         instanceTag: String?
     ) -> Bool {
+        if isForegroundCaffeinePairing(macDeviceID: macDeviceID, instanceTag: instanceTag) {
+            return supportsCaffeineControl
+        }
         let key = MacPairingKey(macDeviceID: macDeviceID, instanceTag: instanceTag)
-        if key == foregroundMacKey { return supportsCaffeineControl }
         return secondaryMacSubscriptions[key]?
             .supportedHostCapabilities
             .contains(Self.caffeineControlCapability) == true
@@ -46,8 +70,10 @@ extension MobileShellComposite {
         macDeviceID: String,
         instanceTag: String?
     ) -> Bool {
+        if isForegroundCaffeinePairing(macDeviceID: macDeviceID, instanceTag: instanceTag) {
+            return isCaffeineMutationInFlight
+        }
         let key = MacPairingKey(macDeviceID: macDeviceID, instanceTag: instanceTag)
-        if key == foregroundMacKey { return isCaffeineMutationInFlight }
         return secondaryCaffeineMutationPairingIDs.contains(key.pairingID)
     }
 
@@ -55,8 +81,11 @@ extension MobileShellComposite {
     /// states on the Computers screen.
     public var caffeineMutatingPairingIDs: Set<String> {
         var ids = secondaryCaffeineMutationPairingIDs
-        if isCaffeineMutationInFlight {
-            ids.insert(foregroundMacKey.pairingID)
+        if isCaffeineMutationInFlight, let connectedMacDeviceID {
+            ids.insert(MacPairingKey(
+                macDeviceID: connectedMacDeviceID,
+                instanceTag: connectedMacInstanceTag
+            ).pairingID)
         }
         return ids
     }
@@ -67,10 +96,10 @@ extension MobileShellComposite {
         macDeviceID: String,
         instanceTag: String?
     ) async -> Bool {
-        let key = MacPairingKey(macDeviceID: macDeviceID, instanceTag: instanceTag)
-        if key == foregroundMacKey {
+        if isForegroundCaffeinePairing(macDeviceID: macDeviceID, instanceTag: instanceTag) {
             return await refreshForegroundCaffeineStatus()
         }
+        let key = MacPairingKey(macDeviceID: macDeviceID, instanceTag: instanceTag)
         return await refreshSecondaryCaffeineStatus(ownerKey: key)
     }
 
@@ -81,10 +110,10 @@ extension MobileShellComposite {
         macDeviceID: String,
         instanceTag: String?
     ) async -> Bool {
-        let key = MacPairingKey(macDeviceID: macDeviceID, instanceTag: instanceTag)
-        if key == foregroundMacKey {
+        if isForegroundCaffeinePairing(macDeviceID: macDeviceID, instanceTag: instanceTag) {
             return await setForegroundCaffeineEnabled(enabled)
         }
+        let key = MacPairingKey(macDeviceID: macDeviceID, instanceTag: instanceTag)
         return await setSecondaryCaffeineEnabled(enabled, ownerKey: key)
     }
 

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+Caffeine.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+Caffeine.swift
@@ -148,7 +148,14 @@ extension MobileShellComposite {
     /// directly (no host-status round trip), so the control entry's known
     /// state moves into the foreground slot instead of waiting for a refresh.
     func adoptSecondaryCaffeineStatusForPromotedForeground(ownerKey: MacPairingKey) {
-        guard caffeineStatus == nil, !isCaffeineMutationInFlight,
+        guard caffeineStatus == nil, !isCaffeineMutationInFlight else { return }
+        // A pending control-connection mutation owns this pairing's optimistic
+        // value. Adopting it would let the promoted foreground accept a
+        // conflicting toggle while the Mac is still processing the first one,
+        // and the eventual response could never reconcile the foreground slot.
+        // Stay unknown instead; the status event or the Computers backfill
+        // lands the authoritative value moments later.
+        guard !secondaryCaffeineMutationPairingIDs.contains(ownerKey.pairingID),
               let adopted = secondaryCaffeineStatusesByPairingID[ownerKey.pairingID]
         else { return }
         secondaryCaffeineStatusesByPairingID[ownerKey.pairingID] = nil
@@ -421,12 +428,15 @@ extension MobileShellComposite {
 
     /// Whether the subscription this request was sent on still owns its pool
     /// slot; a retired or replaced control connection's stale response must
-    /// not overwrite the replacement's state.
+    /// not overwrite the replacement's state. A subscription mid-promotion is
+    /// also not current: its pairing is becoming the foreground, so a late
+    /// response must not resurrect a control-side entry that promotion
+    /// adoption just cleared — the foreground event/backfill reconciles it.
     private func isCurrentSecondaryCaffeineOperation(
         ownerKey: MacPairingKey,
         client: MobileCoreRPCClient
     ) -> Bool {
         guard let current = secondaryMacSubscriptions[ownerKey] else { return false }
-        return current.client === client
+        return current.client === client && !current.isTransitioningToFocus
     }
 }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+IrohPeerFocus.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+IrohPeerFocus.swift
@@ -146,6 +146,7 @@ extension MobileShellComposite {
             )
         foregroundMacDeviceID = macDeviceID
         supportedHostCapabilities = subscription.supportedHostCapabilities
+        adoptSecondaryCaffeineStatusForPromotedForeground(ownerKey: ownerKey)
         terminalOutputTransport = Self.resolvedTerminalOutputTransport(
             capabilities: subscription.supportedHostCapabilities,
             terminalFidelity: nil

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+SecondaryPromotion.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+SecondaryPromotion.swift
@@ -697,6 +697,7 @@ extension MobileShellComposite {
             workspacesByMac[foregroundMacKey] = promotedState
         }
         supportedHostCapabilities = sub.supportedHostCapabilities
+        adoptSecondaryCaffeineStatusForPromotedForeground(ownerKey: ownerKey)
         // Promotion has already authenticated this capability snapshot on the
         // control connection. Publish its terminal mode synchronously so input
         // can use the warm connection immediately while the render listener

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -533,6 +533,13 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// Monotonic fence for authoritative caffeine snapshots. It survives
     /// connection resets so an older reconciliation cannot match newer state.
     @ObservationIgnored var caffeineStatusRevision: UInt64 = 0
+    /// Keep-awake state for live CONTROL (secondary) connections, keyed by
+    /// pairing id. The foreground Mac's state stays in ``caffeineStatus``; the
+    /// per-Mac reads funnel through ``caffeineStatus(macDeviceID:instanceTag:)``.
+    public internal(set) var secondaryCaffeineStatusesByPairingID:
+        [String: MobileCaffeineStatus] = [:]
+    /// Pairing ids with a caffeine mutation awaiting a secondary Mac.
+    public internal(set) var secondaryCaffeineMutationPairingIDs: Set<String> = []
 
     /// Whether the authenticated Mac supports changing its independent phone
     /// forwarding privacy gates from iOS.
@@ -6349,6 +6356,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             client: subscription.client,
             displayName: displayName
         )
+        seedSecondaryCaffeineStatus(subscription)
         if subscription.supportedHostCapabilities.contains("events.v1") {
             startSecondaryEventConsumer(
                 subscription,
@@ -6455,6 +6463,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     fallback: displayName
                 )
             )
+        } else if event.topic == "caffeine.status.changed" {
+            handleSecondaryCaffeineStatusEvent(event, ownerKey: ownerKey)
         }
         return true
     }
@@ -7399,6 +7409,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             }
         }
         secondaryMacSubscriptions.removeAll()
+        secondaryCaffeineStatusesByPairingID.removeAll()
+        secondaryCaffeineMutationPairingIDs.removeAll()
         let drainReservations = Array(
             secondaryMacDrainReservations.values
         )
@@ -12191,6 +12203,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             }
             supportedHostCapabilities = Set(payload.capabilities)
             phonePushMacStatus = payload.phonePush
+            seedForegroundCaffeineStatusIfSupported()
             restartActiveMobileBrowserStreams()
             restartActiveMobileSimulatorStreams()
             refreshVisibleMobileBrowserPanels()
@@ -14147,6 +14160,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// start a duplicate foreground fetch.
     public func refreshComputersScreen() async {
         await loadPairedMacs()
+        // Row indicators need every live connection's keep-awake state, and a
+        // promotion/demotion can leave a live connection without one.
+        backfillMissingCaffeineStatuses()
         guard connectionState == .connected, remoteClient != nil else { return }
         if let inFlight = pullToRefreshTask {
             await inFlight.value

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -534,12 +534,13 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// connection resets so an older reconciliation cannot match newer state.
     @ObservationIgnored var caffeineStatusRevision: UInt64 = 0
     /// Keep-awake state for live CONTROL (secondary) connections, keyed by
-    /// pairing id. The foreground Mac's state stays in ``caffeineStatus``; the
-    /// per-Mac reads funnel through ``caffeineStatus(macDeviceID:instanceTag:)``.
-    public internal(set) var secondaryCaffeineStatusesByPairingID:
-        [String: MobileCaffeineStatus] = [:]
+    /// pairing id. Internal on purpose: a raw read would bypass the
+    /// live-subscription gate in ``caffeineStatus(macDeviceID:instanceTag:)``,
+    /// which every consumer must go through.
+    var secondaryCaffeineStatusesByPairingID: [String: MobileCaffeineStatus] = [:]
     /// Pairing ids with a caffeine mutation awaiting a secondary Mac.
-    public internal(set) var secondaryCaffeineMutationPairingIDs: Set<String> = []
+    /// Internal for the same reason; UI reads ``caffeineMutatingPairingIDs``.
+    var secondaryCaffeineMutationPairingIDs: Set<String> = []
 
     /// Whether the authenticated Mac supports changing its independent phone
     /// forwarding privacy gates from iOS.

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/SecondaryMacSubscription.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/SecondaryMacSubscription.swift
@@ -11,6 +11,7 @@ final class SecondaryMacSubscription {
     static let eventTopics: Set<String> = [
         "workspace.updated",
         "notification.feed.changed",
+        "caffeine.status.changed",
     ]
 
     let macDeviceID: String

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
@@ -72,6 +72,8 @@ struct DeviceTreeView: View {
                                 visibleComputers: section.computers,
                                 hiddenComputers: [],
                                 mutatingComputerIDs: store.computerVisibilityMutationIDs,
+                                setCaffeine: setCaffeine,
+                                caffeineMutatingComputerIDs: store.caffeineMutatingPairingIDs,
                                 hide: hideComputer,
                                 unhide: unhideComputer,
                             )
@@ -215,6 +217,18 @@ struct DeviceTreeView: View {
             representativeID: computer.id,
             aliasIDs: computer.aliasIDs
         )
+    }
+
+    /// Leading-swipe keep-awake toggle: targets exactly the swiped Computer's
+    /// own connection, never whichever Mac happens to be active.
+    private func setCaffeine(_ computer: MacComputerSnapshot, _ enabled: Bool) {
+        Task {
+            await store.setCaffeineEnabled(
+                enabled,
+                macDeviceID: computer.deviceId,
+                instanceTag: computer.instanceTag
+            )
+        }
     }
 
     private func unhideComputer(_ computer: MobileHiddenComputer) {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/HiddenComputerRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/HiddenComputerRow.swift
@@ -63,8 +63,21 @@ private struct ComputerVisibilityRow: View {
     var style: MacComputerRow.Style
     let connect: @MainActor (MacComputerSnapshot) -> Void
     let isConnecting: Bool
+    var setCaffeine: @MainActor (MacComputerSnapshot, Bool) -> Void = { _, _ in }
+    var isCaffeineMutating: Bool = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     private var isBusy: Bool { isVisibilityMutating }
+
+    /// The computer this row can toggle keep-awake on via the leading swipe:
+    /// a visible Computers-screen row with a live, capable connection whose
+    /// state is known. Reconnect-style rows have no connection to act on.
+    private var caffeineSwipeTarget: (computer: MacComputerSnapshot, enabled: Bool)? {
+        guard style == .computers,
+              let computer = item.visibleComputer,
+              computer.supportsCaffeineControl,
+              let enabled = computer.caffeineEnabled else { return nil }
+        return (computer, enabled)
+    }
 
     var body: some View {
         HStack(spacing: item.isVisible ? 8 : 12) {
@@ -96,6 +109,39 @@ private struct ComputerVisibilityRow: View {
                 identity: ComputerRowTransitionPhase(shown: true)
             ).animation(.easeOut(duration: 0.12))
         ))
+        // Keep-awake one swipe away; the same control lives visibly in the
+        // computer's detail view, so the hidden gesture is a shortcut, not
+        // the only path. Non-destructive, so full swipe commits it.
+        .swipeActions(edge: .leading, allowsFullSwipe: true) {
+            if let target = caffeineSwipeTarget {
+                Button {
+                    setCaffeine(target.computer, !target.enabled)
+                } label: {
+                    if target.enabled {
+                        Label(
+                            L10n.string(
+                                "mobile.computers.keepAwake.letSleep",
+                                defaultValue: "Let Sleep"
+                            ),
+                            systemImage: "moon.zzz.fill"
+                        )
+                    } else {
+                        Label(
+                            L10n.string(
+                                "mobile.computers.keepAwake.keepAwake",
+                                defaultValue: "Keep Awake"
+                            ),
+                            systemImage: "cup.and.saucer.fill"
+                        )
+                    }
+                }
+                .tint(target.enabled ? .indigo : .orange)
+                .disabled(isCaffeineMutating)
+                .accessibilityIdentifier(
+                    "MobileComputerCaffeineSwipe-\(target.computer.connectionRef.automationID)"
+                )
+            }
+        }
     }
 
     @ViewBuilder
@@ -173,6 +219,8 @@ struct ComputerVisibilityRows: View {
     var connect: @MainActor (MacComputerSnapshot) -> Void = { _ in }
     var connectingComputerID: String?
     var mutatingComputerIDs: Set<String> = []
+    var setCaffeine: @MainActor (MacComputerSnapshot, Bool) -> Void = { _, _ in }
+    var caffeineMutatingComputerIDs: Set<String> = []
     let hide: @MainActor (MacComputerSnapshot) -> Void
     let unhide: @MainActor (MobileHiddenComputer) -> Void
 
@@ -190,6 +238,8 @@ struct ComputerVisibilityRows: View {
                 style: style,
                 connect: connect,
                 isConnecting: connectingComputerID == item.id,
+                setCaffeine: setCaffeine,
+                isCaffeineMutating: caffeineMutatingComputerIDs.contains(item.id),
             )
         }
     }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerDetailView.swift
@@ -58,6 +58,9 @@ struct MacComputerDetailView: View {
     @State private var showsForgetComputer = false
     /// Presents the revoke-failure alert so a failed Forget is never silent.
     @State private var forgetComputerFailed = false
+    /// Keep-awake status read failed for THIS Mac; drives the inline Retry.
+    @State private var caffeineStatusLoadFailed = false
+    @State private var caffeineStatusRetryID = 0
 
     /// Curated icon choices: a few computer/utility SF Symbols + emojis.
     private static let symbolChoices = [
@@ -113,6 +116,7 @@ struct MacComputerDetailView: View {
             connectionMethodSection
             appearanceSection
             connectionSection
+            macPowerSection
             presenceSection
             routesSection
             identitySection
@@ -767,6 +771,73 @@ struct MacComputerDetailView: View {
             }
             LabeledContent(L10n.string("mobile.computers.field.workspaces", defaultValue: "Workspaces"),
                            value: "\(workspaceCount)")
+        }
+    }
+
+    // MARK: - Mac Power (keep-awake)
+
+    private var isConnectedToThisComputer: Bool {
+        connectionStatus == .connected
+    }
+
+    private var supportsCaffeineControl: Bool {
+        store.supportsCaffeineControl(macDeviceID: macDeviceID, instanceTag: instanceTag)
+    }
+
+    /// Restarts the status load whenever the identity, connection, or
+    /// capability underneath it changes, so a reconnect never shows the
+    /// previous connection's stale failure state.
+    private var caffeineLoadID: String {
+        [
+            macDeviceID,
+            instanceTag ?? "",
+            String(supportsCaffeineControl),
+            String(describing: connectionStatus),
+        ].joined(separator: ":")
+    }
+
+    /// This Mac's own keep-awake control. Keep-awake is per device: the
+    /// section reads and mutates exactly the pairing this detail shows,
+    /// whether it is the active Mac or a live secondary connection.
+    @ViewBuilder
+    private var macPowerSection: some View {
+        MobileCaffeineSettingsContent(
+            isEnabled: store.caffeineStatus(
+                macDeviceID: macDeviceID,
+                instanceTag: instanceTag
+            )?.enabled,
+            isSupported: supportsCaffeineControl,
+            isConnected: isConnectedToThisComputer,
+            isBusy: store.isCaffeineMutationInFlight(
+                macDeviceID: macDeviceID,
+                instanceTag: instanceTag
+            ),
+            statusLoadFailed: caffeineStatusLoadFailed,
+            onRetryStatus: {
+                caffeineStatusLoadFailed = false
+                caffeineStatusRetryID &+= 1
+            },
+            onSet: { enabled in
+                await store.setCaffeineEnabled(
+                    enabled,
+                    macDeviceID: macDeviceID,
+                    instanceTag: instanceTag
+                )
+            }
+        )
+        .task(id: "\(caffeineLoadID):\(caffeineStatusRetryID)") {
+            let loadID = caffeineLoadID
+            guard isConnectedToThisComputer, supportsCaffeineControl else {
+                caffeineStatusLoadFailed = false
+                return
+            }
+            caffeineStatusLoadFailed = false
+            let didLoad = await store.refreshCaffeineStatus(
+                macDeviceID: macDeviceID,
+                instanceTag: instanceTag
+            )
+            guard !Task.isCancelled, caffeineLoadID == loadID else { return }
+            caffeineStatusLoadFailed = !didLoad
         }
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
@@ -108,10 +108,30 @@ struct MacComputerRow: View {
                     .lineLimit(1)
             }
             Spacer(minLength: 8)
+            caffeineIndicator
             badge
         }
         .padding(.vertical, 4)
         .contentShape(Rectangle())
+    }
+
+    /// Small cup marking a Mac that cmux is keeping awake. The snapshot only
+    /// carries the state over a live connection, so a stale cup can't linger
+    /// on an unreachable Mac.
+    @ViewBuilder
+    private var caffeineIndicator: some View {
+        if computer.caffeineEnabled == true {
+            Image(systemName: "cup.and.saucer.fill")
+                .font(.caption)
+                .foregroundStyle(.orange)
+                .accessibilityLabel(L10n.string(
+                    "mobile.computers.keepAwake.active",
+                    defaultValue: "Keeping Mac awake"
+                ))
+                .accessibilityIdentifier(
+                    "MobileComputerCaffeine-\(computer.connectionRef.automationID)"
+                )
+        }
     }
 
     /// The connection dot: green only when the PHONE is actually connected to this

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerSnapshot+Store.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerSnapshot+Store.swift
@@ -83,6 +83,20 @@ extension MacComputerSnapshot {
             )
             snapshot.connectionMethod = method
             snapshot.routeKind = method.routeKind
+            // Keep-awake is trusted only over a live connection: a stale
+            // "caffeinated" cup on an unreachable Mac would be a lie.
+            if exactConnectionStatus == .connected {
+                snapshot.supportsCaffeineControl = store.supportsCaffeineControl(
+                    macDeviceID: mac.macDeviceID,
+                    instanceTag: mac.instanceTag
+                )
+                snapshot.caffeineEnabled = snapshot.supportsCaffeineControl
+                    ? store.caffeineStatus(
+                        macDeviceID: mac.macDeviceID,
+                        instanceTag: mac.instanceTag
+                    )?.enabled
+                    : nil
+            }
             return snapshot
         }
         markOlderDuplicates(&snapshots)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerSnapshot.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerSnapshot.swift
@@ -44,6 +44,12 @@ struct MacComputerSnapshot: Equatable, Identifiable {
     /// still reconnect or remove it. Labeled so several identically named
     /// entries stop looking interchangeable.
     var isOlderDuplicate: Bool = false
+    /// Whether the phone can control this Mac's keep-awake state right now
+    /// (live connection + the Mac advertises the caffeine RPC).
+    var supportsCaffeineControl: Bool = false
+    /// This Mac's cmux-owned keep-awake state. `nil` while unknown, on Macs
+    /// without the capability, and whenever the phone isn't connected.
+    var caffeineEnabled: Bool?
     /// This Computer's effective connection method (its own stored choice,
     /// falling back to the app default). Decides the list section.
     var connectionMethod: MobileConnectionMethod?

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileCaffeineSettingsContent.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileCaffeineSettingsContent.swift
@@ -2,10 +2,15 @@
 import CmuxMobileSupport
 import SwiftUI
 
-/// Value-only Settings section for the connected Mac's cmux-owned power state.
+/// Value-only "Mac Power" section for ONE Mac's cmux-owned power state, hosted
+/// by that computer's detail view. Keep-awake is per device: the toggle, the
+/// status, and every message name the Mac whose detail this section sits in.
 struct MobileCaffeineSettingsContent: View {
     let isEnabled: Bool?
     let isSupported: Bool
+    /// Whether the phone has a live connection to THIS Mac. Without one the
+    /// toggle is inert and the footer says how to get control back.
+    let isConnected: Bool
     let isBusy: Bool
     let statusLoadFailed: Bool
     let onRetryStatus: () -> Void
@@ -24,7 +29,18 @@ struct MobileCaffeineSettingsContent: View {
                     systemImage: "cup.and.saucer.fill"
                 )
                 Spacer()
-                if isSupported, isEnabled == nil {
+                if !isConnected {
+                    Toggle(
+                        L10n.string(
+                            "mobile.settings.keepMacAwake",
+                            defaultValue: "Keep Mac Awake"
+                        ),
+                        isOn: .constant(isEnabled ?? false)
+                    )
+                    .labelsHidden()
+                    .disabled(true)
+                    .accessibilityIdentifier("MobileSettingsKeepMacAwakeToggle")
+                } else if isSupported, isEnabled == nil {
                     if statusLoadFailed || mutationFailed {
                         Button(
                             L10n.string("mobile.common.retry", defaultValue: "Retry"),
@@ -59,7 +75,13 @@ struct MobileCaffeineSettingsContent: View {
                 }
             }
 
-            if !isSupported {
+            if !isConnected {
+                Text(L10n.string(
+                    "mobile.settings.keepMacAwake.notConnected",
+                    defaultValue: "Connect to this Mac to control Keep Mac Awake."
+                ))
+                .foregroundStyle(.secondary)
+            } else if !isSupported {
                 Text(L10n.string(
                     "mobile.settings.keepMacAwake.updateRequired",
                     defaultValue: "Update cmux on this Mac to control Keep Mac Awake from iPhone."

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
@@ -51,8 +51,6 @@ struct MobileSettingsView: View {
 #endif
     @State private var showingOnboarding = false
     @State private var showingSetupHelp = false
-    @State private var caffeineStatusLoadFailed = false
-    @State private var caffeineStatusRetryID = 0
     #if DEBUG
     @State private var showingToastGallery = false
     /// Seconds between tapping "Run Toast Demo" and the first toast, so you
@@ -158,7 +156,6 @@ struct MobileSettingsView: View {
                         }
                     }
                 }
-                caffeineSettingsSection
                 if hasConnectionSection {
                     Button {
                         showingSetupHelp = true
@@ -741,45 +738,6 @@ struct MobileSettingsView: View {
     /// so they are hidden.
     private var hasConnectionSection: Bool {
         !connectedHostName.isEmpty || store != nil
-    }
-
-    private var caffeineLoadID: String {
-        guard let store else { return "disconnected" }
-        return [
-            store.connectedMacDeviceID ?? "unknown",
-            String(store.supportsCaffeineControl),
-            String(describing: store.connectionState),
-        ].joined(separator: ":")
-    }
-
-    @ViewBuilder
-    private var caffeineSettingsSection: some View {
-        if let store, store.connectionState == .connected {
-            MobileCaffeineSettingsContent(
-                isEnabled: store.caffeineStatus?.enabled,
-                isSupported: store.supportsCaffeineControl,
-                isBusy: store.isCaffeineMutationInFlight,
-                statusLoadFailed: caffeineStatusLoadFailed,
-                onRetryStatus: {
-                    caffeineStatusLoadFailed = false
-                    caffeineStatusRetryID &+= 1
-                },
-                onSet: { enabled in
-                    await store.setCaffeineEnabled(enabled)
-                }
-            )
-            .task(id: "\(caffeineLoadID):\(caffeineStatusRetryID)") {
-                let loadID = caffeineLoadID
-                guard store.supportsCaffeineControl else {
-                    caffeineStatusLoadFailed = false
-                    return
-                }
-                caffeineStatusLoadFailed = false
-                let didLoad = await store.refreshCaffeineStatus()
-                guard !Task.isCancelled, caffeineLoadID == loadID else { return }
-                caffeineStatusLoadFailed = !didLoad
-            }
-        }
     }
 
     /// Drives the team Picker. Reads the EFFECTIVE current team (`resolvedTeamID`,

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -23681,6 +23681,74 @@
           }
         }
       }
+    },
+    "mobile.computers.keepAwake.active": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keeping Mac awake"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Macをスリープさせない設定が有効"
+          }
+        }
+      }
+    },
+    "mobile.computers.keepAwake.keepAwake": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep Awake"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スリープさせない"
+          }
+        }
+      }
+    },
+    "mobile.computers.keepAwake.letSleep": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Let Sleep"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スリープを許可"
+          }
+        }
+      }
+    },
+    "mobile.settings.keepMacAwake.notConnected": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connect to this Mac to control Keep Mac Awake."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "「Macをスリープさせない」を操作するには、このMacに接続してください。"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -1615,7 +1615,11 @@ final class cmuxUITests: XCTestCase {
         tap(row, in: app)
 
         let toggle = app.switches["MobileSettingsKeepMacAwakeToggle"]
+        for _ in 0..<8 where !toggle.exists || !toggle.isHittable {
+            app.swipeUp(velocity: .slow)
+        }
         XCTAssertTrue(toggle.waitForExistence(timeout: 4))
+        XCTAssertTrue(toggle.isHittable)
         let didRequestInitialStatus = await server.waitForRequest(method: "caffeine.status")
         XCTAssertTrue(didRequestInitialStatus)
         XCTAssertEqual(toggle.value as? String, "0")
@@ -1640,8 +1644,10 @@ final class cmuxUITests: XCTestCase {
         XCTAssertTrue(detailBack.waitForExistence(timeout: 4))
         tap(detailBack, in: app)
 
-        let indicator = app.images.matching(
-            NSPredicate(format: "identifier BEGINSWITH 'MobileComputerCaffeine-'")
+        // The cup indicator lives inside the row's combined accessibility
+        // element, so its label is asserted through the merged row label.
+        let indicator = app.descendants(matching: .any).matching(
+            NSPredicate(format: "label CONTAINS 'Keeping Mac awake'")
         ).firstMatch
         XCTAssertTrue(indicator.waitForExistence(timeout: 4))
 

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -1629,7 +1629,12 @@ final class cmuxUITests: XCTestCase {
             predicate: NSPredicate(format: "value == %@", "1"),
             object: toggle
         )
-        XCTAssertEqual(XCTWaiter.wait(for: [enabled], timeout: 4), .completed)
+        let enabledResult = XCTWaiter.wait(for: [enabled], timeout: 4)
+        if enabledResult != .completed {
+            print("CAFFDBG toggle value=\(String(describing: toggle.value)) isEnabled=\(toggle.isEnabled)")
+            print("CAFFDBG tree begin\n\(app.debugDescription)\nCAFFDBG tree end")
+        }
+        XCTAssertEqual(enabledResult, .completed)
         let didEnableCaffeine = await server.waitForRequest(method: "caffeine.set")
         XCTAssertTrue(didEnableCaffeine)
 

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -1588,7 +1588,7 @@ final class cmuxUITests: XCTestCase {
     }
 
     @MainActor
-    func testIOSCanToggleMacKeepAwakeFromSettings() async throws {
+    func testIOSControlsMacKeepAwakePerComputer() async throws {
         let server = try MobileSyncMockHostServer(advertisesCaffeineControl: true)
         let port = try await server.start()
         defer { server.stop() }
@@ -1600,19 +1600,25 @@ final class cmuxUITests: XCTestCase {
         XCTAssertTrue(backButton.waitForExistence(timeout: 4))
         tap(backButton, in: app)
 
-        let settings = app.buttons["MobileWorkspaceSettingsMenu"]
-        XCTAssertTrue(settings.waitForExistence(timeout: 4))
-        tap(settings, in: app)
+        // Keep-awake is per computer: the toggle lives in the computer's own
+        // detail view, not in app-wide Settings.
+        let devices = app.buttons["MobileWorkspaceDevicesButton"]
+        XCTAssertTrue(devices.waitForExistence(timeout: 4))
+        tap(devices, in: app)
+        let deviceTree = app.descendants(matching: .any)["MobileDeviceTree"]
+        XCTAssertTrue(deviceTree.waitForExistence(timeout: 4))
+
+        let row = app.descendants(matching: .any).matching(
+            NSPredicate(format: "identifier BEGINSWITH 'MobileComputerRow-'")
+        ).firstMatch
+        XCTAssertTrue(row.waitForExistence(timeout: 6))
+        tap(row, in: app)
 
         let toggle = app.switches["MobileSettingsKeepMacAwakeToggle"]
-        for _ in 0..<8 where !toggle.exists || !toggle.isHittable {
-            app.swipeUp(velocity: .slow)
-        }
         XCTAssertTrue(toggle.waitForExistence(timeout: 4))
-        XCTAssertTrue(toggle.isHittable)
-        XCTAssertEqual(toggle.value as? String, "0")
         let didRequestInitialStatus = await server.waitForRequest(method: "caffeine.status")
         XCTAssertTrue(didRequestInitialStatus)
+        XCTAssertEqual(toggle.value as? String, "0")
 
         toggle.coordinate(withNormalizedOffset: CGVector(dx: 0.9, dy: 0.5)).tap()
         let enabled = XCTNSPredicateExpectation(
@@ -1623,17 +1629,40 @@ final class cmuxUITests: XCTestCase {
         let didEnableCaffeine = await server.waitForRequest(method: "caffeine.set")
         XCTAssertTrue(didEnableCaffeine)
 
-        let attachment = XCTAttachment(screenshot: app.screenshot())
-        attachment.name = "ios-keep-mac-awake-enabled"
-        attachment.lifetime = .keepAlways
-        add(attachment)
+        let detailAttachment = XCTAttachment(screenshot: app.screenshot())
+        detailAttachment.name = "ios-keep-mac-awake-detail-enabled"
+        detailAttachment.lifetime = .keepAlways
+        add(detailAttachment)
 
-        toggle.coordinate(withNormalizedOffset: CGVector(dx: 0.9, dy: 0.5)).tap()
-        let disabled = XCTNSPredicateExpectation(
-            predicate: NSPredicate(format: "value == %@", "0"),
-            object: toggle
-        )
-        XCTAssertEqual(XCTWaiter.wait(for: [disabled], timeout: 4), .completed)
+        // Back on the Computers list, the caffeinated Mac's row shows the cup
+        // indicator, and the leading swipe action turns keep-awake back off.
+        let detailBack = app.navigationBars.buttons.firstMatch
+        XCTAssertTrue(detailBack.waitForExistence(timeout: 4))
+        tap(detailBack, in: app)
+
+        let indicator = app.images.matching(
+            NSPredicate(format: "identifier BEGINSWITH 'MobileComputerCaffeine-'")
+        ).firstMatch
+        XCTAssertTrue(indicator.waitForExistence(timeout: 4))
+
+        let listAttachment = XCTAttachment(screenshot: app.screenshot())
+        listAttachment.name = "ios-keep-mac-awake-row-indicator"
+        listAttachment.lifetime = .keepAlways
+        add(listAttachment)
+
+        XCTAssertTrue(row.waitForExistence(timeout: 4))
+        row.swipeRight()
+        let swipeButton = app.buttons.matching(
+            NSPredicate(format: "identifier BEGINSWITH 'MobileComputerCaffeineSwipe-'")
+        ).firstMatch
+        XCTAssertTrue(swipeButton.waitForExistence(timeout: 3))
+
+        let swipeAttachment = XCTAttachment(screenshot: app.screenshot())
+        swipeAttachment.name = "ios-keep-mac-awake-swipe-action"
+        swipeAttachment.lifetime = .keepAlways
+        add(swipeAttachment)
+
+        tap(swipeButton, in: app)
         let didDisableCaffeine = await server.waitForRequest(
             method: "caffeine.set",
             minimumCount: 2
@@ -1641,6 +1670,8 @@ final class cmuxUITests: XCTestCase {
         XCTAssertTrue(didDisableCaffeine)
         let caffeineSetValues = await server.caffeineSetValues()
         XCTAssertEqual(caffeineSetValues, [true, false])
+        // The cup disappears once the Mac confirms keep-awake is off.
+        XCTAssertTrue(indicator.waitForNonExistence(timeout: 4))
     }
 
     @MainActor


### PR DESCRIPTION
Keep Mac Awake was one app-wide Settings toggle that silently targeted whichever Mac was active, so it read as an account-wide setting and offered no control over other connected Macs. It is now per computer.

Each computer's detail view gets a Mac Power section with the Keep Mac Awake toggle for exactly that pairing, including a disabled state with guidance when the phone isn't connected to that Mac. The Computers list rows get a leading (left-to-right, full-swipe-enabled) swipe action that toggles keep-awake (orange cup to caffeinate, indigo moon to let it sleep), and rows show a small orange `cup.and.saucer.fill` indicator while cmux is keeping that Mac awake. The app-wide Settings section is removed.

Under the hood the shell tracks caffeine state per pairing. The foreground connection keeps the existing revision-fenced state; each live control (secondary) connection gets its own status keyed by pairing id, seeded when the control subscription is established, updated live via the `caffeine.status.changed` topic (now part of the control-plane subscription set), and backfilled by the Computers screen's 10s refresh to cover promotions/demotions. Reads only trust a secondary entry while its subscription is live, so a stale cup can't linger on an unreachable Mac. `caffeine.status`/`caffeine.set` are Mac-scoped and same-account authorized on any session, so control connections can drive them for non-active Macs; no Mac-side changes were needed.

The XCUITest `testIOSCanToggleMacKeepAwakeFromSettings` is rewritten as `testIOSControlsMacKeepAwakePerComputer`: it toggles keep-awake from the computer detail view, verifies the row indicator appears, disables it via the leading swipe action, and asserts the mock host saw `caffeine.set` `[true, false]`.

HIG: consulted the Human Interface Guidelines pages for gestures and lists-and-tables. Swipe reveals actions per the standard-gestures table, and because a swipe action is a hidden affordance the same control remains visible in the computer detail view. New strings are localized (en, ja) in `ios/cmux/Resources/Localizable.xcstrings`: swipe labels, the row indicator accessibility label, and the not-connected footer. Localization audit: all new user-facing strings go through `L10n.string`; no bare literals.

Note: macOS `main` currently doesn't compile (CmuxGit break from https://github.com/manaflow-ai/cmux/pull/10326, tracked in https://github.com/manaflow-ai/cmux/issues/11083 with revert https://github.com/manaflow-ai/cmux/pull/11084); this PR touches no macOS code and tagged builds were made with that revert applied as a local overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep Mac Awake was a single app-wide Settings toggle that silently targeted whichever Mac happened to be active. It is now controlled per computer.

**Behavior**
- The app-wide Settings section is removed; each computer's detail view now has a Mac Power section with the Keep Mac Awake toggle for that pairing, disabled with guidance when the phone isn't connected to that Mac.
- Computers list rows show an orange cup indicator while a Mac is kept awake, and a leading swipe action toggles keep-awake.
- The XCUITest now exercises the detail toggle, the row indicator, and the swipe action.

**State tracking**
- Keep-awake state is tracked per pairing; the foreground connection keeps its revision-fenced state, and each live control connection seeds its own status on establishment, updates via `caffeine.status.changed`, and is backfilled by the Computers screen refresh.
- Foreground routing reuses the same Connected correlation the rows and detail render, so manual/anonymous tickets — whose device id settles late — target the right Mac instead of missing it.
- Reads only trust a secondary entry while its subscription is live, promotion adoption skips pairings with a mutation still in flight, and late responses mid-promotion can't resurrect cleared entries.
- No Mac-side changes were needed; `caffeine.status` and `caffeine.set` already work over any same-account Mac-scoped session.

<sup>Written for commit 7aab549361c274d5eb9c82ab5077f2bffbe6676c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Manage “Keep Mac Awake” separately for each connected Mac.
  - Toggle the feature from a Mac’s detail screen or directly from the Computers list.
  - View an indicator showing when a Mac is being kept awake.
  - See clear connection and capability states, with controls disabled when unavailable.
  - Status remains synchronized when switching between Macs.

- **Bug Fixes**
  - Improved status updates and recovery when connections change or reconnect.
  - Added clearer guidance when a Mac must be connected before control is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->