### PR TITLE
fix(tui): preserve hook precedence for socket reports

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/journal_reducers.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_reducers.rs
@@ -171,10 +171,10 @@ impl AgentRoster {
                 let Some(state) = event.normalized("state").and_then(agent_state_from_str) else {
                     return Vec::new();
                 };
-                let source = event
-                    .normalized("source")
-                    .and_then(agent_source_from_str)
-                    .unwrap_or(AgentSource::Socket);
+                // The socket adapter is authoritative about origin. Do not
+                // trust the user-controlled normalized source field, or it
+                // could bypass hook-over-socket precedence.
+                let source = AgentSource::Socket;
                 let updated_at_ms = event
                     .normalized("updated_at_ms")
                     .and_then(|value| value.parse::<u64>().ok())
@@ -315,6 +315,25 @@ mod tests {
         let deltas =
             roster.apply(&hook_event(3, "agent.state.changed", &subjects, &socket_payload));
         assert!(deltas.is_empty());
+        assert_eq!(roster.entries["term_a"].source, "hook");
+    }
+
+    #[test]
+    fn socket_echo_cannot_spoof_hook_source() {
+        let subjects = terminal_subject("term_a");
+        let hook_payload = json!({"adapter": {"id": "claude", "version": 1}});
+        let socket_payload = json!({
+            "adapter": {"id": SOCKET_REPORT_ADAPTER, "version": 1},
+            "normalized": {"state": "idle", "source": "hook"}
+        });
+        let mut roster = AgentRoster::default();
+        roster.apply(&hook_event(1, "agent.turn.started", &subjects, &hook_payload));
+        assert!(
+            roster
+                .apply(&hook_event(2, "agent.state.changed", &subjects, &socket_payload))
+                .is_empty()
+        );
+        assert_eq!(roster.entries["term_a"].state, "working");
         assert_eq!(roster.entries["term_a"].source, "hook");
     }
 


### PR DESCRIPTION
Force socket adapter events to use AgentSource::Socket instead of trusting normalized.source. This prevents a spoofed socket payload from bypassing hook-over-socket precedence and overwriting live hook state. Adds a regression test.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790543958&installation_model_id=21920&pr_number=11160&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11160&signature=3cc23bc49c6225473458032d0099168f458502735317309fb24af5f941ec1ea8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forces socket adapter events to use `AgentSource::Socket` instead of trusting the normalized `source` field. Previously, a socket payload could claim `source: "hook"` and overwrite live hook state; now the socket adapter is authoritative about origin. Adds a regression test for this case.

<sup>Written for commit d8d7abe87d0198efc7098c224b24f3028821eda2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

