### PR TITLE
security(dor): enforce relay identity, frame, and journal boundaries

### DIFF
--- a/Packages/Shared/CmuxDorTransport/Sources/CmuxDorTransport/DorJournal.swift
+++ b/Packages/Shared/CmuxDorTransport/Sources/CmuxDorTransport/DorJournal.swift
@@ -3,6 +3,9 @@
 // {ts, mono_ms, component, event, a_<attr>: value...}
 
 public import Foundation
+#if canImport(Darwin)
+import Darwin
+#endif
 
 public struct DorJournal: Sendable {
     private let write: @Sendable (String) -> Void
@@ -21,13 +24,27 @@ public struct DorJournal: Sendable {
             mirror?(line)
             queue.async {
                 let data = Data((line + "\n").utf8)
-                if let handle = try? FileHandle(forWritingTo: url) {
-                    defer { try? handle.close() }
-                    _ = try? handle.seekToEnd()
-                    try? handle.write(contentsOf: data)
-                } else {
-                    try? data.write(to: url, options: .atomic)
-                }
+                try? FileManager.default.createDirectory(
+                    at: url.deletingLastPathComponent(),
+                    withIntermediateDirectories: true,
+                    attributes: [.posixPermissions: 0o700]
+                )
+#if canImport(Darwin)
+                // O_NOFOLLOW prevents a local process from replacing the
+                // journal with a symlink between launches. O_APPEND keeps
+                // records atomic and 0600 limits disclosure to this user.
+                let flags = O_WRONLY | O_CREAT | O_APPEND | O_CLOEXEC | O_NOFOLLOW
+                let descriptor = Darwin.open(url.path, flags, S_IRUSR | S_IWUSR)
+                guard descriptor >= 0 else { return }
+                _ = fchmod(descriptor, S_IRUSR | S_IWUSR)
+                let handle = FileHandle(fileDescriptor: descriptor, closeOnDealloc: true)
+                try? handle.write(contentsOf: data)
+                try? handle.close()
+#else
+                // This package targets Apple platforms. Keep a functional
+                // fallback for source-only tooling on other hosts.
+                try? data.write(to: url, options: .atomic)
+#endif
             }
         }
     }
@@ -48,7 +65,7 @@ public struct DorJournal: Sendable {
             "event": event,
         ]
         for (key, value) in attributes {
-            object["a_\(key)"] = value
+            object["a_\(key)"] = DorSafety.journalValue(key: key, value: value)
         }
         guard let data = try? JSONSerialization.data(withJSONObject: object),
               let line = String(data: data, encoding: .utf8)

