### PR TITLE
cloud: migrate the freestyle driver to the Freestyle beta platform

### DIFF
--- a/web/scripts/build-devbox-freestyle.ts
+++ b/web/scripts/build-devbox-freestyle.ts
@@ -22,11 +22,11 @@
  * provider (docs/cloud-cmux-tui-daemon.md). No binary is baked: the
  * cmux-tui-daemon systemd unit runs /usr/local/bin/cmux-devbox-boot, which
  * waits for /root/.cmux/bin/cmux-tui and supervises the daemon once a driver
- * installs the pinned build at create time. FORWARD-COMPATIBLE ONLY: the
- * shipped freestyle driver still speaks the legacy (0.1.51) platform and its
- * cmuxd-remote transport; it can neither boot beta snapshots nor talk to
- * cmux-tui. This bake becomes usable when a beta-SDK freestyle driver lands;
- * until then FREESTYLE_SANDBOX_SNAPSHOT must not point at it.
+ * installs the pinned build at create time. The unit binds the listener
+ * dual-stack (CMUX_TUI_REMOTE_WS_BIND=[::]:1337) because the beta driver arm
+ * (web/services/vms/drivers/freestyleBeta.ts) routes attaches to the VM's
+ * stable public IPv6; the legacy (0.1.51) driver arm cannot boot these
+ * snapshots — the manifest marks them features.freestylePlatform: "beta".
  *
  * Builder VM: freestyle/ubuntu-sm, outbound-only firewall, deleted whatever
  * happens.

