### PR TITLE
security(cloud): keep link telemetry free of private diagnostics

### DIFF
--- a/Sources/Cloud/CloudLinkTelemetry.swift
+++ b/Sources/Cloud/CloudLinkTelemetry.swift
@@ -1,5 +1,6 @@
 import Foundation
 import OSLog
+import CryptoKit
 
 /// Production diagnostics for the sidebar's cloud machine links. This path previously
 /// had no non-DEBUG signal at all: `cmuxDebugLog` compiles out of release builds,
@@ -11,8 +12,9 @@ import OSLog
 /// - os.log (subsystem `com.cmuxterm.app`, category `CloudLink`): every lifecycle
 ///   transition, readable from release builds via Console or
 ///   `log show --predicate 'subsystem == "com.cmuxterm.app" AND category == "CloudLink"'`.
-///   Interpolations are `.public` only after `redactSecrets` strips token values,
-///   because link routes carry preview tokens in query strings.
+///   Only bounded enum values and a per-launch keyed machine identifier are public.
+///   Raw routes, socket paths, provider output, and error descriptions never enter a
+///   log record.
 /// - PostHog event `cmux_cloud_link_error`: failures only, matching the server's
 ///   `cloud_vm_provision` errors-only split, throttled per machine+stage so the 45 s
 ///   sidebar refresh loop cannot flood the project while a machine stays broken.
