### PR TITLE
fix(relay): correct rate-limit source and error type ownership

### DIFF
--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerError.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerError.swift
@@ -2,15 +2,9 @@ import Foundation
 
 /// Structured error returned by the Iroh trust broker.
 struct CmxIrohTrustBrokerError: Decodable {
-    enum Source: String, Decodable {
-        case ingressIP = "ingress_ip"
-        case deviceBudget = "device_budget"
-        case authProvider = "auth_provider"
-    }
-
     let error: String
     /// Which enforcement layer produced a 429.
-    let source: Source?
+    let source: CmxIrohTrustBrokerErrorSource?
 
     private enum CodingKeys: String, CodingKey {
         case error
@@ -23,6 +17,6 @@ struct CmxIrohTrustBrokerError: Decodable {
         // Keep the coarse error code when an untrusted or newer server sends
         // an unknown or malformed source.
         source = (try? container.decode(String.self, forKey: .source))
-            .flatMap(Source.init(rawValue:))
+            .flatMap(CmxIrohTrustBrokerErrorSource.init(rawValue:))
     }
 }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerErrorSource.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerErrorSource.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+enum CmxIrohTrustBrokerErrorSource: String, Decodable {
+    case ingressIP = "ingress_ip"
+    case accountBudget = "account_budget"
+    case deviceBudget = "device_budget"
+    case authProvider = "auth_provider"
+}

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohTrustBrokerClientNetworkTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohTrustBrokerClientNetworkTests.swift
@@ -54,6 +54,10 @@ extension CmxIrohTrustBrokerClientTests {
                 "rate_limited:device_budget"
             ),
             (
+                #"{"error":"rate_limited","source":"account_budget"}"#,
+                "rate_limited:account_budget"
+            ),
+            (
                 #"{"error":"rate_limited","source":"auth_provider"}"#,
                 "rate_limited:auth_provider"
             ),

--- a/web/services/relay/errors.ts
+++ b/web/services/relay/errors.ts
@@ -65,7 +65,11 @@ export class RelayAuthenticationError extends Data.TaggedError(
 
 /** Which enforcement layer produced a 429; diagnosing the 08-27 incident
  * required hours of elimination because all three were indistinguishable. */
-export type RelayRateLimitSource = "ingress_ip" | "device_budget" | "auth_provider";
+export type RelayRateLimitSource =
+  | "ingress_ip"
+  | "account_budget"
+  | "device_budget"
+  | "auth_provider";
 
 
 export class RelaySigningError extends Data.TaggedError("RelaySigningError")<{

--- a/web/services/relay/http.ts
+++ b/web/services/relay/http.ts
@@ -66,7 +66,9 @@ export function enforceRelayRateLimit(input: {
       if (rateLimited || error === "blocked") {
         const source: RelayRateLimitSource = input.rateLimitKey === null
           ? "ingress_ip"
-          : "device_budget";
+          : input.devicePartition
+            ? "device_budget"
+            : "account_budget";
         console.warn("relay.rate_limited", { source });
         const retryAfterSeconds = input.retryAfterSeconds;
         return Effect.fail(new RelayRateLimitError({

--- a/web/tests/relay-preferences-route.test.ts
+++ b/web/tests/relay-preferences-route.test.ts
@@ -157,6 +157,7 @@ describe("/api/relay/preferences", () => {
       checkRateLimit: async () => ({ rateLimited: true }),
     }));
     expect(limited.status).toBe(429);
+    expect(await limited.json()).toEqual({ error: "rate_limited", source: "account_budget" });
   });
 
   test("rejects unauthenticated callers", async () => {


### PR DESCRIPTION
Follow-up for https://github.com/manaflow-ai/cmux/pull/11060.

Label account-scoped preference limits as account_budget and isolate the Swift error source type. Focused Bun tests are blocked by a missing local @vercel/firewall dependency; hosted gate and canonical autoreview are pending.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11147"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790536673&installation_model_id=21920&pr_number=11147&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11147&signature=a44f3c744574186b1933fe1fbe2ebaad51f89740f749753ed1acef6a6d9be78a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects rate-limit source labeling so account-scoped preference limits report `account_budget` instead of `device_budget`, and isolates the Swift error source type into its own enum `CmxIrohTrustBrokerErrorSource`.

Adds test coverage for the new `account_budget` source in both Swift response decoding and the relay preferences route.

<sup>Written for commit af43160693b3c8c138d0da063addc3853ccf6c55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