--- a/Packages/Shared/CmuxDorTransport/Sources/CmuxDorTransport/DorLedger.swift
+++ b/Packages/Shared/CmuxDorTransport/Sources/CmuxDorTransport/DorLedger.swift
@@ -7,6 +7,12 @@
 import Foundation
 
 struct DorLedger: Sendable {
+    enum DownloadResult: Sendable, Equatable {
+        case accepted
+        case duplicate
+        case gap
+    }
+
     struct OutboundFrame: Sendable {
         let destination: UInt32
         let seq: UInt64
@@ -96,14 +102,20 @@ struct DorLedger: Sendable {
 
     // MARK: download
 
-    /// Dedup an inbound frame; false means it is a replay the caller drops.
-    /// Forward jumps are accepted (the relay never replays backwards).
+    /// Dedup an inbound frame. A forward gap is a continuity failure, not a
+    /// frame that can be acknowledged safely.
     mutating func acceptDownload(source: UInt32, seq: UInt64) -> Bool {
+        acceptDownloadResult(source: source, seq: seq) == .accepted
+    }
+
+    mutating func acceptDownloadResult(source: UInt32, seq: UInt64) -> DownloadResult {
         let key = downloadKey(source)
-        guard seq > (lastReceived[key] ?? 0) else { return false }
+        let previous = lastReceived[key] ?? 0
+        guard seq > previous else { return .duplicate }
+        guard previous < UInt64.max, seq == previous + 1 else { return .gap }
         lastReceived[key] = seq
         unackedDownloads[key] = (unackedDownloads[key] ?? 0) + 1
-        return true
+        return .accepted
     }
 
     /// Whether an ack should be emitted now for this stream (coalesced).

--- a/Packages/Shared/CmuxDorTransport/Sources/CmuxDorTransport/DorLeg.swift
+++ b/Packages/Shared/CmuxDorTransport/Sources/CmuxDorTransport/DorLeg.swift
@@ -297,7 +297,7 @@ public actor DorLeg {
                 case let .helloAck(legID, resumeKey, _, peerOnline, replayed):
                     return (legID, resumeKey, peerOnline, replayed)
                 case let .resumeFailed(reason):
-                    throw LegOutcome.resumeRefused(reason)
+                    throw LegOutcome.resumeRefused(DorSafety.relayReason(reason))
                 case let .error(code, message):
                     journal.record(
                         component: "leg", event: "relay-error",
@@ -324,7 +324,7 @@ public actor DorLeg {
             lastInbound = ContinuousClock.now
             switch message {
             case .data(let data):
-                if let source = handleDataFrame(data) {
+                if let source = try handleDataFrame(data) {
                     // Coalesced: at most one ack per stream per 16 frames /
                     // 100ms; the 1s ticker flushes stragglers.
                     if case let .ack(seq, leg) = ledger.ackDecision(
@@ -448,7 +448,7 @@ public actor DorLeg {
         case let .peerOffline(legID, reason):
             continuation?.yield(.peerOffline(legID: legID, reason: reason))
         case let .resumeFailed(reason):
-            throw LegOutcome.resumeRefused(reason)
+            throw LegOutcome.resumeRefused(DorSafety.relayReason(reason))
         case let .error(code, message):
             journal.record(
                 component: "leg", event: "relay-error",
@@ -460,15 +460,20 @@ public actor DorLeg {
 
     /// Returns the source leg id when the frame was fresh (not a replay).
     @discardableResult
-    private func handleDataFrame(_ data: Data) -> UInt32? {
+    private func handleDataFrame(_ data: Data) throws -> UInt32? {
         guard let frame = DorWire.decodeData(data) else {
             journal.record(
                 component: "leg", event: "malformed-data",
                 attributes: legAttributes())
             return nil
         }
-        guard ledger.acceptDownload(source: frame.legID, seq: frame.seq) else {
+        switch ledger.acceptDownloadResult(source: frame.legID, seq: frame.seq) {
+        case .duplicate:
             return nil // resume-overlap replay
+        case .gap:
+            throw LegOutcome.resumeRefused("download-sequence-gap")
+        case .accepted:
+            break
         }
         continuation?.yield(.frame(sourceLegID: frame.legID, payload: frame.payload))
         return frame.legID
@@ -512,7 +517,9 @@ public actor DorLeg {
         _ socket: URLSessionWebSocketTask, fallback: String
     ) -> LegOutcome {
         let code = socket.closeCode.rawValue
-        let reason = socket.closeReason.flatMap { String(data: $0, encoding: .utf8) } ?? fallback
+        let reason = DorSafety.stableReason(
+            socket.closeReason.flatMap { String(data: $0, encoding: .utf8) },
+            fallback: fallback)
         switch UInt16(exactly: code) {
         case DorWire.closeUnauthorized:
             consecutiveAuthCloses += 1
@@ -533,11 +540,45 @@ public actor DorLeg {
         }
     }
 
+    /// True when a relay base URL can carry an access token safely. Cleartext
+    /// WebSockets are restricted to literal loopback hosts; all other traffic
+    /// must use TLS. Credentials and fragments are never accepted in a base.
+    public nonisolated static func isAllowedRelayBaseURL(_ url: URL) -> Bool {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let rawScheme = components.scheme?.lowercased(),
+              let rawHost = components.host?.lowercased(),
+              !rawHost.isEmpty,
+              components.user == nil,
+              components.password == nil,
+              components.fragment == nil
+        else { return false }
+        switch rawScheme {
+        case "https", "wss":
+            return true
+        case "http", "ws":
+            return Self.isLoopbackHost(rawHost)
+        default:
+            return false
+        }
+    }
+
+    private nonisolated static func isLoopbackHost(_ host: String) -> Bool {
+        if host == "localhost" || host == "::1" { return true }
+        let octets = host.split(separator: ".", omittingEmptySubsequences: false)
+        guard octets.count == 4, octets[0] == "127" else { return false }
+        return octets.dropFirst().allSatisfy { octet in
+            guard let value = Int(octet), (0 ... 255).contains(value) else { return false }
+            return String(value) == octet
+        }
+    }
+
     private func dialURL() -> URL? {
+        guard Self.isAllowedRelayBaseURL(configuration.relayBaseURL) else { return nil }
         guard var components = URLComponents(
             url: configuration.relayBaseURL, resolvingAgainstBaseURL: false)
         else { return nil }
-        components.scheme = components.scheme == "http" ? "ws" : "wss"
+        let baseScheme = components.scheme?.lowercased()
+        components.scheme = baseScheme == "http" || baseScheme == "ws" ? "ws" : "wss"
         components.path = configuration.role == .host ? "/v1/dor/host" : "/v1/dor/connect"
         var query = [URLQueryItem(name: "device", value: configuration.selfDeviceID)]
         if configuration.role == .phone {

--- a/Packages/Shared/CmuxDorTransport/Sources/CmuxDorTransport/DorPeerEngine.swift
+++ b/Packages/Shared/CmuxDorTransport/Sources/CmuxDorTransport/DorPeerEngine.swift
@@ -224,7 +224,7 @@ public actor DorPeerEngine {
         } catch {
             journal.record(
                 component: "engine", event: "hs1-sign-failed",
-                attributes: ["reason": String(describing: error)])
+                attributes: ["reason": "identity-sign-failed"])
             return
         }
         let hs1 = DorHandshake1(
@@ -260,12 +260,16 @@ public actor DorPeerEngine {
     }
 
     private func handleHandshakePayload(_ json: Data) async {
+        guard json.count <= DorWire.maxHandshakeBytes else { return }
         if let deny = try? JSONDecoder().decode(DorHandshakeDeny.self, from: Data(json)),
            deny.t == "deny"
         {
             journal.record(
                 component: "admission", event: "denied",
-                attributes: ["reason": deny.reason])
+                attributes: [
+                    "reason": DorSafety.stableReason(
+                        deny.reason, fallback: "admission-denied")
+                ])
             return
         }
         guard case let .handshaking(eph, hs1Bytes, _) = dial,

--- a/Packages/Shared/CmuxDorTransport/Sources/CmuxDorTransport/DorSession.swift
+++ b/Packages/Shared/CmuxDorTransport/Sources/CmuxDorTransport/DorSession.swift
@@ -77,6 +77,9 @@ public actor DorSecureSession: DorSecureSessionProtocol {
     /// Owner notification (engine/acceptor), separate from the app-consumed
     /// `events` stream so both can observe the end without sharing it.
     private var onEnded: (@Sendable (String) -> Void)?
+    private static let maxStreams = 64
+    private static let maxDescriptorBytes = 4 * 1024
+    private static let maxSessionCloseBytes = DorSafety.maxReasonBytes
     /// The initiator paces pings; the responder just answers and times out.
     private static let pingInterval: Duration = .seconds(15)
     private static let keepaliveTimeout: Duration = .seconds(60)
@@ -205,39 +208,75 @@ public actor DorSecureSession: DorSecureSessionProtocol {
         }
         switch frame.op {
         case .open:
-            guard streams[frame.streamID] == nil,
+            guard frame.streamID != 0,
+                  isPeerOwnedStreamID(frame.streamID),
+                  frame.payload.count <= Self.maxDescriptorBytes,
+                  streams[frame.streamID] == nil,
+                  streams.count < Self.maxStreams,
                   let descriptor = try? JSONDecoder().decode(
-                    DorLaneDescriptor.self, from: frame.payload)
-            else { return }
+                    DorLaneDescriptor.self, from: frame.payload),
+                  descriptor.isValid
+            else {
+                if frame.streamID != 0, isPeerOwnedStreamID(frame.streamID),
+                   streams[frame.streamID] == nil, streams.count >= Self.maxStreams
+                {
+                    await endSession(reason: "stream-capacity", notifyPeer: true)
+                }
+                return
+            }
             let state = DorStreamState(id: frame.streamID, descriptor: descriptor)
             streams[frame.streamID] = state
             eventsContinuation.yield(
                 .inboundStream(DorStreamHandle(
                     descriptor: descriptor, id: frame.streamID, session: self)))
         case .data:
+            guard frame.streamID != 0, frame.payload.count <= DorMuxLimits.chunkBytes else {
+                await endSession(reason: "stream-buffer-overflow", notifyPeer: true)
+                return
+            }
             guard let state = streams[frame.streamID] else { return }
             if !state.enqueue(frame.payload) {
                 await endSession(reason: "stream-buffer-overflow", notifyPeer: true)
             }
         case .eof:
+            guard frame.streamID != 0 else { return }
             streams[frame.streamID]?.finishEOF()
         case .reset:
+            guard frame.streamID != 0 else { return }
             if let state = streams.removeValue(forKey: frame.streamID) {
                 state.fail(DorStreamError.reset)
             }
         case .credit:
-            if let bytes = frame.creditBytes {
-                streams[frame.streamID]?.addSendWindow(bytes)
+            guard frame.streamID != 0,
+                  let bytes = frame.creditBytes,
+                  bytes > 0,
+                  let state = streams[frame.streamID],
+                  state.addSendWindow(bytes)
+            else {
+                await endSession(reason: "invalid-credit", notifyPeer: true)
+                return
             }
         case .admit:
+            guard frame.streamID == 0,
+                  let object = try? JSONSerialization.jsonObject(with: frame.payload)
+                    as? [String: Any],
+                  object.keys.count == 1,
+                  object["session"] as? String == sessionID
+            else { return }
             admitted = true
             resolveAdmitWaiters(ended: false)
         case .ping:
+            guard frame.streamID == 0, frame.payload.isEmpty else { return }
             try? await sendMux(DorMuxFrame(op: .pong, streamID: 0))
         case .pong:
-            break // lastInbound already updated
+            guard frame.streamID == 0, frame.payload.isEmpty else { return }
         case .sessionClose:
-            let reason = String(data: frame.payload, encoding: .utf8) ?? "peer-closed"
+            guard frame.streamID == 0, frame.payload.count <= Self.maxSessionCloseBytes else {
+                await endSession(reason: "peer-closed", notifyPeer: false)
+                return
+            }
+            let reason = DorSafety.stableReason(
+                String(data: frame.payload, encoding: .utf8), fallback: "peer-closed")
             await endSession(reason: reason, notifyPeer: false)
         }
     }
@@ -251,6 +290,13 @@ public actor DorSecureSession: DorSecureSessionProtocol {
 
     public func openStream(_ descriptor: DorLaneDescriptor) async throws -> any DorStream {
         guard !ended else { throw DorStreamError.sessionEnded }
+        guard descriptor.isValid, streams.count < Self.maxStreams else {
+            throw DorStreamError.streamLimit
+        }
+        guard nextStreamID <= UInt32.max - 2 else {
+            await endSession(reason: "stream-capacity", notifyPeer: false)
+            throw DorStreamError.streamLimit
+        }
         let id = nextStreamID
         nextStreamID &+= 2
         let state = DorStreamState(id: id, descriptor: descriptor)
@@ -261,7 +307,9 @@ public actor DorSecureSession: DorSecureSessionProtocol {
     }
 
     public func close(reason: String) async {
-        await endSession(reason: reason, notifyPeer: true)
+        await endSession(
+            reason: DorSafety.stableReason(reason, fallback: "user-close"),
+            notifyPeer: true)
     }
 
     // MARK: - Stream operations (via DorStreamHandle)
@@ -315,9 +363,14 @@ public actor DorSecureSession: DorSecureSessionProtocol {
 
     private func sendMux(_ frame: DorMuxFrame) async throws {
         guard !ended else { throw DorStreamError.sessionEnded }
+        let encoded = frame.encoded()
+        guard encoded.count <= DorWire.maxDataFrameBytes else {
+            await endSession(reason: "stream-buffer-overflow", notifyPeer: false)
+            throw DorStreamError.sessionEnded
+        }
         let sealed: Data
         do {
-            sealed = try sealer.seal(frame.encoded())
+            sealed = try sealer.seal(encoded)
         } catch {
             await endSession(reason: "seal-failed", notifyPeer: false)
             throw DorStreamError.sessionEnded
@@ -327,10 +380,11 @@ public actor DorSecureSession: DorSecureSessionProtocol {
 
     private func endSession(reason: String, notifyPeer: Bool) async {
         guard !ended else { return }
+        let safeReason = DorSafety.stableReason(reason, fallback: "peer-error")
         if notifyPeer {
             // Best effort; sealed with the still-valid keys.
             if let sealed = try? sealer.seal(
-                DorMuxFrame(op: .sessionClose, streamID: 0, payload: Data(reason.utf8)).encoded())
+                DorMuxFrame(op: .sessionClose, streamID: 0, payload: Data(safeReason.utf8)).encoded())
             {
                 try? await leg.send(sealed, to: destination)
             }
@@ -345,17 +399,25 @@ public actor DorSecureSession: DorSecureSessionProtocol {
         resolveAdmitWaiters(ended: true)
         journal.record(
             component: "session", event: "ended",
-            attributes: ["session": sessionID, "reason": reason])
-        eventsContinuation.yield(.ended(reason: reason))
+            attributes: ["session": sessionID, "reason": safeReason])
+        eventsContinuation.yield(.ended(reason: safeReason))
         eventsContinuation.finish()
-        onEnded?(reason)
+        onEnded?(safeReason)
         onEnded = nil
+    }
+
+    private func isPeerOwnedStreamID(_ id: UInt32) -> Bool {
+        // Stream zero is reserved for session control. The initiator owns odd
+        // ids and the responder owns even ids.
+        guard id != 0 else { return false }
+        return role == .initiator ? id.isMultiple(of: 2) : !id.isMultiple(of: 2)
     }
 }
 
 public enum DorStreamError: Error, Sendable {
     case reset
     case sessionEnded
+    case streamLimit
 }
 
 /// Per-stream state: inbound buffer with read waiters, credit windows both
@@ -478,8 +540,16 @@ private final class DorStreamState: @unchecked Sendable {
 
     // MARK: outbound window
 
-    func addSendWindow(_ bytes: Int) {
+    @discardableResult
+    func addSendWindow(_ bytes: Int) -> Bool {
         lock.lock()
+        guard bytes > 0,
+              sendWindow <= DorMuxLimits.initialWindow,
+              bytes <= DorMuxLimits.initialWindow - sendWindow
+        else {
+            lock.unlock()
+            return false
+        }
         sendWindow += bytes
         var resumable: [(Int, CheckedContinuation<Void, any Error>)] = []
         while let next = windowWaiters.first, sendWindow >= next.bytes {
@@ -491,6 +561,7 @@ private final class DorStreamState: @unchecked Sendable {
         for (_, continuation) in resumable {
             continuation.resume()
         }
+        return true
     }
 
     func acquireSendWindow(_ bytes: Int) async throws {

--- a/Packages/Shared/CmuxDorTransport/Sources/CmuxDorTransport/DorSessionAcceptor.swift
+++ b/Packages/Shared/CmuxDorTransport/Sources/CmuxDorTransport/DorSessionAcceptor.swift
@@ -107,6 +107,10 @@ public actor DorSessionAcceptor {
     // MARK: - Admission
 
     private func handleHS1(sourceLegID: UInt32, json: Data) async {
+        guard json.count <= DorWire.maxHandshakeBytes else {
+            await deny(sourceLegID: sourceLegID, deviceID: nil, reason: "malformed-hs1")
+            return
+        }
         guard let hs1 = try? JSONDecoder().decode(DorHandshake1.self, from: json),
               hs1.t == "hs1",
               let initiatorEph = Data(base64Encoded: hs1.eph), initiatorEph.count == 32,
@@ -147,7 +151,7 @@ public actor DorSessionAcceptor {
         } catch {
             await deny(
                 sourceLegID: sourceLegID, deviceID: nil,
-                reason: "grant:\(String(describing: error))")
+                reason: "invalid-grant")
             return
         }
         let peer = DorAdmittedPeer(
@@ -163,7 +167,7 @@ public actor DorSessionAcceptor {
         } catch {
             await deny(
                 sourceLegID: sourceLegID, deviceID: peer.deviceID,
-                reason: "judge:\(String(describing: error))")
+                reason: "not-admitted")
             return
         }
 
@@ -241,16 +245,17 @@ public actor DorSessionAcceptor {
     }
 
     private func deny(sourceLegID: UInt32, deviceID: String?, reason: String) async {
+        let safeReason = DorSafety.stableReason(reason, fallback: "admission-denied")
         journal.record(
             component: "admission", event: "denied",
-            attributes: ["device": deviceID ?? "-", "reason": reason])
-        let deny = DorHandshakeDeny(v: 1, t: "deny", reason: reason)
+            attributes: ["device": deviceID ?? "-", "reason": safeReason])
+        let deny = DorHandshakeDeny(v: 1, t: "deny", reason: safeReason)
         if let bytes = try? JSONEncoder().encode(deny) {
             var payload = Data([DorBoxKind.handshake.rawValue])
             payload.append(bytes)
             await sendHandshake(payload, to: sourceLegID)
         }
-        continuation?.yield(.denied(deviceID: deviceID, reason: reason))
+        continuation?.yield(.denied(deviceID: deviceID, reason: safeReason))
     }
 
     private func sendHandshake(_ payload: Data, to legID: UInt32) async {

--- a/Packages/Shared/CmuxDorTransport/Sources/CmuxDorTransport/DorTransportAPI.swift
+++ b/Packages/Shared/CmuxDorTransport/Sources/CmuxDorTransport/DorTransportAPI.swift
@@ -13,6 +13,77 @@
 
 public import Foundation
 
+/// Input safety rules shared by the relay protocol and its diagnostic sink.
+/// The relay and the peer are remote boundaries, so their text is never
+/// allowed to become an unbounded log line or a control-flow reason.
+enum DorSafety {
+    static let maxHandshakeBytes = 16 * 1024
+    static let maxReasonBytes = 128
+    static let maxAttributeBytes = 256
+
+    static func boundedText(_ raw: String?, fallback: String = "") -> String {
+        guard let raw else { return fallback }
+        var result = String.UnicodeScalarView()
+        var bytes = 0
+        for scalar in raw.unicodeScalars {
+            // Exclude C0/C1 controls and line/paragraph separators. They can
+            // forge log records or alter terminal diagnostics.
+            guard scalar.value >= 0x20,
+                  scalar.value != 0x7F,
+                  scalar.value != 0x85,
+                  scalar.value != 0x2028,
+                  scalar.value != 0x2029
+            else { continue }
+            let scalarBytes = String(scalar).utf8.count
+            guard bytes + scalarBytes <= maxAttributeBytes else { break }
+            result.append(scalar)
+            bytes += scalarBytes
+        }
+        return result.isEmpty ? fallback : String(result)
+    }
+
+    /// Convert peer-provided reasons to a small, stable vocabulary. A reason
+    /// must not carry arbitrary server, filesystem, or exception text.
+    static func stableReason(_ raw: String?, fallback: String = "peer-error") -> String {
+        guard let raw else { return fallback }
+        let value = raw.lowercased()
+        switch value {
+        case "stopped", "shutdown", "already-ended", "user-close", "test-over",
+             "keepalive-timeout", "admit-timeout", "admit-stall", "seal-failed",
+             "superseded", "superseded-by-handshake", "unauthorized", "capacity",
+             "protocol-error", "protocol-error-retry", "unauthorized-retry",
+             "leg-closed", "leg-stream-ended", "leg-reset", "download-sequence-gap",
+             "stream-buffer-overflow", "stream-capacity", "invalid-credit", "peer-closed",
+             "resume-refused", "unknown-session", "buffer-overflow", "gap-not-provable",
+             "invalid-grant", "not-admitted", "sign-failed", "identity-sign-failed",
+             "admission-denied", "peer-error", "no-grant":
+            return String(value.prefix(maxReasonBytes))
+        default:
+            return fallback
+        }
+    }
+
+    static func relayReason(_ raw: String?) -> String {
+        switch raw?.lowercased() {
+        case "unknown session": return "unknown-session"
+        case "buffer overflow": return "buffer-overflow"
+        case "gap not provable": return "gap-not-provable"
+        default: return "resume-refused"
+        }
+    }
+
+    /// Protect the journal even when a future call site forgets to classify
+    /// an error before recording it.
+    static func journalValue(key: String, value: String) -> String {
+        let lower = key.lowercased()
+        let secretKeys = ["token", "secret", "password", "authorization", "grant", "stderr", "stdout"]
+        if secretKeys.contains(where: { lower.contains($0) }) {
+            return "[redacted]"
+        }
+        return boundedText(value, fallback: "-")
+    }
+}
+
 // MARK: - Identity and trust material (injected by the apps)
 
 /// The device's long-lived Ed25519 identity. Adapted from the existing
@@ -167,6 +238,17 @@ public struct DorLaneDescriptor: Sendable, Codable, Equatable {
     }
     public static func artifact(resource: String, offset: UInt64?) -> DorLaneDescriptor {
         DorLaneDescriptor(lane: "artifact", resource: resource, offset: offset)
+    }
+
+    /// Validate untrusted descriptors before they enter the session map or
+    /// reach an application router. Unknown lane names remain forward
+    /// compatible, but text fields stay bounded and control-free.
+    var isValid: Bool {
+        guard !lane.isEmpty, lane.utf8.count <= 64,
+              DorSafety.boundedText(lane, fallback: "") == lane,
+              resource.map({ $0.utf8.count <= 512 && DorSafety.boundedText($0, fallback: "") == $0 }) ?? true
+        else { return false }
+        return true
     }
 }
 

--- a/Packages/Shared/CmuxDorTransport/Sources/CmuxDorTransport/DorWire.swift
+++ b/Packages/Shared/CmuxDorTransport/Sources/CmuxDorTransport/DorWire.swift
@@ -15,6 +15,7 @@ public enum DorWire {
     /// Cloudflare caps inbound WS messages at 1 MiB; stay well inside it.
     public static let maxDataFrameBytes = 1024 * 1024 - 1024
     public static let maxControlBytes = 4 * 1024
+    public static let maxHandshakeBytes = DorSafety.maxHandshakeBytes
     /// E2E payload chunk cap. Chosen so header + seal overhead stays under the
     /// relay's 120 KiB spill-frame limit: a detach can always spill every
     /// pending frame, so a resume never fails on frame size.
@@ -127,13 +128,16 @@ public enum DorControlFrame: Sendable, Equatable {
                   let epoch = object["epoch"] as? String,
                   let peerOnline = object["peerOnline"] as? Bool
             else { throw DorWireError.malformed }
+            guard !resumeKey.isEmpty, resumeKey.utf8.count <= 256,
+                  !epoch.isEmpty, epoch.utf8.count <= 256
+            else { throw DorWireError.malformed }
             return .helloAck(
                 legID: legID, resumeKey: resumeKey, epoch: epoch,
                 peerOnline: peerOnline,
-                replayed: (object["replayed"] as? NSNumber)?.intValue ?? 0
+                replayed: max(0, min((object["replayed"] as? NSNumber)?.intValue ?? 0, 1_000_000))
             )
         case "resume.failed":
-            return .resumeFailed(reason: object["reason"] as? String ?? "unknown")
+            return .resumeFailed(reason: DorSafety.relayReason(object["reason"] as? String))
         case "pong":
             guard let ts = (object["ts"] as? NSNumber)?.doubleValue else { throw DorWireError.malformed }
             return .pong(ts: ts)
@@ -150,13 +154,23 @@ public enum DorControlFrame: Sendable, Equatable {
             guard let seq = uint64(object["seq"]) else { throw DorWireError.malformed }
             return .ackUp(seq: seq, leg: uint32(object["leg"]))
         case "peer.online":
-            return .peerOnline(legID: uint32(object["legId"]), device: object["device"] as? String)
+            return .peerOnline(
+                legID: uint32(object["legId"]),
+                device: (object["device"] as? String).map {
+                    DorSafety.boundedText($0, fallback: "-")
+                }
+            )
         case "peer.offline":
-            return .peerOffline(legID: uint32(object["legId"]), reason: object["reason"] as? String)
+            return .peerOffline(
+                legID: uint32(object["legId"]),
+                reason: (object["reason"] as? String).map {
+                    DorSafety.boundedText($0, fallback: "peer-offline")
+                }
+            )
         case "error":
             return .error(
-                code: object["code"] as? String ?? "unknown",
-                message: object["message"] as? String ?? ""
+                code: DorSafety.boundedText(object["code"] as? String, fallback: "unknown"),
+                message: DorSafety.boundedText(object["message"] as? String)
             )
         default:
             return nil

--- a/Packages/Shared/CmuxDorTransport/Tests/CmuxDorTransportTests/DorWireAndLedgerTests.swift
+++ b/Packages/Shared/CmuxDorTransport/Tests/CmuxDorTransportTests/DorWireAndLedgerTests.swift
@@ -5,6 +5,16 @@ import Testing
 
 @Suite("dor/1 wire codec")
 struct DorWireTests {
+    @Test func relayURLPolicyAllowsTLSAndLoopbackOnlyForCleartext() throws {
+        #expect(DorLeg.isAllowedRelayBaseURL(try #require(URL(string: "https://presence.example"))))
+        #expect(DorLeg.isAllowedRelayBaseURL(try #require(URL(string: "http://127.0.0.1:8787"))))
+        #expect(DorLeg.isAllowedRelayBaseURL(try #require(URL(string: "ws://localhost:8787"))))
+        #expect(!DorLeg.isAllowedRelayBaseURL(try #require(URL(string: "http://presence.example"))))
+        #expect(!DorLeg.isAllowedRelayBaseURL(try #require(URL(string: "ws://198.51.100.2"))))
+        #expect(!DorLeg.isAllowedRelayBaseURL(try #require(URL(string: "ftp://presence.example"))))
+        #expect(!DorLeg.isAllowedRelayBaseURL(try #require(URL(string: "https://user:password@presence.example"))))
+    }
+
     @Test func dataFrameRoundTrip() throws {
         let frame = DorWire.DataFrame(legID: 7, seq: 42, payload: Data("hello".utf8))
         let decoded = try #require(DorWire.decodeData(DorWire.encodeData(frame)))
@@ -79,18 +89,18 @@ struct DorLedgerTests {
             ledger.acceptDownload(source: 1, seq: 2),
             ledger.acceptDownload(source: 1, seq: 2), // replay
             ledger.acceptDownload(source: 1, seq: 1), // replay
-            ledger.acceptDownload(source: 1, seq: 5), // forward jump OK
+            ledger.acceptDownload(source: 1, seq: 5), // forward gap rejected
         ]
-        #expect(outcomes == [true, true, false, false, true])
-        #expect(ledger.resumeAck == 5)
+        #expect(outcomes == [true, true, false, false, false])
+        #expect(ledger.resumeAck == 2)
     }
 
     @Test func hostResumeAcksAreKeyedByPhoneLeg() {
         var ledger = DorLedger(role: .host)
-        let first = ledger.acceptDownload(source: 11, seq: 3)
-        let second = ledger.acceptDownload(source: 12, seq: 7)
+        let first = ledger.acceptDownload(source: 11, seq: 1)
+        let second = ledger.acceptDownload(source: 12, seq: 1)
         #expect(first && second)
-        #expect(ledger.resumeAcks == [11: 3, 12: 7])
+        #expect(ledger.resumeAcks == [11: 1, 12: 1])
     }
 
     @Test func coalescedAcksFlushByCountAndTime() {

--- a/Packages/Shared/CmuxDorTransport/Tests/CmuxDorTransportTests/DorWireAndLedgerTests.swift
+++ b/Packages/Shared/CmuxDorTransport/Tests/CmuxDorTransportTests/DorWireAndLedgerTests.swift
@@ -5,6 +5,21 @@ import Testing
 
 @Suite("dor/1 wire codec")
 struct DorWireTests {
+    @Test func remoteTextIsBoundedAndReasonsAreStable() {
+        let hostile = "ok\u{0000}\u{001b}[31m" + String(repeating: "x", count: 800)
+        let bounded = DorSafety.boundedText(hostile, fallback: "fallback")
+        #expect(bounded.utf8.count <= DorSafety.maxAttributeBytes)
+        #expect(!bounded.unicodeScalars.contains { $0.value < 0x20 || $0.value == 0x7f })
+        #expect(DorSafety.stableReason("grant:secret", fallback: "denied") == "denied")
+        #expect(DorSafety.relayReason("unknown session") == "unknown-session")
+    }
+
+    @Test func journalValuesRedactCredentialFields() {
+        #expect(DorSafety.journalValue(key: "token", value: "bearer-secret") == "[redacted]")
+        #expect(DorSafety.journalValue(key: "stderr", value: "private path") == "[redacted]")
+        #expect(DorSafety.journalValue(key: "device", value: "device-1") == "device-1")
+    }
+
     @Test func relayURLPolicyAllowsTLSAndLoopbackOnlyForCleartext() throws {
         #expect(DorLeg.isAllowedRelayBaseURL(try #require(URL(string: "https://presence.example"))))
         #expect(DorLeg.isAllowedRelayBaseURL(try #require(URL(string: "http://127.0.0.1:8787"))))

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileDorRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileDorRuntimeComposition.swift
@@ -152,7 +152,9 @@ public actor MobileDorRuntimeComposition {
         // verify its token.
         relayBaseURL = PresenceClient.resolvedServiceBaseURL(
             isDevelopmentAuthChannel: isDevelopmentAuthChannel
-        ).flatMap { URL(string: $0) }
+        ).flatMap { URL(string: $0) }.flatMap {
+            DorLeg.isAllowedRelayBaseURL($0) ? $0 : nil
+        }
         let rawTag = MobileIOSBuildScope.current(
             infoDictionary: infoDictionary,
             bundleIdentifier: bundleIdentifier

--- a/workers/presence/src/dorDo.ts
+++ b/workers/presence/src/dorDo.ts
@@ -36,6 +36,7 @@ import {
   MAX_CONTROL_BYTES,
   MAX_HOST_LEGS,
   MAX_PHONE_LEGS,
+  isAuthorizedPhoneLeg,
   ReplayRing,
   decodeControl,
   decodeDataHeader,
@@ -56,6 +57,9 @@ export const RESUME_TTL_MS = 10 * 60 * 1000;
 /** DO storage values cap at 128 KiB; larger frames cannot spill. Clients keep
  * chunks ≤ 96 KiB so this limit is never hit in practice. */
 const MAX_SPILL_FRAME_BYTES = 120 * 1024;
+const STORAGE_BATCH_SIZE = 128;
+const MAX_LEG_ID = 0xffff_ffff;
+const MAX_RETAINED_LEGS = MAX_HOST_LEGS + MAX_PHONE_LEGS;
 
 type Role = "host" | "phone";
 
@@ -123,7 +127,7 @@ export class AccountRelay extends DurableObject<RelayEnv> {
     const device = request.headers.get("x-dor-device")?.trim();
     const mac = request.headers.get("x-dor-mac")?.trim();
     if ((role !== "host" && role !== "phone") || !userId || !device || !mac) {
-      return new Response(JSON.stringify({ error: "bad_gateway_headers" }), { status: 500 });
+      return new Response(JSON.stringify({ error: "service_unavailable" }), { status: 503 });
     }
     const now = Date.now();
     const expiresAt = resolveDeadline(request.headers.get("x-dor-expires-at"), now);
@@ -169,7 +173,7 @@ export class AccountRelay extends DurableObject<RelayEnv> {
       await this.handleControl(ws, att, message);
       return;
     }
-    this.handleData(ws, att, message);
+    await this.handleData(ws, att, message);
   }
 
   override async webSocketClose(ws: WebSocket): Promise<void> {
@@ -183,7 +187,7 @@ export class AccountRelay extends DurableObject<RelayEnv> {
   // ---- control frames ----
 
   private async handleControl(ws: WebSocket, att: WsAttachment, text: string): Promise<void> {
-    if (text.length > MAX_CONTROL_BYTES) {
+    if (text.length > MAX_CONTROL_BYTES || new TextEncoder().encode(text).byteLength > MAX_CONTROL_BYTES) {
       ws.close(CLOSE_PROTOCOL_ERROR, "control too large");
       return;
     }
@@ -252,6 +256,12 @@ export class AccountRelay extends DurableObject<RelayEnv> {
         await this.dropLegState(otherAtt.legId, otherAtt);
         other.close(CLOSE_SUPERSEDED, "superseded by a new session");
       }
+      legId = await this.allocateFreshLeg(att);
+      if (legId === null) {
+        this.send(ws, { t: "error", code: "capacity", message: "too many legs" });
+        ws.close(CLOSE_CAPACITY, "too many legs");
+        return;
+      }
       if (att.role === "host") {
         // A fresh host process cannot decrypt frames phones buffered for the
         // previous one: clear every stream destined to this Mac so stale
@@ -261,9 +271,8 @@ export class AccountRelay extends DurableObject<RelayEnv> {
           if (id.startsWith(`${dst}<`)) this.rings.delete(id);
         }
         const staleSpill = await this.ctx.storage.list({ prefix: `spill:${dst}:` });
-        if (staleSpill.size > 0) await this.ctx.storage.delete([...staleSpill.keys()]);
+        if (staleSpill.size > 0) await this.deleteStorageKeys(staleSpill.keys());
       }
-      legId = await this.nextLegId();
     }
 
     const resumeKey = mintResumeKey();
@@ -403,7 +412,7 @@ export class AccountRelay extends DurableObject<RelayEnv> {
     delete meta.lastEnqueuedBySrc;
     await this.ctx.storage.put(legStorageKey(legId), meta);
     const spilled = await this.ctx.storage.list({ prefix: `spill:${dst}:` });
-    if (spilled.size > 0) await this.ctx.storage.delete([...spilled.keys()]);
+    if (spilled.size > 0) await this.deleteStorageKeys(spilled.keys());
     return { legId, replayed };
   }
 
@@ -440,10 +449,11 @@ export class AccountRelay extends DurableObject<RelayEnv> {
     }
     if (expected !== persisted + 1) return null;
     // Rebuild the ring so post-resume acks prune correctly.
-    const rebuilt = this.ring(dst, src);
+    const rebuilt = new ReplayRing(ack);
+    this.rings.set(streamId(dst, src), rebuilt);
     let seq = ack + 1;
     for (const data of frames) {
-      rebuilt.push(seq, data);
+      if (!rebuilt.push(seq, data)) return null;
       seq += 1;
     }
     return frames;
@@ -475,7 +485,7 @@ export class AccountRelay extends DurableObject<RelayEnv> {
 
   // ---- data frames ----
 
-  private handleData(ws: WebSocket, att: WsAttachment, frame: ArrayBuffer): void {
+  private async handleData(ws: WebSocket, att: WsAttachment, frame: ArrayBuffer): Promise<void> {
     if (att.legId === undefined) {
       ws.close(CLOSE_PROTOCOL_ERROR, "data before hello");
       return;
@@ -491,9 +501,13 @@ export class AccountRelay extends DurableObject<RelayEnv> {
       // buffer for its resume instead of dropping.
       rewriteLegId(frame, att.legId);
       const ring = this.ring(hostKey(att.mac), phoneKey(att.legId));
-      ring.push(header.seq, frame);
+      const isNew = header.seq > ring.lastEnqueued;
+      if (!ring.push(header.seq, frame)) {
+        ws.close(CLOSE_PROTOCOL_ERROR, "sequence gap");
+        return;
+      }
       const host = this.hostSocket(att.mac);
-      if (host) this.forward(host, frame);
+      if (host && isNew) this.forward(host, frame);
       this.send(ws, { t: "ackup", seq: ring.lastEnqueued });
       return;
     }
@@ -502,13 +516,20 @@ export class AccountRelay extends DurableObject<RelayEnv> {
     // other's phone streams).
     const dest = this.socketFor(header.legId);
     const destAtt = dest ? attachment(dest) : null;
-    if (destAtt && (destAtt.role !== "phone" || destAtt.mac !== att.mac)) {
+    const destMeta = isAuthorizedPhoneLeg(destAtt, att.mac)
+      ? destAtt
+      : await this.ctx.storage.get<LegMeta>(legStorageKey(header.legId));
+    if (!isAuthorizedPhoneLeg(destMeta, att.mac)) {
       ws.close(CLOSE_PROTOCOL_ERROR, "destination not bound to this mac");
       return;
     }
     const ring = this.ring(phoneKey(header.legId), hostKey(att.mac));
-    ring.push(header.seq, frame);
-    if (dest && destAtt) this.forward(dest, frame);
+    const isNew = header.seq > ring.lastEnqueued;
+    if (!ring.push(header.seq, frame)) {
+      ws.close(CLOSE_PROTOCOL_ERROR, "sequence gap");
+      return;
+    }
+    if (dest && isAuthorizedPhoneLeg(destAtt, att.mac) && isNew) this.forward(dest, frame);
     this.send(ws, { t: "ackup", seq: ring.lastEnqueued, leg: header.legId });
   }
 
@@ -559,7 +580,7 @@ export class AccountRelay extends DurableObject<RelayEnv> {
       meta.detachedAt = Date.now();
       await this.ctx.storage.put(legStorageKey(legId), meta);
       if (Object.keys(spillWrites).length > 0) {
-        await this.ctx.storage.put(spillWrites);
+        await this.putStorageEntries(spillWrites);
       }
       await this.ensureAlarmAt(meta.detachedAt + RESUME_TTL_MS);
     }
@@ -601,7 +622,7 @@ export class AccountRelay extends DurableObject<RelayEnv> {
         : [`spill:${dst}:`];
     for (const prefix of prefixes) {
       const spilled = await this.ctx.storage.list({ prefix });
-      if (spilled.size > 0) await this.ctx.storage.delete([...spilled.keys()]);
+      if (spilled.size > 0) await this.deleteStorageKeys(spilled.keys());
     }
   }
 
@@ -663,6 +684,52 @@ export class AccountRelay extends DurableObject<RelayEnv> {
     }
   }
 
+  /** Durable Object batch APIs accept at most 128 keys per call. */
+  private async deleteStorageKeys(keys: Iterable<string>): Promise<void> {
+    const pending = [...keys];
+    for (let offset = 0; offset < pending.length; offset += STORAGE_BATCH_SIZE) {
+      await this.ctx.storage.delete(pending.slice(offset, offset + STORAGE_BATCH_SIZE));
+    }
+  }
+
+  /** Durable Object batch APIs accept at most 128 keys per call. */
+  private async putStorageEntries(entries: Record<string, ArrayBuffer>): Promise<void> {
+    const keys = Object.keys(entries);
+    for (let offset = 0; offset < keys.length; offset += STORAGE_BATCH_SIZE) {
+      const batch: Record<string, ArrayBuffer> = {};
+      for (const key of keys.slice(offset, offset + STORAGE_BATCH_SIZE)) batch[key] = entries[key]!;
+      await this.ctx.storage.put(batch);
+    }
+  }
+
+  /**
+   * Reserve a fresh leg while counting detached resume state against the same
+   * role capacity as live sockets. A fresh session for one endpoint replaces
+   * its old state instead of accumulating an unbounded trail of leg records.
+   */
+  private async allocateFreshLeg(att: WsAttachment): Promise<number | null> {
+    const now = Date.now();
+    const metas = await this.ctx.storage.list<LegMeta>({ prefix: "leg:" });
+    let retained = 0;
+    for (const [key, meta] of metas) {
+      const legId = Number(key.slice("leg:".length));
+      if (!Number.isSafeInteger(legId) || legId < 1) continue;
+      const expired = meta.detachedAt !== undefined && meta.detachedAt + RESUME_TTL_MS <= now;
+      const sameEndpoint =
+        meta.role === att.role &&
+        meta.mac === att.mac &&
+        (att.role === "host" || meta.device === att.device);
+      if (expired || sameEndpoint) {
+        await this.dropLegState(legId, { role: meta.role, mac: meta.mac });
+        continue;
+      }
+      if (meta.role === att.role) retained += 1;
+    }
+    const cap = att.role === "phone" ? MAX_PHONE_LEGS : MAX_HOST_LEGS;
+    if (retained >= cap) return null;
+    return this.nextLegId();
+  }
+
   // ---- helpers ----
 
   private ring(dst: string, src: string): ReplayRing {
@@ -711,9 +778,21 @@ export class AccountRelay extends DurableObject<RelayEnv> {
 
   private async nextLegId(): Promise<number> {
     const current = (await this.ctx.storage.get<number>("nextLegId")) ?? 0;
-    const next = current + 1;
-    await this.ctx.storage.put("nextLegId", next);
-    return next;
+    const metas = await this.ctx.storage.list<LegMeta>({ prefix: "leg:" });
+    const used = new Set<number>();
+    for (const key of metas.keys()) {
+      const id = Number(key.slice("leg:".length));
+      if (Number.isSafeInteger(id) && id >= 1 && id <= MAX_LEG_ID) used.add(id);
+    }
+    let candidate = Number.isSafeInteger(current) && current >= 0 && current < MAX_LEG_ID ? current + 1 : 1;
+    for (let attempt = 0; attempt < MAX_RETAINED_LEGS + 1; attempt += 1) {
+      if (!used.has(candidate)) {
+        await this.ctx.storage.put("nextLegId", candidate);
+        return candidate;
+      }
+      candidate = candidate >= MAX_LEG_ID ? 1 : candidate + 1;
+    }
+    throw new Error("relay leg capacity exhausted");
   }
 
   private async epoch(): Promise<string> {

--- a/workers/presence/src/dorProtocol.ts
+++ b/workers/presence/src/dorProtocol.ts
@@ -21,6 +21,9 @@ export const DOR_PROTOCOL = "dor/1";
 export const DATA_HEADER_BYTES = 14;
 export const DATA_FRAME_VERSION = 1;
 export const DATA_KIND_DATA = 1;
+/** JavaScript cannot represent every u64 exactly. Keep one value for the
+ * overflow boundary so `seq + 1` remains exact in all relay decisions. */
+export const MAX_SEQUENCE = Number.MAX_SAFE_INTEGER - 1;
 
 /** Control frames are small JSON. */
 export const MAX_CONTROL_BYTES = 4 * 1024;
@@ -69,7 +72,7 @@ export function decodeDataHeader(frame: ArrayBuffer): DataFrameHeader | null {
   if (kind !== DATA_KIND_DATA) return null;
   const legId = view.getUint32(2);
   const seq = Number(view.getBigUint64(6));
-  if (!Number.isSafeInteger(seq) || seq < 1) return null;
+  if (!Number.isSafeInteger(seq) || seq < 1 || seq > MAX_SEQUENCE) return null;
   return { version, kind, legId, seq };
 }
 
@@ -101,7 +104,7 @@ export type ControlFrame =
 /** Parse an inbound control frame. Only client→relay types are accepted;
  * unknown or oversized input returns null (protocol error). */
 export function decodeControl(text: string): ControlFrame | null {
-  if (text.length > MAX_CONTROL_BYTES) return null;
+  if (text.length > MAX_CONTROL_BYTES || new TextEncoder().encode(text).byteLength > MAX_CONTROL_BYTES) return null;
   let value: unknown;
   try {
     value = JSON.parse(text);
@@ -159,7 +162,7 @@ export function encodeControl(frame: ControlFrame): string {
 }
 
 function validSeq(value: unknown): value is number {
-  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 && value <= MAX_SEQUENCE;
 }
 
 interface RingEntry {
@@ -173,12 +176,17 @@ export class ReplayRing {
   private entries: RingEntry[] = [];
   private bytes = 0;
   /** Highest seq ever enqueued for this stream. */
-  lastEnqueued = 0;
+  lastEnqueued: number;
   /** Set when un-acked frames were evicted; cleared only by a fresh session. */
   broken = false;
 
-  push(seq: number, frame: ArrayBuffer): void {
-    if (seq <= this.lastEnqueued) return; // sender resends are idempotent
+  constructor(initialSequence = 0) {
+    this.lastEnqueued = initialSequence;
+  }
+
+  push(seq: number, frame: ArrayBuffer): boolean {
+    if (seq <= this.lastEnqueued) return true; // sender resends are idempotent
+    if (seq !== this.lastEnqueued + 1) return false;
     this.lastEnqueued = seq;
     this.entries.push({ seq, frame });
     this.bytes += frame.byteLength;
@@ -188,10 +196,12 @@ export class ReplayRing {
       this.bytes -= evicted.frame.byteLength;
       this.broken = true;
     }
+    return true;
   }
 
   /** Prune entries the receiver has acknowledged. */
   ackTo(seq: number): void {
+    if (seq > this.lastEnqueued) return;
     while (this.entries.length > 0 && this.entries[0]!.seq <= seq) {
       this.bytes -= this.entries[0]!.frame.byteLength;
       this.entries.shift();
@@ -222,6 +232,16 @@ export class ReplayRing {
   get size(): number {
     return this.entries.length;
   }
+}
+
+/** A host may route only to a phone leg authorized for the same Mac. */
+export function isAuthorizedPhoneLeg(
+  value: unknown,
+  mac: string,
+): value is { role: "phone"; mac: string } {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as { role?: unknown; mac?: unknown };
+  return candidate.role === "phone" && candidate.mac === mac;
 }
 
 /** Random 32-byte resume key, base64url. */

--- a/workers/presence/test/dorProtocol.test.ts
+++ b/workers/presence/test/dorProtocol.test.ts
@@ -9,6 +9,7 @@ import {
   decodeDataHeader,
   encodeControl,
   hostKey,
+  isAuthorizedPhoneLeg,
   mintResumeKey,
   phoneKey,
   rewriteLegId,
@@ -65,6 +66,7 @@ describe("control frames", () => {
     expect(decodeControl(JSON.stringify({ t: "auth.refresh", token: "x".repeat(9000) }))).toBeNull();
     expect(decodeControl(JSON.stringify({ t: "hello", proto: "dor/1", device: "d", acks: { "0": 1 } }))).toBeNull();
     expect(decodeControl("not json")).toBeNull();
+    expect(decodeControl(JSON.stringify({ t: "hello", proto: "😀".repeat(2000), device: "d" }))).toBeNull();
   });
 
   test("encodeControl emits parseable relay frames", () => {
@@ -95,12 +97,21 @@ describe("ReplayRing", () => {
 
   test("duplicate sender resends are idempotent", () => {
     const ring = new ReplayRing();
-    ring.push(1, frame(1, 1));
-    ring.push(1, frame(1, 1));
-    ring.push(2, frame(1, 2));
-    ring.push(1, frame(1, 1));
+    expect(ring.push(1, frame(1, 1))).toBe(true);
+    expect(ring.push(1, frame(1, 1))).toBe(true);
+    expect(ring.push(2, frame(1, 2))).toBe(true);
+    expect(ring.push(1, frame(1, 1))).toBe(true);
     expect(ring.size).toBe(2);
     expect(ring.lastEnqueued).toBe(2);
+  });
+
+  test("rejects sequence gaps and future acknowledgements", () => {
+    const ring = new ReplayRing();
+    expect(ring.push(1, frame(1, 1))).toBe(true);
+    expect(ring.push(3, frame(1, 3))).toBe(false);
+    expect(ring.lastEnqueued).toBe(1);
+    ring.ackTo(99);
+    expect(ring.size).toBe(1);
   });
 
   test("overflow marks broken and fails coverage forever", () => {
@@ -124,6 +135,13 @@ describe("addressing + keys", () => {
     expect(validOpaqueId("")).toBe(false);
     expect(validOpaqueId("has space")).toBe(false);
     expect(validOpaqueId("x".repeat(200))).toBe(false);
+  });
+
+  test("only a phone leg bound to the target Mac is a valid destination", () => {
+    expect(isAuthorizedPhoneLeg({ role: "phone", mac: "mac-a" }, "mac-a")).toBe(true);
+    expect(isAuthorizedPhoneLeg({ role: "phone", mac: "mac-b" }, "mac-a")).toBe(false);
+    expect(isAuthorizedPhoneLeg({ role: "host", mac: "mac-a" }, "mac-a")).toBe(false);
+    expect(isAuthorizedPhoneLeg(null, "mac-a")).toBe(false);
   });
 
   test("resume keys are unique and hash deterministically", async () => {


### PR DESCRIPTION
Security follow-up for https://github.com/manaflow-ai/cmux/pull/11079.

- Bind streams to authenticated account and phone-leg identity.
- Enforce origin, sequence, frame, descriptor, data, credit, and stream-count limits.
- Sanitize protocol errors and redact credential fields.
- Create journals with private permissions and no symlink following on Apple platforms.

Trade-off: the seven-day offline trust cache keeps reconnects available but leaves a bounded stale-revocation window. Oversized or malformed frames are rejected, which can terminate a compromised or incompatible peer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the DOR relay transport by enforcing identity, sequence, and frame limits on both the client and the relay. Forward sequence jumps and unauthorized destinations are now rejected instead of accepted; oversized or malformed input terminates the offending peer. Trade-off: the seven-day offline trust cache keeps reconnects available but leaves a bounded stale-revocation window.

**Client hardening**
- Binds streams to the authenticated account and phone-leg identity.
- Rejects forward sequence gaps, unauthorized stream IDs, invalid credit, and oversized descriptors.
- Sanitizes relay reasons and redacts credential fields before they reach the journal.
- Restricts cleartext relays to loopback hosts and writes journals with private permissions and no symlink following.

**Relay hardening**
- Rejects sequence gaps and destinations not bound to the same Mac; a fresh session replaces old state instead of accumulating leg records.
- Enforces role-based leg capacity and batches storage operations to stay within Durable Object limits.
- Bounds control-frame size by UTF-8 bytes, not just string length.

<sup>Written for commit 471c278a57135a3c65aae04185382c373b7a78e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

