### PR TITLE
Bound daemon loss classification probes

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -25,7 +25,7 @@ use std::io::{BufRead, Write};
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::mpsc::{Receiver, SyncSender};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use base64::Engine as _;
 use cmux_tui_core::SurfaceId;
@@ -162,14 +162,17 @@ fn classify_daemon_loss(
     socket_path: &Path,
     terminal: &TerminalPublicId,
 ) -> PipeIoExitReason {
-    let terminal_still_exists =
-        remote.refresh_tree_with_timeout(DAEMON_LOSS_PROBE_TIMEOUT).ok().map(|tree| tree.resolve_terminal(terminal).is_some()).or_else(
-            || {
-                let probe = RemoteSession::connect_for_terminal_attach(socket_path).ok()?;
-                let tree = probe.refresh_tree_with_timeout(DAEMON_LOSS_PROBE_TIMEOUT).ok()?;
-                Some(tree.resolve_terminal(terminal).is_some())
-            },
-        );
+    let deadline = Instant::now() + DAEMON_LOSS_PROBE_TIMEOUT;
+    let terminal_still_exists = remote
+        .refresh_tree_until(deadline)
+        .ok()
+        .map(|tree| tree.resolve_terminal(terminal).is_some())
+        .or_else(|| {
+            let probe =
+                RemoteSession::connect_for_terminal_attach_until(socket_path, deadline).ok()?;
+            let tree = probe.refresh_tree_until(deadline).ok()?;
+            Some(tree.resolve_terminal(terminal).is_some())
+        });
     match terminal_still_exists {
         Some(false) => PipeIoExitReason::TerminalEnded,
         Some(true) | None => PipeIoExitReason::DaemonLost,

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -25,6 +25,7 @@ use std::io::{BufRead, Write};
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::mpsc::{Receiver, SyncSender};
+use std::time::Duration;
 
 use base64::Engine as _;
 use cmux_tui_core::SurfaceId;
@@ -46,6 +47,7 @@ const EVENT_QUEUE_CAPACITY: usize = 4096;
 /// reset plus erase-scrollback, so the replacement replay does not stack on
 /// top of the embedder's previous terminal state.
 const REPLAY_RESET: &[u8] = b"\x1bc\x1b[3J";
+const DAEMON_LOSS_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PipeIoExitReason {
@@ -161,10 +163,10 @@ fn classify_daemon_loss(
     terminal: &TerminalPublicId,
 ) -> PipeIoExitReason {
     let terminal_still_exists =
-        remote.refresh_tree().ok().map(|tree| tree.resolve_terminal(terminal).is_some()).or_else(
+        remote.refresh_tree_with_timeout(DAEMON_LOSS_PROBE_TIMEOUT).ok().map(|tree| tree.resolve_terminal(terminal).is_some()).or_else(
             || {
                 let probe = RemoteSession::connect_for_terminal_attach(socket_path).ok()?;
-                let tree = probe.refresh_tree().ok()?;
+                let tree = probe.refresh_tree_with_timeout(DAEMON_LOSS_PROBE_TIMEOUT).ok()?;
                 Some(tree.resolve_terminal(terminal).is_some())
             },
         );

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -7,7 +7,7 @@ use std::io::{self, BufRead, BufReader, Read, Write};
 use std::net::Shutdown;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, channel};
+use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, channel, sync_channel};
 use std::sync::{Arc, Condvar, Mutex, Weak};
 use std::time::{Duration, Instant};
 
@@ -967,6 +967,25 @@ enum RequestDeadline {
     Standard,
     Attach,
     Fixed(Duration),
+    /// A deadline shared by a sequence of requests, such as reconnect
+    /// classification. Each phase consumes only the time that remains.
+    Until(Instant),
+}
+
+impl RequestDeadline {
+    fn remaining(self) -> Result<Duration, RemoteRequestError> {
+        match self {
+            Self::Standard => Ok(REMOTE_REQUEST_TIMEOUT),
+            Self::Fixed(timeout) => Ok(timeout),
+            Self::Until(deadline) => {
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                if remaining.is_zero() { Err(RemoteRequestError::Timeout) } else { Ok(remaining) }
+            }
+            // Attach has its own progress-aware response deadline, but its
+            // enqueue/write phase still needs the normal bounded write wait.
+            Self::Attach => Ok(remote_write_timeout()),
+        }
+    }
 }
 
 struct AttachResponseDeadline {
@@ -1617,6 +1636,19 @@ impl RemoteTransport {
 
     pub fn json_lines(stream: Box<dyn transport::Stream>) -> io::Result<Self> {
         stream.set_write_timeout(Some(remote_write_timeout()))?;
+        Self::json_lines_parts(stream)
+    }
+
+    fn json_lines_with_timeout(
+        stream: Box<dyn transport::Stream>,
+        timeout: Duration,
+    ) -> io::Result<Self> {
+        stream.set_read_timeout(Some(timeout))?;
+        stream.set_write_timeout(Some(timeout))?;
+        Self::json_lines_parts(stream)
+    }
+
+    fn json_lines_parts(stream: Box<dyn transport::Stream>) -> io::Result<Self> {
         let read_half = stream.try_clone_box()?;
         let abort_stream = stream.try_clone_box()?;
         Ok(Self {
@@ -1805,15 +1837,52 @@ impl RemoteSession {
         Self::connect_path(path, false)
     }
 
+    pub(crate) fn connect_for_terminal_attach_until(
+        path: &Path,
+        deadline: Instant,
+    ) -> anyhow::Result<Arc<Self>> {
+        Self::connect_path_until(path, false, deadline)
+    }
+
     fn connect_path(path: &Path, subscribe: bool) -> anyhow::Result<Arc<Self>> {
         let stream = transport::connect(path).map_err(|e| {
             anyhow::anyhow!("cannot connect to session socket {}: {e}", path.display())
         })?;
-        if subscribe {
-            Self::connect_stream(stream)
-        } else {
-            Self::connect_stream_with_subscription(stream, false)
-        }
+        Self::connect_stream_with_subscription(stream, subscribe)
+    }
+
+    fn connect_path_until(
+        path: &Path,
+        subscribe: bool,
+        deadline: Instant,
+    ) -> anyhow::Result<Arc<Self>> {
+        let path_for_thread = path.to_path_buf();
+        let display = path.display().to_string();
+        let (sender, receiver) = sync_channel(1);
+        let connector =
+            std::thread::Builder::new().name("remote-probe-connect".into()).spawn(move || {
+                let _ = sender.send(transport::connect(&path_for_thread));
+            })?;
+        let stream = match receiver.recv_timeout(deadline.saturating_duration_since(Instant::now()))
+        {
+            Ok(result) => {
+                let _ = connector.join();
+                result.map_err(|error| {
+                    anyhow::anyhow!("cannot connect to session socket {display}: {error}")
+                })?
+            }
+            Err(RecvTimeoutError::Disconnected) => {
+                let _ = connector.join();
+                anyhow::bail!("remote probe connector stopped without a result")
+            }
+            Err(RecvTimeoutError::Timeout) => {
+                // The pipe-io process exits after classification. Dropping the
+                // connector lets that process terminate any blocked connect.
+                drop(connector);
+                anyhow::bail!(RemoteRequestError::Timeout)
+            }
+        };
+        Self::connect_stream_with_subscription_until(stream, subscribe, deadline)
     }
 
     /// Connect over an already-established full-duplex byte stream.
@@ -1834,6 +1903,27 @@ impl RemoteSession {
             anyhow::anyhow!("cannot configure JSON-lines session transport: {error}")
         })?;
         Self::connect_transport_with_initial_subscription(transport, subscribe)
+    }
+
+    fn connect_stream_with_subscription_until(
+        stream: Box<dyn transport::Stream>,
+        subscribe: bool,
+        deadline: Instant,
+    ) -> anyhow::Result<Arc<Self>> {
+        let timeout = deadline.saturating_duration_since(Instant::now());
+        if timeout.is_zero() {
+            anyhow::bail!(RemoteRequestError::Timeout);
+        }
+        let transport =
+            RemoteTransport::json_lines_with_timeout(stream, timeout).map_err(|error| {
+                anyhow::anyhow!("cannot configure JSON-lines session transport: {error}")
+            })?;
+        Self::connect_transport_with_provider_authority_until(
+            transport,
+            None,
+            subscribe,
+            Some(deadline),
+        )
     }
 
     pub fn connect_transport(transport: RemoteTransport) -> anyhow::Result<Arc<Self>> {
@@ -1858,6 +1948,20 @@ impl RemoteSession {
         transport: RemoteTransport,
         provider_workspace_authority: Option<BearerToken>,
         subscribe: bool,
+    ) -> anyhow::Result<Arc<Self>> {
+        Self::connect_transport_with_provider_authority_until(
+            transport,
+            provider_workspace_authority,
+            subscribe,
+            None,
+        )
+    }
+
+    fn connect_transport_with_provider_authority_until(
+        transport: RemoteTransport,
+        provider_workspace_authority: Option<BearerToken>,
+        subscribe: bool,
+        deadline: Option<Instant>,
     ) -> anyhow::Result<Arc<Self>> {
         let RemoteTransport { mut reader, writer, abort } = transport;
         let interactive_writer = InteractiveWriter::spawn(writer, abort)
@@ -1923,7 +2027,11 @@ impl RemoteSession {
             }
         })?;
 
-        if let Err(error) = session.initialize(subscribe) {
+        let initialization = deadline.map_or_else(
+            || session.initialize(subscribe),
+            |deadline| session.initialize_until(subscribe, deadline),
+        );
+        if let Err(error) = initialization {
             session.disconnect_transport();
             return Err(error);
         }
@@ -1931,8 +2039,20 @@ impl RemoteSession {
     }
 
     fn initialize(&self, subscribe: bool) -> anyhow::Result<()> {
+        self.initialize_with_deadline(subscribe, RequestDeadline::Standard)
+    }
+
+    fn initialize_until(&self, subscribe: bool, deadline: Instant) -> anyhow::Result<()> {
+        self.initialize_with_deadline(subscribe, RequestDeadline::Until(deadline))
+    }
+
+    fn initialize_with_deadline(
+        &self,
+        subscribe: bool,
+        deadline: RequestDeadline,
+    ) -> anyhow::Result<()> {
         // Identify the endpoint and register this connection before any optional subscription.
-        let ident = self.request(json!({"cmd": "identify"}))?;
+        let ident = self.request_with_deadline(json!({"cmd": "identify"}), deadline)?;
         validate_remote_identity(&ident)?;
         *self.capabilities.lock().unwrap() = identity_capabilities(&ident);
         let mut client_info = json!({"cmd": "set-client-info", "kind": "tui"});
@@ -1958,10 +2078,10 @@ impl RemoteSession {
         if !negotiated.is_empty() {
             client_info["capabilities"] = json!(negotiated);
         }
-        self.request(client_info)?;
+        self.request_with_deadline(client_info, deadline)?;
         if subscribe {
             self.prime_local_subscription();
-            if let Err(error) = self.request(self.subscription_request()) {
+            if let Err(error) = self.request_with_deadline(self.subscription_request(), deadline) {
                 self.primed_subscription.lock().unwrap().take();
                 return Err(error);
             }
@@ -2631,6 +2751,12 @@ impl RemoteSession {
         mut cmd: Value,
         deadline: RequestDeadline,
     ) -> anyhow::Result<Value> {
+        // A shared deadline must cover enqueueing, the ordered write, and the
+        // response wait. Check it before creating a pending request so an
+        // expired reconnect probe cannot add work to the relay.
+        if let Err(error) = deadline.remaining() {
+            return Err(error.into());
+        }
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
         let progress = Arc::new(AtomicU64::new(0));
         let attach_progress = matches!(deadline, RequestDeadline::Attach)
@@ -2658,7 +2784,14 @@ impl RemoteSession {
                 return Err(RemoteRequestError::Transport(error).into());
             }
         };
-        if let Err(error) = self.wait_for_ordered_write(sequence) {
+        let write_timeout = match deadline.remaining() {
+            Ok(timeout) => timeout,
+            Err(error) => {
+                self.pending.lock().unwrap().remove(&id);
+                return Err(error.into());
+            }
+        };
+        if let Err(error) = self.wait_for_ordered_write_with_timeout(sequence, write_timeout) {
             self.pending.lock().unwrap().remove(&id);
             return Err(RemoteRequestError::Transport(error).into());
         }
@@ -2702,12 +2835,10 @@ impl RemoteSession {
         progress: Arc<AtomicU64>,
         attach_progress: Option<u64>,
     ) -> Result<Value, RemoteRequestError> {
-        if let RequestDeadline::Standard | RequestDeadline::Fixed(_) = deadline {
-            let timeout = match deadline {
-                RequestDeadline::Standard => REMOTE_REQUEST_TIMEOUT,
-                RequestDeadline::Fixed(timeout) => timeout,
-                RequestDeadline::Attach => unreachable!(),
-            };
+        if let RequestDeadline::Standard | RequestDeadline::Fixed(_) | RequestDeadline::Until(_) =
+            deadline
+        {
+            let timeout = deadline.remaining().map_err(|_| RemoteRequestError::Timeout)?;
             return match rx.recv_timeout(timeout) {
                 Ok(response) => Ok(response),
                 Err(RecvTimeoutError::Timeout) => Err(RemoteRequestError::Timeout),
@@ -2897,7 +3028,15 @@ impl RemoteSession {
     }
 
     fn wait_for_ordered_write(&self, sequence: u64) -> io::Result<()> {
-        match self.interactive_writer.wait_until_written(sequence, remote_write_timeout()) {
+        self.wait_for_ordered_write_with_timeout(sequence, remote_write_timeout())
+    }
+
+    fn wait_for_ordered_write_with_timeout(
+        &self,
+        sequence: u64,
+        timeout: Duration,
+    ) -> io::Result<()> {
+        match self.interactive_writer.wait_until_written(sequence, timeout) {
             Ok(()) => Ok(()),
             Err(error) => {
                 if error.kind() == io::ErrorKind::TimedOut {
@@ -3417,7 +3556,11 @@ impl RemoteSession {
     /// Refresh the workspace tree with a bounded request deadline. Used by
     /// reconnect classification, where a stale daemon must not hold the relay.
     pub fn refresh_tree_with_timeout(&self, timeout: Duration) -> anyhow::Result<TreeView> {
-        self.refresh_tree_inner_with_deadline(true, RequestDeadline::Fixed(timeout))
+        self.refresh_tree_until(Instant::now() + timeout)
+    }
+
+    pub(crate) fn refresh_tree_until(&self, deadline: Instant) -> anyhow::Result<TreeView> {
+        self.refresh_tree_inner_with_deadline(true, RequestDeadline::Until(deadline))
     }
 
     pub fn refresh_tree_background(&self) -> anyhow::Result<TreeView> {
@@ -3433,8 +3576,7 @@ impl RemoteSession {
         identity_refresh: bool,
         deadline: RequestDeadline,
     ) -> anyhow::Result<TreeView> {
-        let _refresh = if let RequestDeadline::Fixed(timeout) = deadline {
-            let deadline = Instant::now() + timeout;
+        let _refresh = if let RequestDeadline::Until(deadline) = deadline {
             loop {
                 match self.tree_refresh.try_lock() {
                     Ok(lock) => break lock,
@@ -6867,7 +7009,59 @@ mod tests {
             error.downcast_ref::<RemoteRequestError>(),
             Some(RemoteRequestError::Timeout)
         ));
-        assert!(started.elapsed() < Duration::from_secs(1));
+        assert!(
+            started.elapsed() < Duration::from_millis(100),
+            "5ms probe deadline was exceeded by {:?}",
+            started.elapsed()
+        );
+        assert!(session.pending.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn bounded_tree_refresh_does_not_wait_for_another_refresh_lock() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+        let _refresh = session.tree_refresh.lock().unwrap();
+        let started = Instant::now();
+        let error = session
+            .refresh_tree_with_timeout(Duration::from_millis(5))
+            .expect_err("a contended refresh lock must time out");
+
+        assert!(matches!(
+            error.downcast_ref::<RemoteRequestError>(),
+            Some(RemoteRequestError::Timeout)
+        ));
+        assert!(
+            started.elapsed() < Duration::from_millis(100),
+            "5ms lock deadline was exceeded by {:?}",
+            started.elapsed()
+        );
+        assert!(session.pending.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn bounded_tree_refresh_aborts_a_blocked_ordered_write() {
+        let (stream, control) = BlockingWriteStream::new();
+        let session = blocking_test_session(stream);
+        session.send_bytes(7, b"blocked").unwrap();
+        control.wait_until_entered();
+
+        let started = Instant::now();
+        let error = session
+            .refresh_tree_with_timeout(Duration::from_millis(5))
+            .expect_err("a blocked probe write must time out");
+
+        assert!(error.downcast_ref::<RemoteRequestError>().is_some_and(|error| {
+            matches!(error, RemoteRequestError::Transport(io_error)
+                if io_error.kind() == io::ErrorKind::TimedOut)
+        }));
+        assert!(
+            started.elapsed() < Duration::from_millis(100),
+            "5ms write deadline was exceeded by {:?}",
+            started.elapsed()
+        );
+        assert!(control.state.0.lock().unwrap().aborted);
         assert!(session.pending.lock().unwrap().is_empty());
     }
 

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -6840,6 +6840,24 @@ mod tests {
         assert!(closed.load(Ordering::Acquire));
     }
 
+    #[test]
+    fn bounded_tree_refresh_times_out_and_clears_pending_probe() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+        let started = Instant::now();
+        let error = session
+            .refresh_tree_with_timeout(Duration::from_millis(5))
+            .expect_err("a silent probe must time out");
+
+        assert!(matches!(
+            error.downcast_ref::<RemoteRequestError>(),
+            Some(RemoteRequestError::Timeout)
+        ));
+        assert!(started.elapsed() < Duration::from_secs(1));
+        assert!(session.pending.lock().unwrap().is_empty());
+    }
+
     #[cfg(unix)]
     #[test]
     fn eof_cancels_a_pending_request_without_waiting_for_the_request_timeout() {

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -7001,9 +7001,10 @@ mod tests {
             closed: Arc::new(AtomicBool::new(false)),
         }));
         let started = Instant::now();
-        let error = session
-            .refresh_tree_with_timeout(Duration::from_millis(5))
-            .expect_err("a silent probe must time out");
+        let error = match session.refresh_tree_with_timeout(Duration::from_millis(5)) {
+            Err(error) => error,
+            Ok(_) => panic!("a silent probe unexpectedly completed"),
+        };
 
         assert!(matches!(
             error.downcast_ref::<RemoteRequestError>(),
@@ -7024,9 +7025,10 @@ mod tests {
         }));
         let _refresh = session.tree_refresh.lock().unwrap();
         let started = Instant::now();
-        let error = session
-            .refresh_tree_with_timeout(Duration::from_millis(5))
-            .expect_err("a contended refresh lock must time out");
+        let error = match session.refresh_tree_with_timeout(Duration::from_millis(5)) {
+            Err(error) => error,
+            Ok(_) => panic!("a contended refresh lock unexpectedly completed"),
+        };
 
         assert!(matches!(
             error.downcast_ref::<RemoteRequestError>(),
@@ -7048,9 +7050,10 @@ mod tests {
         control.wait_until_entered();
 
         let started = Instant::now();
-        let error = session
-            .refresh_tree_with_timeout(Duration::from_millis(5))
-            .expect_err("a blocked probe write must time out");
+        let error = match session.refresh_tree_with_timeout(Duration::from_millis(5)) {
+            Err(error) => error,
+            Ok(_) => panic!("a blocked probe write unexpectedly completed"),
+        };
 
         assert!(error.downcast_ref::<RemoteRequestError>().is_some_and(|error| {
             matches!(error, RemoteRequestError::Transport(io_error)

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3433,7 +3433,20 @@ impl RemoteSession {
         identity_refresh: bool,
         deadline: RequestDeadline,
     ) -> anyhow::Result<TreeView> {
-        let _refresh = self.tree_refresh.lock().unwrap();
+        let _refresh = if let RequestDeadline::Fixed(timeout) = deadline {
+            let deadline = Instant::now() + timeout;
+            loop {
+                match self.tree_refresh.try_lock() {
+                    Ok(lock) => break lock,
+                    Err(_) if Instant::now() >= deadline => {
+                        anyhow::bail!(RemoteRequestError::Timeout)
+                    }
+                    Err(_) => std::thread::yield_now(),
+                }
+            }
+        } else {
+            self.tree_refresh.lock().unwrap()
+        };
         if identity_refresh {
             self.tree_stale.store(false, Ordering::Release);
         }

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -32,6 +32,7 @@ use ghostty_vt::{
     MouseEncoders, MouseInput, RenderState, Terminal, TerminalColorOverrides,
     TerminalPointerSemanticSnapshot, parse_color,
 };
+use parking_lot::Mutex as ParkingMutex;
 use serde_json::{Value, json};
 use zeroize::{Zeroize, Zeroizing};
 
@@ -1519,7 +1520,7 @@ pub struct RemoteSession {
     retired_surfaces: Mutex<HashSet<SurfaceId>>,
     tree: Mutex<RemoteTreeCache>,
     browser_sources: Mutex<HashMap<SurfaceId, BrowserSource>>,
-    tree_refresh: Mutex<()>,
+    tree_refresh: ParkingMutex<()>,
     tree_stale: AtomicBool,
     subscription_started: AtomicBool,
     event_surface_filter: AtomicU64,
@@ -1979,7 +1980,7 @@ impl RemoteSession {
             retired_surfaces: Mutex::new(HashSet::new()),
             tree: Mutex::new(RemoteTreeCache::default()),
             browser_sources: Mutex::new(HashMap::new()),
-            tree_refresh: Mutex::new(()),
+            tree_refresh: ParkingMutex::new(()),
             tree_stale: AtomicBool::new(true),
             subscription_started: AtomicBool::new(false),
             event_surface_filter: AtomicU64::new(0),
@@ -3577,17 +3578,11 @@ impl RemoteSession {
         deadline: RequestDeadline,
     ) -> anyhow::Result<TreeView> {
         let _refresh = if let RequestDeadline::Until(deadline) = deadline {
-            loop {
-                match self.tree_refresh.try_lock() {
-                    Ok(lock) => break lock,
-                    Err(_) if Instant::now() >= deadline => {
-                        anyhow::bail!(RemoteRequestError::Timeout)
-                    }
-                    Err(_) => std::thread::yield_now(),
-                }
-            }
+            self.tree_refresh
+                .try_lock_for(deadline.saturating_duration_since(Instant::now()))
+                .ok_or(RemoteRequestError::Timeout)?
         } else {
-            self.tree_refresh.lock().unwrap()
+            self.tree_refresh.lock()
         };
         if identity_refresh {
             self.tree_stale.store(false, Ordering::Release);
@@ -4045,7 +4040,7 @@ fn test_session_with_writer(
         retired_surfaces: Mutex::new(HashSet::new()),
         tree: Mutex::new(RemoteTreeCache::default()),
         browser_sources: Mutex::new(HashMap::new()),
-        tree_refresh: Mutex::new(()),
+        tree_refresh: ParkingMutex::new(()),
         tree_stale: AtomicBool::new(true),
         subscription_started: AtomicBool::new(false),
         event_surface_filter: AtomicU64::new(0),
@@ -5287,7 +5282,7 @@ mod tests {
             retired_surfaces: Mutex::new(HashSet::new()),
             tree: Mutex::new(RemoteTreeCache::default()),
             browser_sources: Mutex::new(HashMap::new()),
-            tree_refresh: Mutex::new(()),
+            tree_refresh: ParkingMutex::new(()),
             tree_stale: AtomicBool::new(true),
             subscription_started: AtomicBool::new(false),
             event_surface_filter: AtomicU64::new(0),
@@ -7023,7 +7018,7 @@ mod tests {
         let session = test_session(Box::new(CloseTrackingWriter {
             closed: Arc::new(AtomicBool::new(false)),
         }));
-        let _refresh = session.tree_refresh.lock().unwrap();
+        let _refresh = session.tree_refresh.lock();
         let started = Instant::now();
         let error = match session.refresh_tree_with_timeout(Duration::from_millis(5)) {
             Err(error) => error,

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3414,11 +3414,25 @@ impl RemoteSession {
         self.refresh_tree_inner(true)
     }
 
+    /// Refresh the workspace tree with a bounded request deadline. Used by
+    /// reconnect classification, where a stale daemon must not hold the relay.
+    pub fn refresh_tree_with_timeout(&self, timeout: Duration) -> anyhow::Result<TreeView> {
+        self.refresh_tree_inner_with_deadline(true, RequestDeadline::Fixed(timeout))
+    }
+
     pub fn refresh_tree_background(&self) -> anyhow::Result<TreeView> {
         self.refresh_tree_inner(false)
     }
 
     fn refresh_tree_inner(&self, identity_refresh: bool) -> anyhow::Result<TreeView> {
+        self.refresh_tree_inner_with_deadline(identity_refresh, RequestDeadline::Standard)
+    }
+
+    fn refresh_tree_inner_with_deadline(
+        &self,
+        identity_refresh: bool,
+        deadline: RequestDeadline,
+    ) -> anyhow::Result<TreeView> {
         let _refresh = self.tree_refresh.lock().unwrap();
         if identity_refresh {
             self.tree_stale.store(false, Ordering::Release);
@@ -3427,7 +3441,7 @@ impl RemoteSession {
             let cache = self.tree.lock().unwrap();
             (cache.title_generation(), cache.agent_generation())
         };
-        let data = match self.request(json!({"cmd": "list-workspaces"})) {
+        let data = match self.request_with_deadline(json!({"cmd": "list-workspaces"}), deadline) {
             Ok(data) => data,
             Err(e) => {
                 if identity_refresh {
@@ -3438,7 +3452,7 @@ impl RemoteSession {
             }
         };
         let agents = self
-            .request(json!({"cmd": "list-agents"}))
+            .request_with_deadline(json!({"cmd": "list-agents"}), deadline)
             .ok()
             .and_then(|data| {
                 data.get("agents")


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/cmux/pull/11062.

Adds a fixed request deadline to both existing-tree and fallback reconnect probes, so synchronous request waits are bounded and pending requests are removed on timeout.

Tokio reference: https://docs.rs/tokio/latest/tokio/time/fn.timeout.html

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790537715&installation_model_id=21920&pr_number=11151&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11151&signature=d8b1a119017767cc2d29a6709718745fd22991aacac0f5dc6ad4ecfe9434761b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds daemon loss classification probes so reconnect checks no longer hang when a daemon stops responding. Previously the existing-tree refresh and fallback reconnect probe could block indefinitely on the refresh lock, connection, or synchronous requests; now both share a single 500ms deadline across connect, transport setup, initialization, and tree refresh, with pending requests dropped on timeout.

<sup>Written for commit befc23928a356f4d481b2ce258f222f602eda86d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

