### PR TITLE
security(tui): harden plugin journal and error boundaries

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/localization.rs
+++ b/cmux-tui/crates/cmux-tui/src/localization.rs
@@ -122,6 +122,11 @@ pub(crate) struct SessionMessages {
     mux_subscription_recovery_failed: &'static str,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct PluginMessages {
+    pub operation_failed: &'static str,
+}
+
 impl SessionMessages {
     pub(crate) fn mux_subscription_recovery_failed(&self, error: &str) -> String {
         self.mux_subscription_recovery_failed.replace("{error}", error)
@@ -1096,6 +1101,7 @@ pub(crate) struct Catalog {
     pub graphics: GraphicsMessages,
     pub terminal: TerminalMessages,
     pub session: SessionMessages,
+    pub plugin: PluginMessages,
     pub session_reset: SessionResetMessages,
     pub machine_agent: MachineAgentMessages,
     pub menu: MenuMessages,
@@ -1235,6 +1241,7 @@ static ENGLISH: Catalog = Catalog {
         mux_subscription_recovered: "Mux event backlog overflowed; subscription recovered",
         mux_subscription_recovery_failed: "Mux event backlog recovery failed; queued input was discarded while retrying: {error}",
     },
+    plugin: PluginMessages { operation_failed: "Plugin operation failed; retry the command" },
     session_reset: SessionResetMessages {
         help: "  cmux session <name> reset-state [--force --confirm-reset <token>] [--state <path>]\n    Preview or confirm a scoped saved-state reset",
         exact_name_required: "session reset-state requires an exact session name",
@@ -1880,6 +1887,9 @@ static JAPANESE: Catalog = Catalog {
         operation_canceled: "セッション操作はキャンセルされました",
         mux_subscription_recovered: "Mux イベントの滞留が上限を超えました。購読を復旧しました",
         mux_subscription_recovery_failed: "Mux イベントの滞留から復旧できませんでした。再試行中のキュー入力を破棄しました: {error}",
+    },
+    plugin: PluginMessages {
+        operation_failed: "プラグイン操作に失敗しました。コマンドを再試行してください",
     },
     session_reset: SessionResetMessages {
         help: "  cmux session <name> reset-state [--force --confirm-reset <token>] [--state <path>]\n    スコープ付き保存状態のリセットをプレビューまたは確認実行",

--- a/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
+++ b/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
@@ -141,6 +141,11 @@ enum InstallJournalPhase {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct InstallJournal {
+    // Journals written before the v2 format carry an owner token and a
+    // commit marker. Keep the field so an interrupted old transaction can be
+    // recovered after an upgrade.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    owner_token: Option<String>,
     name: String,
     target_backup: PathBuf,
     metadata_backup: PathBuf,
@@ -161,7 +166,11 @@ struct InstallJournal {
 #[serde(deny_unknown_fields)]
 struct ConfigSnapshot {
     path: PathBuf,
+    #[serde(default)]
+    config_existed: bool,
     sidebar_plugin: Option<Value>,
+    #[serde(default)]
+    original_non_object: Option<Value>,
 }
 
 const INVALID_INSTALL_JOURNAL_DIR: &str = ".invalid-install-journals";
@@ -801,10 +810,17 @@ fn read_install_journal(path: &Path) -> anyhow::Result<Vec<u8>> {
     anyhow::ensure!(metadata.is_file(), "install journal is not a regular file");
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt as _;
+        use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+        // v1 journals were created with the process umask and are commonly
+        // 0644. Accept those files only when they are not writable by another
+        // uid or group. New journals remain 0600.
         anyhow::ensure!(
-            metadata.permissions().mode() & 0o7777 == 0o600,
-            "install journal permissions are not private"
+            metadata.permissions().mode() & 0o022 == 0,
+            "install journal is writable by another user"
+        );
+        anyhow::ensure!(
+            metadata.uid() == unsafe { libc::geteuid() },
+            "install journal is not owned by the current user"
         );
     }
     let mut bytes = Vec::new();
@@ -814,6 +830,19 @@ fn read_install_journal(path: &Path) -> anyhow::Result<Vec<u8>> {
         "install journal exceeds {MAX_INSTALL_JOURNAL_BYTES} bytes"
     );
     Ok(bytes)
+}
+
+fn install_commit_marker_path(install_root: &Path, name: &str) -> PathBuf {
+    install_root.join(format!(".{name}.install-commit"))
+}
+
+fn commit_marker_matches(path: &Path, owner_token: &str) -> anyhow::Result<bool> {
+    let contents = match fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error.into()),
+    };
+    Ok(contents.trim() == owner_token)
 }
 
 #[cfg(unix)]
@@ -991,43 +1020,66 @@ fn reconcile_install_transactions(install_root: &Path) -> anyhow::Result<()> {
             quarantine_install_journal(install_root, &path)?;
             continue;
         }
-        match journal.phase {
-            InstallJournalPhase::Committed => {
-                remove_path_if_present(&journal.target_backup)?;
-                remove_path_if_present(&journal.metadata_backup)?;
-                remove_path_if_present(&journal.temp_dir)?;
-                remove_path_if_present(&journal.metadata_temp)?;
+        let marker_path = install_commit_marker_path(install_root, &journal.name);
+        let legacy_marker_committed = journal
+            .owner_token
+            .as_deref()
+            .map(|token| commit_marker_matches(&marker_path, token))
+            .transpose()?
+            .unwrap_or(false);
+        let committed =
+            matches!(&journal.phase, InstallJournalPhase::Committed) || legacy_marker_committed;
+        if committed {
+            remove_path_if_present(&journal.target_backup)?;
+            remove_path_if_present(&journal.metadata_backup)?;
+            remove_path_if_present(&journal.temp_dir)?;
+            remove_path_if_present(&journal.metadata_temp)?;
+        } else {
+            // A v1 journal did not always persist the compare-and-swap
+            // value. Derive it from the installed target when possible,
+            // so stale recovery cannot overwrite a newer selection.
+            let legacy_expected = (journal.owner_token.is_some()
+                && journal.expected_sidebar_plugin.is_none())
+                .then(|| expected_sidebar_plugin_for_target(install_root, &journal.name))
+                .flatten();
+            let expected = journal.expected_sidebar_plugin.as_ref().or(legacy_expected.as_ref());
+            if let Some(snapshot) = &journal.config_snapshot {
+                restore_config_snapshot(snapshot, expected)?;
             }
-            InstallJournalPhase::Prepared => {
-                if let (Some(snapshot), Some(expected)) =
-                    (&journal.config_snapshot, journal.expected_sidebar_plugin.as_ref())
-                {
-                    restore_config_snapshot(snapshot, expected)?;
-                }
-                if journal.target_existed {
-                    if path_entry_exists(&journal.target_backup)? {
-                        remove_path_if_present(&install_root.join(&journal.name))?;
-                        fs::rename(&journal.target_backup, install_root.join(&journal.name))?;
-                    }
-                } else {
+            if journal.target_existed {
+                if path_entry_exists(&journal.target_backup)? {
                     remove_path_if_present(&install_root.join(&journal.name))?;
+                    fs::rename(&journal.target_backup, install_root.join(&journal.name))?;
                 }
-                if journal.metadata_existed {
-                    let metadata_path = registry_metadata_path(install_root, &journal.name);
-                    if path_entry_exists(&journal.metadata_backup)? {
-                        remove_path_if_present(&metadata_path)?;
-                        fs::rename(&journal.metadata_backup, metadata_path)?;
-                    }
-                } else {
-                    remove_path_if_present(&registry_metadata_path(install_root, &journal.name))?;
-                }
-                remove_path_if_present(&journal.temp_dir)?;
-                remove_path_if_present(&journal.metadata_temp)?;
+            } else {
+                remove_path_if_present(&install_root.join(&journal.name))?;
             }
+            if journal.metadata_existed {
+                let metadata_path = registry_metadata_path(install_root, &journal.name);
+                if path_entry_exists(&journal.metadata_backup)? {
+                    remove_path_if_present(&metadata_path)?;
+                    fs::rename(&journal.metadata_backup, metadata_path)?;
+                }
+            } else {
+                remove_path_if_present(&registry_metadata_path(install_root, &journal.name))?;
+            }
+            remove_path_if_present(&journal.temp_dir)?;
+            remove_path_if_present(&journal.metadata_temp)?;
         }
         remove_path_if_present(&path)?;
+        if legacy_marker_committed || path_entry_exists(&marker_path)? {
+            remove_path_if_present(&marker_path)?;
+        }
     }
     Ok(())
+}
+
+fn expected_sidebar_plugin_for_target(install_root: &Path, name: &str) -> Option<Value> {
+    let target = install_root.join(name);
+    let manifest = read_manifest(&target).ok()?;
+    let command = resolved_run_command(&manifest, &target).ok()?;
+    let cwd = canonical_path(&target).ok()?;
+    Some(json!({"command": command, "cwd": cwd.display().to_string()}))
 }
 
 fn restore_config_snapshot(
@@ -1047,6 +1099,9 @@ fn restore_config_snapshot(
             // this transaction started. Leave that newer state untouched.
             return Ok(());
         }
+    }
+    if let Some(original) = &snapshot.original_non_object {
+        return write_config_value_atomic_local(&snapshot.path, original);
     }
     let Some(root_object) = root.as_object_mut() else {
         anyhow::bail!("{} must contain a JSON object", snapshot.path.display());
@@ -1069,6 +1124,13 @@ fn restore_config_snapshot(
                 sidebar_object.remove("plugin");
             }
         }
+    }
+    if !snapshot.config_existed && snapshot.sidebar_plugin.is_none() {
+        return match fs::remove_file(&snapshot.path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error.into()),
+        };
     }
     write_config_value_atomic_local(&snapshot.path, &root)
 }
@@ -1143,16 +1205,22 @@ fn replace_installed_plugin_with_config<C: FnOnce() -> anyhow::Result<()>>(
 
 fn capture_config_snapshot() -> anyhow::Result<ConfigSnapshot> {
     let path = config::config_path()?;
-    let sidebar_plugin = match fs::read_to_string(&path) {
-        Ok(text) if text.trim().is_empty() => None,
-        Ok(text) => serde_json::from_str::<Value>(&text)?
-            .get("sidebar")
-            .and_then(|sidebar| sidebar.get("plugin"))
-            .cloned(),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+    let (config_existed, sidebar_plugin, original_non_object) = match fs::read_to_string(&path) {
+        Ok(text) if text.trim().is_empty() => (true, None, None),
+        Ok(text) => {
+            let value: Value = serde_json::from_str(&text)?;
+            let sidebar_plugin = value
+                .as_object()
+                .and_then(|root| root.get("sidebar"))
+                .and_then(|sidebar| sidebar.get("plugin"))
+                .cloned();
+            let original_non_object = (!value.is_object()).then_some(value);
+            (true, sidebar_plugin, original_non_object)
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => (false, None, None),
         Err(error) => return Err(error.into()),
     };
-    Ok(ConfigSnapshot { path, sidebar_plugin })
+    Ok(ConfigSnapshot { path, config_existed, sidebar_plugin, original_non_object })
 }
 
 fn replace_installed_plugin_with_fs<F: InstallFilesystem, C: FnOnce() -> anyhow::Result<()>>(
@@ -1162,6 +1230,7 @@ fn replace_installed_plugin_with_fs<F: InstallFilesystem, C: FnOnce() -> anyhow:
     temp_dir: &Path,
     metadata_temp: &Path,
     config_snapshot: Option<ConfigSnapshot>,
+    expected_sidebar_plugin: Option<Value>,
     after_install: C,
 ) -> anyhow::Result<()> {
     ensure_real_directory(install_root)?;
@@ -1178,6 +1247,7 @@ fn replace_installed_plugin_with_fs<F: InstallFilesystem, C: FnOnce() -> anyhow:
     let metadata_exists = path_entry_exists(&metadata_path)?;
     let journal_path = install_journal_path(install_root, name);
     let journal = InstallJournal {
+        owner_token: None,
         name: name.to_string(),
         target_backup: target_backup.clone(),
         metadata_backup: metadata_backup.clone(),
@@ -1416,6 +1486,54 @@ mod tests {
         assert!(!rendered.contains("injected detail"));
         assert!(!details.contains("/private/plugin-state/secret.toml"));
         assert!(!details.contains("injected detail"));
+    }
+
+    #[test]
+    fn legacy_install_journal_shape_remains_readable() {
+        let journal: InstallJournal = serde_json::from_value(json!({
+            "owner_token": "legacy-owner",
+            "name": "demo",
+            "target_backup": "/state/.demo.backup.plugin-backup",
+            "metadata_backup": "/state/.registry/.demo.backup.metadata-backup.json",
+            "temp_dir": "/state/.install-1-2",
+            "metadata_temp": "/state/.registry/.demo.1-2.tmp",
+            "target_existed": true,
+            "metadata_existed": true,
+            "config_snapshot": {
+                "path": "/config/cmux.json",
+                "config_existed": true,
+                "sidebar_plugin": {"command": ["old"]},
+                "original_non_object": null
+            },
+            "phase": "prepared"
+        }))
+        .unwrap();
+        assert_eq!(journal.owner_token.as_deref(), Some("legacy-owner"));
+        let snapshot = journal.config_snapshot.unwrap();
+        assert!(snapshot.config_existed);
+        assert_eq!(snapshot.sidebar_plugin, Some(json!({"command": ["old"]})));
+    }
+
+    #[test]
+    fn config_restore_preserves_legacy_non_object_value() {
+        let path = std::env::temp_dir().join(format!(
+            "cmux-plugin-config-legacy-{}-{}",
+            std::process::id(),
+            now_nanos()
+        ));
+        fs::write(&path, "{\"sidebar\":{\"plugin\":{\"command\":[\"new\"]}}}").unwrap();
+        let snapshot = ConfigSnapshot {
+            path: path.clone(),
+            config_existed: true,
+            sidebar_plugin: None,
+            original_non_object: Some(json!("legacy")),
+        };
+        restore_config_snapshot(&snapshot, Some(&json!({
+            "command": ["new"]
+        })))
+        .unwrap();
+        assert_eq!(fs::read_to_string(&path).unwrap().trim(), "\"legacy\"");
+        fs::remove_file(path).unwrap();
     }
 
     #[test]
@@ -1748,6 +1866,7 @@ mod tests {
         write_install_journal(
             &journal_path,
             &InstallJournal {
+                owner_token: None,
                 name: "demo".into(),
                 target_backup: target_backup.clone(),
                 metadata_backup: metadata_backup.clone(),
@@ -1791,6 +1910,7 @@ mod tests {
         write_install_journal(
             &journal_path,
             &InstallJournal {
+                owner_token: None,
                 name: "demo".into(),
                 target_backup: outside.clone(),
                 metadata_backup: registry.join(".demo.recovery.metadata-backup.json"),
@@ -1825,7 +1945,9 @@ mod tests {
         .unwrap();
         let snapshot = ConfigSnapshot {
             path: config_path.clone(),
+            config_existed: true,
             sidebar_plugin: Some(json!({"command": ["old"]})),
+            original_non_object: None,
         };
         let expected = json!({"command": ["new"]});
         let error = replace_installed_plugin_with_fs(
@@ -1869,7 +1991,9 @@ mod tests {
         .unwrap();
         let snapshot = ConfigSnapshot {
             path: config_path.clone(),
+            config_existed: true,
             sidebar_plugin: Some(json!({"command": ["old"]})),
+            original_non_object: None,
         };
         let error = replace_installed_plugin_with_fs(
             &StandardInstallFilesystem,

--- a/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
+++ b/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use fs4::FileExt;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
@@ -125,13 +126,77 @@ struct PluginRegistryMetadata {
     id: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum InstallJournalPhase {
+    Prepared,
+    Committed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct InstallJournal {
+    #[serde(default = "default_owner_token")]
+    owner_token: String,
+    name: String,
+    target_backup: PathBuf,
+    metadata_backup: PathBuf,
+    temp_dir: PathBuf,
+    metadata_temp: PathBuf,
+    target_existed: bool,
+    metadata_existed: bool,
+    config_snapshot: Option<ConfigSnapshot>,
+    #[serde(default)]
+    expected_sidebar_plugin: Option<Value>,
+    phase: InstallJournalPhase,
+}
+
+fn default_owner_token() -> String {
+    "legacy".to_string()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ConfigSnapshot {
+    path: PathBuf,
+    #[serde(default)]
+    config_existed: bool,
+    #[serde(default)]
+    sidebar_plugin: Option<Value>,
+    #[serde(default)]
+    original_non_object: Option<Value>,
+}
+
+struct PluginOperationLock {
+    _file: fs::File,
+}
+
+fn acquire_plugin_operation_lock() -> anyhow::Result<PluginOperationLock> {
+    let root = install_root()?;
+    fs::create_dir_all(&root)?;
+    let path = root.join(".install.lock");
+    let file = fs::OpenOptions::new().create(true).read(true).write(true).open(path)?;
+    file.lock()?;
+    Ok(PluginOperationLock { _file: file })
+}
+
 pub(crate) fn execute(positionals: &[String], options: CliOptions) -> Result<Value, ManagerError> {
     match positionals.first().map(String::as_str) {
-        Some("install") => install_command(positionals, &options),
+        Some("install") => {
+            let _lock = acquire_plugin_operation_lock().map_err(ManagerError::Failure)?;
+            install_command(positionals, &options)
+        }
         Some("list") => list_command(positionals, &options),
-        Some("use") => use_command(positionals, &options),
-        Some("update") => update_command(positionals, &options),
-        Some("remove") => remove_command(positionals, &options),
+        Some("use") => {
+            let _lock = acquire_plugin_operation_lock().map_err(ManagerError::Failure)?;
+            use_command(positionals, &options)
+        }
+        Some("update") => {
+            let _lock = acquire_plugin_operation_lock().map_err(ManagerError::Failure)?;
+            update_command(positionals, &options)
+        }
+        Some("remove") => {
+            let _lock = acquire_plugin_operation_lock().map_err(ManagerError::Failure)?;
+            remove_command(positionals, &options)
+        }
         Some(other) => Err(ManagerError::Usage(format!("unknown plugin subcommand {other:?}"))),
         None => Err(ManagerError::Usage("plugin subcommand is required".to_string())),
     }
@@ -149,6 +214,7 @@ fn install_command(positionals: &[String], options: &CliOptions) -> Result<Value
     }
     let root = install_root()?;
     fs::create_dir_all(&root)?;
+    reconcile_install_transactions(&root)?;
     let temp_dir = root.join(format!(".install-{}-{}", std::process::id(), now_nanos()));
     let clone_result =
         run_git(["clone", "--depth", "1", positionals[1].as_str()], Some(&temp_dir), None);
@@ -180,16 +246,52 @@ fn install_command(positionals: &[String], options: &CliOptions) -> Result<Value
         let metadata_temp = write_registry_metadata_temp(&root, &name, &metadata)?;
         metadata_temp_path = Some(metadata_temp.clone());
         let id = metadata.id;
-        replace_installed_plugin(&root, &name, &temp_dir, &metadata_temp)?;
         let selected = selected_plugin_cwd()?.is_some_and(|cwd| same_path(&cwd, &target));
-        if selected {
-            let command = resolved_run_command(&manifest, &target)?;
-            let cwd = canonical_path(&target)?;
-            persist_sidebar_plugin(Some(&SidebarPluginConfig {
-                command,
-                cwd: Some(cwd.display().to_string()),
-            }))?;
-        }
+        let config_snapshot = selected.then(capture_config_snapshot).transpose()?;
+        let expected_sidebar_plugin = if selected {
+            let staging_command = resolved_run_command(&manifest, &temp_dir)?;
+            let staging_root = canonical_path(&temp_dir)?;
+            let target_root = canonical_path(&target)?;
+            let expected_command = staging_command
+                .into_iter()
+                .enumerate()
+                .map(|(index, argument)| {
+                    if index == 0 {
+                        let command_path = Path::new(&argument);
+                        if let Ok(relative) = command_path.strip_prefix(&staging_root) {
+                            return target_root.join(relative).display().to_string();
+                        }
+                    }
+                    argument
+                })
+                .collect::<Vec<_>>();
+            let expected_cwd = canonical_path(&target)?;
+            Some(json!({
+                "command": expected_command,
+                "cwd": expected_cwd.display().to_string(),
+            }))
+        } else {
+            None
+        };
+        replace_installed_plugin_with_config(
+            &root,
+            &name,
+            &temp_dir,
+            &metadata_temp,
+            config_snapshot,
+            expected_sidebar_plugin,
+            || {
+                if selected {
+                    let command = resolved_run_command(&manifest, &target)?;
+                    let cwd = canonical_path(&target)?;
+                    config::write_sidebar_plugin(Some(&SidebarPluginConfig {
+                        command,
+                        cwd: Some(cwd.display().to_string()),
+                    }))?;
+                }
+                Ok(())
+            },
+        )?;
         Ok(json!({"plugin": plugin_json(&InstalledPlugin {
             id,
             name,
@@ -234,7 +336,7 @@ fn use_command(positionals: &[String], options: &CliOptions) -> Result<Value, Ma
     let command = resolved_run_command(&plugin.manifest, &plugin.dir)?;
     verify_executable(&command[0])?;
     let cwd = canonical_path(&plugin.dir)?;
-    persist_sidebar_plugin(Some(&SidebarPluginConfig {
+    config::write_sidebar_plugin(Some(&SidebarPluginConfig {
         command,
         cwd: Some(cwd.display().to_string()),
     }))?;
@@ -257,7 +359,7 @@ fn update_command(positionals: &[String], options: &CliOptions) -> Result<Value,
     verify_executable(&command[0])?;
     if plugin.selected {
         let cwd = canonical_path(&plugin.dir)?;
-        persist_sidebar_plugin(Some(&SidebarPluginConfig {
+        config::write_sidebar_plugin(Some(&SidebarPluginConfig {
             command,
             cwd: Some(cwd.display().to_string()),
         }))?;
@@ -275,7 +377,7 @@ fn remove_command(positionals: &[String], options: &CliOptions) -> Result<Value,
     let installed = resolve_installed_plugin(&positionals[1])?;
     let mut plugin = plugin_json(&installed);
     if installed.selected {
-        persist_sidebar_plugin(None)?;
+        config::write_sidebar_plugin(None)?;
     }
     fs::remove_dir_all(&installed.dir)?;
     remove_registry_metadata(&install_root()?, &installed.name)?;
@@ -285,20 +387,9 @@ fn remove_command(positionals: &[String], options: &CliOptions) -> Result<Value,
 }
 
 fn write_builtin_config(_options: &CliOptions) -> Result<Value, ManagerError> {
-    persist_sidebar_plugin(None)?;
+    config::write_sidebar_plugin(None)?;
     let plugins = installed_plugins()?;
     Ok(json!({"plugins": plugins.iter().map(plugin_json).collect::<Vec<_>>()}))
-}
-
-fn persist_sidebar_plugin(plugin: Option<&SidebarPluginConfig>) -> Result<(), ManagerError> {
-    if let Some(error) = config::write_sidebar_plugin(plugin)?.into_unsynced_error() {
-        crate::client_log::stderr_log!(
-            "config",
-            "{}",
-            crate::localization::catalog().config.write_durability_warning(&error.to_string())
-        );
-    }
-    Ok(())
 }
 
 fn reject_plugin_flags(
@@ -321,6 +412,7 @@ fn reject_plugin_flags(
 
 fn installed_plugins() -> anyhow::Result<Vec<InstalledPlugin>> {
     let root = install_root()?;
+    reconcile_install_transactions(&root)?;
     let selected = selected_plugin_cwd()?;
     let mut plugins = Vec::new();
     let entries = match fs::read_dir(&root) {
@@ -620,6 +712,321 @@ fn unique_backup_path(parent: &Path, name: &str, suffix: &str) -> PathBuf {
     }
 }
 
+fn install_journal_path(install_root: &Path, name: &str) -> PathBuf {
+    install_root.join(format!(".{name}.install-journal.json"))
+}
+
+fn install_commit_marker_path(install_root: &Path, name: &str) -> PathBuf {
+    install_root.join(format!(".{name}.install-commit"))
+}
+
+fn write_install_journal(path: &Path, journal: &InstallJournal) -> anyhow::Result<()> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let temp = parent.join(format!(
+        ".{}.{}-journal.tmp",
+        path.file_name().unwrap().to_string_lossy(),
+        now_nanos()
+    ));
+    let encoded = serde_json::to_vec(journal)?;
+    let result = (|| -> anyhow::Result<()> {
+        let mut file = fs::OpenOptions::new().create_new(true).write(true).open(&temp)?;
+        file.write_all(&encoded)?;
+        file.write_all(b"\n")?;
+        file.sync_all()?;
+        drop(file);
+        fs::rename(&temp, path)?;
+        sync_directory(parent)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temp);
+    }
+    result
+}
+
+#[cfg(unix)]
+fn sync_directory(path: &Path) -> anyhow::Result<()> {
+    fs::File::open(path)?.sync_all()?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn sync_directory(_path: &Path) -> anyhow::Result<()> {
+    Ok(())
+}
+
+fn sync_transaction_directories(install_root: &Path) -> anyhow::Result<()> {
+    sync_directory(install_root)?;
+    sync_directory(&install_root.join(".registry"))?;
+    Ok(())
+}
+
+fn write_install_commit_marker(
+    install_root: &Path,
+    name: &str,
+    owner_token: &str,
+) -> anyhow::Result<()> {
+    let path = install_commit_marker_path(install_root, name);
+    let result = (|| -> anyhow::Result<()> {
+        let mut file = fs::OpenOptions::new().create_new(true).write(true).open(&path)?;
+        file.write_all(owner_token.as_bytes())?;
+        file.write_all(b"\n")?;
+        file.sync_all()?;
+        drop(file);
+        sync_directory(install_root)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&path);
+    }
+    result
+}
+
+fn commit_marker_matches(path: &Path, owner_token: &str) -> anyhow::Result<bool> {
+    let contents = match fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error.into()),
+    };
+    Ok(contents.trim() == owner_token)
+}
+
+fn remove_path_if_present(path: &Path) -> anyhow::Result<()> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.into()),
+    };
+    if metadata.is_dir() {
+        fs::remove_dir_all(path)?;
+    } else {
+        fs::remove_file(path)?;
+    }
+    Ok(())
+}
+
+fn path_exists(path: &Path) -> anyhow::Result<bool> {
+    match fs::symlink_metadata(path) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn reconcile_install_transactions(install_root: &Path) -> anyhow::Result<()> {
+    cleanup_orphan_metadata_temps(install_root)?;
+    cleanup_orphan_commit_markers(install_root)?;
+    let entries = match fs::read_dir(install_root) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.into()),
+    };
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|value| value.to_str()) else { continue };
+        if !name.starts_with('.') || !name.ends_with(".install-journal.json") {
+            continue;
+        }
+        let journal: InstallJournal = match serde_json::from_slice(&fs::read(&path)?) {
+            Ok(journal) => journal,
+            Err(_) => continue,
+        };
+        if validate_install_journal(install_root, &journal).is_err() {
+            continue;
+        }
+        if install_journal_path(install_root, &journal.name) != path {
+            continue;
+        }
+        let marker_path = install_commit_marker_path(install_root, &journal.name);
+        let marker_committed = commit_marker_matches(&marker_path, &journal.owner_token)?;
+        if matches!(&journal.phase, InstallJournalPhase::Committed) || marker_committed {
+            remove_path_if_present(&journal.target_backup)?;
+            remove_path_if_present(&journal.metadata_backup)?;
+            remove_path_if_present(&journal.temp_dir)?;
+            remove_path_if_present(&journal.metadata_temp)?;
+            sync_transaction_directories(install_root)?;
+            remove_path_if_present(&path)?;
+            sync_transaction_directories(install_root)?;
+            remove_path_if_present(&marker_path)?;
+            continue;
+        }
+        match journal.phase {
+            InstallJournalPhase::Prepared => {
+                if let Some(snapshot) = &journal.config_snapshot {
+                    restore_config_snapshot(snapshot, journal.expected_sidebar_plugin.as_ref())?;
+                }
+                if journal.target_existed {
+                    if path_exists(&journal.target_backup)? {
+                        remove_path_if_present(&install_root.join(&journal.name))?;
+                        fs::rename(&journal.target_backup, install_root.join(&journal.name))?;
+                    }
+                } else {
+                    remove_path_if_present(&install_root.join(&journal.name))?;
+                }
+                if journal.metadata_existed {
+                    let metadata_path = registry_metadata_path(install_root, &journal.name);
+                    if path_exists(&journal.metadata_backup)? {
+                        remove_path_if_present(&metadata_path)?;
+                        fs::rename(&journal.metadata_backup, metadata_path)?;
+                    }
+                } else {
+                    remove_path_if_present(&registry_metadata_path(install_root, &journal.name))?;
+                }
+                remove_path_if_present(&journal.temp_dir)?;
+                remove_path_if_present(&journal.metadata_temp)?;
+                sync_transaction_directories(install_root)?;
+            }
+            InstallJournalPhase::Committed => unreachable!(),
+        }
+        remove_path_if_present(&path)?;
+        sync_transaction_directories(install_root)?;
+        remove_path_if_present(&marker_path)?;
+    }
+    Ok(())
+}
+
+fn cleanup_orphan_metadata_temps(install_root: &Path) -> anyhow::Result<()> {
+    let registry = install_root.join(".registry");
+    let entries = match fs::read_dir(&registry) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.into()),
+    };
+    for entry in entries {
+        let path = entry?.path();
+        let Some(name) = path.file_name().and_then(|value| value.to_str()) else { continue };
+        if name.starts_with('.') && name.ends_with(".tmp") {
+            remove_path_if_present(&path)?;
+        }
+    }
+    Ok(())
+}
+
+fn cleanup_orphan_commit_markers(install_root: &Path) -> anyhow::Result<()> {
+    let entries = match fs::read_dir(install_root) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.into()),
+    };
+    for entry in entries {
+        let path = entry?.path();
+        let Some(name) = path.file_name().and_then(|value| value.to_str()) else { continue };
+        if !name.starts_with('.') || !name.ends_with(".install-commit") {
+            continue;
+        }
+        let plugin_name = name.trim_start_matches('.').trim_end_matches(".install-commit");
+        if validate_plugin_name(plugin_name).is_err()
+            || !path_exists(&install_journal_path(install_root, plugin_name))?
+        {
+            remove_path_if_present(&path)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_install_journal(install_root: &Path, journal: &InstallJournal) -> anyhow::Result<()> {
+    if journal.owner_token.is_empty() {
+        anyhow::bail!("transaction owner token is missing");
+    }
+    validate_plugin_name(&journal.name)?;
+    let registry = install_root.join(".registry");
+    let expected_target = install_root.join(&journal.name);
+    let expected_metadata = registry_metadata_path(install_root, &journal.name);
+    let paths = [
+        ("target backup", &journal.target_backup, install_root),
+        ("metadata backup", &journal.metadata_backup, &registry),
+        ("staging directory", &journal.temp_dir, install_root),
+        ("metadata staging", &journal.metadata_temp, &registry),
+    ];
+    for (label, path, parent) in paths {
+        if path.parent() != Some(parent) {
+            anyhow::bail!("{label} path escapes its transaction directory");
+        }
+    }
+    if journal.target_backup == expected_target || journal.temp_dir == expected_target {
+        anyhow::bail!("transaction path aliases the live plugin");
+    }
+    if journal.metadata_backup == expected_metadata || journal.metadata_temp == expected_metadata {
+        anyhow::bail!("transaction path aliases live metadata");
+    }
+    Ok(())
+}
+
+fn restore_config_snapshot(
+    snapshot: &ConfigSnapshot,
+    expected_sidebar_plugin: Option<&Value>,
+) -> anyhow::Result<()> {
+    let mut root = match fs::read_to_string(&snapshot.path) {
+        Ok(text) if text.trim().is_empty() => json!({}),
+        Ok(text) => serde_json::from_str(&text)?,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => json!({}),
+        Err(error) => return Err(error.into()),
+    };
+    if let Some(expected) = expected_sidebar_plugin {
+        let current = root.get("sidebar").and_then(|sidebar| sidebar.get("plugin"));
+        if current != Some(expected) {
+            return Ok(());
+        }
+    }
+    let Some(root_object) = root.as_object_mut() else {
+        if let Some(original) = &snapshot.original_non_object {
+            return write_config_value_atomic_local(&snapshot.path, original);
+        }
+        anyhow::bail!("{} must contain a JSON object", snapshot.path.display());
+    };
+    match &snapshot.sidebar_plugin {
+        Some(plugin) => {
+            let sidebar = root_object.entry("sidebar").or_insert_with(|| json!({}));
+            if !sidebar.is_object() {
+                *sidebar = json!({});
+            }
+            sidebar
+                .as_object_mut()
+                .expect("sidebar was just made an object")
+                .insert("plugin".to_string(), plugin.clone());
+        }
+        None => {
+            if let Some(sidebar) = root_object.get_mut("sidebar")
+                && let Some(sidebar_object) = sidebar.as_object_mut()
+            {
+                sidebar_object.remove("plugin");
+            }
+        }
+    }
+    if !snapshot.config_existed && snapshot.sidebar_plugin.is_none() {
+        return match fs::remove_file(&snapshot.path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error.into()),
+        };
+    }
+    write_config_value_atomic_local(&snapshot.path, &root)
+}
+
+fn write_config_value_atomic_local(path: &Path, value: &Value) -> anyhow::Result<()> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent)?;
+    let file_name = path.file_name().and_then(|name| name.to_str()).unwrap_or("cmux-tui.json");
+    let temp =
+        parent.join(format!(".{file_name}.{}.{}-restore.tmp", std::process::id(), now_nanos()));
+    let result = (|| -> anyhow::Result<()> {
+        let mut file = fs::OpenOptions::new().create_new(true).write(true).open(&temp)?;
+        serde_json::to_writer_pretty(&mut file, value)?;
+        file.write_all(b"\n")?;
+        file.sync_all()?;
+        drop(file);
+        fs::rename(&temp, path)?;
+        sync_directory(parent)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temp);
+    }
+    result
+}
+
+#[cfg(test)]
 fn replace_installed_plugin(
     install_root: &Path,
     name: &str,
@@ -632,23 +1039,85 @@ fn replace_installed_plugin(
         name,
         temp_dir,
         metadata_temp,
+        None,
+        None,
+        || Ok(()),
     )
 }
 
-fn replace_installed_plugin_with_fs<F: InstallFilesystem>(
+fn replace_installed_plugin_with_config<C: FnOnce() -> anyhow::Result<()>>(
+    install_root: &Path,
+    name: &str,
+    temp_dir: &Path,
+    metadata_temp: &Path,
+    config_snapshot: Option<ConfigSnapshot>,
+    expected_sidebar_plugin: Option<Value>,
+    after_install: C,
+) -> anyhow::Result<()> {
+    replace_installed_plugin_with_fs(
+        &StandardInstallFilesystem,
+        install_root,
+        name,
+        temp_dir,
+        metadata_temp,
+        config_snapshot,
+        expected_sidebar_plugin,
+        after_install,
+    )
+}
+
+fn capture_config_snapshot() -> anyhow::Result<ConfigSnapshot> {
+    let path = config::config_path()?;
+    let (config_existed, sidebar_plugin, original_non_object) = match fs::read_to_string(&path) {
+        Ok(text) if text.trim().is_empty() => (true, None, None),
+        Ok(text) => {
+            let value: Value = serde_json::from_str(&text)?;
+            let sidebar_plugin = value
+                .as_object()
+                .and_then(|root| root.get("sidebar"))
+                .and_then(|sidebar| sidebar.get("plugin"))
+                .cloned();
+            let original_non_object = (!value.is_object()).then_some(value);
+            (true, sidebar_plugin, original_non_object)
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => (false, None, None),
+        Err(error) => return Err(error.into()),
+    };
+    Ok(ConfigSnapshot { path, config_existed, sidebar_plugin, original_non_object })
+}
+
+fn replace_installed_plugin_with_fs<F: InstallFilesystem, C: FnOnce() -> anyhow::Result<()>>(
     filesystem: &F,
     install_root: &Path,
     name: &str,
     temp_dir: &Path,
     metadata_temp: &Path,
+    config_snapshot: Option<ConfigSnapshot>,
+    expected_sidebar_plugin: Option<Value>,
+    after_install: C,
 ) -> anyhow::Result<()> {
     let target = install_root.join(name);
-    let target_exists = target.exists();
+    let target_exists = path_exists(&target)?;
     let metadata_path = registry_metadata_path(install_root, name);
     let target_backup = unique_backup_path(install_root, name, ".plugin-backup");
     let metadata_backup =
         unique_backup_path(&install_root.join(".registry"), name, ".metadata-backup.json");
-    let metadata_exists = metadata_path.exists();
+    let metadata_exists = path_exists(&metadata_path)?;
+    let journal_path = install_journal_path(install_root, name);
+    let journal = InstallJournal {
+        owner_token: format!("{}-{}", std::process::id(), now_nanos()),
+        name: name.to_string(),
+        target_backup: target_backup.clone(),
+        metadata_backup: metadata_backup.clone(),
+        temp_dir: temp_dir.to_path_buf(),
+        metadata_temp: metadata_temp.to_path_buf(),
+        target_existed: target_exists,
+        metadata_existed: metadata_exists,
+        config_snapshot,
+        expected_sidebar_plugin,
+        phase: InstallJournalPhase::Prepared,
+    };
+    write_install_journal(&journal_path, &journal)?;
     let mut target_backed_up = false;
     let mut metadata_backed_up = false;
     let mut target_installed = false;
@@ -675,27 +1144,67 @@ fn replace_installed_plugin_with_fs<F: InstallFilesystem>(
             anyhow::anyhow!("failed to persist {}: {error}", metadata_path.display())
         })?;
         metadata_installed = true;
+        after_install()?;
+        sync_transaction_directories(install_root)?;
+        write_install_commit_marker(install_root, name, &journal.owner_token)?;
         Ok(())
     })();
 
     if let Err(error) = result {
         let mut rollback_errors = Vec::new();
-        if metadata_installed
-            && let Err(rollback_error) = filesystem.rename(&metadata_path, metadata_temp)
-        {
-            rollback_errors.push(format!("metadata staging: {rollback_error}"));
+        if metadata_installed {
+            if let Err(rollback_error) = filesystem.rename(&metadata_path, metadata_temp) {
+                rollback_errors.push(format!("metadata staging: {rollback_error}"));
+                match filesystem.remove_file(&metadata_path) {
+                    Ok(()) => {}
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(error) => rollback_errors.push(format!("metadata removal: {error}")),
+                }
+            }
         }
-        if metadata_backed_up
-            && let Err(rollback_error) = filesystem.rename(&metadata_backup, &metadata_path)
-        {
-            rollback_errors.push(format!("metadata restore: {rollback_error}"));
+        if metadata_backed_up {
+            if let Err(rollback_error) = filesystem.rename(&metadata_backup, &metadata_path) {
+                rollback_errors.push(format!("metadata restore: {rollback_error}"));
+            }
         }
-        if target_installed && let Err(rollback_error) = filesystem.rename(&target, temp_dir) {
-            rollback_errors.push(format!("plugin staging: {rollback_error}"));
+        if target_installed {
+            if let Err(rollback_error) = filesystem.rename(&target, temp_dir) {
+                rollback_errors.push(format!("plugin staging: {rollback_error}"));
+                match filesystem.remove_dir_all(&target) {
+                    Ok(()) => {}
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(error) => rollback_errors.push(format!("plugin removal: {error}")),
+                }
+            }
         }
-        if target_backed_up && let Err(rollback_error) = filesystem.rename(&target_backup, &target)
+        if target_backed_up {
+            if let Err(rollback_error) = filesystem.rename(&target_backup, &target) {
+                rollback_errors.push(format!("plugin restore: {rollback_error}"));
+            }
+        }
+        if let Some(snapshot) = &journal.config_snapshot
+            && let Err(rollback_error) =
+                restore_config_snapshot(snapshot, journal.expected_sidebar_plugin.as_ref())
         {
-            rollback_errors.push(format!("plugin restore: {rollback_error}"));
+            rollback_errors.push(format!("config restore: {rollback_error}"));
+        }
+        if rollback_errors.is_empty()
+            && let Err(sync_error) = sync_transaction_directories(install_root)
+        {
+            rollback_errors.push(format!("rollback directory sync: {sync_error}"));
+        }
+        if rollback_errors.is_empty() {
+            let marker_path = install_commit_marker_path(install_root, name);
+            if let Err(marker_error) = remove_path_if_present(&marker_path) {
+                rollback_errors.push(format!("commit marker cleanup: {marker_error}"));
+            }
+        }
+        if rollback_errors.is_empty() {
+            if let Err(rollback_error) = filesystem.remove_file(&journal_path)
+                && rollback_error.kind() != std::io::ErrorKind::NotFound
+            {
+                rollback_errors.push(format!("journal cleanup: {rollback_error}"));
+            }
         }
         if !rollback_errors.is_empty() {
             anyhow::bail!("{error}; rollback failed: {}", rollback_errors.join("; "));
@@ -703,11 +1212,31 @@ fn replace_installed_plugin_with_fs<F: InstallFilesystem>(
         return Err(error);
     }
 
-    // The replacement is committed once both new paths are in place. Cleanup is
-    // deliberately best effort: retaining an old same-parent backup is safe and
-    // preserves recovery data if the process loses access after commit.
-    let _ = filesystem.remove_dir_all(&target_backup);
-    let _ = filesystem.remove_file(&metadata_backup);
+    // The replacement is committed once both new paths are in place. Keep the
+    // committed journal until all cleanup succeeds, so a later invocation can
+    // retry cleanup if access is temporarily unavailable.
+    let backup_dir_clean = match filesystem.remove_dir_all(&target_backup) {
+        Ok(()) => true,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => true,
+        Err(_) => false,
+    };
+    let metadata_backup_clean = match filesystem.remove_file(&metadata_backup) {
+        Ok(()) => true,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => true,
+        Err(_) => false,
+    };
+    let marker_path = install_commit_marker_path(install_root, name);
+    if backup_dir_clean
+        && metadata_backup_clean
+        && sync_transaction_directories(install_root).is_ok()
+    {
+        let journal_removed = filesystem.remove_file(&journal_path).is_ok();
+        if journal_removed {
+            let _ = sync_transaction_directories(install_root);
+            let _ = remove_path_if_present(&marker_path);
+            let _ = sync_transaction_directories(install_root);
+        }
+    }
     Ok(())
 }
 
@@ -730,6 +1259,7 @@ fn write_registry_metadata_temp(
     Ok(temp)
 }
 
+#[cfg(test)]
 fn replace_registry_metadata(
     install_root: &Path,
     name: &str,
@@ -963,9 +1493,17 @@ mod tests {
     fn replacement_failure_after_backup_restores_plugin_and_metadata() {
         let (root, target, temp_dir, metadata_temp) = replacement_fixture("rollback");
         let filesystem = FailingRenameFilesystem { fail_at: 2, calls: Cell::new(0) };
-        let error =
-            replace_installed_plugin_with_fs(&filesystem, &root, "demo", &temp_dir, &metadata_temp)
-                .unwrap_err();
+        let error = replace_installed_plugin_with_fs(
+            &filesystem,
+            &root,
+            "demo",
+            &temp_dir,
+            &metadata_temp,
+            None,
+            None,
+            || Ok(()),
+        )
+        .unwrap_err();
         assert!(error.to_string().contains("back up"));
         assert_eq!(fs::read_to_string(target.join("marker")).unwrap(), "old");
         assert_eq!(
@@ -994,6 +1532,129 @@ mod tests {
             .filter(|entry| !entry.file_name().to_string_lossy().starts_with('.'))
             .count();
         assert_eq!(visible_entries, 1);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn reconciliation_restores_an_interrupted_replacement() {
+        let (root, target, temp_dir, metadata_temp) = replacement_fixture("reconcile");
+        let metadata_path = registry_metadata_path(&root, "demo");
+        let target_backup = root.join(".demo.recovery.plugin-backup");
+        let metadata_backup = root.join(".registry/.demo.recovery.metadata-backup.json");
+        fs::rename(&target, &target_backup).unwrap();
+        fs::rename(&metadata_path, &metadata_backup).unwrap();
+        fs::rename(&temp_dir, &target).unwrap();
+        let journal_path = install_journal_path(&root, "demo");
+        write_install_journal(
+            &journal_path,
+            &InstallJournal {
+                owner_token: "test-owner".into(),
+                name: "demo".into(),
+                target_backup: target_backup.clone(),
+                metadata_backup: metadata_backup.clone(),
+                temp_dir: temp_dir.clone(),
+                metadata_temp: metadata_temp.clone(),
+                target_existed: true,
+                metadata_existed: true,
+                config_snapshot: None,
+                expected_sidebar_plugin: None,
+                phase: InstallJournalPhase::Prepared,
+            },
+        )
+        .unwrap();
+
+        reconcile_install_transactions(&root).unwrap();
+        assert_eq!(fs::read_to_string(target.join("marker")).unwrap(), "old");
+        assert_eq!(
+            read_registry_metadata(&root, "demo").unwrap().id,
+            "sidebar_plugin_11111111111111111111111111111111"
+        );
+        assert!(!journal_path.exists());
+        assert!(!target_backup.exists());
+        assert!(!metadata_backup.exists());
+        assert!(!metadata_temp.exists());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn reconciliation_cleans_committed_backups() {
+        let (root, target, temp_dir, metadata_temp) = replacement_fixture("committed-cleanup");
+        let metadata_path = registry_metadata_path(&root, "demo");
+        let target_backup = root.join(".demo.recovery.plugin-backup");
+        let metadata_backup = root.join(".registry/.demo.recovery.metadata-backup.json");
+        fs::rename(&target, &target_backup).unwrap();
+        fs::rename(&metadata_path, &metadata_backup).unwrap();
+        fs::rename(&temp_dir, &target).unwrap();
+        let journal_path = install_journal_path(&root, "demo");
+        write_install_journal(
+            &journal_path,
+            &InstallJournal {
+                owner_token: "test-owner".into(),
+                name: "demo".into(),
+                target_backup: target_backup.clone(),
+                metadata_backup: metadata_backup.clone(),
+                temp_dir,
+                metadata_temp,
+                target_existed: true,
+                metadata_existed: true,
+                config_snapshot: None,
+                expected_sidebar_plugin: None,
+                phase: InstallJournalPhase::Committed,
+            },
+        )
+        .unwrap();
+        write_install_commit_marker(&root, "demo", "test-owner").unwrap();
+        reconcile_install_transactions(&root).unwrap();
+        assert!(target.exists());
+        assert!(!target_backup.exists());
+        assert!(!metadata_backup.exists());
+        assert!(!journal_path.exists());
+        assert!(!install_commit_marker_path(&root, "demo").exists());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn config_callback_failure_rolls_back_filesystem_and_config() {
+        let (root, target, temp_dir, metadata_temp) = replacement_fixture("config-rollback");
+        let config_path = root.join("config.json");
+        fs::write(
+            &config_path,
+            "{\"sidebar\":{\"plugin\":{\"command\":[\"old\"]}},\"theme\":{\"name\":\"keep\"}}\n",
+        )
+        .unwrap();
+        let snapshot = ConfigSnapshot {
+            path: config_path.clone(),
+            config_existed: true,
+            sidebar_plugin: Some(json!({"command": ["old"]})),
+            original_non_object: None,
+        };
+        let error = replace_installed_plugin_with_fs(
+            &StandardInstallFilesystem,
+            &root,
+            "demo",
+            &temp_dir,
+            &metadata_temp,
+            Some(snapshot),
+            Some(json!({"command": ["new"]})),
+            || {
+                fs::write(
+                    &config_path,
+                    "{\"sidebar\":{\"plugin\":{\"command\":[\"new\"]}},\"theme\":{\"name\":\"keep\"}}\n",
+                )?;
+                anyhow::bail!("injected config failure")
+            },
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("injected config failure"));
+        assert_eq!(fs::read_to_string(target.join("marker")).unwrap(), "old");
+        let restored: Value =
+            serde_json::from_str(&fs::read_to_string(config_path).unwrap()).unwrap();
+        assert_eq!(restored["sidebar"]["plugin"]["command"], json!(["old"]));
+        assert_eq!(restored["theme"]["name"], json!("keep"));
+        assert_eq!(
+            read_registry_metadata(&root, "demo").unwrap().id,
+            "sidebar_plugin_11111111111111111111111111111111"
+        );
         fs::remove_dir_all(root).unwrap();
     }
 

--- a/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
+++ b/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
@@ -1329,7 +1329,7 @@ fn replace_installed_plugin_with_fs<F: InstallFilesystem, C: FnOnce() -> anyhow:
         }
         if let (Some(snapshot), Some(expected)) =
             (&journal.config_snapshot, journal.expected_sidebar_plugin.as_ref())
-            && let Err(rollback_error) = restore_config_snapshot(snapshot, expected)
+            && let Err(rollback_error) = restore_config_snapshot(snapshot, Some(expected))
         {
             rollback_errors.push(format!("config restore: {rollback_error}"));
         }

--- a/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
+++ b/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -49,7 +49,9 @@ impl ManagerError {
                 }
                 details
             }
-            Self::Failure(error) => json!({"reason": error.to_string()}),
+            Self::Failure(_) => {
+                json!({"reason": crate::localization::catalog().plugin.operation_failed})
+            }
         }
     }
 
@@ -63,7 +65,9 @@ impl std::fmt::Display for ManagerError {
         match self {
             Self::Usage(message) => formatter.write_str(message),
             Self::Validation { reason, .. } => formatter.write_str(reason),
-            Self::Failure(error) => std::fmt::Display::fmt(error, formatter),
+            Self::Failure(_) => {
+                formatter.write_str(crate::localization::catalog().plugin.operation_failed)
+            }
         }
     }
 }
@@ -127,6 +131,7 @@ struct PluginRegistryMetadata {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 #[serde(rename_all = "snake_case")]
 enum InstallJournalPhase {
     Prepared,
@@ -134,9 +139,8 @@ enum InstallJournalPhase {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct InstallJournal {
-    #[serde(default = "default_owner_token")]
-    owner_token: String,
     name: String,
     target_backup: PathBuf,
     metadata_backup: PathBuf,
@@ -145,61 +149,59 @@ struct InstallJournal {
     target_existed: bool,
     metadata_existed: bool,
     config_snapshot: Option<ConfigSnapshot>,
-    #[serde(default)]
-    expected_sidebar_plugin: Option<Value>,
     phase: InstallJournalPhase,
 }
 
-fn default_owner_token() -> String {
-    "legacy".to_string()
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct ConfigSnapshot {
     path: PathBuf,
-    #[serde(default)]
-    config_existed: bool,
-    #[serde(default)]
     sidebar_plugin: Option<Value>,
-    #[serde(default)]
-    original_non_object: Option<Value>,
 }
 
-struct PluginOperationLock {
-    _file: fs::File,
-}
+const INVALID_INSTALL_JOURNAL_DIR: &str = ".invalid-install-journals";
+const MAX_INSTALL_JOURNAL_BYTES: usize = 1024 * 1024;
+const JOURNAL_QUARANTINE_ATTEMPTS: usize = 16;
+
+struct PluginOperationLock(fs::File);
 
 fn acquire_plugin_operation_lock() -> anyhow::Result<PluginOperationLock> {
     let root = install_root()?;
     fs::create_dir_all(&root)?;
+    ensure_real_directory(&root)?;
     let path = root.join(".install.lock");
     let file = fs::OpenOptions::new().create(true).read(true).write(true).open(path)?;
-    file.lock()?;
-    Ok(PluginOperationLock { _file: file })
+    FileExt::lock(&file)?;
+    Ok(PluginOperationLock(file))
 }
 
 pub(crate) fn execute(positionals: &[String], options: CliOptions) -> Result<Value, ManagerError> {
-    match positionals.first().map(String::as_str) {
-        Some("install") => {
-            let _lock = acquire_plugin_operation_lock().map_err(ManagerError::Failure)?;
-            install_command(positionals, &options)
-        }
-        Some("list") => list_command(positionals, &options),
-        Some("use") => {
-            let _lock = acquire_plugin_operation_lock().map_err(ManagerError::Failure)?;
-            use_command(positionals, &options)
-        }
-        Some("update") => {
-            let _lock = acquire_plugin_operation_lock().map_err(ManagerError::Failure)?;
-            update_command(positionals, &options)
-        }
-        Some("remove") => {
-            let _lock = acquire_plugin_operation_lock().map_err(ManagerError::Failure)?;
-            remove_command(positionals, &options)
-        }
-        Some(other) => Err(ManagerError::Usage(format!("unknown plugin subcommand {other:?}"))),
-        None => Err(ManagerError::Usage("plugin subcommand is required".to_string())),
-    }
+    with_optional_operation_lock(
+        command_requires_operation_lock(positionals),
+        || acquire_plugin_operation_lock().map_err(ManagerError::Failure),
+        || match positionals.first().map(String::as_str) {
+            Some("install") => install_command(positionals, &options),
+            Some("list") => list_command(positionals, &options),
+            Some("use") => use_command(positionals, &options),
+            Some("update") => update_command(positionals, &options),
+            Some("remove") => remove_command(positionals, &options),
+            Some(other) => Err(ManagerError::Usage(format!("unknown plugin subcommand {other:?}"))),
+            None => Err(ManagerError::Usage("plugin subcommand is required".to_string())),
+        },
+    )
+}
+
+fn command_requires_operation_lock(positionals: &[String]) -> bool {
+    matches!(positionals.first().map(String::as_str), Some("install" | "use" | "update" | "remove"))
+}
+
+fn with_optional_operation_lock<T>(
+    requires_lock: bool,
+    acquire: impl FnOnce() -> Result<PluginOperationLock, ManagerError>,
+    operation: impl FnOnce() -> Result<T, ManagerError>,
+) -> Result<T, ManagerError> {
+    let _lock = requires_lock.then(acquire).transpose()?;
+    operation()
 }
 
 fn install_command(positionals: &[String], options: &CliOptions) -> Result<Value, ManagerError> {
@@ -225,18 +227,16 @@ fn install_command(positionals: &[String], options: &CliOptions) -> Result<Value
 
     let mut metadata_temp_path = None;
     let result = (|| -> Result<Value, ManagerError> {
-        let manifest = read_manifest(&temp_dir)
-            .map_err(|error| ManagerError::validation(None, error.to_string()))?;
+        let manifest = read_manifest(&temp_dir).map_err(|_| {
+            ManagerError::validation(Some("manifest"), "plugin manifest is invalid")
+        })?;
         let name = installed_name(&manifest, options.name.as_deref())
-            .map_err(|error| ManagerError::validation(Some("name"), error.to_string()))?;
+            .map_err(|_| ManagerError::validation(Some("name"), "plugin name is invalid"))?;
         let target = root.join(&name);
-        if target.exists() && !options.force {
+        if path_entry_exists(&target)? && !options.force {
             return Err(ManagerError::validation(
                 Some("name"),
-                format!(
-                    "plugin {name:?} is already installed at {}; use --force to replace it",
-                    target.display()
-                ),
+                "plugin is already installed; use --force to replace it",
             ));
         }
         run_build_if_needed(&manifest, &temp_dir)?;
@@ -248,38 +248,12 @@ fn install_command(positionals: &[String], options: &CliOptions) -> Result<Value
         let id = metadata.id;
         let selected = selected_plugin_cwd()?.is_some_and(|cwd| same_path(&cwd, &target));
         let config_snapshot = selected.then(capture_config_snapshot).transpose()?;
-        let expected_sidebar_plugin = if selected {
-            let staging_command = resolved_run_command(&manifest, &temp_dir)?;
-            let staging_root = canonical_path(&temp_dir)?;
-            let target_root = canonical_path(&target)?;
-            let expected_command = staging_command
-                .into_iter()
-                .enumerate()
-                .map(|(index, argument)| {
-                    if index == 0 {
-                        let command_path = Path::new(&argument);
-                        if let Ok(relative) = command_path.strip_prefix(&staging_root) {
-                            return target_root.join(relative).display().to_string();
-                        }
-                    }
-                    argument
-                })
-                .collect::<Vec<_>>();
-            let expected_cwd = canonical_path(&target)?;
-            Some(json!({
-                "command": expected_command,
-                "cwd": expected_cwd.display().to_string(),
-            }))
-        } else {
-            None
-        };
         replace_installed_plugin_with_config(
             &root,
             &name,
             &temp_dir,
             &metadata_temp,
             config_snapshot,
-            expected_sidebar_plugin,
             || {
                 if selected {
                     let command = resolved_run_command(&manifest, &target)?;
@@ -301,8 +275,8 @@ fn install_command(positionals: &[String], options: &CliOptions) -> Result<Value
         })}))
     })();
     if result.is_err() {
-        if temp_dir.exists() {
-            let _ = fs::remove_dir_all(&temp_dir);
+        if path_entry_exists(&temp_dir).unwrap_or(false) {
+            let _ = remove_path_if_present(&temp_dir);
         }
         if let Some(metadata_temp) = metadata_temp_path {
             let _ = fs::remove_file(metadata_temp);
@@ -316,7 +290,7 @@ fn list_command(positionals: &[String], options: &CliOptions) -> Result<Value, M
     if positionals.len() != 1 {
         return Err(ManagerError::Usage("usage: cmux sidebar plugin list".to_string()));
     }
-    let plugins = installed_plugins()?;
+    let plugins = installed_plugins(false)?;
     Ok(Value::Array(plugins.iter().map(plugin_json).collect()))
 }
 
@@ -336,7 +310,7 @@ fn use_command(positionals: &[String], options: &CliOptions) -> Result<Value, Ma
     let command = resolved_run_command(&plugin.manifest, &plugin.dir)?;
     verify_executable(&command[0])?;
     let cwd = canonical_path(&plugin.dir)?;
-    config::write_sidebar_plugin(Some(&SidebarPluginConfig {
+    persist_sidebar_plugin(Some(&SidebarPluginConfig {
         command,
         cwd: Some(cwd.display().to_string()),
     }))?;
@@ -359,7 +333,7 @@ fn update_command(positionals: &[String], options: &CliOptions) -> Result<Value,
     verify_executable(&command[0])?;
     if plugin.selected {
         let cwd = canonical_path(&plugin.dir)?;
-        config::write_sidebar_plugin(Some(&SidebarPluginConfig {
+        persist_sidebar_plugin(Some(&SidebarPluginConfig {
             command,
             cwd: Some(cwd.display().to_string()),
         }))?;
@@ -377,7 +351,7 @@ fn remove_command(positionals: &[String], options: &CliOptions) -> Result<Value,
     let installed = resolve_installed_plugin(&positionals[1])?;
     let mut plugin = plugin_json(&installed);
     if installed.selected {
-        config::write_sidebar_plugin(None)?;
+        persist_sidebar_plugin(None)?;
     }
     fs::remove_dir_all(&installed.dir)?;
     remove_registry_metadata(&install_root()?, &installed.name)?;
@@ -387,9 +361,25 @@ fn remove_command(positionals: &[String], options: &CliOptions) -> Result<Value,
 }
 
 fn write_builtin_config(_options: &CliOptions) -> Result<Value, ManagerError> {
-    config::write_sidebar_plugin(None)?;
-    let plugins = installed_plugins()?;
+    // Recovery must complete before changing the user's selection. Otherwise a
+    // prepared transaction can restore its snapshot after we select the
+    // builtin plugin, silently undoing the requested operation.
+    let root = install_root()?;
+    reconcile_install_transactions(&root)?;
+    persist_sidebar_plugin(None)?;
+    let plugins = installed_plugins(false)?;
     Ok(json!({"plugins": plugins.iter().map(plugin_json).collect::<Vec<_>>()}))
+}
+
+fn persist_sidebar_plugin(plugin: Option<&SidebarPluginConfig>) -> Result<(), ManagerError> {
+    if let Some(error) = config::write_sidebar_plugin(plugin)?.into_unsynced_error() {
+        crate::client_log::stderr_log!(
+            "config",
+            "{}",
+            crate::localization::catalog().config.write_durability_warning(&error.to_string())
+        );
+    }
+    Ok(())
 }
 
 fn reject_plugin_flags(
@@ -410,9 +400,15 @@ fn reject_plugin_flags(
     Ok(())
 }
 
-fn installed_plugins() -> anyhow::Result<Vec<InstalledPlugin>> {
+fn installed_plugins(reconcile: bool) -> anyhow::Result<Vec<InstalledPlugin>> {
     let root = install_root()?;
-    reconcile_install_transactions(&root)?;
+    // Read-only listing skips recovery so a read-only install root does not
+    // need a lock file. Mutating callers hold the operation lock and reconcile.
+    if reconcile {
+        reconcile_install_transactions(&root)?;
+    } else {
+        reject_listing_with_pending_transaction(&root)?;
+    }
     let selected = selected_plugin_cwd()?;
     let mut plugins = Vec::new();
     let entries = match fs::read_dir(&root) {
@@ -450,6 +446,22 @@ fn installed_plugins() -> anyhow::Result<Vec<InstalledPlugin>> {
     Ok(plugins)
 }
 
+fn reject_listing_with_pending_transaction(install_root: &Path) -> anyhow::Result<()> {
+    let entries = match fs::read_dir(install_root) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.into()),
+    };
+    for entry in entries {
+        let entry = entry?;
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else { continue };
+        if name.starts_with('.') && name.ends_with(".install-journal.json") {
+            anyhow::bail!("plugin installation recovery is pending");
+        }
+    }
+    Ok(())
+}
+
 fn resolve_installed_plugin(selector: &str) -> Result<InstalledPlugin, ManagerError> {
     let forced_name = selector.strip_prefix("name:");
     let selector = forced_name.unwrap_or(selector);
@@ -461,7 +473,7 @@ fn resolve_installed_plugin(selector: &str) -> Result<InstalledPlugin, ManagerEr
         validate_plugin_name(selector)
             .map_err(|error| ManagerError::validation(Some("sidebar_plugin"), error.to_string()))?;
     }
-    installed_plugins()?
+    installed_plugins(true)?
         .into_iter()
         .find(|plugin| if by_id { plugin.id == selector } else { plugin.name == selector })
         .ok_or_else(|| {
@@ -703,21 +715,27 @@ impl InstallFilesystem for StandardInstallFilesystem {
     }
 }
 
-fn unique_backup_path(parent: &Path, name: &str, suffix: &str) -> PathBuf {
+fn remove_entry_with_filesystem<F: InstallFilesystem>(
+    filesystem: &F,
+    path: &Path,
+) -> std::io::Result<()> {
+    let metadata = fs::symlink_metadata(path)?;
+    if metadata.is_dir() { filesystem.remove_dir_all(path) } else { filesystem.remove_file(path) }
+}
+
+fn unique_backup_path(parent: &Path, name: &str, suffix: &str) -> anyhow::Result<PathBuf> {
     loop {
         let path = parent.join(format!(".{name}.{}-{}{suffix}", std::process::id(), now_nanos()));
-        if !path.exists() {
-            return path;
+        match fs::symlink_metadata(&path) {
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(path),
+            Err(error) => return Err(error.into()),
         }
     }
 }
 
 fn install_journal_path(install_root: &Path, name: &str) -> PathBuf {
     install_root.join(format!(".{name}.install-journal.json"))
-}
-
-fn install_commit_marker_path(install_root: &Path, name: &str) -> PathBuf {
-    install_root.join(format!(".{name}.install-commit"))
 }
 
 fn write_install_journal(path: &Path, journal: &InstallJournal) -> anyhow::Result<()> {
@@ -729,7 +747,14 @@ fn write_install_journal(path: &Path, journal: &InstallJournal) -> anyhow::Resul
     ));
     let encoded = serde_json::to_vec(journal)?;
     let result = (|| -> anyhow::Result<()> {
-        let mut file = fs::OpenOptions::new().create_new(true).write(true).open(&temp)?;
+        let mut options = fs::OpenOptions::new();
+        options.create_new(true).write(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt as _;
+            options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC).mode(0o600);
+        }
+        let mut file = options.open(&temp)?;
         file.write_all(&encoded)?;
         file.write_all(b"\n")?;
         file.sync_all()?;
@@ -744,6 +769,38 @@ fn write_install_journal(path: &Path, journal: &InstallJournal) -> anyhow::Resul
     result
 }
 
+/// Read a recovery journal without following a final-component symlink or
+/// accepting an unbounded file. Journals control cleanup after a crash, so a
+/// malformed or attacker-written file must never become an arbitrary file
+/// operation.
+fn read_install_journal(path: &Path) -> anyhow::Result<Vec<u8>> {
+    let mut options = fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+    }
+    let mut file = options.open(path)?;
+    let metadata = file.metadata()?;
+    anyhow::ensure!(metadata.is_file(), "install journal is not a regular file");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        anyhow::ensure!(
+            metadata.permissions().mode() & 0o7777 == 0o600,
+            "install journal permissions are not private"
+        );
+    }
+    let mut bytes = Vec::new();
+    file.take((MAX_INSTALL_JOURNAL_BYTES + 1) as u64).read_to_end(&mut bytes)?;
+    anyhow::ensure!(
+        bytes.len() <= MAX_INSTALL_JOURNAL_BYTES,
+        "install journal exceeds {MAX_INSTALL_JOURNAL_BYTES} bytes"
+    );
+    Ok(bytes)
+}
+
 #[cfg(unix)]
 fn sync_directory(path: &Path) -> anyhow::Result<()> {
     fs::File::open(path)?.sync_all()?;
@@ -755,40 +812,16 @@ fn sync_directory(_path: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn sync_transaction_directories(install_root: &Path) -> anyhow::Result<()> {
-    sync_directory(install_root)?;
-    sync_directory(&install_root.join(".registry"))?;
-    Ok(())
-}
-
-fn write_install_commit_marker(
-    install_root: &Path,
-    name: &str,
-    owner_token: &str,
-) -> anyhow::Result<()> {
-    let path = install_commit_marker_path(install_root, name);
-    let result = (|| -> anyhow::Result<()> {
-        let mut file = fs::OpenOptions::new().create_new(true).write(true).open(&path)?;
-        file.write_all(owner_token.as_bytes())?;
-        file.write_all(b"\n")?;
-        file.sync_all()?;
-        drop(file);
-        sync_directory(install_root)?;
-        Ok(())
-    })();
-    if result.is_err() {
-        let _ = fs::remove_file(&path);
+/// Returns whether a directory entry exists, including a dangling symlink.
+/// `Path::exists` follows symlinks and therefore cannot represent an existing
+/// entry whose target has been removed. Transaction replacement and recovery
+/// must preserve those entries as well as regular files and directories.
+fn path_entry_exists(path: &Path) -> anyhow::Result<bool> {
+    match fs::symlink_metadata(path) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error.into()),
     }
-    result
-}
-
-fn commit_marker_matches(path: &Path, owner_token: &str) -> anyhow::Result<bool> {
-    let contents = match fs::read_to_string(path) {
-        Ok(contents) => contents,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
-        Err(error) => return Err(error.into()),
-    };
-    Ok(contents.trim() == owner_token)
 }
 
 fn remove_path_if_present(path: &Path) -> anyhow::Result<()> {
@@ -805,17 +838,114 @@ fn remove_path_if_present(path: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn path_exists(path: &Path) -> anyhow::Result<bool> {
-    match fs::symlink_metadata(path) {
-        Ok(_) => Ok(true),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
-        Err(error) => Err(error.into()),
+fn ensure_real_directory(path: &Path) -> anyhow::Result<()> {
+    let metadata = fs::symlink_metadata(path)?;
+    anyhow::ensure!(
+        metadata.is_dir() && !metadata.file_type().is_symlink(),
+        "plugin state directory is not a real directory"
+    );
+    Ok(())
+}
+
+fn direct_child_named(parent: &Path, path: &Path, predicate: impl FnOnce(&str) -> bool) -> bool {
+    path.parent() == Some(parent)
+        && path.file_name().and_then(|name| name.to_str()).is_some_and(predicate)
+}
+
+fn validate_install_journal_paths(
+    install_root: &Path,
+    journal_path: &Path,
+    journal: &InstallJournal,
+) -> anyhow::Result<()> {
+    validate_plugin_name(&journal.name)?;
+    anyhow::ensure!(
+        journal_path == install_journal_path(install_root, &journal.name),
+        "install journal name does not match its path"
+    );
+    anyhow::ensure!(
+        direct_child_named(install_root, &journal.target_backup, |name| {
+            name.starts_with(&format!(".{}.", journal.name)) && name.ends_with(".plugin-backup")
+        }),
+        "install journal target backup is outside the install root"
+    );
+    anyhow::ensure!(
+        direct_child_named(install_root, &journal.temp_dir, |name| {
+            name.starts_with(".install-")
+        }),
+        "install journal temporary directory is outside the install root"
+    );
+    let registry = install_root.join(".registry");
+    if fs::symlink_metadata(&registry).is_ok() {
+        ensure_real_directory(&registry)?;
     }
+    anyhow::ensure!(
+        direct_child_named(&registry, &journal.metadata_backup, |name| {
+            name.starts_with(&format!(".{}.", journal.name))
+                && name.ends_with(".metadata-backup.json")
+        }),
+        "install journal metadata backup is outside the registry"
+    );
+    anyhow::ensure!(
+        direct_child_named(&registry, &journal.metadata_temp, |name| {
+            name.starts_with(&format!(".{}.", journal.name)) && name.ends_with(".tmp")
+        }),
+        "install journal metadata staging path is outside the registry"
+    );
+    if let Some(snapshot) = &journal.config_snapshot {
+        anyhow::ensure!(
+            snapshot.path == config::config_path()?,
+            "install journal config snapshot path is not the active config"
+        );
+    }
+    Ok(())
+}
+
+fn quarantine_install_journal(install_root: &Path, path: &Path) -> anyhow::Result<()> {
+    let quarantine = install_root.join(INVALID_INSTALL_JOURNAL_DIR);
+    match fs::symlink_metadata(&quarantine) {
+        Ok(metadata) => {
+            anyhow::ensure!(metadata.is_dir(), "invalid journal quarantine is not a directory")
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            match fs::create_dir(&quarantine) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                    ensure_real_directory(&quarantine)?;
+                }
+                Err(error) => return Err(error.into()),
+            }
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt as _;
+                fs::set_permissions(&quarantine, fs::Permissions::from_mode(0o700))?;
+            }
+        }
+        Err(error) => return Err(error.into()),
+    }
+    let basename =
+        path.file_name().and_then(|name| name.to_str()).unwrap_or("invalid-install-journal");
+    for attempt in 0..JOURNAL_QUARANTINE_ATTEMPTS {
+        let destination =
+            quarantine.join(format!("{basename}.{}-{attempt}.quarantined", std::process::id()));
+        if fs::symlink_metadata(&destination).is_ok() {
+            continue;
+        }
+        match fs::rename(path, &destination) {
+            Ok(()) => return Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => return Err(error.into()),
+        }
+    }
+    anyhow::bail!("could not quarantine invalid install journal")
 }
 
 fn reconcile_install_transactions(install_root: &Path) -> anyhow::Result<()> {
-    cleanup_orphan_metadata_temps(install_root)?;
-    cleanup_orphan_commit_markers(install_root)?;
+    if let Ok(metadata) = fs::symlink_metadata(install_root) {
+        anyhow::ensure!(
+            metadata.is_dir() && !metadata.file_type().is_symlink(),
+            "plugin install root is not a real directory"
+        );
+    }
     let entries = match fs::read_dir(install_root) {
         Ok(entries) => entries,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
@@ -828,36 +958,37 @@ fn reconcile_install_transactions(install_root: &Path) -> anyhow::Result<()> {
         if !name.starts_with('.') || !name.ends_with(".install-journal.json") {
             continue;
         }
-        let journal: InstallJournal = match serde_json::from_slice(&fs::read(&path)?) {
-            Ok(journal) => journal,
-            Err(_) => continue,
+        let journal_bytes = match read_install_journal(&path) {
+            Ok(bytes) => bytes,
+            Err(_) => {
+                quarantine_install_journal(install_root, &path)?;
+                continue;
+            }
         };
-        if validate_install_journal(install_root, &journal).is_err() {
-            continue;
-        }
-        if install_journal_path(install_root, &journal.name) != path {
-            continue;
-        }
-        let marker_path = install_commit_marker_path(install_root, &journal.name);
-        let marker_committed = commit_marker_matches(&marker_path, &journal.owner_token)?;
-        if matches!(&journal.phase, InstallJournalPhase::Committed) || marker_committed {
-            remove_path_if_present(&journal.target_backup)?;
-            remove_path_if_present(&journal.metadata_backup)?;
-            remove_path_if_present(&journal.temp_dir)?;
-            remove_path_if_present(&journal.metadata_temp)?;
-            sync_transaction_directories(install_root)?;
-            remove_path_if_present(&path)?;
-            sync_transaction_directories(install_root)?;
-            remove_path_if_present(&marker_path)?;
+        let journal: InstallJournal = match serde_json::from_slice(&journal_bytes) {
+            Ok(journal) => journal,
+            Err(_) => {
+                quarantine_install_journal(install_root, &path)?;
+                continue;
+            }
+        };
+        if validate_install_journal_paths(install_root, &path, &journal).is_err() {
+            quarantine_install_journal(install_root, &path)?;
             continue;
         }
         match journal.phase {
+            InstallJournalPhase::Committed => {
+                remove_path_if_present(&journal.target_backup)?;
+                remove_path_if_present(&journal.metadata_backup)?;
+                remove_path_if_present(&journal.temp_dir)?;
+                remove_path_if_present(&journal.metadata_temp)?;
+            }
             InstallJournalPhase::Prepared => {
                 if let Some(snapshot) = &journal.config_snapshot {
-                    restore_config_snapshot(snapshot, journal.expected_sidebar_plugin.as_ref())?;
+                    restore_config_snapshot(snapshot)?;
                 }
                 if journal.target_existed {
-                    if path_exists(&journal.target_backup)? {
+                    if path_entry_exists(&journal.target_backup)? {
                         remove_path_if_present(&install_root.join(&journal.name))?;
                         fs::rename(&journal.target_backup, install_root.join(&journal.name))?;
                     }
@@ -866,7 +997,7 @@ fn reconcile_install_transactions(install_root: &Path) -> anyhow::Result<()> {
                 }
                 if journal.metadata_existed {
                     let metadata_path = registry_metadata_path(install_root, &journal.name);
-                    if path_exists(&journal.metadata_backup)? {
+                    if path_entry_exists(&journal.metadata_backup)? {
                         remove_path_if_present(&metadata_path)?;
                         fs::rename(&journal.metadata_backup, metadata_path)?;
                     }
@@ -875,104 +1006,21 @@ fn reconcile_install_transactions(install_root: &Path) -> anyhow::Result<()> {
                 }
                 remove_path_if_present(&journal.temp_dir)?;
                 remove_path_if_present(&journal.metadata_temp)?;
-                sync_transaction_directories(install_root)?;
             }
-            InstallJournalPhase::Committed => unreachable!(),
         }
         remove_path_if_present(&path)?;
-        sync_transaction_directories(install_root)?;
-        remove_path_if_present(&marker_path)?;
     }
     Ok(())
 }
 
-fn cleanup_orphan_metadata_temps(install_root: &Path) -> anyhow::Result<()> {
-    let registry = install_root.join(".registry");
-    let entries = match fs::read_dir(&registry) {
-        Ok(entries) => entries,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-        Err(error) => return Err(error.into()),
-    };
-    for entry in entries {
-        let path = entry?.path();
-        let Some(name) = path.file_name().and_then(|value| value.to_str()) else { continue };
-        if name.starts_with('.') && name.ends_with(".tmp") {
-            remove_path_if_present(&path)?;
-        }
-    }
-    Ok(())
-}
-
-fn cleanup_orphan_commit_markers(install_root: &Path) -> anyhow::Result<()> {
-    let entries = match fs::read_dir(install_root) {
-        Ok(entries) => entries,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-        Err(error) => return Err(error.into()),
-    };
-    for entry in entries {
-        let path = entry?.path();
-        let Some(name) = path.file_name().and_then(|value| value.to_str()) else { continue };
-        if !name.starts_with('.') || !name.ends_with(".install-commit") {
-            continue;
-        }
-        let plugin_name = name.trim_start_matches('.').trim_end_matches(".install-commit");
-        if validate_plugin_name(plugin_name).is_err()
-            || !path_exists(&install_journal_path(install_root, plugin_name))?
-        {
-            remove_path_if_present(&path)?;
-        }
-    }
-    Ok(())
-}
-
-fn validate_install_journal(install_root: &Path, journal: &InstallJournal) -> anyhow::Result<()> {
-    if journal.owner_token.is_empty() {
-        anyhow::bail!("transaction owner token is missing");
-    }
-    validate_plugin_name(&journal.name)?;
-    let registry = install_root.join(".registry");
-    let expected_target = install_root.join(&journal.name);
-    let expected_metadata = registry_metadata_path(install_root, &journal.name);
-    let paths = [
-        ("target backup", &journal.target_backup, install_root),
-        ("metadata backup", &journal.metadata_backup, &registry),
-        ("staging directory", &journal.temp_dir, install_root),
-        ("metadata staging", &journal.metadata_temp, &registry),
-    ];
-    for (label, path, parent) in paths {
-        if path.parent() != Some(parent) {
-            anyhow::bail!("{label} path escapes its transaction directory");
-        }
-    }
-    if journal.target_backup == expected_target || journal.temp_dir == expected_target {
-        anyhow::bail!("transaction path aliases the live plugin");
-    }
-    if journal.metadata_backup == expected_metadata || journal.metadata_temp == expected_metadata {
-        anyhow::bail!("transaction path aliases live metadata");
-    }
-    Ok(())
-}
-
-fn restore_config_snapshot(
-    snapshot: &ConfigSnapshot,
-    expected_sidebar_plugin: Option<&Value>,
-) -> anyhow::Result<()> {
+fn restore_config_snapshot(snapshot: &ConfigSnapshot) -> anyhow::Result<()> {
     let mut root = match fs::read_to_string(&snapshot.path) {
         Ok(text) if text.trim().is_empty() => json!({}),
         Ok(text) => serde_json::from_str(&text)?,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => json!({}),
         Err(error) => return Err(error.into()),
     };
-    if let Some(expected) = expected_sidebar_plugin {
-        let current = root.get("sidebar").and_then(|sidebar| sidebar.get("plugin"));
-        if current != Some(expected) {
-            return Ok(());
-        }
-    }
     let Some(root_object) = root.as_object_mut() else {
-        if let Some(original) = &snapshot.original_non_object {
-            return write_config_value_atomic_local(&snapshot.path, original);
-        }
         anyhow::bail!("{} must contain a JSON object", snapshot.path.display());
     };
     match &snapshot.sidebar_plugin {
@@ -994,13 +1042,6 @@ fn restore_config_snapshot(
             }
         }
     }
-    if !snapshot.config_existed && snapshot.sidebar_plugin.is_none() {
-        return match fs::remove_file(&snapshot.path) {
-            Ok(()) => Ok(()),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-            Err(error) => Err(error.into()),
-        };
-    }
     write_config_value_atomic_local(&snapshot.path, &root)
 }
 
@@ -1011,7 +1052,14 @@ fn write_config_value_atomic_local(path: &Path, value: &Value) -> anyhow::Result
     let temp =
         parent.join(format!(".{file_name}.{}.{}-restore.tmp", std::process::id(), now_nanos()));
     let result = (|| -> anyhow::Result<()> {
-        let mut file = fs::OpenOptions::new().create_new(true).write(true).open(&temp)?;
+        let mut options = fs::OpenOptions::new();
+        options.create_new(true).write(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt as _;
+            options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC).mode(0o600);
+        }
+        let mut file = options.open(&temp)?;
         serde_json::to_writer_pretty(&mut file, value)?;
         file.write_all(b"\n")?;
         file.sync_all()?;
@@ -1026,7 +1074,6 @@ fn write_config_value_atomic_local(path: &Path, value: &Value) -> anyhow::Result
     result
 }
 
-#[cfg(test)]
 fn replace_installed_plugin(
     install_root: &Path,
     name: &str,
@@ -1040,7 +1087,6 @@ fn replace_installed_plugin(
         temp_dir,
         metadata_temp,
         None,
-        None,
         || Ok(()),
     )
 }
@@ -1051,7 +1097,6 @@ fn replace_installed_plugin_with_config<C: FnOnce() -> anyhow::Result<()>>(
     temp_dir: &Path,
     metadata_temp: &Path,
     config_snapshot: Option<ConfigSnapshot>,
-    expected_sidebar_plugin: Option<Value>,
     after_install: C,
 ) -> anyhow::Result<()> {
     replace_installed_plugin_with_fs(
@@ -1061,29 +1106,22 @@ fn replace_installed_plugin_with_config<C: FnOnce() -> anyhow::Result<()>>(
         temp_dir,
         metadata_temp,
         config_snapshot,
-        expected_sidebar_plugin,
         after_install,
     )
 }
 
 fn capture_config_snapshot() -> anyhow::Result<ConfigSnapshot> {
     let path = config::config_path()?;
-    let (config_existed, sidebar_plugin, original_non_object) = match fs::read_to_string(&path) {
-        Ok(text) if text.trim().is_empty() => (true, None, None),
-        Ok(text) => {
-            let value: Value = serde_json::from_str(&text)?;
-            let sidebar_plugin = value
-                .as_object()
-                .and_then(|root| root.get("sidebar"))
-                .and_then(|sidebar| sidebar.get("plugin"))
-                .cloned();
-            let original_non_object = (!value.is_object()).then_some(value);
-            (true, sidebar_plugin, original_non_object)
-        }
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => (false, None, None),
+    let sidebar_plugin = match fs::read_to_string(&path) {
+        Ok(text) if text.trim().is_empty() => None,
+        Ok(text) => serde_json::from_str::<Value>(&text)?
+            .get("sidebar")
+            .and_then(|sidebar| sidebar.get("plugin"))
+            .cloned(),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
         Err(error) => return Err(error.into()),
     };
-    Ok(ConfigSnapshot { path, config_existed, sidebar_plugin, original_non_object })
+    Ok(ConfigSnapshot { path, sidebar_plugin })
 }
 
 fn replace_installed_plugin_with_fs<F: InstallFilesystem, C: FnOnce() -> anyhow::Result<()>>(
@@ -1093,19 +1131,22 @@ fn replace_installed_plugin_with_fs<F: InstallFilesystem, C: FnOnce() -> anyhow:
     temp_dir: &Path,
     metadata_temp: &Path,
     config_snapshot: Option<ConfigSnapshot>,
-    expected_sidebar_plugin: Option<Value>,
     after_install: C,
 ) -> anyhow::Result<()> {
+    ensure_real_directory(install_root)?;
+    let registry = install_root.join(".registry");
+    if fs::symlink_metadata(&registry).is_ok() {
+        ensure_real_directory(&registry)?;
+    }
     let target = install_root.join(name);
-    let target_exists = path_exists(&target)?;
+    let target_exists = path_entry_exists(&target)?;
     let metadata_path = registry_metadata_path(install_root, name);
-    let target_backup = unique_backup_path(install_root, name, ".plugin-backup");
+    let target_backup = unique_backup_path(install_root, name, ".plugin-backup")?;
     let metadata_backup =
-        unique_backup_path(&install_root.join(".registry"), name, ".metadata-backup.json");
-    let metadata_exists = path_exists(&metadata_path)?;
+        unique_backup_path(&install_root.join(".registry"), name, ".metadata-backup.json")?;
+    let metadata_exists = path_entry_exists(&metadata_path)?;
     let journal_path = install_journal_path(install_root, name);
     let journal = InstallJournal {
-        owner_token: format!("{}-{}", std::process::id(), now_nanos()),
         name: name.to_string(),
         target_backup: target_backup.clone(),
         metadata_backup: metadata_backup.clone(),
@@ -1114,7 +1155,6 @@ fn replace_installed_plugin_with_fs<F: InstallFilesystem, C: FnOnce() -> anyhow:
         target_existed: target_exists,
         metadata_existed: metadata_exists,
         config_snapshot,
-        expected_sidebar_plugin,
         phase: InstallJournalPhase::Prepared,
     };
     write_install_journal(&journal_path, &journal)?;
@@ -1144,9 +1184,12 @@ fn replace_installed_plugin_with_fs<F: InstallFilesystem, C: FnOnce() -> anyhow:
             anyhow::anyhow!("failed to persist {}: {error}", metadata_path.display())
         })?;
         metadata_installed = true;
+        sync_directory(&registry)?;
         after_install()?;
-        sync_transaction_directories(install_root)?;
-        write_install_commit_marker(install_root, name, &journal.owner_token)?;
+        write_install_journal(
+            &journal_path,
+            &InstallJournal { phase: InstallJournalPhase::Committed, ..journal.clone() },
+        )?;
         Ok(())
     })();
 
@@ -1170,7 +1213,7 @@ fn replace_installed_plugin_with_fs<F: InstallFilesystem, C: FnOnce() -> anyhow:
         if target_installed {
             if let Err(rollback_error) = filesystem.rename(&target, temp_dir) {
                 rollback_errors.push(format!("plugin staging: {rollback_error}"));
-                match filesystem.remove_dir_all(&target) {
+                match remove_entry_with_filesystem(filesystem, &target) {
                     Ok(()) => {}
                     Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
                     Err(error) => rollback_errors.push(format!("plugin removal: {error}")),
@@ -1183,21 +1226,9 @@ fn replace_installed_plugin_with_fs<F: InstallFilesystem, C: FnOnce() -> anyhow:
             }
         }
         if let Some(snapshot) = &journal.config_snapshot
-            && let Err(rollback_error) =
-                restore_config_snapshot(snapshot, journal.expected_sidebar_plugin.as_ref())
+            && let Err(rollback_error) = restore_config_snapshot(snapshot)
         {
             rollback_errors.push(format!("config restore: {rollback_error}"));
-        }
-        if rollback_errors.is_empty()
-            && let Err(sync_error) = sync_transaction_directories(install_root)
-        {
-            rollback_errors.push(format!("rollback directory sync: {sync_error}"));
-        }
-        if rollback_errors.is_empty() {
-            let marker_path = install_commit_marker_path(install_root, name);
-            if let Err(marker_error) = remove_path_if_present(&marker_path) {
-                rollback_errors.push(format!("commit marker cleanup: {marker_error}"));
-            }
         }
         if rollback_errors.is_empty() {
             if let Err(rollback_error) = filesystem.remove_file(&journal_path)
@@ -1215,7 +1246,7 @@ fn replace_installed_plugin_with_fs<F: InstallFilesystem, C: FnOnce() -> anyhow:
     // The replacement is committed once both new paths are in place. Keep the
     // committed journal until all cleanup succeeds, so a later invocation can
     // retry cleanup if access is temporarily unavailable.
-    let backup_dir_clean = match filesystem.remove_dir_all(&target_backup) {
+    let backup_dir_clean = match remove_entry_with_filesystem(filesystem, &target_backup) {
         Ok(()) => true,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => true,
         Err(_) => false,
@@ -1225,17 +1256,9 @@ fn replace_installed_plugin_with_fs<F: InstallFilesystem, C: FnOnce() -> anyhow:
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => true,
         Err(_) => false,
     };
-    let marker_path = install_commit_marker_path(install_root, name);
-    if backup_dir_clean
-        && metadata_backup_clean
-        && sync_transaction_directories(install_root).is_ok()
-    {
-        let journal_removed = filesystem.remove_file(&journal_path).is_ok();
-        if journal_removed {
-            let _ = sync_transaction_directories(install_root);
-            let _ = remove_path_if_present(&marker_path);
-            let _ = sync_transaction_directories(install_root);
-        }
+    let backups_clean = backup_dir_clean && metadata_backup_clean;
+    if backups_clean {
+        let _ = filesystem.remove_file(&journal_path);
     }
     Ok(())
 }
@@ -1249,6 +1272,7 @@ fn write_registry_metadata_temp(
     validate_plugin_id(&metadata.id)?;
     let registry = install_root.join(".registry");
     fs::create_dir_all(&registry)?;
+    ensure_real_directory(&registry)?;
     let temp = registry.join(format!(".{name}.{}-{}.tmp", std::process::id(), now_nanos()));
     let encoded = serde_json::to_vec(metadata)?;
     let mut file = fs::OpenOptions::new().create_new(true).write(true).open(&temp)?;
@@ -1259,7 +1283,6 @@ fn write_registry_metadata_temp(
     Ok(temp)
 }
 
-#[cfg(test)]
 fn replace_registry_metadata(
     install_root: &Path,
     name: &str,
@@ -1348,6 +1371,93 @@ fn now_nanos() -> u128 {
 mod tests {
     use super::*;
     use std::cell::Cell;
+
+    #[test]
+    fn manager_failure_response_redacts_internal_error_details() {
+        let error = ManagerError::from(anyhow::anyhow!(
+            "failed to read /private/plugin-state/secret.toml: injected detail"
+        ));
+        let rendered = error.to_string();
+        let details = error.details().to_string();
+        assert!(!rendered.contains("/private/plugin-state/secret.toml"));
+        assert!(!rendered.contains("injected detail"));
+        assert!(!details.contains("/private/plugin-state/secret.toml"));
+        assert!(!details.contains("injected detail"));
+    }
+
+    #[test]
+    fn read_only_plugin_command_skips_operation_lock() {
+        let operation_ran = Cell::new(false);
+        let result = with_optional_operation_lock(
+            false,
+            || panic!("read-only plugin command must not acquire the operation lock"),
+            || {
+                operation_ran.set(true);
+                Ok::<_, ManagerError>(())
+            },
+        );
+        assert!(result.is_ok());
+        assert!(operation_ran.get());
+    }
+
+    #[test]
+    fn mutating_plugin_command_acquires_operation_lock_before_running() {
+        let lock_acquired = Cell::new(false);
+        let operation_ran = Cell::new(false);
+        let result = with_optional_operation_lock(
+            true,
+            || {
+                lock_acquired.set(true);
+                Err(ManagerError::Usage("lock probe".to_string()))
+            },
+            || {
+                operation_ran.set(true);
+                Ok::<_, ManagerError>(())
+            },
+        );
+        assert!(result.is_err());
+        assert!(lock_acquired.get());
+        assert!(!operation_ran.get());
+    }
+
+    #[test]
+    fn only_mutating_plugin_commands_require_operation_lock() {
+        assert!(!command_requires_operation_lock(&["list".to_string()]));
+        for command in ["install", "use", "update", "remove"] {
+            assert!(command_requires_operation_lock(&[command.to_string()]));
+        }
+        assert!(!command_requires_operation_lock(&[]));
+    }
+
+    #[test]
+    fn read_only_listing_allows_a_clean_root_without_creating_a_lock() {
+        let root = std::env::temp_dir().join(format!(
+            "cmux-plugin-read-only-list-{}-{}",
+            std::process::id(),
+            now_nanos()
+        ));
+        fs::create_dir_all(&root).unwrap();
+        assert!(reject_listing_with_pending_transaction(&root).is_ok());
+        assert!(!root.join(".install.lock").exists());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn read_only_listing_rejects_pending_journal_without_mutating_root() {
+        let root = std::env::temp_dir().join(format!(
+            "cmux-plugin-read-only-pending-{}-{}",
+            std::process::id(),
+            now_nanos()
+        ));
+        fs::create_dir_all(&root).unwrap();
+        let journal = root.join(".demo.install-journal.json");
+        fs::write(&journal, b"pending").unwrap();
+        let error = reject_listing_with_pending_transaction(&root).unwrap_err();
+        assert_eq!(error.to_string(), "plugin installation recovery is pending");
+        assert!(journal.exists());
+        assert!(!root.join(".install.lock").exists());
+        fs::remove_dir_all(root).unwrap();
+    }
 
     fn manifest_text(name: &str) -> String {
         format!(
@@ -1500,7 +1610,6 @@ mod tests {
             &temp_dir,
             &metadata_temp,
             None,
-            None,
             || Ok(()),
         )
         .unwrap_err();
@@ -1512,6 +1621,40 @@ mod tests {
         );
         assert!(temp_dir.exists());
         assert!(metadata_temp.exists());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn replacement_failure_preserves_dangling_plugin_and_metadata_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let (root, target, temp_dir, metadata_temp) = replacement_fixture("dangling");
+        let metadata_path = registry_metadata_path(&root, "demo");
+        fs::remove_dir_all(&target).unwrap();
+        fs::remove_file(&metadata_path).unwrap();
+        let missing_target = root.join("missing-target");
+        let missing_metadata = root.join("missing-metadata");
+        symlink(&missing_target, &target).unwrap();
+        symlink(&missing_metadata, &metadata_path).unwrap();
+
+        // The fourth rename is the metadata install. It fails after both
+        // dangling entries have been backed up, so rollback must restore the
+        // symlinks rather than treating them as absent.
+        let filesystem = FailingRenameFilesystem { fail_at: 4, calls: Cell::new(0) };
+        let error = replace_installed_plugin_with_fs(
+            &filesystem,
+            &root,
+            "demo",
+            &temp_dir,
+            &metadata_temp,
+            None,
+            || Ok(()),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("failed to persist"));
+        assert_eq!(fs::read_link(&target).unwrap(), missing_target);
+        assert_eq!(fs::read_link(&metadata_path).unwrap(), missing_metadata);
         fs::remove_dir_all(root).unwrap();
     }
 
@@ -1536,6 +1679,28 @@ mod tests {
     }
 
     #[test]
+    fn replacement_cleans_up_a_regular_file_target_backup() {
+        let (root, target, temp_dir, metadata_temp) = replacement_fixture("file-target");
+        fs::remove_dir_all(&target).unwrap();
+        fs::write(&target, b"old file").unwrap();
+
+        replace_installed_plugin(&root, "demo", &temp_dir, &metadata_temp).unwrap();
+        assert_eq!(fs::read_to_string(target.join("marker")).unwrap(), "new");
+        assert_eq!(
+            read_registry_metadata(&root, "demo").unwrap().id,
+            "sidebar_plugin_22222222222222222222222222222222"
+        );
+        assert!(!install_journal_path(&root, "demo").exists());
+        assert!(
+            fs::read_dir(&root)
+                .unwrap()
+                .filter_map(Result::ok)
+                .all(|entry| !entry.file_name().to_string_lossy().contains("plugin-backup"))
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
     fn reconciliation_restores_an_interrupted_replacement() {
         let (root, target, temp_dir, metadata_temp) = replacement_fixture("reconcile");
         let metadata_path = registry_metadata_path(&root, "demo");
@@ -1548,7 +1713,6 @@ mod tests {
         write_install_journal(
             &journal_path,
             &InstallJournal {
-                owner_token: "test-owner".into(),
                 name: "demo".into(),
                 target_backup: target_backup.clone(),
                 metadata_backup: metadata_backup.clone(),
@@ -1557,7 +1721,6 @@ mod tests {
                 target_existed: true,
                 metadata_existed: true,
                 config_snapshot: None,
-                expected_sidebar_plugin: None,
                 phase: InstallJournalPhase::Prepared,
             },
         )
@@ -1577,39 +1740,40 @@ mod tests {
     }
 
     #[test]
-    fn reconciliation_cleans_committed_backups() {
-        let (root, target, temp_dir, metadata_temp) = replacement_fixture("committed-cleanup");
-        let metadata_path = registry_metadata_path(&root, "demo");
-        let target_backup = root.join(".demo.recovery.plugin-backup");
-        let metadata_backup = root.join(".registry/.demo.recovery.metadata-backup.json");
-        fs::rename(&target, &target_backup).unwrap();
-        fs::rename(&metadata_path, &metadata_backup).unwrap();
-        fs::rename(&temp_dir, &target).unwrap();
+    fn invalid_journal_paths_are_quarantined_without_touching_outside_files() {
+        let root = std::env::temp_dir().join(format!(
+            "cmux-plugin-journal-boundary-{}-{}",
+            std::process::id(),
+            now_nanos()
+        ));
+        let registry = root.join(".registry");
+        let outside =
+            root.with_file_name(format!("{}-outside", root.file_name().unwrap().to_string_lossy()));
+        fs::create_dir_all(&registry).unwrap();
+        fs::write(&outside, b"keep").unwrap();
         let journal_path = install_journal_path(&root, "demo");
         write_install_journal(
             &journal_path,
             &InstallJournal {
-                owner_token: "test-owner".into(),
                 name: "demo".into(),
-                target_backup: target_backup.clone(),
-                metadata_backup: metadata_backup.clone(),
-                temp_dir,
-                metadata_temp,
-                target_existed: true,
-                metadata_existed: true,
+                target_backup: outside.clone(),
+                metadata_backup: registry.join(".demo.recovery.metadata-backup.json"),
+                temp_dir: root.join(".install-1-2"),
+                metadata_temp: registry.join(".demo.1-2.tmp"),
+                target_existed: false,
+                metadata_existed: false,
                 config_snapshot: None,
-                expected_sidebar_plugin: None,
                 phase: InstallJournalPhase::Committed,
             },
         )
         .unwrap();
-        write_install_commit_marker(&root, "demo", "test-owner").unwrap();
+
         reconcile_install_transactions(&root).unwrap();
-        assert!(target.exists());
-        assert!(!target_backup.exists());
-        assert!(!metadata_backup.exists());
+        assert_eq!(fs::read(&outside).unwrap(), b"keep");
         assert!(!journal_path.exists());
-        assert!(!install_commit_marker_path(&root, "demo").exists());
+        let quarantined = root.join(INVALID_INSTALL_JOURNAL_DIR);
+        assert_eq!(fs::read_dir(quarantined).unwrap().count(), 1);
+        fs::remove_file(outside).unwrap();
         fs::remove_dir_all(root).unwrap();
     }
 
@@ -1624,9 +1788,7 @@ mod tests {
         .unwrap();
         let snapshot = ConfigSnapshot {
             path: config_path.clone(),
-            config_existed: true,
             sidebar_plugin: Some(json!({"command": ["old"]})),
-            original_non_object: None,
         };
         let error = replace_installed_plugin_with_fs(
             &StandardInstallFilesystem,
@@ -1635,7 +1797,6 @@ mod tests {
             &temp_dir,
             &metadata_temp,
             Some(snapshot),
-            Some(json!({"command": ["new"]})),
             || {
                 fs::write(
                     &config_path,

--- a/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
+++ b/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
@@ -768,6 +768,105 @@ mod tests {
         fs::remove_dir_all(root).unwrap();
     }
 
+    struct FailingRenameFilesystem {
+        fail_at: usize,
+        calls: Cell<usize>,
+    }
+
+    impl InstallFilesystem for FailingRenameFilesystem {
+        fn rename(&self, from: &Path, to: &Path) -> std::io::Result<()> {
+            let call = self.calls.get() + 1;
+            self.calls.set(call);
+            if call == self.fail_at {
+                return Err(std::io::Error::other("injected rename failure"));
+            }
+            fs::rename(from, to)
+        }
+
+        fn remove_dir_all(&self, path: &Path) -> std::io::Result<()> {
+            fs::remove_dir_all(path)
+        }
+
+        fn remove_file(&self, path: &Path) -> std::io::Result<()> {
+            fs::remove_file(path)
+        }
+    }
+
+    fn replacement_fixture(label: &str) -> (PathBuf, PathBuf, PathBuf, PathBuf) {
+        let root = std::env::temp_dir().join(format!(
+            "cmux-plugin-replacement-test-{label}-{}-{}",
+            std::process::id(),
+            now_nanos()
+        ));
+        let target = root.join("demo");
+        let registry = root.join(".registry");
+        let metadata_path = registry.join("demo.json");
+        let temp_dir = root.join(".install");
+        let metadata_temp = registry.join(".demo.tmp");
+        fs::create_dir_all(target.join("bin")).unwrap();
+        fs::write(target.join("marker"), "old").unwrap();
+        fs::create_dir_all(&registry).unwrap();
+        fs::write(
+            &metadata_path,
+            r#"{"id":"sidebar_plugin_11111111111111111111111111111111"}
+"#,
+        )
+        .unwrap();
+        fs::create_dir_all(temp_dir.join("bin")).unwrap();
+        fs::write(temp_dir.join("marker"), "new").unwrap();
+        fs::write(
+            &metadata_temp,
+            r#"{"id":"sidebar_plugin_22222222222222222222222222222222"}
+"#,
+        )
+        .unwrap();
+        (root, target, temp_dir, metadata_temp)
+    }
+
+    #[test]
+    fn replacement_failure_after_backup_restores_plugin_and_metadata() {
+        let (root, target, temp_dir, metadata_temp) = replacement_fixture("rollback");
+        let filesystem = FailingRenameFilesystem { fail_at: 2, calls: Cell::new(0) };
+        let error = replace_installed_plugin_with_fs(
+            &filesystem,
+            &root,
+            "demo",
+            &temp_dir,
+            &metadata_temp,
+            true,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("back up"));
+        assert_eq!(fs::read_to_string(target.join("marker")).unwrap(), "old");
+        assert_eq!(
+            read_registry_metadata(&root, "demo").unwrap().id,
+            "sidebar_plugin_11111111111111111111111111111111"
+        );
+        assert!(temp_dir.exists());
+        assert!(metadata_temp.exists());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn replacement_commits_new_plugin_and_metadata_together() {
+        let (root, target, temp_dir, metadata_temp) = replacement_fixture("success");
+        replace_installed_plugin(&root, "demo", &temp_dir, &metadata_temp, true).unwrap();
+        assert_eq!(fs::read_to_string(target.join("marker")).unwrap(), "new");
+        assert_eq!(
+            read_registry_metadata(&root, "demo").unwrap().id,
+            "sidebar_plugin_22222222222222222222222222222222"
+        );
+        assert!(!temp_dir.exists());
+        assert!(!metadata_temp.exists());
+        let visible_entries = fs::read_dir(&root)
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|entry| !entry.file_name().to_string_lossy().starts_with('.'))
+            .count();
+        assert_eq!(visible_entries, 1);
+        fs::remove_dir_all(root).unwrap();
+    }
+
     #[test]
     fn plugin_snapshot_matches_the_closed_catalog_shape() {
         let root = std::env::temp_dir().join(format!(

--- a/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
+++ b/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
@@ -1040,8 +1040,8 @@ fn reconcile_install_transactions(install_root: &Path) -> anyhow::Result<()> {
             // so stale recovery cannot overwrite a newer selection.
             let legacy_expected = (journal.owner_token.is_some()
                 && journal.expected_sidebar_plugin.is_none())
-                .then(|| expected_sidebar_plugin_for_target(install_root, &journal.name))
-                .flatten();
+            .then(|| expected_sidebar_plugin_for_target(install_root, &journal.name))
+            .flatten();
             let expected = journal.expected_sidebar_plugin.as_ref().or(legacy_expected.as_ref());
             if let Some(snapshot) = &journal.config_snapshot {
                 restore_config_snapshot(snapshot, expected)?;
@@ -1528,9 +1528,12 @@ mod tests {
             sidebar_plugin: None,
             original_non_object: Some(json!("legacy")),
         };
-        restore_config_snapshot(&snapshot, Some(&json!({
-            "command": ["new"]
-        })))
+        restore_config_snapshot(
+            &snapshot,
+            Some(&json!({
+                "command": ["new"]
+            })),
+        )
         .unwrap();
         assert_eq!(fs::read_to_string(&path).unwrap().trim(), "\"legacy\"");
         fs::remove_file(path).unwrap();
@@ -2013,7 +2016,8 @@ mod tests {
         )
         .unwrap_err();
         assert!(error.to_string().contains("injected config failure"));
-        let current: Value = serde_json::from_str(&fs::read_to_string(config_path).unwrap()).unwrap();
+        let current: Value =
+            serde_json::from_str(&fs::read_to_string(config_path).unwrap()).unwrap();
         assert_eq!(current["sidebar"]["plugin"]["command"], json!(["newer"]));
         assert_eq!(current["theme"]["name"], json!("changed"));
         fs::remove_dir_all(root).unwrap();

--- a/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
+++ b/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
@@ -149,6 +149,11 @@ struct InstallJournal {
     target_existed: bool,
     metadata_existed: bool,
     config_snapshot: Option<ConfigSnapshot>,
+    /// The value this transaction wrote to the selected-plugin key. Recovery
+    /// restores the old value only while this exact value is still present;
+    /// a later user selection must never be overwritten by stale recovery.
+    #[serde(default)]
+    expected_sidebar_plugin: Option<Value>,
     phase: InstallJournalPhase,
 }
 
@@ -248,12 +253,22 @@ fn install_command(positionals: &[String], options: &CliOptions) -> Result<Value
         let id = metadata.id;
         let selected = selected_plugin_cwd()?.is_some_and(|cwd| same_path(&cwd, &target));
         let config_snapshot = selected.then(capture_config_snapshot).transpose()?;
+        // Compute the exact JSON value that the config writer will install. Recovery
+        // uses it as a compare-and-swap guard, so a newer selection is never lost.
+        let expected_sidebar_plugin = if selected {
+            let command = resolved_run_command(&manifest, &target)?;
+            let cwd = canonical_path(&target)?;
+            Some(json!({"command": command, "cwd": cwd.display().to_string()}))
+        } else {
+            None
+        };
         replace_installed_plugin_with_config(
             &root,
             &name,
             &temp_dir,
             &metadata_temp,
             config_snapshot,
+            expected_sidebar_plugin,
             || {
                 if selected {
                     let command = resolved_run_command(&manifest, &target)?;
@@ -984,8 +999,10 @@ fn reconcile_install_transactions(install_root: &Path) -> anyhow::Result<()> {
                 remove_path_if_present(&journal.metadata_temp)?;
             }
             InstallJournalPhase::Prepared => {
-                if let Some(snapshot) = &journal.config_snapshot {
-                    restore_config_snapshot(snapshot)?;
+                if let (Some(snapshot), Some(expected)) =
+                    (&journal.config_snapshot, journal.expected_sidebar_plugin.as_ref())
+                {
+                    restore_config_snapshot(snapshot, expected)?;
                 }
                 if journal.target_existed {
                     if path_entry_exists(&journal.target_backup)? {
@@ -1013,13 +1030,24 @@ fn reconcile_install_transactions(install_root: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn restore_config_snapshot(snapshot: &ConfigSnapshot) -> anyhow::Result<()> {
+fn restore_config_snapshot(
+    snapshot: &ConfigSnapshot,
+    expected_sidebar_plugin: Option<&Value>,
+) -> anyhow::Result<()> {
     let mut root = match fs::read_to_string(&snapshot.path) {
         Ok(text) if text.trim().is_empty() => json!({}),
         Ok(text) => serde_json::from_str(&text)?,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => json!({}),
         Err(error) => return Err(error.into()),
     };
+    if let Some(expected) = expected_sidebar_plugin {
+        let current = root.get("sidebar").and_then(|sidebar| sidebar.get("plugin"));
+        if current != Some(expected) {
+            // The user or another cmux process selected a different plugin after
+            // this transaction started. Leave that newer state untouched.
+            return Ok(());
+        }
+    }
     let Some(root_object) = root.as_object_mut() else {
         anyhow::bail!("{} must contain a JSON object", snapshot.path.display());
     };
@@ -1087,6 +1115,7 @@ fn replace_installed_plugin(
         temp_dir,
         metadata_temp,
         None,
+        None,
         || Ok(()),
     )
 }
@@ -1097,6 +1126,7 @@ fn replace_installed_plugin_with_config<C: FnOnce() -> anyhow::Result<()>>(
     temp_dir: &Path,
     metadata_temp: &Path,
     config_snapshot: Option<ConfigSnapshot>,
+    expected_sidebar_plugin: Option<Value>,
     after_install: C,
 ) -> anyhow::Result<()> {
     replace_installed_plugin_with_fs(
@@ -1106,6 +1136,7 @@ fn replace_installed_plugin_with_config<C: FnOnce() -> anyhow::Result<()>>(
         temp_dir,
         metadata_temp,
         config_snapshot,
+        expected_sidebar_plugin,
         after_install,
     )
 }
@@ -1155,6 +1186,7 @@ fn replace_installed_plugin_with_fs<F: InstallFilesystem, C: FnOnce() -> anyhow:
         target_existed: target_exists,
         metadata_existed: metadata_exists,
         config_snapshot,
+        expected_sidebar_plugin,
         phase: InstallJournalPhase::Prepared,
     };
     write_install_journal(&journal_path, &journal)?;
@@ -1225,8 +1257,9 @@ fn replace_installed_plugin_with_fs<F: InstallFilesystem, C: FnOnce() -> anyhow:
                 rollback_errors.push(format!("plugin restore: {rollback_error}"));
             }
         }
-        if let Some(snapshot) = &journal.config_snapshot
-            && let Err(rollback_error) = restore_config_snapshot(snapshot)
+        if let (Some(snapshot), Some(expected)) =
+            (&journal.config_snapshot, journal.expected_sidebar_plugin.as_ref())
+            && let Err(rollback_error) = restore_config_snapshot(snapshot, expected)
         {
             rollback_errors.push(format!("config restore: {rollback_error}"));
         }
@@ -1610,6 +1643,7 @@ mod tests {
             &temp_dir,
             &metadata_temp,
             None,
+            None,
             || Ok(()),
         )
         .unwrap_err();
@@ -1648,6 +1682,7 @@ mod tests {
             "demo",
             &temp_dir,
             &metadata_temp,
+            None,
             None,
             || Ok(()),
         )
@@ -1721,6 +1756,7 @@ mod tests {
                 target_existed: true,
                 metadata_existed: true,
                 config_snapshot: None,
+                expected_sidebar_plugin: None,
                 phase: InstallJournalPhase::Prepared,
             },
         )
@@ -1763,6 +1799,7 @@ mod tests {
                 target_existed: false,
                 metadata_existed: false,
                 config_snapshot: None,
+                expected_sidebar_plugin: None,
                 phase: InstallJournalPhase::Committed,
             },
         )
@@ -1790,6 +1827,7 @@ mod tests {
             path: config_path.clone(),
             sidebar_plugin: Some(json!({"command": ["old"]})),
         };
+        let expected = json!({"command": ["new"]});
         let error = replace_installed_plugin_with_fs(
             &StandardInstallFilesystem,
             &root,
@@ -1797,6 +1835,7 @@ mod tests {
             &temp_dir,
             &metadata_temp,
             Some(snapshot),
+            Some(expected),
             || {
                 fs::write(
                     &config_path,
@@ -1816,6 +1855,43 @@ mod tests {
             read_registry_metadata(&root, "demo").unwrap().id,
             "sidebar_plugin_11111111111111111111111111111111"
         );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn config_rollback_preserves_a_newer_plugin_selection() {
+        let (root, _target, temp_dir, metadata_temp) = replacement_fixture("config-newer");
+        let config_path = root.join("config.json");
+        fs::write(
+            &config_path,
+            "{\"sidebar\":{\"plugin\":{\"command\":[\"old\"]}},\"theme\":{\"name\":\"keep\"}}\n",
+        )
+        .unwrap();
+        let snapshot = ConfigSnapshot {
+            path: config_path.clone(),
+            sidebar_plugin: Some(json!({"command": ["old"]})),
+        };
+        let error = replace_installed_plugin_with_fs(
+            &StandardInstallFilesystem,
+            &root,
+            "demo",
+            &temp_dir,
+            &metadata_temp,
+            Some(snapshot),
+            Some(json!({"command": ["new"]})),
+            || {
+                fs::write(
+                    &config_path,
+                    "{\"sidebar\":{\"plugin\":{\"command\":[\"newer\"]}},\"theme\":{\"name\":\"changed\"}}\n",
+                )?;
+                anyhow::bail!("injected config failure")
+            },
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("injected config failure"));
+        let current: Value = serde_json::from_str(&fs::read_to_string(config_path).unwrap()).unwrap();
+        assert_eq!(current["sidebar"]["plugin"]["command"], json!(["newer"]));
+        assert_eq!(current["theme"]["name"], json!("changed"));
         fs::remove_dir_all(root).unwrap();
     }
 

--- a/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
+++ b/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
@@ -157,6 +157,7 @@ fn install_command(positionals: &[String], options: &CliOptions) -> Result<Value
         return Err(error.into());
     }
 
+    let mut metadata_temp_path = None;
     let result = (|| -> Result<Value, ManagerError> {
         let manifest = read_manifest(&temp_dir)
             .map_err(|error| ManagerError::validation(None, error.to_string()))?;
@@ -176,12 +177,10 @@ fn install_command(positionals: &[String], options: &CliOptions) -> Result<Value
         let command = resolved_run_command(&manifest, &temp_dir)?;
         verify_executable(&command[0])?;
         let metadata = PluginRegistryMetadata { id: random_plugin_id()? };
-        replace_registry_metadata(&root, &name, &metadata)?;
+        let metadata_temp = write_registry_metadata_temp(&root, &name, &metadata)?;
+        metadata_temp_path = Some(metadata_temp.clone());
         let id = metadata.id;
-        if target.exists() {
-            fs::remove_dir_all(&target)?;
-        }
-        fs::rename(&temp_dir, &target)?;
+        replace_installed_plugin(&root, &name, &temp_dir, &metadata_temp)?;
         let selected = selected_plugin_cwd()?.is_some_and(|cwd| same_path(&cwd, &target));
         if selected {
             let command = resolved_run_command(&manifest, &target)?;
@@ -199,8 +198,13 @@ fn install_command(positionals: &[String], options: &CliOptions) -> Result<Value
             selected,
         })}))
     })();
-    if result.is_err() && temp_dir.exists() {
-        let _ = fs::remove_dir_all(&temp_dir);
+    if result.is_err() {
+        if temp_dir.exists() {
+            let _ = fs::remove_dir_all(&temp_dir);
+        }
+        if let Some(metadata_temp) = metadata_temp_path {
+            let _ = fs::remove_file(metadata_temp);
+        }
     }
     result
 }
@@ -585,16 +589,137 @@ fn registry_metadata_path(install_root: &Path, name: &str) -> PathBuf {
     install_root.join(".registry").join(format!("{name}.json"))
 }
 
-fn replace_registry_metadata(
+trait InstallFilesystem {
+    fn rename(&self, from: &Path, to: &Path) -> std::io::Result<()>;
+    fn remove_dir_all(&self, path: &Path) -> std::io::Result<()>;
+    fn remove_file(&self, path: &Path) -> std::io::Result<()>;
+}
+
+struct StandardInstallFilesystem;
+
+impl InstallFilesystem for StandardInstallFilesystem {
+    fn rename(&self, from: &Path, to: &Path) -> std::io::Result<()> {
+        fs::rename(from, to)
+    }
+
+    fn remove_dir_all(&self, path: &Path) -> std::io::Result<()> {
+        fs::remove_dir_all(path)
+    }
+
+    fn remove_file(&self, path: &Path) -> std::io::Result<()> {
+        fs::remove_file(path)
+    }
+}
+
+fn unique_backup_path(parent: &Path, name: &str, suffix: &str) -> PathBuf {
+    loop {
+        let path = parent.join(format!(".{name}.{}-{}{suffix}", std::process::id(), now_nanos()));
+        if !path.exists() {
+            return path;
+        }
+    }
+}
+
+fn replace_installed_plugin(
+    install_root: &Path,
+    name: &str,
+    temp_dir: &Path,
+    metadata_temp: &Path,
+) -> anyhow::Result<()> {
+    replace_installed_plugin_with_fs(
+        &StandardInstallFilesystem,
+        install_root,
+        name,
+        temp_dir,
+        metadata_temp,
+    )
+}
+
+fn replace_installed_plugin_with_fs<F: InstallFilesystem>(
+    filesystem: &F,
+    install_root: &Path,
+    name: &str,
+    temp_dir: &Path,
+    metadata_temp: &Path,
+) -> anyhow::Result<()> {
+    let target = install_root.join(name);
+    let target_exists = target.exists();
+    let metadata_path = registry_metadata_path(install_root, name);
+    let target_backup = unique_backup_path(install_root, name, ".plugin-backup");
+    let metadata_backup =
+        unique_backup_path(&install_root.join(".registry"), name, ".metadata-backup.json");
+    let metadata_exists = metadata_path.exists();
+    let mut target_backed_up = false;
+    let mut metadata_backed_up = false;
+    let mut target_installed = false;
+    let mut metadata_installed = false;
+
+    let result = (|| -> anyhow::Result<()> {
+        if target_exists {
+            filesystem.rename(&target, &target_backup).map_err(|error| {
+                anyhow::anyhow!("failed to back up {}: {error}", target.display())
+            })?;
+            target_backed_up = true;
+        }
+        if metadata_exists {
+            filesystem.rename(&metadata_path, &metadata_backup).map_err(|error| {
+                anyhow::anyhow!("failed to back up {}: {error}", metadata_path.display())
+            })?;
+            metadata_backed_up = true;
+        }
+        filesystem
+            .rename(temp_dir, &target)
+            .map_err(|error| anyhow::anyhow!("failed to install {}: {error}", target.display()))?;
+        target_installed = true;
+        filesystem.rename(metadata_temp, &metadata_path).map_err(|error| {
+            anyhow::anyhow!("failed to persist {}: {error}", metadata_path.display())
+        })?;
+        metadata_installed = true;
+        Ok(())
+    })();
+
+    if let Err(error) = result {
+        let mut rollback_errors = Vec::new();
+        if metadata_installed
+            && let Err(rollback_error) = filesystem.rename(&metadata_path, metadata_temp)
+        {
+            rollback_errors.push(format!("metadata staging: {rollback_error}"));
+        }
+        if metadata_backed_up
+            && let Err(rollback_error) = filesystem.rename(&metadata_backup, &metadata_path)
+        {
+            rollback_errors.push(format!("metadata restore: {rollback_error}"));
+        }
+        if target_installed && let Err(rollback_error) = filesystem.rename(&target, temp_dir) {
+            rollback_errors.push(format!("plugin staging: {rollback_error}"));
+        }
+        if target_backed_up && let Err(rollback_error) = filesystem.rename(&target_backup, &target)
+        {
+            rollback_errors.push(format!("plugin restore: {rollback_error}"));
+        }
+        if !rollback_errors.is_empty() {
+            anyhow::bail!("{error}; rollback failed: {}", rollback_errors.join("; "));
+        }
+        return Err(error);
+    }
+
+    // The replacement is committed once both new paths are in place. Cleanup is
+    // deliberately best effort: retaining an old same-parent backup is safe and
+    // preserves recovery data if the process loses access after commit.
+    let _ = filesystem.remove_dir_all(&target_backup);
+    let _ = filesystem.remove_file(&metadata_backup);
+    Ok(())
+}
+
+fn write_registry_metadata_temp(
     install_root: &Path,
     name: &str,
     metadata: &PluginRegistryMetadata,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<PathBuf> {
     validate_plugin_name(name)?;
     validate_plugin_id(&metadata.id)?;
     let registry = install_root.join(".registry");
     fs::create_dir_all(&registry)?;
-    let path = registry_metadata_path(install_root, name);
     let temp = registry.join(format!(".{name}.{}-{}.tmp", std::process::id(), now_nanos()));
     let encoded = serde_json::to_vec(metadata)?;
     let mut file = fs::OpenOptions::new().create_new(true).write(true).open(&temp)?;
@@ -602,6 +727,16 @@ fn replace_registry_metadata(
     file.write_all(b"\n")?;
     file.sync_all()?;
     drop(file);
+    Ok(temp)
+}
+
+fn replace_registry_metadata(
+    install_root: &Path,
+    name: &str,
+    metadata: &PluginRegistryMetadata,
+) -> anyhow::Result<()> {
+    let path = registry_metadata_path(install_root, name);
+    let temp = write_registry_metadata_temp(install_root, name, metadata)?;
     if let Err(error) = fs::rename(&temp, &path) {
         let _ = fs::remove_file(&temp);
         return Err(anyhow::anyhow!("failed to persist {}: {error}", path.display()));
@@ -682,6 +817,7 @@ fn now_nanos() -> u128 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::Cell;
 
     fn manifest_text(name: &str) -> String {
         format!(
@@ -827,15 +963,9 @@ mod tests {
     fn replacement_failure_after_backup_restores_plugin_and_metadata() {
         let (root, target, temp_dir, metadata_temp) = replacement_fixture("rollback");
         let filesystem = FailingRenameFilesystem { fail_at: 2, calls: Cell::new(0) };
-        let error = replace_installed_plugin_with_fs(
-            &filesystem,
-            &root,
-            "demo",
-            &temp_dir,
-            &metadata_temp,
-            true,
-        )
-        .unwrap_err();
+        let error =
+            replace_installed_plugin_with_fs(&filesystem, &root, "demo", &temp_dir, &metadata_temp)
+                .unwrap_err();
         assert!(error.to_string().contains("back up"));
         assert_eq!(fs::read_to_string(target.join("marker")).unwrap(), "old");
         assert_eq!(
@@ -850,7 +980,7 @@ mod tests {
     #[test]
     fn replacement_commits_new_plugin_and_metadata_together() {
         let (root, target, temp_dir, metadata_temp) = replacement_fixture("success");
-        replace_installed_plugin(&root, "demo", &temp_dir, &metadata_temp, true).unwrap();
+        replace_installed_plugin(&root, "demo", &temp_dir, &metadata_temp).unwrap();
         assert_eq!(fs::read_to_string(target.join("marker")).unwrap(), "new");
         assert_eq!(
             read_registry_metadata(&root, "demo").unwrap().id,

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3,7 +3,7 @@
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs;
-use std::io::{self, BufRead, BufReader, Read, Write};
+use std::io::{self, BufRead, BufReader, Write};
 use std::net::Shutdown;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};


### PR DESCRIPTION
This follow-up carries the plugin-manager security audit onto the current parent branch.

It redacts internal failure details, validates and bounds crash journals, rejects symlinked transaction roots, serializes mutating commands only, and preserves dangling entries during rollback.

Hosted verification will use the cmux-tui workflow. Rust MSRV remains unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790531475&installation_model_id=21920&pr_number=11137&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11137&signature=6c3bf4fdfa3b0805702718d2c27dfe09cd2a196c2c0d559df91883cc4ef61d1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes plugin manager bugs and hardens it against malformed crash journals, internal error leaks, and stale config rollback; narrows the operation lock to mutating commands, and recovers legacy v1 journals safely.

**Hardening**
- Failure responses show a generic localized message instead of internal error details.
- Crash journals are size-bounded, schema-strict, validated so their paths stay inside the install root, reject symlinks, and require private permissions.
- Invalid journals move to a `.invalid-install-journals` quarantine directory instead of being silently skipped.

**Lock and recovery behavior**
- Read-only commands like `list` skip the operation lock and reconciliation and refuse to run when a pending journal exists.
- Rollback preserves dangling symlinks and restores config only while the transaction's plugin value is still current, restoring the original value even when the config root is a non-object; legacy v1 journals lacking the stored value derive it from the installed target, so a newer selection is never overwritten.
- Legacy v1 journals still honor their owner-token commit markers; new journals track prepared vs committed via the journal phase alone.

<sup>Written for commit f537298575b1563bfe9f77e810ec5bd2f38b8c77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

