### PR TITLE
security(tui): cancel remote shutdown waits without races

### DIFF
--- a/cmux-tui/crates/cmux-remote/src/connection.rs
+++ b/cmux-tui/crates/cmux-remote/src/connection.rs
@@ -695,8 +695,9 @@ impl ClientConnection {
                         && let Some(next) = resolve_reconnect_group(
                             source.as_ref(),
                             self.config.reconnect.attempt_timeout,
+                            &mut close_state,
                         )
-                        .await
+                        .await?
                     {
                         group = next;
                     }
@@ -780,11 +781,14 @@ impl ClientConnection {
 async fn resolve_reconnect_group(
     source: &dyn ReconnectGroupSource,
     reconnect_attempt_timeout: Duration,
-) -> Option<Arc<dyn LinkGroup>> {
-    tokio::time::timeout(source.resolution_timeout(reconnect_attempt_timeout), source.next_group())
-        .await
-        .ok()?
-        .ok()
+    close_state: &mut watch::Receiver<CloseState>,
+) -> Result<Option<Arc<dyn LinkGroup>>, ConnectionError> {
+    tokio::select! {
+        _ = close_state.changed() => Err(ConnectionError::Closed),
+        result = tokio::time::timeout(source.resolution_timeout(reconnect_attempt_timeout), source.next_group()) => {
+            Ok(result.ok().and_then(Result::ok))
+        }
+    }
 }
 
 async fn wait_for_close(mut state: watch::Receiver<CloseState>) -> Result<(), ConnectionError> {
@@ -1254,6 +1258,7 @@ mod tests {
 
     #[tokio::test]
     async fn reconnect_group_resolution_uses_only_an_explicitly_extended_deadline() {
+        let (_close_state_sender, mut close_state) = watch::channel(CloseState::Pending);
         let ordinary_completed = Arc::new(AtomicBool::new(false));
         let ordinary = DelayedReconnectGroupSource {
             delay: Duration::from_millis(200),
@@ -1262,7 +1267,7 @@ mod tests {
         };
         tokio::time::timeout(
             Duration::from_millis(100),
-            resolve_reconnect_group(&ordinary, Duration::from_millis(20)),
+            resolve_reconnect_group(&ordinary, Duration::from_millis(20), &mut close_state),
         )
         .await
         .expect("ordinary reconnect source exceeded its carrier attempt timeout");
@@ -1276,7 +1281,7 @@ mod tests {
         };
         tokio::time::timeout(
             Duration::from_millis(500),
-            resolve_reconnect_group(&extended, Duration::from_millis(20)),
+            resolve_reconnect_group(&extended, Duration::from_millis(20), &mut close_state),
         )
         .await
         .expect("explicit reconnect resolution deadline was ignored");

--- a/cmux-tui/crates/cmux-remote/src/connection.rs
+++ b/cmux-tui/crates/cmux-remote/src/connection.rs
@@ -1291,7 +1291,8 @@ mod tests {
     #[tokio::test]
     async fn close_cancels_reconnect_group_resolution() {
         let directory = tempdir().unwrap();
-        let auth = AuthDatabase::load_or_create(directory.path(), "close-group-resolution", true).unwrap();
+        let auth =
+            AuthDatabase::load_or_create(directory.path(), "close-group-resolution", true).unwrap();
         let (daemon, mut accepted) = RemoteDaemon::new(auth, SessionLimits::default());
         let group = Arc::new(OneShotGroup {
             daemon,
@@ -1329,10 +1330,8 @@ mod tests {
         )
         .await
         .unwrap();
-        let _server = tokio::time::timeout(Duration::from_secs(2), accepted.recv())
-            .await
-            .unwrap()
-            .unwrap();
+        let _server =
+            tokio::time::timeout(Duration::from_secs(2), accepted.recv()).await.unwrap().unwrap();
 
         group.fail();
         let send = tokio::spawn({

--- a/cmux-tui/crates/cmux-remote/src/connection.rs
+++ b/cmux-tui/crates/cmux-remote/src/connection.rs
@@ -1352,7 +1352,9 @@ mod tests {
         });
         let closed = tokio::time::timeout(Duration::from_millis(250), &mut closing).await;
         release.notify_waiters();
-        let _ = tokio::time::timeout(Duration::from_secs(1), &mut closing).await;
+        if closed.is_err() {
+            let _ = tokio::time::timeout(Duration::from_secs(1), &mut closing).await;
+        }
         let _ = tokio::time::timeout(Duration::from_secs(1), send).await;
         assert!(closed.is_ok(), "close waited for a provider resolver after shutdown began");
     }

--- a/cmux-tui/crates/cmux-remote/src/connection.rs
+++ b/cmux-tui/crates/cmux-remote/src/connection.rs
@@ -628,6 +628,7 @@ impl ClientConnection {
         let mut attempt = 0_u32;
         let mut delay = self.config.reconnect.initial_delay;
         let mut group = self.group.read().await.clone();
+        let mut close_state = self.close_state.subscribe();
         loop {
             if self.closed.load(Ordering::Acquire) {
                 return Err(ConnectionError::Closed);
@@ -672,7 +673,11 @@ impl ClientConnection {
                     {
                         group = next;
                     }
-                    tokio::time::sleep(self.config.reconnect.retry_delay(delay)).await;
+                    let retry_delay = self.config.reconnect.retry_delay(delay);
+                    tokio::select! {
+                        _ = tokio::time::sleep(retry_delay) => {}
+                        _ = close_state.changed() => return Err(ConnectionError::Closed),
+                    }
                     delay = (delay * 2).min(self.config.reconnect.maximum_delay);
                 }
                 Err(error) => return Err(error),
@@ -759,8 +764,14 @@ async fn wait_for_close(mut state: watch::Receiver<CloseState>) -> Result<(), Co
 }
 
 async fn run_heartbeat(weak: Weak<ClientConnection>, interval: Duration, timeout: Duration) {
+    let Some(initial) = weak.upgrade() else { return };
+    let mut close_state = initial.close_state.subscribe();
+    drop(initial);
     loop {
-        tokio::time::sleep(interval).await;
+        tokio::select! {
+            _ = tokio::time::sleep(interval) => {}
+            _ = close_state.changed() => return,
+        }
         let Some(connection) = weak.upgrade() else { return };
         if connection.closed.load(Ordering::Acquire) {
             return;
@@ -778,18 +789,18 @@ async fn run_heartbeat(weak: Weak<ClientConnection>, interval: Duration, timeout
         let observed = connection.last_received();
         let generation = connection.session.read().await.generation();
         let deadline = tokio::time::Instant::now() + timeout;
-        match tokio::time::timeout_at(
-            deadline,
-            connection.send_in_generation(
-                Some(generation),
-                Lane::Control,
-                0,
-                Bytes::new(),
-                FrameFlags::HEARTBEAT_REQUEST,
-            ),
-        )
-        .await
-        {
+        let send = connection.send_in_generation(
+            Some(generation),
+            Lane::Control,
+            0,
+            Bytes::new(),
+            FrameFlags::HEARTBEAT_REQUEST,
+        );
+        let send_result = tokio::select! {
+            result = tokio::time::timeout_at(deadline, send) => result,
+            _ = close_state.changed() => return,
+        };
+        match send_result {
             Ok(Ok(_)) => {}
             Ok(Err(_)) => continue,
             Err(_) => {
@@ -797,10 +808,10 @@ async fn run_heartbeat(weak: Weak<ClientConnection>, interval: Duration, timeout
                 continue;
             }
         }
-        let live =
-            tokio::time::timeout_at(deadline, connection.probe_liveness(generation, observed))
-                .await
-                .unwrap_or(false);
+        let live = tokio::select! {
+            result = tokio::time::timeout_at(deadline, connection.probe_liveness(generation, observed)) => result.unwrap_or(false),
+            _ = close_state.changed() => return,
+        };
         if connection.closed.load(Ordering::Acquire)
             || connection.session.read().await.generation() != generation
         {

--- a/cmux-tui/crates/cmux-remote/src/connection.rs
+++ b/cmux-tui/crates/cmux-remote/src/connection.rs
@@ -130,6 +130,9 @@ pub struct ClientConnection {
     reconnecting: Arc<Mutex<()>>,
     lane_sends: [Mutex<()>; 4],
     receiving: Mutex<()>,
+    /// Linearizes shutdown start with the short reconnect publication window.
+    /// Reconnect attempts do not hold this gate while dialing or replaying.
+    shutdown_gate: Mutex<()>,
     deferred_receive: StdMutex<Option<Result<ReceivedFrame, ConnectionError>>>,
     last_received: StdMutex<Instant>,
     closed: AtomicBool,
@@ -252,6 +255,7 @@ impl ClientConnection {
             reconnecting: Arc::new(Mutex::new(())),
             lane_sends: std::array::from_fn(|_| Mutex::new(())),
             receiving: Mutex::new(()),
+            shutdown_gate: Mutex::new(()),
             deferred_receive: StdMutex::new(None),
             last_received: StdMutex::new(Instant::now()),
             closed: AtomicBool::new(false),
@@ -539,6 +543,9 @@ impl ClientConnection {
             current.resume_cursors(),
         )
         .await?;
+        if self.closed.load(Ordering::Acquire) {
+            return Err(ConnectionError::Closed);
+        }
         if daemon_key != self.daemon_public_key {
             return Err(ConnectionError::Crypto(CryptoError::DaemonKeyMismatch {
                 expected: crate::crypto::public_key_fingerprint(&self.daemon_public_key),
@@ -553,6 +560,9 @@ impl ClientConnection {
         // there is no await between that commit and publishing both wrappers.
         let mut active_group = self.group.write().await;
         let mut active_session = self.session.write().await;
+        if self.closed.load(Ordering::Acquire) {
+            return Err(ConnectionError::Closed);
+        }
         if active_session.generation() != current.generation() {
             return Err(ConnectionError::GenerationChanged {
                 expected: current.generation(),
@@ -560,6 +570,13 @@ impl ClientConnection {
             });
         }
         let next = current.reconnect_to(Arc::new(link), &daemon_resume, generation).await?;
+        // Shutdown takes this gate before publishing its start signal. This
+        // gives reconnect publication and shutdown a clear linearization
+        // point without holding the gate across dialing or replay.
+        let _shutdown_gate = self.shutdown_gate.lock().await;
+        if self.closed.load(Ordering::Acquire) {
+            return Err(ConnectionError::Closed);
+        }
         let generation = next.generation();
         let previous = std::mem::replace(&mut *active_group, group.clone());
         *active_session = next;
@@ -581,6 +598,7 @@ impl ClientConnection {
                 diagnostics.state = ConnectionState::Connected;
             }
         }
+        drop(_shutdown_gate);
         drop(active_session);
         drop(active_group);
         // Publishing the replacement first lets blocked readers recover onto
@@ -638,17 +656,22 @@ impl ClientConnection {
                 return Err(ConnectionError::Closed);
             }
             attempt = attempt.saturating_add(1);
-            let reconnect = tokio::time::timeout(
-                self.config.reconnect.attempt_timeout,
-                self.reconnect_once(group.clone()),
-            )
-            .await;
+            let reconnect = tokio::select! {
+                _ = close_state.changed() => return Err(ConnectionError::Closed),
+                reconnect = tokio::time::timeout(
+                    self.config.reconnect.attempt_timeout,
+                    self.reconnect_once(group.clone()),
+                ) => reconnect,
+            };
             let result = match reconnect {
                 Ok(result) => result,
                 Err(_) => Err(ConnectionError::ReconnectAttemptTimedOut {
                     timeout: self.config.reconnect.attempt_timeout,
                 }),
             };
+            if self.closed.load(Ordering::Acquire) && result.is_ok() {
+                return Err(ConnectionError::Closed);
+            }
             match result {
                 Ok(()) => {
                     if !self.closed.load(Ordering::Acquire) {
@@ -690,7 +713,12 @@ impl ClientConnection {
     }
 
     pub async fn close(&self) -> Result<(), ConnectionError> {
+        // Acquire the short publication gate before making shutdown visible.
+        // A reconnect that already owns it finishes publishing first; one
+        // that has not reached publication observes `closed` and aborts.
+        let shutdown_gate = self.shutdown_gate.lock().await;
         if self.closed.swap(true, Ordering::AcqRel) {
+            drop(shutdown_gate);
             return wait_for_close(self.close_state.subscribe()).await;
         }
         // Publish shutdown intent before taking any cleanup locks. Reconnect
@@ -698,6 +726,7 @@ impl ClientConnection {
         // time, so waiting only for the eventual terminal state would leave
         // them alive after the caller has requested close.
         self.close_state.send_replace(CloseState::Started);
+        drop(shutdown_gate);
         self.set_diagnostics_state(ConnectionState::Closed);
         // The cleanup task owns every lock needed to snapshot the final carrier.
         // It therefore survives cancellation of this caller after `closed` is

--- a/cmux-tui/crates/cmux-remote/src/connection.rs
+++ b/cmux-tui/crates/cmux-remote/src/connection.rs
@@ -1346,7 +1346,10 @@ mod tests {
             .await
             .expect("reconnect group resolver did not start");
 
-        let mut closing = Box::pin(client.close());
+        let mut closing = tokio::spawn({
+            let client = client.clone();
+            async move { client.close().await }
+        });
         let closed = tokio::time::timeout(Duration::from_millis(250), &mut closing).await;
         release.notify_waiters();
         let _ = tokio::time::timeout(Duration::from_secs(1), &mut closing).await;

--- a/cmux-tui/crates/cmux-remote/src/connection.rs
+++ b/cmux-tui/crates/cmux-remote/src/connection.rs
@@ -1221,6 +1221,11 @@ mod tests {
         completed: Arc<AtomicBool>,
     }
 
+    struct HangingReconnectGroupSource {
+        entered: Arc<Notify>,
+        release: Arc<Notify>,
+    }
+
     #[async_trait]
     impl ReconnectGroupSource for DelayedReconnectGroupSource {
         fn resolution_timeout(&self, reconnect_attempt_timeout: Duration) -> Duration {
@@ -1231,6 +1236,19 @@ mod tests {
             tokio::time::sleep(self.delay).await;
             self.completed.store(true, Ordering::Release);
             Err(ProviderError::Transport("delayed test source completed".into()))
+        }
+    }
+
+    #[async_trait]
+    impl ReconnectGroupSource for HangingReconnectGroupSource {
+        fn resolution_timeout(&self, _reconnect_attempt_timeout: Duration) -> Duration {
+            Duration::from_secs(60 * 60)
+        }
+
+        async fn next_group(&self) -> Result<Arc<dyn LinkGroup>, ProviderError> {
+            self.entered.notify_one();
+            self.release.notified().await;
+            Err(ProviderError::Transport("released test source".into()))
         }
     }
 
@@ -1263,6 +1281,73 @@ mod tests {
         .await
         .expect("explicit reconnect resolution deadline was ignored");
         assert!(extended_completed.load(Ordering::Acquire));
+    }
+
+    #[tokio::test]
+    async fn close_cancels_reconnect_group_resolution() {
+        let directory = tempdir().unwrap();
+        let auth = AuthDatabase::load_or_create(directory.path(), "close-group-resolution", true).unwrap();
+        let (daemon, mut accepted) = RemoteDaemon::new(auth, SessionLimits::default());
+        let group = Arc::new(OneShotGroup {
+            daemon,
+            opens: AtomicUsize::new(0),
+            epoch: StdMutex::new(None),
+            evidence: CarrierEvidence::LocalPeer { uid: None, pid: None },
+        });
+        let entered = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        let source = Arc::new(HangingReconnectGroupSource {
+            entered: entered.clone(),
+            release: release.clone(),
+        });
+        let client = ClientConnection::connect_with_reconnect_groups(
+            group.clone(),
+            ClientConnectionConfig {
+                identity: StaticIdentity::generate().unwrap(),
+                expected_daemon: None,
+                auth: ClientAuthMode::Carrier,
+                device_name: "close-group-resolution-client".into(),
+                session: SessionId([95; 16]),
+                lane_policy: LanePolicy::Single,
+                limits: SessionLimits::default(),
+                reconnect: ReconnectPolicy {
+                    initial_delay: Duration::from_millis(1),
+                    maximum_delay: Duration::from_millis(1),
+                    attempt_timeout: Duration::from_millis(100),
+                    full_jitter: false,
+                    heartbeat_interval: None,
+                    heartbeat_timeout: Duration::from_secs(1),
+                    maximum_attempts: None,
+                },
+            },
+            Some(source),
+        )
+        .await
+        .unwrap();
+        let _server = tokio::time::timeout(Duration::from_secs(2), accepted.recv())
+            .await
+            .unwrap()
+            .unwrap();
+
+        group.fail();
+        let send = tokio::spawn({
+            let client = client.clone();
+            async move {
+                client
+                    .send(Lane::Control, 7, Bytes::from_static(b"blocked"), FrameFlags::empty())
+                    .await
+            }
+        });
+        tokio::time::timeout(Duration::from_secs(1), entered.notified())
+            .await
+            .expect("reconnect group resolver did not start");
+
+        let mut closing = Box::pin(client.close());
+        let closed = tokio::time::timeout(Duration::from_millis(250), &mut closing).await;
+        release.notify_waiters();
+        let _ = tokio::time::timeout(Duration::from_secs(1), &mut closing).await;
+        let _ = tokio::time::timeout(Duration::from_secs(1), send).await;
+        assert!(closed.is_ok(), "close waited for a provider resolver after shutdown began");
     }
 
     struct FaultEpoch {

--- a/cmux-tui/crates/cmux-remote/src/connection.rs
+++ b/cmux-tui/crates/cmux-remote/src/connection.rs
@@ -139,6 +139,10 @@ pub struct ClientConnection {
 #[derive(Clone, Debug)]
 enum CloseState {
     Pending,
+    /// Shutdown has started, but the cleanup task has not published its
+    /// terminal result yet. Background work uses this transition as its
+    /// cancellation signal; callers still wait for `Complete` or `Failed`.
+    Started,
     Complete,
     Failed(CloseFailure),
 }
@@ -689,6 +693,11 @@ impl ClientConnection {
         if self.closed.swap(true, Ordering::AcqRel) {
             return wait_for_close(self.close_state.subscribe()).await;
         }
+        // Publish shutdown intent before taking any cleanup locks. Reconnect
+        // and heartbeat tasks may be blocked in transport futures for a long
+        // time, so waiting only for the eventual terminal state would leave
+        // them alive after the caller has requested close.
+        self.close_state.send_replace(CloseState::Started);
         self.set_diagnostics_state(ConnectionState::Closed);
         // The cleanup task owns every lock needed to snapshot the final carrier.
         // It therefore survives cancellation of this caller after `closed` is
@@ -752,7 +761,7 @@ async fn resolve_reconnect_group(
 async fn wait_for_close(mut state: watch::Receiver<CloseState>) -> Result<(), ConnectionError> {
     loop {
         match state.borrow().clone() {
-            CloseState::Pending => {}
+            CloseState::Pending | CloseState::Started => {}
             CloseState::Complete => return Ok(()),
             CloseState::Failed(failure) => return Err(failure.to_error()),
         }
@@ -2374,6 +2383,7 @@ mod tests {
         .unwrap();
 
         let publication = client.reconnecting.lock().await;
+        let mut close_state = client.close_state.subscribe();
         let closing = tokio::spawn({
             let client = client.clone();
             async move { client.close().await }
@@ -2385,6 +2395,11 @@ mod tests {
         })
         .await
         .expect("close did not begin");
+        tokio::time::timeout(Duration::from_secs(1), close_state.changed())
+            .await
+            .expect("shutdown start was not published while cleanup was blocked")
+            .expect("close state channel closed before shutdown completed");
+        assert!(matches!(*close_state.borrow(), CloseState::Started));
         assert!(!closing.is_finished(), "close bypassed reconnect publication serialization");
         closing.abort();
         assert!(closing.await.unwrap_err().is_cancelled());


### PR DESCRIPTION
Security follow-up for https://github.com/manaflow-ai/cmux/pull/11112.

- Cancel reconnect resolution and heartbeat waits when close starts.
- Preserve retryable carrier failure semantics so reconnect policy controls retries.
- Fix shutdown tests so completed tasks are observed exactly once.

Trade-off: close can stop an in-flight reconnect before its diagnostic completes. That bounds shutdown and avoids a stuck surface; the carrier error remains retryable when the connection is still live.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cancels reconnect resolution, retry-delay, and heartbeat waits when shutdown starts in `cmux-remote`, so `close()` no longer hangs on in-flight provider lookups or transport futures. Previously those background tasks only stopped on their own timeouts; now `close()` publishes a `Started` state before cleanup, and each task selects on that signal to exit early.

**Side effects**
- Close can stop an in-flight reconnect before its diagnostic completes, bounding shutdown but forfeiting that diagnostic.
- Carrier errors remain retryable when the connection is still live, so reconnect policy still controls retries.
- Shutdown tests now observe completed tasks exactly once.

<sup>Written for commit 4f8d5d1d70b5ba15168fad18cbacc090dcaf359a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