--- a/web/scripts/build-devbox-freestyle.ts
+++ b/web/scripts/build-devbox-freestyle.ts
@@ -182,6 +182,11 @@ const service = [
   "[Service]",
   "Type=simple",
   "User=root",
+  // Freestyle beta machines are reached at their stable public IPv6, so the
+  // daemon listens dual-stack ([::] accepts IPv4 too). cmux-devbox-boot
+  // defaults to 0.0.0.0 for the container providers, whose runtimes may have
+  // IPv6 disabled entirely.
+  "Environment=CMUX_TUI_REMOTE_WS_BIND=[::]:1337",
   "ExecStart=/usr/local/bin/cmux-devbox-boot",
   "Restart=always",
   "RestartSec=2",

--- a/web/services/vms/drivers/cmuxTuiDaemon.ts
+++ b/web/services/vms/drivers/cmuxTuiDaemon.ts
@@ -133,9 +133,19 @@ export function cmuxTuiPinCheckCommand(source: CmuxTuiSource): string {
   return `test -x ${shellQuote(CMUX_TUI_BINARY_PATH)} && printf '%s  %s\n' ${shellQuote(source.sha256)} ${shellQuote(CMUX_TUI_BINARY_PATH)} | sha256sum -c >/dev/null 2>&1`;
 }
 
-/** The daemon command every provider's supervisor runs. Launch cwd = /root so new terminals open in the persistent home. */
-export function cmuxTuiDaemonCommand(): string {
-  return `cd /root && env HOME=/root TERM=xterm-256color ${CMUX_TUI_BINARY_PATH} server start --session ${CMUX_TUI_SESSION} --remote-ws 0.0.0.0:${CMUX_TUI_PORT} --remote-ws-insecure-bind`;
+/** The listener bind every container provider uses; cmux-devbox-boot's CMUX_TUI_REMOTE_WS_BIND default. */
+export const CMUX_TUI_DEFAULT_REMOTE_WS_BIND = `0.0.0.0:${CMUX_TUI_PORT}`;
+
+/**
+ * The daemon command every provider's supervisor runs. Launch cwd = /root so
+ * new terminals open in the persistent home. `remoteWsBind` defaults to the
+ * IPv4 wildcard the container providers' proxies dial; Freestyle beta machines
+ * are reached at their public IPv6 and pass a dual-stack `[::]` bind instead
+ * (a container with IPv6 disabled cannot bind `[::]` at all, so dual-stack is
+ * per-provider, not the default).
+ */
+export function cmuxTuiDaemonCommand(remoteWsBind: string = CMUX_TUI_DEFAULT_REMOTE_WS_BIND): string {
+  return `cd /root && env HOME=/root TERM=xterm-256color ${CMUX_TUI_BINARY_PATH} server start --session ${CMUX_TUI_SESSION} --remote-ws ${remoteWsBind} --remote-ws-insecure-bind`;
 }
 
 /** Enrollment invitations are `cmux://enroll/<base64url JSON>`; the id and expiry inside are what the approve flow needs. */

--- a/web/services/vms/drivers/freestyle.ts
+++ b/web/services/vms/drivers/freestyle.ts
@@ -29,6 +29,17 @@ import {
   shellQuote,
   type ReusableRpcLease,
 } from "./wsLease";
+import {
+  FreestyleBetaPlatform,
+  freestylePlatformIsBeta,
+  isFreestyleBetaVmId,
+} from "./freestyleBeta";
+import type {
+  AttachTransport,
+  CmuxRemoteApprovalResult,
+  CmuxRemoteAttachOptions,
+  CmuxRemoteEndpoint,
+} from "./types";
 
 // Freestyle VMs reach the outside world only via their SSH gateway, which terminates on
 // `vm-ssh.freestyle.sh:22`. `ssh <vmId>+<user>@vm-ssh.freestyle.sh` authenticates against
@@ -82,10 +93,36 @@ function mapStatus(state: string | null | undefined): VMStatus {
   }
 }
 
+// The freestyle ProviderId spans TWO Freestyle platforms. Existing production
+// machines live on the legacy platform (api.freestyle.sh, SDK freestyle@0.1.51,
+// cmuxd-remote on 7777) and keep the code below unchanged. New creates from a
+// beta image dispatch to FreestyleBetaPlatform (./freestyleBeta.ts): the beta
+// devbox snapshot, cmux-tui on 1337, transport cmux-remote. Per-machine
+// dispatch keys on the id shape — beta ids are `vm-<32 hex>`, legacy ids bare
+// 20-char base36 — with the persisted providerMetadata.freestylePlatform
+// marker (written by every beta create) as the authoritative override where
+// metadata flows (attach paths).
 export class FreestyleProvider implements VMProvider {
   readonly id = "freestyle" as const;
+  private readonly beta = new FreestyleBetaPlatform();
+
+  /**
+   * The union across both platforms: legacy machines serve websocket/SSH via
+   * openAttach, beta machines only cmux-remote. A cmux-remote-only list here
+   * would make the workflow gate refuse openAttach for the legacy fleet, so
+   * per-machine refusal happens inside openAttach/openCmuxRemote instead.
+   */
+  readonly attachTransports: readonly AttachTransport[] = ["cmux-remote", "websocket", "ssh"];
+
+  /** Beta marker where metadata flows, id shape everywhere else. */
+  private isBetaMachine(vmId: string, metadata?: Record<string, unknown>): boolean {
+    return freestylePlatformIsBeta(metadata) || isFreestyleBetaVmId(vmId);
+  }
 
   async create(options: CreateOptions): Promise<VMHandle> {
+    if (this.beta.createTargetsBeta(options)) {
+      return this.beta.create(options);
+    }
     const image = options.image.trim();
     if (!image) {
       throw new ProviderError("freestyle", "create requires a resolved image");
@@ -147,6 +184,7 @@ export class FreestyleProvider implements VMProvider {
   }
 
   async destroy(vmId: string): Promise<void> {
+    if (isFreestyleBetaVmId(vmId)) return this.beta.destroy(vmId);
     return withVmSpan(
       "cmux.vm.provider.destroy",
       {
@@ -168,6 +206,7 @@ export class FreestyleProvider implements VMProvider {
   }
 
   async getStatus(vmId: string): Promise<VMStatus> {
+    if (isFreestyleBetaVmId(vmId)) return this.beta.getStatus(vmId);
     return withVmSpan(
       "cmux.vm.provider.get_status",
       {
@@ -190,6 +229,7 @@ export class FreestyleProvider implements VMProvider {
   }
 
   async pause(vmId: string): Promise<void> {
+    if (isFreestyleBetaVmId(vmId)) return this.beta.pause(vmId);
     return withVmSpan(
       "cmux.vm.provider.pause",
       {
@@ -211,6 +251,7 @@ export class FreestyleProvider implements VMProvider {
   }
 
   async resume(vmId: string): Promise<VMHandle> {
+    if (isFreestyleBetaVmId(vmId)) return this.beta.resume(vmId);
     return withVmSpan(
       "cmux.vm.provider.resume",
       {
@@ -246,6 +287,7 @@ export class FreestyleProvider implements VMProvider {
     command: string,
     opts?: { timeoutMs?: number },
   ): Promise<ExecResult> {
+    if (isFreestyleBetaVmId(vmId)) return this.beta.exec(vmId, command, opts);
     const timeoutMs = normalizeExecTimeout(opts?.timeoutMs);
     return withVmSpan(
       "cmux.vm.provider.exec",
@@ -277,6 +319,7 @@ export class FreestyleProvider implements VMProvider {
   }
 
   async snapshot(vmId: string, name?: string): Promise<SnapshotRef> {
+    if (isFreestyleBetaVmId(vmId)) return this.beta.snapshot(vmId, name);
     return withVmSpan(
       "cmux.vm.provider.snapshot",
       {
@@ -306,6 +349,7 @@ export class FreestyleProvider implements VMProvider {
   }
 
   async restore(snapshotId: string): Promise<VMHandle> {
+    if (this.beta.restoreTargetsBeta(snapshotId)) return this.beta.restore(snapshotId);
     return withVmSpan(
       "cmux.vm.provider.restore",
       {
@@ -349,6 +393,13 @@ export class FreestyleProvider implements VMProvider {
   }
 
   async fork(vmId: string): Promise<VMHandle> {
+    if (isFreestyleBetaVmId(vmId)) {
+      // The beta API has no fork; snapshot + restore is the equivalent flow.
+      throw new ProviderError(
+        "freestyle",
+        `fork(${vmId}) is not supported on the Freestyle beta platform; snapshot the machine and restore from the snapshot instead`,
+      );
+    }
     return withVmSpan(
       "cmux.vm.provider.fork",
       {
@@ -390,6 +441,12 @@ export class FreestyleProvider implements VMProvider {
    * still fall back to Freestyle SSH, but the mac client must treat that as shell-only.
    */
   async openAttach(vmId: string, options?: AttachOptions): Promise<AttachEndpoint> {
+    if (this.isBetaMachine(vmId, options?.providerMetadata)) {
+      throw new ProviderError(
+        "freestyle",
+        `openAttach(${vmId}) is not supported on the Freestyle beta platform: these machines attach through the cmux-tui remote daemon (transport cmux-remote).`,
+      );
+    }
     try {
       const endpoint = await this.openWebSocketPty(vmId, options);
       if (options?.requireDaemon && !endpoint.daemon) {
@@ -554,7 +611,35 @@ export class FreestyleProvider implements VMProvider {
    * client will dial. Freestyle's gateway terminates at `vm-ssh.freestyle.sh:22`, username is
    * `<vmId>+<linuxUser>`, password is the access token we just minted.
    */
+  async openCmuxRemote(vmId: string, options?: CmuxRemoteAttachOptions): Promise<CmuxRemoteEndpoint> {
+    if (!this.isBetaMachine(vmId, options?.providerMetadata)) {
+      throw new ProviderError(
+        "freestyle",
+        `openCmuxRemote(${vmId}) is not supported on legacy-platform freestyle machines (no cmux-tui daemon); attach over the legacy websocket transport, or recreate the machine on a beta devbox image.`,
+      );
+    }
+    return this.beta.openCmuxRemote(vmId, options);
+  }
+
+  async approveCmuxRemoteEnrollment(vmId: string, invitationId: string): Promise<CmuxRemoteApprovalResult> {
+    if (!this.isBetaMachine(vmId)) {
+      throw new ProviderError(
+        "freestyle",
+        `approveCmuxRemoteEnrollment(${vmId}) is not supported on legacy-platform freestyle machines (no cmux-tui daemon).`,
+      );
+    }
+    return this.beta.approveCmuxRemoteEnrollment(vmId, invitationId);
+  }
+
   async openSSH(vmId: string): Promise<SSHEndpoint> {
+    if (isFreestyleBetaVmId(vmId)) {
+      // The beta API has no SSH gateway (its CLI's `vm ssh` is the API pty in
+      // disguise); sessions go through the cmux-tui daemon.
+      throw new ProviderError(
+        "freestyle",
+        `openSSH(${vmId}) is not supported on the Freestyle beta platform; attach through the cmux-tui remote daemon (transport cmux-remote).`,
+      );
+    }
     return withVmSpan(
       "cmux.vm.provider.open_ssh",
       {

--- a/web/services/vms/drivers/freestyleBeta.ts
+++ b/web/services/vms/drivers/freestyleBeta.ts
@@ -1,0 +1,613 @@
+import { Freestyle, FreestyleApiError, type VmData, type Vm } from "freestyle-beta";
+import { randomBytes } from "node:crypto";
+import {
+  ProviderError,
+  type AttachTransport,
+  type CmuxRemoteApprovalResult,
+  type CmuxRemoteAttachOptions,
+  type CmuxRemoteEndpoint,
+  type CreateOptions,
+  type ExecResult,
+  type SnapshotRef,
+  type VMHandle,
+  type VMStatus,
+} from "./types";
+import { recordSpanError, setSpanAttributes, withVmSpan } from "../telemetry";
+import { imageUsesFreestyleBetaPlatform } from "../images/resolver";
+import {
+  CMUX_TUI_INSTALL_TIMEOUT_MS,
+  CMUX_TUI_PORT,
+  CMUX_TUI_SESSION,
+  approveCmuxTuiEnrollment,
+  cmuxTuiDaemonBuild,
+  cmuxTuiDaemonCommand,
+  cmuxTuiInstallCommand,
+  cmuxTuiPinCheckCommand,
+  isCmuxTuiDeviceEnrolled,
+  mintCmuxTuiInvitation,
+  resolveCmuxTuiSource,
+  waitForCmuxTuiReady,
+  type CmuxTuiInvoke,
+} from "./cmuxTuiDaemon";
+
+// The Freestyle BETA platform arm of the freestyle driver (beta-api.freestyle.sh
+// /v5, SDK alias freestyle-beta = npm:freestyle@0.2.0-beta.7). FreestyleProvider
+// in ./freestyle.ts owns the ProviderId and dispatches here per machine; the
+// legacy 0.1.51 platform code there keeps serving existing production machines.
+//
+// Machines attach through the cmux-tui remote daemon (transport `cmux-remote`,
+// docs/cloud-cmux-tui-daemon.md), the same model as Blaxel/E2B/Daytona. The
+// beta API has no HTTP ingress proxy to arbitrary VM ports (verified against
+// /openapi.json: no preview/port routes; TLS edge rules need a customer-verified
+// domain), so the route is the VM's stable public IPv6 straight to the daemon:
+// `ws://[<publicIpv6>]:1337/v1/link`. The daemon's Noise handshake encrypts and
+// authenticates the session end to end (carrier TLS is not required and the
+// route token only feeds the lease ledger, exactly like E2B's public proxy).
+// The daemon must therefore bind dual-stack: the baked systemd unit sets
+// CMUX_TUI_REMOTE_WS_BIND=[::]:1337 and the driver re-asserts it on heal.
+//
+// Beta creates take NO ports field, NO create-time env, and NO systemd
+// injection; `firewall` is mandatory. Model-plane env is delivered by writing
+// the persisted /root/.config/cmux/model-plane.env file (0600) that
+// /etc/cmux/agent-config.sh already sources when the boot env is absent.
+
+export const FREESTYLE_PLATFORM_METADATA_KEY = "freestylePlatform";
+/** Beta VM ids are `vm-<32 hex>`; legacy ids are bare 20-char base36. */
+const FREESTYLE_BETA_VM_ID_PATTERN = /^vm-[0-9a-f]{32}$/;
+/** Beta snapshot ids are `sh-<32 hex>`; legacy ones are `sh-`/`sc-` + 20 base36. */
+const FREESTYLE_BETA_SNAPSHOT_ID_PATTERN = /^sh-[0-9a-f]{32}$/;
+
+export const FREESTYLE_BETA_REMOTE_WS_BIND = `[::]:${CMUX_TUI_PORT}`;
+export const FREESTYLE_BETA_ATTACH_TRANSPORT: AttachTransport = "cmux-remote";
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+const CREATE_TIMEOUT_MS = 15 * 60 * 1000;
+const SNAPSHOT_TIMEOUT_MS = 15 * 60 * 1000;
+const EXEC_DEFAULT_TIMEOUT_MS = 30_000;
+/** The beta exec API rejects timeoutMs above 300000 (5 minutes per exec). */
+const MAX_EXEC_TIMEOUT_MS = 300_000;
+const EXEC_OVERHEAD_TIMEOUT_MS = 15_000;
+const ROUTE_TOKEN_TTL_SECONDS = 12 * 60 * 60;
+const MODEL_PLANE_ENV_PATH = "/root/.config/cmux/model-plane.env";
+
+export function isFreestyleBetaVmId(vmId: string): boolean {
+  return FREESTYLE_BETA_VM_ID_PATTERN.test(vmId.trim());
+}
+
+export function isFreestyleBetaSnapshotId(snapshotId: string): boolean {
+  return FREESTYLE_BETA_SNAPSHOT_ID_PATTERN.test(snapshotId.trim());
+}
+
+export function freestylePlatformIsBeta(metadata: Record<string, unknown> | undefined): boolean {
+  return metadata?.[FREESTYLE_PLATFORM_METADATA_KEY] === "beta";
+}
+
+/**
+ * Legacy and beta are different platforms with different API keys (a legacy key
+ * answers 401 on beta-api). FREESTYLE_BETA_API_KEY lets a deployment serve both
+ * at once; single-platform setups keep using FREESTYLE_API_KEY. The stack-token
+ * pair mirrors build-devbox-freestyle.ts for interactive use.
+ */
+function betaClient(timeoutMs = DEFAULT_TIMEOUT_MS): Freestyle {
+  const longFetch: typeof fetch = (input, init) =>
+    fetch(input as Request, { ...(init ?? {}), signal: AbortSignal.timeout(timeoutMs) });
+  const baseUrl = process.env.FREESTYLE_BETA_API_URL?.trim() || undefined;
+  const apiKey = process.env.FREESTYLE_BETA_API_KEY?.trim() || process.env.FREESTYLE_API_KEY?.trim();
+  if (apiKey) return new Freestyle({ apiKey, baseUrl, fetch: longFetch });
+  const stackAccessToken = process.env.FREESTYLE_STACK_ACCESS_TOKEN?.trim();
+  const teamId = process.env.FREESTYLE_TEAM_ID?.trim();
+  if (stackAccessToken && teamId) {
+    return new Freestyle({ stackAccessToken, teamId, baseUrl, fetch: longFetch });
+  }
+  throw new ProviderError(
+    "freestyle",
+    "beta platform requires FREESTYLE_BETA_API_KEY or FREESTYLE_API_KEY (or FREESTYLE_STACK_ACCESS_TOKEN + FREESTYLE_TEAM_ID)",
+  );
+}
+
+/**
+ * Outbound open (package installs, files.cmux.com, agents); inbound only the
+ * cmux-tui daemon port. Beta's mandatory `firewall` field defaults to NOTHING —
+ * no outbound, no inbound — so both rules are stated. Session auth on 1337 is
+ * the daemon's Noise device enrollment; the platform edge closing every other
+ * port is the same posture the e2b driver builds by hand with iptables.
+ */
+export function freestyleBetaFirewallRules() {
+  return [
+    { action: "allow" as const, source: {}, destination: { public: true as const } },
+    {
+      action: "allow" as const,
+      source: { public: true as const },
+      destination: { port: CMUX_TUI_PORT, protocol: "tcp" as const },
+    },
+  ];
+}
+
+/** `ws://[<publicIpv6>]:1337/v1/link` — see the ingress note at the top of this file. */
+export function freestyleBetaCmuxRemoteRoute(publicIpv6: string | null | undefined, vmId: string): string {
+  const ipv6 = publicIpv6?.trim();
+  if (!ipv6) {
+    throw new ProviderError(
+      "freestyle",
+      `VM ${vmId} has no public IPv6 address, so its cmux-tui daemon is unreachable (the beta platform has no HTTP ingress to arbitrary ports)`,
+    );
+  }
+  return `ws://[${ipv6}]:${CMUX_TUI_PORT}/v1/link`;
+}
+
+/**
+ * The persisted model-plane env file, byte-compatible with what
+ * /etc/cmux/agent-config.sh itself writes from a boot env: shells that see no
+ * boot env source this copy and then materialize the codex/pi/opencode
+ * configs. Beta has no create-time env, so the driver writes the file instead.
+ */
+export function renderFreestyleModelPlaneEnvFile(envs: Readonly<Record<string, string>>): string | null {
+  const baseUrl = envs.OPENAI_BASE_URL?.trim();
+  if (!baseUrl) return null;
+  const quote = (value: string) => `'${value.replace(/'/g, `'\\''`)}'`;
+  const lines = [
+    "# generated by cmux from machine boot env; managed, do not edit",
+    `export OPENAI_BASE_URL=${quote(baseUrl)}`,
+  ];
+  if (envs.OPENAI_API_KEY) lines.push(`export OPENAI_API_KEY=${quote(envs.OPENAI_API_KEY)}`);
+  if (envs.CMUX_CODEROUTER_URL) lines.push(`export CMUX_CODEROUTER_URL=${quote(envs.CMUX_CODEROUTER_URL)}`);
+  return `${lines.join("\n")}\n`;
+}
+
+export function normalizeFreestyleBetaExecTimeout(timeoutMs: number | undefined): number {
+  if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return EXEC_DEFAULT_TIMEOUT_MS;
+  }
+  return Math.min(Math.floor(timeoutMs), MAX_EXEC_TIMEOUT_MS);
+}
+
+/**
+ * `stopped` maps to paused, not destroyed: a stopped beta VM still exists and
+ * `start()` boots it again (poweroff, an idle timeout, or a failure with
+ * automaticRestart off all leave a recoverable machine).
+ */
+export function mapFreestyleBetaState(state: VmData["state"] | null | undefined): VMStatus {
+  switch (state) {
+    case "starting":
+      return "creating";
+    case "running":
+      return "running";
+    case "pausing":
+    case "paused":
+    case "stopped":
+      return "paused";
+    default:
+      return "running";
+  }
+}
+
+/**
+ * Healthy = the daemon process is up AND something listens on 1337 in the v6
+ * table (a dual-stack `[::]` bind; 0x0539 = 1337). A daemon bound 0.0.0.0 only
+ * appears in /proc/net/tcp, is unreachable at the public IPv6, and must be
+ * restarted under the dual-stack override.
+ */
+export function freestyleBetaDaemonHealthyCommand(): string {
+  return "pgrep -f 'cmux-tui server start' >/dev/null 2>&1 && grep -qi ':0539 ' /proc/net/tcp6";
+}
+
+const REMOTE_WS_BIND_OVERRIDE =
+  "/etc/systemd/system/cmux-tui-daemon.service.d/10-cmux-remote-ws-bind.conf";
+
+/**
+ * (Re)start the daemon listening dual-stack. Under systemd (the baked
+ * cmux-tui-daemon unit), install a drop-in setting
+ * CMUX_TUI_REMOTE_WS_BIND=[::]:1337 — the env cmux-devbox-boot reads — then
+ * restart the unit, healing machines from bakes that predate the env default.
+ * Without systemd (or the unit), fall back to a direct daemon launch with the
+ * dual-stack bind, mirroring the Daytona driver's fallback.
+ */
+export function freestyleBetaStartDaemonCommand(): string {
+  return [
+    "if [ -d /run/systemd/system ] && [ -f /etc/systemd/system/cmux-tui-daemon.service ]; then",
+    `mkdir -p ${REMOTE_WS_BIND_OVERRIDE.replace(/\/[^/]+$/, "")};`,
+    `printf '[Service]\\nEnvironment=CMUX_TUI_REMOTE_WS_BIND=${FREESTYLE_BETA_REMOTE_WS_BIND}\\n' > ${REMOTE_WS_BIND_OVERRIDE};`,
+    "systemctl daemon-reload;",
+    "systemctl restart cmux-tui-daemon;",
+    "else",
+    `pgrep -f 'cmux-tui server start' >/dev/null 2>&1 || (setsid nohup sh -c '${cmuxTuiDaemonCommand(FREESTYLE_BETA_REMOTE_WS_BIND)}' >>/tmp/cmux-tui-daemon.log 2>&1 &);`,
+    "fi",
+  ].join(" ");
+}
+
+function isBetaNotFound(err: unknown): boolean {
+  return err instanceof FreestyleApiError && (err.status === 404 || err.code === "NOT_FOUND");
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function betaSpanAttributes(vmId: string, operation: string, extra: Record<string, string | number | boolean> = {}) {
+  return {
+    "cmux.vm.provider": "freestyle",
+    "cmux.vm.operation": operation,
+    "cmux.vm.id": vmId,
+    "cmux.vm.platform": "beta",
+    ...extra,
+  };
+}
+
+export class FreestyleBetaPlatform {
+  /**
+   * A create targets beta when any of these say so: the caller's metadata
+   * marker, the image's manifest entry (`features.freestylePlatform: "beta"`),
+   * the CMUX_FREESTYLE_PLATFORM=beta operator override (unmanifested beta
+   * snapshots in local dev), or the snapshot id's beta shape. Everything else
+   * stays on the legacy platform, so existing images and deployments are
+   * untouched until an operator points at a beta image.
+   */
+  createTargetsBeta(options: CreateOptions): boolean {
+    if (freestylePlatformIsBeta(options.providerMetadata)) return true;
+    if (imageUsesFreestyleBetaPlatform("freestyle", options.image.trim())) return true;
+    if (process.env.CMUX_FREESTYLE_PLATFORM?.trim().toLowerCase() === "beta") return true;
+    return isFreestyleBetaSnapshotId(options.image);
+  }
+
+  restoreTargetsBeta(snapshotId: string): boolean {
+    if (imageUsesFreestyleBetaPlatform("freestyle", snapshotId.trim())) return true;
+    if (process.env.CMUX_FREESTYLE_PLATFORM?.trim().toLowerCase() === "beta") return true;
+    return isFreestyleBetaSnapshotId(snapshotId);
+  }
+
+  async create(options: CreateOptions): Promise<VMHandle> {
+    const image = options.image.trim();
+    if (!image) {
+      throw new ProviderError("freestyle", "create requires a resolved image");
+    }
+    return withVmSpan(
+      "cmux.vm.provider.create",
+      {
+        "cmux.vm.provider": "freestyle",
+        "cmux.vm.operation": "create",
+        "cmux.vm.image": image,
+        "cmux.vm.platform": "beta",
+        "cmux.timeout_ms": CREATE_TIMEOUT_MS,
+      },
+      async (span) => {
+        try {
+          const fs = betaClient(CREATE_TIMEOUT_MS);
+          const { vm, vmId } = await fs.vms.create({
+            snapshotId: image,
+            displayName: "cmux Cloud VM",
+            metadata: { cmux: "cloud" },
+            firewall: { rules: freestyleBetaFirewallRules() },
+          });
+          setSpanAttributes(span, { "cmux.vm.id": vmId });
+          try {
+            await this.bootstrapCmuxTui(vm, vmId, options.envs);
+          } catch (err) {
+            // A VM that failed to bootstrap must not survive as an orphan.
+            await vm.delete().catch((cleanupErr) => {
+              console.error(`[freestyle-beta] create rollback failed; VM ${vmId} may be orphaned`, cleanupErr);
+            });
+            throw err;
+          }
+          return {
+            provider: "freestyle" as const,
+            providerVmId: vmId,
+            status: "running" as const,
+            image,
+            createdAt: Date.now(),
+            providerMetadata: {
+              ...(options.providerMetadata ?? {}),
+              [FREESTYLE_PLATFORM_METADATA_KEY]: "beta",
+            },
+          };
+        } catch (err) {
+          throw err instanceof ProviderError ? err : new ProviderError("freestyle", `create(${image}) on beta failed`, err);
+        }
+      },
+    );
+  }
+
+  async destroy(vmId: string): Promise<void> {
+    return withVmSpan(
+      "cmux.vm.provider.destroy",
+      betaSpanAttributes(vmId, "destroy"),
+      async () => {
+        try {
+          await betaClient().vms.ref(vmId).delete();
+        } catch (err) {
+          if (isBetaNotFound(err)) return; // already gone; destroy is idempotent
+          throw new ProviderError("freestyle", `destroy(${vmId}) on beta`, err);
+        }
+      },
+    );
+  }
+
+  async getStatus(vmId: string): Promise<VMStatus> {
+    return withVmSpan(
+      "cmux.vm.provider.get_status",
+      betaSpanAttributes(vmId, "get_status"),
+      async (span) => {
+        try {
+          const data = await betaClient().vms.get(vmId);
+          const status = mapFreestyleBetaState(data.state);
+          setSpanAttributes(span, { "cmux.vm.provider_state": data.state, "cmux.vm.status": status });
+          return status;
+        } catch (err) {
+          if (isBetaNotFound(err)) return "destroyed";
+          throw new ProviderError("freestyle", `getStatus(${vmId}) on beta`, err);
+        }
+      },
+    );
+  }
+
+  /** Beta pause freezes memory, so a later start resumes the daemon in place. */
+  async pause(vmId: string): Promise<void> {
+    return withVmSpan(
+      "cmux.vm.provider.pause",
+      betaSpanAttributes(vmId, "pause"),
+      async () => {
+        try {
+          await betaClient(CREATE_TIMEOUT_MS).vms.ref(vmId).pause();
+        } catch (err) {
+          throw new ProviderError("freestyle", `pause(${vmId}) on beta`, err);
+        }
+      },
+    );
+  }
+
+  async resume(vmId: string): Promise<VMHandle> {
+    return withVmSpan(
+      "cmux.vm.provider.resume",
+      betaSpanAttributes(vmId, "resume"),
+      async (span) => {
+        try {
+          const fs = betaClient(CREATE_TIMEOUT_MS);
+          const vm = fs.vms.ref(vmId);
+          const data = await vm.start();
+          const status = mapFreestyleBetaState(data.state);
+          setSpanAttributes(span, { "cmux.vm.provider_state": data.state, "cmux.vm.status": status });
+          // A memory-preserving pause keeps the daemon; a cold boot (the VM had
+          // stopped) relies on the baked systemd unit. Heal best-effort so the
+          // first attach doesn't race the unit; attach re-verifies anyway.
+          try {
+            await this.ensureCmuxTuiRunning(vm, vmId);
+          } catch (healErr) {
+            recordSpanError(span, healErr);
+          }
+          return {
+            provider: "freestyle" as const,
+            providerVmId: data.id,
+            status,
+            image: data.snapshotId ?? "freestyle:resumed",
+            createdAt: Date.now(),
+            providerMetadata: { [FREESTYLE_PLATFORM_METADATA_KEY]: "beta" },
+          };
+        } catch (err) {
+          throw new ProviderError("freestyle", `resume(${vmId}) on beta`, err);
+        }
+      },
+    );
+  }
+
+  async exec(vmId: string, command: string, opts?: { timeoutMs?: number }): Promise<ExecResult> {
+    const timeoutMs = normalizeFreestyleBetaExecTimeout(opts?.timeoutMs);
+    return withVmSpan(
+      "cmux.vm.provider.exec",
+      betaSpanAttributes(vmId, "exec", {
+        "cmux.command_length": command.length,
+        "cmux.timeout_ms": timeoutMs,
+      }),
+      async (span) => {
+        try {
+          const fs = betaClient(timeoutMs + EXEC_OVERHEAD_TIMEOUT_MS);
+          const r = await fs.vms.ref(vmId).exec({ command, timeoutMs });
+          // statusCode is null when the guest killed the command at its timeout.
+          const exitCode = r.statusCode ?? 124;
+          setSpanAttributes(span, { "cmux.exec.exit_code": exitCode });
+          return { exitCode, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+        } catch (err) {
+          throw new ProviderError("freestyle", `exec(${vmId}) on beta`, err);
+        }
+      },
+    );
+  }
+
+  async snapshot(vmId: string, name?: string): Promise<SnapshotRef> {
+    return withVmSpan(
+      "cmux.vm.provider.snapshot",
+      betaSpanAttributes(vmId, "snapshot", {
+        "cmux.snapshot.named": !!name,
+        "cmux.timeout_ms": SNAPSHOT_TIMEOUT_MS,
+      }),
+      async (span) => {
+        try {
+          const fs = betaClient(SNAPSHOT_TIMEOUT_MS);
+          // Beta snapshots capture memory + disk of a running or paused VM. The
+          // caller's name goes to displayName only: slugs are unique per account
+          // and a collision would fail the snapshot for a cosmetic label.
+          const out = await fs.vms.ref(vmId).snapshot(name ? { displayName: name } : undefined);
+          if (!out.snapshotId) throw new Error("snapshot response missing snapshotId");
+          setSpanAttributes(span, { "cmux.snapshot.id": out.snapshotId });
+          return { id: out.snapshotId, createdAt: Date.now(), name };
+        } catch (err) {
+          throw new ProviderError("freestyle", `snapshot(${vmId}) on beta`, err);
+        }
+      },
+    );
+  }
+
+  async restore(snapshotId: string): Promise<VMHandle> {
+    return withVmSpan(
+      "cmux.vm.provider.restore",
+      {
+        "cmux.vm.provider": "freestyle",
+        "cmux.vm.operation": "restore",
+        "cmux.snapshot.id": snapshotId,
+        "cmux.vm.platform": "beta",
+        "cmux.timeout_ms": CREATE_TIMEOUT_MS,
+      },
+      async (span) => {
+        try {
+          const fs = betaClient(CREATE_TIMEOUT_MS);
+          const { vm, vmId } = await fs.vms.create({
+            snapshotId,
+            displayName: "cmux Cloud VM",
+            metadata: { cmux: "cloud" },
+            firewall: { rules: freestyleBetaFirewallRules() },
+          });
+          setSpanAttributes(span, { "cmux.vm.id": vmId });
+          // The snapshot carries the installed binary and the persisted
+          // model-plane file; heal best-effort so the machine is attach-ready
+          // without failing restore on a transient error.
+          await this.ensureCmuxTuiRunning(vm, vmId).catch(() => undefined);
+          return {
+            provider: "freestyle" as const,
+            providerVmId: vmId,
+            status: "running" as const,
+            image: snapshotId,
+            createdAt: Date.now(),
+            providerMetadata: { [FREESTYLE_PLATFORM_METADATA_KEY]: "beta" },
+          };
+        } catch (err) {
+          throw new ProviderError("freestyle", `restore(${snapshotId}) on beta`, err);
+        }
+      },
+    );
+  }
+
+  async openCmuxRemote(vmId: string, options?: CmuxRemoteAttachOptions): Promise<CmuxRemoteEndpoint> {
+    return withVmSpan(
+      "cmux.vm.provider.open_cmux_remote",
+      betaSpanAttributes(vmId, "open_cmux_remote"),
+      async (span) => {
+        try {
+          const fs = betaClient(CMUX_TUI_INSTALL_TIMEOUT_MS + EXEC_OVERHEAD_TIMEOUT_MS);
+          const vm = fs.vms.ref(vmId);
+          const data = await vm.data();
+          const route = freestyleBetaCmuxRemoteRoute(data.publicIpv6, vmId);
+          await this.ensureCmuxTuiRunning(vm, vmId);
+          const invoke = this.cmuxTuiInvoke(vm);
+          // Direct-IPv6 carries no URL token; this one exists only for the
+          // lease ledger. The daemon's Noise enrollment is the session gate —
+          // the same trust model as E2B's public proxy route.
+          const token = `cmux-freestyle-route-${randomBytes(32).toString("hex")}`;
+          const expiresAtUnix = Math.floor(Date.now() / 1000) + ROUTE_TOKEN_TTL_SECONDS;
+          let invitation: CmuxRemoteEndpoint["invitation"];
+          const enrolled = options?.deviceFingerprint
+            ? await isCmuxTuiDeviceEnrolled(invoke, options.deviceFingerprint)
+            : false;
+          if (!enrolled) {
+            invitation = await mintCmuxTuiInvitation(invoke, "freestyle", vmId);
+          }
+          span.setAttribute("cmux.vm.cmux_remote.invited", !enrolled);
+          const daemonBuild = await cmuxTuiDaemonBuild(invoke);
+          return {
+            transport: "cmux-remote" as const,
+            route,
+            token,
+            expiresAtUnix,
+            session: CMUX_TUI_SESSION,
+            ...(daemonBuild ? { daemonBuild } : {}),
+            ...(invitation ? { invitation } : {}),
+          };
+        } catch (err) {
+          throw err instanceof ProviderError
+            ? err
+            : new ProviderError("freestyle", `openCmuxRemote(${vmId}) on beta failed`, err);
+        }
+      },
+    );
+  }
+
+  async approveCmuxRemoteEnrollment(vmId: string, invitationId: string): Promise<CmuxRemoteApprovalResult> {
+    return withVmSpan(
+      "cmux.vm.provider.approve_cmux_remote_enrollment",
+      betaSpanAttributes(vmId, "approve_cmux_remote_enrollment"),
+      async () => {
+        try {
+          const vm = betaClient().vms.ref(vmId);
+          return await approveCmuxTuiEnrollment(this.cmuxTuiInvoke(vm), "freestyle", vmId, invitationId);
+        } catch (err) {
+          throw err instanceof ProviderError
+            ? err
+            : new ProviderError("freestyle", `approveCmuxRemoteEnrollment(${vmId}) on beta failed`, err);
+        }
+      },
+    );
+  }
+
+  /** Installs the pinned binary, persists the model-plane env, starts the daemon (fresh create). */
+  private async bootstrapCmuxTui(vm: Vm, vmId: string, envs?: Readonly<Record<string, string>>): Promise<void> {
+    const source = await resolveCmuxTuiSource("freestyle");
+    await this.execOrThrow(vm, vmId, cmuxTuiInstallCommand(source), CMUX_TUI_INSTALL_TIMEOUT_MS)
+      .catch((err: unknown) => {
+        throw new ProviderError("freestyle", `cmux-tui install in ${vmId} failed: ${errorMessage(err)}`);
+      });
+    if (envs) await this.writeModelPlaneEnv(vm, vmId, envs);
+    await this.execOrThrow(vm, vmId, freestyleBetaStartDaemonCommand(), 60_000);
+    await waitForCmuxTuiReady(this.cmuxTuiInvoke(vm), "freestyle", vmId);
+  }
+
+  /**
+   * Beta has no create-time env. The coderouter model-plane vars are delivered
+   * by writing the persisted file /etc/cmux/agent-config.sh already reads
+   * (0600, root); every shell the daemon spawns sources it through the
+   * profile/bashrc chain and materializes the harness configs from it.
+   */
+  private async writeModelPlaneEnv(vm: Vm, vmId: string, envs: Readonly<Record<string, string>>): Promise<void> {
+    const content = renderFreestyleModelPlaneEnvFile(envs);
+    if (!content) return;
+    try {
+      await vm.exec({ command: `mkdir -p ${MODEL_PLANE_ENV_PATH.replace(/\/[^/]+$/, "")}`, timeoutMs: 30_000 });
+      await vm.fs.writeTextFile(MODEL_PLANE_ENV_PATH, content, { mode: 0o600 });
+    } catch (err) {
+      throw new ProviderError("freestyle", `model-plane env write in ${vmId} failed`, err);
+    }
+  }
+
+  /**
+   * Attach-time heal, mirroring the other cmux-tui drivers: a daemon that is
+   * running AND listening dual-stack is left alone; anything else is repaired,
+   * reinstalling first when the binary is missing or superseded by a manifest
+   * pin change. The dual-stack check matters because a machine from an older
+   * bake boots the daemon on 0.0.0.0, which the public-IPv6 route cannot reach.
+   */
+  private async ensureCmuxTuiRunning(vm: Vm, vmId: string): Promise<void> {
+    const healthy = await this.execResult(vm, freestyleBetaDaemonHealthyCommand());
+    if (healthy?.exitCode === 0) return;
+    const source = await resolveCmuxTuiSource("freestyle");
+    const pinned = await this.execResult(vm, cmuxTuiPinCheckCommand(source));
+    if (pinned?.exitCode !== 0) {
+      await this.execOrThrow(vm, vmId, cmuxTuiInstallCommand(source), CMUX_TUI_INSTALL_TIMEOUT_MS)
+        .catch((err: unknown) => {
+          throw new ProviderError("freestyle", `cmux-tui install in ${vmId} failed: ${errorMessage(err)}`);
+        });
+    }
+    await this.execOrThrow(vm, vmId, freestyleBetaStartDaemonCommand(), 60_000);
+    await waitForCmuxTuiReady(this.cmuxTuiInvoke(vm), "freestyle", vmId);
+  }
+
+  private async execResult(vm: Vm, command: string, timeoutMs = EXEC_DEFAULT_TIMEOUT_MS): Promise<ExecResult | null> {
+    try {
+      const r = await vm.exec({ command, timeoutMs });
+      return { exitCode: r.statusCode ?? 124, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+    } catch {
+      return null;
+    }
+  }
+
+  private async execOrThrow(vm: Vm, vmId: string, command: string, timeoutMs: number): Promise<ExecResult> {
+    const r = await vm.exec({ command, timeoutMs });
+    const exitCode = r.statusCode ?? 124;
+    if (exitCode !== 0) {
+      throw new Error(`beta exec in ${vmId} exited ${exitCode}: ${(r.stderr ?? r.stdout ?? "").trim().slice(0, 500)}`);
+    }
+    return { exitCode, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+  }
+
+  private cmuxTuiInvoke(vm: Vm): CmuxTuiInvoke {
+    return async (args, timeoutMs) => {
+      const r = await this.execResult(vm, `env HOME=/root /root/.cmux/bin/cmux-tui ${args}`, timeoutMs ?? EXEC_DEFAULT_TIMEOUT_MS);
+      return r ?? { exitCode: 124, stdout: "", stderr: "exec failed" };
+    };
+  }
+}

--- a/web/services/vms/images/devbox/README.md
+++ b/web/services/vms/images/devbox/README.md
@@ -36,11 +36,15 @@ the daemon:
   with its token as the `DAYTONA_SANDBOX_AUTH_KEY` query parameter, minted
   fresh per attach.
 - freestyle (beta platform, `freestyle-beta` npm alias): the baked
-  `cmux-tui-daemon` systemd unit runs the supervisor. FORWARD-COMPATIBLE
-  ONLY: the shipped freestyle driver still speaks the legacy 0.1.51 platform
-  and its cmuxd-remote transport, so this bake becomes usable when a
-  beta-SDK freestyle driver lands; until then `FREESTYLE_SANDBOX_SNAPSHOT`
-  must not point at it.
+  `cmux-tui-daemon` systemd unit runs the supervisor with
+  `CMUX_TUI_REMOTE_WS_BIND=[::]:1337` — the beta API has no HTTP ingress to
+  arbitrary ports, so the route is the VM's stable public IPv6 straight to
+  the daemon (`ws://[ipv6]:1337/v1/link`, Noise enrollment as the session
+  gate) and the listener must be dual-stack. The freestyle driver's beta arm
+  (`drivers/freestyleBeta.ts`) serves these machines; its legacy arm keeps
+  serving the old-platform fleet, dispatched per machine on the id shape and
+  the `providerMetadata.freestylePlatform` marker. The manifest entry marks
+  beta images with `features.freestylePlatform: "beta"`.
 
 Shells spawned by the daemon run as root with HOME=/root and get the bash
 devshell (ble.sh ghost text, half-life prompt, seeded history) through the

--- a/web/services/vms/images/devbox/cmux-devbox-boot
+++ b/web/services/vms/images/devbox/cmux-devbox-boot
@@ -14,9 +14,13 @@
 # on disk). The Freestyle beta bake runs it from the cmux-tui-daemon systemd
 # unit. E2B does not use it (pause/resume preserves processes; the driver
 # starts the daemon directly), but ships it for uniformity.
+# CMUX_TUI_REMOTE_WS_BIND overrides the listener bind. Default: the IPv4
+# wildcard the container providers' proxies dial. Freestyle beta sets
+# [::]:1337 (its systemd unit / a driver drop-in) because those machines are
+# reached directly at their public IPv6; a dual-stack bind still accepts IPv4.
 while true; do
   if [ -x /root/.cmux/bin/cmux-tui ]; then
-    (cd /root && env HOME=/root TERM=xterm-256color /root/.cmux/bin/cmux-tui server start --session cloud --remote-ws 0.0.0.0:1337 --remote-ws-insecure-bind)
+    (cd /root && env HOME=/root TERM=xterm-256color /root/.cmux/bin/cmux-tui server start --session cloud --remote-ws "${CMUX_TUI_REMOTE_WS_BIND:-0.0.0.0:1337}" --remote-ws-insecure-bind)
   fi
   sleep 2
 done

--- a/web/services/vms/images/manifest.json
+++ b/web/services/vms/images/manifest.json
@@ -233,6 +233,28 @@
       },
       "validationStatus": "passed",
       "notes": "Shared devbox image (services/vms/images/devbox), cmux-tui transport. Baked fresh (never trusting Daytona's layer cache) with build-devbox-daytona.ts; the cmux-devbox-boot supervisor is the registered snapshot entrypoint (Daytona stop kills processes, start re-runs it). Validated 2026-08-28 with verify-devbox-image.ts against cmux-tui pin 102aa3d63086bf0617a6b5a34d5cb2465f2a74a7: pinned agents, mise toolchain, devtools, Chrome + DuckDuckGo managed policy, cua-driver, ffmpeg/Xvfb, byte-identical baked files, ble.sh ghost text under a tmux PTY, agent-config generator, cmux-tui install + daemon serving session cloud on 1337 through the entrypoint supervisor, and the preview proxy route with the DAYTONA_SANDBOX_AUTH_KEY query token. Region shared us. Not the default provider; Blaxel stays default."
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-beta1",
+      "imageId": "sh-fb3dcf7b47894114889b10186626af5b",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "defaultForLocalDev": false,
+      "features": {
+        "freestylePlatform": "beta"
+      },
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "builtAt": "2026-08-28T10:35:57.736Z",
+      "builderScriptVersion": "6e40d373a9e25289770d1bfbfc515becafbd905f3b448741df4cc4ea2f2c6cd1",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.246",
+        "@openai/codex": "0.150.0",
+        "opencode-ai": "1.18.23",
+        "@earendil-works/pi-coding-agent": "0.84.3",
+        "agent-browser": "0.35.1"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-08-28-r1 on the Freestyle BETA platform (beta-api.freestyle.sh; slug cmux-devbox-beta1). cmux-tui transport over the VM public IPv6; systemd unit binds [::]:1337. verify-devbox-image.ts passed all toolchain, agent-pin, ghost-text, baked-file, and daemon checks 2026-08-28. Requires the beta driver arm; the legacy driver cannot boot it."
     }
   ]
 }

--- a/web/services/vms/images/resolver.ts
+++ b/web/services/vms/images/resolver.ts
@@ -27,6 +27,11 @@ export type VmImageManifestEntry = {
   readonly defaultForKind?: boolean;
   readonly features?: {
     readonly bakedFreestyleSignedAdmin?: boolean;
+    /**
+     * The image lives on the Freestyle BETA platform (beta-api.freestyle.sh);
+     * the freestyle driver dispatches creates from it to the beta arm.
+     */
+    readonly freestylePlatform?: "beta";
   };
   readonly cmuxdRemoteCommit: string;
   readonly builtAt: string;
@@ -161,6 +166,11 @@ export function imageUsesBakedFreestyleSignedAdmin(provider: ProviderId, imageId
     candidate.provider === provider && candidate.imageId === imageId
   );
   return entry?.features?.bakedFreestyleSignedAdmin === true;
+}
+
+/** Whether an image id or version names a Freestyle BETA platform image (see `features.freestylePlatform`). */
+export function imageUsesFreestyleBetaPlatform(provider: ProviderId, image: string): boolean {
+  return findVmImageManifestEntry(provider, image)?.features?.freestylePlatform === "beta";
 }
 
 /**

--- a/web/tests/vm-devbox-image.test.ts
+++ b/web/tests/vm-devbox-image.test.ts
@@ -178,7 +178,14 @@ describe("devbox image template", () => {
     // two can never drift apart.
     expect(CMUX_TUI_PORT).toBe(1337);
     expect(CMUX_TUI_SESSION).toBe("cloud");
-    expect(devboxBoot).toContain(cmuxTuiDaemonCommand().replace("cd /root && ", ""));
+    // The boot script parameterizes only the listener bind (the env Freestyle
+    // beta's systemd unit sets); everything else must match the drivers'
+    // command byte for byte, so passing the shell expansion as the bind
+    // reconstructs the script's exact line.
+    expect(devboxBoot).toContain(
+      cmuxTuiDaemonCommand('"${CMUX_TUI_REMOTE_WS_BIND:-0.0.0.0:1337}"').replace("cd /root && ", ""),
+    );
+    expect(cmuxTuiDaemonCommand()).toContain("--remote-ws 0.0.0.0:1337");
     expect(devboxBoot).toContain("if [ -x /root/.cmux/bin/cmux-tui ]");
     expect(dockerfile).toContain("COPY cmux-devbox-boot /usr/local/bin/cmux-devbox-boot");
     // No binary is baked and the old cmuxd stack is gone everywhere.
@@ -214,15 +221,28 @@ describe("devbox image template", () => {
     expect(freestyleScript).toContain("Restart=always");
   });
 
-  test("freestyle bake and verify ride the beta SDK; the legacy driver stays on 0.1.51", () => {
+  test("the beta SDK serves the bake, verify, and beta driver arm; the legacy arm stays on 0.1.51", () => {
     expect(readScript("build-devbox-freestyle.ts")).toContain('from "freestyle-beta"');
     expect(readScript("verify-devbox-image.ts")).toContain('from "freestyle-beta"');
+    // The freestyle bake's systemd unit binds the daemon dual-stack: the beta
+    // driver's route is the VM's public IPv6 straight to port 1337.
+    expect(readScript("build-devbox-freestyle.ts")).toContain(
+      "Environment=CMUX_TUI_REMOTE_WS_BIND=[::]:1337",
+    );
+    // The freestyle driver spans both platforms: the legacy arm (existing
+    // production machines) keeps the 0.1.51 SDK, the beta arm rides the alias.
     const driver = readFileSync(
       path.join(import.meta.dirname, "../services/vms/drivers/freestyle.ts"),
       "utf8",
     );
     expect(driver).toContain('from "freestyle"');
-    expect(driver).not.toContain("freestyle-beta");
+    expect(driver).toContain('from "./freestyleBeta"');
+    const betaArm = readFileSync(
+      path.join(import.meta.dirname, "../services/vms/drivers/freestyleBeta.ts"),
+      "utf8",
+    );
+    expect(betaArm).toContain('from "freestyle-beta"');
+    expect(betaArm).not.toContain('from "freestyle";');
     const packageJson = JSON.parse(
       readFileSync(path.join(import.meta.dirname, "../package.json"), "utf8"),
     ) as { dependencies: Record<string, string> };

--- a/web/tests/vm-freestyle-provider.test.ts
+++ b/web/tests/vm-freestyle-provider.test.ts
@@ -1,9 +1,28 @@
 import { describe, expect, test } from "bun:test";
 import { FreestyleProvider } from "../services/vms/drivers/freestyle";
+import {
+  FREESTYLE_PLATFORM_METADATA_KEY,
+  freestyleBetaCmuxRemoteRoute,
+  freestyleBetaDaemonHealthyCommand,
+  freestyleBetaFirewallRules,
+  freestyleBetaStartDaemonCommand,
+  isFreestyleBetaSnapshotId,
+  isFreestyleBetaVmId,
+  mapFreestyleBetaState,
+  normalizeFreestyleBetaExecTimeout,
+  renderFreestyleModelPlaneEnvFile,
+} from "../services/vms/drivers/freestyleBeta";
+import { ProviderError } from "../services/vms/drivers/types";
 import type {
   SSHEndpoint,
   WebSocketPtyEndpoint,
 } from "../services/vms/drivers/types";
+
+// A real beta id/snapshot shape (vm-/sh- + 32 hex) vs the legacy platform's
+// bare 20-char base36 ids; the driver dispatches per machine on this shape.
+const BETA_VM_ID = "vm-d05087e5773e4a978036fc806b0cd759";
+const BETA_SNAPSHOT_ID = "sh-9581282fc6c644b399fd49fdcdbcf130";
+const LEGACY_VM_ID = "t9mstkvydmb4x0tjmnqu";
 
 const sshEndpoint: SSHEndpoint = {
   transport: "ssh",
@@ -162,5 +181,114 @@ describe("FreestyleProvider attach fallback", () => {
         process.env.FREESTYLE_API_KEY = originalApiKey;
       }
     }
+  });
+});
+
+describe("Freestyle platform dispatch", () => {
+  test("beta ids are vm-<32 hex>; legacy ids and near-misses stay legacy", () => {
+    expect(isFreestyleBetaVmId(BETA_VM_ID)).toBe(true);
+    expect(isFreestyleBetaVmId(LEGACY_VM_ID)).toBe(false);
+    expect(isFreestyleBetaVmId("vm-1")).toBe(false); // legacy test fixtures
+    expect(isFreestyleBetaVmId("vm-D05087E5773E4A978036FC806B0CD759")).toBe(false);
+  });
+
+  test("beta snapshots are sh-<32 hex>; legacy sh-/sc- + 20 base36 stay legacy", () => {
+    expect(isFreestyleBetaSnapshotId(BETA_SNAPSHOT_ID)).toBe(true);
+    expect(isFreestyleBetaSnapshotId("sh-6ch5p9k23xrcx24056n8")).toBe(false);
+    expect(isFreestyleBetaSnapshotId("sc-mt237w1nd7c7673bd03m")).toBe(false);
+  });
+
+  test("attachTransports is the union across both platforms", () => {
+    // cmux-remote-only would make the workflow gate refuse openAttach for the
+    // whole legacy fleet; the per-machine refusal lives inside the methods.
+    const provider = new FreestyleProvider();
+    expect(provider.attachTransports).toEqual(["cmux-remote", "websocket", "ssh"]);
+    expect(typeof provider.openCmuxRemote).toBe("function");
+    expect(typeof provider.approveCmuxRemoteEnrollment).toBe("function");
+  });
+
+  test("openAttach on a beta machine refuses and names cmux-remote", async () => {
+    const provider = new TestFreestyleProvider();
+    await expect(provider.openAttach(BETA_VM_ID)).rejects.toThrow("cmux-remote");
+    await expect(
+      provider.openAttach("vm-1", { providerMetadata: { [FREESTYLE_PLATFORM_METADATA_KEY]: "beta" } }),
+    ).rejects.toThrow("cmux-remote");
+    expect(provider.sshCalls).toBe(0);
+  });
+
+  test("openCmuxRemote on a legacy machine refuses and names recreation", async () => {
+    const provider = new FreestyleProvider();
+    await expect(provider.openCmuxRemote(LEGACY_VM_ID)).rejects.toThrow(ProviderError);
+    await expect(provider.openCmuxRemote(LEGACY_VM_ID)).rejects.toThrow("beta devbox image");
+    await expect(provider.approveCmuxRemoteEnrollment(LEGACY_VM_ID, "inv-1")).rejects.toThrow(ProviderError);
+  });
+
+  test("openSSH and fork refuse on beta machines", async () => {
+    const provider = new FreestyleProvider();
+    await expect(provider.openSSH(BETA_VM_ID)).rejects.toThrow("cmux-remote");
+    await expect(provider.fork(BETA_VM_ID)).rejects.toThrow("snapshot");
+  });
+});
+
+describe("Freestyle beta platform contract", () => {
+  test("firewall: outbound open, inbound only the daemon port", () => {
+    expect(freestyleBetaFirewallRules()).toEqual([
+      { action: "allow", source: {}, destination: { public: true } },
+      { action: "allow", source: { public: true }, destination: { port: 1337, protocol: "tcp" } },
+    ]);
+  });
+
+  test("cmux-remote route is the public IPv6 straight to the daemon", () => {
+    expect(freestyleBetaCmuxRemoteRoute("2602:f75c:0:1::2a", BETA_VM_ID)).toBe(
+      "ws://[2602:f75c:0:1::2a]:1337/v1/link",
+    );
+    expect(() => freestyleBetaCmuxRemoteRoute(null, BETA_VM_ID)).toThrow("public IPv6");
+    expect(() => freestyleBetaCmuxRemoteRoute("  ", BETA_VM_ID)).toThrow("public IPv6");
+  });
+
+  test("daemon health requires a v6-table listener; start installs the dual-stack override", () => {
+    // 0x0539 = 1337; a 0.0.0.0-bound daemon appears only in /proc/net/tcp and
+    // is unreachable at the public IPv6, so it must be restarted.
+    expect(freestyleBetaDaemonHealthyCommand()).toContain("/proc/net/tcp6");
+    expect(freestyleBetaDaemonHealthyCommand()).toContain(":0539 ");
+    const start = freestyleBetaStartDaemonCommand();
+    expect(start).toContain("Environment=CMUX_TUI_REMOTE_WS_BIND=[::]:1337");
+    expect(start).toContain("systemctl restart cmux-tui-daemon");
+    expect(start).toContain("--remote-ws [::]:1337"); // non-systemd fallback
+  });
+
+  test("model-plane env renders the exact file agent-config.sh persists", () => {
+    expect(
+      renderFreestyleModelPlaneEnvFile({
+        OPENAI_BASE_URL: "https://cmux.example/v1",
+        OPENAI_API_KEY: "crt_secret'quote",
+        CMUX_CODEROUTER_URL: "https://cmux.example",
+      }),
+    ).toBe(
+      [
+        "# generated by cmux from machine boot env; managed, do not edit",
+        "export OPENAI_BASE_URL='https://cmux.example/v1'",
+        `export OPENAI_API_KEY='crt_secret'\\''quote'`,
+        "export CMUX_CODEROUTER_URL='https://cmux.example'",
+        "",
+      ].join("\n"),
+    );
+    expect(renderFreestyleModelPlaneEnvFile({})).toBeNull();
+    expect(renderFreestyleModelPlaneEnvFile({ OPENAI_API_KEY: "crt_x" })).toBeNull();
+  });
+
+  test("exec timeouts clamp to the beta per-exec cap; killed execs read as 124", () => {
+    expect(normalizeFreestyleBetaExecTimeout(undefined)).toBe(30_000);
+    expect(normalizeFreestyleBetaExecTimeout(-5)).toBe(30_000);
+    expect(normalizeFreestyleBetaExecTimeout(10 * 60 * 1000)).toBe(300_000);
+    expect(normalizeFreestyleBetaExecTimeout(12_345)).toBe(12_345);
+  });
+
+  test("stopped beta VMs read as paused (start() recovers them), not destroyed", () => {
+    expect(mapFreestyleBetaState("starting")).toBe("creating");
+    expect(mapFreestyleBetaState("running")).toBe("running");
+    expect(mapFreestyleBetaState("pausing")).toBe("paused");
+    expect(mapFreestyleBetaState("paused")).toBe("paused");
+    expect(mapFreestyleBetaState("stopped")).toBe("paused");
   });
 });

--- a/web/tests/vm-image-resolver.test.ts
+++ b/web/tests/vm-image-resolver.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   reportVmImageConfigError,
   imageUsesBakedFreestyleSignedAdmin,
+  imageUsesFreestyleBetaPlatform,
   inferVmProviderForImage,
   listVmImageKinds,
   providerImageEnvKey,
@@ -189,6 +190,25 @@ describe("VM image resolver", () => {
       imageVersion: "freestyle-signedadmin-20260625b",
     });
     expect(imageUsesBakedFreestyleSignedAdmin("freestyle", "sh-b3jqa6o88qe6l738dw9z")).toBe(true);
+  });
+
+  test("the baked beta devbox snapshot reads as a beta-platform image", () => {
+    expect(imageUsesFreestyleBetaPlatform("freestyle", "sh-fb3dcf7b47894114889b10186626af5b")).toBe(true);
+    expect(imageUsesFreestyleBetaPlatform("freestyle", "freestyle-cmux-devbox-beta1")).toBe(true);
+  });
+
+  test("legacy freestyle images never read as beta-platform images", () => {
+    // The freestyle driver dispatches creates on this flag; a legacy image
+    // reading as beta would boot the old snapshot on the wrong platform.
+    for (const image of [
+      "sc-mt237w1nd7c7673bd03m",
+      "sh-6ch5p9k23xrcx24056n8",
+      "sh-17agfasevrc18c8f15nn",
+      "sh-w2otfp1g287lzrpuc2gr",
+      "sh-b3jqa6o88qe6l738dw9z",
+    ]) {
+      expect(imageUsesFreestyleBetaPlatform("freestyle", image)).toBe(false);
+    }
   });
 
   test("daytona has no local default until a validated snapshot lands in the manifest", () => {


### PR DESCRIPTION
Makes the already-merged beta devbox bake usable: the freestyle provider now serves BOTH Freestyle platforms, and new creates from a beta image attach through the cmux-tui remote daemon like Blaxel/E2B/Daytona. Existing production machines on the legacy platform (api.freestyle.sh, freestyle@0.1.51, cmuxd-remote on 7777) keep the legacy code path unchanged.

**Platform gating.** Create-time selection comes from the image manifest entry (`features.freestylePlatform: "beta"`, new field), the `providerMetadata.freestylePlatform` marker, the beta snapshot id shape, or `CMUX_FREESTYLE_PLATFORM=beta` (operator override for unmanifested snapshots). Per-machine dispatch for vmId-only operations keys on the id shape, which the two platforms cannot confuse: beta ids are `vm-<32 hex>`, legacy ids bare 20-char base36 (verified against both live APIs). Every beta create persists the metadata marker, which overrides where metadata flows (attach paths). `attachTransports` is the union `["cmux-remote", "websocket", "ssh"]` because a cmux-remote-only list would make the workflow gate refuse `openAttach` for the whole legacy fleet; per-machine refusal lives inside the methods. Auth: the beta client reads `FREESTYLE_BETA_API_KEY ?? FREESTYLE_API_KEY` (a legacy key answers 401 on beta-api, verified live), so mixed deployments set both and single-platform setups need nothing new.

**Transport shipped: `cmux-remote` over the VM's stable public IPv6** — `ws://[ipv6]:1337/v1/link`. The beta API exposes no HTTP ingress to arbitrary VM ports (verified against `/openapi.json`: no preview/port-proxy routes; TLS edge rules need a customer-verified domain plus wildcard cert, which is account DNS infra, not driver code; the SDK pty WebSocket speaks Freestyle's own protocol, not the cmux-tui link protocol). The cmux-tui client dials `ws` and `wss` alike and the Noise handshake encrypts and authenticates the session end to end, so carrier TLS is not required; the route token feeds only the lease ledger, the same trust model as E2B's public proxy. Firewall (mandatory on beta, default nothing): outbound open, inbound only tcp/1337 — the platform-edge equivalent of the iptables posture #11099 built by hand for E2B. Known limitation, stated plainly: a client on an IPv4-only network cannot reach the route; the fallback once cmux verifies a domain on the beta account is a TLS edge rule mapping `<vm>.domain -> vmId:1337`.

The daemon must listen dual-stack for this route, so `cmux-devbox-boot` gains a `CMUX_TUI_REMOTE_WS_BIND` override (default unchanged `0.0.0.0:1337`; container runtimes may have IPv6 disabled, so dual-stack is per-provider), the freestyle bake's systemd unit sets `[::]:1337`, and the driver heals older machines through a systemd drop-in plus a `/proc/net/tcp6` listener check.

**Model-plane delivery.** Beta has no create-time env, so `create` writes `/root/.config/cmux/model-plane.env` (0600, via the beta fs API, no shell quoting of secrets) — the exact file `/etc/cmux/agent-config.sh` persists and re-sources; daemon-spawned shells (HOME=/root) source it through the profile/bashrc chain and materialize the codex/pi/opencode configs.

**Bake + live smoke (all VMs deleted).** Baked `sh-fb3dcf7b47894114889b10186626af5b` (slug `cmux-devbox-beta1`, epoch 2026-08-28-r1); `verify-devbox-image.ts freestyle` passed every toolchain, agent-pin, ghost-text, baked-file, and daemon check. Driver-level smoke against that snapshot: create wrote the marker and the exact model-plane file (0600); the baked unit came up listening in the v6 table; `openCmuxRemote` returned the IPv6 route, minted an invitation, and read the real daemon build (commit fa77ad23364, protocol 5); `openAttach` refused naming cmux-remote; a second VM dialing the route host over the public Internet got HTTP 400 from the daemon (reachability through the platform firewall proven); a HOME=/root login shell echoed the sourced `OPENAI_BASE_URL` and had materialized `~/.codex/config.toml`; destroy left `getStatus` reporting destroyed and zero cmux VMs on the account.

Beta arm quirks encoded in code comments: exec caps at 300s per call (`statusCode: null` = killed at timeout, mapped to 124), `stopped` maps to `paused` because `start()` recovers a stopped beta VM, pause is a memory freeze, fork is unsupported (snapshot + restore instead), snapshot names go to `displayName` only (slugs are unique per account and would fail on collision).

Gates: `tsgo --noEmit` clean; all vm-* suites green (307 pass / 0 fail). Rollout is opt-in: nothing changes until an operator points `FREESTYLE_SANDBOX_SNAPSHOT` at the beta image (`defaultForLocalDev` stays on the legacy signed-admin entry).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790506016&installation_model_id=21920&pr_number=11105&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11105&signature=3928a668caab6403f7ea78439f553bcea054399a47b9ca9a794db6641f451f24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the Freestyle beta devbox image usable: the freestyle provider now serves both Freestyle platforms, routing new creates from a beta image through the cmux-tui remote daemon, while existing production machines on the legacy platform keep the legacy code path unchanged.

**Platform dispatch**

- Create-time beta selection comes from the image manifest entry (`features.freestylePlatform: "beta"`), the `providerMetadata` marker, the beta snapshot id shape (`sh-<32 hex>`), or the `CMUX_FREESTYLE_PLATFORM=beta` operator override.
- Per-machine operations dispatch on the id shape: beta ids are `vm-<32 hex>`, legacy ids bare 20-char base36.
- Beta machines attach through transport `cmux-remote` at `ws://[<public ipv6>]:1337/v1/link`; `openAttach`, `openSSH`, and `fork` refuse on beta machines, and `openCmuxRemote` refuses on legacy machines.

**Beta platform integration**

- The daemon must listen dual-stack: `cmux-devbox-boot` gains a `CMUX_TUI_REMOTE_WS_BIND` override (default unchanged), the bake's systemd unit sets `[::]:1337`, and the driver heals older machines via a systemd drop-in.
- Beta has no create-time env, so the model-plane vars are written to `/root/.config/cmux/model-plane.env` (0600), the file `agent-config.sh` already persists and re-sources.
- The beta firewall allows outbound and inbound tcp/1337 only; exec calls cap at 300s per request.
- Rollout is opt-in: nothing changes until `FREESTYLE_SANDBOX_SNAPSHOT` points at the beta image.

<sup>Written for commit 57b931f1ea6f797718d238c671b93161884ca199. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Freestyle beta devbox images and VM lifecycle operations.
  * Enabled secure cmux-remote connections over stable public IPv6 with dual-stack networking.
  * Added enrollment and attachment support for beta machines.
  * Added a validated beta devbox image with pinned development tools.
  * Preserved compatibility with existing Freestyle machines.

* **Documentation**
  * Updated setup and image documentation with beta platform, networking, and connection details.

* **Tests**
  * Expanded coverage for beta detection, routing, daemon configuration, and VM operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->