### PR TITLE
style(tui): apply rustfmt to resource topology imports

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
@@ -14,8 +14,8 @@ use crate::resource_mutation::ResourceMutationPlan;
 use crate::server::MAX_CREATION_SELECTOR_FALLBACKS;
 use crate::workspace_registry::{
     RegistryPane, RegistryScreen, RegistryViewportColumn, ResourceCreationPreparation,
-    ResourceCreationRecovery, ResourcePatchCommit, ResourceWorkspaceClose,
-    ResourceWorkspaceLedger, TerminalLifecycle, TerminalOnExit, TerminalResourceCloseCommit,
+    ResourceCreationRecovery, ResourcePatchCommit, ResourceWorkspaceClose, ResourceWorkspaceLedger,
+    TerminalLifecycle, TerminalOnExit, TerminalResourceCloseCommit,
 };
 use crate::{ResolvedResourcePath, ResourceSelectors, ResourceTarget, SurfaceKind};
 


### PR DESCRIPTION
Fix the cargo-fmt regression introduced by PR #11114.

The change is limited to the rustfmt-required wrapping of the `ResourceWorkspaceLedger` import in `cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs`. No behavior or tests change.

Verification will run through the exact-head hosted cmux-tui workflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the rustfmt regression from PR #11114 by applying the required import wrapping in `cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs`. No behavior or tests change.

<sup>Written for commit d961beee26ee091bfbdca5734ec28caab3399fcf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted an internal import list without changing application behavior or user-visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->