@@ -23,25 +25,31 @@ enum CloudLinkTelemetry {
 
     /// One capture per machine+stage per interval; os.log still records every occurrence.
     private static let captureThrottle = CloudLinkCaptureThrottle(interval: 5 * 60)
+    /// A fresh key on every launch prevents the analytics event from becoming a stable
+    /// cross-install machine identifier while still grouping one machine's failures
+    /// during the current launch.
+    private static let correlationSalt = Data(UUID().uuidString.utf8)
 
     // MARK: - Lifecycle logs
 
     static func connectStarted(machineID: String) {
-        logger.info("connect start machine=\(machineID, privacy: .public)")
+        logger.info("connect start machine=\(machineCorrelationID(machineID), privacy: .public)")
     }
 
     static func attachEndpointResolved(machineID: String, durationMs: Int) {
-        logger.info("attach-endpoint resolved machine=\(machineID, privacy: .public) duration_ms=\(durationMs, privacy: .public)")
+        logger.info("attach-endpoint resolved machine=\(machineCorrelationID(machineID), privacy: .public) duration_ms=\(boundedDuration(durationMs), privacy: .public)")
     }
 
     static func connected(machineID: String, socketPath: String, durationMs: Int) {
-        logger.info("connected machine=\(machineID, privacy: .public) socket=\(socketPath, privacy: .public) duration_ms=\(durationMs, privacy: .public)")
+        // `socketPath` is intentionally ignored. It contains a local filesystem path
+        // and can include account names or other private state.
+        logger.info("connected machine=\(machineCorrelationID(machineID), privacy: .public) duration_ms=\(boundedDuration(durationMs), privacy: .public)")
     }
 
     static func connectFailed(machineID: String, error: Error, durationMs: Int) {
         let stage = Self.stage(for: error)
-        let text = redactSecrets(CloudMachineLink.errorText(error))
-        logger.error("connect failed machine=\(machineID, privacy: .public) stage=\(stage, privacy: .public) duration_ms=\(durationMs, privacy: .public) error=\(text, privacy: .public)")
+        let errorClass = Self.errorClass(for: error)
+        logger.error("connect failed machine=\(machineCorrelationID(machineID), privacy: .public) stage=\(stage, privacy: .public) class=\(errorClass, privacy: .public) duration_ms=\(boundedDuration(durationMs), privacy: .public)")
         // A backoff rejection re-reports the failure that armed it; capturing it again
         // would double-count one incident.
         guard stage != "retry_backoff" else { return }
@@ -49,15 +57,17 @@ enum CloudLinkTelemetry {
     }
 
     static func linkExited(machineID: String, status: Int32, wasConnected: Bool, stderrTail: String) {
-        let tail = redactSecrets(stderrTail)
-        logger.error("link exited machine=\(machineID, privacy: .public) status=\(status, privacy: .public) was_connected=\(wasConnected, privacy: .public) stderr=\(tail, privacy: .public)")
+        // The child controls stderr. A token regex cannot reliably distinguish a
+        // secret from a path, prompt, or future credential format, so the tail is
+        // deliberately discarded at this boundary.
+        _ = stderrTail
+        logger.error("link exited machine=\(machineCorrelationID(machineID), privacy: .public) status=\(boundedExitStatus(status), privacy: .public) was_connected=\(wasConnected, privacy: .public)")
         guard status != 0 else { return }
         capture(
             machineID: machineID,
             stage: "link_exit",
             errorClass: "exited",
-            errorText: tail,
-            extra: ["exit_status": Int(status), "was_connected": wasConnected]
+            extra: ["exit_status": Int(boundedExitStatus(status)), "was_connected": wasConnected]
         )
     }
 
@@ -65,14 +75,12 @@ enum CloudLinkTelemetry {
     /// This was a silent `try?` before: under a sustained failure (rate limiting, auth,
     /// backend outage) the whole cloud tree froze in its last state with no trace.
     static func machineListFailed(error: Error) {
-        let text = redactSecrets(CloudMachineLink.errorText(error))
-        logger.error("machine list refresh failed error=\(text, privacy: .public)")
+        logger.error("machine list refresh failed class=\(errorClass(for: error), privacy: .public)")
         capture(machineID: "all", stage: "list_machines", error: error)
     }
 
     static func providerRefreshFailed(machineID: String, state: SurfaceLinkState, error: Error) {
-        let text = redactSecrets(CloudMachineLink.errorText(error))
-        logger.error("provider refresh failed machine=\(machineID, privacy: .public) link_state=\(state.rawValue, privacy: .public) error=\(text, privacy: .public)")
+        logger.error("provider refresh failed machine=\(machineCorrelationID(machineID), privacy: .public) link_state=\(state.rawValue, privacy: .public) class=\(errorClass(for: error), privacy: .public)")
         // `connecting` here means another attempt is already in flight and will report
         // its own outcome; only a settled error state is a new incident.
         guard state == .error else { return }
@@ -81,7 +89,7 @@ enum CloudLinkTelemetry {
 
     static func linkStateChanged(machineID: String, from: SurfaceLinkState, to: SurfaceLinkState) {
         guard from != to else { return }
-        logger.info("link state machine=\(machineID, privacy: .public) \(from.rawValue, privacy: .public) -> \(to.rawValue, privacy: .public)")
+        logger.info("link state machine=\(machineCorrelationID(machineID), privacy: .public) \(from.rawValue, privacy: .public) -> \(to.rawValue, privacy: .public)")
     }
 
     // MARK: - Classification
@@ -139,15 +147,15 @@ enum CloudLinkTelemetry {
         }
     }
 
-    /// Strips secret query values (`bl_preview_token=…`, any `*token*=` parameter) from
-    /// text that may embed a link route, so it is safe to log publicly and send to
-    /// PostHog. Routes appear in child-process stderr and in error descriptions.
+    /// Legacy helper for callers that need to display a route in a local diagnostic.
+    /// Telemetry does not call it because arbitrary non-token data is still sensitive.
     static func redactSecrets(_ text: String) -> String {
-        text.replacingOccurrences(
+        let redacted = text.replacingOccurrences(
             of: #"([?&][A-Za-z0-9_-]*token[A-Za-z0-9_-]*=)[^&\s"'\\]+"#,
             with: "$1REDACTED",
             options: [.regularExpression, .caseInsensitive]
         )
+        return String(redacted.unicodeScalars.filter { !$0.properties.isControl }.prefix(512))
     }
 
     // MARK: - Capture
@@ -162,7 +170,6 @@ enum CloudLinkTelemetry {
             machineID: machineID,
             stage: stage,
             errorClass: errorClass(for: error),
-            errorText: redactSecrets(CloudMachineLink.errorText(error)),
             extra: extra
         )
     }
@@ -171,19 +178,56 @@ enum CloudLinkTelemetry {
         machineID: String,
         stage: String,
         errorClass: String,
-        errorText: String,
         extra: [String: Any]
     ) {
         guard captureThrottle.shouldSend(key: "\(machineID)|\(stage)") else { return }
         var properties: [String: Any] = [
-            "machine_id": machineID,
+            "machine_id": machineCorrelationID(machineID),
             "stage": stage,
             "error_class": errorClass,
-            "error": String(errorText.prefix(500)),
-            "schema_version": 1,
+            "schema_version": 2,
         ]
-        properties.merge(extra) { _, new in new }
+        for (key, value) in extra {
+            switch key {
+            case "duration_ms":
+                if let number = value as? Int { properties[key] = boundedDuration(number) }
+            case "exit_status":
+                if let number = value as? Int {
+                    properties[key] = Int(boundedExitStatus(Int32(number)))
+                }
+            case "was_connected":
+                if let flag = value as? Bool { properties[key] = flag }
+            case "link_state":
+                if let state = value as? String, Self.allowedLinkStates.contains(state) { properties[key] = state }
+            default:
+                break
+            }
+        }
         PostHogAnalytics.shared.captureDiagnostic(event: eventName, properties: properties)
+    }
+
+    private static let allowedLinkStates: Set<String> = [
+        SurfaceLinkState.connecting.rawValue,
+        SurfaceLinkState.connected.rawValue,
+        SurfaceLinkState.error.rawValue,
+        SurfaceLinkState.unavailable.rawValue,
+        SurfaceLinkState.asleep.rawValue,
+    ]
+
+    /// A short, non-reversible correlation value for this process. A plain SHA-256
+    /// would let anyone with a machine-ID dictionary reverse the identifier, so the
+    /// per-launch salt is part of the digest input.
+    static func machineCorrelationID(_ machineID: String) -> String {
+        let digest = SHA256.hash(data: correlationSalt + Data(machineID.utf8))
+        return digest.prefix(10).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func boundedDuration(_ value: Int) -> Int {
+        min(max(value, 0), 24 * 60 * 60 * 1_000)
+    }
+
+    private static func boundedExitStatus(_ value: Int32) -> Int32 {
+        min(max(value, -1), 255)
     }
 }
 

--- a/Sources/Cloud/CloudLinkTelemetry.swift
+++ b/Sources/Cloud/CloudLinkTelemetry.swift
@@ -219,7 +219,21 @@ enum CloudLinkTelemetry {
     /// per-launch salt is part of the digest input.
     static func machineCorrelationID(_ machineID: String) -> String {
         let digest = SHA256.hash(data: correlationSalt + Data(machineID.utf8))
-        return digest.prefix(10).map { String(format: "%02x", $0) }.joined()
+        return hex(digest.prefix(10))
+    }
+
+    /// Encode digest bytes without Foundation's locale-sensitive varargs
+    /// formatter. This runs on every link poll and must stay deterministic
+    /// across supported SDK versions.
+    private static func hex<Bytes: Collection>(_ bytes: Bytes) -> String where Bytes.Element == UInt8 {
+        let digits = Array("0123456789abcdef".utf8)
+        var encoded = [UInt8]()
+        encoded.reserveCapacity(bytes.count * 2)
+        for byte in bytes {
+            encoded.append(digits[Int(byte >> 4)])
+            encoded.append(digits[Int(byte & 0x0f)])
+        }
+        return String(decoding: encoded, as: UTF8.self)
     }
 
     private static func boundedDuration(_ value: Int) -> Int {

--- a/cmuxTests/CloudLinkTelemetryTests.swift
+++ b/cmuxTests/CloudLinkTelemetryTests.swift
@@ -55,5 +55,15 @@ struct CloudLinkTelemetryTests {
         #expect(throttle.shouldSend(key: "vm-1|socket_wait", now: start.addingTimeInterval(301)))
         #expect(!throttle.shouldSend(key: "vm-1|socket_wait", now: start.addingTimeInterval(302)))
     }
+
+    @Test("machine correlation identifiers are launch-scoped and do not expose the input")
+    func machineCorrelationIdentifiersDoNotExposeMachineIDs() {
+        let secret = "vm-with-private-user-data"
+        let first = CloudLinkTelemetry.machineCorrelationID(secret)
+        #expect(first != secret)
+        #expect(first.count == 20)
+        #expect(first == CloudLinkTelemetry.machineCorrelationID(secret))
+        #expect(first != CloudLinkTelemetry.machineCorrelationID("another-machine"))
+    }
 }
 #endif


### PR DESCRIPTION
Security follow-up for https://github.com/manaflow-ai/cmux/pull/11052.

Telemetry fields now contain operation, outcome, and bounded numeric timing data only. Private provider errors, command output, paths, identifiers, and invitation material are excluded before emission.

Trade-off: operators lose raw diagnostic text in telemetry and must use local structured logs for incident investigation. This prevents sensitive cloud data from entering the analytics system.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes private data from cloud link telemetry so analytics events no longer carry machine IDs, raw error text, stderr, or socket paths. Telemetry now emits only the operation, outcome, bounded numeric values, and a per-launch hashed machine correlation ID.

Operators lose raw diagnostic text in telemetry; use local structured logs for incident investigation instead.

- Machine IDs are replaced by a salted SHA-256 hash that resets per launch.
- Error text, stderr tails, and socket paths are dropped; only the error class enum remains.
- Duration and exit status are clamped to bounded ranges.
- Telemetry schema version bumps to 2 for the reduced property set.

<sup>Written for commit dd324e9e8de6264712524a62431f752c0aa30447. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

