### PR TITLE
ci: simplify TUI bindings verification

### DIFF
--- a/.github/workflows/cmux-tui.yml
+++ b/.github/workflows/cmux-tui.yml
@@ -560,7 +560,7 @@ jobs:
 
       - name: Build cmux-tui server
         working-directory: cmux-tui
-        run: cargo build -p cmux-tui
+        run: cargo build -p cmux-tui --locked
 
       - name: Resolve Zig SDK version
         id: zig-sdk-version
@@ -581,10 +581,6 @@ jobs:
           ZIG_REQUIRED: ${{ steps.zig-sdk-version.outputs.version }}
           ZIG_FORCE_LOCAL_INSTALL: "1"
         run: ./scripts/install-zig-ci.sh
-
-      - name: Install TypeScript adapter build tools
-        working-directory: cmux-tui/bindings/typescript
-        run: npm ci --no-audit --no-fund
 
       - name: Python conformance fixtures
         run: |


### PR DESCRIPTION
Remove the second identical `npm ci` from `bindings-e2e`; the first clean install remains before all conformance work. Add `--locked` to the job's `cargo build -p cmux-tui` command so dependency resolution cannot update `Cargo.lock`.

Static verification:
- `actionlint -config-file .github/actionlint.yaml .github/workflows/cmux-tui.yml`
- PyYAML parse plus bindings-e2e invariants
- `git diff --check HEAD^ HEAD`
- `bash -n scripts/verify-cmux-tui-hosted.sh`

No focused-mode semantics changed. No local build or test ran.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790552238&installation_model_id=21920&pr_number=11164&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11164&signature=0161f72f084c0ca23f570b5cb2419a6eecab6c3a9b7985d78d5e443577d40f67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the duplicate `npm ci` from `bindings-e2e` and adds `--locked` to the `cargo build -p cmux-tui` step so dependency resolution cannot update `Cargo.lock`.

- The first clean install still runs before all conformance work.
- No focused-mode behavior changes; no local build or test was run.

<sup>Written for commit f2ec373fe19166c89e93a7819ca2c32150325029. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the cmux-tui server build to use locked dependency versions.
  * Simplified the TypeScript adapter build workflow by removing a separate tool-installation step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->