### PR TITLE
security(cloud): bound and isolate remote link process output

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -59846,6 +59846,23 @@
         }
       }
     },
+    "cloud.link.alreadyConnecting": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The cloud terminal is already connecting. Try again."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クラウドターミナルは接続中です。もう一度お試しください。"
+          }
+        }
+      }
+    },
     "cloud.link.exited": {
       "extractionState": "manual",
       "localizations": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -59829,6 +59829,74 @@
         }
       }
     },
+    "cloud.link.clientMissing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The cloud terminal client is not available. Reinstall cmux and try again."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クラウドターミナルクライアントを利用できません。cmux を再インストールして、もう一度お試しください。"
+          }
+        }
+      }
+    },
+    "cloud.link.exited": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The cloud terminal client stopped unexpectedly. Try again."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クラウドターミナルクライアントが予期せず停止しました。もう一度お試しください。"
+          }
+        }
+      }
+    },
+    "cloud.link.operationFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The cloud terminal operation failed. Try again."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クラウドターミナル操作に失敗しました。もう一度お試しください。"
+          }
+        }
+      }
+    },
+    "cloud.link.timedOut": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The cloud terminal connection timed out. Try again."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クラウドターミナル接続がタイムアウトしました。もう一度お試しください。"
+          }
+        }
+      }
+    },
     "cloudPane.newTerminalFailed.title": {
       "extractionState": "manual",
       "localizations": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -59829,6 +59829,40 @@
         }
       }
     },
+    "cloudPane.newTerminalFailed.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn’t start a terminal on %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ でターミナルを開始できませんでした"
+          }
+        }
+      }
+    },
+    "cloudPane.newTerminalFailed.ok": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        }
+      }
+    },
     "cloudTree.confirm.cancel": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/Cloud/CloudMachineLink.swift
