### PR TITLE
build: update Rust toolchains to 1.98

### DIFF
--- a/.github/workflows/cmux-tui-build-package.yml
+++ b/.github/workflows/cmux-tui-build-package.yml
@@ -223,7 +223,9 @@ jobs:
       - name: Install cargo-zigbuild
         if: matrix.cross == true && runner.os == 'Linux'
         shell: bash
-        run: cargo install --locked cargo-zigbuild@0.20.0
+        # Rust 1.98 adds the Cortex-A53 erratum linker flag for AArch64.
+        # cargo-zigbuild 0.23.2 filters that flag for Zig's linker wrapper.
+        run: cargo install --locked cargo-zigbuild@0.23.2
 
       - name: Build cmux-tui (native)
         if: matrix.cross == false

--- a/.github/workflows/cmux-tui-sdks.yml
+++ b/.github/workflows/cmux-tui-sdks.yml
@@ -477,6 +477,8 @@ jobs:
           zig build -Doptimize=Debug
           zig build -Doptimize=ReleaseSafe
 
+  # Keep this compatibility gate on the public SDK MSRV. Other Rust jobs use
+  # cmux-tui/rust-toolchain.toml for the current Rust release.
   rust-msrv:
     name: Rust SDK MSRV (1.88)
     needs: contract

--- a/.github/workflows/cmux-tui.yml
+++ b/.github/workflows/cmux-tui.yml
@@ -79,6 +79,8 @@ jobs:
               ;;
           esac
 
+  # Keep this compatibility gate on the workspace MSRV. The build and test
+  # jobs below use cmux-tui/rust-toolchain.toml for the current Rust release.
   msrv-check:
     name: Rust MSRV (1.91)
     needs: validate-inputs

--- a/.github/workflows/iroh-relay-minter.yml
+++ b/.github/workflows/iroh-relay-minter.yml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: false
 
       - name: Install pinned Rust toolchain
-        run: rustup toolchain install 1.91.0 --profile minimal --component clippy --component rustfmt
+        run: rustup toolchain install 1.98.0 --profile minimal --component clippy --component rustfmt
 
       - name: Check formatting
         run: cargo fmt --check

--- a/.github/workflows/sdk-bootstrap-crates.yml
+++ b/.github/workflows/sdk-bootstrap-crates.yml
@@ -12,7 +12,7 @@ concurrency:
 
 env:
   BOOTSTRAP_VERSION: "0.0.0-bootstrap.0"
-  RUST_TOOLCHAIN: "1.95.0"
+  RUST_TOOLCHAIN: "1.98.0"
 
 jobs:
   build:

--- a/.github/workflows/sdk-publish-crates.yml
+++ b/.github/workflows/sdk-publish-crates.yml
@@ -17,7 +17,7 @@ on:
 permissions: {}
 
 env:
-  RUST_TOOLCHAIN: "1.95.0"
+  RUST_TOOLCHAIN: "1.98.0"
 
 concurrency:
   group: sdk-publish-crates-${{ github.ref }}

--- a/.github/workflows/sdk-publish-npm.yml
+++ b/.github/workflows/sdk-publish-npm.yml
@@ -24,7 +24,7 @@ on:
 permissions: {}
 
 env:
-  RUST_TOOLCHAIN: "1.95.0"
+  RUST_TOOLCHAIN: "1.98.0"
 
 concurrency:
   group: sdk-publish-npm-${{ github.ref }}

--- a/.github/workflows/sdk-publish-python.yml
+++ b/.github/workflows/sdk-publish-python.yml
@@ -24,7 +24,7 @@ on:
 permissions: {}
 
 env:
-  RUST_TOOLCHAIN: "1.95.0"
+  RUST_TOOLCHAIN: "1.98.0"
 
 concurrency:
   group: sdk-publish-python-${{ github.ref }}

--- a/.github/workflows/sdk-release-cut.yml
+++ b/.github/workflows/sdk-release-cut.yml
@@ -7,7 +7,7 @@ on:
 permissions: {}
 
 env:
-  RUST_TOOLCHAIN: "1.95.0"
+  RUST_TOOLCHAIN: "1.98.0"
 
 concurrency:
   group: sdk-release-cut

--- a/Native/CommandPaletteNucleoFFI/rust-toolchain.toml
+++ b/Native/CommandPaletteNucleoFFI/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.98.0"
+profile = "minimal"

--- a/Native/DiffSidecar/README.md
+++ b/Native/DiffSidecar/README.md
@@ -8,7 +8,7 @@ The bundled production binary has no default Cargo features. It includes only `r
 
 The stdio transport accepts one request of at most 1 MiB and requires EOF within 10 seconds. Timeout, oversized, and malformed envelopes return a typed failure with ID `__cmux_untrusted_request__`, because no caller-supplied request ID is trusted until the complete envelope parses.
 
-Rust is a required macOS build dependency. `rust-toolchain.toml` pins Rust 1.88.0, including both Apple targets. Every setup, CI, generation, benchmark, and Xcode command runs Cargo through that exact rustup toolchain with `--locked`. Release builds use size optimization, fat LTO, one codegen unit, symbol stripping, isolated per-architecture target directories, and `MACOSX_DEPLOYMENT_TARGET=14.0`.
+Rust is a required macOS build dependency. `rust-toolchain.toml` pins the current Rust release, including both Apple targets. Every setup, CI, generation, benchmark, and Xcode command runs Cargo through that exact rustup toolchain with `--locked`. Release builds use size optimization, fat LTO, one codegen unit, symbol stripping, isolated per-architecture target directories, and `MACOSX_DEPLOYMENT_TARGET=14.0`.
 
 `scripts/build-diff-sidecar.sh` creates the requested slices and combines them with `lipo`. `scripts/verify-diff-sidecar-artifact.sh` executes the handshake and rejects missing slices, non-system dynamic dependencies, a deployment target other than macOS 14.0, linkable symbols, invalid executable permissions, or a binary larger than 5 MiB. Release signing runs the same check again and requires a valid code signature.
 

--- a/Native/DiffSidecar/rust-toolchain.toml
+++ b/Native/DiffSidecar/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.88.0"
+channel = "1.98.0"
 profile = "minimal"
 components = ["clippy", "rustfmt"]
 targets = ["aarch64-apple-darwin", "x86_64-apple-darwin"]

--- a/cmux-tui/apps/macos/TerminalBytesDemo/README.md
+++ b/cmux-tui/apps/macos/TerminalBytesDemo/README.md
@@ -41,8 +41,8 @@ Verification:
    `local_parser_cursor` and `raw_frames` prove that raw PTY bytes are being
    parsed in the app. `server_snapshot_rpc_count` remains zero.
 
-The build requires Rust 1.97.1, the Zig version declared by Ghostty, the Swift
-toolchain, `jq`, and OpenSSL. The Swift executable is built under the launcher's
+The build uses the Rust channel in `cmux-tui/rust-toolchain.toml`, plus the Zig
+version declared by Ghostty, the Swift toolchain, `jq`, and OpenSSL. The Swift executable is built under the launcher's
 temporary directory, so concurrent launches do not clean or share SwiftPM
 artifacts. `run-demo.sh` validates `zig` from `PATH`; set `ZIG=/path/to/zig` to
 select another compatible executable.

--- a/cmux-tui/apps/macos/TerminalBytesDemo/run-demo.sh
+++ b/cmux-tui/apps/macos/TerminalBytesDemo/run-demo.sh
@@ -9,6 +9,11 @@ REPO_ROOT="$(cd "$TUI_ROOT/.." && pwd -P)"
 # shellcheck source=/dev/null
 source "$REPO_ROOT/scripts/ghostty-zig-version.sh"
 ZIG_REQUIRED="$(ghostty_minimum_zig_version "$REPO_ROOT")"
+RUST_REQUIRED="$(awk -F '"' '/^[[:space:]]*channel[[:space:]]*=/{print $2; exit}' "$TUI_ROOT/rust-toolchain.toml")"
+if [[ -z "$RUST_REQUIRED" ]]; then
+  echo "cmux-tui/rust-toolchain.toml does not declare a Rust channel." >&2
+  exit 1
+fi
 
 for command in cargo codesign jq openssl swift; do
   if ! command -v "$command" >/dev/null 2>&1; then
@@ -17,7 +22,6 @@ for command in cargo codesign jq openssl swift; do
   fi
 done
 
-RUST_REQUIRED=1.97.1
 if ! cargo "+$RUST_REQUIRED" --version >/dev/null 2>&1; then
   echo "TerminalBytes demo needs Rust $RUST_REQUIRED; run: rustup toolchain install $RUST_REQUIRED" >&2
   exit 1

--- a/cmux-tui/bindings/RELEASING.md
+++ b/cmux-tui/bindings/RELEASING.md
@@ -148,7 +148,7 @@ authorization is valid for the same workflow run attempt and 15 minutes.
     -F 'client_payload[confirm_bootstrap]=true'
   ```
 
-  A credential-free job installs Cargo 1.95.0, tests the source-controlled
+  A credential-free job installs the repository-pinned Rust toolchain, tests the source-controlled
   minimal `cmux-sdk` and `cmux-sidebar` crates, and uploads their packaged
   archives. Fresh serialized jobs check each archive digest and allowlisted
   paths, reconstruct the original manifest, and prove Cargo reproduces the

--- a/cmux-tui/bindings/examples/rust-sidebar-monitor/README.md
+++ b/cmux-tui/bindings/examples/rust-sidebar-monitor/README.md
@@ -19,9 +19,9 @@ Keys:
 - Other supported keyboard, mouse, paste, and focus events are forwarded.
 - Terminal resize events resize the remote sidebar view.
 
-Run the deterministic fake-server tests with Rust 1.88:
+Run the deterministic fake-server tests with the checked-in Rust toolchain:
 
 ```bash
-cargo +1.88.0 test --all-targets
-cargo +1.88.0 clippy --all-targets -- -D warnings
+cargo test --all-targets
+cargo clippy --all-targets -- -D warnings
 ```

--- a/cmux-tui/bindings/examples/rust-sidebar-monitor/rust-toolchain.toml
+++ b/cmux-tui/bindings/examples/rust-sidebar-monitor/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.88.0"
+channel = "1.98.0"
 profile = "minimal"

--- a/cmux-tui/crates/chatmux-relay/src/config.rs
+++ b/cmux-tui/crates/chatmux-relay/src/config.rs
@@ -242,7 +242,7 @@ pub fn save_config(path: &Path, config: &Config) -> std::io::Result<()> {
         path.file_name().and_then(|name| name.to_str()).unwrap_or("config.json"),
         std::process::id(),
     ));
