### PR TITLE
fix: restore workspace row context menu (pin, rename, color)

### DIFF
--- a/Sources/Sidebar/AppKitList/Cells/SidebarGroupHeaderRowView.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarGroupHeaderRowView.swift
@@ -35,6 +35,22 @@ final class SidebarGroupHeaderTableCellView: NSTableCellView {
 
     override var isFlipped: Bool { true }
 
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        let hit = super.hitTest(point)
+        guard SidebarSecondaryClick.isActive(NSApp.currentEvent) else { return hit }
+        let local = convert(point, from: superview)
+        guard !isHidden, alphaValue > 0.01, bounds.contains(local) else { return hit }
+        return self
+    }
+
+    override func rightMouseDown(with event: NSEvent) {
+        if let menu = menu(for: event) {
+            NSMenu.popUpContextMenu(menu, with: event, for: self)
+            return
+        }
+        super.rightMouseDown(with: event)
+    }
+
     override func setFrameSize(_ newSize: NSSize) {
         let changed = newSize != frame.size
         super.setFrameSize(newSize)

--- a/Sources/Sidebar/AppKitList/Cells/SidebarRowContentContainerView.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarRowContentContainerView.swift
@@ -7,4 +7,9 @@ import SwiftUI
 @MainActor
 final class SidebarRowContentContainerView: NSView {
     override var isFlipped: Bool { true }
+
+    override func menu(for event: NSEvent) -> NSMenu? {
+        (superview as? SidebarWorkspaceRowTableCellView)?.menu(for: event)
+            ?? super.menu(for: event)
+    }
 }

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
@@ -177,6 +177,27 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
 
     override var isFlipped: Bool { true }
 
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        let hit = super.hitTest(point)
+        guard SidebarSecondaryClick.isActive(NSApp.currentEvent) else { return hit }
+        if let hit, ownsContextMenu(hit) { return hit }
+        let local = convert(point, from: superview)
+        guard !isHidden, alphaValue > 0.01, bounds.contains(local) else { return hit }
+        return self
+    }
+
+    private func ownsContextMenu(_ hit: NSView) -> Bool {
+        hit is SidebarRowChecklistItemLine || hit.isDescendant(of: checklistSection)
+    }
+
+    override func rightMouseDown(with event: NSEvent) {
+        if let menu = menu(for: event) {
+            NSMenu.popUpContextMenu(menu, with: event, for: self)
+            return
+        }
+        super.rightMouseDown(with: event)
+    }
+
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
         identifier = Self.reuseIdentifier

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSupportViews.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSupportViews.swift
@@ -4,6 +4,24 @@ import CmuxSidebar
 import CmuxWorkspaces
 import SwiftUI
 
+/// Physical right-click and Control-click both need the workspace/group cell
+/// to be the hit-tested view. Title/status subviews return `nil` from
+/// `hitTest` (or swallow `menu(for:)`), so AppKit never asks the cell and
+/// no menu appears — while empty-area clicks still reach the table.
+enum SidebarSecondaryClick {
+    static func isActive(_ event: NSEvent?) -> Bool {
+        guard let event else { return false }
+        switch event.type {
+        case .rightMouseDown, .rightMouseUp:
+            return true
+        case .leftMouseDown, .leftMouseUp:
+            return event.modifierFlags.contains(.control)
+        default:
+            return false
+        }
+    }
+}
+
 /// Row-owned color helpers that preserve native semantic variants while
 /// deriving selected colors from the row model (parity with SwiftUI).
 @MainActor

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
@@ -1530,6 +1530,23 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
         actions?.createEmptyWorkspaceGroup()
     }
 
