### PR TITLE
cloud: bake + register e2b and daytona devbox images, harden e2b ingress

### DIFF
--- a/web/scripts/verify-devbox-image.ts
+++ b/web/scripts/verify-devbox-image.ts
@@ -31,6 +31,7 @@ import {
   cmuxTuiInstallCommand,
   resolveCmuxTuiSource,
 } from "../services/vms/drivers/cmuxTuiDaemon";
+import { ENVD_CONTROL_PORT, INBOUND_FIREWALL_COMMAND } from "../services/vms/drivers/e2b";
 import { devboxAgentPins, devboxDir, sha256File } from "./devbox-image-common";
 
 const pins = devboxAgentPins();
@@ -110,27 +111,81 @@ async function runChecks(label: string, checks: readonly string[], exec: Exec): 
 /**
  * Replays the driver's create-time bootstrap: install the pinned build
  * (sha256-verified by the install command itself), make sure something runs
- * the daemon (the image supervisor on Daytona/Freestyle; a detached launch
- * here stands in for the E2B driver's background command), and wait for the
- * session to answer.
+ * the daemon, and wait for the session to answer.
+ *
+ * How the daemon is started differs per provider, exactly as in production:
+ * E2B has no in-image supervisor, so its driver launches the daemon through
+ * the provider's native background-process API (a `setsid nohup … &` shell
+ * trick races E2B's cgroup teardown when the exec returns); Daytona and
+ * Freestyle bake a supervisor (`cmux-devbox-boot` as the snapshot entrypoint
+ * or a systemd unit) that starts the daemon on its own once the binary
+ * exists, so `startDaemon` is a no-op there.
  */
-async function bootstrapDaemon(provider: string, exec: Exec): Promise<void> {
+async function bootstrapDaemon(
+  provider: string,
+  exec: Exec,
+  startDaemon: () => Promise<void>,
+): Promise<void> {
   const source = await resolveCmuxTuiSource();
   console.log(`cmux-tui pin: commit ${source.commit} sha256 ${source.sha256.slice(0, 12)}…`);
   const install = await exec(cmuxTuiInstallCommand(source), 5 * 60 * 1000);
   if (install.exitCode !== 0) {
     throw new Error(`cmux-tui install failed: ${install.output.slice(-2000)}`);
   }
-  await exec(
-    `pgrep -f 'cmux-tui server start' >/dev/null 2>&1 || (setsid nohup sh -c '${cmuxTuiDaemonCommand()}' >>/tmp/cmux-tui-daemon.log 2>&1 &)`,
-    60_000,
-  );
-  for (let attempt = 0; attempt < 30; attempt += 1) {
+  await startDaemon();
+  for (let attempt = 0; attempt < 45; attempt += 1) {
     const status = await exec(`env HOME=/root /root/.cmux/bin/cmux-tui server status --session ${CMUX_TUI_SESSION}`, 30_000);
     if (status.exitCode === 0) return;
     await new Promise((resolve) => setTimeout(resolve, 1000));
   }
   throw new Error(`${provider}: cmux-tui daemon did not become ready`);
+}
+
+/**
+ * Proves the E2B driver's inbound firewall (INBOUND_FIREWALL_COMMAND) does
+ * what it must: after applying it, envd control (this very exec path) and the
+ * cmux-tui daemon (1337) stay reachable, while a scratch listener on a
+ * non-allowed port becomes unreachable from outside. Uses the exact command
+ * string the driver runs, so drift can't hide.
+ */
+async function verifyE2bFirewall(sbx: Sandbox, exec: Exec): Promise<boolean> {
+  const scratchPort = 4820;
+  // A minimal HTTP responder on the scratch port (reachable before firewall).
+  await sbx.commands
+    .run(
+      `nohup sh -c 'while true; do printf "HTTP/1.1 200 OK\\r\\ncontent-length: 2\\r\\n\\r\\nok" | nc -l -p ${scratchPort} -q1; done' >/tmp/scratch.log 2>&1`,
+      { background: true, user: "root", timeoutMs: 0 },
+    )
+    .catch(() => undefined);
+  await new Promise((resolve) => setTimeout(resolve, 1500));
+  const probe = async (port: number): Promise<string> => {
+    const host = sbx.getHost(port);
+    const res = await fetch(`https://${host}/`, { signal: AbortSignal.timeout(12_000) }).catch((e) => String(e));
+    return typeof res === "string" ? (res.includes("imeout") ? "blocked" : res) : `reachable(${res.status})`;
+  };
+  const scratchBefore = await probe(scratchPort);
+
+  const applied = await exec(INBOUND_FIREWALL_COMMAND, 60_000);
+  if (applied.exitCode !== 0) {
+    console.log(`[e2b firewall] apply FAILED exit=${applied.exitCode}\n    ${applied.output.trim()}`);
+    return false;
+  }
+  // envd control must survive (this exec reaches the VM through envd on 49983).
+  const ctrl = await exec("echo envd-control-alive", 30_000);
+  const daemon = await exec(`env HOME=/root /root/.cmux/bin/cmux-tui server status --session ${CMUX_TUI_SESSION} >/dev/null && echo daemon-alive`, 30_000);
+  const scratchAfter = await probe(scratchPort);
+
+  const ok =
+    ctrl.exitCode === 0 &&
+    daemon.exitCode === 0 &&
+    scratchBefore.startsWith("reachable") &&
+    scratchAfter === "blocked";
+  console.log(
+    `[e2b firewall] envd(${ENVD_CONTROL_PORT})=${ctrl.exitCode === 0 ? "alive" : "DEAD"} ` +
+      `daemon(1337)=${daemon.exitCode === 0 ? "alive" : "DEAD"} ` +
+      `scratch(${scratchPort}) before=${scratchBefore} after=${scratchAfter} => ${ok ? "PASS" : "FAIL"}`,
+  );
+  return ok;
 }
 
 const provider = process.argv[2] ?? "";
@@ -155,8 +210,17 @@ if (provider === "e2b") {
       });
       return { exitCode: r.exitCode, output: `${r.stdout}${r.stderr}` };
     };
