### PR TITLE
fix(cmux-tui): back off connection-level admission errors

### DIFF
--- a/cmux-tui/crates/cmux-relay/src/admission.rs
+++ b/cmux-tui/crates/cmux-relay/src/admission.rs
@@ -63,7 +63,6 @@ impl Listener for AdmissionListener {
                         address,
                     );
                 }
-                Err(error) if is_connection_error(&error) => continue,
                 Err(_) => {
                     // Back off transient listener failures without a busy loop. The sleep
                     // future is cancellation-safe: dropping the listener drops this future.
@@ -238,15 +237,6 @@ impl AsyncWrite for AdmissionStream {
     ) -> Poll<Result<(), io::Error>> {
         Pin::new(&mut self.inner).poll_shutdown(context)
     }
-}
-
-fn is_connection_error(error: &io::Error) -> bool {
-    matches!(
-        error.kind(),
-        io::ErrorKind::ConnectionRefused
-            | io::ErrorKind::ConnectionAborted
-            | io::ErrorKind::ConnectionReset
-    )
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Follow-up for https://github.com/manaflow-ai/cmux/pull/11140.

Route refused, aborted, and reset listener errors through the bounded cancellable exponential backoff. Add regression coverage to prevent a hot accept loop. Exact hosted gate and canonical autoreview are pending.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790536671&installation_model_id=21920&pr_number=11146&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11146&signature=246eefd27cd9f2ede89611fe4644a39482c5ab9f9c752527d015be04d77239b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes connection-level admission errors through the bounded cancellable exponential backoff instead of retrying them immediately. Removes the special-case that treated refused, aborted, and reset connections as transient, preventing a hot accept loop.

<sup>Written for commit 44e8e39fff831de62818c9ef285f01bd9db90f20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