+    func menu(forRow row: Int, event: NSEvent) -> NSMenu? {
+        guard rows.indices.contains(row),
+              let table = containerView?.tableView else { return nil }
+        let cell: NSView
+        switch table.view(atColumn: 0, row: row, makeIfNecessary: false) {
+        case let workspaceCell as SidebarWorkspaceRowTableCellView:
+            cell = workspaceCell
+        case let headerCell as SidebarGroupHeaderTableCellView:
+            cell = headerCell
+        default:
+            // Hosted SwiftUI rows retain their existing responder-chain path.
+            return nil
+        }
+
+        return SidebarWorkspaceContextMenuResolver(rowView: cell).menu(for: event)
+    }
+
     func emptyAreaMenu() -> NSMenu {
         let menu = NSMenu()
         let item = NSMenuItem(
@@ -2162,5 +2179,31 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
             width: max(0, container.bounds.width - 16 - leadingIndent),
             height: 2
         )
+    }
+}
+
+/// Resolves a native sidebar row's most specific context-menu provider.
+///
+/// AppKit sends Control-click menu lookup to the table even when a descendant
+/// owns the menu. Walking from the hit-tested view back to the row preserves
+/// nested providers (for example, checklist items) while making the row menu
+/// the deterministic fallback.
+@MainActor
+private struct SidebarWorkspaceContextMenuResolver {
+    let rowView: NSView
+
+    func menu(for event: NSEvent) -> NSMenu? {
+        guard let coordinateView = rowView.superview else {
+            return rowView.menu(for: event)
+        }
+        let point = coordinateView.convert(event.locationInWindow, from: nil)
+        var candidate = rowView.hitTest(point)
+        while let view = candidate, view !== rowView {
+            if let menu = view.menu(for: event), !menu.items.isEmpty {
+                return menu
+            }
+            candidate = view.superview
+        }
+        return rowView.menu(for: event)
     }
 }

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableViewImpl.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableViewImpl.swift
@@ -67,8 +67,12 @@ final class SidebarWorkspaceTableViewImpl: NSTableView {
 
     override func menu(for event: NSEvent) -> NSMenu? {
         let row = row(at: convert(event.locationInWindow, from: nil))
-        guard row < 0 else { return super.menu(for: event) }
-        return workspaceController?.emptyAreaMenu()
+        guard row >= 0 else { return workspaceController?.emptyAreaMenu() }
+        // AppKit can ask the table for a Control-click but the cell for a
+        // physical right-click. Resolve the row here so both gestures reach
+        // the same live cell-owned menu provider.
+        return workspaceController?.menu(forRow: row, event: event)
+            ?? super.menu(for: event)
     }
 
     private func updatePointer(with event: NSEvent) {

--- a/cmuxTests/SidebarAppKitRowCellTests.swift
+++ b/cmuxTests/SidebarAppKitRowCellTests.swift
@@ -2114,4 +2114,64 @@ struct SidebarPinnedIndicatorColorTests {
 
         #expect(groupPin.contentTintColor == workspacePin.contentTintColor)
     }
+
+    @Test
+    func secondaryClickClassifierMatchesRightAndControlClick() throws {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 40, height: 40),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.close() }
+        func mouseEvent(
+            _ type: NSEvent.EventType,
+            flags: NSEvent.ModifierFlags = []
+        ) throws -> NSEvent {
+            try #require(NSEvent.mouseEvent(
+                with: type,
+                location: NSPoint(x: 8, y: 8),
+                modifierFlags: flags,
+                timestamp: 0,
+                windowNumber: window.windowNumber,
+                context: nil,
+                eventNumber: 1,
+                clickCount: 1,
+                pressure: 1
+            ))
+        }
+        #expect(SidebarSecondaryClick.isActive(try mouseEvent(.rightMouseDown)))
+        #expect(SidebarSecondaryClick.isActive(try mouseEvent(.leftMouseDown, flags: [.control])))
+        #expect(!SidebarSecondaryClick.isActive(try mouseEvent(.leftMouseDown)))
+    }
+
+    @Test
+    func workspaceRowMenuIncludesPinRenameAndColor() throws {
+        let cell = Self.configuredCell(model: Self.makeModel())
+        let event = try #require(NSEvent.mouseEvent(
+            with: .rightMouseDown,
+            location: NSPoint(x: 16, y: 16),
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            eventNumber: 1,
+            clickCount: 1,
+            pressure: 1
+        ))
+        let menu = cell.menu(for: event)
+        let titles = menu?.items.map(\.title) ?? []
+        #expect(titles.contains(String(
+            localized: "contextMenu.pinWorkspace",
+            defaultValue: "Pin Workspace"
+        )))
+        #expect(titles.contains(String(
+            localized: "contextMenu.renameWorkspace",
+            defaultValue: "Rename Workspace…"
+        )))
+        #expect(titles.contains(String(
+            localized: "contextMenu.workspaceColor",
+            defaultValue: "Workspace Color"
+        )))
+    }
 }


### PR DESCRIPTION
## Summary

- Restore the left-sidebar workspace context menu (Pin / Unpin, Rename, Workspace Color, move, close, etc.) that stopped appearing when right-clicking a workspace row.
- Empty-area right-click still worked; only a click **on a workspace** (or group header) failed to show a menu.

