### PR TITLE
cmux-tui: cancel reconnect and heartbeat waits on close

### DIFF
--- a/cmux-tui/crates/cmux-remote/src/connection.rs
+++ b/cmux-tui/crates/cmux-remote/src/connection.rs
@@ -628,6 +628,7 @@ impl ClientConnection {
         let mut attempt = 0_u32;
         let mut delay = self.config.reconnect.initial_delay;
         let mut group = self.group.read().await.clone();
+        let mut close_state = self.close_state.subscribe();
         loop {
             if self.closed.load(Ordering::Acquire) {
                 return Err(ConnectionError::Closed);
@@ -672,7 +673,11 @@ impl ClientConnection {
                     {
                         group = next;
                     }
-                    tokio::time::sleep(self.config.reconnect.retry_delay(delay)).await;
+                    let retry_delay = self.config.reconnect.retry_delay(delay);
+                    tokio::select! {
+                        _ = tokio::time::sleep(retry_delay) => {}
+                        _ = close_state.changed() => return Err(ConnectionError::Closed),
+                    }
                     delay = (delay * 2).min(self.config.reconnect.maximum_delay);
                 }
                 Err(error) => return Err(error),
@@ -759,8 +764,14 @@ async fn wait_for_close(mut state: watch::Receiver<CloseState>) -> Result<(), Co
 }
 
 async fn run_heartbeat(weak: Weak<ClientConnection>, interval: Duration, timeout: Duration) {
+    let Some(initial) = weak.upgrade() else { return };
+    let mut close_state = initial.close_state.subscribe();
+    drop(initial);
     loop {
-        tokio::time::sleep(interval).await;
+        tokio::select! {
+            _ = tokio::time::sleep(interval) => {}
+            _ = close_state.changed() => return,
+        }
         let Some(connection) = weak.upgrade() else { return };
         if connection.closed.load(Ordering::Acquire) {
             return;
@@ -778,18 +789,18 @@ async fn run_heartbeat(weak: Weak<ClientConnection>, interval: Duration, timeout
         let observed = connection.last_received();
         let generation = connection.session.read().await.generation();
         let deadline = tokio::time::Instant::now() + timeout;
-        match tokio::time::timeout_at(
-            deadline,
-            connection.send_in_generation(
-                Some(generation),
-                Lane::Control,
-                0,
-                Bytes::new(),
-                FrameFlags::HEARTBEAT_REQUEST,
-            ),
-        )
-        .await
-        {
+        let send = connection.send_in_generation(
+            Some(generation),
+            Lane::Control,
+            0,
+            Bytes::new(),
+            FrameFlags::HEARTBEAT_REQUEST,
+        );
+        let send_result = tokio::select! {
+            result = tokio::time::timeout_at(deadline, send) => result,
+            _ = close_state.changed() => return,
+        };
+        match send_result {
             Ok(Ok(_)) => {}
             Ok(Err(_)) => continue,
             Err(_) => {
@@ -797,10 +808,10 @@ async fn run_heartbeat(weak: Weak<ClientConnection>, interval: Duration, timeout
                 continue;
             }
         }
-        let live =
-            tokio::time::timeout_at(deadline, connection.probe_liveness(generation, observed))
-                .await
-                .unwrap_or(false);
+        let live = tokio::select! {
+            result = tokio::time::timeout_at(deadline, connection.probe_liveness(generation, observed)) => result.unwrap_or(false),
+            _ = close_state.changed() => return,
+        };
         if connection.closed.load(Ordering::Acquire)
             || connection.session.read().await.generation() != generation
         {

--- a/cmux-tui/crates/cmux-remote/src/connection.rs
+++ b/cmux-tui/crates/cmux-remote/src/connection.rs
@@ -130,6 +130,9 @@ pub struct ClientConnection {
     reconnecting: Arc<Mutex<()>>,
     lane_sends: [Mutex<()>; 4],
     receiving: Mutex<()>,
+    /// Linearizes shutdown start with the short reconnect publication window.
+    /// Reconnect attempts do not hold this gate while dialing or replaying.
+    shutdown_gate: Mutex<()>,
     deferred_receive: StdMutex<Option<Result<ReceivedFrame, ConnectionError>>>,
     last_received: StdMutex<Instant>,
     closed: AtomicBool,
@@ -252,6 +255,7 @@ impl ClientConnection {
             reconnecting: Arc::new(Mutex::new(())),
             lane_sends: std::array::from_fn(|_| Mutex::new(())),
             receiving: Mutex::new(()),
+            shutdown_gate: Mutex::new(()),
             deferred_receive: StdMutex::new(None),
             last_received: StdMutex::new(Instant::now()),
             closed: AtomicBool::new(false),
@@ -539,6 +543,9 @@ impl ClientConnection {
             current.resume_cursors(),
         )
         .await?;
+        if self.closed.load(Ordering::Acquire) {
+            return Err(ConnectionError::Closed);
+        }
         if daemon_key != self.daemon_public_key {
             return Err(ConnectionError::Crypto(CryptoError::DaemonKeyMismatch {
                 expected: crate::crypto::public_key_fingerprint(&self.daemon_public_key),
@@ -553,6 +560,9 @@ impl ClientConnection {
         // there is no await between that commit and publishing both wrappers.
         let mut active_group = self.group.write().await;
         let mut active_session = self.session.write().await;
+        if self.closed.load(Ordering::Acquire) {
+            return Err(ConnectionError::Closed);
+        }
         if active_session.generation() != current.generation() {
             return Err(ConnectionError::GenerationChanged {
                 expected: current.generation(),
@@ -560,6 +570,13 @@ impl ClientConnection {
             });
         }
         let next = current.reconnect_to(Arc::new(link), &daemon_resume, generation).await?;
+        // Shutdown takes this gate before publishing its start signal. This
+        // gives reconnect publication and shutdown a clear linearization
+        // point without holding the gate across dialing or replay.
+        let _shutdown_gate = self.shutdown_gate.lock().await;
+        if self.closed.load(Ordering::Acquire) {
+            return Err(ConnectionError::Closed);
+        }
         let generation = next.generation();
         let previous = std::mem::replace(&mut *active_group, group.clone());
         *active_session = next;
@@ -581,6 +598,7 @@ impl ClientConnection {
                 diagnostics.state = ConnectionState::Connected;
             }
         }
+        drop(_shutdown_gate);
         drop(active_session);
         drop(active_group);
         // Publishing the replacement first lets blocked readers recover onto
@@ -638,17 +656,22 @@ impl ClientConnection {
                 return Err(ConnectionError::Closed);
             }
             attempt = attempt.saturating_add(1);
-            let reconnect = tokio::time::timeout(
-                self.config.reconnect.attempt_timeout,
-                self.reconnect_once(group.clone()),
-            )
-            .await;
+            let reconnect = tokio::select! {
+                _ = close_state.changed() => return Err(ConnectionError::Closed),
+                reconnect = tokio::time::timeout(
+                    self.config.reconnect.attempt_timeout,
+                    self.reconnect_once(group.clone()),
+                ) => reconnect,
+            };
             let result = match reconnect {
                 Ok(result) => result,
                 Err(_) => Err(ConnectionError::ReconnectAttemptTimedOut {
                     timeout: self.config.reconnect.attempt_timeout,
                 }),
             };
+            if self.closed.load(Ordering::Acquire) && result.is_ok() {
+                return Err(ConnectionError::Closed);
+            }
             match result {
                 Ok(()) => {
                     if !self.closed.load(Ordering::Acquire) {
@@ -690,7 +713,12 @@ impl ClientConnection {
     }
 
     pub async fn close(&self) -> Result<(), ConnectionError> {
+        // Acquire the short publication gate before making shutdown visible.
+        // A reconnect that already owns it finishes publishing first; one
+        // that has not reached publication observes `closed` and aborts.
+        let shutdown_gate = self.shutdown_gate.lock().await;
         if self.closed.swap(true, Ordering::AcqRel) {
+            drop(shutdown_gate);
             return wait_for_close(self.close_state.subscribe()).await;
         }
         // Publish shutdown intent before taking any cleanup locks. Reconnect
@@ -698,6 +726,7 @@ impl ClientConnection {
         // time, so waiting only for the eventual terminal state would leave
         // them alive after the caller has requested close.
         self.close_state.send_replace(CloseState::Started);
+        drop(shutdown_gate);
         self.set_diagnostics_state(ConnectionState::Closed);
         // The cleanup task owns every lock needed to snapshot the final carrier.
         // It therefore survives cancellation of this caller after `closed` is

--- a/cmux-tui/crates/cmux-remote/src/connection.rs
+++ b/cmux-tui/crates/cmux-remote/src/connection.rs
@@ -636,16 +636,22 @@ impl ClientConnection {
         // Publishing the replacement first lets blocked readers recover onto
         // it when closing the prior carrier wakes them. The provider group may
         // be reused across generations, so close the old session link even
-        // when the group identity did not change.
+        // when the group identity did not change. Keep this bounded retirement
+        // in an owned task. If the caller is cancelled after publication, the
+        // dropped JoinHandle detaches a task that still owns both old carriers
+        // and closes them instead of leaking the displaced group.
         let close_previous_group = !Arc::ptr_eq(&previous, &group);
-        let _ = tokio::time::timeout(TERMINAL_SHUTDOWN_TIMEOUT, async {
-            if close_previous_group {
-                let _ = tokio::join!(current.close(), previous.close());
-            } else {
-                let _ = current.close().await;
-            }
-        })
-        .await;
+        let retirement = tokio::spawn(async move {
+            let _ = tokio::time::timeout(TERMINAL_SHUTDOWN_TIMEOUT, async {
+                if close_previous_group {
+                    let _ = tokio::join!(current.close(), previous.close());
+                } else {
+                    let _ = current.close().await;
+                }
+            })
+            .await;
+        });
+        let _ = retirement.await;
         Ok(())
     }
 
@@ -1653,6 +1659,20 @@ mod tests {
 
     struct HangingCloseGroup {
         inner: Arc<FaultGroup>,
+        close_started: Arc<Semaphore>,
+        release_close: Arc<Semaphore>,
+        close_finished: Arc<Semaphore>,
+    }
+
+    impl HangingCloseGroup {
+        fn new(inner: Arc<FaultGroup>) -> Arc<Self> {
+            Arc::new(Self {
+                inner,
+                close_started: Arc::new(Semaphore::new(0)),
+                release_close: Arc::new(Semaphore::new(0)),
+                close_finished: Arc::new(Semaphore::new(0)),
+            })
+        }
     }
 
     struct MutableSnapshotGroup {
@@ -1861,7 +1881,11 @@ mod tests {
         }
 
         async fn close(&self) -> Result<(), ProviderError> {
-            std::future::pending().await
+            self.close_started.add_permits(1);
+            self.release_close.acquire().await.unwrap().forget();
+            self.inner.close().await?;
+            self.close_finished.add_permits(1);
+            Ok(())
         }
     }
 
@@ -2324,13 +2348,14 @@ mod tests {
         let auth =
             AuthDatabase::load_or_create(directory.path(), "cancel-reconnect", true).unwrap();
         let (daemon, _accepted) = RemoteDaemon::new(auth, SessionLimits::default());
-        let initial = Arc::new(HangingCloseGroup {
-            inner: Arc::new(FaultGroup {
+        let initial = HangingCloseGroup::new(Arc::new(FaultGroup {
                 daemon: daemon.clone(),
                 epochs: Mutex::new(Vec::new()),
                 evidence: CarrierEvidence::LocalPeer { uid: None, pid: None },
-            }),
-        });
+            }));
+        let initial_close_started = initial.close_started.clone();
+        let initial_release_close = initial.release_close.clone();
+        let initial_close_finished = initial.close_finished.clone();
         let client = ClientConnection::connect(
             initial,
             ClientConnectionConfig {
@@ -2372,6 +2397,17 @@ mod tests {
 
         reconnect.abort();
         assert!(reconnect.await.unwrap_err().is_cancelled());
+        tokio::time::timeout(Duration::from_secs(1), initial_close_started.acquire())
+            .await
+            .expect("cancelled reconnect did not start displaced-group retirement")
+            .unwrap()
+            .forget();
+        initial_release_close.add_permits(1);
+        tokio::time::timeout(Duration::from_secs(1), initial_close_finished.acquire())
+            .await
+            .expect("displaced-group retirement did not finish after reconnect cancellation")
+            .unwrap()
+            .forget();
         let snapshot = client.snapshot().await;
         assert_eq!(snapshot.generation, 1);
         assert_eq!(snapshot.state, ConnectionState::Connected);
@@ -2510,13 +2546,11 @@ mod tests {
         let directory = tempdir().unwrap();
         let auth = AuthDatabase::load_or_create(directory.path(), "failed-close", true).unwrap();
         let (daemon, _accepted) = RemoteDaemon::new(auth, SessionLimits::default());
-        let group = Arc::new(HangingCloseGroup {
-            inner: Arc::new(FaultGroup {
+        let group = HangingCloseGroup::new(Arc::new(FaultGroup {
                 daemon,
                 epochs: Mutex::new(Vec::new()),
                 evidence: CarrierEvidence::LocalPeer { uid: None, pid: None },
-            }),
-        });
+            }));
         let client = ClientConnection::connect(
             group,
             ClientConnectionConfig {

--- a/cmux-tui/crates/cmux-remote/src/connection.rs
+++ b/cmux-tui/crates/cmux-remote/src/connection.rs
@@ -502,7 +502,11 @@ impl ClientConnection {
         }
         let previous_state = self.diagnostics_state();
         self.set_diagnostics_state(ConnectionState::Reconnecting);
-        let result = self.reconnect_once(group).await;
+        let mut close_state = self.close_state.subscribe();
+        let result = tokio::select! {
+            _ = close_state.changed() => Err(ConnectionError::Closed),
+            result = self.reconnect_once(group) => result,
+        };
         // Explicit route replacement preserves the previously published
         // carrier when setup or replay of the candidate fails.
         if !self.closed.load(Ordering::Acquire) {
@@ -691,14 +695,17 @@ impl ClientConnection {
                             last: error.to_string(),
                         });
                     }
-                    if let Some(source) = &self.reconnect_groups
-                        && let Some(next) = resolve_reconnect_group(
-                            source.as_ref(),
-                            self.config.reconnect.attempt_timeout,
-                        )
-                        .await
-                    {
-                        group = next;
+                    if let Some(source) = &self.reconnect_groups {
+                        let next = tokio::select! {
+                            _ = close_state.changed() => return Err(ConnectionError::Closed),
+                            next = resolve_reconnect_group(
+                                source.as_ref(),
+                                self.config.reconnect.attempt_timeout,
+                            ) => next,
+                        };
+                        if let Some(next) = next {
+                            group = next;
+                        }
                     }
                     let retry_delay = self.config.reconnect.retry_delay(delay);
                     tokio::select! {

--- a/cmux-tui/crates/cmux-remote/src/connection.rs
+++ b/cmux-tui/crates/cmux-remote/src/connection.rs
@@ -493,17 +493,41 @@ impl ClientConnection {
         }
     }
 
-    /// Replace a failed provider group while preserving reliable application
-    /// sequence numbers and replaying only frames the daemon did not ack.
-    pub async fn reconnect(&self, group: Arc<dyn LinkGroup>) -> Result<(), ConnectionError> {
-        let _reconnecting = self.reconnecting.lock().await;
+    /// Acquire the single reconnect owner while remaining interruptible by
+    /// shutdown. A Tokio mutex queues waiters, so subscribing before the lock
+    /// avoids making a waiter sit behind cleanup after close has started.
+    async fn lock_reconnecting(
+        &self,
+        close_state: &mut watch::Receiver<CloseState>,
+    ) -> Result<tokio::sync::OwnedMutexGuard<()>, ConnectionError> {
         if self.closed.load(Ordering::Acquire) {
             return Err(ConnectionError::Closed);
         }
+        let lock = self.reconnecting.clone().lock_owned();
+        tokio::pin!(lock);
+        tokio::select! {
+            biased;
+            _ = close_state.changed() => Err(ConnectionError::Closed),
+            guard = &mut lock => {
+                if self.closed.load(Ordering::Acquire) {
+                    drop(guard);
+                    Err(ConnectionError::Closed)
+                } else {
+                    Ok(guard)
+                }
+            }
+        }
+    }
+
+    /// Replace a failed provider group while preserving reliable application
+    /// sequence numbers and replaying only frames the daemon did not ack.
+    pub async fn reconnect(&self, group: Arc<dyn LinkGroup>) -> Result<(), ConnectionError> {
+        let mut close_state = self.close_state.subscribe();
+        let _reconnecting = self.lock_reconnecting(&mut close_state).await?;
         let previous_state = self.diagnostics_state();
         self.set_diagnostics_state(ConnectionState::Reconnecting);
-        let mut close_state = self.close_state.subscribe();
         let result = tokio::select! {
+            biased;
             _ = close_state.changed() => Err(ConnectionError::Closed),
             result = self.reconnect_once(group) => result,
         };
@@ -559,9 +583,10 @@ impl ClientConnection {
         let lane_bindings = lane_bindings(self.config.lane_policy, group.capabilities());
         let physical_link_count = lane_bindings.len();
         let transport = group.transport_snapshot().await;
-        // Take both publication guards before the cancellation-sensitive replay
-        // transition. ReliableSession commits only after replay succeeds, and
-        // there is no await between that commit and publishing both wrappers.
+        // Keep the connection publication locks while preparing the candidate,
+        // but do not mutate shared reliability state until shutdown owns the
+        // publication gate below. A dropped preparation therefore leaves the
+        // old session fully usable.
         let mut active_group = self.group.write().await;
         let mut active_session = self.session.write().await;
         if self.closed.load(Ordering::Acquire) {
@@ -573,14 +598,18 @@ impl ClientConnection {
                 actual: active_session.generation(),
             });
         }
-        let next = current.reconnect_to(Arc::new(link), &daemon_resume, generation).await?;
-        // Shutdown takes this gate before publishing its start signal. This
-        // gives reconnect publication and shutdown a clear linearization
-        // point without holding the gate across dialing or replay.
-        let _shutdown_gate = self.shutdown_gate.lock().await;
+        let prepared = current
+            .prepare_reconnect_to(Arc::new(link), &daemon_resume, generation)
+            .await?;
+        // The transaction has not changed shared reliability state yet. Once
+        // this gate is acquired, `commit` and all wrapper publication below
+        // contain no await points, so close cannot observe a half-published
+        // generation and cancellation cannot strand one.
+        let shutdown_gate = self.shutdown_gate.lock().await;
         if self.closed.load(Ordering::Acquire) {
             return Err(ConnectionError::Closed);
         }
+        let next = prepared.commit()?;
         let generation = next.generation();
         let previous = std::mem::replace(&mut *active_group, group.clone());
         *active_session = next;
@@ -602,7 +631,7 @@ impl ClientConnection {
                 diagnostics.state = ConnectionState::Connected;
             }
         }
-        drop(_shutdown_gate);
+        drop(shutdown_gate);
         drop(active_session);
         drop(active_group);
         // Publishing the replacement first lets blocked readers recover onto
@@ -638,29 +667,33 @@ impl ClientConnection {
     }
 
     async fn recover(&self, observed_generation: u64) -> Result<(), ConnectionError> {
-        let _reconnecting = self.reconnecting.lock().await;
+        let mut close_state = self.close_state.subscribe();
+        let _reconnecting = self.lock_reconnecting(&mut close_state).await?;
         if self.session.read().await.generation() != observed_generation {
             return Ok(());
         }
         self.set_diagnostics_state(ConnectionState::Reconnecting);
-        let result = self.recover_locked().await;
+        let result = self.recover_locked(&mut close_state).await;
         if result.is_err() && !self.closed.load(Ordering::Acquire) {
             self.set_diagnostics_state(ConnectionState::Disconnected);
         }
         result
     }
 
-    async fn recover_locked(&self) -> Result<(), ConnectionError> {
+    async fn recover_locked(
+        &self,
+        close_state: &mut watch::Receiver<CloseState>,
+    ) -> Result<(), ConnectionError> {
         let mut attempt = 0_u32;
         let mut delay = self.config.reconnect.initial_delay;
         let mut group = self.group.read().await.clone();
-        let mut close_state = self.close_state.subscribe();
         loop {
             if self.closed.load(Ordering::Acquire) {
                 return Err(ConnectionError::Closed);
             }
             attempt = attempt.saturating_add(1);
             let reconnect = tokio::select! {
+                biased;
                 _ = close_state.changed() => return Err(ConnectionError::Closed),
                 reconnect = tokio::time::timeout(
                     self.config.reconnect.attempt_timeout,
@@ -697,6 +730,7 @@ impl ClientConnection {
                     }
                     if let Some(source) = &self.reconnect_groups {
                         let next = tokio::select! {
+                            biased;
                             _ = close_state.changed() => return Err(ConnectionError::Closed),
                             next = resolve_reconnect_group(
                                 source.as_ref(),
@@ -709,6 +743,7 @@ impl ClientConnection {
                     }
                     let retry_delay = self.config.reconnect.retry_delay(delay);
                     tokio::select! {
+                        biased;
                         _ = tokio::time::sleep(retry_delay) => {}
                         _ = close_state.changed() => return Err(ConnectionError::Closed),
                     }
@@ -811,9 +846,15 @@ async fn wait_for_close(mut state: watch::Receiver<CloseState>) -> Result<(), Co
 async fn run_heartbeat(weak: Weak<ClientConnection>, interval: Duration, timeout: Duration) {
     let Some(initial) = weak.upgrade() else { return };
     let mut close_state = initial.close_state.subscribe();
+    // A new watch receiver considers the current value seen. The atomic flag
+    // closes the gap when shutdown started immediately before subscription.
+    if initial.closed.load(Ordering::Acquire) {
+        return;
+    }
     drop(initial);
     loop {
         tokio::select! {
+            biased;
             _ = tokio::time::sleep(interval) => {}
             _ = close_state.changed() => return,
         }
@@ -842,6 +883,7 @@ async fn run_heartbeat(weak: Weak<ClientConnection>, interval: Duration, timeout
             FrameFlags::HEARTBEAT_REQUEST,
         );
         let send_result = tokio::select! {
+            biased;
             result = tokio::time::timeout_at(deadline, send) => result,
             _ = close_state.changed() => return,
         };
@@ -854,6 +896,7 @@ async fn run_heartbeat(weak: Weak<ClientConnection>, interval: Duration, timeout
             }
         }
         let live = tokio::select! {
+            biased;
             result = tokio::time::timeout_at(deadline, connection.probe_liveness(generation, observed)) => result.unwrap_or(false),
             _ = close_state.changed() => return,
         };
@@ -2402,6 +2445,7 @@ mod tests {
             epochs: Mutex::new(Vec::new()),
             evidence: CarrierEvidence::LocalPeer { uid: None, pid: None },
         });
+        let reconnect_group = group.clone();
         let client = ClientConnection::connect(
             group,
             ClientConnectionConfig {
@@ -2420,6 +2464,10 @@ mod tests {
 
         let publication = client.reconnecting.lock().await;
         let mut close_state = client.close_state.subscribe();
+        let waiting_reconnect = tokio::spawn({
+            let client = client.clone();
+            async move { client.reconnect(reconnect_group).await }
+        });
         let closing = tokio::spawn({
             let client = client.clone();
             async move { client.close().await }
@@ -2436,7 +2484,18 @@ mod tests {
             .expect("shutdown start was not published while cleanup was blocked")
             .expect("close state channel closed before shutdown completed");
         assert!(matches!(*close_state.borrow(), CloseState::Started));
+        tokio::time::timeout(
+            Duration::from_millis(100),
+            run_heartbeat(Arc::downgrade(&client), Duration::from_secs(60), Duration::from_secs(1)),
+        )
+        .await
+        .expect("heartbeat missed shutdown that was published before subscription");
         assert!(!closing.is_finished(), "close bypassed reconnect publication serialization");
+        let waiting_result = tokio::time::timeout(Duration::from_secs(1), waiting_reconnect)
+            .await
+            .expect("reconnect waiter remained behind cleanup after shutdown started")
+            .expect("reconnect waiter task panicked");
+        assert!(matches!(waiting_result, Err(ConnectionError::Closed)));
         closing.abort();
         assert!(closing.await.unwrap_err().is_cancelled());
 

--- a/cmux-tui/crates/cmux-remote/src/connection.rs
+++ b/cmux-tui/crates/cmux-remote/src/connection.rs
@@ -2349,10 +2349,10 @@ mod tests {
             AuthDatabase::load_or_create(directory.path(), "cancel-reconnect", true).unwrap();
         let (daemon, _accepted) = RemoteDaemon::new(auth, SessionLimits::default());
         let initial = HangingCloseGroup::new(Arc::new(FaultGroup {
-                daemon: daemon.clone(),
-                epochs: Mutex::new(Vec::new()),
-                evidence: CarrierEvidence::LocalPeer { uid: None, pid: None },
-            }));
+            daemon: daemon.clone(),
+            epochs: Mutex::new(Vec::new()),
+            evidence: CarrierEvidence::LocalPeer { uid: None, pid: None },
+        }));
         let initial_close_started = initial.close_started.clone();
         let initial_release_close = initial.release_close.clone();
         let initial_close_finished = initial.close_finished.clone();
@@ -2547,10 +2547,10 @@ mod tests {
         let auth = AuthDatabase::load_or_create(directory.path(), "failed-close", true).unwrap();
         let (daemon, _accepted) = RemoteDaemon::new(auth, SessionLimits::default());
         let group = HangingCloseGroup::new(Arc::new(FaultGroup {
-                daemon,
-                epochs: Mutex::new(Vec::new()),
-                evidence: CarrierEvidence::LocalPeer { uid: None, pid: None },
-            }));
+            daemon,
+            epochs: Mutex::new(Vec::new()),
+            evidence: CarrierEvidence::LocalPeer { uid: None, pid: None },
+        }));
         let client = ClientConnection::connect(
             group,
             ClientConnectionConfig {

--- a/cmux-tui/crates/cmux-remote/src/connection.rs
+++ b/cmux-tui/crates/cmux-remote/src/connection.rs
@@ -598,9 +598,8 @@ impl ClientConnection {
                 actual: active_session.generation(),
             });
         }
-        let prepared = current
-            .prepare_reconnect_to(Arc::new(link), &daemon_resume, generation)
-            .await?;
+        let prepared =
+            current.prepare_reconnect_to(Arc::new(link), &daemon_resume, generation).await?;
         // The transaction has not changed shared reliability state yet. Once
         // this gate is acquired, `commit` and all wrapper publication below
         // contain no await points, so close cannot observe a half-published

--- a/cmux-tui/crates/cmux-remote/src/connection.rs
+++ b/cmux-tui/crates/cmux-remote/src/connection.rs
@@ -139,6 +139,10 @@ pub struct ClientConnection {
 #[derive(Clone, Debug)]
 enum CloseState {
     Pending,
+    /// Shutdown has started, but the cleanup task has not published its
+    /// terminal result yet. Background work uses this transition as its
+    /// cancellation signal; callers still wait for `Complete` or `Failed`.
+    Started,
     Complete,
     Failed(CloseFailure),
 }
@@ -689,6 +693,11 @@ impl ClientConnection {
         if self.closed.swap(true, Ordering::AcqRel) {
             return wait_for_close(self.close_state.subscribe()).await;
         }
+        // Publish shutdown intent before taking any cleanup locks. Reconnect
+        // and heartbeat tasks may be blocked in transport futures for a long
+        // time, so waiting only for the eventual terminal state would leave
+        // them alive after the caller has requested close.
+        self.close_state.send_replace(CloseState::Started);
         self.set_diagnostics_state(ConnectionState::Closed);
         // The cleanup task owns every lock needed to snapshot the final carrier.
         // It therefore survives cancellation of this caller after `closed` is
@@ -752,7 +761,7 @@ async fn resolve_reconnect_group(
 async fn wait_for_close(mut state: watch::Receiver<CloseState>) -> Result<(), ConnectionError> {
     loop {
         match state.borrow().clone() {
-            CloseState::Pending => {}
+            CloseState::Pending | CloseState::Started => {}
             CloseState::Complete => return Ok(()),
             CloseState::Failed(failure) => return Err(failure.to_error()),
         }
@@ -2374,6 +2383,7 @@ mod tests {
         .unwrap();
 
         let publication = client.reconnecting.lock().await;
+        let mut close_state = client.close_state.subscribe();
         let closing = tokio::spawn({
             let client = client.clone();
             async move { client.close().await }
@@ -2385,6 +2395,11 @@ mod tests {
         })
         .await
         .expect("close did not begin");
+        tokio::time::timeout(Duration::from_secs(1), close_state.changed())
+            .await
+            .expect("shutdown start was not published while cleanup was blocked")
+            .expect("close state channel closed before shutdown completed");
+        assert!(matches!(*close_state.borrow(), CloseState::Started));
         assert!(!closing.is_finished(), "close bypassed reconnect publication serialization");
         closing.abort();
         assert!(closing.await.unwrap_err().is_cancelled());

--- a/cmux-tui/crates/cmux-remote/src/session.rs
+++ b/cmux-tui/crates/cmux-remote/src/session.rs
@@ -1491,11 +1491,8 @@ mod tests {
     #[tokio::test]
     async fn cancelled_prepared_reconnect_leaves_shared_state_unchanged() {
         let (old_link, old_peer) = test_support::pair(128 * 1024);
-        let session = ReliableSession::new(
-            SessionId([17; 16]),
-            Arc::new(old_link),
-            SessionLimits::default(),
-        );
+        let session =
+            ReliableSession::new(SessionId([17; 16]), Arc::new(old_link), SessionLimits::default());
         session
             .send(Lane::Control, 1, Bytes::from_static(b"keep me"), FrameFlags::empty())
             .await
@@ -1509,10 +1506,8 @@ mod tests {
             let session = session.clone();
             let candidate = candidate.clone();
             async move {
-                let prepared = session
-                    .prepare_reconnect_to(candidate, &BTreeMap::new(), 1)
-                    .await
-                    .unwrap();
+                let prepared =
+                    session.prepare_reconnect_to(candidate, &BTreeMap::new(), 1).await.unwrap();
                 prepared_tx.send(()).unwrap();
                 std::future::pending::<()>().await;
                 let _ = prepared.commit();

--- a/cmux-tui/crates/cmux-remote/src/session.rs
+++ b/cmux-tui/crates/cmux-remote/src/session.rs
@@ -76,6 +76,49 @@ impl Drop for CloseUncommittedLink {
     }
 }
 
+/// A reconnect whose transport replay is complete but whose shared reliability
+/// state has not been committed yet.
+///
+/// The transition write guard stays with the transaction while the owning
+/// connection coordinates its publication with shutdown. Dropping this value
+/// before [`Self::commit`] leaves the old session untouched and closes the
+/// candidate link through `CloseUncommittedLink`.
+pub(crate) struct PreparedReconnect {
+    shared: Arc<SharedState>,
+    transition: Option<tokio::sync::OwnedRwLockWriteGuard<()>>,
+    staged: ReliabilityState,
+    reconnected: ReliableSession,
+    close_uncommitted: CloseUncommittedLink,
+    original_generation: u64,
+}
+
+impl PreparedReconnect {
+    /// Atomically commit the staged reliability state and return its session.
+    /// There are no await points after the state write, so a caller can hold a
+    /// higher-level publication gate across this method without exposing a
+    /// half-published generation to cancellation.
+    pub(crate) fn commit(self) -> Result<ReliableSession, SessionError> {
+        let PreparedReconnect {
+            shared,
+            mut transition,
+            staged,
+            reconnected,
+            close_uncommitted,
+            original_generation,
+        } = self;
+        let mut state = shared.state.lock().unwrap();
+        state.require_generation(original_generation)?;
+        *state = staged;
+        drop(state);
+        for progress in &shared.outbound_progress {
+            progress.notify_waiters();
+        }
+        close_uncommitted.disarm();
+        drop(transition.take());
+        Ok(reconnected)
+    }
+}
+
 impl fmt::Debug for ReliableSession {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
@@ -92,7 +135,7 @@ impl ReliableSession {
         let shared = Arc::new(SharedState {
             session,
             limits,
-            transition: tokio::sync::RwLock::new(()),
+            transition: Arc::new(tokio::sync::RwLock::new(())),
             lane_sends: std::array::from_fn(|_| tokio::sync::Mutex::new(())),
             outbound_progress: std::array::from_fn(|_| tokio::sync::Notify::new()),
             state: Mutex::new(ReliabilityState::new()),
@@ -404,13 +447,13 @@ impl ReliableSession {
     /// but need not be contiguous: a cancelled connection attempt burns its
     /// generation so a later attempt cannot collide with a daemon that already
     /// committed the cancelled attempt.
-    pub(crate) async fn reconnect_to(
+    pub(crate) async fn prepare_reconnect_to(
         &self,
         link: Arc<dyn FrameLink>,
         peer_resume: &BTreeMap<Lane, u64>,
         generation: u64,
-    ) -> Result<Self, SessionError> {
-        let _transition = self.shared.transition.write().await;
+    ) -> Result<PreparedReconnect, SessionError> {
+        let transition = self.shared.transition.clone().write_owned().await;
         let (staged, replay) = {
             let state = self.shared.state.lock().unwrap();
             state.require_generation(self.generation)?;
@@ -453,15 +496,23 @@ impl ReliableSession {
                 .await
                 .map_err(ScheduleError::into_session_error)?;
         }
-        let mut state = self.shared.state.lock().unwrap();
-        state.require_generation(self.generation)?;
-        *state = staged;
-        drop(state);
-        for progress in &self.shared.outbound_progress {
-            progress.notify_waiters();
-        }
-        close_uncommitted.disarm();
-        Ok(reconnected)
+        Ok(PreparedReconnect {
+            shared: self.shared.clone(),
+            transition: Some(transition),
+            staged,
+            reconnected,
+            close_uncommitted,
+            original_generation: self.generation,
+        })
+    }
+
+    pub(crate) async fn reconnect_to(
+        &self,
+        link: Arc<dyn FrameLink>,
+        peer_resume: &BTreeMap<Lane, u64>,
+        generation: u64,
+    ) -> Result<Self, SessionError> {
+        self.prepare_reconnect_to(link, peer_resume, generation).await?.commit()
     }
 
     pub async fn close(&self) -> Result<(), SessionError> {
@@ -511,7 +562,7 @@ async fn run_ack_sender(
 struct SharedState {
     session: SessionId,
     limits: SessionLimits,
-    transition: tokio::sync::RwLock<()>,
+    transition: Arc<tokio::sync::RwLock<()>>,
     lane_sends: [tokio::sync::Mutex<()>; 4],
     outbound_progress: [tokio::sync::Notify; 4],
     state: Mutex<ReliabilityState>,
@@ -900,7 +951,7 @@ mod tests {
     use std::sync::atomic::AtomicBool;
 
     use async_trait::async_trait;
-    use tokio::sync::{Mutex as AsyncMutex, Semaphore};
+    use tokio::sync::{Mutex as AsyncMutex, Semaphore, oneshot};
 
     use super::*;
     use crate::link::{LaneMuxLink, LinkRoute, test_support};
@@ -1435,6 +1486,64 @@ mod tests {
         assert_eq!(replay.generation, 2);
         assert_eq!(replay.payload, b"replay me");
         assert!(replay.flags.contains(FrameFlags::REPLAY));
+    }
+
+    #[tokio::test]
+    async fn cancelled_prepared_reconnect_leaves_shared_state_unchanged() {
+        let (old_link, old_peer) = test_support::pair(128 * 1024);
+        let session = ReliableSession::new(
+            SessionId([17; 16]),
+            Arc::new(old_link),
+            SessionLimits::default(),
+        );
+        session
+            .send(Lane::Control, 1, Bytes::from_static(b"keep me"), FrameFlags::empty())
+            .await
+            .unwrap();
+        let first = WireFrame::decode(&old_peer.receive().await.unwrap().unwrap()).unwrap();
+        assert_eq!(first.generation, 0);
+
+        let candidate = Arc::new(GatedRecordingLink::new());
+        let (prepared_tx, prepared_rx) = oneshot::channel();
+        let attempt = tokio::spawn({
+            let session = session.clone();
+            let candidate = candidate.clone();
+            async move {
+                let prepared = session
+                    .prepare_reconnect_to(candidate, &BTreeMap::new(), 1)
+                    .await
+                    .unwrap();
+                prepared_tx.send(()).unwrap();
+                std::future::pending::<()>().await;
+                let _ = prepared.commit();
+            }
+        });
+
+        candidate.entered.acquire().await.unwrap().forget();
+        candidate.release.add_permits(1);
+        prepared_rx.await.unwrap();
+        attempt.abort();
+        assert!(attempt.await.unwrap_err().is_cancelled());
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !candidate.closed.load(Ordering::Acquire) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("cancelled prepared reconnect did not close its candidate link");
+
+        // Cancellation before commit must not advance the shared reliability
+        // epoch. The original session remains usable and keeps its sequence.
+        assert_eq!(session.generation(), 0);
+        let sequence = session
+            .send(Lane::Control, 1, Bytes::from_static(b"still here"), FrameFlags::empty())
+            .await
+            .unwrap();
+        assert_eq!(sequence, 2);
+        let second = WireFrame::decode(&old_peer.receive().await.unwrap().unwrap()).unwrap();
+        assert_eq!(second.generation, 0);
+        assert_eq!(second.sequence, 2);
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
@@ -14,8 +14,8 @@ use crate::resource_mutation::ResourceMutationPlan;
 use crate::server::MAX_CREATION_SELECTOR_FALLBACKS;
 use crate::workspace_registry::{
     RegistryPane, RegistryScreen, RegistryViewportColumn, ResourceCreationPreparation,
-    ResourceCreationRecovery, ResourcePatchCommit, ResourceWorkspaceClose,
-    ResourceWorkspaceLedger, TerminalLifecycle, TerminalOnExit, TerminalResourceCloseCommit,
+    ResourceCreationRecovery, ResourcePatchCommit, ResourceWorkspaceClose, ResourceWorkspaceLedger,
+    TerminalLifecycle, TerminalOnExit, TerminalResourceCloseCommit,
 };
 use crate::{ResolvedResourcePath, ResourceSelectors, ResourceTarget, SurfaceKind};
 


### PR DESCRIPTION
Make reconnect backoff and heartbeat waits observe the existing close watch channel. Shutdown now interrupts long sleeps, heartbeat sends, and liveness probes without changing protocol behavior. Static checks: git diff --check; rustfmt --edition 2024 --check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cancels reconnect and heartbeat work on close in `cmux-tui` so shutdown no longer waits for retry delays, heartbeat intervals, sends, or liveness probes. Reconnect publication is now transactional, so cancellation can't leave a half-published generation or strand the old session.

- Shutdown intent is published before cleanup locks are taken, so background tasks cancel even when cleanup is blocked.
- Reconnect loops and heartbeat watch the close state channel and return immediately when shutdown starts.
- A prepared reconnect stages new reliability state without mutating shared state; aborting before commit closes the candidate link and leaves the old session fully usable.
- Post-publication retirement of displaced carriers runs in a detached task, so a cancelled reconnect still closes the old group.

<sup>Written for commit 3f5673d2994e470c80b1be91bb1858ea8578e484. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coordination between connection shutdown and reconnect attempts.
  * Reconnection and heartbeat activity now stop promptly when a connection closes.
  * Reduced unnecessary waiting during retry delays, heartbeat sends, and liveness checks after disconnection.
  * Ensured shutdown completes reliably when reconnection is already in progress.
  * Prevented cancelled reconnections from leaving partial session state or open connections.
  * Improved reliability when switching sessions during recovery and reconnect operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->