### PR TITLE
Cloud panes: local Ghostty theme on machines, Cmd+D/Cmd+T create remote terminals, visible tree errors

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -60160,6 +60160,40 @@
         }
       }
     },
+    "cloudPane.newTerminalFailed.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn’t start a terminal on %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ でターミナルを開始できませんでした"
+          }
+        }
+      }
+    },
+    "cloudPane.newTerminalFailed.ok": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        }
+      }
+    },
     "cloudTree.confirm.cancel": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/Cloud/CloudMachineLinkManager.swift
+++ b/Sources/Cloud/CloudMachineLinkManager.swift
@@ -1,3 +1,4 @@
+import CmuxFoundation
 import Foundation
 
 /// The app's headless cmux-tui links, one per awake cloud machine. Links are created on
@@ -37,13 +38,24 @@ actor CloudMachineLinkManager {
     /// A failed link is not retried for this long, so a polling sidebar does not hammer
     /// a machine whose route is broken.
     private let retryBackoff: TimeInterval = 15
+    /// This Mac's resolved Ghostty default colors ("#rrggbb"), pushed to each machine as
+    /// its cmux-tui session defaults (`set-default-colors`) so remote panes render with
+    /// the local theme. Injected so tests need no Ghostty runtime.
+    private let hostThemeColors: @Sendable () async -> (foreground: String, background: String)?
 
     init(
         paths: CloudTuiClientPaths = CloudTuiClientPaths(),
-        clientURL: URL? = CloudTuiClientPaths.clientURL()
+        clientURL: URL? = CloudTuiClientPaths.clientURL(),
+        hostThemeColors: @escaping @Sendable () async -> (foreground: String, background: String)? = {
+            await MainActor.run {
+                let app = GhosttyApp.shared
+                return (app.defaultForegroundColor.hexString(), app.defaultBackgroundColor.hexString())
+            }
+        }
     ) {
         self.paths = paths
         self.clientURL = clientURL
+        self.hostThemeColors = hostThemeColors
     }
 
     var hasClient: Bool { clientURL != nil }
@@ -95,6 +107,7 @@ actor CloudMachineLinkManager {
             #if DEBUG
             cmuxDebugLog("cloud.link.connected machine=\(machineID) socket=\(connected.socketPath)")
             #endif
+            pushHostTheme(machineID: machineID, socketPath: connected.socketPath)
             return connected
         } catch {
             let text = CloudMachineLink.errorText(error)
@@ -149,7 +162,39 @@ actor CloudMachineLinkManager {
         }
     }
 
+    /// Re-sends this Mac's theme to every connected machine (a Ghostty config reload
+    /// changed the resolved colors). Live attach panes repaint via `colors-changed`.
+    func pushHostThemeToConnectedLinks() async {
+        for (machineID, link) in links {
+            guard await link.isConnected, let connected = await link.connected else { continue }
+            pushHostTheme(machineID: machineID, socketPath: connected.socketPath)
+        }
+    }
+
     // MARK: - internals
+
+    /// Fire-and-forget: theme parity is cosmetic, so a machine that predates
+    /// `set-default-colors` (or a link that just dropped) must not fail the operation
+    /// that connected it.
+    private func pushHostTheme(machineID: String, socketPath: String) {
+        guard let link = links[machineID] else { return }
+        Task { [hostThemeColors] in
+            guard let colors = await hostThemeColors(),
+                  let arguments = CloudTuiCommandLine.setDefaultColorsArguments(
+                      socketPath: socketPath, foreground: colors.foreground, background: colors.background
+                  ) else { return }
+            do {
+                _ = try await link.run(arguments: arguments)
+                #if DEBUG
+                cmuxDebugLog("cloud.link.theme machine=\(machineID) fg=\(colors.foreground) bg=\(colors.background)")
+                #endif
+            } catch {
+                #if DEBUG
+                cmuxDebugLog("cloud.link.themeFailed machine=\(machineID) error=\(CloudMachineLink.errorText(error))")
+                #endif
+            }
+        }
+    }
 
     private func store(link: CloudMachineLink, for machineID: String) {
         links[machineID] = link

--- a/Sources/Cloud/CloudMachineLinkManager.swift
+++ b/Sources/Cloud/CloudMachineLinkManager.swift
@@ -42,6 +42,10 @@ actor CloudMachineLinkManager {
     /// its cmux-tui session defaults (`set-default-colors`) so remote panes render with
     /// the local theme. Injected so tests need no Ghostty runtime.
     private let hostThemeColors: @Sendable () async -> (foreground: String, background: String)?
+    /// One theme-push chain per machine: each push awaits the previous one and reads the
+    /// colors only after it finishes, so rapid config reloads coalesce into an ordered,
+    /// latest-wins sequence instead of overlapping commands racing out of order.
+    private var themePushes: [String: Task<Void, Never>] = [:]
 
     init(
         paths: CloudTuiClientPaths = CloudTuiClientPaths(),
@@ -140,6 +144,7 @@ actor CloudMachineLinkManager {
     func disconnect(machineID: String) async {
         connecting[machineID]?.cancel()
         connecting[machineID] = nil
+        themePushes.removeValue(forKey: machineID)?.cancel()
         if let link = links.removeValue(forKey: machineID) {
             await link.disconnect()
         }
@@ -174,11 +179,16 @@ actor CloudMachineLinkManager {
     // MARK: - internals
 
     /// Fire-and-forget: theme parity is cosmetic, so a machine that predates
-    /// `set-default-colors` (or a link that just dropped) must not fail the operation
-    /// that connected it.
+    /// the defaults verb (or a link that just dropped) must not fail the operation
+    /// that connected it. Pushes chain per machine: each awaits its predecessor and
+    /// reads the colors only then, so a burst of config reloads settles on the
+    /// latest theme instead of racing commands out of order.
     private func pushHostTheme(machineID: String, socketPath: String) {
         guard let link = links[machineID] else { return }
-        Task { [hostThemeColors] in
+        let previous = themePushes[machineID]
+        themePushes[machineID] = Task { [hostThemeColors] in
+            await previous?.value
+            guard !Task.isCancelled else { return }
             guard let colors = await hostThemeColors(),
                   let arguments = CloudTuiCommandLine.setDefaultColorsArguments(
                       socketPath: socketPath, foreground: colors.foreground, background: colors.background

--- a/Sources/Cloud/CloudMachineLinkManager.swift
+++ b/Sources/Cloud/CloudMachineLinkManager.swift
@@ -42,10 +42,12 @@ actor CloudMachineLinkManager {
     /// its cmux-tui session defaults (`set-default-colors`) so remote panes render with
     /// the local theme. Injected so tests need no Ghostty runtime.
     private let hostThemeColors: @Sendable () async -> (foreground: String, background: String)?
-    /// One theme-push chain per machine: each push awaits the previous one and reads the
-    /// colors only after it finishes, so rapid config reloads coalesce into an ordered,
-    /// latest-wins sequence instead of overlapping commands racing out of order.
-    private var themePushes: [String: Task<Void, Never>] = [:]
+    /// Theme-push coalescing: at most ONE in-flight push and ONE queued rerun per
+    /// machine. A reload burst collapses to a single trailing push that reads the
+    /// colors when it runs, so the machine always ends on the latest theme and the
+    /// link never accumulates a backlog of defaults commands.
+    private var themePushInFlight: Set<String> = []
+    private var themePushQueued: Set<String> = []
 
     init(
         paths: CloudTuiClientPaths = CloudTuiClientPaths(),
@@ -144,7 +146,9 @@ actor CloudMachineLinkManager {
     func disconnect(machineID: String) async {
         connecting[machineID]?.cancel()
         connecting[machineID] = nil
-        themePushes.removeValue(forKey: machineID)?.cancel()
+        // An in-flight drain notices the removed link on its next run; dropping the
+        // queued mark keeps it from issuing one more command to a machine being cut.
+        themePushQueued.remove(machineID)
         if let link = links.removeValue(forKey: machineID) {
             await link.disconnect()
         }
@@ -180,29 +184,42 @@ actor CloudMachineLinkManager {
 
     /// Fire-and-forget: theme parity is cosmetic, so a machine that predates
     /// the defaults verb (or a link that just dropped) must not fail the operation
-    /// that connected it. Pushes chain per machine: each awaits its predecessor and
-    /// reads the colors only then, so a burst of config reloads settles on the
-    /// latest theme instead of racing commands out of order.
+    /// that connected it. While a push is in flight, further requests only mark a
+    /// rerun; the trailing run reads the colors when it starts, so a reload burst
+    /// costs at most one extra command and always lands on the latest theme.
     private func pushHostTheme(machineID: String, socketPath: String) {
+        guard links[machineID] != nil else { return }
+        guard !themePushInFlight.contains(machineID) else {
+            themePushQueued.insert(machineID)
+            return
+        }
+        themePushInFlight.insert(machineID)
+        Task { await self.drainThemePushes(machineID: machineID, socketPath: socketPath) }
+    }
+
+    private func drainThemePushes(machineID: String, socketPath: String) async {
+        repeat {
+            themePushQueued.remove(machineID)
+            await runThemePush(machineID: machineID, socketPath: socketPath)
+        } while themePushQueued.contains(machineID)
+        themePushInFlight.remove(machineID)
+    }
+
+    private func runThemePush(machineID: String, socketPath: String) async {
         guard let link = links[machineID] else { return }
-        let previous = themePushes[machineID]
-        themePushes[machineID] = Task { [hostThemeColors] in
-            await previous?.value
-            guard !Task.isCancelled else { return }
-            guard let colors = await hostThemeColors(),
-                  let arguments = CloudTuiCommandLine.setDefaultColorsArguments(
-                      socketPath: socketPath, foreground: colors.foreground, background: colors.background
-                  ) else { return }
-            do {
-                _ = try await link.run(arguments: arguments)
-                #if DEBUG
-                cmuxDebugLog("cloud.link.theme machine=\(machineID) fg=\(colors.foreground) bg=\(colors.background)")
-                #endif
-            } catch {
-                #if DEBUG
-                cmuxDebugLog("cloud.link.themeFailed machine=\(machineID) error=\(CloudMachineLink.errorText(error))")
-                #endif
-            }
+        guard let colors = await hostThemeColors(),
+              let arguments = CloudTuiCommandLine.setDefaultColorsArguments(
+                  socketPath: socketPath, foreground: colors.foreground, background: colors.background
+              ) else { return }
+        do {
+            _ = try await link.run(arguments: arguments)
+            #if DEBUG
+            cmuxDebugLog("cloud.link.theme machine=\(machineID) fg=\(colors.foreground) bg=\(colors.background)")
+            #endif
+        } catch {
+            #if DEBUG
+            cmuxDebugLog("cloud.link.themeFailed machine=\(machineID) error=\(CloudMachineLink.errorText(error))")
+            #endif
         }
     }
 

--- a/Sources/Cloud/CloudTreeNodeActions.swift
+++ b/Sources/Cloud/CloudTreeNodeActions.swift
@@ -51,7 +51,9 @@ struct CloudTreeNodeActions {
                 do {
                     try await operation(catalog())
                 } catch {
-                    onFailure(String(describing: error))
+                    // Human wording first: the panel now shows this text inline, and a
+                    // raw enum dump ("noProvider(cloud(\"m\"))") explains nothing there.
+                    onFailure((error as? LocalizedError)?.errorDescription ?? String(describing: error))
                 }
                 onDidMutate()
             }

--- a/Sources/Cloud/CloudTuiCommandLine.swift
+++ b/Sources/Cloud/CloudTuiCommandLine.swift
@@ -70,15 +70,17 @@ struct CloudTuiCommandLine: Sendable {
         ["--socket", socketPath, "attach", "--terminal", terminalID]
     }
 
-    /// `set-default-colors [--fg #rrggbb] [--bg #rrggbb]` (spec `set-default-colors`,
-    /// protocol 5): the session defaults every PTY surface renders with unless an
-    /// application on the machine authored its own OSC 10/11. Pushing this Mac's
-    /// resolved Ghostty colors makes remote panes match the local theme.
+    /// `session current terminal defaults set [--foreground #rrggbb] [--background #rrggbb]`
+    /// (spec `session.terminal_defaults.update`): the session defaults every PTY surface
+    /// renders with unless an application on the machine authored its own OSC 10/11.
+    /// Pushing this Mac's resolved Ghostty colors makes remote panes match the local
+    /// theme. (The flat `set-default-colors` verb in spec/commands.md is the protocol
+    /// name; the v2 resource CLI rejects it — verified live against a machine.)
     static func setDefaultColorsArguments(socketPath: String, foreground: String?, background: String?) -> [String]? {
-        var arguments = ["--socket", socketPath, "--json", "set-default-colors"]
-        if let foreground { arguments += ["--fg", foreground] }
-        if let background { arguments += ["--bg", background] }
-        return arguments.count > 4 ? arguments : nil
+        var arguments = ["--socket", socketPath, "--json", "session", "current", "terminal", "defaults", "set"]
+        if let foreground { arguments += ["--foreground", foreground] }
+        if let background { arguments += ["--background", background] }
+        return arguments.count > 8 ? arguments : nil
     }
 
     /// The argv `vm.terminal_new` runs in the machine when the caller gives none: a login

--- a/Sources/Cloud/CloudTuiCommandLine.swift
+++ b/Sources/Cloud/CloudTuiCommandLine.swift
@@ -70,6 +70,17 @@ struct CloudTuiCommandLine: Sendable {
         ["--socket", socketPath, "attach", "--terminal", terminalID]
     }
 
+    /// `set-default-colors [--fg #rrggbb] [--bg #rrggbb]` (spec `set-default-colors`,
+    /// protocol 5): the session defaults every PTY surface renders with unless an
+    /// application on the machine authored its own OSC 10/11. Pushing this Mac's
+    /// resolved Ghostty colors makes remote panes match the local theme.
+    static func setDefaultColorsArguments(socketPath: String, foreground: String?, background: String?) -> [String]? {
+        var arguments = ["--socket", socketPath, "--json", "set-default-colors"]
+        if let foreground { arguments += ["--fg", foreground] }
+        if let background { arguments += ["--bg", background] }
+        return arguments.count > 4 ? arguments : nil
+    }
+
     /// The argv `vm.terminal_new` runs in the machine when the caller gives none: a login
     /// shell in the persistent home.
     static let defaultTerminalCommand = ["bash", "-l"]

--- a/Sources/Cloud/MachinesPanelView.swift
+++ b/Sources/Cloud/MachinesPanelView.swift
@@ -120,12 +120,15 @@ struct MachinesPanelView: View {
                     .foregroundColor(.orange.opacity(0.9))
                     .help(viewModel.lastErrorDescription ?? "")
                 } else if let treeError = viewModel.treeErrorDescription {
-                    HStack(spacing: 5) {
+                    // The message itself, not a generic label: a failed tree verb (New
+                    // Terminal Here, Open Shell, …) otherwise reads as a dead menu item,
+                    // with the only explanation hidden behind a hover tooltip.
+                    HStack(alignment: .firstTextBaseline, spacing: 5) {
                         Image(systemName: "exclamationmark.triangle")
                             .font(.system(size: 10, weight: .semibold))
-                        Text(String(localized: "machines.tree.error", defaultValue: "Cloud tree error"))
+                        Text(treeError)
                             .cmuxFont(size: 11)
-                            .lineLimit(1)
+                            .lineLimit(2)
                             .truncationMode(.tail)
                     }
                     .foregroundColor(.orange.opacity(0.9))

--- a/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
+++ b/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
@@ -13,6 +13,7 @@ final class CmuxTuiSurfaceProviderRegistry {
     private let links: CloudMachineLinkManager
     private var pollTask: Task<Void, Never>?
     private var accessObserver: NSObjectProtocol?
+    private var themeObserver: NSObjectProtocol?
     private var refreshInFlight: Task<Void, Never>?
     /// Same cadence as the Machines panel's list refresh.
     private let pollInterval: Duration = .seconds(45)
@@ -30,6 +31,16 @@ final class CmuxTuiSurfaceProviderRegistry {
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor in await self?.accessDidEnd() }
+        }
+        // A Ghostty config reload can change the resolved theme; re-push it so remote
+        // panes keep matching the local ones (connect-time push covers new links).
+        themeObserver = NotificationCenter.default.addObserver(
+            forName: .ghosttyConfigDidReload,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            Task { await self.links.pushHostThemeToConnectedLinks() }
         }
         pollTask?.cancel()
         pollTask = Task { [weak self] in

--- a/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
+++ b/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
@@ -25,6 +25,9 @@ final class CmuxTuiSurfaceProviderRegistry {
     /// Registers this Mac's cloud machines with the catalog and starts polling.
     func start(catalog: SurfaceCatalog) {
         self.catalog = catalog
+        // Block observers are retained by NotificationCenter: drop the previous
+        // tokens so a re-start never leaves stale callbacks registered.
+        if let accessObserver { NotificationCenter.default.removeObserver(accessObserver) }
         accessObserver = NotificationCenter.default.addObserver(
             forName: .cmuxCloudVMAccessDidEnd,
             object: nil,
@@ -34,6 +37,7 @@ final class CmuxTuiSurfaceProviderRegistry {
         }
         // A Ghostty config reload can change the resolved theme; re-push it so remote
         // panes keep matching the local ones (connect-time push covers new links).
+        if let themeObserver { NotificationCenter.default.removeObserver(themeObserver) }
         themeObserver = NotificationCenter.default.addObserver(
             forName: .ghosttyConfigDidReload,
             object: nil,

--- a/Sources/Surfaces/Workspace+CloudPaneRouting.swift
+++ b/Sources/Surfaces/Workspace+CloudPaneRouting.swift
@@ -1,0 +1,116 @@
+import AppKit
+import Bonsplit
+import Foundation
+
+/// Cmd+D / Cmd+T from a pane that projects a cloud resource create the new terminal ON
+/// that machine — in the same cmux-tui workspace — instead of a local shell. Same rule
+/// as the remote tmux mirror: a "split" next to a remote pane means "another terminal
+/// where that pane lives". The new terminal is created through the machine's provider
+/// (`workspace <ws> run`) and projected back into this workspace at the requested spot,
+/// so the sidebar, the socket, and the shortcut agree on what exists.
+extension Workspace {
+    /// The cloud resource behind a panel, when the panel projects one.
+    func cloudProjectedResource(forPanel panelID: UUID) -> SurfaceResource? {
+        let catalog = SurfaceCatalog.shared
+        guard let projection = catalog.projection(forPanel: panelID),
+              projection.workspaceID == id,
+              !projection.resource.machine.isLocal else { return nil }
+        return catalog.resource(forPanel: panelID)
+    }
+
+    /// The cloud resource behind the selected tab of a pane (the Cmd+T anchor).
+    func cloudProjectedResource(inPane paneID: PaneID) -> SurfaceResource? {
+        guard let selectedTabID = bonsplitController.selectedTab(inPane: paneID)?.id,
+              let panelID = panelIdFromSurfaceId(selectedTabID) else { return nil }
+        return cloudProjectedResource(forPanel: panelID)
+    }
+
+    /// Routes a Cmd+D-style split from a cloud-projected panel to its machine.
+    /// Returns false when the source panel is not a cloud projection (create locally).
+    func routeCloudPaneTerminalSplit(
+        from panelID: UUID,
+        orientation: SplitOrientation,
+        insertFirst: Bool,
+        focus: Bool
+    ) -> Bool {
+        guard let resource = cloudProjectedResource(forPanel: panelID),
+              let paneID = paneId(forPanelId: panelID) else { return false }
+        let direction: SurfaceSplitDirection = orientation == .horizontal
+            ? (insertFirst ? .left : .right)
+            : (insertFirst ? .up : .down)
+        return routeCloudPaneTerminalCreate(
+            near: resource,
+            destination: .split(workspaceID: id, paneID: paneID.id.uuidString, direction: direction),
+            focus: focus
+        )
+    }
+
+    /// Routes a bonsplit UI split (the pane-divider split button) whose source pane
+    /// projects a cloud resource: the already-created empty pane receives the machine's
+    /// new terminal as its first tab. Returns false when the source is not cloud-anchored.
+    func routeCloudPaneUISplit(from sourcePanelID: UUID, into newPane: PaneID) -> Bool {
+        guard let resource = cloudProjectedResource(forPanel: sourcePanelID) else { return false }
+        return routeCloudPaneTerminalCreate(
+            near: resource,
+            destination: .tab(workspaceID: id, paneID: newPane.id.uuidString, index: nil),
+            focus: true
+        )
+    }
+
+    /// Routes a Cmd+T-style new tab in a pane whose selected tab projects a cloud
+    /// resource to that machine. Returns false when the pane is not cloud-anchored.
+    func routeCloudPaneTerminalTab(inPane paneID: PaneID, focus: Bool) -> Bool {
+        guard let resource = cloudProjectedResource(inPane: paneID) else { return false }
+        return routeCloudPaneTerminalCreate(
+            near: resource,
+            destination: .tab(workspaceID: id, paneID: paneID.id.uuidString, index: nil),
+            focus: focus
+        )
+    }
+
+    /// Creates a terminal on `resource`'s machine (in the remote workspace of the
+    /// anchor's first view, when it has one) and projects it at `destination`.
+    /// Optimistic like the cloud tree's "New Terminal Here": the pane appears when the
+    /// machine reports the terminal; a failure is announced instead of silently doing
+    /// nothing, because the user's gesture otherwise looks dead.
+    private func routeCloudPaneTerminalCreate(
+        near resource: SurfaceResource,
+        destination: SurfaceDestination,
+        focus: Bool
+    ) -> Bool {
+        let catalog = SurfaceCatalog.shared
+        guard let provider = catalog.provider(for: resource.machine) else { return false }
+        let remoteWorkspaceID = resource.remoteWorkspaces.first?.id
+        let machine = resource.machine
+        Task { @MainActor in
+            do {
+                let created = try await provider.createTerminal(
+                    command: nil, cwd: nil, name: nil, remoteWorkspaceID: remoteWorkspaceID
+                )
+                _ = try await catalog.project(created.id, into: destination, focus: focus, reuseExisting: true)
+            } catch {
+                Self.presentCloudPaneCreationFailure(machine: machine, error: error)
+            }
+        }
+        return true
+    }
+
+    @MainActor
+    private static func presentCloudPaneCreationFailure(machine: SurfaceMachineID, error: Error) {
+        #if DEBUG
+        cmuxDebugLog("cloud.pane.createFailed machine=\(machine.rawValue) error=\(String(reflecting: error))")
+        #endif
+        let alert = NSAlert()
+        alert.messageText = String(
+            format: String(
+                localized: "cloudPane.newTerminalFailed.title",
+                defaultValue: "Couldn’t start a terminal on %@"
+            ),
+            machine.rawValue
+        )
+        alert.informativeText = CloudMachineLink.errorText(error)
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: String(localized: "cloudPane.newTerminalFailed.ok", defaultValue: "OK"))
+        alert.runModal()
+    }
+}

--- a/Sources/Surfaces/Workspace+CloudPaneRouting.swift
+++ b/Sources/Surfaces/Workspace+CloudPaneRouting.swift
@@ -80,7 +80,14 @@ extension Workspace {
     ) -> Bool {
         let catalog = SurfaceCatalog.shared
         guard let provider = catalog.provider(for: resource.machine) else { return false }
-        let remoteWorkspaceID = resource.remoteWorkspaces.first?.id
+        // The attach pane shows the TERMINAL, not one of its views, so with
+        // multiple views there is no single "anchor's" remote workspace. Prefer
+        // the daemon-focused workspace among the anchor's own views (the one the
+        // user is most plausibly working in), else its first view in daemon
+        // order; a viewless pool terminal passes nil and the provider falls back
+        // to the machine's focused workspace.
+        let anchorWorkspaces = resource.remoteWorkspaces
+        let remoteWorkspaceID = (anchorWorkspaces.first(where: \.focused) ?? anchorWorkspaces.first)?.id
         let machine = resource.machine
         Task { @MainActor in
             do {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -8571,6 +8571,16 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
             ) ?? false
             return routed ? .routedToRemote : .failed
         }
+        // A split next to a pane projecting a cloud resource creates the terminal ON
+        // that machine and projects it back (Workspace+CloudPaneRouting). Only plain
+        // requests route: an explicit command, cwd, PTY session, or restore scaffold
+        // is a local-terminal request by construction (including the attach panes the
+        // routed create itself materializes, whose initialCommand is the attach argv).
+        if initialCommand == nil, tmuxStartCommand == nil, remotePTYSessionID == nil,
+           workingDirectory == nil, !suppressWorkspaceRemoteStartupCommand,
+           routeCloudPaneTerminalSplit(from: panelId, orientation: orientation, insertFirst: insertFirst, focus: focus) {
+            return .routedToRemote
+        }
         guard let panel = newTerminalSplitLocal(
             from: panelId,
             orientation: orientation,
@@ -8882,6 +8892,17 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
                     focus: focus ?? (bonsplitController.focusedPaneId == paneId)
                 ) ?? false
             return routed ? .routedToRemote : .failed
+        }
+        // A new tab in a pane whose selected tab projects a cloud resource creates the
+        // terminal ON that machine (Workspace+CloudPaneRouting). Only plain requests
+        // route; an explicit command, cwd, input, restore payload, or PTY session is a
+        // local-terminal request by construction (including the attach panes the routed
+        // create itself materializes, whose initialCommand is the attach argv).
+        if initialCommand == nil, tmuxStartCommand == nil, remotePTYSessionID == nil,
+           workingDirectory == nil, initialInput == nil, startupRestoreAgent == nil,
+           restoredSurfaceId == nil, !suppressWorkspaceRemoteStartupCommand,
+           routeCloudPaneTerminalTab(inPane: paneId, focus: focus ?? (bonsplitController.focusedPaneId == paneId)) {
+            return .routedToRemote
         }
         guard let panel = newTerminalSurfaceLocal(
             inPane: paneId,
@@ -14260,6 +14281,15 @@ extension Workspace: BonsplitDelegate {
         // (or fall back to defaults) instead of leaving an empty selector pane.
         let sourceTabId = controller.selectedTab(inPane: originalPane)?.id
         let sourcePanelId = sourceTabId.flatMap { panelIdFromSurfaceId($0) }
+
+        // Same rule as Cmd+D: a UI split next to a cloud-projected pane continues on that
+        // machine (Workspace+CloudPaneRouting). The new pane already exists and is empty;
+        // the machine's terminal arrives as its first tab when the projection materializes.
+        if let sourcePanelId,
+           routeCloudPaneUISplit(from: sourcePanelId, into: newPane) {
+            scheduleTerminalGeometryReconcile()
+            return
+        }
 
 #if DEBUG
         cmuxDebugLog(

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2793,6 +2793,7 @@
 		A6AC73020000000000000001 /* Workspace+AgentLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6AC73020000000000000002 /* Workspace+AgentLifecycle.swift */; };
 		8777E0018777E0018777E001 /* Workspace+AttentionFlashRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8777E0028777E0028777E002 /* Workspace+AttentionFlashRouting.swift */; };
 		CA52B0150000000000000000 /* Workspace+CanvasLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA52C0150000000000000000 /* Workspace+CanvasLayout.swift */; };
+		65221C81A129236D52702D99 /* Workspace+CloudPaneRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5797FE9CD70513E4FFAC6EB /* Workspace+CloudPaneRouting.swift */; };
 		C54860020000000000000001 /* Workspace+CmuxNavigationDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54860020000000000000002 /* Workspace+CmuxNavigationDescriptor.swift */; };
 		A5FB120D /* Workspace+CustomLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5FB120E /* Workspace+CustomLayout.swift */; };
 		C57B00030000000000000001 /* Workspace+CustomSidebarPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57B00030000000000000002 /* Workspace+CustomSidebarPane.swift */; };
@@ -5734,6 +5735,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		A6AC73020000000000000002 /* Workspace+AgentLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+AgentLifecycle.swift"; sourceTree = "<group>"; };
 		8777E0028777E0028777E002 /* Workspace+AttentionFlashRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+AttentionFlashRouting.swift"; sourceTree = "<group>"; };
 		CA52C0150000000000000000 /* Workspace+CanvasLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CanvasLayout.swift"; sourceTree = "<group>"; };
+		C5797FE9CD70513E4FFAC6EB /* Workspace+CloudPaneRouting.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Workspace+CloudPaneRouting.swift"; sourceTree = "<group>"; };
 		C54860020000000000000002 /* Workspace+CmuxNavigationDescriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CmuxNavigationDescriptor.swift"; sourceTree = "<group>"; };
 		A5FB120E /* Workspace+CustomLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CustomLayout.swift"; sourceTree = "<group>"; };
 		C57B00030000000000000002 /* Workspace+CustomSidebarPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CustomSidebarPane.swift"; sourceTree = "<group>"; };
@@ -6289,6 +6291,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				660286CE22B478E887361407 /* SurfaceCatalog+Groups.swift */,
 				278BEFB3583AED9627966DFF /* SurfaceSocketCommands.swift */,
 				47BBA1A8703756FDDFD53CF3 /* Workspace+SurfaceCatalog.swift */,
+				C5797FE9CD70513E4FFAC6EB /* Workspace+CloudPaneRouting.swift */,
 				1EDD243C7C87A2AB78B12BAD /* LocalSurfaceProvider.swift */,
 				63F5BDFB110A8A96C9CA0A75 /* CmuxTuiSurfaceProviders.swift */,
 				1FE7223A65E72C46927A4F02 /* SurfacePaneFactory.swift */,
@@ -11305,6 +11308,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				A6AC73020000000000000001 /* Workspace+AgentLifecycle.swift in Sources */,
 				8777E0018777E0018777E001 /* Workspace+AttentionFlashRouting.swift in Sources */,
 				CA52B0150000000000000000 /* Workspace+CanvasLayout.swift in Sources */,
+				65221C81A129236D52702D99 /* Workspace+CloudPaneRouting.swift in Sources */,
 				C54860020000000000000001 /* Workspace+CmuxNavigationDescriptor.swift in Sources */,
 				A5FB120D /* Workspace+CustomLayout.swift in Sources */,
 				C57B00030000000000000001 /* Workspace+CustomSidebarPane.swift in Sources */,

--- a/cmuxTests/CmuxTuiSurfaceProviderTests.swift
+++ b/cmuxTests/CmuxTuiSurfaceProviderTests.swift
@@ -232,11 +232,13 @@ import Testing
         // Rename takes the name via --name (verified live; positional is usage.invalid).
         #expect(CloudTuiCommandLine.renameWorkspaceArguments(socketPath: "/k.sock", workspaceID: "ws_main", name: "backend work") ==
             ["--socket", "/k.sock", "--json", "workspace", "ws_main", "rename", "--name", "backend work"])
+        // Verified live: the flat `set-default-colors` verb is `usage.invalid` in the v2
+        // resource CLI; the session-scoped form below is the one machines accept.
         #expect(CloudTuiCommandLine.setDefaultColorsArguments(socketPath: "/k.sock", foreground: "#d8dee9", background: "#171b2e") ==
-            ["--socket", "/k.sock", "--json", "set-default-colors", "--fg", "#d8dee9", "--bg", "#171b2e"])
+            ["--socket", "/k.sock", "--json", "session", "current", "terminal", "defaults", "set", "--foreground", "#d8dee9", "--background", "#171b2e"])
         #expect(CloudTuiCommandLine.setDefaultColorsArguments(socketPath: "/k.sock", foreground: nil, background: "#171b2e") ==
-            ["--socket", "/k.sock", "--json", "set-default-colors", "--bg", "#171b2e"])
-        // No colors, no command: pushing an empty set-default-colors would be a no-op round trip.
+            ["--socket", "/k.sock", "--json", "session", "current", "terminal", "defaults", "set", "--background", "#171b2e"])
+        // No colors, no command: pushing an empty defaults update would be a no-op round trip.
         #expect(CloudTuiCommandLine.setDefaultColorsArguments(socketPath: "/k.sock", foreground: nil, background: nil) == nil)
     }
 

--- a/cmuxTests/CmuxTuiSurfaceProviderTests.swift
+++ b/cmuxTests/CmuxTuiSurfaceProviderTests.swift
@@ -232,6 +232,12 @@ import Testing
         // Rename takes the name via --name (verified live; positional is usage.invalid).
         #expect(CloudTuiCommandLine.renameWorkspaceArguments(socketPath: "/k.sock", workspaceID: "ws_main", name: "backend work") ==
             ["--socket", "/k.sock", "--json", "workspace", "ws_main", "rename", "--name", "backend work"])
+        #expect(CloudTuiCommandLine.setDefaultColorsArguments(socketPath: "/k.sock", foreground: "#d8dee9", background: "#171b2e") ==
+            ["--socket", "/k.sock", "--json", "set-default-colors", "--fg", "#d8dee9", "--bg", "#171b2e"])
+        #expect(CloudTuiCommandLine.setDefaultColorsArguments(socketPath: "/k.sock", foreground: nil, background: "#171b2e") ==
+            ["--socket", "/k.sock", "--json", "set-default-colors", "--bg", "#171b2e"])
+        // No colors, no command: pushing an empty set-default-colors would be a no-op round trip.
+        #expect(CloudTuiCommandLine.setDefaultColorsArguments(socketPath: "/k.sock", foreground: nil, background: nil) == nil)
     }
 
     @Test func clientPathsMirrorTheCLI() throws {


### PR DESCRIPTION
Fixes three cloud-terminal gaps reported while dogfooding the Cloud sidebar.

**Remote terminals now respect the local Ghostty theme.** Panes attached through the machine link render `cmux-tui attach`, which paints the machine session's default colors as explicit RGB, so the local theme never showed. On every link connect (and again on each `.ghosttyConfigDidReload`) the app pushes its resolved default foreground/background to the machine with the spec operation `session.terminal_defaults.update` (`session current terminal defaults set`). Live attach panes repaint via `colors-changed`; application-authored OSC 10/11 on the machine stays authoritative; non-overridden palette indexes already pass through to the local Ghostty palette. Verified against a live dev machine: push accepted (revision bump, snapshot shows the Mac's colors), `cloud.link.theme machine=quiet-seal fg=#FDFFF1 bg=#272822` in the debug log. Note: the flat `set-default-colors` CLI verb documented in `cmux-tui/spec/commands.md` is rejected by the v2 resource CLI (`usage.invalid`, verified live); the session-scoped form is what machines accept.

**Cmd+D / Cmd+Shift+D / Cmd+T / pane-divider split next to a cloud pane now create the terminal ON that machine**, in the same cmux-tui workspace as the anchor pane, projected back at the requested spot (same optimistic path as the tree's New Terminal Here) — previously they spawned a local shell beside remote panes. Routing is per-pane: only plain requests route; an explicit command, cwd, initial input, restore payload, or PTY session stays local by construction, which also keeps the attach panes the routed create itself materializes local. A routed create that fails shows an alert instead of a dead keystroke. Verified live through the shared socket entrypoints (`new-split`, `new-surface`): each created a new `term_…` on the machine in the same remote workspace and the pane attached to it.

**Cloud tree operation failures are now visible.** `New Terminal Here` and the other tree verbs swallowed every error into a hover tooltip on a generic label, so any failure read as a dead menu item. The panel now shows the error text inline and prefers `LocalizedError` wording over raw enum dumps. The reported 'right click new terminal here doesn't work' could not be reproduced at head (the action chain works against a live machine); with this change a recurrence explains itself on screen.

Known gaps, deliberately out of scope: new BROWSER panes in a cloud-projected workspace are still local (remote browsers are port-backed; a generic remote browser needs the machine proxy design), and the `.routedToRemote` socket reply still says 'routed to remote tmux' even when the route went to a cloud machine.

Heads-up for reviewers: **main is currently unbuildable on the reload/CI toolchain** — #10326's CmuxGit changes fail to compile (`Darwin.stat` shadowing, `byteCount`/`usesGitPlumbing` mismatches). This PR's dogfood builds reverted #10326 locally; the revert is not part of this branch. CI on this PR will stay red until main is fixed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three cloud-terminal gaps: remote panes now match the local Ghostty theme, Cmd+D/Cmd+T and pane-divider splits next to a cloud pane create the terminal on that machine, and cloud tree failures show their error text inline.

**New Features**
- Plain splits and tabs from a cloud-projected pane route to that machine's workspace via the provider and project back at the requested spot; explicit command, cwd, input, restore payload, or PTY session requests stay local.
- A routed create prefers the anchor's daemon-focused remote workspace when its pane has multiple views, and a create that fails shows an alert instead of a dead gesture.

**Bug Fixes**
- Pushes the resolved Ghostty default fg/bg to connected machines on link connect and config reload using `session terminal defaults set`; coalesces pushes to one in-flight plus one trailing rerun per machine so reload bursts settle on the latest theme, and live attach panes repaint but application-authored OSC 10/11 stays authoritative.
- Tree verb failures now show the `LocalizedError` message inline instead of a generic label with a hover tooltip.

Known gaps: new BROWSER panes in a cloud-projected workspace remain local, and the `.routedToRemote` socket reply still says "routed to remote tmux" for cloud machines. Note: main is currently unbuildable (CmuxGit changes from #10326), so CI on this PR will stay red until main is fixed.

<sup>Written for commit 05d534c4605b9cd575690c3b3c8e306f18136a16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Terminal splits and new tabs created from cloud-connected panes now open on the corresponding remote machine.
  - Connected cloud machines automatically receive the current terminal theme, including updates after configuration changes.

- **Bug Fixes**
  - Cloud launch failures now show clear, localized messages with an acknowledgment option.
  - Cloud pane errors display specific error details instead of a generic message.
  - Error reporting now provides more readable descriptions when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->