### PR TITLE
fix: preserve auto-named workspace titles across restart

### DIFF
--- a/Sources/TabManager+WorkspaceCustomizationPersistence.swift
+++ b/Sources/TabManager+WorkspaceCustomizationPersistence.swift
@@ -108,7 +108,15 @@ extension TabManager {
         case let .value(title):
             workspace.setCustomTitle(title)
         case .cleared:
-            workspace.setCustomTitle(nil)
+            // A prior user clear re-enables auto-naming; it must not evict
+            // a subsequently auto-derived title restored from the session
+            // snapshot. Without this guard, the durable customization journal
+            // clobbers the snapshot's `.auto` title on every restore, so
+            // auto-named workspaces lose their title across restart until the
+            // next turn re-derives it.
+            if workspace.effectiveCustomTitleSource != .auto {
+                workspace.setCustomTitle(nil)
+            }
         }
 
         switch customization.customColor {

--- a/cmuxTests/WorkspaceRecoveryTests.swift
+++ b/cmuxTests/WorkspaceRecoveryTests.swift
@@ -393,6 +393,52 @@ struct WorkspaceRecoveryTests {
     }
 
     @Test
+    func clearedUserTitleDoesNotEvictAutoTitleAcrossRestart() throws {
+        // Regression: a durable `.cleared` customization record (the user once
+        // cleared their title) must not clobber an `.auto` title restored from
+        // the session snapshot. Clearing re-enables auto-naming; it does not
+        // forbid it. Without the guard in applyWorkspaceCustomization, the
+        // reconcile pass that runs after restoreTitleState wipes the restored
+        // auto title on every restart.
+        let fixture = try makeCustomizationStore()
+        defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
+        let store = fixture.store
+
+        // Seed the durable journal with a `.cleared` record for a stable id by
+        // setting then clearing a user title in a source manager.
+        let sourceManager = TabManager(
+            initialWorkingDirectory: "/tmp/cleared-vs-auto",
+            autoWelcomeIfNeeded: false,
+            workspaceCustomizationStore: store
+        )
+        let sourceWorkspace = try #require(sourceManager.selectedWorkspace)
+        #expect(sourceManager.setCustomTitle(tabId: sourceWorkspace.id, title: "Old User Title"))
+        sourceManager.clearCustomTitle(tabId: sourceWorkspace.id)
+        #expect(
+            store.customization(for: sourceWorkspace.stableId) ==
+                WorkspaceCustomization(customTitle: .cleared, customColor: .absent)
+        )
+
+        // Simulate a later session where auto-naming derived a title for the
+        // same workspace; the snapshot persists it with `.auto` provenance.
+        var snapshot = sourceWorkspace.sessionSnapshot(includeScrollback: false)
+        snapshot.customTitle = "Auto Derived Title"
+        snapshot.customTitleSource = .auto
+
+        let restoredManager = TabManager(
+            autoWelcomeIfNeeded: false,
+            workspaceCustomizationStore: store
+        )
+        restoredManager.restoreSessionSnapshot(SessionTabManagerSnapshot(
+            selectedWorkspaceIndex: 0,
+            workspaces: [snapshot]
+        ))
+        let restoredWorkspace = try #require(restoredManager.selectedWorkspace)
+        #expect(restoredWorkspace.customTitle == "Auto Derived Title")
+        #expect(restoredWorkspace.effectiveCustomTitleSource == .auto)
+    }
+
+    @Test
     func titleAndColorRecoveryFieldsRemainIndependent() throws {
         let fixture = try makeCustomizationStore()
         defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }


### PR DESCRIPTION
## Summary

- Auto-named workspace titles (`.auto` provenance) were lost on restart when the durable customization journal held a `.cleared` record for the workspace's stable id (any workspace whose title the user had once cleared).
- Root cause: `applyWorkspaceCustomization` runs after `restoreTitleState` and unconditionally applied the stored `.cleared` record, evicting the `.auto` title just restored from the session snapshot — so the workspace fell back to the default process title until the next turn re-derived it.
- Fix: guard the `.cleared` branch so it only clears when the restored title is not `.auto`. A user clear re-enables auto-naming (per the auto-naming docs); it must not forbid a subsequently auto-derived title from surviving restart. The snapshot's `.auto` provenance now round-trips across restart.

## Testing

- Added `clearedUserTitleDoesNotEvictAutoTitleAcrossRestart` to `WorkspaceRecoveryTests`: seeds a `.cleared` journal record, restores a snapshot with `customTitleSource: .auto`, and asserts the title survives reconcile.
- Existing `stableWorkspaceJournalRecoversStaleTitleColorAndClears` still passes: its snapshot restores a title with no recorded source (`.user`), so `.cleared` still clears it — only `.auto` titles are now preserved.
- Two commits per repo norm: test first (CI red without the fix), fix second (CI green).

## Demo Video

N/A — no UI change; the workspace title that already appears in the sidebar now persists across restart instead of dropping to the default for one turn.

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where auto-named workspace titles were lost on restart if the user had ever cleared their title manually. Previously, a stored `.cleared` customization record would override the restored `.auto` title, causing the workspace to fall back to the default title until the next turn. Now the clearing only applies when the restored title is not `.auto`, so auto-derived titles persist across restarts.

- Adds a regression test that verifies a prior user clear does not evict an auto-derived title restored from a snapshot.

<sup>Written for commit 69465c02723798e5fdd001ff39f604f57f30d5c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

