### PR TITLE
Bound ThreadOutput backlog and terminate on overflow

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -14,7 +14,7 @@ use std::mem::{offset_of, size_of};
 use std::os::fd::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::{Arc, Condvar, Mutex, mpsc};
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
@@ -417,11 +417,23 @@ impl PtyControl for MasterControl {
     }
 }
 
-/// A degraded pipe-mode shell (no TTY) used when PTY allocation fails. The
-/// child is owned by its wait thread; kill signals it by pid.
+/// A command sent to the thread that owns a degraded pipe-mode child.
+///
+/// Keeping the child in one thread gives overflow cleanup an owned process
+/// handle. A numeric PID is never retained by the output callback, so a late
+/// callback cannot signal a process that reused the old PID.
+enum PipeChildCommand {
+    Kill,
+    ExitReady,
+}
+
+/// A degraded pipe-mode shell (no TTY) used when PTY allocation fails.
+/// The child itself remains owned by the wait thread. The control only sends
+/// commands to that owner and retains the child's stdin for input.
 struct PipeControl {
     stdin: Mutex<Option<std::process::ChildStdin>>,
-    pid: i32,
+    command_tx: mpsc::Sender<PipeChildCommand>,
+    kill_requested: AtomicBool,
 }
 
 impl PtyControl for PipeControl {
@@ -437,9 +449,35 @@ impl PtyControl for PipeControl {
     fn pause(&self) {}
     fn resume(&self) {}
     fn kill(&self) {
-        // SAFETY: signalling a child pid this handle spawned; harmless if gone.
-        unsafe {
-            libc::kill(self.pid, libc::SIGKILL);
+        if self.kill_requested.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        let _ = self.command_tx.send(PipeChildCommand::Kill);
+    }
+}
+
+/// Observe a child becoming waitable without reaping it. `WNOWAIT` keeps the
+/// child's PID reserved until the owner thread handles the event and calls
+/// `Child::wait`, which closes the PID-reuse window around overflow cleanup.
+fn wait_for_child_exit_without_reaping(pid: libc::pid_t) -> std::io::Result<()> {
+    loop {
+        let mut status = std::mem::MaybeUninit::<libc::siginfo_t>::zeroed();
+        // SAFETY: status points to writable siginfo storage. WNOWAIT observes
+        // this child without releasing its PID for reuse.
+        let result = unsafe {
+            libc::waitid(
+                libc::P_PID,
+                pid as libc::id_t,
+                status.as_mut_ptr(),
+                libc::WEXITED | libc::WNOWAIT,
+            )
+        };
+        if result == 0 {
+            return Ok(());
+        }
+        let error = std::io::Error::last_os_error();
+        if error.kind() != std::io::ErrorKind::Interrupted {
+            return Err(error);
         }
     }
 }
@@ -519,8 +557,13 @@ fn spawn_pipe_mode(spec: &SpawnSpec, reason: &str) -> PtyHandle {
     match command.spawn() {
         Ok(mut child) => {
             let stdin = child.stdin.take();
-            let pid = child.id() as i32;
-            let control = Arc::new(PipeControl { stdin: Mutex::new(stdin), pid });
+            let pid = child.id() as libc::pid_t;
+            let (command_tx, command_rx) = mpsc::channel();
+            let control = Arc::new(PipeControl {
+                stdin: Mutex::new(stdin),
+                command_tx: command_tx.clone(),
+                kill_requested: AtomicBool::new(false),
+            });
             output.set_overflow_control(&control);
             let reader_count = child.stdout.is_some() as usize + child.stderr.is_some() as usize;
             let completion = ProcessOutputCompletion::new(reader_count, Arc::clone(&output));
@@ -534,11 +577,26 @@ fn spawn_pipe_mode(spec: &SpawnSpec, reason: &str) -> PtyHandle {
                 let done = Arc::clone(&completion);
                 std::thread::spawn(move || pump_pipe(stderr, out, done));
             }
-            // The wait would need its own thread; the shell exits when its
-            // pipes close, and the manager treats a data EOF plus process
-            // teardown as the end. Report exit when both pipes close.
+            // Observe exit without reaping. The owner thread handles both
+            // overflow kill requests and the final wait, so all process
+            // signals use the still-owned Child handle.
+            let observer_tx = command_tx;
+            std::thread::spawn(move || {
+                let _ = wait_for_child_exit_without_reaping(pid);
+                let _ = observer_tx.send(PipeChildCommand::ExitReady);
+            });
             let wait_completion = Arc::clone(&completion);
             std::thread::spawn(move || {
+                let mut exit_ready = false;
+                while !exit_ready {
+                    match command_rx.recv() {
+                        Ok(PipeChildCommand::ExitReady) => exit_ready = true,
+                        Ok(PipeChildCommand::Kill) => {
+                            let _ = child.kill();
+                        }
+                        Err(_) => exit_ready = true,
+                    }
+                }
                 let code =
                     child.wait().map(|status| status.code().unwrap_or(0) as i64).unwrap_or(0);
                 wait_completion.child_exited(code);
@@ -936,6 +994,32 @@ mod tests {
         drop(control);
         assert!(weak_control.upgrade().is_none());
         assert_eq!(drops.load(AtomicOrdering::Relaxed), 1);
+    }
+
+    #[test]
+    fn pipe_control_sends_one_kill_request_to_owned_child() {
+        let (command_tx, command_rx) = mpsc::channel();
+        let control = PipeControl {
+            stdin: Mutex::new(None),
+            command_tx,
+            kill_requested: AtomicBool::new(false),
+        };
+
+        control.kill();
+        control.kill();
+
+        assert!(matches!(command_rx.recv(), Ok(PipeChildCommand::Kill)));
+        assert!(command_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn child_exit_observer_leaves_child_owned_for_wait() {
+        let mut child = std::process::Command::new("/bin/sh")
+            .args(["-c", "exit 23"])
+            .spawn()
+            .expect("spawn child");
+        wait_for_child_exit_without_reaping(child.id() as libc::pid_t).expect("observe child");
+        assert_eq!(child.wait().expect("reap child").code(), Some(23));
     }
 
     #[test]

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -336,10 +336,8 @@ impl ProcessOutputCompletion {
         let mut state = self.state.lock().expect("process output completion lock");
         while state.readers_remaining != 0 && state.child_exit.is_some() {
             let Some(remaining) = deadline.checked_duration_since(Instant::now()) else { break };
-            let (next, timeout) = self
-                .wake
-                .wait_timeout(state, remaining)
-                .expect("process output completion lock");
+            let (next, timeout) =
+                self.wake.wait_timeout(state, remaining).expect("process output completion lock");
             state = next;
             if timeout.timed_out() {
                 break;

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -138,6 +138,20 @@ impl ThreadOutput {
         *self.overflow_handler.lock().expect("overflow handler lock") = Some(handler);
     }
 
+    /// Bind overflow cleanup without extending the control owner's lifetime.
+    /// The source can outlive its `PtyHandle` while its reader thread drains.
+    fn set_overflow_control<T>(&self, control: &Arc<T>)
+    where
+        T: PtyControl + 'static,
+    {
+        let weak_control = Arc::downgrade(control);
+        self.set_overflow_handler(Arc::new(move || {
+            if let Some(control) = weak_control.upgrade() {
+                control.kill();
+            }
+        }));
+    }
+
     /// Mark the queue as owned by a drainer, if a subscriber is ready.
     fn start_delivery(state: &mut SourceState) -> bool {
         if state.delivering
@@ -335,8 +349,7 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
         writer: Mutex::new(writer),
         killer: Mutex::new(killer),
     });
-    let overflow_control = Arc::clone(&control);
-    output.set_overflow_handler(Arc::new(move || overflow_control.kill()));
+    output.set_overflow_control(&control);
 
     // Blocking reader thread -> output sink.
     let data_output = Arc::clone(&output);
@@ -384,8 +397,7 @@ fn spawn_pipe_mode(spec: &SpawnSpec, reason: &str) -> PtyHandle {
             let stdin = child.stdin.take();
             let pid = child.id() as i32;
             let control = Arc::new(PipeControl { stdin: Mutex::new(stdin), pid });
-            let overflow_control = Arc::clone(&control);
-            output.set_overflow_handler(Arc::new(move || overflow_control.kill()));
+            output.set_overflow_control(&control);
             if let Some(stdout) = child.stdout.take() {
                 let out = Arc::clone(&output);
                 std::thread::spawn(move || pump_pipe(stdout, out));
@@ -634,6 +646,27 @@ mod tests {
     use std::sync::{Arc as TestArc, Barrier, Mutex as TestMutex};
     use std::thread;
 
+    struct TestControl {
+        kills: TestArc<AtomicUsize>,
+        drops: TestArc<AtomicUsize>,
+    }
+
+    impl Drop for TestControl {
+        fn drop(&mut self) {
+            self.drops.fetch_add(1, AtomicOrdering::Relaxed);
+        }
+    }
+
+    impl PtyControl for TestControl {
+        fn write(&self, _data: &[u8]) {}
+        fn resize(&self, _cols: u16, _rows: u16) {}
+        fn pause(&self) {}
+        fn resume(&self) {}
+        fn kill(&self) {
+            self.kills.fetch_add(1, AtomicOrdering::Relaxed);
+        }
+    }
+
     #[test]
     fn session_socket_path_matches_core_fallback_order() {
         let session = format!("legacy-{}", "x".repeat(200));
@@ -729,6 +762,27 @@ mod tests {
         );
         output.push_data(Bytes::from_static(b"another overflow"));
         assert_eq!(kills.load(AtomicOrdering::Relaxed), 1);
+    }
+
+    #[test]
+    fn overflow_control_kills_live_owner_without_retaining_it() {
+        let output = ThreadOutput::new();
+        let kills = TestArc::new(AtomicUsize::new(0));
+        let drops = TestArc::new(AtomicUsize::new(0));
+        let control = TestArc::new(TestControl {
+            kills: TestArc::clone(&kills),
+            drops: TestArc::clone(&drops),
+        });
+        let weak_control = TestArc::downgrade(&control);
+        output.set_overflow_control(&control);
+
+        output.push_data(Bytes::from(vec![b'x'; THREAD_OUTPUT_BACKLOG_CAP]));
+        output.push_data(Bytes::from_static(b"overflow"));
+        assert_eq!(kills.load(AtomicOrdering::Relaxed), 1);
+
+        drop(control);
+        assert!(weak_control.upgrade().is_none());
+        assert_eq!(drops.load(AtomicOrdering::Relaxed), 1);
     }
 
     #[test]

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -888,9 +888,6 @@ mod tests {
             }),
         );
 
-        assert_eq!(
-            *seen.lock().expect("seen lock"),
-            vec!["tail".to_owned(), "exit:23".to_owned()]
-        );
+        assert_eq!(*seen.lock().expect("seen lock"), vec!["tail".to_owned(), "exit:23".to_owned()]);
     }
 }

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -9,9 +9,11 @@
 #![cfg(unix)]
 
 use std::collections::{HashMap, VecDeque};
+use std::fs::File;
 use std::io::{Read, Write};
 use std::mem::{offset_of, size_of};
 use std::os::fd::AsRawFd;
+use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Condvar, Mutex, mpsc};
@@ -262,20 +264,47 @@ impl PtyOutput for ThreadOutput {
 /// Orders the process exit notification after every reader has reached EOF.
 /// A child can exit while bytes remain buffered in a pipe or PTY master. The
 /// wait thread records the exit code, and the final reader publishes it only
-/// after its last `push_data` call. Pipe fallback uses a bounded grace period;
-/// the PTY path keeps its terminal EOF semantics. The output callback runs
-/// outside this coordinator's mutex.
+/// after its last `push_data` call. Both paths use a bounded grace period; the
+/// PTY reader has an explicit poll cancellation wake for inherited slave
+/// descriptors. The output callback runs outside this coordinator's mutex.
 struct ProcessOutputCompletion {
     state: Mutex<ProcessOutputCompletionState>,
     wake: Condvar,
     output: Arc<ThreadOutput>,
     post_exit_grace: Option<Duration>,
     cancelled: AtomicBool,
+    cancel_wake: Option<Arc<CancellationWake>>,
 }
 
 struct ProcessOutputCompletionState {
     readers_remaining: usize,
     child_exit: Option<i64>,
+}
+
+/// Wakes a PTY reader that is waiting in `poll` when completion reaches its
+/// bounded grace deadline. A socket pair avoids closing a descriptor from a
+/// different thread, which can race with descriptor reuse.
+struct CancellationWake {
+    writer: Mutex<UnixStream>,
+}
+
+impl CancellationWake {
+    fn new() -> std::io::Result<(Arc<Self>, UnixStream)> {
+        let (reader, writer) = UnixStream::pair()?;
+        writer.set_nonblocking(true)?;
+        Ok((Arc::new(Self { writer: Mutex::new(writer) }), reader))
+    }
+
+    fn signal(&self) {
+        let Ok(mut writer) = self.writer.lock() else { return };
+        loop {
+            match writer.write(&[1]) {
+                Ok(_) => break,
+                Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(_) => break,
+            }
+        }
+    }
 }
 
 impl ProcessOutputCompletion {
@@ -288,12 +317,41 @@ impl ProcessOutputCompletion {
         output: Arc<ThreadOutput>,
         post_exit_grace: Option<Duration>,
     ) -> Arc<Self> {
+        Self::with_post_exit_grace_and_cancel(
+            readers_remaining,
+            output,
+            post_exit_grace,
+            None,
+        )
+    }
+
+    fn with_pty_cancellation(
+        readers_remaining: usize,
+        output: Arc<ThreadOutput>,
+    ) -> std::io::Result<(Arc<Self>, UnixStream)> {
+        let (cancel_wake, cancel_reader) = CancellationWake::new()?;
+        let completion = Self::with_post_exit_grace_and_cancel(
+            readers_remaining,
+            output,
+            Some(PIPE_OUTPUT_DRAIN_GRACE),
+            Some(cancel_wake),
+        );
+        Ok((completion, cancel_reader))
+    }
+
+    fn with_post_exit_grace_and_cancel(
+        readers_remaining: usize,
+        output: Arc<ThreadOutput>,
+        post_exit_grace: Option<Duration>,
+        cancel_wake: Option<Arc<CancellationWake>>,
+    ) -> Arc<Self> {
         Arc::new(Self {
             state: Mutex::new(ProcessOutputCompletionState { readers_remaining, child_exit: None }),
             wake: Condvar::new(),
             output,
             post_exit_grace,
             cancelled: AtomicBool::new(false),
+            cancel_wake,
         })
     }
 
@@ -344,11 +402,14 @@ impl ProcessOutputCompletion {
         }
         let code = state.child_exit.take();
         self.cancelled.store(true, Ordering::Release);
+        if let Some(cancel_wake) = &self.cancel_wake {
+            cancel_wake.signal();
+        }
         drop(state);
         if let Some(code) = code {
-            // End the source after the bounded grace period. Readers poll for
-            // cancellation, so inherited descriptors cannot retain threads
-            // after the child has exited.
+            // End the source after the bounded grace period. The PTY reader's
+            // poll set includes the cancellation wake, so inherited
+            // descriptors cannot retain a reader thread after this point.
             self.output.push_exit(code);
         }
     }
@@ -483,6 +544,7 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
         pixel_width: 0,
         pixel_height: 0,
     })?;
+    let reader = File::from(pair.try_clone_reader_descriptor()?);
     let mut command = cmux_pty::PtyCommand::new(spec.file.clone());
     command.args(spec.args.clone());
     command.cwd(&spec.cwd);
@@ -491,7 +553,6 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
         command.env(key, value);
     }
     let spawned = pair.spawn(command)?;
-    let reader = spawned.master.try_clone_reader()?;
     let writer = spawned.master.take_writer()?;
     let killer = spawned.child.clone_killer();
     let output = ThreadOutput::new();
@@ -504,21 +565,14 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
     // Use the same bounded post-exit grace as pipe fallback. A background
     // descendant can inherit the PTY slave, so waiting for terminal EOF here
     // would otherwise delay the primary child exit without a bound.
-    let completion = ProcessOutputCompletion::new(1, Arc::clone(&output));
+    let (completion, cancel_reader) =
+        ProcessOutputCompletion::with_pty_cancellation(1, Arc::clone(&output))?;
 
     // Blocking reader thread -> output sink.
     let data_output = Arc::clone(&output);
     let data_completion = Arc::clone(&completion);
     std::thread::spawn(move || {
-        let mut reader = reader;
-        let mut buffer = [0_u8; 32_768];
-        loop {
-            match reader.read(&mut buffer) {
-                Ok(0) | Err(_) => break,
-                Ok(count) => data_output.push_data(Bytes::copy_from_slice(&buffer[..count])),
-            }
-        }
-        data_completion.reader_finished();
+        pump_pty(reader, cancel_reader, data_output, data_completion);
     });
     // Blocking wait thread -> exit.
     let mut child = spawned.child;
@@ -529,6 +583,47 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
     });
 
     Ok(PtyHandle { control, output, banner: None })
+}
+
+/// Read a PTY with an owned descriptor and an explicit cancellation wake.
+/// `Read::read` is called only after the descriptor reports readiness, so a
+/// descendant-held PTY slave cannot leave this thread blocked past the grace
+/// deadline.
+fn pump_pty(
+    mut reader: impl Read + AsRawFd,
+    cancel_reader: UnixStream,
+    output: Arc<ThreadOutput>,
+    completion: Arc<ProcessOutputCompletion>,
+) {
+    let reader_fd = reader.as_raw_fd();
+    let cancel_fd = cancel_reader.as_raw_fd();
+    let mut buffer = [0_u8; 32_768];
+    loop {
+        let mut poll_fds = [
+            libc::pollfd { fd: reader_fd, events: libc::POLLIN, revents: 0 },
+            libc::pollfd { fd: cancel_fd, events: libc::POLLIN, revents: 0 },
+        ];
+        let poll_result = unsafe { libc::poll(poll_fds.as_mut_ptr(), poll_fds.len() as _, -1) };
+        if poll_result < 0 {
+            if std::io::Error::last_os_error().kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            break;
+        }
+        if completion.cancelled() || poll_fds[1].revents != 0 {
+            break;
+        }
+        if poll_fds[0].revents == 0 {
+            continue;
+        }
+        match reader.read(&mut buffer) {
+            Ok(0) => break,
+            Err(error) if error.raw_os_error() == Some(libc::EIO) => break,
+            Err(_) => break,
+            Ok(count) => output.push_data(Bytes::copy_from_slice(&buffer[..count])),
+        }
+    }
+    completion.reader_finished();
 }
 
 fn spawn_pipe_mode(spec: &SpawnSpec, reason: &str) -> PtyHandle {
@@ -1087,5 +1182,28 @@ mod tests {
         reader_done_rx
             .recv_timeout(Duration::from_secs(1))
             .expect("reader must stop after bounded post-exit recovery");
+    }
+
+    #[test]
+    fn pty_reader_cancellation_wakes_a_blocked_poll() {
+        let output = ThreadOutput::new();
+        let (completion, cancel_reader) =
+            ProcessOutputCompletion::with_pty_cancellation(1, TestArc::clone(&output))
+                .expect("cancellation wake");
+        let (reader_stream, _writer_stream) = UnixStream::pair().expect("PTY-like stream pair");
+        let reader = reader_stream;
+        let (reader_done_tx, reader_done_rx) = mpsc::channel();
+        let pump_output = TestArc::clone(&output);
+        let pump_completion = TestArc::clone(&completion);
+        thread::spawn(move || {
+            pump_pty(reader, cancel_reader, pump_output, pump_completion);
+            reader_done_tx.send(()).expect("reader completion");
+        });
+
+        completion.child_exited(41);
+
+        reader_done_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("cancellation must wake a blocked PTY poll");
     }
 }

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -710,8 +710,9 @@ pub fn valid_session(name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::os::unix::net::UnixStream;
     use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
-    use std::sync::{Arc as TestArc, Barrier, Mutex as TestMutex};
+    use std::sync::{Arc as TestArc, Barrier, Mutex as TestMutex, mpsc};
     use std::thread;
 
     struct TestControl {
@@ -889,5 +890,36 @@ mod tests {
         );
 
         assert_eq!(*seen.lock().expect("seen lock"), vec!["tail".to_owned(), "exit:23".to_owned()]);
+    }
+
+    #[test]
+    fn inherited_pipe_descriptor_cannot_hold_exit_forever() {
+        let output = ThreadOutput::new();
+        let completion = ProcessOutputCompletion::new(1, TestArc::clone(&output));
+        let (reader, _writer) = UnixStream::pair().expect("pipe pair");
+        let (exit_tx, exit_rx) = mpsc::channel();
+        let (reader_done_tx, reader_done_rx) = mpsc::channel();
+        let pump_output = TestArc::clone(&output);
+        let pump_completion = TestArc::clone(&completion);
+        thread::spawn(move || {
+            pump_pipe(reader, pump_output, pump_completion);
+            reader_done_tx.send(()).expect("reader completion");
+        });
+        output.subscribe(
+            TestArc::new(|_| {}),
+            TestArc::new(move |code| exit_tx.send(code).expect("exit delivery")),
+        );
+
+        completion.child_exited(41);
+
+        assert_eq!(
+            exit_rx
+                .recv_timeout(Duration::from_secs(1))
+                .expect("inherited descriptors must not suppress exit"),
+            41
+        );
+        reader_done_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("reader must stop after bounded post-exit recovery");
     }
 }

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -11,7 +11,7 @@
 use std::collections::{HashMap, VecDeque};
 use std::io::{Read, Write};
 use std::mem::{offset_of, size_of};
-use std::os::fd::{AsRawFd, RawFd};
+use std::os::fd::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
@@ -568,10 +568,6 @@ fn pump_pipe(
     completion: Arc<ProcessOutputCompletion>,
 ) {
     let fd = stream.as_raw_fd();
-    if set_nonblocking(fd).is_err() {
-        completion.reader_finished();
-        return;
-    }
     let mut buffer = [0_u8; 32_768];
     loop {
         if completion.cancelled() {
@@ -593,23 +589,11 @@ fn pump_pipe(
         }
         match stream.read(&mut buffer) {
             Ok(0) => break,
-            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => continue,
             Err(_) => break,
             Ok(count) => output.push_data(Bytes::copy_from_slice(&buffer[..count])),
         }
     }
     completion.reader_finished();
-}
-
-fn set_nonblocking(fd: RawFd) -> std::io::Result<()> {
-    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
-    if flags < 0 {
-        return Err(std::io::Error::last_os_error());
-    }
-    if unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0 {
-        return Err(std::io::Error::last_os_error());
-    }
-    Ok(())
 }
 
 async fn socket_exists(path: &Path) -> bool {

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -283,10 +283,6 @@ impl ProcessOutputCompletion {
         Self::with_post_exit_grace(readers_remaining, output, Some(PIPE_OUTPUT_DRAIN_GRACE))
     }
 
-    fn unbounded(readers_remaining: usize, output: Arc<ThreadOutput>) -> Arc<Self> {
-        Self::with_post_exit_grace(readers_remaining, output, None)
-    }
-
     fn with_post_exit_grace(
         readers_remaining: usize,
         output: Arc<ThreadOutput>,
@@ -505,9 +501,10 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
         killer: Mutex::new(killer),
     });
     output.set_overflow_control(&control);
-    // PTY EOF is the terminal's lifecycle boundary. Unlike pipe fallback,
-    // background jobs intentionally retain the PTY until they finish.
-    let completion = ProcessOutputCompletion::unbounded(1, Arc::clone(&output));
+    // Use the same bounded post-exit grace as pipe fallback. A background
+    // descendant can inherit the PTY slave, so waiting for terminal EOF here
+    // would otherwise delay the primary child exit without a bound.
+    let completion = ProcessOutputCompletion::new(1, Arc::clone(&output));
 
     // Blocking reader thread -> output sink.
     let data_output = Arc::clone(&output);
@@ -1059,7 +1056,10 @@ mod tests {
     }
 
     #[test]
-    fn inherited_pipe_descriptor_cannot_hold_exit_forever() {
+    fn inherited_pty_descriptor_cannot_hold_exit_forever() {
+        // The PTY completion path uses the same bounded grace coordinator as
+        // pipe fallback. An open stream models a background descendant that
+        // inherited the PTY slave and keeps the reader from reaching EOF.
         let output = ThreadOutput::new();
         let completion = ProcessOutputCompletion::new(1, TestArc::clone(&output));
         let (reader, _writer) = UnixStream::pair().expect("pipe pair");

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -167,6 +167,11 @@ impl ThreadOutput {
     }
 
     fn push_data(&self, chunk: Bytes) {
+        // Empty reads carry no output and must not consume an unbounded queue
+        // entry while a subscriber is late.
+        if chunk.is_empty() {
+            return;
+        }
         let should_drain = {
             let mut state = self.state.lock().expect("source lock");
             if state.exited || state.overflowed {
@@ -700,5 +705,17 @@ mod tests {
             *seen.lock().expect("seen lock"),
             vec![format!("data:{THREAD_OUTPUT_BACKLOG_CAP}"), "exit:75".to_owned()]
         );
+    }
+
+    #[test]
+    fn empty_chunks_do_not_bypass_backlog_cap() {
+        let output = ThreadOutput::new();
+        for _ in 0..10_000 {
+            output.push_data(Bytes::new());
+        }
+
+        let state = output.state.lock().expect("source lock");
+        assert!(state.backlog.is_empty());
+        assert_eq!(state.backlog_bytes, 0);
     }
 }

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -27,6 +27,8 @@ use crate::pty::{
 };
 
 const DAEMON_SOCKET_WAIT_MS: u64 = 5_000;
+const THREAD_OUTPUT_BACKLOG_CAP: usize = 1024 * 1024;
+const THREAD_OUTPUT_OVERFLOW_EXIT: i64 = 75;
 // `lifecycle_ready` was added to the cmux-tui control protocol at version 12.
 // This is distinct from the relay's lower-level CONTROL_MIN_PROTOCOL floor.
 const DAEMON_LIFECYCLE_PROTOCOL_MIN: u64 = 12;
@@ -108,10 +110,12 @@ struct SourceState {
     on_data: Option<DataSink>,
     on_exit: Option<ExitSink>,
     backlog: VecDeque<Bytes>,
+    backlog_bytes: usize,
     // Keep exit behind bytes that arrive before the subscriber drains.
     pending_exit: Option<i64>,
     delivering: bool,
     exited: bool,
+    overflowed: bool,
 }
 
 struct ThreadOutput {
@@ -144,6 +148,7 @@ impl ThreadOutput {
             let next = {
                 let mut state = self.state.lock().expect("source lock");
                 if let Some(chunk) = state.backlog.pop_front() {
+                    state.backlog_bytes = state.backlog_bytes.saturating_sub(chunk.len());
                     (Some(chunk), None, state.on_data.clone(), state.on_exit.clone())
                 } else if let Some(code) = state.pending_exit.take() {
                     (None, Some(code), state.on_data.clone(), state.on_exit.clone())
@@ -164,7 +169,17 @@ impl ThreadOutput {
     fn push_data(&self, chunk: Bytes) {
         let should_drain = {
             let mut state = self.state.lock().expect("source lock");
-            state.backlog.push_back(chunk);
+            if state.exited || state.overflowed {
+                return;
+            }
+            if chunk.len() > THREAD_OUTPUT_BACKLOG_CAP.saturating_sub(state.backlog_bytes) {
+                state.overflowed = true;
+                state.exited = true;
+                state.pending_exit = Some(THREAD_OUTPUT_OVERFLOW_EXIT);
+            } else {
+                state.backlog_bytes += chunk.len();
+                state.backlog.push_back(chunk);
+            }
             Self::start_delivery(&mut state)
         };
         if should_drain {
@@ -661,6 +676,29 @@ mod tests {
         assert_eq!(
             *seen.lock().expect("seen lock"),
             vec!["buffered".to_owned(), "live".to_owned(), "exit:7".to_owned()]
+        );
+    }
+
+    #[test]
+    fn backlog_overflow_preserves_prefix_and_emits_terminal_exit_once() {
+        let output = ThreadOutput::new();
+        output.push_data(Bytes::from(vec![b'x'; THREAD_OUTPUT_BACKLOG_CAP]));
+        output.push_data(Bytes::from_static(b"overflow"));
+        output.push_exit(0);
+        let seen = TestArc::new(TestMutex::new(Vec::new()));
+        let data_seen = TestArc::clone(&seen);
+        let exit_seen = TestArc::clone(&seen);
+        output.subscribe(
+            TestArc::new(move |chunk| {
+                data_seen.lock().expect("seen lock").push(format!("data:{}", chunk.len()))
+            }),
+            TestArc::new(move |code| {
+                exit_seen.lock().expect("seen lock").push(format!("exit:{code}"))
+            }),
+        );
+        assert_eq!(
+            *seen.lock().expect("seen lock"),
+            vec![format!("data:{THREAD_OUTPUT_BACKLOG_CAP}"), "exit:75".to_owned()]
         );
     }
 }

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -120,11 +120,22 @@ struct SourceState {
 
 struct ThreadOutput {
     state: Mutex<SourceState>,
+    overflow_handler: Mutex<Option<Arc<dyn Fn() + Send + Sync>>>,
 }
 
 impl ThreadOutput {
     fn new() -> Arc<ThreadOutput> {
-        Arc::new(ThreadOutput { state: Mutex::new(SourceState::default()) })
+        Arc::new(ThreadOutput {
+            state: Mutex::new(SourceState::default()),
+            overflow_handler: Mutex::new(None),
+        })
+    }
+
+    /// Install the owner cleanup that must run when the bounded source queue
+    /// overflows. The callback is invoked at most once and never while the
+    /// source mutex is held.
+    fn set_overflow_handler(&self, handler: Arc<dyn Fn() + Send + Sync>) {
+        *self.overflow_handler.lock().expect("overflow handler lock") = Some(handler);
     }
 
     /// Mark the queue as owned by a drainer, if a subscriber is ready.
@@ -172,21 +183,28 @@ impl ThreadOutput {
         if chunk.is_empty() {
             return;
         }
-        let should_drain = {
+        let (should_drain, overflowed) = {
             let mut state = self.state.lock().expect("source lock");
             if state.exited || state.overflowed {
                 return;
             }
+            let mut overflowed = false;
             if chunk.len() > THREAD_OUTPUT_BACKLOG_CAP.saturating_sub(state.backlog_bytes) {
                 state.overflowed = true;
                 state.exited = true;
                 state.pending_exit = Some(THREAD_OUTPUT_OVERFLOW_EXIT);
+                overflowed = true;
             } else {
                 state.backlog_bytes += chunk.len();
                 state.backlog.push_back(chunk);
             }
-            Self::start_delivery(&mut state)
+            (Self::start_delivery(&mut state), overflowed)
         };
+        if overflowed
+            && let Some(handler) = self.overflow_handler.lock().expect("overflow handler lock").clone()
+        {
+            handler();
+        }
         if should_drain {
             self.drain();
         }
@@ -311,6 +329,13 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
     let writer = spawned.master.take_writer()?;
     let killer = spawned.child.clone_killer();
     let output = ThreadOutput::new();
+    let control = Arc::new(MasterControl {
+        master: Mutex::new(spawned.master),
+        writer: Mutex::new(writer),
+        killer: Mutex::new(killer),
+    });
+    let overflow_control = Arc::clone(&control);
+    output.set_overflow_handler(Arc::new(move || overflow_control.kill()));
 
     // Blocking reader thread -> output sink.
     let data_output = Arc::clone(&output);
@@ -333,11 +358,7 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
     });
 
     Ok(PtyHandle {
-        control: Arc::new(MasterControl {
-            master: Mutex::new(spawned.master),
-            writer: Mutex::new(writer),
-            killer: Mutex::new(killer),
-        }),
+        control,
         output,
         banner: None,
     })
@@ -365,6 +386,9 @@ fn spawn_pipe_mode(spec: &SpawnSpec, reason: &str) -> PtyHandle {
         Ok(mut child) => {
             let stdin = child.stdin.take();
             let pid = child.id() as i32;
+            let control = Arc::new(PipeControl { stdin: Mutex::new(stdin), pid });
+            let overflow_control = Arc::clone(&control);
+            output.set_overflow_handler(Arc::new(move || overflow_control.kill()));
             if let Some(stdout) = child.stdout.take() {
                 let out = Arc::clone(&output);
                 std::thread::spawn(move || pump_pipe(stdout, out));
@@ -383,7 +407,7 @@ fn spawn_pipe_mode(spec: &SpawnSpec, reason: &str) -> PtyHandle {
                 wait_output.push_exit(code);
             });
             PtyHandle {
-                control: Arc::new(PipeControl { stdin: Mutex::new(stdin), pid }),
+                control,
                 output,
                 banner: Some(banner.into_bytes()),
             }
@@ -687,6 +711,11 @@ mod tests {
     #[test]
     fn backlog_overflow_preserves_prefix_and_emits_terminal_exit_once() {
         let output = ThreadOutput::new();
+        let kills = TestArc::new(AtomicUsize::new(0));
+        let kill_counter = TestArc::clone(&kills);
+        output.set_overflow_handler(TestArc::new(move || {
+            kill_counter.fetch_add(1, AtomicOrdering::Relaxed);
+        }));
         output.push_data(Bytes::from(vec![b'x'; THREAD_OUTPUT_BACKLOG_CAP]));
         output.push_data(Bytes::from_static(b"overflow"));
         output.push_exit(0);
@@ -705,6 +734,8 @@ mod tests {
             *seen.lock().expect("seen lock"),
             vec![format!("data:{THREAD_OUTPUT_BACKLOG_CAP}"), "exit:75".to_owned()]
         );
+        output.push_data(Bytes::from_static(b"another overflow"));
+        assert_eq!(kills.load(AtomicOrdering::Relaxed), 1);
     }
 
     #[test]

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -255,6 +255,62 @@ impl PtyOutput for ThreadOutput {
     }
 }
 
+/// Orders the process exit notification after every reader has reached EOF.
+/// A child can exit while bytes remain buffered in a pipe or PTY master. The
+/// wait thread records the exit code, and the final reader publishes it only
+/// after its last `push_data` call. The output callback runs outside this
+/// coordinator's mutex.
+struct ProcessOutputCompletion {
+    state: Mutex<ProcessOutputCompletionState>,
+    output: Arc<ThreadOutput>,
+}
+
+struct ProcessOutputCompletionState {
+    readers_remaining: usize,
+    child_exit: Option<i64>,
+}
+
+impl ProcessOutputCompletion {
+    fn new(readers_remaining: usize, output: Arc<ThreadOutput>) -> Arc<Self> {
+        Arc::new(Self {
+            state: Mutex::new(ProcessOutputCompletionState { readers_remaining, child_exit: None }),
+            output,
+        })
+    }
+
+    fn child_exited(&self, code: i64) {
+        {
+            let mut state = self.state.lock().expect("process output completion lock");
+            if state.child_exit.is_some() {
+                return;
+            }
+            state.child_exit = Some(code);
+        }
+        self.emit_if_ready();
+    }
+
+    fn reader_finished(&self) {
+        {
+            let mut state = self.state.lock().expect("process output completion lock");
+            if state.readers_remaining == 0 {
+                return;
+            }
+            state.readers_remaining -= 1;
+        }
+        self.emit_if_ready();
+    }
+
+    fn emit_if_ready(&self) {
+        let code = {
+            let mut state = self.state.lock().expect("process output completion lock");
+            (state.readers_remaining == 0).then(|| state.child_exit.take()).flatten()
+        };
+        if let Some(code) = code {
+            self.output.push_exit(code);
+        }
+    }
+}
+
 pub struct RealPtyDeps {
     env: HashMap<String, String>,
     uid: u32,
@@ -350,9 +406,11 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
         killer: Mutex::new(killer),
     });
     output.set_overflow_control(&control);
+    let completion = ProcessOutputCompletion::new(1, Arc::clone(&output));
 
     // Blocking reader thread -> output sink.
     let data_output = Arc::clone(&output);
+    let data_completion = Arc::clone(&completion);
     std::thread::spawn(move || {
         let mut reader = reader;
         let mut buffer = [0_u8; 32_768];
@@ -362,13 +420,14 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
                 Ok(count) => data_output.push_data(Bytes::copy_from_slice(&buffer[..count])),
             }
         }
+        data_completion.reader_finished();
     });
     // Blocking wait thread -> exit.
     let mut child = spawned.child;
-    let exit_output = Arc::clone(&output);
+    let exit_completion = Arc::clone(&completion);
     std::thread::spawn(move || {
         let code = child.wait().map(|status| i64::from(status.exit_code() as i32)).unwrap_or(0);
-        exit_output.push_exit(code);
+        exit_completion.child_exited(code);
     });
 
     Ok(PtyHandle { control, output, banner: None })
@@ -398,22 +457,26 @@ fn spawn_pipe_mode(spec: &SpawnSpec, reason: &str) -> PtyHandle {
             let pid = child.id() as i32;
             let control = Arc::new(PipeControl { stdin: Mutex::new(stdin), pid });
             output.set_overflow_control(&control);
+            let reader_count = child.stdout.is_some() as usize + child.stderr.is_some() as usize;
+            let completion = ProcessOutputCompletion::new(reader_count, Arc::clone(&output));
             if let Some(stdout) = child.stdout.take() {
                 let out = Arc::clone(&output);
-                std::thread::spawn(move || pump_pipe(stdout, out));
+                let done = Arc::clone(&completion);
+                std::thread::spawn(move || pump_pipe(stdout, out, done));
             }
             if let Some(stderr) = child.stderr.take() {
                 let out = Arc::clone(&output);
-                std::thread::spawn(move || pump_pipe(stderr, out));
+                let done = Arc::clone(&completion);
+                std::thread::spawn(move || pump_pipe(stderr, out, done));
             }
             // The wait would need its own thread; the shell exits when its
             // pipes close, and the manager treats a data EOF plus process
             // teardown as the end. Report exit when both pipes close.
-            let wait_output = Arc::clone(&output);
+            let wait_completion = Arc::clone(&completion);
             std::thread::spawn(move || {
                 let code =
                     child.wait().map(|status| status.code().unwrap_or(0) as i64).unwrap_or(0);
-                wait_output.push_exit(code);
+                wait_completion.child_exited(code);
             });
             PtyHandle { control, output, banner: Some(banner.into_bytes()) }
         }
@@ -434,7 +497,11 @@ impl PtyControl for DeadControl {
     fn kill(&self) {}
 }
 
-fn pump_pipe(mut stream: impl Read, output: Arc<ThreadOutput>) {
+fn pump_pipe(
+    mut stream: impl Read,
+    output: Arc<ThreadOutput>,
+    completion: Arc<ProcessOutputCompletion>,
+) {
     let mut buffer = [0_u8; 32_768];
     loop {
         match stream.read(&mut buffer) {
@@ -442,6 +509,7 @@ fn pump_pipe(mut stream: impl Read, output: Arc<ThreadOutput>) {
             Ok(count) => output.push_data(Bytes::copy_from_slice(&buffer[..count])),
         }
     }
+    completion.reader_finished();
 }
 
 async fn socket_exists(path: &Path) -> bool {
@@ -800,7 +868,7 @@ mod tests {
     #[test]
     fn pipe_exit_waits_for_reader_eof_before_delivering_late_bytes() {
         let output = ThreadOutput::new();
-        let completion = PipeExitCoordinator::new(1, TestArc::clone(&output));
+        let completion = ProcessOutputCompletion::new(1, TestArc::clone(&output));
         completion.child_exited(23);
         output.push_data(Bytes::from_static(b"tail"));
         completion.reader_finished();

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -317,12 +317,7 @@ impl ProcessOutputCompletion {
         output: Arc<ThreadOutput>,
         post_exit_grace: Option<Duration>,
     ) -> Arc<Self> {
-        Self::with_post_exit_grace_and_cancel(
-            readers_remaining,
-            output,
-            post_exit_grace,
-            None,
-        )
+        Self::with_post_exit_grace_and_cancel(readers_remaining, output, post_exit_grace, None)
     }
 
     fn with_pty_cancellation(

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -11,8 +11,10 @@
 use std::collections::{HashMap, VecDeque};
 use std::io::{Read, Write};
 use std::mem::{offset_of, size_of};
+use std::os::fd::{AsRawFd, RawFd};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
@@ -29,6 +31,8 @@ use crate::pty::{
 const DAEMON_SOCKET_WAIT_MS: u64 = 5_000;
 const THREAD_OUTPUT_BACKLOG_CAP: usize = 1024 * 1024;
 const THREAD_OUTPUT_OVERFLOW_EXIT: i64 = 75;
+const PIPE_OUTPUT_DRAIN_GRACE: Duration = Duration::from_millis(250);
+const PIPE_READ_POLL_MS: i32 = 100;
 // `lifecycle_ready` was added to the cmux-tui control protocol at version 12.
 // This is distinct from the relay's lower-level CONTROL_MIN_PROTOCOL floor.
 const DAEMON_LIFECYCLE_PROTOCOL_MIN: u64 = 12;
@@ -258,11 +262,15 @@ impl PtyOutput for ThreadOutput {
 /// Orders the process exit notification after every reader has reached EOF.
 /// A child can exit while bytes remain buffered in a pipe or PTY master. The
 /// wait thread records the exit code, and the final reader publishes it only
-/// after its last `push_data` call. The output callback runs outside this
-/// coordinator's mutex.
+/// after its last `push_data` call. Pipe fallback uses a bounded grace period;
+/// the PTY path keeps its terminal EOF semantics. The output callback runs
+/// outside this coordinator's mutex.
 struct ProcessOutputCompletion {
     state: Mutex<ProcessOutputCompletionState>,
+    wake: Condvar,
     output: Arc<ThreadOutput>,
+    post_exit_grace: Option<Duration>,
+    cancelled: AtomicBool,
 }
 
 struct ProcessOutputCompletionState {
@@ -272,21 +280,42 @@ struct ProcessOutputCompletionState {
 
 impl ProcessOutputCompletion {
     fn new(readers_remaining: usize, output: Arc<ThreadOutput>) -> Arc<Self> {
+        Self::with_post_exit_grace(readers_remaining, output, Some(PIPE_OUTPUT_DRAIN_GRACE))
+    }
+
+    fn unbounded(readers_remaining: usize, output: Arc<ThreadOutput>) -> Arc<Self> {
+        Self::with_post_exit_grace(readers_remaining, output, None)
+    }
+
+    fn with_post_exit_grace(
+        readers_remaining: usize,
+        output: Arc<ThreadOutput>,
+        post_exit_grace: Option<Duration>,
+    ) -> Arc<Self> {
         Arc::new(Self {
             state: Mutex::new(ProcessOutputCompletionState { readers_remaining, child_exit: None }),
+            wake: Condvar::new(),
             output,
+            post_exit_grace,
+            cancelled: AtomicBool::new(false),
         })
     }
 
-    fn child_exited(&self, code: i64) {
-        {
+    fn child_exited(self: &Arc<Self>, code: i64) {
+        let should_watch = {
             let mut state = self.state.lock().expect("process output completion lock");
             if state.child_exit.is_some() {
                 return;
             }
             state.child_exit = Some(code);
+            state.readers_remaining != 0 && self.post_exit_grace.is_some()
+        };
+        if should_watch {
+            let completion = Arc::clone(self);
+            std::thread::spawn(move || completion.wait_for_readers());
+        } else {
+            self.emit_if_ready();
         }
-        self.emit_if_ready();
     }
 
     fn reader_finished(&self) {
@@ -297,7 +326,41 @@ impl ProcessOutputCompletion {
             }
             state.readers_remaining -= 1;
         }
+        self.wake.notify_all();
         self.emit_if_ready();
+    }
+
+    fn wait_for_readers(self: Arc<Self>) {
+        let grace = self.post_exit_grace.expect("bounded completion grace");
+        let deadline = Instant::now() + grace;
+        let mut state = self.state.lock().expect("process output completion lock");
+        while state.readers_remaining != 0 && state.child_exit.is_some() {
+            let Some(remaining) = deadline.checked_duration_since(Instant::now()) else { break };
+            let (next, timeout) = self
+                .wake
+                .wait_timeout(state, remaining)
+                .expect("process output completion lock");
+            state = next;
+            if timeout.timed_out() {
+                break;
+            }
+        }
+        if state.readers_remaining == 0 || state.child_exit.is_none() {
+            return;
+        }
+        let code = state.child_exit.take();
+        self.cancelled.store(true, Ordering::Release);
+        drop(state);
+        if let Some(code) = code {
+            // End the source after the bounded grace period. Readers poll for
+            // cancellation, so inherited descriptors cannot retain threads
+            // after the child has exited.
+            self.output.push_exit(code);
+        }
+    }
+
+    fn cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::Acquire)
     }
 
     fn emit_if_ready(&self) {
@@ -406,7 +469,9 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
         killer: Mutex::new(killer),
     });
     output.set_overflow_control(&control);
-    let completion = ProcessOutputCompletion::new(1, Arc::clone(&output));
+    // PTY EOF is the terminal's lifecycle boundary. Unlike pipe fallback,
+    // background jobs intentionally retain the PTY until they finish.
+    let completion = ProcessOutputCompletion::unbounded(1, Arc::clone(&output));
 
     // Blocking reader thread -> output sink.
     let data_output = Arc::clone(&output);
@@ -498,18 +563,53 @@ impl PtyControl for DeadControl {
 }
 
 fn pump_pipe(
-    mut stream: impl Read,
+    mut stream: impl Read + AsRawFd,
     output: Arc<ThreadOutput>,
     completion: Arc<ProcessOutputCompletion>,
 ) {
+    let fd = stream.as_raw_fd();
+    if set_nonblocking(fd).is_err() {
+        completion.reader_finished();
+        return;
+    }
     let mut buffer = [0_u8; 32_768];
     loop {
+        if completion.cancelled() {
+            break;
+        }
+        let mut poll_fd = libc::pollfd { fd, events: libc::POLLIN, revents: 0 };
+        let poll_result = unsafe { libc::poll(&mut poll_fd, 1, PIPE_READ_POLL_MS) };
+        if poll_result < 0 {
+            if std::io::Error::last_os_error().raw_os_error() == Some(libc::EINTR) {
+                continue;
+            }
+            break;
+        }
+        if poll_result == 0 {
+            continue;
+        }
+        if poll_fd.revents & libc::POLLNVAL != 0 {
+            break;
+        }
         match stream.read(&mut buffer) {
-            Ok(0) | Err(_) => break,
+            Ok(0) => break,
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => continue,
+            Err(_) => break,
             Ok(count) => output.push_data(Bytes::copy_from_slice(&buffer[..count])),
         }
     }
     completion.reader_finished();
+}
+
+fn set_nonblocking(fd: RawFd) -> std::io::Result<()> {
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    if unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
 }
 
 async fn socket_exists(path: &Path) -> bool {

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -439,6 +439,36 @@ impl RealPtyDeps {
     }
 }
 
+/// Owns a spawned child until the PTY setup has transferred it to the wait
+/// thread. Any setup error must terminate and reap the child before the
+/// caller can choose pipe mode, otherwise one failed PTY attempt leaks a
+/// process outside the relay's lifecycle.
+struct SpawnedChildCleanup {
+    child: Option<Box<dyn cmux_pty::Child + Send + Sync>>,
+}
+
+impl SpawnedChildCleanup {
+    fn new(child: Box<dyn cmux_pty::Child + Send + Sync>) -> Self {
+        Self { child: Some(child) }
+    }
+
+    fn child(&self) -> &(dyn cmux_pty::Child + Send + Sync) {
+        self.child.as_deref().expect("spawned child cleanup owns a child")
+    }
+
+    fn take(&mut self) -> Box<dyn cmux_pty::Child + Send + Sync> {
+        self.child.take().expect("spawned child cleanup owns a child")
+    }
+}
+
+impl Drop for SpawnedChildCleanup {
+    fn drop(&mut self) {
+        let Some(mut child) = self.child.take() else { return };
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+}
+
 /// A real PTY master behind a mutex; write/resize block briefly.
 struct MasterControl {
     master: Mutex<Box<dyn MasterPty + Send>>,
@@ -547,12 +577,18 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
     for (key, value) in &spec.env {
         command.env(key, value);
     }
-    let spawned = pair.spawn(command)?;
-    let writer = spawned.master.take_writer()?;
-    let killer = spawned.child.clone_killer();
     let output = ThreadOutput::new();
+    // Set up every fallible cancellation primitive before spawning. This
+    // keeps descriptor exhaustion on the no-child side of the boundary.
+    let (completion, cancel_reader) =
+        ProcessOutputCompletion::with_pty_cancellation(1, Arc::clone(&output))?;
+    let spawned = pair.spawn(command)?;
+    let cmux_pty::SpawnedPty { mut master, child } = spawned;
+    let mut child_cleanup = SpawnedChildCleanup::new(child);
+    let writer = master.take_writer()?;
+    let killer = child_cleanup.child().clone_killer();
     let control = Arc::new(MasterControl {
-        master: Mutex::new(spawned.master),
+        master: Mutex::new(master),
         writer: Mutex::new(writer),
         killer: Mutex::new(killer),
     });
@@ -560,9 +596,6 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
     // Use the same bounded post-exit grace as pipe fallback. A background
     // descendant can inherit the PTY slave, so waiting for terminal EOF here
     // would otherwise delay the primary child exit without a bound.
-    let (completion, cancel_reader) =
-        ProcessOutputCompletion::with_pty_cancellation(1, Arc::clone(&output))?;
-
     // Blocking reader thread -> output sink.
     let data_output = Arc::clone(&output);
     let data_completion = Arc::clone(&completion);
@@ -570,7 +603,7 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
         pump_pty(reader, cancel_reader, data_output, data_completion);
     });
     // Blocking wait thread -> exit.
-    let mut child = spawned.child;
+    let mut child = child_cleanup.take();
     let exit_completion = Arc::clone(&completion);
     std::thread::spawn(move || {
         let code = child.wait().map(|status| i64::from(status.exit_code() as i32)).unwrap_or(0);

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -796,4 +796,33 @@ mod tests {
         assert!(state.backlog.is_empty());
         assert_eq!(state.backlog_bytes, 0);
     }
+
+    #[test]
+    fn pipe_exit_waits_for_reader_eof_before_delivering_late_bytes() {
+        let output = ThreadOutput::new();
+        let completion = PipeExitCoordinator::new(1, TestArc::clone(&output));
+        completion.child_exited(23);
+        output.push_data(Bytes::from_static(b"tail"));
+        completion.reader_finished();
+
+        let seen = TestArc::new(TestMutex::new(Vec::<String>::new()));
+        let data_seen = TestArc::clone(&seen);
+        let exit_seen = TestArc::clone(&seen);
+        output.subscribe(
+            TestArc::new(move |chunk| {
+                data_seen
+                    .lock()
+                    .expect("seen lock")
+                    .push(String::from_utf8_lossy(&chunk).into_owned())
+            }),
+            TestArc::new(move |code| {
+                exit_seen.lock().expect("seen lock").push(format!("exit:{code}"))
+            }),
+        );
+
+        assert_eq!(
+            *seen.lock().expect("seen lock"),
+            vec!["tail".to_owned(), "exit:23".to_owned()]
+        );
+    }
 }

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -201,7 +201,8 @@ impl ThreadOutput {
             (Self::start_delivery(&mut state), overflowed)
         };
         if overflowed
-            && let Some(handler) = self.overflow_handler.lock().expect("overflow handler lock").clone()
+            && let Some(handler) =
+                self.overflow_handler.lock().expect("overflow handler lock").clone()
         {
             handler();
         }
@@ -357,11 +358,7 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
         exit_output.push_exit(code);
     });
 
-    Ok(PtyHandle {
-        control,
-        output,
-        banner: None,
-    })
+    Ok(PtyHandle { control, output, banner: None })
 }
 
 fn spawn_pipe_mode(spec: &SpawnSpec, reason: &str) -> PtyHandle {
@@ -406,11 +403,7 @@ fn spawn_pipe_mode(spec: &SpawnSpec, reason: &str) -> PtyHandle {
                     child.wait().map(|status| status.code().unwrap_or(0) as i64).unwrap_or(0);
                 wait_output.push_exit(code);
             });
-            PtyHandle {
-                control,
-                output,
-                banner: Some(banner.into_bytes()),
-            }
+            PtyHandle { control, output, banner: Some(banner.into_bytes()) }
         }
         Err(error) => {
             let _ = error;

--- a/cmux-tui/crates/cmux-pty/src/lib.rs
+++ b/cmux-tui/crates/cmux-pty/src/lib.rs
@@ -9,6 +9,8 @@ use std::fmt;
 #[cfg(unix)]
 use std::fs::File;
 use std::io;
+#[cfg(unix)]
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 use std::path::{Path, PathBuf};
 #[cfg(unix)]
 use std::sync::Arc;
@@ -151,6 +153,34 @@ pub struct PtyPair {
 }
 
 impl PtyPair {
+    /// Duplicate the master descriptor before spawning so a reader can poll
+    /// its own owned descriptor without borrowing a handle that another
+    /// thread may close. `F_DUPFD_CLOEXEC` keeps the duplicate out of child
+    /// exec environments without a descriptor-inheritance race.
+    #[cfg(unix)]
+    pub fn try_clone_reader_descriptor(&self) -> anyhow::Result<OwnedFd> {
+        let source = self
+            .master
+            .as_raw_fd()
+            .ok_or_else(|| anyhow::anyhow!("PTY master does not expose a reader descriptor"))?;
+        loop {
+            // SAFETY: `source` is owned by this still-live PTY pair. The
+            // successful fcntl call returns a new descriptor we immediately
+            // wrap in OwnedFd.
+            let descriptor = unsafe { libc::fcntl(source, libc::F_DUPFD_CLOEXEC, 0) };
+            if descriptor >= 0 {
+                // SAFETY: ownership transfers from fcntl to OwnedFd exactly
+                // once on a successful call.
+                return Ok(unsafe { OwnedFd::from_raw_fd(descriptor) });
+            }
+            let error = io::Error::last_os_error();
+            if error.kind() == io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(anyhow::anyhow!("failed to duplicate PTY reader: {error}"));
+        }
+    }
+
     /// Spawn the command, close the parent's slave descriptor, and return the
     /// master and child as one ownership-safe unit.
     pub fn spawn(self, command: PtyCommand) -> anyhow::Result<SpawnedPty> {


### PR DESCRIPTION
ThreadOutput now caps queued bytes at 1 MiB. It preserves the accepted FIFO prefix, emits one terminal exit code 75 on overflow, and ignores subsequent output and exit notifications. Added a behavior test for overflow ordering and single terminal exit.

Validation: rustfmt --edition 2024; no local Cargo tests per repository policy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790547005&installation_model_id=21920&pr_number=11162&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11162&signature=2328e2ab5edcf0b2a72882252291bd329d170852f38abd3a687f1140510ac6ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps queued `ThreadOutput` bytes at 1 MiB and ignores empty chunks; on overflow it emits a terminal exit code 75, drops later output/exit events, and kills the source control without keeping it alive.

- The overflow handler holds the control by weak reference; pipe kills route through the child owner thread to avoid signaling a reused PID.
- Exit delivery waits for reader EOF within a bounded grace period in both PTY and pipe modes; PTY readers get a socket-pair wake and pipe readers poll, so inherited descriptors can't stall exit or leak threads.
- Failed PTY setups now kill and reap the spawned child before falling back to pipe mode.
- Tests cover overflow ordering, single exit, kill-once, control lifetime, empty chunks, exit ordering, inherited-descriptor recovery, and setup cleanup.

<sup>Written for commit 7dfd37a8ccdb521349570b0fcf9295bfe2faf917. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Limited buffered terminal output to 1 MiB to prevent excessive backlog growth.
  * Preserved previously buffered output when the limit is exceeded.
  * Added a clear terminal exit status when output exceeds the limit.
  * Ensured overflow notifications are emitted only once.
  * Prevented empty reads from consuming buffer capacity.
  * Automatically stopped the associated terminal process when the output limit is exceeded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->