### PR TITLE
cloud: rebake e2b + daytona devbox images at epoch 2026-08-28-r1

### DIFF
--- a/web/services/vms/images/manifest.json
+++ b/web/services/vms/images/manifest.json
@@ -196,13 +196,13 @@
     },
     {
       "provider": "e2b",
-      "version": "e2b-devbox-20260828a",
-      "imageId": "cmux-devbox:devbox-20260828a",
+      "version": "e2b-devbox-20260828b",
+      "imageId": "cmux-devbox:devbox-20260828b",
       "envVar": "E2B_CMUXD_WS_TEMPLATE",
       "defaultForLocalDev": false,
       "kind": "base",
       "cmuxdRemoteCommit": "none-cmux-tui",
-      "builtAt": "2026-08-28T08:40:23.678Z",
+      "builtAt": "2026-08-28T10:01:44.701Z",
       "builderScriptVersion": "b87b2a7d33d83e2213f0afc407bae5d2fdd90083bbba2a9fccffaa368d1d3aa6",
       "agentToolResolvedVersions": {
         "@anthropic-ai/claude-code": "2.1.246",
@@ -212,17 +212,17 @@
         "agent-browser": "0.35.1"
       },
       "validationStatus": "passed",
-      "notes": "Shared devbox image (services/vms/images/devbox), cmux-tui transport. Baked with build-devbox-e2b.ts (templateId 3fktz2o6rxgms895lclw). Validated 2026-08-28 with verify-devbox-image.ts against cmux-tui pin 102aa3d63086bf0617a6b5a34d5cb2465f2a74a7: pinned agents, mise toolchain, gh/jq/fd/fzf/sqlite3/tmux/vim, Chrome + DuckDuckGo managed policy, cua-driver, ffmpeg/Xvfb, byte-identical baked files, ble.sh ghost text under a tmux PTY, agent-config generator materializing the codex custom provider, cmux-tui install + daemon serving session cloud on 1337. Inbound firewall proven live: after the driver's default-deny INPUT (allow lo/established/icmp + envd 49983 + cmux-tui 1337) envd control and 1337 stayed reachable while a scratch dev server on 4820 was reachable before and blocked after. Not the default provider; Blaxel stays default."
+      "notes": "Shared devbox image (services/vms/images/devbox) at epoch 2026-08-28-r1 (#11099: agent-config also wires pi models.json and the opencode config fetch to the coderouter model plane), cmux-tui transport. Supersedes cmux-devbox:devbox-20260828a. Baked with build-devbox-e2b.ts (templateId 3fktz2o6rxgms895lclw). Validated 2026-08-28 with verify-devbox-image.ts against cmux-tui pin fa77ad23364aa12993644b357b425513d61ca632: pinned agents, mise toolchain, devtools, Chrome + DuckDuckGo managed policy, cua-driver, ffmpeg/Xvfb, byte-identical baked files, ble.sh ghost text under a tmux PTY, agent-config generator (codex custom provider + pi models.json with the x-coderouter-route-token env reference and no literal token; no opencode.json when the config endpoint is unreachable), cmux-tui install + daemon serving session cloud on 1337. Inbound firewall proven live again: after the driver's default-deny INPUT (allow lo/established/icmp + envd 49983 + cmux-tui 1337) envd control and 1337 stayed reachable while a scratch dev server on 4820 was reachable before and blocked after. Not the default provider; Blaxel stays default."
     },
     {
       "provider": "daytona",
-      "version": "daytona-cmux-devbox-20260828a",
-      "imageId": "cmux-devbox-20260828a",
+      "version": "daytona-cmux-devbox-20260828b",
+      "imageId": "cmux-devbox-20260828b",
       "envVar": "DAYTONA_SANDBOX_SNAPSHOT",
       "defaultForLocalDev": false,
       "kind": "base",
       "cmuxdRemoteCommit": "none-cmux-tui",
-      "builtAt": "2026-08-28T08:41:18.226Z",
+      "builtAt": "2026-08-28T10:02:08.431Z",
       "builderScriptVersion": "64efcb7124e5e135ad25939b11568c940c69ee208d32ffdd38d466ddade5d643",
       "agentToolResolvedVersions": {
         "@anthropic-ai/claude-code": "2.1.246",
@@ -232,7 +232,7 @@
         "agent-browser": "0.35.1"
       },
       "validationStatus": "passed",
-      "notes": "Shared devbox image (services/vms/images/devbox), cmux-tui transport. Baked fresh (never trusting Daytona's layer cache) with build-devbox-daytona.ts; the cmux-devbox-boot supervisor is the registered snapshot entrypoint (Daytona stop kills processes, start re-runs it). Validated 2026-08-28 with verify-devbox-image.ts against cmux-tui pin 102aa3d63086bf0617a6b5a34d5cb2465f2a74a7: pinned agents, mise toolchain, devtools, Chrome + DuckDuckGo managed policy, cua-driver, ffmpeg/Xvfb, byte-identical baked files, ble.sh ghost text under a tmux PTY, agent-config generator, cmux-tui install + daemon serving session cloud on 1337 through the entrypoint supervisor, and the preview proxy route with the DAYTONA_SANDBOX_AUTH_KEY query token. Region shared us. Not the default provider; Blaxel stays default."
+      "notes": "Shared devbox image (services/vms/images/devbox) at epoch 2026-08-28-r1 (#11099: agent-config also wires pi models.json and the opencode config fetch to the coderouter model plane), cmux-tui transport. Supersedes cmux-devbox-20260828a. Baked fresh (never trusting Daytona's layer cache) with build-devbox-daytona.ts; the cmux-devbox-boot supervisor is the registered snapshot entrypoint (Daytona stop kills processes, start re-runs it). Validated 2026-08-28 with verify-devbox-image.ts against cmux-tui pin fa77ad23364aa12993644b357b425513d61ca632: pinned agents, mise toolchain, devtools, Chrome + DuckDuckGo managed policy, cua-driver, ffmpeg/Xvfb, byte-identical baked files, ble.sh ghost text under a tmux PTY, agent-config generator (codex custom provider + pi models.json with the x-coderouter-route-token env reference and no literal token; no opencode.json when the config endpoint is unreachable), cmux-tui install + daemon serving session cloud on 1337 through the entrypoint supervisor, and the preview proxy route with the DAYTONA_SANDBOX_AUTH_KEY query token. Region shared us. Not the default provider; Blaxel stays default."
     }
   ]
 }