-    let mut options = std::fs::OpenOptions::new();
+    let mut options = OpenOptions::new();
     options.write(true).create_new(true);
     #[cfg(unix)]
     {

--- a/cmux-tui/crates/chatmux-relay/src/preview_proxy.rs
+++ b/cmux-tui/crates/chatmux-relay/src/preview_proxy.rs
@@ -810,15 +810,15 @@ async fn connect_target(
     shared: &ProxyShared,
 ) -> Result<
     (hyper::client::conn::http1::SendRequest<hyper::body::Incoming>, tokio::task::JoinHandle<()>),
-    hyper::Response<ProxyBody>,
+    Box<hyper::Response<ProxyBody>>,
 > {
     let stream = tokio::net::TcpStream::connect(("127.0.0.1", shared.target_port)).await.map_err(
-        |error| text_response(502, &format!("preview target port is not reachable: {error}")),
+        |error| Box::new(text_response(502, &format!("preview target port is not reachable: {error}"))),
     )?;
     let io = hyper_util::rt::TokioIo::new(stream);
     let (sender, connection) = hyper::client::conn::http1::handshake(io)
         .await
-        .map_err(|error| text_response(502, &format!("target handshake failed: {error}")))?;
+        .map_err(|error| Box::new(text_response(502, &format!("target handshake failed: {error}"))))?;
     let driver = tokio::spawn(async move {
         let _ = connection.with_upgrades().await;
     });
@@ -859,7 +859,7 @@ async fn forward_plain(
 ) -> hyper::Response<ProxyBody> {
     let (mut sender, _driver) = match connect_target(&shared).await {
         Ok(ready) => ready,
-        Err(response) => return response,
+        Err(response) => return *response,
     };
     let skip_inject = header_is_one(request.headers(), NO_INJECT_HEADER);
     let (parts, body) = request.into_parts();
@@ -917,7 +917,7 @@ async fn forward_upgrade(
 ) -> hyper::Response<ProxyBody> {
     let (mut sender, _driver) = match connect_target(&shared).await {
         Ok(ready) => ready,
-        Err(response) => return response,
+        Err(response) => return *response,
     };
     let (mut parts, body) = request.into_parts();
     let Some(server_upgrade) = parts.extensions.remove::<hyper::upgrade::OnUpgrade>() else {

--- a/cmux-tui/crates/chatmux-relay/src/preview_proxy.rs
+++ b/cmux-tui/crates/chatmux-relay/src/preview_proxy.rs
@@ -813,12 +813,15 @@ async fn connect_target(
     Box<hyper::Response<ProxyBody>>,
 > {
     let stream = tokio::net::TcpStream::connect(("127.0.0.1", shared.target_port)).await.map_err(
-        |error| Box::new(text_response(502, &format!("preview target port is not reachable: {error}"))),
+        |error| {
+            Box::new(text_response(502, &format!("preview target port is not reachable: {error}")))
+        },
     )?;
     let io = hyper_util::rt::TokioIo::new(stream);
-    let (sender, connection) = hyper::client::conn::http1::handshake(io)
-        .await
-        .map_err(|error| Box::new(text_response(502, &format!("target handshake failed: {error}"))))?;
+    let (sender, connection) =
+        hyper::client::conn::http1::handshake(io).await.map_err(|error| {
+            Box::new(text_response(502, &format!("target handshake failed: {error}")))
+        })?;
     let driver = tokio::spawn(async move {
         let _ = connection.with_upgrades().await;
     });

--- a/cmux-tui/crates/chatmux-relay/src/watch.rs
+++ b/cmux-tui/crates/chatmux-relay/src/watch.rs
@@ -450,12 +450,7 @@ async fn coordinate_open(
 /// Publish the acknowledgement and active task as one state transition.
 /// `prepared` stays outside the mutex on every rejection path so dropping a
 /// notify watcher cannot run while registry state is locked.
-fn commit_open(
-    watch_id: String,
-    root: PathBuf,
-    prepared: PreparedWatch,
-    context: OpenContext,
-) {
+fn commit_open(watch_id: String, root: PathBuf, prepared: PreparedWatch, context: OpenContext) {
     let OpenContext {
         generation,
         live,

--- a/cmux-tui/crates/chatmux-relay/src/watch.rs
+++ b/cmux-tui/crates/chatmux-relay/src/watch.rs
@@ -218,6 +218,7 @@ async fn report_watch_failure(
 }
 
 impl WatchRegistry {
+    #[cfg(test)]
     pub(crate) fn new(outbound: OutboundSink) -> WatchRegistry {
         Self::new_with_teardown_slots(
             outbound,
@@ -225,6 +226,7 @@ impl WatchRegistry {
         )
     }
 
+    #[cfg(test)]
     pub(crate) fn new_with_teardown_slots(
         outbound: OutboundSink,
         teardown_slots: Arc<Semaphore>,
@@ -302,18 +304,20 @@ impl WatchRegistry {
                     // this slot. Tokio guarantees `spawn` does not poll the
                     // future synchronously as part of this call.
                     let task_id = watch_id.clone();
-                    let task_cancellation = opening_cancellation.clone();
+                    let context = OpenContext {
+                        generation,
+                        live: Arc::clone(&opening_live),
+                        cancellation: opening_cancellation,
+                        sessions: Arc::clone(&sessions),
+                        outbound,
+                        setup_slots,
+                        teardown_slots,
+                    };
                     let task = tokio::spawn(coordinate_open(
                         task_id,
                         frame,
                         local_roots_for_task,
-                        generation,
-                        Arc::clone(&opening_live),
-                        task_cancellation,
-                        Arc::clone(&sessions),
-                        outbound,
-                        setup_slots,
-                        teardown_slots,
+                        context,
                     ));
                     slot.opening.as_mut().expect("opening was just reserved").abort =
                         Some(task.abort_handle());
@@ -343,6 +347,19 @@ enum SetupFailure {
     Cancelled,
     Refused { code: wire::WorkspaceErrorCode, message: String },
     Failed(String),
+}
+
+/// State owned by one asynchronous open attempt. Keeping the lifecycle state
+/// together prevents a generation token from being paired with a different
+/// cancellation or liveness token.
+struct OpenContext {
+    generation: u64,
+    live: Arc<AtomicBool>,
+    cancellation: CancellationToken,
+    sessions: Sessions,
+    outbound: OutboundSink,
+    setup_slots: Arc<Semaphore>,
+    teardown_slots: Arc<Semaphore>,
 }
 
 /// Resolve the scoped root, install notify, and discover ignore files on a
@@ -406,57 +423,26 @@ async fn coordinate_open(
     watch_id: String,
     frame: wire::RelayFsWatchOpen,
     local_roots: Option<Vec<String>>,
-    generation: u64,
-    live: Arc<AtomicBool>,
-    cancellation: CancellationToken,
-    sessions: Sessions,
-    outbound: OutboundSink,
-    setup_slots: Arc<Semaphore>,
-    teardown_slots: Arc<Semaphore>,
+    context: OpenContext,
 ) {
-    let setup =
-        setup_watch(frame, local_roots, cancellation.clone(), setup_slots.clone(), teardown_slots)
-            .await;
+    let setup = setup_watch(
+        frame,
+        local_roots,
+        context.cancellation.clone(),
+        context.setup_slots.clone(),
+        context.teardown_slots.clone(),
+    )
+    .await;
     match setup {
         Ok((root, prepared)) => {
-            commit_open(
-                watch_id,
-                root,
-                prepared,
-                generation,
-                live,
-                cancellation,
-                sessions,
-                outbound,
-                setup_slots,
-            );
+            commit_open(watch_id, root, prepared, context);
         }
         Err(SetupFailure::Cancelled) => {}
         Err(SetupFailure::Refused { code, message }) => {
-            finish_open_failure(
-                &watch_id,
-                generation,
-                live,
-                cancellation,
-                sessions,
-                outbound,
-                code,
-                Some(message),
-            )
-            .await;
+            finish_open_failure(&watch_id, code, Some(message), context).await;
         }
         Err(SetupFailure::Failed(_message)) => {
-            finish_open_failure(
-                &watch_id,
-                generation,
-                live,
-                cancellation,
-                sessions,
-                outbound,
-                wire::WorkspaceErrorCode::Failed,
-                None,
-            )
-            .await;
+            finish_open_failure(&watch_id, wire::WorkspaceErrorCode::Failed, None, context).await;
         }
     }
 }
@@ -468,13 +454,17 @@ fn commit_open(
     watch_id: String,
     root: PathBuf,
     prepared: PreparedWatch,
-    generation: u64,
-    live: Arc<AtomicBool>,
-    cancellation: CancellationToken,
-    sessions: Sessions,
-    outbound: OutboundSink,
-    setup_slots: Arc<Semaphore>,
+    context: OpenContext,
 ) {
+    let OpenContext {
+        generation,
+        live,
+        cancellation,
+        sessions,
+        outbound,
+        setup_slots,
+        teardown_slots: _,
+    } = context;
     let opened = serde_json::to_string(&wire::RelayFsWatchOpened {
         version: WORKSPACE_FRAME_VERSION,
         r#type: wire::TagFsWatchOpened::FsWatchOpened,
@@ -496,10 +486,10 @@ fn commit_open(
         {
             let (start_tx, start_rx) = oneshot::channel();
             let run_id = watch_id.clone();
-            let run_root = root.clone();
-            let run_outbound = outbound.clone();
+            let run_root = root;
+            let run_outbound = outbound;
             let run_sessions = Arc::clone(&sessions);
-            let run_setup_slots = Arc::clone(&setup_slots);
+            let run_setup_slots = setup_slots;
             let run_cancellation = cancellation.clone();
             let run_live = Arc::clone(&live);
             let run_prepared = prepared.take().expect("prepared watch present");
@@ -565,14 +555,11 @@ fn commit_open(
 
 async fn finish_open_failure(
     watch_id: &str,
-    generation: u64,
-    live: Arc<AtomicBool>,
-    cancellation: CancellationToken,
-    sessions: Sessions,
-    outbound: OutboundSink,
     code: wire::WorkspaceErrorCode,
     message: Option<String>,
+    context: OpenContext,
 ) {
+    let OpenContext { generation, live, cancellation, sessions, outbound, .. } = context;
     let text = watch_error_frame(watch_id, code, message.as_deref());
     let should_report = sessions.lock().ok().is_some_and(|state| {
         state.get(watch_id).is_some_and(|slot| {
@@ -1322,15 +1309,20 @@ mod tests {
                 }),
             },
         );
-        let task = tokio::spawn(finish_open_failure(
-            "failed",
-            1,
+        let context = OpenContext {
+            generation: 1,
             live,
             cancellation,
-            Arc::clone(&sessions),
-            sink,
+            sessions: Arc::clone(&sessions),
+            outbound: sink,
+            setup_slots: Arc::new(Semaphore::new(WATCH_SETUP_CONCURRENCY)),
+            teardown_slots: Arc::new(Semaphore::new(WATCH_TEARDOWN_CONCURRENCY)),
+        };
+        let task = tokio::spawn(finish_open_failure(
+            "failed",
             wire::WorkspaceErrorCode::Failed,
             None,
+            context,
         ));
         let mut frame = critical.recv().await.expect("failure frame");
         assert!(frame.live.is_some(), "failure keeps its opening liveness token until delivery");
@@ -1362,15 +1354,20 @@ mod tests {
                 }),
             },
         );
-        let task = tokio::spawn(finish_open_failure(
-            "saturated",
-            1,
+        let context = OpenContext {
+            generation: 1,
             live,
             cancellation,
-            Arc::clone(&sessions),
-            sink,
+            sessions: Arc::clone(&sessions),
+            outbound: sink,
+            setup_slots: Arc::new(Semaphore::new(WATCH_SETUP_CONCURRENCY)),
+            teardown_slots: Arc::new(Semaphore::new(WATCH_TEARDOWN_CONCURRENCY)),
+        };
+        let task = tokio::spawn(finish_open_failure(
+            "saturated",
             wire::WorkspaceErrorCode::Failed,
             None,
+            context,
         ));
         tokio::task::yield_now().await;
         assert!(!task.is_finished(), "failure waits instead of dropping under queue pressure");

--- a/cmux-tui/crates/chatmux-relay/src/workspace.rs
+++ b/cmux-tui/crates/chatmux-relay/src/workspace.rs
@@ -1787,6 +1787,7 @@ fn porcelain_v1_xy(xy: &str) -> String {
     xy.chars().map(|column| if column == '.' { ' ' } else { column }).collect()
 }
 
+#[cfg(test)]
 async fn run_git_status(scope: &Scope) -> Result<wire::WorkspaceResultBody, Refusal> {
     let cancellation = CancellationToken::new();
     run_git_status_with_cancel_until(
@@ -1797,6 +1798,7 @@ async fn run_git_status(scope: &Scope) -> Result<wire::WorkspaceResultBody, Refu
     .await
 }
 
+#[cfg(test)]
 async fn run_git_status_with_cancel(
     scope: &Scope,
     cancellation: &CancellationToken,
@@ -1991,6 +1993,7 @@ async fn run_git_status_with_cancel_until(
     }))
 }
 
+#[cfg(test)]
 async fn run_git_diff(
     scope: &Scope,
     op: &wire::GitDiffOp,
@@ -2459,16 +2462,16 @@ impl Connection {
         }
         let outbound = self.outbound.clone();
         let cancellation = self.request_cancel.clone();
-        if let Ok(mut requests) = self.requests.lock() {
-            if !self.request_cancel.is_cancelled() {
-                requests.spawn(async move {
-                    let _ = tokio::select! {
-                        biased;
-                        _ = cancellation.cancelled() => Err(()),
-                        result = outbound.critical_text(text) => result,
-                    };
-                });
-            }
+        if let Ok(mut requests) = self.requests.lock()
+            && !self.request_cancel.is_cancelled()
+        {
+            requests.spawn(async move {
+                let _ = tokio::select! {
+                    biased;
+                    _ = cancellation.cancelled() => Err(()),
+                    result = outbound.critical_text(text) => result,
+                };
+            });
         }
     }
 }
@@ -2534,7 +2537,7 @@ async fn execute(
     let started = std::time::Instant::now();
     let deadline = started + Duration::from_millis(timeout_ms as u64);
     let outcome = run_op(runtime, request, permit, cancellation, deadline).await;
-    if started.elapsed() > std::time::Duration::from_millis(timeout_ms.unsigned_abs()) {
+    if started.elapsed() > Duration::from_millis(timeout_ms.unsigned_abs()) {
         Err(Refusal::new(
             wire::WorkspaceErrorCode::Timeout,
             format!("workspace op exceeded {timeout_ms}ms"),
@@ -3440,7 +3443,7 @@ mod tests {
         let (sink, mut critical, _watch) = OutboundSink::channels();
         let connection = Connection::new(runtime, sink);
         connection.handle_frame(patched);
-        let frame = tokio::time::timeout(std::time::Duration::from_secs(15), critical.recv())
+        let frame = tokio::time::timeout(Duration::from_secs(15), critical.recv())
             .await
             .expect("no answer within 15s")
             .expect("channel open");
@@ -3482,11 +3485,11 @@ mod tests {
         }
 
         let mut ids = [
-            tokio::time::timeout(std::time::Duration::from_secs(15), critical.recv())
+            tokio::time::timeout(Duration::from_secs(15), critical.recv())
                 .await
                 .expect("first request timed out")
                 .expect("channel closed"),
-            tokio::time::timeout(std::time::Duration::from_secs(15), critical.recv())
+            tokio::time::timeout(Duration::from_secs(15), critical.recv())
                 .await
                 .expect("second request timed out")
                 .expect("channel closed"),

--- a/cmux-tui/crates/cmux-remote-protocol/src/frame.rs
+++ b/cmux-tui/crates/cmux-remote-protocol/src/frame.rs
@@ -121,7 +121,7 @@ impl SessionId {
             return Err("session ID contains a non-hexadecimal character".into());
         }
         let mut bytes = [0_u8; 16];
-        for (index, chunk) in value.as_bytes().chunks_exact(2).enumerate() {
+        for (index, chunk) in value.as_bytes().as_chunks::<2>().0.iter().enumerate() {
             let encoded = std::str::from_utf8(chunk).expect("ASCII was checked above");
             bytes[index] = u8::from_str_radix(encoded, 16)
                 .map_err(|_| "session ID contains a non-hexadecimal character".to_string())?;

--- a/cmux-tui/crates/cmux-remote/src/mux_codec.rs
+++ b/cmux-tui/crates/cmux-remote/src/mux_codec.rs
@@ -313,7 +313,7 @@ mod tests {
     #[test]
     fn relay_download_limit_keeps_server_egress_budget() {
         assert_eq!(MAX_MUX_DOWNLOAD_LINE_BYTES - 1, REMOTE_SESSION_MESSAGE_MAX_BYTES);
-        assert!(MAX_MUX_DOWNLOAD_LINE_BYTES > MAX_MUX_UPLOAD_LINE_BYTES);
+        const { assert!(MAX_MUX_DOWNLOAD_LINE_BYTES > MAX_MUX_UPLOAD_LINE_BYTES) };
         let line = vec![b'x'; 32];
         let packets = encode_line_with_limit(1, &line, MAX_MUX_DOWNLOAD_LINE_BYTES).unwrap();
         let mut assembler = MuxLineAssembler::with_maximum(MAX_MUX_DOWNLOAD_LINE_BYTES);

--- a/cmux-tui/crates/cmux-remote/src/provider/websocket.rs
+++ b/cmux-tui/crates/cmux-remote/src/provider/websocket.rs
@@ -334,10 +334,10 @@ mod tests {
             "wss://machine-1337.vm.cmux.sh/v1/link?bl_preview_token=t&cmux_lane=control",
         )
         .unwrap();
-        let request = super::client_request(&endpoint).unwrap();
+        let request = client_request(&endpoint).unwrap();
         assert_eq!(
             request.headers().get("user-agent").and_then(|value| value.to_str().ok()),
-            Some(super::CLIENT_USER_AGENT)
+            Some(CLIENT_USER_AGENT)
         );
         assert!(request.headers().get("origin").is_none());
         assert_eq!(request.uri().query(), Some("bl_preview_token=t&cmux_lane=control"));

--- a/cmux-tui/crates/cmux-remote/src/services.rs
+++ b/cmux-tui/crates/cmux-remote/src/services.rs
@@ -869,7 +869,7 @@ fn decode_hex_32(value: &str) -> Result<[u8; 32], ServicesError> {
         return Err(ServicesError::Remote("renderer grant has invalid token".into()));
     }
     let mut output = [0u8; 32];
-    for (index, pair) in value.as_bytes().chunks_exact(2).enumerate() {
+    for (index, pair) in value.as_bytes().as_chunks::<2>().0.iter().enumerate() {
         let nibble = |byte: u8| match byte {
             b'0'..=b'9' => Some(byte - b'0'),
             b'a'..=b'f' => Some(byte - b'a' + 10),

--- a/cmux-tui/crates/cmux-remote/src/workspace/files.rs
+++ b/cmux-tui/crates/cmux-remote/src/workspace/files.rs
@@ -1362,7 +1362,7 @@ pub(crate) async fn write_bytes_locked_with_outcome(
     bytes: &[u8],
     precondition: &FilePrecondition,
     create_parents: bool,
-) -> Result<String, MutationFailure> {
+) -> Result<String, Box<MutationFailure>> {
     write_bytes_locked_with_mode_and_outcome(root, path, bytes, precondition, create_parents, None)
         .await
 }
@@ -1374,12 +1374,12 @@ pub(crate) async fn write_bytes_locked_with_mode_and_outcome(
     precondition: &FilePrecondition,
     create_parents: bool,
     mode: Option<u32>,
-) -> Result<String, MutationFailure> {
+) -> Result<String, Box<MutationFailure>> {
     if bytes.len() > MAX_WRITE_BYTES {
-        return Err(MutationFailure::unchanged(RpcError::new(
+        return Err(Box::new(MutationFailure::unchanged(RpcError::new(
             "resource-exhausted",
             format!("write exceeds {MAX_WRITE_BYTES} bytes"),
-        )));
+        ))));
     }
     #[cfg(unix)]
     {
@@ -1396,8 +1396,8 @@ pub(crate) async fn write_bytes_locked_with_mode_and_outcome(
             )
         })
         .await
-        .map_err(|error| MutationFailure::unchanged(blocking_task_error(error)))?
-        .map_err(MutationFailure::unchanged)?;
+        .map_err(|error| Box::new(MutationFailure::unchanged(blocking_task_error(error))))?
+        .map_err(|failure| Box::new(MutationFailure::unchanged(failure)))?;
         #[cfg(test)]
         pause_at_mutation_test_barrier(root, path, MutationTestPoint::AfterPrecondition).await;
         let bytes = bytes.to_vec();
@@ -1407,26 +1407,26 @@ pub(crate) async fn write_bytes_locked_with_mode_and_outcome(
             (result, progress)
         })
         .await
-        .map_err(|error| MutationFailure::unknown(blocking_task_error(error)))?;
-        result.map_err(|error| progress.fail(error))
+        .map_err(|error| Box::new(MutationFailure::unknown(blocking_task_error(error))))?;
+        result.map_err(|error| Box::new(progress.fail(error)))
     }
     #[cfg(not(unix))]
     {
         if mode.is_some() {
-            return Err(MutationFailure::unchanged(RpcError::new(
+            return Err(Box::new(MutationFailure::unchanged(RpcError::new(
                 "unsupported-platform",
                 "workspace file modes require Unix descriptor-relative file operations",
-            )));
+            ))));
         }
         if !matches!(precondition, FilePrecondition::Any) {
-            return Err(MutationFailure::unchanged(RpcError::new(
+            return Err(Box::new(MutationFailure::unchanged(RpcError::new(
                 "unsupported-platform",
                 "guarded workspace writes require Unix descriptor-relative file operations",
-            )));
+            ))));
         }
         write_bytes_locked_path(root, path, bytes, precondition, create_parents)
             .await
-            .map_err(MutationFailure::unknown)
+            .map_err(|error| Box::new(MutationFailure::unknown(error)))
     }
 }
 
@@ -1534,7 +1534,7 @@ pub(crate) async fn remove_file_precondition_locked_with_outcome(
     root: &WorkspaceRoot,
     path: &str,
     precondition: &FilePrecondition,
-) -> Result<(), MutationFailure> {
+) -> Result<(), Box<MutationFailure>> {
     #[cfg(unix)]
     {
         let root_handle = root.unix_root();
@@ -1544,8 +1544,8 @@ pub(crate) async fn remove_file_precondition_locked_with_outcome(
             prepare_unix_remove(root_handle, prepared_path, prepared_precondition)
         })
         .await
-        .map_err(|error| MutationFailure::unchanged(blocking_task_error(error)))?
-        .map_err(MutationFailure::unchanged)?;
+        .map_err(|error| Box::new(MutationFailure::unchanged(blocking_task_error(error))))?
+        .map_err(|failure| Box::new(MutationFailure::unchanged(failure)))?;
         #[cfg(test)]
         pause_at_mutation_test_barrier(root, path, MutationTestPoint::AfterPrecondition).await;
         let (result, progress) = tokio::task::spawn_blocking(move || {
@@ -1554,20 +1554,20 @@ pub(crate) async fn remove_file_precondition_locked_with_outcome(
             (result, progress)
         })
         .await
-        .map_err(|error| MutationFailure::unknown(blocking_task_error(error)))?;
-        result.map_err(|error| progress.fail(error))
+        .map_err(|error| Box::new(MutationFailure::unknown(blocking_task_error(error))))?;
+        result.map_err(|error| Box::new(progress.fail(error)))
     }
     #[cfg(not(unix))]
     {
         if !matches!(precondition, FilePrecondition::Any) {
-            return Err(MutationFailure::unchanged(RpcError::new(
+            return Err(Box::new(MutationFailure::unchanged(RpcError::new(
                 "unsupported-platform",
                 "guarded workspace removals require Unix descriptor-relative file operations",
-            )));
+            ))));
         }
         remove_file_precondition_locked_path(root, path, precondition)
             .await
-            .map_err(MutationFailure::unknown)
+            .map_err(|error| Box::new(MutationFailure::unknown(error)))
     }
 }
 

--- a/cmux-tui/crates/cmux-remote/src/workspace/patch.rs
+++ b/cmux-tui/crates/cmux-remote/src/workspace/patch.rs
@@ -79,32 +79,34 @@ impl CommitTracker {
         mut self,
         path: &str,
         applied_state: AppliedState,
-        failure: MutationFailure,
+        failure: Box<MutationFailure>,
     ) -> CommitFailure {
-        match failure.outcome {
+        let MutationFailure { error, outcome, recovery_path } = *failure;
+        match outcome {
             MutationOutcome::Unchanged | MutationOutcome::Restored => {}
             MutationOutcome::Applied => self.applied(path, applied_state),
             MutationOutcome::Unknown => {
                 self.uncertain.insert(path.to_owned());
             }
         }
-        if let Some(recovery_path) = failure.recovery_path {
+        if let Some(recovery_path) = recovery_path {
             self.recovery_paths
                 .entry(path.to_owned())
                 .or_default()
                 .insert(recovery_path.to_string_lossy().into_owned());
         }
-        self.failure(failure.error)
+        self.failure(error)
     }
 }
 
 impl RollbackReport {
-    fn failure(&mut self, path: &str, failure: MutationFailure) {
+    fn failure(&mut self, path: &str, failure: Box<MutationFailure>) {
+        let MutationFailure { error, outcome, recovery_path } = *failure;
         self.failures.push(RollbackFailure {
             path: path.to_owned(),
-            error: failure.error,
-            outcome: failure.outcome,
-            recovery_path: failure.recovery_path.map(|path| path.to_string_lossy().into_owned()),
+            error,
+            outcome,
+            recovery_path: recovery_path.map(|path| path.to_string_lossy().into_owned()),
         });
     }
 }
@@ -134,7 +136,7 @@ pub(crate) async fn apply_patch(
     }
 
     if let Err(failure) = commit_changes(root, &changes, &snapshots).await {
-        let CommitFailure { error, applied, mut uncertain, mut recovery_paths } = failure;
+        let CommitFailure { error, applied, mut uncertain, mut recovery_paths } = *failure;
         let rollback = rollback(root, &snapshots, &applied).await;
         let mut unresolved = uncertain.clone();
         let mut rollback_errors = Vec::new();
@@ -610,7 +612,7 @@ fn unified_hunk_line_counts(line: &str) -> Option<(usize, usize)> {
 }
 
 fn unified_range_line_count(range: &str) -> Option<usize> {
-    let (start, count) = range.split_once(',').map_or((range, "1"), |parts| parts);
+    let (start, count) = range.split_once(',').unwrap_or((range, "1"));
     start.parse::<usize>().ok()?;
     count.parse().ok()
 }
@@ -629,13 +631,13 @@ async fn commit_changes(
     root: &WorkspaceRoot,
     changes: &[PreparedChange],
     snapshots: &FileSnapshots,
-) -> Result<(), CommitFailure> {
+) -> Result<(), Box<CommitFailure>> {
     let mut tracker = CommitTracker::default();
     macro_rules! commit_try {
         ($operation:expr) => {
             match $operation {
                 Ok(value) => value,
-                Err(error) => return Err(tracker.failure(error)),
+                Err(error) => return Err(Box::new(tracker.failure(error))),
             }
         };
     }
@@ -657,17 +659,21 @@ async fn commit_changes(
                 {
                     Ok(hash) => tracker.applied(new, AppliedState::Present(hash)),
                     Err(failure) => {
-                        return Err(tracker.mutation_failure(
+                        return Err(Box::new(tracker.mutation_failure(
                             new,
                             AppliedState::Present(hash_bytes(contents)),
                             failure,
-                        ));
+                        )));
                     }
                 }
                 match remove_file_precondition_locked_with_outcome(root, old, &source).await {
                     Ok(()) => tracker.applied(old, AppliedState::Missing),
                     Err(failure) => {
-                        return Err(tracker.mutation_failure(old, AppliedState::Missing, failure));
+                        return Err(Box::new(tracker.mutation_failure(
+                            old,
+                            AppliedState::Missing,
+                            failure,
+                        )));
                     }
                 }
             }
@@ -678,11 +684,11 @@ async fn commit_changes(
                 {
                     Ok(hash) => tracker.applied(new, AppliedState::Present(hash)),
                     Err(failure) => {
-                        return Err(tracker.mutation_failure(
+                        return Err(Box::new(tracker.mutation_failure(
                             new,
                             AppliedState::Present(hash_bytes(contents)),
                             failure,
-                        ));
+                        )));
                     }
                 }
             }
@@ -691,15 +697,19 @@ async fn commit_changes(
                 match remove_file_precondition_locked_with_outcome(root, old, &precondition).await {
                     Ok(()) => tracker.applied(old, AppliedState::Missing),
                     Err(failure) => {
-                        return Err(tracker.mutation_failure(old, AppliedState::Missing, failure));
+                        return Err(Box::new(tracker.mutation_failure(
+                            old,
+                            AppliedState::Missing,
+                            failure,
+                        )));
                     }
                 }
             }
             _ => {
-                return Err(tracker.failure(RpcError::new(
+                return Err(Box::new(tracker.failure(RpcError::new(
                     "invalid-patch",
                     "patch produced an invalid file transition",
-                )));
+                ))));
             }
         }
     }

--- a/cmux-tui/crates/cmux-remote/src/workspace/patch.rs
+++ b/cmux-tui/crates/cmux-remote/src/workspace/patch.rs
@@ -79,9 +79,9 @@ impl CommitTracker {
         mut self,
         path: &str,
         applied_state: AppliedState,
-        failure: Box<MutationFailure>,
+        failure: MutationFailure,
     ) -> CommitFailure {
-        let MutationFailure { error, outcome, recovery_path } = *failure;
+        let MutationFailure { error, outcome, recovery_path } = failure;
         match outcome {
             MutationOutcome::Unchanged | MutationOutcome::Restored => {}
             MutationOutcome::Applied => self.applied(path, applied_state),
@@ -100,8 +100,8 @@ impl CommitTracker {
 }
 
 impl RollbackReport {
-    fn failure(&mut self, path: &str, failure: Box<MutationFailure>) {
-        let MutationFailure { error, outcome, recovery_path } = *failure;
+    fn failure(&mut self, path: &str, failure: MutationFailure) {
+        let MutationFailure { error, outcome, recovery_path } = failure;
         self.failures.push(RollbackFailure {
             path: path.to_owned(),
             error,
@@ -662,7 +662,7 @@ async fn commit_changes(
                         return Err(Box::new(tracker.mutation_failure(
                             new,
                             AppliedState::Present(hash_bytes(contents)),
-                            failure,
+                            *failure,
                         )));
                     }
                 }
@@ -672,7 +672,7 @@ async fn commit_changes(
                         return Err(Box::new(tracker.mutation_failure(
                             old,
                             AppliedState::Missing,
-                            failure,
+                            *failure,
                         )));
                     }
                 }
@@ -687,7 +687,7 @@ async fn commit_changes(
                         return Err(Box::new(tracker.mutation_failure(
                             new,
                             AppliedState::Present(hash_bytes(contents)),
-                            failure,
+                            *failure,
                         )));
                     }
                 }
@@ -700,7 +700,7 @@ async fn commit_changes(
                         return Err(Box::new(tracker.mutation_failure(
                             old,
                             AppliedState::Missing,
-                            failure,
+                            *failure,
                         )));
                     }
                 }
@@ -785,7 +785,7 @@ async fn rollback(
             (None, AppliedState::Missing) => Ok(()),
         };
         if let Err(failure) = result {
-            report.failure(path, failure);
+            report.failure(path, *failure);
         }
     }
     report

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -2174,7 +2174,7 @@ mod tests {
         capacity: usize,
         outbound_byte_budget: usize,
     ) -> (Arc<Inner>, Receiver<Outbound>) {
-        let (outbound, outbound_rx) = std::sync::mpsc::sync_channel(capacity);
+        let (outbound, outbound_rx) = sync_channel(capacity);
         (
             Arc::new(Inner {
                 outbound,

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -3926,7 +3926,7 @@ impl Mux {
                     id: workspace_slot,
                     public_id: public_id.clone(),
                     key: key.clone(),
-                    name: name.clone(),
+                    name,
                     screens: Vec::new(),
                     active_screen: 0,
                 };

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -3926,7 +3926,7 @@ impl Mux {
                     id: workspace_slot,
                     public_id: public_id.clone(),
                     key: key.clone(),
-                    name,
+                    name: name.clone(),
                     screens: Vec::new(),
                     active_screen: 0,
                 };

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -3966,7 +3966,7 @@ impl Mux {
                     id: workspace.id,
                     public_id: public_id.clone(),
                     key: key.clone(),
-                    name: name.clone(),
+                    name,
                     group_key: self.session.clone(),
                 };
                 let mut desired = self.registry_projection(state);

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -60,6 +60,7 @@ use crate::terminal_host_runtime::TerminalHostIdentity;
 #[cfg(unix)]
 use crate::terminal_host_runtime::TerminalHostLiveness;
 use crate::workspace_registry::{
+    AgentHookPendingProjection,
     FrontendProjection, ProjectionCommit, RESOURCE_API_FRONTEND_PROJECTION_SCHEMA_VERSION,
     RegistryBrowser, RegistryBrowserReconnect, RegistryCommit, RegistryLayoutNode,
     RegistrySnapshot, RegistryTab, RegistryTerminal, RegistryViewport, RegistryWorkspace,
@@ -2541,14 +2542,14 @@ impl Mux {
         // Keep startup work bounded. Remaining rows stay durable for a later
         // availability signal or restart.
         for _ in 0..crate::workspace_registry::AGENT_HOOK_MAX_RETRY_PAGES_PER_WAKE {
-            let (pending, next_cursor) = self
+            let page = self
                 .workspace_registry
                 .lock()
                 .unwrap()
                 .pending_agent_hook_projections_page(cursor.clone())?;
-            let Some(next_cursor) = next_cursor else { break };
+            let Some(next_cursor) = page.next_cursor else { break };
             cursor = Some(next_cursor);
-            self.retry_pending_agent_hooks_rows(pending)?;
+            self.retry_pending_agent_hooks_rows(page.rows)?;
         }
         Ok(())
     }
@@ -2578,10 +2579,17 @@ impl Mux {
 
     fn retry_pending_agent_hooks_rows(
         &self,
-        pending: Vec<(String, String, String, u64, crate::JournalIngress)>,
+        pending: Vec<AgentHookPendingProjection>,
     ) -> anyhow::Result<usize> {
         let mut applied = 0;
-        for (producer_id, origin, key, sequence, ingress) in pending {
+        for row in pending {
+            let AgentHookPendingProjection {
+                producer_id,
+                origin,
+                idempotency_key: key,
+                sequence,
+                ingress,
+            } = row;
             match self.apply_agent_hook_record(&ingress, sequence) {
                 Ok(()) => {
                     if self
@@ -22490,7 +22498,10 @@ mod tests {
         let pending =
             mux.workspace_registry.lock().unwrap().pending_agent_hook_projections().unwrap();
         assert_eq!(pending.len(), 1);
-        assert_eq!(pending[0].0, crate::agent_hooks::AGENT_HOOK_PRODUCER_ID);
+        assert_eq!(
+            pending[0].producer_id,
+            crate::agent_hooks::AGENT_HOOK_PRODUCER_ID
+        );
         assert!(
             mux.workspace_registry
                 .lock()

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -9244,14 +9244,14 @@ impl Mux {
             && let (Some(direct_state), Some(sequence_guard)) =
                 (direct_hook_state.as_ref(), sequence_guard.as_mut())
         {
-                sequence_guard.insert(
-                    terminal_id.clone(),
-                    HookFence {
-                        session_id: direct_state.agent_session_id.clone(),
-                        sequence: direct_state.applied_sequence,
-                        ended: false,
-                    },
-                );
+            sequence_guard.insert(
+                terminal_id.clone(),
+                HookFence {
+                    session_id: direct_state.agent_session_id.clone(),
+                    sequence: direct_state.applied_sequence,
+                    ended: false,
+                },
+            );
         }
         state.resource_revision = commit.revision;
         if !commit.replayed {

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -5531,7 +5531,6 @@ impl Mux {
         // fence for a start would let a delayed, session-less start mutate a
         // newer lifecycle.
         let agent_session_id = explicit_session_id
-            .clone()
             .or_else(|| {
                 (!is_session_start)
                     .then(|| previous_fence.as_ref().filter(|fence| !fence.ended))
@@ -8949,6 +8948,10 @@ impl Mux {
         self.report_agent_with_sequence_lock(surface, state, source, session, false, None, None)
     }
 
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "The journal report path keeps each authorization and ordering field explicit."
+    )]
     fn report_agent_with_sequence_lock(
         &self,
         surface: SurfaceId,
@@ -9196,10 +9199,10 @@ impl Mux {
             "state":record.state.as_str(),
             "source":record.source.as_str(),
             "updated_at_ms":record.updated_at_ms.to_string(),
-            "source_session":persisted_source_session.clone().or(record.session.clone()),
+            "source_session":persisted_source_session.or(record.session.clone()),
         });
         let mut public_value = value.clone();
-        public_value["source_session"] = serde_json::json!(record.session.clone());
+        public_value["source_session"] = serde_json::json!(record.session);
         let deltas = if effective_hook_state.is_some_and(|state| state.ended) {
             serde_json::json!([{
                 "kind":"delete",
@@ -9237,10 +9240,10 @@ impl Mux {
                 effective_hook_state,
             )?,
         };
-        if !commit.replayed {
-            if let (Some(direct_state), Some(sequence_guard)) =
+        if !commit.replayed
+            && let (Some(direct_state), Some(sequence_guard)) =
                 (direct_hook_state.as_ref(), sequence_guard.as_mut())
-            {
+        {
                 sequence_guard.insert(
                     terminal_id.clone(),
                     HookFence {
@@ -9249,7 +9252,6 @@ impl Mux {
                         ended: false,
                     },
                 );
-            }
         }
         state.resource_revision = commit.revision;
         if !commit.replayed {

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -60,13 +60,13 @@ use crate::terminal_host_runtime::TerminalHostIdentity;
 #[cfg(unix)]
 use crate::terminal_host_runtime::TerminalHostLiveness;
 use crate::workspace_registry::{
-    AgentHookPendingProjection,
-    FrontendProjection, ProjectionCommit, RESOURCE_API_FRONTEND_PROJECTION_SCHEMA_VERSION,
-    RegistryBrowser, RegistryBrowserReconnect, RegistryCommit, RegistryLayoutNode,
-    RegistrySnapshot, RegistryTab, RegistryTerminal, RegistryViewport, RegistryWorkspace,
-    ResourceChange, ResourceEffectOutcome, ResourceEffectPreparation, ResourcePatch,
-    ResourcePatchCommit, ResourceTopologySnapshot, ResourceWorkspaceLedger, TerminalLifecycle,
-    TerminalOnExit, TerminalRegistrySnapshot, WorkspaceMutation, WorkspaceRegistry,
+    AgentHookPendingProjection, FrontendProjection, ProjectionCommit,
+    RESOURCE_API_FRONTEND_PROJECTION_SCHEMA_VERSION, RegistryBrowser, RegistryBrowserReconnect,
+    RegistryCommit, RegistryLayoutNode, RegistrySnapshot, RegistryTab, RegistryTerminal,
+    RegistryViewport, RegistryWorkspace, ResourceChange, ResourceEffectOutcome,
+    ResourceEffectPreparation, ResourcePatch, ResourcePatchCommit, ResourceTopologySnapshot,
+    ResourceWorkspaceLedger, TerminalLifecycle, TerminalOnExit, TerminalRegistrySnapshot,
+    WorkspaceMutation, WorkspaceRegistry,
 };
 use crate::{
     PairingChallenge, PairingDecision, PairingError, PaneId, ScreenId, SplitDir, SplitId,
@@ -22498,10 +22498,7 @@ mod tests {
         let pending =
             mux.workspace_registry.lock().unwrap().pending_agent_hook_projections().unwrap();
         assert_eq!(pending.len(), 1);
-        assert_eq!(
-            pending[0].producer_id,
-            crate::agent_hooks::AGENT_HOOK_PRODUCER_ID
-        );
+        assert_eq!(pending[0].producer_id, crate::agent_hooks::AGENT_HOOK_PRODUCER_ID);
         assert!(
             mux.workspace_registry
                 .lock()

--- a/cmux-tui/crates/cmux-tui-core/src/mux/public_projections.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux/public_projections.rs
@@ -9,7 +9,7 @@ pub(super) struct RestoredPublicProjections {
     pub(super) has_terminal_defaults: bool,
     pub(super) next_notification_id: u64,
     pub(super) agent_records: HashMap<TerminalPublicId, TerminalAgentRecord>,
-    pub(super) agent_hook_fences: HashMap<TerminalPublicId, super::HookFence>,
+    pub(super) agent_hook_fences: HashMap<TerminalPublicId, HookFence>,
     pub(super) terminal_notifications: HashMap<TerminalPublicId, SurfaceNotification>,
     pub(super) notification_ledger: VecDeque<ResourceNotification>,
 }
@@ -64,7 +64,7 @@ pub(super) fn restore_public_projections(
     for hook_state in projections.agent_hook_states {
         agent_hook_fences.insert(
             hook_state.terminal_id,
-            super::HookFence {
+            HookFence {
                 session_id: hook_state.agent_session_id,
                 sequence: hook_state.applied_sequence,
                 ended: hook_state.ended,
@@ -84,8 +84,8 @@ pub(super) fn restore_public_projections(
                 // marker sequence as their legacy generation token so a
                 // session-less event continues the same lifecycle after a
                 // restart without reusing a terminal-wide identity.
-                agent_hook_fences.entry(agent.terminal_id.clone()).or_insert(super::HookFence {
-                    session_id: super::legacy_hook_session_id(&agent.terminal_id, value),
+                agent_hook_fences.entry(agent.terminal_id.clone()).or_insert(HookFence {
+                    session_id: legacy_hook_session_id(&agent.terminal_id, value),
                     sequence: value,
                     ended: ended.is_some(),
                 });
@@ -97,8 +97,8 @@ pub(super) fn restore_public_projections(
             // cannot resurrect the completed session. Sequence zero is the
             // one-release compatibility generation for records without a
             // marker.
-            agent_hook_fences.entry(agent.terminal_id.clone()).or_insert(super::HookFence {
-                session_id: super::legacy_hook_session_id(&agent.terminal_id, 0),
+            agent_hook_fences.entry(agent.terminal_id.clone()).or_insert(HookFence {
+                session_id: legacy_hook_session_id(&agent.terminal_id, 0),
                 sequence: 0,
                 ended: true,
             });

--- a/cmux-tui/crates/cmux-tui-core/src/mux/resource_content.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux/resource_content.rs
@@ -1150,7 +1150,7 @@ fn tab_resource_identity(state: &State, surface_slot: SurfaceId) -> Option<TabRe
 
 fn ordered_terminal_tab_ids(
     state: &State,
-) -> anyhow::Result<HashMap<crate::resource::TerminalPublicId, Vec<TabPublicId>>> {
+) -> anyhow::Result<HashMap<TerminalPublicId, Vec<TabPublicId>>> {
     let mut tabs = Vec::new();
     for pane in state.panes.values() {
         for (position, surface_slot) in pane.tabs.iter().enumerate() {

--- a/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
@@ -2833,7 +2833,7 @@ impl Mux {
                 }
             }
             ResourceOperation::TerminalClose => {
-                let public_id = slots.terminal.clone().context("terminal disappeared")?;
+                let public_id = slots.terminal.context("terminal disappeared")?;
                 let host_id = registry
                     .terminal_host_id(&public_id)?
                     .with_context(|| format!("terminal {public_id} has no durable host"))?;

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -320,8 +320,7 @@ fn has_windows_device_prefix(path: &[u16]) -> bool {
 
 #[cfg(windows)]
 fn has_windows_parent_component(path: &[u16]) -> bool {
-    path.split(|unit| *unit == b'\\' as u16)
-        .any(|segment| segment == [b'.' as u16, b'.' as u16])
+    path.split(|unit| *unit == b'\\' as u16).any(|segment| segment == [b'.' as u16, b'.' as u16])
 }
 
 #[cfg(any(windows, test))]

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -267,6 +267,15 @@ pub fn normalize_filesystem_path(path: PathBuf) -> PathBuf {
         if has_windows_device_prefix(&wide) {
             return path;
         }
+        // A verbatim path disables Win32's component parsing. Removing a
+        // parent component here would therefore change the meaning of a path
+        // that traverses a junction or symbolic link. Keep the original path
+        // spelling until a handle-aware canonicalization path is available.
+        // This is a deliberate fail-closed choice for the uncommon long path
+        // case, and preserves the pre-upgrade filesystem target.
+        if has_windows_parent_component(&wide) {
+            return path;
+        }
         let Some(normalized) = normalize_windows_absolute_path(&wide) else {
             return path;
         };
@@ -300,6 +309,12 @@ fn has_windows_device_prefix(path: &[u16]) -> bool {
     path.starts_with(&[b'\\' as u16, b'\\' as u16, b'?' as u16, b'\\' as u16])
         || path.starts_with(&[b'\\' as u16, b'\\' as u16, b'.' as u16, b'\\' as u16])
         || path.starts_with(&[b'\\' as u16, b'?' as u16, b'?' as u16, b'\\' as u16])
+}
+
+#[cfg(windows)]
+fn has_windows_parent_component(path: &[u16]) -> bool {
+    path.split(|unit| *unit == b'\\' as u16)
+        .any(|segment| segment == [b'.' as u16, b'.' as u16])
 }
 
 #[cfg(windows)]
@@ -1317,12 +1332,11 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
-    fn normalize_long_windows_state_paths_uses_the_verbatim_namespace() {
+    fn normalize_long_windows_parent_paths_preserve_component_semantics() {
         let path = PathBuf::from(format!(r"C:\{}\..\state", "segment".repeat(42)));
-        let normalized = normalize_filesystem_path(path);
+        let normalized = normalize_filesystem_path(path.clone());
         let text = normalized.to_string_lossy();
-        assert!(text.starts_with(r"\\?\C:\"), "{text}");
-        assert!(!text.contains(r"\..\"), "{text}");
+        assert_eq!(normalized, path, "{text}");
     }
 
     #[cfg(windows)]

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -256,7 +256,13 @@ pub fn normalize_filesystem_path(path: PathBuf) -> PathBuf {
             path
         } else {
             match std::env::current_dir() {
-                Ok(current) => current.join(path),
+                Ok(current) => {
+                    let resolved = current.join(&path);
+                    if resolved.as_os_str().encode_wide().count() < WINDOWS_PATH_HEADROOM {
+                        return path;
+                    }
+                    resolved
+                }
                 Err(_) => return path,
             }
         };
@@ -389,7 +395,7 @@ fn windows_component_is_reserved_device_name(stem: &[u16]) -> bool {
             })
     }
 
-    if [b"CON".as_slice(), b"PRN", b"AUX", b"NUL"]
+    if [b"CON".as_slice(), b"PRN", b"AUX", b"NUL", b"CONIN$", b"CONOUT$"]
         .iter()
         .any(|name| ascii_eq_ignore_case(stem, name))
     {

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -239,7 +239,8 @@ pub fn workspace_state_dir() -> Option<PathBuf> {
 /// Return a path that every state-file owner can use without hitting the
 /// legacy Windows MAX_PATH boundary. Windows' verbatim namespace is applied
 /// only to long, absolute drive or UNC paths. Short paths keep their existing
-/// spelling so callers and persisted diagnostics remain compatible.
+/// spelling so callers and persisted diagnostics remain compatible. Long paths
+/// with names that Win32 would reinterpret also keep their original spelling.
 pub fn normalize_filesystem_path(path: PathBuf) -> PathBuf {
     #[cfg(windows)]
     {
@@ -279,6 +280,12 @@ pub fn normalize_filesystem_path(path: PathBuf) -> PathBuf {
         let Some(normalized) = normalize_windows_absolute_path(&wide) else {
             return path;
         };
+        // `\\?\` disables Win32 string parsing. Prefix only components that
+        // already have ordinary Win32 file-name semantics, or the same input
+        // could select a different filesystem object after normalization.
+        if !windows_absolute_path_is_verbatim_safe(&normalized) {
+            return path;
+        }
         let is_unc = normalized.starts_with(&[b'\\' as u16, b'\\' as u16]);
         let mut prefixed = if is_unc {
             // `\\server\\share` becomes `\\?\\UNC\\server\\share`.
@@ -315,6 +322,83 @@ fn has_windows_device_prefix(path: &[u16]) -> bool {
 fn has_windows_parent_component(path: &[u16]) -> bool {
     path.split(|unit| *unit == b'\\' as u16)
         .any(|segment| segment == [b'.' as u16, b'.' as u16])
+}
+
+#[cfg(any(windows, test))]
+fn windows_absolute_path_is_verbatim_safe(path: &[u16]) -> bool {
+    let components = if path.len() >= 3
+        && path[0] <= 0x7f
+        && (path[0] as u8).is_ascii_alphabetic()
+        && path[1] == b':' as u16
+        && path[2] == b'\\' as u16
+    {
+        &path[3..]
+    } else if path.starts_with(&[b'\\' as u16, b'\\' as u16]) {
+        // Include the server and share. Keeping their spelling in the same
+        // conservative component contract avoids changing UNC lookup rules.
+        &path[2..]
+    } else {
+        return false;
+    };
+
+    components
+        .split(|unit| *unit == b'\\' as u16)
+        .filter(|component| !component.is_empty())
+        .all(windows_component_is_verbatim_safe)
+}
+
+#[cfg(any(windows, test))]
+fn windows_component_is_verbatim_safe(component: &[u16]) -> bool {
+    if component.is_empty()
+        || component.last().is_some_and(|unit| *unit == b'.' as u16 || *unit == b' ' as u16)
+    {
+        return false;
+    }
+    if component.iter().any(|unit| {
+        *unit < 32
+            || *unit == b'<' as u16
+            || *unit == b'>' as u16
+            || *unit == b':' as u16
+            || *unit == b'"' as u16
+            || *unit == b'/' as u16
+            || *unit == b'|' as u16
+            || *unit == b'?' as u16
+            || *unit == b'*' as u16
+    }) {
+        return false;
+    }
+
+    let stem_end =
+        component.iter().position(|unit| *unit == b'.' as u16).unwrap_or(component.len());
+    let mut stem = &component[..stem_end];
+    while stem.last().is_some_and(|unit| *unit == b'.' as u16 || *unit == b' ' as u16) {
+        stem = &stem[..stem.len() - 1];
+    }
+    !windows_component_is_reserved_device_name(stem)
+}
+
+#[cfg(any(windows, test))]
+fn windows_component_is_reserved_device_name(stem: &[u16]) -> bool {
+    fn ascii_eq_ignore_case(actual: &[u16], expected: &[u8]) -> bool {
+        actual.len() == expected.len()
+            && actual.iter().zip(expected).all(|(actual, expected)| {
+                *actual <= 0x7f && (*actual as u8).eq_ignore_ascii_case(expected)
+            })
+    }
+
+    if [b"CON".as_slice(), b"PRN", b"AUX", b"NUL"]
+        .iter()
+        .any(|name| ascii_eq_ignore_case(stem, name))
+    {
+        return true;
+    }
+    if stem.len() != 4
+        || !(ascii_eq_ignore_case(&stem[..3], b"COM") || ascii_eq_ignore_case(&stem[..3], b"LPT"))
+    {
+        return false;
+    }
+    matches!(stem[3], unit if (b'1' as u16..=b'9' as u16).contains(&unit))
+        || matches!(stem[3], 0x00b9 | 0x00b2 | 0x00b3)
 }
 
 #[cfg(windows)]
@@ -1337,6 +1421,55 @@ mod tests {
         let normalized = normalize_filesystem_path(path.clone());
         let text = normalized.to_string_lossy();
         assert_eq!(normalized, path, "{text}");
+    }
+
+    #[test]
+    fn windows_verbatim_component_guard_rejects_win32_semantic_changes() {
+        for component in ["state.", "state ", "CON", "nul.txt", "Com9.log", "LPT¹"] {
+            let wide = component.encode_utf16().collect::<Vec<_>>();
+            assert!(!windows_component_is_verbatim_safe(&wide), "{component}");
+        }
+    }
+
+    #[test]
+    fn windows_verbatim_component_guard_accepts_ordinary_names() {
+        for component in ["state", "state data.v1", ".state", "COM10", "日本語"] {
+            let wide = component.encode_utf16().collect::<Vec<_>>();
+            assert!(windows_component_is_verbatim_safe(&wide), "{component}");
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn normalize_long_windows_trailing_dot_or_space_paths_preserve_component_semantics() {
+        let parent = vec!["segment"; 36].join(r"\");
+        for child in ["state.", "state "] {
+            let path = PathBuf::from(format!(r"C:\{parent}\{child}"));
+            let normalized = normalize_filesystem_path(path.clone());
+            assert_eq!(normalized, path, "{}", normalized.display());
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn normalize_long_windows_reserved_device_paths_preserve_component_semantics() {
+        let parent = vec!["segment"; 36].join(r"\");
+        for child in ["CON", "nul.txt", "Com9.log", "LPT¹"] {
+            let path = PathBuf::from(format!(r"C:\{parent}\{child}"));
+            let normalized = normalize_filesystem_path(path.clone());
+            assert_eq!(normalized, path, "{}", normalized.display());
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn normalize_long_windows_valid_components_use_the_verbatim_namespace() {
+        let parent = vec!["segment"; 36].join(r"\");
+        let path = PathBuf::from(format!(r"C:\{parent}\state data.v1"));
+        let normalized = normalize_filesystem_path(path);
+        let text = normalized.to_string_lossy();
+        assert!(text.starts_with(r"\\?\C:\"), "{text}");
+        assert!(text.ends_with(r"\state data.v1"), "{text}");
     }
 
     #[cfg(windows)]

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -323,7 +323,7 @@ fn has_windows_parent_component(path: &[u16]) -> bool {
     path.split(|unit| *unit == b'\\' as u16).any(|segment| segment == [b'.' as u16, b'.' as u16])
 }
 
-#[cfg(any(windows, test))]
+#[cfg(windows)]
 fn windows_absolute_path_is_verbatim_safe(path: &[u16]) -> bool {
     let components = if path.len() >= 3
         && path[0] <= 0x7f

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -248,7 +248,11 @@ pub fn normalize_filesystem_path(path: PathBuf) -> PathBuf {
         use std::os::windows::ffi::{OsStrExt, OsStringExt};
 
         const WINDOWS_PATH_HEADROOM: usize = 240;
-        let path = if path.is_absolute() {
+        let has_path_prefix = path
+            .components()
+            .next()
+            .is_some_and(|component| matches!(component, std::path::Component::Prefix(_)));
+        let path = if path.is_absolute() || has_path_prefix {
             path
         } else {
             match std::env::current_dir() {

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -195,44 +195,35 @@ pub fn invalid_runtime_dir() -> PathBuf {
 /// ledgers live here across daemon and machine reboots.
 pub fn workspace_state_dir() -> Option<PathBuf> {
     if let Some(path) = env_path("CMUX_TUI_STATE_DIR") {
-        return Some(normalize_filesystem_path(path));
+        return Some(path);
     }
     #[cfg(target_os = "macos")]
     {
         home_dir().map(|home| {
-            normalize_filesystem_path(
-                home.join("Library").join("Application Support").join("cmux-tui").join("sessions"),
-            )
+            home.join("Library").join("Application Support").join("cmux-tui").join("sessions")
         })
     }
     #[cfg(target_os = "linux")]
     {
-        env_path("XDG_STATE_HOME")
-            .map(|state| normalize_filesystem_path(state.join("cmux-tui").join("sessions")))
-            .or_else(|| {
-                home_dir().map(|home| {
-                    normalize_filesystem_path(
-                        home.join(".local").join("state").join("cmux-tui").join("sessions"),
-                    )
-                })
-            })
+        env_path("XDG_STATE_HOME").map(|state| state.join("cmux-tui").join("sessions")).or_else(
+            || {
+                home_dir()
+                    .map(|home| home.join(".local").join("state").join("cmux-tui").join("sessions"))
+            },
+        )
     }
     #[cfg(windows)]
     {
-        return env_path("LOCALAPPDATA")
-            .map(|dir| normalize_filesystem_path(dir.join("cmux-tui").join("sessions")));
+        return env_path("LOCALAPPDATA").map(|dir| dir.join("cmux-tui").join("sessions"));
     }
     #[cfg(all(not(target_os = "macos"), not(target_os = "linux"), not(windows)))]
     {
-        env_path("XDG_STATE_HOME")
-            .map(|state| normalize_filesystem_path(state.join("cmux-tui").join("sessions")))
-            .or_else(|| {
-                home_dir().map(|home| {
-                    normalize_filesystem_path(
-                        home.join(".local").join("state").join("cmux-tui").join("sessions"),
-                    )
-                })
-            })
+        env_path("XDG_STATE_HOME").map(|state| state.join("cmux-tui").join("sessions")).or_else(
+            || {
+                home_dir()
+                    .map(|home| home.join(".local").join("state").join("cmux-tui").join("sessions"))
+            },
+        )
     }
 }
 

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -1431,6 +1431,9 @@ mod tests {
         let drive_relative = PathBuf::from(r"C:state");
         assert_eq!(normalize_filesystem_path(drive_relative.clone()), drive_relative);
 
+        let relative = PathBuf::from("state");
+        assert_eq!(normalize_filesystem_path(relative.clone()), relative);
+
         for rooted in [PathBuf::from(r"C:\state"), PathBuf::from(r"\\server\share\state")] {
             assert_eq!(normalize_filesystem_path(rooted.clone()), rooted);
         }
@@ -1438,7 +1441,18 @@ mod tests {
 
     #[test]
     fn windows_verbatim_component_guard_rejects_win32_semantic_changes() {
-        for component in ["state.", "state ", "CON", "nul.txt", "Com9.log", "LPT¹"] {
+        for component in [
+            "state.",
+            "state ",
+            "CON",
+            "nul.txt",
+            "Com9.log",
+            "LPT¹",
+            "CONIN$",
+            "CONOUT$",
+            "conin$.log",
+            "ConOut$.log",
+        ] {
             let wide = component.encode_utf16().collect::<Vec<_>>();
             assert!(!windows_component_is_verbatim_safe(&wide), "{component}");
         }

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -1423,6 +1423,16 @@ mod tests {
     }
 
     #[test]
+    fn normalize_windows_paths_preserves_drive_relative_and_rooted_controls() {
+        let drive_relative = PathBuf::from(r"C:state");
+        assert_eq!(normalize_filesystem_path(drive_relative.clone()), drive_relative);
+
+        for rooted in [PathBuf::from(r"C:\state"), PathBuf::from(r"\\server\share\state")] {
+            assert_eq!(normalize_filesystem_path(rooted.clone()), rooted);
+        }
+    }
+
+    #[test]
     fn windows_verbatim_component_guard_rejects_win32_semantic_changes() {
         for component in ["state.", "state ", "CON", "nul.txt", "Com9.log", "LPT¹"] {
             let wide = component.encode_utf16().collect::<Vec<_>>();

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -195,36 +195,175 @@ pub fn invalid_runtime_dir() -> PathBuf {
 /// ledgers live here across daemon and machine reboots.
 pub fn workspace_state_dir() -> Option<PathBuf> {
     if let Some(path) = env_path("CMUX_TUI_STATE_DIR") {
-        return Some(path);
+        return Some(normalize_filesystem_path(path));
     }
     #[cfg(target_os = "macos")]
     {
         home_dir().map(|home| {
-            home.join("Library").join("Application Support").join("cmux-tui").join("sessions")
+            normalize_filesystem_path(
+                home.join("Library").join("Application Support").join("cmux-tui").join("sessions"),
+            )
         })
     }
     #[cfg(target_os = "linux")]
     {
-        env_path("XDG_STATE_HOME").map(|state| state.join("cmux-tui").join("sessions")).or_else(
-            || {
-                home_dir()
-                    .map(|home| home.join(".local").join("state").join("cmux-tui").join("sessions"))
-            },
-        )
+        env_path("XDG_STATE_HOME")
+            .map(|state| normalize_filesystem_path(state.join("cmux-tui").join("sessions")))
+            .or_else(|| {
+                home_dir().map(|home| {
+                    normalize_filesystem_path(
+                        home.join(".local").join("state").join("cmux-tui").join("sessions"),
+                    )
+                })
+            })
     }
     #[cfg(windows)]
     {
-        return env_path("LOCALAPPDATA").map(|dir| dir.join("cmux-tui").join("sessions"));
+        return env_path("LOCALAPPDATA")
+            .map(|dir| normalize_filesystem_path(dir.join("cmux-tui").join("sessions")));
     }
     #[cfg(all(not(target_os = "macos"), not(target_os = "linux"), not(windows)))]
     {
-        env_path("XDG_STATE_HOME").map(|state| state.join("cmux-tui").join("sessions")).or_else(
-            || {
-                home_dir()
-                    .map(|home| home.join(".local").join("state").join("cmux-tui").join("sessions"))
-            },
-        )
+        env_path("XDG_STATE_HOME")
+            .map(|state| normalize_filesystem_path(state.join("cmux-tui").join("sessions")))
+            .or_else(|| {
+                home_dir().map(|home| {
+                    normalize_filesystem_path(
+                        home.join(".local").join("state").join("cmux-tui").join("sessions"),
+                    )
+                })
+            })
     }
+}
+
+/// Return a path that every state-file owner can use without hitting the
+/// legacy Windows MAX_PATH boundary. Windows' verbatim namespace is applied
+/// only to long, absolute drive or UNC paths. Short paths keep their existing
+/// spelling so callers and persisted diagnostics remain compatible.
+pub fn normalize_filesystem_path(path: PathBuf) -> PathBuf {
+    #[cfg(windows)]
+    {
+        use std::ffi::OsString;
+        use std::os::windows::ffi::{OsStrExt, OsStringExt};
+
+        const WINDOWS_PATH_HEADROOM: usize = 240;
+        let path = if path.is_absolute() {
+            path
+        } else {
+            match std::env::current_dir() {
+                Ok(current) => current.join(path),
+                Err(_) => return path,
+            }
+        };
+        let mut wide = path.as_os_str().encode_wide().collect::<Vec<_>>();
+        if wide.len() < WINDOWS_PATH_HEADROOM {
+            return path;
+        }
+        for unit in &mut wide {
+            if *unit == b'/' as u16 {
+                *unit = b'\\' as u16;
+            }
+        }
+        if has_windows_device_prefix(&wide) {
+            return path;
+        }
+        let Some(normalized) = normalize_windows_absolute_path(&wide) else {
+            return path;
+        };
+        let is_unc = normalized.starts_with(&[b'\\' as u16, b'\\' as u16]);
+        let mut prefixed = if is_unc {
+            // `\\server\\share` becomes `\\?\\UNC\\server\\share`.
+            vec![
+                b'\\' as u16,
+                b'\\' as u16,
+                b'?' as u16,
+                b'\\' as u16,
+                b'U' as u16,
+                b'N' as u16,
+                b'C' as u16,
+                b'\\' as u16,
+            ]
+        } else {
+            vec![b'\\' as u16, b'\\' as u16, b'?' as u16, b'\\' as u16]
+        };
+        prefixed.extend_from_slice(if is_unc { &normalized[2..] } else { &normalized });
+        PathBuf::from(OsString::from_wide(&prefixed))
+    }
+    #[cfg(not(windows))]
+    {
+        path
+    }
+}
+
+#[cfg(windows)]
+fn has_windows_device_prefix(path: &[u16]) -> bool {
+    path.starts_with(&[b'\\' as u16, b'\\' as u16, b'?' as u16, b'\\' as u16])
+        || path.starts_with(&[b'\\' as u16, b'\\' as u16, b'.' as u16, b'\\' as u16])
+        || path.starts_with(&[b'\\' as u16, b'?' as u16, b'?' as u16, b'\\' as u16])
+}
+
+#[cfg(windows)]
+fn normalize_windows_absolute_path(path: &[u16]) -> Option<Vec<u16>> {
+    let is_drive = path.len() >= 3
+        && path[0] <= 0x7f
+        && (path[0] as u8).is_ascii_alphabetic()
+        && path[1] == b':' as u16
+        && path[2] == b'\\' as u16;
+    let (root, rest, root_has_separator) = if is_drive {
+        (&path[..3], &path[3..], true)
+    } else if path.starts_with(&[b'\\' as u16, b'\\' as u16]) {
+        let mut index = 2;
+        let server_start = index;
+        while index < path.len() && path[index] != b'\\' as u16 {
+            index += 1;
+        }
+        if index == server_start {
+            return None;
+        }
+        while index < path.len() && path[index] == b'\\' as u16 {
+            index += 1;
+        }
+        let share_start = index;
+        while index < path.len() && path[index] != b'\\' as u16 {
+            index += 1;
+        }
+        if index == share_start {
+            return None;
+        }
+        let root_end = index;
+        let rest_start = (index < path.len()).then_some(index + 1).unwrap_or(index);
+        (&path[..root_end], &path[rest_start..], false)
+    } else {
+        return None;
+    };
+
+    let mut segments = Vec::<Vec<u16>>::new();
+    let mut segment_start = 0;
+    for index in 0..=rest.len() {
+        if index != rest.len() && rest[index] != b'\\' as u16 {
+            continue;
+        }
+        let segment = &rest[segment_start..index];
+        if segment.is_empty() || segment == [b'.' as u16] {
+            // Repeated separators and current-directory components do not
+            // change the path and must not survive the verbatim prefix.
+        } else if segment == [b'.' as u16, b'.' as u16] {
+            // An absolute path cannot walk above its root.
+            let _ = segments.pop();
+        } else {
+            segments.push(segment.to_vec());
+        }
+        segment_start = index.saturating_add(1);
+    }
+
+    let mut output = root.to_vec();
+    for segment in segments {
+        if !root_has_separator || output.last() != Some(&(b'\\' as u16)) {
+            output.push(b'\\' as u16);
+        }
+        output.extend_from_slice(&segment);
+    }
+    Some(output)
 }
 
 /// Path of the client's bounded rolling log file: the `cmux-tui` state root
@@ -1174,6 +1313,25 @@ mod tests {
         sync_directory(&root).unwrap();
 
         std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn normalize_long_windows_state_paths_uses_the_verbatim_namespace() {
+        let path = PathBuf::from(format!(r"C:\{}\..\state", "segment".repeat(42)));
+        let normalized = normalize_filesystem_path(path);
+        let text = normalized.to_string_lossy();
+        assert!(text.starts_with(r"\\?\C:\"), "{text}");
+        assert!(!text.contains(r"\..\"), "{text}");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn normalize_long_windows_unc_paths_preserves_the_share_boundary() {
+        let path = PathBuf::from(format!(r"\\server\share\{}", "segment".repeat(42)));
+        let normalized = normalize_filesystem_path(path);
+        let text = normalized.to_string_lossy();
+        assert!(text.starts_with(r"\\?\UNC\server\share\"), "{text}");
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/resource.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/resource.rs
@@ -378,7 +378,6 @@ pub enum ResourceOperation {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-
 pub enum OperationClass {
     Read,
     Mutation,

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host.rs
@@ -50,7 +50,7 @@ impl TerminalId {
             return None;
         }
         let mut bytes = [0u8; TERMINAL_ID_LEN];
-        for (index, pair) in value.as_bytes().chunks_exact(2).enumerate() {
+        for (index, pair) in value.as_bytes().as_chunks::<2>().0.iter().enumerate() {
             bytes[index] = (hex_nibble(pair[0])? << 4) | hex_nibble(pair[1])?;
         }
         Some(Self(bytes))

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -9162,9 +9162,7 @@ pub(crate) use unix::{
 
 #[cfg(not(unix))]
 pub fn terminal_host_root(state_root: &Path, session: &str) -> PathBuf {
-    crate::platform::normalize_filesystem_path(
-        state_root.join(format!("{session}.terminal-hosts")),
-    )
+    crate::platform::normalize_filesystem_path(state_root.join(format!("{session}.terminal-hosts")))
 }
 
 #[cfg(not(unix))]

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -1688,7 +1688,9 @@ mod unix {
     }
 
     pub fn terminal_host_root(state_root: &Path, session: &str) -> PathBuf {
-        state_root.join(format!("terminal-hosts-{}", stable_token(session)))
+        crate::platform::normalize_filesystem_path(
+            state_root.join(format!("terminal-hosts-{}", stable_token(session))),
+        )
     }
 
     /// Strip every descriptor except the private bootstrap stdio before the
@@ -9160,7 +9162,9 @@ pub(crate) use unix::{
 
 #[cfg(not(unix))]
 pub fn terminal_host_root(state_root: &Path, session: &str) -> PathBuf {
-    state_root.join(format!("{session}.terminal-hosts"))
+    crate::platform::normalize_filesystem_path(
+        state_root.join(format!("{session}.terminal-hosts")),
+    )
 }
 
 #[cfg(not(unix))]

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -443,7 +443,9 @@ pub struct PersistentSessionStateResetter {
 impl PersistentSessionStateResetter {
     /// Creates a reset owner for one durable workspace state root.
     pub fn new(state_root: impl Into<PathBuf>) -> Self {
-        Self { state_root: state_root.into() }
+        Self {
+            state_root: platform::normalize_filesystem_path(state_root.into()),
+        }
     }
 
     /// Returns the workspace state root this reset owner can mutate.
@@ -2301,6 +2303,8 @@ impl WorkspaceRegistry {
     }
 
     pub fn open(root: &Path, session_name: &str) -> anyhow::Result<Self> {
+        let normalized_root = platform::normalize_filesystem_path(root.to_path_buf());
+        let root = normalized_root.as_path();
         let session_dir = root.join(session_storage_component(session_name));
         let db_path = session_dir.join(WORKSPACE_REGISTRY_FILE);
         if db_path.is_file()

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -2303,7 +2303,9 @@ impl WorkspaceRegistry {
     pub fn open(root: &Path, session_name: &str) -> anyhow::Result<Self> {
         let normalized_root = platform::normalize_filesystem_path(root.to_path_buf());
         let root = normalized_root.as_path();
-        let session_dir = root.join(session_storage_component(session_name));
+        let session_dir = platform::normalize_filesystem_path(
+            root.join(session_storage_component(session_name)),
+        );
         // Normalize the complete database path. The state root can be below
         // the legacy MAX_PATH threshold while its session and database
         // descendants exceed it.

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -2306,7 +2306,12 @@ impl WorkspaceRegistry {
         let normalized_root = platform::normalize_filesystem_path(root.to_path_buf());
         let root = normalized_root.as_path();
         let session_dir = root.join(session_storage_component(session_name));
-        let db_path = session_dir.join(WORKSPACE_REGISTRY_FILE);
+        // Normalize the complete database path. The state root can be below
+        // the legacy MAX_PATH threshold while its session and database
+        // descendants exceed it.
+        let db_path = platform::normalize_filesystem_path(
+            session_dir.join(WORKSPACE_REGISTRY_FILE),
+        );
         if db_path.is_file()
             && let Some(error) = preflight_unsupported_schema(&db_path)
         {

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -2303,9 +2303,8 @@ impl WorkspaceRegistry {
     pub fn open(root: &Path, session_name: &str) -> anyhow::Result<Self> {
         let normalized_root = platform::normalize_filesystem_path(root.to_path_buf());
         let root = normalized_root.as_path();
-        let session_dir = platform::normalize_filesystem_path(
-            root.join(session_storage_component(session_name)),
-        );
+        let session_dir =
+            platform::normalize_filesystem_path(root.join(session_storage_component(session_name)));
         // Normalize the complete database path. The state root can be below
         // the legacy MAX_PATH threshold while its session and database
         // descendants exceed it.

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -865,10 +865,9 @@ fn rename_reset_dir_for_deletion(
 ) -> anyhow::Result<PathBuf> {
     let storage_component = session_storage_component(session_name);
     for _ in 0..16 {
-        let candidate = platform::normalize_filesystem_path(root.join(format!(
-            ".reset-{storage_component}-{kind}-{}.deleting",
-            try_new_uuid_v4()?
-        )));
+        let candidate = platform::normalize_filesystem_path(
+            root.join(format!(".reset-{storage_component}-{kind}-{}.deleting", try_new_uuid_v4()?)),
+        );
         ensure_reset_dir_fingerprint(source, kind, expected_fingerprint)?;
         match fs::rename(source, &candidate) {
             Ok(()) => {
@@ -2329,9 +2328,8 @@ impl WorkspaceRegistry {
         {
             return Err(error.into());
         }
-        let session_lock = platform::normalize_filesystem_path(
-            session_dir.join(SESSION_WRITER_LOCK_FILE),
-        );
+        let session_lock =
+            platform::normalize_filesystem_path(session_dir.join(SESSION_WRITER_LOCK_FILE));
         let lease = SessionLease::acquire(&session_lock)?;
         let connection = open_registry_database(&db_path)
             .with_context(|| format!("open workspace registry {}", db_path.display()))?;

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -689,7 +689,7 @@ pub struct WorkspaceRegistry {
 }
 
 fn persistent_session_state_dir(root: &Path, session_name: &str) -> PathBuf {
-    root.join(session_storage_component(session_name))
+    platform::normalize_filesystem_path(root.join(session_storage_component(session_name)))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -770,7 +770,7 @@ fn pending_session_reset_dirs(
         let Some(kind) = pending_session_reset_kind(rest) else {
             continue;
         };
-        let path = entry.path();
+        let path = platform::normalize_filesystem_path(entry.path());
         let metadata = fs::symlink_metadata(&path)
             .with_context(|| format!("inspect private reset path {}", path.display()))?;
         if !metadata.file_type().is_dir() {
@@ -865,8 +865,10 @@ fn rename_reset_dir_for_deletion(
 ) -> anyhow::Result<PathBuf> {
     let storage_component = session_storage_component(session_name);
     for _ in 0..16 {
-        let candidate =
-            root.join(format!(".reset-{storage_component}-{kind}-{}.deleting", try_new_uuid_v4()?));
+        let candidate = platform::normalize_filesystem_path(root.join(format!(
+            ".reset-{storage_component}-{kind}-{}.deleting",
+            try_new_uuid_v4()?
+        )));
         ensure_reset_dir_fingerprint(source, kind, expected_fingerprint)?;
         match fs::rename(source, &candidate) {
             Ok(()) => {
@@ -2327,7 +2329,10 @@ impl WorkspaceRegistry {
         {
             return Err(error.into());
         }
-        let lease = SessionLease::acquire(&session_dir.join(SESSION_WRITER_LOCK_FILE))?;
+        let session_lock = platform::normalize_filesystem_path(
+            session_dir.join(SESSION_WRITER_LOCK_FILE),
+        );
+        let lease = SessionLease::acquire(&session_lock)?;
         let connection = open_registry_database(&db_path)
             .with_context(|| format!("open workspace registry {}", db_path.display()))?;
         platform::restrict_file(&db_path)?;
@@ -5076,7 +5081,7 @@ fn acquire_session_guard_from_private_dir(
 }
 
 fn prepare_session_guard_dir(root: &Path) -> anyhow::Result<PathBuf> {
-    let lock_dir = root.join(SESSION_GUARD_DIR);
+    let lock_dir = platform::normalize_filesystem_path(root.join(SESSION_GUARD_DIR));
     match fs::symlink_metadata(&lock_dir) {
         Ok(metadata) if metadata.file_type().is_dir() => {}
         Ok(_) => anyhow::bail!("session lock directory is not a directory: {}", lock_dir.display()),
@@ -5102,11 +5107,13 @@ fn prepare_session_guard_dir(root: &Path) -> anyhow::Result<PathBuf> {
 }
 
 fn session_guard_lock_path(lock_dir: &Path, session_name: &str) -> PathBuf {
-    lock_dir.join(format!("{}.lock", session_storage_component(session_name)))
+    platform::normalize_filesystem_path(
+        lock_dir.join(format!("{}.lock", session_storage_component(session_name))),
+    )
 }
 
 fn session_guard_coordinator_path(lock_dir: &Path) -> PathBuf {
-    lock_dir.join(SESSION_GUARD_COORDINATOR_FILE)
+    platform::normalize_filesystem_path(lock_dir.join(SESSION_GUARD_COORDINATOR_FILE))
 }
 
 #[cfg(unix)]
@@ -5266,7 +5273,8 @@ fn prepare_terminal_host_root_for_reset(
 fn load_or_create_resource_effect_pepper(root: &Path) -> anyhow::Result<ResourceEffectPepper> {
     fs::create_dir_all(root).with_context(|| format!("create state root {}", root.display()))?;
     platform::restrict_directory(root)?;
-    let lock_path = root.join(RESOURCE_EFFECT_PEPPER_LOCK_FILE);
+    let lock_path =
+        platform::normalize_filesystem_path(root.join(RESOURCE_EFFECT_PEPPER_LOCK_FILE));
     let lock = OpenOptions::new()
         .create(true)
         .truncate(false)
@@ -5278,7 +5286,7 @@ fn load_or_create_resource_effect_pepper(root: &Path) -> anyhow::Result<Resource
     FileExt::lock(&lock)
         .with_context(|| format!("lock resource receipt pepper {}", lock_path.display()))?;
 
-    let path = root.join(RESOURCE_EFFECT_PEPPER_FILE);
+    let path = platform::normalize_filesystem_path(root.join(RESOURCE_EFFECT_PEPPER_FILE));
     let result = match fs::symlink_metadata(&path) {
         Ok(metadata) => {
             anyhow::ensure!(
@@ -5329,7 +5337,8 @@ fn ensure_missing_pepper_can_migrate(root: &Path, pepper_path: &Path) -> anyhow:
         if !entry.file_type()?.is_dir() {
             continue;
         }
-        let database = entry.path().join(WORKSPACE_REGISTRY_FILE);
+        let database =
+            platform::normalize_filesystem_path(entry.path().join(WORKSPACE_REGISTRY_FILE));
         if !database.try_exists()? {
             continue;
         }
@@ -5353,7 +5362,7 @@ fn ensure_missing_pepper_can_migrate(root: &Path, pepper_path: &Path) -> anyhow:
 fn load_or_create_machine_id(root: &Path) -> anyhow::Result<MachinePublicId> {
     fs::create_dir_all(root).with_context(|| format!("create state root {}", root.display()))?;
     platform::restrict_directory(root)?;
-    let lock_path = root.join(MACHINE_ID_LOCK_FILE);
+    let lock_path = platform::normalize_filesystem_path(root.join(MACHINE_ID_LOCK_FILE));
     let lock = OpenOptions::new()
         .create(true)
         .truncate(false)
@@ -5365,7 +5374,7 @@ fn load_or_create_machine_id(root: &Path) -> anyhow::Result<MachinePublicId> {
     FileExt::lock(&lock)
         .with_context(|| format!("lock machine identity {}", lock_path.display()))?;
 
-    let path = root.join(MACHINE_ID_FILE);
+    let path = platform::normalize_filesystem_path(root.join(MACHINE_ID_FILE));
     let result = match fs::read(&path) {
         Ok(bytes) => {
             platform::restrict_file(&path)?;

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -443,9 +443,7 @@ pub struct PersistentSessionStateResetter {
 impl PersistentSessionStateResetter {
     /// Creates a reset owner for one durable workspace state root.
     pub fn new(state_root: impl Into<PathBuf>) -> Self {
-        Self {
-            state_root: platform::normalize_filesystem_path(state_root.into()),
-        }
+        Self { state_root: platform::normalize_filesystem_path(state_root.into()) }
     }
 
     /// Returns the workspace state root this reset owner can mutate.
@@ -2309,9 +2307,8 @@ impl WorkspaceRegistry {
         // Normalize the complete database path. The state root can be below
         // the legacy MAX_PATH threshold while its session and database
         // descendants exceed it.
-        let db_path = platform::normalize_filesystem_path(
-            session_dir.join(WORKSPACE_REGISTRY_FILE),
-        );
+        let db_path =
+            platform::normalize_filesystem_path(session_dir.join(WORKSPACE_REGISTRY_FILE));
         if db_path.is_file()
             && let Some(error) = preflight_unsupported_schema(&db_path)
         {

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -62,9 +62,11 @@ pub use public_projection_store::RegistryPublicProjections;
 pub use public_projection_store::{RegistryAgentProjection, RegistryNotificationProjection};
 pub(crate) use resource_store::validate_registry_screen_projection;
 pub(crate) use resource_store::{
-    AGENT_HOOK_MAX_ATTEMPTS, AGENT_HOOK_MAX_RETRY_PAGES_PER_WAKE, AgentHookProjectionState,
-    AgentHookRetryClass,
+    AGENT_HOOK_MAX_RETRY_PAGES_PER_WAKE, AgentHookProjectionState, AgentHookRetryClass,
 };
+#[cfg(test)]
+#[allow(unused_imports)]
+pub(crate) use resource_store::AGENT_HOOK_MAX_ATTEMPTS;
 #[allow(unused_imports)]
 pub use resource_store::{
     RegistryBrowser, RegistryBrowserLaunch, RegistryBrowserReconnect, RegistryBrowserSource,

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -2305,8 +2305,9 @@ impl WorkspaceRegistry {
     }
 
     pub fn open(root: &Path, session_name: &str) -> anyhow::Result<Self> {
-        let normalized_root = platform::normalize_filesystem_path(root.to_path_buf());
-        let root = normalized_root.as_path();
+        // Keep the caller's root spelling for the root-level guard and identity
+        // files. Rust's Windows filesystem APIs add the verbatim prefix when
+        // needed; passing a manually prefixed root breaks long-path startup.
         let session_dir =
             platform::normalize_filesystem_path(root.join(session_storage_component(session_name)));
         // Normalize the complete database path. The state root can be below
@@ -5082,7 +5083,7 @@ fn acquire_session_guard_from_private_dir(
 }
 
 fn prepare_session_guard_dir(root: &Path) -> anyhow::Result<PathBuf> {
-    let lock_dir = platform::normalize_filesystem_path(root.join(SESSION_GUARD_DIR));
+    let lock_dir = root.join(SESSION_GUARD_DIR);
     match fs::symlink_metadata(&lock_dir) {
         Ok(metadata) if metadata.file_type().is_dir() => {}
         Ok(_) => anyhow::bail!("session lock directory is not a directory: {}", lock_dir.display()),
@@ -5108,13 +5109,11 @@ fn prepare_session_guard_dir(root: &Path) -> anyhow::Result<PathBuf> {
 }
 
 fn session_guard_lock_path(lock_dir: &Path, session_name: &str) -> PathBuf {
-    platform::normalize_filesystem_path(
-        lock_dir.join(format!("{}.lock", session_storage_component(session_name))),
-    )
+    lock_dir.join(format!("{}.lock", session_storage_component(session_name)))
 }
 
 fn session_guard_coordinator_path(lock_dir: &Path) -> PathBuf {
-    platform::normalize_filesystem_path(lock_dir.join(SESSION_GUARD_COORDINATOR_FILE))
+    lock_dir.join(SESSION_GUARD_COORDINATOR_FILE)
 }
 
 #[cfg(unix)]
@@ -5274,8 +5273,7 @@ fn prepare_terminal_host_root_for_reset(
 fn load_or_create_resource_effect_pepper(root: &Path) -> anyhow::Result<ResourceEffectPepper> {
     fs::create_dir_all(root).with_context(|| format!("create state root {}", root.display()))?;
     platform::restrict_directory(root)?;
-    let lock_path =
-        platform::normalize_filesystem_path(root.join(RESOURCE_EFFECT_PEPPER_LOCK_FILE));
+    let lock_path = root.join(RESOURCE_EFFECT_PEPPER_LOCK_FILE);
     let lock = OpenOptions::new()
         .create(true)
         .truncate(false)
@@ -5287,7 +5285,7 @@ fn load_or_create_resource_effect_pepper(root: &Path) -> anyhow::Result<Resource
     FileExt::lock(&lock)
         .with_context(|| format!("lock resource receipt pepper {}", lock_path.display()))?;
 
-    let path = platform::normalize_filesystem_path(root.join(RESOURCE_EFFECT_PEPPER_FILE));
+    let path = root.join(RESOURCE_EFFECT_PEPPER_FILE);
     let result = match fs::symlink_metadata(&path) {
         Ok(metadata) => {
             anyhow::ensure!(
@@ -5363,7 +5361,7 @@ fn ensure_missing_pepper_can_migrate(root: &Path, pepper_path: &Path) -> anyhow:
 fn load_or_create_machine_id(root: &Path) -> anyhow::Result<MachinePublicId> {
     fs::create_dir_all(root).with_context(|| format!("create state root {}", root.display()))?;
     platform::restrict_directory(root)?;
-    let lock_path = platform::normalize_filesystem_path(root.join(MACHINE_ID_LOCK_FILE));
+    let lock_path = root.join(MACHINE_ID_LOCK_FILE);
     let lock = OpenOptions::new()
         .create(true)
         .truncate(false)
@@ -5375,7 +5373,7 @@ fn load_or_create_machine_id(root: &Path) -> anyhow::Result<MachinePublicId> {
     FileExt::lock(&lock)
         .with_context(|| format!("lock machine identity {}", lock_path.display()))?;
 
-    let path = platform::normalize_filesystem_path(root.join(MACHINE_ID_FILE));
+    let path = root.join(MACHINE_ID_FILE);
     let result = match fs::read(&path) {
         Ok(bytes) => {
             platform::restrict_file(&path)?;

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -60,13 +60,13 @@ pub(crate) use journal_extensions::{
 pub use public_projection_store::RegistryPublicProjections;
 #[cfg(test)]
 pub use public_projection_store::{RegistryAgentProjection, RegistryNotificationProjection};
+#[cfg(test)]
+#[allow(unused_imports)]
+pub(crate) use resource_store::AGENT_HOOK_MAX_ATTEMPTS;
 pub(crate) use resource_store::validate_registry_screen_projection;
 pub(crate) use resource_store::{
     AGENT_HOOK_MAX_RETRY_PAGES_PER_WAKE, AgentHookProjectionState, AgentHookRetryClass,
 };
-#[cfg(test)]
-#[allow(unused_imports)]
-pub(crate) use resource_store::AGENT_HOOK_MAX_ATTEMPTS;
 #[allow(unused_imports)]
 pub use resource_store::{
     RegistryBrowser, RegistryBrowserLaunch, RegistryBrowserReconnect, RegistryBrowserSource,

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -65,7 +65,8 @@ pub use public_projection_store::{RegistryAgentProjection, RegistryNotificationP
 pub(crate) use resource_store::AGENT_HOOK_MAX_ATTEMPTS;
 pub(crate) use resource_store::validate_registry_screen_projection;
 pub(crate) use resource_store::{
-    AGENT_HOOK_MAX_RETRY_PAGES_PER_WAKE, AgentHookProjectionState, AgentHookRetryClass,
+    AGENT_HOOK_MAX_RETRY_PAGES_PER_WAKE, AgentHookPendingCursor, AgentHookPendingPage,
+    AgentHookPendingProjection, AgentHookProjectionState, AgentHookRetryClass,
 };
 #[allow(unused_imports)]
 pub use resource_store::{

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/effect_store.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/effect_store.rs
@@ -703,7 +703,7 @@ impl WorkspaceRegistry {
         // does); otherwise later legacy CAS mutations conflict forever.
         let workspace_revision = workspace_ledger
             .map(|ledger| {
-                super::commit_workspace_registry_in_transaction(
+                commit_workspace_registry_in_transaction(
                     &tx,
                     mutation,
                     &fingerprint,

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/journal_extensions.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/journal_extensions.rs
@@ -2902,7 +2902,7 @@ fn encode_hex(bytes: &[u8]) -> String {
 fn decode_sha256(value: &str) -> anyhow::Result<[u8; 32]> {
     anyhow::ensure!(value.len() == 64, "SHA-256 digest must contain 64 hexadecimal characters");
     let mut decoded = [0_u8; 32];
-    for (index, chunk) in value.as_bytes().chunks_exact(2).enumerate() {
+    for (index, chunk) in value.as_bytes().as_chunks::<2>().0.iter().enumerate() {
         let text = std::str::from_utf8(chunk)?;
         decoded[index] =
             u8::from_str_radix(text, 16).context("SHA-256 digest is not hexadecimal")?;

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/resource_store.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/resource_store.rs
@@ -1385,7 +1385,7 @@ impl WorkspaceRegistry {
         // patch's own upserts inside this same transaction.
         let workspace_revision = workspace_ledger
             .map(|ledger| {
-                super::commit_workspace_registry_in_transaction(
+                commit_workspace_registry_in_transaction(
                     &tx,
                     mutation,
                     &fingerprint,

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/resource_store.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/resource_store.rs
@@ -1601,7 +1601,6 @@ impl WorkspaceRegistry {
         u64::try_from(count).context("resource agent projection count is negative")
     }
 
-
     #[cfg(test)]
     pub(crate) fn agent_hook_pending_retry_state_for_test(
         &self,

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/resource_store.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/resource_store.rs
@@ -14,6 +14,35 @@ pub(crate) const AGENT_HOOK_MAX_ATTEMPTS: i64 = 8;
 pub(crate) const AGENT_HOOK_MAX_RETRY_PAGES_PER_WAKE: usize = 16;
 pub(crate) const AGENT_HOOK_DEAD_LETTER_CAP: i64 = 1024;
 
+/// A durable hook projection selected for one retry attempt.
+///
+/// This is a named record rather than a positional tuple. Retry identity,
+/// ordering, and payload have different invariants, and named fields keep a
+/// future column change from silently swapping them at a call site.
+#[derive(Debug)]
+pub(crate) struct AgentHookPendingProjection {
+    pub(crate) producer_id: String,
+    pub(crate) origin: String,
+    pub(crate) idempotency_key: String,
+    pub(crate) sequence: u64,
+    pub(crate) ingress: JournalIngress,
+}
+
+/// Stable key for paging durable hook projections.
+#[derive(Debug, Clone)]
+pub(crate) struct AgentHookPendingCursor {
+    pub(crate) sequence: u64,
+    pub(crate) idempotency_key: String,
+    pub(crate) rowid: i64,
+}
+
+/// One bounded page of durable hook projections.
+#[derive(Debug)]
+pub(crate) struct AgentHookPendingPage {
+    pub(crate) rows: Vec<AgentHookPendingProjection>,
+    pub(crate) next_cursor: Option<AgentHookPendingCursor>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum AgentHookRetryClass {
     Transient,
@@ -582,7 +611,7 @@ impl WorkspaceRegistry {
         origin: &str,
         idempotency_key: &str,
         sequence: u64,
-        ingress: &crate::JournalIngress,
+        ingress: &JournalIngress,
         error: &str,
         retry_class: AgentHookRetryClass,
     ) -> anyhow::Result<()> {
@@ -694,9 +723,10 @@ impl WorkspaceRegistry {
         Ok(())
     }
 
+    #[cfg(test)]
     pub(crate) fn pending_agent_hook_projections(
         &self,
-    ) -> anyhow::Result<Vec<(String, String, String, u64, JournalIngress)>> {
+    ) -> anyhow::Result<Vec<AgentHookPendingProjection>> {
         let mut statement = self.connection.prepare(
             "SELECT producer_id, origin, idempotency_key, event_sequence, ingress_json
              FROM resource_agent_hook_pending ORDER BY event_sequence ASC, idempotency_key ASC",
@@ -713,13 +743,14 @@ impl WorkspaceRegistry {
             })?
             .map(|row| {
                 let (producer_id, origin, key, sequence, ingress_json) = row?;
-                Ok((
+                Ok(AgentHookPendingProjection {
                     producer_id,
                     origin,
-                    key,
-                    u64::try_from(sequence).context("pending hook sequence is negative")?,
-                    serde_json::from_str(&ingress_json)?,
-                ))
+                    idempotency_key: key,
+                    sequence: u64::try_from(sequence)
+                        .context("pending hook sequence is negative")?,
+                    ingress: serde_json::from_str(&ingress_json)?,
+                })
             })
             .collect()
     }
@@ -727,7 +758,7 @@ impl WorkspaceRegistry {
     pub(crate) fn pending_agent_hook_projections_for_terminal(
         &self,
         terminal_id: &TerminalPublicId,
-    ) -> anyhow::Result<Vec<(String, String, String, u64, JournalIngress)>> {
+    ) -> anyhow::Result<Vec<AgentHookPendingProjection>> {
         let mut statement = self.connection.prepare(
             "SELECT producer_id, origin, idempotency_key, event_sequence, ingress_json
              FROM resource_agent_hook_pending
@@ -759,25 +790,25 @@ impl WorkspaceRegistry {
                     continue;
                 }
             };
-            pending.push((
+            pending.push(AgentHookPendingProjection {
                 producer_id,
                 origin,
-                key,
-                u64::try_from(sequence).context("pending hook sequence is negative")?,
+                idempotency_key: key,
+                sequence: u64::try_from(sequence)
+                    .context("pending hook sequence is negative")?,
                 ingress,
-            ));
+            });
         }
         Ok(pending)
     }
 
     pub(crate) fn pending_agent_hook_projections_page(
         &self,
-        after: Option<(u64, String, i64)>,
-    ) -> anyhow::Result<(
-        Vec<(String, String, String, u64, JournalIngress)>,
-        Option<(u64, String, i64)>,
-    )> {
-        let (after_sequence, after_key, after_rowid) = after.unwrap_or((0, String::new(), 0));
+        after: Option<AgentHookPendingCursor>,
+    ) -> anyhow::Result<AgentHookPendingPage> {
+        let (after_sequence, after_key, after_rowid) = after
+            .map(|cursor| (cursor.sequence, cursor.idempotency_key, cursor.rowid))
+            .unwrap_or((0, String::new(), 0));
         let mut statement = self.connection.prepare(
             "SELECT rowid, producer_id, origin, idempotency_key, event_sequence, ingress_json
              FROM resource_agent_hook_pending
@@ -814,7 +845,11 @@ impl WorkspaceRegistry {
         let mut next_cursor = None;
         for (rowid, producer_id, origin, key, sequence, ingress_json) in rows {
             let sequence = u64::try_from(sequence).context("pending hook sequence is negative")?;
-            next_cursor = Some((sequence, key.clone(), rowid));
+            next_cursor = Some(AgentHookPendingCursor {
+                sequence,
+                idempotency_key: key.clone(),
+                rowid,
+            });
             let ingress = match serde_json::from_str(&ingress_json) {
                 Ok(ingress) => ingress,
                 Err(_) => {
@@ -822,9 +857,15 @@ impl WorkspaceRegistry {
                     continue;
                 }
             };
-            pending.push((producer_id, origin, key, sequence, ingress));
+            pending.push(AgentHookPendingProjection {
+                producer_id,
+                origin,
+                idempotency_key: key,
+                sequence,
+                ingress,
+            });
         }
-        Ok((pending, next_cursor))
+        Ok(AgentHookPendingPage { rows: pending, next_cursor })
     }
 
     #[expect(

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/resource_store.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/resource_store.rs
@@ -794,8 +794,7 @@ impl WorkspaceRegistry {
                 producer_id,
                 origin,
                 idempotency_key: key,
-                sequence: u64::try_from(sequence)
-                    .context("pending hook sequence is negative")?,
+                sequence: u64::try_from(sequence).context("pending hook sequence is negative")?,
                 ingress,
             });
         }
@@ -845,11 +844,8 @@ impl WorkspaceRegistry {
         let mut next_cursor = None;
         for (rowid, producer_id, origin, key, sequence, ingress_json) in rows {
             let sequence = u64::try_from(sequence).context("pending hook sequence is negative")?;
-            next_cursor = Some(AgentHookPendingCursor {
-                sequence,
-                idempotency_key: key.clone(),
-                rowid,
-            });
+            next_cursor =
+                Some(AgentHookPendingCursor { sequence, idempotency_key: key.clone(), rowid });
             let ingress = match serde_json::from_str(&ingress_json) {
                 Ok(ingress) => ingress,
                 Err(_) => {

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/resource_store.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/resource_store.rs
@@ -551,7 +551,7 @@ impl WorkspaceRegistry {
         origin: &str,
         idempotency_key: &str,
         sequence: u64,
-        ingress: &crate::JournalIngress,
+        ingress: &JournalIngress,
     ) -> anyhow::Result<()> {
         let ingress_json = serde_json::to_string(ingress)?;
         let terminal_id = ingress
@@ -572,7 +572,11 @@ impl WorkspaceRegistry {
         Ok(())
     }
 
-    pub fn enqueue_agent_hook_pending(
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "Each durable retry identity and policy field maps to one journal column."
+    )]
+    pub(crate) fn enqueue_agent_hook_pending(
         &mut self,
         producer_id: &str,
         origin: &str,
@@ -645,7 +649,7 @@ impl WorkspaceRegistry {
 
     pub(crate) fn purge_agent_hook_pending_for_terminal(
         &mut self,
-        terminal_id: &crate::resource::TerminalPublicId,
+        terminal_id: &TerminalPublicId,
     ) -> anyhow::Result<()> {
         self.connection.execute(
             "DELETE FROM resource_agent_hook_pending WHERE terminal_id = ?1",
@@ -690,9 +694,9 @@ impl WorkspaceRegistry {
         Ok(())
     }
 
-    pub fn pending_agent_hook_projections(
+    pub(crate) fn pending_agent_hook_projections(
         &self,
-    ) -> anyhow::Result<Vec<(String, String, String, u64, crate::JournalIngress)>> {
+    ) -> anyhow::Result<Vec<(String, String, String, u64, JournalIngress)>> {
         let mut statement = self.connection.prepare(
             "SELECT producer_id, origin, idempotency_key, event_sequence, ingress_json
              FROM resource_agent_hook_pending ORDER BY event_sequence ASC, idempotency_key ASC",
@@ -720,10 +724,10 @@ impl WorkspaceRegistry {
             .collect()
     }
 
-    pub fn pending_agent_hook_projections_for_terminal(
+    pub(crate) fn pending_agent_hook_projections_for_terminal(
         &self,
-        terminal_id: &crate::resource::TerminalPublicId,
-    ) -> anyhow::Result<Vec<(String, String, String, u64, crate::JournalIngress)>> {
+        terminal_id: &TerminalPublicId,
+    ) -> anyhow::Result<Vec<(String, String, String, u64, JournalIngress)>> {
         let mut statement = self.connection.prepare(
             "SELECT producer_id, origin, idempotency_key, event_sequence, ingress_json
              FROM resource_agent_hook_pending
@@ -766,11 +770,11 @@ impl WorkspaceRegistry {
         Ok(pending)
     }
 
-    pub fn pending_agent_hook_projections_page(
+    pub(crate) fn pending_agent_hook_projections_page(
         &self,
         after: Option<(u64, String, i64)>,
     ) -> anyhow::Result<(
-        Vec<(String, String, String, u64, crate::JournalIngress)>,
+        Vec<(String, String, String, u64, JournalIngress)>,
         Option<(u64, String, i64)>,
     )> {
         let (after_sequence, after_key, after_rowid) = after.unwrap_or((0, String::new(), 0));
@@ -823,7 +827,11 @@ impl WorkspaceRegistry {
         Ok((pending, next_cursor))
     }
 
-    pub fn commit_agent_projection_with_hook_state(
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "The projection commit API mirrors the durable mutation contract."
+    )]
+    pub(crate) fn commit_agent_projection_with_hook_state(
         &mut self,
         mutation: &WorkspaceMutation,
         fingerprint: &Value,
@@ -845,7 +853,11 @@ impl WorkspaceRegistry {
         )
     }
 
-    pub fn commit_agent_projection_with_hook_state_and_sequence(
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "The sequence-aware projection API mirrors the durable mutation contract."
+    )]
+    pub(crate) fn commit_agent_projection_with_hook_state_and_sequence(
         &mut self,
         mutation: &WorkspaceMutation,
         fingerprint: &Value,
@@ -1589,17 +1601,6 @@ impl WorkspaceRegistry {
         u64::try_from(count).context("resource agent projection count is negative")
     }
 
-    #[cfg(test)]
-    pub(crate) fn delete_agent_hook_state_for_test(
-        &mut self,
-        terminal_id: &crate::resource::TerminalPublicId,
-    ) -> anyhow::Result<()> {
-        self.connection.execute(
-            "DELETE FROM resource_agent_hook_state WHERE terminal_id = ?1",
-            [terminal_id.as_str()],
-        )?;
-        Ok(())
-    }
 
     #[cfg(test)]
     pub(crate) fn agent_hook_pending_retry_state_for_test(

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/tests.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/tests.rs
@@ -5659,3 +5659,14 @@ fn schema_preflight_failures_defer_to_authoritative_open() {
 
     fs::remove_dir_all(root).unwrap();
 }
+
+#[cfg(windows)]
+#[test]
+fn long_database_descendant_is_normalized_even_when_root_is_short() {
+    let root = PathBuf::from(format!(r"C:\{}", "r".repeat(230)));
+    let database = root
+        .join(session_storage_component("session"))
+        .join(WORKSPACE_REGISTRY_FILE);
+    let normalized = crate::platform::normalize_filesystem_path(database);
+    assert!(normalized.to_string_lossy().starts_with(r"\\?\C:\"));
+}

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/tests.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/tests.rs
@@ -5668,9 +5668,7 @@ fn long_database_descendant_is_normalized_even_when_root_is_short() {
     let normalized_session = crate::platform::normalize_filesystem_path(session_dir);
     assert!(normalized_session.to_string_lossy().starts_with(r"\\?\C:\"));
 
-    let database = root
-        .join(session_storage_component("session"))
-        .join(WORKSPACE_REGISTRY_FILE);
+    let database = root.join(session_storage_component("session")).join(WORKSPACE_REGISTRY_FILE);
     let normalized = crate::platform::normalize_filesystem_path(database);
     assert!(normalized.to_string_lossy().starts_with(r"\\?\C:\"));
 }

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/tests.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/tests.rs
@@ -5668,6 +5668,12 @@ fn long_database_descendant_is_normalized_even_when_root_is_short() {
     let normalized_session = crate::platform::normalize_filesystem_path(session_dir);
     assert!(normalized_session.to_string_lossy().starts_with(r"\\?\C:\"));
 
+    let resetter_session =
+        PersistentSessionStateResetter::new(root.clone()).session_dir("session");
+    assert!(resetter_session.to_string_lossy().starts_with(r"\\?\C:\"));
+    let terminal_hosts = crate::terminal_host_runtime::terminal_host_root(&root, "session");
+    assert!(terminal_hosts.to_string_lossy().starts_with(r"\\?\C:\"));
+
     let database = root.join(session_storage_component("session")).join(WORKSPACE_REGISTRY_FILE);
     let normalized = crate::platform::normalize_filesystem_path(database);
     assert!(normalized.to_string_lossy().starts_with(r"\\?\C:\"));

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/tests.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/tests.rs
@@ -5664,7 +5664,13 @@ fn schema_preflight_failures_defer_to_authoritative_open() {
 #[test]
 fn long_database_descendant_is_normalized_even_when_root_is_short() {
     let root = PathBuf::from(format!(r"C:\{}", "r".repeat(230)));
-    let database = root.join(session_storage_component("session")).join(WORKSPACE_REGISTRY_FILE);
+    let session_dir = root.join(session_storage_component("session"));
+    let normalized_session = crate::platform::normalize_filesystem_path(session_dir);
+    assert!(normalized_session.to_string_lossy().starts_with(r"\\?\C:\"));
+
+    let database = root
+        .join(session_storage_component("session"))
+        .join(WORKSPACE_REGISTRY_FILE);
     let normalized = crate::platform::normalize_filesystem_path(database);
     assert!(normalized.to_string_lossy().starts_with(r"\\?\C:\"));
 }

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/tests.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/tests.rs
@@ -5668,8 +5668,7 @@ fn long_database_descendant_is_normalized_even_when_root_is_short() {
     let normalized_session = crate::platform::normalize_filesystem_path(session_dir);
     assert!(normalized_session.to_string_lossy().starts_with(r"\\?\C:\"));
 
-    let resetter_session =
-        PersistentSessionStateResetter::new(root.clone()).session_dir("session");
+    let resetter_session = PersistentSessionStateResetter::new(root.clone()).session_dir("session");
     assert!(resetter_session.to_string_lossy().starts_with(r"\\?\C:\"));
     let terminal_hosts = crate::terminal_host_runtime::terminal_host_root(&root, "session");
     assert!(terminal_hosts.to_string_lossy().starts_with(r"\\?\C:\"));

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/tests.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/tests.rs
@@ -5664,9 +5664,7 @@ fn schema_preflight_failures_defer_to_authoritative_open() {
 #[test]
 fn long_database_descendant_is_normalized_even_when_root_is_short() {
     let root = PathBuf::from(format!(r"C:\{}", "r".repeat(230)));
-    let database = root
-        .join(session_storage_component("session"))
-        .join(WORKSPACE_REGISTRY_FILE);
+    let database = root.join(session_storage_component("session")).join(WORKSPACE_REGISTRY_FILE);
     let normalized = crate::platform::normalize_filesystem_path(database);
     assert!(normalized.to_string_lossy().starts_with(r"\\?\C:\"));
 }

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/tests.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/tests.rs
@@ -37,6 +37,36 @@ fn seed_workspace(registry: &mut WorkspaceRegistry, key: &str) {
         .unwrap();
 }
 
+#[cfg(windows)]
+#[test]
+fn registry_opens_and_persists_under_a_long_windows_state_root() {
+    use std::os::windows::ffi::OsStrExt;
+
+    let mut root = temp_root("windows-long-state-root");
+    while root.as_os_str().encode_wide().count() + 1 + 120 < 423 {
+        root.push("x".repeat(120));
+    }
+    let remaining = 423 - root.as_os_str().encode_wide().count() - 1;
+    assert!((1..=255).contains(&remaining));
+    root.push("x".repeat(remaining));
+    assert_eq!(root.as_os_str().encode_wide().count(), 423);
+
+    fs::create_dir_all(&root).unwrap();
+    let machine_id = MachinePublicId::random().unwrap();
+    fs::write(root.join(MACHINE_ID_FILE), format!("{}\n", machine_id.as_str())).unwrap();
+    let pepper = ResourceEffectPepper::random().unwrap();
+    fs::write(root.join(RESOURCE_EFFECT_PEPPER_FILE), pepper.0.as_ref()).unwrap();
+
+    let mut registry = WorkspaceRegistry::open(&root, "long-state-path").unwrap();
+    seed_workspace(&mut registry, "persisted");
+    drop(registry);
+
+    let reopened = WorkspaceRegistry::open(&root, "long-state-path").unwrap();
+    assert_eq!(reopened.snapshot().unwrap().workspaces[0].key, "persisted");
+    drop(reopened);
+    fs::remove_dir_all(root).unwrap();
+}
+
 #[test]
 fn interrupted_staged_workspace_keeps_reserved_public_id_without_early_publication() {
     let root = temp_root("interrupted-workspace-public-id");

--- a/cmux-tui/crates/cmux-tui/Cargo.toml
+++ b/cmux-tui/crates/cmux-tui/Cargo.toml
@@ -46,11 +46,11 @@ sha2.workspace = true
 uuid.workspace = true
 wait-timeout.workspace = true
 fs4.workspace = true
+tokio.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 cmux-remote.workspace = true
 cmux-remote-protocol.workspace = true
-tokio.workspace = true
 url.workspace = true
 async-trait.workspace = true
 

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -29342,6 +29342,12 @@ mod tests {
         app.replace_tree(browser_completion_tree(surface_id, surface_id));
         app.sidebar_visible = false;
         let area = browser_completion_area(surface_id);
+        // `commit_rendered_pointer_frame` intentionally clears the frame for
+        // an unmeasured app. Give this fixture the same non-zero viewport that
+        // the event loop has after its first layout pass, so the admission
+        // assertion exercises the pointer token rather than the zero-size
+        // guard.
+        app.outer_size = (area.rect.width, area.rect.height);
         app.pane_areas = vec![area];
         app.rendered_pane_content_generations
             .insert(surface_id, PaneContentGeneration::Browser(41));

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -5919,15 +5919,14 @@ impl RenderedPointerFrame {
         }
         if let Some((kind, rect)) =
             self.projection_rails.iter().copied().find(|(_, rect)| rect.contains(x, y))
+            && !self.panes.iter().any(|pane| pane.content.contains(x, y))
         {
-            if !self.panes.iter().any(|pane| pane.content.contains(x, y)) {
-                return PointerRouteIdentity::Rail {
-                    kind,
-                    rect,
-                    column: x.saturating_sub(rect.x),
-                    row: y.saturating_sub(rect.y),
-                };
-            }
+            return PointerRouteIdentity::Rail {
+                kind,
+                rect,
+                column: x.saturating_sub(rect.x),
+                row: y.saturating_sub(rect.y),
+            };
         }
         if let Some(pane) = self.panes.iter().find(|pane| pane.rect.contains(x, y)) {
             let region = if pane.content.contains(x, y) {
@@ -7006,7 +7005,7 @@ pub struct App {
     active_pointer_buttons: HashSet<MouseButton>,
     ignored_pty_mouse_buttons: HashSet<MouseButton>,
     #[cfg(test)]
-    timeout_drain_hook: Option<Box<dyn FnOnce(&mut Self) + Send>>,
+    timeout_drain_hook: Option<TimeoutDrainHook>,
     encoder: KeyEncoder,
     encode_buf: Vec<u8>,
     quit: bool,
@@ -8735,14 +8734,24 @@ fn ensure_managed_workspace_guard(
     Ok(())
 }
 
+/// Runtime dependencies for the managed-machine event loop. Keeping these
+/// related values together gives the loop one stable boundary and prevents a
+/// growing positional argument list as machine support expands.
+pub struct MachineUpdateContext {
+    pub owner_mux: Option<Arc<Mux>>,
+    pub machine_ui: Option<MachineUiState>,
+    pub machine_controller: Option<Box<dyn MachineController>>,
+}
+
+#[cfg(test)]
+type TimeoutDrainHook = Box<dyn FnOnce(&mut App) + Send>;
+
 pub fn run_with_machine_updates(
     session: Session,
     session_label: String,
     default_colors: cmux_tui_core::DefaultColors,
     surface_only: Option<SurfaceId>,
-    owner_mux: Option<Arc<Mux>>,
-    machine_ui: Option<MachineUiState>,
-    machine_controller: Option<Box<dyn MachineController>>,
+    machine_context: MachineUpdateContext,
     startup_config: crate::config::StartupConfigSnapshot,
 ) -> anyhow::Result<RunOutcome> {
     type PanicHook = dyn for<'a> Fn(&std::panic::PanicHookInfo<'a>) + Send + Sync + 'static;
@@ -8764,9 +8773,7 @@ pub fn run_with_machine_updates(
             session_label,
             default_colors,
             surface_only,
-            owner_mux,
-            machine_ui,
-            machine_controller,
+            machine_context,
             startup_config,
         )
     }));
@@ -8789,11 +8796,10 @@ fn run_with_machine_updates_inner(
     session_label: String,
     default_colors: cmux_tui_core::DefaultColors,
     surface_only: Option<SurfaceId>,
-    owner_mux: Option<Arc<Mux>>,
-    machine_ui: Option<MachineUiState>,
-    machine_controller: Option<Box<dyn MachineController>>,
+    machine_context: MachineUpdateContext,
     startup_config: crate::config::StartupConfigSnapshot,
 ) -> anyhow::Result<RunOutcome> {
+    let MachineUpdateContext { owner_mux, machine_ui, machine_controller } = machine_context;
     if let Session::Local(mux) = &session {
         install_mux_diagnostic_logger(mux);
     }
@@ -36797,11 +36803,11 @@ mod tests {
             text: "expired".to_string(),
             deadline: Instant::now() - Duration::from_millis(1),
         });
-        let timeout_seen = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let timeout_seen = Arc::new(AtomicBool::new(false));
         let timeout_seen_in_hook = timeout_seen.clone();
         let (events, receiver) = crossbeam_channel::unbounded();
         app.timeout_drain_hook = Some(Box::new(move |app| {
-            timeout_seen_in_hook.store(true, std::sync::atomic::Ordering::Relaxed);
+            timeout_seen_in_hook.store(true, Ordering::Relaxed);
             app.toast = Some(Toast {
                 text: "reintroduced".to_string(),
                 deadline: Instant::now() - Duration::from_millis(1),
@@ -42863,7 +42869,6 @@ mod tests {
         );
     }
 
-    #[test]
     #[test]
     fn replaced_session_ignores_old_surface_lane_completion() {
         let first = Mux::new("surface-lane-generation-first", SurfaceOptions::default());

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -36818,7 +36818,7 @@ mod tests {
 
         app.event_loop(&mut terminal, receiver).unwrap();
 
-        assert!(timeout_seen.load(std::sync::atomic::Ordering::Relaxed));
+        assert!(timeout_seen.load(Ordering::Relaxed));
         assert_eq!(app.toast.as_ref().map(|toast| toast.text.as_str()), Some("reintroduced"));
     }
 

--- a/cmux-tui/crates/cmux-tui/src/cli.rs
+++ b/cmux-tui/crates/cmux-tui/src/cli.rs
@@ -82,7 +82,7 @@ pub(super) fn is_remote_invocation(args: &[String]) -> bool {
                     || value.starts_with("--session=")
                     || value.starts_with("--machine=") =>
             {
-                index += 1
+                index += 1;
             }
             value if value.starts_with('-') => return false,
             value => return REMOTE_COMMANDS.contains(&value),

--- a/cmux-tui/crates/cmux-tui/src/cli/command.rs
+++ b/cmux-tui/crates/cmux-tui/src/cli/command.rs
@@ -2734,7 +2734,7 @@ pub(super) fn run_session_reset_state(global: GlobalArgs, plan: SessionResetStat
     }
     let state_root =
         match plan.state.map(PathBuf::from).or_else(cmux_tui_core::platform::workspace_state_dir) {
-            Some(path) => path,
+            Some(path) => cmux_tui_core::platform::normalize_filesystem_path(path),
             None => {
                 return super::wire::print_local_error(
                     &json!({

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -4165,7 +4165,6 @@ fn write_config_value_atomic_with_sync(
     value: &Value,
     sync_parent: &dyn Fn(&Path) -> anyhow::Result<ConfigParentSyncOutcome>,
 ) -> anyhow::Result<ConfigWriteOutcome> {
-    let parent = config_parent_directory(path);
     let file_name = path.file_name().and_then(|name| name.to_str()).unwrap_or("cmux-tui.json");
     let stamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_nanos();
     let process_id = std::process::id();
@@ -4283,11 +4282,10 @@ enum ConfigParentSyncOutcome {
 fn sync_config_parent_directory(parent: &Path) -> anyhow::Result<ConfigParentSyncOutcome> {
     let result = std::fs::File::open(parent).and_then(|directory| directory.sync_all());
     #[cfg(target_os = "macos")]
-    if let Err(error) = &result {
-        if matches!(error.raw_os_error(), Some(code) if code == libc::EINVAL || code == libc::ENOTSUP)
-        {
-            return Ok(ConfigParentSyncOutcome::Unsupported);
-        }
+    if let Err(error) = &result
+        && matches!(error.raw_os_error(), Some(code) if code == libc::EINVAL || code == libc::ENOTSUP)
+    {
+        return Ok(ConfigParentSyncOutcome::Unsupported);
     }
     result.map(|()| ConfigParentSyncOutcome::Synced).map_err(Into::into)
 }

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_transport.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_transport.rs
@@ -875,7 +875,7 @@ mod tests {
             "{}::command_connector_does_not_inherit_provider_capability_secrets",
             module_path!()
         );
-        let output = std::process::Command::new(
+        let output = Command::new(
             std::env::current_exe().expect("locate provider environment test binary"),
         )
         .arg("--exact")

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_transport.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_transport.rs
@@ -875,17 +875,16 @@ mod tests {
             "{}::command_connector_does_not_inherit_provider_capability_secrets",
             module_path!()
         );
-        let output = Command::new(
-            std::env::current_exe().expect("locate provider environment test binary"),
-        )
-        .arg("--exact")
-        .arg(&helper_test)
-        .arg("--nocapture")
-        .env(CHILD_MARKER, "1")
-        .env("CMUX_MACHINE_PROVIDER_TOKEN", "provider-token-test")
-        .env("CMUX_PROVIDER_WORKSPACE_AUTHORITY", "provider-authority-test")
-        .output()
-        .expect("run provider environment test helper");
+        let output =
+            Command::new(std::env::current_exe().expect("locate provider environment test binary"))
+                .arg("--exact")
+                .arg(&helper_test)
+                .arg("--nocapture")
+                .env(CHILD_MARKER, "1")
+                .env("CMUX_MACHINE_PROVIDER_TOKEN", "provider-token-test")
+                .env("CMUX_PROVIDER_WORKSPACE_AUTHORITY", "provider-authority-test")
+                .output()
+                .expect("run provider environment test helper");
         assert!(
             output.status.success(),
             "provider environment test helper failed:\nstdout:\n{}\nstderr:\n{}",

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -1408,7 +1408,7 @@ fn normalize_remote_resource_args(raw_args: &mut Vec<String>) -> Result<(), Stri
     let Some(command) = raw_args.get(index).cloned() else {
         return Ok(());
     };
-    if !crate::cli::is_remote_invocation(raw_args) {
+    if !cli::is_remote_invocation(raw_args) {
         return Ok(());
     }
     let rest = raw_args[index + 1..].to_vec();
@@ -1434,7 +1434,7 @@ fn normalize_remote_resource_args(raw_args: &mut Vec<String>) -> Result<(), Stri
         }
         if let Some(action) = raw_args.get(action_index).cloned() {
             raw_args.remove(action_index);
-            if let Some(command) = crate::cli::remote_action_command(&action) {
+            if let Some(command) = cli::remote_action_command(&action) {
                 raw_args.remove(0);
                 raw_args.insert(0, command.to_string());
                 return Ok(());

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -2369,10 +2369,7 @@ fn start_detached_owner_session(
         session: args.session.clone(),
         socket: socket_path.clone(),
         socket_is_derived: args.socket.is_none(),
-        state: args
-            .state
-            .clone()
-            .map(cmux_tui_core::platform::normalize_filesystem_path),
+        state: args.state.clone().map(cmux_tui_core::platform::normalize_filesystem_path),
         term: args.term.clone(),
     };
     let deadline = std::time::Instant::now() + local_owner::ENSURE_DEADLINE;

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -1983,7 +1983,7 @@ fn run_server(
         None
     } else {
         Some(match args.state {
-            Some(path) => path,
+            Some(path) => cmux_tui_core::platform::normalize_filesystem_path(path),
             None => cmux_tui_core::platform::workspace_state_dir()
                 .ok_or_else(|| anyhow::anyhow!("cannot determine durable state directory"))?,
         })
@@ -2369,7 +2369,10 @@ fn start_detached_owner_session(
         session: args.session.clone(),
         socket: socket_path.clone(),
         socket_is_derived: args.socket.is_none(),
-        state: args.state.clone(),
+        state: args
+            .state
+            .clone()
+            .map(cmux_tui_core::platform::normalize_filesystem_path),
         term: args.term.clone(),
     };
     let deadline = std::time::Instant::now() + local_owner::ENSURE_DEADLINE;

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -1427,7 +1427,7 @@ fn normalize_remote_resource_args(raw_args: &mut Vec<String>) -> Result<(), Stri
                         || value.starts_with("--session=")
                         || value.starts_with("--machine=") =>
                 {
-                    action_index += 1
+                    action_index += 1;
                 }
                 _ => break,
             }
@@ -2678,9 +2678,7 @@ fn run_tui_once(
         session_label,
         colors,
         surface_only,
-        owner_mux,
-        machine_ui,
-        machine_controller,
+        app::MachineUpdateContext { owner_mux, machine_ui, machine_controller },
         config,
     )
 }
@@ -2842,7 +2840,7 @@ mod remote_args_tests {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
 
     use super::*;
 
@@ -3305,7 +3303,7 @@ mod tests {
 
         let application_background = cmux_tui_core::Rgb { r: 0x17, g: 0x1b, b: 0x2e };
         authoritative.write_bytes(b"\x1b]11;#171b2e\x1b\\\n").unwrap();
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        let deadline = Instant::now() + Duration::from_secs(5);
         loop {
             let mut existing_render = ghostty_vt::RenderState::new().unwrap();
             let existing_background =
@@ -3319,10 +3317,10 @@ mod tests {
                 break;
             }
             assert!(
-                std::time::Instant::now() < deadline,
+                Instant::now() < deadline,
                 "application-authored OSC defaults did not reach both client projections"
             );
-            std::thread::sleep(std::time::Duration::from_millis(10));
+            std::thread::sleep(Duration::from_millis(10));
         }
     }
 

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -1983,7 +1983,7 @@ fn run_server(
         None
     } else {
         Some(match args.state {
-            Some(path) => cmux_tui_core::platform::normalize_filesystem_path(path),
+            Some(path) => path,
             None => cmux_tui_core::platform::workspace_state_dir()
                 .ok_or_else(|| anyhow::anyhow!("cannot determine durable state directory"))?,
         })
@@ -2369,7 +2369,7 @@ fn start_detached_owner_session(
         session: args.session.clone(),
         socket: socket_path.clone(),
         socket_is_derived: args.socket.is_none(),
-        state: args.state.clone().map(cmux_tui_core::platform::normalize_filesystem_path),
+        state: args.state.clone(),
         term: args.term.clone(),
     };
     let deadline = std::time::Instant::now() + local_owner::ENSURE_DEADLINE;

--- a/cmux-tui/crates/cmux-tui/src/remote_cli.rs
+++ b/cmux-tui/crates/cmux-tui/src/remote_cli.rs
@@ -2554,7 +2554,7 @@ mod tests {
         let load_count = std::cell::Cell::new(0);
         let help_args = ["connect", "--help"].map(str::to_string);
         assert!(
-            super::run_inner(&help_args, "usage", || {
+            run_inner(&help_args, "usage", || {
                 load_count.set(load_count.get() + 1);
                 panic!("remote help must not load startup config");
             })
@@ -2563,7 +2563,7 @@ mod tests {
 
         let invalid_args = ["ssh", "--unknown"].map(str::to_string);
         assert!(
-            super::run_inner(&invalid_args, "usage", || {
+            run_inner(&invalid_args, "usage", || {
                 load_count.set(load_count.get() + 1);
                 panic!("remote parse errors must not load startup config");
             })
@@ -2574,7 +2574,7 @@ mod tests {
 
     #[test]
     fn probe_capabilities_include_direct_ws_user_agent() {
-        assert!(super::PROBE_CAPABILITIES.contains(&"direct-ws-user-agent"));
+        assert!(PROBE_CAPABILITIES.contains(&"direct-ws-user-agent"));
     }
 
     use super::*;

--- a/cmux-tui/crates/cmux-tui/src/session/cursor_provenance.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/cursor_provenance.rs
@@ -263,7 +263,7 @@ mod tests {
     #[test]
     fn c1_string_terminator_ends_all_string_bodies() {
         let mut p = CursorStyleProvenance::default();
-        for opener in [b']', b'P', b'_', b'^', b'X'] {
+        for opener in *b"]P_^X" {
             p.scan(&[0x1b, opener]);
             p.scan(b"payload 5 q");
             p.scan(&[0x9c]);
@@ -342,7 +342,7 @@ fn bell_only_terminates_osc_strings() {
     p.scan(b"\x1b]payload\x1b\x07\x1b[5 q");
     assert!(p.authored(), "BEL must still close OSC after a non-ST ESC");
 
-    for opener in [b'P', b'_', b'^', b'X'] {
+    for opener in *b"P_^X" {
         let mut p = CursorStyleProvenance::default();
         p.scan(&[0x1b, opener]);
         p.scan(b"payload\x07\x1b[5 q");
@@ -354,7 +354,7 @@ fn bell_only_terminates_osc_strings() {
 
 #[test]
 fn can_and_sub_abort_string_bodies() {
-    for opener in [b']', b'P', b'_', b'^', b'X'] {
+    for opener in *b"]P_^X" {
         for abort in [0x18, 0x1a] {
             let mut p = CursorStyleProvenance::default();
             p.scan(&[0x1b, opener, abort]);

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3,7 +3,7 @@
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs;
-use std::io::{self, BufRead, BufReader, Read, Write};
+use std::io::{self, BufRead, BufReader, Write};
 use std::net::Shutdown;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -1679,7 +1679,7 @@ fn remote_reader_end_reason(result: &io::Result<Option<String>>) -> Option<Strin
     }
 }
 
-fn remote_reader_message_too_large(message: &mut String) -> String {
+fn remote_reader_message_too_large(message: &mut str) -> String {
     let reason = format!(
         "remote session message exceeds the \
          {REMOTE_SESSION_MESSAGE_MAX_BYTES}-byte limit"

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -4243,8 +4243,9 @@ pub(super) fn test_session_with_blocked_attach_transport_failure(
 
 #[cfg(test)]
 mod tests {
+    use std::io::Read;
     #[cfg(unix)]
-    use std::io::{BufRead, Read, Write};
+    use std::io::{BufRead, Write};
     #[cfg(unix)]
     use std::os::unix::net::UnixStream;
     use std::sync::atomic::{AtomicBool, AtomicU64};

--- a/cmux-tui/crates/cmux-tui/src/ui/graphics.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/graphics.rs
@@ -1260,7 +1260,6 @@ fn parse_startup_input_event(bytes: &[u8]) -> Option<crossterm::event::Event> {
 
 #[cfg(test)]
 mod tests {
-    use base64::Engine as _;
     use ghostty_vt::{Callbacks, KittyPlacement, KittyPlacementKey, Terminal};
 
     use super::*;

--- a/cmux-tui/crates/ghostty-vt/src/kitty.rs
+++ b/cmux-tui/crates/ghostty-vt/src/kitty.rs
@@ -1028,12 +1028,12 @@ unsafe extern "C" fn decode_png(
                 let mut rgba = Vec::with_capacity(rgba_len);
                 match color_type {
                     png::ColorType::Rgb => {
-                        for pixel in source.chunks_exact(3) {
+                        for pixel in source.as_chunks::<3>().0 {
                             rgba.extend_from_slice(&[pixel[0], pixel[1], pixel[2], 255]);
                         }
                     }
                     png::ColorType::GrayscaleAlpha => {
-                        for pixel in source.chunks_exact(2) {
+                        for pixel in source.as_chunks::<2>().0 {
                             rgba.extend_from_slice(&[pixel[0], pixel[0], pixel[0], pixel[1]]);
                         }
                     }

--- a/cmux-tui/crates/ghostty-vt/src/kitty.rs
+++ b/cmux-tui/crates/ghostty-vt/src/kitty.rs
@@ -1028,12 +1028,12 @@ unsafe extern "C" fn decode_png(
                 let mut rgba = Vec::with_capacity(rgba_len);
                 match color_type {
                     png::ColorType::Rgb => {
-                        for pixel in source.as_chunks::<3>().0 {
+                        for pixel in source.as_chunks::<3>().0.iter() {
                             rgba.extend_from_slice(&[pixel[0], pixel[1], pixel[2], 255]);
                         }
                     }
                     png::ColorType::GrayscaleAlpha => {
-                        for pixel in source.as_chunks::<2>().0 {
+                        for pixel in source.as_chunks::<2>().0.iter() {
                             rgba.extend_from_slice(&[pixel[0], pixel[0], pixel[0], pixel[1]]);
                         }
                     }

--- a/cmux-tui/rust-toolchain.toml
+++ b/cmux-tui/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.98.0"
 profile = "minimal"
 components = ["clippy", "rustfmt"]

--- a/experiments/iroh-byte-transport/README.md
+++ b/experiments/iroh-byte-transport/README.md
@@ -2,6 +2,8 @@
 
 This is a deliberately small Rust experiment for the cmux mobile Iroh path. It is not linked into the iOS app. It proves the byte-stream shape we need before we decide whether the production bridge is an FFI library, a local helper, or a later Swift-native Iroh package.
 
+The checked-in `rust-toolchain.toml` pins the build to the current Rust release.
+
 The experiment uses one Iroh ALPN:
 
 ```text

--- a/experiments/iroh-byte-transport/rust-toolchain.toml
+++ b/experiments/iroh-byte-transport/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.98.0"
+profile = "minimal"

--- a/experiments/iroh-swift-ffi-spike/README.md
+++ b/experiments/iroh-swift-ffi-spike/README.md
@@ -23,7 +23,7 @@ plain bridging header (`include/cmux_iroh_ffi.h`).
 ## Versions
 
 - iroh `1.0.0-rc.1` (n0-error `1.0.0-rc.0`, tokio `1.48`), Rust edition 2024
-- rustc/cargo `1.94.0`, targets `aarch64-apple-darwin`, `aarch64-apple-ios-sim`
+- rustc/cargo `1.98.0`, targets `aarch64-apple-darwin`, `aarch64-apple-ios-sim`
 - Swift harness: `xcrun swiftc -O`, targets `arm64-apple-macos14.0` and
   `arm64-apple-ios17.0-simulator`
 - Proof ran on macOS 26.5 host + iPhone 17 simulator (iOS 26.4)

--- a/experiments/iroh-swift-ffi-spike/rust-toolchain.toml
+++ b/experiments/iroh-swift-ffi-spike/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.98.0"
+profile = "minimal"
+targets = ["aarch64-apple-darwin", "aarch64-apple-ios-sim"]

--- a/services/iroh-relay-minter/rust-toolchain.toml
+++ b/services/iroh-relay-minter/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.91.0"
+channel = "1.98.0"
 profile = "minimal"
 components = ["clippy", "rustfmt"]

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -250,7 +250,7 @@ def test_crates_bootstrap_preserves_the_first_stable_version() -> None:
         "repository_dispatch": {"types": ["sdk-bootstrap-crates"]}
     }
     assert "runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}" in bootstrap
-    assert 'RUST_TOOLCHAIN: "1.95.0"' in bootstrap
+    assert 'RUST_TOOLCHAIN: "1.98.0"' in bootstrap
     assert 'BOOTSTRAP_VERSION: "0.0.0-bootstrap.0"' in bootstrap
     assert "CARGO_BOOTSTRAP_TOKEN" in bootstrap
     assert "cargo test --manifest-path" in bootstrap
@@ -1204,7 +1204,7 @@ def test_rust_release_uses_pinned_cargo_and_verifies_packaged_sidebar() -> None:
     release = workflow("sdk-release-cut.yml")
 
     for text in (preflight, release):
-        assert 'RUST_TOOLCHAIN: "1.95.0"' in text
+        assert 'RUST_TOOLCHAIN: "1.98.0"' in text
         assert 'rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal' in text
         assert 'rustup default "$RUST_TOOLCHAIN"' in text
 


### PR DESCRIPTION
Updates stable Rust toolchain pins to 1.98.0 across cmux-tui, SDK release workflows, relay tooling, and standalone Rust components. Keeps public MSRV declarations and compatibility gates at 1.91 and 1.88.

Also makes the workspace clean under Rust 1.98 clippy/rustfmt and keeps Windows and cross-target builds supported. Hosted verification must be green before merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790538528&installation_model_id=21920&pr_number=11153&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11153&signature=70ad5647a63fd309432509407c944c33292fa9f0276af228fdc7a92f718aa88f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Rust toolchain pins to 1.98.0 across `cmux-tui`, SDK release workflows, relay tooling, experiments, and standalone Rust components, and keeps the public MSRV gates at 1.91 (workspace) and 1.88 (SDK). Makes the workspace clean under 1.98 clippy/rustfmt and keeps Windows and cross-target builds working; hosted verification must be green before merge.

**Lint and refactor fixes**
- Applies 1.98 lint fixes: boxes large mutation and commit failure types, switches chunked hex/PNG decoding to `as_chunks`, uses let-chains and `const` assertions, and narrows workspace-registry APIs to `pub(crate)` with `too_many_arguments` allowances.
- Groups open-watch lifecycle state into `OpenContext`, machine-loop dependencies into `MachineUpdateContext`, and names durable hook retry records and paging cursors.
- Normalizes long Windows state, session, and workspace database paths into the `\\?\` verbatim namespace, including state roots supplied on the CLI and every derived path; paths with `..`, Win32-reserved device names, drive-relative forms, or trailing dots/spaces keep their original spelling to preserve junction, symlink, and Win32 lookup semantics.
- Bumps `cargo-zigbuild` to 0.23.2 so AArch64 cross builds filter the new Cortex-A53 linker flag.
- Updates READMEs and the demo launcher to read the Rust channel from the checked-in toolchain file.

<sup>Written for commit 259141803af40699c6eb60418d42b330d9185b07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Standardized development, validation, and release workflows on Rust 1.98.0.
  * Improved ARM64 build compatibility and cross-platform filesystem path handling.
  * Demo and example build instructions now use repository-pinned toolchain settings automatically.
  * Clarified toolchain and compatibility requirements in documentation.

* **Performance & Reliability**
  * Improved handling of long and network paths on Windows.
  * Reduced unnecessary memory copying and improved data-processing efficiency.

* **Refactor**
  * Simplified internal state management and code organization without changing user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->