### PR TITLE
Make new windows honor configured sidebar width

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9835,9 +9835,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             restoredSessionSnapshotHandler?(restoredPanelIdsByWorkspaceIndex, tabManager)
         }
 
-        let sidebarWidth = sessionWindowSnapshot?.sidebar.width
-            .map { SessionPersistencePolicy.sanitizedSidebarWidth($0) }
-            ?? SessionPersistencePolicy.defaultSidebarWidth
+        let sidebarWidth = SessionPersistencePolicy.sanitizedSidebarWidth(
+            sessionWindowSnapshot?.sidebar.width
+        )
 #if DEBUG
         let shouldStartWithHiddenSidebarForTerminalViewportUITest =
             ProcessInfo.processInfo.environment["CMUX_UI_TEST_TERMINAL_VIEWPORT_HIDE_SIDEBAR"] == "1"

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -36,8 +36,7 @@ enum SessionPersistencePolicy {
 
     static func sanitizedSidebarWidth(_ candidate: Double?, defaults: UserDefaults = .standard) -> Double {
         let resolvedMinimum = resolvedMinimumSidebarWidth(defaults: defaults)
-        let fallback = min(max(defaultSidebarWidth, resolvedMinimum), maximumSidebarWidth)
-        guard let candidate, candidate.isFinite else { return fallback }
+        guard let candidate, candidate.isFinite else { return resolvedMinimum }
         return min(max(candidate, resolvedMinimum), maximumSidebarWidth)
     }
 

--- a/cmuxTests/SidebarWidthPolicyTests.swift
+++ b/cmuxTests/SidebarWidthPolicyTests.swift
@@ -60,6 +60,11 @@ final class SidebarWidthPolicyTests: XCTestCase {
 
         defaults.set(160.0, forKey: SessionPersistencePolicy.sidebarMinimumWidthKey)
         XCTAssertEqual(
+            SessionPersistencePolicy.sanitizedSidebarWidth(nil, defaults: defaults),
+            160,
+            accuracy: 0.001
+        )
+        XCTAssertEqual(
             SessionPersistencePolicy.sanitizedSidebarWidth(140, defaults: defaults),
             160,
             accuracy: 0.001
@@ -275,6 +280,44 @@ final class SidebarWidthPolicyTests: XCTestCase {
         XCTAssertTrue(range.contains(684))
         XCTAssertFalse(range.contains(675.9))
         XCTAssertFalse(range.contains(686.1))
+    }
+}
+
+@MainActor
+@Suite(.serialized)
+struct SidebarWidthWindowCreationTests {
+    @Test func newWindowUsesConfiguredMinimumWhenNoWidthWasPersisted() async throws {
+        try await AppContextSerialGate.withExclusiveAppContext {
+            _ = NSApplication.shared
+            let defaults = UserDefaults.standard
+            let key = SessionPersistencePolicy.sidebarMinimumWidthKey
+            let savedValue = defaults.object(forKey: key)
+            let previousAppDelegate = AppDelegate.shared
+
+            defaults.set(160.0, forKey: key)
+            let appDelegate = AppDelegate()
+            AppDelegate.shared = appDelegate
+            var windowId: UUID?
+            defer {
+                if let windowId {
+                    _ = appDelegate.closeMainWindow(windowId: windowId, recordHistory: false)
+                }
+                if let savedValue {
+                    defaults.set(savedValue, forKey: key)
+                } else {
+                    defaults.removeObject(forKey: key)
+                }
+                AppDelegate.shared = previousAppDelegate
+            }
+
+            let createdWindowId = appDelegate.createMainWindow(shouldActivate: false)
+            windowId = createdWindowId
+            let context = try #require(
+                appDelegate.mainWindowContexts.values.first { $0.windowId == createdWindowId }
+            )
+
+            #expect(context.sidebarState.persistedWidth == 160)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Route new windows and session snapshots without a persisted sidebar width through `SessionPersistencePolicy.sanitizedSidebarWidth`.
- Use the resolved configured minimum as the fallback for a missing or non-finite width, while continuing to clamp explicit persisted widths normally.
- Add policy-level coverage and a regression test through the real `AppDelegate.createMainWindow` entrypoint.

`sidebarMinimumWidth` currently changes the drag floor, but `createMainWindow` bypasses that policy when no width was persisted and falls back to the compiled product default. As a result, a user can configure a narrower sidebar and resize to it, yet every newly created window still starts wide.

This change makes the configured minimum the initial width only when no explicit width exists. Fresh defaults are unchanged, and restored explicit widths keep their existing behavior.

Related to #6784 and #8253; complements #6875.

## Testing

- `git diff --check`
- `/Library/Developer/CommandLineTools/usr/bin/swiftc -parse Sources/AppDelegate.swift Sources/SessionPersistence.swift cmuxTests/SidebarWidthPolicyTests.swift cmuxTests/AppDelegateMainWindowTestingSupport.swift`
- Added a serialized app-context test that sets the minimum to 160, creates a real non-activating main window, and verifies its `SidebarState.persistedWidth` is 160.
- Pre-fix manual reproduction on a released build: with `sidebarMinimumWidth=160`, a fresh window still opened at the compiled default width.
- Full local Xcode run of `SidebarWidthPolicyTests` and `SidebarWidthWindowCreationTests`: 16 passed, 0 failed. The run exercised the real non-activating `AppDelegate.createMainWindow` path. It used separate local toolchain-compatibility adjustments outside this PR; those unrelated adjustments were not pushed into this change.
- A local arm64 Release build succeeded and was installed for dogfood. With `sidebarMinimumWidth=160`, the installed build starts a genuinely new window at 160 while preserving explicit restored widths.

## Demo Video

- Video URL or attachment: Not attached. The real new-window entrypoint is covered by the passing Xcode test above, and the local Release build was dogfooded on the affected Mac.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed (not needed for this behavior fix)
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
New windows now honor the configured sidebar minimum width instead of starting at the compiled default when no explicit width was persisted.

**Bug Fixes**
- Missing or non-finite sidebar widths now fall back to the resolved configured minimum; explicit persisted widths are still clamped as before.
- Added policy-level and window-creation tests covering the new fallback behavior.

<sup>Written for commit 4f1359c181f187c8effdd15fc899c1a54970555b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed sidebar sizing when no previous width is saved.
  - Newly created windows now use the configured minimum sidebar width instead of an unintended default.
  - Restored sidebar widths now consistently fall back to the configured minimum when saved data is unavailable or invalid.
  - Preserved existing behavior for valid saved sidebar widths, including normal size constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
