### PR TITLE
test: remove stale connectivity builder release

### DIFF
--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxConnectivityPeerSessionTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxConnectivityPeerSessionTests.swift
@@ -38,15 +38,17 @@ struct CmxConnectivityPeerSessionTests {
         let peerID = try CmxConnectivityPeerID(request: request)
         let log = DiagnosticLog(capacity: 32, role: .mobileClient)
         let admitted = TestConnectivitySession(continuityID: 17)
-        let builder = SequencedConnectivitySessionBuilder(sessions: [admitted])
+        // This fixture returns the admitted session immediately. It is not a
+        // gated builder, so there is no release operation to await.
+        let sequencedBuilder = SequencedConnectivitySessionBuilder(sessions: [admitted])
         let peer = CmxConnectivityPeerSession(
             peerID: peerID,
-            buildSession: { request in try await builder.build(request) },
+            buildSession: { request in try await sequencedBuilder.build(request) },
             diagnosticLog: log
         )
 
         let dial = Task { try await peer.connectedSession(for: request) }
-        try await Self.waitUntil { await builder.callCount() == 1 }
+        try await Self.waitUntil { await sequencedBuilder.callCount() == 1 }
         _ = try await dial.value
         await peer.releaseControl(ownerID: UUID())
         await peer.invalidate()

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxConnectivityPeerSessionTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxConnectivityPeerSessionTests.swift
@@ -45,12 +45,8 @@ struct CmxConnectivityPeerSessionTests {
             diagnosticLog: log
         )
 
-        // The gated builder parks every dial until released. Awaiting the
-        // dial before releasing the gate deadlocked this test (and the
-        // package CI job) permanently.
         let dial = Task { try await peer.connectedSession(for: request) }
         try await Self.waitUntil { await builder.callCount() == 1 }
-        await builder.release()
         _ = try await dial.value
         await peer.releaseControl(ownerID: UUID())
         await peer.invalidate()


### PR DESCRIPTION
Fixes the CmuxIrohTransport package test compile failure on main.

CmxConnectivityPeerSessionTests used `await builder.release()` in a test whose builder is SequencedConnectivitySessionBuilder and has no release gate. Remove the stale call and obsolete comment.

Focused verification: `swift test --package-path Packages/Shared/CmuxIrohTransport --filter CmxConnectivityPeerSessionTests` (17 tests passed).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a test compile failure on `main` where `CmxConnectivityPeerSessionTests` called `builder.release()` on a `SequencedConnectivitySessionBuilder` that has no release gate. Removes the stale `release()` call and its obsolete comment, renames the builder to make its immediate behavior explicit, and keeps the dial verification.

<sup>Written for commit 1a718d774c652c39a646f719cd5ffdc818cc834f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated connectivity coverage to allow dial operations to complete without manual gate release.
  * Preserved validation of peer tracing aliases and established session events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->