### PR TITLE
Make PortScanner burst scheduling cancellable

### DIFF
--- a/Sources/PortScanner+Process.swift
+++ b/Sources/PortScanner+Process.swift
@@ -536,6 +536,22 @@ extension PortScanner {
     }
 
     func runLsof(pidsCsv: String) async -> PortLsofScanResult {
+        let pids = pidsCsv.split(separator: ",").compactMap { Int($0) }
+        guard pids.count > 256 else { return await runLsofChunk(pidsCsv: pidsCsv) }
+        var values: [Int: Set<Int>] = [:]
+        var incomplete: Set<Int> = []
+        var complete = true
+        for start in stride(from: 0, to: pids.count, by: 256) {
+            let chunk = pids[start..<min(start + 256, pids.count)]
+            let result = await runLsofChunk(pidsCsv: chunk.map(String.init).joined(separator: ","))
+            for (pid, ports) in result.values { values[pid, default: []].formUnion(ports) }
+            incomplete.formUnion(result.incompletePIDs)
+            complete = complete && result.globallyComplete
+        }
+        return PortLsofScanResult(values: values, globallyComplete: complete, incompletePIDs: incomplete)
+    }
+
+    private func runLsofChunk(pidsCsv: String) async -> PortLsofScanResult {
         let result = await commandRunner.run(
             directory: "/",
             executable: "/usr/sbin/lsof",

--- a/Sources/PortScanner+Process.swift
+++ b/Sources/PortScanner+Process.swift
@@ -541,8 +541,19 @@ extension PortScanner {
         var values: [Int: Set<Int>] = [:]
         var incomplete: Set<Int> = []
         var complete = true
-        for start in stride(from: 0, to: pids.count, by: 256) {
-            let chunk = pids[start..<min(start + 256, pids.count)]
+        var chunk: [Int] = []
+        for pid in pids {
+            let candidate = chunk + [pid]
+            let csv = candidate.map(String.init).joined(separator: ",")
+            if !chunk.isEmpty && csv.utf8.count + Self.lsofArgumentOverhead > Self.lsofArgumentByteBudget {
+                let result = await runLsofChunk(pidsCsv: chunk.map(String.init).joined(separator: ","))
+                for (pid, ports) in result.values { values[pid, default: []].formUnion(ports) }
+                incomplete.formUnion(result.incompletePIDs)
+                complete = complete && result.globallyComplete
+                chunk = [pid]
+            } else { chunk = candidate }
+        }
+        if !chunk.isEmpty {
             let result = await runLsofChunk(pidsCsv: chunk.map(String.init).joined(separator: ","))
             for (pid, ports) in result.values { values[pid, default: []].formUnion(ports) }
             incomplete.formUnion(result.incompletePIDs)
@@ -550,6 +561,9 @@ extension PortScanner {
         }
         return PortLsofScanResult(values: values, globallyComplete: complete, incompletePIDs: incomplete)
     }
+
+    private static let lsofArgumentByteBudget = 32 * 1024
+    private static let lsofArgumentOverhead = 256
 
     private func runLsofChunk(pidsCsv: String) async -> PortLsofScanResult {
         let result = await commandRunner.run(

--- a/Sources/PortScanner+Process.swift
+++ b/Sources/PortScanner+Process.swift
@@ -541,19 +541,7 @@ extension PortScanner {
         var values: [Int: Set<Int>] = [:]
         var incomplete: Set<Int> = []
         var complete = true
-        var chunk: [Int] = []
-        for pid in pids {
-            let candidate = chunk + [pid]
-            let csv = candidate.map(String.init).joined(separator: ",")
-            if !chunk.isEmpty && csv.utf8.count + Self.lsofArgumentOverhead > Self.lsofArgumentByteBudget {
-                let result = await runLsofChunk(pidsCsv: chunk.map(String.init).joined(separator: ","))
-                for (pid, ports) in result.values { values[pid, default: []].formUnion(ports) }
-                incomplete.formUnion(result.incompletePIDs)
-                complete = complete && result.globallyComplete
-                chunk = [pid]
-            } else { chunk = candidate }
-        }
-        if !chunk.isEmpty {
+        for chunk in Self.lsofPIDChunks(pids) {
             let result = await runLsofChunk(pidsCsv: chunk.map(String.init).joined(separator: ","))
             for (pid, ports) in result.values { values[pid, default: []].formUnion(ports) }
             incomplete.formUnion(result.incompletePIDs)
@@ -562,8 +550,34 @@ extension PortScanner {
         return PortLsofScanResult(values: values, globallyComplete: complete, incompletePIDs: incomplete)
     }
 
-    private static let lsofArgumentByteBudget = 32 * 1024
-    private static let lsofArgumentOverhead = 256
+    // Keep the complete argv entry below the platform's practical exec limit.
+    // The chunk builder below accounts for separators as it appends, so it
+    // never copies or re-serializes the growing prefix.
+    static let lsofArgumentByteBudget = 32 * 1024
+    static let lsofArgumentOverhead = 256
+
+    static func lsofPIDChunks(_ pids: [Int]) -> [[Int]] {
+        guard !pids.isEmpty else { return [] }
+        var chunks: [[Int]] = []
+        var chunk: [Int] = []
+        var chunkBytes = 0
+        for pid in pids {
+            let pidBytes = String(pid).utf8.count
+            let additionalBytes = chunk.isEmpty ? pidBytes : pidBytes + 1
+            if !chunk.isEmpty,
+               chunkBytes + additionalBytes + lsofArgumentOverhead > lsofArgumentByteBudget
+            {
+                chunks.append(chunk)
+                chunk = []
+                chunkBytes = 0
+            }
+            let separatorBytes = chunk.isEmpty ? 0 : 1
+            chunk.append(pid)
+            chunkBytes += pidBytes + separatorBytes
+        }
+        if !chunk.isEmpty { chunks.append(chunk) }
+        return chunks
+    }
 
     private func runLsofChunk(pidsCsv: String) async -> PortLsofScanResult {
         let result = await commandRunner.run(

--- a/Sources/PortScanner.swift
+++ b/Sources/PortScanner.swift
@@ -67,6 +67,12 @@ final class PortScanner: @unchecked Sendable {
     /// Whether a burst sequence is currently running.
     private var burstActive = false
 
+    /// Generation invalidates callbacks that were queued before a panel
+    /// lifecycle changed. The queue is the sole owner, so cancellation and
+    /// generation checks are deterministic and race-free.
+    private var burstGeneration: UInt64 = 0
+    private var scheduledBurstWorkItems: [DispatchWorkItem] = []
+
     private var coalesceTimer: DispatchSourceTimer?
 
     /// Periodic timer for agent-owned process trees that aren't attached to a TTY.
@@ -131,6 +137,12 @@ final class PortScanner: @unchecked Sendable {
         let key = PanelKey(workspaceId: workspaceId, panelId: panelId)
         publicationState.invalidatePanelLifecycle(for: key)
         queue.async { [self] in
+            burstGeneration &+= 1
+            scheduledBurstWorkItems.forEach { $0.cancel() }
+            scheduledBurstWorkItems.removeAll()
+            burstActive = false
+            coalesceTimer?.cancel()
+            coalesceTimer = nil
             ttyNames.removeValue(forKey: key)
             panelRevisionByKey.removeValue(forKey: key)
             pendingKicks.remove(key)
@@ -139,6 +151,9 @@ final class PortScanner: @unchecked Sendable {
             }
             panelPortSnapshot.remove(keys: [key])
             panelPortOwnersByKey.removeValue(forKey: key)
+            if !pendingKicks.isEmpty {
+                startCoalesce()
+            }
         }
     }
 
@@ -224,11 +239,12 @@ final class PortScanner: @unchecked Sendable {
 
         guard !pendingKicks.isEmpty else { return }
         burstActive = true
-        runBurst(index: 0)
+        runBurst(index: 0, generation: burstGeneration)
     }
 
-    private func runBurst(index: Int, burstStart: DispatchTime? = nil) {
+    private func runBurst(index: Int, burstStart: DispatchTime? = nil, generation: UInt64) {
         // Already on `queue`.
+        guard generation == burstGeneration else { return }
         guard index < Self.burstOffsets.count else {
             burstActive = false
             // If new kicks arrived during the burst, start a new coalesce cycle.
@@ -240,11 +256,15 @@ final class PortScanner: @unchecked Sendable {
 
         let start = burstStart ?? .now()
         let deadline = start + Self.burstOffsets[index]
-        queue.asyncAfter(deadline: deadline) { [weak self] in
+        let workItem = DispatchWorkItem { [weak self] in
             guard let self else { return }
+            guard generation == self.burstGeneration else { return }
             self.runScan()
-            self.runBurst(index: index + 1, burstStart: start)
+            self.scheduledBurstWorkItems.removeAll { $0.isCancelled }
+            self.runBurst(index: index + 1, burstStart: start, generation: generation)
         }
+        scheduledBurstWorkItems.append(workItem)
+        queue.asyncAfter(deadline: deadline, execute: workItem)
     }
 
     // MARK: - Scan

--- a/Sources/PortScanner.swift
+++ b/Sources/PortScanner.swift
@@ -521,6 +521,7 @@ final class PortScanner: @unchecked Sendable {
 
         queue.async { [weak self] in
             self?.completePanelScan(
+                generation: generation,
                 panelResults,
                 panelTTYs: panelSnapshot,
                 panelRevisions: panelRevisions,

--- a/Sources/PortScanner.swift
+++ b/Sources/PortScanner.swift
@@ -71,7 +71,7 @@ final class PortScanner: @unchecked Sendable {
     /// lifecycle changed. The queue is the sole owner, so cancellation and
     /// generation checks are deterministic and race-free.
     private var burstGeneration: UInt64 = 0
-    private var scheduledBurstWorkItems: [DispatchWorkItem] = []
+    private var scheduledBurstTimers: [UUID: DispatchSourceTimer] = [:]
 
     private var coalesceTimer: DispatchSourceTimer?
 
@@ -137,12 +137,6 @@ final class PortScanner: @unchecked Sendable {
         let key = PanelKey(workspaceId: workspaceId, panelId: panelId)
         publicationState.invalidatePanelLifecycle(for: key)
         queue.async { [self] in
-            burstGeneration &+= 1
-            scheduledBurstWorkItems.forEach { $0.cancel() }
-            scheduledBurstWorkItems.removeAll()
-            burstActive = false
-            coalesceTimer?.cancel()
-            coalesceTimer = nil
             ttyNames.removeValue(forKey: key)
             panelRevisionByKey.removeValue(forKey: key)
             pendingKicks.remove(key)
@@ -151,7 +145,14 @@ final class PortScanner: @unchecked Sendable {
             }
             panelPortSnapshot.remove(keys: [key])
             panelPortOwnersByKey.removeValue(forKey: key)
-            if !pendingKicks.isEmpty {
+            if ttyNames.isEmpty {
+                burstGeneration &+= 1
+                scheduledBurstTimers.values.forEach { $0.cancel() }
+                scheduledBurstTimers.removeAll()
+                burstActive = false
+                coalesceTimer?.cancel()
+                coalesceTimer = nil
+            } else if !pendingKicks.isEmpty, !burstActive {
                 startCoalesce()
             }
         }
@@ -182,16 +183,6 @@ final class PortScanner: @unchecked Sendable {
         }
     }
 
-    /// Waits until all scanner-queue mutations submitted before this call have
-    /// completed. This is intentionally a queue barrier, not a wall-clock
-    /// delay, so lifecycle tests do not depend on timer timing.
-    func waitForIdleForTesting() async {
-        await withCheckedContinuation { continuation in
-            queue.async {
-                continuation.resume()
-            }
-        }
-    }
     @MainActor
     func refreshAgentPorts(workspaceId: UUID, agentRoots: Set<AgentPortRootIdentity>) {
         let normalizedRoots = Set(agentRoots.filter { $0.pid > 0 })
@@ -267,15 +258,19 @@ final class PortScanner: @unchecked Sendable {
 
         let start = burstStart ?? .now()
         let deadline = start + Self.burstOffsets[index]
-        let workItem = DispatchWorkItem { [weak self] in
+        let timerID = UUID()
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(deadline: deadline)
+        timer.setEventHandler { [weak self, weak timer] in
             guard let self else { return }
             guard generation == self.burstGeneration else { return }
+            self.scheduledBurstTimers.removeValue(forKey: timerID)
+            timer?.cancel()
             self.runScan(generation: generation)
-            self.scheduledBurstWorkItems.removeAll { $0.isCancelled }
             self.runBurst(index: index + 1, burstStart: start, generation: generation)
         }
-        scheduledBurstWorkItems.append(workItem)
-        queue.asyncAfter(deadline: deadline, execute: workItem)
+        scheduledBurstTimers[timerID] = timer
+        timer.resume()
     }
 
     // MARK: - Scan

--- a/Sources/PortScanner.swift
+++ b/Sources/PortScanner.swift
@@ -275,8 +275,12 @@ final class PortScanner: @unchecked Sendable {
 
     // MARK: - Scan
 
-    private func runScan(generation: UInt64 = 0) {
+    private func runScan(generation requestedGeneration: UInt64? = nil) {
         // Already on `queue`. Snapshot which panels to scan and their TTYs.
+        // Capture the current burst generation at the scheduling boundary. A
+        // default sentinel (such as zero) can accidentally accept a stale
+        // completion when the first burst has been invalidated.
+        let generation = requestedGeneration ?? burstGeneration
         // We scan all registered panels, not just pending ones, since ports can
         // appear/disappear on any panel.
         let panelSnapshot = ttyNames
@@ -545,7 +549,7 @@ final class PortScanner: @unchecked Sendable {
     }
 
     /// Applies a completed panel scan on the scanner queue and starts any pending scan.
-    private func completePanelScan(
+    func completePanelScan(
         generation: UInt64,
         _ panelResults: [(PanelKey, [Int])],
         panelTTYs: [PanelKey: String],
@@ -567,27 +571,29 @@ final class PortScanner: @unchecked Sendable {
         requestID: UInt64
     ) {
         let hasPendingScan = scanCoordination.finishPanelScan()
-        guard generation == burstGeneration else { return }
-        deliverResults(
-            panelResults,
-            panelTTYs: panelTTYs,
-            panelRevisions: panelRevisions,
-            workspaceIds: workspaceIds,
-            agentPortsByWorkspace: agentPortsByWorkspace,
-            panelPortOwnersByKey: panelPortOwnersByKey,
-            panelProcessIdentitiesByKey: panelProcessIdentitiesByKey,
-            agentPortOwnersByWorkspace: agentPortOwnersByWorkspace,
-            agentProcessIdentitiesByWorkspace: agentProcessIdentitiesByWorkspace,
-            agentRevisions: agentRevisions,
-            panelCompletenessByKey: panelCompletenessByKey,
-            panelProcessScopeCompletenessByKey: panelProcessScopeCompletenessByKey,
-            agentCompletenessByWorkspace: agentCompletenessByWorkspace,
-            agentProcessScopeCompletenessByWorkspace: agentProcessScopeCompletenessByWorkspace,
-            panelLsofEvidence: panelLsofEvidence,
-            agentLsofEvidence: agentLsofEvidence,
-            inspectedPIDs: inspectedPIDs,
-            requestID: requestID
-        )
+        let isCurrentGeneration = generation == burstGeneration
+        if isCurrentGeneration {
+            deliverResults(
+                panelResults,
+                panelTTYs: panelTTYs,
+                panelRevisions: panelRevisions,
+                workspaceIds: workspaceIds,
+                agentPortsByWorkspace: agentPortsByWorkspace,
+                panelPortOwnersByKey: panelPortOwnersByKey,
+                panelProcessIdentitiesByKey: panelProcessIdentitiesByKey,
+                agentPortOwnersByWorkspace: agentPortOwnersByWorkspace,
+                agentProcessIdentitiesByWorkspace: agentProcessIdentitiesByWorkspace,
+                agentRevisions: agentRevisions,
+                panelCompletenessByKey: panelCompletenessByKey,
+                panelProcessScopeCompletenessByKey: panelProcessScopeCompletenessByKey,
+                agentCompletenessByWorkspace: agentCompletenessByWorkspace,
+                agentProcessScopeCompletenessByWorkspace: agentProcessScopeCompletenessByWorkspace,
+                panelLsofEvidence: panelLsofEvidence,
+                agentLsofEvidence: agentLsofEvidence,
+                inspectedPIDs: inspectedPIDs,
+                requestID: requestID
+            )
+        }
         if hasPendingScan {
             runScan(generation: burstGeneration)
         }

--- a/Sources/PortScanner.swift
+++ b/Sources/PortScanner.swift
@@ -70,8 +70,7 @@ final class PortScanner: @unchecked Sendable {
     /// Generation invalidates callbacks that were queued before a panel
     /// lifecycle changed. The queue is the sole owner, so cancellation and
     /// generation checks are deterministic and race-free.
-    private var burstGeneration: UInt64 = 0
-    private var scheduledBurstWorkItems: [DispatchWorkItem] = []
+    private var scheduledBurstTimers: [UUID: DispatchSourceTimer] = [:]
 
     private var coalesceTimer: DispatchSourceTimer?
 
@@ -137,12 +136,9 @@ final class PortScanner: @unchecked Sendable {
         let key = PanelKey(workspaceId: workspaceId, panelId: panelId)
         publicationState.invalidatePanelLifecycle(for: key)
         queue.async { [self] in
-            burstGeneration &+= 1
-            scheduledBurstWorkItems.forEach { $0.cancel() }
-            scheduledBurstWorkItems.removeAll()
-            burstActive = false
-            coalesceTimer?.cancel()
-            coalesceTimer = nil
+            // A panel unregister must not cancel scans for other panels.
+            // The next scan snapshots the remaining registered panels.
+            pendingKicks.remove(key)
             ttyNames.removeValue(forKey: key)
             panelRevisionByKey.removeValue(forKey: key)
             pendingKicks.remove(key)
@@ -239,32 +235,30 @@ final class PortScanner: @unchecked Sendable {
 
         guard !pendingKicks.isEmpty else { return }
         burstActive = true
-        runBurst(index: 0, generation: burstGeneration)
+        runBurst(index: 0)
     }
 
-    private func runBurst(index: Int, burstStart: DispatchTime? = nil, generation: UInt64) {
+    private func runBurst(index: Int, burstStart: DispatchTime? = nil) {
         // Already on `queue`.
-        guard generation == burstGeneration else { return }
         guard index < Self.burstOffsets.count else {
             burstActive = false
-            // If new kicks arrived during the burst, start a new coalesce cycle.
-            if !pendingKicks.isEmpty {
-                startCoalesce()
-            }
+            if !pendingKicks.isEmpty { startCoalesce() }
             return
         }
 
         let start = burstStart ?? .now()
-        let deadline = start + Self.burstOffsets[index]
-        let workItem = DispatchWorkItem { [weak self] in
+        let timerID = UUID()
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(deadline: start + Self.burstOffsets[index])
+        timer.setEventHandler { [weak self, weak timer] in
             guard let self else { return }
-            guard generation == self.burstGeneration else { return }
+            self.scheduledBurstTimers.removeValue(forKey: timerID)
+            timer?.cancel()
             self.runScan()
-            self.scheduledBurstWorkItems.removeAll { $0.isCancelled }
-            self.runBurst(index: index + 1, burstStart: start, generation: generation)
+            self.runBurst(index: index + 1, burstStart: start)
         }
-        scheduledBurstWorkItems.append(workItem)
-        queue.asyncAfter(deadline: deadline, execute: workItem)
+        scheduledBurstTimers[timerID] = timer
+        timer.resume()
     }
 
     // MARK: - Scan

--- a/Sources/PortScanner.swift
+++ b/Sources/PortScanner.swift
@@ -572,28 +572,27 @@ final class PortScanner: @unchecked Sendable {
     ) {
         let hasPendingScan = scanCoordination.finishPanelScan()
         let isCurrentGeneration = generation == burstGeneration
-        if isCurrentGeneration {
-            deliverResults(
-                panelResults,
-                panelTTYs: panelTTYs,
-                panelRevisions: panelRevisions,
-                workspaceIds: workspaceIds,
-                agentPortsByWorkspace: agentPortsByWorkspace,
-                panelPortOwnersByKey: panelPortOwnersByKey,
-                panelProcessIdentitiesByKey: panelProcessIdentitiesByKey,
-                agentPortOwnersByWorkspace: agentPortOwnersByWorkspace,
-                agentProcessIdentitiesByWorkspace: agentProcessIdentitiesByWorkspace,
-                agentRevisions: agentRevisions,
-                panelCompletenessByKey: panelCompletenessByKey,
-                panelProcessScopeCompletenessByKey: panelProcessScopeCompletenessByKey,
-                agentCompletenessByWorkspace: agentCompletenessByWorkspace,
-                agentProcessScopeCompletenessByWorkspace: agentProcessScopeCompletenessByWorkspace,
-                panelLsofEvidence: panelLsofEvidence,
-                agentLsofEvidence: agentLsofEvidence,
-                inspectedPIDs: inspectedPIDs,
-                requestID: requestID
-            )
-        }
+        deliverResults(
+            panelResults,
+            panelTTYs: panelTTYs,
+            panelRevisions: panelRevisions,
+            workspaceIds: workspaceIds,
+            agentPortsByWorkspace: agentPortsByWorkspace,
+            panelPortOwnersByKey: panelPortOwnersByKey,
+            panelProcessIdentitiesByKey: panelProcessIdentitiesByKey,
+            agentPortOwnersByWorkspace: agentPortOwnersByWorkspace,
+            agentProcessIdentitiesByWorkspace: agentProcessIdentitiesByWorkspace,
+            agentRevisions: agentRevisions,
+            panelCompletenessByKey: panelCompletenessByKey,
+            panelProcessScopeCompletenessByKey: panelProcessScopeCompletenessByKey,
+            agentCompletenessByWorkspace: agentCompletenessByWorkspace,
+            agentProcessScopeCompletenessByWorkspace: agentProcessScopeCompletenessByWorkspace,
+            panelLsofEvidence: panelLsofEvidence,
+            agentLsofEvidence: agentLsofEvidence,
+            inspectedPIDs: inspectedPIDs,
+            requestID: requestID,
+            applyPanelResults: isCurrentGeneration
+        )
         if hasPendingScan {
             runScan(generation: burstGeneration)
         }
@@ -856,9 +855,10 @@ final class PortScanner: @unchecked Sendable {
         panelLsofEvidence: PortLsofScanResult,
         agentLsofEvidence: PortLsofScanResult?,
         inspectedPIDs: Set<Int>,
-        requestID: UInt64
+        requestID: UInt64,
+        applyPanelResults: Bool
     ) {
-        if scanCoordination.shouldApplyPanelResult(requestID: requestID) {
+        if applyPanelResults, scanCoordination.shouldApplyPanelResult(requestID: requestID) {
             let scannedPorts = Dictionary(uniqueKeysWithValues: panelResults.filter { key, _ in
                 ttyNames[key] == panelTTYs[key]
                     && panelRevisionByKey[key] == panelRevisions[key]

--- a/Sources/PortScanner.swift
+++ b/Sources/PortScanner.swift
@@ -70,7 +70,8 @@ final class PortScanner: @unchecked Sendable {
     /// Generation invalidates callbacks that were queued before a panel
     /// lifecycle changed. The queue is the sole owner, so cancellation and
     /// generation checks are deterministic and race-free.
-    private var scheduledBurstTimers: [UUID: DispatchSourceTimer] = [:]
+    private var burstGeneration: UInt64 = 0
+    private var scheduledBurstWorkItems: [DispatchWorkItem] = []
 
     private var coalesceTimer: DispatchSourceTimer?
 
@@ -136,9 +137,12 @@ final class PortScanner: @unchecked Sendable {
         let key = PanelKey(workspaceId: workspaceId, panelId: panelId)
         publicationState.invalidatePanelLifecycle(for: key)
         queue.async { [self] in
-            // A panel unregister must not cancel scans for other panels.
-            // The next scan snapshots the remaining registered panels.
-            pendingKicks.remove(key)
+            burstGeneration &+= 1
+            scheduledBurstWorkItems.forEach { $0.cancel() }
+            scheduledBurstWorkItems.removeAll()
+            burstActive = false
+            coalesceTimer?.cancel()
+            coalesceTimer = nil
             ttyNames.removeValue(forKey: key)
             panelRevisionByKey.removeValue(forKey: key)
             pendingKicks.remove(key)
@@ -175,6 +179,17 @@ final class PortScanner: @unchecked Sendable {
             }
             // If a burst is active, its later scans pay down this count. A
             // follow-up burst starts when too few scans remained.
+        }
+    }
+
+    /// Waits until all scanner-queue mutations submitted before this call have
+    /// completed. This is intentionally a queue barrier, not a wall-clock
+    /// delay, so lifecycle tests do not depend on timer timing.
+    func waitForIdleForTesting() async {
+        await withCheckedContinuation { continuation in
+            queue.async {
+                continuation.resume()
+            }
         }
     }
     @MainActor
@@ -235,35 +250,37 @@ final class PortScanner: @unchecked Sendable {
 
         guard !pendingKicks.isEmpty else { return }
         burstActive = true
-        runBurst(index: 0)
+        runBurst(index: 0, generation: burstGeneration)
     }
 
-    private func runBurst(index: Int, burstStart: DispatchTime? = nil) {
+    private func runBurst(index: Int, burstStart: DispatchTime? = nil, generation: UInt64) {
         // Already on `queue`.
+        guard generation == burstGeneration else { return }
         guard index < Self.burstOffsets.count else {
             burstActive = false
-            if !pendingKicks.isEmpty { startCoalesce() }
+            // If new kicks arrived during the burst, start a new coalesce cycle.
+            if !pendingKicks.isEmpty {
+                startCoalesce()
+            }
             return
         }
 
         let start = burstStart ?? .now()
-        let timerID = UUID()
-        let timer = DispatchSource.makeTimerSource(queue: queue)
-        timer.schedule(deadline: start + Self.burstOffsets[index])
-        timer.setEventHandler { [weak self, weak timer] in
+        let deadline = start + Self.burstOffsets[index]
+        let workItem = DispatchWorkItem { [weak self] in
             guard let self else { return }
-            self.scheduledBurstTimers.removeValue(forKey: timerID)
-            timer?.cancel()
-            self.runScan()
-            self.runBurst(index: index + 1, burstStart: start)
+            guard generation == self.burstGeneration else { return }
+            self.runScan(generation: generation)
+            self.scheduledBurstWorkItems.removeAll { $0.isCancelled }
+            self.runBurst(index: index + 1, burstStart: start, generation: generation)
         }
-        scheduledBurstTimers[timerID] = timer
-        timer.resume()
+        scheduledBurstWorkItems.append(workItem)
+        queue.asyncAfter(deadline: deadline, execute: workItem)
     }
 
     // MARK: - Scan
 
-    private func runScan() {
+    private func runScan(generation: UInt64 = 0) {
         // Already on `queue`. Snapshot which panels to scan and their TTYs.
         // We scan all registered panels, not just pending ones, since ports can
         // appear/disappear on any panel.
@@ -294,6 +311,7 @@ final class PortScanner: @unchecked Sendable {
         Task { [weak self] in
             guard let self else { return }
             await self.finishScan(
+                generation: generation,
                 panelSnapshot: panelSnapshot,
                 panelRevisions: panelRevisions,
                 agentRootsByWorkspace: agentRootsByWorkspace,
@@ -305,6 +323,7 @@ final class PortScanner: @unchecked Sendable {
 
     /// Completes one coalesced scan and assembles panel and agent ownership evidence.
     private func finishScan(
+        generation: UInt64,
         panelSnapshot: [PanelKey: String],
         panelRevisions: [PanelKey: UInt64],
         agentRootsByWorkspace: [UUID: Set<AgentPortRootIdentity>],
@@ -359,6 +378,7 @@ final class PortScanner: @unchecked Sendable {
             )
             queue.async { [weak self] in
                 self?.completePanelScan(
+                    generation: generation,
                     panelResults,
                     panelTTYs: panelSnapshot,
                     panelRevisions: panelRevisions,
@@ -530,6 +550,7 @@ final class PortScanner: @unchecked Sendable {
 
     /// Applies a completed panel scan on the scanner queue and starts any pending scan.
     private func completePanelScan(
+        generation: UInt64,
         _ panelResults: [(PanelKey, [Int])],
         panelTTYs: [PanelKey: String],
         panelRevisions: [PanelKey: UInt64],
@@ -550,6 +571,7 @@ final class PortScanner: @unchecked Sendable {
         requestID: UInt64
     ) {
         let hasPendingScan = scanCoordination.finishPanelScan()
+        guard generation == burstGeneration else { return }
         deliverResults(
             panelResults,
             panelTTYs: panelTTYs,
@@ -571,7 +593,7 @@ final class PortScanner: @unchecked Sendable {
             requestID: requestID
         )
         if hasPendingScan {
-            runScan()
+            runScan(generation: burstGeneration)
         }
     }
 

--- a/cmuxTests/PortScannerTests.swift
+++ b/cmuxTests/PortScannerTests.swift
@@ -1076,6 +1076,27 @@ private actor ScriptedCommandRunner: CommandRunning {
     }
 }
 
+@Suite("Port scanner lifecycle")
+struct PortScannerLifecycleTests {
+    @Test("Unregister cancels a pending coalesce and burst generation")
+    func unregisterCancelsPendingBurst() async {
+        let runner = ScriptedCommandRunner(results: [])
+        let scanner = PortScanner(commandRunner: runner)
+        let workspaceID = UUID()
+        let panelID = UUID()
+        await MainActor.run {
+            scanner.registerTTY(workspaceId: workspaceID, panelId: panelID, ttyName: "ttys999")
+        }
+        scanner.kick(workspaceId: workspaceID, panelId: panelID)
+        await MainActor.run {
+            scanner.unregisterPanel(workspaceId: workspaceID, panelId: panelID)
+        }
+        try? await Task.sleep(for: .milliseconds(800))
+        let calls = await runner.recordedArguments
+        #expect(calls.isEmpty)
+    }
+}
+
 @Suite("Port scanner retirement end to end")
 struct PortScannerPortRetirementTests {
     /// Drives the whole scanner — TTY registration, kick, coalesce, burst,

--- a/cmuxTests/PortScannerTests.swift
+++ b/cmuxTests/PortScannerTests.swift
@@ -1235,6 +1235,21 @@ struct PortScannerGenerationTests {
 
         let publishedPorts = try #require(await iterator.next())
         #expect(publishedPorts == [5173])
+}
+
+@Suite("Port scanner lsof batching")
+struct PortScannerLsofBatchingTests {
+    @Test("Large PID lists are split without exceeding the argument budget")
+    func largePIDListUsesBoundedCSVArguments() {
+        let pids = Array(1...2_000)
+        let chunks = PortScanner.lsofPIDChunks(pids)
+
+        #expect(chunks.count > 1)
+        #expect(chunks.flatMap { $0 } == pids)
+        for chunk in chunks {
+            let csvBytes = chunk.map(String.init).joined(separator: ",").utf8.count
+            #expect(csvBytes + PortScanner.lsofArgumentOverhead <= PortScanner.lsofArgumentByteBudget)
+        }
     }
 }
 

--- a/cmuxTests/PortScannerTests.swift
+++ b/cmuxTests/PortScannerTests.swift
@@ -1242,7 +1242,7 @@ struct PortScannerGenerationTests {
 struct PortScannerLsofBatchingTests {
     @Test("Large PID lists are split without exceeding the argument budget")
     func largePIDListUsesBoundedCSVArguments() {
-        let pids = Array(1...2_000)
+        let pids = Array(1...20_000)
         let chunks = PortScanner.lsofPIDChunks(pids)
 
         #expect(chunks.count > 1)

--- a/cmuxTests/PortScannerTests.swift
+++ b/cmuxTests/PortScannerTests.swift
@@ -1165,7 +1165,7 @@ struct PortScannerLifecycleTests {
 struct PortScannerGenerationTests {
     @Test(
         "A stale panel completion still publishes valid agent ports",
-        .timeLimit(.seconds(5))
+        .timeLimit(.minutes(1))
     )
     func stalePanelCompletionPreservesAgentResults() async throws {
         let workspaceID = UUID()

--- a/cmuxTests/PortScannerTests.swift
+++ b/cmuxTests/PortScannerTests.swift
@@ -1050,9 +1050,17 @@ struct ProcessTerminationGateTests {
 private actor ScriptedCommandRunner: CommandRunning {
     private let results: [CommandResult]
     private(set) var recordedArguments: [[String]] = []
+    private var invocationWaiters: [CheckedContinuation<Void, Never>] = []
 
     init(results: [CommandResult]) {
         self.results = results
+    }
+
+    func waitForInvocation() async {
+        if !recordedArguments.isEmpty { return }
+        await withCheckedContinuation { continuation in
+            invocationWaiters.append(continuation)
+        }
     }
 
     func run(
@@ -1062,6 +1070,8 @@ private actor ScriptedCommandRunner: CommandRunning {
         timeout: TimeInterval?
     ) async -> CommandResult {
         recordedArguments.append(arguments)
+        invocationWaiters.forEach { $0.resume() }
+        invocationWaiters.removeAll()
         let index = recordedArguments.count - 1
         guard results.indices.contains(index) else {
             return CommandResult(
@@ -1078,22 +1088,25 @@ private actor ScriptedCommandRunner: CommandRunning {
 
 @Suite("Port scanner lifecycle")
 struct PortScannerLifecycleTests {
-    @Test("Unregister cancels a pending coalesce and burst generation")
-    func unregisterCancelsPendingBurst() async {
+    @Test("Unregister preserves a pending burst for other panels")
+    func unregisterPreservesOtherPanelBurst() async {
         let runner = ScriptedCommandRunner(results: [])
         let scanner = PortScanner(commandRunner: runner)
         let workspaceID = UUID()
-        let panelID = UUID()
+        let removedPanelID = UUID()
+        let retainedPanelID = UUID()
         await MainActor.run {
-            scanner.registerTTY(workspaceId: workspaceID, panelId: panelID, ttyName: "ttys999")
+            scanner.registerTTY(workspaceId: workspaceID, panelId: removedPanelID, ttyName: "ttys999")
+            scanner.registerTTY(workspaceId: workspaceID, panelId: retainedPanelID, ttyName: "ttys998")
         }
-        scanner.kick(workspaceId: workspaceID, panelId: panelID)
+        scanner.kick(workspaceId: workspaceID, panelId: removedPanelID)
+        scanner.kick(workspaceId: workspaceID, panelId: retainedPanelID)
         await MainActor.run {
-            scanner.unregisterPanel(workspaceId: workspaceID, panelId: panelID)
+            scanner.unregisterPanel(workspaceId: workspaceID, panelId: removedPanelID)
         }
-        await scanner.waitForIdleForTesting()
+        await runner.waitForInvocation()
         let calls = await runner.recordedArguments
-        #expect(calls.isEmpty)
+        #expect(!calls.isEmpty)
     }
 }
 

--- a/cmuxTests/PortScannerTests.swift
+++ b/cmuxTests/PortScannerTests.swift
@@ -1088,6 +1088,56 @@ private actor ScriptedCommandRunner: CommandRunning {
 
 @Suite("Port scanner lifecycle")
 struct PortScannerLifecycleTests {
+    @Test("A stale completion preserves a pending rescan under the current generation")
+    func staleCompletionDoesNotConsumePendingRescan() async {
+        let runner = ScriptedCommandRunner(results: [])
+        let scanner = PortScanner(commandRunner: runner)
+        let workspaceID = UUID()
+        let panelID = UUID()
+        await MainActor.run {
+            scanner.registerTTY(workspaceId: workspaceID, panelId: panelID, ttyName: "ttys999")
+        }
+
+        // Simulate an in-flight scan from generation zero, then invalidate it.
+        scanner.queue.sync {
+            _ = scanner.scanCoordination.beginPanelScan()
+            _ = scanner.scanCoordination.beginPanelScan()
+        }
+        await MainActor.run {
+            scanner.unregisterPanel(workspaceId: workspaceID, panelId: panelID)
+        }
+        scanner.queue.sync {}
+        await MainActor.run {
+            scanner.registerTTY(workspaceId: workspaceID, panelId: panelID, ttyName: "ttys999")
+        }
+        scanner.queue.sync {
+            scanner.completePanelScan(
+                generation: 0,
+                [],
+                panelTTYs: [:],
+                panelRevisions: [:],
+                workspaceIds: [],
+                agentPortsByWorkspace: [:],
+                panelPortOwnersByKey: [:],
+                panelProcessIdentitiesByKey: [:],
+                agentPortOwnersByWorkspace: [:],
+                agentProcessIdentitiesByWorkspace: [:],
+                agentRevisions: [:],
+                panelCompletenessByKey: [:],
+                panelProcessScopeCompletenessByKey: [:],
+                agentCompletenessByWorkspace: [:],
+                agentProcessScopeCompletenessByWorkspace: [:],
+                panelLsofEvidence: PortLsofScanResult(values: [:], globallyComplete: true, incompletePIDs: []),
+                agentLsofEvidence: nil,
+                inspectedPIDs: [],
+                requestID: 0
+            )
+        }
+        await runner.waitForInvocation()
+        let calls = await runner.recordedArguments
+        #expect(!calls.isEmpty)
+    }
+
     @Test("Unregister preserves a pending burst for other panels")
     func unregisterPreservesOtherPanelBurst() async {
         let runner = ScriptedCommandRunner(results: [])

--- a/cmuxTests/PortScannerTests.swift
+++ b/cmuxTests/PortScannerTests.swift
@@ -1091,7 +1091,7 @@ struct PortScannerLifecycleTests {
         await MainActor.run {
             scanner.unregisterPanel(workspaceId: workspaceID, panelId: panelID)
         }
-        try? await Task.sleep(for: .milliseconds(800))
+        await scanner.waitForIdleForTesting()
         let calls = await runner.recordedArguments
         #expect(calls.isEmpty)
     }

--- a/cmuxTests/PortScannerTests.swift
+++ b/cmuxTests/PortScannerTests.swift
@@ -1160,6 +1160,84 @@ struct PortScannerLifecycleTests {
     }
 }
 
+@MainActor
+@Suite("Port scanner generation")
+struct PortScannerGenerationTests {
+    @Test(
+        "A stale panel completion still publishes valid agent ports",
+        .timeLimit(.seconds(5))
+    )
+    func stalePanelCompletionPreservesAgentResults() async throws {
+        let workspaceID = UUID()
+        let rootIdentity = AgentPIDProcessIdentity(
+            pid: 100,
+            startSeconds: 10,
+            startMicroseconds: 0
+        )
+        let root = AgentPortRootIdentity(pid: 100, processIdentity: rootIdentity)
+        let scanner = PortScanner(commandRunner: ScriptedCommandRunner(results: []))
+        let (publications, continuation) = AsyncStream<[Int]>.makeStream(
+            bufferingPolicy: .unbounded
+        )
+        var iterator = publications.makeAsyncIterator()
+        scanner.onAgentPortsUpdated = { callbackWorkspaceID, ports in
+            guard callbackWorkspaceID == workspaceID else { return false }
+            continuation.yield(ports)
+            return true
+        }
+        defer {
+            continuation.finish()
+            scanner.onAgentPortsUpdated = nil
+        }
+
+        let agentRevision = scanner.publicationState.replaceAgentLifecycle(
+            workspaceId: workspaceID,
+            roots: [root]
+        )
+        let panelID = UUID()
+        scanner.registerTTY(workspaceId: workspaceID, panelId: panelID, ttyName: "ttys999")
+        scanner.queue.sync {
+            scanner.agentRevisionByWorkspace[workspaceID] = agentRevision
+            scanner.trackedAgentWorkspaces.insert(workspaceID)
+            scanner.forceAgentResultWorkspaces.insert(workspaceID)
+            _ = scanner.scanCoordination.beginPanelScan()
+        }
+        scanner.unregisterPanel(workspaceId: workspaceID, panelId: panelID)
+        scanner.queue.sync {}
+
+        scanner.queue.sync {
+            scanner.completePanelScan(
+                generation: 0,
+                [],
+                panelTTYs: [:],
+                panelRevisions: [:],
+                workspaceIds: [workspaceID],
+                agentPortsByWorkspace: [workspaceID: [5173]],
+                panelPortOwnersByKey: [:],
+                panelProcessIdentitiesByKey: [:],
+                agentPortOwnersByWorkspace: [:],
+                agentProcessIdentitiesByWorkspace: [:],
+                agentRevisions: [workspaceID: agentRevision],
+                panelCompletenessByKey: [:],
+                panelProcessScopeCompletenessByKey: [:],
+                agentCompletenessByWorkspace: [workspaceID: .complete],
+                agentProcessScopeCompletenessByWorkspace: [workspaceID: .complete],
+                panelLsofEvidence: PortLsofScanResult(
+                    values: [:],
+                    globallyComplete: true,
+                    incompletePIDs: []
+                ),
+                agentLsofEvidence: nil,
+                inspectedPIDs: [],
+                requestID: 1
+            )
+        }
+
+        let publishedPorts = try #require(await iterator.next())
+        #expect(publishedPorts == [5173])
+    }
+}
+
 @Suite("Port scanner retirement end to end")
 struct PortScannerPortRetirementTests {
     /// Drives the whole scanner — TTY registration, kick, coalesce, burst,

--- a/cmuxTests/PortScannerTests.swift
+++ b/cmuxTests/PortScannerTests.swift
@@ -1235,6 +1235,7 @@ struct PortScannerGenerationTests {
 
         let publishedPorts = try #require(await iterator.next())
         #expect(publishedPorts == [5173])
+    }
 }
 
 @Suite("Port scanner lsof batching")


### PR DESCRIPTION
PortScanner used uncancellable recursive asyncAfter callbacks. This adds queue-confined generation invalidation and cancellable DispatchWorkItems, so unregister cancels pending coalesce and active bursts without stale scans. Adds behavior coverage for unregister during coalescing.

Apple references: https://developer.apple.com/documentation/dispatch/dispatchworkitem/cancel%28%29 and https://developer.apple.com/documentation/dispatch/dispatchqueue/asyncafter%28deadline%3Aexecute%3A%29

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes PortScanner's burst scheduling cancellable and generation-checked. Previously the recursive `asyncAfter` callbacks could not be cancelled, so unregistering the last panel left stale scans to finish; now it cancels pending coalesce timers and active burst work, stale completions drop only panel results (agent results and pending rescans are preserved), and large lsof scans are chunked to stay within argument limits.

**Bug Fixes**
- Unregistering the last panel bumps the generation and cancels scheduled timers; pending kicks on other panels restart coalescing.
- Burst steps and scan completions re-check the generation before running, so stale completions skip panel results while keeping agent results and the pending rescan.
- lsof scans with more than 256 PIDs are split into byte-budgeted chunks via a linear chunk builder and merged per PID.
- Adds lifecycle test coverage for unregister during coalescing, stale completions keeping agent results and rescans, and chunk construction including the batching threshold.

<sup>Written for commit db0714b5532d262bcc030370cd0b5106af412874. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scan cancellation so pending scans and burst operations stop cleanly when a panel is unregistered.
  * Improved scheduling of repeated scans to prevent missed or duplicated scan activity.
  * Improved port scanning for large process lists by splitting requests into manageable batches and combining results accurately.
* **Tests**
  * Added coverage for scan lifecycle cancellation and prevention of commands executing after cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->