### PR TITLE
fix: echo requested PID from delivery target resolution

### DIFF
--- a/Sources/AgentDeliveryTargetResolution.swift
+++ b/Sources/AgentDeliveryTargetResolution.swift
@@ -429,6 +429,7 @@ extension TerminalController {
                     "workspace_id": target.workspaceId.uuidString,
                     "surface_id": target.surfaceId.uuidString,
                     "source": "pid",
+                    "pid": pid,
                     "pid_resolution": pidResolution.rawValue,
                 ])
             }

--- a/cmuxTests/AgentNotificationMutationBoundaryTests.swift
+++ b/cmuxTests/AgentNotificationMutationBoundaryTests.swift
@@ -81,6 +81,17 @@ extension AgentNotificationRegressionTests {
                     surfaceId: fixture.panelId
                 )
         )
+
+        let result = TerminalController.shared.v2AgentResolveDeliveryTarget(params: [
+            "pid": Int(process.processIdentifier),
+        ])
+        guard case .ok(let payload) = result,
+              let target = payload as? [String: Any] else {
+            Issue.record("Expected live PID delivery target, got \(result)")
+            return
+        }
+        #expect(target["source"] as? String == "pid")
+        #expect(target["pid"] as? Int == Int(process.processIdentifier))
     }
 
     @Test("Local PID routing excludes remote TTY device namespaces")


### PR DESCRIPTION
## Summary

- Echo the strictly validated requested PID in successful `agent.resolve_delivery_target` PID responses.
- Add a live spawned-process regression assertion for the response field.
- This lets callers bind the response to the exact process they asked cmux to resolve, without changing resolution, authorization, fallback, or error behavior.

## Testing

- `git diff --check` passed.
- Exact branch autoreview against `upstream/main` completed clean with no accepted/actionable findings.
- Attempted the focused test with:
  `xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination platform=macOS -derivedDataPath /tmp/cmux-pid-echo-20260828 test -only-testing:cmuxTests/AgentNotificationRegressionTests/pidResolutionBypassesStaleNegativeTelemetryCacheAfterExec`
- The test target did not compile because current upstream `main` fails first in unrelated existing code at `Sources/SessionDragSessionSource.swift:53`: pinned `TabDragTransferRegistration` has no member `clearResidualCapability`. The changed resolver/test produced no reported diagnostic before that failure; this is not a claim that the focused test passed.

## Demo Video

Not applicable; socket response contract only.

## Checklist

- [ ] I tested the change locally (blocked by the unrelated current-main compile failure above)
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed (not needed for this additive response field)
- [ ] I requested bot reviews after my latest commit
- [x] All code review bot comments are resolved (none yet)
- [x] All human review comments are resolved (none yet)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790554853&installation_model_id=21920&pr_number=11166&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11166&signature=5eb5c4b77c01f726bd90b23df777b6b82c5799e944a4cf9d8fc4273712f3d7bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Echoes the requested PID back in `agent.resolve_delivery_target` PID responses so callers can bind the response to the exact process they asked for. The response previously omitted the PID; now it includes the strictly validated PID from the request. Resolution, authorization, fallback, and error behavior are unchanged. Adds a regression assertion that a live spawned process returns the matching PID.

<sup>Written for commit c91bea782eea95e92d15d03aa4533459cfa9a7f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Delivery-target resolution responses now include the resolved process ID when resolution succeeds.

* **Tests**
  * Added coverage confirming process-ID resolution returns the expected source and process ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->