### PR TITLE
Expose preview file paths in surface.list

### DIFF
--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface.swift
@@ -164,6 +164,9 @@ extension ControlCommandCoordinator {
                 if let dev = surface.developerToolsVisible {
                     item["developer_tools_visible"] = .bool(dev)
                 }
+                if let filePath = surface.filePath {
+                    item["file_path"] = .string(filePath)
+                }
                 if surface.isTerminal {
                     item["requested_working_directory"] = orNull(surface.requestedWorkingDirectory)
                     item["initial_command"] = orNull(surface.initialCommand)

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlSurfaceSummary.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlSurfaceSummary.swift
@@ -6,8 +6,8 @@ public import Foundation
 /// Mirrors the legacy per-surface dictionary the `v2SurfaceList` body built. The
 /// coordinator mints the surface and pane refs itself and writes the optional
 /// fields with `null` defaults exactly as the legacy `v2OrNull` writes did. The
-/// browser/terminal-only extras are carried as optionals: they are emitted only
-/// when present, matching the legacy `if let` conditional key writes.
+/// Browser, terminal, and file-backed extras are carried as optionals: they are
+/// emitted only when present, matching the legacy conditional key writes.
 public struct ControlSurfaceSummary: Sendable, Equatable {
     /// The surface's panel identifier.
     public let surfaceID: UUID
@@ -15,6 +15,8 @@ public struct ControlSurfaceSummary: Sendable, Equatable {
     public let typeRawValue: String
     /// The resolved display title.
     public let title: String
+    /// The absolute file path represented by a file-preview or Markdown surface.
+    public let filePath: String?
     /// Whether this surface is the workspace's focused surface.
     public let isFocused: Bool
     /// The enclosing pane's identifier, if it resolved.
@@ -59,6 +61,7 @@ public struct ControlSurfaceSummary: Sendable, Equatable {
     ///   - surfaceID: The surface's panel identifier.
     ///   - typeRawValue: The panel type's raw value.
     ///   - title: The resolved display title.
+    ///   - filePath: The absolute path represented by a file-backed surface.
     ///   - isFocused: Whether this surface is focused.
     ///   - paneID: The enclosing pane's identifier, if resolved.
     ///   - indexInPane: The surface's index within its pane, if resolved.
@@ -74,6 +77,7 @@ public struct ControlSurfaceSummary: Sendable, Equatable {
         surfaceID: UUID,
         typeRawValue: String,
         title: String,
+        filePath: String? = nil,
         isFocused: Bool,
         paneID: UUID?,
         indexInPane: Int?,
@@ -94,6 +98,7 @@ public struct ControlSurfaceSummary: Sendable, Equatable {
         self.surfaceID = surfaceID
         self.typeRawValue = typeRawValue
         self.title = title
+        self.filePath = filePath
         self.isFocused = isFocused
         self.paneID = paneID
         self.indexInPane = indexInPane

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorSurfaceTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorSurfaceTests.swift
@@ -297,6 +297,48 @@ struct ControlCommandCoordinatorSurfaceTests {
         #expect(row["state"] == .string("Booted"))
     }
 
+    @Test func surfaceListIncludesFilePathWhenAvailable() throws {
+        let context = FakeSurfaceControlCommandContext()
+        let workspaceID = UUID()
+        let surfaceID = UUID()
+        let filePath = "/tmp/project/nested/source.swift"
+        context.surfaceListSnapshot = ControlSurfaceListSnapshot(
+            workspaceID: workspaceID,
+            windowID: nil,
+            surfaces: [ControlSurfaceSummary(
+                surfaceID: surfaceID,
+                typeRawValue: "filepreview",
+                title: "source.swift",
+                filePath: filePath,
+                isFocused: true,
+                paneID: nil,
+                indexInPane: nil,
+                selectedInPane: nil,
+                developerToolsVisible: nil,
+                requestedWorkingDirectory: nil,
+                initialCommand: nil,
+                tmuxStartCommand: nil,
+                isTerminal: false,
+                resumeBinding: nil
+            )]
+        )
+        let coordinator = ControlCommandCoordinator(context: context)
+
+        let result = coordinator.handle(ControlRequest(
+            id: .int(1),
+            method: "surface.list",
+            params: ["workspace_id": .string(workspaceID.uuidString)]
+        ))
+
+        guard case let .ok(.object(payload)) = result,
+              case let .array(rows)? = payload["surfaces"],
+              case let .object(row)? = rows.first else {
+            Issue.record("Expected a file-preview surface row")
+            return
+        }
+        #expect(row["file_path"] == .string(filePath))
+    }
+
     @Test func surfaceResumePendingApprovalReturnsRetryableBusyError() {
         let context = FakeSurfaceControlCommandContext()
         let message = "Resume approval data is still loading. Retry the request."

--- a/Sources/TerminalController+ControlSurfaceContext.swift
+++ b/Sources/TerminalController+ControlSurfaceContext.swift
@@ -154,6 +154,7 @@ extension TerminalController: ControlSurfaceContext {
                 surfaceID: summary.surfaceID,
                 typeRawValue: summary.typeRawValue,
                 title: summary.title,
+                filePath: summary.filePath,
                 isFocused: summary.isFocused,
                 paneID: summary.paneID,
                 indexInPane: summary.indexInPane,

--- a/Sources/TerminalController+RemoteTmuxControlTopology.swift
+++ b/Sources/TerminalController+RemoteTmuxControlTopology.swift
@@ -354,10 +354,13 @@ extension TerminalController {
             }
             let terminalPanel = panel as? TerminalPanel
             let simulatorPanel = panel as? SimulatorPanel
+            let filePath = (panel as? FilePreviewPanel)?.filePath
+                ?? (panel as? MarkdownPanel)?.filePath
             return [ControlSurfaceSummary(
                 surfaceID: panel.id,
                 typeRawValue: panel.panelType.rawValue,
                 title: workspace.panelTitle(panelId: panel.id) ?? panel.displayTitle,
+                filePath: filePath,
                 isFocused: panel.id == workspace.focusedPanelId,
                 paneID: paneByPanelID[panel.id],
                 indexInPane: indexInPaneByPanelID[panel.id],

--- a/cmuxTests/FilePreviewReviewFeedbackTests.swift
+++ b/cmuxTests/FilePreviewReviewFeedbackTests.swift
@@ -431,6 +431,55 @@ struct FilePreviewReviewFeedbackTests {
         )
     }
 
+    @Test
+    func surfaceListIncludesFilePathsForPreviewSurfaces() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-surface-list-\(UUID().uuidString)", isDirectory: true)
+        let fileURL = directory.appendingPathComponent("source.swift")
+        let markdownURL = directory.appendingPathComponent("README.md")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try "let value = 1\n".write(to: fileURL, atomically: true, encoding: .utf8)
+        try "# Preview\n".write(to: markdownURL, atomically: true, encoding: .utf8)
+        defer {
+            try? FileManager.default.removeItem(at: directory)
+            TerminalController.shared.setActiveTabManager(nil)
+        }
+
+        let manager = TabManager()
+        let workspace = manager.addWorkspace(select: true, eagerLoadTerminal: false)
+        defer { workspace.teardownAllPanels() }
+        let pane = try #require(workspace.bonsplitController.allPaneIds.first)
+        let filePanel = try #require(workspace.newFilePreviewSurface(
+            inPane: pane,
+            filePath: fileURL.path,
+            focus: false
+        ))
+        let markdownPanel = try #require(workspace.newMarkdownSurface(
+            inPane: pane,
+            filePath: markdownURL.path,
+            focus: false
+        ))
+        TerminalController.shared.setActiveTabManager(manager)
+
+        let request: [String: Any] = [
+            "id": "surface-list-file-path",
+            "method": "surface.list",
+            "params": ["workspace_id": workspace.id.uuidString],
+        ]
+        let requestData = try JSONSerialization.data(withJSONObject: request)
+        let requestLine = try #require(String(data: requestData, encoding: .utf8))
+        let response = TerminalController.shared.handleSocketLine(requestLine)
+        let responseData = try #require(response.data(using: .utf8))
+        let envelope = try #require(JSONSerialization.jsonObject(with: responseData) as? [String: Any])
+        let result = try #require(envelope["result"] as? [String: Any])
+        let surfaces = try #require(result["surfaces"] as? [[String: Any]])
+        let fileRow = try #require(surfaces.first { ($0["id"] as? String) == filePanel.id.uuidString })
+        let markdownRow = try #require(surfaces.first { ($0["id"] as? String) == markdownPanel.id.uuidString })
+
+        #expect(fileRow["file_path"] as? String == fileURL.path)
+        #expect(markdownRow["file_path"] as? String == markdownURL.path)
+    }
+
     private func temporaryTextFile(contents: String, encoding: String.Encoding) throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)

--- a/docs/data-driven-sidebar-plan.md
+++ b/docs/data-driven-sidebar-plan.md
@@ -34,7 +34,7 @@ Full machine catalog: `cmux capabilities` (method list) — should be generated 
 Query methods returning structured payloads (project all into the `data` tree):
 - `workspace.list` / `workspace.current` / `workspace.group.list` — id, ref, title, description, selected, pinned, listening_ports, remote, current_directory, custom_color, latest_conversation_message, latest_submitted_message, latest_submitted_at, index.
 - `extension.sidebar.snapshot` (richest) — adds root_path, project_root_path, branch_summary, remote_display_target, remote_connection_state, unread_count, latest_notification_text, pull_request_urls, panel_directories, git_branches. (`TerminalController.swift:5525`)
-- `surface.list` / `surface.current` — id, ref, index, type, title, focused, pane_id, working dir, initial_command, resume_binding; browser: developer_tools_visible. (`:8615`)
+- `surface.list` — id, ref, index, type, title, focused, pane_id, working dir, initial_command, resume_binding; file-backed previews: file_path; browser: developer_tools_visible. `surface.current` returns the focused surface identity and type. (`:8615`)
 - `pane.list`, `window.list`/`window.current`, `notification.list`, `feed.list`, `vm.list`, `auth.status`, `workspace.remote.status`.
 
 Underlying model (`Workspace.swift:10243+`) carries even more per-workspace/per-surface state: `gitBranch`/`panelGitBranches` (branch + dirty), `pullRequest`/`panelPullRequests`, `surfaceListeningPorts`, `remote*` (connection state, detected/forwarded/conflicting ports, live SSH session count), `latestConversationMessage`/`latestSubmittedMessage`, `progress`, `logEntries`, `statusEntries`, `metadataBlocks`, `manualUnreadPanelIds`, `panelShellActivityStates`, `agentPIDs`/`agentPIDPanelIdsByKey`.


### PR DESCRIPTION
## Motivation

`surface.list` reports preview titles but not their canonical paths. Integrations cannot safely distinguish nested files with the same basename, blocking workflows such as opening the selected preview in Neovim.

## Change

- Add optional `file_path` to Markdown and file-preview surface rows.
- Keep the field absent for non-file surfaces.
- Cover real panel extraction and socket serialization.

Closes #11134
Related: #8346

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790537691&installation_model_id=21920&pr_number=11150&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11150&signature=1a19e43a54c36de2adea3c839d7e2b5692486cb0025c5d594e2c8e15be8950ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional `file_path` field to `surface.list` rows for file-preview and Markdown surfaces, so integrations can distinguish nested files with the same basename. The field is omitted for other surface types. Closes #11134.

<sup>Written for commit e715638f71c4675b52c15d7a4f597706e7459e22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `surface.list` now reports the file path for file preview and Markdown surfaces.
  - File-backed surface details are consistently included across supported views.

- **Documentation**
  - Updated command documentation to describe `file_path` for `surface.list` and clarify `surface.current`.

- **Tests**
  - Added coverage verifying file paths appear for file preview and Markdown surfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->