### PR TITLE
fix(cdp): repair tungstenite client call and lockfile

### DIFF
--- a/cmux-tui/Cargo.lock
+++ b/cmux-tui/Cargo.lock
@@ -106,12 +106,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayref"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
-
-[[package]]
 name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -129,7 +123,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
 ]
 
@@ -158,13 +152,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.91"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -199,7 +193,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "http",
  "log",
  "url",
@@ -218,7 +212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -288,6 +282,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "base64ct"
@@ -377,16 +377,15 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.6"
+version = "1.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ae7bad254120e9e4c63bafc385310756f90c484eac0e36b8317cf09cb92a77"
+checksum = "6d9e454fc11f76977dc803893aff6304ed33d6a26efae8696573bea74baa27ae"
 dependencies = [
- "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
 ]
 
 [[package]]
@@ -473,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.0"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "shlex 2.0.1",
@@ -527,12 +526,12 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "rand_core 0.10.1",
 ]
 
@@ -555,7 +554,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "cmux-pty",
  "futures-util",
@@ -637,7 +636,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "cmux-remote-protocol",
  "futures-util",
@@ -658,7 +657,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "cmux-pty",
  "cmux-relay",
@@ -699,7 +698,7 @@ dependencies = [
 name = "cmux-remote-protocol"
 version = "0.1.0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde",
  "serde_json",
  "uuid",
@@ -709,7 +708,7 @@ dependencies = [
 name = "cmux-sdk"
 version = "1.0.0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "getrandom 0.3.4",
  "libc",
  "serde",
@@ -721,7 +720,7 @@ dependencies = [
 name = "cmux-sidebar"
 version = "1.0.0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "cmux-sdk",
  "crossterm",
  "ratatui",
@@ -733,11 +732,10 @@ name = "cmux-terminal-client"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "cmux-remote",
  "cmux-remote-protocol",
- "cmux-tui-cdp",
  "cmux-tui-core",
  "getrandom 0.3.4",
  "ghostty-vt",
@@ -754,15 +752,16 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "cmux-pty",
  "cmux-remote",
  "cmux-remote-protocol",
+ "cmux-tui-cdp",
  "cmux-tui-core",
  "cmux-tui-machine-agent-protocol",
  "cmux-tui-machine-protocol",
- "crossterm",
  "crossbeam-channel",
+ "crossterm",
  "fs4",
  "getrandom 0.3.4",
  "ghostty-vt",
@@ -794,7 +793,7 @@ name = "cmux-tui-cdp"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "serde_json",
  "tungstenite",
 ]
@@ -804,7 +803,7 @@ name = "cmux-tui-core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "cmux-pty",
  "cmux-remote-protocol",
  "cmux-tui-cdp",
@@ -832,7 +831,7 @@ dependencies = [
 name = "cmux-tui-machine-agent-protocol"
 version = "0.1.0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde",
  "serde_json",
  "subtle",
@@ -859,14 +858,14 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "combine"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
 dependencies = [
  "bytes",
  "memchr",
@@ -954,18 +953,18 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
@@ -1105,7 +1104,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "curve25519-dalek-derive",
  "digest 0.11.3",
  "fiat-crypto 0.3.0",
@@ -1129,9 +1128,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -1139,26 +1138,26 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
 dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
 dependencies = [
  "darling_core",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1184,7 +1183,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1303,7 +1302,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1361,9 +1360,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "email_address"
@@ -1388,13 +1387,13 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "enum-assoc"
-version = "1.3.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed8956bd5c1f0415200516e78ff07ec9e16415ade83c056c230d7b7ea0d55b7"
+checksum = "0590c4a94da3372e83493b956755a6e2266830b6e4e3b101afe66e3f39477b91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1495,9 +1494,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "finl_unicode"
@@ -1513,12 +1512,13 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.9.1",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1584,9 +1584,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1612,9 +1612,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1622,15 +1622,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1639,9 +1639,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-lite"
@@ -1658,32 +1658,32 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1774,7 +1774,7 @@ dependencies = [
 name = "ghostty-vt"
 version = "0.1.0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "ghostty-vt-sys",
  "png",
 ]
@@ -1819,9 +1819,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1891,7 +1891,7 @@ dependencies = [
  "jni 0.22.4",
  "rand 0.10.2",
  "rustls",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tinyvec",
  "tokio",
  "tokio-rustls",
@@ -1913,7 +1913,7 @@ dependencies = [
  "prefix-trie",
  "rand 0.10.2",
  "ring",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "url",
@@ -1941,7 +1941,7 @@ dependencies = [
  "rustls",
  "smallvec",
  "system-configuration",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-rustls",
  "tracing",
@@ -1978,9 +1978,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2012,9 +2012,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2053,7 +2053,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2096,9 +2096,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -2110,9 +2110,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2123,9 +2123,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -2137,16 +2137,17 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -2157,15 +2158,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2247,9 +2248,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -2303,7 +2304,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2330,9 +2331,9 @@ dependencies = [
 
 [[package]]
 name = "iroh"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460de6bc52163b41b1646931f2897e5ab986f0966ade444467fec25024751a72"
+checksum = "329552fad4e46b5ccb4439d5635216f6289eec2c46f3fde4bc732d762694b9e5"
 dependencies = [
  "backon",
  "blake3",
@@ -2381,9 +2382,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-base"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6be73e16ee21c923aca9b3121aaa0db936f7c7ecc156ff47b8dac944c68d59a8"
+checksum = "3ccf4cde68a02ef03c0095ab2c031c6adfe508f3bc8e7c258558a027ebe64a8e"
 dependencies = [
  "curve25519-dalek 5.0.0",
  "data-encoding",
@@ -2400,9 +2401,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-dns"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f6a9b39d18e6345f5c151afd299f2488e2cb5c520fe41b107b6bd3dc4c3349"
+checksum = "9a41224eb0140a5c519935d4073fc6b236d174080be401f9bf7da126b2ee3aa4"
 dependencies = [
  "arc-swap",
  "cfg_aliases 0.2.2",
@@ -2451,9 +2452,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-relay"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24bd586cf927f7b700f56ec3639b53cb5fa901ce284784051ff71092bfbf8193"
+checksum = "1b5f6f07e2c9b0c4bc82e2864be09f4aea4320165d5316e668616dbc822f428a"
 dependencies = [
  "blake3",
  "bytes",
@@ -2546,7 +2547,7 @@ dependencies = [
  "jni-sys 0.4.1",
  "log",
  "simd_cesu8",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "walkdir",
  "windows-link",
 ]
@@ -2594,9 +2595,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2610,7 +2611,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1b46a0365a611fbf1d2143104dcf910aada96fafd295bab16c60b802bf6fa1d"
 dependencies = [
  "ahash",
- "base64",
+ "base64 0.22.1",
  "bytecount",
  "email_address",
  "fancy-regex 0.14.0",
@@ -2637,7 +2638,7 @@ checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
 dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2722,9 +2723,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "litrs"
@@ -2743,9 +2744,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "loom"
@@ -2762,9 +2763,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
+checksum = "0d317b4b9eb398e6acce275758ec6125535505e7a146fb1a9b8bda2451b0ff4c"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -2850,6 +2851,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2863,9 +2874,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.15"
+version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+checksum = "4293f18e7567a1caf3c584855554377025c65e0aa445344d04171f5ad63d19b9"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -2965,6 +2976,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "netdev"
+version = "0.46.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a5f88621a4b468e8ce92626f847cc02462cef3e06d793baa8b1c8617e304b20"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "dlopen2",
+ "ipnet",
+ "jni 0.21.1",
+ "libc",
+ "mac-addr",
+ "ndk-context",
+ "netlink-packet-core",
+ "netlink-packet-route",
+ "netlink-sys",
+ "objc2-core-foundation",
+ "objc2-system-configuration",
+ "once_cell",
+ "plist",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "netlink-packet-core"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2987,9 +3022,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-proto"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6f7398dddf5f152d2a91a2921a134c6097056e292c0d4b9906007855e7cece6"
+checksum = "93af8261786086024cd5e96e0a991dd65ced07bbf7c233a487bbc96b971d5539"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2997,7 +3032,7 @@ dependencies = [
  "log",
  "netlink-packet-core",
  "netlink-sys",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -3015,9 +3050,9 @@ dependencies = [
 
 [[package]]
 name = "netwatch"
-version = "0.19.1"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d9cbe01741347ef750d743d6690603f5eed8341e679fb51c8e629337aa11976"
+checksum = "39da9cad5f23aa43401f09497d3b280e51b5feba115d9ffbf38ca35d6ff95e96"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3029,7 +3064,8 @@ dependencies = [
  "n0-error",
  "n0-future",
  "n0-watcher",
- "netdev",
+ "netdev 0.45.0",
+ "netdev 0.46.1",
  "netlink-packet-core",
  "netlink-packet-route",
  "netlink-proto",
@@ -3087,9 +3123,9 @@ dependencies = [
 
 [[package]]
 name = "noq"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09e4bb6601fa543c110d8957813267d5a8d775a0f8fbaccf1f615d06ba9b10da"
+checksum = "f1e6c57353d26be91a242f0ec96073066c4481a03f6be874daafb18902394515"
 dependencies = [
  "bytes",
  "cfg_aliases 0.2.2",
@@ -3100,7 +3136,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2 0.6.5",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -3109,9 +3145,9 @@ dependencies = [
 
 [[package]]
 name = "noq-proto"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baa7b5ccd819a9c68a0d955e67a881032d09b1a17219b1f90b0997a0888e1a15"
+checksum = "9a46813e306c29c4f86357b6ffa39a8e1c97bb274b9a296a19a56d62e4111225"
 dependencies = [
  "aes-gcm",
  "bytes",
@@ -3128,7 +3164,7 @@ dependencies = [
  "rustls-pki-types",
  "slab",
  "sorted-index-buffer",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3136,9 +3172,9 @@ dependencies = [
 
 [[package]]
 name = "noq-udp"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bba20e097a5a16cd0ad14ec882fae1e80a092a124e9422fc4dddd92e96a647"
+checksum = "b56d621ed2c1773b5356ab39cc68c819f8d0103f7493d8661c4a5f5f8ea55f40"
 dependencies = [
  "cfg_aliases 0.2.2",
  "libc",
@@ -3241,9 +3277,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
@@ -3480,9 +3516,9 @@ dependencies = [
 
 [[package]]
 name = "papaya"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "997ee03cd38c01469a7046643714f0ad28880bcb9e6679ff0666e24817ca19b7"
+checksum = "da2442474a9404698c42509b8967f437249dbc7b50493e83020333d3943ec0ae"
 dependencies = [
  "equivalent",
  "seize",
@@ -3525,11 +3561,11 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem"
-version = "3.0.6"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+checksum = "d354a98a3d1251555de99e8fdd8afda05573c31b82f59063a7b0a29b5527f120"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "serde_core",
 ]
 
@@ -3550,9 +3586,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
+checksum = "5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -3560,9 +3596,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
+checksum = "b3a83744a5c8455b8b3e0dc5031362780a347c878bdd11584d1a8984228cc88d"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3570,9 +3606,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
+checksum = "e0cd3451aa3de60d4b9a1e736885e4dea6b31617598026f12256ad566d63304a"
 dependencies = [
  "pest",
  "pest_meta",
@@ -3583,9 +3619,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
+checksum = "e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496"
 dependencies = [
  "pest",
 ]
@@ -3627,7 +3663,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.7",
+ "rand 0.8.8",
 ]
 
 [[package]]
@@ -3690,9 +3726,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plist"
@@ -3700,7 +3736,7 @@ version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "indexmap",
  "quick-xml",
  "serde",
@@ -3717,7 +3753,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
 ]
 
 [[package]]
@@ -3745,9 +3781,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 dependencies = [
  "serde",
 ]
@@ -3775,11 +3811,11 @@ dependencies = [
 
 [[package]]
 name = "portmapper"
-version = "0.19.1"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3713e4977408279158444a18c1a01ac9bf2e7eaf1fbfd1a19ac9cd18d90721"
+checksum = "ca97242f016e090a25330613bc2382aab65eb22f9149dbe84d8f8e711d49a530"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "derive_more",
  "hyper-util",
@@ -3828,9 +3864,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
@@ -3921,9 +3957,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
  "rand_core 0.6.4",
 ]
@@ -3944,7 +3980,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20 0.10.1",
+ "chacha20 0.10.2",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
@@ -4021,7 +4057,7 @@ dependencies = [
  "palette",
  "serde",
  "strum",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width",
@@ -4092,9 +4128,9 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.14.8"
+version = "0.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
+checksum = "8774e05a7d0de114588e6a28fe7e71694b82614ed569d86d8b389dfbc98b8ad8"
 dependencies = [
  "pem",
  "ring",
@@ -4115,22 +4151,22 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4182,7 +4218,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -4242,7 +4278,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -4362,9 +4398,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4441,10 +4477,6 @@ name = "seize"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "semver"
@@ -4495,7 +4527,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4599,7 +4631,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "digest 0.11.3",
 ]
 
@@ -4704,9 +4736,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple-dns"
-version = "0.11.3"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a75cbde1bf934313596a004973e462f9a82caa814dcf1a5f507bdf51597eeb4"
+checksum = "2b6f884fa9a8d48101774bfbd3aeb81e968dd22cffd19a372da69f183db22c1a"
 dependencies = [
  "bitflags 2.13.1",
 ]
@@ -4880,9 +4912,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5007,7 +5039,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.1",
  "fancy-regex 0.11.0",
  "filedescriptor",
@@ -5053,11 +5085,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -5073,13 +5105,13 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5126,9 +5158,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -5173,7 +5205,7 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5235,7 +5267,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52efb639344a7c6adb8e62c6f3d2c19c001ff1b79a5041ba1c6ed42e19c6aa5"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -5453,7 +5485,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -5557,9 +5589,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.24.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
  "atomic",
  "getrandom 0.4.3",
@@ -5657,9 +5689,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5670,9 +5702,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5680,9 +5712,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5690,9 +5722,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5703,9 +5735,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
@@ -5725,9 +5757,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6256,16 +6288,16 @@ dependencies = [
  "futures",
  "log",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "windows",
  "windows-core",
 ]
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "ws_stream_wasm"
@@ -6280,7 +6312,7 @@ dependencies = [
  "pharos",
  "rustc_version",
  "send_wrapper",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -6312,15 +6344,15 @@ dependencies = [
  "oid-registry",
  "ring",
  "rusticata-macros",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
 ]
 
 [[package]]
 name = "xml-rs"
-version = "0.8.28"
+version = "0.8.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+checksum = "e450f9b2ed1dff33c94c12589a87338689467b9c4f5d8a5710bd09a847d2c8a7"
 
 [[package]]
 name = "xmltree"
@@ -6427,9 +6459,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -6438,9 +6470,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -6449,14 +6481,20 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/cmux-tui/Cargo.lock
+++ b/cmux-tui/Cargo.lock
@@ -737,6 +737,7 @@ dependencies = [
  "bytes",
  "cmux-remote",
  "cmux-remote-protocol",
+ "cmux-tui-cdp",
  "cmux-tui-core",
  "getrandom 0.3.4",
  "ghostty-vt",

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -10,6 +10,7 @@ use std::sync::mpsc::{
 use std::sync::{Arc, Condvar, Mutex, Weak};
 use std::time::{Duration, Instant};
 
+use anyhow::Context;
 use base64::Engine;
 use serde_json::{Value, json};
 use tungstenite::client::IntoClientRequest;

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -2180,6 +2180,13 @@ mod tests {
         let error = client.send_value(&json!({"payload": "0123456789"})).unwrap_err();
         assert_eq!(error.to_string(), "browser connection unavailable; retry the command");
         assert!(format!("{error:#}").contains("CDP outbound queue byte budget exceeded"));
+        assert!(is_connection_unavailable(&error));
+    }
+
+    #[test]
+    fn protocol_errors_are_not_classified_as_connection_failures() {
+        let error = anyhow::anyhow!("browser failed: invalid target");
+        assert!(!is_connection_unavailable(&error));
     }
 
     struct BlockingOutboundWriter {

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -10,6 +10,7 @@ use std::sync::mpsc::{
 use std::sync::{Arc, Condvar, Mutex, Weak};
 use std::time::{Duration, Instant};
 
+use anyhow::Context;
 use base64::Engine;
 use serde_json::{Value, json};
 use tungstenite::client::IntoClientRequest;
@@ -39,6 +40,9 @@ pub const CDP_EVENT_QUEUE_MAX_BYTES: usize = 32 * 1024 * 1024;
 /// full, so a blocked reader cannot block the TUI thread indefinitely.
 const CDP_OUTBOUND_QUEUE_CAPACITY: usize = 256;
 const CDP_OUTBOUND_QUEUE_MAX_BYTES: usize = 8 * 1024 * 1024;
+const CDP_CONNECTION_UNAVAILABLE_MESSAGE: &str =
+    "browser connection unavailable; retry the command";
+const CDP_OUTBOUND_QUEUE_BYTE_BUDGET_DETAIL: &str = "CDP outbound queue byte budget exceeded";
 const MAX_ENCODED_FRAME_BYTES: usize = 16 * 1024 * 1024;
 const MAX_DECODED_FRAME_BYTES: usize = 12 * 1024 * 1024;
 const TIMESTAMPLESS_CAPTURE_INTERVAL: Duration = Duration::from_secs(1);
@@ -1418,9 +1422,9 @@ fn reserve_outbound_bytes(inner: &Inner, bytes: usize) -> anyhow::Result<()> {
         let current = inner.outbound_bytes.load(Ordering::Acquire);
         let next = current
             .checked_add(bytes)
-            .ok_or_else(|| anyhow::anyhow!("CDP outbound queue byte budget exceeded"))?;
+            .ok_or_else(outbound_byte_budget_error)?;
         if next > inner.outbound_byte_budget as u64 {
-            anyhow::bail!("CDP outbound queue byte budget exceeded");
+            return Err(outbound_byte_budget_error());
         }
         if inner
             .outbound_bytes
@@ -1430,6 +1434,11 @@ fn reserve_outbound_bytes(inner: &Inner, bytes: usize) -> anyhow::Result<()> {
             return Ok(());
         }
     }
+}
+
+fn outbound_byte_budget_error() -> anyhow::Error {
+    anyhow::anyhow!(CDP_OUTBOUND_QUEUE_BYTE_BUDGET_DETAIL)
+        .context(CDP_CONNECTION_UNAVAILABLE_MESSAGE)
 }
 
 fn outbound_bytes_sub(inner: &Inner, bytes: usize) {
@@ -1841,8 +1850,9 @@ fn ack_screencast_frame(inner: &Arc<Inner>, target_session: &str, frame_session:
         "params": { "sessionId": frame_session },
     });
     let Ok(text) = serde_json::to_string(&msg) else { return };
-    if reserve_outbound_bytes(inner, text.len()).is_err() {
-        close_inner(inner, "CDP outbound queue byte budget exceeded");
+    if let Err(error) = reserve_outbound_bytes(inner, text.len()) {
+        eprintln!("cmux-tui-cdp: screencast acknowledgment rejected: {error:#}");
+        close_inner(inner, CDP_CONNECTION_UNAVAILABLE_MESSAGE);
         return;
     }
     if let Err(error) = inner.outbound.try_send(Outbound::Message(text)) {

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -2199,6 +2199,14 @@ mod tests {
     }
 
     #[test]
+    fn websocket_write_buffer_is_bounded_to_the_outbound_budget() {
+        let config = cdp_websocket_config();
+
+        assert!(config.max_write_buffer_size < usize::MAX);
+        assert!(config.max_write_buffer_size >= CDP_OUTBOUND_QUEUE_MAX_BYTES);
+    }
+
+    #[test]
     fn protocol_errors_are_not_classified_as_connection_failures() {
         let error = anyhow::anyhow!("browser failed: invalid target");
         assert!(!is_connection_unavailable(&error));

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -1440,6 +1440,10 @@ fn outbound_byte_budget_error() -> anyhow::Error {
         .context(CDP_CONNECTION_UNAVAILABLE_MESSAGE)
 }
 
+pub fn is_connection_unavailable(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| cause.to_string() == CDP_CONNECTION_UNAVAILABLE_MESSAGE)
+}
+
 fn outbound_bytes_sub(inner: &Inner, bytes: usize) {
     inner.outbound_bytes.fetch_sub(bytes as u64, Ordering::AcqRel);
 }

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -1521,8 +1521,16 @@ fn drain_outbound<W: OutboundWriter>(
     loop {
         match outbound.try_recv() {
             Ok(Outbound::Message(text)) => {
-                outbound_bytes_sub(inner, text.len());
-                ws.send_text(text)?;
+                let bytes = text.len();
+                // Keep the reservation while the socket write is in progress.
+                // Release it only after the write returns, including errors.
+                match ws.send_text(text) {
+                    Ok(()) => outbound_bytes_sub(inner, bytes),
+                    Err(error) => {
+                        outbound_bytes_sub(inner, bytes);
+                        return Err(error);
+                    }
+                }
             }
             Ok(Outbound::Flush(done)) => {
                 let _ = done.send(());

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -2085,6 +2085,15 @@ mod tests {
     }
 
     #[test]
+    fn outbound_commands_fail_fast_at_the_byte_bound() {
+        let (inner, _outbound_rx) = test_inner_with_capacity(8);
+        let client = CdpClient { inner };
+
+        let error = client.send_value(&json!({"payload": "0123456789"})).unwrap_err();
+        assert!(error.to_string().contains("outbound queue byte budget"));
+    }
+
+    #[test]
     fn outbound_commands_fail_fast_at_the_queue_bound() {
         let (inner, _outbound_rx) = test_inner_with_capacity(1);
         let client = CdpClient { inner };

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -1502,16 +1502,27 @@ fn reader_loop(
     }
 }
 
-fn drain_outbound(
+trait OutboundWriter {
+    fn send_text(&mut self, text: String) -> anyhow::Result<()>;
+}
+
+impl OutboundWriter for WebSocket<TcpStream> {
+    fn send_text(&mut self, text: String) -> anyhow::Result<()> {
+        self.send(Message::Text(text.into()))?;
+        Ok(())
+    }
+}
+
+fn drain_outbound<W: OutboundWriter>(
     inner: &Arc<Inner>,
-    ws: &mut WebSocket<TcpStream>,
+    ws: &mut W,
     outbound: &Receiver<Outbound>,
 ) -> anyhow::Result<()> {
     loop {
         match outbound.try_recv() {
             Ok(Outbound::Message(text)) => {
                 outbound_bytes_sub(inner, text.len());
-                ws.send(Message::Text(text.into()))?
+                ws.send_text(text)?;
             }
             Ok(Outbound::Flush(done)) => {
                 let _ = done.send(());
@@ -2150,6 +2161,43 @@ mod tests {
 
         let error = client.send_value(&json!({"payload": "0123456789"})).unwrap_err();
         assert!(error.to_string().contains("outbound queue byte budget"));
+    }
+
+    struct BlockingOutboundWriter {
+        started: Arc<Barrier>,
+        release: Arc<Barrier>,
+    }
+
+    impl OutboundWriter for BlockingOutboundWriter {
+        fn send_text(&mut self, _text: String) -> anyhow::Result<()> {
+            self.started.wait();
+            self.release.wait();
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn outbound_bytes_remain_reserved_while_write_is_in_flight() {
+        let value = json!({"payload": "0123456789"});
+        let message_bytes = serde_json::to_string(&value).unwrap().len();
+        let (inner, outbound_rx) = test_inner_with_limits(2, message_bytes);
+        let client = CdpClient { inner: inner.clone() };
+        client.send_value(&value).unwrap();
+
+        let started = Arc::new(Barrier::new(2));
+        let release = Arc::new(Barrier::new(2));
+        let writer = BlockingOutboundWriter { started: started.clone(), release: release.clone() };
+        let drain_inner = inner.clone();
+        let drain = thread::spawn(move || {
+            let mut writer = writer;
+            drain_outbound(&drain_inner, &mut writer, &outbound_rx).unwrap();
+        });
+
+        started.wait();
+        let error = client.send_value(&value).unwrap_err();
+        assert!(error.to_string().contains("outbound queue byte budget"));
+        release.wait();
+        drain.join().unwrap();
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -38,6 +38,7 @@ pub const CDP_EVENT_QUEUE_MAX_BYTES: usize = 32 * 1024 * 1024;
 /// unbounded number of JSON messages. Callers fail fast when the queue is
 /// full, so a blocked reader cannot block the TUI thread indefinitely.
 const CDP_OUTBOUND_QUEUE_CAPACITY: usize = 256;
+const CDP_OUTBOUND_QUEUE_MAX_BYTES: usize = 8 * 1024 * 1024;
 const MAX_ENCODED_FRAME_BYTES: usize = 16 * 1024 * 1024;
 const MAX_DECODED_FRAME_BYTES: usize = 12 * 1024 * 1024;
 const TIMESTAMPLESS_CAPTURE_INTERVAL: Duration = Duration::from_secs(1);
@@ -282,6 +283,8 @@ pub struct CdpClient {
 
 struct Inner {
     outbound: SyncSender<Outbound>,
+    outbound_bytes: AtomicU64,
+    outbound_byte_budget: usize,
     pending: Mutex<HashMap<u64, PendingCall>>,
     events: Arc<EventQueue>,
     frame_epochs: Mutex<HashMap<String, FrameSession>>,
@@ -578,6 +581,8 @@ impl CdpClient {
         let client = CdpClient {
             inner: Arc::new(Inner {
                 outbound: outbound_tx,
+                outbound_bytes: AtomicU64::new(0),
+                outbound_byte_budget: CDP_OUTBOUND_QUEUE_MAX_BYTES,
                 pending: Mutex::new(HashMap::new()),
                 events: event_queue,
                 frame_epochs: Mutex::new(HashMap::new()),
@@ -1383,8 +1388,20 @@ impl CdpClient {
         if cdp_debug() {
             eprintln!("cdp-> {text}");
         }
-        self.inner.outbound.try_send(Outbound::Message(text)).map_err(outbound_send_error)?;
+        reserve_outbound_bytes(&self.inner, text.len())?;
+        if let Err(error) = self.inner.outbound.try_send(Outbound::Message(text)) {
+            outbound_bytes_sub(&self.inner, outbound_bytes(&error));
+            return Err(outbound_send_error(error));
+        }
         Ok(())
+    }
+}
+
+fn outbound_bytes(error: &TrySendError<Outbound>) -> usize {
+    match error {
+        TrySendError::Full(Outbound::Message(text))
+        | TrySendError::Disconnected(Outbound::Message(text)) => text.len(),
+        _ => 0,
     }
 }
 
@@ -1393,6 +1410,30 @@ fn outbound_send_error(error: TrySendError<Outbound>) -> anyhow::Error {
         TrySendError::Full(_) => anyhow::anyhow!("CDP outbound queue is full"),
         TrySendError::Disconnected(_) => anyhow::anyhow!("CDP connection is closed"),
     }
+}
+
+fn reserve_outbound_bytes(inner: &Inner, bytes: usize) -> anyhow::Result<()> {
+    let bytes = u64::try_from(bytes).unwrap_or(u64::MAX);
+    loop {
+        let current = inner.outbound_bytes.load(Ordering::Acquire);
+        let next = current
+            .checked_add(bytes)
+            .ok_or_else(|| anyhow::anyhow!("CDP outbound queue byte budget exceeded"))?;
+        if next > inner.outbound_byte_budget as u64 {
+            anyhow::bail!("CDP outbound queue byte budget exceeded");
+        }
+        if inner
+            .outbound_bytes
+            .compare_exchange(current, next, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            return Ok(());
+        }
+    }
+}
+
+fn outbound_bytes_sub(inner: &Inner, bytes: usize) {
+    inner.outbound_bytes.fetch_sub(bytes as u64, Ordering::AcqRel);
 }
 
 pub fn resolve_browser_ws_url(input: &str) -> anyhow::Result<String> {
@@ -1426,7 +1467,7 @@ fn reader_loop(
         if inner.closed.load(Ordering::Acquire) {
             break;
         }
-        if let Err(err) = drain_outbound(&mut ws, outbound) {
+        if let Err(err) = drain_outbound(&inner, &mut ws, outbound) {
             close_inner(&inner, &format!("CDP socket error: {err}"));
             break;
         }
@@ -1462,12 +1503,16 @@ fn reader_loop(
 }
 
 fn drain_outbound(
+    inner: &Arc<Inner>,
     ws: &mut WebSocket<TcpStream>,
     outbound: &Receiver<Outbound>,
 ) -> anyhow::Result<()> {
     loop {
         match outbound.try_recv() {
-            Ok(Outbound::Message(text)) => ws.send(Message::Text(text.into()))?,
+            Ok(Outbound::Message(text)) => {
+                outbound_bytes_sub(inner, text.len());
+                ws.send(Message::Text(text.into()))?
+            }
             Ok(Outbound::Flush(done)) => {
                 let _ = done.send(());
             }
@@ -1777,7 +1822,12 @@ fn ack_screencast_frame(inner: &Arc<Inner>, target_session: &str, frame_session:
         "params": { "sessionId": frame_session },
     });
     let Ok(text) = serde_json::to_string(&msg) else { return };
+    if reserve_outbound_bytes(inner, text.len()).is_err() {
+        close_inner(inner, "CDP outbound queue byte budget exceeded");
+        return;
+    }
     if let Err(error) = inner.outbound.try_send(Outbound::Message(text)) {
+        outbound_bytes_sub(inner, outbound_bytes(&error));
         let reason = match error {
             TrySendError::Full(_) => "CDP outbound queue overflow",
             TrySendError::Disconnected(_) => "CDP connection is closed",
@@ -2063,14 +2113,23 @@ mod tests {
     use super::*;
 
     fn test_inner() -> (Arc<Inner>, Receiver<Outbound>) {
-        test_inner_with_capacity(256)
+        test_inner_with_limits(256, CDP_OUTBOUND_QUEUE_MAX_BYTES)
     }
 
     fn test_inner_with_capacity(capacity: usize) -> (Arc<Inner>, Receiver<Outbound>) {
+        test_inner_with_limits(capacity, CDP_OUTBOUND_QUEUE_MAX_BYTES)
+    }
+
+    fn test_inner_with_limits(
+        capacity: usize,
+        outbound_byte_budget: usize,
+    ) -> (Arc<Inner>, Receiver<Outbound>) {
         let (outbound, outbound_rx) = std::sync::mpsc::sync_channel(capacity);
         (
             Arc::new(Inner {
                 outbound,
+                outbound_bytes: AtomicU64::new(0),
+                outbound_byte_budget,
                 pending: Mutex::new(HashMap::new()),
                 events: Arc::new(EventQueue::new()),
                 frame_epochs: Mutex::new(HashMap::new()),
@@ -2086,7 +2145,7 @@ mod tests {
 
     #[test]
     fn outbound_commands_fail_fast_at_the_byte_bound() {
-        let (inner, _outbound_rx) = test_inner_with_capacity(8);
+        let (inner, _outbound_rx) = test_inner_with_limits(8, 16);
         let client = CdpClient { inner };
 
         let error = client.send_value(&json!({"payload": "0123456789"})).unwrap_err();

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -15,7 +15,8 @@ use serde_json::{Value, json};
 use tungstenite::client::IntoClientRequest;
 use tungstenite::http::HeaderValue;
 use tungstenite::http::header::AUTHORIZATION;
-use tungstenite::{Error as WsError, Message, WebSocket, client};
+use tungstenite::protocol::WebSocketConfig;
+use tungstenite::{Error as WsError, Message, WebSocket, client_with_config};
 
 /// Maximum number of pending events in each bounded CDP event queue.
 ///
@@ -39,6 +40,9 @@ pub const CDP_EVENT_QUEUE_MAX_BYTES: usize = 32 * 1024 * 1024;
 /// full, so a blocked reader cannot block the TUI thread indefinitely.
 const CDP_OUTBOUND_QUEUE_CAPACITY: usize = 256;
 const CDP_OUTBOUND_QUEUE_MAX_BYTES: usize = 8 * 1024 * 1024;
+// Include tungstenite's default 128 KiB staging buffer and frame overhead in
+// addition to the largest message admitted by the outbound byte budget.
+const CDP_SOCKET_WRITE_BUFFER_MAX_BYTES: usize = CDP_OUTBOUND_QUEUE_MAX_BYTES + 256 * 1024;
 const CDP_CONNECTION_UNAVAILABLE_MESSAGE: &str =
     "browser connection unavailable; retry the command";
 const CDP_OUTBOUND_QUEUE_BYTE_BUDGET_DETAIL: &str = "CDP outbound queue byte budget exceeded";
@@ -572,7 +576,7 @@ impl CdpClient {
                 .map_err(|error| anyhow::anyhow!("invalid CDP bearer token: {error}"))?;
             request.headers_mut().insert(AUTHORIZATION, value);
         }
-        let (ws, _) = client(request, stream)?;
+        let (ws, _) = client_with_config(request, stream, Some(cdp_websocket_config()))?;
         // The reader thread owns the socket and drains queued outbound
         // writes before each read poll. A message enqueued just after a
         // read starts can wait for this window, but writers never contend
@@ -1398,6 +1402,10 @@ impl CdpClient {
         }
         Ok(())
     }
+}
+
+fn cdp_websocket_config() -> WebSocketConfig {
+    WebSocketConfig::default().max_write_buffer_size(CDP_SOCKET_WRITE_BUFFER_MAX_BYTES)
 }
 
 fn outbound_bytes(error: &TrySendError<Outbound>) -> usize {

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -1419,9 +1419,7 @@ fn reserve_outbound_bytes(inner: &Inner, bytes: usize) -> anyhow::Result<()> {
     let bytes = u64::try_from(bytes).unwrap_or(u64::MAX);
     loop {
         let current = inner.outbound_bytes.load(Ordering::Acquire);
-        let next = current
-            .checked_add(bytes)
-            .ok_or_else(outbound_byte_budget_error)?;
+        let next = current.checked_add(bytes).ok_or_else(outbound_byte_budget_error)?;
         if next > inner.outbound_byte_budget as u64 {
             return Err(outbound_byte_budget_error());
         }

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -2204,7 +2204,7 @@ mod tests {
         assert!(!public.contains("ws://"));
         assert!(!public.contains("CDP outbound queue byte budget exceeded"));
         assert!(format!("{error:#}").contains("CDP outbound queue byte budget exceeded"));
-        assert!(is_connection_unavailable(&error));
+        assert!(is_connection_unavailable(&public));
     }
 
     #[test]
@@ -2218,7 +2218,7 @@ mod tests {
     #[test]
     fn protocol_errors_are_not_classified_as_connection_failures() {
         let error = anyhow::anyhow!("browser failed: invalid target");
-        assert!(!is_connection_unavailable(&error));
+        assert!(!is_connection_unavailable(&error.to_string()));
     }
 
     struct BlockingOutboundWriter {

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -17,7 +17,7 @@ use tungstenite::client::IntoClientRequest;
 use tungstenite::http::HeaderValue;
 use tungstenite::http::header::AUTHORIZATION;
 use tungstenite::protocol::WebSocketConfig;
-use tungstenite::{Error as WsError, Message, WebSocket, client_with_config};
+use tungstenite::{Error as WsError, Message, WebSocket, client};
 
 /// Maximum number of pending events in each bounded CDP event queue.
 ///

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -1447,8 +1447,8 @@ fn outbound_byte_budget_error() -> anyhow::Error {
         .context(CDP_CONNECTION_UNAVAILABLE_MESSAGE)
 }
 
-pub fn is_connection_unavailable(error: &anyhow::Error) -> bool {
-    error.chain().any(|cause| cause.to_string() == CDP_CONNECTION_UNAVAILABLE_MESSAGE)
+pub fn is_connection_unavailable(error: &str) -> bool {
+    error == CDP_CONNECTION_UNAVAILABLE_MESSAGE
 }
 
 fn outbound_bytes_sub(inner: &Inner, bytes: usize) {

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -1581,7 +1581,9 @@ fn handle_text(inner: &Arc<Inner>, text: &str) {
                 let Some(ack_id) = params.get("sessionId").and_then(|value| value.as_u64()) else {
                     return;
                 };
-                ack_screencast_frame(inner, target_session, ack_id);
+                ack_screencast_frame(inner, target_session, ack_id, |message| {
+                    eprintln!("{message}");
+                });
                 let (
                     frame_epoch,
                     navigation_epoch,
@@ -1842,7 +1844,14 @@ fn dispatch_event(inner: &Arc<Inner>, event: CdpEvent) {
     }
 }
 
-fn ack_screencast_frame(inner: &Arc<Inner>, target_session: &str, frame_session: u64) {
+const CDP_ACK_REJECTED_DIAGNOSTIC: &str = "cmux-tui-cdp: screencast acknowledgment rejected";
+
+fn ack_screencast_frame(
+    inner: &Arc<Inner>,
+    target_session: &str,
+    frame_session: u64,
+    report: impl FnOnce(&str),
+) {
     let id = inner.next_id.fetch_add(1, Ordering::Relaxed);
     let msg = json!({
         "id": id,
@@ -1852,7 +1861,9 @@ fn ack_screencast_frame(inner: &Arc<Inner>, target_session: &str, frame_session:
     });
     let Ok(text) = serde_json::to_string(&msg) else { return };
     if reserve_outbound_bytes(inner, text.len()).is_err() {
-        eprintln!("cmux-tui-cdp: screencast acknowledgment rejected");
+        // Keep queue and protocol details out of stderr. The close event
+        // carries the stable recovery message to callers.
+        report(CDP_ACK_REJECTED_DIAGNOSTIC);
         close_inner(inner, CDP_CONNECTION_UNAVAILABLE_MESSAGE);
         return;
     }
@@ -2179,7 +2190,10 @@ mod tests {
         let client = CdpClient { inner };
 
         let error = client.send_value(&json!({"payload": "0123456789"})).unwrap_err();
-        assert_eq!(error.to_string(), "browser connection unavailable; retry the command");
+        let public = error.to_string();
+        assert_eq!(public, "browser connection unavailable; retry the command");
+        assert!(!public.contains("ws://"));
+        assert!(!public.contains("CDP outbound queue byte budget exceeded"));
         assert!(format!("{error:#}").contains("CDP outbound queue byte budget exceeded"));
         assert!(is_connection_unavailable(&error));
     }
@@ -2231,7 +2245,10 @@ mod tests {
     #[test]
     fn screencast_ack_byte_budget_closure_hides_internal_reason() {
         let (inner, _outbound_rx) = test_inner_with_limits(1, 1);
-        ack_screencast_frame(&inner, "session-1", 7);
+        let mut diagnostics = Vec::new();
+        ack_screencast_frame(&inner, "session-1", 7, |message| {
+            diagnostics.push(message.to_string());
+        });
 
         let (event_tx, event_rx) = sync_channel(1);
         inner.events.drain_into(&event_tx).unwrap();
@@ -2240,6 +2257,9 @@ mod tests {
         };
         assert_eq!(reason, "browser connection unavailable; retry the command");
         assert!(!reason.contains("CDP"));
+        assert_eq!(diagnostics, vec![CDP_ACK_REJECTED_DIAGNOSTIC.to_string()]);
+        assert!(!diagnostics[0].contains("ws://"));
+        assert!(!diagnostics[0].contains("queue byte budget"));
     }
 
     #[test]
@@ -2266,7 +2286,7 @@ mod tests {
     #[test]
     fn screencast_ack_queue_overflow_closes_the_connection() {
         let (inner, _outbound_rx) = test_inner_with_capacity(0);
-        ack_screencast_frame(&inner, "session-1", 7);
+        ack_screencast_frame(&inner, "session-1", 7, |_| {});
         assert!(inner.closed.load(Ordering::Acquire));
     }
 

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -2168,7 +2168,8 @@ mod tests {
         let client = CdpClient { inner };
 
         let error = client.send_value(&json!({"payload": "0123456789"})).unwrap_err();
-        assert!(error.to_string().contains("outbound queue byte budget"));
+        assert_eq!(error.to_string(), "browser connection unavailable; retry the command");
+        assert!(format!("{error:#}").contains("CDP outbound queue byte budget exceeded"));
     }
 
     struct BlockingOutboundWriter {
@@ -2203,9 +2204,24 @@ mod tests {
 
         started.wait();
         let error = client.send_value(&value).unwrap_err();
-        assert!(error.to_string().contains("outbound queue byte budget"));
+        assert_eq!(error.to_string(), "browser connection unavailable; retry the command");
+        assert!(format!("{error:#}").contains("CDP outbound queue byte budget exceeded"));
         release.wait();
         drain.join().unwrap();
+    }
+
+    #[test]
+    fn screencast_ack_byte_budget_closure_hides_internal_reason() {
+        let (inner, _outbound_rx) = test_inner_with_limits(1, 1);
+        ack_screencast_frame(&inner, "session-1", 7);
+
+        let (event_tx, event_rx) = sync_channel(1);
+        inner.events.drain_into(&event_tx).unwrap();
+        let CdpEvent::Closed(reason) = event_rx.recv().unwrap() else {
+            panic!("expected a close event");
+        };
+        assert_eq!(reason, "browser connection unavailable; retry the command");
+        assert!(!reason.contains("CDP"));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -10,7 +10,6 @@ use std::sync::mpsc::{
 use std::sync::{Arc, Condvar, Mutex, Weak};
 use std::time::{Duration, Instant};
 
-use anyhow::Context;
 use base64::Engine;
 use serde_json::{Value, json};
 use tungstenite::client::IntoClientRequest;
@@ -1850,8 +1849,8 @@ fn ack_screencast_frame(inner: &Arc<Inner>, target_session: &str, frame_session:
         "params": { "sessionId": frame_session },
     });
     let Ok(text) = serde_json::to_string(&msg) else { return };
-    if let Err(error) = reserve_outbound_bytes(inner, text.len()) {
-        eprintln!("cmux-tui-cdp: screencast acknowledgment rejected: {error:#}");
+    if reserve_outbound_bytes(inner, text.len()).is_err() {
+        eprintln!("cmux-tui-cdp: screencast acknowledgment rejected");
         close_inner(inner, CDP_CONNECTION_UNAVAILABLE_MESSAGE);
         return;
     }

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -577,7 +577,7 @@ impl CdpClient {
                 .map_err(|error| anyhow::anyhow!("invalid CDP bearer token: {error}"))?;
             request.headers_mut().insert(AUTHORIZATION, value);
         }
-        let (ws, _) = client_with_config(request, stream, Some(cdp_websocket_config()))?;
+        let (ws, _) = client::client_with_config(request, stream, Some(cdp_websocket_config()))?;
         // The reader thread owns the socket and drains queued outbound
         // writes before each read poll. A message enqueued just after a
         // read starts can wait for this window, but writers never contend

--- a/cmux-tui/crates/cmux-tui-cdp/src/lib.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/lib.rs
@@ -12,4 +12,5 @@ pub use client::{
     CDP_EVENT_QUEUE_CAPACITY, CDP_EVENT_QUEUE_MAX_BYTES, CapturedFrame, CdpClient, CdpEvent,
     CdpKeyEvent, FrameEpoch, NavigationEntry, NavigationHistory, ScreencastFrame, TargetCreated,
     TargetInfo, discover_browser_ws_url, event_retained_bytes, resolve_browser_ws_url,
+    is_connection_unavailable,
 };

--- a/cmux-tui/crates/cmux-tui-cdp/src/lib.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/lib.rs
@@ -11,6 +11,6 @@ pub use chrome::{BrowserMode, Chrome, ChromeLaunchOptions};
 pub use client::{
     CDP_EVENT_QUEUE_CAPACITY, CDP_EVENT_QUEUE_MAX_BYTES, CapturedFrame, CdpClient, CdpEvent,
     CdpKeyEvent, FrameEpoch, NavigationEntry, NavigationHistory, ScreencastFrame, TargetCreated,
-    TargetInfo, discover_browser_ws_url, event_retained_bytes, resolve_browser_ws_url,
-    is_connection_unavailable,
+    TargetInfo, discover_browser_ws_url, event_retained_bytes, is_connection_unavailable,
+    resolve_browser_ws_url,
 };

--- a/cmux-tui/crates/cmux-tui/Cargo.toml
+++ b/cmux-tui/crates/cmux-tui/Cargo.toml
@@ -21,6 +21,7 @@ path = "src/bin/cmux-tui-hook.rs"
 [dependencies]
 ghostty-vt.workspace = true
 cmux-tui-core.workspace = true
+cmux-tui-cdp.workspace = true
 cmux-tui-machine-agent-protocol.workspace = true
 cmux-tui-machine-protocol.workspace = true
 ratatui.workspace = true

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -18,6 +18,7 @@ use std::time::{Duration, Instant};
 
 use base64::Engine;
 use cmux_tui_core::resource::FrontendProjectionPublicId;
+use cmux_tui_cdp::is_connection_unavailable;
 use cmux_tui_core::{
     BrowserFrame, BrowserSource, BrowserStatus, ClearHistoryDelivery, ClearHistoryFailure,
     DEFAULT_VIEWPORT_PANE_WIDTH, Direction, FrontendFocusTarget, FrontendJournalEvent,
@@ -8842,7 +8843,11 @@ fn run_with_machine_updates_inner(
         },
         move |error| {
             crate::client_log::error("browser-control", &error);
-            let message = localization::catalog().browser.control_unavailable();
+            let message = if is_connection_unavailable(&error) {
+                localization::catalog().browser.control_unavailable()
+            } else {
+                localization::catalog().browser.control_failed(&error.to_string())
+            };
             let _ = browser_control_tx.send(AppEvent::Mux(MuxEvent::Status(message)));
         },
     )?;

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -17,8 +17,8 @@ use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 use base64::Engine;
-use cmux_tui_core::resource::FrontendProjectionPublicId;
 use cmux_tui_cdp::is_connection_unavailable;
+use cmux_tui_core::resource::FrontendProjectionPublicId;
 use cmux_tui_core::{
     BrowserFrame, BrowserSource, BrowserStatus, ClearHistoryDelivery, ClearHistoryFailure,
     DEFAULT_VIEWPORT_PANE_WIDTH, Direction, FrontendFocusTarget, FrontendJournalEvent,

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -8842,6 +8842,7 @@ fn run_with_machine_updates_inner(
             let _ = browser_failure_tx.send(AppEvent::BrowserResizeFailed(failure));
         },
         move |error| {
+            let error = anyhow::anyhow!(error);
             crate::client_log::error("browser-control", &error);
             let message = if is_connection_unavailable(&error) {
                 localization::catalog().browser.control_unavailable()

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -8843,7 +8843,8 @@ fn run_with_machine_updates_inner(
         },
         move |error| {
             let error = anyhow::anyhow!(error);
-            crate::client_log::error("browser-control", &error);
+            let error_text = error.to_string();
+            crate::client_log::error("browser-control", &error_text);
             let message = if is_connection_unavailable(&error) {
                 localization::catalog().browser.control_unavailable()
             } else {

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -8841,7 +8841,8 @@ fn run_with_machine_updates_inner(
             let _ = browser_failure_tx.send(AppEvent::BrowserResizeFailed(failure));
         },
         move |error| {
-            let message = localization::catalog().browser.control_failed(&error);
+            crate::client_log::error("browser-control", &error);
+            let message = localization::catalog().browser.control_unavailable();
             let _ = browser_control_tx.send(AppEvent::Mux(MuxEvent::Status(message)));
         },
     )?;

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -8842,13 +8842,12 @@ fn run_with_machine_updates_inner(
             let _ = browser_failure_tx.send(AppEvent::BrowserResizeFailed(failure));
         },
         move |error| {
-            let error = anyhow::anyhow!(error);
-            let error_text = error.to_string();
+            let error_text = error;
             crate::client_log::error("browser-control", &error_text);
-            let message = if is_connection_unavailable(&error) {
+            let message = if is_connection_unavailable(&error_text) {
                 localization::catalog().browser.control_unavailable()
             } else {
-                localization::catalog().browser.control_failed(&error.to_string())
+                localization::catalog().browser.control_failed(&error_text)
             };
             let _ = browser_control_tx.send(AppEvent::Mux(MuxEvent::Status(message)));
         },

--- a/cmux-tui/crates/cmux-tui/src/localization.rs
+++ b/cmux-tui/crates/cmux-tui/src/localization.rs
@@ -249,6 +249,7 @@ pub(crate) struct ShortcutMessages {
 pub(crate) struct BrowserMessages {
     failed_prefix: &'static str,
     control_failed: &'static str,
+    control_unavailable: &'static str,
     not_responding: &'static str,
     resize_recovery: &'static str,
     new_page_verification_prefix: &'static str,
@@ -267,6 +268,10 @@ pub(crate) struct BrowserMessages {
 impl BrowserMessages {
     pub(crate) fn control_failed(&self, error: &str) -> String {
         self.control_failed.replace("{error}", error)
+    }
+
+    pub(crate) fn control_unavailable(&self) -> String {
+        self.control_failed.replace("{error}", self.control_unavailable)
     }
 
     pub(crate) fn loading(&self, url: &str) -> String {
@@ -1337,6 +1342,7 @@ edits shell files. Authenticate with the configured host before retrying.
     browser: BrowserMessages {
         failed_prefix: "browser failed: ",
         control_failed: "browser command failed: {error}",
+        control_unavailable: "browser connection unavailable; retry the command",
         not_responding: "browser failed: browser is not responding",
         resize_recovery: "browser failed: browser resize recovery failed; reload to retry",
         new_page_verification_prefix: "browser failed: could not verify new page pixels: ",
@@ -1983,6 +1989,7 @@ cmux machine-agent - ローカルの cmux セッションをリモートサー�
     browser: BrowserMessages {
         failed_prefix: "ブラウザでエラーが発生しました: ",
         control_failed: "ブラウザ操作に失敗しました: {error}",
+        control_unavailable: "ブラウザ接続を利用できません。コマンドを再試行してください",
         not_responding: "ブラウザが応答していません",
         resize_recovery: "ブラウザのサイズ変更を復旧できませんでした。再読み込みして再試行してください",
         new_page_verification_prefix: "新しいページの表示を確認できませんでした: ",


### PR DESCRIPTION
Fixes the compile and --locked failures found while auditing PR #11013. Uses tungstenite::client::client_with_config and updates Cargo.lock.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790559084&installation_model_id=21920&pr_number=11168&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11168&signature=d33d46c617d832a45e747c3291150dfe678ab282fe0712f58e9cefdb8232ff32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the compile and `--locked` failures found while auditing PR #11013. Calls `tungstenite::client::client_with_config`, updates `Cargo.lock` to match the resolved dependency graph, and classifies browser-control failures by their string form so connection-unavailable detection stays stable.

<sup>Written for commit 0e661efa39b3ac7d86bb91d5d42df4c3140da467. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

