### PR TITLE
fix(relay): keep rate-limit source internal

### DIFF
--- a/web/services/relay/http.ts
+++ b/web/services/relay/http.ts
@@ -103,10 +103,9 @@ export function relayErrorResponse(error: unknown): Response {
   if (tag === "RelayAuthenticationError") {
     const typed = error as RelayAuthenticationError;
     const rateLimited = typed.code === "rate_limited";
-    const source = rateLimited ? { source: "auth_provider" } : {};
     console.error("relay.auth.unavailable", { reason: typed.code });
     return jsonResponse(
-      { error: rateLimited ? "rate_limited" : "authentication_unavailable", ...source },
+      { error: rateLimited ? "rate_limited" : "authentication_unavailable" },
       rateLimited ? 429 : 503,
       typed.retryAfterSeconds === undefined
         ? undefined
@@ -115,9 +114,8 @@ export function relayErrorResponse(error: unknown): Response {
   }
   if (tag === "RelayRateLimitError") {
     const code = (error as RelayRateLimitError).code;
-    const limitSource = (error as RelayRateLimitError).source;
     return jsonResponse(
-      { error: code, ...(limitSource ? { source: limitSource } : {}) },
+      { error: code },
       code === "rate_limited" ? 429 : 503,
       code === "rate_limited" &&
       (error as RelayRateLimitError).retryAfterSeconds !== undefined

--- a/web/tests/relay-token-route.test.ts
+++ b/web/tests/relay-token-route.test.ts
@@ -418,7 +418,6 @@ describe("POST /api/relay/token", () => {
     expect(response.headers.get("retry-after")).toBe("60");
     expect(await response.json()).toEqual({
       error: "rate_limited",
-      source: "auth_provider",
     });
 
     const statusLimited = await handleRelayTokenRequest(
@@ -468,7 +467,6 @@ describe("POST /api/relay/token", () => {
     expect(response.headers.get("retry-after")).toBe("60");
     expect(await response.json()).toEqual({
       error: "rate_limited",
-      source: "ingress_ip",
     });
     expect(authCalls).toBe(0);
   });
@@ -490,9 +488,7 @@ describe("POST /api/relay/token", () => {
       }),
     );
     expect(limited.status).toBe(429);
-    expect(await limited.clone().json()).toEqual(
-      expect.objectContaining({ error: "rate_limited", source: "device_budget" }),
-    );
+    expect(await limited.clone().json()).toEqual({ error: "rate_limited" });
     // Partitioned per device, protocol phase, and minute: a storming endpoint
     // starves only its duplicate work, never bootstrap, renewal, or another
     // phone, simulator, or tagged build.


### PR DESCRIPTION
Keep enforcement source labels in server diagnostics only. Public 429 responses now expose only the stable error code, so clients cannot infer account, device, or ingress partition details.

Follow-up to https://github.com/manaflow-ai/cmux/pull/11060.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790528051&installation_model_id=21920&pr_number=11133&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11133&signature=1e64b387824983e8d4e821465471651823f4bb2aa25accee86aa500ec0542c53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps rate-limit source labels in server diagnostics only. Public 429 responses now expose only the stable error code, so clients can no longer infer account, device, or ingress partition details.

<sup>Written for commit 823b336b290cfc2eea336542d3ee6311509b2e10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

