### PR TITLE
ios: first-pair Mac discovery from the active irx runtime

### DIFF
--- a/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/IrxBrokerService.swift
+++ b/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/IrxBrokerService.swift
@@ -331,6 +331,19 @@ public actor IrxBrokerService {
         return response
     }
 
+    /// Drops the in-memory discovery snapshot after a presence push proves it
+    /// stale, so the next discovery-consuming call refetches.
+    public func invalidateDiscoverySnapshot() {
+        lastDiscovery = nil
+        lastDiscoveryAt = nil
+    }
+
+    /// Revokes one account-owned binding (the "forget computer" server leg).
+    public func revoke(bindingID: String) async throws {
+        try await client.revoke(bindingID: bindingID)
+        journal.record("broker", "binding-revoked", ["binding": bindingID])
+    }
+
     // MARK: - Relay credentials
 
     public func cachedRelayCredentials() -> [IrxRelayCredential] {

--- a/ios/cmux/AppCompositionRoot.swift
+++ b/ios/cmux/AppCompositionRoot.swift
@@ -25,6 +25,8 @@ final class AppCompositionRoot {
     /// The irx (from-scratch iroh) composition when its DEBUG flag owns the
     /// `.iroh` route; nil when the legacy runtime is active.
     let irx: MobileIrxRuntimeComposition?
+    /// irx-backed first-pair discovery/forget; nil when legacy owns the slot.
+    let irxDiscovery: MobileIrxDiscoveryProvider?
     /// One build-compatibility policy shared by discovery, persistence, and
     /// connection validation. Keeping it here prevents composition paths from
     /// admitting different Mac app instances.
@@ -87,6 +89,7 @@ final class AppCompositionRoot {
         auth: MobileAuthComposition,
         iroh: MobileIrohRuntimeComposition,
         irx: MobileIrxRuntimeComposition? = nil,
+        irxDiscovery: MobileIrxDiscoveryProvider? = nil,
         buildCompatibilityPolicy: MobileMacBuildCompatibilityPolicy,
         reachability: any ReachabilityProviding,
         diagnosticLog: DiagnosticLog
@@ -101,6 +104,7 @@ final class AppCompositionRoot {
         self.auth = auth
         self.iroh = iroh
         self.irx = irx
+        self.irxDiscovery = irxDiscovery
         self.buildCompatibilityPolicy = buildCompatibilityPolicy
         self.reachability = reachability
         self.diagnosticLog = diagnosticLog

--- a/ios/cmux/cmuxApp.swift
+++ b/ios/cmux/cmuxApp.swift
@@ -165,6 +165,13 @@ struct cmuxApp: App {
             auth: auth,
             iroh: iroh,
             irx: irxEnabled ? irx : nil,
+            irxDiscovery: irxEnabled
+                ? MobileIrxDiscoveryProvider(
+                    irx: irx,
+                    preferredTag: irx.tag,
+                    compatibilityPolicy: buildCompatibilityPolicy
+                )
+                : nil,
             buildCompatibilityPolicy: buildCompatibilityPolicy,
             reachability: reachability,
             diagnosticLog: diagnosticLog
@@ -230,9 +237,13 @@ struct cmuxApp: App {
             autoConnectMigrationStore: Self.root.autoConnectMigrationStore,
             onboardingStore: Self.root.onboardingStore,
             tailscaleStatusMonitor: Self.root.tailscaleStatusMonitor,
-            personalIrohRouteCatalog: Self.root.iroh.routeCatalog,
-            personalIrohDiscovery: Self.root.iroh,
-            personalIrohForget: Self.root.iroh,
+            // First-pair discovery must come from the ACTIVE transport: the
+            // dormant one answers "endpoint unavailable" and a fresh install
+            // (empty paired-Mac store) then lists zero Macs forever.
+            personalIrohRouteCatalog: Self.root.irxDiscovery?.routeCatalog
+                ?? Self.root.iroh.routeCatalog,
+            personalIrohDiscovery: Self.root.irxDiscovery ?? Self.root.iroh,
+            personalIrohForget: Self.root.irxDiscovery ?? Self.root.iroh,
             buildCompatibilityPolicy: Self.root.buildCompatibilityPolicy,
             signOutHook: Self.root.signOutHook,
             diagnosticLog: Self.root.diagnosticLog

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrxDiscoveryProvider.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrxDiscoveryProvider.swift
@@ -76,11 +76,11 @@ public final class MobileIrxDiscoveryProvider: MobileIrohMacDiscovering,
     public func discoverLiveMacs() async -> [MobileDiscoveredIrohMac] {
         scope &+= 1
         let currentScope = scope
-        routeCatalog.activate(scope: currentScope)
+        await routeCatalog.activate(scope: currentScope)
         guard let discovery = await discover() else { return [] }
         guard scope == currentScope else { return [] }
-        routeCatalog.replace(with: discovery, scope: currentScope)
-        return routeCatalog.liveMacCandidates(
+        await routeCatalog.replace(with: discovery, scope: currentScope)
+        return await routeCatalog.liveMacCandidates(
             preferredTag: preferredTag,
             compatibleWith: compatibilityPolicy,
             limit: 4

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrxDiscoveryProvider.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrxDiscoveryProvider.swift
@@ -1,0 +1,130 @@
+public import CMUXMobileCore
+public import CmuxIrohTransport
+public import CmuxMobileShell
+import Foundation
+
+/// Failure reasons for an irx-backed forget, surfaced so the shell keeps the
+/// local row instead of claiming a revoke that never reached the server.
+public enum MobileIrxForgetError: Error, Equatable {
+    case notAuthenticated
+    case accountMismatch
+    case discoveryUnavailable
+}
+
+/// Bridges first-pair Mac discovery and forget onto the ACTIVE irx runtime.
+///
+/// The Computers picker's zero-touch path talks to whatever the scene injects
+/// as `personalIrohDiscovery`. When irx became the primary transport the
+/// scene kept injecting the dormant legacy runtime, which answers every query
+/// with "endpoint unavailable": a freshly installed phone (empty paired-Mac
+/// store) therefore listed ZERO Macs while the live irx engine could see the
+/// whole fleet (08-28 field incident). This provider implements the same two
+/// capabilities on top of irx broker discovery, reusing the legacy route
+/// catalog's binding-to-candidate mapping so pairability filtering, build
+/// compatibility, ordering, and attach-route construction stay identical
+/// between transports.
+@MainActor
+public final class MobileIrxDiscoveryProvider: MobileIrohMacDiscovering,
+    MobileIrohMacForgetting
+{
+    /// Exposed so the scene injects the SAME catalog the provider fills as
+    /// `personalIrohRouteCatalog` (known-Mac route lookups read it).
+    public let routeCatalog = MobileIrohRouteCatalog()
+
+    private let preferredTag: String
+    private let compatibilityPolicy: MobileMacBuildCompatibilityPolicy?
+    private let discover: @Sendable () async -> CmxIrohDiscoveryResponse?
+    private let invalidateSnapshot: @Sendable () async -> Void
+    private let revokeBinding: @Sendable (String) async throws -> Void
+    private let authenticatedAccountID: @Sendable () async -> String?
+    private var scope: UInt64 = 0
+
+    /// Closure-injected core, so tests can drive it without the actor stack.
+    public init(
+        preferredTag: String,
+        compatibilityPolicy: MobileMacBuildCompatibilityPolicy?,
+        discover: @escaping @Sendable () async -> CmxIrohDiscoveryResponse?,
+        invalidateSnapshot: @escaping @Sendable () async -> Void,
+        revokeBinding: @escaping @Sendable (String) async throws -> Void,
+        authenticatedAccountID: @escaping @Sendable () async -> String?
+    ) {
+        self.preferredTag = preferredTag
+        self.compatibilityPolicy = compatibilityPolicy
+        self.discover = discover
+        self.invalidateSnapshot = invalidateSnapshot
+        self.revokeBinding = revokeBinding
+        self.authenticatedAccountID = authenticatedAccountID
+    }
+
+    public convenience init(
+        irx: MobileIrxRuntimeComposition,
+        preferredTag: String,
+        compatibilityPolicy: MobileMacBuildCompatibilityPolicy?
+    ) {
+        self.init(
+            preferredTag: preferredTag,
+            compatibilityPolicy: compatibilityPolicy,
+            discover: { await irx.freshLiveDiscovery() },
+            invalidateSnapshot: { await irx.invalidateDiscoverySnapshot() },
+            revokeBinding: { try await irx.revokeBinding($0) },
+            authenticatedAccountID: { await irx.authenticatedAccountID() }
+        )
+    }
+
+    // MARK: - MobileIrohMacDiscovering
+
+    public func discoverLiveMacs() async -> [MobileDiscoveredIrohMac] {
+        scope &+= 1
+        let currentScope = scope
+        routeCatalog.activate(scope: currentScope)
+        guard let discovery = await discover() else { return [] }
+        guard scope == currentScope else { return [] }
+        routeCatalog.replace(with: discovery, scope: currentScope)
+        return routeCatalog.liveMacCandidates(
+            preferredTag: preferredTag,
+            compatibleWith: compatibilityPolicy,
+            limit: 4
+        )
+    }
+
+    public func invalidateDiscovery(forMacDeviceID deviceID: String) async {
+        _ = deviceID
+        await invalidateSnapshot()
+    }
+
+    // MARK: - MobileIrohMacForgetting
+
+    public func forgetComputer(
+        macDeviceID: String,
+        instanceTag: String?,
+        expectedAccountID: String
+    ) async throws {
+        guard let account = await authenticatedAccountID() else {
+            throw MobileIrxForgetError.notAuthenticated
+        }
+        guard account == expectedAccountID else {
+            throw MobileIrxForgetError.accountMismatch
+        }
+        guard let discovery = await discover() else {
+            throw MobileIrxForgetError.discoveryUnavailable
+        }
+        let canonicalDeviceID = cmxCanonicalDeviceID(macDeviceID)
+        let wantedTag = instanceTag.map {
+            CmxMacAppInstanceIdentity(
+                macDeviceID: macDeviceID, instanceTag: $0
+            ).instanceTag ?? ""
+        }
+        let matches = discovery.bindings.filter { binding in
+            cmxCanonicalDeviceID(binding.deviceID) == canonicalDeviceID
+                && (wantedTag == nil || binding.tag == wantedTag)
+        }
+        for binding in matches {
+            // Re-verify before each revoke: an account switch landing
+            // mid-operation must never revoke another account's binding.
+            guard await authenticatedAccountID() == expectedAccountID else {
+                throw MobileIrxForgetError.accountMismatch
+            }
+            try await revokeBinding(binding.bindingID)
+        }
+    }
+}

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrxRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrxRuntimeComposition.swift
@@ -64,7 +64,7 @@ public actor MobileIrxRuntimeComposition {
 
     private let brokerBaseURL: URL?
     private let clientNamespace: String
-    private let tag: String
+    public nonisolated let tag: String
     private let stateDirectory: URL
 
     private weak var auth: AuthCoordinator?
@@ -320,6 +320,42 @@ public actor MobileIrxRuntimeComposition {
         endpointSupervisor = supervisor
         autopilot = pilot
         return broker
+    }
+
+    // MARK: - First-pair picker surface
+
+    /// Fresh authenticated broker discovery for the first-pair picker.
+    /// Returns nil instead of throwing so the picker degrades to an empty
+    /// candidate list, mirroring the legacy discovery contract.
+    public func freshLiveDiscovery() async -> CmxIrohDiscoveryResponse? {
+        guard let broker = try? await provisionedBroker() else {
+            Self.journal.record(
+                "client-runtime", "picker-discovery", ["bindings": "unprovisioned"])
+            return nil
+        }
+        let discovery = try? await broker.discover(maximumAge: 5)
+        Self.journal.record(
+            "client-runtime", "picker-discovery",
+            ["bindings": discovery.map { String($0.bindings.count) } ?? "unavailable"]
+        )
+        return discovery
+    }
+
+    /// Drops the reusable discovery snapshot after a presence route push.
+    public func invalidateDiscoverySnapshot() async {
+        await broker?.invalidateDiscoverySnapshot()
+    }
+
+    /// Revokes one account-owned binding (forget-computer server leg).
+    public func revokeBinding(_ bindingID: String) async throws {
+        let broker = try await provisionedBroker()
+        try await broker.revoke(bindingID: bindingID)
+    }
+
+    /// The live authenticated account, or nil when signed out.
+    public func authenticatedAccountID() async -> String? {
+        guard let auth else { return nil }
+        return try? await auth.authenticatedSessionSnapshot().accountID
     }
 
     // MARK: - Dialing

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrxDiscoveryProviderTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrxDiscoveryProviderTests.swift
@@ -1,0 +1,153 @@
+import CmuxIrohTransport
+import CmuxMobileShell
+import Foundation
+import Testing
+
+@testable import cmuxFeature
+
+/// Regression for the 08-28 fresh-install incident: the first-pair picker
+/// asked the dormant legacy runtime for Macs and rendered zero forever. The
+/// irx provider must surface pairable Macs from irx broker discovery with
+/// dialable iroh routes, and forget must revoke only under the expected
+/// account.
+@MainActor
+@Suite("irx discovery provider")
+struct MobileIrxDiscoveryProviderTests {
+    static func discovery(
+        bindings: [[String: Any]]
+    ) throws -> CmxIrohDiscoveryResponse {
+        let object: [String: Any] = [
+            "route_contract_version": 1,
+            "bindings": bindings,
+            "relay_fleet": ["https://usw1.relay.cmux.dev/"],
+            "lan_rendezvous": [
+                "generation": 1,
+                "key": Data(repeating: 0, count: 32).base64EncodedString()
+                    .replacingOccurrences(of: "+", with: "-")
+                    .replacingOccurrences(of: "/", with: "_")
+                    .replacingOccurrences(of: "=", with: ""),
+            ],
+            "grant_verification_keys": [
+                "version": 1,
+                "current_kid": "test-key",
+                "keys": [["kid": "test-key", "alg": "EdDSA", "spki_der_base64": "AA=="]],
+            ],
+        ]
+        return try JSONDecoder().decode(
+            CmxIrohDiscoveryResponse.self,
+            from: JSONSerialization.data(withJSONObject: object)
+        )
+    }
+
+    static func binding(
+        bindingID: String,
+        deviceID: String,
+        platform: String,
+        tag: String = "default",
+        pairingEnabled: Bool = true,
+        endpointFill: Character = "a"
+    ) -> [String: Any] {
+        [
+            "binding_id": bindingID,
+            "device_id": deviceID,
+            "app_instance_id": "123e4567-e89b-42d3-a456-426614174012",
+            "client_namespace": "legacy",
+            "tag": tag,
+            "platform": platform,
+            "display_name": "Fixture \(platform)",
+            "endpoint_id": String(repeating: endpointFill, count: 64),
+            "identity_generation": 1,
+            "pairing_enabled": pairingEnabled,
+            "capabilities": ["rpc"],
+            "path_hints": [],
+            "last_seen_at": ISO8601DateFormatter()
+                .string(from: Date(timeIntervalSince1970: 1_800_000_000)),
+        ]
+    }
+
+    static func provider(
+        discovery: CmxIrohDiscoveryResponse?,
+        accountID: String? = "account-a",
+        onRevoke: (@Sendable (String) -> Void)? = nil
+    ) -> MobileIrxDiscoveryProvider {
+        MobileIrxDiscoveryProvider(
+            preferredTag: "default",
+            compatibilityPolicy: nil,
+            discover: { discovery },
+            invalidateSnapshot: {},
+            revokeBinding: { onRevoke?($0) },
+            authenticatedAccountID: { accountID }
+        )
+    }
+
+    @Test("pairable Macs from irx discovery become candidates with iroh routes")
+    func discoverySurfacesPairableMacs() async throws {
+        let mac = "123e4567-e89b-42d3-a456-426614174011"
+        let phone = "123e4567-e89b-42d3-a456-426614174022"
+        let response = try Self.discovery(bindings: [
+            Self.binding(
+                bindingID: "123e4567-e89b-42d3-a456-426614174001",
+                deviceID: mac, platform: "mac", endpointFill: "a"),
+            Self.binding(
+                bindingID: "123e4567-e89b-42d3-a456-426614174002",
+                deviceID: phone, platform: "ios", endpointFill: "b"),
+        ])
+        let candidates = await Self.provider(discovery: response).discoverLiveMacs()
+        #expect(candidates.count == 1)
+        #expect(candidates.first?.deviceID == mac)
+        #expect(candidates.first?.routes.first?.kind == .iroh)
+    }
+
+    @Test("discovery outage degrades to zero candidates instead of throwing")
+    func discoveryOutage() async {
+        let candidates = await Self.provider(discovery: nil).discoverLiveMacs()
+        #expect(candidates.isEmpty)
+    }
+
+    @Test("forget revokes exactly the matching device's bindings")
+    func forgetRevokesMatches() async throws {
+        let mac = "123e4567-e89b-42d3-a456-426614174011"
+        let other = "123e4567-e89b-42d3-a456-426614174033"
+        let response = try Self.discovery(bindings: [
+            Self.binding(
+                bindingID: "123e4567-e89b-42d3-a456-426614174001",
+                deviceID: mac, platform: "mac", endpointFill: "a"),
+            Self.binding(
+                bindingID: "123e4567-e89b-42d3-a456-426614174003",
+                deviceID: other, platform: "mac", endpointFill: "c"),
+        ])
+        let revoked = RevokedBox()
+        let provider = Self.provider(discovery: response) { revoked.append($0) }
+        try await provider.forgetComputer(
+            macDeviceID: mac, instanceTag: nil, expectedAccountID: "account-a")
+        #expect(revoked.values == ["123e4567-e89b-42d3-a456-426614174001"])
+    }
+
+    @Test("forget refuses when the live account is not the expected owner")
+    func forgetAccountGuard() async throws {
+        let response = try Self.discovery(bindings: [])
+        let provider = Self.provider(discovery: response, accountID: "account-b")
+        await #expect(throws: MobileIrxForgetError.accountMismatch) {
+            try await provider.forgetComputer(
+                macDeviceID: "123e4567-e89b-42d3-a456-426614174011",
+                instanceTag: nil,
+                expectedAccountID: "account-a"
+            )
+        }
+    }
+}
+
+private final class RevokedBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [String] = []
+    var values: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+    func append(_ value: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        storage.append(value)
+    }
+}


### PR DESCRIPTION
Fixes the 08-28 field incident (diagnosed by Austin in the group chat): after a fresh install of latest INTERNAL, **zero Macs appear**, and re-sign-in doesn't help.

Root cause: \`cmuxApp.swift\` made irx the active transport but still injected the **dormant legacy runtime** as \`personalIrohDiscovery\` / route catalog / forget. The picker's zero-touch first-pair path asks that dormant engine, which answers "endpoint unavailable" — while the irx engine's own broker discovery sees the entire fleet. Existing installs never notice because persisted paired Macs skip first-pair discovery; every wiped/new phone is bricked for discovery.

Fix: \`MobileIrxDiscoveryProvider\` (closure-injected, testable) implements \`MobileIrohMacDiscovering\` + \`MobileIrohMacForgetting\` on top of irx broker discovery, feeding the existing \`MobileIrohRouteCatalog\` mapping so pairability, build-compatibility policy, ordering, and \`.iroh\` attach-route construction are byte-identical with legacy semantics. \`cmuxApp\` injects the provider and its catalog whenever irx owns the transport. Forget revokes account-owned bindings with the same expected-account guard.

Tests: provider surfaces pairable Macs with iroh routes from a decoded broker response, degrades to zero on outage, forget revokes exactly the matching bindings and refuses on account mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790547244&installation_model_id=21920&pr_number=11163&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11163&signature=c37530958ee280818ed23ba768198a0ce5d6c525931995beb0343e30107a3485"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the 08-28 field incident where fresh iPhone installs listed zero Macs because the first-pair picker queried the dormant legacy runtime instead of the active irx transport.

**Bug Fixes**
- Adds `MobileIrxDiscoveryProvider`, implementing discovery and forget on irx broker discovery and reusing the legacy route catalog for identical candidate mapping.
- `cmuxApp` now injects the provider and its catalog whenever irx owns the transport, so fresh installs see pairable Macs and forget revokes via the broker with the account-ownership guard.
- Adds tests covering candidate surfacing, outage degradation, and forget revocation.

<sup>Written for commit eaa2e50e1d84fff97ba96ec53ac2a64bbd799022. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added IRX-based Mac discovery, route lookup, and forget functionality.
  * Added support for revoking matching device bindings with account validation.
  * Added discovery refresh controls and improved handling of unavailable discovery services.
  * Rate-limit responses now identify their enforcement source.

* **Bug Fixes**
  * Clarified cooldown rate-limit errors so local retry delays are distinguishable from server rejections.
  * Improved stale discovery handling and prevented incorrect forget operations.
  * Discovery outages now degrade gracefully without showing incorrect Mac candidates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->