### PR TITLE
fix(custom-sidebar): complete nested context-menu correctness

### DIFF
--- a/Packages/macOS/CmuxSwiftRenderUI/Sources/CmuxSwiftRenderUI/Rendering/RenderNodeContextMenuBuilder.swift
+++ b/Packages/macOS/CmuxSwiftRenderUI/Sources/CmuxSwiftRenderUI/Rendering/RenderNodeContextMenuBuilder.swift
@@ -32,7 +32,7 @@ struct RenderNodeContextMenuBuilder {
         // Enablement is decided by the IR (`.disabled`), not responder-chain
         // validation, so autoenable would re-disable every targeted item.
         menu.autoenablesItems = false
-        append(nodes, to: menu, inheritedDisabled: false)
+        _ = append(nodes, to: menu, inheritedDisabled: false)
         return menu
     }
 
@@ -78,7 +78,9 @@ struct RenderNodeContextMenuBuilder {
         return false
     }
 
-    private func append(_ nodes: [RenderNode], to menu: NSMenu, inheritedDisabled: Bool) {
+    @discardableResult
+    private func append(_ nodes: [RenderNode], to menu: NSMenu, inheritedDisabled: Bool) -> Bool {
+        var emitted = false
         for node in nodes {
             // SwiftUI propagates `.disabled(true)` from a container down the
             // environment; a child cannot re-enable inside a disabled ancestor.
@@ -89,45 +91,50 @@ struct RenderNodeContextMenuBuilder {
             case .menu:
                 if let item = submenuItem(for: node, disabled: disabled) {
                     menu.addItem(item)
+                    emitted = true
                 }
             case .button:
                 menu.addItem(actionItem(for: node, disabled: disabled))
+                emitted = true
             case .text, .label:
                 // Informational rows render like SwiftUI menu text: visible
                 // but inert (unless `.onTapGesture` gave the node an action).
                 menu.addItem(actionItem(for: node, disabled: disabled))
+                emitted = true
             case .vstack, .hstack, .zstack, .lazyVStack, .lazyHStack, .group,
                  .list, .hscroll, .grid, .gridRow, .lazyVGrid, .lazyHGrid,
                  .viewThatFits, .hsplit, .reorderable:
-                append(node.children, to: menu, inheritedDisabled: disabled)
+                emitted = append(node.children, to: menu, inheritedDisabled: disabled) || emitted
             case .section:
                 if let header = node.text, !header.isEmpty {
                     let item = NSMenuItem(title: header, action: nil, keyEquivalent: "")
                     item.isEnabled = false
                     menu.addItem(item)
+                    emitted = true
                 }
-                append(node.children, to: menu, inheritedDisabled: disabled)
+                emitted = append(node.children, to: menu, inheritedDisabled: disabled) || emitted
             default:
                 // Shapes, images, gradients, progress, spacers: no NSMenu
                 // representation. Fall back to a text-only row when text (or
                 // a tap action) exists rather than re-hosting SwiftUI.
                 if node.action != nil || !renderNodePlainText(of: node).isEmpty {
                     menu.addItem(actionItem(for: node, disabled: disabled))
+                    emitted = true
                 }
             }
         }
+        return emitted
     }
 
     /// A `Menu("…") { … }` node as an item with a recursive submenu. A
     /// disabled menu disables its item and every descendant, matching SwiftUI.
     private func submenuItem(for node: RenderNode, disabled: Bool) -> NSMenuItem? {
-        guard hasPresentableItems(in: node.children) else { return nil }
         let title = node.text ?? ""
-        let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
-        item.isEnabled = !disabled
         let submenu = NSMenu(title: title)
         submenu.autoenablesItems = false
-        append(node.children, to: submenu, inheritedDisabled: disabled)
+        guard append(node.children, to: submenu, inheritedDisabled: disabled) else { return nil }
+        let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+        item.isEnabled = !disabled
         item.submenu = submenu
         return item
     }
@@ -160,7 +167,11 @@ struct RenderNodeContextMenuBuilder {
 /// Mirrors `RenderNodeView`'s `.disabled` semantics: disabled only when
 /// the argument explicitly resolves to `true`.
 private func isRenderNodeDisabled(_ node: RenderNode) -> Bool {
-    node.modifiers.contains { $0.name == "disabled" && $0.firstValue == "true" }
+    node.modifiers.contains { $0.name == "disabled" && cleanRenderToken($0.firstValue) == "true" }
+}
+
+private func cleanRenderToken(_ token: String?) -> String? {
+    token?.trimmingCharacters(in: CharacterSet(charactersIn: ".\" "))
 }
 
 /// Maps a `.keyboardShortcut` modifier to the item's key-equivalent hint.
@@ -194,6 +205,7 @@ private func renderNodeNSKeyEquivalent(_ token: String?) -> String? {
     case "downarrow": return String(UnicodeScalar(NSDownArrowFunctionKey)!)
     case "leftarrow": return String(UnicodeScalar(NSLeftArrowFunctionKey)!)
     case "rightarrow": return String(UnicodeScalar(NSRightArrowFunctionKey)!)
+    case "deleteforward", "home", "end", "pageup", "pagedown", "clear": return nil
     default: return raw.count == 1 ? raw.lowercased() : nil
     }
 }


### PR DESCRIPTION
Follow-up for https://github.com/manaflow-ai/cmux/pull/11130.

Build nested menus once and prune empty trees. Normalize disabled tokens and align unsupported key-equivalent handling. This removes repeated subtree scans and avoids unusable native menu items.

Verification: `swift test --package-path Packages/macOS/CmuxSwiftRenderUI --filter RenderNodeMenuBuilderTests` (16 passed). Exact hosted gate and canonical autoreview are pending.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790536667&installation_model_id=21920&pr_number=11145&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11145&signature=0b6d7bd8ce7499f2011bf8bc0d8eb0f1049da078c4fe6a41b244c3f7c4e74dfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes nested context-menu correctness so empty submenus are pruned and disabled state is normalized across render nodes. Previously, the builder pre-scanned subtrees and could produce unusable empty submenu items; now it builds each menu in one pass and only adds the item if children were emitted. Also trims disabled tokens and ignores unsupported key equivalents.

<sup>Written for commit c23328f29a1708316cf5d942a50836bd2a9b36ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

