### PR TITLE
fix(remote): cap partial line part entries

### DIFF
--- a/cmux-tui/crates/cmux-remote/src/mux_codec.rs
+++ b/cmux-tui/crates/cmux-remote/src/mux_codec.rs
@@ -334,9 +334,6 @@ mod tests {
         packet.put_u32(parts);
 
         let mut assembler = MuxLineAssembler::with_maximum(usize::MAX);
-        assert_eq!(
-            assembler.push(Lane::Bulk, packet.freeze()),
-            Err(MuxCodecError::InvalidPacket)
-        );
+        assert_eq!(assembler.push(Lane::Bulk, packet.freeze()), Err(MuxCodecError::InvalidPacket));
     }
 }

--- a/cmux-tui/crates/cmux-remote/src/mux_codec.rs
+++ b/cmux-tui/crates/cmux-remote/src/mux_codec.rs
@@ -19,6 +19,10 @@ pub(crate) const MAX_MUX_DOWNLOAD_LINE_BYTES: usize = REMOTE_SESSION_MESSAGE_MAX
 pub(crate) const MAX_MUX_LINE_BYTES: usize = MAX_MUX_UPLOAD_LINE_BYTES;
 const MAX_IN_FLIGHT_LINES: usize = 256;
 const MAX_IN_FLIGHT_BYTES: usize = MAX_MUX_DOWNLOAD_LINE_BYTES * 2;
+// Keep packet-declared part counts bounded even when callers configure an
+// unusually large byte maximum. `Vec::with_capacity(parts)` allocates before
+// any payload arrives, so the protocol needs an independent entry cap.
+const MAX_PARTS_PER_LINE: usize = MAX_MUX_DOWNLOAD_LINE_BYTES.div_ceil(CHUNK_BYTES);
 
 /// Return the serialized payload size for one JSONL message. A trailing LF is
 /// framing and is not part of the directional payload budget. EOF-terminated
@@ -150,7 +154,11 @@ impl<R> MuxLineAssembler<R> {
         let message = u64::from_be_bytes(packet[4..12].try_into().unwrap());
         let part = u32::from_be_bytes(packet[12..16].try_into().unwrap());
         let parts = u32::from_be_bytes(packet[16..20].try_into().unwrap());
-        if parts == 0 || part >= parts || parts as usize > self.maximum.div_ceil(CHUNK_BYTES) {
+        if parts == 0
+            || part >= parts
+            || parts as usize > self.maximum.div_ceil(CHUNK_BYTES)
+            || parts as usize > MAX_PARTS_PER_LINE
+        {
             return Err(MuxCodecError::InvalidPacket);
         }
         if !self.lines.contains_key(&message) {
@@ -314,5 +322,21 @@ mod tests {
             assembled = assembler.push(Lane::Bulk, packet).unwrap().or(assembled);
         }
         assert_eq!(assembled.unwrap().1, line);
+    }
+
+    #[test]
+    fn assembler_rejects_excessive_part_count_before_allocating() {
+        let parts = u32::try_from(MAX_PARTS_PER_LINE + 1).expect("test limit fits in u32");
+        let mut packet = BytesMut::with_capacity(HEADER_BYTES);
+        packet.extend_from_slice(&MAGIC);
+        packet.put_u64(1);
+        packet.put_u32(0);
+        packet.put_u32(parts);
+
+        let mut assembler = MuxLineAssembler::with_maximum(usize::MAX);
+        assert_eq!(
+            assembler.push(Lane::Bulk, packet.freeze()),
+            Err(MuxCodecError::InvalidPacket)
+        );
     }
 }


### PR DESCRIPTION
Adds an independent cap on packet-declared partial-line entries before Vec allocation, preventing excessive part-count allocation when byte limits are configured unusually high. Includes a regression test.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790533250&installation_model_id=21920&pr_number=11141&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11141&signature=1e7f52536a02aff86cdcfd6f66943de0be86858b84c45edde4742b22456c3fbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps packet-declared partial-line part counts before `Vec` allocation so an unusually large configured byte maximum can no longer cause excessive memory allocation. Previously, the limit was derived solely from the configured maximum divided by chunk size, which let a very high maximum permit a huge pre-allocation from a single packet. The protocol now enforces an independent `MAX_PARTS_PER_LINE` cap and rejects oversized packets before any allocation. Adds a regression test for this case.

<sup>Written for commit 532d22635e9ed17c56e0e6aa64e508d230ea6606. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for incoming packet data with excessive declared parts.
  * Prevented invalid packets from triggering unnecessary memory allocation.
  * Preserved existing safeguards for empty, out-of-range, and oversized packets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->