### PR TITLE
Fix deterministic web CI failures on main (support variants, resume-test fixtures)

### DIFF
--- a/web/app/lib/agent-page-paths.ts
+++ b/web/app/lib/agent-page-paths.ts
@@ -132,6 +132,7 @@ export const agentReadablePages = [
   { path: "/browser", title: "cmux Browser" },
   ...agentReadableDownloadPages,
   { path: "/pricing", title: "Pricing", locales: fallbackContentLocales },
+  { path: "/support", title: "Support" },
   { path: "/enterprise", title: "Enterprise" },
   { path: "/blog", title: "Blog" },
   {

--- a/web/tests/vm-workflows.test.ts
+++ b/web/tests/vm-workflows.test.ts
@@ -2629,9 +2629,12 @@ describe("VM Effect workflows", () => {
   dbTest("resumes a paused VM before minting SSH credentials", async () => {
     if (!sql) throw new Error("test database not initialized");
     await sql`truncate cloud_vm_billing_grants, cloud_vm_usage_events, cloud_vm_leases, cloud_vms restart identity cascade`;
+    // A paid plan: the free plan's active-VM limit is 0 since #10948, which
+    // would fail the resume reservation before the SSH mechanics under test
+    // ever run.
     await sql`
       insert into cloud_vms (user_id, billing_team_id, billing_plan_id, provider, provider_vm_id, image_id, status)
-      values ('user-workflow-resume-ssh', 'team-workflow-resume-ssh', 'free', 'freestyle', 'provider-vm-resume-ssh', 'snapshot-test', 'paused')
+      values ('user-workflow-resume-ssh', 'team-workflow-resume-ssh', 'pro', 'freestyle', 'provider-vm-resume-ssh', 'snapshot-test', 'paused')
     `;
 
     let resumeCalls = 0;
@@ -2890,9 +2893,12 @@ describe("VM Effect workflows", () => {
   dbTest("rolls back a paused resume reservation when provider resume fails", async () => {
     if (!sql) throw new Error("test database not initialized");
     await sql`truncate cloud_vm_billing_grants, cloud_vm_usage_events, cloud_vm_leases, cloud_vms restart identity cascade`;
+    // A paid plan: the free plan's active-VM limit is 0 since #10948, which
+    // would fail the resume reservation before the rollback path under test
+    // ever runs.
     await sql`
       insert into cloud_vms (user_id, billing_team_id, billing_plan_id, provider, provider_vm_id, image_id, status)
-      values ('user-workflow-resume-fail', 'team-workflow-resume-fail', 'free', 'freestyle', 'provider-vm-resume-fail', 'snapshot-test', 'paused')
+      values ('user-workflow-resume-fail', 'team-workflow-resume-fail', 'pro', 'freestyle', 'provider-vm-resume-fail', 'snapshot-test', 'paused')
     `;
 
     const resumeError = new VmProviderOperationError({


### PR DESCRIPTION
Two deterministic failures have kept ci.yml red on main.

1. `agent page variants > supports Markdown and text variants for sitemap pages`: the localized /support page (https://github.com/manaflow-ai/cmux/pull/11007) entered the sitemap without an `agentReadablePages` entry, so `/support.md`/`.txt` resolved null for every locale. Fix: register the page (all locales, like other fallback-rendered pages).

2. `VM Effect workflows > resumes a paused VM before minting SSH credentials` and `> rolls back a paused resume reservation when provider resume fails`: these July tests use free-plan fixtures, and https://github.com/manaflow-ai/cmux/pull/10948 set the free plan's active-VM limit to 0, so `reservePausedResume` now throws `VmLimitExceededError(limit: 0)` before the mechanics under test run. Fix: move the fixtures to a paid plan (default limit 5), matching the tests' intent (resume mechanics, not plan policy).

Design question raised separately, not resolved here: `requireAccessibleUserVm` keeps a free-plan machine reachable inside the free-access window, but the resume reservation's limit of 0 makes a paused free machine un-resumable inside that same window. One of the two gates is wrong.

Verified locally: `bun run db:test` 77 pass / 0 fail (was 75/2); `bun test tests/agent-page-variants.test.ts` 24/24; `bun run typecheck` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two deterministic web CI failures on main by making the `/support` page's Markdown/text variants resolvable and adjusting two VM resume workflow tests to use a paid plan.

- Registers `/support` in `agentReadablePages` so its `.md` and `.txt` variants no longer return null for any locale.
- Switches the two paused-resume test fixtures from `free` to `pro` because the free plan's active-VM limit is now 0, which prevented the resume mechanics from being exercised.
- Whether a paused free-plan VM should be resumable inside its access window at all is left as an open design question tracked separately.

<sup>Written for commit 53022c32a7d831403759125d15030cef7d67c986. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the Support page to the list of pages available for agent-assisted navigation.

- **Tests**
  - Updated paused virtual machine workflow tests to use a plan that allows VM resumption.
  - Improved test coverage for SSH credential generation and rollback behavior when resumption fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->