### PR TITLE
fix(cmux-tui): bound relay admission retry backoff

### DIFF
--- a/cmux-tui/crates/cmux-relay/src/admission.rs
+++ b/cmux-tui/crates/cmux-relay/src/admission.rs
@@ -51,7 +51,6 @@ impl Listener for AdmissionListener {
                 .expect("relay admission semaphore cannot close while its listener exists");
             match self.inner.accept().await {
                 Ok((stream, address)) => {
-                    retry_attempt = 0;
                     let _ = stream.set_nodelay(true);
                     return (
                         AdmissionStream::new(

--- a/cmux-tui/crates/cmux-relay/src/admission.rs
+++ b/cmux-tui/crates/cmux-relay/src/admission.rs
@@ -12,6 +12,9 @@ use tokio::time::{Instant, Sleep};
 
 use crate::config::RelayConfig;
 
+const ACCEPT_RETRY_INITIAL: Duration = Duration::from_millis(50);
+const ACCEPT_RETRY_MAX: Duration = Duration::from_secs(1);
+
 /// Applies resource and time bounds before a connection reaches HTTP parsing.
 pub struct AdmissionListener {
     inner: TcpListener,
@@ -38,6 +41,7 @@ impl Listener for AdmissionListener {
     type Addr = std::net::SocketAddr;
 
     async fn accept(&mut self) -> (Self::Io, Self::Addr) {
+        let mut retry_attempt = 0u32;
         loop {
             let permit = self
                 .permits
@@ -47,6 +51,7 @@ impl Listener for AdmissionListener {
                 .expect("relay admission semaphore cannot close while its listener exists");
             match self.inner.accept().await {
                 Ok((stream, address)) => {
+                    retry_attempt = 0;
                     let _ = stream.set_nodelay(true);
                     return (
                         AdmissionStream::new(
@@ -60,7 +65,12 @@ impl Listener for AdmissionListener {
                     );
                 }
                 Err(error) if is_connection_error(&error) => continue,
-                Err(_) => tokio::time::sleep(Duration::from_secs(1)).await,
+                Err(_) => {
+                    // Back off transient listener failures without a busy loop. The sleep
+                    // future is cancellation-safe: dropping the listener drops this future.
+                    tokio::time::sleep(accept_retry_delay(retry_attempt)).await;
+                    retry_attempt = retry_attempt.saturating_add(1);
+                }
             }
         }
     }
@@ -68,6 +78,15 @@ impl Listener for AdmissionListener {
     fn local_addr(&self) -> io::Result<Self::Addr> {
         self.inner.local_addr()
     }
+}
+
+fn accept_retry_delay(attempt: u32) -> Duration {
+    let shift = attempt.min(6);
+    let multiplier = 1u32 << shift;
+    ACCEPT_RETRY_INITIAL
+        .checked_mul(multiplier)
+        .unwrap_or(ACCEPT_RETRY_MAX)
+        .min(ACCEPT_RETRY_MAX)
 }
 
 pub struct AdmissionStream {
@@ -246,5 +265,14 @@ mod tests {
         let config = RelayConfig::default();
         let admission = AdmissionListener::new(listener, &config);
         assert_eq!(admission.permits.available_permits(), config.max_http_connections);
+    }
+
+    #[test]
+    fn accept_retry_delay_is_bounded_exponential_backoff() {
+        assert_eq!(accept_retry_delay(0), Duration::from_millis(50));
+        assert_eq!(accept_retry_delay(1), Duration::from_millis(100));
+        assert_eq!(accept_retry_delay(4), Duration::from_millis(800));
+        assert_eq!(accept_retry_delay(5), ACCEPT_RETRY_MAX);
+        assert_eq!(accept_retry_delay(u32::MAX), ACCEPT_RETRY_MAX);
     }
 }

--- a/cmux-tui/crates/cmux-relay/src/admission.rs
+++ b/cmux-tui/crates/cmux-relay/src/admission.rs
@@ -63,7 +63,6 @@ impl Listener for AdmissionListener {
                         address,
                     );
                 }
-                Err(error) if is_connection_error(&error) => continue,
                 Err(_) => {
                     // Back off transient listener failures without a busy loop. The sleep
                     // future is cancellation-safe: dropping the listener drops this future.
@@ -238,15 +237,6 @@ impl AsyncWrite for AdmissionStream {
     ) -> Poll<Result<(), io::Error>> {
         Pin::new(&mut self.inner).poll_shutdown(context)
     }
-}
-
-fn is_connection_error(error: &io::Error) -> bool {
-    matches!(
-        error.kind(),
-        io::ErrorKind::ConnectionRefused
-            | io::ErrorKind::ConnectionAborted
-            | io::ErrorKind::ConnectionReset
-    )
 }
 
 #[cfg(test)]

--- a/cmux-tui/crates/cmux-relay/src/admission.rs
+++ b/cmux-tui/crates/cmux-relay/src/admission.rs
@@ -83,10 +83,7 @@ impl Listener for AdmissionListener {
 fn accept_retry_delay(attempt: u32) -> Duration {
     let shift = attempt.min(6);
     let multiplier = 1u32 << shift;
-    ACCEPT_RETRY_INITIAL
-        .checked_mul(multiplier)
-        .unwrap_or(ACCEPT_RETRY_MAX)
-        .min(ACCEPT_RETRY_MAX)
+    ACCEPT_RETRY_INITIAL.checked_mul(multiplier).unwrap_or(ACCEPT_RETRY_MAX).min(ACCEPT_RETRY_MAX)
 }
 
 pub struct AdmissionStream {

--- a/cmux-tui/crates/cmux-relay/src/admission.rs
+++ b/cmux-tui/crates/cmux-relay/src/admission.rs
@@ -63,10 +63,11 @@ impl Listener for AdmissionListener {
                         address,
                     );
                 }
-                Err(error) if is_connection_error(&error) => continue,
                 Err(_) => {
-                    // Back off transient listener failures without a busy loop. The sleep
-                    // future is cancellation-safe: dropping the listener drops this future.
+                    // Back off every listener failure, including per-connection aborts. A
+                    // peer can cause those errors repeatedly, so an immediate retry would
+                    // let it turn the accept task into a CPU spin. The sleep future is
+                    // cancellation-safe: dropping the listener drops this future.
                     tokio::time::sleep(accept_retry_delay(retry_attempt)).await;
                     retry_attempt = retry_attempt.saturating_add(1);
                 }
@@ -238,15 +239,6 @@ impl AsyncWrite for AdmissionStream {
     ) -> Poll<Result<(), io::Error>> {
         Pin::new(&mut self.inner).poll_shutdown(context)
     }
-}
-
-fn is_connection_error(error: &io::Error) -> bool {
-    matches!(
-        error.kind(),
-        io::ErrorKind::ConnectionRefused
-            | io::ErrorKind::ConnectionAborted
-            | io::ErrorKind::ConnectionReset
-    )
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Replace the fixed one-second listener retry sleep with bounded exponential backoff.

The delay is cancellable because it is awaited in the listener task. Add a focused delay-bound regression test.

Hosted TUI verification is required before merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11140"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790533087&installation_model_id=21920&pr_number=11140&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11140&signature=f4da59a4e8d1f420ebbd3ef57c98939657ac960ad614b5c069ae1bdf89cdfb8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changes relay admission retry behavior so every accept failure backs off with bounded exponential delay (50ms to 1s) instead of the previous fixed 1s sleep or immediate retry on connection errors. The delay resets on the next accept, and a regression test covers the bounds. Hosted TUI verification is required before merge.

<sup>Written for commit 46b92214005d7330b43463cde5e49d0c159f07dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of temporary listener failures.
  * Added adaptive retry delays for smoother recovery and fewer rapid repeated attempts.
  * Retry delays now increase gradually from a short initial wait to a one-second maximum.
  * Retry timing resets after a successful connection, helping future failures recover promptly.
  * Added safeguards to ensure retry behavior remains stable during prolonged failure conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->