### PR TITLE
fix(tui): advance the workspace ledger on receipted workspace mutations

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -64,8 +64,8 @@ use crate::workspace_registry::{
     RegistryBrowser, RegistryBrowserReconnect, RegistryCommit, RegistryLayoutNode,
     RegistrySnapshot, RegistryTab, RegistryTerminal, RegistryViewport, RegistryWorkspace,
     ResourceChange, ResourceEffectOutcome, ResourceEffectPreparation, ResourcePatch,
-    ResourcePatchCommit, ResourceTopologySnapshot, TerminalLifecycle, TerminalOnExit,
-    TerminalRegistrySnapshot, WorkspaceMutation, WorkspaceRegistry,
+    ResourcePatchCommit, ResourceTopologySnapshot, ResourceWorkspaceLedger, TerminalLifecycle,
+    TerminalOnExit, TerminalRegistrySnapshot, WorkspaceMutation, WorkspaceRegistry,
 };
 use crate::{
     PairingChallenge, PairingDecision, PairingError, PaneId, ScreenId, SplitDir, SplitId,
@@ -3678,7 +3678,7 @@ impl Mux {
         {
             *self.resource_mutation_metrics.lock().unwrap() = Some(plan.metrics);
         }
-        let commit = registry.commit_resource_patch(
+        let (commit, workspace_revision) = registry.commit_resource_patch_with_workspace_ledger(
             mutation,
             operation,
             fingerprint,
@@ -3687,8 +3687,9 @@ impl Mux {
             &plan.patch,
             &plan.result,
             &plan.deltas,
+            plan.workspace_ledger.as_ref(),
         )?;
-        plan.apply(&mut state, &commit);
+        plan.apply(&mut state, &commit, workspace_revision);
         drop(state);
         drop(registry);
         if !commit.replayed {
@@ -3770,17 +3771,20 @@ impl Mux {
                     index,
                     true,
                 ));
+                let durable = RegistryWorkspace {
+                    id: workspace.id,
+                    public_id: public_id.clone(),
+                    key: key.clone(),
+                    name: name.clone(),
+                    group_key: self.session.clone(),
+                };
+                let mut desired = self.registry_projection(state);
+                desired.push(durable.clone());
                 Ok(ResourceMutationPlan::new(
                     ResourcePatch {
                         changes: vec![
                             ResourceChange::UpsertWorkspace {
-                                workspace: RegistryWorkspace {
-                                    id: workspace.id,
-                                    public_id: public_id.clone(),
-                                    key,
-                                    name,
-                                    group_key: self.session.clone(),
-                                },
+                                workspace: durable,
                                 position: index,
                                 active_screen: None,
                             },
@@ -3788,14 +3792,19 @@ impl Mux {
                             ResourceChange::SetActiveWorkspace { workspace_id: Some(public_id) },
                         ],
                     },
-                    result,
+                    result.clone(),
                     Value::Array(deltas),
                     move |state| {
                         state.push_workspace(workspace);
                         state.active_workspace = index;
-                        state.workspace_revision = state.workspace_revision.saturating_add(1);
                     },
                 )
+                .with_workspace_ledger(ResourceWorkspaceLedger {
+                    event_kind: "workspace-added",
+                    workspace_key: key,
+                    workspaces: desired,
+                    legacy_result: result,
+                })
                 .with_metrics(ResourceMutationMetrics {
                     touched_resources: 1,
                     order_entries: index + 1,
@@ -3863,6 +3872,9 @@ impl Mux {
                     index,
                     index == state.active_workspace,
                 )]);
+                let mut desired = self.registry_projection(state);
+                desired[index] = durable.clone();
+                let workspace_key = durable.key.clone();
                 Ok(ResourceMutationPlan::new(
                     ResourcePatch {
                         changes: vec![ResourceChange::UpsertWorkspace {
@@ -3871,13 +3883,18 @@ impl Mux {
                             active_screen,
                         }],
                     },
-                    result,
+                    result.clone(),
                     deltas,
                     move |state| {
                         state.workspaces[index].name = name;
-                        state.workspace_revision = state.workspace_revision.saturating_add(1);
                     },
                 )
+                .with_workspace_ledger(ResourceWorkspaceLedger {
+                    event_kind: "workspace-renamed",
+                    workspace_key,
+                    workspaces: desired,
+                    legacy_result: result,
+                })
                 .with_metrics(ResourceMutationMetrics {
                     touched_resources: 1,
                     order_entries: 0,
@@ -3958,6 +3975,9 @@ impl Mux {
                     index,
                     index == state.active_workspace,
                 )]);
+                let mut desired = self.registry_projection(state);
+                desired[index] = durable.clone();
+                let workspace_key = durable.key.clone();
                 Ok(ResourceMutationPlan::new(
                     ResourcePatch {
                         changes: vec![ResourceChange::UpsertWorkspace {
@@ -3966,13 +3986,18 @@ impl Mux {
                             active_screen,
                         }],
                     },
-                    result,
+                    result.clone(),
                     deltas,
                     move |state| {
                         state.workspaces[index].name = name;
-                        state.workspace_revision = state.workspace_revision.saturating_add(1);
                     },
                 )
+                .with_workspace_ledger(ResourceWorkspaceLedger {
+                    event_kind: "workspace-renamed",
+                    workspace_key,
+                    workspaces: desired,
+                    legacy_result: result,
+                })
                 .with_metrics(ResourceMutationMetrics {
                     touched_resources: 1,
                     order_entries: 0,
@@ -4072,9 +4097,21 @@ impl Mux {
                         .collect(),
                 );
                 let order_entries = usize::from(changed) * order.len();
+                let projection = self.registry_projection(state);
+                let desired = order
+                    .iter()
+                    .map(|workspace_id| {
+                        projection
+                            .iter()
+                            .find(|workspace| &workspace.public_id == workspace_id)
+                            .expect("workspace order was built from live workspaces")
+                            .clone()
+                    })
+                    .collect::<Vec<_>>();
+                let workspace_key = state.workspaces[old_index].key.clone();
                 Ok(ResourceMutationPlan::new(
                     ResourcePatch { changes },
-                    result,
+                    result.clone(),
                     deltas,
                     move |state| {
                         if changed {
@@ -4098,9 +4135,14 @@ impl Mux {
                                 .and_then(|slot| state.workspace_index(slot))
                                 .unwrap_or_else(|| state.workspaces.len().saturating_sub(1));
                         }
-                        state.workspace_revision = state.workspace_revision.saturating_add(1);
                     },
                 )
+                .with_workspace_ledger(ResourceWorkspaceLedger {
+                    event_kind: "workspace-moved",
+                    workspace_key,
+                    workspaces: desired,
+                    legacy_result: result,
+                })
                 .with_metrics(ResourceMutationMetrics {
                     touched_resources: 1,
                     order_entries,
@@ -4207,9 +4249,21 @@ impl Mux {
                         .collect(),
                 );
                 let order_entries = usize::from(changed) * order.len();
+                let projection = self.registry_projection(state);
+                let desired = order
+                    .iter()
+                    .map(|workspace_id| {
+                        projection
+                            .iter()
+                            .find(|workspace| &workspace.public_id == workspace_id)
+                            .expect("workspace order was built from live workspaces")
+                            .clone()
+                    })
+                    .collect::<Vec<_>>();
+                let workspace_key = state.workspaces[old_index].key.clone();
                 Ok(ResourceMutationPlan::new(
                     ResourcePatch { changes },
-                    result,
+                    result.clone(),
                     deltas,
                     move |state| {
                         if changed {
@@ -4233,9 +4287,14 @@ impl Mux {
                                 .and_then(|slot| state.workspace_index(slot))
                                 .unwrap_or_else(|| state.workspaces.len().saturating_sub(1));
                         }
-                        state.workspace_revision = state.workspace_revision.saturating_add(1);
                     },
                 )
+                .with_workspace_ledger(ResourceWorkspaceLedger {
+                    event_kind: "workspace-moved",
+                    workspace_key,
+                    workspaces: desired,
+                    legacy_result: result,
+                })
                 .with_metrics(ResourceMutationMetrics {
                     touched_resources: 1,
                     order_entries,

--- a/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
@@ -14,8 +14,8 @@ use crate::resource_mutation::ResourceMutationPlan;
 use crate::server::MAX_CREATION_SELECTOR_FALLBACKS;
 use crate::workspace_registry::{
     RegistryPane, RegistryScreen, RegistryViewportColumn, ResourceCreationPreparation,
-    ResourceCreationRecovery, ResourcePatchCommit, ResourceWorkspaceClose, TerminalLifecycle,
-    TerminalOnExit, TerminalResourceCloseCommit,
+    ResourceCreationRecovery, ResourcePatchCommit, ResourceWorkspaceClose,
+    ResourceWorkspaceLedger, TerminalLifecycle, TerminalOnExit, TerminalResourceCloseCommit,
 };
 use crate::{ResolvedResourcePath, ResourceSelectors, ResourceTarget, SurfaceKind};
 
@@ -386,17 +386,20 @@ impl Mux {
             true,
         ));
         let created_path = json!({"kind":"workspace","workspace_id":public_id});
+        let durable = RegistryWorkspace {
+            id: workspace.id,
+            public_id: public_id.clone(),
+            key: key.clone(),
+            name: name.clone(),
+            group_key: self.session.clone(),
+        };
+        let mut desired = self.registry_projection(&state);
+        desired.push(durable.clone());
         let plan = ResourceMutationPlan::new(
             ResourcePatch {
                 changes: vec![
                     ResourceChange::UpsertWorkspace {
-                        workspace: RegistryWorkspace {
-                            id: workspace.id,
-                            public_id: public_id.clone(),
-                            key,
-                            name: name.clone(),
-                            group_key: self.session.clone(),
-                        },
+                        workspace: durable,
                         position: index,
                         active_screen: None,
                     },
@@ -413,9 +416,18 @@ impl Mux {
             move |state| {
                 state.push_workspace(workspace);
                 state.active_workspace = index;
-                state.workspace_revision = state.workspace_revision.saturating_add(1);
             },
         )
+        .with_workspace_ledger(ResourceWorkspaceLedger {
+            event_kind: "workspace-added",
+            workspace_key: key,
+            workspaces: desired,
+            legacy_result: json!({
+                "workspace":public_id,
+                "name":name,
+                "index":index,
+            }),
+        })
         .with_metrics(ResourceMutationMetrics {
             touched_resources: 1,
             order_entries: index + 1,
@@ -426,7 +438,7 @@ impl Mux {
         {
             *self.resource_mutation_metrics.lock().unwrap() = Some(plan.metrics);
         }
-        let commit = registry.commit_resource_creation_patch(
+        let (commit, workspace_revision) = registry.commit_resource_creation_patch(
             correlation_key,
             mutation,
             "workspace.create",
@@ -435,8 +447,9 @@ impl Mux {
             &plan.result,
             &created_path,
             &plan.deltas,
+            plan.workspace_ledger.as_ref(),
         )?;
-        plan.apply(&mut state, &commit);
+        plan.apply(&mut state, &commit, workspace_revision);
         drop(state);
         drop(registry);
         self.publish_resource_event();

--- a/cmux-tui/crates/cmux-tui-core/src/resource_mutation.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/resource_mutation.rs
@@ -8,7 +8,7 @@
 use serde_json::Value;
 
 use crate::State;
-use crate::workspace_registry::{ResourcePatch, ResourcePatchCommit};
+use crate::workspace_registry::{ResourcePatch, ResourcePatchCommit, ResourceWorkspaceLedger};
 
 type StateApply = Box<dyn FnOnce(&mut State) + Send + 'static>;
 
@@ -25,6 +25,7 @@ pub(crate) struct ResourceMutationPlan {
     pub(crate) result: Value,
     pub(crate) deltas: Value,
     pub(crate) metrics: ResourceMutationMetrics,
+    pub(crate) workspace_ledger: Option<ResourceWorkspaceLedger>,
     apply: StateApply,
 }
 
@@ -40,6 +41,7 @@ impl ResourceMutationPlan {
             result,
             deltas,
             metrics: ResourceMutationMetrics::default(),
+            workspace_ledger: None,
             apply: Box::new(apply),
         }
     }
@@ -49,13 +51,31 @@ impl ResourceMutationPlan {
         self
     }
 
+    /// Declare that this plan changes the workspace projection, so its commit
+    /// must advance the legacy workspace ledger in the same transaction. The
+    /// in-memory `state.workspace_revision` is then set to the committed
+    /// ledger revision (never bumped independently), keeping the revision the
+    /// daemon reports equal to the one the legacy CAS checks.
+    pub(crate) fn with_workspace_ledger(mut self, ledger: ResourceWorkspaceLedger) -> Self {
+        self.workspace_ledger = Some(ledger);
+        self
+    }
+
     /// This call occurs only after the matching durable transaction commits.
     /// Plan builders reserve all needed capacities before returning.
-    pub(crate) fn apply(self, state: &mut State, commit: &ResourcePatchCommit) {
+    pub(crate) fn apply(
+        self,
+        state: &mut State,
+        commit: &ResourcePatchCommit,
+        workspace_revision: Option<u64>,
+    ) {
         if commit.replayed {
             return;
         }
         (self.apply)(state);
+        if let Some(workspace_revision) = workspace_revision {
+            state.workspace_revision = workspace_revision;
+        }
         state.resource_revision = commit.revision;
     }
 }

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -21808,6 +21808,140 @@ mod tests {
         }
     }
 
+    /// Regression test for the packaged-browser alt+n wedge (cmux-browser
+    /// issue #417): a receipted resource `workspace.create` advanced the
+    /// reported `workspace_revision` without advancing the legacy workspace
+    /// ledger, so every later legacy CAS mutation failed with
+    /// "workspace revision conflict: expected 1, current 0" forever.
+    #[test]
+    fn receipted_workspace_create_keeps_legacy_workspace_cas_consistent() {
+        let mux = test_mux();
+        let writer = test_writer();
+        let client = mux.control_clients.register(ClientTransport::Unix, writer.clone());
+
+        // The packaged browser bootstraps its first workspace through the
+        // receipted resource API (workspace.create, initial_content=empty).
+        let selectors = crate::ResourceSelectors {
+            machine: Some("current".to_string()),
+            session: Some("current".to_string()),
+            ..crate::ResourceSelectors::default()
+        };
+        let before = handle_command(&mux, client, Command::ListWorkspaces, &writer).unwrap();
+        let before_revision = before["workspace_revision"].as_u64().unwrap();
+        let created = mux
+            .resource_create_empty_workspace_selected(
+                selectors,
+                Some("bootstrap".into()),
+                "bootstrap-receipt-00000001",
+                None,
+                &WorkspaceMutation::new("bootstrap-create", "chrome-gui").unwrap(),
+            )
+            .unwrap();
+        assert!(!created.replayed);
+
+        // The browser then snapshots the registry and sends its alt+n create
+        // with the reported revision, exactly like SyncWorkspaceRegistry.
+        let listed = handle_command(&mux, client, Command::ListWorkspaces, &writer).unwrap();
+        let revision = listed["workspace_revision"].as_u64().unwrap();
+        // A real registry change must advance the reported revision: clients
+        // gate delta application and snapshot refreshes on it.
+        assert_eq!(revision, before_revision + 1);
+        let response = handle_command(
+            &mux,
+            client,
+            Command::CreateWorkspace {
+                name: Some("alt-n".into()),
+                key: Some("018f6e21-7b70-7e70-8000-0000000000aa".into()),
+                mutation: MutationRequest {
+                    origin: Some("chrome-gui".into()),
+                    mutation_id: Some("alt-n-create".into()),
+                    expected_generation: None,
+                    expected_revision: Some(revision),
+                },
+            },
+            &writer,
+        )
+        .unwrap();
+        assert_eq!(response["replayed"], false);
+        let after = handle_command(&mux, client, Command::ListWorkspaces, &writer).unwrap();
+        assert_eq!(after["workspace_revision"].as_u64().unwrap(), revision + 1);
+    }
+
+    /// Same ledger invariant for the resource rename and move paths: the
+    /// revision the daemon reports must stay usable as a legacy CAS expected
+    /// value after every workspace-projection mutation.
+    #[test]
+    fn resource_rename_and_move_keep_legacy_workspace_cas_consistent() {
+        let mux = test_mux();
+        let writer = test_writer();
+        let client = mux.control_clients.register(ClientTransport::Unix, writer.clone());
+        mux.create_empty_workspace(
+            Some("first".into()),
+            Some("018f6e21-7b70-7e70-8000-0000000000b1".into()),
+            None,
+        )
+        .unwrap();
+        mux.create_empty_workspace(
+            Some("second".into()),
+            Some("018f6e21-7b70-7e70-8000-0000000000b2".into()),
+            None,
+        )
+        .unwrap();
+        let first_id = mux.with_state(|state| state.workspaces[0].public_id.clone());
+
+        mux.resource_rename_workspace(
+            &first_id,
+            "renamed".into(),
+            None,
+            None,
+            &WorkspaceMutation::new("resource-rename", "resource-api").unwrap(),
+        )
+        .unwrap();
+        let listed = handle_command(&mux, client, Command::ListWorkspaces, &writer).unwrap();
+        let revision = listed["workspace_revision"].as_u64().unwrap();
+        handle_command(
+            &mux,
+            client,
+            Command::RenameWorkspace {
+                workspace: None,
+                key: Some("018f6e21-7b70-7e70-8000-0000000000b2".into()),
+                name: "legacy-rename".into(),
+                mutation: MutationRequest {
+                    expected_revision: Some(revision),
+                    ..Default::default()
+                },
+            },
+            &writer,
+        )
+        .expect("legacy CAS rename must accept the reported revision");
+
+        mux.resource_move_workspace(
+            &first_id,
+            1,
+            None,
+            None,
+            &WorkspaceMutation::new("resource-move", "resource-api").unwrap(),
+        )
+        .unwrap();
+        let listed = handle_command(&mux, client, Command::ListWorkspaces, &writer).unwrap();
+        let revision = listed["workspace_revision"].as_u64().unwrap();
+        handle_command(
+            &mux,
+            client,
+            Command::MoveWorkspace {
+                workspace: None,
+                key: Some("018f6e21-7b70-7e70-8000-0000000000b2".into()),
+                index: 0,
+                mutation: MutationRequest {
+                    expected_revision: Some(revision),
+                    ..Default::default()
+                },
+            },
+            &writer,
+        )
+        .expect("legacy CAS move must accept the reported revision");
+    }
+
     #[test]
     fn provider_managed_mux_is_locked_before_authority_handshake() {
         let mux = provider_test_mux();

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -67,6 +67,7 @@ pub use resource_store::{
     RegistryBrowserStatus, RegistryLayoutNode, RegistryPane, RegistryScreen, RegistryTab,
     RegistryViewport, RegistryViewportColumn, ResourceChange, ResourceEventBatch,
     ResourceEventPage, ResourcePatch, ResourcePatchCommit, ResourceTopologySnapshot,
+    ResourceWorkspaceLedger,
 };
 use resource_store::{
     apply_resource_patch, create_resource_schema, initialize_resource_mutation_retention,

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/effect_store.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/effect_store.rs
@@ -660,7 +660,8 @@ impl WorkspaceRegistry {
         result: &Value,
         created_path: &Value,
         deltas: &Value,
-    ) -> anyhow::Result<ResourcePatchCommit> {
+        workspace_ledger: Option<&ResourceWorkspaceLedger>,
+    ) -> anyhow::Result<(ResourcePatchCommit, Option<u64>)> {
         validate_correlation_key(correlation_key)?;
         validate_identifier("mutation id", &mutation.id)?;
         validate_identifier("mutation origin", &mutation.origin)?;
@@ -697,6 +698,24 @@ impl WorkspaceRegistry {
             .ok_or_else(|| anyhow::anyhow!("resource revision exhausted"))?;
         let sqlite_revision =
             i64::try_from(revision).context("resource revision exceeds SQLite range")?;
+        // Workspace-projection creations must advance the legacy workspace
+        // ledger in this same transaction (the resource close path already
+        // does); otherwise later legacy CAS mutations conflict forever.
+        let workspace_revision = workspace_ledger
+            .map(|ledger| {
+                super::commit_workspace_registry_in_transaction(
+                    &tx,
+                    mutation,
+                    &fingerprint,
+                    None,
+                    ledger.event_kind,
+                    &ledger.workspace_key,
+                    &ledger.workspaces,
+                    &canonical_json(&ledger.legacy_result)?,
+                )
+                .map(|(revision, _)| revision)
+            })
+            .transpose()?;
         apply_resource_patch(&tx, patch, sqlite_revision)?;
         tx.execute(
             "UPDATE meta SET value = ?1 WHERE key = 'resource_revision'",
@@ -738,7 +757,10 @@ impl WorkspaceRegistry {
         // replay window and must count toward a boundary compaction.
         resource_store::prune_resource_mutations(&tx)?;
         tx.commit()?;
-        Ok(ResourcePatchCommit { revision, result: result.clone(), replayed: false })
+        Ok((
+            ResourcePatchCommit { revision, result: result.clone(), replayed: false },
+            workspace_revision,
+        ))
     }
 
     pub fn prepare_resource_effect(

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/resource_store.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/resource_store.rs
@@ -790,6 +790,33 @@ impl WorkspaceRegistry {
         result: &Value,
         deltas: &Value,
     ) -> anyhow::Result<ResourcePatchCommit> {
+        self.commit_resource_patch_with_workspace_ledger(
+            mutation,
+            operation,
+            fingerprint,
+            expected_generation,
+            expected_revision,
+            patch,
+            result,
+            deltas,
+            None,
+        )
+        .map(|(commit, _)| commit)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn commit_resource_patch_with_workspace_ledger(
+        &mut self,
+        mutation: &WorkspaceMutation,
+        operation: &str,
+        fingerprint: &Value,
+        expected_generation: Option<&str>,
+        expected_revision: Option<u64>,
+        patch: &ResourcePatch,
+        result: &Value,
+        deltas: &Value,
+        workspace_ledger: Option<&ResourceWorkspaceLedger>,
+    ) -> anyhow::Result<(ResourcePatchCommit, Option<u64>)> {
         validate_identifier("mutation id", &mutation.id)?;
         validate_identifier("mutation origin", &mutation.origin)?;
         validate_identifier("resource operation", operation)?;
@@ -798,7 +825,7 @@ impl WorkspaceRegistry {
         let result_json = canonical_json(result)?;
         let tx = self.connection.transaction()?;
         if let Some(replayed) = resource_patch_replay(&tx, mutation, operation, &fingerprint)? {
-            return Ok(replayed);
+            return Ok((replayed, None));
         }
         if let Some(expected) = expected_generation
             && expected != self.generation
@@ -821,6 +848,25 @@ impl WorkspaceRegistry {
             .ok_or_else(|| anyhow::anyhow!("resource revision exhausted"))?;
         let sqlite_revision =
             i64::try_from(revision).context("resource revision exceeds SQLite range")?;
+
+        // The legacy ledger commit runs first, mirroring the resource close
+        // path: its full-registry rewrite is then corrected in place by the
+        // patch's own upserts inside this same transaction.
+        let workspace_revision = workspace_ledger
+            .map(|ledger| {
+                super::commit_workspace_registry_in_transaction(
+                    &tx,
+                    mutation,
+                    &fingerprint,
+                    None,
+                    ledger.event_kind,
+                    &ledger.workspace_key,
+                    &ledger.workspaces,
+                    &canonical_json(&ledger.legacy_result)?,
+                )
+                .map(|(revision, _)| revision)
+            })
+            .transpose()?;
 
         apply_resource_patch(&tx, patch, sqlite_revision)?;
         tx.execute(
@@ -853,7 +899,10 @@ impl WorkspaceRegistry {
         )?;
         prune_resource_mutations(&tx)?;
         tx.commit()?;
-        Ok(ResourcePatchCommit { revision, result: result.clone(), replayed: false })
+        Ok((
+            ResourcePatchCommit { revision, result: result.clone(), replayed: false },
+            workspace_revision,
+        ))
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1224,6 +1273,21 @@ pub struct ResourcePatchCommit {
     pub revision: u64,
     pub result: Value,
     pub replayed: bool,
+}
+
+/// Legacy workspace-ledger commit to run inside the same transaction as a
+/// resource patch that changes the workspace projection. The legacy CAS
+/// (`create-workspace`/`rename-workspace`/`move-workspace`/`close-workspace`)
+/// compares client snapshot revisions against this ledger, so any resource
+/// commit that changes the reported workspace registry without advancing the
+/// ledger permanently wedges every later legacy mutation (issue: packaged
+/// browsers fail alt+n forever after a receipted `workspace.create`).
+#[derive(Debug, Clone)]
+pub struct ResourceWorkspaceLedger {
+    pub event_kind: &'static str,
+    pub workspace_key: String,
+    pub workspaces: Vec<RegistryWorkspace>,
+    pub legacy_result: Value,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/tests.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/tests.rs
@@ -2135,6 +2135,7 @@ fn completed_creation_counts_in_the_boundary_replay_window() {
             &json!({"created":true}),
             &json!({"kind":"test","id":"boundary"}),
             &json!([]),
+            None,
         )
         .unwrap();
     assert_eq!(
@@ -2240,6 +2241,7 @@ fn startup_mutation_compaction_preserves_recovery_authorities_and_recent_replay(
                 &json!({"created":true}),
                 &created_path,
                 &json!([]),
+                None,
             )
             .unwrap();
         registry


### PR DESCRIPTION
## Problem

The receipted resource paths (`workspace.create` with `initial_content=empty`, resource rename, resource move) bump the in-memory `workspace_revision` that the daemon reports through `list-workspaces`, but never advance the legacy workspace ledger that the `create-workspace`/`rename-workspace`/`move-workspace`/`close-workspace` CAS compares against (`commit_workspace_registry_in_transaction`).

A packaged cmux-browser bootstraps its first workspace through the receipted create, so the daemon reports revision 1 while the ledger holds 0 — and every later legacy workspace mutation fails with `workspace revision conflict: expected 1, current 0`, forever, on a fresh session. This is manaflow-ai/cmux-browser#417 (alt+n workspace phase), the sole remaining Linux nightly blocker there, and the same family as the macOS `revision.conflict` noise.

## Fix

Workspace-projection resource commits now run the legacy ledger commit inside the same SQLite transaction — the exact pattern `commit_resource_close_patch` already uses for workspace closes — and the in-memory revision mirrors the committed ledger value instead of bumping independently.

- `ResourceWorkspaceLedger` declares the ledger commit (event kind, key, desired registry, legacy result); `ResourceMutationPlan::with_workspace_ledger` carries it.
- `commit_resource_patch_with_workspace_ledger` / `commit_resource_creation_patch` thread it and return the committed ledger revision; plan apply sets `state.workspace_revision` from it.
- Fixed paths: receipted empty `workspace.create` (browser bootstrap), resource rename ×2, resource move ×2.

## Tests

- `receipted_workspace_create_keeps_legacy_workspace_cas_consistent` reproduces the packaged-browser sequence (receipted create → list-workspaces → legacy CAS create) and additionally pins that the reported revision advances on a real registry change. Verified to FAIL on the previous behavior.
- `resource_rename_and_move_keep_legacy_workspace_cas_consistent` covers the rename/move variants.
- Full `cmux-tui-core` suite: 1135 lib + 56 integration tests pass (`TMPDIR=/tmp` needed on macOS for two pre-existing SUN_LEN-sensitive socket tests).
- `cmux-tui` bin suite: 1484 pass; `final_browser_pointer_admission_accepts_exact_presented_frame` fails identically on pristine main (pre-existing, unrelated).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11114"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790516731&installation_model_id=21920&pr_number=11114&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11114&signature=bf3f8bddc5760a6af52e9d563ea6a42a2bd84445496e7a2b8cae7a15eb95ecfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a wedge where receipted workspace mutations (empty `workspace.create`, resource rename, resource move) advanced the reported `workspace_revision` without advancing the legacy workspace ledger, so the next legacy CAS mutation failed forever with `workspace revision conflict: expected 1, current 0`. The ledger commit now runs in the same SQLite transaction as the resource patch (the pattern the workspace close path already uses), and the in-memory revision mirrors the committed ledger value instead of bumping independently.

**Tests**
- `receipted_workspace_create_keeps_legacy_workspace_cas_consistent` reproduces the packaged-browser bootstrap sequence and fails on the old behavior.
- `resource_rename_and_move_keep_legacy_workspace_cas_consistent` covers the rename and move variants.
- Full `cmux-tui-core` suite (1135 lib + 56 integration) passes; the `cmux-tui` bin suite passes 1484, with one pre-existing unrelated failure.

<sup>Written for commit 07e19ab2865e4eabbc559f39a27a737814bfda85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace creation, renaming, and moving now persist reliably with resource changes.
  * Workspace revision tracking remains compatible with existing compare-and-swap operations.
  * Related updates are committed together to prevent inconsistent workspace state.

* **Tests**
  * Added regression coverage for workspace creation, renaming, and moving scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->