-    await bootstrapDaemon("e2b", exec);
-    pass = await runChecks("e2b", [...CHECKS, ...DAEMON_CHECKS], exec);
+    // Mirror the E2B driver: start the daemon through the native background
+    // API so envd does not reap it when the launching exec returns.
+    await bootstrapDaemon("e2b", exec, async () => {
+      await sbx.commands.run(cmuxTuiDaemonCommand(), { background: true, user: "root", timeoutMs: 0 });
+    });
+    // Prove the driver's inbound firewall keeps attach alive: start a scratch
+    // listener on a non-allowed port, apply the exact firewall the driver
+    // applies, then confirm envd control + 1337 still work and the scratch
+    // port is unreachable from outside.
+    const firewallOk = await verifyE2bFirewall(sbx, exec);
+    pass = firewallOk && (await runChecks("e2b", [...CHECKS, ...DAEMON_CHECKS], exec));
   } finally {
     await sbx.kill();
     console.log(`killed ${sbx.sandboxId}`);
@@ -180,7 +244,9 @@ if (provider === "e2b") {
         return { exitCode: 124, output: String(error).slice(0, 500) };
       }
     };
-    await bootstrapDaemon("daytona", exec);
+    // The snapshot entrypoint (cmux-devbox-boot) supervises the daemon and
+    // starts it on its own once the binary is installed.
+    await bootstrapDaemon("daytona", exec, async () => {});
     pass = await runChecks("daytona", [
       ...CHECKS,
       ...DAEMON_CHECKS,
@@ -222,7 +288,8 @@ if (provider === "e2b") {
         output: `${r.stdout ?? ""}${r.stderr ?? ""}`,
       };
     };
-    await bootstrapDaemon("freestyle", exec);
+    // The baked cmux-tui-daemon systemd unit supervises the daemon.
+    await bootstrapDaemon("freestyle", exec, async () => {});
     pass = await runChecks("freestyle", [
       ...CHECKS,
       ...DAEMON_CHECKS,

--- a/web/services/vms/drivers/e2b.ts
+++ b/web/services/vms/drivers/e2b.ts
@@ -51,6 +51,30 @@ import {
 const ROUTE_TOKEN_TTL_SECONDS = 12 * 60 * 60;
 const DEFAULT_SANDBOX_ENVS = { LANG: "C.UTF-8" };
 const EXEC_DEFAULT_TIMEOUT_MS = 30_000;
+// envd is E2B's in-VM control plane (process exec + filesystem): the SDK reaches
+// it through the SAME public port proxy on 49983, so an inbound firewall MUST
+// keep it open or every commands.run/attach breaks (researched live 2026-08-28:
+// ss shows `envd` listening on *:49983; a default-deny INPUT that allows 49983 +
+// 1337 kept control and attach alive while a port-3000 dev server became
+// unreachable externally). ConnectionConfig.envdPort in the e2b SDK is the same
+// constant.
+export const ENVD_CONTROL_PORT = 49983;
+// A dedicated INPUT chain that ends in DROP, hooked once. Reversible (flush the
+// chain) and idempotent (re-hook only if absent), unlike flipping INPUT's policy.
+// allowPublicTraffic exposes every listening port at `<port>-<id>.e2b.app`; this
+// closes all of them except the cmux-tui daemon (1337) and envd (49983), so a
+// user's dev server on 3000 is not silently world-reachable.
+export const INBOUND_FIREWALL_COMMAND = [
+  "command -v iptables >/dev/null 2>&1 || exit 0",
+  "iptables -w -N CMUX_FW 2>/dev/null || iptables -w -F CMUX_FW",
+  "iptables -w -A CMUX_FW -i lo -j ACCEPT",
+  "iptables -w -A CMUX_FW -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT",
+  "iptables -w -A CMUX_FW -p icmp -j ACCEPT",
+  `iptables -w -A CMUX_FW -p tcp --dport ${ENVD_CONTROL_PORT} -j ACCEPT`,
+  `iptables -w -A CMUX_FW -p tcp --dport ${CMUX_TUI_PORT} -j ACCEPT`,
+  "iptables -w -A CMUX_FW -j DROP",
+  "iptables -w -C INPUT -j CMUX_FW 2>/dev/null || iptables -w -I INPUT 1 -j CMUX_FW",
+].join(" && ");
 
 export class E2BProvider implements VMProvider {
   readonly id = "e2b" as const;
@@ -303,6 +327,25 @@ export class E2BProvider implements VMProvider {
     }
     await this.startCmuxTuiDaemon(sandbox);
     await waitForCmuxTuiReady(this.cmuxTuiInvoke(sandbox), "e2b", sandbox.sandboxId);
+    await this.applyInboundFirewall(sandbox);
+  }
+
+  /**
+   * Close every externally reachable port except the cmux-tui daemon (1337)
+   * and envd (49983). allowPublicTraffic exposes every listener at
+   * `<port>-<id>.e2b.app`, so without this a user's dev server would be
+   * world-reachable. Best-effort: a firewall failure must not brick a machine
+   * whose daemon is already up, so it is logged, not thrown. Idempotent, so
+   * ensureCmuxTuiRunning re-asserts it after resume/restore.
+   */
+  private async applyInboundFirewall(sandbox: Sandbox): Promise<void> {
+    const result = await this.rootExec(sandbox, INBOUND_FIREWALL_COMMAND).catch(() => null);
+    if (!result || result.exitCode !== 0) {
+      console.error(
+        `[e2b] inbound firewall on ${sandbox.sandboxId} did not apply cleanly; ports other than ${CMUX_TUI_PORT}/${ENVD_CONTROL_PORT} may be publicly reachable`,
+        result?.stderr || result?.stdout || "",
+      );
+    }
   }
 
   /**
@@ -324,6 +367,9 @@ export class E2BProvider implements VMProvider {
     }
     await this.startCmuxTuiDaemon(sandbox);
     await waitForCmuxTuiReady(this.cmuxTuiInvoke(sandbox), "e2b", sandbox.sandboxId);
+    // Re-assert the inbound firewall: a fresh restore boots with no rules, and
+    // a resume that somehow lost them is repaired here (idempotent).
+    await this.applyInboundFirewall(sandbox);
   }
 
   private async startCmuxTuiDaemon(sandbox: Sandbox): Promise<void> {

--- a/web/services/vms/images/manifest.json
+++ b/web/services/vms/images/manifest.json
@@ -193,6 +193,46 @@
       "builderScriptVersion": "bootstrap-on-create",
       "validationStatus": "passed",
       "notes": "Stock Blaxel Alpine shell image, no desktop; `cmux vm new --base` and `vm run` pool provisioning send this id explicitly. Nothing is baked: the driver bootstraps every image at create time, installing the pinned cmux-tui build onto the persistent home volume (the installer adds curl via apk first, since the stock image ships without it). Validated live in #10478 in us-pdx-1: create + bootstrap, cmux-remote attach (route + enrollment), exec, and standby/wake process preservation. Listed so deployed runtimes accept the id the CLI sends; it was missing from the manifest between #10478 and this entry, so `vm new --base` failed closed in production."
+    },
+    {
+      "provider": "e2b",
+      "version": "e2b-devbox-20260828a",
+      "imageId": "cmux-devbox:devbox-20260828a",
+      "envVar": "E2B_CMUXD_WS_TEMPLATE",
+      "defaultForLocalDev": false,
+      "kind": "base",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "builtAt": "2026-08-28T08:40:23.678Z",
+      "builderScriptVersion": "b87b2a7d33d83e2213f0afc407bae5d2fdd90083bbba2a9fccffaa368d1d3aa6",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.246",
+        "@openai/codex": "0.150.0",
+        "opencode-ai": "1.18.23",
+        "@earendil-works/pi-coding-agent": "0.84.3",
+        "agent-browser": "0.35.1"
+      },
+      "validationStatus": "passed",
+      "notes": "Shared devbox image (services/vms/images/devbox), cmux-tui transport. Baked with build-devbox-e2b.ts (templateId 3fktz2o6rxgms895lclw). Validated 2026-08-28 with verify-devbox-image.ts against cmux-tui pin 102aa3d63086bf0617a6b5a34d5cb2465f2a74a7: pinned agents, mise toolchain, gh/jq/fd/fzf/sqlite3/tmux/vim, Chrome + DuckDuckGo managed policy, cua-driver, ffmpeg/Xvfb, byte-identical baked files, ble.sh ghost text under a tmux PTY, agent-config generator materializing the codex custom provider, cmux-tui install + daemon serving session cloud on 1337. Inbound firewall proven live: after the driver's default-deny INPUT (allow lo/established/icmp + envd 49983 + cmux-tui 1337) envd control and 1337 stayed reachable while a scratch dev server on 4820 was reachable before and blocked after. Not the default provider; Blaxel stays default."
+    },
+    {
+      "provider": "daytona",
+      "version": "daytona-cmux-devbox-20260828a",
+      "imageId": "cmux-devbox-20260828a",
+      "envVar": "DAYTONA_SANDBOX_SNAPSHOT",
+      "defaultForLocalDev": false,
+      "kind": "base",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "builtAt": "2026-08-28T08:41:18.226Z",
+      "builderScriptVersion": "64efcb7124e5e135ad25939b11568c940c69ee208d32ffdd38d466ddade5d643",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.246",
+        "@openai/codex": "0.150.0",
+        "opencode-ai": "1.18.23",
+        "@earendil-works/pi-coding-agent": "0.84.3",
+        "agent-browser": "0.35.1"
+      },
+      "validationStatus": "passed",
+      "notes": "Shared devbox image (services/vms/images/devbox), cmux-tui transport. Baked fresh (never trusting Daytona's layer cache) with build-devbox-daytona.ts; the cmux-devbox-boot supervisor is the registered snapshot entrypoint (Daytona stop kills processes, start re-runs it). Validated 2026-08-28 with verify-devbox-image.ts against cmux-tui pin 102aa3d63086bf0617a6b5a34d5cb2465f2a74a7: pinned agents, mise toolchain, devtools, Chrome + DuckDuckGo managed policy, cua-driver, ffmpeg/Xvfb, byte-identical baked files, ble.sh ghost text under a tmux PTY, agent-config generator, cmux-tui install + daemon serving session cloud on 1337 through the entrypoint supervisor, and the preview proxy route with the DAYTONA_SANDBOX_AUTH_KEY query token. Region shared us. Not the default provider; Blaxel stays default."
     }
   ]
 }

--- a/web/tests/vm-e2b-provider.test.ts
+++ b/web/tests/vm-e2b-provider.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import path from "node:path";
-import { E2BProvider } from "../services/vms/drivers/e2b";
+import { E2BProvider, ENVD_CONTROL_PORT, INBOUND_FIREWALL_COMMAND } from "../services/vms/drivers/e2b";
 import { ProviderError } from "../services/vms/drivers/types";
 
 // E2B machines attach exclusively through the cmux-tui remote daemon
@@ -53,5 +53,33 @@ describe("E2BProvider cmux-remote route", () => {
     expect(driver).not.toContain("network: { allowPublicTraffic: false }");
     expect(driver).toContain("/v1/link");
     expect(driver).toContain("getHost(CMUX_TUI_PORT)");
+  });
+});
+
+describe("E2BProvider inbound firewall", () => {
+  test("closes every port except cmux-tui and envd, and keeps envd reachable", () => {
+    // allowPublicTraffic exposes every listener at <port>-<id>.e2b.app, so the
+    // driver applies a default-deny INPUT that allows only lo, established,
+    // icmp, envd (49983), and the cmux-tui daemon (1337). envd MUST stay open
+    // or the SDK's commands.run/attach break (they reach envd through the same
+    // proxy). Verified live 2026-08-28 by verify-devbox-image.ts.
+    expect(ENVD_CONTROL_PORT).toBe(49983);
+    const cmd = INBOUND_FIREWALL_COMMAND;
+    expect(cmd).toContain("--dport 49983 -j ACCEPT");
+    expect(cmd).toContain("--dport 1337 -j ACCEPT");
+    expect(cmd).toContain("-i lo -j ACCEPT");
+    expect(cmd).toContain("ESTABLISHED,RELATED -j ACCEPT");
+    expect(cmd).toContain("-A CMUX_FW -j DROP");
+    // Reversible + idempotent: a dedicated chain hooked into INPUT only once.
+    expect(cmd).toContain("iptables -w -C INPUT -j CMUX_FW 2>/dev/null || iptables -w -I INPUT 1 -j CMUX_FW");
+    // Applied on create and re-asserted on the attach/restore heal path.
+    const driver = readFileSync(
+      path.join(import.meta.dirname, "../services/vms/drivers/e2b.ts"),
+      "utf8",
+    );
+    expect(driver.match(/applyInboundFirewall\(sandbox\)/g)?.length).toBeGreaterThanOrEqual(2);
+    // Best-effort: a firewall failure is logged, never thrown (must not brick a
+    // machine whose daemon is already up).
+    expect(driver).toContain("did not apply cleanly");
   });
 });


### PR DESCRIPTION
Bakes the shared devbox image (`web/services/vms/images/devbox/`, merged in #10964) on e2b and daytona, verifies both, registers them in the manifest, and hardens the e2b ingress. Blaxel bakes untouched.

## Bakes

- **e2b**: `build-devbox-e2b.ts --tag devbox-20260828a` → template `cmux-devbox:devbox-20260828a` (templateId `3fktz2o6rxgms895lclw`), skipCache default.
- **daytona**: `build-devbox-daytona.ts cmux-devbox-20260828a` → snapshot `cmux-devbox-20260828a`, fresh build (Daytona's layer cache is never trusted; versioned immutable name).

## Verify (both green)

`verify-devbox-image.ts` per provider: pinned agents (claude 2.1.246, codex 0.150.0, opencode 1.18.23, pi 0.84.3, agent-browser 0.35.1), mise node/python/bun + uv, devtools (gh/jq/fd/fzf/sqlite3/tmux/vim), Chrome + DuckDuckGo managed policy, cua-driver, ffmpeg/Xvfb, byte-identical baked files, ble.sh ghost text under a tmux PTY, the agent-config generator materializing the codex custom provider, and cmux-tui install (pin `102aa3d63086bf0617a6b5a34d5cb2465f2a74a7`) + daemon serving session `cloud` on 1337. Daytona also proves the `cmux-devbox-boot` entrypoint supervisor.

Verify fix: E2B has no in-image supervisor, so the daemon must start through E2B's native background-process API. The prior `setsid nohup … &` shell trick raced envd's cgroup teardown when the launching exec returned, so the daemon never came up (the image and driver were fine — the driver already uses `background: true`). Daytona/Freestyle keep their baked supervisor, so their start is a no-op.

## e2b ingress hardening (default-deny inbound firewall)

`allowPublicTraffic: true` exposes every listening port at `https://<port>-<id>.e2b.app`, so a user's dev server on any port would be world-reachable at an unguessable host. Researched the real ingress inside a live sandbox before touching anything:

- kernel 6.1 / Debian 12; `iptables` (nft-backed) present and functional, INPUT policy ACCEPT by default.
- **envd is E2B's control plane on port 49983**, reached through the SAME public port proxy as any exposed port (`ConnectionConfig.envdPort = 49983` in the SDK; `ss` shows `envd` listening on `*:49983`). Every `commands.run`/attach goes through it, so it MUST stay open or the driver bricks.
- Inbound arrives over `eth0` from the E2B edge proxy; source IP is not distinguishable per-purpose, so the filter is by destination port.

The driver now applies, after the daemon is ready (and re-asserts on the attach/restore heal), a dedicated `CMUX_FW` chain hooked into INPUT exactly once: allow `lo`, established/related, icmp, tcp/49983 (envd), tcp/1337 (cmux-tui), terminal DROP. Reversible (flush the chain), idempotent (re-hook only if absent), and best-effort — a firewall failure is logged, never thrown, so it cannot brick a machine whose daemon is already up. In-image firewalling is feasible (not the alternative-doc path).

`verify-devbox-image.ts` proves attach survives it live: a scratch listener on port 4820, apply the exact `INBOUND_FIREWALL_COMMAND` the driver runs, then `envd(49983)=alive daemon(1337)=alive scratch(4820) before=reachable after=blocked => PASS`.

Scope note: this is a per-machine default, not a multi-tenant boundary — a root shell on the machine can flush it, which is fine for a single-owner devbox. It closes the accidental-exposure hole (an agent binds 0.0.0.0:3000 and it is silently public).

## Manifest

Two entries appended (never rewriting existing ones), both `kind: base`, `validationStatus: passed`, `defaultForLocalDev: false` — Blaxel stays the default provider. Env vars (`E2B_CMUXD_WS_TEMPLATE`, `DAYTONA_SANDBOX_SNAPSHOT`) are not flipped here; that is a deploy-time decision.

## Gates

- `cd web && bun run typecheck` clean.
- `bun test tests/vm-image-resolver.test.ts tests/vm-devbox-image.test.ts tests/vm-e2b-provider.test.ts tests/vm-daytona-provider.test.ts tests/vm-blaxel-image.test.ts tests/vm-blaxel-provider.test.ts tests/vm-blaxel-cmux-tui.test.ts tests/vm-freestyle-provider.test.ts tests/vm-workflows.test.ts` — 138 pass, 0 fail. New `vm-e2b-provider` firewall test pins the allow-list, reversibility, both apply sites, and best-effort behavior.

Live bakes/verifies were run against real provider accounts; the daytona snapshot and e2b template exist now. Not done: flipping the serving env vars (deploy decision).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bakes and registers the shared devbox image on e2b and daytona, and hardens e2b's ingress so a dev server bound to 0.0.0.0 isn't silently world-reachable. Blaxel stays the default provider — the serving env vars are not flipped, which is a deploy-time decision.

**E2B ingress**
- The driver now applies a default-deny INPUT chain allowing only lo, established, icmp, envd (49983), and cmux-tui (1337) — before, `allowPublicTraffic: true` exposed every listener at `<port>-<id>.e2b.app` — and re-asserts it on restore; best-effort, a failure is logged, not thrown.
- envd is E2B's control plane reached through the same public proxy, so it must stay open or every `commands.run`/attach breaks.
- verify-devbox-image.ts now starts the e2b daemon through E2B's native background API (the old `setsid nohup` trick raced envd's cgroup teardown) and proves the firewall live: envd + 1337 stay reachable while a scratch listener on 4820 goes from reachable to blocked.

<sup>Written for commit 41e21b3843ab2c68edffefd54f361a9ff913602e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Improved sandbox network protection by blocking unauthorized inbound ports while preserving required development and control connections.
  - Firewall protections are restored automatically after sandbox resume or restore.

- **Reliability**
  - Improved background service startup and readiness handling across supported VM providers.

- **New Features**
  - Added validated E2B and Daytona development images for provider-specific environments.

- **Tests**
  - Expanded verification of firewall rules, service connectivity, lifecycle recovery, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->