### PR TITLE
security(cdp): keep close diagnostics out of public events

### DIFF
--- a/cmux-tui/Cargo.lock
+++ b/cmux-tui/Cargo.lock
@@ -757,6 +757,7 @@ dependencies = [
  "cmux-pty",
  "cmux-remote",
  "cmux-remote-protocol",
+ "cmux-tui-cdp",
  "cmux-tui-core",
  "cmux-tui-machine-agent-protocol",
  "cmux-tui-machine-protocol",

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -186,6 +186,34 @@ pub struct NavigationHistory {
     pub entries: Vec<NavigationEntry>,
 }
 
+/// A connection close classification that is safe to pass across crate and
+/// UI boundaries. Transport details stay in the reader's diagnostic stream;
+/// callers receive only this stable recovery message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CdpCloseReason {
+    EventReceiverClosed,
+    TransportFailure,
+    SocketClosed,
+    EventQueueOverflow,
+    OutboundQueueOverflow,
+    ConnectionClosed,
+    ClientDropped,
+    RuntimeClosed,
+    SurfaceClosed,
+}
+
+impl CdpCloseReason {
+    pub const fn public_message(self) -> &'static str {
+        CDP_CONNECTION_UNAVAILABLE_MESSAGE
+    }
+}
+
+impl std::fmt::Display for CdpCloseReason {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.public_message())
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NavigationResult {
     pub error_text: Option<String>,
@@ -236,7 +264,7 @@ pub enum CdpEvent {
         params: Value,
         session_id: Option<String>,
     },
-    Closed(String),
+    Closed(CdpCloseReason),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -432,13 +460,13 @@ impl EventQueue {
         Ok(())
     }
 
-    fn close(&self, reason: &str) {
+    fn close(&self, reason: CdpCloseReason) {
         let mut state = self.state.lock().unwrap();
         if state.closed {
             return;
         }
         state.events.clear();
-        let event = CdpEvent::Closed(reason.to_string());
+        let event = CdpEvent::Closed(reason);
         let retained_bytes = event_retained_bytes(&event);
         state.retained_bytes = retained_bytes;
         state.events.push_back(QueuedEvent { event, retained_bytes });
@@ -518,7 +546,7 @@ pub fn event_retained_bytes(event: &CdpEvent) -> usize {
             .len()
             .saturating_add(json_retained_bytes(params))
             .saturating_add(session_id.as_ref().map_or(0, String::len)),
-        CdpEvent::Closed(reason) => reason.len(),
+        CdpEvent::Closed(reason) => reason.public_message().len(),
     }
 }
 
@@ -543,7 +571,7 @@ fn json_retained_bytes(value: &Value) -> usize {
 
 impl Drop for Inner {
     fn drop(&mut self) {
-        self.events.close("CDP client dropped");
+        self.events.close(CdpCloseReason::ClientDropped);
     }
 }
 
@@ -1480,14 +1508,14 @@ fn reader_loop(
     loop {
         let Some(inner) = weak.upgrade() else { break };
         if inner.events.drain_into(event_output).is_err() {
-            close_inner(&inner, "CDP event receiver closed");
+            close_inner(&inner, CdpCloseReason::EventReceiverClosed);
             break;
         }
         if inner.closed.load(Ordering::Acquire) {
             break;
         }
         if let Err(err) = drain_outbound(&inner, &mut ws, outbound) {
-            close_inner(&inner, &format!("CDP socket error: {err}"));
+            close_inner_with_detail(&inner, CdpCloseReason::TransportFailure, err);
             break;
         }
         let message = ws.read();
@@ -1499,7 +1527,7 @@ fn reader_loop(
                 }
             }
             Ok(Message::Close(_)) => {
-                close_inner(&inner, "CDP socket closed");
+                close_inner(&inner, CdpCloseReason::SocketClosed);
                 let _ = inner.events.drain_into(event_output);
                 break;
             }
@@ -1513,7 +1541,7 @@ fn reader_loop(
                 continue;
             }
             Err(e) => {
-                close_inner(&inner, &format!("CDP socket error: {e}"));
+                close_inner_with_detail(&inner, CdpCloseReason::TransportFailure, e);
                 let _ = inner.events.drain_into(event_output);
                 break;
             }
@@ -1849,7 +1877,7 @@ fn main_frame_same_document_navigation(
 
 fn dispatch_event(inner: &Arc<Inner>, event: CdpEvent) {
     if inner.events.push(event).is_err() {
-        close_inner(inner, "CDP event queue overflow");
+        close_inner(inner, CdpCloseReason::EventQueueOverflow);
     }
 }
 
@@ -1873,14 +1901,14 @@ fn ack_screencast_frame(
         // Keep queue and protocol details out of stderr. The close event
         // carries the stable recovery message to callers.
         report(CDP_ACK_REJECTED_DIAGNOSTIC);
-        close_inner(inner, CDP_CONNECTION_UNAVAILABLE_MESSAGE);
+        close_inner(inner, CdpCloseReason::OutboundQueueOverflow);
         return;
     }
     if let Err(error) = inner.outbound.try_send(Outbound::Message(text)) {
         outbound_bytes_sub(inner, outbound_bytes(&error));
         let reason = match error {
-            TrySendError::Full(_) => "CDP outbound queue overflow",
-            TrySendError::Disconnected(_) => "CDP connection is closed",
+            TrySendError::Full(_) => CdpCloseReason::OutboundQueueOverflow,
+            TrySendError::Disconnected(_) => CdpCloseReason::ConnectionClosed,
         };
         close_inner(inner, reason);
     }
@@ -1999,14 +2027,26 @@ fn target_created(params: &Value) -> Option<TargetCreated> {
     })
 }
 
-fn close_inner(inner: &Arc<Inner>, why: &str) {
+fn close_inner(inner: &Arc<Inner>, reason: CdpCloseReason) {
     if inner.closed.swap(true, Ordering::AcqRel) {
         return;
     }
+    let message = reason.public_message();
     for (_, pending) in inner.pending.lock().unwrap().drain() {
-        let _ = pending.response.send(Err(why.to_string()));
+        let _ = pending.response.send(Err(message.to_string()));
     }
-    inner.events.close(why);
+    inner.events.close(reason);
+}
+
+fn close_inner_with_detail<D: std::fmt::Display>(
+    inner: &Arc<Inner>,
+    reason: CdpCloseReason,
+    _detail: D,
+) {
+    // Keep transport diagnostics out of the public error and event channels.
+    // The detail is intentionally not formatted here because websocket
+    // errors can contain endpoint URLs and server-provided text.
+    close_inner(inner, reason);
 }
 
 struct WsEndpoint {
@@ -2288,7 +2328,11 @@ mod tests {
             PendingCall { response: response_tx, frame_barrier: None },
         );
 
-        close_inner(&inner, "CDP socket error: ws://secret.example/devtools/browser/token");
+        close_inner_with_detail(
+            &inner,
+            CdpCloseReason::TransportFailure,
+            "CDP socket error: ws://secret.example/devtools/browser/token",
+        );
 
         assert_eq!(
             response_rx.recv().unwrap().unwrap_err(),

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -2323,10 +2323,11 @@ mod tests {
     fn transport_close_does_not_publish_socket_details() {
         let (inner, _outbound_rx) = test_inner();
         let (response_tx, response_rx) = channel();
-        inner.pending.lock().unwrap().insert(
-            7,
-            PendingCall { response: response_tx, frame_barrier: None },
-        );
+        inner
+            .pending
+            .lock()
+            .unwrap()
+            .insert(7, PendingCall { response: response_tx, frame_barrier: None });
 
         close_inner_with_detail(
             &inner,
@@ -2334,10 +2335,7 @@ mod tests {
             "CDP socket error: ws://secret.example/devtools/browser/token",
         );
 
-        assert_eq!(
-            response_rx.recv().unwrap().unwrap_err(),
-            CDP_CONNECTION_UNAVAILABLE_MESSAGE
-        );
+        assert_eq!(response_rx.recv().unwrap().unwrap_err(), CDP_CONNECTION_UNAVAILABLE_MESSAGE);
         let (event_tx, event_rx) = sync_channel(1);
         inner.events.drain_into(&event_tx).unwrap();
         let CdpEvent::Closed(reason) = event_rx.recv().unwrap() else {

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -10,6 +10,7 @@ use std::sync::mpsc::{
 use std::sync::{Arc, Condvar, Mutex, Weak};
 use std::time::{Duration, Instant};
 
+use anyhow::Context;
 use base64::Engine;
 use serde_json::{Value, json};
 use tungstenite::client::IntoClientRequest;

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -2180,6 +2180,13 @@ mod tests {
         let error = client.send_value(&json!({"payload": "0123456789"})).unwrap_err();
         assert_eq!(error.to_string(), "browser connection unavailable; retry the command");
         assert!(format!("{error:#}").contains("CDP outbound queue byte budget exceeded"));
+        assert!(is_connection_unavailable(&error));
+    }
+
+    #[test]
+    fn protocol_errors_are_not_classified_as_connection_failures() {
+        let error = anyhow::anyhow!("browser failed: invalid target");
+        assert!(!is_connection_unavailable(&error));
     }
 
     struct BlockingOutboundWriter {

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -10,6 +10,7 @@ use std::sync::mpsc::{
 use std::sync::{Arc, Condvar, Mutex, Weak};
 use std::time::{Duration, Instant};
 
+use anyhow::Context;
 use base64::Engine;
 use serde_json::{Value, json};
 use tungstenite::client::IntoClientRequest;
@@ -39,6 +40,9 @@ pub const CDP_EVENT_QUEUE_MAX_BYTES: usize = 32 * 1024 * 1024;
 /// full, so a blocked reader cannot block the TUI thread indefinitely.
 const CDP_OUTBOUND_QUEUE_CAPACITY: usize = 256;
 const CDP_OUTBOUND_QUEUE_MAX_BYTES: usize = 8 * 1024 * 1024;
+const CDP_CONNECTION_UNAVAILABLE_MESSAGE: &str =
+    "browser connection unavailable; retry the command";
+const CDP_OUTBOUND_QUEUE_BYTE_BUDGET_DETAIL: &str = "CDP outbound queue byte budget exceeded";
 const MAX_ENCODED_FRAME_BYTES: usize = 16 * 1024 * 1024;
 const MAX_DECODED_FRAME_BYTES: usize = 12 * 1024 * 1024;
 const TIMESTAMPLESS_CAPTURE_INTERVAL: Duration = Duration::from_secs(1);
@@ -1418,9 +1422,9 @@ fn reserve_outbound_bytes(inner: &Inner, bytes: usize) -> anyhow::Result<()> {
         let current = inner.outbound_bytes.load(Ordering::Acquire);
         let next = current
             .checked_add(bytes)
-            .ok_or_else(|| anyhow::anyhow!("CDP outbound queue byte budget exceeded"))?;
+            .ok_or_else(outbound_byte_budget_error)?;
         if next > inner.outbound_byte_budget as u64 {
-            anyhow::bail!("CDP outbound queue byte budget exceeded");
+            return Err(outbound_byte_budget_error());
         }
         if inner
             .outbound_bytes
@@ -1430,6 +1434,11 @@ fn reserve_outbound_bytes(inner: &Inner, bytes: usize) -> anyhow::Result<()> {
             return Ok(());
         }
     }
+}
+
+fn outbound_byte_budget_error() -> anyhow::Error {
+    anyhow::anyhow!(CDP_OUTBOUND_QUEUE_BYTE_BUDGET_DETAIL)
+        .context(CDP_CONNECTION_UNAVAILABLE_MESSAGE)
 }
 
 fn outbound_bytes_sub(inner: &Inner, bytes: usize) {
@@ -1841,8 +1850,9 @@ fn ack_screencast_frame(inner: &Arc<Inner>, target_session: &str, frame_session:
         "params": { "sessionId": frame_session },
     });
     let Ok(text) = serde_json::to_string(&msg) else { return };
-    if reserve_outbound_bytes(inner, text.len()).is_err() {
-        close_inner(inner, "CDP outbound queue byte budget exceeded");
+    if let Err(error) = reserve_outbound_bytes(inner, text.len()) {
+        eprintln!("cmux-tui-cdp: screencast acknowledgment rejected: {error:#}");
+        close_inner(inner, CDP_CONNECTION_UNAVAILABLE_MESSAGE);
         return;
     }
     if let Err(error) = inner.outbound.try_send(Outbound::Message(text)) {

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -2199,6 +2199,14 @@ mod tests {
     }
 
     #[test]
+    fn websocket_write_buffer_is_bounded_to_the_outbound_budget() {
+        let config = cdp_websocket_config();
+
+        assert!(config.max_write_buffer_size < usize::MAX);
+        assert!(config.max_write_buffer_size >= CDP_OUTBOUND_QUEUE_MAX_BYTES);
+    }
+
+    #[test]
     fn protocol_errors_are_not_classified_as_connection_failures() {
         let error = anyhow::anyhow!("browser failed: invalid target");
         assert!(!is_connection_unavailable(&error));

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -1440,6 +1440,10 @@ fn outbound_byte_budget_error() -> anyhow::Error {
         .context(CDP_CONNECTION_UNAVAILABLE_MESSAGE)
 }
 
+pub fn is_connection_unavailable(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| cause.to_string() == CDP_CONNECTION_UNAVAILABLE_MESSAGE)
+}
+
 fn outbound_bytes_sub(inner: &Inner, bytes: usize) {
     inner.outbound_bytes.fetch_sub(bytes as u64, Ordering::AcqRel);
 }

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -2280,6 +2280,31 @@ mod tests {
     }
 
     #[test]
+    fn transport_close_does_not_publish_socket_details() {
+        let (inner, _outbound_rx) = test_inner();
+        let (response_tx, response_rx) = channel();
+        inner.pending.lock().unwrap().insert(
+            7,
+            PendingCall { response: response_tx, frame_barrier: None },
+        );
+
+        close_inner(&inner, "CDP socket error: ws://secret.example/devtools/browser/token");
+
+        assert_eq!(
+            response_rx.recv().unwrap().unwrap_err(),
+            CDP_CONNECTION_UNAVAILABLE_MESSAGE
+        );
+        let (event_tx, event_rx) = sync_channel(1);
+        inner.events.drain_into(&event_tx).unwrap();
+        let CdpEvent::Closed(reason) = event_rx.recv().unwrap() else {
+            panic!("expected a close event");
+        };
+        assert_eq!(reason, CDP_CONNECTION_UNAVAILABLE_MESSAGE);
+        assert!(!reason.contains("ws://"));
+        assert!(!reason.contains("secret"));
+    }
+
+    #[test]
     fn outbound_commands_fail_fast_at_the_queue_bound() {
         let (inner, _outbound_rx) = test_inner_with_capacity(1);
         let client = CdpClient { inner };

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -1521,8 +1521,16 @@ fn drain_outbound<W: OutboundWriter>(
     loop {
         match outbound.try_recv() {
             Ok(Outbound::Message(text)) => {
-                outbound_bytes_sub(inner, text.len());
-                ws.send_text(text)?;
+                let bytes = text.len();
+                // Keep the reservation while the socket write is in progress.
+                // Release it only after the write returns, including errors.
+                match ws.send_text(text) {
+                    Ok(()) => outbound_bytes_sub(inner, bytes),
+                    Err(error) => {
+                        outbound_bytes_sub(inner, bytes);
+                        return Err(error);
+                    }
+                }
             }
             Ok(Outbound::Flush(done)) => {
                 let _ = done.send(());

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -2085,6 +2085,15 @@ mod tests {
     }
 
     #[test]
+    fn outbound_commands_fail_fast_at_the_byte_bound() {
+        let (inner, _outbound_rx) = test_inner_with_capacity(8);
+        let client = CdpClient { inner };
+
+        let error = client.send_value(&json!({"payload": "0123456789"})).unwrap_err();
+        assert!(error.to_string().contains("outbound queue byte budget"));
+    }
+
+    #[test]
     fn outbound_commands_fail_fast_at_the_queue_bound() {
         let (inner, _outbound_rx) = test_inner_with_capacity(1);
         let client = CdpClient { inner };

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -1502,16 +1502,27 @@ fn reader_loop(
     }
 }
 
-fn drain_outbound(
+trait OutboundWriter {
+    fn send_text(&mut self, text: String) -> anyhow::Result<()>;
+}
+
+impl OutboundWriter for WebSocket<TcpStream> {
+    fn send_text(&mut self, text: String) -> anyhow::Result<()> {
+        self.send(Message::Text(text.into()))?;
+        Ok(())
+    }
+}
+
+fn drain_outbound<W: OutboundWriter>(
     inner: &Arc<Inner>,
-    ws: &mut WebSocket<TcpStream>,
+    ws: &mut W,
     outbound: &Receiver<Outbound>,
 ) -> anyhow::Result<()> {
     loop {
         match outbound.try_recv() {
             Ok(Outbound::Message(text)) => {
                 outbound_bytes_sub(inner, text.len());
-                ws.send(Message::Text(text.into()))?
+                ws.send_text(text)?;
             }
             Ok(Outbound::Flush(done)) => {
                 let _ = done.send(());
@@ -2150,6 +2161,43 @@ mod tests {
 
         let error = client.send_value(&json!({"payload": "0123456789"})).unwrap_err();
         assert!(error.to_string().contains("outbound queue byte budget"));
+    }
+
+    struct BlockingOutboundWriter {
+        started: Arc<Barrier>,
+        release: Arc<Barrier>,
+    }
+
+    impl OutboundWriter for BlockingOutboundWriter {
+        fn send_text(&mut self, _text: String) -> anyhow::Result<()> {
+            self.started.wait();
+            self.release.wait();
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn outbound_bytes_remain_reserved_while_write_is_in_flight() {
+        let value = json!({"payload": "0123456789"});
+        let message_bytes = serde_json::to_string(&value).unwrap().len();
+        let (inner, outbound_rx) = test_inner_with_limits(2, message_bytes);
+        let client = CdpClient { inner: inner.clone() };
+        client.send_value(&value).unwrap();
+
+        let started = Arc::new(Barrier::new(2));
+        let release = Arc::new(Barrier::new(2));
+        let writer = BlockingOutboundWriter { started: started.clone(), release: release.clone() };
+        let drain_inner = inner.clone();
+        let drain = thread::spawn(move || {
+            let mut writer = writer;
+            drain_outbound(&drain_inner, &mut writer, &outbound_rx).unwrap();
+        });
+
+        started.wait();
+        let error = client.send_value(&value).unwrap_err();
+        assert!(error.to_string().contains("outbound queue byte budget"));
+        release.wait();
+        drain.join().unwrap();
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -38,6 +38,7 @@ pub const CDP_EVENT_QUEUE_MAX_BYTES: usize = 32 * 1024 * 1024;
 /// unbounded number of JSON messages. Callers fail fast when the queue is
 /// full, so a blocked reader cannot block the TUI thread indefinitely.
 const CDP_OUTBOUND_QUEUE_CAPACITY: usize = 256;
+const CDP_OUTBOUND_QUEUE_MAX_BYTES: usize = 8 * 1024 * 1024;
 const MAX_ENCODED_FRAME_BYTES: usize = 16 * 1024 * 1024;
 const MAX_DECODED_FRAME_BYTES: usize = 12 * 1024 * 1024;
 const TIMESTAMPLESS_CAPTURE_INTERVAL: Duration = Duration::from_secs(1);
@@ -282,6 +283,8 @@ pub struct CdpClient {
 
 struct Inner {
     outbound: SyncSender<Outbound>,
+    outbound_bytes: AtomicU64,
+    outbound_byte_budget: usize,
     pending: Mutex<HashMap<u64, PendingCall>>,
     events: Arc<EventQueue>,
     frame_epochs: Mutex<HashMap<String, FrameSession>>,
@@ -578,6 +581,8 @@ impl CdpClient {
         let client = CdpClient {
             inner: Arc::new(Inner {
                 outbound: outbound_tx,
+                outbound_bytes: AtomicU64::new(0),
+                outbound_byte_budget: CDP_OUTBOUND_QUEUE_MAX_BYTES,
                 pending: Mutex::new(HashMap::new()),
                 events: event_queue,
                 frame_epochs: Mutex::new(HashMap::new()),
@@ -1383,8 +1388,20 @@ impl CdpClient {
         if cdp_debug() {
             eprintln!("cdp-> {text}");
         }
-        self.inner.outbound.try_send(Outbound::Message(text)).map_err(outbound_send_error)?;
+        reserve_outbound_bytes(&self.inner, text.len())?;
+        if let Err(error) = self.inner.outbound.try_send(Outbound::Message(text)) {
+            outbound_bytes_sub(&self.inner, outbound_bytes(&error));
+            return Err(outbound_send_error(error));
+        }
         Ok(())
+    }
+}
+
+fn outbound_bytes(error: &TrySendError<Outbound>) -> usize {
+    match error {
+        TrySendError::Full(Outbound::Message(text))
+        | TrySendError::Disconnected(Outbound::Message(text)) => text.len(),
+        _ => 0,
     }
 }
 
@@ -1393,6 +1410,30 @@ fn outbound_send_error(error: TrySendError<Outbound>) -> anyhow::Error {
         TrySendError::Full(_) => anyhow::anyhow!("CDP outbound queue is full"),
         TrySendError::Disconnected(_) => anyhow::anyhow!("CDP connection is closed"),
     }
+}
+
+fn reserve_outbound_bytes(inner: &Inner, bytes: usize) -> anyhow::Result<()> {
+    let bytes = u64::try_from(bytes).unwrap_or(u64::MAX);
+    loop {
+        let current = inner.outbound_bytes.load(Ordering::Acquire);
+        let next = current
+            .checked_add(bytes)
+            .ok_or_else(|| anyhow::anyhow!("CDP outbound queue byte budget exceeded"))?;
+        if next > inner.outbound_byte_budget as u64 {
+            anyhow::bail!("CDP outbound queue byte budget exceeded");
+        }
+        if inner
+            .outbound_bytes
+            .compare_exchange(current, next, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            return Ok(());
+        }
+    }
+}
+
+fn outbound_bytes_sub(inner: &Inner, bytes: usize) {
+    inner.outbound_bytes.fetch_sub(bytes as u64, Ordering::AcqRel);
 }
 
 pub fn resolve_browser_ws_url(input: &str) -> anyhow::Result<String> {
@@ -1426,7 +1467,7 @@ fn reader_loop(
         if inner.closed.load(Ordering::Acquire) {
             break;
         }
-        if let Err(err) = drain_outbound(&mut ws, outbound) {
+        if let Err(err) = drain_outbound(&inner, &mut ws, outbound) {
             close_inner(&inner, &format!("CDP socket error: {err}"));
             break;
         }
@@ -1462,12 +1503,16 @@ fn reader_loop(
 }
 
 fn drain_outbound(
+    inner: &Arc<Inner>,
     ws: &mut WebSocket<TcpStream>,
     outbound: &Receiver<Outbound>,
 ) -> anyhow::Result<()> {
     loop {
         match outbound.try_recv() {
-            Ok(Outbound::Message(text)) => ws.send(Message::Text(text.into()))?,
+            Ok(Outbound::Message(text)) => {
+                outbound_bytes_sub(inner, text.len());
+                ws.send(Message::Text(text.into()))?
+            }
             Ok(Outbound::Flush(done)) => {
                 let _ = done.send(());
             }
@@ -1777,7 +1822,12 @@ fn ack_screencast_frame(inner: &Arc<Inner>, target_session: &str, frame_session:
         "params": { "sessionId": frame_session },
     });
     let Ok(text) = serde_json::to_string(&msg) else { return };
+    if reserve_outbound_bytes(inner, text.len()).is_err() {
+        close_inner(inner, "CDP outbound queue byte budget exceeded");
+        return;
+    }
     if let Err(error) = inner.outbound.try_send(Outbound::Message(text)) {
+        outbound_bytes_sub(inner, outbound_bytes(&error));
         let reason = match error {
             TrySendError::Full(_) => "CDP outbound queue overflow",
             TrySendError::Disconnected(_) => "CDP connection is closed",
@@ -2063,14 +2113,23 @@ mod tests {
     use super::*;
 
     fn test_inner() -> (Arc<Inner>, Receiver<Outbound>) {
-        test_inner_with_capacity(256)
+        test_inner_with_limits(256, CDP_OUTBOUND_QUEUE_MAX_BYTES)
     }
 
     fn test_inner_with_capacity(capacity: usize) -> (Arc<Inner>, Receiver<Outbound>) {
+        test_inner_with_limits(capacity, CDP_OUTBOUND_QUEUE_MAX_BYTES)
+    }
+
+    fn test_inner_with_limits(
+        capacity: usize,
+        outbound_byte_budget: usize,
+    ) -> (Arc<Inner>, Receiver<Outbound>) {
         let (outbound, outbound_rx) = std::sync::mpsc::sync_channel(capacity);
         (
             Arc::new(Inner {
                 outbound,
+                outbound_bytes: AtomicU64::new(0),
+                outbound_byte_budget,
                 pending: Mutex::new(HashMap::new()),
                 events: Arc::new(EventQueue::new()),
                 frame_epochs: Mutex::new(HashMap::new()),
@@ -2086,7 +2145,7 @@ mod tests {
 
     #[test]
     fn outbound_commands_fail_fast_at_the_byte_bound() {
-        let (inner, _outbound_rx) = test_inner_with_capacity(8);
+        let (inner, _outbound_rx) = test_inner_with_limits(8, 16);
         let client = CdpClient { inner };
 
         let error = client.send_value(&json!({"payload": "0123456789"})).unwrap_err();

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -15,7 +15,8 @@ use serde_json::{Value, json};
 use tungstenite::client::IntoClientRequest;
 use tungstenite::http::HeaderValue;
 use tungstenite::http::header::AUTHORIZATION;
-use tungstenite::{Error as WsError, Message, WebSocket, client};
+use tungstenite::protocol::WebSocketConfig;
+use tungstenite::{Error as WsError, Message, WebSocket, client_with_config};
 
 /// Maximum number of pending events in each bounded CDP event queue.
 ///
@@ -39,6 +40,9 @@ pub const CDP_EVENT_QUEUE_MAX_BYTES: usize = 32 * 1024 * 1024;
 /// full, so a blocked reader cannot block the TUI thread indefinitely.
 const CDP_OUTBOUND_QUEUE_CAPACITY: usize = 256;
 const CDP_OUTBOUND_QUEUE_MAX_BYTES: usize = 8 * 1024 * 1024;
+// Include tungstenite's default 128 KiB staging buffer and frame overhead in
+// addition to the largest message admitted by the outbound byte budget.
+const CDP_SOCKET_WRITE_BUFFER_MAX_BYTES: usize = CDP_OUTBOUND_QUEUE_MAX_BYTES + 256 * 1024;
 const CDP_CONNECTION_UNAVAILABLE_MESSAGE: &str =
     "browser connection unavailable; retry the command";
 const CDP_OUTBOUND_QUEUE_BYTE_BUDGET_DETAIL: &str = "CDP outbound queue byte budget exceeded";
@@ -572,7 +576,7 @@ impl CdpClient {
                 .map_err(|error| anyhow::anyhow!("invalid CDP bearer token: {error}"))?;
             request.headers_mut().insert(AUTHORIZATION, value);
         }
-        let (ws, _) = client(request, stream)?;
+        let (ws, _) = client_with_config(request, stream, Some(cdp_websocket_config()))?;
         // The reader thread owns the socket and drains queued outbound
         // writes before each read poll. A message enqueued just after a
         // read starts can wait for this window, but writers never contend
@@ -1398,6 +1402,10 @@ impl CdpClient {
         }
         Ok(())
     }
+}
+
+fn cdp_websocket_config() -> WebSocketConfig {
+    WebSocketConfig::default().max_write_buffer_size(CDP_SOCKET_WRITE_BUFFER_MAX_BYTES)
 }
 
 fn outbound_bytes(error: &TrySendError<Outbound>) -> usize {

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -1419,9 +1419,7 @@ fn reserve_outbound_bytes(inner: &Inner, bytes: usize) -> anyhow::Result<()> {
     let bytes = u64::try_from(bytes).unwrap_or(u64::MAX);
     loop {
         let current = inner.outbound_bytes.load(Ordering::Acquire);
-        let next = current
-            .checked_add(bytes)
-            .ok_or_else(outbound_byte_budget_error)?;
+        let next = current.checked_add(bytes).ok_or_else(outbound_byte_budget_error)?;
         if next > inner.outbound_byte_budget as u64 {
             return Err(outbound_byte_budget_error());
         }

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -44,7 +44,7 @@ const CDP_OUTBOUND_QUEUE_MAX_BYTES: usize = 8 * 1024 * 1024;
 // Include tungstenite's default 128 KiB staging buffer and frame overhead in
 // addition to the largest message admitted by the outbound byte budget.
 const CDP_SOCKET_WRITE_BUFFER_MAX_BYTES: usize = CDP_OUTBOUND_QUEUE_MAX_BYTES + 256 * 1024;
-const CDP_CONNECTION_UNAVAILABLE_MESSAGE: &str =
+pub const CDP_CONNECTION_UNAVAILABLE_MESSAGE: &str =
     "browser connection unavailable; retry the command";
 const CDP_OUTBOUND_QUEUE_BYTE_BUDGET_DETAIL: &str = "CDP outbound queue byte budget exceeded";
 const MAX_ENCODED_FRAME_BYTES: usize = 16 * 1024 * 1024;
@@ -2312,8 +2312,8 @@ mod tests {
         let CdpEvent::Closed(reason) = event_rx.recv().unwrap() else {
             panic!("expected a close event");
         };
-        assert_eq!(reason, "browser connection unavailable; retry the command");
-        assert!(!reason.contains("CDP"));
+        assert_eq!(reason.public_message(), "browser connection unavailable; retry the command");
+        assert!(!reason.public_message().contains("CDP"));
         assert_eq!(diagnostics, vec![CDP_ACK_REJECTED_DIAGNOSTIC.to_string()]);
         assert!(!diagnostics[0].contains("ws://"));
         assert!(!diagnostics[0].contains("queue byte budget"));
@@ -2341,9 +2341,9 @@ mod tests {
         let CdpEvent::Closed(reason) = event_rx.recv().unwrap() else {
             panic!("expected a close event");
         };
-        assert_eq!(reason, CDP_CONNECTION_UNAVAILABLE_MESSAGE);
-        assert!(!reason.contains("ws://"));
-        assert!(!reason.contains("secret"));
+        assert_eq!(reason.public_message(), CDP_CONNECTION_UNAVAILABLE_MESSAGE);
+        assert!(!reason.public_message().contains("ws://"));
+        assert!(!reason.public_message().contains("secret"));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -1581,7 +1581,9 @@ fn handle_text(inner: &Arc<Inner>, text: &str) {
                 let Some(ack_id) = params.get("sessionId").and_then(|value| value.as_u64()) else {
                     return;
                 };
-                ack_screencast_frame(inner, target_session, ack_id);
+                ack_screencast_frame(inner, target_session, ack_id, |message| {
+                    eprintln!("{message}");
+                });
                 let (
                     frame_epoch,
                     navigation_epoch,
@@ -1842,7 +1844,14 @@ fn dispatch_event(inner: &Arc<Inner>, event: CdpEvent) {
     }
 }
 
-fn ack_screencast_frame(inner: &Arc<Inner>, target_session: &str, frame_session: u64) {
+const CDP_ACK_REJECTED_DIAGNOSTIC: &str = "cmux-tui-cdp: screencast acknowledgment rejected";
+
+fn ack_screencast_frame(
+    inner: &Arc<Inner>,
+    target_session: &str,
+    frame_session: u64,
+    report: impl FnOnce(&str),
+) {
     let id = inner.next_id.fetch_add(1, Ordering::Relaxed);
     let msg = json!({
         "id": id,
@@ -1852,7 +1861,9 @@ fn ack_screencast_frame(inner: &Arc<Inner>, target_session: &str, frame_session:
     });
     let Ok(text) = serde_json::to_string(&msg) else { return };
     if reserve_outbound_bytes(inner, text.len()).is_err() {
-        eprintln!("cmux-tui-cdp: screencast acknowledgment rejected");
+        // Keep queue and protocol details out of stderr. The close event
+        // carries the stable recovery message to callers.
+        report(CDP_ACK_REJECTED_DIAGNOSTIC);
         close_inner(inner, CDP_CONNECTION_UNAVAILABLE_MESSAGE);
         return;
     }
@@ -2179,7 +2190,10 @@ mod tests {
         let client = CdpClient { inner };
 
         let error = client.send_value(&json!({"payload": "0123456789"})).unwrap_err();
-        assert_eq!(error.to_string(), "browser connection unavailable; retry the command");
+        let public = error.to_string();
+        assert_eq!(public, "browser connection unavailable; retry the command");
+        assert!(!public.contains("ws://"));
+        assert!(!public.contains("CDP outbound queue byte budget exceeded"));
         assert!(format!("{error:#}").contains("CDP outbound queue byte budget exceeded"));
         assert!(is_connection_unavailable(&error));
     }
@@ -2231,7 +2245,10 @@ mod tests {
     #[test]
     fn screencast_ack_byte_budget_closure_hides_internal_reason() {
         let (inner, _outbound_rx) = test_inner_with_limits(1, 1);
-        ack_screencast_frame(&inner, "session-1", 7);
+        let mut diagnostics = Vec::new();
+        ack_screencast_frame(&inner, "session-1", 7, |message| {
+            diagnostics.push(message.to_string());
+        });
 
         let (event_tx, event_rx) = sync_channel(1);
         inner.events.drain_into(&event_tx).unwrap();
@@ -2240,6 +2257,9 @@ mod tests {
         };
         assert_eq!(reason, "browser connection unavailable; retry the command");
         assert!(!reason.contains("CDP"));
+        assert_eq!(diagnostics, vec![CDP_ACK_REJECTED_DIAGNOSTIC.to_string()]);
+        assert!(!diagnostics[0].contains("ws://"));
+        assert!(!diagnostics[0].contains("queue byte budget"));
     }
 
     #[test]
@@ -2266,7 +2286,7 @@ mod tests {
     #[test]
     fn screencast_ack_queue_overflow_closes_the_connection() {
         let (inner, _outbound_rx) = test_inner_with_capacity(0);
-        ack_screencast_frame(&inner, "session-1", 7);
+        ack_screencast_frame(&inner, "session-1", 7, |_| {});
         assert!(inner.closed.load(Ordering::Acquire));
     }
 

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -2168,7 +2168,8 @@ mod tests {
         let client = CdpClient { inner };
 
         let error = client.send_value(&json!({"payload": "0123456789"})).unwrap_err();
-        assert!(error.to_string().contains("outbound queue byte budget"));
+        assert_eq!(error.to_string(), "browser connection unavailable; retry the command");
+        assert!(format!("{error:#}").contains("CDP outbound queue byte budget exceeded"));
     }
 
     struct BlockingOutboundWriter {
@@ -2203,9 +2204,24 @@ mod tests {
 
         started.wait();
         let error = client.send_value(&value).unwrap_err();
-        assert!(error.to_string().contains("outbound queue byte budget"));
+        assert_eq!(error.to_string(), "browser connection unavailable; retry the command");
+        assert!(format!("{error:#}").contains("CDP outbound queue byte budget exceeded"));
         release.wait();
         drain.join().unwrap();
+    }
+
+    #[test]
+    fn screencast_ack_byte_budget_closure_hides_internal_reason() {
+        let (inner, _outbound_rx) = test_inner_with_limits(1, 1);
+        ack_screencast_frame(&inner, "session-1", 7);
+
+        let (event_tx, event_rx) = sync_channel(1);
+        inner.events.drain_into(&event_tx).unwrap();
+        let CdpEvent::Closed(reason) = event_rx.recv().unwrap() else {
+            panic!("expected a close event");
+        };
+        assert_eq!(reason, "browser connection unavailable; retry the command");
+        assert!(!reason.contains("CDP"));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -10,7 +10,6 @@ use std::sync::mpsc::{
 use std::sync::{Arc, Condvar, Mutex, Weak};
 use std::time::{Duration, Instant};
 
-use anyhow::Context;
 use base64::Engine;
 use serde_json::{Value, json};
 use tungstenite::client::IntoClientRequest;
@@ -1850,8 +1849,8 @@ fn ack_screencast_frame(inner: &Arc<Inner>, target_session: &str, frame_session:
         "params": { "sessionId": frame_session },
     });
     let Ok(text) = serde_json::to_string(&msg) else { return };
-    if let Err(error) = reserve_outbound_bytes(inner, text.len()) {
-        eprintln!("cmux-tui-cdp: screencast acknowledgment rejected: {error:#}");
+    if reserve_outbound_bytes(inner, text.len()).is_err() {
+        eprintln!("cmux-tui-cdp: screencast acknowledgment rejected");
         close_inner(inner, CDP_CONNECTION_UNAVAILABLE_MESSAGE);
         return;
     }

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -13,11 +13,11 @@ use std::time::{Duration, Instant};
 use anyhow::Context;
 use base64::Engine;
 use serde_json::{Value, json};
-use tungstenite::client::IntoClientRequest;
+use tungstenite::client::{IntoClientRequest, client_with_config};
 use tungstenite::http::HeaderValue;
 use tungstenite::http::header::AUTHORIZATION;
 use tungstenite::protocol::WebSocketConfig;
-use tungstenite::{Error as WsError, Message, WebSocket, client_with_config};
+use tungstenite::{Error as WsError, Message, WebSocket};
 
 /// Maximum number of pending events in each bounded CDP event queue.
 ///

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -206,6 +206,20 @@ impl CdpCloseReason {
     pub const fn public_message(self) -> &'static str {
         CDP_CONNECTION_UNAVAILABLE_MESSAGE
     }
+
+    const fn diagnostic_code(self) -> &'static str {
+        match self {
+            Self::EventReceiverClosed => "event_receiver_closed",
+            Self::TransportFailure => "transport_failure",
+            Self::SocketClosed => "socket_closed",
+            Self::EventQueueOverflow => "event_queue_overflow",
+            Self::OutboundQueueOverflow => "outbound_queue_overflow",
+            Self::ConnectionClosed => "connection_closed",
+            Self::ClientDropped => "client_dropped",
+            Self::RuntimeClosed => "runtime_closed",
+            Self::SurfaceClosed => "surface_closed",
+        }
+    }
 }
 
 impl std::fmt::Display for CdpCloseReason {
@@ -2041,12 +2055,44 @@ fn close_inner(inner: &Arc<Inner>, reason: CdpCloseReason) {
 fn close_inner_with_detail<D: std::fmt::Display>(
     inner: &Arc<Inner>,
     reason: CdpCloseReason,
-    _detail: D,
+    detail: D,
 ) {
     // Keep transport diagnostics out of the public error and event channels.
-    // The detail is intentionally not formatted here because websocket
-    // errors can contain endpoint URLs and server-provided text.
+    // The debug stream is opt-in, and the detail is reduced to a bounded,
+    // control-free message before it is emitted. This preserves operator
+    // visibility without echoing endpoint credentials or server text.
+    if cdp_debug() {
+        eprintln!(
+            "cmux-tui-cdp: {}: {}",
+            reason.diagnostic_code(),
+            redacted_transport_detail(&detail.to_string())
+        );
+    }
     close_inner(inner, reason);
+}
+
+/// Map a transport error to a fixed diagnostic class. Error text can contain
+/// bearer URLs, peer-controlled protocol strings, or local paths, so it is
+/// never copied into the diagnostic stream.
+fn redacted_transport_detail(detail: &str) -> &'static str {
+    if detail.contains("HTTP error: 401")
+        || detail.contains("HTTP error: 403")
+        || detail.contains("HTTP error: 407")
+    {
+        "authentication"
+    } else if detail.contains("WebSocket protocol error")
+        || detail.contains("Attack attempt detected")
+    {
+        "protocol"
+    } else if detail.contains("TLS error") || detail.contains("IO error") {
+        "network"
+    } else if detail.contains("Space limit exceeded") {
+        "capacity"
+    } else if detail.contains("URL error") {
+        "configuration"
+    } else {
+        "unknown"
+    }
 }
 
 struct WsEndpoint {
@@ -2344,6 +2390,27 @@ mod tests {
         assert_eq!(reason.public_message(), CDP_CONNECTION_UNAVAILABLE_MESSAGE);
         assert!(!reason.public_message().contains("ws://"));
         assert!(!reason.public_message().contains("secret"));
+    }
+
+    #[test]
+    fn transport_diagnostics_keep_only_a_safe_failure_class() {
+        let cases = [
+            (
+                "HTTP error: 401 (ws://user:secret@example.test/devtools/token)",
+                "authentication",
+            ),
+            ("WebSocket protocol error: peer supplied secret", "protocol"),
+            ("IO error: connection refused at /private/secret", "network"),
+            ("Space limit exceeded: secret payload", "capacity"),
+            ("URL error: ws://user:secret@example.test/token", "configuration"),
+            ("unexpected peer text", "unknown"),
+        ];
+        for (detail, expected) in cases {
+            let class = redacted_transport_detail(detail);
+            assert_eq!(class, expected);
+            assert!(!class.contains("secret"));
+            assert!(!class.contains("ws://"));
+        }
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-cdp/src/lib.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/lib.rs
@@ -10,7 +10,7 @@ mod client;
 pub use chrome::{BrowserMode, Chrome, ChromeLaunchOptions};
 pub use client::{
     CDP_EVENT_QUEUE_CAPACITY, CDP_EVENT_QUEUE_MAX_BYTES, CapturedFrame, CdpClient, CdpEvent,
-    CdpKeyEvent, FrameEpoch, NavigationEntry, NavigationHistory, ScreencastFrame, TargetCreated,
-    TargetInfo, discover_browser_ws_url, event_retained_bytes, is_connection_unavailable,
-    resolve_browser_ws_url,
+    CdpCloseReason, CdpKeyEvent, FrameEpoch, NavigationEntry, NavigationHistory, ScreencastFrame,
+    TargetCreated, TargetInfo, discover_browser_ws_url, event_retained_bytes,
+    is_connection_unavailable, resolve_browser_ws_url,
 };

--- a/cmux-tui/crates/cmux-tui-cdp/src/lib.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/lib.rs
@@ -10,8 +10,7 @@ mod client;
 pub use chrome::{BrowserMode, Chrome, ChromeLaunchOptions};
 pub use client::{
     CDP_CONNECTION_UNAVAILABLE_MESSAGE, CDP_EVENT_QUEUE_CAPACITY, CDP_EVENT_QUEUE_MAX_BYTES,
-    CapturedFrame, CdpClient, CdpCloseReason,
-    CdpEvent, CdpKeyEvent, FrameEpoch, NavigationEntry, NavigationHistory, ScreencastFrame,
-    TargetCreated, TargetInfo, discover_browser_ws_url, event_retained_bytes,
-    is_connection_unavailable, resolve_browser_ws_url,
+    CapturedFrame, CdpClient, CdpCloseReason, CdpEvent, CdpKeyEvent, FrameEpoch, NavigationEntry,
+    NavigationHistory, ScreencastFrame, TargetCreated, TargetInfo, discover_browser_ws_url,
+    event_retained_bytes, is_connection_unavailable, resolve_browser_ws_url,
 };

--- a/cmux-tui/crates/cmux-tui-cdp/src/lib.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/lib.rs
@@ -12,4 +12,5 @@ pub use client::{
     CDP_EVENT_QUEUE_CAPACITY, CDP_EVENT_QUEUE_MAX_BYTES, CapturedFrame, CdpClient, CdpEvent,
     CdpKeyEvent, FrameEpoch, NavigationEntry, NavigationHistory, ScreencastFrame, TargetCreated,
     TargetInfo, discover_browser_ws_url, event_retained_bytes, resolve_browser_ws_url,
+    is_connection_unavailable,
 };

--- a/cmux-tui/crates/cmux-tui-cdp/src/lib.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/lib.rs
@@ -9,8 +9,8 @@ mod client;
 
 pub use chrome::{BrowserMode, Chrome, ChromeLaunchOptions};
 pub use client::{
-    CDP_EVENT_QUEUE_CAPACITY, CDP_EVENT_QUEUE_MAX_BYTES, CapturedFrame, CdpClient, CdpEvent,
-    CdpCloseReason, CdpKeyEvent, FrameEpoch, NavigationEntry, NavigationHistory, ScreencastFrame,
+    CDP_EVENT_QUEUE_CAPACITY, CDP_EVENT_QUEUE_MAX_BYTES, CapturedFrame, CdpClient, CdpCloseReason,
+    CdpEvent, CdpKeyEvent, FrameEpoch, NavigationEntry, NavigationHistory, ScreencastFrame,
     TargetCreated, TargetInfo, discover_browser_ws_url, event_retained_bytes,
     is_connection_unavailable, resolve_browser_ws_url,
 };

--- a/cmux-tui/crates/cmux-tui-cdp/src/lib.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/lib.rs
@@ -9,7 +9,8 @@ mod client;
 
 pub use chrome::{BrowserMode, Chrome, ChromeLaunchOptions};
 pub use client::{
-    CDP_EVENT_QUEUE_CAPACITY, CDP_EVENT_QUEUE_MAX_BYTES, CapturedFrame, CdpClient, CdpCloseReason,
+    CDP_CONNECTION_UNAVAILABLE_MESSAGE, CDP_EVENT_QUEUE_CAPACITY, CDP_EVENT_QUEUE_MAX_BYTES,
+    CapturedFrame, CdpClient, CdpCloseReason,
     CdpEvent, CdpKeyEvent, FrameEpoch, NavigationEntry, NavigationHistory, ScreencastFrame,
     TargetCreated, TargetInfo, discover_browser_ws_url, event_retained_bytes,
     is_connection_unavailable, resolve_browser_ws_url,

--- a/cmux-tui/crates/cmux-tui-cdp/src/lib.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/lib.rs
@@ -11,6 +11,6 @@ pub use chrome::{BrowserMode, Chrome, ChromeLaunchOptions};
 pub use client::{
     CDP_EVENT_QUEUE_CAPACITY, CDP_EVENT_QUEUE_MAX_BYTES, CapturedFrame, CdpClient, CdpEvent,
     CdpKeyEvent, FrameEpoch, NavigationEntry, NavigationHistory, ScreencastFrame, TargetCreated,
-    TargetInfo, discover_browser_ws_url, event_retained_bytes, resolve_browser_ws_url,
-    is_connection_unavailable,
+    TargetInfo, discover_browser_ws_url, event_retained_bytes, is_connection_unavailable,
+    resolve_browser_ws_url,
 };

--- a/cmux-tui/crates/cmux-tui-core/src/browser.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/browser.rs
@@ -6365,7 +6365,7 @@ mod tests {
         runtime.shutdown();
         server.join().unwrap();
         if events.is_err() {
-            cleanup_route.close(CdpCloseReason::SurfaceClosed);
+            cleanup_route.close(cmux_tui_cdp::CdpCloseReason::SurfaceClosed);
         }
         waiter.join().unwrap();
         let (first, second) = events.expect("unregister left surface route blocked");
@@ -6452,7 +6452,7 @@ mod tests {
         )
         .unwrap();
 
-        route.close(CdpCloseReason::EventQueueOverflow);
+        route.close(cmux_tui_cdp::CdpCloseReason::EventQueueOverflow);
         closed_rx
             .recv_timeout(Duration::from_secs(1))
             .expect("closed surface route did not close its CDP target");
@@ -8116,7 +8116,7 @@ mod tests {
         );
         assert!(!browser.take_dirty(), "a rejected frame must not mark the surface dirty");
 
-        route.close(CdpCloseReason::SurfaceClosed);
+        route.close(cmux_tui_cdp::CdpCloseReason::SurfaceClosed);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/browser.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/browser.rs
@@ -5,8 +5,8 @@ use std::sync::{Arc, Condvar, Mutex, Weak};
 use std::time::{Duration, Instant};
 
 use cmux_tui_cdp::{
-    CDP_EVENT_QUEUE_CAPACITY, CapturedFrame, CdpClient, CdpEvent, CdpKeyEvent, Chrome, FrameEpoch,
-    TargetCreated, resolve_browser_ws_url,
+    CDP_EVENT_QUEUE_CAPACITY, CapturedFrame, CdpClient, CdpCloseReason, CdpEvent, CdpKeyEvent,
+    Chrome, FrameEpoch, TargetCreated, resolve_browser_ws_url,
 };
 
 use crate::browser_provider::{BrowserProviderAuthentication, BrowserProviderTargetLease};
@@ -648,7 +648,7 @@ impl SurfaceRoute {
         if state.events.len() >= CDP_EVENT_QUEUE_CAPACITY
             || event_bytes > cmux_tui_cdp::CDP_EVENT_QUEUE_MAX_BYTES - state.retained_bytes
         {
-            fail_surface_route(&mut state, "CDP surface event queue overflow");
+            fail_surface_route(&mut state, CdpCloseReason::EventQueueOverflow);
             self.ready.notify_one();
             return true;
         }
@@ -672,12 +672,12 @@ impl SurfaceRoute {
         }
     }
 
-    fn close(&self, reason: String) {
+    fn close(&self, reason: CdpCloseReason) {
         let mut state = self.state.lock().unwrap();
         if state.closed {
             return;
         }
-        fail_surface_route(&mut state, &reason);
+        fail_surface_route(&mut state, reason);
         self.ready.notify_one();
     }
 
@@ -695,9 +695,9 @@ impl SurfaceRoute {
     }
 }
 
-fn fail_surface_route(state: &mut SurfaceRouteState, reason: &str) {
+fn fail_surface_route(state: &mut SurfaceRouteState, reason: CdpCloseReason) {
     state.events.clear();
-    let event = CdpEvent::Closed(reason.to_string());
+    let event = CdpEvent::Closed(reason);
     let retained_bytes = cmux_tui_cdp::event_retained_bytes(&event);
     state.retained_bytes = retained_bytes;
     state.events.push_back(QueuedSurfaceEvent { event, retained_bytes });
@@ -906,7 +906,7 @@ impl BrowserRuntime {
         let mut routes = self.routes.lock().unwrap();
         if self.closed.load(Ordering::Acquire) {
             drop(routes);
-            route.close("browser runtime closed".to_string());
+            route.close(CdpCloseReason::RuntimeClosed);
             return route;
         }
         routes.by_session.insert(session_id.to_string(), route.clone());
@@ -923,7 +923,7 @@ impl BrowserRuntime {
             by_session.or(by_target)
         };
         if let Some(route) = route {
-            route.close("browser surface closed".to_string());
+            route.close(CdpCloseReason::SurfaceClosed);
         }
     }
 
@@ -958,7 +958,7 @@ impl BrowserRuntime {
     }
 
     pub fn shutdown(&self) {
-        close_browser_runtime(self, "browser runtime shut down".to_string());
+        close_browser_runtime(self, CdpCloseReason::RuntimeClosed);
         let _ = self.client.flush_outbound(Duration::from_secs(1));
         if let Some(chrome) = &self.chrome {
             chrome.kill();
@@ -1278,13 +1278,13 @@ fn start_router(runtime: Weak<BrowserRuntime>, events: Receiver<CdpEvent>) -> an
             }
         }
         if let Some(runtime) = runtime.upgrade() {
-            close_browser_runtime(&runtime, "CDP event channel closed".to_string());
+            close_browser_runtime(&runtime, CdpCloseReason::EventReceiverClosed);
         }
     })?;
     Ok(())
 }
 
-fn close_browser_runtime(runtime: &BrowserRuntime, reason: String) {
+fn close_browser_runtime(runtime: &BrowserRuntime, reason: CdpCloseReason) {
     let senders = {
         let mut routes = runtime.routes.lock().unwrap();
         runtime.closed.store(true, Ordering::Release);
@@ -1294,7 +1294,7 @@ fn close_browser_runtime(runtime: &BrowserRuntime, reason: String) {
         senders
     };
     for tx in senders {
-        tx.close(reason.clone());
+        tx.close(reason);
     }
 }
 
@@ -1460,7 +1460,8 @@ fn start_surface_thread(
                             && let Some(mux) = mux.upgrade()
                         {
                             mux.emit(MuxEvent::Status(format!(
-                                "cmux-browser provider disconnected: {reason}; waiting to reconnect"
+                                "cmux-browser provider disconnected: {}; waiting to reconnect",
+                                reason.public_message()
                             )));
                             mux.emit(MuxEvent::SurfaceOutput(id));
                             mux.restart_provider_browser_surface(surface.clone());
@@ -6364,7 +6365,7 @@ mod tests {
         runtime.shutdown();
         server.join().unwrap();
         if events.is_err() {
-            cleanup_route.close("test cleanup".to_string());
+            cleanup_route.close(CdpCloseReason::SurfaceClosed);
         }
         waiter.join().unwrap();
         let (first, second) = events.expect("unregister left surface route blocked");
@@ -6451,7 +6452,7 @@ mod tests {
         )
         .unwrap();
 
-        route.close("CDP surface event queue overflow".to_string());
+        route.close(CdpCloseReason::EventQueueOverflow);
         closed_rx
             .recv_timeout(Duration::from_secs(1))
             .expect("closed surface route did not close its CDP target");
@@ -8115,7 +8116,7 @@ mod tests {
         );
         assert!(!browser.take_dirty(), "a rejected frame must not mark the surface dirty");
 
-        route.close("test cleanup".to_string());
+        route.close(CdpCloseReason::SurfaceClosed);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/Cargo.toml
+++ b/cmux-tui/crates/cmux-tui/Cargo.toml
@@ -21,6 +21,7 @@ path = "src/bin/cmux-tui-hook.rs"
 [dependencies]
 ghostty-vt.workspace = true
 cmux-tui-core.workspace = true
+cmux-tui-cdp.workspace = true
 cmux-tui-machine-agent-protocol.workspace = true
 cmux-tui-machine-protocol.workspace = true
 ratatui.workspace = true

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -18,6 +18,7 @@ use std::time::{Duration, Instant};
 
 use base64::Engine;
 use cmux_tui_core::resource::FrontendProjectionPublicId;
+use cmux_tui_cdp::is_connection_unavailable;
 use cmux_tui_core::{
     BrowserFrame, BrowserSource, BrowserStatus, ClearHistoryDelivery, ClearHistoryFailure,
     DEFAULT_VIEWPORT_PANE_WIDTH, Direction, FrontendFocusTarget, FrontendJournalEvent,
@@ -8842,7 +8843,11 @@ fn run_with_machine_updates_inner(
         },
         move |error| {
             crate::client_log::error("browser-control", &error);
-            let message = localization::catalog().browser.control_unavailable();
+            let message = if is_connection_unavailable(&error) {
+                localization::catalog().browser.control_unavailable()
+            } else {
+                localization::catalog().browser.control_failed(&error.to_string())
+            };
             let _ = browser_control_tx.send(AppEvent::Mux(MuxEvent::Status(message)));
         },
     )?;

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -17,8 +17,8 @@ use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 use base64::Engine;
-use cmux_tui_core::resource::FrontendProjectionPublicId;
 use cmux_tui_cdp::is_connection_unavailable;
+use cmux_tui_core::resource::FrontendProjectionPublicId;
 use cmux_tui_core::{
     BrowserFrame, BrowserSource, BrowserStatus, ClearHistoryDelivery, ClearHistoryFailure,
     DEFAULT_VIEWPORT_PANE_WIDTH, Direction, FrontendFocusTarget, FrontendJournalEvent,

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -8841,7 +8841,8 @@ fn run_with_machine_updates_inner(
             let _ = browser_failure_tx.send(AppEvent::BrowserResizeFailed(failure));
         },
         move |error| {
-            let message = localization::catalog().browser.control_failed(&error);
+            crate::client_log::error("browser-control", &error);
+            let message = localization::catalog().browser.control_unavailable();
             let _ = browser_control_tx.send(AppEvent::Mux(MuxEvent::Status(message)));
         },
     )?;

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -17,7 +17,6 @@ use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 use base64::Engine;
-use cmux_tui_cdp::is_connection_unavailable;
 use cmux_tui_core::resource::FrontendProjectionPublicId;
 use cmux_tui_core::{
     BrowserFrame, BrowserSource, BrowserStatus, ClearHistoryDelivery, ClearHistoryFailure,
@@ -29,6 +28,7 @@ use cmux_tui_core::{
     ZoomMode, exact_split_for_pane_edge, exact_split_for_pane_edge_with_viewport, layout_screen,
     layout_screen_with_viewport, split_sides, zellij_default_pane_layout,
 };
+use cmux_tui_cdp::CDP_CONNECTION_UNAVAILABLE_MESSAGE;
 use crossbeam_channel::{Sender as SyncSender, TrySendError, bounded as sync_channel};
 use crossterm::ExecutableCommand;
 use crossterm::event::{
@@ -8843,10 +8843,18 @@ fn run_with_machine_updates_inner(
         },
         move |error| {
             crate::client_log::error("browser-control", &error);
-            let message = if is_connection_unavailable(&error) {
+            // The dispatcher exposes only a string. Match the one stable CDP
+            // classification and discard every other internal detail before
+            // creating a user-facing status event.
+            let browser = localization::catalog().browser;
+            let message = if error == CDP_CONNECTION_UNAVAILABLE_MESSAGE {
                 localization::catalog().browser.control_unavailable()
+            } else if error == browser.attach_unsupported {
+                browser.control_failed(browser.attach_unsupported)
             } else {
-                localization::catalog().browser.control_failed(&error.to_string())
+                // Keep the failure category stable. The raw error is already
+                // in the private diagnostic log and must not cross this UI boundary.
+                browser.control_failed("browser operation failed")
             };
             let _ = browser_control_tx.send(AppEvent::Mux(MuxEvent::Status(message)));
         },

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -17,6 +17,7 @@ use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 use base64::Engine;
+use cmux_tui_cdp::CDP_CONNECTION_UNAVAILABLE_MESSAGE;
 use cmux_tui_core::resource::FrontendProjectionPublicId;
 use cmux_tui_core::{
     BrowserFrame, BrowserSource, BrowserStatus, ClearHistoryDelivery, ClearHistoryFailure,
@@ -28,7 +29,6 @@ use cmux_tui_core::{
     ZoomMode, exact_split_for_pane_edge, exact_split_for_pane_edge_with_viewport, layout_screen,
     layout_screen_with_viewport, split_sides, zellij_default_pane_layout,
 };
-use cmux_tui_cdp::CDP_CONNECTION_UNAVAILABLE_MESSAGE;
 use crossbeam_channel::{Sender as SyncSender, TrySendError, bounded as sync_channel};
 use crossterm::ExecutableCommand;
 use crossterm::event::{
@@ -8846,7 +8846,7 @@ fn run_with_machine_updates_inner(
             // The dispatcher exposes only a string. Match the one stable CDP
             // classification and discard every other internal detail before
             // creating a user-facing status event.
-            let browser = localization::catalog().browser;
+            let browser = &localization::catalog().browser;
             let message = if error == CDP_CONNECTION_UNAVAILABLE_MESSAGE {
                 localization::catalog().browser.control_unavailable()
             } else if error == browser.attach_unsupported {

--- a/cmux-tui/crates/cmux-tui/src/localization.rs
+++ b/cmux-tui/crates/cmux-tui/src/localization.rs
@@ -249,6 +249,7 @@ pub(crate) struct ShortcutMessages {
 pub(crate) struct BrowserMessages {
     failed_prefix: &'static str,
     control_failed: &'static str,
+    control_unavailable: &'static str,
     not_responding: &'static str,
     resize_recovery: &'static str,
     new_page_verification_prefix: &'static str,
@@ -267,6 +268,10 @@ pub(crate) struct BrowserMessages {
 impl BrowserMessages {
     pub(crate) fn control_failed(&self, error: &str) -> String {
         self.control_failed.replace("{error}", error)
+    }
+
+    pub(crate) fn control_unavailable(&self) -> String {
+        self.control_failed.replace("{error}", self.control_unavailable)
     }
 
     pub(crate) fn loading(&self, url: &str) -> String {
@@ -1337,6 +1342,7 @@ edits shell files. Authenticate with the configured host before retrying.
     browser: BrowserMessages {
         failed_prefix: "browser failed: ",
         control_failed: "browser command failed: {error}",
+        control_unavailable: "browser connection unavailable; retry the command",
         not_responding: "browser failed: browser is not responding",
         resize_recovery: "browser failed: browser resize recovery failed; reload to retry",
         new_page_verification_prefix: "browser failed: could not verify new page pixels: ",
@@ -1983,6 +1989,7 @@ cmux machine-agent - ローカルの cmux セッションをリモートサー�
     browser: BrowserMessages {
         failed_prefix: "ブラウザでエラーが発生しました: ",
         control_failed: "ブラウザ操作に失敗しました: {error}",
+        control_unavailable: "ブラウザ接続を利用できません。コマンドを再試行してください",
         not_responding: "ブラウザが応答していません",
         resize_recovery: "ブラウザのサイズ変更を復旧できませんでした。再読み込みして再試行してください",
         new_page_verification_prefix: "新しいページの表示を確認できませんでした: ",


### PR DESCRIPTION
## Summary
- make CDP close reasons typed and stable
- drop raw endpoint and socket details before public events
- keep UI failures generic while preserving safe attach-unsupported text

## Verification
- hosted TUI verification run from the exact head: https://github.com/manaflow-ai/cmux/actions/runs/33199611510
- red test commit proved raw close detail reached the public event path

## Review trigger
Please review the typed error boundary and the absence of endpoint disclosure.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790535414&installation_model_id=21920&pr_number=11143&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11143&signature=d193c3acf6f34c4d8535901a676a9e168fbbbfb077fe7d046e61691097f114e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps CDP connection close reasons typed and sanitized so raw endpoint and socket details never reach public events or user-facing errors.

- Close events now carry a typed `CdpCloseReason` instead of a raw string, and every reason maps to the same stable public message.
- Transport diagnostics are reduced to fixed failure classes (authentication, network, etc.) before reaching the opt-in debug stream; queue-overflow diagnostics never cross crate or UI boundaries.
- The TUI error mapper recognizes only the stable message, keeping the attach-unsupported text while genericizing every other failure.

<sup>Written for commit 969fe125f505f3c20f5e20338791385afbddb8a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

