### PR TITLE
Expose per-surface prompt and unread state to custom sidebars

### DIFF
--- a/Packages/macOS/CmuxSidebar/Sources/CmuxSidebar/Layout/CustomSidebarDataContextBuilder.swift
+++ b/Packages/macOS/CmuxSidebar/Sources/CmuxSidebar/Layout/CustomSidebarDataContextBuilder.swift
@@ -196,13 +196,15 @@ public struct CustomSidebarDataContextBuilder {
     }
 
     /// Projects one surface snapshot into the interpreter value tree, enriched
-    /// with per-surface directory, pin, git, and ports where available.
+    /// with per-surface directory, pin, git, ports, unread state, and the
+    /// prompt last submitted in that surface where available.
     public func surfaceValue(_ surface: CustomSidebarSurfaceSnapshot) -> SwiftValue {
         var surfaceFields: [String: SwiftValue] = [
             "id": .string(surface.panelId.uuidString),
             "title": .string(surface.title),
             "focused": .bool(surface.isFocused),
             "pinned": .bool(surface.isPinned),
+            "unread": .int(surface.hasUnreadNotification ? 1 : 0),
         ]
         if let surfaceId = surface.surfaceId {
             // The id surface.* verbs accept (surface.focus etc.); `id` above
@@ -218,6 +220,12 @@ public struct CustomSidebarDataContextBuilder {
         }
         if !surface.listeningPorts.isEmpty {
             surfaceFields["ports"] = .array(surface.listeningPorts.map { .int($0) })
+        }
+        if let prompt = surface.latestSubmittedMessage, !prompt.isEmpty {
+            surfaceFields["latestPrompt"] = .string(prompt)
+        }
+        if let at = surface.latestSubmittedAt {
+            surfaceFields["latestAt"] = .int(Int(at.timeIntervalSince1970))
         }
         return .object(surfaceFields)
     }

--- a/Packages/macOS/CmuxSidebar/Sources/CmuxSidebar/Layout/CustomSidebarSurfaceSnapshot.swift
+++ b/Packages/macOS/CmuxSidebar/Sources/CmuxSidebar/Layout/CustomSidebarSurfaceSnapshot.swift
@@ -30,6 +30,14 @@ public struct CustomSidebarSurfaceSnapshot: Sendable, Equatable {
     public let gitIsDirty: Bool
     /// The surface's listening ports, or empty when none (`tabs[i].ports`).
     public let listeningPorts: [Int]
+    /// The prompt last submitted in this surface; `nil`/empty when the surface
+    /// has not seen one (`tabs[i].latestPrompt`).
+    public let latestSubmittedMessage: String?
+    /// When that prompt was submitted; `nil` when unknown (`tabs[i].latestAt`).
+    public let latestSubmittedAt: Date?
+    /// Whether this surface has an unread notification (`tabs[i].unread`,
+    /// projected as `0`/`1` so it reads like the workspace-level count).
+    public let hasUnreadNotification: Bool
 
     /// Creates a surface snapshot from already-resolved leaf values.
     public init(
@@ -41,7 +49,10 @@ public struct CustomSidebarSurfaceSnapshot: Sendable, Equatable {
         directory: String?,
         gitBranch: String?,
         gitIsDirty: Bool,
-        listeningPorts: [Int]
+        listeningPorts: [Int],
+        latestSubmittedMessage: String? = nil,
+        latestSubmittedAt: Date? = nil,
+        hasUnreadNotification: Bool = false
     ) {
         self.panelId = panelId
         self.surfaceId = surfaceId
@@ -52,5 +63,8 @@ public struct CustomSidebarSurfaceSnapshot: Sendable, Equatable {
         self.gitBranch = gitBranch
         self.gitIsDirty = gitIsDirty
         self.listeningPorts = listeningPorts
+        self.latestSubmittedMessage = latestSubmittedMessage
+        self.latestSubmittedAt = latestSubmittedAt
+        self.hasUnreadNotification = hasUnreadNotification
     }
 }

--- a/Packages/macOS/CmuxSidebar/Sources/CmuxSidebar/WorkspaceModel/SidebarPanelPromptState.swift
+++ b/Packages/macOS/CmuxSidebar/Sources/CmuxSidebar/WorkspaceModel/SidebarPanelPromptState.swift
@@ -1,0 +1,20 @@
+public import Foundation
+
+/// The prompt last submitted inside one panel, shown per surface in the
+/// sidebar.
+///
+/// The workspace keeps one of these per panel id so a workspace running several
+/// agents can report which surface is waiting, instead of collapsing every
+/// panel into the single workspace-level `latestSubmittedMessage`.
+public struct SidebarPanelPromptState: Equatable, Sendable {
+    /// The submitted prompt preview.
+    public let message: String
+    /// When it was submitted.
+    public let submittedAt: Date
+
+    /// Creates a panel prompt state.
+    public init(message: String, submittedAt: Date) {
+        self.message = message
+        self.submittedAt = submittedAt
+    }
+}

--- a/Packages/macOS/CmuxSidebar/Sources/CmuxSidebar/WorkspaceModel/WorkspaceSidebarMetadataModel.swift
+++ b/Packages/macOS/CmuxSidebar/Sources/CmuxSidebar/WorkspaceModel/WorkspaceSidebarMetadataModel.swift
@@ -61,6 +61,13 @@ public final class WorkspaceSidebarMetadataModel {
         didSet { panelGitBranchesSubject.send(panelGitBranches) }
     }
 
+    /// Per-panel prompt state keyed by panel id. Lets a workspace report which
+    /// of its surfaces last received a prompt, rather than only the newest one
+    /// across the whole workspace.
+    public var panelPrompts: [UUID: SidebarPanelPromptState] = [:] {
+        didSet { panelPromptsSubject.send(panelPrompts) }
+    }
+
     /// The workspace-level pull-request state shown in the sidebar (legacy
     /// `Workspace.pullRequest`).
     public var pullRequest: SidebarPullRequestState? {
@@ -96,6 +103,8 @@ public final class WorkspaceSidebarMetadataModel {
     private lazy var gitBranchSubject = CurrentValueSubject<SidebarGitBranchState?, Never>(gitBranch)
     @ObservationIgnored
     private lazy var panelGitBranchesSubject = CurrentValueSubject<[UUID: SidebarGitBranchState], Never>(panelGitBranches)
+    @ObservationIgnored
+    private lazy var panelPromptsSubject = CurrentValueSubject<[UUID: SidebarPanelPromptState], Never>(panelPrompts)
     @ObservationIgnored
     private lazy var pullRequestSubject = CurrentValueSubject<SidebarPullRequestState?, Never>(pullRequest)
     @ObservationIgnored
@@ -145,6 +154,12 @@ public final class WorkspaceSidebarMetadataModel {
     /// every change (replaces the legacy `Workspace.$panelGitBranches`).
     public var panelGitBranchesPublisher: AnyPublisher<[UUID: SidebarGitBranchState], Never> {
         panelGitBranchesSubject.eraseToAnyPublisher()
+    }
+
+    /// Emits the current per-panel prompt state on subscription, then on every
+    /// change.
+    public var panelPromptsPublisher: AnyPublisher<[UUID: SidebarPanelPromptState], Never> {
+        panelPromptsSubject.eraseToAnyPublisher()
     }
 
     /// Emits the current workspace pull-request state on subscription, then on

--- a/Packages/macOS/CmuxSidebar/Tests/CmuxSidebarTests/CustomSidebarDataContextBuilderTests.swift
+++ b/Packages/macOS/CmuxSidebar/Tests/CmuxSidebarTests/CustomSidebarDataContextBuilderTests.swift
@@ -480,4 +480,55 @@ struct CustomSidebarDataContextBuilderTests {
         #expect(value.member("color") == .string("#FF8800"))
         #expect(value.member("icon") == nil)
     }
+
+    @Test("Surface prompt and unread fields project per surface")
+    func surfacePromptFields() {
+        let builder = CustomSidebarDataContextBuilder()
+        let id = UUID()
+        let submittedAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let waiting = CustomSidebarSurfaceSnapshot(
+            panelId: id,
+            title: "agent",
+            isFocused: false,
+            isPinned: false,
+            directory: nil,
+            gitBranch: nil,
+            gitIsDirty: false,
+            listeningPorts: [],
+            latestSubmittedMessage: "run the migration",
+            latestSubmittedAt: submittedAt,
+            hasUnreadNotification: true
+        )
+
+        let value = builder.surfaceValue(waiting)
+
+        #expect(value.member("latestPrompt") == .string("run the migration"))
+        #expect(value.member("latestAt") == .int(1_700_000_000))
+        #expect(value.member("unread") == .int(1))
+
+        let bare = builder.surfaceValue(minimalSurface(id: id))
+        #expect(bare.member("latestPrompt") == nil)
+        #expect(bare.member("latestAt") == nil)
+        #expect(bare.member("unread") == .int(0))
+    }
+
+    @Test("Empty surface prompt is omitted like the workspace-level field")
+    func surfaceEmptyPromptOmitted() {
+        let builder = CustomSidebarDataContextBuilder()
+        let blank = CustomSidebarSurfaceSnapshot(
+            panelId: UUID(),
+            title: "agent",
+            isFocused: false,
+            isPinned: false,
+            directory: nil,
+            gitBranch: nil,
+            gitIsDirty: false,
+            listeningPorts: [],
+            latestSubmittedMessage: "",
+            latestSubmittedAt: nil,
+            hasUnreadNotification: false
+        )
+
+        #expect(builder.surfaceValue(blank).member("latestPrompt") == nil)
+    }
 }

--- a/Sources/TerminalController+ControlWorkspaceContext.swift
+++ b/Sources/TerminalController+ControlWorkspaceContext.swift
@@ -292,7 +292,8 @@ extension TerminalController: ControlWorkspaceContext {
         guard let outcome = tabManager.handlePromptSubmit(
             workspaceId: workspaceID,
             message: message,
-            iMessageModeEnabled: iMessageModeEnabled
+            iMessageModeEnabled: iMessageModeEnabled,
+            surfaceId: routing.surfaceID?.uuidString
         ) else {
             return .notFound
         }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -6691,7 +6691,8 @@ class TerminalController {
                 _ = tabManager.handlePromptSubmit(
                     workspaceId: workspaceId,
                     message: event.submittedPromptMessage,
-                    iMessageModeEnabled: iMessageModeEnabled
+                    iMessageModeEnabled: iMessageModeEnabled,
+                    surfaceId: event.surfaceId
                 )
             }
         case .stop:

--- a/Sources/Workspace+CustomSidebarSnapshot.swift
+++ b/Sources/Workspace+CustomSidebarSnapshot.swift
@@ -134,6 +134,7 @@ extension Workspace {
             for tab in bonsplitController.tabs(inPane: paneId) {
                 guard let panelId = panelIdFromSurfaceId(tab.id) else { continue }
                 let git = reportedPanelGitBranch(panelId: panelId)
+                let prompt = panelPrompts[panelId]
                 surfaces.append(
                     CustomSidebarSurfaceSnapshot(
                         panelId: panelId,
@@ -144,7 +145,10 @@ extension Workspace {
                         directory: reportedPanelDirectory(panelId: panelId),
                         gitBranch: git?.branch,
                         gitIsDirty: git?.isDirty ?? false,
-                        listeningPorts: surfaceListeningPorts[panelId] ?? []
+                        listeningPorts: surfaceListeningPorts[panelId] ?? [],
+                        latestSubmittedMessage: prompt?.message,
+                        latestSubmittedAt: prompt?.submittedAt,
+                        hasUnreadNotification: hasUnreadNotification(panelId: panelId)
                     )
                 )
             }

--- a/Sources/Workspace+PanelLifecycle.swift
+++ b/Sources/Workspace+PanelLifecycle.swift
@@ -520,6 +520,7 @@ extension Workspace {
         panelDirectories.removeValue(forKey: panelId)
         panelDirectoryDisplayLabels.removeValue(forKey: panelId)
         panelGitBranches.removeValue(forKey: panelId)
+        panelPrompts.removeValue(forKey: panelId)
         panelPullRequests.removeValue(forKey: panelId)
         panelTitles.removeValue(forKey: panelId)
         panelCustomTitles.removeValue(forKey: panelId)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -3057,6 +3057,10 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         get { sidebarMetadata.panelGitBranches }
         set { sidebarMetadata.panelGitBranches = newValue }
     }
+    var panelPrompts: [UUID: SidebarPanelPromptState] {
+        get { sidebarMetadata.panelPrompts }
+        set { sidebarMetadata.panelPrompts = newValue }
+    }
     var pullRequest: SidebarPullRequestState? {
         get { sidebarMetadata.pullRequest }
         set { sidebarMetadata.pullRequest = newValue }
@@ -6457,6 +6461,7 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         progress = nil
         gitBranch = nil
         panelGitBranches.removeAll()
+        panelPrompts.removeAll()
         pullRequest = nil
         panelPullRequests.removeAll()
         surfaceListeningPorts.removeAll()
@@ -6664,12 +6669,25 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         return true
     }
 
+    /// Records a submitted prompt for the workspace, and for one panel when the
+    /// caller knows which surface it came from.
+    ///
+    /// A `nil` `panelId` — an unresolved or absent hook `surface_id` — updates
+    /// only the workspace-level fields, so callers without surface routing keep
+    /// their previous behaviour.
     @discardableResult
-    func recordSubmittedMessage(_ message: String?) -> Bool {
+    func recordSubmittedMessage(_ message: String?, panelId: UUID? = nil) -> Bool {
         guard let preview = Self.conversationMessagePreview(from: message) else { return false }
         _ = recordConversationMessage(preview)
+        let submittedAt = Date()
         latestSubmittedMessage = preview
-        latestSubmittedAt = Date()
+        latestSubmittedAt = submittedAt
+        if let panelId {
+            panelPrompts[panelId] = SidebarPanelPromptState(
+                message: preview,
+                submittedAt: submittedAt
+            )
+        }
         return true
     }
 

--- a/Sources/WorkspacePromptSubmit.swift
+++ b/Sources/WorkspacePromptSubmit.swift
@@ -1,3 +1,4 @@
+import Bonsplit
 import CMUXAgentLaunch
 import Foundation
 
@@ -146,14 +147,16 @@ extension TabManager {
     func handlePromptSubmit(
         workspaceId: UUID,
         message: String?,
-        iMessageModeEnabled: Bool = IMessageModeSettings.isEnabled()
+        iMessageModeEnabled: Bool = IMessageModeSettings.isEnabled(),
+        surfaceId: String? = nil
     ) -> (messageRecorded: Bool, reordered: Bool, index: Int)? {
         handleConversationMessage(
             workspaceId: workspaceId,
             message: message,
             iMessageModeEnabled: iMessageModeEnabled,
             kind: .promptSubmission,
-            reorderWithoutMessage: true
+            reorderWithoutMessage: true,
+            surfaceId: surfaceId
         )
     }
 
@@ -168,7 +171,8 @@ extension TabManager {
             message: message,
             iMessageModeEnabled: iMessageModeEnabled,
             kind: .assistantFinal,
-            reorderWithoutMessage: false
+            reorderWithoutMessage: false,
+            surfaceId: nil
         )
     }
 
@@ -177,7 +181,8 @@ extension TabManager {
         message: String?,
         iMessageModeEnabled: Bool,
         kind: ConversationMessageKind,
-        reorderWithoutMessage: Bool
+        reorderWithoutMessage: Bool,
+        surfaceId: String?
     ) -> (messageRecorded: Bool, reordered: Bool, index: Int)? {
         guard let originalIndex = tabs.firstIndex(where: { $0.id == workspaceId }) else {
             return nil
@@ -188,7 +193,10 @@ extension TabManager {
         let messageRecorded: Bool
         switch kind {
         case .promptSubmission:
-            messageRecorded = workspace.recordSubmittedMessage(message)
+            messageRecorded = workspace.recordSubmittedMessage(
+                message,
+                panelId: Self.panelId(in: workspace, forSurfaceId: surfaceId)
+            )
             if messageRecorded {
                 CmuxEventBus.shared.publishWorkspacePromptSubmitted(
                     workspaceId: workspaceId,
@@ -211,6 +219,19 @@ extension TabManager {
         moveTabToTop(workspaceId)
         let newIndex = tabs.firstIndex(where: { $0.id == workspaceId }) ?? originalIndex
         return (messageRecorded, newIndex != originalIndex, newIndex)
+    }
+
+    /// Resolves a hook-reported surface id to the panel it belongs to.
+    ///
+    /// Hook payloads carry `CMUX_SURFACE_ID`, which is a surface id for split
+    /// panes but already a panel id for the simple case, so both shapes are
+    /// accepted the same way the focused-notification seam accepts them.
+    private static func panelId(in workspace: Workspace, forSurfaceId surfaceId: String?) -> UUID? {
+        guard let surfaceId,
+              let uuid = UUID(uuidString: surfaceId.trimmingCharacters(in: .whitespacesAndNewlines))
+        else { return nil }
+        if workspace.panels[uuid] != nil { return uuid }
+        return workspace.panelIdFromSurfaceId(TabID(uuid: uuid))
     }
 }
 

--- a/Sources/WorkspaceSidebarObservation.swift
+++ b/Sources/WorkspaceSidebarObservation.swift
@@ -169,6 +169,7 @@ private struct SidebarImmediateObservationState: Equatable {
     let latestConversationMessage: String?
     let latestSubmittedMessage: String?
     let latestSubmittedAt: Date?
+    let panelPrompts: [UUID: SidebarPanelPromptState]
     let taskStatusOverride: WorkspaceTaskStatusOverride?
     let statusHidden: Bool
     let checklist: [WorkspaceChecklistItem]
@@ -218,10 +219,11 @@ extension Workspace {
             $customColor
         )
         .combineLatest($isMuted)
-        let conversationFields = Publishers.CombineLatest3(
+        let conversationFields = Publishers.CombineLatest4(
             $latestConversationMessage,
             $latestSubmittedMessage,
-            $latestSubmittedAt
+            $latestSubmittedAt,
+            sidebarMetadata.panelPromptsPublisher
         )
         // Todo state is row-affecting (status pill, checklist progress) but
         // lives in its own sub-model, so fold its publishers in here the same
@@ -244,6 +246,7 @@ extension Workspace {
                     latestConversationMessage: conversationFields.0,
                     latestSubmittedMessage: conversationFields.1,
                     latestSubmittedAt: conversationFields.2,
+                    panelPrompts: conversationFields.3,
                     taskStatusOverride: todoFields.0,
                     statusHidden: todoFields.1,
                     checklist: todoFields.2

--- a/cmuxTests/WorkspacePromptSubmitTests.swift
+++ b/cmuxTests/WorkspacePromptSubmitTests.swift
@@ -1,3 +1,4 @@
+import Bonsplit
 import Foundation
 import Testing
 import CMUXAgentLaunch
@@ -279,5 +280,128 @@ struct WorkspacePromptSubmitTests {
         #expect(!IMessageModeSettings.isEnabled(defaults: defaults))
         defaults.set(true, forKey: IMessageModeSettings.key)
         #expect(IMessageModeSettings.isEnabled(defaults: defaults))
+    }
+
+    @Test func testSubmittedMessageWithoutPanelIdLeavesPanelPromptsEmpty() {
+        let workspace = Workspace()
+
+        #expect(workspace.recordSubmittedMessage("workspace only"))
+        #expect(workspace.latestSubmittedMessage == "workspace only")
+        #expect(workspace.panelPrompts.isEmpty)
+    }
+
+    @Test func testSubmittedMessageWithPanelIdRecordsPerPanelPrompt() {
+        let workspace = Workspace()
+        let panelId = UUID()
+
+        #expect(workspace.recordSubmittedMessage("run the migration", panelId: panelId))
+
+        let recorded = workspace.panelPrompts[panelId]
+        #expect(recorded?.message == "run the migration")
+        #expect(recorded?.submittedAt == workspace.latestSubmittedAt)
+        #expect(workspace.latestSubmittedMessage == "run the migration")
+    }
+
+    @Test func testPanelPromptsKeepOneEntryPerPanel() {
+        let workspace = Workspace()
+        let first = UUID()
+        let second = UUID()
+
+        #expect(workspace.recordSubmittedMessage("first agent", panelId: first))
+        #expect(workspace.recordSubmittedMessage("second agent", panelId: second))
+
+        #expect(workspace.panelPrompts[first]?.message == "first agent")
+        #expect(workspace.panelPrompts[second]?.message == "second agent")
+        #expect(workspace.panelPrompts.count == 2)
+        // The workspace-level field still collapses to the newest prompt.
+        #expect(workspace.latestSubmittedMessage == "second agent")
+    }
+
+    @Test func testBlankSubmittedMessageDoesNotRecordPanelPrompt() {
+        let workspace = Workspace()
+        let panelId = UUID()
+
+        #expect(!workspace.recordSubmittedMessage(" \n ", panelId: panelId))
+        #expect(workspace.panelPrompts.isEmpty)
+    }
+
+    @Test func testResetSidebarContextClearsPanelPrompts() {
+        let workspace = Workspace()
+        let panelId = UUID()
+
+        #expect(workspace.recordSubmittedMessage("before reset", panelId: panelId))
+        workspace.resetSidebarContext(reason: "test")
+
+        #expect(workspace.panelPrompts.isEmpty)
+        #expect(workspace.latestSubmittedMessage == nil)
+    }
+
+    // The hook payload's `CMUX_SURFACE_ID` is already a panel id in the
+    // unsplit case, so the resolver's first branch has to accept it as-is.
+    @Test func testPromptSubmitWithPanelIdSurfaceIdRecordsPanelPrompt() throws {
+        let manager = TabManager()
+        let workspace = manager.addWorkspace(select: false, placementOverride: .end)
+        let panelId = try #require(workspace.focusedPanelId)
+
+        let outcome = try #require(
+            manager.handlePromptSubmit(
+                workspaceId: workspace.id,
+                message: "run the migration",
+                iMessageModeEnabled: false,
+                surfaceId: panelId.uuidString
+            )
+        )
+
+        #expect(outcome.messageRecorded)
+        #expect(workspace.panelPrompts[panelId]?.message == "run the migration")
+        #expect(workspace.latestSubmittedMessage == "run the migration")
+    }
+
+    // In a split pane the surface id is a distinct bonsplit TabID, so the
+    // resolver has to fall through to the surface-to-panel mapping.
+    @Test func testPromptSubmitResolvesBonsplitSurfaceIdToItsPanel() throws {
+        let manager = TabManager()
+        let workspace = manager.addWorkspace(select: false, placementOverride: .end)
+        // Read the panel id first: `bindSurface` is exclusive per panel, so
+        // rebinding drops the panel's original surface mapping and
+        // `focusedPanelId` stops resolving right after this line.
+        let panelId = try #require(workspace.focusedPanelId)
+        let surfaceId = UUID()
+        workspace.bindSurface(TabID(uuid: surfaceId), toPanelId: panelId)
+        #expect(!workspace.panels.keys.contains(surfaceId))
+
+        let outcome = try #require(
+            manager.handlePromptSubmit(
+                workspaceId: workspace.id,
+                message: "split pane prompt",
+                iMessageModeEnabled: false,
+                surfaceId: surfaceId.uuidString
+            )
+        )
+
+        #expect(outcome.messageRecorded)
+        #expect(workspace.panelPrompts[panelId]?.message == "split pane prompt")
+        #expect(workspace.panelPrompts[surfaceId] == nil)
+    }
+
+    // An id that matches neither a panel nor a surface must not invent a
+    // panel entry; the workspace-level fields still have to be written.
+    @Test func testPromptSubmitWithUnresolvableSurfaceIdKeepsWorkspaceLevelFallback() throws {
+        let manager = TabManager()
+        let workspace = manager.addWorkspace(select: false, placementOverride: .end)
+
+        let outcome = try #require(
+            manager.handlePromptSubmit(
+                workspaceId: workspace.id,
+                message: "no surface match",
+                iMessageModeEnabled: false,
+                surfaceId: UUID().uuidString
+            )
+        )
+
+        #expect(outcome.messageRecorded)
+        #expect(workspace.panelPrompts.isEmpty)
+        #expect(workspace.latestSubmittedMessage == "no surface match")
+        #expect(workspace.latestSubmittedAt != nil)
     }
 }

--- a/docs/custom-sidebars.md
+++ b/docs/custom-sidebars.md
@@ -280,8 +280,12 @@ with:
   tab's `tabs[k].surfaceId`, accepted by `surface.focus`), `directory`,
   `transcriptPath`, and `pid`.
 - `tabs` (per workspace) — array of surfaces. Always: `id`, `title`,
-  `focused` (Bool), `pinned` (Bool). When available: `directory`, `branch` +
-  `dirty`, `ports` (array of Int).
+  `focused` (Bool), `pinned` (Bool), `unread` (`0`/`1`, whether that surface
+  has an unread notification). When available: `directory`, `branch` +
+  `dirty`, `ports` (array of Int), `latestPrompt` (the prompt last submitted in
+  that surface, not a pending state) + `latestAt` (epoch). Pair `latestPrompt`
+  with `unread` to show which of a workspace's agents is waiting, instead of
+  collapsing every surface into the workspace-level `latestPrompt`.
 - `workspaceCount` — Int. `selectedTitle` — active workspace's title.
   `selectedId` — its id. `unreadTotal` — total unread notifications.
 - `clock` — `{ time ("HH:mm:ss"), hour, minute, second, weekday, epoch }`. The


### PR DESCRIPTION
## Problem

Custom sidebars see `latestPrompt`, `latestAt` and `unread` only per workspace. A workspace running several agents collapses to whichever prompt arrived last, so a sidebar can show *that* a workspace is waiting, but not *which* of its surfaces. The built-in "Last Prompt" sidebar has the same limitation for the same reason.

## What was already there

Two pieces of the puzzle exist and were simply dropped on the way to the snapshot:

- `WorkstreamEvent` carries `surface_id` ([`WorkstreamEvent.swift:15`](https://github.com/manaflow-ai/cmux/blob/main/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamEvent.swift#L15)), and the hook path resolves it (`CMUXCLI+AgentHookProcessBinding.swift`). `v2ApplyIMessageModeSideEffects` forwarded only `workspaceId`.
- The notification store already tracks unread per `(tabId, surfaceId)`, reachable through the existing `hasUnreadNotification(panelId:)` seam.

## Approach

Follow the existing per-panel state pattern (`panelGitBranches` in `WorkspaceSidebarMetadataModel`) rather than introducing a new mechanism:

- `SidebarPanelPromptState` (message + submittedAt) and `panelPrompts: [UUID: SidebarPanelPromptState]`, with a matching publisher, cleared on panel close and in `resetSidebarContext`
- `recordSubmittedMessage(_:panelId:)` — a `nil` panel id keeps the previous workspace-only behaviour
- both prompt entry points forward the surface id: hook events (`TerminalController`) and the control-socket API (`TerminalController+ControlWorkspaceContext`)
- surface id → panel id resolution accepts both shapes, mirroring `AppDelegate+FocusedNotificationSeam`
- wired into the existing coalesced observation pipeline, so no new publisher and no extra re-render pressure
- `tabs[i].latestPrompt`, `tabs[i].latestAt`, `tabs[i].unread` (`0`/`1`) on the interpreter context

## Semantics

`latestPrompt` stays "last submitted", not "still waiting" — `.assistantFinal` does not touch it, matching the workspace-level field. The docs now say so and point at `unread` for the waiting case.

## Compatibility

Additive only. New snapshot fields have defaults, so no call site outside this change needs updating; `handlePromptSubmit` and `recordSubmittedMessage` gained optional parameters. Existing sidebars are unaffected.

## Testing

- `swift test` in `Packages/macOS/CmuxSidebar`: 57 passing (2 new — per-surface projection, omission of empty values)
- 5 new tests in `cmuxTests/WorkspacePromptSubmitTests.swift`: per-panel write, workspace-only path, two panels in parallel, blank prompt, reset

**Marked as draft because the full app target was not built locally** — my clone lacks the ghostty submodule. The package builds and its tests pass; the app-side changes have been reviewed by hand but not compiled. Happy to fix whatever CI turns up.

## Open questions for maintainers

1. Should `.stop` / `assistantFinal` also carry the surface id, so a sidebar could show a per-panel "answered" state instead of inferring it from `unread`?
2. `DetachedSurfaceTransfer` does not carry `panelPrompts` across a panel move — consistent with `panelGitBranches` and `panelPullRequests` today, so I left it alone. Say the word if it should move with the panel.
3. `CmuxSidebarProviderWorkspace` (ExtensionKit) has no surface array at all, so this change covers interpreted sidebars only. A follow-up could extend the provider snapshot, but that is a Codable wire change across the extension boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0113SqtxGQwjHjzFw8mkSgwU

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790535252&installation_model_id=21920&pr_number=11142&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11142&signature=e7cc2290e2ab30f4410c081753423cba226fecfad7fd7adbba25737c2671ba0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes per-surface prompt and unread state to custom sidebars so a workspace running several agents can show which surface is waiting, instead of collapsing to whichever prompt arrived last.

- `tabs[i]` gains `latestPrompt`, `latestAt`, and `unread` (`0`/`1`) in the interpreter context.
- Prompt submissions record against the panel when the surface id resolves; callers without surface routing keep the old workspace-only behavior.
- Both hook events and the control-socket API now forward the surface id.
- `latestPrompt` means "last submitted", not "still waiting"; pair it with `unread` for the waiting case.
- Additive only — new snapshot fields default, existing sidebars are unaffected, and panel prompts clear on panel close and sidebar reset.

<sup>Written for commit 3aec5f7c78d3fbf64d30163a1dd5e4b8a3276f10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom sidebars now show per-surface unread status and the latest submitted prompt with its timestamp.
  * Prompt activity is tracked separately for each panel, improving visibility in multi-panel workspaces.

* **Documentation**
  * Updated custom sidebar documentation with the new `unread`, `latestPrompt`, and `latestAt` fields.

* **Tests**
  * Added coverage for per-panel prompt tracking, unread indicators, empty prompts, and state resets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive sidebar metadata and optional prompt-submit parameters; behavior unchanged when surface id is absent or unresolvable.
> 
> **Overview**
> Custom sidebars can now show **which surface** in a multi-agent workspace last got a prompt and whether it is unread, instead of only the workspace-wide `latestPrompt`.
> 
> The change adds per-panel prompt tracking (`SidebarPanelPromptState` / `panelPrompts`, same pattern as `panelGitBranches`), extends `recordSubmittedMessage` with an optional `panelId`, and routes hook/control prompt submissions through **surface id → panel id** resolution before recording. Each `tabs[i]` entry in the interpreter context gains **`unread`** (`0`/`1`), **`latestPrompt`**, and **`latestAt`**; empty prompts are omitted like at workspace scope. State clears on panel teardown and sidebar reset, and the immediate sidebar observation pipeline includes `panelPrompts` so custom rows stay in sync. Docs describe pairing per-tab `latestPrompt` with `unread` for “who is waiting.” Additive API defaults preserve callers that omit `surfaceId`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3aec5f7c78d3fbf64d30163a1dd5e4b8a3276f10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->