### PR TITLE
fix(tui): recover agent roster from invalid journal cursors

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -1110,6 +1110,13 @@ struct AgentRosterHost {
     cursor: u64,
 }
 
+/// Only a cursor-range violation is safe to repair by replaying from the
+/// journal floor. I/O, decoding, and integrity failures must not be treated
+/// as derived-state damage because that could hide a broken source journal.
+fn is_recoverable_agent_roster_cursor_error(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| cause.to_string().starts_with("cursor.invalid:"))
+}
+
 /// Restore the roster from its persisted snapshot and fold the journal tail
 /// committed after the cursor. A reducer-version mismatch discards the
 /// snapshot and re-folds from the journal head. Deltas produced here are
@@ -1137,19 +1144,27 @@ fn restore_agent_roster(registry: &WorkspaceRegistry) -> anyhow::Result<AgentRos
     loop {
         let page = match registry.session_journal_after(host.cursor, 512) {
             Ok(page) => page,
-            Err(error) if !reset_after_error && host.cursor != 0 => {
+            Err(error)
+                if !reset_after_error
+                    && host.cursor != 0
+                    && is_recoverable_agent_roster_cursor_error(&error) =>
+            {
                 // A persisted cursor can point past the head or before the
                 // retained journal floor. Do not fail startup on corrupt
                 // derived state. Reset and make one best-effort replay from
                 // the journal head; if the journal itself has a gap, return
                 // an empty, safe roster and let future events rebuild it.
-                eprintln!("cmux-tui: resetting invalid agent roster cursor: {error}");
+                eprintln!("cmux-tui: resetting invalid agent roster cursor");
                 host = AgentRosterHost::default();
                 reset_after_error = true;
                 continue;
             }
-            Err(error) => {
-                eprintln!("cmux-tui: agent journal replay unavailable after cursor reset: {error}");
+            Err(_error) => {
+                // The roster is advisory, so a damaged journal must not
+                // prevent the terminal from starting. Keep this diagnostic
+                // class-only: database paths and decoded payloads are not
+                // safe to place in shared logs.
+                eprintln!("cmux-tui: agent journal replay unavailable");
                 return Ok(AgentRosterHost::default());
             }
         };
@@ -17429,6 +17444,19 @@ mod tests {
 
     fn test_mux() -> Arc<Mux> {
         Mux::new_for_test("test", SurfaceOptions::default())
+    }
+
+    #[test]
+    fn roster_cursor_recovery_accepts_only_explicit_cursor_errors() {
+        assert!(is_recoverable_agent_roster_cursor_error(&anyhow::anyhow!(
+            "cursor.invalid: journal sequence 9 is ahead of 2"
+        )));
+        assert!(!is_recoverable_agent_roster_cursor_error(&anyhow::anyhow!(
+            "journal segment digest is invalid"
+        )));
+        assert!(!is_recoverable_agent_roster_cursor_error(&anyhow::anyhow!(
+            "database is locked"
+        )));
     }
 
     /// A machine resume reconnects every hosted terminal at once. Checkpoint

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -64,8 +64,10 @@ use crate::workspace_registry::{
     RegistryBrowser, RegistryBrowserReconnect, RegistryCommit, RegistryLayoutNode,
     RegistrySnapshot, RegistryTab, RegistryTerminal, RegistryViewport, RegistryWorkspace,
     ResourceChange, ResourceEffectOutcome, ResourceEffectPreparation, ResourcePatch,
-    ResourcePatchCommit, ResourceTopologySnapshot, ResourceWorkspaceLedger, TerminalLifecycle,
-    TerminalOnExit, TerminalRegistrySnapshot, WorkspaceMutation, WorkspaceRegistry,
+<<<<<<< HEAD
+    ResourcePatchCommit, ResourceTopologySnapshot, ResourceWorkspaceLedger, SessionJournalCursorError,
+    TerminalLifecycle, TerminalOnExit, TerminalRegistrySnapshot, WorkspaceMutation,
+    WorkspaceRegistry,
 };
 use crate::{
     PairingChallenge, PairingDecision, PairingError, PaneId, ScreenId, SplitDir, SplitId,
@@ -1110,13 +1112,6 @@ struct AgentRosterHost {
     cursor: u64,
 }
 
-/// Only a cursor-range violation is safe to repair by replaying from the
-/// journal floor. I/O, decoding, and integrity failures must not be treated
-/// as derived-state damage because that could hide a broken source journal.
-fn is_recoverable_agent_roster_cursor_error(error: &anyhow::Error) -> bool {
-    error.chain().any(|cause| cause.to_string().starts_with("cursor.invalid:"))
-}
-
 /// Restore the roster from its persisted snapshot and fold the journal tail
 /// committed after the cursor. A reducer-version mismatch discards the
 /// snapshot and re-folds from the journal head. Deltas produced here are
@@ -1147,26 +1142,25 @@ fn restore_agent_roster(registry: &WorkspaceRegistry) -> anyhow::Result<AgentRos
             Err(error)
                 if !reset_after_error
                     && host.cursor != 0
-                    && is_recoverable_agent_roster_cursor_error(&error) =>
+                    && error.downcast_ref::<SessionJournalCursorError>().is_some() =>
             {
                 // A persisted cursor can point past the head or before the
                 // retained journal floor. Do not fail startup on corrupt
                 // derived state. Reset and make one best-effort replay from
                 // the journal head; if the journal itself has a gap, return
                 // an empty, safe roster and let future events rebuild it.
-                eprintln!("cmux-tui: resetting invalid agent roster cursor");
+                eprintln!("cmux-tui: resetting invalid agent roster cursor: {error}");
                 host = AgentRosterHost::default();
                 reset_after_error = true;
                 continue;
             }
-            Err(_error) => {
-                // The roster is advisory, so a damaged journal must not
-                // prevent the terminal from starting. Keep this diagnostic
-                // class-only: database paths and decoded payloads are not
-                // safe to place in shared logs.
-                eprintln!("cmux-tui: agent journal replay unavailable");
+            Err(error)
+                if error.downcast_ref::<SessionJournalCursorError>().is_some() =>
+            {
+                eprintln!("cmux-tui: agent journal replay unavailable after cursor reset: {error}");
                 return Ok(AgentRosterHost::default());
             }
+            Err(error) => return Err(error.context("restore agent roster from session journal")),
         };
         if page.records.is_empty() {
             break;
@@ -17446,19 +17440,6 @@ mod tests {
         Mux::new_for_test("test", SurfaceOptions::default())
     }
 
-    #[test]
-    fn roster_cursor_recovery_accepts_only_explicit_cursor_errors() {
-        assert!(is_recoverable_agent_roster_cursor_error(&anyhow::anyhow!(
-            "cursor.invalid: journal sequence 9 is ahead of 2"
-        )));
-        assert!(!is_recoverable_agent_roster_cursor_error(&anyhow::anyhow!(
-            "journal segment digest is invalid"
-        )));
-        assert!(!is_recoverable_agent_roster_cursor_error(&anyhow::anyhow!(
-            "database is locked"
-        )));
-    }
-
     /// A machine resume reconnects every hosted terminal at once. Checkpoint
     /// capture can lose its consistency race while those reconnects append to
     /// the journal, but the skipped optimization is recovered by replaying
@@ -22485,6 +22466,28 @@ mod tests {
         assert_eq!(host.roster.entries.get(terminal_id.as_str()).unwrap().state, "idle");
 
         std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn agent_roster_ahead_cursor_rebuilds_from_retained_journal() {
+        use crate::journal_reducers::{
+            AGENT_ROSTER_REDUCER_ID, AGENT_ROSTER_REDUCER_VERSION, AgentRoster,
+        };
+
+        let registry = WorkspaceRegistry::in_memory("roster-ahead").unwrap();
+        let snapshot = AgentRoster::default().snapshot().to_string();
+        registry
+            .put_journal_reducer_state(
+                AGENT_ROSTER_REDUCER_ID,
+                AGENT_ROSTER_REDUCER_VERSION,
+                42,
+                &snapshot,
+            )
+            .unwrap();
+
+        let host = restore_agent_roster(&registry).unwrap();
+        assert_eq!(host.cursor, 0, "an ahead cursor must be repaired to the journal head");
+        assert!(host.roster.entries.is_empty());
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -65,9 +65,8 @@ use crate::workspace_registry::{
     RegistrySnapshot, RegistryTab, RegistryTerminal, RegistryViewport, RegistryWorkspace,
     ResourceChange, ResourceEffectOutcome, ResourceEffectPreparation, ResourcePatch,
     ResourcePatchCommit, ResourceTopologySnapshot, ResourceWorkspaceLedger,
-    SessionJournalCursorError,
-    TerminalLifecycle, TerminalOnExit, TerminalRegistrySnapshot, WorkspaceMutation,
-    WorkspaceRegistry,
+    SessionJournalCursorError, TerminalLifecycle, TerminalOnExit, TerminalRegistrySnapshot,
+    WorkspaceMutation, WorkspaceRegistry,
 };
 use crate::{
     PairingChallenge, PairingDecision, PairingError, PaneId, ScreenId, SplitDir, SplitId,

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -64,8 +64,8 @@ use crate::workspace_registry::{
     RegistryBrowser, RegistryBrowserReconnect, RegistryCommit, RegistryLayoutNode,
     RegistrySnapshot, RegistryTab, RegistryTerminal, RegistryViewport, RegistryWorkspace,
     ResourceChange, ResourceEffectOutcome, ResourceEffectPreparation, ResourcePatch,
-<<<<<<< HEAD
-    ResourcePatchCommit, ResourceTopologySnapshot, ResourceWorkspaceLedger, SessionJournalCursorError,
+    ResourcePatchCommit, ResourceTopologySnapshot, ResourceWorkspaceLedger,
+    SessionJournalCursorError,
     TerminalLifecycle, TerminalOnExit, TerminalRegistrySnapshot, WorkspaceMutation,
     WorkspaceRegistry,
 };
@@ -1135,32 +1135,31 @@ fn restore_agent_roster(registry: &WorkspaceRegistry) -> anyhow::Result<AgentRos
         _ => AgentRosterHost::default(),
     };
     let started_at = host.cursor;
-    let mut reset_after_error = false;
+    let mut recovered_cursor = false;
     loop {
         let page = match registry.session_journal_after(host.cursor, 512) {
             Ok(page) => page,
-            Err(error)
-                if !reset_after_error
-                    && host.cursor != 0
-                    && error.downcast_ref::<SessionJournalCursorError>().is_some() =>
-            {
+            Err(error) => {
+                let Some(cursor_error) = error.downcast_ref::<SessionJournalCursorError>() else {
+                    return Err(error.context("restore agent roster from session journal"));
+                };
+                if recovered_cursor {
+                    return Err(error.context("restore agent roster after cursor recovery"));
+                }
                 // A persisted cursor can point past the head or before the
-                // retained journal floor. Do not fail startup on corrupt
-                // derived state. Reset and make one best-effort replay from
-                // the journal head; if the journal itself has a gap, return
-                // an empty, safe roster and let future events rebuild it.
-                eprintln!("cmux-tui: resetting invalid agent roster cursor: {error}");
-                host = AgentRosterHost::default();
-                reset_after_error = true;
+                // retained journal floor. Rebuild from a valid boundary,
+                // preserving ordinary I/O, decode, and corruption errors.
+                host = match *cursor_error {
+                    SessionJournalCursorError::Ahead { .. } => AgentRosterHost::default(),
+                    SessionJournalCursorError::Gap { first_retained, .. } => AgentRosterHost {
+                        roster: AgentRoster::default(),
+                        cursor: first_retained.saturating_sub(1),
+                    },
+                };
+                recovered_cursor = true;
+                eprintln!("cmux-tui: recovering invalid agent roster cursor: {error}");
                 continue;
             }
-            Err(error)
-                if error.downcast_ref::<SessionJournalCursorError>().is_some() =>
-            {
-                eprintln!("cmux-tui: agent journal replay unavailable after cursor reset: {error}");
-                return Ok(AgentRosterHost::default());
-            }
-            Err(error) => return Err(error.context("restore agent roster from session journal")),
         };
         if page.records.is_empty() {
             break;

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -1133,8 +1133,26 @@ fn restore_agent_roster(registry: &WorkspaceRegistry) -> anyhow::Result<AgentRos
         _ => AgentRosterHost::default(),
     };
     let started_at = host.cursor;
+    let mut reset_after_error = false;
     loop {
-        let page = registry.session_journal_after(host.cursor, 512)?;
+        let page = match registry.session_journal_after(host.cursor, 512) {
+            Ok(page) => page,
+            Err(error) if !reset_after_error && host.cursor != 0 => {
+                // A persisted cursor can point past the head or before the
+                // retained journal floor. Do not fail startup on corrupt
+                // derived state. Reset and make one best-effort replay from
+                // the journal head; if the journal itself has a gap, return
+                // an empty, safe roster and let future events rebuild it.
+                eprintln!("cmux-tui: resetting invalid agent roster cursor: {error}");
+                host = AgentRosterHost::default();
+                reset_after_error = true;
+                continue;
+            }
+            Err(error) => {
+                eprintln!("cmux-tui: agent journal replay unavailable after cursor reset: {error}");
+                return Ok(AgentRosterHost::default());
+            }
+        };
         if page.records.is_empty() {
             break;
         }

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -22489,6 +22489,42 @@ mod tests {
     }
 
     #[test]
+    fn agent_roster_gap_fails_closed_without_complete_snapshot() {
+        use crate::journal_reducers::{
+            AGENT_ROSTER_REDUCER_ID, AGENT_ROSTER_REDUCER_VERSION, AgentRoster,
+        };
+
+        let registry = WorkspaceRegistry::in_memory("roster-gap").unwrap();
+        let snapshot = AgentRoster::default().snapshot().to_string();
+        registry
+            .put_journal_reducer_state(
+                AGENT_ROSTER_REDUCER_ID,
+                AGENT_ROSTER_REDUCER_VERSION,
+                0,
+                &snapshot,
+            )
+            .unwrap();
+        registry
+            .connection
+            .execute(
+                "INSERT INTO journal_segments(
+                   segment_id, start_sequence, end_sequence, record_count, codec, content,
+                   uncompressed_bytes, sha256, sealed_at_ms
+                 ) VALUES(?1, 3, 3, 1, 'test', ?2, 1, ?3, 1)",
+                rusqlite::params!["roster-gap-segment", vec![0_u8], vec![0_u8; 32]],
+            )
+            .unwrap();
+
+        let error = restore_agent_roster(&registry).unwrap_err();
+        assert!(error.to_string().contains("complete reducer snapshot"));
+        let (_, cursor, _) = registry
+            .journal_reducer_state(AGENT_ROSTER_REDUCER_ID)
+            .unwrap()
+            .unwrap();
+        assert_eq!(cursor, 0, "failed recovery must leave the durable snapshot untouched");
+    }
+
+    #[test]
     fn failed_raw_agent_report_rolls_back_projection_memory_revision_and_event() {
         let mux = test_mux();
         let surface = mux.new_workspace(None, None).unwrap();

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -1142,22 +1142,32 @@ fn restore_agent_roster(registry: &WorkspaceRegistry) -> anyhow::Result<AgentRos
                 let Some(cursor_error) = error.downcast_ref::<SessionJournalCursorError>() else {
                     return Err(error.context("restore agent roster from session journal"));
                 };
-                if recovered_cursor {
-                    return Err(error.context("restore agent roster after cursor recovery"));
+                match *cursor_error {
+                    SessionJournalCursorError::Ahead { .. } => {
+                        if recovered_cursor {
+                            return Err(error.context("restore agent roster after cursor recovery"));
+                        }
+                        // A persisted cursor can point past the head. Rebuild
+                        // from the journal head, preserving ordinary I/O,
+                        // decode, and corruption errors.
+                        host = AgentRosterHost::default();
+                        recovered_cursor = true;
+                        eprintln!("cmux-tui: recovering invalid agent roster cursor: {error}");
+                        continue;
+                    }
+                    SessionJournalCursorError::Gap { requested, first_retained } => {
+                        // A retained-history gap means the snapshot does not
+                        // cover the records needed to derive the roster. A
+                        // suffix-only replay would silently drop agents and
+                        // claim a successful recovery. Keep the durable
+                        // snapshot untouched and fail closed so the caller can
+                        // surface the recovery failure and preserve evidence.
+                        return Err(anyhow::anyhow!(
+                            "cannot restore agent roster: journal history before sequence {first_retained} "
+                                "was compacted (snapshot cursor {requested}); a complete reducer snapshot is required"
+                        ));
+                    }
                 }
-                // A persisted cursor can point past the head or before the
-                // retained journal floor. Rebuild from a valid boundary,
-                // preserving ordinary I/O, decode, and corruption errors.
-                host = match *cursor_error {
-                    SessionJournalCursorError::Ahead { .. } => AgentRosterHost::default(),
-                    SessionJournalCursorError::Gap { first_retained, .. } => AgentRosterHost {
-                        roster: AgentRoster::default(),
-                        cursor: first_retained.saturating_sub(1),
-                    },
-                };
-                recovered_cursor = true;
-                eprintln!("cmux-tui: recovering invalid agent roster cursor: {error}");
-                continue;
             }
         };
         if page.records.is_empty() {

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -84,7 +84,7 @@ use session_journal::{
     append_resource_journal_record, create_session_journal_schema,
     migrate_resource_events_to_session_journal,
 };
-pub(crate) use session_journal::{SessionJournalReader, unix_epoch_ms};
+pub(crate) use session_journal::{SessionJournalCursorError, SessionJournalReader, unix_epoch_ms};
 
 // Schema 9 shipped independently on the journal and multiview development
 // branches. Schema 10 shipped the journal extensions. Version 11 is the first

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
@@ -1348,7 +1348,7 @@ fn archived_records_after(
         } else {
             anyhow::ensure!(
                 start_sequence <= sequence.saturating_add(1),
-                "journal segments contain a gap before sequence {start_sequence}"
+                "cursor.invalid: journal retention begins at sequence {start_sequence}"
             );
         }
         previous_end = Some(end_sequence);

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
@@ -2100,6 +2100,27 @@ mod tests {
     }
 
     #[test]
+    fn malformed_retained_segment_is_not_classified_as_cursor_repairable() {
+        let registry = WorkspaceRegistry::in_memory("cursor-corrupt").unwrap();
+        registry
+            .connection
+            .execute(
+                "INSERT INTO journal_segments(
+                   segment_id, start_sequence, end_sequence, record_count, codec, content,
+                   uncompressed_bytes, sha256, sealed_at_ms
+                 ) VALUES(?1, 1, 1, 1, 'test', ?2, 1, ?3, 1)",
+                rusqlite::params!["corrupt-segment", vec![0_u8], vec![0_u8; 32]],
+            )
+            .unwrap();
+
+        let error = registry.session_journal_after(0, 1).unwrap_err();
+        assert!(
+            error.downcast_ref::<SessionJournalCursorError>().is_none(),
+            "segment corruption must propagate instead of triggering a cursor reset"
+        );
+    }
+
+    #[test]
     fn persistent_reader_observes_commits_on_an_independent_connection() {
         let root = std::env::temp_dir().join(format!("cmux-journal-reader-{}", new_uuid_v4()));
         let mut registry = WorkspaceRegistry::open(&root, "reader").unwrap();

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
@@ -131,6 +131,32 @@ pub struct SessionJournalPage {
     pub records: Vec<SessionJournalRecord>,
 }
 
+/// A journal cursor can be unrecoverable because it points beyond the
+/// current head or before the retained history. These are the only replay
+/// errors that a derived reducer may repair by rebuilding from the head.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SessionJournalCursorError {
+    Ahead { requested: u64, head: u64 },
+    Gap { requested: u64, first_retained: u64 },
+}
+
+impl std::fmt::Display for SessionJournalCursorError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Ahead { requested, head } => write!(
+                formatter,
+                "cursor.invalid: journal sequence {requested} is ahead of {head}"
+            ),
+            Self::Gap { requested, first_retained } => write!(
+                formatter,
+                "cursor.gap: journal history before sequence {first_retained} is no longer retained after {requested}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SessionJournalCursorError {}
+
 pub(crate) struct SessionJournalSubjectPage {
     pub(crate) head_sequence: u64,
     pub(crate) scanned_through: u64,
@@ -1054,10 +1080,20 @@ pub(super) fn query_session_journal_after(
     )?;
     let head_sequence =
         u64::try_from(head_sequence).context("journal head sequence is negative")?;
-    anyhow::ensure!(
-        sequence <= head_sequence,
-        "cursor.invalid: journal sequence {sequence} is ahead of {head_sequence}"
-    );
+    if sequence > head_sequence {
+        return Err(anyhow::Error::new(SessionJournalCursorError::Ahead {
+            requested: sequence,
+            head: head_sequence,
+        }));
+    }
+    if let Some(first_retained) = first_retained_journal_sequence(connection)?
+        && sequence.saturating_add(1) < first_retained
+    {
+        return Err(anyhow::Error::new(SessionJournalCursorError::Gap {
+            requested: sequence,
+            first_retained,
+        }));
+    }
     let mut records = archived_records_after(connection, sequence, limit)?;
     if records.len() >= limit {
         records.truncate(limit);
@@ -1101,6 +1137,21 @@ pub(super) fn query_session_journal_after(
         "session journal contains a gap after sequence {sequence}"
     );
     Ok(SessionJournalPage { head_sequence, records })
+}
+
+fn first_retained_journal_sequence(connection: &Connection) -> anyhow::Result<Option<u64>> {
+    let first = connection.query_row(
+        "SELECT MIN(sequence) FROM (
+           SELECT sequence FROM session_journal
+           UNION ALL
+           SELECT start_sequence FROM journal_segments
+         )",
+        [],
+        |row| row.get::<_, Option<i64>>(0),
+    )?;
+    first
+        .map(|value| u64::try_from(value).context("first retained journal sequence is negative"))
+        .transpose()
 }
 
 pub(super) fn query_session_journal_sequences(

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
@@ -143,10 +143,9 @@ pub(crate) enum SessionJournalCursorError {
 impl std::fmt::Display for SessionJournalCursorError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Ahead { requested, head } => write!(
-                formatter,
-                "cursor.invalid: journal sequence {requested} is ahead of {head}"
-            ),
+            Self::Ahead { requested, head } => {
+                write!(formatter, "cursor.invalid: journal sequence {requested} is ahead of {head}")
+            }
             Self::Gap { requested, first_retained } => write!(
                 formatter,
                 "cursor.gap: journal history before sequence {first_retained} is no longer retained after {requested}"

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
@@ -1399,7 +1399,7 @@ fn archived_records_after(
         } else {
             anyhow::ensure!(
                 start_sequence <= sequence.saturating_add(1),
-                "cursor.invalid: journal retention begins at sequence {start_sequence}"
+                "journal segments contain a gap before sequence {start_sequence}"
             );
         }
         previous_end = Some(end_sequence);
@@ -2062,7 +2062,12 @@ mod tests {
     #[test]
     fn journal_cursor_and_page_limits_fail_closed() {
         let registry = WorkspaceRegistry::in_memory("limits").unwrap();
-        assert!(registry.session_journal_after(1, 1).unwrap_err().to_string().contains("ahead"));
+        let ahead = registry.session_journal_after(1, 1).unwrap_err();
+        assert!(ahead.to_string().contains("ahead"));
+        assert_eq!(
+            ahead.downcast_ref::<SessionJournalCursorError>(),
+            Some(&SessionJournalCursorError::Ahead { requested: 1, head: 0 })
+        );
         assert!(registry.session_journal_after(0, 0).unwrap_err().to_string().contains("positive"));
         assert!(
             registry
@@ -2070,6 +2075,27 @@ mod tests {
                 .unwrap_err()
                 .to_string()
                 .contains("exceeds")
+        );
+    }
+
+    #[test]
+    fn retained_history_gap_is_a_typed_cursor_error() {
+        let registry = WorkspaceRegistry::in_memory("cursor-gap").unwrap();
+        registry
+            .connection
+            .execute(
+                "INSERT INTO journal_segments(
+                   segment_id, start_sequence, end_sequence, record_count, codec, content,
+                   uncompressed_bytes, sha256, sealed_at_ms
+                 ) VALUES(?1, 3, 3, 1, 'test', ?2, 1, ?3, 1)",
+                rusqlite::params!["gap-segment", vec![0_u8], vec![0_u8; 32]],
+            )
+            .unwrap();
+
+        let error = registry.session_journal_after(0, 1).unwrap_err();
+        assert_eq!(
+            error.downcast_ref::<SessionJournalCursorError>(),
+            Some(&SessionJournalCursorError::Gap { requested: 0, first_retained: 3 })
         );
     }
 

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
@@ -1139,16 +1139,22 @@ pub(super) fn query_session_journal_after(
 }
 
 fn first_retained_journal_sequence(connection: &Connection) -> anyhow::Result<Option<u64>> {
-    let first = connection.query_row(
-        "SELECT MIN(sequence) FROM (
-           SELECT sequence FROM session_journal
-           UNION ALL
-           SELECT start_sequence FROM journal_segments
-         )",
+    // Keep each MIN over its indexed column. Wrapping both tables in one
+    // UNION makes SQLite materialize the full history for every page read.
+    let active = connection.query_row(
+        "SELECT MIN(sequence) FROM session_journal",
         [],
         |row| row.get::<_, Option<i64>>(0),
     )?;
-    first
+    let archived = connection.query_row(
+        "SELECT MIN(start_sequence) FROM journal_segments",
+        [],
+        |row| row.get::<_, Option<i64>>(0),
+    )?;
+    active
+        .into_iter()
+        .chain(archived)
+        .min()
         .map(|value| u64::try_from(value).context("first retained journal sequence is negative"))
         .transpose()
 }

--- a/cmux-tui/crates/cmux-tui/src/ui/sidebar.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/sidebar.rs
@@ -404,11 +404,7 @@ pub fn draw_projection(app: &mut App, frame: &mut Frame, view_index: usize) {
         // context line (tab title, else the session/workspace subtitle),
         // then the agent type dim underneath. Single-line rows keep the
         // combined detail text.
-        let detail = if two_line {
-            String::new()
-        } else {
-            projection_detail(row).into_owned()
-        };
+        let detail = if two_line { String::new() } else { projection_detail(row).into_owned() };
         let title = if two_line && row.agent_label.as_deref() == Some(row.name.as_str()) {
             row.subtitle.as_str()
         } else {

--- a/cmux-tui/crates/cmux-tui/src/ui/sidebar.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/sidebar.rs
@@ -47,7 +47,7 @@ fn projection_detail<'a>(row: &'a crate::sidebar_projection::ProjectionRow) -> C
     if !row.subtitle.is_empty() {
         detail = format!("{detail} · {}", row.subtitle);
     }
-    detail
+    detail.into()
 }
 
 /// The color of a workspace's unread indicator, or `None` when nothing is
@@ -404,7 +404,11 @@ pub fn draw_projection(app: &mut App, frame: &mut Frame, view_index: usize) {
         // context line (tab title, else the session/workspace subtitle),
         // then the agent type dim underneath. Single-line rows keep the
         // combined detail text.
-        let detail = if two_line { String::new() } else { projection_detail(row) };
+        let detail = if two_line {
+            String::new()
+        } else {
+            projection_detail(row).into_owned()
+        };
         let title = if two_line && row.agent_label.as_deref() == Some(row.name.as_str()) {
             row.subtitle.as_str()
         } else {


### PR DESCRIPTION
Follow-up for https://github.com/manaflow-ai/cmux/pull/11123.

Treat ahead-of-head and retention-gap cursors as recoverable state corruption. Reset the roster and replay from the retained journal floor, returning a safe empty roster if replay is unavailable. The repair avoids startup failure from hostile persisted state. Exact hosted gate and canonical autoreview are pending.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790536705&installation_model_id=21920&pr_number=11148&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11148&signature=ada2481c714dffab4d84d217e559e1bab3fdd6981dbca9404a8ba83fb7fad1ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TUI startup failure when a persisted agent roster cursor points past the journal head or before the retained floor. Ahead cursors rebuild the roster from the journal head; gap cursors now fail closed, leaving the durable snapshot untouched, instead of replaying a suffix that would silently drop agents. Non-cursor journal errors still propagate.

- Sidebar detail rendering now handles Cow string types without behavior change.
- Tests cover ahead-cursor rebuild, retention-gap detection, corrupt-segment propagation, and fail-closed gap handling, including a gap injected into a persistent journal.

<sup>Written for commit 7735ba6d40f1653288ff4ca779b1a71e33ee3f29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