### PR DESCRIPTION
#11099 extended the devbox `agent-config.sh` (pi `models.json` + the opencode config fetch now ride the coderouter model plane) and bumped the devbox image epoch to `2026-08-28-r1`, which made the `20260828a` bakes from #11095 one epoch stale minutes after they landed. This rebakes both providers from current main and points the two manifest entries at the new bakes.

## New bakes (from main @ 0ab1edc814b)

- **e2b**: template `cmux-devbox:devbox-20260828b` (templateId `3fktz2o6rxgms895lclw`), `build-devbox-e2b.ts`, skipCache default.
- **daytona**: snapshot `cmux-devbox-20260828b`, `build-devbox-daytona.ts`, fresh build (Daytona's layer cache never trusted), versioned immutable name.

Superseded ids (still exist provider-side until pruned; no longer in the manifest): `cmux-devbox:devbox-20260828a`, `cmux-devbox-20260828a`.

## Verify (both green)

`verify-devbox-image.ts` against each bake, cmux-tui pin `fa77ad23364aa12993644b357b425513d61ca632`:

- pinned agents (claude 2.1.246, codex 0.150.0, opencode 1.18.23, pi 0.84.3, agent-browser 0.35.1), mise toolchain, devtools, Chrome + DuckDuckGo managed policy, cua-driver, ffmpeg/Xvfb, byte-identical baked files, ble.sh ghost text under a tmux PTY;
- the new #11099 agent-config checks: codex custom provider, pi `models.json` carrying the `x-coderouter-route-token` env reference with no literal token, and no `opencode.json` written when the config endpoint is unreachable;
- cmux-tui daemon serving session `cloud` on 1337 (daytona through the `cmux-devbox-boot` entrypoint supervisor, plus the `DAYTONA_SANDBOX_AUTH_KEY` route);
- e2b inbound-firewall proof re-run live: `envd(49983)=alive daemon(1337)=alive scratch(4820) before=reachable after=blocked => PASS`.

## Change

`web/services/vms/images/manifest.json` only: the two #11095 entries are replaced in place (no duplicate appends), `validationStatus: passed`, `kind: base`, `defaultForLocalDev: false` — Blaxel stays the default provider, and no serving env var is flipped here.

Gates: `cd web && bun run typecheck` clean; `bun test tests/vm-image-resolver.test.ts tests/vm-devbox-image.test.ts tests/vm-e2b-provider.test.ts tests/vm-daytona-provider.test.ts tests/vm-blaxel-image.test.ts tests/vm-workflows.test.ts` — 95 pass, 0 fail.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebakes the e2b and daytona devbox images to epoch 2026-08-28-r1, replacing the stale `20260828a` bakes with fresh ones from current main. The old bakes are no longer referenced in the manifest but still exist provider-side until pruned.

- Updates `web/services/vms/images/manifest.json` to point to the new bakes (`cmux-devbox:devbox-20260828b` for e2b, `cmux-devbox:20260828b` for daytona), replacing the `20260828a` entries in place.
- The new bakes include the #11099 agent-config changes (pi `models.json` and opencode config fetch now route through the coderouter model plane) and pass all verification checks, including the new config-endpoint reachability checks.
- Blaxel remains the default provider; no serving env vars change.

<sup>Written for commit 6633a0647c8de33984ac0cfae4bd6da704588913. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated E2B and Daytona development environment images to the latest build.
  * Included updated terminal UI tooling and improved model configuration connectivity.
  * Refreshed image metadata and build information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->