### PR TITLE
chatmux-relay: reject empty option values

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/cli.rs
+++ b/cmux-tui/crates/chatmux-relay/src/cli.rs
@@ -84,9 +84,8 @@ where
 
         if is_value_flag(argument) {
             let value = args.get(index + 1).map(String::as_str);
-            let usable = value.is_some_and(|value| {
-                !value.is_empty() && value != "--" && !value.starts_with('-')
-            });
+            let usable = value
+                .is_some_and(|value| !value.is_empty() && value != "--" && !value.starts_with('-'));
             if !usable {
                 return Err(missing_value(argument));
             }

--- a/cmux-tui/crates/chatmux-relay/src/cli.rs
+++ b/cmux-tui/crates/chatmux-relay/src/cli.rs
@@ -234,6 +234,7 @@ mod tests {
             &["--backend", "--code"][..],
             &["--backend", "--"][..],
             &["--allow-root", "--status"][..],
+            &["--config", ""][..],
         ] {
             let error = parse(args).expect_err("missing value refused");
             assert!(error.message.contains("requires a value"), "{args:?}: {}", error.message);

--- a/cmux-tui/crates/chatmux-relay/src/cli.rs
+++ b/cmux-tui/crates/chatmux-relay/src/cli.rs
@@ -84,7 +84,9 @@ where
 
         if is_value_flag(argument) {
             let value = args.get(index + 1).map(String::as_str);
-            let usable = value.is_some_and(|value| value != "--" && !value.starts_with('-'));
+            let usable = value.is_some_and(|value| {
+                !value.is_empty() && value != "--" && !value.starts_with('-')
+            });
             if !usable {
                 return Err(missing_value(argument));
             }


### PR DESCRIPTION
Reject empty values for value-taking CLI flags before they reach config or pairing flows. This matches clap non-empty value validation guidance and preserves privacy-safe diagnostics. Regression test is in the first commit; fix is in the second.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects empty values for value-taking CLI flags in `chatmux-relay` so they fail with a `requires a value` error instead of being accepted, matching clap's non-empty value validation and keeping diagnostics privacy-safe.

<sup>Written for commit ba9a5581cf8a57dae070531ac27a151b7b780c38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved command-line validation to reject empty values for backend, root access, enrollment file, and configuration options.
  - Displays a usage error when these options are provided without a valid value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->