Fixes #9658.

Related: #9771 routed Control-click through the table, but a physical right-click is delivered to the row descendant and never reached that path.

## When it broke

This started in **0.64.20** (2026-07-19), when the native AppKit workspace sidebar became the default ([#8270](https://github.com/manaflow-ai/cmux/pull/8270), [#8433](https://github.com/manaflow-ai/cmux/pull/8433); CHANGELOG: “Native AppKit workspace sidebar, now on by default”).

The pre-0.64.20 SwiftUI sidebar attached `.contextMenu` to the row. The AppKit rewrite moved the same items onto `SidebarWorkspaceRowTableCellView.menu(for:)` (Pin, New Group, Rename, Edit Description, **Workspace Color**, move/close, notifications, Copy ID / Link, Show in Finder). Title/status children either return `nil` from `hitTest` (so the event lands on `SidebarRowContentContainerView`) or swallow `menu(for:)` / `rightMouseDown` without walking to the cell. AppKit then has no menu to show. Right-clicking blank space still hits the table and opens “New Empty Workspace Group”, which is why that path looked fine.

Reproduced on brew **0.64.22** and current `main`.

## How the fix works

1. **Workspace and group cells claim secondary clicks.** For right-click and Control-click, `hitTest` returns the cell (unless the hit is a checklist item, which keeps its own Edit / Mark In Progress / Remove menu). The cell then receives the event instead of a mute child.
2. **`rightMouseDown` pops the cell menu** via `NSMenu.popUpContextMenu`, so presentation does not depend on responder-chain walk inside the SwiftUI-hosted table.
3. **Table `menu(for:)` also resolves the live cell menu** so Control-click (which AppKit often asks the table for) shares the same provider as a physical right-click.
4. The content container forwards `menu(for:)` to the cell as a backup if a click still lands there.

The restored menu is the full workspace menu: Pin Workspace, New Empty Workspace Group, New Group from Workspace, Rename Workspace…, Edit Workspace Description…, **Workspace Color** (Choose Custom Color… plus Red / Crimson / Orange / Amber / Olive / Green / Teal / Aqua / Blue / Navy / Indigo / Purple / Magenta / Rose / Brown / Charcoal), Move Up / Down / To Top / To Window, Close Workspace / Close Other Workspaces, mark read/unread, notifications, Copy Workspace ID / Link, Show in Finder.

## Testing

- How did you test this change?
  - Built and launched `./scripts/reload.sh --tag sidebar-ctx --launch`.
  - Right-clicked workspace rows: menu opened; Pin, Rename, and Workspace Color submenu worked.
  - Right-clicked empty sidebar area: empty-area menu still opened.
  - Added tests: `secondaryClickClassifierMatchesRightAndControlClick`, `workspaceRowMenuIncludesPinRenameAndColor`.
- What did you verify manually?
  - Row right-click shows the full menu (including the color submenu).
  - Empty-space right-click is unchanged.

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment: verified locally on `cmux DEV sidebar-ctx`; the restored menu includes Pin, Rename, Workspace Color and the rest of the pre-0.64.20 items.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790532671&installation_model_id=21920&pr_number=11139&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11139&signature=961a6fd36200b49baadbb2d6911022ec00299115275413974df9b34ef57e3eab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the workspace row context menu (Pin, Rename, Workspace Color, etc.) on the native AppKit sidebar. Right-clicking a workspace row stopped showing the menu when the AppKit sidebar became the default in 0.64.20; empty-area right-clicks still worked because they hit the table directly.

The fix captures secondary right-clicks and Control-clicks on workspace and group cells, pops the cell menu from `rightMouseDown`, and routes table-level `menu(for:)` lookup to the same provider so both gestures share one path.

**Bug Fixes**
- Fixes #9658.
- Control-click on a row now resolves the same menu provider as a physical right-click.
- Checklist items keep their own Edit / Mark In Progress / Remove menu.

<sup>Written for commit b3cc3418ad9eee96be6245f07bf04302d40e6de1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added native right-click and Control-click context menus for sidebar workspace rows and group headers.
  - Context menus now provide row-specific actions, including pinning, renaming, and changing workspace colors.
  - Improved menu handling for checklist items and nested sidebar content.
  - Empty sidebar areas continue to display their available context menu.

- **Bug Fixes**
  - Corrected context-menu routing so actions appear for the appropriate sidebar item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->