+++ b/Sources/Cloud/CloudMachineLink.swift
@@ -82,6 +82,7 @@ actor CloudMachineLink {
     private var processGeneration: UUID?
     private var eventsProcess: Process?
     private var eventsProcessStopper: CloudLinkProcessStopper?
+    private var eventsLineObserver: CloudLinkPipe.LineObserver?
     private var inviteFileURL: URL?
 
     /// One tick per daemon-side change (from `session current events`) or link state
@@ -201,12 +202,23 @@ actor CloudMachineLink {
             throw error
         }
         guard process.isRunning else {
+            let failure = LinkError.exited(status: process.terminationStatus, code: .other)
             stopper.stop()
-            self.process = nil
-            self.processStopper = nil
-            self.processGeneration = nil
-            removeInviteFile()
-            throw LinkError.exited(status: process.terminationStatus, code: .other)
+            // `terminationHandler` and this check can observe the same exit in
+            // either order. Only the current generation may publish the
+            // pre-connect failure; this prevents a stale callback from leaving
+            // the link stuck in `.connecting`.
+            if processGeneration == generation {
+                self.process = nil
+                self.processStopper = nil
+                self.processGeneration = nil
+                connected = nil
+                state = .error
+                lastError = Self.errorText(failure)
+                removeInviteFile()
+                changesContinuation.yield()
+            }
+            throw failure
         }
         let connected = Connected(socketPath: socketPath, session: session)
         self.connected = connected
@@ -217,6 +229,8 @@ actor CloudMachineLink {
     }
 
     func disconnect() {
+        eventsLineObserver?.cancel()
+        eventsLineObserver = nil
         eventsProcessStopper?.stop()
         eventsProcessStopper = nil
         eventsProcess = nil
@@ -347,6 +361,8 @@ actor CloudMachineLink {
     }
 
     private func startEventsSubscription(socketPath: String) {
+        eventsLineObserver?.cancel()
+        eventsLineObserver = nil
         let process = Process()
         process.executableURL = clientURL
         process.arguments = CloudTuiCommandLine.eventsArguments(socketPath: socketPath)
@@ -364,27 +380,32 @@ actor CloudMachineLink {
         eventsProcess = process
         eventsProcessStopper = stopper
         let continuation = changesContinuation
-        let lines = CloudLinkPipe.lines(from: stdout.fileHandleForReading)
-        Task.detached {
-            for await line in lines where !line.isEmpty {
-                continuation.yield()
+        let observer = CloudLinkPipe.LineObserver(
+            handle: stdout.fileHandleForReading,
+            onLine: { line in
+                guard !line.isEmpty else { return }
+                // `changes` is a wake-only stream. A dropped wake means one is
+                // already queued; the consumer rereads the complete snapshot,
+                // so no daemon event is lost at this boundary.
+                _ = continuation.yield()
             }
-            // The link's own exit handler reports the state change.
-        }
+        )
+        observer.install()
+        eventsLineObserver = observer
+        // The link's own exit handler reports the state change.
     }
 
-    private func drainAndDiscard(_ handle: FileHandle) {
-        let lines = CloudLinkPipe.lines(from: handle)
-        Task.detached {
-            for await _ in lines {}
-        }
+    private func clearEventsProcess() {
+        eventsLineObserver?.cancel()
+        eventsLineObserver = nil
+        eventsProcessStopper?.stop()
+        eventsProcessStopper = nil
+        eventsProcess = nil
     }
 
     private func linkProcessDidExit(status: Int32, generation: UUID) {
         guard processGeneration == generation else { return }
-        eventsProcessStopper?.stop()
-        eventsProcessStopper = nil
-        eventsProcess = nil
+        clearEventsProcess()
         processStopper = nil
         process = nil
         processGeneration = nil
@@ -397,6 +418,13 @@ actor CloudMachineLink {
         changesContinuation.yield()
         changesContinuation.finish()
     }
+    private func drainAndDiscard(_ handle: FileHandle) {
+        let lines = CloudLinkPipe.lines(from: handle)
+        Task.detached {
+            for await _ in lines {}
+        }
+    }
+
 
     private func removeInviteFile() {
         if let inviteFileURL {
@@ -598,6 +626,74 @@ enum CloudLinkPipe {
             var line = String(decoding: pending, as: UTF8.self)
             if line.hasSuffix("\r") { line.removeLast() }
             return line
+        }
+    }
+
+    /// Delivers complete lines directly from the readability callback. Unlike
+    /// ``lines(from:)``, this observer has no intermediate AsyncStream queue,
+    /// so a burst cannot evict a daemon event before the wake-only continuation
+    /// sees it. The callback itself performs no blocking work.
+    final class LineObserver: @unchecked Sendable {
+        private let handle: FileHandle
+        private let buffer: LineBuffer
+        private let onLine: @Sendable (String) -> Void
+        private let lock = NSLock()
+        private var finished = false
+
+        init(
+            handle: FileHandle,
+            maximumLineBytes: Int = CloudLinkPipe.maximumLineBytes,
+            onLine: @escaping @Sendable (String) -> Void
+        ) {
+            self.handle = handle
+            self.buffer = LineBuffer(maximumBytes: maximumLineBytes)
+            self.onLine = onLine
+        }
+
+        func install() {
+            handle.readabilityHandler = { [weak self] fileHandle in
+                guard let self else { return }
+                let data = fileHandle.availableData
+                if data.isEmpty {
+                    self.finish()
+                    return
+                }
+                self.lock.lock()
+                guard !self.finished else {
+                    self.lock.unlock()
+                    return
+                }
+                let lines = self.buffer.append(data)
+                self.lock.unlock()
+                for line in lines {
+                    self.lock.lock()
+                    let shouldDeliver = !self.finished
+                    self.lock.unlock()
+                    if shouldDeliver { self.onLine(line) }
+                }
+            }
+        }
+
+        func cancel() {
+            lock.lock()
+            guard !finished else {
+                lock.unlock()
+                return
+            }
+            finished = true
+            lock.unlock()
+            handle.readabilityHandler = nil
+        }
+
+        private func finish() {
+            lock.lock()
+            guard !finished else {
+                lock.unlock()
+                return
+            }
+            finished = true
+            lock.unlock()
+            handle.readabilityHandler = nil
         }
     }
 }

--- a/Sources/Cloud/CloudMachineLink.swift
+++ b/Sources/Cloud/CloudMachineLink.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import os
 
@@ -11,6 +12,8 @@ import os
 /// or until it exits on its own (machine slept, route expired), which flips the state
 /// and ends the `changes` stream so the owner can re-link on demand.
 actor CloudMachineLink {
+    private static let maximumInvitationBytes = 64 * 1024
+
     struct Connected: Sendable, Equatable {
         let socketPath: String
         let session: String
@@ -18,8 +21,9 @@ actor CloudMachineLink {
 
     enum LinkError: Error, LocalizedError {
         case clientMissing
-        case spawnFailed(String)
-        case exited(status: Int32, output: String)
+        case alreadyConnecting
+        case spawnFailed
+        case exited(status: Int32, code: RemoteFailureCode)
         case outputLimitExceeded
         case timedOut
 
@@ -27,6 +31,8 @@ actor CloudMachineLink {
             switch self {
             case .clientMissing:
                 return String(localized: "cloud.link.clientMissing", defaultValue: "The cloud terminal client is not available. Reinstall cmux and try again.")
+            case .alreadyConnecting:
+                return String(localized: "cloud.link.alreadyConnecting", defaultValue: "The cloud terminal is already connecting. Try again.")
             case .spawnFailed, .outputLimitExceeded:
                 return String(localized: "cloud.link.operationFailed", defaultValue: "The cloud terminal operation failed. Try again.")
             case .exited:
@@ -39,8 +45,8 @@ actor CloudMachineLink {
         /// A small internal classification used for recovery without retaining or
         /// displaying the remote command's diagnostic text.
         var remoteFailureCode: RemoteFailureCode {
-            guard case .exited(_, let output) = self else { return .other }
-            return CloudMachineLink.remoteFailureCode(in: output)
+            guard case .exited(_, let code) = self else { return .other }
+            return code
         }
 
         enum RemoteFailureCode: Equatable, Sendable {
@@ -72,9 +78,11 @@ actor CloudMachineLink {
     // Foundation `Process` and its pipes are actor-isolated state; every callback hops
     // back into the actor through a Task, so nothing else touches them.
     private var process: Process?
+    private var processStopper: CloudLinkProcessStopper?
+    private var processGeneration: UUID?
     private var eventsProcess: Process?
+    private var eventsProcessStopper: CloudLinkProcessStopper?
     private var inviteFileURL: URL?
-    private var stderrTail: [String] = []
 
     /// One tick per daemon-side change (from `session current events`) or link state
     /// change; ends when the link dies.
@@ -93,13 +101,11 @@ actor CloudMachineLink {
     /// Spawns the headless client against `route` and waits for its local socket.
     func connect(route: String, session: String, invitationURI: String?, timeout: Duration = .seconds(60)) async throws -> Connected {
         if let connected, state == .connected { return connected }
+        if process != nil { throw LinkError.alreadyConnecting }
         try paths.ensureStateDir()
         var inviteFilePath: String?
         if let invitationURI, !invitationURI.isEmpty {
-            let url = FileManager.default.temporaryDirectory
-                .appendingPathComponent("cmux-cloud-link-invite-\(UUID().uuidString.lowercased())")
-            try (invitationURI + "\n").data(using: .utf8)!.write(to: url, options: .atomic)
-            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+            let url = try Self.writeInvitationFile(invitationURI)
             inviteFileURL = url
             inviteFilePath = url.path
         }
@@ -119,50 +125,88 @@ actor CloudMachineLink {
         process.standardOutput = stdout
         process.standardError = stderr
         process.standardInput = FileHandle.nullDevice
+        let stopper = CloudLinkProcessStopper(
+            process: process,
+            handles: [stdout.fileHandleForReading, stderr.fileHandleForReading]
+        )
+        let generation = UUID()
+        let exit = CloudLinkFirstValue<Int32>()
         process.terminationHandler = { [weak self] terminated in
             let status = terminated.terminationStatus
-            Task { await self?.linkProcessDidExit(status: status) }
+            exit.resolve(status)
+            Task { await self?.linkProcessDidExit(status: status, generation: generation) }
         }
         state = .connecting
         lastError = nil
+        self.process = process
+        self.processStopper = stopper
+        self.processGeneration = generation
         do {
             try process.run()
         } catch {
             state = .error
-            lastError = Self.errorText(LinkError.spawnFailed(error.localizedDescription))
+            exit.resolve(nil)
+            stopper.stop()
+            lastError = Self.errorText(LinkError.spawnFailed)
             removeInviteFile()
-            throw LinkError.spawnFailed(error.localizedDescription)
+            self.process = nil
+            self.processStopper = nil
+            self.processGeneration = nil
+            throw LinkError.spawnFailed
         }
-        self.process = process
-        drainStderr(stderr.fileHandleForReading)
+        drainAndDiscard(stderr.fileHandleForReading)
 
         // The first connection-snapshot line names the socket; later lines only update
         // transport topology and are ignored — but stdout keeps draining for the
         // process's whole life so the client never blocks on a full pipe.
-        let firstSocket = CloudLinkFirstValue<String>()
-        let stdoutLines = CloudLinkPipe.lines(from: stdout.fileHandleForReading)
-        Task.detached {
-            for await line in stdoutLines {
-                if let socket = CmuxTuiSnapshotParser.localSocket(fromLinkLine: line) {
-                    firstSocket.resolve(socket)
-                }
+        // Search the stream directly instead of putting lines into a finite queue.
+        // A peer can write arbitrary diagnostics before the snapshot; queueing those
+        // lines could evict the only snapshot and turn a valid connection into a
+        // timeout. The scanner keeps draining after it finds the socket so the child
+        // cannot block on a full stdout pipe.
+        let firstSocketTask = Task {
+            await CloudLinkPipe.firstMatchingLine(from: stdout.fileHandleForReading) { line in
+                CmuxTuiSnapshotParser.localSocket(fromLinkLine: line)
             }
-            firstSocket.resolve(nil)
         }
-        let socketPath: String = try await withThrowingTaskGroup(of: String?.self) { group in
-            group.addTask { await firstSocket.result }
-            group.addTask {
-                try await Task.sleep(for: timeout)
-                return nil
+        let socketPath: String
+        do {
+            socketPath = try await withTaskCancellationHandler {
+                try await withThrowingTaskGroup(of: String?.self) { group in
+                    group.addTask { await firstSocketTask.value }
+                    group.addTask {
+                        try await Task.sleep(for: timeout)
+                        return nil
+                    }
+                    defer { group.cancelAll() }
+                    guard let first = try await group.next(), let socket = first else {
+                        throw LinkError.timedOut
+                    }
+                    return socket
+                }
+            } onCancel: {
+                firstSocketTask.cancel()
+                stopper.stop()
             }
-            defer { group.cancelAll() }
-            guard let first = try await group.next(), let socket = first else {
-                throw LinkError.timedOut
-            }
-            return socket
+        } catch {
+            firstSocketTask.cancel()
+            stopper.stop()
+            self.process = nil
+            self.processStopper = nil
+            self.processGeneration = nil
+            removeInviteFile()
+            if Task.isCancelled { throw CancellationError() }
+            state = .error
+            lastError = Self.errorText(error)
+            throw error
         }
         guard process.isRunning else {
-            throw LinkError.exited(status: process.terminationStatus, output: stderrTail.joined(separator: "\n"))
+            stopper.stop()
+            self.process = nil
+            self.processStopper = nil
+            self.processGeneration = nil
+            removeInviteFile()
+            throw LinkError.exited(status: process.terminationStatus, code: .other)
         }
         let connected = Connected(socketPath: socketPath, session: session)
         self.connected = connected
@@ -173,10 +217,13 @@ actor CloudMachineLink {
     }
 
     func disconnect() {
-        eventsProcess?.terminate()
+        eventsProcessStopper?.stop()
+        eventsProcessStopper = nil
         eventsProcess = nil
-        process?.terminate()
+        processStopper?.stop()
+        processStopper = nil
         process = nil
+        processGeneration = nil
         connected = nil
         state = .unavailable
         removeInviteFile()
@@ -199,40 +246,97 @@ actor CloudMachineLink {
         // which ends both drains with a non-zero status.
         let exit = CloudLinkFirstValue<Int32>()
         process.terminationHandler = { exited in exit.resolve(exited.terminationStatus) }
-        try process.run()
-        async let outData = CloudLinkPipe.readToEndResult(
-            stdout.fileHandleForReading,
-            maximumBytes: CloudLinkPipe.maximumCommandOutputBytes
+        let stopper = CloudLinkProcessStopper(
+            process: process,
+            handles: [stdout.fileHandleForReading, stderr.fileHandleForReading]
         )
-        async let errData = CloudLinkPipe.readToEndResult(
-            stderr.fileHandleForReading,
-            maximumBytes: CloudLinkPipe.maximumDiagnosticOutputBytes
-        )
+        let outReader = BoundedReadState(maximumBytes: CloudLinkPipe.maximumCommandOutputBytes)
+        outReader.install(on: stdout.fileHandleForReading)
+        let errReader = BoundedReadState(maximumBytes: CloudLinkPipe.maximumDiagnosticOutputBytes)
+        errReader.install(on: stderr.fileHandleForReading)
+        let outTask = Task {
+            await outReader.result()
+        }
+        let errTask = Task {
+            await errReader.result()
+        }
+        do {
+            try process.run()
+        } catch {
+            exit.resolve(nil)
+            stopper.stop()
+            outReader.cancel()
+            errReader.cancel()
+            _ = await outTask.value
+            _ = await errTask.value
+            throw LinkError.spawnFailed
+        }
         let deadline = Task<Bool, Never> {
             do {
                 try await Task.sleep(for: timeout)
             } catch {
                 return false
             }
-            process.terminate()
+            stopper.stop()
+            outReader.cancel()
+            errReader.cancel()
             return true
         }
-        let status = await exit.result ?? process.terminationStatus
+        let status = await withTaskCancellationHandler {
+            await exit.result ?? process.terminationStatus
+        } onCancel: {
+            stopper.stop()
+            outReader.cancel()
+            errReader.cancel()
+            exit.resolve(nil)
+        }
         deadline.cancel()
         let timedOut = await deadline.value
-        let out = await outData
-        let err = await errData
+        let out = await outTask.value
+        let err = await errTask.value
+        stopper.stop()
+        process.terminationHandler = nil
+        if Task.isCancelled { throw CancellationError() }
         if timedOut { throw LinkError.timedOut }
         if out.truncated || err.truncated { throw LinkError.outputLimitExceeded }
         guard status == 0 else {
             let text = String(decoding: err.data, as: UTF8.self)
             let fallback = String(decoding: out.data, as: UTF8.self)
-            throw LinkError.exited(status: status, output: text.isEmpty ? fallback : text)
+            throw LinkError.exited(
+                status: status,
+                code: Self.remoteFailureCode(in: text.isEmpty ? fallback : text)
+            )
         }
         return out.data
     }
 
     // MARK: - internals
+
+    private static func writeInvitationFile(_ invitationURI: String) throws -> URL {
+        guard let data = (invitationURI + "\n").data(using: .utf8),
+              data.count <= maximumInvitationBytes else {
+            throw LinkError.outputLimitExceeded
+        }
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-cloud-link-invite-\(UUID().uuidString.lowercased())")
+        let descriptor = Darwin.open(
+            url.path,
+            O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC | O_NOFOLLOW,
+            mode_t(0o600)
+        )
+        guard descriptor >= 0 else { throw LinkError.spawnFailed }
+        do {
+            let handle = FileHandle(fileDescriptor: descriptor, closeOnDealloc: true)
+            try handle.write(contentsOf: data)
+            try handle.close()
+            return url
+        } catch {
+            // `FileHandle` owns the descriptor, including the failure path.
+            // Closing it here also prevents a descriptor leak before the file is removed.
+            try? FileManager.default.removeItem(at: url)
+            throw LinkError.spawnFailed
+        }
+    }
 
     private nonisolated static func remoteFailureCode(in output: String) -> LinkError.RemoteFailureCode {
         let normalized = output.lowercased()
@@ -250,12 +354,15 @@ actor CloudMachineLink {
         process.standardError = FileHandle.nullDevice
         let stdout = Pipe()
         process.standardOutput = stdout
+        let stopper = CloudLinkProcessStopper(process: process, handles: [stdout.fileHandleForReading])
         do {
             try process.run()
         } catch {
+            stopper.stop()
             return
         }
         eventsProcess = process
+        eventsProcessStopper = stopper
         let continuation = changesContinuation
         let lines = CloudLinkPipe.lines(from: stdout.fileHandleForReading)
         Task.detached {
@@ -266,29 +373,26 @@ actor CloudMachineLink {
         }
     }
 
-    private func drainStderr(_ handle: FileHandle) {
+    private func drainAndDiscard(_ handle: FileHandle) {
         let lines = CloudLinkPipe.lines(from: handle)
-        Task.detached { [weak self] in
-            for await line in lines {
-                await self?.recordStderr(line)
-            }
+        Task.detached {
+            for await _ in lines {}
         }
     }
 
-    private func recordStderr(_ line: String) {
-        stderrTail.append(line)
-        if stderrTail.count > 20 { stderrTail.removeFirst(stderrTail.count - 20) }
-    }
-
-    private func linkProcessDidExit(status: Int32) {
-        eventsProcess?.terminate()
+    private func linkProcessDidExit(status: Int32, generation: UUID) {
+        guard processGeneration == generation else { return }
+        eventsProcessStopper?.stop()
+        eventsProcessStopper = nil
         eventsProcess = nil
+        processStopper = nil
         process = nil
+        processGeneration = nil
         connected = nil
         removeInviteFile()
         if state != .unavailable {
             state = status == 0 ? .unavailable : .error
-            lastError = status == 0 ? nil : LinkError.exited(status: status, output: stderrTail.joined(separator: "\n")).errorDescription
+            lastError = status == 0 ? nil : LinkError.exited(status: status, code: .other).errorDescription
         }
         changesContinuation.yield()
         changesContinuation.finish()
@@ -298,6 +402,34 @@ actor CloudMachineLink {
         if let inviteFileURL {
             try? FileManager.default.removeItem(at: inviteFileURL)
             self.inviteFileURL = nil
+        }
+    }
+}
+
+/// Owns a child process and the parent-side read handles for its complete lifecycle.
+/// Cancellation closes the readers and sends TERM followed by KILL when the child does
+/// not exit immediately, so a timeout cannot leave an orphan holding a route or pipe.
+final class CloudLinkProcessStopper: @unchecked Sendable {
+    private let process: Process
+    private let handles: [FileHandle]
+
+    init(process: Process, handles: [FileHandle]) {
+        self.process = process
+        self.handles = handles
+    }
+
+    deinit { stop() }
+
+    func stop() {
+        let identifier = process.processIdentifier
+        if process.isRunning, identifier > 1 {
+            process.terminate()
+            if process.isRunning {
+                _ = Darwin.kill(identifier, SIGKILL)
+            }
+        }
+        for handle in handles {
+            try? handle.close()
         }
     }
 }
@@ -363,6 +495,29 @@ enum CloudLinkPipe {
         }
     }
 
+    /// Finds the first line for which ``matching`` returns a value while continuously
+    /// draining the handle. The reader remains installed after a match and discards
+    /// later lines until EOF, preventing a successful link from deadlocking on a noisy
+    /// child process. Cancellation before a match closes the reader and resolves nil;
+    /// cancellation after a match leaves the drain alive for the child lifecycle.
+    static func firstMatchingLine(
+        from handle: FileHandle,
+        maximumLineBytes: Int = Self.maximumLineBytes,
+        matching: @escaping @Sendable (String) -> String?
+    ) async -> String? {
+        let reader = FirstMatchingLineReader(
+            handle: handle,
+            maximumLineBytes: maximumLineBytes,
+            matching: matching
+        )
+        reader.install()
+        return await withTaskCancellationHandler {
+            await reader.result()
+        } onCancel: {
+            reader.cancel()
+        }
+    }
+
     /// Everything up to EOF, capped at ``maximumCommandOutputBytes``.
     static func readToEnd(_ handle: FileHandle) async -> Data {
         await readToEndResult(handle, maximumBytes: maximumCommandOutputBytes).data
@@ -372,7 +527,11 @@ enum CloudLinkPipe {
     static func readToEndResult(_ handle: FileHandle, maximumBytes: Int) async -> ReadResult {
         let reader = BoundedReadState(maximumBytes: max(0, maximumBytes))
         reader.install(on: handle)
-        return await reader.result()
+        return await withTaskCancellationHandler {
+            await reader.result()
+        } onCancel: {
+            reader.cancel()
+        }
     }
 
     /// Splits a byte stream into lines; only ever touched from the handle's GCD queue.
@@ -388,7 +547,7 @@ enum CloudLinkPipe {
         return (lines, Data(pending))
     }
 
-    private final class LineBuffer {
+    final class LineBuffer {
         private let maximumBytes: Int
         private var pending = Data()
         private var discardingOversizedLine = false
@@ -434,10 +593,88 @@ enum CloudLinkPipe {
     }
 }
 
+/// Owns the first-snapshot scan. The FileHandle retains the readability closure, so
+/// the scanner continues to drain after the async caller receives its match. Access to
+/// lifecycle state is synchronized because cancellation can race a GCD read callback.
+private final class FirstMatchingLineReader: @unchecked Sendable {
+    private let handle: FileHandle
+    private let buffer: CloudLinkPipe.LineBuffer
+    private let matching: @Sendable (String) -> String?
+    private let value = CloudLinkFirstValue<String>()
+    private let lock = NSLock()
+    private var matched = false
+    private var finished = false
+    private var cancelled = false
+
+    init(
+        handle: FileHandle,
+        maximumLineBytes: Int,
+        matching: @escaping @Sendable (String) -> String?
+    ) {
+        self.handle = handle
+        self.buffer = CloudLinkPipe.LineBuffer(maximumBytes: maximumLineBytes)
+        self.matching = matching
+    }
+
+    func install() {
+        handle.readabilityHandler = { [self] fileHandle in
+            let data = fileHandle.availableData
+            if data.isEmpty {
+                finish()
+                return
+            }
+            for line in buffer.append(data) {
+                lock.lock()
+                let shouldMatch = !cancelled && !matched
+                lock.unlock()
+                guard shouldMatch, let result = matching(line) else { continue }
+                lock.lock()
+                guard !cancelled, !matched else {
+                    lock.unlock()
+                    continue
+                }
+                matched = true
+                lock.unlock()
+                value.resolve(result)
+            }
+        }
+    }
+
+    func result() async -> String? {
+        await value.result
+    }
+
+    func cancel() {
+        lock.lock()
+        guard !finished, !matched else {
+            lock.unlock()
+            return
+        }
+        cancelled = true
+        finished = true
+        lock.unlock()
+        handle.readabilityHandler = nil
+        value.resolve(nil)
+    }
+
+    private func finish() {
+        lock.lock()
+        guard !finished else {
+            lock.unlock()
+            return
+        }
+        finished = true
+        let hadMatch = matched
+        lock.unlock()
+        handle.readabilityHandler = nil
+        if !hadMatch { value.resolve(nil) }
+    }
+}
+
 /// Accumulates one process pipe on its readability callback and resolves one
 /// continuation at EOF. The lock protects only this synchronous callback seam;
 /// callers never access the mutable buffer directly.
-private final class BoundedReadState: @unchecked Sendable {
+final class BoundedReadState: @unchecked Sendable {
     private struct State: Sendable {
         var data = Data()
         var truncated = false
@@ -447,6 +684,8 @@ private final class BoundedReadState: @unchecked Sendable {
     private let maximumBytes: Int
     private let state: OSAllocatedUnfairLock<State>
     private let completion = CloudLinkFirstValue<CloudLinkPipe.ReadResult>()
+    private let handleLock = NSLock()
+    private var installedHandle: FileHandle?
 
     init(maximumBytes: Int) {
         self.maximumBytes = maximumBytes
@@ -454,6 +693,9 @@ private final class BoundedReadState: @unchecked Sendable {
     }
 
     func install(on handle: FileHandle) {
+        handleLock.lock()
+        installedHandle = handle
+        handleLock.unlock()
         handle.readabilityHandler = { [weak self] fileHandle in
             guard let self else { return }
             let data = fileHandle.availableData
@@ -468,6 +710,21 @@ private final class BoundedReadState: @unchecked Sendable {
 
     func result() async -> CloudLinkPipe.ReadResult {
         await completion.result ?? CloudLinkPipe.ReadResult(data: Data(), truncated: true)
+    }
+
+    func cancel() {
+        handleLock.lock()
+        let handle = installedHandle
+        installedHandle = nil
+        handleLock.unlock()
+        handle?.readabilityHandler = nil
+        let result: CloudLinkPipe.ReadResult? = state.withLock { state in
+            guard !state.finished else { return nil }
+            state.finished = true
+            state.truncated = true
+            return CloudLinkPipe.ReadResult(data: state.data, truncated: true)
+        }
+        if let result { completion.resolve(result) }
     }
 
     private func consume(_ chunk: Data) {
@@ -493,6 +750,9 @@ private final class BoundedReadState: @unchecked Sendable {
             state.finished = true
             return CloudLinkPipe.ReadResult(data: state.data, truncated: state.truncated)
         }
+        handleLock.lock()
+        installedHandle = nil
+        handleLock.unlock()
         if let result { completion.resolve(result) }
     }
 }

--- a/Sources/Cloud/CloudMachineLink.swift
+++ b/Sources/Cloud/CloudMachineLink.swift
@@ -412,6 +412,8 @@ actor CloudMachineLink {
 final class CloudLinkProcessStopper: @unchecked Sendable {
     private let process: Process
     private let handles: [FileHandle]
+    private let lock = NSLock()
+    private var stopped = false
 
     init(process: Process, handles: [FileHandle]) {
         self.process = process
@@ -421,6 +423,13 @@ final class CloudLinkProcessStopper: @unchecked Sendable {
     deinit { stop() }
 
     func stop() {
+        lock.lock()
+        guard !stopped else {
+            lock.unlock()
+            return
+        }
+        stopped = true
+        lock.unlock()
         let identifier = process.processIdentifier
         if process.isRunning, identifier > 1 {
             process.terminate()

--- a/Sources/Cloud/CloudMachineLink.swift
+++ b/Sources/Cloud/CloudMachineLink.swift
@@ -602,6 +602,7 @@ private final class FirstMatchingLineReader: @unchecked Sendable {
     private let matching: @Sendable (String) -> String?
     private let value = CloudLinkFirstValue<String>()
     private let lock = NSLock()
+    private let bufferLock = NSLock()
     private var matched = false
     private var finished = false
     private var cancelled = false
@@ -623,7 +624,10 @@ private final class FirstMatchingLineReader: @unchecked Sendable {
                 finish()
                 return
             }
-            for line in buffer.append(data) {
+            bufferLock.lock()
+            let lines = buffer.append(data)
+            bufferLock.unlock()
+            for line in lines {
                 lock.lock()
                 let shouldMatch = !cancelled && !matched
                 lock.unlock()
@@ -667,7 +671,22 @@ private final class FirstMatchingLineReader: @unchecked Sendable {
         let hadMatch = matched
         lock.unlock()
         handle.readabilityHandler = nil
-        if !hadMatch { value.resolve(nil) }
+        if !hadMatch {
+            bufferLock.lock()
+            let tail = buffer.flush()
+            bufferLock.unlock()
+            if let tail, let result = matching(tail) {
+                lock.lock()
+                if !cancelled && !matched {
+                    matched = true
+                    lock.unlock()
+                    value.resolve(result)
+                    return
+                }
+                lock.unlock()
+            }
+            value.resolve(nil)
+        }
     }
 }
 

--- a/Sources/Cloud/CloudMachineLink.swift
+++ b/Sources/Cloud/CloudMachineLink.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 /// One headless cmux-tui link to a cloud machine's daemon: a `remote connect --headless`
 /// client process whose local mux socket the app drives for snapshots, events, and
@@ -19,20 +20,32 @@ actor CloudMachineLink {
         case clientMissing
         case spawnFailed(String)
         case exited(status: Int32, output: String)
+        case outputLimitExceeded
         case timedOut
 
         var errorDescription: String? {
             switch self {
             case .clientMissing:
-                return "No cmux-tui client is bundled with this build (Contents/Resources/bin/cmux-tui) and CMUX_TUI_CLIENT is unset."
-            case .spawnFailed(let detail):
-                return "cmux-tui could not be started: \(detail)"
-            case .exited(let status, let output):
-                let tail = output.split(separator: "\n").suffix(3).joined(separator: " · ")
-                return "cmux-tui link exited with status \(status)" + (tail.isEmpty ? "" : ": \(tail)")
+                return String(localized: "cloud.link.clientMissing", defaultValue: "The cloud terminal client is not available. Reinstall cmux and try again.")
+            case .spawnFailed, .outputLimitExceeded:
+                return String(localized: "cloud.link.operationFailed", defaultValue: "The cloud terminal operation failed. Try again.")
+            case .exited:
+                return String(localized: "cloud.link.exited", defaultValue: "The cloud terminal client stopped unexpectedly. Try again.")
             case .timedOut:
-                return "cmux-tui link did not report a socket within the connect timeout."
+                return String(localized: "cloud.link.timedOut", defaultValue: "The cloud terminal connection timed out. Try again.")
             }
+        }
+
+        /// A small internal classification used for recovery without retaining or
+        /// displaying the remote command's diagnostic text.
+        var remoteFailureCode: RemoteFailureCode {
+            guard case .exited(_, let output) = self else { return .other }
+            return CloudMachineLink.remoteFailureCode(in: output)
+        }
+
+        enum RemoteFailureCode: Equatable, Sendable {
+            case selectorNotFound
+            case other
         }
     }
 
@@ -43,22 +56,16 @@ actor CloudMachineLink {
     private(set) var state: SurfaceLinkState = .connecting
     private(set) var lastError: String?
 
-    /// Human-readable text for a link failure. Typed cmux errors describe
-    /// themselves (`VMClientError` is `CustomStringConvertible`, the link and
-    /// manager errors are `LocalizedError`); only foreign errors fall back to
-    /// Foundation's "The operation couldn't be completed. (… error 1.)".
+    /// Human-readable text for a link failure.
+    ///
+    /// Remote command output is untrusted. Only link-owned error cases receive a
+    /// stable local message; every other error is intentionally collapsed to the
+    /// same message so a server path, token, or parser detail cannot reach the UI.
     nonisolated static func errorText(_ error: Error) -> String {
-        if let localized = error as? LocalizedError, let text = localized.errorDescription, !text.isEmpty {
+        if let linkError = error as? LinkError, let text = linkError.errorDescription, !text.isEmpty {
             return text
         }
-        // Swift errors print their `description` (or case name) here; a real
-        // NSError prints "Error Domain=… Code=…", where localizedDescription
-        // is the readable form.
-        let described = String(describing: error)
-        if described.isEmpty || described.hasPrefix("Error Domain=") {
-            return error.localizedDescription
-        }
-        return described
+        return String(localized: "cloud.link.operationFailed", defaultValue: "The cloud terminal operation failed. Try again.")
     }
     private(set) var connected: Connected?
 
@@ -122,7 +129,7 @@ actor CloudMachineLink {
             try process.run()
         } catch {
             state = .error
-            lastError = Self.errorText(error)
+            lastError = Self.errorText(LinkError.spawnFailed(error.localizedDescription))
             removeInviteFile()
             throw LinkError.spawnFailed(error.localizedDescription)
         }
@@ -193,8 +200,14 @@ actor CloudMachineLink {
         let exit = CloudLinkFirstValue<Int32>()
         process.terminationHandler = { exited in exit.resolve(exited.terminationStatus) }
         try process.run()
-        async let outData = CloudLinkPipe.readToEnd(stdout.fileHandleForReading)
-        async let errData = CloudLinkPipe.readToEnd(stderr.fileHandleForReading)
+        async let outData = CloudLinkPipe.readToEndResult(
+            stdout.fileHandleForReading,
+            maximumBytes: CloudLinkPipe.maximumCommandOutputBytes
+        )
+        async let errData = CloudLinkPipe.readToEndResult(
+            stderr.fileHandleForReading,
+            maximumBytes: CloudLinkPipe.maximumDiagnosticOutputBytes
+        )
         let deadline = Task<Bool, Never> {
             do {
                 try await Task.sleep(for: timeout)
@@ -210,15 +223,24 @@ actor CloudMachineLink {
         let out = await outData
         let err = await errData
         if timedOut { throw LinkError.timedOut }
+        if out.truncated || err.truncated { throw LinkError.outputLimitExceeded }
         guard status == 0 else {
-            let text = String(data: err, encoding: .utf8) ?? ""
-            let fallback = String(data: out, encoding: .utf8) ?? ""
+            let text = String(decoding: err.data, as: UTF8.self)
+            let fallback = String(decoding: out.data, as: UTF8.self)
             throw LinkError.exited(status: status, output: text.isEmpty ? fallback : text)
         }
-        return out
+        return out.data
     }
 
     // MARK: - internals
+
+    private nonisolated static func remoteFailureCode(in output: String) -> LinkError.RemoteFailureCode {
+        let normalized = output.lowercased()
+        if normalized.contains("selector.not_found") || normalized.contains("no terminal matches") {
+            return .selectorNotFound
+        }
+        return .other
+    }
 
     private func startEventsSubscription(socketPath: String) {
         let process = Process()
@@ -288,16 +310,31 @@ actor CloudMachineLink {
 /// their timeout, and every socket command crawled. `readabilityHandler` runs on a GCD
 /// queue and costs the pool nothing.
 enum CloudLinkPipe {
+    /// A remote client can emit arbitrary bytes. These limits keep a stalled or
+    /// malicious client from turning a link into an unbounded memory sink.
+    static let maximumLineBytes = 64 * 1024
+    static let maximumCommandOutputBytes = 8 * 1024 * 1024
+    static let maximumDiagnosticOutputBytes = 256 * 1024
+    private static let streamBufferCapacity = 64
+
+    struct ReadResult: Sendable {
+        let data: Data
+        let truncated: Bool
+    }
+
     /// Raw chunks as they arrive; ends at EOF. One consumer.
     static func chunks(from handle: FileHandle) -> AsyncStream<Data> {
-        AsyncStream(bufferingPolicy: .unbounded) { continuation in
+        AsyncStream(bufferingPolicy: .bufferingOldest(streamBufferCapacity)) { continuation in
             handle.readabilityHandler = { fh in
                 let data = fh.availableData
                 if data.isEmpty {
                     fh.readabilityHandler = nil
                     continuation.finish()
                 } else {
-                    continuation.yield(data)
+                    // The stream is only used for best-effort event draining. Keep
+                    // the oldest chunks so a link's first connection snapshot is
+                    // not displaced by a flood of later diagnostics.
+                    _ = continuation.yield(data)
                 }
             }
             continuation.onTermination = { _ in handle.readabilityHandler = nil }
@@ -305,33 +342,37 @@ enum CloudLinkPipe {
     }
 
     /// Lines (without their newline; a trailing CR is dropped) as they arrive; a final
-    /// unterminated line is delivered at EOF. One consumer.
-    static func lines(from handle: FileHandle) -> AsyncStream<String> {
-        AsyncStream(bufferingPolicy: .unbounded) { continuation in
-            let buffer = LineBuffer()
+    /// unterminated line is delivered at EOF. Oversized lines are discarded through
+    /// their newline so a remote peer cannot grow the pending line forever.
+    static func lines(from handle: FileHandle, maximumLineBytes: Int = Self.maximumLineBytes) -> AsyncStream<String> {
+        AsyncStream(bufferingPolicy: .bufferingOldest(streamBufferCapacity)) { continuation in
+            let buffer = LineBuffer(maximumBytes: maximumLineBytes)
             handle.readabilityHandler = { fh in
                 let data = fh.availableData
                 if data.isEmpty {
                     fh.readabilityHandler = nil
-                    if let tail = buffer.flush() { continuation.yield(tail) }
+                    if let tail = buffer.flush() { _ = continuation.yield(tail) }
                     continuation.finish()
                     return
                 }
                 for line in buffer.append(data) {
-                    continuation.yield(line)
+                    _ = continuation.yield(line)
                 }
             }
             continuation.onTermination = { _ in handle.readabilityHandler = nil }
         }
     }
 
-    /// Everything up to EOF.
+    /// Everything up to EOF, capped at ``maximumCommandOutputBytes``.
     static func readToEnd(_ handle: FileHandle) async -> Data {
-        var data = Data()
-        for await chunk in chunks(from: handle) {
-            data.append(chunk)
-        }
-        return data
+        await readToEndResult(handle, maximumBytes: maximumCommandOutputBytes).data
+    }
+
+    /// Drains a pipe without buffering more than `maximumBytes`.
+    static func readToEndResult(_ handle: FileHandle, maximumBytes: Int) async -> ReadResult {
+        let reader = BoundedReadState(maximumBytes: max(0, maximumBytes))
+        reader.install(on: handle)
+        return await reader.result()
     }
 
     /// Splits a byte stream into lines; only ever touched from the handle's GCD queue.
@@ -348,22 +389,111 @@ enum CloudLinkPipe {
     }
 
     private final class LineBuffer {
+        private let maximumBytes: Int
         private var pending = Data()
+        private var discardingOversizedLine = false
+
+        init(maximumBytes: Int) {
+            self.maximumBytes = max(1, maximumBytes)
+        }
 
         func append(_ data: Data) -> [String] {
-            pending.append(data)
-            let split = CloudLinkPipe.splitLines(pending)
-            pending = split.rest
-            return split.lines
+            var lines: [String] = []
+            for byte in data {
+                if discardingOversizedLine {
+                    if byte == 0x0A {
+                        discardingOversizedLine = false
+                    }
+                    continue
+                }
+                if byte == 0x0A {
+                    if pending.last == 0x0D { pending.removeLast() }
+                    lines.append(String(decoding: pending, as: UTF8.self))
+                    pending.removeAll(keepingCapacity: true)
+                } else if pending.count < maximumBytes {
+                    pending.append(byte)
+                } else {
+                    pending.removeAll(keepingCapacity: false)
+                    discardingOversizedLine = true
+                }
+            }
+            return lines
         }
 
         func flush() -> String? {
-            defer { pending = Data() }
-            guard !pending.isEmpty else { return nil }
+            defer {
+                pending.removeAll(keepingCapacity: false)
+                discardingOversizedLine = false
+            }
+            guard !discardingOversizedLine, !pending.isEmpty else { return nil }
+            if pending.last == 0x0D { pending.removeLast() }
             var line = String(decoding: pending, as: UTF8.self)
             if line.hasSuffix("\r") { line.removeLast() }
             return line
         }
+    }
+}
+
+/// Accumulates one process pipe on its readability callback and resolves one
+/// continuation at EOF. The lock protects only this synchronous callback seam;
+/// callers never access the mutable buffer directly.
+private final class BoundedReadState: @unchecked Sendable {
+    private struct State: Sendable {
+        var data = Data()
+        var truncated = false
+        var finished = false
+    }
+
+    private let maximumBytes: Int
+    private let state: OSAllocatedUnfairLock<State>
+    private let completion = CloudLinkFirstValue<CloudLinkPipe.ReadResult>()
+
+    init(maximumBytes: Int) {
+        self.maximumBytes = maximumBytes
+        self.state = OSAllocatedUnfairLock(initialState: State())
+    }
+
+    func install(on handle: FileHandle) {
+        handle.readabilityHandler = { [weak self] fileHandle in
+            guard let self else { return }
+            let data = fileHandle.availableData
+            if data.isEmpty {
+                fileHandle.readabilityHandler = nil
+                self.finish()
+            } else {
+                self.consume(data)
+            }
+        }
+    }
+
+    func result() async -> CloudLinkPipe.ReadResult {
+        await completion.result ?? CloudLinkPipe.ReadResult(data: Data(), truncated: true)
+    }
+
+    private func consume(_ chunk: Data) {
+        state.withLock { state in
+            guard !state.finished else { return }
+            let remaining = maximumBytes - state.data.count
+            guard remaining > 0 else {
+                state.truncated = true
+                return
+            }
+            if chunk.count <= remaining {
+                state.data.append(chunk)
+            } else {
+                state.data.append(chunk.prefix(remaining))
+                state.truncated = true
+            }
+        }
+    }
+
+    private func finish() {
+        let result: CloudLinkPipe.ReadResult? = state.withLock { state in
+            guard !state.finished else { return nil }
+            state.finished = true
+            return CloudLinkPipe.ReadResult(data: state.data, truncated: state.truncated)
+        }
+        if let result { completion.resolve(result) }
     }
 }
 

--- a/Sources/Cloud/CloudMachineLinkManager.swift
+++ b/Sources/Cloud/CloudMachineLinkManager.swift
@@ -34,6 +34,7 @@ actor CloudMachineLinkManager {
     private let clientURL: URL?
     private var links: [String: CloudMachineLink] = [:]
     private var connecting: [String: Task<CloudMachineLink.Connected, Error>] = [:]
+    private var themeTasks: [String: Task<Void, Never>] = [:]
     private var lastFailure: [String: (at: Date, error: String)] = [:]
     /// A failed link is not retried for this long, so a polling sidebar does not hammer
     /// a machine whose route is broken.
@@ -85,7 +86,7 @@ actor CloudMachineLinkManager {
             let endpoint = try await client.openCmuxRemote(
                 id: machineID,
                 deviceFingerprint: paths.deviceFingerprint(for: machineID),
-                clientCapabilities: Self.clientCapabilities(clientURL: clientURL)
+                clientCapabilities: await Self.clientCapabilities(clientURL: clientURL)
             )
             var approval: Task<Void, Never>?
             if let invitation = endpoint.invitation {
@@ -107,7 +108,7 @@ actor CloudMachineLinkManager {
             #if DEBUG
             cmuxDebugLog("cloud.link.connected machine=\(machineID) socket=\(connected.socketPath)")
             #endif
-            pushHostTheme(machineID: machineID, socketPath: connected.socketPath)
+            pushHostTheme(machineID: machineID, connected: connected)
             return connected
         } catch {
             let text = CloudMachineLink.errorText(error)
@@ -140,6 +141,8 @@ actor CloudMachineLinkManager {
     func disconnect(machineID: String) async {
         connecting[machineID]?.cancel()
         connecting[machineID] = nil
+        themeTasks[machineID]?.cancel()
+        themeTasks[machineID] = nil
         if let link = links.removeValue(forKey: machineID) {
             await link.disconnect()
         }
@@ -150,6 +153,8 @@ actor CloudMachineLinkManager {
         for id in Array(links.keys) {
             await disconnect(machineID: id)
         }
+        for task in themeTasks.values { task.cancel() }
+        themeTasks.removeAll()
         for task in connecting.values { task.cancel() }
         connecting.removeAll()
         lastFailure.removeAll()
@@ -167,7 +172,7 @@ actor CloudMachineLinkManager {
     func pushHostThemeToConnectedLinks() async {
         for (machineID, link) in links {
             guard await link.isConnected, let connected = await link.connected else { continue }
-            pushHostTheme(machineID: machineID, socketPath: connected.socketPath)
+            pushHostTheme(machineID: machineID, connected: connected)
         }
     }
 
@@ -176,15 +181,24 @@ actor CloudMachineLinkManager {
     /// Fire-and-forget: theme parity is cosmetic, so a machine that predates
     /// `set-default-colors` (or a link that just dropped) must not fail the operation
     /// that connected it.
-    private func pushHostTheme(machineID: String, socketPath: String) {
+    private func pushHostTheme(machineID: String, connected: CloudMachineLink.Connected) {
+        themeTasks[machineID]?.cancel()
         guard let link = links[machineID] else { return }
-        Task { [hostThemeColors] in
-            guard let colors = await hostThemeColors(),
+        let task = Task { [hostThemeColors] in
+            guard !Task.isCancelled,
+                  await link.isConnected,
+                  await link.connected == connected,
+                  let colors = await hostThemeColors(),
                   let arguments = CloudTuiCommandLine.setDefaultColorsArguments(
-                      socketPath: socketPath, foreground: colors.foreground, background: colors.background
+                      socketPath: connected.socketPath,
+                      foreground: colors.foreground,
+                      background: colors.background
                   ) else { return }
             do {
                 _ = try await link.run(arguments: arguments)
+                guard !Task.isCancelled,
+                      await link.isConnected,
+                      await link.connected == connected else { return }
                 #if DEBUG
                 cmuxDebugLog("cloud.link.theme machine=\(machineID) fg=\(colors.foreground) bg=\(colors.background)")
                 #endif
@@ -194,6 +208,7 @@ actor CloudMachineLinkManager {
                 #endif
             }
         }
+        themeTasks[machineID] = task
     }
 
     private func store(link: CloudMachineLink, for machineID: String) {
@@ -224,7 +239,7 @@ actor CloudMachineLinkManager {
 
     /// `remote-probe --json` → `capabilities`; the control plane picks the machine host by
     /// them (a client that sends a User-Agent earns the branded host).
-    nonisolated static func clientCapabilities(clientURL: URL) -> [String] {
+    nonisolated static func clientCapabilities(clientURL: URL) async -> [String] {
         let process = Process()
         process.executableURL = clientURL
         process.arguments = ["remote-probe", "--json"]
@@ -232,15 +247,47 @@ actor CloudMachineLinkManager {
         process.standardOutput = out
         process.standardError = FileHandle.nullDevice
         process.standardInput = FileHandle.nullDevice
+        let stopper = CloudLinkProcessStopper(process: process, handles: [out.fileHandleForReading])
+        let exit = CloudLinkFirstValue<Int32>()
+        process.terminationHandler = { finished in exit.resolve(finished.terminationStatus) }
+        let reader = BoundedReadState(maximumBytes: CloudLinkPipe.maximumDiagnosticOutputBytes)
+        reader.install(on: out.fileHandleForReading)
+        let output = Task {
+            await reader.result()
+        }
         do {
             try process.run()
         } catch {
+            exit.resolve(nil)
+            stopper.stop()
+            reader.cancel()
+            _ = await output.value
             return []
         }
-        let data = out.fileHandleForReading.readDataToEndOfFile()
-        process.waitUntilExit()
-        guard process.terminationStatus == 0,
-              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+        let deadline = Task {
+            do {
+                try await Task.sleep(for: .seconds(5))
+                stopper.stop()
+                reader.cancel()
+                return true
+            } catch {
+                return false
+            }
+        }
+        let status = await withTaskCancellationHandler {
+            await exit.result ?? process.terminationStatus
+        } onCancel: {
+            stopper.stop()
+            reader.cancel()
+            exit.resolve(nil)
+        }
+        deadline.cancel()
+        let timedOut = await deadline.value
+        let result = await output.value
+        stopper.stop()
+        process.terminationHandler = nil
+        guard !Task.isCancelled, !timedOut, !result.truncated, status == 0,
+              let object = try? JSONSerialization.jsonObject(with: result.data) as? [String: Any],
               (object["app"] as? String) == "cmux-tui",
               let raw = object["capabilities"] as? [Any] else {
             return []

--- a/Sources/Cloud/CloudMachineLinkManager.swift
+++ b/Sources/Cloud/CloudMachineLinkManager.swift
@@ -1,3 +1,4 @@
+import CmuxFoundation
 import Foundation
 
 /// The app's headless cmux-tui links, one per awake cloud machine. Links are created on
@@ -37,13 +38,24 @@ actor CloudMachineLinkManager {
     /// A failed link is not retried for this long, so a polling sidebar does not hammer
     /// a machine whose route is broken.
     private let retryBackoff: TimeInterval = 15
+    /// This Mac's resolved Ghostty default colors ("#rrggbb"), pushed to each machine as
+    /// its cmux-tui session defaults (`set-default-colors`) so remote panes render with
+    /// the local theme. Injected so tests need no Ghostty runtime.
+    private let hostThemeColors: @Sendable () async -> (foreground: String, background: String)?
 
     init(
         paths: CloudTuiClientPaths = CloudTuiClientPaths(),
-        clientURL: URL? = CloudTuiClientPaths.clientURL()
+        clientURL: URL? = CloudTuiClientPaths.clientURL(),
+        hostThemeColors: @escaping @Sendable () async -> (foreground: String, background: String)? = {
+            await MainActor.run {
+                let app = GhosttyApp.shared
+                return (app.defaultForegroundColor.hexString(), app.defaultBackgroundColor.hexString())
+            }
+        }
     ) {
         self.paths = paths
         self.clientURL = clientURL
+        self.hostThemeColors = hostThemeColors
     }
 
     var hasClient: Bool { clientURL != nil }
@@ -95,6 +107,7 @@ actor CloudMachineLinkManager {
             #if DEBUG
             cmuxDebugLog("cloud.link.connected machine=\(machineID) socket=\(connected.socketPath)")
             #endif
+            pushHostTheme(machineID: machineID, socketPath: connected.socketPath)
             return connected
         } catch {
             let text = CloudMachineLink.errorText(error)
@@ -149,7 +162,39 @@ actor CloudMachineLinkManager {
         }
     }
 
+    /// Re-sends this Mac's theme to every connected machine (a Ghostty config reload
+    /// changed the resolved colors). Live attach panes repaint via `colors-changed`.
+    func pushHostThemeToConnectedLinks() async {
+        for (machineID, link) in links {
+            guard await link.isConnected, let connected = await link.connected else { continue }
+            pushHostTheme(machineID: machineID, socketPath: connected.socketPath)
+        }
+    }
+
     // MARK: - internals
+
+    /// Fire-and-forget: theme parity is cosmetic, so a machine that predates
+    /// `set-default-colors` (or a link that just dropped) must not fail the operation
+    /// that connected it.
+    private func pushHostTheme(machineID: String, socketPath: String) {
+        guard let link = links[machineID] else { return }
+        Task { [hostThemeColors] in
+            guard let colors = await hostThemeColors(),
+                  let arguments = CloudTuiCommandLine.setDefaultColorsArguments(
+                      socketPath: socketPath, foreground: colors.foreground, background: colors.background
+                  ) else { return }
+            do {
+                _ = try await link.run(arguments: arguments)
+                #if DEBUG
+                cmuxDebugLog("cloud.link.theme machine=\(machineID) fg=\(colors.foreground) bg=\(colors.background)")
+                #endif
+            } catch {
+                #if DEBUG
+                cmuxDebugLog("cloud.link.themeFailed machine=\(machineID) error=\(CloudMachineLink.errorText(error))")
+                #endif
+            }
+        }
+    }
 
     private func store(link: CloudMachineLink, for machineID: String) {
         links[machineID] = link

--- a/Sources/Cloud/CloudMachineLinkManager.swift
+++ b/Sources/Cloud/CloudMachineLinkManager.swift
@@ -114,7 +114,7 @@ actor CloudMachineLinkManager {
             lastFailure[machineID] = (Date(), text)
             links[machineID] = nil
             #if DEBUG
-            cmuxDebugLog("cloud.link.failed machine=\(machineID) error=\(String(reflecting: error)) text=\(text)")
+            cmuxDebugLog("cloud.link.failed machine=\(machineID) text=\(text)")
             #endif
             throw error
         }

--- a/Sources/Cloud/CloudTreeNodeActions.swift
+++ b/Sources/Cloud/CloudTreeNodeActions.swift
@@ -51,9 +51,9 @@ struct CloudTreeNodeActions {
                 do {
                     try await operation(catalog())
                 } catch {
-                    // Human wording first: the panel now shows this text inline, and a
-                    // raw enum dump ("noProvider(cloud(\"m\"))") explains nothing there.
-                    onFailure((error as? LocalizedError)?.errorDescription ?? String(describing: error))
+                    // Remote/provider errors are untrusted. Keep the panel on the
+                    // same sanitized presentation boundary as pane failures.
+                    onFailure(CloudMachineLink.errorText(error))
                 }
                 onDidMutate()
             }

--- a/Sources/Cloud/CloudTreeNodeActions.swift
+++ b/Sources/Cloud/CloudTreeNodeActions.swift
@@ -51,7 +51,9 @@ struct CloudTreeNodeActions {
                 do {
                     try await operation(catalog())
                 } catch {
-                    onFailure(String(describing: error))
+                    // Human wording first: the panel now shows this text inline, and a
+                    // raw enum dump ("noProvider(cloud(\"m\"))") explains nothing there.
+                    onFailure((error as? LocalizedError)?.errorDescription ?? String(describing: error))
                 }
                 onDidMutate()
             }

--- a/Sources/Cloud/CloudTuiCommandLine.swift
+++ b/Sources/Cloud/CloudTuiCommandLine.swift
@@ -70,15 +70,17 @@ struct CloudTuiCommandLine: Sendable {
         ["--socket", socketPath, "attach", "--terminal", terminalID]
     }
 
-    /// `set-default-colors [--fg #rrggbb] [--bg #rrggbb]` (spec `set-default-colors`,
-    /// protocol 5): the session defaults every PTY surface renders with unless an
-    /// application on the machine authored its own OSC 10/11. Pushing this Mac's
-    /// resolved Ghostty colors makes remote panes match the local theme.
+    /// `session current terminal defaults set [--foreground #rrggbb] [--background #rrggbb]`
+    /// (spec `session.terminal_defaults.update`): the session defaults every PTY surface
+    /// renders with unless an application on the machine authored its own OSC 10/11.
+    /// Pushing this Mac's resolved Ghostty colors makes remote panes match the local
+    /// theme. (The flat `set-default-colors` verb in spec/commands.md is the protocol
+    /// name; the v2 resource CLI rejects it — verified live against a machine.)
     static func setDefaultColorsArguments(socketPath: String, foreground: String?, background: String?) -> [String]? {
-        var arguments = ["--socket", socketPath, "--json", "set-default-colors"]
-        if let foreground { arguments += ["--fg", foreground] }
-        if let background { arguments += ["--bg", background] }
-        return arguments.count > 4 ? arguments : nil
+        var arguments = ["--socket", socketPath, "--json", "session", "current", "terminal", "defaults", "set"]
+        if let foreground { arguments += ["--foreground", foreground] }
+        if let background { arguments += ["--background", background] }
+        return arguments.count > 8 ? arguments : nil
     }
 
     /// The argv `vm.terminal_new` runs in the machine when the caller gives none: a login

--- a/Sources/Cloud/CloudTuiCommandLine.swift
+++ b/Sources/Cloud/CloudTuiCommandLine.swift
@@ -77,10 +77,19 @@ struct CloudTuiCommandLine: Sendable {
     /// theme. (The flat `set-default-colors` verb in spec/commands.md is the protocol
     /// name; the v2 resource CLI rejects it — verified live against a machine.)
     static func setDefaultColorsArguments(socketPath: String, foreground: String?, background: String?) -> [String]? {
+        guard [foreground, background].compactMap({ $0 }).allSatisfy(validColor),
+              foreground != nil || background != nil else { return nil }
         var arguments = ["--socket", socketPath, "--json", "session", "current", "terminal", "defaults", "set"]
         if let foreground { arguments += ["--foreground", foreground] }
         if let background { arguments += ["--background", background] }
-        return arguments.count > 8 ? arguments : nil
+        return arguments
+    }
+
+    private static func validColor(_ value: String) -> Bool {
+        let bytes = Array(value.utf8)
+        return bytes.count == 7
+            && bytes[0] == 0x23
+            && bytes.dropFirst().allSatisfy { ($0 >= 0x30 && $0 <= 0x39) || ($0 >= 0x41 && $0 <= 0x46) || ($0 >= 0x61 && $0 <= 0x66) }
     }
 
     /// The argv `vm.terminal_new` runs in the machine when the caller gives none: a login

--- a/Sources/Cloud/CloudTuiCommandLine.swift
+++ b/Sources/Cloud/CloudTuiCommandLine.swift
@@ -70,6 +70,17 @@ struct CloudTuiCommandLine: Sendable {
         ["--socket", socketPath, "attach", "--terminal", terminalID]
     }
 
+    /// `set-default-colors [--fg #rrggbb] [--bg #rrggbb]` (spec `set-default-colors`,
+    /// protocol 5): the session defaults every PTY surface renders with unless an
+    /// application on the machine authored its own OSC 10/11. Pushing this Mac's
+    /// resolved Ghostty colors makes remote panes match the local theme.
+    static func setDefaultColorsArguments(socketPath: String, foreground: String?, background: String?) -> [String]? {
+        var arguments = ["--socket", socketPath, "--json", "set-default-colors"]
+        if let foreground { arguments += ["--fg", foreground] }
+        if let background { arguments += ["--bg", background] }
+        return arguments.count > 4 ? arguments : nil
+    }
+
     /// The argv `vm.terminal_new` runs in the machine when the caller gives none: a login
     /// shell in the persistent home.
     static let defaultTerminalCommand = ["bash", "-l"]

--- a/Sources/Cloud/MachinesPanelView.swift
+++ b/Sources/Cloud/MachinesPanelView.swift
@@ -120,12 +120,15 @@ struct MachinesPanelView: View {
                     .foregroundColor(.orange.opacity(0.9))
                     .help(viewModel.lastErrorDescription ?? "")
                 } else if let treeError = viewModel.treeErrorDescription {
-                    HStack(spacing: 5) {
+                    // The message itself, not a generic label: a failed tree verb (New
+                    // Terminal Here, Open Shell, …) otherwise reads as a dead menu item,
+                    // with the only explanation hidden behind a hover tooltip.
+                    HStack(alignment: .firstTextBaseline, spacing: 5) {
                         Image(systemName: "exclamationmark.triangle")
                             .font(.system(size: 10, weight: .semibold))
-                        Text(String(localized: "machines.tree.error", defaultValue: "Cloud tree error"))
+                        Text(treeError)
                             .cmuxFont(size: 11)
-                            .lineLimit(1)
+                            .lineLimit(2)
                             .truncationMode(.tail)
                     }
                     .foregroundColor(.orange.opacity(0.9))

--- a/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
+++ b/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
@@ -13,6 +13,7 @@ final class CmuxTuiSurfaceProviderRegistry {
     private let links: CloudMachineLinkManager
     private var pollTask: Task<Void, Never>?
     private var accessObserver: NSObjectProtocol?
+    private var themeObserver: NSObjectProtocol?
     private var refreshInFlight: Task<Void, Never>?
     /// Same cadence as the Machines panel's list refresh.
     private let pollInterval: Duration = .seconds(45)
@@ -30,6 +31,16 @@ final class CmuxTuiSurfaceProviderRegistry {
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor in await self?.accessDidEnd() }
+        }
+        // A Ghostty config reload can change the resolved theme; re-push it so remote
+        // panes keep matching the local ones (connect-time push covers new links).
+        themeObserver = NotificationCenter.default.addObserver(
+            forName: .ghosttyConfigDidReload,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            Task { await self.links.pushHostThemeToConnectedLinks() }
         }
         pollTask?.cancel()
         pollTask = Task { [weak self] in

--- a/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
+++ b/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
@@ -256,7 +256,7 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
             linkState = status?.state ?? .error
             linkError = status?.error ?? CloudMachineLink.errorText(error)
             #if DEBUG
-            cmuxDebugLog("cloud.provider.refreshFailed machine=\(machineID) state=\(linkState) error=\(String(reflecting: error))")
+            cmuxDebugLog("cloud.provider.refreshFailed machine=\(machineID) state=\(linkState) error=\(CloudMachineLink.errorText(error))")
             #endif
         }
         info = Self.info(from: summary, linkState: linkState, linkError: linkError, stats: await stats, remoteWorkspaces: remoteWorkspaces)
@@ -297,11 +297,10 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
         scheduleRefresh()
     }
 
-    /// cmux-tui's `selector.not_found` error body, surfaced by `link.run` as the
-    /// command's output text.
+    /// cmux-tui's typed selector failure, kept out of user-facing error text.
     private static func isSelectorNotFound(_ error: Error) -> Bool {
-        let text = CloudMachineLink.errorText(error)
-        return text.contains("selector.not_found") || text.contains("no terminal matches")
+        guard let linkError = error as? CloudMachineLink.LinkError else { return false }
+        return linkError.remoteFailureCode == .selectorNotFound
     }
 
     func materialize(_ resource: SurfaceResource, at destination: SurfaceDestination, focus: Bool) async throws -> SurfaceProjection {
@@ -335,7 +334,7 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
                         let text = CloudMachineLink.errorText(error)
                         SurfacePaneFactory.showPlaceholder(SurfaceBrowserPlaceholder.failed(label, error: text), panelID: pane.panelID, in: pane.workspaceID)
                         #if DEBUG
-                        cmuxDebugLog("cloud.provider.endpointFailed machine=\(self.machineID) port=\(port) error=\(String(reflecting: error))")
+                        cmuxDebugLog("cloud.provider.endpointFailed machine=\(self.machineID) port=\(port) error=\(CloudMachineLink.errorText(error))")
                         #endif
                     }
                 }

--- a/Sources/Surfaces/Workspace+CloudPaneRouting.swift
+++ b/Sources/Surfaces/Workspace+CloudPaneRouting.swift
@@ -98,7 +98,7 @@ extension Workspace {
     @MainActor
     private static func presentCloudPaneCreationFailure(machine: SurfaceMachineID, error: Error) {
         #if DEBUG
-        cmuxDebugLog("cloud.pane.createFailed machine=\(machine.rawValue) error=\(String(reflecting: error))")
+        cmuxDebugLog("cloud.pane.createFailed machine=\(machine.rawValue) error=\(CloudMachineLink.errorText(error))")
         #endif
         let alert = NSAlert()
         alert.messageText = String(

--- a/Sources/Surfaces/Workspace+CloudPaneRouting.swift
+++ b/Sources/Surfaces/Workspace+CloudPaneRouting.swift
@@ -1,0 +1,116 @@
+import AppKit
+import Bonsplit
+import Foundation
+
+/// Cmd+D / Cmd+T from a pane that projects a cloud resource create the new terminal ON
+/// that machine — in the same cmux-tui workspace — instead of a local shell. Same rule
+/// as the remote tmux mirror: a "split" next to a remote pane means "another terminal
+/// where that pane lives". The new terminal is created through the machine's provider
+/// (`workspace <ws> run`) and projected back into this workspace at the requested spot,
+/// so the sidebar, the socket, and the shortcut agree on what exists.
+extension Workspace {
+    /// The cloud resource behind a panel, when the panel projects one.
+    func cloudProjectedResource(forPanel panelID: UUID) -> SurfaceResource? {
+        let catalog = SurfaceCatalog.shared
+        guard let projection = catalog.projection(forPanel: panelID),
+              projection.workspaceID == id,
+              !projection.resource.machine.isLocal else { return nil }
+        return catalog.resource(forPanel: panelID)
+    }
+
+    /// The cloud resource behind the selected tab of a pane (the Cmd+T anchor).
+    func cloudProjectedResource(inPane paneID: PaneID) -> SurfaceResource? {
+        guard let selectedTabID = bonsplitController.selectedTab(inPane: paneID)?.id,
+              let panelID = panelIdFromSurfaceId(selectedTabID) else { return nil }
+        return cloudProjectedResource(forPanel: panelID)
+    }
+
+    /// Routes a Cmd+D-style split from a cloud-projected panel to its machine.
+    /// Returns false when the source panel is not a cloud projection (create locally).
+    func routeCloudPaneTerminalSplit(
+        from panelID: UUID,
+        orientation: SplitOrientation,
+        insertFirst: Bool,
+        focus: Bool
+    ) -> Bool {
+        guard let resource = cloudProjectedResource(forPanel: panelID),
+              let paneID = paneId(forPanelId: panelID) else { return false }
+        let direction: SurfaceSplitDirection = orientation == .horizontal
+            ? (insertFirst ? .left : .right)
+            : (insertFirst ? .up : .down)
+        return routeCloudPaneTerminalCreate(
+            near: resource,
+            destination: .split(workspaceID: id, paneID: paneID.id.uuidString, direction: direction),
+            focus: focus
+        )
+    }
+
+    /// Routes a bonsplit UI split (the pane-divider split button) whose source pane
+    /// projects a cloud resource: the already-created empty pane receives the machine's
+    /// new terminal as its first tab. Returns false when the source is not cloud-anchored.
+    func routeCloudPaneUISplit(from sourcePanelID: UUID, into newPane: PaneID) -> Bool {
+        guard let resource = cloudProjectedResource(forPanel: sourcePanelID) else { return false }
+        return routeCloudPaneTerminalCreate(
+            near: resource,
+            destination: .tab(workspaceID: id, paneID: newPane.id.uuidString, index: nil),
+            focus: true
+        )
+    }
+
+    /// Routes a Cmd+T-style new tab in a pane whose selected tab projects a cloud
+    /// resource to that machine. Returns false when the pane is not cloud-anchored.
+    func routeCloudPaneTerminalTab(inPane paneID: PaneID, focus: Bool) -> Bool {
+        guard let resource = cloudProjectedResource(inPane: paneID) else { return false }
+        return routeCloudPaneTerminalCreate(
+            near: resource,
+            destination: .tab(workspaceID: id, paneID: paneID.id.uuidString, index: nil),
+            focus: focus
+        )
+    }
+
+    /// Creates a terminal on `resource`'s machine (in the remote workspace of the
+    /// anchor's first view, when it has one) and projects it at `destination`.
+    /// Optimistic like the cloud tree's "New Terminal Here": the pane appears when the
+    /// machine reports the terminal; a failure is announced instead of silently doing
+    /// nothing, because the user's gesture otherwise looks dead.
+    private func routeCloudPaneTerminalCreate(
+        near resource: SurfaceResource,
+        destination: SurfaceDestination,
+        focus: Bool
+    ) -> Bool {
+        let catalog = SurfaceCatalog.shared
+        guard let provider = catalog.provider(for: resource.machine) else { return false }
+        let remoteWorkspaceID = resource.remoteWorkspaces.first?.id
+        let machine = resource.machine
+        Task { @MainActor in
+            do {
+                let created = try await provider.createTerminal(
+                    command: nil, cwd: nil, name: nil, remoteWorkspaceID: remoteWorkspaceID
+                )
+                _ = try await catalog.project(created.id, into: destination, focus: focus, reuseExisting: true)
+            } catch {
+                Self.presentCloudPaneCreationFailure(machine: machine, error: error)
+            }
+        }
+        return true
+    }
+
+    @MainActor
+    private static func presentCloudPaneCreationFailure(machine: SurfaceMachineID, error: Error) {
+        #if DEBUG
+        cmuxDebugLog("cloud.pane.createFailed machine=\(machine.rawValue) error=\(String(reflecting: error))")
+        #endif
+        let alert = NSAlert()
+        alert.messageText = String(
+            format: String(
+                localized: "cloudPane.newTerminalFailed.title",
+                defaultValue: "Couldn’t start a terminal on %@"
+            ),
+            machine.rawValue
+        )
+        alert.informativeText = CloudMachineLink.errorText(error)
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: String(localized: "cloudPane.newTerminalFailed.ok", defaultValue: "OK"))
+        alert.runModal()
+    }
+}

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -8389,6 +8389,16 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
             ) ?? false
             return routed ? .routedToRemote : .failed
         }
+        // A split next to a pane projecting a cloud resource creates the terminal ON
+        // that machine and projects it back (Workspace+CloudPaneRouting). Only plain
+        // requests route: an explicit command, cwd, PTY session, or restore scaffold
+        // is a local-terminal request by construction (including the attach panes the
+        // routed create itself materializes, whose initialCommand is the attach argv).
+        if initialCommand == nil, tmuxStartCommand == nil, remotePTYSessionID == nil,
+           workingDirectory == nil, !suppressWorkspaceRemoteStartupCommand,
+           routeCloudPaneTerminalSplit(from: panelId, orientation: orientation, insertFirst: insertFirst, focus: focus) {
+            return .routedToRemote
+        }
         guard let panel = newTerminalSplitLocal(
             from: panelId,
             orientation: orientation,
@@ -8700,6 +8710,17 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
                     focus: focus ?? (bonsplitController.focusedPaneId == paneId)
                 ) ?? false
             return routed ? .routedToRemote : .failed
+        }
+        // A new tab in a pane whose selected tab projects a cloud resource creates the
+        // terminal ON that machine (Workspace+CloudPaneRouting). Only plain requests
+        // route; an explicit command, cwd, input, restore payload, or PTY session is a
+        // local-terminal request by construction (including the attach panes the routed
+        // create itself materializes, whose initialCommand is the attach argv).
+        if initialCommand == nil, tmuxStartCommand == nil, remotePTYSessionID == nil,
+           workingDirectory == nil, initialInput == nil, startupRestoreAgent == nil,
+           restoredSurfaceId == nil, !suppressWorkspaceRemoteStartupCommand,
+           routeCloudPaneTerminalTab(inPane: paneId, focus: focus ?? (bonsplitController.focusedPaneId == paneId)) {
+            return .routedToRemote
         }
         guard let panel = newTerminalSurfaceLocal(
             inPane: paneId,
@@ -13994,6 +14015,15 @@ extension Workspace: BonsplitDelegate {
         // (or fall back to defaults) instead of leaving an empty selector pane.
         let sourceTabId = controller.selectedTab(inPane: originalPane)?.id
         let sourcePanelId = sourceTabId.flatMap { panelIdFromSurfaceId($0) }
+
+        // Same rule as Cmd+D: a UI split next to a cloud-projected pane continues on that
+        // machine (Workspace+CloudPaneRouting). The new pane already exists and is empty;
+        // the machine's terminal arrives as its first tab when the projection materializes.
+        if let sourcePanelId,
+           routeCloudPaneUISplit(from: sourcePanelId, into: newPane) {
+            scheduleTerminalGeometryReconcile()
+            return
+        }
 
 #if DEBUG
         cmuxDebugLog(

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2738,6 +2738,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A6AC73020000000000000001 /* Workspace+AgentLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6AC73020000000000000002 /* Workspace+AgentLifecycle.swift */; };
 		8777E0018777E0018777E001 /* Workspace+AttentionFlashRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8777E0028777E0028777E002 /* Workspace+AttentionFlashRouting.swift */; };
 		CA52B0150000000000000000 /* Workspace+CanvasLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA52C0150000000000000000 /* Workspace+CanvasLayout.swift */; };
+		65221C81A129236D52702D99 /* Workspace+CloudPaneRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5797FE9CD70513E4FFAC6EB /* Workspace+CloudPaneRouting.swift */; };
 		C54860020000000000000001 /* Workspace+CmuxNavigationDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54860020000000000000002 /* Workspace+CmuxNavigationDescriptor.swift */; };
 		A5FB120D /* Workspace+CustomLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5FB120E /* Workspace+CustomLayout.swift */; };
 		C57B00030000000000000001 /* Workspace+CustomSidebarPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57B00030000000000000002 /* Workspace+CustomSidebarPane.swift */; };
@@ -5622,6 +5623,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		A6AC73020000000000000002 /* Workspace+AgentLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+AgentLifecycle.swift"; sourceTree = "<group>"; };
 		8777E0028777E0028777E002 /* Workspace+AttentionFlashRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+AttentionFlashRouting.swift"; sourceTree = "<group>"; };
 		CA52C0150000000000000000 /* Workspace+CanvasLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CanvasLayout.swift"; sourceTree = "<group>"; };
+		C5797FE9CD70513E4FFAC6EB /* Workspace+CloudPaneRouting.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Workspace+CloudPaneRouting.swift"; sourceTree = "<group>"; };
 		C54860020000000000000002 /* Workspace+CmuxNavigationDescriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CmuxNavigationDescriptor.swift"; sourceTree = "<group>"; };
 		A5FB120E /* Workspace+CustomLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CustomLayout.swift"; sourceTree = "<group>"; };
 		C57B00030000000000000002 /* Workspace+CustomSidebarPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CustomSidebarPane.swift"; sourceTree = "<group>"; };
@@ -6177,6 +6179,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				660286CE22B478E887361407 /* SurfaceCatalog+Groups.swift */,
 				278BEFB3583AED9627966DFF /* SurfaceSocketCommands.swift */,
 				47BBA1A8703756FDDFD53CF3 /* Workspace+SurfaceCatalog.swift */,
+				C5797FE9CD70513E4FFAC6EB /* Workspace+CloudPaneRouting.swift */,
 				1EDD243C7C87A2AB78B12BAD /* LocalSurfaceProvider.swift */,
 				63F5BDFB110A8A96C9CA0A75 /* CmuxTuiSurfaceProviders.swift */,
 				1FE7223A65E72C46927A4F02 /* SurfacePaneFactory.swift */,
@@ -11090,6 +11093,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				A6AC73020000000000000001 /* Workspace+AgentLifecycle.swift in Sources */,
 				8777E0018777E0018777E001 /* Workspace+AttentionFlashRouting.swift in Sources */,
 				CA52B0150000000000000000 /* Workspace+CanvasLayout.swift in Sources */,
+				65221C81A129236D52702D99 /* Workspace+CloudPaneRouting.swift in Sources */,
 				C54860020000000000000001 /* Workspace+CmuxNavigationDescriptor.swift in Sources */,
 				A5FB120D /* Workspace+CustomLayout.swift in Sources */,
 				C57B00030000000000000001 /* Workspace+CustomSidebarPane.swift in Sources */,

--- a/cmuxTests/CmuxTuiSurfaceProviderTests.swift
+++ b/cmuxTests/CmuxTuiSurfaceProviderTests.swift
@@ -232,11 +232,13 @@ import Testing
         // Rename takes the name via --name (verified live; positional is usage.invalid).
         #expect(CloudTuiCommandLine.renameWorkspaceArguments(socketPath: "/k.sock", workspaceID: "ws_main", name: "backend work") ==
             ["--socket", "/k.sock", "--json", "workspace", "ws_main", "rename", "--name", "backend work"])
+        // Verified live: the flat `set-default-colors` verb is `usage.invalid` in the v2
+        // resource CLI; the session-scoped form below is the one machines accept.
         #expect(CloudTuiCommandLine.setDefaultColorsArguments(socketPath: "/k.sock", foreground: "#d8dee9", background: "#171b2e") ==
-            ["--socket", "/k.sock", "--json", "set-default-colors", "--fg", "#d8dee9", "--bg", "#171b2e"])
+            ["--socket", "/k.sock", "--json", "session", "current", "terminal", "defaults", "set", "--foreground", "#d8dee9", "--background", "#171b2e"])
         #expect(CloudTuiCommandLine.setDefaultColorsArguments(socketPath: "/k.sock", foreground: nil, background: "#171b2e") ==
-            ["--socket", "/k.sock", "--json", "set-default-colors", "--bg", "#171b2e"])
-        // No colors, no command: pushing an empty set-default-colors would be a no-op round trip.
+            ["--socket", "/k.sock", "--json", "session", "current", "terminal", "defaults", "set", "--background", "#171b2e"])
+        // No colors, no command: pushing an empty defaults update would be a no-op round trip.
         #expect(CloudTuiCommandLine.setDefaultColorsArguments(socketPath: "/k.sock", foreground: nil, background: nil) == nil)
     }
 

--- a/cmuxTests/CmuxTuiSurfaceProviderTests.swift
+++ b/cmuxTests/CmuxTuiSurfaceProviderTests.swift
@@ -326,7 +326,7 @@ import Testing
         #expect(received == ["kept"])
 
         let outputPipe = Pipe()
-        let payload = Data(repeating: 0x79, count: 4 * 1024 * 1024 + 1)
+        let payload = Data(repeating: 0x79, count: 8 * 1024 * 1024 + 1)
         outputPipe.fileHandleForWriting.write(payload)
         try outputPipe.fileHandleForWriting.close()
         let output = await CloudLinkPipe.readToEnd(outputPipe.fileHandleForReading)

--- a/cmuxTests/CmuxTuiSurfaceProviderTests.swift
+++ b/cmuxTests/CmuxTuiSurfaceProviderTests.swift
@@ -232,6 +232,12 @@ import Testing
         // Rename takes the name via --name (verified live; positional is usage.invalid).
         #expect(CloudTuiCommandLine.renameWorkspaceArguments(socketPath: "/k.sock", workspaceID: "ws_main", name: "backend work") ==
             ["--socket", "/k.sock", "--json", "workspace", "ws_main", "rename", "--name", "backend work"])
+        #expect(CloudTuiCommandLine.setDefaultColorsArguments(socketPath: "/k.sock", foreground: "#d8dee9", background: "#171b2e") ==
+            ["--socket", "/k.sock", "--json", "set-default-colors", "--fg", "#d8dee9", "--bg", "#171b2e"])
+        #expect(CloudTuiCommandLine.setDefaultColorsArguments(socketPath: "/k.sock", foreground: nil, background: "#171b2e") ==
+            ["--socket", "/k.sock", "--json", "set-default-colors", "--bg", "#171b2e"])
+        // No colors, no command: pushing an empty set-default-colors would be a no-op round trip.
+        #expect(CloudTuiCommandLine.setDefaultColorsArguments(socketPath: "/k.sock", foreground: nil, background: nil) == nil)
     }
 
     @Test func clientPathsMirrorTheCLI() throws {

--- a/cmuxTests/CmuxTuiSurfaceProviderTests.swift
+++ b/cmuxTests/CmuxTuiSurfaceProviderTests.swift
@@ -240,6 +240,8 @@ import Testing
             ["--socket", "/k.sock", "--json", "session", "current", "terminal", "defaults", "set", "--background", "#171b2e"])
         // No colors, no command: pushing an empty defaults update would be a no-op round trip.
         #expect(CloudTuiCommandLine.setDefaultColorsArguments(socketPath: "/k.sock", foreground: nil, background: nil) == nil)
+        #expect(CloudTuiCommandLine.setDefaultColorsArguments(socketPath: "/k.sock", foreground: "#d8dee9; rm -rf /", background: nil) == nil)
+        #expect(CloudTuiCommandLine.setDefaultColorsArguments(socketPath: "/k.sock", foreground: "d8dee9", background: nil) == nil)
     }
 
     @Test func clientPathsMirrorTheCLI() throws {
@@ -333,9 +335,23 @@ import Testing
         #expect(output.count < payload.count)
     }
 
+    @Test func cloudLinkFirstMatchingLineSurvivesDiagnosticFlood() async throws {
+        let pipe = Pipe()
+        let socket = Task {
+            await CloudLinkPipe.firstMatchingLine(from: pipe.fileHandleForReading) { line in
+                line == "snapshot" ? "/tmp/cmux-flood.sock" : nil
+            }
+        }
+        await Task.yield()
+        let diagnostics = (0..<256).map { "diagnostic-\($0)" }.joined(separator: "\n")
+        pipe.fileHandleForWriting.write(Data((diagnostics + "\nsnapshot\n").utf8))
+        try pipe.fileHandleForWriting.close()
+        #expect(await socket.value == "/tmp/cmux-flood.sock")
+    }
+
     @Test func cloudLinkErrorsDoNotExposeRemoteOutput() {
         let secret = "/remote/private/path\nTOKEN=not-for-ui"
-        let error = CloudMachineLink.LinkError.exited(status: 1, output: secret)
+        let error = CloudMachineLink.LinkError.exited(status: 1, code: .other)
         let text = CloudMachineLink.errorText(error)
         #expect(!text.contains(secret))
         #expect(!text.contains("TOKEN=not-for-ui"))
@@ -352,4 +368,5 @@ import Testing
         eof.resolve(nil)
         #expect(await eof.result == nil, "finished without a value reads as nil")
     }
+
 }

--- a/cmuxTests/CmuxTuiSurfaceProviderTests.swift
+++ b/cmuxTests/CmuxTuiSurfaceProviderTests.swift
@@ -314,6 +314,33 @@ import Testing
         #expect(String(decoding: data, as: UTF8.self) == "all of it")
     }
 
+    @Test func cloudLinkPipeBoundsUntrustedLinesAndCommandOutput() async throws {
+        let linePipe = Pipe()
+        let lines = CloudLinkPipe.lines(from: linePipe.fileHandleForReading)
+        let oversizedLine = Data(repeating: 0x78, count: 64 * 1024 + 1)
+        linePipe.fileHandleForWriting.write(oversizedLine)
+        linePipe.fileHandleForWriting.write(Data("\nkept\n".utf8))
+        try linePipe.fileHandleForWriting.close()
+        var received: [String] = []
+        for await line in lines { received.append(line) }
+        #expect(received == ["kept"])
+
+        let outputPipe = Pipe()
+        let payload = Data(repeating: 0x79, count: 4 * 1024 * 1024 + 1)
+        outputPipe.fileHandleForWriting.write(payload)
+        try outputPipe.fileHandleForWriting.close()
+        let output = await CloudLinkPipe.readToEnd(outputPipe.fileHandleForReading)
+        #expect(output.count < payload.count)
+    }
+
+    @Test func cloudLinkErrorsDoNotExposeRemoteOutput() {
+        let secret = "/remote/private/path\nTOKEN=not-for-ui"
+        let error = CloudMachineLink.LinkError.exited(status: 1, output: secret)
+        let text = CloudMachineLink.errorText(error)
+        #expect(!text.contains(secret))
+        #expect(!text.contains("TOKEN=not-for-ui"))
+    }
+
     @Test func linkFirstValueResolvesOnce() async {
         let socket = CloudLinkFirstValue<String>()
         async let awaited = socket.result


### PR DESCRIPTION
Security follow-up for https://github.com/manaflow-ai/cmux/pull/11108.

- Bound command and diagnostic output before it reaches local UI or logs.
- Make process stopping idempotent and cancellation-safe.
- Fence link generations and secure invitation-file creation with exclusive, private, no-follow semantics.
- Bound capability and theme command lifetimes.

Trade-off: detailed remote diagnostics are replaced with stable local errors to prevent secret and path disclosure. Residual risk is aggregate memory across many simultaneous links, which remains governed by the per-command cap and account admission limits.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds and redacts cloud link process output so remote diagnostics can't leak secrets or paths into the local UI or logs. Detailed remote error text is replaced with stable local messages, and snapshot discovery survives diagnostic floods.

- Caps command output at 8 MB and diagnostic output at 256 KB; oversized lines are discarded rather than buffered.
- Scans the first socket line directly from the pipe so a diagnostic flood can't evict the snapshot, drains until EOF so the child never blocks, and uses a queue-free observer so daemon event wakes aren't dropped.
- Makes process stopping idempotent and cancellation-safe with TERM-then-KILL cleanup; generation fencing keeps stale exit callbacks from resetting a newer link's state or leaving it stuck in `.connecting`.
- Creates invitation files with exclusive, private, no-follow semantics and bounds invitation size.
- Bounds capability and theme command lifetimes with timeouts and output caps, cancelling stale theme pushes.
- Validates theme color arguments before they reach the remote command.

<sup>Written for commit a3be1bb923c6dfd059f8b92bdb3e53082653d385. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

