### PR TITLE
fix(tui): restore scrollback limit compatibility

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/lib.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/lib.rs
@@ -8,25 +8,13 @@
 //! [`MuxEvent`]s and read surface state; they never own terminal state
 //! themselves, which is what makes the backend attachable.
 
-mod agent_hooks;
 mod browser;
-mod browser_provider;
 mod event_bus;
-mod journal_checkpoint;
-mod journal_hooks;
-mod journal_ingress;
-mod journal_kernel;
 mod model;
 mod mux;
 mod pairing;
 pub mod provider_management;
-pub mod resource;
-mod resource_api;
-mod resource_mutation;
-mod resource_router;
-mod resource_selector;
 mod short_id;
-mod sidebar_resource;
 mod surface;
 mod workspace_registry;
 
@@ -36,15 +24,9 @@ pub mod server;
 pub mod terminal_host;
 pub mod terminal_host_protocol;
 pub mod terminal_host_runtime;
-#[cfg(unix)]
-pub mod unix_process_scope;
 
-pub use agent_hooks::{
-    AGENT_HOOK_MANIFEST_VERSION, AGENT_HOOK_PRODUCER_ID, agent_hook_journal_ingress,
-};
-pub use browser::{BrowserFailure, TRANSPORT_SAFE_CAPTURE_MEGAPIXELS, normalize_url};
+pub use browser::{TRANSPORT_SAFE_CAPTURE_MEGAPIXELS, normalize_url};
 pub use event_bus::{MuxEventBroadcaster, MuxEventReceiver};
-pub use journal_ingress::{FrontendFocusTarget, FrontendJournalEvent};
 pub use layout::{
     DEFAULT_VIEWPORT_PANE_WIDTH, ExactSplitResize, ExactViewportSplitResize, LayoutResult,
     MAX_VIEWPORT_PANE_WIDTH, MIN_VIEWPORT_PANE_WIDTH, Rect, SplitEdge, SplitResize,
@@ -55,41 +37,28 @@ pub use layout::{
 pub use model::{Node, Pane, Screen, State, ViewportColumn, Workspace};
 pub use mux::{
     AgentRecord, AgentSource, AgentState, AppliedLayout, AppliedPane, CellPixelUpdate,
-    CellPixelUpdateFailure, ConfigReloadError, DiagnosticReporter, Direction, GraphicsStatus,
-    LayoutLeafSpec, LayoutRatioError, LayoutSpec, LayoutUndoError, LayoutUndoResult, Mux, MuxEvent,
-    NotificationEvent, NotificationLevel, ProviderWorkspaceAuthority,
-    ProviderWorkspaceAuthorityStatus, ProviderWorkspaceAuthorityUpdateError, ResourceNotification,
-    RunPlacement, SidebarPluginOptions, SidebarPluginStatus, SurfaceNotification,
-    SurfaceResizeReporter, TreeDelta, TreeDeltaKind, ViewportWidthError, WorkspaceMutationResult,
-    WorkspacePlacement, ZoomMode, ZoomState,
+    CellPixelUpdateFailure, Direction, LayoutLeafSpec, LayoutRatioError, LayoutSpec,
+    LayoutUndoError, LayoutUndoResult, Mux, MuxEvent, NotificationEvent, NotificationLevel,
+    ProviderWorkspaceAuthority, ProviderWorkspaceAuthorityStatus,
+    ProviderWorkspaceAuthorityUpdateError, RunPlacement, SidebarPluginOptions, SidebarPluginStatus,
+    SurfaceNotification, SurfaceResizeReporter, TreeDelta, TreeDeltaKind, ViewportWidthError,
+    WorkspaceMutationResult, WorkspacePlacement, ZoomMode, ZoomState,
 };
 pub use pairing::{PairingChallenge, PairingDecision, PairingError};
-pub use resource_api::{ResourceMachineRequest, ResourceMachineService};
-pub use resource_selector::{ResolvedResourcePath, ResourceSelectors, ResourceTarget};
 pub use short_id::assign_short_ids;
-pub use surface::apply_terminal_color_overrides;
 pub use surface::{
     AttachFrame, AttachFrameReceiver, AttachStream, BrowserAttachState, BrowserFrame,
-    BrowserFrameStream, BrowserFrameUpdate, BrowserSource, BrowserStatus,
-    CLEAR_HISTORY_FALLBACK_UNREPRESENTABLE_ERROR, CLEAR_HISTORY_FALLBACK_WRITE_TIMEOUT_ERROR,
-    CLEAR_HISTORY_PRESERVATION_ERROR, CLEAR_HISTORY_STREAM_TIMEOUT_ERROR, ClearHistoryDelivery,
-    ClearHistoryFailure, DefaultColors, GuardedMouseEncode, PointerSemanticProbe,
-    PointerSnapshotProbe, RenderAttachFrame, RenderAttachStream, Surface, SurfaceKind,
-    SurfaceOptions, SurfaceRenderFrame, TerminalColors, TerminalHostConnectionState,
-    TerminalPointerSnapshot,
+    BrowserFrameStream, BrowserSource, BrowserStatus, CLEAR_HISTORY_FALLBACK_UNREPRESENTABLE_ERROR,
+    CLEAR_HISTORY_FALLBACK_WRITE_TIMEOUT_ERROR, CLEAR_HISTORY_PRESERVATION_ERROR,
+    CLEAR_HISTORY_STREAM_TIMEOUT_ERROR, ClearHistoryDelivery, ClearHistoryFailure,
+    DEFAULT_SCROLLBACK_LIMIT_BYTES, DefaultColors, RenderAttachFrame, RenderAttachStream, Surface,
+    SurfaceKind, SurfaceOptions, SurfaceRenderFrame, TerminalColors, TerminalHostConnectionState,
 };
 pub use workspace_registry::{
-    FrontendProjection, JournalAppendCommit, JournalAuthority, JournalCheckpoint, JournalClass,
-    JournalContentRef, JournalEventSchema, JournalHookDeliveryPolicy, JournalHookExec,
-    JournalHookFilter, JournalHookManifest, JournalHookRegex, JournalHookRetry, JournalIngress,
-    JournalProducer, JournalProducerManifest, JournalReplayPolicy, JournalSegment,
-    JournalSensitivity, JournalSubject, PersistentSessionStateReset,
-    PersistentSessionStateResetPreview, PersistentSessionStateResetter, ProjectionCommit,
-    RegistryCommit, RegistryEvent, RegistrySnapshot, RegistryWorkspace, SessionJournalPage,
-    SessionJournalRecord, UnsupportedWorkspaceRegistrySchema, WorkspaceMutation, WorkspaceRegistry,
+    FrontendProjection, ProjectionCommit, RegistryCommit, RegistryEvent, RegistrySnapshot,
+    RegistryWorkspace, WorkspaceMutation, WorkspaceRegistry,
 };
 
-pub use cmux_remote_protocol::{REMOTE_CLIENT_MESSAGE_MAX_BYTES, REMOTE_SESSION_MESSAGE_MAX_BYTES};
 pub use cmux_tui_cdp::BrowserMode;
 pub use ghostty_vt::{CursorShape, Rgb};
 

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -6983,6 +6983,23 @@ mod tests {
             .expect("macOS surface PTY spawn failed");
     }
 
+    #[test]
+    fn default_scrollback_retains_long_agent_transcript() {
+        let options = SurfaceOptions::default();
+        let mut terminal =
+            Terminal::new(options.cols, options.rows, options.scrollback, Callbacks::default())
+                .unwrap();
+        for line in 0..20_000 {
+            terminal.vt_write(
+                format!("omp-history-{line:05} {}\r\n", "x".repeat(64)).as_bytes(),
+            );
+        }
+
+        let scrollback = terminal.plain_text().unwrap();
+        assert!(scrollback.contains("omp-history-00000"));
+        assert!(scrollback.contains("omp-history-19999"));
+    }
+
     #[derive(Clone, Default)]
     struct CapturingWriter(Arc<Mutex<Vec<u8>>>);
 

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -6,90 +6,35 @@
 //! VT operations.
 
 use std::borrow::Cow;
-use std::collections::{HashMap, VecDeque};
 use std::io::{Read, Write};
 use std::mem::size_of;
 use std::ops::Deref;
 use std::path::PathBuf;
-#[cfg(test)]
-use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, AtomicUsize, Ordering};
 use std::sync::mpsc::{
     Receiver, RecvError, RecvTimeoutError, SyncSender, TryRecvError, TrySendError, sync_channel,
 };
 use std::sync::{Arc, Condvar, Mutex, TryLockError, Weak};
 use std::time::{Duration, Instant};
 
-use cmux_pty::{ChildKiller, MasterPty, PtyCommand, PtySize};
 use ghostty_vt::{
-    Callbacks, ClearHistoryOutcome, CursorShape, Dirty, KeyEncoder, KeyInput, KittyGraphicsLimits,
-    KittyReplayState, MouseEncoders, MouseInput, RenderFrame, RenderState, Rgb, Screen, Scrollbar,
-    Terminal, TerminalColorOverrides, TerminalPointerSemanticSnapshot, TrackedScreenPoint,
+    Callbacks, ClearHistoryOutcome, CursorShape, KeyEncoder, KeyInput, MouseEncoders, MouseInput,
+    RenderFrame, RenderState, Rgb, Screen, Terminal, TerminalColorOverrides,
 };
+use portable_pty::{ChildKiller, CommandBuilder, MasterPty, PtySize, native_pty_system};
 
-use crate::mux::ResourceWaitWake;
 use crate::platform;
-use crate::resource::{ContentPublicId, TabResourceIdentity, TerminalPublicId};
-use crate::terminal_host_protocol::{TerminalExit, wait_for_native_child_status};
 use crate::{Mux, MuxEvent, SurfaceId};
 
 pub use crate::browser::{
-    BrowserAttachState, BrowserFrame, BrowserFrameStream, BrowserFrameUpdate, BrowserSource,
-    BrowserStatus,
+    BrowserAttachState, BrowserFrame, BrowserFrameStream, BrowserSource, BrowserStatus,
 };
-use crate::browser::{
-    BrowserMouseDispatch, BrowserPointerOwner, BrowserResizeWaiter, BrowserSurface,
-    PendingBrowserResize,
-};
-#[cfg(all(unix, test))]
-use crate::terminal_host_protocol::PROTOCOL_VERSION;
+use crate::browser::{BrowserResizeWaiter, BrowserSurface, PendingBrowserResize};
 #[cfg(unix)]
-use crate::terminal_host_protocol::{
-    CLEAR_HISTORY_ACK_OK, FLAG_COLORS_FOLLOW, Frame, MessageKind, decode_terminal_exit,
-};
+use crate::terminal_host_protocol::{FLAG_COLORS_FOLLOW, Frame, MessageKind, PROTOCOL_VERSION};
 use cmux_tui_cdp::BrowserMode;
 
-/// Result of encoding terminal mouse input against a previously observed
-/// pointer snapshot without blocking on terminal parsing.
-#[derive(Debug)]
-pub enum GuardedMouseEncode {
-    /// The guards still matched and the encoder returned this result.
-    Encoded(ghostty_vt::Result<()>),
-    /// The terminal's mouse protocol or reporting mode changed.
-    SemanticsChanged,
-    /// Terminal output changed the content generation used by the route.
-    ContentChanged,
-    /// Terminal parsing currently owns a required lock. The caller may retry
-    /// after the next surface update without changing the pointer route.
-    Contended,
-}
-
-/// Nonblocking probe for the terminal mouse protocol and reporting mode.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum PointerSemanticProbe {
-    /// The semantic snapshot was read consistently.
-    Ready(TerminalPointerSemanticSnapshot),
-    /// Terminal parsing currently owns the semantic state lock.
-    Contended,
-}
-
-/// Terminal pointer state captured from one consistent rendered generation.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct TerminalPointerSnapshot {
-    /// Mouse protocol and reporting mode used to encode pointer input.
-    pub semantics: TerminalPointerSemanticSnapshot,
-    /// Terminal content generation that produced the rendered hit route.
-    pub content_generation: u64,
-}
-
-/// Nonblocking probe for a complete terminal pointer snapshot.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum PointerSnapshotProbe {
-    /// Semantic and content-generation state were read consistently.
-    Ready(TerminalPointerSnapshot),
-    /// Terminal parsing currently owns a required state lock.
-    Contended,
-}
+pub const DEFAULT_SCROLLBACK_LIMIT_BYTES: usize = 50_000_000;
 
 /// How to spawn surface children.
 #[derive(Debug, Clone)]
@@ -97,12 +42,12 @@ pub struct SurfaceOptions {
     /// Command argv; defaults to the platform shell.
     pub command: Option<Vec<String>>,
     pub cwd: Option<String>,
-    /// TERM value for children: the outer terminal's xterm-ghostty when it
-    /// advertised that (see [`default_child_term`]), else the compatible
-    /// xterm-256color. CMUX_TUI_TERM/CMUX_MUX_TERM override.
+    /// TERM value for children. xterm-256color is the compatible default;
+    /// set xterm-ghostty when the ghostty terminfo is installed.
     pub term: String,
     pub cols: u16,
     pub rows: u16,
+    /// Maximum retained scrollback backing storage in bytes.
     pub scrollback: usize,
     /// Extra environment for children (e.g. CMUX_TUI_SOCKET).
     pub extra_env: Vec<(String, String)>,
@@ -131,32 +76,6 @@ pub struct SurfaceOptions {
     pub terminal_host_root: Option<PathBuf>,
 }
 
-/// Default TERM for child shells.
-///
-/// `xterm-ghostty` when the OUTER terminal advertised it (this process's
-/// own TERM), else the compatible `xterm-256color`. No terminfo probing:
-/// a Ghostty session that sets TERM=xterm-ghostty also exports TERMINFO
-/// pointing at its bundled database, and children inherit that variable
-/// through cmux-tui untouched, so the entry resolves for them exactly as
-/// it does for programs in the raw Ghostty pane. Children — local and
-/// remote (ssh forwards TERM, not terminfo) — therefore see precisely the
-/// TERM they would have seen without the multiplexer, never a less
-/// compatible one, and TERM-name-sniffing prompts (oh-my-zsh themes
-/// matching `*256color`) take the same branch inside cmux-tui as in raw
-/// Ghostty, so colors match. Only xterm-ghostty passes through: the inner
-/// terminal IS ghostty-vt, so that name is truthful regardless of which
-/// client later attaches; any other outer TERM would misdescribe it.
-/// Servers started outside a Ghostty session (launchd, ssh, cron) keep
-/// xterm-256color. CMUX_TUI_TERM, CMUX_MUX_TERM, and --term override.
-pub fn default_child_term() -> String {
-    child_term_for(std::env::var("TERM").ok().as_deref()).into()
-}
-
-/// Pure selection rule for [`default_child_term`].
-fn child_term_for(outer_term: Option<&str>) -> &'static str {
-    if outer_term == Some("xterm-ghostty") { "xterm-ghostty" } else { "xterm-256color" }
-}
-
 impl Default for SurfaceOptions {
     fn default() -> Self {
         SurfaceOptions {
@@ -164,10 +83,10 @@ impl Default for SurfaceOptions {
             cwd: None,
             term: std::env::var("CMUX_TUI_TERM")
                 .or_else(|_| std::env::var("CMUX_MUX_TERM"))
-                .unwrap_or_else(|_| default_child_term()),
+                .unwrap_or_else(|_| "xterm-256color".into()),
             cols: 80,
             rows: 24,
-            scrollback: 10_000,
+            scrollback: DEFAULT_SCROLLBACK_LIMIT_BYTES,
             extra_env: Vec::new(),
             chrome_binary: None,
             cdp_url: None,
@@ -285,9 +204,7 @@ impl TerminalColors {
 pub struct AttachStream {
     pub cols: u16,
     pub rows: u16,
-    pub replay: Arc<[u8]>,
-    pub kitty_image_aliases: Vec<ghostty_vt::KittyImageAlias>,
-    pub kitty_state: KittyReplayState,
+    pub replay: Vec<u8>,
     pub colors: TerminalColors,
     pub stream: AttachFrameReceiver,
     pub(crate) lifecycle: AttachLifecycle,
@@ -305,18 +222,14 @@ pub enum AttachFrame {
     Resized {
         cols: u16,
         rows: u16,
-        replay: Arc<[u8]>,
-        kitty_image_aliases: Vec<ghostty_vt::KittyImageAlias>,
-        kitty_state: KittyReplayState,
+        replay: Vec<u8>,
     },
     /// One parser transition: `replay` is theme-portable, so `colors` is part
     /// of the same replacement snapshot rather than a subsequent callback.
     ResizedWithColors {
         cols: u16,
         rows: u16,
-        replay: Arc<[u8]>,
-        kitty_image_aliases: Vec<ghostty_vt::KittyImageAlias>,
-        kitty_state: KittyReplayState,
+        replay: Vec<u8>,
         colors: Box<TerminalColors>,
     },
     ColorsChanged(Arc<TerminalColors>),
@@ -329,26 +242,10 @@ pub enum AttachFrame {
 #[derive(Debug)]
 enum HostedTransition {
     Output(Vec<u8>),
-    OutputWithColors {
-        output: Vec<u8>,
-        colors: TerminalColorOverrides,
-    },
-    Resized {
-        cols: u16,
-        rows: u16,
-        cell_pixels: Option<(u16, u16)>,
-    },
-    ResizedWithColors {
-        cols: u16,
-        rows: u16,
-        cell_pixels: (u16, u16),
-        replay: Vec<u8>,
-        kitty_image_aliases: Vec<ghostty_vt::KittyImageAlias>,
-        kitty_state: KittyReplayState,
-        colors: TerminalColorOverrides,
-    },
+    OutputWithColors { output: Vec<u8>, colors: TerminalColorOverrides },
+    ResizedWithColors { cols: u16, rows: u16, replay: Vec<u8>, colors: TerminalColorOverrides },
     Metadata(MessageKind),
-    Exit(TerminalExit),
+    Exit,
     ResyncRequired,
 }
 
@@ -356,46 +253,23 @@ enum HostedTransition {
 #[derive(Debug)]
 enum PendingHostedTransition {
     Output(Vec<u8>),
-    Resized {
-        cols: u16,
-        rows: u16,
-        cell_pixels: (u16, u16),
-        replay: Vec<u8>,
-        kitty_image_aliases: Vec<ghostty_vt::KittyImageAlias>,
-        kitty_state: KittyReplayState,
-    },
+    Resized { cols: u16, rows: u16, replay: Vec<u8> },
 }
 
 #[cfg(unix)]
 struct HostedFrameStager {
-    protocol_version: u16,
     expected_sequence: u64,
-    smart_renderer: bool,
     pending: Option<PendingHostedTransition>,
 }
 
 #[cfg(unix)]
 impl HostedFrameStager {
-    #[cfg(test)]
-    fn new(sequence_boundary: u64, smart_renderer: bool) -> Self {
-        Self::new_for_version(sequence_boundary, PROTOCOL_VERSION, smart_renderer)
-    }
-
-    fn new_for_version(
-        sequence_boundary: u64,
-        protocol_version: u16,
-        smart_renderer: bool,
-    ) -> Self {
-        Self {
-            protocol_version,
-            expected_sequence: sequence_boundary.wrapping_add(1),
-            smart_renderer,
-            pending: None,
-        }
+    fn new(sequence_boundary: u64) -> Self {
+        Self { expected_sequence: sequence_boundary.wrapping_add(1), pending: None }
     }
 
     fn push(&mut self, frame: Frame) -> Result<Option<HostedTransition>, &'static str> {
-        if frame.version != self.protocol_version || frame.request_id != 0 {
+        if frame.version != PROTOCOL_VERSION || frame.request_id != 0 {
             return Err("invalid live-frame envelope");
         }
         if frame.sequence != self.expected_sequence {
@@ -414,22 +288,9 @@ impl HostedFrameStager {
                 PendingHostedTransition::Output(output) => {
                     HostedTransition::OutputWithColors { output, colors }
                 }
-                PendingHostedTransition::Resized {
-                    cols,
-                    rows,
-                    cell_pixels,
-                    replay,
-                    kitty_image_aliases,
-                    kitty_state,
-                } => HostedTransition::ResizedWithColors {
-                    cols,
-                    rows,
-                    cell_pixels,
-                    replay,
-                    kitty_image_aliases,
-                    kitty_state,
-                    colors,
-                },
+                PendingHostedTransition::Resized { cols, rows, replay } => {
+                    HostedTransition::ResizedWithColors { cols, rows, replay, colors }
+                }
             }));
         }
 
@@ -443,62 +304,28 @@ impl HostedFrameStager {
                 _ => Err("unknown Output flags"),
             },
             MessageKind::Resized => {
-                let valid_smart =
-                    self.smart_renderer && frame.flags == 0 && matches!(frame.payload.len(), 4 | 8);
-                let valid_legacy = !self.smart_renderer
-                    && frame.flags == FLAG_COLORS_FOLLOW
-                    && frame.payload.len() >= 4
-                    && frame.payload.len() - 4 <= VT_REPLAY_MAX_BYTES;
-                if !valid_smart && !valid_legacy {
+                if frame.flags != FLAG_COLORS_FOLLOW
+                    || frame.payload.len() < 4
+                    || frame.payload.len() - 4 > VT_REPLAY_MAX_BYTES
+                {
                     return Err("invalid Resized frame");
                 }
-                if valid_smart {
-                    let cols = u16::from_le_bytes([frame.payload[0], frame.payload[1]]);
-                    let rows = u16::from_le_bytes([frame.payload[2], frame.payload[3]]);
-                    let (cols, rows) =
-                        crate::terminal_host_runtime::normalize_terminal_geometry(cols, rows)
-                            .map_err(|_| "invalid Resized geometry")?;
-                    let cell_pixels = (frame.payload.len() == 8).then(|| {
-                        (
-                            u16::from_le_bytes([frame.payload[4], frame.payload[5]]).max(1),
-                            u16::from_le_bytes([frame.payload[6], frame.payload[7]]).max(1),
-                        )
-                    });
-                    return Ok(Some(HostedTransition::Resized { cols, rows, cell_pixels }));
-                }
-                let crate::terminal_host_runtime::DecodedHostResize {
-                    cols,
-                    rows,
-                    cell_pixels,
-                    replay,
-                    kitty_image_aliases,
-                    kitty_state,
-                } = crate::terminal_host_runtime::decode_host_resize_payload_for_version(
-                    &frame.payload,
-                    self.protocol_version,
+                let (cols, rows) = crate::terminal_host_runtime::normalize_terminal_geometry(
+                    u16::from_le_bytes([frame.payload[0], frame.payload[1]]),
+                    u16::from_le_bytes([frame.payload[2], frame.payload[3]]),
                 )
                 .map_err(|_| "invalid Resized geometry")?;
                 self.pending = Some(PendingHostedTransition::Resized {
                     cols,
                     rows,
-                    cell_pixels,
-                    replay,
-                    kitty_image_aliases,
-                    kitty_state,
+                    replay: frame.payload[4..].to_vec(),
                 });
                 Ok(None)
             }
             MessageKind::Title | MessageKind::Pwd | MessageKind::Bell if frame.flags == 0 => {
                 Ok(Some(HostedTransition::Metadata(frame.kind)))
             }
-            MessageKind::Exit if frame.flags == 0 => {
-                let exit = if frame.payload.is_empty() {
-                    TerminalExit::unknown("terminal host omitted exit status")
-                } else {
-                    decode_terminal_exit(&frame.payload).map_err(|_| "invalid Exit payload")?
-                };
-                Ok(Some(HostedTransition::Exit(exit)))
-            }
+            MessageKind::Exit if frame.flags == 0 => Ok(Some(HostedTransition::Exit)),
             MessageKind::ResyncRequired if frame.flags == 0 => {
                 Ok(Some(HostedTransition::ResyncRequired))
             }
@@ -511,150 +338,52 @@ impl HostedFrameStager {
 
 const ATTACH_STREAM_CAPACITY: usize = 256;
 const ATTACH_STREAM_MAX_BYTES: usize = 16 * 1024 * 1024;
-// Preserve every valid upload prefix plus enough recent text while fitting
-// both the raw attach queue and its 32 MiB base64-encoded transport.
-const VT_REPLAY_TEXT_HEADROOM_BYTES: usize = 2 * 1024 * 1024;
-pub(crate) const VT_REPLAY_MAX_BYTES: usize =
-    ghostty_vt::KITTY_INFLIGHT_REPLAY_MAX_BYTES + VT_REPLAY_TEXT_HEADROOM_BYTES;
-const VT_REPLAY_FRAME_METADATA_HEADROOM_BYTES: usize = 64 * 1024;
-const VT_REPLAY_ENCODED_TRANSPORT_MAX_BYTES: usize = 32 * 1024 * 1024;
-const _: () = assert!(
-    VT_REPLAY_MAX_BYTES + VT_REPLAY_FRAME_METADATA_HEADROOM_BYTES <= ATTACH_STREAM_MAX_BYTES
-);
-const _: () = assert!(VT_REPLAY_MAX_BYTES.div_ceil(3) * 4 < VT_REPLAY_ENCODED_TRANSPORT_MAX_BYTES);
+pub(crate) const VT_REPLAY_MAX_BYTES: usize = 8 * 1024 * 1024;
 
 pub struct AttachFrameReceiver {
-    state: Arc<AttachTapState>,
-    lifecycle: AttachLifecycle,
+    receiver: Receiver<AttachFrame>,
+    queued_bytes: Arc<AtomicUsize>,
 }
 
 impl AttachFrameReceiver {
-    fn pop(queue: &mut AttachTapQueue) -> Option<AttachFrame> {
-        let frame = queue.frames.pop_front()?;
-        queue.retained_bytes = queue.retained_bytes.saturating_sub(frame.retained_bytes());
-        Some(frame)
+    fn account_received(&self, frame: &AttachFrame) {
+        self.queued_bytes.fetch_sub(frame.retained_bytes(), Ordering::AcqRel);
     }
 
     pub fn recv(&self) -> Result<AttachFrame, RecvError> {
-        let mut queue = self.state.queue.lock().unwrap();
-        loop {
-            if let Some(frame) = Self::pop(&mut queue) {
-                return Ok(frame);
-            }
-            if !queue.sender_alive {
-                return Err(RecvError);
-            }
-            queue = self.state.ready.wait(queue).unwrap();
-        }
+        let frame = self.receiver.recv()?;
+        self.account_received(&frame);
+        Ok(frame)
     }
 
     pub fn recv_timeout(&self, timeout: Duration) -> Result<AttachFrame, RecvTimeoutError> {
-        let started = Instant::now();
-        let mut queue = self.state.queue.lock().unwrap();
-        loop {
-            if let Some(frame) = Self::pop(&mut queue) {
-                return Ok(frame);
-            }
-            if !queue.sender_alive {
-                return Err(RecvTimeoutError::Disconnected);
-            }
-            let Some(remaining) = timeout.checked_sub(started.elapsed()) else {
-                return Err(RecvTimeoutError::Timeout);
-            };
-            let (next, result) = self.state.ready.wait_timeout(queue, remaining).unwrap();
-            queue = next;
-            if result.timed_out() && queue.frames.is_empty() {
-                return Err(RecvTimeoutError::Timeout);
-            }
-        }
+        let frame = self.receiver.recv_timeout(timeout)?;
+        self.account_received(&frame);
+        Ok(frame)
     }
 
     pub fn try_recv(&self) -> Result<AttachFrame, TryRecvError> {
-        let mut queue = self.state.queue.lock().unwrap();
-        if let Some(frame) = Self::pop(&mut queue) {
-            Ok(frame)
-        } else if queue.sender_alive {
-            Err(TryRecvError::Empty)
-        } else {
-            Err(TryRecvError::Disconnected)
-        }
-    }
-}
-
-impl Drop for AttachFrameReceiver {
-    fn drop(&mut self) {
-        let mut queue = self.state.queue.lock().unwrap();
-        queue.receiver_alive = false;
-        queue.frames.clear();
-        queue.retained_bytes = 0;
-        drop(queue);
-        self.lifecycle.cancel();
-        self.state.ready.notify_all();
+        let frame = self.receiver.try_recv()?;
+        self.account_received(&frame);
+        Ok(frame)
     }
 }
 
 impl AttachFrame {
-    fn merge_adjacent_output(
-        &mut self,
-        next: AttachFrame,
-        max_retained_bytes: usize,
-    ) -> AttachFrameMerge {
-        let mut next = match next {
-            AttachFrame::Output(next) => next,
-            other => return AttachFrameMerge::Unmerged(other),
-        };
-        let AttachFrame::Output(pending) = self else {
-            return AttachFrameMerge::Unmerged(AttachFrame::Output(next));
-        };
-        let Some(max_capacity) = max_retained_bytes.checked_sub(size_of::<Self>()) else {
-            return AttachFrameMerge::Overflow;
-        };
-        let Some(required) = pending.len().checked_add(next.len()) else {
-            return AttachFrameMerge::Overflow;
-        };
-        if required > max_capacity {
-            return AttachFrameMerge::Overflow;
-        }
-        if required > pending.capacity() {
-            let desired = pending.capacity().saturating_mul(2).max(required).min(max_capacity);
-            let mut merged = Vec::new();
-            if merged.try_reserve_exact(desired).is_err() || merged.capacity() > max_capacity {
-                return AttachFrameMerge::Overflow;
-            }
-            merged.extend_from_slice(pending);
-            merged.append(&mut next);
-            *pending = merged;
-        } else {
-            pending.append(&mut next);
-        }
-        AttachFrameMerge::Merged
-    }
-
     fn retained_bytes(&self) -> usize {
         size_of::<Self>()
             + match self {
                 Self::Output(bytes) => bytes.capacity(),
-                Self::Resized { replay, kitty_image_aliases, .. } => {
-                    replay.len()
-                        + kitty_image_aliases.capacity() * size_of::<ghostty_vt::KittyImageAlias>()
-                }
                 Self::OutputWithColors { output, .. } => {
                     output.capacity() + size_of::<TerminalColors>()
                 }
-                Self::ResizedWithColors { replay, kitty_image_aliases, .. } => {
-                    replay.len()
-                        + kitty_image_aliases.capacity() * size_of::<ghostty_vt::KittyImageAlias>()
-                        + size_of::<TerminalColors>()
+                Self::Resized { replay, .. } => replay.capacity(),
+                Self::ResizedWithColors { replay, .. } => {
+                    replay.capacity() + size_of::<TerminalColors>()
                 }
                 Self::ColorsChanged(_) => size_of::<TerminalColors>(),
             }
     }
-}
-
-enum AttachFrameMerge {
-    Merged,
-    Unmerged(AttachFrame),
-    Overflow,
 }
 
 #[derive(Clone, Default)]
@@ -698,115 +427,49 @@ impl AttachLifecycle {
 }
 
 struct AttachTap {
-    state: Arc<AttachTapState>,
+    sender: SyncSender<AttachFrame>,
     lifecycle: AttachLifecycle,
-}
-
-struct AttachTapState {
-    queue: Mutex<AttachTapQueue>,
-    ready: Condvar,
-}
-
-struct AttachTapQueue {
-    frames: VecDeque<AttachFrame>,
-    retained_bytes: usize,
-    max_frames: usize,
-    max_retained_bytes: usize,
-    sender_alive: bool,
-    receiver_alive: bool,
+    queued_bytes: Arc<AtomicUsize>,
+    max_queued_bytes: usize,
 }
 
 impl AttachTap {
-    fn pair(
-        lifecycle: AttachLifecycle,
-        max_frames: usize,
-        max_retained_bytes: usize,
-    ) -> (Self, AttachFrameReceiver) {
-        let state = Arc::new(AttachTapState {
-            queue: Mutex::new(AttachTapQueue {
-                frames: VecDeque::new(),
-                retained_bytes: 0,
-                max_frames,
-                max_retained_bytes,
-                sender_alive: true,
-                receiver_alive: true,
-            }),
-            ready: Condvar::new(),
-        });
-        (
-            Self { state: state.clone(), lifecycle: lifecycle.clone() },
-            AttachFrameReceiver { state, lifecycle },
-        )
-    }
-
-    fn try_send(&self, mut frame: AttachFrame) -> bool {
+    fn try_send(&self, frame: AttachFrame) -> bool {
         if self.lifecycle.is_canceled() {
             return false;
         }
-        let mut queue = self.state.queue.lock().unwrap();
-        if !queue.receiver_alive {
-            self.lifecycle.cancel();
+        let frame_bytes = frame.retained_bytes();
+        if self
+            .queued_bytes
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |queued| {
+                queued.checked_add(frame_bytes).filter(|next| *next <= self.max_queued_bytes)
+            })
+            .is_err()
+        {
+            self.lifecycle.mark_overflow();
             return false;
         }
-        let queue_retained_bytes = queue.retained_bytes;
-        let queue_max_retained_bytes = queue.max_retained_bytes;
-        if let Some(pending) = queue.frames.back_mut() {
-            let previous_bytes = pending.retained_bytes();
-            let max_frame_bytes = queue_max_retained_bytes
-                .saturating_sub(queue_retained_bytes.saturating_sub(previous_bytes));
-            match pending.merge_adjacent_output(frame, max_frame_bytes) {
-                AttachFrameMerge::Merged => {
-                    let merged_bytes = pending.retained_bytes();
-                    queue.retained_bytes = queue
-                        .retained_bytes
-                        .saturating_sub(previous_bytes)
-                        .saturating_add(merged_bytes);
-                    drop(queue);
-                    self.state.ready.notify_one();
-                    return true;
-                }
-                AttachFrameMerge::Unmerged(unmerged) => frame = unmerged,
-                AttachFrameMerge::Overflow => {
-                    drop(queue);
-                    self.lifecycle.mark_overflow();
-                    return false;
-                }
+        match self.sender.try_send(frame) {
+            Ok(()) => true,
+            Err(TrySendError::Full(_)) => {
+                self.queued_bytes.fetch_sub(frame_bytes, Ordering::AcqRel);
+                self.lifecycle.mark_overflow();
+                false
+            }
+            Err(TrySendError::Disconnected(_)) => {
+                self.queued_bytes.fetch_sub(frame_bytes, Ordering::AcqRel);
+                self.lifecycle.cancel();
+                false
             }
         }
-        let frame_bytes = frame.retained_bytes();
-        if frame_bytes > queue.max_retained_bytes.saturating_sub(queue.retained_bytes) {
-            drop(queue);
-            self.lifecycle.mark_overflow();
-            return false;
-        }
-        if queue.frames.len() >= queue.max_frames {
-            drop(queue);
-            self.lifecycle.mark_overflow();
-            return false;
-        }
-        queue.retained_bytes = queue.retained_bytes.saturating_add(frame_bytes);
-        queue.frames.push_back(frame);
-        drop(queue);
-        self.state.ready.notify_one();
-        true
     }
 }
 
-impl Drop for AttachTap {
-    fn drop(&mut self) {
-        self.state.queue.lock().unwrap().sender_alive = false;
-        self.state.ready.notify_all();
-    }
-}
-
-/// One immutable terminal frame plus retained-history metadata captured with it.
+/// One immutable terminal frame plus the scrollback count captured with it.
 #[derive(Debug, Clone)]
 pub struct SurfaceRenderFrame {
     pub frame: RenderFrame,
-    pub content_generation: u64,
     pub scrollback_rows: u32,
-    pub history_epoch: u64,
-    pub pointer_semantics: TerminalPointerSemanticSnapshot,
     pub palette_colors: [Rgb; 256],
     pub palette_overridden: [bool; 256],
 }
@@ -818,246 +481,18 @@ pub enum RenderAttachFrame {
     ScrollChanged { offset: u64, at_bottom: bool },
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum PendingRenderKind {
-    Frame,
-    Scroll,
-}
-
-struct RenderTapQueue {
-    pending_frame: Option<PendingRenderFrame>,
-    pending_scroll: Option<(u64, bool)>,
-    latest_kind: Option<PendingRenderKind>,
-    sender_alive: bool,
-    receiver_alive: bool,
-}
-
-struct PendingRenderFrame {
-    latest: Arc<SurfaceRenderFrame>,
-    dirty: Dirty,
-    dirty_rows: Vec<u16>,
-}
-
-impl PendingRenderFrame {
-    fn new(latest: Arc<SurfaceRenderFrame>) -> Self {
-        Self { dirty: latest.frame.dirty, dirty_rows: latest.frame.dirty_rows.clone(), latest }
-    }
-
-    /// Replace the immutable snapshot while retaining every row damaged since
-    /// the tap last drained. Only damage metadata is copied on this hot path.
-    fn coalesce(&mut self, latest: Arc<SurfaceRenderFrame>) {
-        if self.dirty == Dirty::Full
-            || latest.frame.dirty == Dirty::Full
-            || self.latest.frame.size != latest.frame.size
-        {
-            self.dirty = Dirty::Full;
-            self.dirty_rows = (0..latest.frame.size.1).collect();
-        } else {
-            self.dirty_rows.extend(latest.frame.dirty_rows.iter().copied());
-            self.dirty_rows.sort_unstable();
-            self.dirty_rows.dedup();
-            self.dirty =
-                if self.dirty_rows.is_empty() { latest.frame.dirty } else { Dirty::Partial };
-        }
-        self.latest = latest;
-    }
-
-    /// Materialize one coalesced frame when the receiver drains. A tap that
-    /// keeps up returns the original shared frame without cloning row state.
-    fn into_frame(self) -> Arc<SurfaceRenderFrame> {
-        if self.dirty == self.latest.frame.dirty && self.dirty_rows == self.latest.frame.dirty_rows
-        {
-            return self.latest;
-        }
-        let mut combined = (*self.latest).clone();
-        combined.frame.dirty = self.dirty;
-        combined.frame.dirty_rows = self.dirty_rows;
-        Arc::new(combined)
-    }
-}
-
-impl RenderTapQueue {
-    fn push(&mut self, event: RenderAttachFrame) {
-        match event {
-            RenderAttachFrame::Frame(frame) => {
-                match &mut self.pending_frame {
-                    Some(pending) => pending.coalesce(frame),
-                    None => self.pending_frame = Some(PendingRenderFrame::new(frame)),
-                }
-                self.latest_kind = Some(PendingRenderKind::Frame);
-            }
-            RenderAttachFrame::ScrollChanged { offset, at_bottom } => {
-                self.pending_scroll = Some((offset, at_bottom));
-                self.latest_kind = Some(PendingRenderKind::Scroll);
-            }
-        }
-    }
-
-    fn pop(&mut self) -> Option<RenderAttachFrame> {
-        let next =
-            match (self.pending_frame.is_some(), self.pending_scroll.is_some(), self.latest_kind) {
-                (true, true, Some(PendingRenderKind::Frame)) => {
-                    let (offset, at_bottom) = self.pending_scroll.take().unwrap();
-                    RenderAttachFrame::ScrollChanged { offset, at_bottom }
-                }
-                (true, true, Some(PendingRenderKind::Scroll)) => {
-                    RenderAttachFrame::Frame(self.pending_frame.take().unwrap().into_frame())
-                }
-                (true, true, None) => unreachable!("pending render events have an ordering"),
-                (true, false, _) => {
-                    RenderAttachFrame::Frame(self.pending_frame.take().unwrap().into_frame())
-                }
-                (false, true, _) => {
-                    let (offset, at_bottom) = self.pending_scroll.take().unwrap();
-                    RenderAttachFrame::ScrollChanged { offset, at_bottom }
-                }
-                (false, false, _) => return None,
-            };
-        if self.pending_frame.is_none() && self.pending_scroll.is_none() {
-            self.latest_kind = None;
-        }
-        Some(next)
-    }
-}
-
-struct RenderTapState {
-    queue: Mutex<RenderTapQueue>,
-    ready: Condvar,
-}
-
-struct RenderTap {
-    state: Arc<RenderTapState>,
-}
-
-impl RenderTap {
-    fn pair(render: &Arc<Mutex<RenderHub>>) -> (Self, RenderAttachFrameReceiver) {
-        let state = Arc::new(RenderTapState {
-            queue: Mutex::new(RenderTapQueue {
-                pending_frame: None,
-                pending_scroll: None,
-                latest_kind: None,
-                sender_alive: true,
-                receiver_alive: true,
-            }),
-            ready: Condvar::new(),
-        });
-        (
-            Self { state: state.clone() },
-            RenderAttachFrameReceiver { state, render: Arc::downgrade(render) },
-        )
-    }
-
-    fn send(&self, event: RenderAttachFrame) -> bool {
-        let mut queue = self.state.queue.lock().unwrap();
-        if !queue.receiver_alive {
-            return false;
-        }
-        queue.push(event);
-        drop(queue);
-        self.state.ready.notify_one();
-        true
-    }
-}
-
-impl Drop for RenderTap {
-    fn drop(&mut self) {
-        self.state.queue.lock().unwrap().sender_alive = false;
-        self.state.ready.notify_all();
-    }
-}
-
-/// Bounded receiver for one render attachment.
-pub struct RenderAttachFrameReceiver {
-    state: Arc<RenderTapState>,
-    render: Weak<Mutex<RenderHub>>,
-}
-
-impl RenderAttachFrameReceiver {
-    pub fn recv(&self) -> Result<RenderAttachFrame, RecvError> {
-        let mut queue = self.state.queue.lock().unwrap();
-        loop {
-            if let Some(event) = queue.pop() {
-                return Ok(event);
-            }
-            if !queue.sender_alive {
-                return Err(RecvError);
-            }
-            queue = self.state.ready.wait(queue).unwrap();
-        }
-    }
-
-    pub fn recv_timeout(&self, timeout: Duration) -> Result<RenderAttachFrame, RecvTimeoutError> {
-        let started = Instant::now();
-        let mut queue = self.state.queue.lock().unwrap();
-        loop {
-            if let Some(event) = queue.pop() {
-                return Ok(event);
-            }
-            if !queue.sender_alive {
-                return Err(RecvTimeoutError::Disconnected);
-            }
-            let Some(remaining) = timeout.checked_sub(started.elapsed()) else {
-                return Err(RecvTimeoutError::Timeout);
-            };
-            let (next, result) = self.state.ready.wait_timeout(queue, remaining).unwrap();
-            queue = next;
-            if result.timed_out() && queue.pending_frame.is_none() && queue.pending_scroll.is_none()
-            {
-                return Err(RecvTimeoutError::Timeout);
-            }
-        }
-    }
-
-    pub fn try_recv(&self) -> Result<RenderAttachFrame, TryRecvError> {
-        let mut queue = self.state.queue.lock().unwrap();
-        if let Some(event) = queue.pop() {
-            Ok(event)
-        } else if queue.sender_alive {
-            Err(TryRecvError::Empty)
-        } else {
-            Err(TryRecvError::Disconnected)
-        }
-    }
-}
-
-impl Drop for RenderAttachFrameReceiver {
-    fn drop(&mut self) {
-        // Frame fan-out holds the hub before this queue. Release the queue
-        // before taking the hub so receiver teardown cannot invert that order.
-        {
-            let mut queue = self.state.queue.lock().unwrap();
-            queue.receiver_alive = false;
-            queue.pending_frame = None;
-            queue.pending_scroll = None;
-        }
-        if let Some(render) = self.render.upgrade() {
-            render.lock().unwrap().taps.retain(|tap| !Arc::ptr_eq(&tap.state, &self.state));
-        }
-    }
-}
-
 /// Initial render snapshot and the ordered live stream registered with it.
 pub struct RenderAttachStream {
     pub initial: Arc<SurfaceRenderFrame>,
-    pub stream: RenderAttachFrameReceiver,
-    _permit: crate::mux::RenderAttachmentPermit,
+    pub stream: Receiver<RenderAttachFrame>,
 }
 
 struct RenderHub {
     state: Box<RenderState>,
     built_generation: u64,
     latest: Option<Arc<SurfaceRenderFrame>>,
-    initial_graphics: Option<InitialGraphicsSnapshot>,
-    taps: Vec<RenderTap>,
+    taps: Vec<std::sync::mpsc::Sender<RenderAttachFrame>>,
 }
-
-struct InitialGraphicsSnapshot {
-    source: Arc<ghostty_vt::KittyGraphicsSnapshot>,
-    snapshot: Arc<ghostty_vt::KittyGraphicsSnapshot>,
-}
-
-#[cfg(test)]
-type FrameProducerTestHook = Arc<Mutex<Option<Arc<dyn Fn() + Send + Sync>>>>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SurfaceKind {
@@ -1071,7 +506,6 @@ pub enum TerminalHostConnectionState {
     Connected = 0,
     Reconnecting = 1,
     Exited = 2,
-    Failed = 3,
 }
 
 impl TerminalHostConnectionState {
@@ -1079,58 +513,9 @@ impl TerminalHostConnectionState {
         match value {
             1 => Self::Reconnecting,
             2 => Self::Exited,
-            3 => Self::Failed,
             _ => Self::Connected,
         }
     }
-}
-
-#[cfg(unix)]
-const TERMINAL_HOST_RECONNECT_MAX_FAILURES: u8 = 16;
-#[cfg(unix)]
-const TERMINAL_HOST_RECONNECT_MAX_DELAY: Duration = Duration::from_secs(1);
-
-#[cfg(unix)]
-#[derive(Default)]
-struct TerminalHostReconnectBackoff {
-    failures: u8,
-}
-
-#[cfg(unix)]
-impl TerminalHostReconnectBackoff {
-    fn next_delay(&mut self) -> Option<Duration> {
-        if self.failures >= TERMINAL_HOST_RECONNECT_MAX_FAILURES {
-            return None;
-        }
-        let multiplier = 1_u32 << self.failures.min(6);
-        self.failures += 1;
-        Some((Duration::from_millis(25) * multiplier).min(TERMINAL_HOST_RECONNECT_MAX_DELAY))
-    }
-
-    fn wait_or_fail(&mut self, pty: &PtySurface) -> bool {
-        let Some(delay) = self.next_delay() else {
-            pty.host_connection_state
-                .store(TerminalHostConnectionState::Failed as u8, Ordering::Release);
-            if let PtyRuntime::Hosted(host) = &*pty.runtime.lock().unwrap() {
-                host.disconnect();
-            }
-            return false;
-        };
-        #[cfg(test)]
-        pty.run_geometry_test_hook(PtyGeometryTestStep::ReconnectBackoffStarted);
-        std::thread::sleep(delay);
-        true
-    }
-}
-
-#[cfg(unix)]
-fn wait_for_reconnect_after_geometry_failure(
-    retry: &mut TerminalHostReconnectBackoff,
-    pty: &PtySurface,
-    geometry: std::sync::MutexGuard<'_, PtyGeometry>,
-) -> bool {
-    drop(geometry);
-    retry.wait_or_fail(pty)
 }
 
 impl SurfaceKind {
@@ -1144,9 +529,6 @@ impl SurfaceKind {
 
 pub struct SurfaceMeta {
     pub id: SurfaceId,
-    /// Public tab/content identities. Auxiliary surfaces, including sidebar
-    /// runtimes, deliberately carry no tab identity.
-    pub(crate) resource_identity: Option<TabResourceIdentity>,
     /// User-assigned tab name (rename tab); shared by every surface kind.
     pub(crate) name: Mutex<Option<String>>,
     pub(crate) selection: Mutex<Option<String>>,
@@ -1177,251 +559,17 @@ impl Deref for Surface {
 /// The terminal is behind a mutex; the pty reader thread holds it only
 /// while feeding bytes, renderers hold it only while snapshotting into a
 /// [`RenderState`].
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct PtyGeometry {
-    cols: u16,
-    rows: u16,
-    cell_width: u16,
-    cell_height: u16,
-}
-
-impl PtyGeometry {
-    fn pty_size(self) -> anyhow::Result<PtySize> {
-        let pixel_width = self.cols.checked_mul(self.cell_width.max(1)).ok_or_else(|| {
-            anyhow::anyhow!(
-                "PTY pixel width exceeds {}: {} columns at {} pixels per cell",
-                u16::MAX,
-                self.cols,
-                self.cell_width.max(1)
-            )
-        })?;
-        let pixel_height = self.rows.checked_mul(self.cell_height.max(1)).ok_or_else(|| {
-            anyhow::anyhow!(
-                "PTY pixel height exceeds {}: {} rows at {} pixels per cell",
-                u16::MAX,
-                self.rows,
-                self.cell_height.max(1)
-            )
-        })?;
-        Ok(PtySize { rows: self.rows, cols: self.cols, pixel_width, pixel_height })
-    }
-}
-
-#[cfg(test)]
-type PtyGeometryTestHook = Arc<dyn Fn(PtyGeometryTestStep) + Send + Sync>;
-
-#[cfg(test)]
-type DeferredCellPixelAckTestHook = Arc<dyn Fn() + Send + Sync>;
-
 pub struct PtySurface {
     pub(crate) meta: SurfaceMeta,
-    terminal: Arc<PtyTerminalRuntime>,
-    viewport: Mutex<TerminalViewportState>,
-}
-
-#[derive(Default)]
-struct TerminalViewportState {
-    primary: Option<TrackedScreenPoint>,
-    alternate: Option<TrackedScreenPoint>,
-}
-
-impl TerminalViewportState {
-    fn anchor(&self, screen: Screen) -> Option<&TrackedScreenPoint> {
-        match screen {
-            Screen::Primary => self.primary.as_ref(),
-            Screen::Alternate => self.alternate.as_ref(),
-        }
-    }
-
-    fn anchor_mut(&mut self, screen: Screen) -> &mut Option<TrackedScreenPoint> {
-        match screen {
-            Screen::Primary => &mut self.primary,
-            Screen::Alternate => &mut self.alternate,
-        }
-    }
-}
-
-impl Deref for PtySurface {
-    type Target = PtyTerminalRuntime;
-
-    fn deref(&self) -> &Self::Target {
-        &self.terminal
-    }
-}
-
-pub(crate) struct TerminalJournalUpdateGuard<'a> {
-    owner: &'a PtyTerminalRuntime,
-}
-
-impl TerminalJournalUpdateGuard<'_> {
-    pub(crate) fn activate(&mut self) -> bool {
-        let _gate = self.owner.journal_capture_gate.lock().unwrap();
-        if !self.owner.journal_capture_open.load(Ordering::Acquire) {
-            return false;
-        }
-        let reserved = self.owner.journal_capture_reserved.swap(false, Ordering::AcqRel);
-        debug_assert!(reserved, "terminal journal update activated without a read reservation");
-        self.owner.journal_capture_active.store(true, Ordering::Release);
-        let previous = self.owner.journal_capture_epoch.fetch_add(1, Ordering::AcqRel);
-        debug_assert_eq!(previous & 1, 0, "terminal journal updates must not overlap");
-        true
-    }
-}
-
-impl Drop for TerminalJournalUpdateGuard<'_> {
-    fn drop(&mut self) {
-        let _gate = self.owner.journal_capture_gate.lock().unwrap();
-        self.owner.journal_capture_reserved.store(false, Ordering::Release);
-        if self.owner.journal_capture_active.swap(false, Ordering::AcqRel) {
-            self.owner.journal_capture_epoch.fetch_add(1, Ordering::Release);
-        }
-        self.owner.journal_capture_idle.notify_all();
-    }
-}
-
-#[derive(Default)]
-struct ReaderCompletion {
-    finished: Mutex<bool>,
-    changed: Condvar,
-}
-
-impl ReaderCompletion {
-    #[cfg(test)]
-    fn reset(&self) {
-        *self.finished.lock().unwrap() = false;
-    }
-
-    fn complete(&self) {
-        let mut finished = self.finished.lock().unwrap();
-        *finished = true;
-        self.changed.notify_all();
-    }
-
-    fn wait_until(&self, deadline: Instant) -> bool {
-        let mut finished = self.finished.lock().unwrap();
-        while !*finished {
-            let remaining = deadline.saturating_duration_since(Instant::now());
-            if remaining.is_zero() {
-                return false;
-            }
-            let (next, result) = self.changed.wait_timeout(finished, remaining).unwrap();
-            finished = next;
-            if result.timed_out() && !*finished {
-                return false;
-            }
-        }
-        true
-    }
-}
-
-struct ReaderCompletionGuard(Arc<ReaderCompletion>);
-
-impl Drop for ReaderCompletionGuard {
-    fn drop(&mut self) {
-        self.0.complete();
-    }
-}
-
-impl PtyTerminalRuntime {
-    fn begin_terminal_journal_update(&self) -> Option<TerminalJournalUpdateGuard<'_>> {
-        let _gate = self.journal_capture_gate.lock().unwrap();
-        if !self.journal_capture_open.load(Ordering::Acquire) {
-            return None;
-        }
-        let reserved = self.journal_capture_reserved.swap(true, Ordering::AcqRel);
-        debug_assert!(!reserved, "terminal journal reads must not overlap");
-        Some(TerminalJournalUpdateGuard { owner: self })
-    }
-
-    fn close_terminal_journal_capture_when_idle(&self, deadline: Instant) -> bool {
-        let mut gate = self.journal_capture_gate.lock().unwrap();
-        let active_deadline = deadline + Duration::from_secs(2);
-        loop {
-            if !self.journal_capture_reserved.load(Ordering::Acquire)
-                && self.journal_capture_epoch.load(Ordering::Acquire) & 1 == 0
-            {
-                self.journal_capture_open.store(false, Ordering::Release);
-                return false;
-            }
-            if Instant::now() >= deadline {
-                if !self.journal_capture_active.load(Ordering::Acquire) {
-                    // A read is still blocked or has not started terminal
-                    // mutation. Revoke its reservation. The reader checks the
-                    // gate before parsing and exits without changing state.
-                    self.journal_capture_open.store(false, Ordering::Release);
-                    return false;
-                }
-                let remaining = active_deadline.saturating_duration_since(Instant::now());
-                if remaining.is_zero() {
-                    // Keep shutdown bounded if a source-owned parser or
-                    // callback violates the active-update time contract. The
-                    // closed gate prevents a late journal insert after the
-                    // final barrier, and the daemon is already stopping.
-                    self.journal_capture_open.store(false, Ordering::Release);
-                    eprintln!(
-                        "cmux-tui: active terminal journal update exceeded shutdown grace; closing capture and recording an output gap"
-                    );
-                    return true;
-                }
-                let (next, _) = self.journal_capture_idle.wait_timeout(gate, remaining).unwrap();
-                gate = next;
-            } else {
-                let remaining = deadline.saturating_duration_since(Instant::now());
-                let (next, _) = self.journal_capture_idle.wait_timeout(gate, remaining).unwrap();
-                gate = next;
-            }
-        }
-    }
-}
-
-/// Content runtime shared by every view placement of one terminal.
-///
-/// A [`PtySurface`] is a lightweight placement carrying tab-local metadata.
-/// This object owns the process, terminal emulator, ordered input/output, and
-/// canonical geometry. Keeping the two identities distinct makes a terminal
-/// projectable into any number of panes without cloning its PTY or VT state.
-pub struct PtyTerminalRuntime {
-    event_surface_id: SurfaceId,
-    /// Stable public content identity. This belongs to the terminal runtime,
-    /// while `SurfaceMeta::resource_identity` belongs to one view placement.
-    terminal_public_id: Option<Arc<TerminalPublicId>>,
-    journal_generation: Arc<str>,
-    /// Legacy terminal hosts remain attachable, but cannot source-fence
-    /// output at daemon shutdown and therefore never enter journal capture.
-    journal_capture_supported: bool,
-    /// Even while the emulator and terminal journal agree, odd while one
-    /// output frame has updated one side but not yet reached the other.
-    journal_capture_epoch: AtomicU64,
-    journal_capture_gate: Mutex<()>,
-    journal_capture_idle: Condvar,
-    journal_capture_open: AtomicBool,
-    journal_capture_reserved: AtomicBool,
-    journal_capture_active: AtomicBool,
-    /// Owned reader join fence. Shutdown gives this reader a bounded drain
-    /// interval, then closes journal capture before it inserts the final
-    /// journal barrier.
-    reader_thread: Mutex<Option<std::thread::JoinHandle<()>>>,
-    reader_completion: Arc<ReaderCompletion>,
-    term: Mutex<Box<Terminal>>,
+    term: Mutex<Terminal>,
     stream_progress: Box<TerminalStreamProgress>,
-    mouse_encoders: Mutex<Box<MouseEncoders>>,
+    mouse_encoders: Mutex<MouseEncoders>,
     runtime: Mutex<PtyRuntime>,
-    /// Explicit lifecycle authority for this process. Session content may
-    /// survive a daemon replacement through a durable host; daemon-owned
-    /// auxiliaries must terminate with the backend that created them.
-    lifetime: PtyLifetime,
     supports_clear_history_key_fallback: AtomicBool,
     host_identity: Option<crate::terminal_host_runtime::TerminalHostIdentity>,
-    #[cfg(unix)]
-    pending_host_binding: Mutex<Option<crate::mux::PendingTerminalHostBinding>>,
-    #[cfg(unix)]
-    host_exit_record_path: Option<PathBuf>,
     pid: Option<u32>,
     command: Vec<String>,
     cwd: Option<String>,
-    exit: Mutex<Option<TerminalExit>>,
-    local_pty_drained: AtomicBool,
-    exit_notified: AtomicBool,
     dead: AtomicBool,
     /// The daemon is intentionally dropping its compatibility proxy while
     /// leaving the terminal host alive for a later daemon to adopt.
@@ -1434,16 +582,7 @@ pub struct PtyTerminalRuntime {
     dirty: AtomicBool,
     title: Mutex<String>,
     pwd: Mutex<Option<String>>,
-    geometry: Mutex<PtyGeometry>,
-    kitty_graphics_limits: Box<Mutex<KittyGraphicsLimits>>,
-    #[cfg(test)]
-    geometry_test_hook: Mutex<Option<PtyGeometryTestHook>>,
-    #[cfg(test)]
-    deferred_cell_pixel_ack_test_hook: Mutex<Option<DeferredCellPixelAckTestHook>>,
-    #[cfg(test)]
-    test_master_control: Option<Arc<TestMasterPtyControl>>,
-    #[cfg(test)]
-    vt_replay_builds: AtomicUsize,
+    size: Mutex<(u16, u16)>,
     mux: Weak<Mux>,
     /// Live output subscribers (attach streams). Guarded by the terminal
     /// lock ordering: the reader thread broadcasts while holding the
@@ -1463,46 +602,21 @@ pub struct PtyTerminalRuntime {
     last_attach_colors: Mutex<Option<Box<TerminalColors>>>,
     /// Single consume-once Ghostty render state shared by the local TUI and
     /// every protocol-v7 render attachment.
-    render: Arc<Mutex<RenderHub>>,
+    render: Mutex<RenderHub>,
     render_generation: AtomicU64,
     frame_requests: SyncSender<u64>,
-    #[cfg(test)]
-    frame_producer_before_upgrade: FrameProducerTestHook,
-}
-
-pub(crate) struct TerminalJournalGap {
-    pub(crate) terminal_id: Arc<TerminalPublicId>,
-    pub(crate) generation: Arc<str>,
-    pub(crate) reason: &'static str,
 }
 
 enum PtyRuntime {
     Local {
         writer: Box<dyn Write + Send>,
-        master: Option<Box<dyn MasterPty + Send>>,
+        master: Box<dyn MasterPty + Send>,
         killer: Box<dyn ChildKiller + Send>,
     },
     #[cfg(unix)]
     Hosted(Box<crate::terminal_host_runtime::HostAttachment>),
     #[cfg(unix)]
     ExitedHosted,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum PtyLifetime {
-    SessionOwned,
-    DaemonOwned,
-}
-
-#[cfg(unix)]
-struct HostedSurfaceLaunch {
-    attachment: crate::terminal_host_runtime::HostAttachment,
-    kitty_reservation: Option<crate::mux::KittyImageBudgetReservation>,
-    terminate_on_error: bool,
-    defer_launch_activation: bool,
-    lifetime: PtyLifetime,
-    terminal_public_id: Option<TerminalPublicId>,
-    resource_identity: Option<TabResourceIdentity>,
 }
 
 pub const CLEAR_HISTORY_FALLBACK_UNREPRESENTABLE_ERROR: &str =
@@ -1732,7 +846,6 @@ pub(crate) fn apply_clear_history_transition(
 }
 
 pub(crate) struct TerminalStreamProgress {
-    next_resource_waiter_id: AtomicU64,
     state: Mutex<TerminalStreamProgressState>,
     changed: Condvar,
 }
@@ -1740,10 +853,6 @@ pub(crate) struct TerminalStreamProgress {
 #[derive(Default)]
 struct TerminalStreamProgressState {
     revision: u64,
-    waiters: usize,
-    resource_waiters: HashMap<u64, Weak<ResourceWaitWake>>,
-    #[cfg(test)]
-    resource_subscriptions: u64,
     clear_history_wait: Option<ClearHistoryWaitState>,
 }
 
@@ -1760,15 +869,6 @@ pub(crate) struct ClearHistoryWaitLease<'a> {
     progress: &'a TerminalStreamProgress,
     deadline: Instant,
     timed_out: bool,
-}
-
-/// One-shot terminal-stream wakeup. Registering before reading the viewport
-/// closes the read/wait race, while cancellation and writer shutdown can wake
-/// the same blocking primitive without a polling deadline.
-pub(crate) struct TerminalStreamSubscription<'a> {
-    progress: &'a TerminalStreamProgress,
-    waiter_id: u64,
-    wake: Arc<ResourceWaitWake>,
 }
 
 impl ClearHistoryWaitLease<'_> {
@@ -1789,11 +889,7 @@ impl Drop for ClearHistoryWaitLease<'_> {
 
 impl Default for TerminalStreamProgress {
     fn default() -> Self {
-        Self {
-            next_resource_waiter_id: AtomicU64::new(1),
-            state: Mutex::new(TerminalStreamProgressState::default()),
-            changed: Condvar::new(),
-        }
+        Self { state: Mutex::new(TerminalStreamProgressState::default()), changed: Condvar::new() }
     }
 }
 
@@ -1810,28 +906,7 @@ impl TerminalStreamProgress {
         if state.clear_history_wait.as_ref().is_some_and(|wait| wait.waiters == 0) {
             state.clear_history_wait = None;
         }
-        let resource_waiters = std::mem::take(&mut state.resource_waiters);
         self.changed.notify_all();
-        drop(state);
-        for wake in resource_waiters.into_values().filter_map(|waiter| waiter.upgrade()) {
-            wake.notify();
-        }
-    }
-
-    fn notify_reconnect(&self) {
-        self.notify();
-    }
-
-    pub(crate) fn subscribe(&self) -> TerminalStreamSubscription<'_> {
-        let waiter_id = self.next_resource_waiter_id.fetch_add(1, Ordering::Relaxed);
-        let wake = Arc::new(ResourceWaitWake::default());
-        let mut state = self.state.lock().unwrap();
-        state.resource_waiters.insert(waiter_id, Arc::downgrade(&wake));
-        #[cfg(test)]
-        {
-            state.resource_subscriptions = state.resource_subscriptions.wrapping_add(1);
-        }
-        TerminalStreamSubscription { progress: self, waiter_id, wake }
     }
 
     pub(crate) fn begin_clear_history_wait(&self, timeout: Duration) -> ClearHistoryWaitLease<'_> {
@@ -1863,62 +938,16 @@ impl TerminalStreamProgress {
     }
 
     pub(crate) fn wait_for_change(&self, observed: u64, deadline: Instant) -> Option<u64> {
-        self.wait_for_change_until(observed, Some(deadline))
-    }
-
-    fn wait_for_change_until(&self, observed: u64, deadline: Option<Instant>) -> Option<u64> {
         let mut state = self.state.lock().unwrap();
-        if state.revision != observed {
-            return Some(state.revision);
-        }
-        state.waiters += 1;
         while state.revision == observed {
-            match deadline {
-                Some(deadline) => {
-                    let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
-                        state.waiters -= 1;
-                        return None;
-                    };
-                    let (next, timeout) = self.changed.wait_timeout(state, remaining).unwrap();
-                    state = next;
-                    if timeout.timed_out() && state.revision == observed {
-                        state.waiters -= 1;
-                        return None;
-                    }
-                }
-                None => state = self.changed.wait(state).unwrap(),
+            let remaining = deadline.checked_duration_since(Instant::now())?;
+            let (next, timeout) = self.changed.wait_timeout(state, remaining).unwrap();
+            state = next;
+            if timeout.timed_out() && state.revision == observed {
+                return None;
             }
         }
-        let revision = state.revision;
-        state.waiters -= 1;
-        Some(revision)
-    }
-
-    #[cfg(test)]
-    fn waiter_count(&self) -> usize {
-        let state = self.state.lock().unwrap();
-        state.waiters + state.resource_waiters.len()
-    }
-
-    #[cfg(test)]
-    fn resource_subscription_count(&self) -> u64 {
-        self.state.lock().unwrap().resource_subscriptions
-    }
-}
-
-impl TerminalStreamSubscription<'_> {
-    pub(crate) fn wake(&self) -> Arc<ResourceWaitWake> {
-        self.wake.clone()
-    }
-
-    pub(crate) fn wait_until(&self, deadline: Option<Instant>) -> bool {
-        self.wake.wait_until(deadline)
-    }
-}
-
-impl Drop for TerminalStreamSubscription<'_> {
-    fn drop(&mut self) {
-        self.progress.state.lock().unwrap().resource_waiters.remove(&self.waiter_id);
+        Some(state.revision)
     }
 }
 
@@ -1950,7 +979,7 @@ fn hosted_terminal_callbacks(
         })),
         on_bell: Some(Box::new(move || {
             if let Some(mux) = mux.upgrade() {
-                mux.emit_terminal_bell(id);
+                mux.emit(MuxEvent::Bell(id));
             }
         })),
     }
@@ -1972,50 +1001,6 @@ fn mark_hosted_runtime_exited(
         }
         *runtime = PtyRuntime::ExitedHosted;
         pty.supports_clear_history_key_fallback.store(false, Ordering::Release);
-        drop(runtime);
-        pty.finish_hosted_exit();
-    }
-}
-
-fn publish_local_exit_if_ready(surface: &Arc<Surface>) {
-    let Some(pty) = surface.as_pty() else { return };
-    if !pty.local_pty_drained.load(Ordering::Acquire) || pty.exit.lock().unwrap().is_none() {
-        return;
-    }
-    if pty.exit_notified.compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire).is_err()
-    {
-        return;
-    }
-    pty.dead.store(true, Ordering::Release);
-    if let Some(mux) = pty.mux.upgrade() {
-        mux.surface_exited(surface.id);
-    }
-}
-
-#[cfg(windows)]
-fn close_local_terminal_master_after_exit(surface: &Arc<Surface>) {
-    let Some(pty) = surface.as_pty() else { return };
-    let master = {
-        let mut runtime = pty.runtime.lock().unwrap();
-        let PtyRuntime::Local { master, .. } = &mut *runtime;
-        master.take()
-    };
-    // portable-pty's ConPTY reader keeps a separate output handle. Closing
-    // the master closes the pseudoconsole, which lets that reader drain the
-    // final bytes and then observe EOF.
-    drop(master);
-}
-
-#[cfg(not(windows))]
-fn close_local_terminal_master_after_exit(_surface: &Arc<Surface>) {}
-
-fn terminal_public_id_from_resource_identity(
-    identity: &TabResourceIdentity,
-    invalid_context: &str,
-) -> anyhow::Result<TerminalPublicId> {
-    match &identity.content_id {
-        ContentPublicId::Terminal(terminal_id) => Ok(terminal_id.clone()),
-        ContentPublicId::Browser(_) => anyhow::bail!("{invalid_context}"),
     }
 }
 
@@ -2026,202 +1011,22 @@ impl std::fmt::Debug for Surface {
 }
 
 impl Surface {
-    pub fn resource_identity(&self) -> Option<&TabResourceIdentity> {
-        match self {
-            Self::Pty(surface) => surface.meta.resource_identity.as_ref(),
-            Self::Browser(surface) => surface.meta.resource_identity.as_ref(),
-        }
-    }
-
-    pub fn terminal_public_id(&self) -> Option<&TerminalPublicId> {
-        match self {
-            Self::Pty(surface) => surface.terminal_public_id.as_deref(),
-            Self::Browser(_) => None,
-        }
-    }
-
-    /// Create another view placement for this terminal without creating a
-    /// second process or terminal emulator.
-    pub(crate) fn project_terminal(
-        &self,
-        id: SurfaceId,
-        resource_identity: TabResourceIdentity,
-    ) -> anyhow::Result<Arc<Surface>> {
-        let projected_id = terminal_public_id_from_resource_identity(
-            &resource_identity,
-            "terminal placement requires a terminal content identity",
-        )?;
-        anyhow::ensure!(
-            self.terminal_public_id() == Some(&projected_id),
-            "terminal placement cannot change content identity"
-        );
-        let Surface::Pty(surface) = self else {
-            anyhow::bail!("browser content cannot be projected as a terminal");
-        };
-        Ok(Arc::new(Surface::Pty(PtySurface {
-            meta: SurfaceMeta {
-                id,
-                resource_identity: Some(resource_identity),
-                name: Mutex::new(None),
-                selection: Mutex::new(None),
-            },
-            terminal: surface.terminal.clone(),
-            viewport: Mutex::new(TerminalViewportState::default()),
-        })))
-    }
-
-    pub(crate) fn shares_terminal_runtime(&self, other: &Surface) -> bool {
-        match (self, other) {
-            (Surface::Pty(left), Surface::Pty(right)) => {
-                Arc::ptr_eq(&left.terminal, &right.terminal)
-            }
-            _ => false,
-        }
-    }
-
-    pub(crate) fn terminal_runtime_id(&self) -> Option<SurfaceId> {
-        match self {
-            Surface::Pty(surface) => Some(surface.event_surface_id),
-            Surface::Browser(_) => None,
-        }
-    }
-
-    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn spawn(
         id: SurfaceId,
         opts: SurfaceOptions,
         mux: Weak<Mux>,
     ) -> anyhow::Result<Arc<Surface>> {
-        let cell_pixels =
-            mux.upgrade().map(|mux| mux.cell_pixel_creation_size()).unwrap_or((8, 16));
-        Self::spawn_at_cell_pixels(id, opts, mux, cell_pixels)
+        Self::spawn_with_terminal_id(id, opts, mux, None)
     }
 
-    /// Spawn runtime-only terminal content which is not part of the public
-    /// resource tree, such as a sidebar view process.
-    #[allow(dead_code)]
-    pub(crate) fn spawn_auxiliary(
-        id: SurfaceId,
-        opts: SurfaceOptions,
-        mux: Weak<Mux>,
-    ) -> anyhow::Result<Arc<Surface>> {
-        let cell_pixels =
-            mux.upgrade().map(|mux| mux.cell_pixel_creation_size()).unwrap_or((8, 16));
-        Self::spawn_auxiliary_at_cell_pixels(id, opts, mux, cell_pixels)
-    }
-
-    pub(crate) fn spawn_auxiliary_at_cell_pixels(
-        id: SurfaceId,
-        opts: SurfaceOptions,
-        mux: Weak<Mux>,
-        cell_pixels: (u16, u16),
-    ) -> anyhow::Result<Arc<Surface>> {
-        Self::spawn_with_terminal_id_and_resource_identity_at_cell_pixels(
-            id,
-            opts,
-            mux,
-            None,
-            None,
-            PtyLifetime::DaemonOwned,
-            cell_pixels,
-        )
-    }
-
-    pub(crate) fn spawn_at_cell_pixels(
-        id: SurfaceId,
-        opts: SurfaceOptions,
-        mux: Weak<Mux>,
-        cell_pixels: (u16, u16),
-    ) -> anyhow::Result<Arc<Surface>> {
-        Self::spawn_with_terminal_id_and_resource_identity_at_cell_pixels(
-            id,
-            opts,
-            mux,
-            None,
-            Some(TabResourceIdentity::terminal(None)?),
-            PtyLifetime::SessionOwned,
-            cell_pixels,
-        )
-    }
-
-    pub(crate) fn spawn_with_terminal_id_at_cell_pixels(
+    pub(crate) fn spawn_with_terminal_id(
         id: SurfaceId,
         opts: SurfaceOptions,
         mux: Weak<Mux>,
         terminal_id: Option<crate::terminal_host::TerminalId>,
-        cell_pixels: (u16, u16),
     ) -> anyhow::Result<Arc<Surface>> {
-        let identity = Some(TabResourceIdentity::terminal(None)?);
-        Self::spawn_with_terminal_id_and_resource_identity_at_cell_pixels(
-            id,
-            opts,
-            mux,
-            terminal_id,
-            identity,
-            PtyLifetime::SessionOwned,
-            cell_pixels,
-        )
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn spawn_with_resource_identity(
-        id: SurfaceId,
-        opts: SurfaceOptions,
-        mux: Weak<Mux>,
-        resource_identity: Option<TabResourceIdentity>,
-    ) -> anyhow::Result<Arc<Surface>> {
-        let cell_pixels =
-            mux.upgrade().map(|mux| mux.cell_pixel_creation_size()).unwrap_or((8, 16));
-        Self::spawn_with_terminal_id_and_resource_identity_at_cell_pixels(
-            id,
-            opts,
-            mux,
-            None,
-            resource_identity,
-            PtyLifetime::SessionOwned,
-            cell_pixels,
-        )
-    }
-
-    fn spawn_with_terminal_id_and_resource_identity_at_cell_pixels(
-        id: SurfaceId,
-        mut opts: SurfaceOptions,
-        mux: Weak<Mux>,
-        terminal_id: Option<crate::terminal_host::TerminalId>,
-        resource_identity: Option<TabResourceIdentity>,
-        lifetime: PtyLifetime,
-        cell_pixels: (u16, u16),
-    ) -> anyhow::Result<Arc<Surface>> {
-        let terminal_public_id = resource_identity
-            .as_ref()
-            .map(|identity| {
-                terminal_public_id_from_resource_identity(
-                    identity,
-                    "terminal surface cannot use a browser resource identity",
-                )
-            })
-            .transpose()?;
-        if let Some(terminal_public_id) = terminal_public_id.as_ref() {
-            set_surface_environment(&mut opts, "CMUX_TUI_TERMINAL_ID", terminal_public_id.as_str());
-            configure_agent_browser_session(&mut opts, terminal_public_id.as_str());
-        }
-        if let Some(mux) = mux.upgrade() {
-            set_surface_environment(
-                &mut opts,
-                "CMUX_TUI_SESSION_ID",
-                mux.session_public_id().as_str(),
-            );
-        }
-        let kitty_reservation =
-            mux.upgrade().map(|mux| mux.reserve_kitty_image_surface(id)).transpose()?;
-        let initial_kitty_limits = kitty_reservation
-            .as_ref()
-            .map(crate::mux::KittyImageBudgetReservation::initial_limits)
-            .unwrap_or_default();
         #[cfg(unix)]
-        if lifetime == PtyLifetime::SessionOwned
-            && let Some(root) = opts.terminal_host_root.clone()
-        {
+        if let Some(root) = opts.terminal_host_root.clone() {
             let default_colors = mux.upgrade().map(|mux| mux.default_colors()).unwrap_or_default();
             let attachment = match terminal_id {
                 Some(terminal_id) => {
@@ -2229,8 +1034,6 @@ impl Surface {
                         &opts,
                         &root,
                         default_colors,
-                        cell_pixels,
-                        initial_kitty_limits,
                         terminal_id,
                     )?
                 }
@@ -2238,66 +1041,47 @@ impl Surface {
                     &opts,
                     &root,
                     default_colors,
-                    cell_pixels,
-                    initial_kitty_limits,
                 )?,
             };
-            let defer_launch_activation = terminal_public_id.is_some();
-            return Self::spawn_hosted(
-                id,
-                opts,
-                mux,
-                HostedSurfaceLaunch {
-                    attachment,
-                    kitty_reservation,
-                    terminate_on_error: true,
-                    defer_launch_activation,
-                    lifetime,
-                    terminal_public_id,
-                    resource_identity,
-                },
-            );
+            return Self::spawn_hosted(id, opts, mux, attachment, true);
         }
         let _ = terminal_id;
-        let initial_geometry = PtyGeometry {
-            cols: opts.cols,
+        let pty = native_pty_system().openpty(PtySize {
             rows: opts.rows,
-            cell_width: cell_pixels.0,
-            cell_height: cell_pixels.1,
-        };
-        let pty = cmux_pty::open(initial_geometry.pty_size()?)?;
+            cols: opts.cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        })?;
 
         let argv = opts
             .command
             .clone()
             .filter(|argv| !argv.is_empty())
             .unwrap_or_else(|| vec![platform::default_shell()]);
-        let mut cmd = PtyCommand::new(&argv[0]);
-        cmd.args(argv[1..].iter().cloned());
+        let mut cmd = CommandBuilder::new(&argv[0]);
+        cmd.args(&argv[1..]);
         cmd.env("TERM", &opts.term);
-        // The embedded ghostty-vt terminal always parses 24-bit SGR and every
-        // frontend forwards RGB cells losslessly, so children can rely on
-        // truecolor regardless of where the session server was started
-        // (launchd, ssh, cron strip COLORTERM). Set before extra_env so a
-        // caller can still override it.
-        cmd.env("COLORTERM", "truecolor");
         for (k, v) in &opts.extra_env {
             cmd.env(k, v);
         }
-        let cwd = opts.cwd.clone().or_else(platform::default_terminal_cwd);
+        let cwd = opts
+            .cwd
+            .clone()
+            .or_else(|| platform::home_dir().map(|path| path.to_string_lossy().into_owned()));
         if let Some(cwd) = cwd.as_deref() {
             cmd.cwd(cwd);
         }
 
-        let cmux_pty::SpawnedPty { master, mut child } = pty.spawn(cmd)?;
+        let mut child = pty.slave.spawn_command(cmd)?;
         let pid = child.process_id();
+        drop(pty.slave);
         let killer = child.clone_killer();
+        let mut reader = pty.master.try_clone_reader()?;
+        let writer = pty.master.take_writer()?;
         #[cfg(unix)]
-        let supports_clear_history_key_fallback = master.as_raw_fd().is_some();
+        let supports_clear_history_key_fallback = pty.master.as_raw_fd().is_some();
         #[cfg(not(unix))]
         let supports_clear_history_key_fallback = false;
-        let mut reader = master.try_clone_reader()?;
-        let writer = master.take_writer()?;
 
         // Query responses generated while parsing pty output are queued
         // here and flushed to the pty after each vt_write (the callback
@@ -2319,15 +1103,13 @@ impl Surface {
                 let mux = mux.clone();
                 move || {
                     if let Some(mux) = mux.upgrade() {
-                        mux.emit_terminal_bell(id);
+                        mux.emit(MuxEvent::Bell(id));
                     }
                 }
             })),
         };
 
         let mut term = Terminal::new(opts.cols, opts.rows, opts.scrollback, callbacks)?;
-        term.resize(opts.cols, opts.rows, u32::from(cell_pixels.0), u32::from(cell_pixels.1))?;
-        term.set_kitty_graphics_limits(initial_kitty_limits)?;
         if let Some(mux) = mux.upgrade() {
             let colors = mux.default_colors();
             term.replace_default_colors(colors.fg, colors.bg, colors.cursor);
@@ -2338,392 +1120,141 @@ impl Surface {
         mouse_encoders.sync_from_terminal(&term);
         let render_state = RenderState::new()?;
         let (frame_requests, frame_rx) = sync_channel(1);
-        #[cfg(test)]
-        let frame_producer_before_upgrade = Arc::new(Mutex::new(None));
         let surface = Arc::new(Surface::Pty(PtySurface {
-            meta: SurfaceMeta {
-                id,
-                resource_identity,
-                name: Mutex::new(None),
-                selection: Mutex::new(None),
-            },
-            terminal: Arc::new(PtyTerminalRuntime {
-                event_surface_id: id,
-                terminal_public_id: terminal_public_id.map(Arc::new),
-                journal_generation: Arc::from(format!(
-                    "local-{}",
-                    crate::workspace_registry::new_uuid_v4()
-                )),
-                journal_capture_supported: true,
-                journal_capture_epoch: AtomicU64::new(0),
-                journal_capture_gate: Mutex::new(()),
-                journal_capture_idle: Condvar::new(),
-                journal_capture_open: AtomicBool::new(true),
-                journal_capture_reserved: AtomicBool::new(false),
-                journal_capture_active: AtomicBool::new(false),
-                reader_thread: Mutex::new(None),
-                reader_completion: Arc::new(ReaderCompletion::default()),
-                term: Mutex::new(Box::new(term)),
-                stream_progress: Box::new(TerminalStreamProgress::default()),
-                mouse_encoders: Mutex::new(Box::new(mouse_encoders)),
-                runtime: Mutex::new(PtyRuntime::Local { writer, master: Some(master), killer }),
-                lifetime,
-                supports_clear_history_key_fallback: AtomicBool::new(
-                    supports_clear_history_key_fallback,
-                ),
-                host_identity: None,
-                #[cfg(unix)]
-                pending_host_binding: Mutex::new(None),
-                #[cfg(unix)]
-                host_exit_record_path: None,
-                pid,
-                command: argv,
-                cwd,
-                exit: Mutex::new(None),
-                local_pty_drained: AtomicBool::new(false),
-                exit_notified: AtomicBool::new(false),
-                dead: AtomicBool::new(false),
-                owner_detaching: AtomicBool::new(false),
-                host_connection_state: AtomicU8::new(TerminalHostConnectionState::Connected as u8),
-                dirty: AtomicBool::new(false),
-                title: Mutex::new(String::new()),
-                pwd: Mutex::new(None),
-                geometry: Mutex::new(initial_geometry),
-                kitty_graphics_limits: Box::new(Mutex::new(initial_kitty_limits)),
-                #[cfg(test)]
-                geometry_test_hook: Mutex::new(None),
-                #[cfg(test)]
-                deferred_cell_pixel_ack_test_hook: Mutex::new(None),
-                #[cfg(test)]
-                test_master_control: None,
-                #[cfg(test)]
-                vt_replay_builds: AtomicUsize::new(0),
-                mux: mux.clone(),
-                taps: Mutex::new(Vec::new()),
-                attach_colors_pending: AtomicBool::new(false),
-                attach_colors_force_pending: AtomicBool::new(false),
-                last_attach_colors: Mutex::new(None),
-                render: Arc::new(Mutex::new(RenderHub {
-                    state: Box::new(render_state),
-                    built_generation: 0,
-                    latest: None,
-                    initial_graphics: None,
-                    taps: Vec::new(),
-                })),
-                render_generation: AtomicU64::new(1),
-                frame_requests,
-                #[cfg(test)]
-                frame_producer_before_upgrade,
+            meta: SurfaceMeta { id, name: Mutex::new(None), selection: Mutex::new(None) },
+            term: Mutex::new(term),
+            stream_progress: Box::new(TerminalStreamProgress::default()),
+            mouse_encoders: Mutex::new(mouse_encoders),
+            runtime: Mutex::new(PtyRuntime::Local { writer, master: pty.master, killer }),
+            supports_clear_history_key_fallback: AtomicBool::new(
+                supports_clear_history_key_fallback,
+            ),
+            host_identity: None,
+            pid,
+            command: argv,
+            cwd,
+            dead: AtomicBool::new(false),
+            owner_detaching: AtomicBool::new(false),
+            host_connection_state: AtomicU8::new(TerminalHostConnectionState::Connected as u8),
+            dirty: AtomicBool::new(false),
+            title: Mutex::new(String::new()),
+            pwd: Mutex::new(None),
+            size: Mutex::new((opts.cols, opts.rows)),
+            mux: mux.clone(),
+            taps: Mutex::new(Vec::new()),
+            attach_colors_pending: AtomicBool::new(false),
+            attach_colors_force_pending: AtomicBool::new(false),
+            last_attach_colors: Mutex::new(None),
+            render: Mutex::new(RenderHub {
+                state: Box::new(render_state),
+                built_generation: 0,
+                latest: None,
+                taps: Vec::new(),
             }),
-            viewport: Mutex::new(TerminalViewportState::default()),
+            render_generation: AtomicU64::new(1),
+            frame_requests,
         }));
 
-        if let Some(reservation) = kitty_reservation
-            && let Err(error) = reservation.commit(&surface, initial_kitty_limits)
-        {
-            surface.kill();
-            return Err(error);
-        }
         spawn_frame_producer(&surface, frame_rx)?;
 
         // PTY reader: pty bytes -> terminal state -> SurfaceOutput events.
-        let reader_thread =
-            std::thread::Builder::new().name(format!("surface-{id}-reader")).spawn({
-                let surface = surface.clone();
-                move || {
-                    let _reader_completion = ReaderCompletionGuard(
-                        surface
-                            .as_pty()
-                            .expect("local PTY reader owns a PTY surface")
-                            .reader_completion
-                            .clone(),
-                    );
-                    let mut buf = [0u8; 64 * 1024];
-                    loop {
-                        let pty = surface.as_pty().expect("surface reader got non-pty surface");
-                        let journal_target = pty.journal_target();
-                        // Reserve the capture epoch before read(2). Shutdown
-                        // can revoke a blocked reservation, but it cannot place
-                        // its final barrier in the read-to-parser gap.
-                        let mut journal_update = journal_target
-                            .as_ref()
-                            .and_then(|_| pty.begin_terminal_journal_update());
-                        if journal_target.is_some() && journal_update.is_none() {
-                            break;
-                        }
-                        let n = match reader.read(&mut buf) {
-                            Ok(0) => break,
-                            Ok(n) => n,
-                            Err(error)
-                                if matches!(
-                                    error.kind(),
-                                    std::io::ErrorKind::Interrupted
-                                        | std::io::ErrorKind::WouldBlock
-                                ) =>
-                            {
-                                std::thread::sleep(Duration::from_millis(1));
-                                continue;
-                            }
-                            Err(_) => break,
-                        };
-                        let mut scroll_changed = None;
-                        let generation = {
-                            let mut term = pty.term.lock().unwrap();
-                            if let Some(update) = journal_update.as_mut()
-                                && !update.activate()
-                            {
-                                break;
-                            }
-                            let journal_enabled = journal_update.is_some();
-                            let before = terminal_scroll_position(&term);
-                            let color_revision = term.color_revision();
-                            let color_reapply_revision = term.color_reapply_revision();
-                            let cursor_activity = term
-                                .cursor_activity()
-                                .expect("valid local terminals expose cursor activity");
-                            let normalized = term.vt_write_with_normalized(&buf[..n]);
-                            let cursor_changed = term
-                                .cursor_activity()
-                                .expect("valid local terminals expose cursor activity")
-                                != cursor_activity;
-                            pty.mouse_encoders.lock().unwrap().sync_from_terminal(&term);
-                            let after = terminal_scroll_position(&term);
-                            let has_attach_taps = pty.broadcast_attach_output(normalized.as_ref());
-                            if has_attach_taps
-                                && (term.color_revision() != color_revision || cursor_changed)
-                            {
-                                pty.attach_colors_pending.store(true, Ordering::Release);
-                                if term.color_reapply_revision() != color_reapply_revision
-                                    || cursor_changed
-                                {
-                                    pty.attach_colors_force_pending.store(true, Ordering::Release);
-                                }
-                            }
-                            if title_changed.swap(false, Ordering::Relaxed) {
-                                let title = term.title().unwrap_or_default();
-                                *pty.title.lock().unwrap() = title.clone();
-                                if let Some(mux) = mux.upgrade() {
-                                    mux.emit_terminal_title(surface.id, title.into());
-                                }
-                            }
-                            if let Some(pwd) = term.pwd() {
-                                *pty.pwd.lock().unwrap() = Some(pwd);
-                            }
-                            if before != after {
-                                scroll_changed = Some(after);
-                                broadcast_render_scroll_locked(pty, after);
-                            }
-                            // Keep the terminal lock scoped to parser and observer work. A
-                            // borrowed normalized frame still points into `buf`, which lives
-                            // for the reader loop, so any journal allocation can happen after
-                            // releasing the lock.
-                            let journal_output = journal_enabled.then_some(normalized);
-                            (
-                                pty.render_generation.fetch_add(1, Ordering::AcqRel) + 1,
-                                journal_output,
-                            )
-                        };
-                        let (generation, journal_output) = generation;
-                        if let (Some(journal_target), Some(journal_output)) =
-                            (journal_target, journal_output)
-                        {
-                            pty.journal_output_if_open(journal_target, journal_output.into_owned());
-                        }
-                        drop(journal_update);
-                        pty.stream_progress.notify();
-                        pty.request_frame(generation);
-                        if let Some((offset, at_bottom)) = scroll_changed
-                            && let Some(mux) = mux.upgrade()
-                        {
-                            mux.emit_terminal_scroll(surface.id, offset, at_bottom);
-                        }
-                        let responses = std::mem::take(&mut *pending_responses.lock().unwrap());
-                        if !responses.is_empty() {
-                            let _ = surface.write_bytes(&responses);
-                        }
-                    }
-                    if let Some(pty) = surface.as_pty() {
-                        pty.publish_final_frame();
-                        pty.local_pty_drained.store(true, Ordering::Release);
-                    }
-                    publish_local_exit_if_ready(&surface);
-                }
-            })?;
-        *surface
-            .as_pty()
-            .expect("local PTY surface owns its reader")
-            .reader_thread
-            .lock()
-            .unwrap() = Some(reader_thread);
-
-        // Child reaper: retain the native status and rendezvous with PTY EOF
-        // so final output is visible before the mux observes completion.
-        std::thread::Builder::new().name(format!("surface-{id}-wait")).spawn({
+        std::thread::Builder::new().name(format!("surface-{id}-reader")).spawn({
             let surface = surface.clone();
             move || {
-                let exit = wait_for_native_child_status(child.as_mut());
-                if let Some(pty) = surface.as_pty() {
-                    *pty.exit.lock().unwrap() = Some(exit);
+                let mut buf = [0u8; 64 * 1024];
+                loop {
+                    let n = match reader.read(&mut buf) {
+                        Ok(0) => break,
+                        Ok(n) => n,
+                        Err(error)
+                            if matches!(
+                                error.kind(),
+                                std::io::ErrorKind::Interrupted | std::io::ErrorKind::WouldBlock
+                            ) =>
+                        {
+                            std::thread::sleep(Duration::from_millis(1));
+                            continue;
+                        }
+                        Err(_) => break,
+                    };
+                    let pty = surface.as_pty().expect("surface reader got non-pty surface");
+                    let mut scroll_changed = None;
+                    let generation = {
+                        let mut term = pty.term.lock().unwrap();
+                        let before = terminal_scroll_position(&term);
+                        let color_revision = term.color_revision();
+                        let color_reapply_revision = term.color_reapply_revision();
+                        let cursor_activity = term
+                            .cursor_activity()
+                            .expect("valid local terminals expose cursor activity");
+                        let normalized = term.vt_write_with_normalized(&buf[..n]);
+                        let cursor_changed = term
+                            .cursor_activity()
+                            .expect("valid local terminals expose cursor activity")
+                            != cursor_activity;
+                        pty.mouse_encoders.lock().unwrap().sync_from_terminal(&term);
+                        let after = terminal_scroll_position(&term);
+                        let has_attach_taps = pty.broadcast_attach_output(normalized.as_ref());
+                        if has_attach_taps
+                            && (term.color_revision() != color_revision || cursor_changed)
+                        {
+                            pty.attach_colors_pending.store(true, Ordering::Release);
+                            if term.color_reapply_revision() != color_reapply_revision
+                                || cursor_changed
+                            {
+                                pty.attach_colors_force_pending.store(true, Ordering::Release);
+                            }
+                        }
+                        if title_changed.swap(false, Ordering::Relaxed) {
+                            let title = term.title().unwrap_or_default();
+                            *pty.title.lock().unwrap() = title.clone();
+                            if let Some(mux) = mux.upgrade() {
+                                mux.emit(MuxEvent::TitleChanged {
+                                    surface: surface.id,
+                                    title: title.into(),
+                                });
+                            }
+                        }
+                        if let Some(pwd) = term.pwd() {
+                            *pty.pwd.lock().unwrap() = Some(pwd);
+                        }
+                        if before != after {
+                            scroll_changed = Some(after);
+                            broadcast_render_scroll_locked(pty, after);
+                        }
+                        pty.render_generation.fetch_add(1, Ordering::AcqRel) + 1
+                    };
+                    pty.stream_progress.notify();
+                    pty.request_frame(generation);
+                    if let Some((offset, at_bottom)) = scroll_changed
+                        && let Some(mux) = mux.upgrade()
+                    {
+                        mux.emit(MuxEvent::ScrollChanged {
+                            surface: surface.id,
+                            offset,
+                            at_bottom,
+                        });
+                    }
+                    let responses = std::mem::take(&mut *pending_responses.lock().unwrap());
+                    if !responses.is_empty() {
+                        let _ = surface.write_bytes(&responses);
+                    }
                 }
-                close_local_terminal_master_after_exit(&surface);
-                publish_local_exit_if_ready(&surface);
+                if let Some(pty) = surface.as_pty() {
+                    pty.dead.store(true, Ordering::Release);
+                }
+                if let Some(mux) = mux.upgrade() {
+                    mux.surface_exited(surface.id);
+                }
             }
         })?;
 
+        // Child reaper: avoid zombies; the reader thread handles EOF.
+        std::thread::Builder::new().name(format!("surface-{id}-wait")).spawn(move || {
+            let _ = child.wait();
+        })?;
+
         Ok(surface)
-    }
-
-    #[cfg(unix)]
-    fn install_deferred_cell_pixel_handler(
-        surface: &Arc<Surface>,
-        responses: &Arc<crate::terminal_host_runtime::ControlResponses>,
-    ) {
-        let surface = Arc::downgrade(surface);
-        let responses = Arc::downgrade(responses);
-        responses
-            .upgrade()
-            .expect("control responses are live while installing their handler")
-            .set_deferred_cell_pixel_handler(Arc::new(move |request_id, expected, resolution| {
-                if matches!(
-                    &resolution,
-                    crate::terminal_host_runtime::DeferredCellPixelResolution::Disconnected
-                ) {
-                    return;
-                }
-                let (Some(surface), Some(responses)) = (surface.upgrade(), responses.upgrade())
-                else {
-                    return;
-                };
-                let Some(mux) = surface.as_pty().and_then(|pty| pty.mux.upgrade()) else {
-                    return;
-                };
-                let queued_surface = surface.clone();
-                let queued_responses = responses.clone();
-                let queued_resolution = resolution.clone();
-                if !mux.submit_deferred_cell_pixel_ack(move || {
-                    queued_surface.reconcile_deferred_cell_pixel_ack(
-                        &queued_responses,
-                        request_id,
-                        expected,
-                        queued_resolution,
-                    );
-                }) {
-                    // The bounded pool is saturated or cannot create its first
-                    // worker. Reconcile on the already-owned host reader
-                    // instead of dropping a valid acknowledgement.
-                    surface.reconcile_deferred_cell_pixel_ack(
-                        &responses, request_id, expected, resolution,
-                    );
-                }
-            }));
-    }
-
-    #[cfg(unix)]
-    fn reconcile_deferred_cell_pixel_ack(
-        &self,
-        responses: &Arc<crate::terminal_host_runtime::ControlResponses>,
-        request_id: u64,
-        expected: (u16, u16),
-        resolution: crate::terminal_host_runtime::DeferredCellPixelResolution,
-    ) {
-        #[cfg(test)]
-        if let Some(pty) = self.as_pty()
-            && let Some(hook) = pty.deferred_cell_pixel_ack_test_hook.lock().unwrap().clone()
-        {
-            hook();
-        }
-        let crate::terminal_host_runtime::DeferredCellPixelResolution::Response(frame) = resolution
-        else {
-            // The replacement host snapshot is authoritative for an
-            // acknowledgement whose delivery raced a broken admin stream.
-            return;
-        };
-        let Some(pty) = self.as_pty() else { return };
-        let owns_response = {
-            let runtime = pty.runtime.lock().unwrap();
-            matches!(
-                &*runtime,
-                PtyRuntime::Hosted(host)
-                    if Arc::ptr_eq(&host.control_responses(), responses)
-            )
-        };
-        if !owns_response || responses.latest_cell_pixel_ack() > request_id {
-            return;
-        }
-        let expected_payload = [expected.0.to_le_bytes(), expected.1.to_le_bytes()].concat();
-        if frame.kind != MessageKind::CellPixelSizeAck
-            || frame.payload.as_slice() != expected_payload
-        {
-            if let PtyRuntime::Hosted(host) = &*pty.runtime.lock().unwrap() {
-                host.disconnect();
-            }
-            return;
-        }
-
-        let mut geometry = pty.geometry.lock().unwrap();
-        let still_owns_response = {
-            let runtime = pty.runtime.lock().unwrap();
-            matches!(
-                &*runtime,
-                PtyRuntime::Hosted(host)
-                    if Arc::ptr_eq(&host.control_responses(), responses)
-            )
-        };
-        if !still_owns_response || responses.latest_cell_pixel_ack() > request_id {
-            return;
-        }
-        let next = PtyGeometry { cell_width: expected.0, cell_height: expected.1, ..*geometry };
-        let committed = pty.commit_geometry(&mut geometry, next, false);
-        drop(geometry);
-        match committed {
-            Ok(changed) => {
-                if let Some(mux) = pty.mux.upgrade() {
-                    if changed {
-                        mux.emit_terminal_output(pty.event_surface_id);
-                    }
-                    mux.reconcile_deferred_cell_pixel_ack(self.id, expected);
-                }
-            }
-            Err(_) => {
-                if let PtyRuntime::Hosted(host) = &*pty.runtime.lock().unwrap() {
-                    host.disconnect();
-                }
-            }
-        }
-    }
-
-    #[cfg(unix)]
-    fn apply_hosted_clear_history_replay(
-        surface: &Arc<Surface>,
-        pty: &PtySurface,
-        replay: &[u8],
-        mux: &Weak<Mux>,
-    ) {
-        let mut scroll_changed = None;
-        let generation = {
-            let mut term = pty.term.lock().unwrap();
-            let before = terminal_scroll_position(&term);
-            let normalized = term.vt_write_with_normalized(replay);
-            let output = match normalized {
-                Cow::Borrowed(_) => replay.to_vec(),
-                Cow::Owned(normalized) => normalized,
-            };
-            pty.mouse_encoders.lock().unwrap().sync_from_terminal(&term);
-            pty.broadcast_attach_output(&output);
-            let after = terminal_scroll_position(&term);
-            if before != after {
-                scroll_changed = Some(after);
-                broadcast_render_scroll_locked(pty, after);
-            }
-            pty.render_generation.fetch_add(1, Ordering::AcqRel) + 1
-        };
-        pty.stream_progress.notify();
-        pty.request_frame(generation);
-        if let Some((offset, at_bottom)) = scroll_changed
-            && let Some(mux) = mux.upgrade()
-        {
-            mux.emit(MuxEvent::ScrollChanged { surface: surface.id, offset, at_bottom });
-        }
     }
 
     #[cfg(unix)]
@@ -2731,31 +1262,9 @@ impl Surface {
         id: SurfaceId,
         opts: SurfaceOptions,
         mux: Weak<Mux>,
-        launch: HostedSurfaceLaunch,
+        mut attachment: crate::terminal_host_runtime::HostAttachment,
+        terminate_on_error: bool,
     ) -> anyhow::Result<Arc<Surface>> {
-        let HostedSurfaceLaunch {
-            mut attachment,
-            kitty_reservation,
-            terminate_on_error,
-            defer_launch_activation,
-            lifetime,
-            terminal_public_id,
-            resource_identity,
-        } = launch;
-        anyhow::ensure!(
-            lifetime == PtyLifetime::SessionOwned,
-            "daemon-owned PTYs cannot use durable terminal hosts"
-        );
-        if let Some(identity) = resource_identity.as_ref() {
-            let content_id = terminal_public_id_from_resource_identity(
-                identity,
-                "hosted terminal cannot use a browser resource identity",
-            )?;
-            anyhow::ensure!(
-                terminal_public_id.as_ref() == Some(&content_id),
-                "terminal runtime identity does not match its placement"
-            );
-        }
         let initial_defaults = mux.upgrade().map(|mux| mux.default_colors()).unwrap_or_default();
         attachment.send_default_colors(initial_defaults)?;
         let mut reader = attachment.take_reader()?;
@@ -2766,223 +1275,98 @@ impl Surface {
             anyhow::bail!("injected hosted surface setup failure after attachment");
         }
         let mut control_responses = attachment.control_responses();
-        let smart_renderer = attachment.is_smart_renderer();
         let snapshot = attachment.snapshot.clone();
         let mut applied_color_overrides = snapshot.colors.clone();
         let title_changed = Arc::new(AtomicBool::new(false));
         let callbacks = hosted_terminal_callbacks(id, mux.clone(), title_changed.clone());
         let mut term = Terminal::new(snapshot.cols, snapshot.rows, opts.scrollback, callbacks)?;
-        term.resize(
-            snapshot.cols,
-            snapshot.rows,
-            u32::from(snapshot.cell_pixels.0),
-            u32::from(snapshot.cell_pixels.1),
-        )?;
         if let Some(mux) = mux.upgrade() {
             let colors = mux.default_colors();
             term.replace_default_colors(colors.fg, colors.bg, colors.cursor);
             term.set_default_palette(&colors.palette);
             replace_ghostty_cursor_defaults(&mut term, colors);
         }
-        term.apply_vt_replay_parts(
-            &snapshot.replay,
-            &snapshot.kitty_image_aliases,
-            snapshot.kitty_state,
-        )?;
+        term.vt_write(&snapshot.replay);
         let initial_color_delta = terminal_color_override_full_state(&snapshot.colors);
         if !initial_color_delta.is_empty() {
             term.vt_write(&initial_color_delta);
         }
-        let initial_color_revision = term.color_revision();
-        let initial_cursor_activity = term.cursor_activity().ok();
         let title = term.title().unwrap_or_default();
         let pwd = term.pwd();
         let mut mouse_encoders = MouseEncoders::new()?;
         mouse_encoders.sync_from_terminal(&term);
         let sequence_boundary = snapshot.sequence_boundary;
-        let protocol_version = attachment.protocol_version();
         let host_identity = attachment.identity();
-        let mux_owner =
-            mux.upgrade().ok_or_else(|| anyhow::anyhow!("terminal host has no mux owner"))?;
-        let pending_host_binding =
-            mux_owner.register_pending_terminal_host(id, host_identity.clone())?;
-        drop(mux_owner);
-        let journal_generation = Arc::from(host_identity.incarnation.clone());
-        let host_exit_record_path = attachment.exit_record_path();
         let supports_clear_history_key_fallback = attachment.supports_clear_history();
-        let journal_capture_supported = attachment.supports_journal_detach_fence();
         let render_state = RenderState::new()?;
         let (frame_requests, frame_rx) = sync_channel(1);
-        #[cfg(test)]
-        let frame_producer_before_upgrade = Arc::new(Mutex::new(None));
         let surface = Arc::new(Surface::Pty(PtySurface {
-            meta: SurfaceMeta {
-                id,
-                resource_identity,
-                name: Mutex::new(None),
-                selection: Mutex::new(None),
-            },
-            terminal: Arc::new(PtyTerminalRuntime {
-                event_surface_id: id,
-                terminal_public_id: terminal_public_id.map(Arc::new),
-                journal_generation,
-                journal_capture_supported,
-                journal_capture_epoch: AtomicU64::new(0),
-                journal_capture_gate: Mutex::new(()),
-                journal_capture_idle: Condvar::new(),
-                journal_capture_open: AtomicBool::new(true),
-                journal_capture_reserved: AtomicBool::new(false),
-                journal_capture_active: AtomicBool::new(false),
-                reader_thread: Mutex::new(None),
-                reader_completion: Arc::new(ReaderCompletion::default()),
-                term: Mutex::new(Box::new(term)),
-                stream_progress: Box::new(TerminalStreamProgress::default()),
-                mouse_encoders: Mutex::new(Box::new(mouse_encoders)),
-                runtime: Mutex::new(PtyRuntime::Hosted(Box::new(attachment))),
-                lifetime,
-                supports_clear_history_key_fallback: AtomicBool::new(
-                    supports_clear_history_key_fallback,
-                ),
-                host_identity: Some(host_identity),
-                pending_host_binding: Mutex::new(Some(pending_host_binding)),
-                host_exit_record_path: Some(host_exit_record_path),
-                pid: snapshot.pid,
-                command: snapshot.command,
-                cwd: snapshot.cwd,
-                exit: Mutex::new(None),
-                local_pty_drained: AtomicBool::new(true),
-                exit_notified: AtomicBool::new(false),
-                dead: AtomicBool::new(false),
-                owner_detaching: AtomicBool::new(false),
-                host_connection_state: AtomicU8::new(TerminalHostConnectionState::Connected as u8),
-                dirty: AtomicBool::new(true),
-                title: Mutex::new(title),
-                pwd: Mutex::new(pwd),
-                geometry: Mutex::new(PtyGeometry {
-                    cols: snapshot.cols,
-                    rows: snapshot.rows,
-                    cell_width: snapshot.cell_pixels.0,
-                    cell_height: snapshot.cell_pixels.1,
-                }),
-                kitty_graphics_limits: Box::new(Mutex::new(snapshot.kitty_state.limits)),
-                #[cfg(test)]
-                geometry_test_hook: Mutex::new(None),
-                #[cfg(test)]
-                deferred_cell_pixel_ack_test_hook: Mutex::new(None),
-                #[cfg(test)]
-                test_master_control: None,
-                #[cfg(test)]
-                vt_replay_builds: AtomicUsize::new(0),
-                mux: mux.clone(),
-                taps: Mutex::new(Vec::new()),
-                attach_colors_pending: AtomicBool::new(false),
-                attach_colors_force_pending: AtomicBool::new(false),
-                last_attach_colors: Mutex::new(None),
-                render: Arc::new(Mutex::new(RenderHub {
-                    state: Box::new(render_state),
-                    built_generation: 0,
-                    latest: None,
-                    initial_graphics: None,
-                    taps: Vec::new(),
-                })),
-                render_generation: AtomicU64::new(1),
-                frame_requests,
-                #[cfg(test)]
-                frame_producer_before_upgrade,
+            meta: SurfaceMeta { id, name: Mutex::new(None), selection: Mutex::new(None) },
+            term: Mutex::new(term),
+            stream_progress: Box::new(TerminalStreamProgress::default()),
+            mouse_encoders: Mutex::new(mouse_encoders),
+            runtime: Mutex::new(PtyRuntime::Hosted(Box::new(attachment))),
+            supports_clear_history_key_fallback: AtomicBool::new(
+                supports_clear_history_key_fallback,
+            ),
+            host_identity: Some(host_identity),
+            pid: snapshot.pid,
+            command: snapshot.command,
+            cwd: snapshot.cwd,
+            dead: AtomicBool::new(false),
+            owner_detaching: AtomicBool::new(false),
+            host_connection_state: AtomicU8::new(TerminalHostConnectionState::Connected as u8),
+            dirty: AtomicBool::new(true),
+            title: Mutex::new(title),
+            pwd: Mutex::new(pwd),
+            size: Mutex::new((snapshot.cols, snapshot.rows)),
+            mux: mux.clone(),
+            taps: Mutex::new(Vec::new()),
+            attach_colors_pending: AtomicBool::new(false),
+            attach_colors_force_pending: AtomicBool::new(false),
+            last_attach_colors: Mutex::new(None),
+            render: Mutex::new(RenderHub {
+                state: Box::new(render_state),
+                built_generation: 0,
+                latest: None,
+                taps: Vec::new(),
             }),
-            viewport: Mutex::new(TerminalViewportState::default()),
+            render_generation: AtomicU64::new(1),
+            frame_requests,
         }));
-        Self::install_deferred_cell_pixel_handler(&surface, &control_responses);
         spawn_frame_producer(&surface, frame_rx)?;
 
         // Keep exact-child rollback ownership armed through the final thread
         // spawn. If Builder::spawn fails, dropping the closure clone and
         // function-local Surface drops the still-armed attachment, so no
         // control-write failure can convert this Err into a live orphan.
-        let reader_thread = std::thread::Builder::new().name(format!("surface-{id}-host")).spawn({
+        std::thread::Builder::new().name(format!("surface-{id}-host")).spawn({
             let surface = surface.clone();
-            let mux = mux.clone();
             let scrollback = opts.scrollback;
             move || {
-                let _reader_completion = ReaderCompletionGuard(
-                    surface
-                        .as_pty()
-                        .expect("host reader owns a PTY surface")
-                        .reader_completion
-                        .clone(),
-                );
                 let mut sequence_boundary = sequence_boundary;
-                let mut protocol_version = protocol_version;
-                let mut smart_renderer = smart_renderer;
-                let mut applied_color_revision = initial_color_revision;
-                let mut applied_cursor_activity = initial_cursor_activity;
                 'connection: loop {
-                    let pty = surface.as_pty().expect("host reader owns a PTY surface");
-                    let mut stager = HostedFrameStager::new_for_version(
-                        sequence_boundary,
-                        protocol_version,
-                        smart_renderer,
-                    );
-                    let mut received_exit = None;
-                    let mut resync_requested = false;
-                    let mut journal_target = None;
-                    let mut journal_update = None;
-                    'host_stream: loop {
-                        if journal_update.is_none() {
-                            journal_target = pty.journal_target();
-                            journal_update = journal_target
-                                .as_ref()
-                                .and_then(|_| pty.begin_terminal_journal_update());
-                            if journal_target.is_some() && journal_update.is_none() {
-                                break;
-                            }
-                        }
-                        let frame = match crate::terminal_host_protocol::read_frame(
+                    let mut stager = HostedFrameStager::new(sequence_boundary);
+                    let mut received_exit = false;
+                    'host_stream: while let Ok(Some(frame)) =
+                        crate::terminal_host_protocol::read_frame(
                             &mut reader,
                             crate::terminal_host_protocol::MAX_FRAME_PAYLOAD,
-                        ) {
-                            Ok(Some(frame)) => frame,
-                            Ok(None) | Err(_) => break,
-                        };
+                        )
+                    {
+                        let Some(pty) = surface.as_pty() else { break };
                         if matches!(
                             frame.kind,
-                            MessageKind::Capability
-                                | MessageKind::CellPixelSizeAck
-                                | MessageKind::KittyGraphicsLimitsAck
-                                | MessageKind::ClearHistoryAck
-                                | MessageKind::TerminateAck
-                                | MessageKind::DetachAck
+                            MessageKind::Capability | MessageKind::ClearHistoryAck
                         ) && frame.request_id != 0
                         {
-                            if frame.version != protocol_version
+                            if frame.version != PROTOCOL_VERSION
                                 || frame.flags != 0
                                 || frame.sequence != 0
+                                || !control_responses.resolve(&frame)
                             {
                                 break;
                             }
-                            let clear_replay = if frame.kind == MessageKind::ClearHistoryAck
-                                && frame.payload.len() > 1
-                            {
-                                if !smart_renderer
-                                    || frame.payload.first() != Some(&CLEAR_HISTORY_ACK_OK)
-                                {
-                                    break;
-                                }
-                                Some(&frame.payload[1..])
-                            } else {
-                                None
-                            };
-                            if !control_responses.resolve_after(&frame, || {
-                                if let Some(replay) = clear_replay {
-                                    Self::apply_hosted_clear_history_replay(
-                                        &surface, pty, replay, &mux,
-                                    );
-                                }
-                            }) {
-                                break;
-                            }
-                            drop(journal_update.take());
-                            journal_target = None;
                             continue;
                         }
                         let Ok(transition) = stager.push(frame) else {
@@ -3007,12 +1391,6 @@ impl Surface {
                                     .unwrap_or_default();
                                 let generation = {
                                     let mut term = pty.term.lock().unwrap();
-                                    if let Some(update) = journal_update.as_mut()
-                                        && !update.activate()
-                                    {
-                                        break 'host_stream;
-                                    }
-                                    let journal_enabled = journal_update.is_some();
                                     let before = terminal_scroll_position(&term);
                                     let normalized = term.vt_write_with_normalized(&output);
                                     let output = match normalized {
@@ -3028,18 +1406,6 @@ impl Surface {
                                             term.vt_write(&delta);
                                         }
                                         applied_color_overrides = colors.clone();
-                                        applied_color_revision = term.color_revision();
-                                        applied_cursor_activity = term.cursor_activity().ok();
-                                    } else if smart_renderer {
-                                        let color_revision = term.color_revision();
-                                        let cursor_activity = term.cursor_activity().ok();
-                                        if color_revision != applied_color_revision
-                                            || cursor_activity != applied_cursor_activity
-                                        {
-                                            applied_color_overrides = term.color_overrides();
-                                            applied_color_revision = color_revision;
-                                            applied_cursor_activity = cursor_activity;
-                                        }
                                     } else if !terminal_color_overrides_match_applied(
                                         term.color_overrides(),
                                         &applied_color_overrides,
@@ -3053,20 +1419,16 @@ impl Surface {
                                     // The parser already contains the complete
                                     // coupled state before any attach observer can
                                     // see the Output or ColorsChanged callback.
-                                    let journal_output = if colors.is_some() {
-                                        let journal_output =
-                                            journal_enabled.then(|| output.clone());
+                                    if colors.is_some() {
                                         pty.broadcast_attach_frame(AttachFrame::OutputWithColors {
                                             output,
                                             colors: Box::new(
                                                 pty.terminal_colors_locked(&term, defaults),
                                             ),
                                         });
-                                        journal_output
                                     } else {
                                         pty.broadcast_attach_output(&output);
-                                        journal_enabled.then_some(output)
-                                    };
+                                    }
                                     if title_changed.swap(false, Ordering::Relaxed) {
                                         let title = term.title().unwrap_or_default();
                                         *pty.title.lock().unwrap() = title.clone();
@@ -3079,79 +1441,28 @@ impl Surface {
                                         scroll_changed = Some(after);
                                         broadcast_render_scroll_locked(pty, after);
                                     }
-                                    (
-                                        pty.render_generation.fetch_add(1, Ordering::AcqRel) + 1,
-                                        journal_output,
-                                    )
+                                    pty.render_generation.fetch_add(1, Ordering::AcqRel) + 1
                                 };
-                                let (generation, journal_output) = generation;
-                                if let (Some(journal_target), Some(journal_output)) =
-                                    (journal_target, journal_output)
-                                {
-                                    pty.journal_output_if_open(journal_target, journal_output);
-                                }
-                                drop(journal_update.take());
-                                pty.stream_progress.notify();
                                 pty.request_frame(generation);
                                 if let Some(title) = title_update
                                     && let Some(mux) = mux.upgrade()
                                 {
-                                    mux.emit_terminal_title(surface.id, title.into());
+                                    mux.emit(MuxEvent::TitleChanged {
+                                        surface: surface.id,
+                                        title: title.into(),
+                                    });
                                 }
                                 if let Some((offset, at_bottom)) = scroll_changed
                                     && let Some(mux) = mux.upgrade()
                                 {
-                                    mux.emit_terminal_scroll(surface.id, offset, at_bottom);
-                                }
-                            }
-                            HostedTransition::Resized { cols, rows, cell_pixels } => {
-                                let mut geometry = pty.geometry.lock().unwrap();
-                                let next_geometry = PtyGeometry {
-                                    cols,
-                                    rows,
-                                    cell_width: cell_pixels
-                                        .map(|pixels| pixels.0)
-                                        .unwrap_or(geometry.cell_width),
-                                    cell_height: cell_pixels
-                                        .map(|pixels| pixels.1)
-                                        .unwrap_or(geometry.cell_height),
-                                };
-                                let changed = match pty.commit_hosted_geometry(
-                                    &mut geometry,
-                                    next_geometry,
-                                    false,
-                                ) {
-                                    Ok(changed) => changed,
-                                    Err(_) => break 'host_stream,
-                                };
-                                drop(geometry);
-                                if changed
-                                    && let Some(mux) = mux.upgrade()
-                                {
-                                    mux.emit(MuxEvent::SurfaceResized {
+                                    mux.emit(MuxEvent::ScrollChanged {
                                         surface: surface.id,
-                                        cols,
-                                        rows,
-                                        reservation_id: None,
+                                        offset,
+                                        at_bottom,
                                     });
                                 }
                             }
-                            HostedTransition::ResizedWithColors {
-                                cols,
-                                rows,
-                                cell_pixels,
-                                replay,
-                                kitty_image_aliases,
-                                kitty_state,
-                                colors,
-                            } => {
-                                let mut geometry = pty.geometry.lock().unwrap();
-                                let next_geometry = PtyGeometry {
-                                    cols,
-                                    rows,
-                                    cell_width: cell_pixels.0,
-                                    cell_height: cell_pixels.1,
-                                };
+                            HostedTransition::ResizedWithColors { cols, rows, replay, colors } => {
                                 let defaults = mux
                                     .upgrade()
                                     .map(|mux| mux.default_colors())
@@ -3166,17 +1477,6 @@ impl Surface {
                                 else {
                                     break;
                                 };
-                                if replacement
-                                    .resize(
-                                        cols,
-                                        rows,
-                                        u32::from(next_geometry.cell_width),
-                                        u32::from(next_geometry.cell_height),
-                                    )
-                                    .is_err()
-                                {
-                                    break;
-                                }
                                 replacement.replace_default_colors(
                                     defaults.fg,
                                     defaults.bg,
@@ -3184,16 +1484,7 @@ impl Surface {
                                 );
                                 replacement.set_default_palette(&defaults.palette);
                                 replace_ghostty_cursor_defaults(&mut replacement, defaults);
-                                if replacement
-                                    .apply_vt_replay_parts(
-                                        &replay,
-                                        &kitty_image_aliases,
-                                        kitty_state,
-                                    )
-                                    .is_err()
-                                {
-                                    break;
-                                }
+                                replacement.vt_write(&replay);
                                 let delta = terminal_color_override_full_state(&colors);
                                 if !delta.is_empty() {
                                     replacement.vt_write(&delta);
@@ -3205,16 +1496,12 @@ impl Surface {
                                 let generation = {
                                     let mut term = pty.term.lock().unwrap();
                                     let before = terminal_scroll_position(&term);
-                                    **term = replacement;
+                                    *term = replacement;
                                     pty.mouse_encoders.lock().unwrap().sync_from_terminal(&term);
-                                    *geometry = next_geometry;
-                                    pty.journal_geometry(next_geometry);
+                                    *pty.size.lock().unwrap() = (cols, rows);
                                     *pty.title.lock().unwrap() = title.clone();
                                     *pty.pwd.lock().unwrap() = pwd;
-                                    *pty.kitty_graphics_limits.lock().unwrap() = kitty_state.limits;
                                     applied_color_overrides = colors;
-                                    applied_color_revision = term.color_revision();
-                                    applied_cursor_activity = term.cursor_activity().ok();
                                     let after = terminal_scroll_position(&term);
                                     if before != after {
                                         scroll_changed = Some(after);
@@ -3226,23 +1513,31 @@ impl Surface {
                                     pty.broadcast_attach_frame(AttachFrame::ResizedWithColors {
                                         cols,
                                         rows,
-                                        replay: replay.into(),
-                                        kitty_image_aliases,
-                                        kitty_state,
+                                        replay,
                                         colors: Box::new(
                                             pty.terminal_colors_locked(&term, defaults),
                                         ),
                                     });
                                     pty.render_generation.fetch_add(1, Ordering::AcqRel) + 1
                                 };
-                                drop(geometry);
-                                pty.stream_progress.notify();
                                 pty.request_frame(generation);
                                 if let Some(mux) = mux.upgrade() {
-                                    mux.emit_terminal_title(surface.id, title.into());
-                                    mux.emit_terminal_resized(surface.id, cols, rows, None);
+                                    mux.emit(MuxEvent::TitleChanged {
+                                        surface: surface.id,
+                                        title: title.into(),
+                                    });
+                                    mux.emit(MuxEvent::SurfaceResized {
+                                        surface: surface.id,
+                                        cols,
+                                        rows,
+                                        reservation_id: None,
+                                    });
                                     if let Some((offset, at_bottom)) = scroll_changed {
-                                        mux.emit_terminal_scroll(surface.id, offset, at_bottom);
+                                        mux.emit(MuxEvent::ScrollChanged {
+                                            surface: surface.id,
+                                            offset,
+                                            at_bottom,
+                                        });
                                     }
                                 }
                             }
@@ -3250,51 +1545,34 @@ impl Surface {
                             // the sequenced metadata frames are still consumed so
                             // they cannot hide a stream gap.
                             HostedTransition::Metadata(_kind) => {}
-                            HostedTransition::Exit(exit) => {
-                                received_exit = Some(exit);
+                            HostedTransition::Exit => {
+                                received_exit = true;
                                 break;
                             }
-                            HostedTransition::ResyncRequired => {
-                                resync_requested = true;
-                                break;
-                            }
+                            HostedTransition::ResyncRequired => break,
                         }
-                        drop(journal_update.take());
-                        journal_target = None;
                     }
-                    control_responses.fail_all();
+                    control_responses.cancel_all();
                     let Some(pty) = surface.as_pty() else { return };
                     if pty.owner_detaching.load(Ordering::Acquire) {
                         return;
                     }
                     let Some(identity) = pty.host_identity.clone() else { return };
-                    if let Some(exit) = received_exit {
-                        *pty.exit.lock().unwrap() = Some(exit);
+                    if received_exit {
                         mark_hosted_runtime_exited(pty, &identity);
                         pty.host_connection_state
                             .store(TerminalHostConnectionState::Exited as u8, Ordering::Release);
-                        pty.stream_progress.notify();
+                        pty.dead.store(true, Ordering::Release);
                         if let Some(mux) = mux.upgrade() {
                             mux.surface_exited(surface.id);
                         }
                         return;
                     }
 
-                    // ResyncRequired is an ordered renderer reset from a live
-                    // host, not evidence that its admin stream or PTY was
-                    // lost. Reconnect from a fresh snapshot without moving
-                    // either the observable connection state or the durable
-                    // lifecycle through Adopting. This also keeps initial
-                    // topology binding valid if defaults legitimately change
-                    // while a new hosted surface is being installed.
-                    let first_loss = !resync_requested
-                        && pty
-                            .host_connection_state
-                            .swap(
-                                TerminalHostConnectionState::Reconnecting as u8,
-                                Ordering::AcqRel,
-                            )
-                            != TerminalHostConnectionState::Reconnecting as u8;
+                    let first_loss = pty
+                        .host_connection_state
+                        .swap(TerminalHostConnectionState::Reconnecting as u8, Ordering::AcqRel)
+                        != TerminalHostConnectionState::Reconnecting as u8;
                     if first_loss
                         && let Some(mux) = mux.upgrade()
                         && !mux.terminal_host_connection_lost(surface.id, &identity)
@@ -3302,7 +1580,7 @@ impl Surface {
                         return;
                     }
 
-                    let mut retry = TerminalHostReconnectBackoff::default();
+                    let mut retry_delay = Duration::from_millis(25);
                     loop {
                         if pty.owner_detaching.load(Ordering::Acquire) {
                             return;
@@ -3320,28 +1598,12 @@ impl Surface {
                             &record,
                         ) {
                             Ok(crate::terminal_host_runtime::TerminalHostLiveness::Dead) => {
-                                let exit = crate::terminal_host_runtime::terminal_host_exit_record(
-                                    &record_path,
-                                )
-                                .ok()
-                                .flatten()
-                                .filter(|(_, exit)| {
-                                    exit.terminal_id == identity.terminal_id
-                                        && exit.incarnation == identity.incarnation
-                                })
-                                .map(|(_, exit)| exit.exit)
-                                .unwrap_or_else(|| {
-                                    TerminalExit::unknown(
-                                        "terminal host ended without a durable exit sidecar",
-                                    )
-                                });
-                                *pty.exit.lock().unwrap() = Some(exit);
                                 mark_hosted_runtime_exited(pty, &identity);
                                 pty.host_connection_state.store(
                                     TerminalHostConnectionState::Exited as u8,
                                     Ordering::Release,
                                 );
-                                pty.stream_progress.notify();
+                                pty.dead.store(true, Ordering::Release);
                                 if let Some(mux) = mux.upgrade() {
                                     mux.surface_exited(surface.id);
                                 }
@@ -3354,29 +1616,18 @@ impl Surface {
                             | Err(_) => {}
                         }
 
-                        let Some(reconnect_mux) = mux.upgrade() else { return };
-                        let Ok(kitty_limits) =
-                            reconnect_mux.kitty_image_limits_for_reconnect(&surface)
-                        else {
-                            return;
-                        };
-                        let replacement = match crate::terminal_host_runtime::adopt_terminal_host_with_kitty_limits(
+                        let replacement = match crate::terminal_host_runtime::adopt_terminal_host(
                             record,
                             record_path,
-                            kitty_limits,
                         ) {
                             Ok(replacement) if replacement.identity() == identity => replacement,
                             Ok(_) | Err(_) => {
-                                if !retry.wait_or_fail(pty) {
-                                    return;
-                                }
+                                std::thread::sleep(retry_delay);
+                                retry_delay = (retry_delay * 2).min(Duration::from_secs(1));
                                 continue;
                             }
                         };
-                        let replacement_protocol_version = replacement.protocol_version();
-                        let replacement_smart_renderer = replacement.is_smart_renderer();
                         let replacement_snapshot = replacement.snapshot.clone();
-                        let replacement_sequence_boundary = replacement_snapshot.sequence_boundary;
                         let replacement_control_responses = replacement.control_responses();
                         let installed = {
                             let mut runtime = pty.runtime.lock().unwrap();
@@ -3415,15 +1666,9 @@ impl Surface {
                             }
                         };
                         if !installed {
-                            if !retry.wait_or_fail(pty) {
-                                return;
-                            }
+                            std::thread::sleep(retry_delay);
                             continue;
                         }
-                        Self::install_deferred_cell_pixel_handler(
-                            &surface,
-                            &replacement_control_responses,
-                        );
 
                         let replacement_reader = {
                             let mut runtime = pty.runtime.lock().unwrap();
@@ -3431,21 +1676,12 @@ impl Surface {
                             replacement.take_reader().ok()
                         };
                         let Some(replacement_reader) = replacement_reader else {
-                            if !retry.wait_or_fail(pty) {
-                                return;
-                            }
+                            std::thread::sleep(retry_delay);
                             continue;
                         };
 
                         let defaults =
                             mux.upgrade().map(|mux| mux.default_colors()).unwrap_or_default();
-                        let mut geometry = pty.geometry.lock().unwrap();
-                        let next_geometry = PtyGeometry {
-                            cols: replacement_snapshot.cols,
-                            rows: replacement_snapshot.rows,
-                            cell_width: replacement_snapshot.cell_pixels.0,
-                            cell_height: replacement_snapshot.cell_pixels.1,
-                        };
                         let callbacks =
                             hosted_terminal_callbacks(id, mux.clone(), title_changed.clone());
                         let Ok(mut replacement_term) = Terminal::new(
@@ -3454,27 +1690,9 @@ impl Surface {
                             scrollback,
                             callbacks,
                         ) else {
-                            if !wait_for_reconnect_after_geometry_failure(&mut retry, pty, geometry)
-                            {
-                                return;
-                            }
+                            std::thread::sleep(retry_delay);
                             continue;
                         };
-                        if replacement_term
-                            .resize(
-                                next_geometry.cols,
-                                next_geometry.rows,
-                                u32::from(next_geometry.cell_width),
-                                u32::from(next_geometry.cell_height),
-                            )
-                            .is_err()
-                        {
-                            if !wait_for_reconnect_after_geometry_failure(&mut retry, pty, geometry)
-                            {
-                                return;
-                            }
-                            continue;
-                        }
                         replacement_term.replace_default_colors(
                             defaults.fg,
                             defaults.bg,
@@ -3482,20 +1700,7 @@ impl Surface {
                         );
                         replacement_term.set_default_palette(&defaults.palette);
                         replace_ghostty_cursor_defaults(&mut replacement_term, defaults);
-                        if replacement_term
-                            .apply_vt_replay_parts(
-                                &replacement_snapshot.replay,
-                                &replacement_snapshot.kitty_image_aliases,
-                                replacement_snapshot.kitty_state,
-                            )
-                            .is_err()
-                        {
-                            if !wait_for_reconnect_after_geometry_failure(&mut retry, pty, geometry)
-                            {
-                                return;
-                            }
-                            continue;
-                        }
+                        replacement_term.vt_write(&replacement_snapshot.replay);
                         let color_delta =
                             terminal_color_override_full_state(&replacement_snapshot.colors);
                         if !color_delta.is_empty() {
@@ -3506,166 +1711,52 @@ impl Surface {
                         let pwd = replacement_term.pwd();
                         let generation = {
                             let mut term = pty.term.lock().unwrap();
-                            **term = replacement_term;
+                            *term = replacement_term;
                             pty.mouse_encoders.lock().unwrap().sync_from_terminal(&term);
-                            *geometry = next_geometry;
+                            *pty.size.lock().unwrap() =
+                                (replacement_snapshot.cols, replacement_snapshot.rows);
                             *pty.title.lock().unwrap() = title.clone();
                             *pty.pwd.lock().unwrap() = pwd;
-                            *pty.kitty_graphics_limits.lock().unwrap() =
-                                replacement_snapshot.kitty_state.limits;
                             applied_color_overrides = replacement_snapshot.colors;
-                            applied_color_revision = term.color_revision();
-                            applied_cursor_activity = term.cursor_activity().ok();
                             pty.broadcast_attach_frame(AttachFrame::ResizedWithColors {
                                 cols: replacement_snapshot.cols,
                                 rows: replacement_snapshot.rows,
-                                replay: replacement_snapshot.replay.into(),
-                                kitty_image_aliases: replacement_snapshot.kitty_image_aliases,
-                                kitty_state: replacement_snapshot.kitty_state,
+                                replay: replacement_snapshot.replay,
                                 colors: Box::new(pty.terminal_colors_locked(&term, defaults)),
                             });
                             pty.render_generation.fetch_add(1, Ordering::AcqRel) + 1
                         };
-                        drop(geometry);
-                        pty.stream_progress.notify_reconnect();
                         pty.request_frame(generation);
-                        if !reconnect_mux.terminal_host_reconnected(
-                            surface.id,
-                            &identity,
-                            replacement_snapshot.kitty_state.limits,
-                        ) {
-                            replacement_control_responses.fail_all();
-                            if let PtyRuntime::Hosted(host) = &*pty.runtime.lock().unwrap()
-                                && host.identity() == identity
-                            {
-                                host.disconnect();
-                            }
-                            pty.host_connection_state.store(
-                                TerminalHostConnectionState::Reconnecting as u8,
-                                Ordering::Release,
-                            );
-                            if !reconnect_mux.terminal_host_connection_lost(surface.id, &identity) {
-                                pty.host_connection_state.store(
-                                    TerminalHostConnectionState::Failed as u8,
-                                    Ordering::Release,
-                                );
-                                return;
-                            }
-                            if !retry.wait_or_fail(pty) {
-                                return;
-                            }
-                            continue;
-                        }
-                        if reconnect_mux.terminal_journal_enabled()
-                            && pty.journal_capture_supported
-                        {
-                            let checkpoint_key = format!(
-                                "host-reconnect:{}:{}:{}",
-                                identity.terminal_id,
-                                identity.incarnation,
-                                replacement_sequence_boundary
-                            );
-                            // The checkpoint is a journal-replay optimization:
-                            // failing to capture one only means the next replay
-                            // starts from an older boundary. Capture races with
-                            // every other terminal's concurrent reconnect
-                            // appends, so retry it in place a few times - and
-                            // never tear down the freshly reconnected, healthy
-                            // host over it. The old path disconnected and re-ran
-                            // the full reconnect up to 16 times per terminal,
-                            // each attempt's journal writes re-poisoning the
-                            // other terminals' captures.
-                            let mut checkpoint = reconnect_mux.create_journal_checkpoint(
-                                "terminal_host_reconnect",
-                                &checkpoint_key,
-                            );
-                            for attempt in 1u32..4 {
-                                if checkpoint.is_ok() {
-                                    break;
-                                }
-                                std::thread::sleep(Duration::from_millis(25 << attempt));
-                                checkpoint = reconnect_mux.create_journal_checkpoint(
-                                    "terminal_host_reconnect",
-                                    &checkpoint_key,
-                                );
-                            }
-                            match checkpoint {
-                                Ok(_) => reconnect_mux.note_reconnect_checkpoint_captured(),
-                                Err(error) => reconnect_mux.report_skipped_reconnect_checkpoint(
-                                    &identity.terminal_id,
-                                    &error,
-                                ),
-                            }
-                        }
-                        reconnect_mux.reconcile_deferred_cell_pixel_ack(
-                            surface.id,
-                            replacement_snapshot.cell_pixels,
-                        );
-                        reconnect_mux.emit_terminal_title(pty.event_surface_id, title.into());
-                        reconnect_mux.emit_terminal_resized(
-                            pty.event_surface_id,
-                            replacement_snapshot.cols,
-                            replacement_snapshot.rows,
-                            None,
-                        );
                         reader = replacement_reader;
                         control_responses = replacement_control_responses;
                         sequence_boundary = replacement_snapshot.sequence_boundary;
-                        protocol_version = replacement_protocol_version;
-                        smart_renderer = replacement_smart_renderer;
                         pty.host_connection_state
                             .store(TerminalHostConnectionState::Connected as u8, Ordering::Release);
+                        if let Some(mux) = mux.upgrade() {
+                            mux.emit(MuxEvent::TitleChanged {
+                                surface: surface.id,
+                                title: title.into(),
+                            });
+                            mux.emit(MuxEvent::SurfaceResized {
+                                surface: surface.id,
+                                cols: replacement_snapshot.cols,
+                                rows: replacement_snapshot.rows,
+                                reservation_id: None,
+                            });
+                            if !mux.terminal_host_reconnected(surface.id, &identity) {
+                                return;
+                            }
+                        }
                         continue 'connection;
                     }
                 }
             }
         })?;
-        *surface
-            .as_pty()
-            .expect("hosted PTY surface owns its reader")
-            .reader_thread
-            .lock()
-            .unwrap() = Some(reader_thread);
-        let kitty_registration = kitty_reservation.map_or(Ok(()), |reservation| {
-            reservation.commit(&surface, snapshot.kitty_state.limits)
-        });
-        if let Err(error) = kitty_registration {
-            if let Some(pty) = surface.as_pty()
-                && let PtyRuntime::Hosted(host) = &mut *pty.runtime.lock().unwrap()
-            {
-                if terminate_on_error {
-                    let _ = host.terminate();
-                }
-                host.disconnect();
-            }
-            return Err(error);
-        }
         if terminate_on_error
             && let Some(pty) = surface.as_pty()
             && let PtyRuntime::Hosted(host) = &mut *pty.runtime.lock().unwrap()
         {
-            if !defer_launch_activation && let Err(error) = host.activate_launched_host() {
-                let _ = host.terminate();
-                host.disconnect();
-                return Err(error.into());
-            }
             host.commit_launched_host();
-        }
-        #[cfg(debug_assertions)]
-        if let Some(delay) =
-            mux.upgrade().and_then(|mux| mux.take_test_terminal_host_disconnect_after_spawn())
-        {
-            let test_surface = surface.clone();
-            let _ = std::thread::Builder::new().name("terminal-host-test-disconnect".into()).spawn(
-                move || {
-                    std::thread::sleep(delay);
-                    if let Some(pty) = test_surface.as_pty()
-                        && let PtyRuntime::Hosted(host) = &*pty.runtime.lock().unwrap()
-                    {
-                        host.disconnect();
-                    }
-                },
-            );
         }
         Ok(surface)
     }
@@ -3678,169 +1769,25 @@ impl Surface {
         record: crate::terminal_host_runtime::TerminalHostRecord,
         record_path: PathBuf,
     ) -> anyhow::Result<Arc<Surface>> {
-        Self::adopt_hosted_with_resource_identity(
-            id,
-            opts,
-            mux,
-            record,
-            record_path,
-            TabResourceIdentity::terminal(None)?,
-        )
+        let attachment = crate::terminal_host_runtime::adopt_terminal_host(record, record_path)?;
+        Self::spawn_hosted(id, opts, mux, attachment, false)
     }
 
+    /// Materialize canonical Exited registry state without inventing a live
+    /// host connection. The stable identity stays queryable so later
+    /// placement mutations operate on the same terminal object rather than a
+    /// daemon-local surrogate.
     #[cfg(unix)]
-    pub(crate) fn adopt_hosted_with_resource_identity(
-        id: SurfaceId,
-        opts: SurfaceOptions,
-        mux: Weak<Mux>,
-        record: crate::terminal_host_runtime::TerminalHostRecord,
-        record_path: PathBuf,
-        resource_identity: TabResourceIdentity,
-    ) -> anyhow::Result<Arc<Surface>> {
-        let terminal_public_id = terminal_public_id_from_resource_identity(
-            &resource_identity,
-            "hosted terminal cannot use a browser resource identity",
-        )?;
-        let kitty_reservation =
-            mux.upgrade().map(|mux| mux.reserve_kitty_image_surface(id)).transpose()?;
-        let initial_kitty_limits = kitty_reservation
-            .as_ref()
-            .map(crate::mux::KittyImageBudgetReservation::initial_limits)
-            .unwrap_or_default();
-        let attachment = crate::terminal_host_runtime::adopt_terminal_host_with_kitty_limits(
-            record,
-            record_path,
-            initial_kitty_limits,
-        )?;
-        Self::spawn_hosted(
-            id,
-            opts,
-            mux,
-            HostedSurfaceLaunch {
-                attachment,
-                kitty_reservation,
-                terminate_on_error: false,
-                defer_launch_activation: false,
-                lifetime: PtyLifetime::SessionOwned,
-                terminal_public_id: Some(terminal_public_id),
-                resource_identity: Some(resource_identity),
-            },
-        )
-    }
-
-    #[cfg(unix)]
-    pub(crate) fn adopt_hosted_with_terminal_public_id(
-        id: SurfaceId,
-        opts: SurfaceOptions,
-        mux: Weak<Mux>,
-        record: crate::terminal_host_runtime::TerminalHostRecord,
-        record_path: PathBuf,
-        terminal_public_id: TerminalPublicId,
-    ) -> anyhow::Result<Arc<Surface>> {
-        let kitty_reservation =
-            mux.upgrade().map(|mux| mux.reserve_kitty_image_surface(id)).transpose()?;
-        let initial_kitty_limits = kitty_reservation
-            .as_ref()
-            .map(crate::mux::KittyImageBudgetReservation::initial_limits)
-            .unwrap_or_default();
-        let attachment = crate::terminal_host_runtime::adopt_terminal_host_with_kitty_limits(
-            record,
-            record_path,
-            initial_kitty_limits,
-        )?;
-        Self::spawn_hosted(
-            id,
-            opts,
-            mux,
-            HostedSurfaceLaunch {
-                attachment,
-                kitty_reservation,
-                terminate_on_error: false,
-                defer_launch_activation: false,
-                lifetime: PtyLifetime::SessionOwned,
-                terminal_public_id: Some(terminal_public_id),
-                resource_identity: None,
-            },
-        )
-    }
-
-    /// Construct a dead hosted surface for lifecycle tests without inventing
-    /// a live host connection. Production keeps exit receipts in the registry.
-    #[cfg(all(unix, test))]
     pub(crate) fn exited_terminal_placeholder(
         id: SurfaceId,
         opts: SurfaceOptions,
         mux: Weak<Mux>,
         identity: crate::terminal_host_runtime::TerminalHostIdentity,
     ) -> anyhow::Result<Arc<Surface>> {
-        Self::exited_terminal_placeholder_with_resource_identity(
-            id,
-            opts,
-            mux,
-            identity,
-            TabResourceIdentity::terminal(None)?,
-        )
-    }
-
-    #[cfg(all(unix, test))]
-    pub(crate) fn exited_terminal_placeholder_with_resource_identity(
-        id: SurfaceId,
-        opts: SurfaceOptions,
-        mux: Weak<Mux>,
-        identity: crate::terminal_host_runtime::TerminalHostIdentity,
-        resource_identity: TabResourceIdentity,
-    ) -> anyhow::Result<Arc<Surface>> {
-        let terminal_public_id = terminal_public_id_from_resource_identity(
-            &resource_identity,
-            "exited terminal cannot use a browser resource identity",
-        )?;
-        Self::exited_terminal_placeholder_with_identities(
-            id,
-            opts,
-            mux,
-            identity,
-            terminal_public_id,
-            Some(resource_identity),
-        )
-    }
-
-    #[cfg(all(unix, test))]
-    pub(crate) fn exited_terminal_placeholder_with_terminal_public_id(
-        id: SurfaceId,
-        opts: SurfaceOptions,
-        mux: Weak<Mux>,
-        identity: crate::terminal_host_runtime::TerminalHostIdentity,
-        terminal_public_id: TerminalPublicId,
-    ) -> anyhow::Result<Arc<Surface>> {
-        Self::exited_terminal_placeholder_with_identities(
-            id,
-            opts,
-            mux,
-            identity,
-            terminal_public_id,
-            None,
-        )
-    }
-
-    #[cfg(all(unix, test))]
-    fn exited_terminal_placeholder_with_identities(
-        id: SurfaceId,
-        opts: SurfaceOptions,
-        mux: Weak<Mux>,
-        identity: crate::terminal_host_runtime::TerminalHostIdentity,
-        terminal_public_id: TerminalPublicId,
-        resource_identity: Option<TabResourceIdentity>,
-    ) -> anyhow::Result<Arc<Surface>> {
-        let journal_generation = Arc::from(identity.incarnation.clone());
-        let initial_kitty_limits = KittyGraphicsLimits::disabled();
         let title_changed = Arc::new(AtomicBool::new(false));
         let callbacks = hosted_terminal_callbacks(id, mux.clone(), title_changed);
         let (cols, rows) = (opts.cols.max(1), opts.rows.max(1));
-        let cell_pixels =
-            mux.upgrade().map(|mux| mux.cell_pixel_creation_size()).unwrap_or((8, 16));
         let mut term = Terminal::new(cols, rows, opts.scrollback, callbacks)?;
-        term.resize(cols, rows, u32::from(cell_pixels.0), u32::from(cell_pixels.1))?;
-        term.set_kitty_graphics_limits(initial_kitty_limits)?;
         if let Some(mux) = mux.upgrade() {
             let colors = mux.default_colors();
             term.replace_default_colors(colors.fg, colors.bg, colors.cursor);
@@ -3851,87 +1798,42 @@ impl Surface {
         mouse_encoders.sync_from_terminal(&term);
         let render_state = RenderState::new()?;
         let (frame_requests, frame_rx) = sync_channel(1);
-        #[cfg(test)]
-        let frame_producer_before_upgrade = Arc::new(Mutex::new(None));
         let command = opts
             .command
             .clone()
             .filter(|command| !command.is_empty())
             .unwrap_or_else(|| vec![platform::default_shell()]);
         let surface = Arc::new(Surface::Pty(PtySurface {
-            meta: SurfaceMeta {
-                id,
-                resource_identity,
-                name: Mutex::new(None),
-                selection: Mutex::new(None),
-            },
-            terminal: Arc::new(PtyTerminalRuntime {
-                event_surface_id: id,
-                terminal_public_id: Some(Arc::new(terminal_public_id)),
-                journal_generation,
-                journal_capture_supported: true,
-                journal_capture_epoch: AtomicU64::new(0),
-                journal_capture_gate: Mutex::new(()),
-                journal_capture_idle: Condvar::new(),
-                journal_capture_open: AtomicBool::new(true),
-                journal_capture_reserved: AtomicBool::new(false),
-                journal_capture_active: AtomicBool::new(false),
-                reader_thread: Mutex::new(None),
-                reader_completion: Arc::new(ReaderCompletion::default()),
-                term: Mutex::new(Box::new(term)),
-                stream_progress: Box::new(TerminalStreamProgress::default()),
-                mouse_encoders: Mutex::new(Box::new(mouse_encoders)),
-                runtime: Mutex::new(PtyRuntime::ExitedHosted),
-                lifetime: PtyLifetime::SessionOwned,
-                supports_clear_history_key_fallback: AtomicBool::new(false),
-                host_identity: Some(identity),
-                pending_host_binding: Mutex::new(None),
-                host_exit_record_path: None,
-                pid: None,
-                command,
-                cwd: opts.cwd,
-                exit: Mutex::new(None),
-                local_pty_drained: AtomicBool::new(true),
-                exit_notified: AtomicBool::new(true),
-                dead: AtomicBool::new(true),
-                owner_detaching: AtomicBool::new(false),
-                host_connection_state: AtomicU8::new(TerminalHostConnectionState::Exited as u8),
-                dirty: AtomicBool::new(true),
-                title: Mutex::new(String::new()),
-                pwd: Mutex::new(None),
-                geometry: Mutex::new(PtyGeometry {
-                    cols,
-                    rows,
-                    cell_width: cell_pixels.0,
-                    cell_height: cell_pixels.1,
-                }),
-                kitty_graphics_limits: Box::new(Mutex::new(initial_kitty_limits)),
-                #[cfg(test)]
-                geometry_test_hook: Mutex::new(None),
-                #[cfg(test)]
-                deferred_cell_pixel_ack_test_hook: Mutex::new(None),
-                #[cfg(test)]
-                test_master_control: None,
-                #[cfg(test)]
-                vt_replay_builds: AtomicUsize::new(0),
-                mux,
-                taps: Mutex::new(Vec::new()),
-                attach_colors_pending: AtomicBool::new(false),
-                attach_colors_force_pending: AtomicBool::new(false),
-                last_attach_colors: Mutex::new(None),
-                render: Arc::new(Mutex::new(RenderHub {
-                    state: Box::new(render_state),
-                    built_generation: 0,
-                    latest: None,
-                    initial_graphics: None,
-                    taps: Vec::new(),
-                })),
-                render_generation: AtomicU64::new(1),
-                frame_requests,
-                #[cfg(test)]
-                frame_producer_before_upgrade,
+            meta: SurfaceMeta { id, name: Mutex::new(None), selection: Mutex::new(None) },
+            term: Mutex::new(term),
+            stream_progress: Box::new(TerminalStreamProgress::default()),
+            mouse_encoders: Mutex::new(mouse_encoders),
+            runtime: Mutex::new(PtyRuntime::ExitedHosted),
+            supports_clear_history_key_fallback: AtomicBool::new(false),
+            host_identity: Some(identity),
+            pid: None,
+            command,
+            cwd: opts.cwd,
+            dead: AtomicBool::new(true),
+            owner_detaching: AtomicBool::new(false),
+            host_connection_state: AtomicU8::new(TerminalHostConnectionState::Exited as u8),
+            dirty: AtomicBool::new(true),
+            title: Mutex::new(String::new()),
+            pwd: Mutex::new(None),
+            size: Mutex::new((cols, rows)),
+            mux,
+            taps: Mutex::new(Vec::new()),
+            attach_colors_pending: AtomicBool::new(false),
+            attach_colors_force_pending: AtomicBool::new(false),
+            last_attach_colors: Mutex::new(None),
+            render: Mutex::new(RenderHub {
+                state: Box::new(render_state),
+                built_generation: 0,
+                latest: None,
+                taps: Vec::new(),
             }),
-            viewport: Mutex::new(TerminalViewportState::default()),
+            render_generation: AtomicU64::new(1),
+            frame_requests,
         }));
         spawn_frame_producer(&surface, frame_rx)?;
         Ok(surface)
@@ -3943,123 +1845,12 @@ impl Surface {
         opts: SurfaceOptions,
         mux: Weak<Mux>,
     ) -> anyhow::Result<Arc<Surface>> {
-        let cell_pixels =
-            mux.upgrade().map(|mux| mux.cell_pixel_creation_size()).unwrap_or((8, 16));
-        Self::spawn_for_test_with_resource_identity_at_cell_pixels(
-            id,
-            opts,
-            mux,
-            Some(TabResourceIdentity::terminal(None)?),
-            cell_pixels,
-        )
-    }
-
-    #[cfg(test)]
-    pub(crate) fn spawn_for_test_at_cell_pixels(
-        id: SurfaceId,
-        opts: SurfaceOptions,
-        mux: Weak<Mux>,
-        cell_pixels: (u16, u16),
-    ) -> anyhow::Result<Arc<Surface>> {
-        Self::spawn_for_test_with_resource_identity_at_cell_pixels(
-            id,
-            opts,
-            mux,
-            Some(TabResourceIdentity::terminal(None)?),
-            cell_pixels,
-        )
-    }
-
-    #[cfg(test)]
-    pub(crate) fn spawn_for_test_with_resource_identity(
-        id: SurfaceId,
-        opts: SurfaceOptions,
-        mux: Weak<Mux>,
-        resource_identity: Option<TabResourceIdentity>,
-    ) -> anyhow::Result<Arc<Surface>> {
-        let cell_pixels =
-            mux.upgrade().map(|mux| mux.cell_pixel_creation_size()).unwrap_or((8, 16));
-        Self::spawn_for_test_with_resource_identity_at_cell_pixels(
-            id,
-            opts,
-            mux,
-            resource_identity,
-            cell_pixels,
-        )
-    }
-
-    #[cfg(test)]
-    pub(crate) fn spawn_for_test_with_resource_identity_at_cell_pixels(
-        id: SurfaceId,
-        opts: SurfaceOptions,
-        mux: Weak<Mux>,
-        resource_identity: Option<TabResourceIdentity>,
-        cell_pixels: (u16, u16),
-    ) -> anyhow::Result<Arc<Surface>> {
-        Self::spawn_for_test_with_lifetime_at_cell_pixels(
-            id,
-            opts,
-            mux,
-            resource_identity,
-            PtyLifetime::SessionOwned,
-            cell_pixels,
-        )
-    }
-
-    #[cfg(test)]
-    pub(crate) fn spawn_auxiliary_for_test_at_cell_pixels(
-        id: SurfaceId,
-        opts: SurfaceOptions,
-        mux: Weak<Mux>,
-        cell_pixels: (u16, u16),
-    ) -> anyhow::Result<Arc<Surface>> {
-        Self::spawn_for_test_with_lifetime_at_cell_pixels(
-            id,
-            opts,
-            mux,
-            None,
-            PtyLifetime::DaemonOwned,
-            cell_pixels,
-        )
-    }
-
-    #[cfg(test)]
-    fn spawn_for_test_with_lifetime_at_cell_pixels(
-        id: SurfaceId,
-        opts: SurfaceOptions,
-        mux: Weak<Mux>,
-        resource_identity: Option<TabResourceIdentity>,
-        lifetime: PtyLifetime,
-        cell_pixels: (u16, u16),
-    ) -> anyhow::Result<Arc<Surface>> {
-        let terminal_public_id = resource_identity
-            .as_ref()
-            .map(|identity| {
-                terminal_public_id_from_resource_identity(
-                    identity,
-                    "terminal surface cannot use a browser resource identity",
-                )
-            })
-            .transpose()?;
-        let kitty_reservation =
-            mux.upgrade().map(|mux| mux.reserve_kitty_image_surface(id)).transpose()?;
-        let initial_kitty_limits = kitty_reservation
-            .as_ref()
-            .map(crate::mux::KittyImageBudgetReservation::initial_limits)
-            .unwrap_or_default();
-        let initial_geometry = PtyGeometry {
-            cols: opts.cols,
-            rows: opts.rows,
-            cell_width: cell_pixels.0,
-            cell_height: cell_pixels.1,
-        };
-        let initial_pty_size = initial_geometry.pty_size()?;
         let callbacks = Callbacks {
             on_bell: Some(Box::new({
                 let mux = mux.clone();
                 move || {
                     if let Some(mux) = mux.upgrade() {
-                        mux.emit_terminal_bell(id);
+                        mux.emit(MuxEvent::Bell(id));
                     }
                 }
             })),
@@ -4067,8 +1858,6 @@ impl Surface {
         };
 
         let mut term = Terminal::new(opts.cols, opts.rows, opts.scrollback, callbacks)?;
-        term.resize(opts.cols, opts.rows, u32::from(cell_pixels.0), u32::from(cell_pixels.1))?;
-        term.set_kitty_graphics_limits(initial_kitty_limits)?;
         if let Some(mux) = mux.upgrade() {
             let colors = mux.default_colors();
             term.replace_default_colors(colors.fg, colors.bg, colors.cursor);
@@ -4080,87 +1869,50 @@ impl Surface {
 
         let render_state = RenderState::new()?;
         let (frame_requests, _frame_rx) = sync_channel(1);
-        let test_master_control = Arc::new(TestMasterPtyControl::default());
-        let frame_producer_before_upgrade = Arc::new(Mutex::new(None));
 
-        let surface = Arc::new(Surface::Pty(PtySurface {
-            meta: SurfaceMeta {
-                id,
-                resource_identity,
-                name: Mutex::new(None),
-                selection: Mutex::new(None),
-            },
-            terminal: Arc::new(PtyTerminalRuntime {
-                event_surface_id: id,
-                terminal_public_id: terminal_public_id.map(Arc::new),
-                journal_generation: Arc::from(format!("test-{id}")),
-                journal_capture_supported: true,
-                journal_capture_epoch: AtomicU64::new(0),
-                journal_capture_gate: Mutex::new(()),
-                journal_capture_idle: Condvar::new(),
-                journal_capture_open: AtomicBool::new(true),
-                journal_capture_reserved: AtomicBool::new(false),
-                journal_capture_active: AtomicBool::new(false),
-                reader_thread: Mutex::new(None),
-                reader_completion: Arc::new(ReaderCompletion::default()),
-                term: Mutex::new(Box::new(term)),
-                stream_progress: Box::new(TerminalStreamProgress::default()),
-                mouse_encoders: Mutex::new(Box::new(mouse_encoders)),
-                runtime: Mutex::new(PtyRuntime::Local {
-                    writer: Box::new(std::io::sink()),
-                    master: Some(Box::new(TestMasterPty {
-                        size: Mutex::new(initial_pty_size),
-                        control: test_master_control.clone(),
-                    })),
-                    killer: Box::new(TestChildKiller),
+        Ok(Arc::new(Surface::Pty(PtySurface {
+            meta: SurfaceMeta { id, name: Mutex::new(None), selection: Mutex::new(None) },
+            term: Mutex::new(term),
+            stream_progress: Box::new(TerminalStreamProgress::default()),
+            mouse_encoders: Mutex::new(mouse_encoders),
+            runtime: Mutex::new(PtyRuntime::Local {
+                writer: Box::new(std::io::sink()),
+                master: Box::new(TestMasterPty {
+                    size: Mutex::new(PtySize {
+                        rows: opts.rows,
+                        cols: opts.cols,
+                        pixel_width: 0,
+                        pixel_height: 0,
+                    }),
                 }),
-                lifetime,
-                supports_clear_history_key_fallback: AtomicBool::new(false),
-                host_identity: None,
-                #[cfg(unix)]
-                pending_host_binding: Mutex::new(None),
-                #[cfg(unix)]
-                host_exit_record_path: None,
-                pid: Some(id as u32),
-                command: opts.command.unwrap_or_else(|| vec![platform::default_shell()]),
-                cwd: opts.cwd,
-                exit: Mutex::new(None),
-                local_pty_drained: AtomicBool::new(false),
-                exit_notified: AtomicBool::new(false),
-                dead: AtomicBool::new(false),
-                owner_detaching: AtomicBool::new(false),
-                host_connection_state: AtomicU8::new(TerminalHostConnectionState::Connected as u8),
-                dirty: AtomicBool::new(false),
-                title: Mutex::new(String::new()),
-                pwd: Mutex::new(None),
-                geometry: Mutex::new(initial_geometry),
-                kitty_graphics_limits: Box::new(Mutex::new(initial_kitty_limits)),
-                geometry_test_hook: Mutex::new(None),
-                deferred_cell_pixel_ack_test_hook: Mutex::new(None),
-                test_master_control: Some(test_master_control),
-                vt_replay_builds: AtomicUsize::new(0),
-                mux,
-                taps: Mutex::new(Vec::new()),
-                attach_colors_pending: AtomicBool::new(false),
-                attach_colors_force_pending: AtomicBool::new(false),
-                last_attach_colors: Mutex::new(None),
-                render: Arc::new(Mutex::new(RenderHub {
-                    state: Box::new(render_state),
-                    built_generation: 0,
-                    latest: None,
-                    initial_graphics: None,
-                    taps: Vec::new(),
-                })),
-                render_generation: AtomicU64::new(1),
-                frame_requests,
-                frame_producer_before_upgrade,
+                killer: Box::new(TestChildKiller),
             }),
-            viewport: Mutex::new(TerminalViewportState::default()),
-        }));
-        if let Some(reservation) = kitty_reservation {
-            reservation.commit(&surface, initial_kitty_limits)?;
-        }
-        Ok(surface)
+            supports_clear_history_key_fallback: AtomicBool::new(false),
+            host_identity: None,
+            pid: Some(id as u32),
+            command: opts.command.unwrap_or_else(|| vec![platform::default_shell()]),
+            cwd: opts.cwd,
+            dead: AtomicBool::new(false),
+            owner_detaching: AtomicBool::new(false),
+            host_connection_state: AtomicU8::new(TerminalHostConnectionState::Connected as u8),
+            dirty: AtomicBool::new(false),
+            title: Mutex::new(String::new()),
+            pwd: Mutex::new(None),
+            size: Mutex::new((opts.cols, opts.rows)),
+            mux,
+            taps: Mutex::new(Vec::new()),
+            attach_colors_pending: AtomicBool::new(false),
+            attach_colors_force_pending: AtomicBool::new(false),
+            last_attach_colors: Mutex::new(None),
+            render: Mutex::new(RenderHub {
+                state: Box::new(render_state),
+                built_generation: 0,
+                latest: None,
+                taps: Vec::new(),
+            }),
+            render_generation: AtomicU64::new(1),
+            frame_requests,
+        })))
     }
 
     fn as_pty(&self) -> Option<&PtySurface> {
@@ -4168,64 +1920,6 @@ impl Surface {
             Surface::Pty(surface) => Some(surface),
             Surface::Browser(_) => None,
         }
-    }
-
-    pub(crate) fn terminal_journal_capture_epoch(&self) -> Option<u64> {
-        self.as_pty().map(|pty| pty.journal_capture_epoch.load(Ordering::Acquire))
-    }
-
-    pub(crate) fn finish_terminal_reader(&self, deadline: Instant) -> Option<TerminalJournalGap> {
-        let pty = self.as_pty()?;
-        if let Some(reader) = pty.reader_thread.lock().unwrap().take() {
-            if pty.reader_completion.wait_until(deadline) {
-                if reader.join().is_err() {
-                    eprintln!("cmux-tui: terminal reader thread panicked during shutdown");
-                }
-            } else {
-                eprintln!(
-                    "cmux-tui: terminal reader did not stop before the shared shutdown deadline; closing journal capture"
-                );
-            }
-        }
-        // A reader that is blocked in the PTY has an even capture epoch and
-        // does not delay shutdown. Close the gate between updates. If one
-        // update crossed the reader deadline, wait through the active-update
-        // grace. Report a gap if that update still did not complete.
-        let output_gap = pty.close_terminal_journal_capture_when_idle(deadline);
-        if !output_gap || !pty.journal_capture_supported {
-            return None;
-        }
-        pty.terminal_public_id.clone().map(|terminal_id| TerminalJournalGap {
-            terminal_id,
-            generation: pty.journal_generation.clone(),
-            reason: "active_update_timeout",
-        })
-    }
-
-    #[cfg(test)]
-    pub(crate) fn install_terminal_reader_for_test(&self, reader: std::thread::JoinHandle<()>) {
-        let pty = self.as_pty().expect("test reader requires a PTY surface");
-        pty.reader_completion.reset();
-        let completion = pty.reader_completion.clone();
-        let reader = std::thread::spawn(move || {
-            let result = reader.join();
-            completion.complete();
-            result.expect("installed test terminal reader panicked");
-        });
-        let previous = pty.reader_thread.lock().unwrap().replace(reader);
-        assert!(previous.is_none(), "test PTY already owns a reader thread");
-    }
-
-    #[cfg(test)]
-    pub(crate) fn wait_for_terminal_reader_for_test(&self, deadline: Instant) -> bool {
-        self.as_pty().is_some_and(|pty| pty.reader_completion.wait_until(deadline))
-    }
-
-    #[cfg(test)]
-    pub(crate) fn begin_terminal_journal_update_for_test(
-        &self,
-    ) -> Option<TerminalJournalUpdateGuard<'_>> {
-        self.as_pty().and_then(|pty| pty.begin_terminal_journal_update())
     }
 
     pub(crate) fn as_browser(&self) -> Option<&BrowserSurface> {
@@ -4258,11 +1952,10 @@ impl Surface {
             }
             #[cfg(unix)]
             PtyRuntime::Hosted(host) => host.send(MessageKind::Input, bytes),
-            // A keep-on-exit terminal outlives its child, so typing into the
-            // dead PTY is an expected interaction: drop the bytes silently
-            // instead of failing every keystroke on the final screen.
             #[cfg(unix)]
-            PtyRuntime::ExitedHosted => Ok(()),
+            PtyRuntime::ExitedHosted => {
+                Err(std::io::Error::new(std::io::ErrorKind::BrokenPipe, "terminal host has exited"))
+            }
         }
     }
 
@@ -4284,10 +1977,11 @@ impl Surface {
             if let PtyRuntime::Hosted(host) = &*runtime {
                 return host.send(MessageKind::Paste, bytes);
             }
-            // Keep-on-exit terminals accept and drop paste input the same
-            // way as keystrokes: the final screen is read-only, not broken.
             if matches!(&*runtime, PtyRuntime::ExitedHosted) {
-                return Ok(());
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::BrokenPipe,
+                    "terminal host has exited",
+                ));
             }
         }
         let bracketed = {
@@ -4322,122 +2016,8 @@ impl Surface {
         Some(result)
     }
 
-    fn configure_terminal_kitty_graphics_limits(
-        terminal: &mut Terminal,
-        limits: KittyGraphicsLimits,
-    ) -> anyhow::Result<bool> {
-        terminal.set_kitty_graphics_limits(limits).map_err(Into::into)
-    }
-
-    #[cfg_attr(not(test), allow(dead_code))]
-    pub(crate) fn set_kitty_graphics_limits(
-        &self,
-        bytes: u64,
-        inflight_bytes: u64,
-        images: u64,
-        placements: u64,
-    ) -> anyhow::Result<()> {
-        let requested =
-            KittyGraphicsLimits { image_bytes: bytes, inflight_bytes, images, placements };
-        self.set_kitty_graphics_limits_until(
-            requested,
-            Instant::now() + crate::terminal_host_runtime::CONTROL_RESPONSE_TIMEOUT,
-        )
-    }
-
-    pub(crate) fn set_kitty_graphics_limits_until(
-        &self,
-        requested: KittyGraphicsLimits,
-        deadline: Instant,
-    ) -> anyhow::Result<()> {
-        let Some(pty) = self.as_pty() else {
-            return Ok(());
-        };
-        let requested = requested
-            .validate()
-            .map_err(|_| anyhow::anyhow!("Kitty graphics limits are out of range"))?;
-        #[cfg(unix)]
-        let next = {
-            let runtime = pty.runtime.lock().unwrap();
-            if let PtyRuntime::Hosted(host) = &*runtime {
-                if *pty.kitty_graphics_limits.lock().unwrap() == requested {
-                    return Ok(());
-                }
-                if host.send_kitty_graphics_limits_until(requested, deadline)? {
-                    // The host publishes a complete replacement before its
-                    // acknowledgement. The reader has therefore committed the
-                    // authoritative parser and cache before this returns.
-                    return Ok(());
-                }
-                // Older hosts cannot carry Kitty sidecar state. Keep the
-                // disposable mirror disabled so it cannot silently diverge.
-                KittyGraphicsLimits::disabled()
-            } else {
-                requested
-            }
-        };
-        #[cfg(not(unix))]
-        let next = requested;
-        let graphics_changed = {
-            let mut term = pty.term.lock().unwrap();
-            let mut limits = pty.kitty_graphics_limits.lock().unwrap();
-            if *limits == next {
-                return Ok(());
-            }
-            let graphics_changed = Self::configure_terminal_kitty_graphics_limits(&mut term, next)?;
-            *limits = next;
-            pty.resynchronize_attach_taps_locked(&mut term);
-            if graphics_changed {
-                let mut render = pty.render.lock().unwrap();
-                render.state.clear_kitty_graphics_cache();
-                render.latest = None;
-                render.initial_graphics = None;
-            }
-            graphics_changed
-        };
-        if !graphics_changed {
-            return Ok(());
-        }
-        let generation = pty.render_generation.fetch_add(1, Ordering::AcqRel) + 1;
-        pty.request_frame(generation);
-        Ok(())
-    }
-
-    /// Return the coalesced revision advanced after terminal output or another
-    /// viewport-text transition is applied. Callers can snapshot terminal
-    /// state after reading this value, then wait on the same revision without
-    /// losing an intervening update.
-    pub(crate) fn terminal_stream_revision(&self) -> ghostty_vt::Result<u64> {
-        let Some(pty) = self.as_pty() else {
-            return Err(ghostty_vt::Error::InvalidValue);
-        };
-        Ok(pty.stream_progress.revision())
-    }
-
-    pub(crate) fn subscribe_terminal_stream_change(
-        &self,
-    ) -> ghostty_vt::Result<TerminalStreamSubscription<'_>> {
-        let Some(pty) = self.as_pty() else {
-            return Err(ghostty_vt::Error::InvalidValue);
-        };
-        Ok(pty.stream_progress.subscribe())
-    }
-
-    /// Wait until PTY output advances beyond `observed`, or until `deadline`.
-    /// Unlike an attach stream, this wakeup is coalesced and cannot overflow.
-    pub(crate) fn wait_for_terminal_stream_change(
-        &self,
-        observed: u64,
-        deadline: Option<Instant>,
-    ) -> ghostty_vt::Result<Option<u64>> {
-        let Some(pty) = self.as_pty() else {
-            return Err(ghostty_vt::Error::InvalidValue);
-        };
-        Ok(pty.stream_progress.wait_for_change_until(observed, deadline))
-    }
-
     #[cfg(test)]
-    pub(crate) fn apply_stream_output_for_test(&self, bytes: &[u8]) -> Option<()> {
+    fn apply_stream_output_for_test(&self, bytes: &[u8]) -> Option<()> {
         let pty = self.as_pty()?;
         let mut term = pty.term.lock().unwrap();
         term.vt_write(bytes);
@@ -4447,20 +2027,10 @@ impl Surface {
         Some(())
     }
 
-    #[cfg(test)]
-    pub(crate) fn terminal_stream_waiter_count_for_test(&self) -> Option<usize> {
-        Some(self.as_pty()?.stream_progress.waiter_count())
-    }
-
-    #[cfg(test)]
-    pub(crate) fn terminal_stream_subscription_count_for_test(&self) -> Option<u64> {
-        Some(self.as_pty()?.stream_progress.resource_subscription_count())
-    }
-
     pub fn encode_mouse(
         &self,
         input: MouseInput,
-        output: &mut impl Extend<u8>,
+        output: &mut Vec<u8>,
     ) -> Option<ghostty_vt::Result<()>> {
         let pty = self.as_pty()?;
         match pty.mouse_encoders.try_lock() {
@@ -4470,66 +2040,10 @@ impl Surface {
         }
     }
 
-    /// Encode only when the terminal still matches the semantics captured
-    /// with the rendered frame. The terminal and encoder locks stay held
-    /// across comparison and encoding so parser updates cannot interleave.
-    pub fn encode_mouse_if_semantics(
-        &self,
-        expected: TerminalPointerSemanticSnapshot,
-        input: MouseInput,
-        output: &mut impl Extend<u8>,
-    ) -> Option<GuardedMouseEncode> {
-        let pty = self.as_pty()?;
-        let term = match pty.term.try_lock() {
-            Ok(term) => term,
-            Err(TryLockError::Poisoned(error)) => error.into_inner(),
-            Err(TryLockError::WouldBlock) => return Some(GuardedMouseEncode::Contended),
-        };
-        if term.pointer_semantic_snapshot() != expected {
-            return Some(GuardedMouseEncode::SemanticsChanged);
-        }
-        let mut encoders = match pty.mouse_encoders.try_lock() {
-            Ok(encoders) => encoders,
-            Err(TryLockError::Poisoned(error)) => error.into_inner(),
-            Err(TryLockError::WouldBlock) => return Some(GuardedMouseEncode::Contended),
-        };
-        encoders.sync_from_terminal(&term);
-        Some(GuardedMouseEncode::Encoded(encoders.encode(input, output)))
-    }
-
-    /// Encode only when both terminal semantics and content still match the
-    /// immutable frame that admitted this uncaptured pointer event.
-    pub fn encode_mouse_if_snapshot(
-        &self,
-        expected: TerminalPointerSnapshot,
-        input: MouseInput,
-        output: &mut impl Extend<u8>,
-    ) -> Option<GuardedMouseEncode> {
-        let pty = self.as_pty()?;
-        let term = match pty.term.try_lock() {
-            Ok(term) => term,
-            Err(TryLockError::Poisoned(error)) => error.into_inner(),
-            Err(TryLockError::WouldBlock) => return Some(GuardedMouseEncode::Contended),
-        };
-        if term.pointer_semantic_snapshot() != expected.semantics {
-            return Some(GuardedMouseEncode::SemanticsChanged);
-        }
-        if pty.render_generation.load(Ordering::Acquire) != expected.content_generation {
-            return Some(GuardedMouseEncode::ContentChanged);
-        }
-        let mut encoders = match pty.mouse_encoders.try_lock() {
-            Ok(encoders) => encoders,
-            Err(TryLockError::Poisoned(error)) => error.into_inner(),
-            Err(TryLockError::WouldBlock) => return Some(GuardedMouseEncode::Contended),
-        };
-        encoders.sync_from_terminal(&term);
-        Some(GuardedMouseEncode::Encoded(encoders.encode(input, output)))
-    }
-
     pub fn encode_mouse_release(
         &self,
         input: MouseInput,
-        output: &mut impl Extend<u8>,
+        output: &mut Vec<u8>,
     ) -> Option<ghostty_vt::Result<()>> {
         let pty = self.as_pty()?;
         match pty.mouse_encoders.try_lock() {
@@ -4545,8 +2059,8 @@ impl Surface {
         &self,
         press: MouseInput,
         release: MouseInput,
-        press_output: &mut impl Extend<u8>,
-        release_output: &mut impl Extend<u8>,
+        press_output: &mut Vec<u8>,
+        release_output: &mut Vec<u8>,
     ) -> Option<ghostty_vt::Result<()>> {
         let pty = self.as_pty()?;
         match pty.mouse_encoders.try_lock() {
@@ -4563,76 +2077,6 @@ impl Surface {
         }
     }
 
-    /// Encode a press and its matching release against one rendered terminal
-    /// semantic snapshot, without a parser update between validation and
-    /// encoding either half.
-    pub fn encode_mouse_press_pair_if_semantics(
-        &self,
-        expected: TerminalPointerSemanticSnapshot,
-        press: MouseInput,
-        release: MouseInput,
-        press_output: &mut impl Extend<u8>,
-        release_output: &mut impl Extend<u8>,
-    ) -> Option<GuardedMouseEncode> {
-        let pty = self.as_pty()?;
-        let term = match pty.term.try_lock() {
-            Ok(term) => term,
-            Err(TryLockError::Poisoned(error)) => error.into_inner(),
-            Err(TryLockError::WouldBlock) => return Some(GuardedMouseEncode::Contended),
-        };
-        if term.pointer_semantic_snapshot() != expected {
-            return Some(GuardedMouseEncode::SemanticsChanged);
-        }
-        let mut encoders = match pty.mouse_encoders.try_lock() {
-            Ok(encoders) => encoders,
-            Err(TryLockError::Poisoned(error)) => error.into_inner(),
-            Err(TryLockError::WouldBlock) => return Some(GuardedMouseEncode::Contended),
-        };
-        encoders.sync_from_terminal(&term);
-        Some(GuardedMouseEncode::Encoded(encoders.encode_press_pair(
-            press,
-            release,
-            press_output,
-            release_output,
-        )))
-    }
-
-    /// Encode a press and its matching release only while the terminal still
-    /// matches the immutable content frame that admitted the press.
-    pub fn encode_mouse_press_pair_if_snapshot(
-        &self,
-        expected: TerminalPointerSnapshot,
-        press: MouseInput,
-        release: MouseInput,
-        press_output: &mut impl Extend<u8>,
-        release_output: &mut impl Extend<u8>,
-    ) -> Option<GuardedMouseEncode> {
-        let pty = self.as_pty()?;
-        let term = match pty.term.try_lock() {
-            Ok(term) => term,
-            Err(TryLockError::Poisoned(error)) => error.into_inner(),
-            Err(TryLockError::WouldBlock) => return Some(GuardedMouseEncode::Contended),
-        };
-        if term.pointer_semantic_snapshot() != expected.semantics {
-            return Some(GuardedMouseEncode::SemanticsChanged);
-        }
-        if pty.render_generation.load(Ordering::Acquire) != expected.content_generation {
-            return Some(GuardedMouseEncode::ContentChanged);
-        }
-        let mut encoders = match pty.mouse_encoders.try_lock() {
-            Ok(encoders) => encoders,
-            Err(TryLockError::Poisoned(error)) => error.into_inner(),
-            Err(TryLockError::WouldBlock) => return Some(GuardedMouseEncode::Contended),
-        };
-        encoders.sync_from_terminal(&term);
-        Some(GuardedMouseEncode::Encoded(encoders.encode_press_pair(
-            press,
-            release,
-            press_output,
-            release_output,
-        )))
-    }
-
     pub fn reset_mouse_motion_dedupe(&self) {
         let Some(pty) = self.as_pty() else { return };
         pty.mouse_encoders.lock().unwrap().reset_motion_dedupe();
@@ -4646,114 +2090,29 @@ impl Surface {
     }
 
     pub fn scroll_delta(&self, delta: isize) -> anyhow::Result<()> {
-        let _ = self.apply_scroll_delta(None, delta)?;
-        Ok(())
-    }
-
-    /// Scroll only this placement's in-process frontend viewport. Byte-mode
-    /// frontends own the equivalent state in their terminal mirror.
-    pub fn view_scroll_delta(&self, delta: isize) -> anyhow::Result<Option<Scrollbar>> {
         let Some(pty) = self.as_pty() else {
             anyhow::bail!("browser surface does not have a VT terminal");
         };
-        let mut term = pty.term.lock().unwrap();
-        let Some(scrollbar) = pty.view_scrollbar_locked(&mut term) else { return Ok(None) };
-        let target = if delta < 0 {
-            scrollbar.offset.saturating_sub(delta.unsigned_abs() as u64)
-        } else {
-            scrollbar.offset.saturating_add(delta as u64)
-        }
-        .min(scrollbar.total.saturating_sub(scrollbar.len));
-        if target == scrollbar.offset {
-            return Ok(Some(scrollbar));
-        }
-        pty.set_view_scroll_offset_locked(&mut term, target);
-        Ok(Some(Scrollbar { offset: target, ..scrollbar }))
-    }
-
-    pub fn view_scroll_delta_if_scrollbar(
-        &self,
-        expected: Scrollbar,
-        delta: isize,
-    ) -> anyhow::Result<Option<Scrollbar>> {
-        let Some(pty) = self.as_pty() else {
-            anyhow::bail!("browser surface does not have a VT terminal");
-        };
-        let mut term = pty.term.lock().unwrap();
-        let Some(scrollbar) = pty.view_scrollbar_locked(&mut term) else { return Ok(None) };
-        if scrollbar != expected {
-            return Ok(None);
-        }
-        let target = if delta < 0 {
-            scrollbar.offset.saturating_sub(delta.unsigned_abs() as u64)
-        } else {
-            scrollbar.offset.saturating_add(delta as u64)
-        }
-        .min(scrollbar.total.saturating_sub(scrollbar.len));
-        pty.set_view_scroll_offset_locked(&mut term, target);
-        Ok(Some(Scrollbar { offset: target, ..scrollbar }))
-    }
-
-    pub fn view_scrollbar(&self) -> Option<Scrollbar> {
-        let pty = self.as_pty()?;
-        let mut term = pty.term.lock().unwrap();
-        pty.view_scrollbar_locked(&mut term)
-    }
-
-    pub fn view_scroll_to_bottom(&self) -> anyhow::Result<bool> {
-        let Some(pty) = self.as_pty() else {
-            anyhow::bail!("browser surface does not have a VT terminal");
-        };
-        let mut term = pty.term.lock().unwrap();
-        let Some(scrollbar) = pty.view_scrollbar_locked(&mut term) else { return Ok(false) };
-        let bottom = scrollbar.total.saturating_sub(scrollbar.len);
-        let changed = scrollbar.offset != bottom;
-        pty.set_view_scroll_offset_locked(&mut term, bottom);
-        Ok(changed)
-    }
-
-    /// Apply a scroll only while the terminal still matches the rendered
-    /// scrollbar geometry that admitted the pointer gesture.
-    pub fn scroll_delta_if_scrollbar(
-        &self,
-        expected: Scrollbar,
-        delta: isize,
-    ) -> anyhow::Result<Option<Scrollbar>> {
-        self.apply_scroll_delta(Some(expected), delta)
-    }
-
-    fn apply_scroll_delta(
-        &self,
-        expected: Option<Scrollbar>,
-        delta: isize,
-    ) -> anyhow::Result<Option<Scrollbar>> {
-        let Some(pty) = self.as_pty() else {
-            anyhow::bail!("browser surface does not have a VT terminal");
-        };
-        let (scrollbar, changed) = {
+        let changed = {
             let mut term = pty.term.lock().unwrap();
-            if expected.is_some_and(|expected| term.scrollbar() != Some(expected)) {
-                return Ok(None);
-            }
             let before = terminal_scroll_position(&term);
             term.scroll_delta(delta);
             let after = terminal_scroll_position(&term);
-            let changed = if before == after {
+            if before == after {
                 None
             } else {
                 broadcast_render_scroll_locked(pty, after);
                 let generation = pty.render_generation.fetch_add(1, Ordering::AcqRel) + 1;
                 let _ = pty.build_frame_locked(&mut term, generation, false);
                 Some(after)
-            };
-            (term.scrollbar(), changed)
+            }
         };
         if let Some((offset, at_bottom)) = changed
             && let Some(mux) = pty.mux.upgrade()
         {
-            mux.emit_terminal_scroll(pty.event_surface_id, offset, at_bottom);
+            mux.emit(MuxEvent::ScrollChanged { surface: self.id, offset, at_bottom });
         }
-        Ok(scrollbar)
+        Ok(())
     }
 
     pub fn scroll_to_bottom(&self) -> anyhow::Result<()> {
@@ -4777,7 +2136,7 @@ impl Surface {
         if let Some((offset, at_bottom)) = changed
             && let Some(mux) = pty.mux.upgrade()
         {
-            mux.emit_terminal_scroll(pty.event_surface_id, offset, at_bottom);
+            mux.emit(MuxEvent::ScrollChanged { surface: self.id, offset, at_bottom });
         }
         Ok(())
     }
@@ -4875,19 +2234,17 @@ impl Surface {
                     let PtyRuntime::Local { writer, master, .. } = &mut *runtime else {
                         unreachable!("a local PTY runtime cannot become hosted")
                     };
-                    let Some(master) = master.as_deref() else {
-                        return Err(ClearHistoryFailure::known_not_delivered(anyhow::anyhow!(
-                            "terminal process has exited"
-                        )));
-                    };
                     drop(term);
-                    return write_clear_history_fallback(master, writer.as_mut(), &encoded);
+                    return write_clear_history_fallback(
+                        master.as_ref(),
+                        writer.as_mut(),
+                        &encoded,
+                    );
                 }
                 ClearHistoryTransition::Noop => return Ok(()),
                 ClearHistoryTransition::Cleared(clear) => {
                     pty.mouse_encoders.lock().unwrap().sync_from_terminal(&term);
                     pty.broadcast_attach_output(&clear);
-                    pty.stream_progress.notify();
                     let after = terminal_scroll_position(&term);
                     if before != after {
                         broadcast_render_scroll_locked(pty, after);
@@ -4901,7 +2258,7 @@ impl Surface {
             if let Some((offset, at_bottom)) = scroll_changed
                 && let Some(mux) = pty.mux.upgrade()
             {
-                mux.emit_terminal_scroll(pty.event_surface_id, offset, at_bottom);
+                mux.emit(MuxEvent::ScrollChanged { surface: self.id, offset, at_bottom });
             }
             pty.mark_output_dirty();
             return Ok(());
@@ -4970,88 +2327,13 @@ impl Surface {
         pty.render.lock().unwrap().latest.clone().ok_or(ghostty_vt::Error::NoValue)
     }
 
-    /// Render this placement's frontend-local viewport without changing the
-    /// session compatibility viewport used by backend render projections.
-    pub fn render_view_frame(
-        &self,
-        render: &mut RenderState,
-    ) -> ghostty_vt::Result<Arc<SurfaceRenderFrame>> {
-        let Some(pty) = self.as_pty() else {
-            return Err(ghostty_vt::Error::InvalidValue);
-        };
-        let mut term = pty.term.lock().unwrap();
-        let original_offset = term.scrollbar().map(|scrollbar| scrollbar.offset);
-        let view_offset = pty.view_scrollbar_locked(&mut term).map(|scrollbar| scrollbar.offset);
-        let applied =
-            view_offset.is_none_or(|offset| set_terminal_scroll_offset(&mut term, offset));
-        let result = if applied {
-            (|| {
-                render.update(&mut term)?;
-                let palette_colors = std::array::from_fn(|index| render.palette_color(index as u8));
-                let palette_overridden =
-                    std::array::from_fn(|index| render.palette_overridden(index as u8));
-                Ok(Arc::new(SurfaceRenderFrame {
-                    frame: render.build_frame()?,
-                    content_generation: pty.render_generation.load(Ordering::Acquire),
-                    scrollback_rows: term.history_rows(),
-                    history_epoch: term.history_epoch(),
-                    pointer_semantics: term.pointer_semantic_snapshot(),
-                    palette_colors,
-                    palette_overridden,
-                }))
-            })()
-        } else {
-            Err(ghostty_vt::Error::NoValue)
-        };
-        let restored =
-            original_offset.is_none_or(|offset| set_terminal_scroll_offset(&mut term, offset));
-        if !restored {
-            // Cleanup errors take precedence because a successful-looking
-            // frame would conceal mutation of the shared compatibility view.
-            return Err(ghostty_vt::Error::NoValue);
-        }
-        result
-    }
-
-    /// Read current pointer-routing state without waiting behind terminal parsing.
-    /// Contention is distinct so discrete input can be retained for replay.
-    pub fn try_pointer_semantics(&self) -> Option<PointerSemanticProbe> {
-        let pty = self.as_pty()?;
-        match pty.term.try_lock() {
-            Ok(term) => Some(PointerSemanticProbe::Ready(term.pointer_semantic_snapshot())),
-            Err(TryLockError::Poisoned(error)) => {
-                Some(PointerSemanticProbe::Ready(error.into_inner().pointer_semantic_snapshot()))
-            }
-            Err(TryLockError::WouldBlock) => Some(PointerSemanticProbe::Contended),
-        }
-    }
-
-    /// Read terminal pointer semantics and content generation without waiting
-    /// behind terminal parsing. Returns `None` for non-PTY surfaces.
-    pub fn try_pointer_snapshot(&self) -> Option<PointerSnapshotProbe> {
-        let pty = self.as_pty()?;
-        match pty.term.try_lock() {
-            Ok(term) => Some(PointerSnapshotProbe::Ready(TerminalPointerSnapshot {
-                semantics: term.pointer_semantic_snapshot(),
-                content_generation: pty.render_generation.load(Ordering::Acquire),
-            })),
-            Err(TryLockError::Poisoned(error)) => {
-                Some(PointerSnapshotProbe::Ready(TerminalPointerSnapshot {
-                    semantics: error.into_inner().pointer_semantic_snapshot(),
-                    content_generation: pty.render_generation.load(Ordering::Acquire),
-                }))
-            }
-            Err(TryLockError::WouldBlock) => Some(PointerSnapshotProbe::Contended),
-        }
-    }
-
     /// Resize this surface. PTYs receive cell dimensions; browsers also
     /// use the last configured cell pixel size for CDP device metrics.
     /// Returns whether a clamped size change was applied or accepted. Browser
     /// reconfiguration completes on its worker and emits the final size there.
     pub fn resize(&self, cols: u16, rows: u16) -> anyhow::Result<bool> {
         match self {
-            Surface::Pty(pty) => pty.resize(cols, rows),
+            Surface::Pty(pty) => Ok(pty.resize(cols, rows)),
             Surface::Browser(browser) => browser.resize(cols, rows),
         }
     }
@@ -5081,16 +2363,11 @@ impl Surface {
         report: Box<dyn FnOnce(Option<u64>) + Send>,
     ) -> anyhow::Result<Option<u64>> {
         match self {
-            Surface::Pty(pty) => match pty.resize(cols, rows) {
-                Ok(accepted) => {
-                    report(accepted.then_some(0));
-                    Ok(accepted.then_some(0))
-                }
-                Err(error) => {
-                    report(None);
-                    Err(error)
-                }
-            },
+            Surface::Pty(pty) => {
+                let accepted = pty.resize(cols, rows);
+                report(accepted.then_some(0));
+                Ok(accepted.then_some(0))
+            }
             Surface::Browser(browser) => browser.resize_reporting_acceptance(cols, rows, report),
         }
     }
@@ -5103,22 +2380,14 @@ impl Surface {
         completion: Option<BrowserResizeWaiter>,
     ) -> anyhow::Result<Option<u64>> {
         match self {
-            Surface::Pty(pty) => match pty.resize(cols, rows) {
-                Ok(accepted) => {
-                    report(accepted.then_some(0));
-                    if let Some(completion) = completion {
-                        let _ = completion.send(Ok(()));
-                    }
-                    Ok(accepted.then_some(0))
+            Surface::Pty(pty) => {
+                let accepted = pty.resize(cols, rows);
+                report(accepted.then_some(0));
+                if let Some(completion) = completion {
+                    let _ = completion.send(Ok(()));
                 }
-                Err(error) => {
-                    report(None);
-                    if let Some(completion) = completion {
-                        let _ = completion.send(Err(error.to_string().into()));
-                    }
-                    Err(error)
-                }
-            },
+                Ok(accepted.then_some(0))
+            }
             Surface::Browser(browser) => {
                 browser.resize_reporting_completion(cols, rows, report, completion)
             }
@@ -5128,10 +2397,7 @@ impl Surface {
     pub fn resize_needed(&self, cols: u16, rows: u16) -> bool {
         let desired = (cols.max(1), rows.max(1));
         match self {
-            Surface::Pty(pty) => {
-                let geometry = *pty.geometry.lock().unwrap();
-                (geometry.cols, geometry.rows) != desired
-            }
+            Surface::Pty(pty) => *pty.size.lock().unwrap() != desired,
             Surface::Browser(browser) => browser.resize_needed(desired.0, desired.1),
         }
     }
@@ -5158,91 +2424,19 @@ impl Surface {
         height_px: u16,
         report: Box<dyn FnOnce(Option<u64>) + Send>,
     ) -> anyhow::Result<Option<u64>> {
-        match self {
-            Surface::Pty(pty) => match pty.set_cell_pixel_size(width_px, height_px) {
-                Ok(changed) => {
-                    report(changed.then_some(0));
-                    Ok(changed.then_some(0))
-                }
-                Err(error) => {
-                    report(None);
-                    Err(error)
-                }
-            },
-            Surface::Browser(browser) => {
-                browser.set_cell_pixel_size_reporting(width_px, height_px, report)
-            }
-        }
-    }
-
-    pub(crate) fn set_cell_pixel_size_reporting_until(
-        &self,
-        width_px: u16,
-        height_px: u16,
-        deadline: Instant,
-        report: Box<dyn FnOnce(Option<u64>) + Send>,
-    ) -> anyhow::Result<Option<u64>> {
-        match self {
-            Surface::Pty(pty) => {
-                match pty.set_cell_pixel_size_until(width_px, height_px, Some(deadline)) {
-                    Ok(changed) => {
-                        report(changed.then_some(0));
-                        Ok(changed.then_some(0))
-                    }
-                    Err(error) => {
-                        report(None);
-                        Err(error)
-                    }
-                }
-            }
-            Surface::Browser(browser) => {
-                browser.set_cell_pixel_size_reporting(width_px, height_px, report)
-            }
+        if let Some(browser) = self.as_browser() {
+            browser.set_cell_pixel_size_reporting(width_px, height_px, report)
+        } else {
+            report(None);
+            Ok(None)
         }
     }
 
     pub fn size(&self) -> (u16, u16) {
         match self {
-            Surface::Pty(pty) => {
-                let geometry = *pty.geometry.lock().unwrap();
-                (geometry.cols, geometry.rows)
-            }
+            Surface::Pty(pty) => *pty.size.lock().unwrap(),
             Surface::Browser(browser) => browser.size(),
         }
-    }
-
-    pub(crate) fn cell_pixel_size(&self) -> (u16, u16) {
-        match self {
-            Surface::Pty(pty) => {
-                let geometry = *pty.geometry.lock().unwrap();
-                (geometry.cell_width, geometry.cell_height)
-            }
-            Surface::Browser(browser) => browser.cell_pixel_size(),
-        }
-    }
-
-    #[cfg(test)]
-    pub(crate) fn fail_next_test_master_resize(&self) {
-        self.as_pty()
-            .and_then(|pty| pty.test_master_control.as_ref())
-            .expect("test PTY surface")
-            .fail_next_resize
-            .store(true, Ordering::Release);
-    }
-
-    #[cfg(test)]
-    pub(crate) fn test_master_size(&self) -> PtySize {
-        let runtime = self.as_pty().expect("test PTY surface").runtime.lock().unwrap();
-        let PtyRuntime::Local { master, .. } = &*runtime else {
-            panic!("test PTY surface uses a local runtime");
-        };
-        master.as_deref().expect("test PTY master is open").get_size().unwrap()
-    }
-
-    #[cfg(test)]
-    pub(crate) fn test_cell_pixel_size(&self) -> (u16, u16) {
-        let geometry = *self.as_pty().expect("test PTY surface").geometry.lock().unwrap();
-        (geometry.cell_width, geometry.cell_height)
     }
 
     /// Stop the daemon's durable hosted-terminal mirror from constraining the
@@ -5271,14 +2465,6 @@ impl Surface {
         self.as_pty().and_then(|pty| pty.pwd.lock().unwrap().clone())
     }
 
-    pub fn local_cwd(&self) -> Option<String> {
-        self.pwd()
-            .as_deref()
-            .and_then(platform::terminal_pwd_to_local_path)
-            .map(|path| path.to_string_lossy().into_owned())
-            .or_else(|| self.spawn_cwd())
-    }
-
     pub fn process_id(&self) -> Option<u32> {
         self.as_pty().and_then(|pty| pty.pid)
     }
@@ -5287,71 +2473,8 @@ impl Surface {
         self.as_pty().map(|pty| pty.command.join(" "))
     }
 
-    pub fn spawn_argv(&self) -> Option<Vec<String>> {
-        self.as_pty().map(|pty| pty.command.clone())
-    }
-
     pub fn spawn_cwd(&self) -> Option<String> {
         self.as_pty().and_then(|pty| pty.cwd.clone())
-    }
-
-    pub fn terminal_exit(&self) -> Option<TerminalExit> {
-        self.as_pty().and_then(|pty| pty.exit.lock().unwrap().clone())
-    }
-
-    /// Terminate a hosted terminal through its existing owner connection and
-    /// wait for that same ordered stream to publish the durable exit receipt.
-    /// Local terminals return `None` and keep their existing kill path.
-    #[cfg(unix)]
-    pub(crate) fn terminate_host_and_wait_for_exit(
-        &self,
-        deadline: Instant,
-    ) -> anyhow::Result<Option<(PathBuf, crate::terminal_host_runtime::TerminalHostExitRecord)>>
-    {
-        let Some(pty) = self.as_pty() else { return Ok(None) };
-        let Some(identity) = pty.host_identity.clone() else { return Ok(None) };
-        let Some(path) = pty.host_exit_record_path.clone() else { return Ok(None) };
-        let mut observed = pty.stream_progress.revision();
-        let already_exited = {
-            let mut runtime = pty.runtime.lock().unwrap();
-            match &mut *runtime {
-                PtyRuntime::Hosted(host) => {
-                    host.terminate().map_err(|error| {
-                        anyhow::anyhow!("send terminal-host termination: {error}")
-                    })?;
-                    false
-                }
-                PtyRuntime::ExitedHosted => true,
-                PtyRuntime::Local { .. } => return Ok(None),
-            }
-        };
-        loop {
-            if let Some(exit) = pty.exit.lock().unwrap().clone() {
-                return Ok(Some((
-                    path,
-                    crate::terminal_host_runtime::TerminalHostExitRecord::new(&identity, exit),
-                )));
-            }
-            anyhow::ensure!(
-                !already_exited,
-                "terminal host exited without publishing an exit outcome"
-            );
-            observed =
-                pty.stream_progress.wait_for_change(observed, deadline).ok_or_else(|| {
-                    anyhow::anyhow!("terminal host did not exit before the close deadline")
-                })?;
-        }
-    }
-
-    #[cfg(unix)]
-    pub(crate) fn terminal_host_exit_sidecar(
-        &self,
-    ) -> Option<(PathBuf, crate::terminal_host_runtime::TerminalHostExitRecord)> {
-        let pty = self.as_pty()?;
-        let path = pty.host_exit_record_path.clone()?;
-        let identity = pty.host_identity.as_ref()?;
-        let exit = pty.exit.lock().unwrap().clone()?;
-        Some((path, crate::terminal_host_runtime::TerminalHostExitRecord::new(identity, exit)))
     }
 
     /// Process-stable identity for hosted terminals. Surface ids remain
@@ -5360,13 +2483,6 @@ impl Surface {
         &self,
     ) -> Option<crate::terminal_host_runtime::TerminalHostIdentity> {
         self.as_pty().and_then(|pty| pty.host_identity.clone())
-    }
-
-    #[cfg(unix)]
-    pub(crate) fn release_pending_terminal_host_binding(&self) {
-        if let Some(pty) = self.as_pty() {
-            pty.pending_host_binding.lock().unwrap().take();
-        }
     }
 
     pub fn terminal_host_connection_state(&self) -> Option<TerminalHostConnectionState> {
@@ -5421,35 +2537,31 @@ impl Surface {
             return Err(ghostty_vt::Error::InvalidValue);
         };
         let mut term = pty.term.lock().unwrap();
-        if pty.dead.load(Ordering::Acquire) {
-            return Err(ghostty_vt::Error::NoValue);
-        }
-        let (tap, stream) =
-            AttachTap::pair(lifecycle.clone(), ATTACH_STREAM_CAPACITY, ATTACH_STREAM_MAX_BYTES);
+        let (tx, rx) = sync_channel(ATTACH_STREAM_CAPACITY);
+        let queued_bytes = Arc::new(AtomicUsize::new(0));
         // Snapshot and tap registration under the same terminal lock:
         // the reader thread cannot apply bytes between the two.
-        #[cfg(test)]
-        pty.vt_replay_builds.fetch_add(1, Ordering::AcqRel);
         let replay = term.vt_replay_bounded(VT_REPLAY_MAX_BYTES)?;
         let (cols, rows) = (term.cols(), term.rows());
         let defaults = pty.mux.upgrade().map(|mux| mux.default_colors()).unwrap_or_default();
         let colors = pty.terminal_colors_locked(&term, defaults);
-        if !pty.dead.load(Ordering::Acquire) {
-            let mut taps = pty.taps.lock().unwrap();
-            if taps.is_empty() {
-                *pty.last_attach_colors.lock().unwrap() =
-                    Some(Box::new(TerminalColors::from_pty_output(&term, defaults)));
-            }
-            taps.push(tap);
+        let mut taps = pty.taps.lock().unwrap();
+        if taps.is_empty() {
+            *pty.last_attach_colors.lock().unwrap() =
+                Some(Box::new(TerminalColors::from_pty_output(&term, defaults)));
         }
+        taps.push(AttachTap {
+            sender: tx,
+            lifecycle: lifecycle.clone(),
+            queued_bytes: queued_bytes.clone(),
+            max_queued_bytes: ATTACH_STREAM_MAX_BYTES,
+        });
         Ok(AttachStream {
             cols,
             rows,
-            replay: replay.bytes.into(),
-            kitty_image_aliases: replay.kitty_image_aliases,
-            kitty_state: replay.kitty_state,
+            replay,
             colors,
-            stream,
+            stream: AttachFrameReceiver { receiver: rx, queued_bytes },
             lifecycle,
         })
     }
@@ -5460,82 +2572,37 @@ impl Surface {
         let Some(pty) = self.as_pty() else {
             return Err(ghostty_vt::Error::InvalidValue);
         };
-        let permit = pty
-            .mux
-            .upgrade()
-            .and_then(|mux| mux.claim_render_attachment())
-            .ok_or(ghostty_vt::Error::OutOfSpace)?;
         let mut term = pty.term.lock().unwrap();
-        if pty.dead.load(Ordering::Acquire) {
-            return Err(ghostty_vt::Error::NoValue);
-        }
         let generation = pty.render_generation.load(Ordering::Acquire);
         let _ = pty.build_frame_locked(&mut term, generation, false)?;
-        let (tap, stream) = RenderTap::pair(&pty.render);
+        let (tx, rx) = std::sync::mpsc::channel();
         let initial = {
             let mut render = pty.render.lock().unwrap();
-            let shared = render.latest.clone().ok_or(ghostty_vt::Error::NoValue)?;
-            let initial_graphics = match render.initial_graphics.as_ref() {
-                Some(cached) if Arc::ptr_eq(&cached.source, &shared.frame.kitty_graphics) => {
-                    cached.snapshot.clone()
-                }
-                _ => {
-                    let snapshot = render.state.snapshot_kitty_graphics(&term, true)?;
-                    render.initial_graphics = Some(InitialGraphicsSnapshot {
-                        source: shared.frame.kitty_graphics.clone(),
-                        snapshot: snapshot.clone(),
-                    });
-                    snapshot
-                }
-            };
-            let mut initial = (*shared).clone();
-            initial.frame.kitty_graphics = initial_graphics;
-            if !pty.dead.load(Ordering::Acquire) {
-                render.taps.push(tap);
-            }
-            Arc::new(initial)
+            let initial = render.latest.clone().ok_or(ghostty_vt::Error::NoValue)?;
+            render.taps.push(tx);
+            initial
         };
-        Ok(RenderAttachStream { initial, stream, _permit: permit })
+        Ok(RenderAttachStream { initial, stream: rx })
     }
 
     pub fn kill(&self) {
         match self {
             Surface::Pty(pty) => {
-                #[cfg(unix)]
-                let mut terminate_fallback = None;
-                // Removal is authoritative. Prevent the mirror reader from
-                // racing termination by reconnecting a Surface that no longer
-                // exists in the mux topology.
-                pty.owner_detaching.store(true, Ordering::Release);
-                {
-                    let mut runtime = pty.runtime.lock().unwrap();
-                    match &mut *runtime {
-                        PtyRuntime::Local { killer, .. } => {
-                            let _ = killer.kill();
-                        }
-                        #[cfg(unix)]
-                        PtyRuntime::Hosted(host) => {
-                            // The host owns record cleanup and removes it only
-                            // after the PTY process has actually exited. Unlinking
-                            // here would make a failed Terminate write turn a live
-                            // shell into an undiscoverable orphan.
-                            if host.terminate().is_err() {
-                                terminate_fallback = Some(host.identity());
-                            }
-                        }
-                        #[cfg(unix)]
-                        PtyRuntime::ExitedHosted => {}
+                let mut runtime = pty.runtime.lock().unwrap();
+                match &mut *runtime {
+                    PtyRuntime::Local { killer, .. } => {
+                        let _ = killer.kill();
                     }
-                }
-                if let Some(mux) = pty.mux.upgrade() {
                     #[cfg(unix)]
-                    if let Some(identity) = terminate_fallback {
-                        mux.terminate_discovered_terminal_host(
-                            &identity.terminal_id,
-                            Some(&identity.incarnation),
-                        );
+                    PtyRuntime::Hosted(host) => {
+                        // The host owns record cleanup and removes it only
+                        // after the PTY process has actually exited. Unlinking
+                        // here would make a failed Terminate write turn a live
+                        // shell into an undiscoverable orphan.
+                        let _ = host.terminate();
                     }
-                    let _ = mux.unregister_kitty_image_surface(self);
+                    #[cfg(unix)]
+                    PtyRuntime::ExitedHosted => {}
                 }
             }
             Surface::Browser(browser) => browser.kill(),
@@ -5562,41 +2629,6 @@ impl Surface {
         }
     }
 
-    pub(crate) fn shutdown_for_daemon(&self, deadline: Instant) -> Option<TerminalJournalGap> {
-        if self.as_pty().is_some_and(|pty| pty.lifetime == PtyLifetime::DaemonOwned) {
-            self.kill();
-            return None;
-        }
-        #[cfg(unix)]
-        if let Some(pty) = self.as_pty() {
-            let runtime = pty.runtime.lock().unwrap();
-            if let PtyRuntime::Hosted(host) = &*runtime {
-                pty.owner_detaching.store(true, Ordering::Release);
-                let mut gap = None;
-                if host.supports_journal_detach_fence()
-                    && let Err(error) = host.detach_for_daemon_shutdown_until(deadline)
-                {
-                    eprintln!(
-                        "cmux-tui: terminal host {} detach fence failed: {error:#}",
-                        pty.event_surface_id
-                    );
-                    gap = pty.terminal_public_id.clone().map(|terminal_id| TerminalJournalGap {
-                        terminal_id,
-                        generation: pty.journal_generation.clone(),
-                        reason: "detach_fence_failed",
-                    });
-                }
-                host.disconnect();
-                return gap;
-            }
-            if matches!(&*runtime, PtyRuntime::ExitedHosted) {
-                return None;
-            }
-        }
-        self.disconnect_for_daemon_shutdown();
-        None
-    }
-
     pub(crate) fn persist_host_workspace(&self, workspace_key: &str) -> anyhow::Result<()> {
         #[cfg(unix)]
         if let Some(pty) = self.as_pty()
@@ -5607,72 +2639,12 @@ impl Surface {
         Ok(())
     }
 
-    /// Release a newly launched host after the caller commits the terminal's
-    /// public topology. Adoption and local PTYs are already active, making
-    /// this idempotent for shared creation paths.
-    pub(crate) fn activate_hosted_launch_stream(&self) -> anyhow::Result<bool> {
-        #[cfg(unix)]
-        {
-            let Some(pty) = self.as_pty() else { return Ok(false) };
-            let mut runtime = pty.runtime.lock().unwrap();
-            let PtyRuntime::Hosted(host) = &mut *runtime else { return Ok(false) };
-            host.activate_launched_host().map_err(anyhow::Error::new)
-        }
-        #[cfg(not(unix))]
-        Ok(false)
-    }
-
     pub fn browser_frame(&self) -> Option<BrowserFrame> {
         self.browser_frame_shared().map(|frame| frame.as_ref().clone())
     }
 
     pub fn browser_frame_shared(&self) -> Option<Arc<BrowserFrame>> {
         self.as_browser().and_then(BrowserSurface::latest_frame)
-    }
-
-    pub fn browser_frame_metadata(&self) -> Option<(u64, u32, u32, Option<u64>)> {
-        self.as_browser().and_then(BrowserSurface::latest_frame_metadata)
-    }
-
-    pub fn browser_frame_update(&self) -> Option<BrowserFrameUpdate> {
-        self.as_browser().and_then(BrowserSurface::latest_frame_update)
-    }
-
-    /// Return the opaque browser pointer-authority token for guarded input.
-    pub fn browser_frame_seq(&self) -> Option<u64> {
-        self.as_browser().and_then(BrowserSurface::latest_frame_seq)
-    }
-
-    /// Return whether the local renderer acknowledged this exact browser
-    /// bitmap as its current presentation.
-    pub fn browser_accepts_pointer_frame(&self, frame_seq: u64) -> bool {
-        self.as_browser().is_some_and(|browser| browser.accepts_pointer_frame(frame_seq))
-    }
-
-    /// Return whether a browser bitmap belongs to the current document and
-    /// coordinate mapping without granting it input authority.
-    pub fn browser_pointer_frame_is_in_current_route(&self, frame_seq: u64) -> bool {
-        self.as_browser()
-            .is_some_and(|browser| browser.pointer_frame_is_in_current_route(frame_seq))
-    }
-
-    pub fn browser_acknowledge_pointer_frame(&self, frame_seq: u64) -> bool {
-        self.as_browser().is_some_and(|browser| browser.acknowledge_pointer_frame(frame_seq))
-    }
-
-    pub(crate) fn browser_acknowledge_pointer_frame_from(
-        &self,
-        owner: BrowserPointerOwner,
-        frame_seq: u64,
-    ) -> bool {
-        self.as_browser()
-            .is_some_and(|browser| browser.acknowledge_pointer_frame_from(owner, frame_seq))
-    }
-
-    pub(crate) fn forget_browser_pointer_owner(&self, owner: BrowserPointerOwner) {
-        if let Some(browser) = self.as_browser() {
-            browser.forget_pointer_owner(owner);
-        }
     }
 
     pub fn has_browser_frame(&self) -> bool {
@@ -5724,20 +2696,6 @@ impl Surface {
         browser.key_event(event_type, key, code, windows_virtual_key_code, modifiers, text)
     }
 
-    pub fn browser_key_press(
-        &self,
-        key: &str,
-        code: &str,
-        windows_virtual_key_code: u32,
-        modifiers: u32,
-        text: Option<&str>,
-    ) -> anyhow::Result<()> {
-        let Some(browser) = self.as_browser() else {
-            anyhow::bail!("PTY surface is not a browser surface");
-        };
-        browser.key_press(key, code, windows_virtual_key_code, modifiers, text)
-    }
-
     pub fn browser_mouse_event(
         &self,
         event_type: &str,
@@ -5752,83 +2710,11 @@ impl Surface {
         browser.mouse_event(event_type, x, y, button, click_count)
     }
 
-    /// Queue browser mouse input admitted by a rendered frame sequence.
-    /// Returns `None` for non-browser surfaces.
-    pub fn browser_mouse_event_for_frame(
-        &self,
-        event_type: &str,
-        x: f64,
-        y: f64,
-        button: Option<&str>,
-        click_count: Option<u32>,
-        frame_seq: Option<u64>,
-    ) -> anyhow::Result<()> {
-        let Some(browser) = self.as_browser() else {
-            anyhow::bail!("PTY surface is not a browser surface");
-        };
-        browser.mouse_event_for_frame(event_type, x, y, button, click_count, frame_seq)
-    }
-
-    pub(crate) fn browser_mouse_event_for_frame_from(
-        &self,
-        dispatch: BrowserMouseDispatch<'_>,
-    ) -> anyhow::Result<()> {
-        let Some(browser) = self.as_browser() else {
-            anyhow::bail!("PTY surface is not a browser surface");
-        };
-        browser.mouse_event_for_frame_from(dispatch)
-    }
-
-    pub(crate) fn wake_browser_pointer_cleanup(&self) {
-        if let Some(browser) = self.as_browser() {
-            browser.wake_pointer_cleanup();
-        }
-    }
-
     pub fn browser_wheel(&self, x: f64, y: f64, delta_y: f64) -> anyhow::Result<()> {
-        self.browser_wheel_2d(x, y, 0.0, delta_y)
-    }
-
-    pub fn browser_wheel_2d(
-        &self,
-        x: f64,
-        y: f64,
-        delta_x: f64,
-        delta_y: f64,
-    ) -> anyhow::Result<()> {
         let Some(browser) = self.as_browser() else {
             anyhow::bail!("PTY surface is not a browser surface");
         };
-        browser.wheel_2d(x, y, delta_x, delta_y)
-    }
-
-    /// Queue browser wheel input only while its rendered frame remains live.
-    /// Returns `None` for non-browser surfaces.
-    pub fn browser_wheel_for_frame(
-        &self,
-        x: f64,
-        y: f64,
-        delta_y: f64,
-        frame_seq: Option<u64>,
-    ) -> anyhow::Result<()> {
-        let Some(browser) = self.as_browser() else {
-            anyhow::bail!("PTY surface is not a browser surface");
-        };
-        browser.wheel_for_frame(x, y, delta_y, frame_seq)
-    }
-
-    pub(crate) fn browser_wheel_for_frame_from(
-        &self,
-        owner: BrowserPointerOwner,
-        x: f64,
-        y: f64,
-        delta_y: f64,
-        frame_seq: Option<u64>,
-    ) -> anyhow::Result<()> {
-        let Some(browser) = self.as_browser() else {
-            anyhow::bail!("PTY surface is not a browser surface");
-        };
-        browser.wheel_for_frame_from(owner, x, y, delta_y, frame_seq)
+        browser.wheel(x, y, delta_y)
     }
 
     pub fn browser_navigate(&self, url: &str) -> anyhow::Result<()> {
@@ -5865,148 +2751,16 @@ impl Surface {
         };
         browser.activate()
     }
-
-    pub(crate) fn browser_insert_text_confirmed(&self, text: &str) -> anyhow::Result<()> {
-        let Some(browser) = self.as_browser() else {
-            anyhow::bail!("PTY surface is not a browser surface");
-        };
-        browser.insert_text_confirmed(text)
-    }
-
-    pub(crate) fn browser_key_event_confirmed(
-        &self,
-        event_type: &str,
-        key: &str,
-        code: &str,
-        windows_virtual_key_code: u32,
-        modifiers: u32,
-        text: Option<&str>,
-    ) -> anyhow::Result<()> {
-        let Some(browser) = self.as_browser() else {
-            anyhow::bail!("PTY surface is not a browser surface");
-        };
-        browser.key_event_confirmed(
-            event_type,
-            key,
-            code,
-            windows_virtual_key_code,
-            modifiers,
-            text,
-        )
-    }
-
-    pub(crate) fn browser_mouse_event_confirmed(
-        &self,
-        event_type: &str,
-        x: f64,
-        y: f64,
-        button: Option<&str>,
-        click_count: Option<u32>,
-        frame_seq: u64,
-    ) -> anyhow::Result<()> {
-        let Some(browser) = self.as_browser() else {
-            anyhow::bail!("PTY surface is not a browser surface");
-        };
-        browser.mouse_event_confirmed(event_type, x, y, button, click_count, frame_seq)
-    }
-
-    pub(crate) fn browser_wheel_confirmed(
-        &self,
-        x: f64,
-        y: f64,
-        delta_x: f64,
-        delta_y: f64,
-        frame_seq: u64,
-    ) -> anyhow::Result<()> {
-        let Some(browser) = self.as_browser() else {
-            anyhow::bail!("PTY surface is not a browser surface");
-        };
-        browser.wheel_confirmed(x, y, delta_x, delta_y, frame_seq)
-    }
-
-    pub(crate) fn browser_navigate_confirmed(&self, url: &str) -> anyhow::Result<()> {
-        let Some(browser) = self.as_browser() else {
-            anyhow::bail!("PTY surface is not a browser surface");
-        };
-        browser.navigate_confirmed(url)
-    }
-
-    pub(crate) fn browser_back_confirmed(&self) -> anyhow::Result<()> {
-        let Some(browser) = self.as_browser() else {
-            anyhow::bail!("PTY surface is not a browser surface");
-        };
-        browser.back_confirmed()
-    }
-
-    pub(crate) fn browser_forward_confirmed(&self) -> anyhow::Result<()> {
-        let Some(browser) = self.as_browser() else {
-            anyhow::bail!("PTY surface is not a browser surface");
-        };
-        browser.forward_confirmed()
-    }
-
-    pub(crate) fn browser_reload_confirmed(&self) -> anyhow::Result<()> {
-        let Some(browser) = self.as_browser() else {
-            anyhow::bail!("PTY surface is not a browser surface");
-        };
-        browser.reload_confirmed()
-    }
-
-    pub(crate) fn browser_activate_confirmed(&self) -> anyhow::Result<()> {
-        let Some(browser) = self.as_browser() else {
-            anyhow::bail!("PTY surface is not a browser surface");
-        };
-        browser.activate_confirmed()
-    }
-
-    pub(crate) fn browser_close_confirmed(&self) -> anyhow::Result<()> {
-        let Some(browser) = self.as_browser() else {
-            anyhow::bail!("PTY surface is not a browser surface");
-        };
-        browser.close_confirmed()
-    }
-}
-
-fn set_surface_environment(options: &mut SurfaceOptions, key: &str, value: &str) {
-    if let Some((_, current)) = options.extra_env.iter_mut().find(|(candidate, _)| candidate == key)
-    {
-        *current = value.into();
-    } else {
-        options.extra_env.push((key.into(), value.into()));
-    }
-}
-
-fn configure_agent_browser_session(options: &mut SurfaceOptions, terminal_id: &str) {
-    let enabled = options
-        .extra_env
-        .iter()
-        .any(|(key, value)| key == "CMUX_TUI_AGENT_BROWSER_PROVIDER" && value == "1");
-    if enabled {
-        // agent-browser daemons are keyed by session. A distinct caller
-        // session prevents a command from another workspace from silently
-        // reusing the first workspace's page-scoped CDP connection.
-        set_surface_environment(options, "AGENT_BROWSER_SESSION", &format!("cmux-{terminal_id}"));
-    }
 }
 
 #[cfg(test)]
 struct TestMasterPty {
     size: Mutex<PtySize>,
-    control: Arc<TestMasterPtyControl>,
-}
-
-#[cfg(test)]
-#[derive(Default)]
-struct TestMasterPtyControl {
-    fail_next_resize: AtomicBool,
 }
 
 #[cfg(test)]
 impl MasterPty for TestMasterPty {
     fn resize(&self, size: PtySize) -> anyhow::Result<()> {
-        if self.control.fail_next_resize.swap(false, Ordering::AcqRel) {
-            anyhow::bail!("injected PTY master resize failure");
-        }
         *self.size.lock().unwrap() = size;
         Ok(())
     }
@@ -6094,134 +2848,6 @@ impl ChildKiller for TestChildKiller {
 }
 
 impl PtySurface {
-    fn journal_target(&self) -> Option<(Arc<Mux>, Arc<TerminalPublicId>)> {
-        let terminal_id = self.terminal_public_id.clone()?;
-        let mux = self.mux.upgrade()?;
-        (mux.terminal_journal_enabled() && self.journal_capture_supported)
-            .then_some((mux, terminal_id))
-    }
-
-    fn journal_output_if_open(
-        &self,
-        (mux, terminal_id): (Arc<Mux>, Arc<TerminalPublicId>),
-        bytes: Vec<u8>,
-    ) {
-        let occurred_at_ms = crate::workspace_registry::unix_epoch_ms().unwrap_or(0);
-        for chunk in bytes.chunks(crate::journal_ingress::TERMINAL_OUTPUT_INGRESS_BYTES) {
-            let mut pending = chunk.to_vec();
-            loop {
-                let space_epoch = {
-                    let _gate = self.journal_capture_gate.lock().unwrap();
-                    if !self.journal_capture_open.load(Ordering::Acquire) {
-                        return;
-                    }
-                    let retry = match mux.try_journal_terminal_output(
-                        terminal_id.clone(),
-                        self.journal_generation.clone(),
-                        occurred_at_ms,
-                        pending,
-                    ) {
-                        Ok(retry) => retry,
-                        Err(error) => {
-                            self.journal_capture_open.store(false, Ordering::Release);
-                            mux.request_daemon_shutdown();
-                            eprintln!(
-                                "cmux-tui: terminal journal capture failed; stopping daemon: {error}"
-                            );
-                            return;
-                        }
-                    };
-                    let Some((retry, space_epoch)) = retry else { break };
-                    pending = retry;
-                    space_epoch
-                };
-                if let Err(error) = mux.wait_for_terminal_journal_space(space_epoch) {
-                    self.journal_capture_open.store(false, Ordering::Release);
-                    mux.request_daemon_shutdown();
-                    eprintln!(
-                        "cmux-tui: terminal journal capture failed; stopping daemon: {error}"
-                    );
-                    return;
-                }
-            }
-        }
-    }
-
-    fn journal_geometry(&self, geometry: PtyGeometry) {
-        let (Some(terminal_id), Some(mux)) = (self.terminal_public_id.clone(), self.mux.upgrade())
-        else {
-            return;
-        };
-        mux.journal_terminal_resize(
-            terminal_id,
-            self.journal_generation.clone(),
-            geometry.cols,
-            geometry.rows,
-            geometry.cell_width,
-            geometry.cell_height,
-        );
-    }
-
-    fn view_scrollbar_locked(&self, term: &mut Terminal) -> Option<Scrollbar> {
-        let scrollbar = term.scrollbar()?;
-        let bottom = scrollbar.total.saturating_sub(scrollbar.len);
-        let screen = term.active_screen();
-        let mut viewport = self.viewport.lock().unwrap();
-        let had_anchor = viewport.anchor(screen).is_some();
-        let resolved = viewport
-            .anchor(screen)
-            .and_then(|anchor| term.tracked_screen_point(anchor))
-            .map(|(_, row)| u64::from(row).min(bottom));
-        let offset = match (had_anchor, resolved) {
-            (_, Some(offset)) => offset,
-            (false, None) => bottom,
-            (true, None) if bottom > 0 => {
-                *viewport.anchor_mut(screen) = term.track_screen_point(0, 0).ok();
-                if viewport.anchor(screen).is_some() { 0 } else { bottom }
-            }
-            (true, None) => {
-                *viewport.anchor_mut(screen) = None;
-                bottom
-            }
-        };
-        if offset == bottom {
-            *viewport.anchor_mut(screen) = None;
-        }
-        Some(Scrollbar { offset, ..scrollbar })
-    }
-
-    fn set_view_scroll_offset_locked(&self, term: &mut Terminal, offset: u64) {
-        let Some(scrollbar) = term.scrollbar() else { return };
-        let bottom = scrollbar.total.saturating_sub(scrollbar.len);
-        let target = offset.min(bottom);
-        let screen = term.active_screen();
-        let mut viewport = self.viewport.lock().unwrap();
-        let anchor = viewport.anchor_mut(screen);
-        if target == bottom {
-            *anchor = None;
-            return;
-        }
-        let Ok(target) = u32::try_from(target) else {
-            *anchor = None;
-            return;
-        };
-        if anchor
-            .as_mut()
-            .is_some_and(|anchor| term.set_tracked_screen_point(anchor, 0, target).is_ok())
-        {
-            return;
-        }
-        *anchor = term.track_screen_point(0, target).ok();
-    }
-
-    #[cfg(test)]
-    fn run_geometry_test_hook(&self, step: PtyGeometryTestStep) {
-        let hook = self.geometry_test_hook.lock().unwrap().clone();
-        if let Some(hook) = hook {
-            hook(step);
-        }
-    }
-
     /// Snapshot sparse colors and the host-resolved cursor visual without
     /// touching the shared renderer or consuming its damage.
     fn terminal_colors_locked(&self, term: &Terminal, defaults: DefaultColors) -> TerminalColors {
@@ -6240,44 +2866,6 @@ impl PtySurface {
 
     fn broadcast_attach_frame(&self, frame: AttachFrame) {
         self.taps.lock().unwrap().retain(|tap| tap.try_send(frame.clone()));
-    }
-
-    /// Replace every byte-stream mirror after a sidecar-only state change.
-    /// Limit eviction has no PTY bytes, so continuing the old stream without
-    /// this replay would leave mirrors on a different Kitty scene.
-    fn resynchronize_attach_taps_locked(&self, term: &mut Terminal) {
-        {
-            let mut taps = self.taps.lock().unwrap();
-            taps.retain(|tap| !tap.lifecycle.is_canceled());
-            if taps.is_empty() {
-                return;
-            }
-        }
-        let replay = match term.vt_replay_bounded(VT_REPLAY_MAX_BYTES) {
-            Ok(replay) => replay,
-            Err(_) => {
-                let mut taps = self.taps.lock().unwrap();
-                for tap in &*taps {
-                    tap.lifecycle.cancel();
-                }
-                taps.clear();
-                return;
-            }
-        };
-        let defaults = self.mux.upgrade().map(|mux| mux.default_colors()).unwrap_or_default();
-        let colors = Box::new(self.terminal_colors_locked(term, defaults));
-        self.attach_colors_pending.store(false, Ordering::Release);
-        self.attach_colors_force_pending.store(false, Ordering::Release);
-        *self.last_attach_colors.lock().unwrap() =
-            Some(Box::new(TerminalColors::from_pty_output(term, defaults)));
-        self.broadcast_attach_frame(AttachFrame::ResizedWithColors {
-            cols: term.cols(),
-            rows: term.rows(),
-            replay: replay.bytes.into(),
-            kitty_image_aliases: replay.kitty_image_aliases,
-            kitty_state: replay.kitty_state,
-            colors,
-        });
     }
 
     /// Emit at most one latest effective palette snapshot per frame cadence.
@@ -6315,35 +2903,11 @@ impl PtySurface {
         }
     }
 
-    /// Publish the last PTY generation before the mux drops this surface.
-    ///
-    /// A normal frame request may still be waiting for the cadence deadline,
-    /// and the frame worker holds only a weak reference. Building here keeps
-    /// the final render frame ordered after the byte taps and before detach.
-    fn publish_final_frame(&self) {
-        let mut term = self.term.lock().unwrap();
-        let generation = self.render_generation.load(Ordering::Acquire);
-        let _ = self.build_frame_locked(&mut term, generation, true);
-    }
-
-    /// Preserve the last hosted frame, then end every live attachment while
-    /// retaining the exited surface as a stable, snapshot-renderable tab.
-    fn finish_hosted_exit(&self) {
-        let mut term = self.term.lock().unwrap();
-        if self.dead.swap(true, Ordering::AcqRel) {
-            return;
-        }
-        let generation = self.render_generation.load(Ordering::Acquire);
-        let _ = self.build_frame_locked(&mut term, generation, true);
-        self.taps.lock().unwrap().clear();
-        self.render.lock().unwrap().taps.clear();
-    }
-
     fn mark_output_dirty(&self) {
         if !self.dirty.swap(true, Ordering::AcqRel)
             && let Some(mux) = self.mux.upgrade()
         {
-            mux.emit_terminal_output(self.event_surface_id);
+            mux.emit(MuxEvent::SurfaceOutput(self.meta.id));
         }
     }
 
@@ -6367,23 +2931,13 @@ impl PtySurface {
                     std::array::from_fn(|idx| render.state.palette_overridden(idx as u8));
                 let frame = Arc::new(SurfaceRenderFrame {
                     frame: render.state.build_frame()?,
-                    content_generation: generation,
                     scrollback_rows: term.history_rows(),
-                    history_epoch: term.history_epoch(),
-                    pointer_semantics: term.pointer_semantic_snapshot(),
                     palette_colors,
                     palette_overridden,
                 });
-                if render
-                    .initial_graphics
-                    .as_ref()
-                    .is_some_and(|cached| !Arc::ptr_eq(&cached.source, &frame.frame.kitty_graphics))
-                {
-                    render.initial_graphics = None;
-                }
                 render.built_generation = generation;
                 render.latest = Some(frame.clone());
-                render.taps.retain(|tap| tap.send(RenderAttachFrame::Frame(frame.clone())));
+                render.taps.retain(|tap| tap.send(RenderAttachFrame::Frame(frame.clone())).is_ok());
                 true
             }
         };
@@ -6396,291 +2950,66 @@ impl PtySurface {
 
     /// Resize both the PTY and the terminal state. Returns whether the
     /// final clamped size actually changed.
-    fn resize(&self, cols: u16, rows: u16) -> anyhow::Result<bool> {
-        #[cfg(test)]
-        self.run_geometry_test_hook(PtyGeometryTestStep::ResizeStarted);
+    fn resize(&self, cols: u16, rows: u16) -> bool {
         let (cols, rows) = (cols.max(1), rows.max(1));
-        let mut geometry = self.geometry.lock().unwrap();
-        let next = PtyGeometry { cols, rows, ..*geometry };
-        next.pty_size()?;
         #[cfg(unix)]
         {
             let runtime = self.runtime.lock().unwrap();
             if let PtyRuntime::Hosted(host) = &*runtime {
-                if *geometry == next && host.viewer_size() == Some((cols, rows)) {
-                    return Ok(false);
+                if *self.size.lock().unwrap() == (cols, rows)
+                    && host.viewer_size() == Some((cols, rows))
+                {
+                    return false;
                 }
-                // Do not speculatively reflow the mirror. The host orders
-                // either a compact smart-renderer marker or a legacy
-                // Resized+Colors replay on its authoritative byte stream.
-                return Ok(host.send_viewer_size(cols, rows).is_ok());
-            }
-            if matches!(&*runtime, PtyRuntime::ExitedHosted) {
-                return Ok(false);
+                // Do not speculatively reflow the mirror. The host returns a
+                // Resized+Colors pair containing the canonical post-resize
+                // replay, which the reader installs as one transition.
+                return host.send_viewer_size(cols, rows).is_ok();
             }
         }
-        self.commit_geometry(&mut geometry, next, true)
-    }
-
-    fn set_cell_pixel_size(&self, width_px: u16, height_px: u16) -> anyhow::Result<bool> {
-        self.set_cell_pixel_size_until(width_px, height_px, None)
-    }
-
-    fn set_cell_pixel_size_until(
-        &self,
-        width_px: u16,
-        height_px: u16,
-        deadline: Option<Instant>,
-    ) -> anyhow::Result<bool> {
-        #[cfg(test)]
-        self.run_geometry_test_hook(PtyGeometryTestStep::CellPixelStarted);
-        let requested = (width_px.max(1), height_px.max(1));
         {
-            let geometry = self.geometry.lock().unwrap();
-            if (geometry.cell_width, geometry.cell_height) == requested {
-                return Ok(false);
+            let mut size = self.size.lock().unwrap();
+            if *size == (cols, rows) {
+                return false;
             }
-            PtyGeometry { cell_width: requested.0, cell_height: requested.1, ..*geometry }
-                .pty_size()?;
+            *size = (cols, rows);
         }
-        #[cfg(unix)]
-        {
-            let runtime = self.runtime.lock().unwrap();
-            match &*runtime {
-                PtyRuntime::Hosted(host) => {
-                    let accepted = match deadline {
-                        Some(deadline) => {
-                            host.send_cell_pixel_size_until(requested.0, requested.1, deadline)?
-                        }
-                        None => host.send_cell_pixel_size(requested.0, requested.1)?,
-                    };
-                    if !accepted {
-                        return Ok(false);
-                    }
-                    drop(runtime);
-                    // The host publishes Resized+Colors before its targeted
-                    // acknowledgement. The reader therefore installs the
-                    // canonical parser and metrics before this wait returns.
-                    let geometry = self.geometry.lock().unwrap();
-                    if (geometry.cell_width, geometry.cell_height) != requested {
-                        drop(geometry);
-                        if let PtyRuntime::Hosted(host) = &*self.runtime.lock().unwrap() {
-                            host.disconnect();
-                        }
-                        anyhow::bail!(
-                            "terminal host acknowledged cell metrics without publishing \
-                             the canonical geometry transition"
-                        );
-                    }
-                    return Ok(true);
-                }
-                PtyRuntime::ExitedHosted => return Ok(false),
-                PtyRuntime::Local { .. } => {}
-            }
-        }
-        let mut geometry = self.geometry.lock().unwrap();
-        let next = PtyGeometry { cell_width: requested.0, cell_height: requested.1, ..*geometry };
-        next.pty_size()?;
-        self.commit_geometry(&mut geometry, next, false)
-    }
-
-    /// Commit the PTY ioctl or hosted mirror metrics, Ghostty geometry, and
-    /// the published logical tuple while holding one geometry transaction.
-    fn commit_geometry(
-        &self,
-        geometry: &mut PtyGeometry,
-        next: PtyGeometry,
-        refresh_attach_colors: bool,
-    ) -> anyhow::Result<bool> {
-        self.commit_geometry_for_runtime(geometry, next, refresh_attach_colors, false)
-    }
-
-    #[cfg(unix)]
-    fn commit_hosted_geometry(
-        &self,
-        geometry: &mut PtyGeometry,
-        next: PtyGeometry,
-        refresh_attach_colors: bool,
-    ) -> anyhow::Result<bool> {
-        // The authoritative host has already resized its PTY. Avoid taking
-        // the attachment lock while applying its ordered mirror transition:
-        // a control caller can be holding that lock while it waits for the
-        // acknowledgement queued immediately after this frame.
-        self.commit_geometry_for_runtime(geometry, next, refresh_attach_colors, true)
-    }
-
-    fn commit_geometry_for_runtime(
-        &self,
-        geometry: &mut PtyGeometry,
-        next: PtyGeometry,
-        refresh_attach_colors: bool,
-        hosted_mirror: bool,
-    ) -> anyhow::Result<bool> {
-        if *geometry == next {
-            return Ok(false);
-        }
-        let previous = *geometry;
-        let next_pty_size = next.pty_size()?;
-        let previous_pty_size = previous.pty_size()?;
-        // Hold the terminal lock while resizing and while sending the attach
-        // marker, so mirrors observe bytes and geometry in server order.
+        // Hold the terminal lock while resizing and while sending the
+        // attach marker, so attach mirrors observe bytes and resizes in
+        // the exact order the server terminal applied them.
         let mut term = self.term.lock().unwrap();
-        let runtime = (!hosted_mirror).then(|| self.runtime.lock().unwrap());
-        let master = match runtime.as_deref() {
-            Some(PtyRuntime::Local { master, .. }) => master.as_deref(),
-            #[cfg(unix)]
-            Some(PtyRuntime::Hosted(_)) => None,
-            #[cfg(unix)]
-            Some(PtyRuntime::ExitedHosted) => return Ok(false),
-            None => None,
-        };
-        let mut has_attach_taps = {
-            let mut taps = self.taps.lock().unwrap();
-            taps.retain(|tap| !tap.lifecycle.is_canceled());
-            !taps.is_empty()
-        };
-        // A replacement replay cannot represent a parser that is between
-        // UTF-8 bytes or escape-sequence states. Smart mirrors resize in
-        // place, while compatibility mirrors reconnect from a fresh safe
-        // snapshot instead of consuming a corrupt replay.
-        if has_attach_taps && !term.vt_stream_is_ground() {
-            let mut taps = self.taps.lock().unwrap();
-            for tap in taps.drain(..) {
-                tap.lifecycle.cancel();
-            }
-            has_attach_taps = false;
-        }
-        // The only replay state that cannot be bounded by dropping old text
-        // and completed graphics is an oversized in-flight Kitty upload.
-        // Reject it before resize mutates Ghostty's reflow and scrollback.
-        if has_attach_taps {
-            term.preflight_vt_replay_bounded(VT_REPLAY_MAX_BYTES).map_err(|error| {
-                anyhow::anyhow!(
-                    "could not preflight attach replay before resizing PTY surface to {}x{} at \
-                     {}x{} px per cell: {error}; geometry unchanged",
-                    next.cols,
-                    next.rows,
-                    next.cell_width,
-                    next.cell_height
-                )
-            })?;
-        }
-        if let Some(master) = master {
-            master.resize(next_pty_size).map_err(|error| {
-                anyhow::anyhow!(
-                    "could not resize PTY master to {}x{} at {}x{} px per cell: {error}",
-                    next.cols,
-                    next.rows,
-                    next.cell_width,
-                    next.cell_height
-                )
-            })?;
-        }
-        if let Err(error) = term.resize(
-            next.cols,
-            next.rows,
-            u32::from(next.cell_width),
-            u32::from(next.cell_height),
-        ) {
-            let rollback = master.map_or(Ok(()), |master| master.resize(previous_pty_size));
-            return match rollback {
-                Ok(()) => Err(anyhow::anyhow!(
-                    "could not resize Ghostty terminal to {}x{} at {}x{} px per cell: {error}",
-                    next.cols,
-                    next.rows,
-                    next.cell_width,
-                    next.cell_height
-                )),
-                Err(rollback_error) => Err(anyhow::anyhow!(
-                    "could not resize Ghostty terminal to {}x{} at {}x{} px per cell: {error}; \
-                     PTY master rollback also failed: {rollback_error}",
-                    next.cols,
-                    next.rows,
-                    next.cell_width,
-                    next.cell_height
-                )),
-            };
-        }
-        let replay = if has_attach_taps {
-            #[cfg(test)]
-            self.vt_replay_builds.fetch_add(1, Ordering::AcqRel);
-            match term.vt_replay_bounded(VT_REPLAY_MAX_BYTES) {
-                Ok(replay) => Some(replay),
-                Err(_) => {
-                    // Budget failure was already ruled out under this same
-                    // terminal lock. A formatter/backend failure must not be
-                    // answered with a destructive inverse resize. Disconnect
-                    // byte mirrors so they reattach from fresh state.
-                    let mut taps = self.taps.lock().unwrap();
-                    for tap in &*taps {
-                        tap.lifecycle.cancel();
-                    }
-                    taps.clear();
-                    None
+        {
+            let mut runtime = self.runtime.lock().unwrap();
+            match &mut *runtime {
+                PtyRuntime::Local { master, .. } => {
+                    let _ = master.resize(PtySize { rows, cols, pixel_width: 0, pixel_height: 0 });
                 }
+                #[cfg(unix)]
+                PtyRuntime::Hosted(_) => unreachable!("hosted resize returned above"),
+                #[cfg(unix)]
+                PtyRuntime::ExitedHosted => return false,
             }
-        } else {
-            None
-        };
-        drop(runtime);
-        *geometry = next;
-        self.journal_geometry(next);
-        #[cfg(test)]
-        self.run_geometry_test_hook(if refresh_attach_colors {
-            PtyGeometryTestStep::ResizeCommitBoundary
-        } else {
-            PtyGeometryTestStep::CellPixelCommitBoundary
-        });
+        }
+        // Nominal cell metrics; only pixel size reports observe these.
+        let _ = term.resize(cols, rows, 8, 16);
+        let replay = term.vt_replay_bounded(VT_REPLAY_MAX_BYTES).unwrap_or_default();
+        let defaults = self.mux.upgrade().map(|mux| mux.default_colors()).unwrap_or_default();
         let generation = self.render_generation.fetch_add(1, Ordering::AcqRel) + 1;
         let _ = self.build_frame_locked(&mut term, generation, false);
-        if let Some(replay) = replay {
-            let defaults = self.mux.upgrade().map(|mux| mux.default_colors()).unwrap_or_default();
-            let colors = Box::new(self.terminal_colors_locked(&term, defaults));
-            if refresh_attach_colors {
-                let live_colors = TerminalColors::from_pty_output(&term, defaults);
-                self.attach_colors_pending.store(false, Ordering::Release);
-                self.attach_colors_force_pending.store(false, Ordering::Release);
-                *self.last_attach_colors.lock().unwrap() = Some(Box::new(live_colors));
-            }
-            self.broadcast_attach_frame(AttachFrame::ResizedWithColors {
-                cols: next.cols,
-                rows: next.rows,
-                replay: replay.bytes.into(),
-                kitty_image_aliases: replay.kitty_image_aliases,
-                kitty_state: replay.kitty_state,
-                colors,
-            });
-        }
-        self.stream_progress.notify();
-        Ok(true)
+        let live_colors = TerminalColors::from_pty_output(&term, defaults);
+        let colors = Box::new(self.terminal_colors_locked(&term, defaults));
+        self.attach_colors_pending.store(false, Ordering::Release);
+        self.attach_colors_force_pending.store(false, Ordering::Release);
+        *self.last_attach_colors.lock().unwrap() = Some(Box::new(live_colors));
+        self.broadcast_attach_frame(AttachFrame::ResizedWithColors { cols, rows, replay, colors });
+        true
     }
-}
-
-#[cfg(test)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum PtyGeometryTestStep {
-    ResizeStarted,
-    ResizeCommitBoundary,
-    CellPixelStarted,
-    CellPixelCommitBoundary,
-    ReconnectBackoffStarted,
 }
 
 fn terminal_color_override_full_state(next: &TerminalColorOverrides) -> Vec<u8> {
     let mut output = if next.cursor_visual.is_some() { b"\x1b[0 q".to_vec() } else { Vec::new() };
     output.extend_from_slice(&terminal_color_override_delta(&Default::default(), next));
     output
-}
-
-/// Apply one complete terminal-host Colors state to a local libghostty parser.
-/// Snapshot replay intentionally leaves embedder defaults local while this
-/// helper restores application-authored dynamic colors, palette entries, and
-/// cursor semantics at the advertised sequence boundary.
-pub fn apply_terminal_color_overrides(terminal: &mut Terminal, colors: &TerminalColorOverrides) {
-    let transition = terminal_color_override_full_state(colors);
-    if !transition.is_empty() {
-        terminal.vt_write(&transition);
-    }
 }
 
 fn terminal_color_overrides_match_applied(
@@ -6756,12 +3085,6 @@ const RENDER_FRAME_CADENCE: Duration = Duration::from_millis(8);
 fn spawn_frame_producer(surface: &Arc<Surface>, requests: Receiver<u64>) -> anyhow::Result<()> {
     let weak = Arc::downgrade(surface);
     let id = surface.id;
-    #[cfg(test)]
-    let before_upgrade = surface
-        .as_pty()
-        .expect("frame producer got non-pty surface")
-        .frame_producer_before_upgrade
-        .clone();
     std::thread::Builder::new().name(format!("surface-{id}-frames")).spawn(move || {
         let mut last_frame = Instant::now() - RENDER_FRAME_CADENCE;
         while let Ok(mut requested) = requests.recv() {
@@ -6776,10 +3099,6 @@ fn spawn_frame_producer(surface: &Arc<Surface>, requests: Receiver<u64>) -> anyh
                     Err(RecvTimeoutError::Timeout) => break,
                     Err(RecvTimeoutError::Disconnected) => return,
                 }
-            }
-            #[cfg(test)]
-            if let Some(hook) = before_upgrade.lock().unwrap().clone() {
-                hook();
             }
             let Some(surface) = weak.upgrade() else { break };
             let Some(pty) = surface.as_pty() else { break };
@@ -6804,7 +3123,9 @@ fn spawn_frame_producer(surface: &Arc<Surface>, requests: Receiver<u64>) -> anyh
 fn broadcast_render_scroll_locked(pty: &PtySurface, position: (u64, bool)) {
     let (offset, at_bottom) = position;
     let mut render = pty.render.lock().unwrap();
-    render.taps.retain(|tap| tap.send(RenderAttachFrame::ScrollChanged { offset, at_bottom }));
+    render
+        .taps
+        .retain(|tap| tap.send(RenderAttachFrame::ScrollChanged { offset, at_bottom }).is_ok());
 }
 
 fn terminal_scroll_position(term: &Terminal) -> (u64, bool) {
@@ -6814,174 +3135,9 @@ fn terminal_scroll_position(term: &Terminal) -> (u64, bool) {
     }
 }
 
-fn set_terminal_scroll_offset(term: &mut Terminal, target: u64) -> bool {
-    let Some(scrollbar) = term.scrollbar() else { return target == 0 };
-    let bottom = scrollbar.total.saturating_sub(scrollbar.len);
-    let target = target.min(bottom);
-    if target == bottom {
-        term.scroll_to_bottom();
-        return term.scrollbar().is_some_and(|scrollbar| scrollbar.offset == target);
-    }
-    let mut current = scrollbar.offset;
-    let mut remaining = current.abs_diff(target);
-    while current != target {
-        let difference = i128::from(target) - i128::from(current);
-        let step = difference.clamp(isize::MIN as i128, isize::MAX as i128) as isize;
-        term.scroll_delta(step);
-        let Some(next) = term.scrollbar().map(|scrollbar| scrollbar.offset) else { return false };
-        let next_remaining = next.abs_diff(target);
-        if next_remaining >= remaining {
-            return false;
-        }
-        current = next;
-        remaining = next_remaining;
-    }
-    true
-}
-
 #[cfg(test)]
 mod tests {
-    use base64::Engine as _;
-
     use super::*;
-    use crate::MuxEvent;
-
-    #[test]
-    fn agent_browser_provider_uses_a_terminal_local_daemon_session() {
-        let mut options = SurfaceOptions {
-            extra_env: vec![
-                ("CMUX_TUI_AGENT_BROWSER_PROVIDER".into(), "1".into()),
-                ("AGENT_BROWSER_SESSION".into(), "unsafe-shared-session".into()),
-            ],
-            ..SurfaceOptions::default()
-        };
-        configure_agent_browser_session(&mut options, "term_0123456789abcdef");
-        assert_eq!(
-            options
-                .extra_env
-                .iter()
-                .find(|(key, _)| key == "AGENT_BROWSER_SESSION")
-                .map(|(_, value)| value.as_str()),
-            Some("cmux-term_0123456789abcdef")
-        );
-    }
-
-    #[test]
-    fn terminal_projection_has_distinct_view_identity_and_shared_runtime() {
-        let mux = Mux::new_for_test("terminal-projection", SurfaceOptions::default());
-        let source =
-            Surface::spawn_for_test(1, SurfaceOptions::default(), Arc::downgrade(&mux)).unwrap();
-        let source_identity = source.resource_identity().unwrap().clone();
-        let projection = source
-            .project_terminal(
-                2,
-                TabResourceIdentity::new(
-                    crate::resource::TabPublicId::random().unwrap(),
-                    source_identity.content_id,
-                ),
-            )
-            .unwrap();
-
-        assert_eq!(source.id, 1);
-        assert_eq!(projection.id, 2);
-        assert!(source.shares_terminal_runtime(&projection));
-        let foreign_identity = TabResourceIdentity::new(
-            crate::resource::TabPublicId::random().unwrap(),
-            ContentPublicId::Terminal(TerminalPublicId::random().unwrap()),
-        );
-        assert!(source.project_terminal(3, foreign_identity).is_err());
-
-        source.set_name(Some("source".into()));
-        projection.set_name(Some("projection".into()));
-        assert_eq!(source.name().as_deref(), Some("source"));
-        assert_eq!(projection.name().as_deref(), Some("projection"));
-
-        projection.resize(91, 37).unwrap();
-        assert_eq!(source.size(), (91, 37));
-        source.with_terminal(|terminal| terminal.vt_write(b"shared-output"));
-        let projected_text =
-            projection.with_terminal(|terminal| terminal.viewport_text().unwrap()).unwrap();
-        assert!(projected_text.contains("shared-output"));
-
-        source.with_terminal(|terminal| {
-            for line in 0..48 {
-                terminal.vt_write(format!("\r\nline-{line:02}").as_bytes());
-            }
-        });
-        let bottom = projection.view_scrollbar().unwrap();
-        assert!(!bottom.scrolled_back());
-        source.view_scroll_delta(-5).unwrap();
-        let source_scrollbar = source.view_scrollbar().unwrap();
-        let projection_scrollbar = projection.view_scrollbar().unwrap();
-        assert!(source_scrollbar.scrolled_back());
-        assert_eq!(projection_scrollbar, bottom);
-        let compatibility_scrollbar =
-            source.with_terminal(|terminal| terminal.scrollbar().unwrap()).unwrap();
-        assert_eq!(compatibility_scrollbar, bottom);
-
-        let mut source_render = RenderState::new().unwrap();
-        let mut projection_render = RenderState::new().unwrap();
-        let source_frame = source.render_view_frame(&mut source_render).unwrap();
-        let projection_frame = projection.render_view_frame(&mut projection_render).unwrap();
-        assert_ne!(source_frame.frame.runs(), projection_frame.frame.runs());
-        assert_eq!(projection.view_scrollbar().unwrap(), bottom);
-        let compatibility_after_render =
-            source.with_terminal(|terminal| terminal.scrollbar().unwrap()).unwrap();
-        assert_eq!(compatibility_after_render, bottom);
-
-        let writer = CapturingWriter::default();
-        replace_local_writer(&source, Box::new(writer.clone()));
-        source.write_bytes(b"first").unwrap();
-        projection.write_bytes(b"second").unwrap();
-        assert_eq!(&*writer.0.lock().unwrap(), b"firstsecond");
-    }
-
-    fn append_disabled_kitty_replay_state(payload: &mut Vec<u8>) {
-        for _ in 0..4 {
-            payload.extend_from_slice(&0u64.to_le_bytes());
-        }
-        payload.extend_from_slice(&0u32.to_le_bytes());
-        for _ in 0..4 {
-            payload.extend_from_slice(
-                &ghostty_vt::KittyImageIdCursors::DEFAULT_NEXT_IMAGE_ID.to_le_bytes(),
-            );
-        }
-    }
-
-    #[test]
-    fn surface_enum_keeps_terminal_state_out_of_line() {
-        // Test-only geometry and PTY hooks add fields that release builds omit.
-        const MAX_TEST_SURFACE_BYTES: usize = 800;
-        assert!(
-            size_of::<Surface>() <= MAX_TEST_SURFACE_BYTES,
-            "Surface grew to {} bytes (PTY {}, browser {}); keep large runtime state out of line",
-            size_of::<Surface>(),
-            size_of::<PtySurface>(),
-            size_of::<BrowserSurface>()
-        );
-    }
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn macos_surface_spawn_returns_within_deadline() {
-        let (result_tx, result_rx) = sync_channel(1);
-        std::thread::spawn(move || {
-            let mux = Mux::new_for_test("macos-pty-deadline", SurfaceOptions::default());
-            let options = SurfaceOptions {
-                command: Some(vec!["/bin/sh".into(), "-c".into(), "exit 0".into()]),
-                ..SurfaceOptions::default()
-            };
-            let result = Surface::spawn(9_001, options, Arc::downgrade(&mux))
-                .map(drop)
-                .map_err(|error| error.to_string());
-            let _ = result_tx.send(result);
-        });
-
-        result_rx
-            .recv_timeout(Duration::from_secs(5))
-            .expect("macOS surface PTY spawn blocked past its five-second deadline")
-            .expect("macOS surface PTY spawn failed");
-    }
 
     #[test]
     fn default_scrollback_retains_long_agent_transcript() {
@@ -6990,9 +3146,7 @@ mod tests {
             Terminal::new(options.cols, options.rows, options.scrollback, Callbacks::default())
                 .unwrap();
         for line in 0..20_000 {
-            terminal.vt_write(
-                format!("omp-history-{line:05} {}\r\n", "x".repeat(64)).as_bytes(),
-            );
+            terminal.vt_write(format!("omp-history-{line:05} {}\r\n", "x".repeat(64)).as_bytes());
         }
 
         let scrollback = terminal.plain_text().unwrap();
@@ -7046,23 +3200,6 @@ mod tests {
         *writer = replacement;
     }
 
-    #[test]
-    fn test_surface_accepts_non_uuid_public_terminal_identity() {
-        let mux = Mux::new_for_test("opaque-terminal-id", SurfaceOptions::default());
-        let terminal = TerminalPublicId::parse("term_ffffffffffffffffffffffffffffffff").unwrap();
-        let tab =
-            crate::resource::TabPublicId::parse("tab_00000000000000000000000000000001").unwrap();
-        let identity = TabResourceIdentity::persisted_terminal(tab, terminal);
-        let surface = Surface::spawn_for_test_with_resource_identity(
-            1,
-            SurfaceOptions::default(),
-            Arc::downgrade(&mux),
-            Some(identity.clone()),
-        )
-        .unwrap();
-        assert_eq!(surface.resource_identity(), Some(&identity));
-    }
-
     #[cfg(unix)]
     #[test]
     fn hosted_mirror_never_answers_terminal_queries() {
@@ -7081,64 +3218,6 @@ mod tests {
         // the child input after the authoritative host has already replied.
         let mut term = Terminal::new(80, 24, 0, callbacks).unwrap();
         term.vt_write(b"\x1b_Gi=31,s=1,v=1,a=q,t=d,f=24;AAAA\x1b\\\x1b[c");
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn deferred_cell_pixel_responses_run_on_the_bounded_mux_pool() {
-        let mux = Mux::new_for_test("bounded-deferred-cell-pixel", SurfaceOptions::default());
-        let surface =
-            Surface::spawn_for_test(1, SurfaceOptions::default(), Arc::downgrade(&mux)).unwrap();
-        let responses = Arc::new(crate::terminal_host_runtime::ControlResponses::new_for_test());
-        Surface::install_deferred_cell_pixel_handler(&surface, &responses);
-        let (thread_name_tx, thread_name_rx) = std::sync::mpsc::channel();
-        surface.as_pty().unwrap().deferred_cell_pixel_ack_test_hook.lock().unwrap().replace(
-            Arc::new(move || {
-                let name = std::thread::current().name().unwrap_or_default().to_owned();
-                let _ = thread_name_tx.send(name);
-            }),
-        );
-
-        let mut frame = Frame::new(MessageKind::CellPixelSizeAck, vec![8, 0, 16, 0]);
-        frame.request_id = 1;
-        responses.invoke_deferred_cell_pixel_handler_for_test(
-            1,
-            (8, 16),
-            crate::terminal_host_runtime::DeferredCellPixelResolution::Response(frame),
-        );
-
-        let thread_name = thread_name_rx.recv_timeout(Duration::from_secs(1)).unwrap();
-        assert!(
-            thread_name.starts_with("mux-deadline-"),
-            "deferred acknowledgement ran on unbounded worker {thread_name:?}"
-        );
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn disconnected_deferred_cell_pixel_resolutions_do_not_schedule_work() {
-        let mux = Mux::new_for_test("disconnected-deferred-cell-pixel", SurfaceOptions::default());
-        let surface =
-            Surface::spawn_for_test(1, SurfaceOptions::default(), Arc::downgrade(&mux)).unwrap();
-        let responses = Arc::new(crate::terminal_host_runtime::ControlResponses::new_for_test());
-        Surface::install_deferred_cell_pixel_handler(&surface, &responses);
-        let (called_tx, called_rx) = std::sync::mpsc::channel();
-        surface.as_pty().unwrap().deferred_cell_pixel_ack_test_hook.lock().unwrap().replace(
-            Arc::new(move || {
-                let _ = called_tx.send(());
-            }),
-        );
-
-        responses.invoke_deferred_cell_pixel_handler_for_test(
-            1,
-            (8, 16),
-            crate::terminal_host_runtime::DeferredCellPixelResolution::Disconnected,
-        );
-
-        assert!(
-            called_rx.recv_timeout(Duration::from_millis(100)).is_err(),
-            "a disconnect-only resolution spawned reconciliation work"
-        );
     }
 
     #[test]
@@ -7176,7 +3255,7 @@ mod tests {
         let _ = TerminalColors::from_terminal(&term, DefaultColors::default());
 
         shared_render.update(&mut term).unwrap();
-        assert_ne!(shared_render.dirty(), Dirty::Clean);
+        assert_ne!(shared_render.dirty(), ghostty_vt::Dirty::Clean);
     }
 
     #[test]
@@ -7381,16 +3460,12 @@ mod tests {
         let mut output = Vec::new();
         let colors = loop {
             assert!(Instant::now() < deadline, "local cursor activity was not published");
-            match attach.stream.recv_timeout(Duration::from_millis(250)) {
-                Ok(AttachFrame::Output(bytes)) => output.extend_from_slice(&bytes),
-                Ok(AttachFrame::ColorsChanged(colors)) => break colors,
-                Ok(AttachFrame::Resized { .. } | AttachFrame::ResizedWithColors { .. }) => {}
-                Ok(AttachFrame::OutputWithColors { .. }) => {
+            match attach.stream.recv_timeout(Duration::from_millis(250)).unwrap() {
+                AttachFrame::Output(bytes) => output.extend_from_slice(&bytes),
+                AttachFrame::ColorsChanged(colors) => break colors,
+                AttachFrame::Resized { .. } | AttachFrame::ResizedWithColors { .. } => {}
+                AttachFrame::OutputWithColors { .. } => {
                     panic!("local PTYs must use ordered Output then ColorsChanged")
-                }
-                Err(RecvTimeoutError::Timeout) => {}
-                Err(RecvTimeoutError::Disconnected) => {
-                    panic!("local cursor activity stream disconnected")
                 }
             }
         };
@@ -7401,130 +3476,6 @@ mod tests {
         );
         assert_eq!((colors.cursor_style, colors.cursor_blink), expected);
         assert!(colors.cursor_style.is_some() && colors.cursor_blink.is_some());
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn local_surface_retains_real_status_after_final_pty_bytes() {
-        fn run(mux: &Arc<Mux>, id: SurfaceId, script: &str, final_text: &str) -> TerminalExit {
-            let surface = Surface::spawn(
-                id,
-                SurfaceOptions {
-                    command: Some(vec!["/bin/sh".into(), "-c".into(), script.into()]),
-                    ..SurfaceOptions::default()
-                },
-                Arc::downgrade(mux),
-            )
-            .unwrap();
-            let deadline = Instant::now() + Duration::from_secs(2);
-            let exit = loop {
-                if let Some(exit) = surface.terminal_exit()
-                    && surface.is_dead()
-                {
-                    break exit;
-                }
-                assert!(Instant::now() < deadline, "local PTY did not publish its exit");
-                std::thread::sleep(Duration::from_millis(5));
-            };
-            let text =
-                surface.try_with_terminal(|terminal| terminal.viewport_text()).unwrap().unwrap();
-            assert!(
-                text.contains(final_text),
-                "exit became visible before final PTY bytes: {text:?}"
-            );
-            exit
-        }
-
-        let mux = Mux::new_for_test("local-exit-status", SurfaceOptions::default());
-        assert_eq!(
-            run(&mux, 101, "printf final-exit; exit 17", "final-exit").outcome,
-            crate::terminal_host_protocol::TerminalExitOutcome::Exit { code: 17 }
-        );
-        assert_eq!(
-            run(&mux, 102, "printf final-signal; kill -TERM $$", "final-signal").outcome,
-            crate::terminal_host_protocol::TerminalExitOutcome::Signal {
-                signal: libc::SIGTERM,
-                core_dumped: false,
-            }
-        );
-    }
-
-    /// The selection rule: pass xterm-ghostty through only when the outer
-    /// terminal already advertised it. Prompts that sniff the TERM name
-    /// then take the same branch inside cmux-tui as in the host terminal
-    /// (colors match), and children never get a less compatible TERM than
-    /// the host terminal gave the user.
-    #[test]
-    fn child_term_passes_ghostty_through_and_nothing_else() {
-        assert_eq!(child_term_for(Some("xterm-ghostty")), "xterm-ghostty");
-        assert_eq!(child_term_for(Some("xterm-256color")), "xterm-256color");
-        assert_eq!(child_term_for(Some("screen")), "xterm-256color");
-        assert_eq!(child_term_for(Some("alacritty")), "xterm-256color");
-        assert_eq!(child_term_for(Some("")), "xterm-256color");
-        assert_eq!(child_term_for(None), "xterm-256color");
-    }
-
-    /// default_child_term composes the rule with this process's real TERM
-    /// and must agree with it.
-    #[test]
-    fn default_child_term_matches_selection_rule() {
-        let outer = std::env::var("TERM").ok();
-        assert_eq!(default_child_term(), child_term_for(outer.as_deref()));
-    }
-
-    #[cfg(unix)]
-    fn spawn_and_read_colorterm(id: SurfaceId, extra_env: Vec<(String, String)>) -> String {
-        let mux = Mux::new_for_test("colorterm-env", SurfaceOptions::default());
-        let surface = Surface::spawn(
-            id,
-            SurfaceOptions {
-                command: Some(vec![
-                    "/bin/sh".into(),
-                    "-c".into(),
-                    "printf 'CT=[%s]' \"$COLORTERM\"".into(),
-                ]),
-                extra_env,
-                ..SurfaceOptions::default()
-            },
-            Arc::downgrade(&mux),
-        )
-        .unwrap();
-        let deadline = Instant::now() + Duration::from_secs(2);
-        loop {
-            let text =
-                surface.try_with_terminal(|terminal| terminal.viewport_text()).unwrap().unwrap();
-            if let Some(start) = text.find("CT=[")
-                && let Some(len) = text[start..].find(']')
-            {
-                return text[start..=start + len].to_string();
-            }
-            assert!(Instant::now() < deadline, "child never printed COLORTERM: {text:?}");
-            std::thread::sleep(Duration::from_millis(5));
-        }
-    }
-
-    /// The embedded ghostty-vt terminal always parses 24-bit SGR and the
-    /// frontends forward RGB cells losslessly, so children must be able to
-    /// rely on truecolor even when the session server itself was started from
-    /// an environment without COLORTERM (launchd, ssh, cron). Without the
-    /// guarantee, truecolor-capable programs quantize to the 256-color cube
-    /// and render visibly different colors than the same program run directly
-    /// in the host terminal.
-    #[cfg(unix)]
-    #[test]
-    fn child_env_advertises_truecolor_colorterm() {
-        assert_eq!(spawn_and_read_colorterm(151, Vec::new()), "CT=[truecolor]");
-    }
-
-    /// extra_env stays authoritative: a caller that sets COLORTERM explicitly
-    /// wins over the built-in truecolor advertisement.
-    #[cfg(unix)]
-    #[test]
-    fn child_env_colorterm_yields_to_extra_env() {
-        assert_eq!(
-            spawn_and_read_colorterm(152, vec![("COLORTERM".into(), "24bit".into())]),
-            "CT=[24bit]"
-        );
     }
 
     #[test]
@@ -7666,10 +3617,16 @@ mod tests {
     #[test]
     fn attach_tap_overflow_cancels_the_shared_lifecycle_once() {
         let lifecycle = AttachLifecycle::default();
-        let (tap, _receiver) = AttachTap::pair(lifecycle.clone(), 1, usize::MAX);
+        let (sender, _receiver) = sync_channel(1);
+        let tap = AttachTap {
+            sender,
+            lifecycle: lifecycle.clone(),
+            queued_bytes: Arc::new(AtomicUsize::new(0)),
+            max_queued_bytes: usize::MAX,
+        };
 
-        assert!(tap.try_send(AttachFrame::ColorsChanged(Arc::new(TerminalColors::default()))));
-        assert!(!tap.try_send(AttachFrame::ColorsChanged(Arc::new(TerminalColors::default()))));
+        assert!(tap.try_send(AttachFrame::Output(vec![1])));
+        assert!(!tap.try_send(AttachFrame::Output(vec![2])));
         assert!(lifecycle.is_canceled());
         assert!(lifecycle.overflowed());
         assert!(lifecycle.claim_overflow_report());
@@ -7679,129 +3636,27 @@ mod tests {
     #[test]
     fn attach_tap_overflow_is_bounded_by_retained_bytes() {
         let lifecycle = AttachLifecycle::default();
+        let (sender, _receiver) = sync_channel(4);
         let frame_bytes = AttachFrame::Output(vec![1]).retained_bytes();
-        let (tap, _receiver) = AttachTap::pair(lifecycle.clone(), 4, frame_bytes);
+        let tap = AttachTap {
+            sender,
+            lifecycle: lifecycle.clone(),
+            queued_bytes: Arc::new(AtomicUsize::new(0)),
+            max_queued_bytes: frame_bytes,
+        };
 
         assert!(tap.try_send(AttachFrame::Output(vec![1])));
         assert!(!tap.try_send(AttachFrame::Output(vec![2])));
         assert!(lifecycle.overflowed());
     }
 
-    #[test]
-    fn adjacent_output_merge_respects_the_exact_retained_budget() {
-        let mut bytes = Vec::with_capacity(1_024);
-        bytes.resize(1_024, 1);
-        let mut frame = AttachFrame::Output(bytes);
-        let max_retained_bytes = size_of::<AttachFrame>() + 1_025;
-
-        assert!(matches!(
-            frame.merge_adjacent_output(AttachFrame::Output(vec![2]), max_retained_bytes),
-            AttachFrameMerge::Merged
-        ));
-        let AttachFrame::Output(merged) = frame else { unreachable!() };
-        assert_eq!(merged.len(), 1_025);
-        assert!(merged.capacity() <= 1_025);
-
-        let mut full = AttachFrame::Output(merged);
-        assert!(matches!(
-            full.merge_adjacent_output(AttachFrame::Output(vec![3]), max_retained_bytes),
-            AttachFrameMerge::Overflow
-        ));
-        let AttachFrame::Output(full) = full else { unreachable!() };
-        assert_eq!(full.len(), 1_025, "overflow must not append rejected bytes");
-    }
-
-    #[test]
-    fn slow_attach_coalesces_adjacent_output_without_losing_bytes() {
-        let mux = Mux::new_for_test("attach-output-coalescing", SurfaceOptions::default());
-        let surface =
-            Surface::spawn_for_test(1, SurfaceOptions::default(), Arc::downgrade(&mux)).unwrap();
-        let attach = surface.attach_stream().unwrap();
-        let pty = surface.as_pty().unwrap();
-        let expected =
-            (0..ATTACH_STREAM_CAPACITY * 4).map(|index| (index % 251) as u8).collect::<Vec<_>>();
-
-        for (index, byte) in expected.iter().copied().enumerate() {
-            assert!(
-                pty.broadcast_attach_output(&[byte]),
-                "lossless attach disconnected at small output chunk {index}"
-            );
-        }
-
-        assert!(!attach.lifecycle.overflowed());
-        let mut received = Vec::new();
-        while let Ok(frame) = attach.stream.try_recv() {
-            match frame {
-                AttachFrame::Output(bytes) => received.extend(bytes),
-                other => panic!("unexpected frame in output-only stream: {other:?}"),
-            }
-        }
-        assert_eq!(received, expected);
-    }
-
-    #[test]
-    fn resized_replay_payload_is_shared_across_attach_taps() {
-        let mux = Mux::new("shared-resize-replay", SurfaceOptions::default());
-        let surface =
-            Surface::spawn_for_test(1, SurfaceOptions::default(), Arc::downgrade(&mux)).unwrap();
-        let first = surface.attach_stream().unwrap();
-        let second = surface.attach_stream().unwrap();
-        let pty = surface.as_pty().unwrap();
-
-        pty.broadcast_attach_frame(AttachFrame::ResizedWithColors {
-            cols: 80,
-            rows: 24,
-            replay: vec![7; 1024].into(),
-            kitty_image_aliases: Vec::new(),
-            kitty_state: KittyReplayState::disabled(),
-            colors: Box::new(TerminalColors::default()),
-        });
-
-        let first_replay = match first.stream.recv_timeout(Duration::from_secs(1)).unwrap() {
-            AttachFrame::ResizedWithColors { replay, .. } => replay,
-            frame => panic!("unexpected first attach frame: {frame:?}"),
-        };
-        let second_replay = match second.stream.recv_timeout(Duration::from_secs(1)).unwrap() {
-            AttachFrame::ResizedWithColors { replay, .. } => replay,
-            frame => panic!("unexpected second attach frame: {frame:?}"),
-        };
-        assert_eq!(
-            first_replay.as_ptr(),
-            second_replay.as_ptr(),
-            "resize replay bytes were deep-cloned for each attach subscriber"
-        );
-    }
-
-    #[test]
-    fn unsafe_legacy_resize_disconnects_the_byte_attachment() {
-        let mux = Mux::new("legacy-resize-disconnect", SurfaceOptions::default());
-        let surface =
-            Surface::spawn_for_test(73, SurfaceOptions::default(), Arc::downgrade(&mux)).unwrap();
-        let attachment = surface.attach_stream().unwrap();
-        let pty = surface.as_pty().unwrap();
-        pty.term.lock().unwrap().vt_write(b"partial \xce");
-        assert!(!pty.term.lock().unwrap().vt_stream_is_ground());
-
-        assert!(surface.resize(100, 30).unwrap());
-        assert!(matches!(
-            attachment.stream.recv_timeout(Duration::from_secs(1)),
-            Err(RecvTimeoutError::Disconnected)
-        ));
-        assert!(attachment.lifecycle.is_canceled());
-    }
-
     #[cfg(unix)]
     #[test]
     fn hosted_stager_exposes_coupled_state_only_after_colors() {
-        let mut stager = HostedFrameStager::new(40, false);
+        let mut stager = HostedFrameStager::new(40);
         let mut resize = Frame::new(MessageKind::Resized, {
             let mut payload = Vec::from([101, 0, 37, 0]);
-            payload.extend_from_slice(&(b"authoritative replay".len() as u32).to_le_bytes());
             payload.extend_from_slice(b"authoritative replay");
-            payload.extend_from_slice(&0u16.to_le_bytes());
-            payload.extend_from_slice(&9u16.to_le_bytes());
-            payload.extend_from_slice(&18u16.to_le_bytes());
-            append_disabled_kitty_replay_state(&mut payload);
             payload
         });
         resize.flags = FLAG_COLORS_FOLLOW;
@@ -7822,19 +3677,9 @@ mod tests {
         );
         colors_frame.sequence = 42;
         match stager.push(colors_frame).unwrap().unwrap() {
-            HostedTransition::ResizedWithColors {
-                cols,
-                rows,
-                cell_pixels,
-                replay,
-                kitty_image_aliases,
-                colors: received,
-                ..
-            } => {
+            HostedTransition::ResizedWithColors { cols, rows, replay, colors: received } => {
                 assert_eq!((cols, rows), (101, 37));
-                assert_eq!(cell_pixels, (9, 18));
                 assert_eq!(replay, b"authoritative replay");
-                assert!(kitty_image_aliases.is_empty());
                 assert_eq!(received, colors);
             }
             other => panic!("unexpected staged transition: {other:?}"),
@@ -7857,162 +3702,19 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn hosted_stager_excludes_resize_framing_and_aliases_from_vt_replay() {
-        let replay = b"\x1b[2Jhost replay";
-        let mut payload = Vec::from([101, 0, 37, 0]);
-        payload.extend_from_slice(&(replay.len() as u32).to_le_bytes());
-        payload.extend_from_slice(replay);
-        payload.extend_from_slice(&1u16.to_le_bytes());
-        payload.extend_from_slice(&41u32.to_le_bytes());
-        payload.extend_from_slice(&77u32.to_le_bytes());
-        payload.extend_from_slice(&9u16.to_le_bytes());
-        payload.extend_from_slice(&18u16.to_le_bytes());
-        append_disabled_kitty_replay_state(&mut payload);
-
-        let mut stager = HostedFrameStager::new(8, false);
-        let mut resize = Frame::new(MessageKind::Resized, payload);
-        resize.flags = FLAG_COLORS_FOLLOW;
-        resize.sequence = 9;
-        assert!(stager.push(resize).unwrap().is_none());
-
-        let colors = TerminalColorOverrides {
-            cursor_visual: Some((CursorShape::Block, true)),
-            ..Default::default()
-        };
-        let mut colors = Frame::new(
-            MessageKind::Colors,
-            crate::terminal_host_runtime::encode_terminal_color_overrides(&colors),
-        );
-        colors.sequence = 10;
-        match stager.push(colors).unwrap().unwrap() {
-            HostedTransition::ResizedWithColors {
-                replay: received, kitty_image_aliases, ..
-            } => {
-                assert_eq!(
-                    received, replay,
-                    "resize length and alias metadata leaked into VT replay bytes"
-                );
-                assert_eq!(
-                    kitty_image_aliases,
-                    vec![ghostty_vt::KittyImageAlias { image_id: 41, image_number: 77 }]
-                );
-            }
-            other => panic!("unexpected staged transition: {other:?}"),
-        }
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn hosted_stager_accepts_protocol_one_resize_without_alias_metadata() {
-        let replay = b"legacy host replay";
-        let mut payload = Vec::from([81, 0, 25, 0]);
-        payload.extend_from_slice(&(replay.len() as u32).to_le_bytes());
-        payload.extend_from_slice(replay);
-
-        let mut stager = HostedFrameStager::new_for_version(0, 1, false);
-        let mut resize = Frame::new(MessageKind::Resized, payload);
-        resize.version = 1;
-        resize.flags = FLAG_COLORS_FOLLOW;
-        resize.sequence = 1;
-        assert!(stager.push(resize).unwrap().is_none());
-
-        let colors = TerminalColorOverrides {
-            cursor_visual: Some((CursorShape::Block, true)),
-            ..Default::default()
-        };
-        let mut colors = Frame::new(
-            MessageKind::Colors,
-            crate::terminal_host_runtime::encode_terminal_color_overrides(&colors),
-        );
-        colors.version = 1;
-        colors.sequence = 2;
-        match stager.push(colors).unwrap().unwrap() {
-            HostedTransition::ResizedWithColors {
-                cols,
-                rows,
-                replay: received,
-                kitty_image_aliases,
-                ..
-            } => {
-                assert_eq!((cols, rows), (81, 25));
-                assert_eq!(received, replay);
-                assert!(kitty_image_aliases.is_empty());
-            }
-            other => panic!("unexpected staged transition: {other:?}"),
-        }
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn smart_hosted_stager_orders_raw_output_and_incremental_resize() {
-        let mut stager = HostedFrameStager::new(7, true);
-        let mut prefix = Frame::new(MessageKind::Output, vec![0xce]);
-        prefix.sequence = 8;
-        assert!(matches!(
-            stager.push(prefix).unwrap(),
-            Some(HostedTransition::Output(bytes)) if bytes == vec![0xce]
-        ));
-
-        let mut resized = Frame::new(MessageKind::Resized, vec![100, 0, 30, 0]);
-        resized.sequence = 9;
-        assert!(matches!(
-            stager.push(resized).unwrap(),
-            Some(HostedTransition::Resized { cols: 100, rows: 30, cell_pixels: None })
-        ));
-
-        let mut metrics = Frame::new(MessageKind::Resized, vec![100, 0, 30, 0, 9, 0, 18, 0]);
-        metrics.sequence = 10;
-        assert!(matches!(
-            stager.push(metrics).unwrap(),
-            Some(HostedTransition::Resized { cols: 100, rows: 30, cell_pixels: Some((9, 18)) })
-        ));
-
-        let mut suffix = Frame::new(MessageKind::Output, vec![0xbb]);
-        suffix.sequence = 11;
-        assert!(matches!(
-            stager.push(suffix).unwrap(),
-            Some(HostedTransition::Output(bytes)) if bytes == vec![0xbb]
-        ));
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn hosted_stager_decodes_authoritative_exit_payload() {
-        let exit = TerminalExit {
-            outcome: crate::terminal_host_protocol::TerminalExitOutcome::Exit { code: 17 },
-            exited_at_ms: 1_234_567,
-        };
-        let mut frame = Frame::new(
-            MessageKind::Exit,
-            crate::terminal_host_protocol::encode_terminal_exit(&exit),
-        );
-        frame.sequence = 1;
-        let mut stager = HostedFrameStager::new(0, false);
-        match stager.push(frame).unwrap() {
-            Some(HostedTransition::Exit(observed)) => assert_eq!(observed, exit),
-            other => panic!("unexpected staged transition: {other:?}"),
-        }
-
-        let mut malformed = Frame::new(MessageKind::Exit, vec![1, 0, 2]);
-        malformed.sequence = 1;
-        assert!(HostedFrameStager::new(0, false).push(malformed).is_err());
-    }
-
-    #[cfg(unix)]
-    #[test]
     fn hosted_stager_fails_closed_on_invalid_flags_and_pairing() {
-        let mut stager = HostedFrameStager::new(0, false);
+        let mut stager = HostedFrameStager::new(0);
         let mut resized = Frame::new(MessageKind::Resized, vec![80, 0, 24, 0]);
         resized.sequence = 1;
         assert!(stager.push(resized).is_err(), "Resized must declare Colors follow");
 
-        let mut stager = HostedFrameStager::new(0, false);
+        let mut stager = HostedFrameStager::new(0);
         let mut output = Frame::new(MessageKind::Output, vec![]);
         output.flags = FLAG_COLORS_FOLLOW | (1 << 7);
         output.sequence = 1;
         assert!(stager.push(output).is_err(), "unknown flags must fail closed");
 
-        let mut stager = HostedFrameStager::new(0, false);
+        let mut stager = HostedFrameStager::new(0);
         let mut output = Frame::new(MessageKind::Output, vec![]);
         output.flags = FLAG_COLORS_FOLLOW;
         output.sequence = 1;
@@ -8020,22 +3722,11 @@ mod tests {
         let mut exit = Frame::new(MessageKind::Exit, vec![]);
         exit.sequence = 2;
         assert!(stager.push(exit).is_err(), "a coupled frame requires Colors exactly next");
-
-        let mut stager = HostedFrameStager::new(0, false);
-        let mut malformed = Frame::new(MessageKind::Resized, {
-            let mut payload = vec![80, 0, 24, 0, 0, 0, 0, 0];
-            payload.extend_from_slice(&1u16.to_le_bytes());
-            payload.extend_from_slice(&41u32.to_le_bytes());
-            payload
-        });
-        malformed.flags = FLAG_COLORS_FOLLOW;
-        malformed.sequence = 1;
-        assert!(stager.push(malformed).is_err(), "truncated aliases must fail closed");
     }
 
     #[cfg(unix)]
     #[test]
-    fn exited_host_placeholder_preserves_identity_and_swallows_input() {
+    fn exited_host_placeholder_preserves_identity_and_rejects_input() {
         let mux = Mux::new_for_test("exited-host-placeholder", SurfaceOptions::default());
         let identity = crate::terminal_host_runtime::TerminalHostIdentity {
             terminal_id: crate::terminal_host::TerminalId::random().unwrap().to_hex(),
@@ -8055,84 +3746,9 @@ mod tests {
             Some(TerminalHostConnectionState::Exited)
         );
         assert!(surface.is_dead());
-        // Keep-on-exit terminals stay interactive surfaces after their child
-        // dies, so input to the dead PTY is a harmless no-op, not an error.
-        surface.write_bytes(b"must not reach a dead host").unwrap();
-        surface.write_paste(b"must not reach a dead host").unwrap();
-    }
-
-    #[test]
-    fn terminal_reconnect_failure_state_never_decodes_as_connected() {
-        assert_ne!(TerminalHostConnectionState::from_u8(3), TerminalHostConnectionState::Connected);
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn terminal_reconnect_backoff_advances_and_reaches_a_terminal_bound() {
-        let mut backoff = TerminalHostReconnectBackoff::default();
-        let delays = (0..TERMINAL_HOST_RECONNECT_MAX_FAILURES)
-            .map(|_| backoff.next_delay().expect("retry within failure bound"))
-            .collect::<Vec<_>>();
-
         assert_eq!(
-            &delays[..7],
-            &[
-                Duration::from_millis(25),
-                Duration::from_millis(50),
-                Duration::from_millis(100),
-                Duration::from_millis(200),
-                Duration::from_millis(400),
-                Duration::from_millis(800),
-                Duration::from_secs(1),
-            ]
-        );
-        assert!(delays[7..].iter().all(|delay| *delay == Duration::from_secs(1)));
-        assert_eq!(backoff.next_delay(), None);
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn hosted_reconnect_backoff_releases_geometry_before_waiting() {
-        let mux = Mux::new_for_test("reconnect-geometry-release", SurfaceOptions::default());
-        let surface =
-            Surface::spawn_for_test(1, SurfaceOptions::default(), Arc::downgrade(&mux)).unwrap();
-        let pty = surface.as_pty().unwrap();
-        let (backoff_started_tx, backoff_started_rx) = std::sync::mpsc::channel();
-        let (release_backoff_tx, release_backoff_rx) = std::sync::mpsc::channel();
-        let release_backoff_rx = Arc::new(Mutex::new(release_backoff_rx));
-        *pty.geometry_test_hook.lock().unwrap() = Some(Arc::new({
-            move |step| {
-                if step == PtyGeometryTestStep::ReconnectBackoffStarted {
-                    backoff_started_tx.send(()).unwrap();
-                    release_backoff_rx.lock().unwrap().recv().unwrap();
-                }
-            }
-        }));
-
-        let reconnect_surface = surface.clone();
-        let reconnect = std::thread::spawn(move || {
-            let pty = reconnect_surface.as_pty().unwrap();
-            let geometry = pty.geometry.lock().unwrap();
-            let mut retry = TerminalHostReconnectBackoff::default();
-            wait_for_reconnect_after_geometry_failure(&mut retry, pty, geometry)
-        });
-        backoff_started_rx.recv().unwrap();
-
-        let probing_surface = surface.clone();
-        let (geometry_acquired_tx, geometry_acquired_rx) = std::sync::mpsc::channel();
-        let geometry_probe = std::thread::spawn(move || {
-            let size = probing_surface.test_cell_pixel_size();
-            geometry_acquired_tx.send(size).unwrap();
-        });
-        let geometry_released_before_backoff =
-            geometry_acquired_rx.recv_timeout(Duration::from_millis(100)).is_ok();
-
-        release_backoff_tx.send(()).unwrap();
-        assert!(reconnect.join().unwrap());
-        geometry_probe.join().unwrap();
-        assert!(
-            geometry_released_before_backoff,
-            "host reconnect backoff held the geometry transaction lock"
+            surface.write_bytes(b"must not reach a dead host").unwrap_err().kind(),
+            std::io::ErrorKind::BrokenPipe
         );
     }
 
@@ -8154,488 +3770,6 @@ mod tests {
         drop(render);
         assert!(pty.dirty.load(Ordering::Acquire));
         assert!(matches!(events.try_recv(), Ok(MuxEvent::SurfaceOutput(1))));
-    }
-
-    #[test]
-    fn stalled_render_tap_retains_only_latest_frame_and_scroll_state_in_order() {
-        let mux = Mux::new_for_test("render-tap-latest", SurfaceOptions::default());
-        let surface =
-            Surface::spawn_for_test(1, SurfaceOptions::default(), Arc::downgrade(&mux)).unwrap();
-        let pty = surface.as_pty().unwrap();
-        let attach = surface.attach_render_stream().unwrap();
-        let mut generation = pty.render.lock().unwrap().built_generation;
-
-        let mut expected_dirty_rows = std::collections::BTreeSet::new();
-        {
-            let mut term = pty.term.lock().unwrap();
-            term.vt_write(b"\x1b[1;1Ha");
-            generation += 1;
-            pty.build_frame_locked(&mut term, generation, false).unwrap();
-            expected_dirty_rows.extend(
-                pty.render
-                    .lock()
-                    .unwrap()
-                    .latest
-                    .as_ref()
-                    .unwrap()
-                    .frame
-                    .dirty_rows
-                    .iter()
-                    .copied(),
-            );
-            broadcast_render_scroll_locked(pty, (4, false));
-            term.vt_write(b"\x1b[2;1Hb");
-            generation += 1;
-            pty.build_frame_locked(&mut term, generation, false).unwrap();
-            expected_dirty_rows.extend(
-                pty.render
-                    .lock()
-                    .unwrap()
-                    .latest
-                    .as_ref()
-                    .unwrap()
-                    .frame
-                    .dirty_rows
-                    .iter()
-                    .copied(),
-            );
-            broadcast_render_scroll_locked(pty, (9, true));
-            term.vt_write(b"\x1b[3;1Hc");
-            generation += 1;
-            pty.build_frame_locked(&mut term, generation, false).unwrap();
-            expected_dirty_rows.extend(
-                pty.render
-                    .lock()
-                    .unwrap()
-                    .latest
-                    .as_ref()
-                    .unwrap()
-                    .frame
-                    .dirty_rows
-                    .iter()
-                    .copied(),
-            );
-        }
-
-        let mut pending = Vec::new();
-        while let Ok(frame) = attach.stream.try_recv() {
-            pending.push(frame);
-        }
-        assert_eq!(
-            pending.len(),
-            2,
-            "a stalled render consumer retained more than one frame plus final scroll state"
-        );
-        assert!(matches!(
-            pending[0],
-            RenderAttachFrame::ScrollChanged { offset: 9, at_bottom: true }
-        ));
-        let RenderAttachFrame::Frame(frame) = &pending[1] else {
-            panic!("final render frame must follow the final preceding scroll state");
-        };
-        let latest = pty.render.lock().unwrap().latest.clone().unwrap();
-        assert_eq!(frame.frame.seq, latest.frame.seq);
-        assert_eq!(
-            frame.frame.dirty_rows.iter().copied().collect::<std::collections::BTreeSet<_>>(),
-            expected_dirty_rows,
-            "coalescing the newest snapshot must preserve every undrained dirty row"
-        );
-        for row in &expected_dirty_rows {
-            assert_eq!(frame.frame.styled_row(*row), latest.frame.styled_row(*row));
-        }
-
-        let latest_uncoalesced = {
-            let mut term = pty.term.lock().unwrap();
-            term.vt_write(b"d");
-            generation += 1;
-            pty.build_frame_locked(&mut term, generation, false).unwrap();
-            let latest = pty.render.lock().unwrap().latest.clone().unwrap();
-            broadcast_render_scroll_locked(pty, (11, false));
-            latest
-        };
-        let first = attach.stream.try_recv().unwrap();
-        let second = attach.stream.try_recv().unwrap();
-        let RenderAttachFrame::Frame(frame) = first else {
-            panic!("frame must precede the later scroll state");
-        };
-        assert!(
-            Arc::ptr_eq(&frame, &latest_uncoalesced),
-            "a tap that keeps up must reuse the shared immutable frame"
-        );
-        assert!(matches!(
-            second,
-            RenderAttachFrame::ScrollChanged { offset: 11, at_bottom: false }
-        ));
-        assert!(matches!(attach.stream.try_recv(), Err(TryRecvError::Empty)));
-    }
-
-    #[test]
-    fn render_attachments_are_bounded_across_a_mux() {
-        const EXPECTED_MAX_ATTACHMENTS: usize = 64;
-
-        let mux = Mux::new_for_test("render-tap-cap", SurfaceOptions::default());
-        let surface =
-            Surface::spawn_for_test(1, SurfaceOptions::default(), Arc::downgrade(&mux)).unwrap();
-        let mut attachments = Vec::with_capacity(EXPECTED_MAX_ATTACHMENTS);
-        for _ in 0..EXPECTED_MAX_ATTACHMENTS {
-            attachments.push(surface.attach_render_stream().unwrap());
-        }
-
-        assert!(matches!(surface.attach_render_stream(), Err(ghostty_vt::Error::OutOfSpace)));
-        attachments.pop();
-        assert!(surface.attach_render_stream().is_ok());
-    }
-
-    #[test]
-    fn dropped_idle_render_attachments_remove_their_taps_immediately() {
-        let mux = Mux::new_for_test("render-tap-drop", SurfaceOptions::default());
-        let surface =
-            Surface::spawn_for_test(1, SurfaceOptions::default(), Arc::downgrade(&mux)).unwrap();
-        let pty = surface.as_pty().unwrap();
-
-        for _ in 0..128 {
-            let attachment = surface.attach_render_stream().unwrap();
-            assert_eq!(pty.render.lock().unwrap().taps.len(), 1);
-            drop(attachment);
-            assert!(
-                pty.render.lock().unwrap().taps.is_empty(),
-                "an idle closed attachment remained registered until later output"
-            );
-        }
-    }
-
-    #[test]
-    fn changed_kitty_limits_resynchronize_live_byte_attachments() {
-        let mux = Mux::new_for_test("kitty-limit-resync", SurfaceOptions::default());
-        let surface =
-            Surface::spawn_for_test(1, SurfaceOptions::default(), Arc::downgrade(&mux)).unwrap();
-        let attach = surface.attach_stream().unwrap();
-        surface
-            .with_terminal(|terminal| {
-                terminal.vt_write(b"\x1b_Ga=T,t=d,f=24,i=41,p=7,s=1,v=1,c=1,r=1,q=2;AAAA\x1b\\");
-            })
-            .unwrap();
-
-        surface.set_kitty_graphics_limits(0, 0, 0, 0).unwrap();
-
-        assert!(
-            matches!(
-                attach.stream.recv_timeout(Duration::from_secs(1)),
-                Ok(AttachFrame::Resized { .. } | AttachFrame::ResizedWithColors { .. })
-            ),
-            "a byte-stream mirror was left on the pre-eviction Kitty scene"
-        );
-    }
-
-    #[test]
-    fn geometry_updates_skip_vt_replay_without_byte_attach_subscribers() {
-        let mux = Mux::new_for_test("resize-without-byte-attach", SurfaceOptions::default());
-        let surface =
-            Surface::spawn_for_test(1, SurfaceOptions::default(), Arc::downgrade(&mux)).unwrap();
-        let pty = surface.as_pty().unwrap();
-        let render = surface.attach_render_stream().unwrap();
-
-        surface.resize(100, 30).unwrap();
-        surface.set_cell_pixel_size(9, 18).unwrap();
-
-        assert_eq!(
-            pty.vt_replay_builds.load(Ordering::Acquire),
-            0,
-            "render-only geometry updates must not construct byte-attach replay"
-        );
-        assert!(matches!(render.stream.try_recv(), Ok(RenderAttachFrame::Frame(_))));
-
-        let byte_attach = surface.attach_stream().unwrap();
-        pty.vt_replay_builds.store(0, Ordering::Release);
-        surface.resize(101, 31).unwrap();
-        assert_eq!(pty.vt_replay_builds.load(Ordering::Acquire), 1);
-
-        drop(byte_attach);
-        pty.vt_replay_builds.store(0, Ordering::Release);
-        surface.resize(102, 31).unwrap();
-        assert_eq!(
-            pty.vt_replay_builds.load(Ordering::Acquire),
-            0,
-            "dropping the final byte attach must suppress the next resize replay"
-        );
-    }
-
-    #[test]
-    fn resize_replay_preserves_a_valid_large_inflight_kitty_upload() {
-        const OLD_VT_REPLAY_MAX_BYTES: usize = 8 * 1024 * 1024;
-        const IMAGE_WIDTH: usize = 2_048;
-        const IMAGE_HEIGHT: usize = 1_024;
-        const IMAGE_ID: u32 = 196;
-
-        let pixels = vec![0xff; IMAGE_WIDTH * IMAGE_HEIGHT * 3];
-        let payload = base64::engine::general_purpose::STANDARD.encode(&pixels);
-        let final_payload = payload.split_at(payload.len() - 4);
-        let first_chunk = format!(
-            "\x1b_Ga=t,t=d,f=24,i={IMAGE_ID},s={IMAGE_WIDTH},v={IMAGE_HEIGHT},m=1,q=2;{}\x1b\\",
-            final_payload.0
-        )
-        .into_bytes();
-        let final_chunk = format!("\x1b_Gm=0,q=2;{}\x1b\\", final_payload.1).into_bytes();
-        assert!(
-            first_chunk.len() > OLD_VT_REPLAY_MAX_BYTES,
-            "fixture must exceed the old {OLD_VT_REPLAY_MAX_BYTES}-byte resize replay budget"
-        );
-        assert!(first_chunk.len() <= ghostty_vt::KITTY_INFLIGHT_REPLAY_MAX_BYTES);
-
-        let mux = Mux::new_for_test("large-inflight-resize", SurfaceOptions::default());
-        let surface =
-            Surface::spawn_for_test(1, SurfaceOptions::default(), Arc::downgrade(&mux)).unwrap();
-        let attach = surface.attach_stream().unwrap();
-        let pty = surface.as_pty().unwrap();
-        {
-            let mut terminal = pty.term.lock().unwrap();
-            terminal.vt_write(&first_chunk);
-            assert!(terminal.kitty_graphics_snapshot().unwrap().image(IMAGE_ID).is_none());
-        }
-
-        surface.resize(81, 24).unwrap();
-        let (cols, rows, replay, kitty_image_aliases) =
-            match attach.stream.recv_timeout(Duration::from_secs(2)).unwrap() {
-                AttachFrame::Resized { cols, rows, replay, kitty_image_aliases, .. }
-                | AttachFrame::ResizedWithColors {
-                    cols, rows, replay, kitty_image_aliases, ..
-                } => (cols, rows, replay, kitty_image_aliases),
-                _ => panic!("resize must publish replacement terminal state"),
-            };
-        assert!(
-            replay.len() >= first_chunk.len(),
-            "{}-byte resize replay omitted the {}-byte in-flight prefix",
-            replay.len(),
-            first_chunk.len()
-        );
-
-        let mut mirror = Terminal::new(cols, rows, 10_000, Callbacks::default()).unwrap();
-        mirror.resize(cols, rows, 8, 16).unwrap();
-        mirror.vt_write(&replay);
-        mirror.restore_kitty_image_aliases(&kitty_image_aliases).unwrap();
-        mirror.vt_write(&final_chunk);
-
-        assert_eq!(
-            mirror
-                .kitty_graphics_snapshot()
-                .unwrap()
-                .image(IMAGE_ID)
-                .expect("resize replay must let a fresh terminal accept the final upload chunk")
-                .data
-                .len(),
-            pixels.len()
-        );
-    }
-
-    #[test]
-    fn resize_replay_budget_covers_inflight_state_and_transport_limits() {
-        assert_eq!(ghostty_vt::KITTY_INFLIGHT_REPLAY_MAX_BYTES, 13_595_480);
-        assert_eq!(VT_REPLAY_TEXT_HEADROOM_BYTES, 2_097_152);
-        assert_eq!(VT_REPLAY_MAX_BYTES, 15_692_632);
-        assert_eq!(ATTACH_STREAM_MAX_BYTES - VT_REPLAY_MAX_BYTES, 1_084_584);
-        assert_eq!(VT_REPLAY_MAX_BYTES.div_ceil(3) * 4, 20_923_512);
-        const {
-            assert!(
-                VT_REPLAY_MAX_BYTES + VT_REPLAY_FRAME_METADATA_HEADROOM_BYTES
-                    <= ATTACH_STREAM_MAX_BYTES
-            );
-        }
-        assert!(VT_REPLAY_MAX_BYTES.div_ceil(3) * 4 < VT_REPLAY_ENCODED_TRANSPORT_MAX_BYTES);
-    }
-
-    #[test]
-    fn resize_replay_failure_preflights_without_mutating_terminal_or_pty_geometry() {
-        let mux = Mux::new_for_test("failed-resize-replay", SurfaceOptions::default());
-        let surface =
-            Surface::spawn_for_test(1, SurfaceOptions::default(), Arc::downgrade(&mux)).unwrap();
-        let attach = surface.attach_stream().unwrap();
-        let pty = surface.as_pty().unwrap();
-        let history = (0..40).map(|line| format!("history-{line:02}\r\n")).collect::<String>();
-        let mut oversized = b"\x1b_Ga=t,t=d,f=24,i=197,s=1,v=1,m=1,q=2;".to_vec();
-        oversized.resize(ghostty_vt::KITTY_INFLIGHT_REPLAY_MAX_BYTES + 1, b'A');
-        oversized.extend_from_slice(b"\x1b\\");
-        let (text_before, scrollbar_before) = {
-            let mut terminal = pty.term.lock().unwrap();
-            terminal.vt_write(history.as_bytes());
-            terminal.vt_write(&oversized);
-            assert_eq!(
-                terminal.vt_replay_bounded(VT_REPLAY_MAX_BYTES),
-                Err(ghostty_vt::Error::OutOfSpace)
-            );
-            (terminal.plain_text().unwrap(), terminal.scrollbar())
-        };
-
-        let error = surface.resize(100, 30).unwrap_err();
-
-        assert!(error.to_string().contains("geometry unchanged"), "{error:#}");
-        assert_eq!(surface.size(), (80, 24));
-        {
-            let mut terminal = pty.term.lock().unwrap();
-            assert_eq!((terminal.cols(), terminal.rows()), (80, 24));
-            assert_eq!(terminal.plain_text().unwrap(), text_before);
-            assert_eq!(terminal.scrollbar(), scrollbar_before);
-        }
-        let master = surface.test_master_size();
-        assert_eq!(
-            (master.cols, master.rows, master.pixel_width, master.pixel_height),
-            (80, 24, 640, 384)
-        );
-        assert!(matches!(attach.stream.try_recv(), Err(TryRecvError::Empty)));
-    }
-
-    #[test]
-    fn concurrent_pty_resize_and_cell_pixel_update_publish_one_geometry_transaction_at_a_time() {
-        let mux = Mux::new_for_test("pty-geometry-transaction", SurfaceOptions::default());
-        let surface =
-            Surface::spawn_for_test(1, SurfaceOptions::default(), Arc::downgrade(&mux)).unwrap();
-        let pty = surface.as_pty().unwrap();
-        let (resize_entered_tx, resize_entered_rx) = std::sync::mpsc::channel();
-        let (release_resize_tx, release_resize_rx) = std::sync::mpsc::channel();
-        let (cell_started_tx, cell_started_rx) = std::sync::mpsc::channel();
-        let release_resize_rx = Arc::new(Mutex::new(release_resize_rx));
-        *pty.geometry_test_hook.lock().unwrap() = Some(Arc::new({
-            move |step| match step {
-                PtyGeometryTestStep::ResizeCommitBoundary => {
-                    resize_entered_tx.send(()).unwrap();
-                    release_resize_rx.lock().unwrap().recv().unwrap();
-                }
-                PtyGeometryTestStep::CellPixelStarted => {
-                    cell_started_tx.send(()).unwrap();
-                }
-                _ => {}
-            }
-        }));
-
-        let resizing_surface = surface.clone();
-        let resizing = std::thread::spawn(move || resizing_surface.resize(100, 30));
-        resize_entered_rx.recv().unwrap();
-
-        let updating_surface = surface.clone();
-        let (cell_done_tx, cell_done_rx) = std::sync::mpsc::channel();
-        let updating = std::thread::spawn(move || {
-            let result = updating_surface.set_cell_pixel_size(9, 18);
-            cell_done_tx.send(result).unwrap();
-        });
-        cell_started_rx.recv().unwrap();
-        let cell_completed_while_resize_was_uncommitted =
-            cell_done_rx.recv_timeout(Duration::from_millis(100)).is_ok();
-
-        release_resize_tx.send(()).unwrap();
-        resizing.join().unwrap().unwrap();
-        updating.join().unwrap();
-
-        assert!(
-            !cell_completed_while_resize_was_uncommitted,
-            "cell pixels published while the resize transaction was paused before its backend commit"
-        );
-        assert_eq!(surface.size(), (100, 30));
-        let master = surface.test_master_size();
-        assert_eq!(
-            (master.cols, master.rows, master.pixel_width, master.pixel_height),
-            (100, 30, 900, 540)
-        );
-    }
-
-    #[test]
-    fn failed_pty_master_resize_commits_nothing_and_the_same_request_retries() {
-        let mux = Mux::new_for_test("pty-resize-failure", SurfaceOptions::default());
-        let surface =
-            Surface::spawn_for_test(1, SurfaceOptions::default(), Arc::downgrade(&mux)).unwrap();
-        surface.fail_next_test_master_resize();
-
-        let failed = surface.resize(100, 30);
-
-        assert!(failed.is_err(), "PTY master resize failure must reach the caller");
-        assert_eq!(surface.size(), (80, 24));
-        {
-            let term = surface.as_pty().unwrap().term.lock().unwrap();
-            assert_eq!((term.cols(), term.rows()), (80, 24));
-        }
-        let master = surface.test_master_size();
-        assert_eq!(
-            (master.cols, master.rows, master.pixel_width, master.pixel_height),
-            (80, 24, 640, 384)
-        );
-
-        assert!(surface.resize(100, 30).unwrap());
-        assert_eq!(surface.size(), (100, 30));
-        let master = surface.test_master_size();
-        assert_eq!(
-            (master.cols, master.rows, master.pixel_width, master.pixel_height),
-            (100, 30, 800, 480)
-        );
-    }
-
-    #[test]
-    fn pty_eof_publishes_final_render_frame_before_surface_removal() {
-        const FINAL_MARKER: &str = "CMUX_FINAL_RENDER_MARKER";
-
-        let mux = Mux::new("pty-final-render", SurfaceOptions::default());
-        let placement = mux
-            .run_command_surface(
-                vec![
-                    "/bin/sh".into(),
-                    "-c".into(),
-                    format!("IFS= read -r _; printf '{FINAL_MARKER}'"),
-                ],
-                None,
-                true,
-                None,
-                None,
-                Some((80, 24)),
-            )
-            .unwrap();
-        let surface = mux.surface(placement.surface).unwrap();
-        let attach = surface.attach_render_stream().unwrap();
-        let events = mux.subscribe();
-
-        let (entered_tx, entered_rx) = sync_channel(1);
-        let (release_tx, release_rx) = sync_channel(1);
-        let release_rx = Mutex::new(release_rx);
-        {
-            let pty = surface.as_pty().unwrap();
-            *pty.frame_producer_before_upgrade.lock().unwrap() = Some(Arc::new(move || {
-                let _ = entered_tx.try_send(());
-                let _ = release_rx.lock().unwrap().recv_timeout(Duration::from_secs(5));
-            }));
-        }
-
-        surface.write_bytes(b"go\n").unwrap();
-        drop(surface);
-        entered_rx
-            .recv_timeout(Duration::from_secs(2))
-            .expect("frame producer did not receive the final output request");
-
-        let deadline = Instant::now() + Duration::from_secs(2);
-        loop {
-            let remaining = deadline.saturating_duration_since(Instant::now());
-            match events.recv_timeout(remaining) {
-                Ok(MuxEvent::SurfaceExited(id)) if id == placement.surface => break,
-                Ok(_) => {}
-                Err(error) => panic!("surface did not exit before frame worker release: {error}"),
-            }
-        }
-        release_tx.send(()).unwrap();
-
-        let frame = attach
-            .stream
-            .recv_timeout(Duration::from_secs(2))
-            .expect("final render frame was dropped with the surface");
-        let RenderAttachFrame::Frame(frame) = frame else {
-            panic!("expected final render frame");
-        };
-        let rendered = frame
-            .frame
-            .styled_rows()
-            .iter()
-            .flat_map(|row| row.iter())
-            .map(|cell| cell.text.as_str())
-            .collect::<String>();
-        assert!(
-            rendered.contains(FINAL_MARKER),
-            "final render frame did not contain producer receipt: {rendered:?}"
-        );
-        mux.shutdown();
     }
 
     #[test]
@@ -8699,46 +3833,6 @@ mod tests {
     }
 
     #[test]
-    fn resource_wait_subscription_wakes_for_output_resize_reconnect_and_clear() {
-        let mux = Mux::new_for_test("terminal-resource-progress", SurfaceOptions::default());
-        let surface =
-            Surface::spawn_for_test(1, SurfaceOptions::default(), Arc::downgrade(&mux)).unwrap();
-        let wake_deadline = || Some(Instant::now() + Duration::from_secs(1));
-
-        let output = surface.subscribe_terminal_stream_change().unwrap();
-        surface.apply_stream_output_for_test(b"progress-output").unwrap();
-        assert!(
-            output.wait_until(wake_deadline()),
-            "terminal output did not wake the subscription"
-        );
-
-        let resize = surface.subscribe_terminal_stream_change().unwrap();
-        assert!(surface.resize(91, 37).unwrap(), "test resize did not change the surface");
-        assert!(
-            resize.wait_until(wake_deadline()),
-            "terminal resize did not wake the subscription"
-        );
-
-        let reconnect = surface.subscribe_terminal_stream_change().unwrap();
-        surface.as_pty().unwrap().stream_progress.notify_reconnect();
-        assert!(
-            reconnect.wait_until(wake_deadline()),
-            "authoritative reconnect progress did not wake the subscription"
-        );
-
-        surface.with_terminal(|term| {
-            term.vt_write(b"\x1b]133;C\x07");
-            for line in 0..40 {
-                term.vt_write(format!("history-{line}\r\n").as_bytes());
-            }
-            term.vt_write(b"active-command");
-        });
-        let clear = surface.subscribe_terminal_stream_change().unwrap();
-        surface.clear_history().unwrap();
-        assert!(clear.wait_until(wake_deadline()), "terminal clear did not wake the subscription");
-    }
-
-    #[test]
     fn stream_progress_rearms_expired_wait_when_output_races_final_release() {
         let progress = TerminalStreamProgress::default();
         let observed = progress.revision();
@@ -8753,34 +3847,6 @@ mod tests {
         assert!(
             rearmed.deadline() > Instant::now(),
             "stream progress left the expired clear-history wait latched"
-        );
-    }
-
-    #[test]
-    fn pty_pixel_overflow_rejects_creation_and_geometry_updates_without_mutation() {
-        let mux = Mux::new_for_test("pty-pixel-overflow", SurfaceOptions::default());
-        let oversized = SurfaceOptions { cols: 10_000, ..SurfaceOptions::default() };
-        let creation_error =
-            Surface::spawn_for_test(1, oversized, Arc::downgrade(&mux)).unwrap_err();
-        assert!(creation_error.to_string().contains("PTY pixel width exceeds 65535"));
-
-        let surface =
-            Surface::spawn_for_test(2, SurfaceOptions::default(), Arc::downgrade(&mux)).unwrap();
-        let resize_error = surface.resize(10_000, 24).unwrap_err();
-        assert!(resize_error.to_string().contains("PTY pixel width exceeds 65535"));
-        let cell_error = surface.set_cell_pixel_size(1_000, 16).unwrap_err();
-        assert!(cell_error.to_string().contains("PTY pixel width exceeds 65535"));
-
-        assert_eq!(surface.size(), (80, 24));
-        assert_eq!(surface.test_cell_pixel_size(), (8, 16));
-        {
-            let terminal = surface.as_pty().unwrap().term.lock().unwrap();
-            assert_eq!((terminal.cols(), terminal.rows()), (80, 24));
-        }
-        let master = surface.test_master_size();
-        assert_eq!(
-            (master.cols, master.rows, master.pixel_width, master.pixel_height),
-            (80, 24, 640, 384)
         );
     }
 
@@ -9064,10 +4130,10 @@ mod tests {
                 panic!("test surface unexpectedly uses a terminal host");
             };
             *writer = Box::new(write_end);
-            *master = Some(Box::new(FdMasterPty {
+            *master = Box::new(FdMasterPty {
                 file: master_file,
                 size: Mutex::new(PtySize { rows: 24, cols: 80, pixel_width: 0, pixel_height: 0 }),
-            }));
+            });
         }
 
         let input = KeyInput {

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -2587,6 +2587,46 @@ mod tests {
         let _ = std::fs::remove_dir_all(root);
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn resolver_without_scrollback_preserves_file_configured_limit() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
+        let old_ghostty_bin = std::env::var_os("GHOSTTY_BIN");
+        let old_mux_config = std::env::var_os("CMUX_MUX_CONFIG");
+        let old_xdg_config_home = std::env::var_os("XDG_CONFIG_HOME");
+        let root = std::env::temp_dir().join(format!(
+            "cmux-tui-ghostty-scrollback-fallback-{}-{}",
+            std::process::id(),
+            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        let ghostty_dir = root.join("ghostty");
+        let binary = root.join("ghostty-config-helper");
+        std::fs::create_dir_all(&ghostty_dir).unwrap();
+        std::fs::write(ghostty_dir.join("config"), "scrollback-limit = 8_000_000\n").unwrap();
+        std::fs::write(
+            &binary,
+            "#!/bin/sh\nprintf 'background = #272822\\nforeground = #fdfff1\\n'\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&binary, std::fs::Permissions::from_mode(0o700)).unwrap();
+        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
+        unsafe {
+            std::env::set_var("GHOSTTY_BIN", &binary);
+            std::env::remove_var("CMUX_MUX_CONFIG");
+            std::env::set_var("XDG_CONFIG_HOME", &root);
+        }
+
+        let config = load();
+
+        restore_env_var("GHOSTTY_BIN", old_ghostty_bin);
+        restore_env_var("CMUX_MUX_CONFIG", old_mux_config);
+        restore_env_var("XDG_CONFIG_HOME", old_xdg_config_home);
+        let _ = std::fs::remove_dir_all(root);
+        assert_eq!(config.scrollback_limit_bytes(), 8_000_000);
+    }
+
     #[test]
     fn fallback_theme_selection_matches_ghostty_first_theme_wins() {
         let dir = std::env::temp_dir().join(format!(

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -31,15 +31,6 @@
 //!     "width": 22,
 //!     "compact_width": 10,
 //!     "max_width": 0,
-//!     "views": [
-//!       {"id": "machines", "levels": ["machines"], "width": 18},
-//!       {
-//!         "id": "workspace-agents",
-//!         "levels": ["workspaces", "agents"],
-//!         "actions": ["new-workspace"],
-//!         "width": 28
-//!       }
-//!     ],
 //!     "plugin": {
 //!       "command": ["/path/to/plugin-binary"],
 //!       "cwd": "/optional"
@@ -48,8 +39,7 @@
 //!   "machine_sidebar": {
 //!     "enabled": false,
 //!     "width": 22,
-//!     "max_width": 0,
-//!     "create_sources": []
+//!     "max_width": 0
 //!   },
 //!   "machine_provider": {
 //!     "cloud": {
@@ -128,30 +118,21 @@
 //! keys.
 
 use std::collections::{HashMap, HashSet};
-use std::fs::OpenOptions;
 use std::io::{Read, Write};
-use std::ops::Deref;
-#[cfg(unix)]
-use std::os::unix::process::CommandExt;
-use std::path::{Component, Path, PathBuf};
-use std::process::Child;
-use std::process::Command;
-use std::process::Stdio;
-use std::sync::mpsc;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use cmux_tui_core::BrowserMode;
 use cmux_tui_core::SidebarPluginOptions;
-use cmux_tui_core::SurfaceOptions;
 use cmux_tui_core::TRANSPORT_SAFE_CAPTURE_MEGAPIXELS;
 use cmux_tui_core::platform;
 use cmux_tui_core::{CursorShape, DefaultColors, Rgb};
+use cmux_tui_core::{DEFAULT_SCROLLBACK_LIMIT_BYTES, SurfaceOptions};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::style::Color;
 use serde::{Deserialize, Deserializer};
 use serde_json::{Value, json};
-use unicode_width::UnicodeWidthStr;
-use wait_timeout::ChildExt;
 
 use crate::localization::catalog;
 
@@ -181,18 +162,10 @@ struct RawConfig {
     machine_provider: RawMachineProvider,
     #[serde(default)]
     machines: Vec<RawMachine>,
-    /// User commands: named argv programs, each optionally bound to key
-    /// chords, opened as a new PTY tab in the active pane.
-    #[serde(default)]
-    commands: Vec<RawUserCommand>,
     #[serde(default)]
     browser: RawBrowser,
     #[serde(default)]
     scrollbar: RawScrollbar,
-    #[serde(default)]
-    pane: RawPane,
-    #[serde(default)]
-    status_bar: RawStatusBar,
     #[serde(default)]
     viewport: RawViewport,
     #[serde(default)]
@@ -210,56 +183,6 @@ struct RawConfig {
 struct RawServer {
     ws: Option<String>,
     ws_token: Option<String>,
-    detached_owner: Option<bool>,
-}
-
-#[derive(Debug, Default, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct RawPane {
-    /// Blank cells between the pane border and the terminal content.
-    padding: Option<u16>,
-}
-
-#[derive(Debug, Default, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct RawStatusBar {
-    visible: Option<bool>,
-    show_screens: Option<bool>,
-    show_session: Option<bool>,
-    left: Option<Vec<RawStatusSegment>>,
-    right: Option<Vec<RawStatusSegment>>,
-    left_separator: Option<String>,
-    right_separator: Option<String>,
-    screens_style: Option<ChipStyle>,
-    screens_plus: Option<RawPlusButton>,
-}
-
-#[derive(Debug, Default, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct RawStatusSegment {
-    /// Literal text with `{variable}` interpolation.
-    text: Option<String>,
-    /// Argv run on an interval; the last stdout line replaces the segment.
-    run: Option<Vec<String>>,
-    /// Refresh interval in seconds for `run` segments.
-    interval: Option<u64>,
-    fg: Option<ColorValue>,
-    bg: Option<ColorValue>,
-}
-
-#[derive(Debug, Default, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct RawUserCommand {
-    id: Option<String>,
-    name: Option<String>,
-    /// Chord string, array of chord strings, or absent for an unbound
-    /// command. Alt- and Super-modified chords are modeless; other chords
-    /// run after the prefix.
-    keys: Option<Value>,
-    /// Argv executed directly, without a shell.
-    run: Option<Vec<String>>,
-    /// Working directory; defaults to the target pane's current directory.
-    cwd: Option<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -267,11 +190,6 @@ struct RawUserCommand {
 struct RawMachineProvider {
     #[serde(default)]
     cloud: RawCloudProvider,
-    /// Config parity with `--machine-provider-command`: the argv of a
-    /// provider process to spawn, no shell. The CLI flag wins when both are
-    /// given.
-    #[serde(default)]
-    command: Option<Vec<String>>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -304,12 +222,6 @@ struct RawTheme {
     notification_info: Option<ColorValue>,
     notification_warning: Option<ColorValue>,
     notification_error: Option<ColorValue>,
-    border_style: Option<BorderStyle>,
-    status_bg: Option<ColorValue>,
-    status_fg: Option<ColorValue>,
-    sidebar_fg: Option<ColorValue>,
-    sidebar_selected_fg: Option<ColorValue>,
-    dim_inactive: Option<bool>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Default)]
@@ -510,104 +422,16 @@ struct RawTabs {
     solid_background: Option<bool>,
     show_titles: Option<bool>,
     agents: Option<Vec<String>>,
-    style: Option<ChipStyle>,
-    plus: Option<RawPlusButton>,
 }
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct RawSidebar {
     view: Option<String>,
-    profile: Option<String>,
     width: Option<u16>,
     compact_width: Option<u16>,
     max_width: Option<u16>,
-    profiles: Option<Vec<RawSidebarProfile>>,
-    views: Option<Vec<RawSidebarView>>,
-    columns: Option<Vec<RawSidebarColumn>>,
     plugin: Option<RawSidebarPlugin>,
-    /// Rows per rail entry: 2 (default) keeps the subtitle line, 1 is a
-    /// dense name-only list.
-    row_height: Option<u16>,
-    /// Blank rows between rail entries: 1 (default) or 0 for no padding.
-    row_gap: Option<u16>,
-    /// Accent glyph on active rail rows; `"none"` removes it.
-    rail_glyph: Option<String>,
-    /// Workspace row label template with `{index}` and `{name}`.
-    workspace_label: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct RawSidebarProfile {
-    id: String,
-    name: Option<String>,
-    views: Vec<RawSidebarView>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct RawSidebarView {
-    id: String,
-    levels: Vec<String>,
-    actions: Option<Vec<RawSidebarAction>>,
-    actions_position: Option<ActionsPosition>,
-    width: Option<u16>,
-    max_width: Option<u16>,
-    collapse_priority: Option<u16>,
-}
-
-/// One pinned action: an action name, or an object that also renames its
-/// button. `"command:<id>"` references a user command from `commands`.
-#[derive(Debug, Deserialize)]
-#[serde(untagged)]
-enum RawSidebarAction {
-    Name(String),
-    Detailed { action: String, label: Option<String> },
-}
-
-impl RawSidebarAction {
-    fn action(&self) -> &str {
-        match self {
-            RawSidebarAction::Name(name) => name,
-            RawSidebarAction::Detailed { action, .. } => action,
-        }
-    }
-
-    fn label(&self) -> Option<&str> {
-        match self {
-            RawSidebarAction::Name(_) => None,
-            RawSidebarAction::Detailed { label, .. } => label.as_deref(),
-        }
-    }
-}
-
-/// Raw form of a configurable `+` button.
-#[derive(Debug, Default, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct RawPlusButton {
-    label: Option<String>,
-    /// Left-click action override; action name or `command:<id>`.
-    action: Option<String>,
-    /// Right-click menu entries; same grammar as sidebar view actions.
-    menu: Option<Vec<RawSidebarAction>>,
-}
-
-/// Where a view's pinned action buttons render.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub enum ActionsPosition {
-    Top,
-    #[default]
-    Bottom,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct RawSidebarColumn {
-    kind: String,
-    width: Option<u16>,
-    max_width: Option<u16>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -623,15 +447,6 @@ struct RawMachineSidebar {
     enabled: Option<bool>,
     width: Option<u16>,
     max_width: Option<u16>,
-    create_sources: Option<Vec<RawMachineCreationSource>>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct RawMachineCreationSource {
-    id: String,
-    name: String,
-    subtitle: Option<String>,
 }
 
 #[derive(Debug)]
@@ -815,101 +630,6 @@ impl ColorValue {
     }
 }
 
-/// Pane border line style. `None` keeps the border cells blank so panes
-/// separate by empty space; geometry is unchanged in every style.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub enum BorderStyle {
-    #[default]
-    Single,
-    Rounded,
-    Thick,
-    Double,
-    None,
-}
-
-/// Chip cap style for tab labels and the active screen chip: `pill` wraps
-/// solid chips in rounded caps, `slant` in angled caps, `block` (default)
-/// keeps the flat rectangle. Cap glyphs come from the Nerd Font powerline
-/// range, the same glyphs tmux and zellij themes use.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub enum ChipStyle {
-    #[default]
-    Block,
-    Pill,
-    Slant,
-}
-
-impl ChipStyle {
-    /// Left and right cap glyphs, or `None` for the flat block style.
-    pub fn caps(self) -> Option<(&'static str, &'static str)> {
-        match self {
-            ChipStyle::Block => None,
-            ChipStyle::Pill => Some(("\u{e0b6}", "\u{e0b4}")),
-            ChipStyle::Slant => Some(("\u{e0be}", "\u{e0b8}")),
-        }
-    }
-}
-
-/// The six glyphs a pane box is drawn with.
-#[derive(Debug, Clone, Copy)]
-pub struct BorderGlyphs {
-    pub horizontal: &'static str,
-    pub vertical: &'static str,
-    pub top_left: &'static str,
-    pub top_right: &'static str,
-    pub bottom_left: &'static str,
-    pub bottom_right: &'static str,
-}
-
-impl BorderStyle {
-    pub fn glyphs(self) -> BorderGlyphs {
-        match self {
-            BorderStyle::Single => BorderGlyphs {
-                horizontal: "─",
-                vertical: "│",
-                top_left: "┌",
-                top_right: "┐",
-                bottom_left: "└",
-                bottom_right: "┘",
-            },
-            BorderStyle::Rounded => BorderGlyphs {
-                horizontal: "─",
-                vertical: "│",
-                top_left: "╭",
-                top_right: "╮",
-                bottom_left: "╰",
-                bottom_right: "╯",
-            },
-            BorderStyle::Thick => BorderGlyphs {
-                horizontal: "━",
-                vertical: "┃",
-                top_left: "┏",
-                top_right: "┓",
-                bottom_left: "┗",
-                bottom_right: "┛",
-            },
-            BorderStyle::Double => BorderGlyphs {
-                horizontal: "═",
-                vertical: "║",
-                top_left: "╔",
-                top_right: "╗",
-                bottom_left: "╚",
-                bottom_right: "╝",
-            },
-            BorderStyle::None => BorderGlyphs {
-                horizontal: " ",
-                vertical: " ",
-                top_left: " ",
-                top_right: " ",
-                bottom_left: " ",
-                bottom_right: " ",
-            },
-        }
-    }
-}
-
 /// Resolved presentation colors used by the renderers.
 #[derive(Debug, Clone, Copy)]
 pub struct Theme {
@@ -927,15 +647,6 @@ pub struct Theme {
     pub notification_info: Color,
     pub notification_warning: Color,
     pub notification_error: Color,
-    pub border_style: BorderStyle,
-    /// Status bar background/foreground; `None` follows the chrome theme.
-    pub status_bg: Option<Color>,
-    pub status_fg: Option<Color>,
-    /// Sidebar row foregrounds; `None` follows terminal/chrome defaults.
-    pub sidebar_fg: Option<Color>,
-    pub sidebar_selected_fg: Option<Color>,
-    /// Render unfocused terminal panes with the DIM attribute.
-    pub dim_inactive: bool,
 }
 
 impl Default for Theme {
@@ -954,12 +665,6 @@ impl Default for Theme {
             notification_info: Color::Indexed(110),
             notification_warning: Color::Indexed(179),
             notification_error: Color::Indexed(167),
-            border_style: BorderStyle::Single,
-            status_bg: None,
-            status_fg: None,
-            sidebar_fg: None,
-            sidebar_selected_fg: None,
-            dim_inactive: false,
         }
     }
 }
@@ -977,10 +682,6 @@ pub struct Tabs {
     /// Program names worth surfacing in the tab label even when
     /// `show_titles` is off (matched as words in the reported title).
     pub agents: Vec<String>,
-    /// Cap style for solid tab chips.
-    pub style: ChipStyle,
-    /// The tab bar's `+` button: label, click override, right-click menu.
-    pub plus: PlusButton,
 }
 
 impl Default for Tabs {
@@ -990,8 +691,6 @@ impl Default for Tabs {
             solid_background: true,
             show_titles: false,
             agents: ["claude", "codex", "opencode", "pi"].map(String::from).to_vec(),
-            style: ChipStyle::Block,
-            plus: PlusButton::default(),
         }
     }
 }
@@ -1004,237 +703,33 @@ pub struct Sidebar {
     pub width: u16,
     pub compact_width: u16,
     pub max_width: u16,
-    /// Ordered native columns. The legacy width fields remain the defaults for
-    /// machine/workspace columns when this list is omitted from the config.
-    pub columns: Vec<SidebarColumn>,
-    pub columns_explicit: bool,
-    /// Ordered native projections. A one-level projection uses the existing
-    /// list behavior; multiple levels render as one native tree column.
-    pub views: Vec<SidebarViewSpec>,
-    pub views_explicit: bool,
-    /// Named native layouts. `views` is always the currently selected
-    /// profile's resolved rail list so older consumers remain compatible.
-    pub profiles: Vec<SidebarProfileSpec>,
-    pub active_profile: String,
     pub plugin: Option<SidebarPluginOptions>,
-    /// Rows per rail entry: 2 keeps the subtitle line, 1 is name-only.
-    pub row_height: u16,
-    /// Blank rows between rail entries.
-    pub row_gap: u16,
-    /// Accent glyph on active rail rows; empty removes it.
-    pub rail_glyph: String,
-    /// Workspace row label template with `{index}` and `{name}`.
-    pub workspace_label: String,
 }
 
 impl Default for Sidebar {
     fn default() -> Self {
-        let views = vec![
-            SidebarViewSpec::legacy(SidebarColumnKind::Machines, 22, 0),
-            SidebarViewSpec::legacy(SidebarColumnKind::Workspaces, 22, 0),
-        ];
         Sidebar {
             view: SidebarView::Workspaces,
             width: 22,
             compact_width: 10,
             max_width: 0,
-            columns: vec![
-                SidebarColumn { kind: SidebarColumnKind::Machines, width: 22, max_width: 0 },
-                SidebarColumn { kind: SidebarColumnKind::Workspaces, width: 22, max_width: 0 },
-            ],
-            columns_explicit: false,
-            views: views.clone(),
-            views_explicit: false,
-            profiles: vec![SidebarProfileSpec {
-                id: "default".to_string(),
-                name: "Default".to_string(),
-                views,
-            }],
-            active_profile: "default".to_string(),
             plugin: None,
-            row_height: 2,
-            row_gap: 1,
-            rail_glyph: "\u{258e}".to_string(),
-            workspace_label: "{name}".to_string(),
         }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SidebarProfileSpec {
-    pub id: String,
-    pub name: String,
-    pub views: Vec<SidebarViewSpec>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum SidebarColumnKind {
-    Machines,
-    Workspaces,
-    Tabs,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct SidebarColumn {
-    pub kind: SidebarColumnKind,
-    pub width: u16,
-    pub max_width: u16,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum SidebarResourceKind {
-    Machines,
-    Workspaces,
-    Panes,
-    Tabs,
-    Agents,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SidebarViewSpec {
-    pub id: String,
-    pub levels: Vec<SidebarResourceKind>,
-    /// Canonical native commands pinned to this view, with optional
-    /// user-facing button labels.
-    pub actions: Vec<SidebarActionSpec>,
-    /// Whether the pinned actions render above or below the resource rows.
-    pub actions_position: ActionsPosition,
-    pub width: u16,
-    pub max_width: u16,
-    /// Lower values collapse first when pane space becomes constrained.
-    pub collapse_priority: u16,
-}
-
-/// One pinned sidebar action and its optional label override.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SidebarActionSpec {
-    pub action: Action,
-    pub label: Option<String>,
-}
-
-impl SidebarActionSpec {
-    pub fn plain(action: Action) -> Self {
-        Self { action, label: None }
-    }
-}
-
-/// A configurable `+` button: its rendered label, an optional left-click
-/// action override, and an optional right-click menu of actions.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PlusButton {
-    pub label: String,
-    pub action: Option<Action>,
-    pub menu: Vec<SidebarActionSpec>,
-}
-
-impl Default for PlusButton {
-    fn default() -> Self {
-        Self { label: " + ".to_string(), action: None, menu: Vec::new() }
-    }
-}
-
-fn resolve_plus_button(raw: RawPlusButton, command_ids: &[String], owner: &str) -> PlusButton {
-    let mut plus = PlusButton::default();
-    if let Some(label) = raw.label {
-        // Keep at least one visible cell so the button stays clickable.
-        if !label.trim().is_empty() {
-            plus.label = label;
-        }
-    }
-    if let Some(action) = raw.action.as_deref() {
-        match parse_sidebar_action(action.trim(), command_ids) {
-            Ok(action) => plus.action = Some(action),
-            Err(warning) => {
-                crate::client_log::stderr_log!("config", "{warning} in {owner} plus button");
-            }
-        }
-    }
-    if let Some(menu) = raw.menu {
-        let mut seen = HashSet::new();
-        for raw_action in &menu {
-            match parse_sidebar_action(raw_action.action().trim(), command_ids) {
-                Ok(action) if seen.insert(action) => plus.menu.push(SidebarActionSpec {
-                    action,
-                    label: raw_action
-                        .label()
-                        .map(str::trim)
-                        .filter(|label| !label.is_empty())
-                        .map(str::to_string),
-                }),
-                Ok(_) => crate::client_log::stderr_log!(
-                    "config",
-                    "cmux-tui: ignoring duplicate {owner} plus menu action {:?}",
-                    raw_action.action().trim()
-                ),
-                Err(warning) => {
-                    crate::client_log::stderr_log!("config", "{warning} in {owner} plus menu");
-                }
-            }
-        }
-    }
-    plus
-}
-
-impl SidebarViewSpec {
-    pub fn legacy(kind: SidebarColumnKind, width: u16, max_width: u16) -> Self {
-        let (id, level, collapse_priority) = match kind {
-            SidebarColumnKind::Machines => ("machines", SidebarResourceKind::Machines, 10),
-            SidebarColumnKind::Workspaces => ("workspaces", SidebarResourceKind::Workspaces, 30),
-            SidebarColumnKind::Tabs => ("tabs", SidebarResourceKind::Tabs, 20),
-        };
-        let levels = vec![level];
-        let actions = default_sidebar_actions(&levels);
-        Self {
-            id: id.to_string(),
-            levels,
-            actions,
-            actions_position: ActionsPosition::Bottom,
-            width,
-            max_width,
-            collapse_priority,
-        }
-    }
-
-    pub fn legacy_kind(&self) -> Option<SidebarColumnKind> {
-        match self.levels.as_slice() {
-            [SidebarResourceKind::Machines] => Some(SidebarColumnKind::Machines),
-            [SidebarResourceKind::Workspaces] => Some(SidebarColumnKind::Workspaces),
-            [SidebarResourceKind::Tabs] if self.actions.is_empty() => Some(SidebarColumnKind::Tabs),
-            _ => None,
-        }
-    }
-
-    pub fn includes(&self, kind: SidebarResourceKind) -> bool {
-        self.levels.contains(&kind)
     }
 }
 
 /// Optional client-local rail listing connection targets. It is disabled for
 /// ordinary local cmux sessions and enabled by a machine provider or config.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MachineSidebar {
     pub enabled: bool,
     pub width: u16,
     pub max_width: u16,
-    /// Session-local prototype sources. They exercise the native provider
-    /// picker without starting containers or consuming cloud resources.
-    pub create_sources: Vec<MachineCreationSourceConfig>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct MachineCreationSourceConfig {
-    pub id: String,
-    pub name: String,
-    pub subtitle: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct MachineProviderConfig {
     pub cloud: CloudProviderConfig,
-    /// Argv of a machine-provider process to spawn, exactly like
-    /// `--machine-provider-command program arg -- `. CLI provider modes
-    /// override it.
-    pub command: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1283,7 +778,7 @@ pub enum MachineTargetConfig {
 
 impl Default for MachineSidebar {
     fn default() -> Self {
-        Self { enabled: false, width: 22, max_width: 0, create_sources: Vec::new() }
+        Self { enabled: false, width: 22, max_width: 0 }
     }
 }
 
@@ -1311,221 +806,6 @@ fn parse_sidebar_view(value: &str) -> Result<SidebarView, String> {
             "cmux-tui: ignoring unknown sidebar.view {value:?}; expected \"files\" or \"workspaces\""
         )),
     }
-}
-
-fn parse_sidebar_column_kind(value: &str) -> Result<SidebarColumnKind, String> {
-    match value {
-        "machines" => Ok(SidebarColumnKind::Machines),
-        "workspaces" => Ok(SidebarColumnKind::Workspaces),
-        "tabs" => Ok(SidebarColumnKind::Tabs),
-        _ => Err(format!(
-            "cmux-tui: ignoring unknown sidebar column {value:?}; expected \"machines\", \"workspaces\", or \"tabs\""
-        )),
-    }
-}
-
-fn parse_sidebar_resource_kind(value: &str) -> Result<SidebarResourceKind, String> {
-    match value {
-        "machines" => Ok(SidebarResourceKind::Machines),
-        "workspaces" => Ok(SidebarResourceKind::Workspaces),
-        "panes" => Ok(SidebarResourceKind::Panes),
-        "tabs" => Ok(SidebarResourceKind::Tabs),
-        "agents" => Ok(SidebarResourceKind::Agents),
-        _ => Err(format!(
-            "cmux-tui: ignoring unknown sidebar resource {value:?}; expected \"machines\", \"workspaces\", \"panes\", \"tabs\", or \"agents\""
-        )),
-    }
-}
-
-fn validate_sidebar_levels(levels: &[SidebarResourceKind]) -> Result<(), &'static str> {
-    if levels.is_empty() {
-        return Err("levels cannot be empty");
-    }
-    if levels.len() > 3 {
-        return Err("at most three resource levels are supported");
-    }
-    let mut seen = HashSet::new();
-    if levels.iter().any(|level| !seen.insert(*level)) {
-        return Err("resource levels cannot repeat");
-    }
-    if levels.contains(&SidebarResourceKind::Machines) {
-        return (levels == [SidebarResourceKind::Machines])
-            .then_some(())
-            .ok_or("machines must be a one-level view");
-    }
-    if let Some(index) = levels.iter().position(|level| *level == SidebarResourceKind::Workspaces)
-        && index != 0
-    {
-        return Err("workspaces must be the first level");
-    }
-    if let Some(index) = levels.iter().position(|level| *level == SidebarResourceKind::Panes)
-        && index > 1
-    {
-        return Err("panes must be first or directly below workspaces");
-    }
-    for leaf in [SidebarResourceKind::Tabs, SidebarResourceKind::Agents] {
-        if let Some(index) = levels.iter().position(|level| *level == leaf)
-            && index + 1 != levels.len()
-        {
-            return Err("tabs and agents must be the final level");
-        }
-    }
-    Ok(())
-}
-
-fn default_sidebar_collapse_priority(levels: &[SidebarResourceKind]) -> u16 {
-    match levels {
-        [SidebarResourceKind::Machines] => 10,
-        [SidebarResourceKind::Workspaces] => 30,
-        _ => 20,
-    }
-}
-
-fn default_sidebar_actions(levels: &[SidebarResourceKind]) -> Vec<SidebarActionSpec> {
-    if levels.first() == Some(&SidebarResourceKind::Workspaces) {
-        vec![SidebarActionSpec::plain(Action::NewWorkspace)]
-    } else {
-        Vec::new()
-    }
-}
-
-/// Parse one pinned action name: an action catalog key, or `command:<id>`
-/// referencing a user command from the top-level `commands` section.
-fn parse_sidebar_action(value: &str, command_ids: &[String]) -> Result<Action, String> {
-    if let Some(command_id) = value.strip_prefix("command:") {
-        return command_ids
-            .iter()
-            .position(|id| id == command_id)
-            .and_then(Action::user_command)
-            .ok_or_else(|| {
-                format!("cmux-tui: ignoring sidebar action for unknown command {command_id:?}")
-            });
-    }
-    action_definitions()
-        .iter()
-        .find(|definition| definition.config_key == value)
-        .map(|definition| definition.action)
-        .ok_or_else(|| format!("cmux-tui: ignoring unknown sidebar action {value:?}"))
-}
-
-fn resolve_sidebar_view_specs(
-    views: &[RawSidebarView],
-    machine_width: u16,
-    machine_max_width: u16,
-    workspace_width: u16,
-    workspace_max_width: u16,
-    owner: &str,
-    command_ids: &[String],
-) -> Vec<SidebarViewSpec> {
-    let mut ids = HashSet::new();
-    let mut legacy_kinds = HashSet::new();
-    let mut resolved = Vec::new();
-    for view in views {
-        let id = view.id.trim();
-        if id.is_empty() || ids.contains(id) {
-            crate::client_log::stderr_log!(
-                "config",
-                "cmux-tui: ignoring {owner} view with an empty or duplicate id"
-            );
-            continue;
-        }
-        let mut levels = Vec::with_capacity(view.levels.len());
-        let mut valid = true;
-        for level in &view.levels {
-            match parse_sidebar_resource_kind(level.trim()) {
-                Ok(level) => levels.push(level),
-                Err(warning) => {
-                    crate::client_log::stderr_log!("config", "{warning}");
-                    valid = false;
-                    break;
-                }
-            }
-        }
-        if !valid {
-            continue;
-        }
-        if let Err(reason) = validate_sidebar_levels(&levels) {
-            crate::client_log::stderr_log!(
-                "config",
-                "cmux-tui: ignoring {owner} view {id:?}: {reason}"
-            );
-            continue;
-        }
-        let legacy_kind = SidebarViewSpec {
-            id: id.to_string(),
-            levels: levels.clone(),
-            actions: Vec::new(),
-            actions_position: ActionsPosition::Bottom,
-            width: 0,
-            max_width: 0,
-            collapse_priority: 0,
-        }
-        .legacy_kind();
-        if legacy_kind.is_some_and(|kind| !legacy_kinds.insert(kind)) {
-            crate::client_log::stderr_log!(
-                "config",
-                "cmux-tui: ignoring {owner} view {id:?}: a one-level view for that resource already exists"
-            );
-            continue;
-        }
-        ids.insert(id.to_string());
-        let (default_width, default_max_width) = match legacy_kind {
-            Some(SidebarColumnKind::Machines) => (machine_width, machine_max_width),
-            Some(SidebarColumnKind::Workspaces) => (workspace_width, workspace_max_width),
-            Some(SidebarColumnKind::Tabs) | None => (22, 0),
-        };
-        let actions = if levels == [SidebarResourceKind::Machines]
-            && view.actions.as_ref().is_some_and(|actions| !actions.is_empty())
-        {
-            crate::client_log::stderr_log!(
-                "config",
-                "cmux-tui: ignoring sidebar actions in {owner} machine view {id:?}; machine actions come from provider capabilities"
-            );
-            Vec::new()
-        } else if let Some(raw_actions) = view.actions.as_ref() {
-            let mut seen = HashSet::new();
-            raw_actions
-                .iter()
-                .filter_map(|raw_action| {
-                    match parse_sidebar_action(raw_action.action().trim(), command_ids) {
-                        Ok(action) if seen.insert(action) => Some(SidebarActionSpec {
-                            action,
-                            label: raw_action
-                                .label()
-                                .map(str::trim)
-                                .filter(|label| !label.is_empty())
-                                .map(str::to_string),
-                        }),
-                        Ok(_) => {
-                            crate::client_log::stderr_log!("config", 
-                                "cmux-tui: ignoring duplicate sidebar action {:?} in {owner} view {id:?}",
-                                raw_action.action().trim()
-                            );
-                            None
-                        }
-                        Err(warning) => {
-                            crate::client_log::stderr_log!("config", "{warning} in {owner} view {id:?}");
-                            None
-                        }
-                    }
-                })
-                .collect()
-        } else {
-            default_sidebar_actions(&levels)
-        };
-        resolved.push(SidebarViewSpec {
-            id: id.to_string(),
-            collapse_priority: view
-                .collapse_priority
-                .unwrap_or_else(|| default_sidebar_collapse_priority(&levels)),
-            levels,
-            actions,
-            actions_position: view.actions_position.unwrap_or_default(),
-            width: view.width.unwrap_or(default_width).clamp(10, 60),
-            max_width: view.max_width.unwrap_or(default_max_width),
-        });
-    }
-    resolved
 }
 
 #[derive(Debug, Clone)]
@@ -1572,28 +852,6 @@ impl ActionIndex {
     }
 }
 
-/// The maximum number of configurable user commands. Chords bound past this
-/// limit are rejected at config load with a visible warning.
-pub const MAX_USER_COMMANDS: usize = 32;
-
-/// The maximum number of chords one command may bind.
-pub const MAX_USER_COMMAND_CHORDS: usize = 8;
-
-/// A validated zero-based index into the configured `commands` list. Its
-/// private field prevents unregistered command actions.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct UserCommandIndex(u8);
-
-impl UserCommandIndex {
-    pub const fn new(value: usize) -> Option<Self> {
-        if value < MAX_USER_COMMANDS { Some(Self(value as u8)) } else { None }
-    }
-
-    pub const fn get(self) -> usize {
-        self.0 as usize
-    }
-}
-
 /// Every prefix-key action, so bindings are configurable end to end.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Action {
@@ -1624,7 +882,6 @@ pub enum Action {
     ToggleSidebarCompact,
     ToggleSidebarView,
     FocusSidebar,
-    ProviderMenu,
     NewPaneRight,
     UndoLayout,
     FocusLeft,
@@ -1646,208 +903,6 @@ pub enum Action {
     BrowserEditUrl,
     ShowShortcuts,
     Detach,
-    /// A user-configured command from the top-level `commands` section,
-    /// opened as a new PTY tab through the mux `run` command.
-    UserCommand(UserCommandIndex),
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg(test)]
-pub(crate) enum ActionExecution {
-    SendPrefix,
-    NewTab,
-    NewBrowserTab,
-    NewPaneSmart,
-    NextTab,
-    PrevTab,
-    SelectTab(ActionIndex),
-    SplitRight,
-    SplitDown,
-    CloseTab,
-    ClosePane,
-    RenameTab,
-    RenameScreen,
-    RenameWorkspace,
-    CloseScreen,
-    PrevScreen,
-    NextScreen,
-    SelectScreen(ActionIndex),
-    NewScreen,
-    PrevWorkspace,
-    NextWorkspace,
-    NewWorkspace,
-    CloseWorkspace,
-    ToggleSidebar,
-    ToggleSidebarCompact,
-    ToggleSidebarView,
-    FocusSidebar,
-    ProviderMenu,
-    NewPaneRight,
-    UndoLayout,
-    FocusLeft,
-    FocusRight,
-    FocusUp,
-    FocusDown,
-    FocusNextPane,
-    SwapPanePrev,
-    SwapPaneNext,
-    ZoomPane,
-    ResizeGrow,
-    ResizeShrink,
-    ScrollUp,
-    ScrollDown,
-    ClearHistory,
-    BrowserBack,
-    BrowserForward,
-    BrowserReload,
-    BrowserEditUrl,
-    ShowShortcuts,
-    Detach,
-    UserCommand(UserCommandIndex),
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg(test)]
-enum ActionClassification {
-    Direct,
-    Composite,
-    PresentationOnly,
-}
-
-#[cfg(test)]
-impl ActionClassification {
-    const fn inventory_name(self) -> &'static str {
-        match self {
-            Self::Direct => "direct",
-            Self::Composite => "composite",
-            Self::PresentationOnly => "presentation-only",
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg(test)]
-enum WorkspaceOwnershipSource {
-    ActiveWorkspaceSession,
-}
-
-#[cfg(test)]
-impl WorkspaceOwnershipSource {
-    const fn inventory_name(self) -> &'static str {
-        match self {
-            Self::ActiveWorkspaceSession => "active-workspace-session",
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg(test)]
-enum ActionRouteTarget {
-    MuxCommand(&'static str),
-    MachineProviderRequest(&'static str),
-}
-
-#[cfg(test)]
-impl ActionRouteTarget {
-    const fn inventory_kind(self) -> &'static str {
-        match self {
-            Self::MuxCommand(_) => "mux-command",
-            Self::MachineProviderRequest(_) => "machine-provider-request",
-        }
-    }
-
-    const fn operation(self) -> &'static str {
-        match self {
-            Self::MuxCommand(operation) | Self::MachineProviderRequest(operation) => operation,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg(test)]
-enum UnknownOwnership {
-    Reject,
-}
-
-#[cfg(test)]
-impl UnknownOwnership {
-    const fn inventory_name(self) -> &'static str {
-        match self {
-            Self::Reject => "reject",
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg(test)]
-enum ActionRoute {
-    Static(&'static str),
-    WorkspaceOwnership {
-        source: WorkspaceOwnershipSource,
-        session_owned: ActionRouteTarget,
-        provider_owned: ActionRouteTarget,
-        unknown: UnknownOwnership,
-    },
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg(test)]
-pub(crate) struct ActionMetadata {
-    key: &'static str,
-    classification: ActionClassification,
-    route: ActionRoute,
-    execution: ActionExecution,
-}
-
-#[cfg(test)]
-impl ActionMetadata {
-    const fn new(
-        key: &'static str,
-        classification: ActionClassification,
-        route: &'static str,
-        execution: ActionExecution,
-    ) -> Self {
-        Self { key, classification, route: ActionRoute::Static(route), execution }
-    }
-
-    const fn workspace_ownership(
-        key: &'static str,
-        classification: ActionClassification,
-        source: WorkspaceOwnershipSource,
-        session_owned: ActionRouteTarget,
-        provider_owned: ActionRouteTarget,
-        unknown: UnknownOwnership,
-        execution: ActionExecution,
-    ) -> Self {
-        Self {
-            key,
-            classification,
-            route: ActionRoute::WorkspaceOwnership {
-                source,
-                session_owned,
-                provider_owned,
-                unknown,
-            },
-            execution,
-        }
-    }
-
-    pub(crate) fn execution(self) -> ActionExecution {
-        debug_assert!(!self.key.is_empty());
-        debug_assert!(!self.classification.inventory_name().is_empty());
-        match self.route {
-            ActionRoute::Static(route) => debug_assert!(!route.is_empty()),
-            ActionRoute::WorkspaceOwnership { source, session_owned, provider_owned, unknown } => {
-                debug_assert!(!source.inventory_name().is_empty());
-                debug_assert_eq!(session_owned.inventory_kind(), "mux-command");
-                debug_assert!(!session_owned.operation().is_empty());
-                debug_assert_eq!(provider_owned.inventory_kind(), "machine-provider-request");
-                debug_assert!(!provider_owned.operation().is_empty());
-                debug_assert_eq!(unknown.inventory_name(), "reject");
-            }
-        }
-        self.execution
-    }
 }
 
 /// One executable TUI action and the metadata shared by key configuration,
@@ -1906,7 +961,6 @@ define_named_action_definitions! {
     TOGGLE_SIDEBAR_COMPACT_DEFINITION => (Action::ToggleSidebarCompact, "toggle-sidebar-compact", "Compact or expand sidebar", "サイドバーの幅を切り替え");
     TOGGLE_SIDEBAR_VIEW_DEFINITION => (Action::ToggleSidebarView, "toggle-sidebar-view", "Switch sidebar view", "サイドバー表示を切り替え");
     FOCUS_SIDEBAR_DEFINITION => (Action::FocusSidebar, "focus-sidebar", "Focus sidebar", "サイドバーにフォーカス");
-    PROVIDER_MENU_DEFINITION => (Action::ProviderMenu, "provider-menu", "Machine provider menu", "マシンプロバイダーメニュー");
     NEW_PANE_RIGHT_DEFINITION => (Action::NewPaneRight, "new-pane-right", "New column to the right", "右に新しい列");
     UNDO_LAYOUT_DEFINITION => (Action::UndoLayout, "undo-layout", "Undo layout", "レイアウトを元に戻す");
     FOCUS_LEFT_DEFINITION => (Action::FocusLeft, "focus-left", "Focus left", "左へフォーカス");
@@ -2059,7 +1113,7 @@ static SELECT_SCREEN_DEFINITIONS: [ActionDefinition; 10] = [
 /// The canonical action catalog. Presentation surfaces derive their labels
 /// and ordering from these named definitions instead of positional offsets.
 pub fn action_definitions() -> &'static [&'static ActionDefinition] {
-    static DEFINITIONS: [&ActionDefinition; 67] = [
+    static DEFINITIONS: [&ActionDefinition; 66] = [
         &SEND_PREFIX_DEFINITION,
         &NEW_TAB_DEFINITION,
         &NEW_BROWSER_TAB_DEFINITION,
@@ -2105,7 +1159,6 @@ pub fn action_definitions() -> &'static [&'static ActionDefinition] {
         &TOGGLE_SIDEBAR_COMPACT_DEFINITION,
         &TOGGLE_SIDEBAR_VIEW_DEFINITION,
         &FOCUS_SIDEBAR_DEFINITION,
-        &PROVIDER_MENU_DEFINITION,
         &NEW_PANE_RIGHT_DEFINITION,
         &UNDO_LAYOUT_DEFINITION,
         &FOCUS_LEFT_DEFINITION,
@@ -2129,334 +1182,6 @@ pub fn action_definitions() -> &'static [&'static ActionDefinition] {
         &DETACH_DEFINITION,
     ];
     &DEFINITIONS
-}
-
-/// Fallback definition for `Action::UserCommand`. It is intentionally not in
-/// `action_definitions()`: user commands are named by the user's config, and
-/// presentation surfaces look the display name up there. The `action` field
-/// pins index 0 only because a definition must carry one concrete action.
-static USER_COMMAND_FALLBACK_DEFINITION: ActionDefinition = action_definition!(
-    Action::UserCommand(UserCommandIndex(0)),
-    "user-command",
-    "User command",
-    "ユーザーコマンド"
-);
-
-impl Action {
-    /// Compiled source of truth for programmability classification and
-    /// execution routing. The specification inventory checker reads this
-    /// exhaustive catalog.
-    #[cfg(test)]
-    pub(crate) fn metadata(&self) -> ActionMetadata {
-        match self {
-            Action::SendPrefix => ActionMetadata::new(
-                "send-prefix",
-                ActionClassification::Composite,
-                "frontend prefix config + active surface + send-key",
-                ActionExecution::SendPrefix,
-            ),
-            Action::NewTab => ActionMetadata::new(
-                "new-tab",
-                ActionClassification::Direct,
-                "new-tab",
-                ActionExecution::NewTab,
-            ),
-            Action::NewBrowserTab => ActionMetadata::new(
-                "new-browser-tab",
-                ActionClassification::Composite,
-                "frontend omnibar + new-browser-tab",
-                ActionExecution::NewBrowserTab,
-            ),
-            Action::NewPaneSmart => ActionMetadata::new(
-                "new-pane-smart",
-                ActionClassification::Composite,
-                "list-workspaces + new-pane",
-                ActionExecution::NewPaneSmart,
-            ),
-            Action::NextTab => ActionMetadata::new(
-                "next-tab",
-                ActionClassification::Direct,
-                "select-tab delta:+1",
-                ActionExecution::NextTab,
-            ),
-            Action::PrevTab => ActionMetadata::new(
-                "prev-tab",
-                ActionClassification::Direct,
-                "select-tab delta:-1",
-                ActionExecution::PrevTab,
-            ),
-            Action::SelectTab(index) => ActionMetadata::new(
-                "select-tab-{number}",
-                ActionClassification::Direct,
-                "select-tab index",
-                ActionExecution::SelectTab(*index),
-            ),
-            Action::SplitRight => ActionMetadata::new(
-                "split-right",
-                ActionClassification::Direct,
-                "split dir:right",
-                ActionExecution::SplitRight,
-            ),
-            Action::SplitDown => ActionMetadata::new(
-                "split-down",
-                ActionClassification::Direct,
-                "split dir:down",
-                ActionExecution::SplitDown,
-            ),
-            Action::CloseTab => ActionMetadata::new(
-                "close-tab",
-                ActionClassification::Direct,
-                "close-surface",
-                ActionExecution::CloseTab,
-            ),
-            Action::ClosePane => ActionMetadata::new(
-                "close-pane",
-                ActionClassification::Direct,
-                "close-pane",
-                ActionExecution::ClosePane,
-            ),
-            Action::RenameTab => ActionMetadata::new(
-                "rename-tab",
-                ActionClassification::Composite,
-                "frontend prompt + rename-surface",
-                ActionExecution::RenameTab,
-            ),
-            Action::RenameScreen => ActionMetadata::new(
-                "rename-screen",
-                ActionClassification::Composite,
-                "frontend prompt + rename-screen",
-                ActionExecution::RenameScreen,
-            ),
-            Action::RenameWorkspace => ActionMetadata::new(
-                "rename-workspace",
-                ActionClassification::Composite,
-                "frontend prompt + rename-workspace",
-                ActionExecution::RenameWorkspace,
-            ),
-            Action::CloseScreen => ActionMetadata::new(
-                "close-screen",
-                ActionClassification::Direct,
-                "close-screen",
-                ActionExecution::CloseScreen,
-            ),
-            Action::PrevScreen => ActionMetadata::new(
-                "prev-screen",
-                ActionClassification::Direct,
-                "select-screen delta:-1",
-                ActionExecution::PrevScreen,
-            ),
-            Action::NextScreen => ActionMetadata::new(
-                "next-screen",
-                ActionClassification::Direct,
-                "select-screen delta:+1",
-                ActionExecution::NextScreen,
-            ),
-            Action::SelectScreen(index) => ActionMetadata::new(
-                "select-screen-{number}",
-                ActionClassification::Direct,
-                "select-screen index",
-                ActionExecution::SelectScreen(*index),
-            ),
-            Action::NewScreen => ActionMetadata::new(
-                "new-screen",
-                ActionClassification::Direct,
-                "new-screen",
-                ActionExecution::NewScreen,
-            ),
-            Action::PrevWorkspace => ActionMetadata::new(
-                "prev-workspace",
-                ActionClassification::Direct,
-                "select-workspace delta:-1",
-                ActionExecution::PrevWorkspace,
-            ),
-            Action::NextWorkspace => ActionMetadata::new(
-                "next-workspace",
-                ActionClassification::Direct,
-                "select-workspace delta:+1",
-                ActionExecution::NextWorkspace,
-            ),
-            Action::NewWorkspace => ActionMetadata::workspace_ownership(
-                "new-workspace",
-                ActionClassification::Composite,
-                WorkspaceOwnershipSource::ActiveWorkspaceSession,
-                ActionRouteTarget::MuxCommand("new-workspace"),
-                ActionRouteTarget::MachineProviderRequest("create_workspace"),
-                UnknownOwnership::Reject,
-                ActionExecution::NewWorkspace,
-            ),
-            Action::CloseWorkspace => ActionMetadata::workspace_ownership(
-                "close-workspace",
-                ActionClassification::Composite,
-                WorkspaceOwnershipSource::ActiveWorkspaceSession,
-                ActionRouteTarget::MuxCommand("close-workspace"),
-                ActionRouteTarget::MachineProviderRequest("delete_workspace"),
-                UnknownOwnership::Reject,
-                ActionExecution::CloseWorkspace,
-            ),
-            Action::ToggleSidebar => ActionMetadata::new(
-                "toggle-sidebar",
-                ActionClassification::PresentationOnly,
-                "frontend action adapter",
-                ActionExecution::ToggleSidebar,
-            ),
-            Action::ToggleSidebarCompact => ActionMetadata::new(
-                "toggle-sidebar-compact",
-                ActionClassification::PresentationOnly,
-                "frontend action adapter",
-                ActionExecution::ToggleSidebarCompact,
-            ),
-            Action::ToggleSidebarView => ActionMetadata::new(
-                "toggle-sidebar-view",
-                ActionClassification::PresentationOnly,
-                "frontend action adapter",
-                ActionExecution::ToggleSidebarView,
-            ),
-            Action::FocusSidebar => ActionMetadata::new(
-                "focus-sidebar",
-                ActionClassification::PresentationOnly,
-                "frontend action adapter",
-                ActionExecution::FocusSidebar,
-            ),
-            Action::ProviderMenu => ActionMetadata::new(
-                "provider-menu",
-                ActionClassification::PresentationOnly,
-                "frontend machine provider menu",
-                ActionExecution::ProviderMenu,
-            ),
-            Action::NewPaneRight => ActionMetadata::new(
-                "new-pane-right",
-                ActionClassification::Direct,
-                "new-pane-right",
-                ActionExecution::NewPaneRight,
-            ),
-            Action::UndoLayout => ActionMetadata::new(
-                "undo-layout",
-                ActionClassification::Direct,
-                "undo-layout",
-                ActionExecution::UndoLayout,
-            ),
-            Action::FocusLeft => ActionMetadata::new(
-                "focus-left",
-                ActionClassification::Composite,
-                "frontend geometry + focus-pane",
-                ActionExecution::FocusLeft,
-            ),
-            Action::FocusRight => ActionMetadata::new(
-                "focus-right",
-                ActionClassification::Composite,
-                "frontend geometry + focus-pane",
-                ActionExecution::FocusRight,
-            ),
-            Action::FocusUp => ActionMetadata::new(
-                "focus-up",
-                ActionClassification::Composite,
-                "frontend geometry + focus-pane",
-                ActionExecution::FocusUp,
-            ),
-            Action::FocusDown => ActionMetadata::new(
-                "focus-down",
-                ActionClassification::Composite,
-                "frontend geometry + focus-pane",
-                ActionExecution::FocusDown,
-            ),
-            Action::FocusNextPane => ActionMetadata::new(
-                "focus-next-pane",
-                ActionClassification::Composite,
-                "list-workspaces + focus-pane",
-                ActionExecution::FocusNextPane,
-            ),
-            Action::SwapPanePrev => ActionMetadata::new(
-                "swap-pane-prev",
-                ActionClassification::Composite,
-                "list-workspaces + swap-pane",
-                ActionExecution::SwapPanePrev,
-            ),
-            Action::SwapPaneNext => ActionMetadata::new(
-                "swap-pane-next",
-                ActionClassification::Composite,
-                "list-workspaces + swap-pane",
-                ActionExecution::SwapPaneNext,
-            ),
-            Action::ZoomPane => ActionMetadata::new(
-                "zoom-pane",
-                ActionClassification::Direct,
-                "zoom-pane",
-                ActionExecution::ZoomPane,
-            ),
-            Action::ResizeGrow => ActionMetadata::new(
-                "resize-grow",
-                ActionClassification::Composite,
-                "list-workspaces + set-split-ratio",
-                ActionExecution::ResizeGrow,
-            ),
-            Action::ResizeShrink => ActionMetadata::new(
-                "resize-shrink",
-                ActionClassification::Composite,
-                "list-workspaces + set-split-ratio",
-                ActionExecution::ResizeShrink,
-            ),
-            Action::ScrollUp => ActionMetadata::new(
-                "scroll-up",
-                ActionClassification::PresentationOnly,
-                "frontend viewport adapter; scroll-surface for shared local viewport",
-                ActionExecution::ScrollUp,
-            ),
-            Action::ScrollDown => ActionMetadata::new(
-                "scroll-down",
-                ActionClassification::PresentationOnly,
-                "frontend viewport adapter; scroll-surface for shared local viewport",
-                ActionExecution::ScrollDown,
-            ),
-            Action::ClearHistory => ActionMetadata::new(
-                "clear-history",
-                ActionClassification::Direct,
-                "clear-history",
-                ActionExecution::ClearHistory,
-            ),
-            Action::BrowserBack => ActionMetadata::new(
-                "browser-back",
-                ActionClassification::Direct,
-                "browser-back",
-                ActionExecution::BrowserBack,
-            ),
-            Action::BrowserForward => ActionMetadata::new(
-                "browser-forward",
-                ActionClassification::Direct,
-                "browser-forward",
-                ActionExecution::BrowserForward,
-            ),
-            Action::BrowserReload => ActionMetadata::new(
-                "browser-reload",
-                ActionClassification::Direct,
-                "browser-reload",
-                ActionExecution::BrowserReload,
-            ),
-            Action::BrowserEditUrl => ActionMetadata::new(
-                "browser-edit-url",
-                ActionClassification::Composite,
-                "frontend prompt + browser-navigate",
-                ActionExecution::BrowserEditUrl,
-            ),
-            Action::ShowShortcuts => ActionMetadata::new(
-                "show-shortcuts",
-                ActionClassification::PresentationOnly,
-                "frontend shortcut overlay",
-                ActionExecution::ShowShortcuts,
-            ),
-            Action::Detach => ActionMetadata::new(
-                "detach",
-                ActionClassification::PresentationOnly,
-                "close frontend transport",
-                ActionExecution::Detach,
-            ),
-            Action::UserCommand(index) => ActionMetadata::new(
-                "user-command-{index}",
-                ActionClassification::Composite,
-                "frontend command config + run",
-                ActionExecution::UserCommand(*index),
-            ),
-        }
-    }
 }
 
 impl Action {
@@ -2489,7 +1214,6 @@ impl Action {
             Action::ToggleSidebarCompact => &TOGGLE_SIDEBAR_COMPACT_DEFINITION,
             Action::ToggleSidebarView => &TOGGLE_SIDEBAR_VIEW_DEFINITION,
             Action::FocusSidebar => &FOCUS_SIDEBAR_DEFINITION,
-            Action::ProviderMenu => &PROVIDER_MENU_DEFINITION,
             Action::NewPaneRight => &NEW_PANE_RIGHT_DEFINITION,
             Action::UndoLayout => &UNDO_LAYOUT_DEFINITION,
             Action::FocusLeft => &FOCUS_LEFT_DEFINITION,
@@ -2511,11 +1235,6 @@ impl Action {
             Action::BrowserEditUrl => &BROWSER_EDIT_URL_DEFINITION,
             Action::ShowShortcuts => &SHOW_SHORTCUTS_DEFINITION,
             Action::Detach => &DETACH_DEFINITION,
-            // One shared fallback: presentation surfaces resolve the
-            // configured display name through the command list instead of
-            // this static definition, which is deliberately outside the
-            // action catalog.
-            Action::UserCommand(_) => &USER_COMMAND_FALLBACK_DEFINITION,
         }
     }
 
@@ -2523,20 +1242,6 @@ impl Action {
         match ActionIndex::new(number) {
             Some(index) => Some(Self::SelectScreen(index)),
             None => None,
-        }
-    }
-
-    pub const fn user_command(number: usize) -> Option<Self> {
-        match UserCommandIndex::new(number) {
-            Some(index) => Some(Self::UserCommand(index)),
-            None => None,
-        }
-    }
-
-    pub fn user_command_index(&self) -> Option<usize> {
-        match self {
-            Action::UserCommand(index) => Some(index.get()),
-            _ => None,
         }
     }
 
@@ -2654,7 +1359,6 @@ pub struct Keys {
     /// macOS Option mode instead of guessing from each event.
     pub macos_option_as_alt: bool,
     bindings: Vec<(Chord, Action)>,
-    pub(crate) provider_menu_overridden: bool,
 }
 
 impl Default for Keys {
@@ -2742,7 +1446,6 @@ impl Default for Keys {
                 bind(KeyCode::Char('?'), Action::ShowShortcuts),
                 bind(KeyCode::Char('d'), Action::Detach),
             ],
-            provider_menu_overridden: false,
         }
     }
 }
@@ -2826,22 +1529,6 @@ impl Keys {
             .collect()
     }
 
-    /// Bind one user-command chord, stealing the chord from any action or
-    /// earlier command that held it. The prefix chord stays reserved.
-    /// Returns whether the chord was bound.
-    fn bind_user_command_chord(&mut self, id: &str, action: Action, chord: Chord) -> bool {
-        if chord == self.prefix {
-            crate::client_log::stderr_log!(
-                "config",
-                "cmux-tui: ignoring command binding {id:?} because it conflicts with the prefix"
-            );
-            return false;
-        }
-        self.bindings.retain(|(existing, _)| existing != &chord);
-        self.bindings.push((chord, action));
-        true
-    }
-
     /// Apply config overrides: `"prefix"` rebinds the prefix; any action
     /// name rebinds that action (replacing ALL default chords for it).
     fn apply(&mut self, raw: &HashMap<String, Value>) {
@@ -2850,11 +1537,7 @@ impl Keys {
                 self.macos_option_as_alt = value;
             } else {
                 let value = format!("{value:?}");
-                crate::client_log::stderr_log!(
-                    "config",
-                    "{}",
-                    catalog().config.invalid_macos_option_as_alt(&value)
-                );
+                eprintln!("{}", catalog().config.invalid_macos_option_as_alt(&value));
             }
         }
         if raw.get("alt_shortcuts").and_then(Value::as_bool) == Some(false) {
@@ -2878,15 +1561,9 @@ impl Keys {
                     *send_prefix = chord;
                 }
             } else if value.as_str().is_some() {
-                crate::client_log::stderr_log!(
-                    "config",
-                    "cmux-tui: ignoring unparseable key binding prefix = {value:?}"
-                );
+                eprintln!("cmux-tui: ignoring unparseable key binding prefix = {value:?}");
             } else {
-                crate::client_log::stderr_log!(
-                    "config",
-                    "cmux-tui: ignoring non-string prefix binding {value:?}"
-                );
+                eprintln!("cmux-tui: ignoring non-string prefix binding {value:?}");
             }
         }
         for (name, value) in raw {
@@ -2912,44 +1589,27 @@ impl Keys {
             }) {
                 Some(definition) => {
                     self.bindings.retain(|(_, action)| *action != definition.action);
-                    let mut provider_menu_override_valid = definition.action
-                        == Action::ProviderMenu
-                        && matches!(value, Value::Array(values) if values.is_empty());
                     for raw_chord in key_values(value) {
                         if raw_chord.eq_ignore_ascii_case("none") {
-                            if definition.action == Action::ProviderMenu {
-                                provider_menu_override_valid = true;
-                            }
                             continue;
                         }
                         let Some(chord) = parse_chord(raw_chord) else {
-                            crate::client_log::stderr_log!(
-                                "config",
+                            eprintln!(
                                 "cmux-tui: ignoring unparseable key binding {name} = {raw_chord:?}"
                             );
                             continue;
                         };
                         if chord == self.prefix && definition.action != Action::SendPrefix {
-                            crate::client_log::stderr_log!(
-                                "config",
+                            eprintln!(
                                 "cmux-tui: ignoring key binding {name} = {raw_chord:?} because it conflicts with the prefix"
                             );
                             continue;
                         }
-                        if definition.action == Action::ProviderMenu {
-                            provider_menu_override_valid = true;
-                        }
                         self.bindings.retain(|(existing, _)| existing != &chord);
                         self.bindings.push((chord, definition.action));
                     }
-                    if definition.action == Action::ProviderMenu {
-                        self.provider_menu_overridden = provider_menu_override_valid;
-                    }
                 }
-                None => crate::client_log::stderr_log!(
-                    "config",
-                    "cmux-tui: ignoring unknown key action {name:?}"
-                ),
+                None => eprintln!("cmux-tui: ignoring unknown key action {name:?}"),
             }
         }
         let prefix = self.prefix;
@@ -3021,6 +1681,7 @@ pub struct Config {
     pub terminal_defaults: DefaultColors,
     pub cursor_style: Option<CursorShape>,
     pub cursor_blink: Option<bool>,
+    scrollback_limit_bytes: Option<usize>,
     pub chrome: ChromeMode,
     pub tabs: Tabs,
     pub sidebar: Sidebar,
@@ -3029,203 +1690,15 @@ pub struct Config {
     pub machines: Vec<MachineConfig>,
     pub browser: Browser,
     pub scrollbar: Scrollbar,
-    pub pane: PaneOptions,
-    pub status_bar: StatusBarOptions,
     pub viewport: Viewport,
     pub server: Server,
     pub keys: Keys,
-    pub commands: Vec<UserCommandConfig>,
 }
 
-/// Configuration resolved once for the process startup path.
-///
-/// The snapshot is consumed by the selected startup mode. Interactive reloads
-/// intentionally call [`load`] again after startup and replace the app state.
-#[derive(Debug)]
-pub(crate) struct StartupConfigSnapshot(Config);
-
-impl StartupConfigSnapshot {
-    pub(crate) fn load() -> Self {
-        Self::from_loader(load)
-    }
-
-    fn from_loader(loader: impl FnOnce() -> Config) -> Self {
-        Self(loader())
-    }
-
-    pub(crate) fn into_config(self) -> Config {
-        self.0
-    }
-}
-
-impl Deref for StartupConfigSnapshot {
-    type Target = Config;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-/// The maximum configurable pane padding, in cells per side.
-pub const MAX_PANE_PADDING: u16 = 4;
-
-/// Pane presentation options.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct PaneOptions {
-    /// Blank cells between the pane border and the terminal content,
-    /// applied on every side, clamped to `MAX_PANE_PADDING`.
-    pub padding: u16,
-}
-
-/// Bottom screens-bar options. A hidden bar gives its row back to the
-/// panes; transient status messages still overlay the last row.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct StatusBarOptions {
-    pub visible: bool,
-    /// Renders the clickable screens strip.
-    pub show_screens: bool,
-    /// Renders the right-aligned session label when no message is shown.
-    pub show_session: bool,
-    /// Segments before the screens strip.
-    pub left: Vec<StatusSegment>,
-    /// Segments right-aligned before the session label.
-    pub right: Vec<StatusSegment>,
-    /// Powerline-style separator drawn between left segments and after the
-    /// last one; its foreground takes the previous segment's background and
-    /// its background the next segment's, tmux `status-left` style.
-    pub left_separator: Option<String>,
-    /// Mirror of `left_separator` for the right-aligned segments.
-    pub right_separator: Option<String>,
-    /// Cap style for the active screen chip in the screens strip.
-    pub screens_style: ChipStyle,
-    /// The screens strip's `+` button.
-    pub screens_plus: PlusButton,
-}
-
-impl Default for StatusBarOptions {
-    fn default() -> Self {
-        Self {
-            visible: true,
-            show_screens: true,
-            show_session: true,
-            left: Vec::new(),
-            right: Vec::new(),
-            left_separator: None,
-            right_separator: None,
-            screens_style: ChipStyle::Block,
-            screens_plus: PlusButton::default(),
-        }
-    }
-}
-
-impl StatusBarOptions {
-    /// Command segments in draw order: left side first, then right.
-    pub fn command_segments(&self) -> Vec<(usize, Vec<String>, Duration)> {
-        self.left
-            .iter()
-            .chain(self.right.iter())
-            .enumerate()
-            .filter_map(|(index, segment)| match &segment.content {
-                StatusSegmentContent::Command { argv, interval } => {
-                    Some((index, argv.clone(), *interval))
-                }
-                StatusSegmentContent::Text(_) => None,
-            })
-            .collect()
-    }
-}
-
-/// The maximum number of configured segments per status bar side.
-pub const MAX_STATUS_SEGMENTS: usize = 8;
-
-/// The maximum length of one literal status segment, in characters.
-pub const MAX_STATUS_SEGMENT_TEXT: usize = 256;
-
-/// One status bar segment: literal text with `{variable}` interpolation, or
-/// a command whose last stdout line becomes the segment text.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct StatusSegment {
-    pub content: StatusSegmentContent,
-    pub fg: Option<Color>,
-    pub bg: Option<Color>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum StatusSegmentContent {
-    Text(String),
-    Command { argv: Vec<String>, interval: Duration },
-}
-
-fn resolve_status_segments(raw: Vec<RawStatusSegment>, side: &str) -> Vec<StatusSegment> {
-    let mut segments = Vec::new();
-    for segment in raw {
-        if segments.len() >= MAX_STATUS_SEGMENTS {
-            crate::client_log::stderr_log!(
-                "config",
-                "cmux-tui: ignoring status_bar.{side} segments beyond the {MAX_STATUS_SEGMENTS}-segment limit"
-            );
-            break;
-        }
-        let content = match (segment.text, segment.run) {
-            (Some(_), Some(_)) | (None, None) => {
-                crate::client_log::stderr_log!(
-                    "config",
-                    "cmux-tui: ignoring status_bar.{side} segment: exactly one of text or run is required"
-                );
-                continue;
-            }
-            (Some(text), None) => {
-                // Bound per-draw expansion work on the render path.
-                StatusSegmentContent::Text(text.chars().take(MAX_STATUS_SEGMENT_TEXT).collect())
-            }
-            (None, Some(run)) => {
-                if run.first().is_none_or(|program| program.is_empty()) {
-                    crate::client_log::stderr_log!(
-                        "config",
-                        "cmux-tui: ignoring status_bar.{side} segment without a run program"
-                    );
-                    continue;
-                }
-                let interval = segment.interval.unwrap_or(5).clamp(1, 3600);
-                StatusSegmentContent::Command { argv: run, interval: Duration::from_secs(interval) }
-            }
-        };
-        segments.push(StatusSegment {
-            content,
-            fg: segment.fg.as_ref().and_then(ColorValue::to_color),
-            bg: segment.bg.as_ref().and_then(ColorValue::to_color),
-        });
-    }
-    segments
-}
-
-/// One resolved user command from the top-level `commands` section.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct UserCommandConfig {
-    /// Stable config identity, unique across the list.
-    pub id: String,
-    /// Display name for shortcut help; defaults to the id.
-    pub name: String,
-    /// Argv executed directly, without a shell.
-    pub run: Vec<String>,
-    /// Working directory; `None` follows the target pane's current directory.
-    pub cwd: Option<String>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Server {
     pub ws: Option<String>,
     pub ws_token: Option<String>,
-    /// Plain interactive launches connect through a detached headless
-    /// session owner so the session survives every client detaching.
-    /// `false` restores hosting the session inside the first TUI process.
-    pub detached_owner: bool,
-}
-
-impl Default for Server {
-    fn default() -> Self {
-        Self { ws: None, ws_token: None, detached_owner: true }
-    }
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -3238,6 +1711,10 @@ pub struct ThemeOverrides {
 }
 
 impl Config {
+    pub fn scrollback_limit_bytes(&self) -> usize {
+        self.scrollback_limit_bytes.unwrap_or(DEFAULT_SCROLLBACK_LIMIT_BYTES)
+    }
+
     pub fn apply_chrome_defaults(&mut self, chrome: ChromeTheme) {
         if !self.theme_overrides.selection {
             self.theme.selection_bg = chrome.selection_bg;
@@ -3257,8 +1734,10 @@ pub struct SidebarPluginConfig {
 pub fn load() -> Config {
     let mut config = Config::default();
 
-    let defaults = ghostty_defaults();
+    let ghostty = ghostty_defaults();
+    let defaults = ghostty.colors;
     config.terminal_defaults = defaults;
+    config.scrollback_limit_bytes = ghostty.scrollback_limit_bytes;
     if let Some(bg) = defaults.selection_bg {
         config.theme.selection_bg = Color::Rgb(bg.r, bg.g, bg.b);
         config.theme_overrides.selection = true;
@@ -3339,9 +1818,6 @@ pub fn load() -> Config {
     if let Some(agents) = raw.tabs.agents {
         config.tabs.agents = agents.into_iter().map(|a| a.to_lowercase()).collect();
     }
-    if let Some(style) = raw.tabs.style {
-        config.tabs.style = style;
-    }
     if let Some(w) = raw.sidebar.width {
         config.sidebar.width = w.clamp(10, 60);
     }
@@ -3352,36 +1828,11 @@ pub fn load() -> Config {
     if let Some(view) = raw.sidebar.view {
         match parse_sidebar_view(&view) {
             Ok(view) => config.sidebar.view = view,
-            Err(warning) => crate::client_log::stderr_log!("config", "{warning}"),
+            Err(warning) => eprintln!("{warning}"),
         }
     }
     if let Some(w) = raw.sidebar.max_width {
         config.sidebar.max_width = w;
-    }
-    if let Some(height) = raw.sidebar.row_height {
-        config.sidebar.row_height = height.clamp(1, 2);
-    }
-    if let Some(gap) = raw.sidebar.row_gap {
-        config.sidebar.row_gap = gap.min(2);
-    }
-    if let Some(glyph) = raw.sidebar.rail_glyph {
-        if glyph.eq_ignore_ascii_case("none") {
-            config.sidebar.rail_glyph = String::new();
-        } else if glyph.chars().count() == 1 && glyph.width() == 1 {
-            // The renderer reserves exactly one cell for the glyph.
-            config.sidebar.rail_glyph = glyph;
-        } else {
-            crate::client_log::stderr_log!(
-                "config",
-                "cmux-tui: ignoring sidebar.rail_glyph {glyph:?}: one single-width character or \"none\""
-            );
-        }
-    }
-    if let Some(template) = raw.sidebar.workspace_label {
-        let template = template.trim().to_string();
-        if !template.is_empty() {
-            config.sidebar.workspace_label = template;
-        }
     }
     if let Some(plugin) = raw.sidebar.plugin {
         let command = plugin
@@ -3391,10 +1842,7 @@ pub fn load() -> Config {
             .filter(|arg| !arg.is_empty())
             .collect::<Vec<_>>();
         if command.is_empty() {
-            crate::client_log::stderr_log!(
-                "config",
-                "cmux-tui: ignoring sidebar.plugin with empty command"
-            );
+            eprintln!("cmux-tui: ignoring sidebar.plugin with empty command");
         } else {
             config.sidebar.plugin = Some(SidebarPluginOptions {
                 command,
@@ -3411,235 +1859,6 @@ pub fn load() -> Config {
     if let Some(max_width) = raw.machine_sidebar.max_width {
         config.machine_sidebar.max_width = max_width;
     }
-    if let Some(sources) = raw.machine_sidebar.create_sources {
-        let mut source_ids = HashSet::new();
-        for source in sources {
-            let id = source.id.trim().to_string();
-            let name = source.name.trim().to_string();
-            if id.is_empty() || name.is_empty() || !source_ids.insert(id.clone()) {
-                crate::client_log::stderr_log!(
-                    "config",
-                    "cmux-tui: ignoring machine creation source with an empty or duplicate id/name"
-                );
-                continue;
-            }
-            let subtitle =
-                source.subtitle.map(|subtitle| subtitle.trim().to_string()).unwrap_or_default();
-            config.machine_sidebar.create_sources.push(MachineCreationSourceConfig {
-                id,
-                name,
-                subtitle,
-            });
-        }
-    }
-    if let Some(columns) = raw.sidebar.columns.as_ref() {
-        let mut seen = HashSet::new();
-        let mut resolved = Vec::new();
-        for column in columns {
-            let kind = match parse_sidebar_column_kind(column.kind.trim()) {
-                Ok(kind) => kind,
-                Err(warning) => {
-                    crate::client_log::stderr_log!("config", "{warning}");
-                    continue;
-                }
-            };
-            if !seen.insert(kind) {
-                crate::client_log::stderr_log!(
-                    "config",
-                    "cmux-tui: ignoring duplicate sidebar column {:?}",
-                    column.kind
-                );
-                continue;
-            }
-            let (default_width, default_max_width) = match kind {
-                SidebarColumnKind::Machines => {
-                    (config.machine_sidebar.width, config.machine_sidebar.max_width)
-                }
-                SidebarColumnKind::Workspaces => (config.sidebar.width, config.sidebar.max_width),
-                SidebarColumnKind::Tabs => (22, 0),
-            };
-            resolved.push(SidebarColumn {
-                kind,
-                width: column.width.unwrap_or(default_width).clamp(10, 60),
-                max_width: column.max_width.unwrap_or(default_max_width),
-            });
-        }
-        if resolved.is_empty() {
-            crate::client_log::stderr_log!(
-                "config",
-                "cmux-tui: sidebar.columns had no usable entries; keeping defaults"
-            );
-        } else {
-            config.sidebar.columns = resolved;
-            config.sidebar.columns_explicit = true;
-        }
-    } else {
-        config.sidebar.columns = vec![
-            SidebarColumn {
-                kind: SidebarColumnKind::Machines,
-                width: config.machine_sidebar.width,
-                max_width: config.machine_sidebar.max_width,
-            },
-            SidebarColumn {
-                kind: SidebarColumnKind::Workspaces,
-                width: config.sidebar.width,
-                max_width: config.sidebar.max_width,
-            },
-        ];
-    }
-    config.sidebar.views = config
-        .sidebar
-        .columns
-        .iter()
-        .map(|column| SidebarViewSpec::legacy(column.kind, column.width, column.max_width))
-        .collect();
-    config.sidebar.views_explicit = config.sidebar.columns_explicit;
-    // User commands resolve before sidebar views so pinned buttons can
-    // reference them as `command:<id>`; their chords bind after `keys`.
-    let (user_commands, user_command_keys) = resolve_user_command_specs(raw.commands);
-    let command_ids: Vec<String> = user_commands.iter().map(|command| command.id.clone()).collect();
-    if let Some(plus) = raw.tabs.plus {
-        config.tabs.plus = resolve_plus_button(plus, &command_ids, "tabs");
-    }
-    if let Some(plus) = raw.status_bar.screens_plus {
-        config.status_bar.screens_plus = resolve_plus_button(plus, &command_ids, "status_bar");
-    }
-    if let Some(views) = raw.sidebar.views.as_ref() {
-        if raw.sidebar.columns.is_some() {
-            crate::client_log::stderr_log!(
-                "config",
-                "cmux-tui: sidebar.views overrides sidebar.columns"
-            );
-        }
-        let resolved = resolve_sidebar_view_specs(
-            views,
-            config.machine_sidebar.width,
-            config.machine_sidebar.max_width,
-            config.sidebar.width,
-            config.sidebar.max_width,
-            "sidebar",
-            &command_ids,
-        );
-        if resolved.is_empty() {
-            crate::client_log::stderr_log!(
-                "config",
-                "cmux-tui: sidebar.views had no usable entries; keeping defaults"
-            );
-        } else {
-            config.sidebar.columns = resolved
-                .iter()
-                .filter_map(|view| {
-                    view.legacy_kind().map(|kind| SidebarColumn {
-                        kind,
-                        width: view.width,
-                        max_width: view.max_width,
-                    })
-                })
-                .collect();
-            config.sidebar.views = resolved;
-            config.sidebar.columns_explicit = false;
-            config.sidebar.views_explicit = true;
-        }
-    }
-    config.sidebar.profiles[0].views.clone_from(&config.sidebar.views);
-    if let Some(raw_profiles) = raw.sidebar.profiles.as_ref() {
-        if raw.sidebar.views.is_some() || raw.sidebar.columns.is_some() {
-            crate::client_log::stderr_log!(
-                "config",
-                "cmux-tui: sidebar.profiles overrides sidebar.views and sidebar.columns"
-            );
-        }
-        let mut ids = HashSet::new();
-        let mut profiles = Vec::new();
-        for raw_profile in raw_profiles {
-            let id = raw_profile.id.trim();
-            if id.is_empty() || !ids.insert(id.to_string()) {
-                crate::client_log::stderr_log!(
-                    "config",
-                    "cmux-tui: ignoring sidebar profile with an empty or duplicate id"
-                );
-                continue;
-            }
-            let owner = format!("sidebar profile {id:?}");
-            let views = resolve_sidebar_view_specs(
-                &raw_profile.views,
-                config.machine_sidebar.width,
-                config.machine_sidebar.max_width,
-                config.sidebar.width,
-                config.sidebar.max_width,
-                &owner,
-                &command_ids,
-            );
-            if views.is_empty() {
-                crate::client_log::stderr_log!(
-                    "config",
-                    "cmux-tui: ignoring sidebar profile {id:?} with no usable views"
-                );
-                continue;
-            }
-            let name = raw_profile
-                .name
-                .as_deref()
-                .map(str::trim)
-                .filter(|name| !name.is_empty())
-                .unwrap_or(id)
-                .to_string();
-            profiles.push(SidebarProfileSpec { id: id.to_string(), name, views });
-        }
-        if profiles.is_empty() {
-            crate::client_log::stderr_log!(
-                "config",
-                "cmux-tui: sidebar.profiles had no usable entries; keeping defaults"
-            );
-        } else {
-            let requested =
-                raw.sidebar.profile.as_deref().map(str::trim).filter(|id| !id.is_empty());
-            let selected = requested
-                .and_then(|id| profiles.iter().position(|profile| profile.id == id))
-                .unwrap_or_else(|| {
-                    if let Some(requested) = requested {
-                        crate::client_log::stderr_log!("config", 
-                            "cmux-tui: sidebar.profile {requested:?} was not found; using the first profile"
-                        );
-                    }
-                    0
-                });
-            config.sidebar.active_profile = profiles[selected].id.clone();
-            config.sidebar.views = profiles[selected].views.clone();
-            config.sidebar.columns = config
-                .sidebar
-                .views
-                .iter()
-                .filter_map(|view| {
-                    view.legacy_kind().map(|kind| SidebarColumn {
-                        kind,
-                        width: view.width,
-                        max_width: view.max_width,
-                    })
-                })
-                .collect();
-            config.sidebar.columns_explicit = false;
-            config.sidebar.views_explicit = true;
-            config.sidebar.profiles = profiles;
-        }
-    } else if raw.sidebar.profile.is_some() {
-        crate::client_log::stderr_log!(
-            "config",
-            "cmux-tui: ignoring sidebar.profile without sidebar.profiles"
-        );
-    }
-    match raw.machine_provider.command {
-        Some(command) if command.first().is_some_and(|program| !program.trim().is_empty()) => {
-            config.machine_provider.command = Some(command);
-        }
-        Some(_) => {
-            crate::client_log::stderr_log!(
-                "config",
-                "cmux-tui: ignoring machine_provider.command without a program"
-            );
-        }
-        None => {}
-    }
     let cloud = raw.machine_provider.cloud;
     if let Some(enabled) = cloud.enabled {
         config.machine_provider.cloud.enabled = enabled;
@@ -3647,10 +1866,7 @@ pub fn load() -> Config {
     if let Some(host) = cloud.host {
         let host = host.trim();
         if host.is_empty() {
-            crate::client_log::stderr_log!(
-                "config",
-                "cmux-tui: ignoring empty machine_provider.cloud.host"
-            );
+            eprintln!("cmux-tui: ignoring empty machine_provider.cloud.host");
         } else {
             config.machine_provider.cloud.host = host.to_string();
         }
@@ -3659,10 +1875,7 @@ pub fn load() -> Config {
         cloud.user.map(|user| user.trim().to_string()).filter(|user| !user.is_empty());
     config.machine_provider.cloud.port = match cloud.port {
         Some(0) => {
-            crate::client_log::stderr_log!(
-                "config",
-                "cmux-tui: ignoring zero machine_provider.cloud.port"
-            );
+            eprintln!("cmux-tui: ignoring zero machine_provider.cloud.port");
             None
         }
         port => port,
@@ -3677,10 +1890,7 @@ pub fn load() -> Config {
         let id = machine.id.trim().to_string();
         let name = machine.name.trim().to_string();
         if id.is_empty() || name.is_empty() || !machine_ids.insert(id.clone()) {
-            crate::client_log::stderr_log!(
-                "config",
-                "cmux-tui: ignoring machine with an empty or duplicate id/name"
-            );
+            eprintln!("cmux-tui: ignoring machine with an empty or duplicate id/name");
             continue;
         }
         let target = match machine.target {
@@ -3703,14 +1913,11 @@ pub fn load() -> Config {
                         .unwrap_or_else(|| "main".to_string()),
                     binary: binary
                         .filter(|value| !value.trim().is_empty())
-                        .unwrap_or_else(|| "~/.local/bin/cmux-tui".to_string()),
+                        .unwrap_or_else(|| "cmux-tui".to_string()),
                 }
             }
             _ => {
-                crate::client_log::stderr_log!(
-                    "config",
-                    "cmux-tui: ignoring machine {id:?} with an empty transport target"
-                );
+                eprintln!("cmux-tui: ignoring machine {id:?} with an empty transport target");
                 continue;
             }
         };
@@ -3738,8 +1945,7 @@ pub fn load() -> Config {
         {
             config.browser.max_capture_megapixels = megapixels;
         } else {
-            crate::client_log::stderr_log!(
-                "config",
+            eprintln!(
                 "cmux-tui: ignoring browser.max_capture_megapixels={megapixels:?}; expected 0 < value <= {TRANSPORT_SAFE_CAPTURE_MEGAPIXELS}"
             );
         }
@@ -3748,8 +1954,7 @@ pub fn load() -> Config {
         if scale.is_finite() && scale > 0.0 && scale <= 1.0 {
             config.browser.capture_scale = Some(scale);
         } else {
-            crate::client_log::stderr_log!(
-                "config",
+            eprintln!(
                 "cmux-tui: ignoring browser.capture_scale={scale:?}; expected 0 < scale <= 1"
             );
         }
@@ -3757,165 +1962,19 @@ pub fn load() -> Config {
     if let Some(position) = raw.scrollbar.position {
         config.scrollbar.position = position;
     }
-    if let Some(style) = raw.theme.border_style {
-        config.theme.border_style = style;
-    }
-    if let Some(c) = raw.theme.status_bg.as_ref().and_then(ColorValue::to_color) {
-        config.theme.status_bg = Some(c);
-    }
-    if let Some(c) = raw.theme.status_fg.as_ref().and_then(ColorValue::to_color) {
-        config.theme.status_fg = Some(c);
-    }
-    if let Some(c) = raw.theme.sidebar_fg.as_ref().and_then(ColorValue::to_color) {
-        config.theme.sidebar_fg = Some(c);
-    }
-    if let Some(c) = raw.theme.sidebar_selected_fg.as_ref().and_then(ColorValue::to_color) {
-        config.theme.sidebar_selected_fg = Some(c);
-    }
-    if let Some(dim) = raw.theme.dim_inactive {
-        config.theme.dim_inactive = dim;
-    }
-    if let Some(padding) = raw.pane.padding {
-        config.pane.padding = padding.min(MAX_PANE_PADDING);
-    }
-    if let Some(visible) = raw.status_bar.visible {
-        config.status_bar.visible = visible;
-    }
-    if let Some(show_screens) = raw.status_bar.show_screens {
-        config.status_bar.show_screens = show_screens;
-    }
-    if let Some(show_session) = raw.status_bar.show_session {
-        config.status_bar.show_session = show_session;
-    }
-    if let Some(left) = raw.status_bar.left {
-        config.status_bar.left = resolve_status_segments(left, "left");
-    }
-    if let Some(right) = raw.status_bar.right {
-        config.status_bar.right = resolve_status_segments(right, "right");
-    }
-    config.status_bar.left_separator =
-        raw.status_bar.left_separator.filter(|separator| !separator.is_empty());
-    config.status_bar.right_separator =
-        raw.status_bar.right_separator.filter(|separator| !separator.is_empty());
-    if let Some(style) = raw.status_bar.screens_style {
-        config.status_bar.screens_style = style;
-    }
     if let Some(animation) = raw.viewport.animation {
         config.viewport.animation = animation;
     }
     config.server.ws = raw.server.ws.filter(|value| !value.trim().is_empty());
     config.server.ws_token = raw.server.ws_token.filter(|value| !value.trim().is_empty());
-    if let Some(detached_owner) = raw.server.detached_owner {
-        config.server.detached_owner = detached_owner;
-    }
     config.keys.apply(&raw.keys);
-    bind_user_command_chords(&mut config.keys, &user_commands, &user_command_keys);
-    config.commands = user_commands;
     config
-}
-
-/// Validate the raw `commands` section into resolved specs plus each
-/// command's raw chord values. Chords bind later, after the `keys` section
-/// applied its overrides, so command chords keep last-write-wins order.
-fn resolve_user_command_specs(
-    raw: Vec<RawUserCommand>,
-) -> (Vec<UserCommandConfig>, Vec<Option<Value>>) {
-    let mut commands = Vec::new();
-    let mut key_values = Vec::new();
-    let mut ids = HashSet::new();
-    for command in raw {
-        let id = command.id.as_deref().unwrap_or("").trim().to_string();
-        if id.is_empty() {
-            crate::client_log::stderr_log!(
-                "config",
-                "cmux-tui: ignoring command with a missing or empty id"
-            );
-            continue;
-        }
-        if ids.contains(&id) {
-            crate::client_log::stderr_log!(
-                "config",
-                "cmux-tui: ignoring command with duplicate id {id:?}"
-            );
-            continue;
-        }
-        // Empty positional arguments stay: argv executes directly, and an
-        // empty argument is valid there. Only the program itself must exist.
-        let run = command.run.unwrap_or_default();
-        if run.first().is_none_or(|program| program.is_empty()) {
-            crate::client_log::stderr_log!(
-                "config",
-                "cmux-tui: ignoring command {id:?} without a run program"
-            );
-            continue;
-        }
-        if Action::user_command(commands.len()).is_none() {
-            crate::client_log::stderr_log!(
-                "config",
-                "cmux-tui: ignoring command {id:?} beyond the {MAX_USER_COMMANDS}-command limit"
-            );
-            continue;
-        }
-        // The id is reserved only after validation, so an ignored invalid
-        // entry never blocks a later valid entry with the same id.
-        ids.insert(id.clone());
-        let name = command
-            .name
-            .map(|name| name.trim().to_string())
-            .filter(|name| !name.is_empty())
-            .unwrap_or_else(|| id.clone());
-        let cwd = command.cwd.map(|cwd| cwd.trim().to_string()).filter(|cwd| !cwd.is_empty());
-        commands.push(UserCommandConfig { id, name, run, cwd });
-        key_values.push(command.keys);
-    }
-    (commands, key_values)
-}
-
-/// Bind every command's chords after `keys` overrides applied.
-fn bind_user_command_chords(
-    keys: &mut Keys,
-    commands: &[UserCommandConfig],
-    chord_values: &[Option<Value>],
-) {
-    for (index, (command, value)) in commands.iter().zip(chord_values).enumerate() {
-        let Some(action) = Action::user_command(index) else { break };
-        let Some(value) = value.as_ref() else { continue };
-        let id = &command.id;
-        let mut bound = 0usize;
-        for raw_chord in key_values(value) {
-            if raw_chord.eq_ignore_ascii_case("none") {
-                continue;
-            }
-            if bound >= MAX_USER_COMMAND_CHORDS {
-                crate::client_log::stderr_log!(
-                    "config",
-                    "cmux-tui: ignoring command {id:?} chords beyond the {MAX_USER_COMMAND_CHORDS}-chord limit"
-                );
-                break;
-            }
-            let Some(chord) = parse_chord(raw_chord) else {
-                crate::client_log::stderr_log!(
-                    "config",
-                    "cmux-tui: ignoring unparseable command binding {id} = {raw_chord:?}"
-                );
-                continue;
-            };
-            // Only a successful bind consumes the limit; rejected chords
-            // leave room for the valid ones after them.
-            if keys.bind_user_command_chord(id, action, chord) {
-                bound += 1;
-            }
-        }
-    }
 }
 
 fn normalize_ssh_machine_port(id: &str, port: Option<u16>) -> Option<u16> {
     match port {
         Some(0) => {
-            crate::client_log::stderr_log!(
-                "config",
-                "cmux-tui: ignoring zero SSH machine port for {id:?}"
-            );
+            eprintln!("cmux-tui: ignoring zero SSH machine port for {id:?}");
             None
         }
         port => port,
@@ -3966,137 +2025,31 @@ fn agent_in_title(tabs: &Tabs, title: &str) -> Option<String> {
 fn load_raw_config() -> RawConfig {
     let Some(path) = platform::config_path() else { return RawConfig::default() };
     let Ok(text) = std::fs::read_to_string(&path) else { return RawConfig::default() };
-    let value: Value = match serde_json::from_str(&text) {
-        Ok(value) => value,
+    match serde_json::from_str(&text) {
+        Ok(config) => config,
         Err(e) => {
-            crate::client_log::stderr_log!(
-                "config",
-                "{} ({})",
-                config_diagnostic(&e),
-                path.display(),
-            );
-            return RawConfig::default();
+            // A broken config should not take the TUI down; complain on
+            // stderr (visible pre-alternate-screen and in logs).
+            eprintln!("cmux-tui: ignoring invalid config {}: {e}", path.display());
+            RawConfig::default()
         }
-    };
-    let Some(object) = value.as_object() else {
-        crate::client_log::stderr_log!(
-            "config",
-            "cmux-tui: ignoring invalid config {}: root must be an object",
-            path.display()
-        );
-        return RawConfig::default();
-    };
-    const KNOWN: &[&str] = &[
-        "theme",
-        "tabs",
-        "sidebar",
-        "machine_sidebar",
-        "machine_provider",
-        "machines",
-        "commands",
-        "browser",
-        "scrollbar",
-        "pane",
-        "status_bar",
-        "viewport",
-        "server",
-        "keys",
-    ];
-    if let Some(unknown) = object.keys().find(|key| !KNOWN.contains(&key.as_str())) {
-        crate::client_log::stderr_log!(
-            "config",
-            "cmux-tui: ignoring invalid config {}: unknown top-level field `{unknown}`",
-            path.display()
-        );
-        return RawConfig::default();
     }
-    let mut raw = RawConfig::default();
-    macro_rules! section {
-        ($field:ident, $name:literal) => {
-            if let Some(value) = object.get($name) {
-                match serde_json::from_value(value.clone()) {
-                    Ok(parsed) => raw.$field = parsed,
-                    Err(error) => crate::client_log::stderr_log!(
-                        "config",
-                        "cmux-tui: ignoring invalid `{}` section in {}: {}",
-                        $name,
-                        path.display(),
-                        error
-                    ),
-                }
-            }
-        };
-    }
-    section!(theme, "theme");
-    section!(tabs, "tabs");
-    section!(sidebar, "sidebar");
-    section!(machine_sidebar, "machine_sidebar");
-    section!(machine_provider, "machine_provider");
-    section!(machines, "machines");
-    section!(commands, "commands");
-    section!(browser, "browser");
-    section!(scrollbar, "scrollbar");
-    section!(pane, "pane");
-    section!(status_bar, "status_bar");
-    section!(viewport, "viewport");
-    section!(server, "server");
-    section!(keys, "keys");
-    raw
-}
-
-fn config_diagnostic(error: &serde_json::Error) -> String {
-    let text = error.to_string();
-    if text.contains("unknown field") {
-        return catalog().config.unknown_field("(see config file)");
-    }
-    if text.contains("invalid type") && text.contains("map") {
-        return catalog().config.invalid_root().to_string();
-    }
-    catalog().config.invalid_section("(see config file)")
 }
 
 pub fn config_path() -> anyhow::Result<PathBuf> {
     platform::config_path().ok_or_else(|| anyhow::anyhow!("could not resolve mux config path"))
 }
 
-/// The result of replacing the config file. A committed replacement is a
-/// successful operation even when the parent directory could not be synced.
-#[must_use = "inspect config durability after a committed write"]
-#[derive(Debug)]
-pub(crate) enum ConfigWriteOutcome {
-    /// The replacement and all relevant directory entries were synced.
-    Committed,
-    /// The replacement committed, but this platform does not support syncing
-    /// directory entries. The staged file itself was synced before rename.
-    CommittedWithoutDirectorySync,
-    /// The replacement committed, but a supported directory sync failed.
-    CommittedButUnsynced { error: anyhow::Error },
-}
-
-impl ConfigWriteOutcome {
-    /// Takes the parent-sync error, if the replacement committed without a
-    /// durability confirmation.
-    pub(crate) fn into_unsynced_error(self) -> Option<anyhow::Error> {
-        match self {
-            Self::Committed | Self::CommittedWithoutDirectorySync => None,
-            Self::CommittedButUnsynced { error } => Some(error),
-        }
-    }
-}
-
-/// Writes the sidebar plugin selection to the configured path.
-pub(crate) fn write_sidebar_plugin(
-    plugin: Option<&SidebarPluginConfig>,
-) -> anyhow::Result<ConfigWriteOutcome> {
+pub fn write_sidebar_plugin(plugin: Option<&SidebarPluginConfig>) -> anyhow::Result<PathBuf> {
     let path = config_path()?;
-    write_sidebar_plugin_at_path(&path, plugin)
+    write_sidebar_plugin_at_path(&path, plugin)?;
+    Ok(path)
 }
 
-/// Writes the sidebar plugin selection to an explicit path.
-pub(crate) fn write_sidebar_plugin_at_path(
+pub fn write_sidebar_plugin_at_path(
     path: &Path,
     plugin: Option<&SidebarPluginConfig>,
-) -> anyhow::Result<ConfigWriteOutcome> {
+) -> anyhow::Result<()> {
     let mut root = read_config_value(path)?;
     let Some(root_object) = root.as_object_mut() else {
         anyhow::bail!("{} must contain a JSON object", path.display());
@@ -4135,75 +2088,16 @@ fn read_config_value(path: &Path) -> anyhow::Result<Value> {
     }
 }
 
-/// Serializes a config value to a private staging file before atomically
-/// replacing the destination and durably syncing its parent directories. An
-/// `Err` means that replacement did not commit. A
-/// [`ConfigWriteOutcome::CommittedWithoutDirectorySync`] means the rename
-/// committed on a platform without directory-sync support. A
-/// [`ConfigWriteOutcome::CommittedButUnsynced`] value means a supported
-/// directory sync failed.
-fn write_config_value_atomic(path: &Path, value: &Value) -> anyhow::Result<ConfigWriteOutcome> {
-    write_config_value_atomic_with_sync(path, value, &sync_config_parent_directory)
-}
-
-fn write_config_value_atomic_with_sync(
-    path: &Path,
-    value: &Value,
-    sync_parent: &dyn Fn(&Path) -> anyhow::Result<ConfigParentSyncOutcome>,
-) -> anyhow::Result<ConfigWriteOutcome> {
-    let parent = config_parent_directory(path);
+fn write_config_value_atomic(path: &Path, value: &Value) -> anyhow::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
     let file_name = path.file_name().and_then(|name| name.to_str()).unwrap_or("cmux-tui.json");
     let stamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_nanos();
-    let process_id = std::process::id();
-    let staging_path = move |parent: &Path, attempt: usize| {
-        let suffix = if attempt == 0 {
-            format!(".{file_name}.{process_id}.{stamp}.tmp")
-        } else {
-            format!(".{file_name}.{process_id}.{stamp}.{attempt}.tmp")
-        };
-        parent.join(suffix)
-    };
-    write_config_value_atomic_with_sync_and_staging(path, value, sync_parent, &staging_path)
-}
-
-const CONFIG_STAGING_ATTEMPTS: usize = 16;
-
-fn write_config_value_atomic_with_sync_and_staging(
-    path: &Path,
-    value: &Value,
-    sync_parent: &dyn Fn(&Path) -> anyhow::Result<ConfigParentSyncOutcome>,
-    staging_path: &dyn Fn(&Path, usize) -> PathBuf,
-) -> anyhow::Result<ConfigWriteOutcome> {
-    let parent = config_parent_directory(path);
-    let created_directories = ensure_config_parent_directory(parent)?;
-    let mut staged = None;
-    for attempt in 0..CONFIG_STAGING_ATTEMPTS {
-        let tmp_path = staging_path(parent, attempt);
-        let mut options = OpenOptions::new();
-        options.write(true).create_new(true);
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::OpenOptionsExt;
-
-            // The config can contain the server authentication token. Create
-            // the staging file private from the start, independent of umask,
-            // and reject a pre-existing symlink if a concurrent writer races
-            // with this process before open(2).
-            options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
-        }
-        match options.open(&tmp_path) {
-            Ok(file) => {
-                staged = Some((tmp_path, file));
-                break;
-            }
-            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
-            Err(error) => return Err(error.into()),
-        }
-    }
-    let Some((tmp_path, mut file)) = staged else {
-        anyhow::bail!("could not create a unique config staging file")
-    };
+    let tmp_path = parent.join(format!(".{file_name}.{}.{}.tmp", std::process::id(), stamp));
     let result = (|| -> anyhow::Result<()> {
+        let mut file = std::fs::File::create(&tmp_path)?;
         serde_json::to_writer_pretty(&mut file, value)?;
         file.write_all(b"\n")?;
         file.sync_all()?;
@@ -4211,101 +2105,10 @@ fn write_config_value_atomic_with_sync_and_staging(
         std::fs::rename(&tmp_path, path)?;
         Ok(())
     })();
-    if let Err(error) = result {
+    if result.is_err() {
         let _ = std::fs::remove_file(&tmp_path);
-        return Err(error);
     }
-
-    #[cfg(unix)]
-    {
-        Ok(match sync_config_parent_directories(parent, &created_directories, sync_parent) {
-            Ok(ConfigParentSyncOutcome::Synced) => ConfigWriteOutcome::Committed,
-            Ok(ConfigParentSyncOutcome::Unsupported) => {
-                ConfigWriteOutcome::CommittedWithoutDirectorySync
-            }
-            Err(error) => ConfigWriteOutcome::CommittedButUnsynced { error },
-        })
-    }
-    #[cfg(not(unix))]
-    {
-        let _ = (created_directories, sync_parent);
-        Ok(ConfigWriteOutcome::CommittedWithoutDirectorySync)
-    }
-}
-
-fn ensure_config_parent_directory(parent: &Path) -> anyhow::Result<Vec<PathBuf>> {
-    let mut created_directories = Vec::new();
-    let mut current = PathBuf::new();
-    for component in parent.components() {
-        current.push(component.as_os_str());
-        // Prefix, root, and navigation components establish path syntax;
-        // only normal components identify directory entries to create.
-        if !matches!(component, Component::Normal(_)) {
-            continue;
-        }
-        match std::fs::create_dir(&current) {
-            Ok(()) => created_directories.push(current.clone()),
-            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-                if !std::fs::metadata(&current)?.is_dir() {
-                    anyhow::bail!(
-                        "config parent component {} is not a directory",
-                        current.display()
-                    );
-                }
-            }
-            Err(error) => return Err(error.into()),
-        }
-    }
-    Ok(created_directories)
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ConfigParentSyncOutcome {
-    Synced,
-    Unsupported,
-}
-
-#[cfg(unix)]
-fn sync_config_parent_directory(parent: &Path) -> anyhow::Result<ConfigParentSyncOutcome> {
-    let result = std::fs::File::open(parent).and_then(|directory| directory.sync_all());
-    #[cfg(target_os = "macos")]
-    if let Err(error) = &result {
-        if matches!(error.raw_os_error(), Some(code) if code == libc::EINVAL || code == libc::ENOTSUP)
-        {
-            return Ok(ConfigParentSyncOutcome::Unsupported);
-        }
-    }
-    result.map(|()| ConfigParentSyncOutcome::Synced).map_err(Into::into)
-}
-
-#[cfg(not(unix))]
-fn sync_config_parent_directory(_parent: &Path) -> anyhow::Result<ConfigParentSyncOutcome> {
-    Ok(ConfigParentSyncOutcome::Unsupported)
-}
-
-#[cfg(unix)]
-fn sync_config_parent_directories(
-    parent: &Path,
-    created_directories: &[PathBuf],
-    sync_parent: &dyn Fn(&Path) -> anyhow::Result<ConfigParentSyncOutcome>,
-) -> anyhow::Result<ConfigParentSyncOutcome> {
-    let mut unsupported = false;
-    for directory in std::iter::once(parent)
-        .chain(created_directories.iter().rev().map(|directory| config_parent_directory(directory)))
-    {
-        if matches!(sync_parent(directory)?, ConfigParentSyncOutcome::Unsupported) {
-            unsupported = true;
-        }
-    }
-    Ok(if unsupported {
-        ConfigParentSyncOutcome::Unsupported
-    } else {
-        ConfigParentSyncOutcome::Synced
-    })
-}
-
-fn config_parent_directory(path: &Path) -> &Path {
-    path.parent().filter(|parent| !parent.as_os_str().is_empty()).unwrap_or_else(|| Path::new("."))
+    result
 }
 
 /// `#rrggbb`, `#rgb`, or an xterm-256 index in a string.
@@ -4330,35 +2133,22 @@ fn parse_color(s: &str) -> Option<Color> {
 
 /// The user's relevant Ghostty settings with non-optional application defaults
 /// resolved for values that the low-level terminal otherwise leaves unset.
-fn ghostty_defaults() -> DefaultColors {
-    let config_paths = platform::ghostty_config_paths();
-    let theme_dirs = platform::ghostty_theme_dirs();
-    #[cfg(not(test))]
-    let helper_defaults = ghostty_defaults_from_helper();
-    #[cfg(test)]
-    let helper_defaults = GhosttyHelperDefaults::Unavailable;
-    ghostty_defaults_from_sources(config_paths, theme_dirs, helper_defaults)
-}
-
-enum GhosttyHelperDefaults {
-    Resolved(Box<DefaultColors>),
-    Unavailable,
-    TimedOut,
-}
-
-fn ghostty_defaults_from_sources(
-    config_paths: Vec<PathBuf>,
-    theme_dirs: Vec<PathBuf>,
-    helper_defaults: GhosttyHelperDefaults,
-) -> DefaultColors {
-    let parsed = match helper_defaults {
-        GhosttyHelperDefaults::Resolved(defaults) => *defaults,
-        GhosttyHelperDefaults::Unavailable => {
-            parse_ghostty_defaults_from_paths(config_paths, theme_dirs).unwrap_or_default()
-        }
-        GhosttyHelperDefaults::TimedOut => DefaultColors::default(),
-    };
-    resolve_ghostty_application_defaults(parsed)
+fn ghostty_defaults() -> GhosttyApplicationDefaults {
+    let parsed = resolved_ghostty_defaults()
+        .or_else(|| {
+            let text = platform::ghostty_config_paths()
+                .iter()
+                .find_map(|path| std::fs::read_to_string(path).ok())?;
+            Some(GhosttyApplicationDefaults {
+                colors: parse_ghostty_defaults(&text),
+                scrollback_limit_bytes: parse_scrollback_limit_bytes(&text),
+            })
+        })
+        .unwrap_or_default();
+    GhosttyApplicationDefaults {
+        colors: resolve_ghostty_application_defaults(parsed.colors),
+        ..parsed
+    }
 }
 
 fn resolve_ghostty_application_defaults(mut defaults: DefaultColors) -> DefaultColors {
@@ -4370,973 +2160,118 @@ fn resolve_ghostty_application_defaults(mut defaults: DefaultColors) -> DefaultC
     defaults
 }
 
-#[cfg(test)]
-fn resolved_ghostty_defaults_from_with(
+#[derive(Default)]
+struct GhosttyApplicationDefaults {
+    colors: DefaultColors,
+    scrollback_limit_bytes: Option<usize>,
+}
+
+/// Ask Ghostty to resolve its configuration so cmux-tui inherits precisely the
+/// same settings as the graphical terminal. A failed or slow invocation is
+/// deliberately ignored; startup then uses the file fallback.
+fn resolved_ghostty_defaults() -> Option<GhosttyApplicationDefaults> {
+    resolved_ghostty_defaults_from(&platform::ghostty_installations())
+}
+
+fn resolved_ghostty_defaults_from(
     installations: &[platform::GhosttyInstallation],
-    mut resolve: impl FnMut(&platform::GhosttyInstallation) -> Option<String>,
-) -> Option<DefaultColors> {
+) -> Option<GhosttyApplicationDefaults> {
     installations.iter().find_map(|installation| {
-        let text = resolve(installation)?;
-        let defaults = parse_resolved_ghostty_defaults(&text);
-        // `+show-config` serializes Ghostty's effective application defaults,
-        // including both colors. An executable that exits successfully but
-        // emits no resolved config (for example a packaging stub) is not a
-        // usable resolver and must not suppress later pinned candidates.
-        (defaults.fg.is_some() && defaults.bg.is_some()).then_some(defaults)
+        let text = run_ghostty_show_config(installation, false)?;
+        let colors = parse_resolved_ghostty_defaults(&text);
+        // `+show-config` serializes Ghostty's effective application colors.
+        // An executable that exits successfully but emits no resolved config
+        // (for example a packaging stub) is not a usable resolver and must
+        // not suppress later pinned candidates.
+        (colors.fg.is_some() && colors.bg.is_some()).then(|| {
+            let scrollback_limit_bytes = parse_scrollback_limit_bytes(&text).or_else(|| {
+                run_ghostty_show_config(installation, true)
+                    .as_deref()
+                    .and_then(parse_scrollback_limit_bytes)
+            });
+            GhosttyApplicationDefaults { colors, scrollback_limit_bytes }
+        })
     })
 }
 
-#[cfg(all(test, unix))]
-fn ghostty_show_config_command(installation: &platform::GhosttyInstallation) -> Command {
+fn parse_scrollback_limit_bytes(text: &str) -> Option<usize> {
+    text.lines()
+        .filter_map(|line| {
+            let (key, value) = line.trim().split_once('=')?;
+            (key.trim() == "scrollback-limit")
+                .then(|| value.trim().trim_matches('"').replace('_', "").parse::<usize>().ok())
+                .flatten()
+        })
+        .last()
+}
+
+fn run_ghostty_show_config(
+    installation: &platform::GhosttyInstallation,
+    show_defaults: bool,
+) -> Option<String> {
     let mut command = Command::new(&installation.binary);
+    command.arg("+show-config");
+    if show_defaults {
+        command.arg("--default");
+    }
     command
-        .args(["+show-config", "--no-pager"])
+        .arg("--no-pager")
         .env_remove("GHOSTTY_RESOURCES_DIR")
         .stdout(Stdio::piped())
         .stderr(Stdio::null());
     if let Some(resources_dir) = installation.resources_dir.as_deref() {
         command.env("GHOSTTY_RESOURCES_DIR", resources_dir);
     }
-    command
+    let mut child = command.spawn().ok()?;
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let status = loop {
+        match child.try_wait().ok()? {
+            Some(status) => break status,
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+            None => std::thread::sleep(Duration::from_millis(10)),
+        }
+    };
+    if !status.success() {
+        return None;
+    }
+
+    let mut output = String::new();
+    child.stdout.take()?.read_to_string(&mut output).ok()?;
+    Some(output)
 }
 
 /// Parse the subset of Ghostty's `key = value` config used by cmux-tui.
 ///
 /// When the Ghostty executable is unavailable, a theme is only accepted if
-/// its file can be read. This preserves Ghostty's fail-soft behavior: keep
-/// looking after unreadable theme entries, then stop after the first theme
-/// that resolves successfully.
-#[cfg(test)]
+/// its file can be read. This preserves Ghostty's fail-soft behavior: a
+/// later theme entries are ignored, matching Ghostty's first-theme-wins
+/// behavior.
 pub(crate) fn parse_ghostty_defaults(text: &str) -> DefaultColors {
     parse_ghostty_defaults_with_theme_dirs(text, &platform::ghostty_theme_dirs())
 }
 
-pub(crate) fn is_ghostty_config_helper_invocation(args: &[String]) -> bool {
-    args.first().map(String::as_str) == Some("__ghostty-config-defaults")
-}
-
-pub(crate) fn run_ghostty_config_helper() -> i32 {
-    match parse_ghostty_defaults_from_paths_result(
-        platform::ghostty_config_paths(),
-        platform::ghostty_theme_dirs(),
-    ) {
-        GhosttyConfigParseOutcome::Parsed(defaults) => {
-            print!("{}", serialize_ghostty_defaults(*defaults));
-            0
-        }
-        GhosttyConfigParseOutcome::Missing => 1,
-        GhosttyConfigParseOutcome::TimedOut => 2,
-    }
-}
-
-#[cfg(not(test))]
-fn ghostty_defaults_from_helper() -> GhosttyHelperDefaults {
-    let Ok(exe) = std::env::current_exe() else {
-        return GhosttyHelperDefaults::Unavailable;
-    };
-    let mut command = Command::new(exe);
-    command
-        .arg("__ghostty-config-defaults")
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null());
-    #[cfg(unix)]
-    command.process_group(0);
-    scrub_ghostty_helper_secret_environment(&mut command);
-    ghostty_defaults_from_helper_command(command, GHOSTTY_CONFIG_HELPER_PARENT_DEADLINE)
-}
-
-#[cfg(any(not(test), all(test, unix)))]
-fn ghostty_defaults_from_helper_command(
-    mut command: Command,
-    parent_deadline: Duration,
-) -> GhosttyHelperDefaults {
-    let Ok(mut child) = command.spawn() else {
-        return GhosttyHelperDefaults::Unavailable;
-    };
-    let Some(stdout) = child.stdout.take() else {
-        terminate_ghostty_helper_child(child);
-        return GhosttyHelperDefaults::Unavailable;
-    };
-    let Some(output_reader) = read_ghostty_helper_output_async(stdout) else {
-        terminate_ghostty_helper_child(child);
-        return GhosttyHelperDefaults::Unavailable;
-    };
-    let status = match child.wait_timeout(parent_deadline) {
-        Ok(status) => status,
-        Err(_) => {
-            terminate_ghostty_helper_child(child);
-            return GhosttyHelperDefaults::Unavailable;
-        }
-    };
-    let status = match status {
-        Some(status) => status,
-        None => {
-            terminate_ghostty_helper_child(child);
-            return GhosttyHelperDefaults::TimedOut;
-        }
-    };
-    if !status.success() {
-        if status.code() == Some(2) {
-            return GhosttyHelperDefaults::TimedOut;
-        }
-        return GhosttyHelperDefaults::Unavailable;
-    }
-    match output_reader.wait() {
-        Some(output) => {
-            GhosttyHelperDefaults::Resolved(Box::new(parse_resolved_ghostty_defaults(&output)))
-        }
-        None => GhosttyHelperDefaults::Unavailable,
-    }
-}
-
-fn read_ghostty_helper_output_async(
-    stdout: impl Read + Send + 'static,
-) -> Option<GhosttyHelperOutputReader> {
-    read_ghostty_limited_output_async(
-        stdout,
-        GHOSTTY_HELPER_OUTPUT_MAX_BYTES,
-        "cmux-tui-ghostty-helper-output",
-    )
-}
-
-fn read_ghostty_limited_output_async(
-    stdout: impl Read + Send + 'static,
-    max_bytes: u64,
-    thread_name: &'static str,
-) -> Option<GhosttyHelperOutputReader> {
-    let (sender, receiver) = mpsc::channel();
-    std::thread::Builder::new()
-        .name(thread_name.to_string())
-        .spawn(move || {
-            let _ = sender.send(read_ghostty_limited_string(stdout, max_bytes));
-        })
-        .ok()?;
-    Some(GhosttyHelperOutputReader { receiver })
-}
-
-struct GhosttyHelperOutputReader {
-    receiver: mpsc::Receiver<Option<String>>,
-}
-
-impl GhosttyHelperOutputReader {
-    fn wait(self) -> Option<String> {
-        self.receiver.recv().ok().flatten()
-    }
-
-    #[cfg(not(target_os = "macos"))]
-    fn recv_timeout(&self, timeout: Duration) -> Result<Option<String>, mpsc::RecvTimeoutError> {
-        self.receiver.recv_timeout(timeout)
-    }
-}
-
-fn terminate_ghostty_helper_child(child: Child) {
-    let _ = terminate_ghostty_helper_child_with_reaped_signal(child);
-}
-
-fn terminate_ghostty_helper_child_with_reaped_signal(mut child: Child) -> mpsc::Receiver<()> {
-    #[cfg(unix)]
-    let descendant_groups = ghostty_helper_descendant_process_groups(child.id() as libc::pid_t);
-    #[cfg(unix)]
-    unsafe {
-        for group in descendant_groups {
-            // SAFETY: group IDs are read from the process table for descendants
-            // of the helper being terminated.
-            libc::killpg(group, libc::SIGKILL);
-        }
-        // SAFETY: killpg only sends SIGKILL to the helper-owned process group.
-        libc::killpg(child.id() as libc::pid_t, libc::SIGKILL);
-    }
-    let _ = child.kill();
-    reap_ghostty_child_after_short_wait(child, "cmux-tui-ghostty-helper-reaper")
-}
-
-#[cfg(unix)]
-fn ghostty_helper_descendant_process_groups(root_pid: libc::pid_t) -> Vec<libc::pid_t> {
-    let Some(text) = ghostty_helper_process_table_snapshot() else {
-        return Vec::new();
-    };
-    ghostty_helper_descendant_process_groups_from_table(root_pid, &text)
-}
-
-#[cfg(unix)]
-fn ghostty_helper_process_table_snapshot() -> Option<String> {
-    let mut command = Command::new("/bin/ps");
-    command
-        .args(["-axo", "pid=,ppid=,pgid="])
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .process_group(0);
-    let Ok(mut child) = command.spawn() else {
-        return None;
-    };
-    let Some(stdout) = child.stdout.take() else {
-        terminate_ghostty_process_scan_child(child);
-        return None;
-    };
-    let Some(output_reader) = read_ghostty_limited_output_async(
-        stdout,
-        GHOSTTY_PROCESS_SCAN_OUTPUT_MAX_BYTES,
-        "cmux-tui-ghostty-process-scan-output",
-    ) else {
-        terminate_ghostty_process_scan_child(child);
-        return None;
-    };
-    let status = match child.wait_timeout(GHOSTTY_PROCESS_SCAN_DEADLINE) {
-        Ok(Some(status)) => status,
-        Ok(None) | Err(_) => {
-            terminate_ghostty_process_scan_child(child);
-            return None;
-        }
-    };
-    if !status.success() {
-        return None;
-    }
-    output_reader.wait()
-}
-
-#[cfg(unix)]
-fn terminate_ghostty_process_scan_child(child: Child) {
-    let _ = terminate_ghostty_process_scan_child_with_reaped_signal(child);
-}
-
-#[cfg(unix)]
-fn terminate_ghostty_process_scan_child_with_reaped_signal(mut child: Child) -> mpsc::Receiver<()> {
-    unsafe {
-        // SAFETY: this only targets the bounded process-scan child group.
-        libc::killpg(child.id() as libc::pid_t, libc::SIGKILL);
-    }
-    let _ = child.kill();
-    reap_ghostty_child_after_short_wait(child, "cmux-tui-ghostty-process-scan-reaper")
-}
-
-fn reap_ghostty_child_after_short_wait(
-    mut child: Child,
-    reaper_name: &'static str,
-) -> mpsc::Receiver<()> {
-    let (reaped_sender, reaped_receiver) = mpsc::sync_channel(1);
-    if matches!(child.wait_timeout(Duration::from_millis(10)), Ok(Some(_))) {
-        let _ = reaped_sender.send(());
-        return reaped_receiver;
-    }
-    let _ = std::thread::Builder::new().name(reaper_name.to_string()).spawn(move || {
-        let _ = child.wait();
-        let _ = reaped_sender.send(());
-    });
-    reaped_receiver
-}
-
-#[cfg(unix)]
-fn ghostty_helper_descendant_process_groups_from_table(
-    root_pid: libc::pid_t,
-    text: &str,
-) -> Vec<libc::pid_t> {
-    let mut children = HashMap::<libc::pid_t, Vec<(libc::pid_t, libc::pid_t)>>::new();
-    for line in text.lines() {
-        let mut parts = line.split_whitespace();
-        let Some(pid) = parts.next().and_then(|value| value.parse::<libc::pid_t>().ok()) else {
-            continue;
-        };
-        let Some(ppid) = parts.next().and_then(|value| value.parse::<libc::pid_t>().ok()) else {
-            continue;
-        };
-        let Some(pgid) = parts.next().and_then(|value| value.parse::<libc::pid_t>().ok()) else {
-            continue;
-        };
-        children.entry(ppid).or_default().push((pid, pgid));
-    }
-
-    let mut groups = HashSet::<libc::pid_t>::new();
-    let mut stack = vec![root_pid];
-    while let Some(parent) = stack.pop() {
-        let Some(descendants) = children.get(&parent) else {
-            continue;
-        };
-        for &(pid, pgid) in descendants {
-            stack.push(pid);
-            if pgid > 0 && pgid != root_pid {
-                groups.insert(pgid);
-            }
-        }
-    }
-    groups.into_iter().collect()
-}
-
-#[cfg(any(not(test), all(test, unix)))]
-fn scrub_ghostty_helper_secret_environment(command: &mut Command) {
-    for name in ["CMUX_MACHINE_PROVIDER_TOKEN", "CMUX_PROVIDER_WORKSPACE_AUTHORITY"] {
-        command.env_remove(name);
-    }
-}
-
-fn parse_ghostty_defaults_from_paths(
-    config_paths: Vec<PathBuf>,
-    theme_dirs: Vec<PathBuf>,
-) -> Option<DefaultColors> {
-    match parse_ghostty_defaults_from_paths_result(config_paths, theme_dirs) {
-        GhosttyConfigParseOutcome::Parsed(defaults) => Some(*defaults),
-        GhosttyConfigParseOutcome::Missing | GhosttyConfigParseOutcome::TimedOut => None,
-    }
-}
-
-enum GhosttyConfigParseOutcome {
-    Parsed(Box<DefaultColors>),
-    Missing,
-    TimedOut,
-}
-
-fn parse_ghostty_defaults_from_paths_result(
-    config_paths: Vec<PathBuf>,
-    theme_dirs: Vec<PathBuf>,
-) -> GhosttyConfigParseOutcome {
-    let deadline_at = ghostty_config_deadline_from_now(GHOSTTY_CONFIG_PARSE_DEADLINE);
-    parse_ghostty_defaults_from_paths_result_until(config_paths, theme_dirs, Some(deadline_at))
-}
-
-fn parse_ghostty_defaults_from_paths_result_until(
-    config_paths: Vec<PathBuf>,
-    theme_dirs: Vec<PathBuf>,
-    deadline_at: Option<Instant>,
-) -> GhosttyConfigParseOutcome {
-    for path in config_paths {
-        if ghostty_config_deadline_expired(deadline_at) {
-            return GhosttyConfigParseOutcome::TimedOut;
-        }
-        match parse_ghostty_defaults_from_path_result_until(&path, &theme_dirs, deadline_at) {
-            GhosttyConfigParseOutcome::Missing => {}
-            outcome => return outcome,
-        }
-    }
-    GhosttyConfigParseOutcome::Missing
-}
-
-#[cfg(test)]
 fn parse_ghostty_defaults_with_theme_dirs(text: &str, theme_dirs: &[PathBuf]) -> DefaultColors {
-    let mut theme_candidates = Vec::new();
-    let parsed = parse_ghostty_config_text(text, None, &mut theme_candidates);
-    resolve_parsed_ghostty_defaults(theme_candidates, theme_dirs, parsed.overrides, None)
-}
-
-#[cfg(test)]
-fn parse_ghostty_defaults_from_path(path: &Path, theme_dirs: &[PathBuf]) -> Option<DefaultColors> {
-    match parse_ghostty_defaults_from_path_result(path, theme_dirs) {
-        GhosttyConfigParseOutcome::Parsed(defaults) => Some(*defaults),
-        GhosttyConfigParseOutcome::Missing | GhosttyConfigParseOutcome::TimedOut => None,
-    }
-}
-
-#[cfg(test)]
-fn parse_ghostty_defaults_from_path_result(
-    path: &Path,
-    theme_dirs: &[PathBuf],
-) -> GhosttyConfigParseOutcome {
-    let deadline_at = ghostty_config_deadline_from_now(GHOSTTY_CONFIG_PARSE_DEADLINE);
-    parse_ghostty_defaults_from_path_result_until(path, theme_dirs, Some(deadline_at))
-}
-
-fn parse_ghostty_defaults_from_path_result_until(
-    path: &Path,
-    theme_dirs: &[PathBuf],
-    deadline_at: Option<Instant>,
-) -> GhosttyConfigParseOutcome {
-    let mut theme_candidates = Vec::new();
-    let overrides = match parse_ghostty_config_file_until(path, &mut theme_candidates, deadline_at)
-    {
-        GhosttyConfigParseOutcome::Parsed(overrides) => *overrides,
-        outcome => return outcome,
-    };
-    GhosttyConfigParseOutcome::Parsed(Box::new(resolve_parsed_ghostty_defaults(
-        theme_candidates,
-        theme_dirs,
-        overrides,
-        deadline_at,
-    )))
-}
-
-const GHOSTTY_CONFIG_MAX_FILES: usize = 64;
-const GHOSTTY_CONFIG_MAX_DEPTH: usize = 16;
-const GHOSTTY_CONFIG_MAX_BYTES: u64 = 1024 * 1024;
-const GHOSTTY_HELPER_OUTPUT_MAX_BYTES: u64 = 64 * 1024;
-#[cfg(unix)]
-const GHOSTTY_PROCESS_SCAN_OUTPUT_MAX_BYTES: u64 = 1024 * 1024;
-const GHOSTTY_CONFIG_PARSE_DEADLINE: Duration = Duration::from_millis(250);
-#[cfg(unix)]
-const GHOSTTY_PROCESS_SCAN_DEADLINE: Duration = Duration::from_millis(150);
-#[cfg(not(target_os = "macos"))]
-const GHOSTTY_HELPER_REAP_DEADLINE: Duration = Duration::from_millis(150);
-// The child owns a 250 ms parse deadline. The parent starts timing before
-// spawn/exec and still needs room for setup, stdout drain, and normal exit.
-const GHOSTTY_CONFIG_HELPER_PARENT_DEADLINE: Duration = Duration::from_millis(500);
-#[cfg(not(target_os = "macos"))]
-const GHOSTTY_DESKTOP_APPEARANCE_DEADLINE: Duration = Duration::from_millis(75);
-
-struct PendingGhosttyConfig {
-    path: PathBuf,
-    depth: usize,
-}
-
-#[cfg(test)]
-fn parse_ghostty_config_file_with_deadline(
-    path: &Path,
-    theme_candidates: &mut Vec<GhosttyThemeCandidate>,
-    deadline: Duration,
-) -> GhosttyConfigParseOutcome {
-    parse_ghostty_config_file_until(
-        path,
-        theme_candidates,
-        Some(ghostty_config_deadline_from_now(deadline)),
-    )
-}
-
-fn parse_ghostty_config_file_until(
-    path: &Path,
-    theme_candidates: &mut Vec<GhosttyThemeCandidate>,
-    deadline_at: Option<Instant>,
-) -> GhosttyConfigParseOutcome {
-    let mut stack = vec![PendingGhosttyConfig { path: path.to_path_buf(), depth: 0 }];
-    let mut loaded = HashSet::new();
-    let mut files_loaded = 0usize;
-    let mut bytes_loaded = 0u64;
-    let mut loaded_root = false;
     let mut overrides = DefaultColors::default();
-
-    while let Some(pending) = stack.pop() {
-        if files_loaded > 0 && ghostty_config_deadline_expired(deadline_at) {
-            return GhosttyConfigParseOutcome::TimedOut;
-        }
-        if pending.depth > GHOSTTY_CONFIG_MAX_DEPTH || files_loaded >= GHOSTTY_CONFIG_MAX_FILES {
-            continue;
-        }
-        let identity = pending.path.canonicalize().unwrap_or_else(|_| pending.path.clone());
-        if !loaded.insert(identity) {
-            continue;
-        }
-        let remaining_bytes = GHOSTTY_CONFIG_MAX_BYTES.saturating_sub(bytes_loaded);
-        let text = match read_ghostty_regular_file(&pending.path, remaining_bytes) {
-            Some(text) => text,
-            None if pending.depth == 0 && files_loaded == 0 => {
-                return GhosttyConfigParseOutcome::Missing;
-            }
-            None => continue,
-        };
-        bytes_loaded = bytes_loaded.saturating_add(text.len() as u64);
-        files_loaded += 1;
-        loaded_root |= pending.depth == 0;
-
-        let base_dir = pending.path.parent().unwrap_or_else(|| Path::new("."));
-        let parsed = parse_ghostty_config_text(&text, Some(base_dir), theme_candidates);
-        overlay_ghostty_defaults(&mut overrides, parsed.overrides);
-
-        for include in
-            parsed.config_files.into_iter().rev().filter_map(|include| include.resolve(base_dir))
-        {
-            stack.push(PendingGhosttyConfig { path: include, depth: pending.depth + 1 });
-        }
-        if ghostty_config_deadline_expired(deadline_at) {
-            return GhosttyConfigParseOutcome::TimedOut;
-        }
-    }
-
-    if loaded_root {
-        GhosttyConfigParseOutcome::Parsed(Box::new(overrides))
-    } else {
-        GhosttyConfigParseOutcome::Missing
-    }
-}
-
-fn ghostty_config_deadline_from_now(deadline: Duration) -> Instant {
-    Instant::now().checked_add(deadline).unwrap_or_else(Instant::now)
-}
-
-fn ghostty_config_deadline_expired(deadline_at: Option<Instant>) -> bool {
-    deadline_at.is_some_and(|deadline_at| Instant::now() >= deadline_at)
-}
-
-#[cfg(not(target_os = "macos"))]
-fn ghostty_config_deadline_remaining(deadline_at: Option<Instant>) -> Option<Duration> {
-    deadline_at.map_or(Some(Duration::MAX), |deadline_at| Some(ghostty_duration_until(deadline_at)))
-}
-
-#[cfg(not(target_os = "macos"))]
-fn ghostty_duration_until(deadline_at: Instant) -> Duration {
-    deadline_at.checked_duration_since(Instant::now()).unwrap_or(Duration::ZERO)
-}
-
-#[cfg(all(unix, not(target_os = "macos")))]
-fn kill_ghostty_process_group(group: libc::pid_t) {
-    if group <= 0 {
-        return;
-    }
-    unsafe {
-        // SAFETY: callers pass process-group IDs that were either created by
-        // cmux-tui for short-lived helpers or discovered under those helpers.
-        libc::killpg(group, libc::SIGKILL);
-    }
-}
-
-struct ParsedGhosttyConfig {
-    overrides: DefaultColors,
-    config_files: Vec<GhosttyConfigFile>,
-}
-
-struct GhosttyThemeCandidate {
-    value: String,
-    base_dir: Option<PathBuf>,
-}
-
-struct GhosttyConfigFile {
-    path: String,
-}
-
-impl GhosttyConfigFile {
-    fn parse(value: &str) -> Option<Self> {
-        let value = value.trim();
-        let value = value.strip_prefix('?').unwrap_or(value);
-        let value =
-            value.strip_prefix('"').and_then(|value| value.strip_suffix('"')).unwrap_or(value);
-        if value.is_empty() { None } else { Some(Self { path: value.to_owned() }) }
-    }
-
-    fn resolve(self, base_dir: &Path) -> Option<PathBuf> {
-        if let Some(path) = expand_home_relative_path(&self.path) {
-            return Some(path);
-        }
-        let path = Path::new(&self.path);
-        if path.is_absolute() { Some(path.to_path_buf()) } else { Some(base_dir.join(path)) }
-    }
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum GhosttyThemeMode {
-    Light,
-    Dark,
-}
-
-impl GhosttyThemeMode {
-    fn parse(value: &std::ffi::OsStr) -> Option<Self> {
-        let value = value.to_string_lossy();
-        match value.trim_matches('"').to_ascii_lowercase().as_str() {
-            "light" => Some(Self::Light),
-            "dark" => Some(Self::Dark),
-            _ => None,
-        }
-    }
-}
-
-fn system_ghostty_theme_mode(deadline_at: Option<Instant>) -> GhosttyThemeMode {
-    system_ghostty_theme_mode_with_platform(|| platform_appearance_theme_mode(deadline_at))
-}
-
-fn system_ghostty_theme_mode_with_platform(
-    mut platform_appearance: impl FnMut() -> Option<GhosttyThemeMode>,
-) -> GhosttyThemeMode {
-    if let Some(mode) =
-        std::env::var_os("AppleInterfaceStyle").as_deref().and_then(GhosttyThemeMode::parse)
-    {
-        return mode;
-    }
-    if let Some(mode) = platform_appearance() {
-        return mode;
-    }
-    GhosttyThemeMode::Light
-}
-
-#[cfg(target_os = "macos")]
-fn platform_appearance_theme_mode(_deadline_at: Option<Instant>) -> Option<GhosttyThemeMode> {
-    macos_appearance_theme_mode()
-}
-
-#[cfg(not(target_os = "macos"))]
-fn platform_appearance_theme_mode(deadline_at: Option<Instant>) -> Option<GhosttyThemeMode> {
-    non_macos_appearance_theme_mode(deadline_at)
-}
-
-#[cfg(not(target_os = "macos"))]
-fn non_macos_appearance_theme_mode(deadline_at: Option<Instant>) -> Option<GhosttyThemeMode> {
-    if let Some(mode) = freedesktop_portal_theme_mode(deadline_at) {
-        return Some(mode);
-    }
-    if let Some(mode) = gnome_color_scheme_theme_mode(deadline_at) {
-        return Some(mode);
-    }
-    if ghostty_config_deadline_expired(deadline_at) {
-        return None;
-    }
-    if let Some(mode) = std::env::var_os("GTK_THEME")
-        .as_deref()
-        .and_then(|value| gtk_theme_name_theme_mode(&value.to_string_lossy()))
-    {
-        return Some(mode);
-    }
-    gtk_settings_paths()
-        .into_iter()
-        .find_map(|path| {
-            if ghostty_config_deadline_expired(deadline_at) {
-                return None;
-            }
-            let text = read_ghostty_regular_file(&path, 64 * 1024)?;
-            gtk_settings_theme_mode(&text)
-        })
-        .or_else(|| kde_globals_theme_mode(deadline_at))
-}
-
-#[cfg(not(target_os = "macos"))]
-fn freedesktop_portal_theme_mode(deadline_at: Option<Instant>) -> Option<GhosttyThemeMode> {
-    let output = desktop_theme_command_output(
-        "gdbus",
-        &[
-            "call",
-            "--session",
-            "--dest",
-            "org.freedesktop.portal.Desktop",
-            "--object-path",
-            "/org/freedesktop/portal/desktop",
-            "--method",
-            "org.freedesktop.portal.Settings.Read",
-            "org.freedesktop.appearance",
-            "color-scheme",
-        ],
-        deadline_at,
-    )?;
-    freedesktop_portal_color_scheme_theme_mode(&output)
-}
-
-#[cfg(not(target_os = "macos"))]
-fn gnome_color_scheme_theme_mode(deadline_at: Option<Instant>) -> Option<GhosttyThemeMode> {
-    let output = desktop_theme_command_output(
-        "gsettings",
-        &["get", "org.gnome.desktop.interface", "color-scheme"],
-        deadline_at,
-    )?;
-    gnome_color_scheme_output_theme_mode(&output)
-}
-
-#[cfg(not(target_os = "macos"))]
-fn desktop_theme_command_output(
-    program: &str,
-    args: &[&str],
-    deadline_at: Option<Instant>,
-) -> Option<String> {
-    desktop_theme_command_output_with_lifecycle_signals(program, args, deadline_at, None, None)
-}
-
-#[cfg(not(target_os = "macos"))]
-fn desktop_theme_command_output_with_lifecycle_signals(
-    program: &str,
-    args: &[&str],
-    deadline_at: Option<Instant>,
-    started_sender: Option<&mpsc::SyncSender<u32>>,
-    reaped_sender: Option<&mpsc::SyncSender<()>>,
-) -> Option<String> {
-    let timeout =
-        ghostty_config_deadline_remaining(deadline_at)?.min(GHOSTTY_DESKTOP_APPEARANCE_DEADLINE);
-    if timeout.is_zero() {
-        return None;
-    }
-    let command_deadline = Instant::now() + timeout;
-    let mut command = Command::new(program);
-    command.args(args).stdin(Stdio::null()).stdout(Stdio::piped()).stderr(Stdio::null());
-    #[cfg(unix)]
-    command.process_group(0);
-    let mut child = command.spawn().ok()?;
-    if let Some(started_sender) = started_sender {
-        let _ = started_sender.send(child.id());
-    }
-    #[cfg(unix)]
-    let child_group = child.id() as libc::pid_t;
-    let Some(stdout) = child.stdout.take() else {
-        terminate_ghostty_helper_child(child);
-        return None;
-    };
-    let Some(output_reader) = read_ghostty_helper_output_async(stdout) else {
-        terminate_ghostty_helper_child(child);
-        return None;
-    };
-    let status = match child.wait_timeout(timeout) {
-        Ok(Some(status)) => status,
-        Ok(None) | Err(_) => {
-            terminate_ghostty_helper_child(child);
-            return None;
-        }
-    };
-    if !status.success() {
-        return None;
-    }
-    match output_reader.recv_timeout(ghostty_duration_until(command_deadline)) {
-        Ok(output) => output,
-        Err(mpsc::RecvTimeoutError::Timeout) => {
-            #[cfg(unix)]
-            kill_ghostty_process_group(child_group);
-            let reap_timeout =
-                ghostty_config_deadline_remaining(deadline_at)?.min(GHOSTTY_HELPER_REAP_DEADLINE);
-            if !reap_timeout.is_zero()
-                && output_reader.recv_timeout(reap_timeout).is_ok()
-                && let Some(reaped_sender) = reaped_sender
+    let mut theme = None;
+    for line in text.lines() {
+        let line = line.trim();
+        let Some((key, value)) = line.split_once('=') else { continue };
+        if key.trim() == "theme" {
+            if theme.is_none()
+                && let Some(theme_defaults) = load_ghostty_theme(value.trim(), theme_dirs)
             {
-                let _ = reaped_sender.send(());
+                theme = Some(theme_defaults);
             }
-            None
-        }
-        Err(mpsc::RecvTimeoutError::Disconnected) => None,
-    }
-}
-
-#[cfg(any(test, not(target_os = "macos")))]
-fn freedesktop_portal_color_scheme_theme_mode(text: &str) -> Option<GhosttyThemeMode> {
-    if text.contains("uint32 1") || text.contains("<1>") {
-        return Some(GhosttyThemeMode::Dark);
-    }
-    if text.contains("uint32 2") || text.contains("<2>") {
-        return Some(GhosttyThemeMode::Light);
-    }
-    None
-}
-
-#[cfg(any(test, not(target_os = "macos")))]
-fn gnome_color_scheme_output_theme_mode(text: &str) -> Option<GhosttyThemeMode> {
-    let text = text.trim().trim_matches('\'').trim_matches('"');
-    match text {
-        "prefer-dark" => Some(GhosttyThemeMode::Dark),
-        "prefer-light" => Some(GhosttyThemeMode::Light),
-        _ => None,
-    }
-}
-
-#[cfg(not(target_os = "macos"))]
-fn kde_globals_theme_mode(deadline_at: Option<Instant>) -> Option<GhosttyThemeMode> {
-    kde_globals_paths().into_iter().find_map(|path| {
-        if ghostty_config_deadline_expired(deadline_at) {
-            return None;
-        }
-        let text = read_ghostty_regular_file(&path, 64 * 1024)?;
-        kde_globals_text_theme_mode(&text)
-    })
-}
-
-#[cfg(not(target_os = "macos"))]
-fn kde_globals_paths() -> Vec<PathBuf> {
-    let mut paths = Vec::new();
-    if let Some(config_home) = std::env::var_os("XDG_CONFIG_HOME").map(PathBuf::from) {
-        paths.push(config_home.join("kdeglobals"));
-    }
-    if let Some(home) = platform::home_dir() {
-        let path = home.join(".config").join("kdeglobals");
-        if !paths.contains(&path) {
-            paths.push(path);
-        }
-    }
-    paths
-}
-
-#[cfg(any(test, not(target_os = "macos")))]
-fn kde_globals_text_theme_mode(text: &str) -> Option<GhosttyThemeMode> {
-    for line in text.lines() {
-        let line = line.trim();
-        let Some((key, value)) = line.split_once('=') else { continue };
-        if key.trim() == "ColorScheme" {
-            return gtk_theme_name_theme_mode(value.trim());
-        }
-    }
-    None
-}
-
-#[cfg(not(target_os = "macos"))]
-fn gtk_settings_paths() -> Vec<PathBuf> {
-    let mut roots = Vec::new();
-    if let Some(config_home) = std::env::var_os("XDG_CONFIG_HOME").map(PathBuf::from) {
-        roots.push(config_home);
-    }
-    if let Some(home) = platform::home_dir() {
-        roots.push(home.join(".config"));
-    }
-
-    let mut paths = Vec::new();
-    for root in roots {
-        for version in ["gtk-4.0", "gtk-3.0"] {
-            let path = root.join(version).join("settings.ini");
-            if !paths.contains(&path) {
-                paths.push(path);
-            }
-        }
-    }
-    paths
-}
-
-#[cfg(any(test, not(target_os = "macos")))]
-fn gtk_settings_theme_mode(text: &str) -> Option<GhosttyThemeMode> {
-    let mut theme_name = None;
-    for line in text.lines() {
-        let line = line.trim();
-        if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
-            continue;
-        }
-        let Some((key, value)) = line.split_once('=') else { continue };
-        let key = key.trim();
-        let value = value.trim().trim_matches('"');
-        match key {
-            "gtk-application-prefer-dark-theme" => match value.to_ascii_lowercase().as_str() {
-                "1" | "true" | "yes" => return Some(GhosttyThemeMode::Dark),
-                "0" | "false" | "no" => {}
-                _ => {}
-            },
-            "gtk-theme-name" => theme_name = gtk_theme_name_theme_mode(value),
-            _ => {}
-        }
-    }
-    theme_name
-}
-
-#[cfg(any(test, not(target_os = "macos")))]
-fn gtk_theme_name_theme_mode(value: &str) -> Option<GhosttyThemeMode> {
-    let value = value.to_ascii_lowercase();
-    if value.ends_with("dark") || value.split([':', '-', '_']).any(|part| part == "dark") {
-        return Some(GhosttyThemeMode::Dark);
-    }
-    if value.ends_with("light") || value.split([':', '-', '_']).any(|part| part == "light") {
-        return Some(GhosttyThemeMode::Light);
-    }
-    None
-}
-
-#[cfg(test)]
-fn ghostty_background_is_light(background: Rgb) -> bool {
-    let luminance = (0.299 * f64::from(background.r)
-        + 0.587 * f64::from(background.g)
-        + 0.114 * f64::from(background.b))
-        / 255.0;
-    luminance > 0.5
-}
-
-#[cfg(target_os = "macos")]
-fn macos_appearance_theme_mode() -> Option<GhosttyThemeMode> {
-    use std::ffi::CString;
-    use std::os::raw::{c_char, c_void};
-    use std::ptr;
-
-    type CfTypeRef = *const c_void;
-    type CfStringRef = *const c_void;
-    type Boolean = u8;
-
-    const K_CF_STRING_ENCODING_UTF8: u32 = 0x0800_0100;
-
-    #[link(name = "CoreFoundation", kind = "framework")]
-    unsafe extern "C" {
-        static kCFPreferencesAnyApplication: CfStringRef;
-        static kCFPreferencesCurrentUser: CfStringRef;
-        static kCFPreferencesAnyHost: CfStringRef;
-
-        fn CFStringCreateWithCString(
-            alloc: *const c_void,
-            c_str: *const c_char,
-            encoding: u32,
-        ) -> CfStringRef;
-        fn CFPreferencesCopyValue(
-            key: CfStringRef,
-            application_id: CfStringRef,
-            user_name: CfStringRef,
-            host_name: CfStringRef,
-        ) -> CfTypeRef;
-        fn CFEqual(cf1: CfTypeRef, cf2: CfTypeRef) -> Boolean;
-        fn CFRelease(cf: CfTypeRef);
-    }
-
-    let key = CString::new("AppleInterfaceStyle").ok()?;
-    let dark = CString::new("Dark").ok()?;
-    unsafe {
-        let key_ref =
-            CFStringCreateWithCString(ptr::null(), key.as_ptr(), K_CF_STRING_ENCODING_UTF8);
-        if key_ref.is_null() {
-            return None;
-        }
-        let dark_ref =
-            CFStringCreateWithCString(ptr::null(), dark.as_ptr(), K_CF_STRING_ENCODING_UTF8);
-        if dark_ref.is_null() {
-            CFRelease(key_ref);
-            return None;
-        }
-        let value = CFPreferencesCopyValue(
-            key_ref,
-            kCFPreferencesAnyApplication,
-            kCFPreferencesCurrentUser,
-            kCFPreferencesAnyHost,
-        );
-        let mode = if !value.is_null() && CFEqual(value, dark_ref) != 0 {
-            GhosttyThemeMode::Dark
         } else {
-            GhosttyThemeMode::Light
-        };
-        if !value.is_null() {
-            CFRelease(value);
-        }
-        CFRelease(dark_ref);
-        CFRelease(key_ref);
-        Some(mode)
-    }
-}
-
-fn parse_ghostty_config_text(
-    text: &str,
-    base_dir: Option<&Path>,
-    theme_candidates: &mut Vec<GhosttyThemeCandidate>,
-) -> ParsedGhosttyConfig {
-    let mut overrides = DefaultColors::default();
-    let mut config_files = Vec::new();
-    for line in text.lines() {
-        let line = line.trim();
-        let Some((key, value)) = line.split_once('=') else { continue };
-        match key.trim() {
-            "theme" => {
-                theme_candidates.push(GhosttyThemeCandidate {
-                    value: value.trim().to_owned(),
-                    base_dir: base_dir.map(Path::to_path_buf),
-                });
-            }
-            "window-theme" => {}
-            "config-file" => {
-                if let Some(include) = GhosttyConfigFile::parse(value) {
-                    config_files.push(include);
-                }
-            }
-            key => apply_ghostty_default(&mut overrides, key, value.trim()),
+            apply_ghostty_default(&mut overrides, key.trim(), value.trim());
         }
     }
 
-    ParsedGhosttyConfig { overrides, config_files }
-}
-
-fn resolve_ghostty_theme_defaults(
-    theme_candidates: &[GhosttyThemeCandidate],
-    theme_dirs: &[PathBuf],
-    deadline_at: Option<Instant>,
-) -> DefaultColors {
-    if theme_candidates.is_empty() {
-        return DefaultColors::default();
-    }
-    if ghostty_config_deadline_expired(deadline_at) {
-        return DefaultColors::default();
-    }
-    let mut theme_mode = None;
-    for candidate in theme_candidates {
-        if ghostty_config_deadline_expired(deadline_at) {
-            return DefaultColors::default();
-        }
-        if let Some(defaults) =
-            load_ghostty_theme(candidate, theme_dirs, deadline_at, &mut theme_mode)
-        {
-            return defaults;
-        }
-    }
-    DefaultColors::default()
-}
-
-fn resolve_parsed_ghostty_defaults(
-    theme_candidates: Vec<GhosttyThemeCandidate>,
-    theme_dirs: &[PathBuf],
-    overrides: DefaultColors,
-    deadline_at: Option<Instant>,
-) -> DefaultColors {
-    let mut defaults = resolve_ghostty_theme_defaults(&theme_candidates, theme_dirs, deadline_at);
+    let mut defaults = theme.unwrap_or_default();
     overlay_ghostty_defaults(&mut defaults, overrides);
     defaults
 }
@@ -5352,49 +2287,6 @@ fn parse_resolved_ghostty_defaults(text: &str) -> DefaultColors {
         apply_ghostty_default(&mut defaults, key.trim(), value.trim());
     }
     defaults
-}
-
-fn serialize_ghostty_defaults(defaults: DefaultColors) -> String {
-    let mut out = String::new();
-    if let Some(color) = defaults.fg {
-        out.push_str(&format!("foreground = {}\n", format_ghostty_rgb(color)));
-    }
-    if let Some(color) = defaults.bg {
-        out.push_str(&format!("background = {}\n", format_ghostty_rgb(color)));
-    }
-    if let Some(color) = defaults.cursor {
-        out.push_str(&format!("cursor-color = {}\n", format_ghostty_rgb(color)));
-    }
-    if let Some(color) = defaults.selection_bg {
-        out.push_str(&format!("selection-background = {}\n", format_ghostty_rgb(color)));
-    }
-    if let Some(color) = defaults.selection_fg {
-        out.push_str(&format!("selection-foreground = {}\n", format_ghostty_rgb(color)));
-    }
-    if let Some(style) = defaults.cursor_style {
-        let style = match style {
-            CursorShape::Block => Some("block"),
-            CursorShape::Underline => Some("underline"),
-            CursorShape::Bar => Some("bar"),
-            CursorShape::BlockHollow => Some("block_hollow"),
-        };
-        if let Some(style) = style {
-            out.push_str(&format!("cursor-style = {style}\n"));
-        }
-    }
-    if let Some(blink) = defaults.cursor_blink {
-        out.push_str(&format!("cursor-style-blink = {blink}\n"));
-    }
-    for (index, color) in defaults.palette.into_iter().enumerate() {
-        if let Some(color) = color {
-            out.push_str(&format!("palette = {index}={}\n", format_ghostty_rgb(color)));
-        }
-    }
-    out
-}
-
-fn format_ghostty_rgb(color: Rgb) -> String {
-    format!("#{:02x}{:02x}{:02x}", color.r, color.g, color.b)
 }
 
 fn apply_ghostty_default(defaults: &mut DefaultColors, key: &str, value: &str) {
@@ -5430,7 +2322,6 @@ fn apply_ghostty_default(defaults: &mut DefaultColors, key: &str, value: &str) {
                 "block" => Some(CursorShape::Block),
                 "underline" => Some(CursorShape::Underline),
                 "bar" => Some(CursorShape::Bar),
-                "block_hollow" => Some(CursorShape::BlockHollow),
                 _ => None,
             };
             if style.is_some() {
@@ -5451,97 +2342,17 @@ fn apply_ghostty_default(defaults: &mut DefaultColors, key: &str, value: &str) {
     }
 }
 
-fn load_ghostty_theme(
-    candidate: &GhosttyThemeCandidate,
-    theme_dirs: &[PathBuf],
-    deadline_at: Option<Instant>,
-    theme_mode: &mut Option<GhosttyThemeMode>,
-) -> Option<DefaultColors> {
-    if ghostty_config_deadline_expired(deadline_at) {
+fn load_ghostty_theme(value: &str, theme_dirs: &[PathBuf]) -> Option<DefaultColors> {
+    let theme = value.trim_matches('"');
+    let path = if Path::new(theme).is_absolute() {
+        PathBuf::from(theme)
+    } else if Path::new(theme).file_name().is_some_and(|name| name == theme) {
+        theme_dirs.iter().map(|dir| dir.join(theme)).find(|path| path.is_file())?
+    } else {
         return None;
-    }
-    let value = candidate.value.trim_matches('"');
-    let theme = selected_ghostty_theme(value, deadline_at, theme_mode);
-    if ghostty_config_deadline_expired(deadline_at) {
-        return None;
-    }
-    let path = resolve_ghostty_theme_path(theme, candidate.base_dir.as_deref(), theme_dirs)?;
-    let text = read_ghostty_regular_file(&path, GHOSTTY_CONFIG_MAX_BYTES)?;
-    Some(parse_resolved_ghostty_defaults(&text))
-}
-
-fn read_ghostty_regular_file(path: &Path, max_bytes: u64) -> Option<String> {
-    let file = std::fs::File::open(path).ok()?;
-    let metadata = file.metadata().ok()?;
-    if !metadata.file_type().is_file() || metadata.len() > max_bytes {
-        return None;
-    }
-    read_ghostty_limited_string(file, max_bytes)
-}
-
-fn read_ghostty_limited_string(reader: impl Read, max_bytes: u64) -> Option<String> {
-    let mut text = String::new();
-    reader.take(max_bytes.saturating_add(1)).read_to_string(&mut text).ok()?;
-    if text.len() as u64 > max_bytes {
-        return None;
-    }
-    Some(text)
-}
-
-fn resolve_ghostty_theme_path(
-    theme: &str,
-    base_dir: Option<&Path>,
-    theme_dirs: &[PathBuf],
-) -> Option<PathBuf> {
-    if let Some(path) = expand_home_relative_path(theme) {
-        return Some(path);
-    }
-    let path = Path::new(theme);
-    if path.is_absolute() {
-        return Some(path.to_path_buf());
-    }
-    if path.file_name().is_some_and(|name| name == theme) {
-        return theme_dirs.iter().map(|dir| dir.join(theme)).find(|path| path.is_file());
-    }
-    base_dir.map(|base_dir| base_dir.join(path))
-}
-
-fn expand_home_relative_path(value: &str) -> Option<PathBuf> {
-    let home = platform::home_dir()?;
-    match value {
-        "~" => Some(home),
-        value => value.strip_prefix("~/").map(|rest| home.join(rest)),
-    }
-}
-
-fn selected_ghostty_theme<'a>(
-    value: &'a str,
-    deadline_at: Option<Instant>,
-    theme_mode: &mut Option<GhosttyThemeMode>,
-) -> &'a str {
-    let Some((light, dark)) = conditional_ghostty_themes(value) else {
-        return value;
     };
-    let mode = *theme_mode.get_or_insert_with(|| system_ghostty_theme_mode(deadline_at));
-    match mode {
-        GhosttyThemeMode::Light => light,
-        GhosttyThemeMode::Dark => dark,
-    }
-}
-
-fn conditional_ghostty_themes(value: &str) -> Option<(&str, &str)> {
-    let mut light = None;
-    let mut dark = None;
-    for part in value.split(',') {
-        let (key, theme) = part.split_once(':').or_else(|| part.split_once('='))?;
-        let theme = theme.trim();
-        match key.trim() {
-            "light" if !theme.is_empty() => light = Some(theme),
-            "dark" if !theme.is_empty() => dark = Some(theme),
-            _ => return None,
-        }
-    }
-    Some((light?, dark?))
+    let text = std::fs::read_to_string(path).ok()?;
+    Some(parse_resolved_ghostty_defaults(&text))
 }
 
 fn overlay_ghostty_defaults(defaults: &mut DefaultColors, overrides: DefaultColors) {
@@ -5576,62 +2387,12 @@ fn overlay_ghostty_defaults(defaults: &mut DefaultColors, overrides: DefaultColo
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::cell::{Cell, RefCell};
-
-    #[test]
-    fn config_diagnostics_do_not_echo_parser_details() {
-        let error = serde_json::from_str::<RawConfig>(r#"{"typo":true}"#).unwrap_err();
-        let diagnostic = config_diagnostic(&error);
-        assert!(diagnostic.contains("unknown config field"));
-        assert!(!diagnostic.contains("typo"));
-    }
     use std::ffi::OsString;
     use std::sync::Mutex;
-    use std::sync::atomic::{AtomicU64, Ordering};
 
     /// Config env vars are process-global state; tests that set them must not
     /// run concurrently with each other.
     static CONFIG_ENV_LOCK: Mutex<()> = Mutex::new(());
-
-    #[test]
-    fn startup_snapshot_invokes_loader_once() {
-        let loads = Cell::new(0);
-        let snapshot = StartupConfigSnapshot::from_loader(|| {
-            loads.set(loads.get() + 1);
-            Config::default()
-        });
-
-        assert!(snapshot.server.detached_owner);
-        assert!(snapshot.server.detached_owner);
-        let _config = snapshot.into_config();
-        assert_eq!(loads.get(), 1);
-    }
-    static NEXT_TEST_DIRECTORY: AtomicU64 = AtomicU64::new(0);
-
-    struct TestDirectory {
-        path: PathBuf,
-    }
-
-    impl TestDirectory {
-        fn new(label: &str) -> Self {
-            loop {
-                let sequence = NEXT_TEST_DIRECTORY.fetch_add(1, Ordering::Relaxed);
-                let path = std::env::temp_dir()
-                    .join(format!("cmux-tui-config-{label}-{}-{sequence}", std::process::id()));
-                match std::fs::create_dir(&path) {
-                    Ok(()) => return Self { path },
-                    Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
-                    Err(error) => panic!("create config test directory failed: {error}"),
-                }
-            }
-        }
-    }
-
-    impl Drop for TestDirectory {
-        fn drop(&mut self) {
-            let _ = std::fs::remove_dir_all(&self.path);
-        }
-    }
 
     fn restore_env_var(key: &str, value: Option<OsString>) {
         match value {
@@ -5639,15 +2400,6 @@ mod tests {
             Some(value) => unsafe { std::env::set_var(key, value) },
             None => unsafe { std::env::remove_var(key) },
         }
-    }
-
-    fn assert_committed(outcome: ConfigWriteOutcome) {
-        assert!(matches!(
-            outcome,
-            ConfigWriteOutcome::Committed
-                | ConfigWriteOutcome::CommittedWithoutDirectorySync
-                | ConfigWriteOutcome::CommittedButUnsynced { .. }
-        ));
     }
 
     #[test]
@@ -5685,9 +2437,6 @@ mod tests {
         );
         assert_eq!(quoted.cursor_style, Some(CursorShape::Bar));
         assert_eq!(quoted.cursor_blink, Some(false));
-
-        let hollow = parse_ghostty_defaults("cursor-style = block_hollow\n");
-        assert_eq!(hollow.cursor_style, Some(CursorShape::BlockHollow));
     }
 
     #[test]
@@ -5727,6 +2476,20 @@ mod tests {
         assert_eq!(defaults.palette[15], Some(Rgb { r: 0xab, g: 0xcd, b: 0xef }));
         assert!(defaults.palette[2..15].iter().all(Option::is_none));
         assert!(defaults.palette[16..].iter().all(Option::is_none));
+    }
+
+    #[test]
+    fn parses_ghostty_scrollback_limit_with_later_valid_entry_wins() {
+        assert_eq!(
+            parse_scrollback_limit_bytes(
+                "scrollback-limit = 4_000_000\n\
+                 scrollback-limit = invalid\n\
+                 scrollback-limit = 50_000_000\n"
+            ),
+            Some(50_000_000)
+        );
+        assert_eq!(parse_scrollback_limit_bytes("scrollback-limit = -1\n"), None);
+        assert_eq!(Config::default().scrollback_limit_bytes(), DEFAULT_SCROLLBACK_LIMIT_BYTES);
     }
 
     #[test]
@@ -5780,14 +2543,11 @@ mod tests {
         .unwrap();
         std::fs::set_permissions(&binary, std::fs::Permissions::from_mode(0o700)).unwrap();
 
-        let output = ghostty_show_config_command(&platform::GhosttyInstallation {
-            binary,
-            resources_dir: Some(resources.clone()),
-        })
-        .output()
+        let output = run_ghostty_show_config(
+            &platform::GhosttyInstallation { binary, resources_dir: Some(resources.clone()) },
+            false,
+        )
         .unwrap();
-        assert!(output.status.success());
-        let output = String::from_utf8(output.stdout).unwrap();
         assert!(output.contains(&format!("resource-path = {}", resources.display())));
         let defaults = parse_resolved_ghostty_defaults(&output);
         assert_eq!(defaults.bg, Some(Rgb { r: 0x27, g: 0x28, b: 0x22 }));
@@ -5797,63 +2557,34 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn ghostty_resolver_drains_output_while_the_child_is_running() {
+    fn unusable_packaged_ghostty_resolver_falls_through() {
         use std::os::unix::fs::PermissionsExt;
 
         let root = std::env::temp_dir().join(format!(
-            "cmux-tui-ghostty-large-output-{}-{}",
+            "cmux-tui-ghostty-fallback-{}-{}",
             std::process::id(),
             SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
         ));
-        let binary = root.join("ghostty-config-helper");
         std::fs::create_dir_all(&root).unwrap();
+        let broken = root.join("copied-app-binary");
+        let working = root.join("standalone-cli-helper");
+        std::fs::write(&broken, "#!/bin/sh\nexit 0\n").unwrap();
         std::fs::write(
-            &binary,
-            "#!/bin/sh\n\
-             i=0\n\
-             while [ \"$i\" -lt 2048 ]; do\n\
-               printf 'palette = 1=#010203\\n'\n\
-               i=$((i + 1))\n\
-             done\n\
-             printf 'background = #272822\\nforeground = #fdfff1\\n'\n",
+            &working,
+            "#!/bin/sh\nif [ \"$2\" = \"--default\" ]; then\n  printf 'scrollback-limit = 4000000\\n'\nelse\n  printf 'background = #272822\\nforeground = #fdfff1\\n'\nfi\n",
         )
         .unwrap();
-        std::fs::set_permissions(&binary, std::fs::Permissions::from_mode(0o700)).unwrap();
+        std::fs::set_permissions(&working, std::fs::Permissions::from_mode(0o700)).unwrap();
 
-        let mut command = Command::new(&binary);
-        command.stdout(Stdio::piped()).stderr(Stdio::null());
-        let defaults = match ghostty_defaults_from_helper_command(command, Duration::from_secs(2)) {
-            GhosttyHelperDefaults::Resolved(defaults) => defaults,
-            GhosttyHelperDefaults::Unavailable => panic!("helper output was not parsed"),
-            GhosttyHelperDefaults::TimedOut => panic!("helper output timed out"),
-        };
-        assert_eq!(defaults.bg, Some(Rgb { r: 0x27, g: 0x28, b: 0x22 }));
-        assert_eq!(defaults.fg, Some(Rgb { r: 0xfd, g: 0xff, b: 0xf1 }));
-        let _ = std::fs::remove_dir_all(root);
-    }
-
-    #[test]
-    fn unusable_packaged_ghostty_resolver_falls_through() {
-        let broken = PathBuf::from("/cmux-test/copied-app-binary");
-        let working = PathBuf::from("/cmux-test/standalone-cli-helper");
-        let installations = [
-            platform::GhosttyInstallation { binary: broken.clone(), resources_dir: None },
-            platform::GhosttyInstallation { binary: working.clone(), resources_dir: None },
-        ];
-        let mut visited = Vec::new();
-        let defaults = resolved_ghostty_defaults_from_with(&installations, |installation| {
-            visited.push(installation.binary.clone());
-            if installation.binary == broken {
-                Some(String::new())
-            } else {
-                Some("background = #272822\nforeground = #fdfff1\n".to_owned())
-            }
-        })
+        let defaults = resolved_ghostty_defaults_from(&[
+            platform::GhosttyInstallation { binary: broken, resources_dir: None },
+            platform::GhosttyInstallation { binary: working, resources_dir: None },
+        ])
         .unwrap();
-
-        assert_eq!(visited, vec![broken, working]);
-        assert_eq!(defaults.bg, Some(Rgb { r: 0x27, g: 0x28, b: 0x22 }));
-        assert_eq!(defaults.fg, Some(Rgb { r: 0xfd, g: 0xff, b: 0xf1 }));
+        assert_eq!(defaults.colors.bg, Some(Rgb { r: 0x27, g: 0x28, b: 0x22 }));
+        assert_eq!(defaults.colors.fg, Some(Rgb { r: 0xfd, g: 0xff, b: 0xf1 }));
+        assert_eq!(defaults.scrollback_limit_bytes, Some(4_000_000));
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]
@@ -5918,12 +2649,7 @@ mod tests {
         );
         mux.set_default_colors(defaults);
         let surface = mux.new_workspace(None, Some((20, 4))).unwrap();
-        surface
-            .try_with_terminal(|term| {
-                term.vt_write(b"\x1b[31mR");
-                term.vt_write(b"\x1b_Ga=T,t=d,f=32,i=75,p=1,s=1,v=1,c=1,r=1,q=2;/wAAfw==\x1b\\");
-            })
-            .unwrap();
+        surface.try_with_terminal(|term| term.vt_write(b"\x1b[31mR")).unwrap();
         // Re-applying through the mux exercises the existing-surface path and
         // publishes a fresh immutable render frame for the protocol server.
         mux.set_default_colors(defaults);
@@ -5957,10 +2683,6 @@ mod tests {
             .find(|run| run["text"].as_str().is_some_and(|text| text.contains('R')))
             .expect("configured palette run");
         assert_eq!(red_run["fg"], "#445566");
-        assert_eq!(state["graphics"]["images"][0]["id"], 75);
-        assert_eq!(state["graphics"]["images"][0]["format"], "rgba");
-        assert_eq!(state["graphics"]["images"][0]["data"], "/wAAfw==");
-        assert_eq!(state["graphics"]["placements"][0]["image_id"], 75);
 
         let colors = surface.attach_stream().unwrap().colors;
         assert_eq!(colors.selection_bg, Some(Rgb { r: 0x22, g: 0x33, b: 0x44 }));
@@ -6070,1437 +2792,6 @@ mod tests {
         assert_eq!(config.terminal_defaults.palette[1], Some(Rgb { r: 0x77, g: 0x88, b: 0x99 }));
     }
 
-    #[cfg(unix)]
-    #[test]
-    fn load_uses_file_ghostty_defaults_without_invoking_external_resolver() {
-        use std::os::unix::fs::PermissionsExt;
-
-        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
-        let old_ghostty_bin = std::env::var_os("GHOSTTY_BIN");
-        let old_ghostty_resources = std::env::var_os("GHOSTTY_RESOURCES_DIR");
-        let old_cmux_tui_config = std::env::var_os("CMUX_TUI_CONFIG");
-        let old_mux_config = std::env::var_os("CMUX_MUX_CONFIG");
-        let old_xdg_config_home = std::env::var_os("XDG_CONFIG_HOME");
-        let old_apple_interface_style = std::env::var_os("AppleInterfaceStyle");
-        let dir = std::env::temp_dir()
-            .join(format!("mux-ghostty-startup-file-only-{}", std::process::id()));
-        let ghostty_dir = dir.join("ghostty");
-        let marker = dir.join("resolver-ran");
-        let resolver = dir.join("ghostty-resolver");
-        std::fs::create_dir_all(&ghostty_dir).unwrap();
-        std::fs::write(ghostty_dir.join("config"), "foreground = #010203\n").unwrap();
-        std::fs::write(
-            &resolver,
-            format!(
-                "#!/bin/sh\n\
-                 printf marker > '{}'\n\
-                 printf 'foreground = #aabbcc\\nbackground = #ddeeff\\n'\n",
-                marker.display()
-            ),
-        )
-        .unwrap();
-        std::fs::set_permissions(&resolver, std::fs::Permissions::from_mode(0o700)).unwrap();
-        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
-        unsafe { std::env::set_var("GHOSTTY_BIN", &resolver) };
-        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
-        unsafe { std::env::remove_var("GHOSTTY_RESOURCES_DIR") };
-        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
-        unsafe { std::env::remove_var("CMUX_TUI_CONFIG") };
-        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
-        unsafe { std::env::remove_var("CMUX_MUX_CONFIG") };
-        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
-        unsafe { std::env::set_var("XDG_CONFIG_HOME", &dir) };
-        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
-        unsafe { std::env::set_var("AppleInterfaceStyle", "Light") };
-
-        let config = load();
-
-        restore_env_var("GHOSTTY_BIN", old_ghostty_bin);
-        restore_env_var("GHOSTTY_RESOURCES_DIR", old_ghostty_resources);
-        restore_env_var("CMUX_TUI_CONFIG", old_cmux_tui_config);
-        restore_env_var("CMUX_MUX_CONFIG", old_mux_config);
-        restore_env_var("XDG_CONFIG_HOME", old_xdg_config_home);
-        restore_env_var("AppleInterfaceStyle", old_apple_interface_style);
-        let resolver_ran = marker.exists();
-        let _ = std::fs::remove_dir_all(&dir);
-
-        assert!(!resolver_ran, "config load must not run ghostty +show-config at startup");
-        assert_eq!(config.terminal_defaults.fg, Some(Rgb { r: 1, g: 2, b: 3 }));
-        assert_eq!(config.terminal_defaults.bg, None);
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn load_resolves_ghostty_resource_theme_without_invoking_external_resolver() {
-        use std::os::unix::fs::PermissionsExt;
-
-        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
-        let old_ghostty_bin = std::env::var_os("GHOSTTY_BIN");
-        let old_ghostty_resources = std::env::var_os("GHOSTTY_RESOURCES_DIR");
-        let old_cmux_tui_config = std::env::var_os("CMUX_TUI_CONFIG");
-        let old_mux_config = std::env::var_os("CMUX_MUX_CONFIG");
-        let old_xdg_config_home = std::env::var_os("XDG_CONFIG_HOME");
-        let old_apple_interface_style = std::env::var_os("AppleInterfaceStyle");
-        let dir = std::env::temp_dir()
-            .join(format!("mux-ghostty-startup-resource-theme-{}", std::process::id()));
-        let ghostty_dir = dir.join("ghostty");
-        let resources = dir.join("resources");
-        let themes = resources.join("themes");
-        let marker = dir.join("resolver-ran");
-        let resolver = dir.join("ghostty-resolver");
-        std::fs::create_dir_all(&ghostty_dir).unwrap();
-        std::fs::create_dir_all(&themes).unwrap();
-        std::fs::write(
-            ghostty_dir.join("config"),
-            "window-theme = light\n\
-             theme = dark:Dark Resource Theme, light:Light Resource Theme\n\
-             background = #444444\n",
-        )
-        .unwrap();
-        std::fs::write(
-            themes.join("Light Resource Theme"),
-            "foreground = #111111\nbackground = #222222\npalette = 1=#333333\n",
-        )
-        .unwrap();
-        std::fs::write(
-            themes.join("Dark Resource Theme"),
-            "foreground = #aaaaaa\nbackground = #bbbbbb\npalette = 1=#cccccc\n",
-        )
-        .unwrap();
-        std::fs::write(
-            &resolver,
-            format!(
-                "#!/bin/sh\n\
-                 printf marker > '{}'\n\
-                 printf 'foreground = #ddeeff\\nbackground = #000000\\n'\n",
-                marker.display()
-            ),
-        )
-        .unwrap();
-        std::fs::set_permissions(&resolver, std::fs::Permissions::from_mode(0o700)).unwrap();
-        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
-        unsafe { std::env::set_var("GHOSTTY_BIN", &resolver) };
-        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
-        unsafe { std::env::set_var("GHOSTTY_RESOURCES_DIR", &resources) };
-        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
-        unsafe { std::env::remove_var("CMUX_TUI_CONFIG") };
-        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
-        unsafe { std::env::remove_var("CMUX_MUX_CONFIG") };
-        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
-        unsafe { std::env::set_var("XDG_CONFIG_HOME", &dir) };
-        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
-        unsafe { std::env::set_var("AppleInterfaceStyle", "Light") };
-        let theme_dirs = platform::ghostty_theme_dirs();
-        assert!(theme_dirs.contains(&themes), "{theme_dirs:?}");
-
-        let config = load();
-
-        restore_env_var("GHOSTTY_BIN", old_ghostty_bin);
-        restore_env_var("GHOSTTY_RESOURCES_DIR", old_ghostty_resources);
-        restore_env_var("CMUX_TUI_CONFIG", old_cmux_tui_config);
-        restore_env_var("CMUX_MUX_CONFIG", old_mux_config);
-        restore_env_var("XDG_CONFIG_HOME", old_xdg_config_home);
-        restore_env_var("AppleInterfaceStyle", old_apple_interface_style);
-        let resolver_ran = marker.exists();
-        let _ = std::fs::remove_dir_all(&dir);
-
-        assert!(!resolver_ran, "config load must not run ghostty +show-config at startup");
-        assert_eq!(config.terminal_defaults.fg, Some(Rgb { r: 0x11, g: 0x11, b: 0x11 }));
-        assert_eq!(config.terminal_defaults.bg, Some(Rgb { r: 0x44, g: 0x44, b: 0x44 }));
-        assert_eq!(config.terminal_defaults.palette[1], Some(Rgb { r: 0x33, g: 0x33, b: 0x33 }));
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn load_applies_ghostty_config_file_after_root_and_respects_dark_theme_mode() {
-        use std::os::unix::fs::PermissionsExt;
-
-        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
-        let old_ghostty_bin = std::env::var_os("GHOSTTY_BIN");
-        let old_ghostty_resources = std::env::var_os("GHOSTTY_RESOURCES_DIR");
-        let old_cmux_tui_config = std::env::var_os("CMUX_TUI_CONFIG");
-        let old_mux_config = std::env::var_os("CMUX_MUX_CONFIG");
-        let old_xdg_config_home = std::env::var_os("XDG_CONFIG_HOME");
-        let old_apple_interface_style = std::env::var_os("AppleInterfaceStyle");
-        let dir = std::env::temp_dir()
-            .join(format!("mux-ghostty-startup-include-theme-{}", std::process::id()));
-        let ghostty_dir = dir.join("ghostty");
-        let resources = dir.join("resources");
-        let themes = resources.join("themes");
-        let marker = dir.join("resolver-ran");
-        let resolver = dir.join("ghostty-resolver");
-        std::fs::create_dir_all(&ghostty_dir).unwrap();
-        std::fs::create_dir_all(&themes).unwrap();
-        std::fs::write(
-            ghostty_dir.join("config"),
-            "foreground = #010101\n\
-             config-file = colors.conf\n\
-             background = #020202\n",
-        )
-        .unwrap();
-        std::fs::write(
-            ghostty_dir.join("colors.conf"),
-            "window-theme = dark\n\
-             theme = light:Light Include Theme,dark:Dark Include Theme\n\
-             background = #444444\n",
-        )
-        .unwrap();
-        std::fs::write(
-            themes.join("Light Include Theme"),
-            "foreground = #111111\nbackground = #222222\npalette = 1=#333333\n",
-        )
-        .unwrap();
-        std::fs::write(
-            themes.join("Dark Include Theme"),
-            "foreground = #aaaaaa\nbackground = #bbbbbb\npalette = 1=#cccccc\n",
-        )
-        .unwrap();
-        std::fs::write(
-            &resolver,
-            format!(
-                "#!/bin/sh\n\
-                 printf marker > '{}'\n\
-                 printf 'foreground = #ddeeff\\nbackground = #000000\\n'\n",
-                marker.display()
-            ),
-        )
-        .unwrap();
-        std::fs::set_permissions(&resolver, std::fs::Permissions::from_mode(0o700)).unwrap();
-        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
-        unsafe { std::env::set_var("GHOSTTY_BIN", &resolver) };
-        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
-        unsafe { std::env::set_var("GHOSTTY_RESOURCES_DIR", &resources) };
-        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
-        unsafe { std::env::remove_var("CMUX_TUI_CONFIG") };
-        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
-        unsafe { std::env::remove_var("CMUX_MUX_CONFIG") };
-        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
-        unsafe { std::env::set_var("XDG_CONFIG_HOME", &dir) };
-        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
-        unsafe { std::env::set_var("AppleInterfaceStyle", "Dark") };
-
-        let config = load();
-
-        restore_env_var("GHOSTTY_BIN", old_ghostty_bin);
-        restore_env_var("GHOSTTY_RESOURCES_DIR", old_ghostty_resources);
-        restore_env_var("CMUX_TUI_CONFIG", old_cmux_tui_config);
-        restore_env_var("CMUX_MUX_CONFIG", old_mux_config);
-        restore_env_var("XDG_CONFIG_HOME", old_xdg_config_home);
-        restore_env_var("AppleInterfaceStyle", old_apple_interface_style);
-        let resolver_ran = marker.exists();
-        let _ = std::fs::remove_dir_all(&dir);
-
-        assert!(!resolver_ran, "config load must not run ghostty +show-config at startup");
-        assert_eq!(config.terminal_defaults.fg, Some(Rgb { r: 0x01, g: 0x01, b: 0x01 }));
-        assert_eq!(config.terminal_defaults.bg, Some(Rgb { r: 0x44, g: 0x44, b: 0x44 }));
-        assert_eq!(config.terminal_defaults.palette[1], Some(Rgb { r: 0xcc, g: 0xcc, b: 0xcc }));
-    }
-
-    #[test]
-    fn ghostty_fallback_theme_selection_skips_unreadable_themes() {
-        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
-        let dir = std::env::temp_dir().join(format!(
-            "cmux-tui-ghostty-theme-missing-{}-{}",
-            std::process::id(),
-            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
-        std::fs::write(
-            dir.join("Readable Theme"),
-            "background = #101112\nforeground = #131415\npalette = 1=#161718\n",
-        )
-        .unwrap();
-
-        let defaults = parse_ghostty_defaults_with_theme_dirs(
-            "theme = Missing Theme\n\
-             theme = Readable Theme\n",
-            std::slice::from_ref(&dir),
-        );
-
-        let _ = std::fs::remove_dir_all(dir);
-
-        assert_eq!(defaults.bg, Some(Rgb { r: 0x10, g: 0x11, b: 0x12 }));
-        assert_eq!(defaults.fg, Some(Rgb { r: 0x13, g: 0x14, b: 0x15 }));
-        assert_eq!(defaults.palette[1], Some(Rgb { r: 0x16, g: 0x17, b: 0x18 }));
-    }
-
-    #[test]
-    fn ghostty_included_config_cannot_replace_successful_root_theme() {
-        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
-        let dir = std::env::temp_dir().join(format!(
-            "cmux-tui-ghostty-theme-include-first-{}-{}",
-            std::process::id(),
-            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
-        ));
-        let ghostty_dir = dir.join("ghostty");
-        let themes = dir.join("themes");
-        std::fs::create_dir_all(&ghostty_dir).unwrap();
-        std::fs::create_dir_all(&themes).unwrap();
-        std::fs::write(
-            ghostty_dir.join("config"),
-            "window-theme = light\n\
-             theme = Root Theme\n\
-             config-file = colors.conf\n",
-        )
-        .unwrap();
-        std::fs::write(
-            ghostty_dir.join("colors.conf"),
-            "theme = Include Theme\n\
-             foreground = #303132\n",
-        )
-        .unwrap();
-        std::fs::write(
-            themes.join("Root Theme"),
-            "background = #202122\nforeground = #232425\npalette = 1=#262728\n",
-        )
-        .unwrap();
-        std::fs::write(
-            themes.join("Include Theme"),
-            "background = #909192\nforeground = #939495\npalette = 1=#969798\n",
-        )
-        .unwrap();
-
-        let defaults = parse_ghostty_defaults_from_path(&ghostty_dir.join("config"), &[themes])
-            .expect("config parses");
-
-        let _ = std::fs::remove_dir_all(dir);
-
-        assert_eq!(defaults.bg, Some(Rgb { r: 0x20, g: 0x21, b: 0x22 }));
-        assert_eq!(defaults.fg, Some(Rgb { r: 0x30, g: 0x31, b: 0x32 }));
-        assert_eq!(defaults.palette[1], Some(Rgb { r: 0x26, g: 0x27, b: 0x28 }));
-    }
-
-    #[test]
-    fn ghostty_parent_explicit_color_wins_over_theme_loaded_by_include() {
-        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
-        let dir = std::env::temp_dir().join(format!(
-            "cmux-tui-ghostty-theme-include-overrides-{}-{}",
-            std::process::id(),
-            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
-        ));
-        let ghostty_dir = dir.join("ghostty");
-        let themes = dir.join("themes");
-        std::fs::create_dir_all(&ghostty_dir).unwrap();
-        std::fs::create_dir_all(&themes).unwrap();
-        std::fs::write(
-            ghostty_dir.join("config"),
-            "window-theme = dark\n\
-             foreground = #010203\n\
-             config-file = colors.conf\n",
-        )
-        .unwrap();
-        std::fs::write(ghostty_dir.join("colors.conf"), "theme = Include Theme\n").unwrap();
-        std::fs::write(
-            themes.join("Include Theme"),
-            "background = #202122\nforeground = #a0a1a2\npalette = 1=#232425\n",
-        )
-        .unwrap();
-
-        let defaults = parse_ghostty_defaults_from_path(&ghostty_dir.join("config"), &[themes])
-            .expect("config parses");
-
-        let _ = std::fs::remove_dir_all(dir);
-
-        assert_eq!(defaults.fg, Some(Rgb { r: 0x01, g: 0x02, b: 0x03 }));
-        assert_eq!(defaults.bg, Some(Rgb { r: 0x20, g: 0x21, b: 0x22 }));
-        assert_eq!(defaults.palette[1], Some(Rgb { r: 0x23, g: 0x24, b: 0x25 }));
-    }
-
-    #[test]
-    fn ghostty_included_window_theme_does_not_control_parent_conditional_theme() {
-        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
-        let old_apple_interface_style = std::env::var_os("AppleInterfaceStyle");
-        let dir = std::env::temp_dir().join(format!(
-            "cmux-tui-ghostty-theme-include-window-theme-{}-{}",
-            std::process::id(),
-            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
-        ));
-        let ghostty_dir = dir.join("ghostty");
-        let themes = dir.join("themes");
-        std::fs::create_dir_all(&ghostty_dir).unwrap();
-        std::fs::create_dir_all(&themes).unwrap();
-        std::fs::write(
-            ghostty_dir.join("config"),
-            "theme = light:Root Light Theme,dark:Root Dark Theme\n\
-             config-file = colors.conf\n",
-        )
-        .unwrap();
-        std::fs::write(ghostty_dir.join("colors.conf"), "window-theme = dark\n").unwrap();
-        std::fs::write(
-            themes.join("Root Light Theme"),
-            "background = #f0f1f2\nforeground = #f3f4f5\npalette = 1=#f6f7f8\n",
-        )
-        .unwrap();
-        std::fs::write(
-            themes.join("Root Dark Theme"),
-            "background = #101112\nforeground = #131415\npalette = 1=#161718\n",
-        )
-        .unwrap();
-        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
-        unsafe { std::env::set_var("AppleInterfaceStyle", "Light") };
-
-        let defaults = parse_ghostty_defaults_from_path(&ghostty_dir.join("config"), &[themes])
-            .expect("config parses");
-
-        restore_env_var("AppleInterfaceStyle", old_apple_interface_style);
-        let _ = std::fs::remove_dir_all(dir);
-
-        assert_eq!(defaults.bg, Some(Rgb { r: 0xf0, g: 0xf1, b: 0xf2 }));
-        assert_eq!(defaults.fg, Some(Rgb { r: 0xf3, g: 0xf4, b: 0xf5 }));
-        assert_eq!(defaults.palette[1], Some(Rgb { r: 0xf6, g: 0xf7, b: 0xf8 }));
-    }
-
-    #[test]
-    fn ghostty_window_theme_does_not_control_conditional_terminal_theme() {
-        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
-        let old_apple_interface_style = std::env::var_os("AppleInterfaceStyle");
-        let dir = std::env::temp_dir().join(format!(
-            "cmux-tui-ghostty-invalid-window-theme-{}-{}",
-            std::process::id(),
-            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
-        std::fs::write(
-            dir.join("Light Theme"),
-            "background = #f0f1f2\nforeground = #f3f4f5\npalette = 1=#f6f7f8\n",
-        )
-        .unwrap();
-        std::fs::write(
-            dir.join("Dark Theme"),
-            "background = #101112\nforeground = #131415\npalette = 1=#161718\n",
-        )
-        .unwrap();
-        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
-        unsafe { std::env::set_var("AppleInterfaceStyle", "Light") };
-
-        let defaults = parse_ghostty_defaults_with_theme_dirs(
-            "window-theme = dark\n\
-             window-theme = drak\n\
-             theme = light:Light Theme,dark:Dark Theme\n",
-            std::slice::from_ref(&dir),
-        );
-
-        restore_env_var("AppleInterfaceStyle", old_apple_interface_style);
-        let _ = std::fs::remove_dir_all(dir);
-
-        assert_eq!(defaults.bg, Some(Rgb { r: 0xf0, g: 0xf1, b: 0xf2 }));
-        assert_eq!(defaults.fg, Some(Rgb { r: 0xf3, g: 0xf4, b: 0xf5 }));
-        assert_eq!(defaults.palette[1], Some(Rgb { r: 0xf6, g: 0xf7, b: 0xf8 }));
-    }
-
-    #[test]
-    fn ghostty_config_file_expands_required_and_optional_home_relative_paths() {
-        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
-        let old_home = std::env::var_os("HOME");
-        let dir = std::env::temp_dir().join(format!(
-            "cmux-tui-ghostty-home-include-{}-{}",
-            std::process::id(),
-            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
-        ));
-        let home = dir.join("home");
-        let ghostty_dir = dir.join("ghostty");
-        let include_dir = home.join(".config").join("ghostty");
-        std::fs::create_dir_all(&ghostty_dir).unwrap();
-        std::fs::create_dir_all(&include_dir).unwrap();
-        std::fs::write(
-            ghostty_dir.join("config"),
-            "config-file = ~/.config/ghostty/colors.conf\n\
-             config-file = ?~/.config/ghostty/missing.conf\n",
-        )
-        .unwrap();
-        std::fs::write(
-            include_dir.join("colors.conf"),
-            "foreground = #010203\nbackground = #040506\n",
-        )
-        .unwrap();
-        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
-        unsafe { std::env::set_var("HOME", &home) };
-
-        let defaults = parse_ghostty_defaults_from_path(&ghostty_dir.join("config"), &[])
-            .expect("config parses");
-
-        restore_env_var("HOME", old_home);
-        let _ = std::fs::remove_dir_all(dir);
-
-        assert_eq!(defaults.fg, Some(Rgb { r: 0x01, g: 0x02, b: 0x03 }));
-        assert_eq!(defaults.bg, Some(Rgb { r: 0x04, g: 0x05, b: 0x06 }));
-    }
-
-    #[test]
-    fn ghostty_relative_theme_path_uses_declaring_config_directory() {
-        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
-        let dir = std::env::temp_dir().join(format!(
-            "cmux-tui-ghostty-relative-theme-{}-{}",
-            std::process::id(),
-            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
-        ));
-        let ghostty_dir = dir.join("ghostty");
-        let nested_dir = ghostty_dir.join("nested");
-        let nested_themes = nested_dir.join("themes");
-        std::fs::create_dir_all(&nested_themes).unwrap();
-        std::fs::write(ghostty_dir.join("config"), "config-file = nested/colors.conf\n").unwrap();
-        std::fs::write(nested_dir.join("colors.conf"), "theme = ./themes/custom\n").unwrap();
-        std::fs::write(
-            nested_themes.join("custom"),
-            "foreground = #111213\nbackground = #141516\npalette = 1=#171819\n",
-        )
-        .unwrap();
-
-        let defaults = parse_ghostty_defaults_from_path(&ghostty_dir.join("config"), &[])
-            .expect("config parses");
-
-        let _ = std::fs::remove_dir_all(dir);
-
-        assert_eq!(defaults.fg, Some(Rgb { r: 0x11, g: 0x12, b: 0x13 }));
-        assert_eq!(defaults.bg, Some(Rgb { r: 0x14, g: 0x15, b: 0x16 }));
-        assert_eq!(defaults.palette[1], Some(Rgb { r: 0x17, g: 0x18, b: 0x19 }));
-    }
-
-    #[test]
-    fn ghostty_config_file_skips_non_regular_includes() {
-        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
-        let dir = std::env::temp_dir().join(format!(
-            "cmux-tui-ghostty-nonregular-include-{}-{}",
-            std::process::id(),
-            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
-        ));
-        let ghostty_dir = dir.join("ghostty");
-        std::fs::create_dir_all(ghostty_dir.join("not-a-file")).unwrap();
-        std::fs::write(
-            ghostty_dir.join("config"),
-            "config-file = not-a-file\n\
-             config-file = colors.conf\n",
-        )
-        .unwrap();
-        std::fs::write(ghostty_dir.join("colors.conf"), "foreground = #010203\n").unwrap();
-
-        let defaults = parse_ghostty_defaults_from_path(&ghostty_dir.join("config"), &[])
-            .expect("config parses");
-
-        let _ = std::fs::remove_dir_all(dir);
-
-        assert_eq!(defaults.fg, Some(Rgb { r: 0x01, g: 0x02, b: 0x03 }));
-    }
-
-    #[test]
-    fn ghostty_config_file_depth_limit_bounds_include_chain() {
-        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
-        let dir = std::env::temp_dir().join(format!(
-            "cmux-tui-ghostty-depth-limit-{}-{}",
-            std::process::id(),
-            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
-        ));
-        let ghostty_dir = dir.join("ghostty");
-        std::fs::create_dir_all(&ghostty_dir).unwrap();
-        for index in 0..=(GHOSTTY_CONFIG_MAX_DEPTH + 2) {
-            let color = 0x10 + index as u8;
-            let include = if index < GHOSTTY_CONFIG_MAX_DEPTH + 2 {
-                format!("config-file = file{}.conf\n", index + 1)
-            } else {
-                String::new()
-            };
-            std::fs::write(
-                ghostty_dir.join(format!("file{index}.conf")),
-                format!("foreground = #{color:02x}{color:02x}{color:02x}\n{include}"),
-            )
-            .unwrap();
-        }
-
-        let defaults = parse_ghostty_defaults_from_path(&ghostty_dir.join("file0.conf"), &[])
-            .expect("config parses");
-
-        let _ = std::fs::remove_dir_all(dir);
-        let color = 0x10 + GHOSTTY_CONFIG_MAX_DEPTH as u8;
-
-        assert_eq!(defaults.fg, Some(Rgb { r: color, g: color, b: color }));
-    }
-
-    #[test]
-    fn ghostty_config_file_count_limit_bounds_broad_include_graph() {
-        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
-        let dir = std::env::temp_dir().join(format!(
-            "cmux-tui-ghostty-file-count-limit-{}-{}",
-            std::process::id(),
-            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
-        ));
-        let ghostty_dir = dir.join("ghostty");
-        std::fs::create_dir_all(&ghostty_dir).unwrap();
-        let include_count = GHOSTTY_CONFIG_MAX_FILES + 2;
-        let mut root = String::new();
-        for index in 0..include_count {
-            root.push_str(&format!("config-file = colors{index}.conf\n"));
-            let color = 0x10 + index as u8;
-            std::fs::write(
-                ghostty_dir.join(format!("colors{index}.conf")),
-                format!("foreground = #{color:02x}{color:02x}{color:02x}\n"),
-            )
-            .unwrap();
-        }
-        std::fs::write(ghostty_dir.join("config"), root).unwrap();
-
-        let defaults = parse_ghostty_defaults_from_path(&ghostty_dir.join("config"), &[])
-            .expect("config parses");
-
-        let _ = std::fs::remove_dir_all(dir);
-        let expected_index = GHOSTTY_CONFIG_MAX_FILES - 2;
-        let color = 0x10 + expected_index as u8;
-
-        assert_eq!(defaults.fg, Some(Rgb { r: color, g: color, b: color }));
-    }
-
-    #[test]
-    fn ghostty_config_file_size_limit_skips_oversized_includes() {
-        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
-        let dir = std::env::temp_dir().join(format!(
-            "cmux-tui-ghostty-size-limit-{}-{}",
-            std::process::id(),
-            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
-        ));
-        let ghostty_dir = dir.join("ghostty");
-        std::fs::create_dir_all(&ghostty_dir).unwrap();
-        std::fs::write(
-            ghostty_dir.join("config"),
-            "config-file = small.conf\n\
-             config-file = large.conf\n\
-             config-file = later.conf\n",
-        )
-        .unwrap();
-        std::fs::write(ghostty_dir.join("small.conf"), "foreground = #010203\n").unwrap();
-        std::fs::write(
-            ghostty_dir.join("large.conf"),
-            "background = #a0a1a2\n".repeat((GHOSTTY_CONFIG_MAX_BYTES as usize / 20) + 1),
-        )
-        .unwrap();
-        std::fs::write(ghostty_dir.join("later.conf"), "background = #040506\n").unwrap();
-
-        let defaults = parse_ghostty_defaults_from_path(&ghostty_dir.join("config"), &[])
-            .expect("config parses");
-
-        let _ = std::fs::remove_dir_all(dir);
-
-        assert_eq!(defaults.fg, Some(Rgb { r: 0x01, g: 0x02, b: 0x03 }));
-        assert_eq!(defaults.bg, Some(Rgb { r: 0x04, g: 0x05, b: 0x06 }));
-    }
-
-    #[test]
-    fn ghostty_config_parse_deadline_discards_partial_defaults() {
-        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
-        let dir = std::env::temp_dir().join(format!(
-            "cmux-tui-ghostty-deadline-{}-{}",
-            std::process::id(),
-            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
-        ));
-        let ghostty_dir = dir.join("ghostty");
-        std::fs::create_dir_all(&ghostty_dir).unwrap();
-        std::fs::write(
-            ghostty_dir.join("config"),
-            "background = #010203\nconfig-file = colors.conf\n",
-        )
-        .unwrap();
-        std::fs::write(ghostty_dir.join("colors.conf"), "foreground = #040506\n").unwrap();
-
-        let mut theme_candidates = Vec::new();
-        let outcome = parse_ghostty_config_file_with_deadline(
-            &ghostty_dir.join("config"),
-            &mut theme_candidates,
-            Duration::ZERO,
-        );
-        let full = parse_ghostty_defaults_from_path(&ghostty_dir.join("config"), &[])
-            .expect("config parses without deadline pressure");
-
-        let _ = std::fs::remove_dir_all(dir);
-
-        assert!(matches!(outcome, GhosttyConfigParseOutcome::TimedOut));
-        assert_eq!(full.bg, Some(Rgb { r: 0x01, g: 0x02, b: 0x03 }));
-        assert_eq!(full.fg, Some(Rgb { r: 0x04, g: 0x05, b: 0x06 }));
-    }
-
-    #[test]
-    fn ghostty_theme_deadline_keeps_parsed_overrides() {
-        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
-        let dir = std::env::temp_dir().join(format!(
-            "cmux-tui-ghostty-theme-deadline-{}-{}",
-            std::process::id(),
-            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
-        std::fs::write(
-            dir.join("Dark Budget Theme"),
-            "background = #101112\nforeground = #131415\npalette = 1=#161718\n",
-        )
-        .unwrap();
-        let overrides = DefaultColors {
-            fg: Some(Rgb { r: 0x01, g: 0x02, b: 0x03 }),
-            bg: Some(Rgb { r: 0x04, g: 0x05, b: 0x06 }),
-            ..Default::default()
-        };
-
-        let loaded = resolve_parsed_ghostty_defaults(
-            vec![GhosttyThemeCandidate { value: "Dark Budget Theme".to_string(), base_dir: None }],
-            std::slice::from_ref(&dir),
-            overrides,
-            None,
-        );
-        let expired = resolve_parsed_ghostty_defaults(
-            vec![GhosttyThemeCandidate { value: "Dark Budget Theme".to_string(), base_dir: None }],
-            std::slice::from_ref(&dir),
-            overrides,
-            Some(Instant::now().checked_sub(Duration::from_millis(1)).unwrap()),
-        );
-
-        let _ = std::fs::remove_dir_all(dir);
-
-        assert_eq!(loaded.palette[1], Some(Rgb { r: 0x16, g: 0x17, b: 0x18 }));
-        assert_eq!(expired.fg, Some(Rgb { r: 0x01, g: 0x02, b: 0x03 }));
-        assert_eq!(expired.bg, Some(Rgb { r: 0x04, g: 0x05, b: 0x06 }));
-        assert_eq!(expired.palette[1], None);
-    }
-
-    #[test]
-    fn ghostty_file_reader_enforces_byte_limit_during_read() {
-        let text = "foreground = #010203\n";
-        assert_eq!(
-            read_ghostty_limited_string(text.as_bytes(), text.len() as u64),
-            Some(text.to_string())
-        );
-        assert_eq!(read_ghostty_limited_string(text.as_bytes(), text.len() as u64 - 1), None);
-    }
-
-    #[test]
-    fn ghostty_theme_loader_skips_non_regular_and_oversized_candidates() {
-        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
-        let dir = std::env::temp_dir().join(format!(
-            "cmux-tui-ghostty-theme-size-limit-{}-{}",
-            std::process::id(),
-            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
-        ));
-        let ghostty_dir = dir.join("ghostty");
-        let themes = ghostty_dir.join("themes");
-        std::fs::create_dir_all(themes.join("Theme Directory")).unwrap();
-        std::fs::write(
-            ghostty_dir.join("config"),
-            "theme = Theme Directory\n\
-             theme = Huge Theme\n\
-             theme = Readable Theme\n",
-        )
-        .unwrap();
-        std::fs::write(
-            themes.join("Huge Theme"),
-            "foreground = #a0a1a2\n".repeat((GHOSTTY_CONFIG_MAX_BYTES as usize / 20) + 1),
-        )
-        .unwrap();
-        std::fs::write(
-            themes.join("Readable Theme"),
-            "foreground = #010203\nbackground = #040506\n",
-        )
-        .unwrap();
-
-        let defaults = parse_ghostty_defaults_from_path(
-            &ghostty_dir.join("config"),
-            std::slice::from_ref(&themes),
-        )
-        .expect("config parses");
-
-        let _ = std::fs::remove_dir_all(dir);
-
-        assert_eq!(defaults.fg, Some(Rgb { r: 0x01, g: 0x02, b: 0x03 }));
-        assert_eq!(defaults.bg, Some(Rgb { r: 0x04, g: 0x05, b: 0x06 }));
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn ghostty_config_helper_scrubs_provider_secret_environment() {
-        let output = {
-            let mut command = Command::new("/usr/bin/env");
-            command
-                .env("CMUX_MACHINE_PROVIDER_TOKEN", "edge-test-bearer")
-                .env("CMUX_PROVIDER_WORKSPACE_AUTHORITY", "provider-workspace-authority-test")
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped());
-            scrub_ghostty_helper_secret_environment(&mut command);
-            command.output().unwrap()
-        };
-        assert!(output.status.success());
-        let stdout = String::from_utf8(output.stdout).unwrap();
-        assert!(!stdout.contains("CMUX_MACHINE_PROVIDER_TOKEN="), "{stdout}");
-        assert!(!stdout.contains("CMUX_PROVIDER_WORKSPACE_AUTHORITY="), "{stdout}");
-    }
-
-    #[cfg(unix)]
-    fn wait_for_helper_ready_pid(
-        stdout: std::process::ChildStdout,
-        marker: &'static str,
-    ) -> libc::pid_t {
-        let (ready_sender, ready_receiver) = mpsc::sync_channel(1);
-        std::thread::Builder::new()
-            .name("cmux-tui-ghostty-test-ready-reader".to_string())
-            .spawn(move || {
-                use std::io::{BufRead, BufReader};
-
-                for line in BufReader::new(stdout).lines().map_while(Result::ok) {
-                    let Some(pid) = line.strip_prefix(marker) else {
-                        continue;
-                    };
-                    if let Ok(pid) = pid.trim().parse::<libc::pid_t>() {
-                        let _ = ready_sender.send(pid);
-                        return;
-                    }
-                }
-            })
-            .unwrap();
-        ready_receiver
-            .recv_timeout(Duration::from_secs(2))
-            .expect("helper did not publish its ready pid")
-    }
-
-    #[cfg(unix)]
-    fn wait_for_helper_reaped(reaped_receiver: mpsc::Receiver<()>) {
-        reaped_receiver
-            .recv_timeout(Duration::from_secs(2))
-            .expect("helper reaper did not publish completion");
-    }
-
-    #[cfg(any(target_os = "linux", target_vendor = "apple"))]
-    struct TestProcessExit {
-        descriptor: std::os::fd::OwnedFd,
-    }
-
-    #[cfg(any(target_os = "linux", target_vendor = "apple"))]
-    impl TestProcessExit {
-        fn observe(pid: libc::pid_t) -> Option<Self> {
-            use std::os::fd::FromRawFd;
-
-            #[cfg(target_os = "linux")]
-            // SAFETY: pidfd_open observes the supplied live test child and
-            // returns a new descriptor without modifying process state.
-            let descriptor = unsafe { libc::syscall(libc::SYS_pidfd_open, pid, 0) };
-            #[cfg(target_vendor = "apple")]
-            // SAFETY: kqueue returns a new descriptor without external state.
-            let descriptor = unsafe { libc::kqueue() };
-            #[cfg(target_os = "linux")]
-            if descriptor < 0 {
-                let error = std::io::Error::last_os_error();
-                if matches!(error.raw_os_error(), Some(libc::ENOSYS) | Some(libc::EPERM)) {
-                    return None;
-                }
-                panic!("observe helper child {pid}: {error}");
-            }
-            #[cfg(target_vendor = "apple")]
-            assert!(
-                descriptor >= 0,
-                "observe helper child {pid}: {}",
-                std::io::Error::last_os_error()
-            );
-            // SAFETY: pidfd_open and kqueue return a new owned descriptor.
-            let descriptor =
-                unsafe { std::os::fd::OwnedFd::from_raw_fd(descriptor as libc::c_int) };
-
-            #[cfg(target_vendor = "apple")]
-            {
-                use std::os::fd::AsRawFd;
-
-                let change = libc::kevent {
-                    ident: pid as libc::uintptr_t,
-                    filter: libc::EVFILT_PROC,
-                    flags: libc::EV_ADD | libc::EV_ENABLE | libc::EV_ONESHOT,
-                    fflags: libc::NOTE_EXIT,
-                    data: 0,
-                    udata: std::ptr::null_mut(),
-                };
-                let registered = unsafe {
-                    libc::kevent(
-                        descriptor.as_raw_fd(),
-                        &raw const change,
-                        1,
-                        std::ptr::null_mut(),
-                        0,
-                        std::ptr::null(),
-                    )
-                };
-                assert!(
-                    registered >= 0,
-                    "register helper child {pid} exit: {}",
-                    std::io::Error::last_os_error()
-                );
-            }
-
-            Some(Self { descriptor })
-        }
-
-        fn wait(self, timeout: Duration) {
-            use std::os::fd::AsRawFd;
-
-            #[cfg(target_os = "linux")]
-            let ready = {
-                let mut descriptor = libc::pollfd {
-                    fd: self.descriptor.as_raw_fd(),
-                    events: libc::POLLIN,
-                    revents: 0,
-                };
-                let timeout_ms = i32::try_from(timeout.as_millis()).unwrap_or(i32::MAX);
-                unsafe { libc::poll(&raw mut descriptor, 1, timeout_ms) }
-            };
-            #[cfg(target_vendor = "apple")]
-            let ready = {
-                // SAFETY: kevent fully initializes the event before it is read.
-                let mut event = unsafe { std::mem::zeroed::<libc::kevent>() };
-                let timeout = libc::timespec {
-                    tv_sec: timeout.as_secs().try_into().unwrap_or(libc::time_t::MAX),
-                    tv_nsec: timeout.subsec_nanos().into(),
-                };
-                unsafe {
-                    libc::kevent(
-                        self.descriptor.as_raw_fd(),
-                        std::ptr::null(),
-                        0,
-                        &raw mut event,
-                        1,
-                        &raw const timeout,
-                    )
-                }
-            };
-            assert!(ready > 0, "helper child did not exit before the final deadline");
-        }
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn ghostty_config_helper_cleanup_reaps_killed_child() {
-        let child = Command::new("/bin/sleep").arg("5").spawn().unwrap();
-        let pid = child.id() as libc::pid_t;
-
-        let reaped_receiver = terminate_ghostty_helper_child_with_reaped_signal(child);
-        wait_for_helper_reaped(reaped_receiver);
-
-        assert!(!unix_process_exists(pid), "helper child {pid} was not reaped");
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn ghostty_process_scan_cleanup_reaps_killed_child() {
-        let mut command = Command::new("/bin/sleep");
-        command.arg("5").process_group(0);
-        let child = command.spawn().unwrap();
-        let pid = child.id() as libc::pid_t;
-
-        let reaped_receiver = terminate_ghostty_process_scan_child_with_reaped_signal(child);
-        wait_for_helper_reaped(reaped_receiver);
-
-        assert!(!unix_process_exists(pid), "process scan child {pid} was not reaped");
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn ghostty_config_helper_parent_deadline_allows_startup_margin() {
-        let mut command = Command::new("/bin/sh");
-        command
-            .args(["-c", "sleep 0.32; printf 'foreground=#010203\nbackground=#040506\n'"])
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::null())
-            .process_group(0);
-
-        let defaults =
-            ghostty_defaults_from_helper_command(command, GHOSTTY_CONFIG_HELPER_PARENT_DEADLINE);
-
-        let GhosttyHelperDefaults::Resolved(defaults) = defaults else {
-            panic!("helper should resolve within parent startup margin");
-        };
-        assert_eq!(defaults.fg, Some(Rgb { r: 0x01, g: 0x02, b: 0x03 }));
-        assert_eq!(defaults.bg, Some(Rgb { r: 0x04, g: 0x05, b: 0x06 }));
-    }
-
-    #[cfg(all(unix, not(target_os = "macos")))]
-    #[test]
-    fn ghostty_desktop_probe_cleanup_kills_stdout_inheriting_child() {
-        let (started_sender, started_receiver) = mpsc::sync_channel(1);
-        let (reaped_sender, reaped_receiver) = mpsc::sync_channel(1);
-
-        let started_at = Instant::now();
-        let output = desktop_theme_command_output_with_lifecycle_signals(
-            "/bin/sh",
-            &["-c", "sleep 5 & printf \"'prefer-dark'\\n\"; exit 0"],
-            Some(Instant::now() + Duration::from_secs(1)),
-            Some(&started_sender),
-            Some(&reaped_sender),
-        );
-        let child_group = started_receiver
-            .recv_timeout(Duration::from_secs(2))
-            .expect("desktop probe did not publish its process group")
-            as libc::pid_t;
-        wait_for_helper_reaped(reaped_receiver);
-
-        assert_eq!(output, None);
-        assert!(
-            started_at.elapsed() < Duration::from_secs(1),
-            "desktop probe output drain was not bounded"
-        );
-
-        assert!(
-            !unix_process_group_is_live(child_group),
-            "stdout-inheriting desktop probe group {child_group} was not killed"
-        );
-    }
-
-    #[cfg(any(target_os = "linux", target_vendor = "apple"))]
-    #[test]
-    fn ghostty_config_helper_cleanup_reaps_process_group_children() {
-        const READY_MARKER: &str = "CMUX_HELPER_READY:";
-        let script = format!("sleep 5 & echo {READY_MARKER}$!; wait");
-        let mut command = Command::new("/bin/sh");
-        command.arg("-c").arg(script).stdout(Stdio::piped()).process_group(0);
-        let mut child = command.spawn().unwrap();
-        let parent_pid = child.id() as libc::pid_t;
-        let child_pid = wait_for_helper_ready_pid(child.stdout.take().unwrap(), READY_MARKER);
-        let child_exit = TestProcessExit::observe(child_pid);
-
-        let reaped_receiver = terminate_ghostty_helper_child_with_reaped_signal(child);
-        wait_for_helper_reaped(reaped_receiver);
-        if let Some(child_exit) = child_exit {
-            child_exit.wait(Duration::from_secs(2));
-            assert!(!unix_process_is_live(child_pid), "helper child {child_pid} was not killed");
-        } else {
-            crate::client_log::stderr_log!(
-                "config",
-                "skipped helper child {child_pid} exit postcondition: pidfd_open is unsupported"
-            );
-        }
-
-        assert!(!unix_process_exists(parent_pid), "helper parent {parent_pid} was not reaped");
-    }
-
-    #[cfg(any(target_os = "linux", target_vendor = "apple"))]
-    #[test]
-    fn ghostty_config_helper_cleanup_kills_descendant_process_groups() {
-        const CHILD_MARKER: &str = "CMUX_TEST_GHOSTTY_HELPER_DESCENDANT_GROUP";
-        const READY_MARKER: &str = "CMUX_DESCENDANT_READY:";
-        if std::env::var_os(CHILD_MARKER).is_some() {
-            let mut command = Command::new("/bin/sleep");
-            command.arg("5").process_group(0);
-            let mut child = command.spawn().unwrap();
-            println!("{READY_MARKER}{}", child.id());
-            std::io::stdout().flush().unwrap();
-            let _ = child.wait();
-            return;
-        }
-
-        let mut command = Command::new(std::env::current_exe().unwrap());
-        command
-            .args([
-                "--exact",
-                "config::tests::ghostty_config_helper_cleanup_kills_descendant_process_groups",
-                "--nocapture",
-            ])
-            .env(CHILD_MARKER, "1")
-            .stdout(Stdio::piped())
-            .stderr(Stdio::null())
-            .process_group(0);
-        let mut child = command.spawn().unwrap();
-        let parent_pid = child.id() as libc::pid_t;
-        let child_pid = wait_for_helper_ready_pid(child.stdout.take().unwrap(), READY_MARKER);
-        let child_exit = TestProcessExit::observe(child_pid);
-
-        let reaped_receiver = terminate_ghostty_helper_child_with_reaped_signal(child);
-        wait_for_helper_reaped(reaped_receiver);
-        if let Some(child_exit) = child_exit {
-            child_exit.wait(Duration::from_secs(2));
-            assert!(
-                !unix_process_is_live(child_pid),
-                "descendant process-group child {child_pid} was not killed"
-            );
-        } else {
-            crate::client_log::stderr_log!(
-                "config",
-                "skipped descendant process-group child {child_pid} exit postcondition: \
-                 pidfd_open is unsupported"
-            );
-        }
-
-        assert!(!unix_process_exists(parent_pid), "helper parent {parent_pid} was not reaped");
-    }
-
-    #[cfg(unix)]
-    fn unix_process_is_live(pid: libc::pid_t) -> bool {
-        if !unix_process_exists(pid) {
-            return false;
-        }
-        let Ok(output) =
-            Command::new("/bin/ps").args(["-o", "stat=", "-p", &pid.to_string()]).output()
-        else {
-            return true;
-        };
-        if !output.status.success() {
-            return unix_process_exists(pid);
-        }
-        let stat = String::from_utf8_lossy(&output.stdout);
-        !stat.trim_start().starts_with('Z')
-    }
-
-    #[cfg(unix)]
-    fn unix_process_exists(pid: libc::pid_t) -> bool {
-        if unsafe { libc::kill(pid, 0) } == 0 {
-            return true;
-        }
-        std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
-    }
-
-    #[cfg(all(unix, not(target_os = "macos")))]
-    fn unix_process_group_is_live(group: libc::pid_t) -> bool {
-        let Ok(output) = Command::new("/bin/ps").args(["-axo", "pgid=,stat="]).output() else {
-            return unsafe { libc::killpg(group, 0) } == 0;
-        };
-        if !output.status.success() {
-            return unsafe { libc::killpg(group, 0) } == 0;
-        }
-        String::from_utf8_lossy(&output.stdout).lines().any(|line| {
-            let mut parts = line.split_whitespace();
-            parts.next().and_then(|value| value.parse::<libc::pid_t>().ok()) == Some(group)
-                && parts.next().is_some_and(|status| !status.starts_with('Z'))
-        })
-    }
-
-    #[test]
-    fn ghostty_config_helper_output_reader_drains_large_palette() {
-        let mut output = String::new();
-        for index in 0..256 {
-            output.push_str(&format!("palette.{index}=#010203\n"));
-        }
-        assert!(output.len() > 4 * 1024);
-
-        let reader =
-            read_ghostty_helper_output_async(std::io::Cursor::new(output.clone())).unwrap();
-
-        assert_eq!(reader.wait(), Some(output));
-    }
-
-    #[test]
-    fn ghostty_config_helper_output_reader_enforces_byte_limit() {
-        let output = "x".repeat(GHOSTTY_HELPER_OUTPUT_MAX_BYTES as usize + 1);
-
-        let reader = read_ghostty_helper_output_async(std::io::Cursor::new(output)).unwrap();
-
-        assert_eq!(reader.wait(), None);
-    }
-
-    #[test]
-    fn ghostty_defaults_falls_back_to_files_when_helper_is_unavailable() {
-        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
-        let dir = std::env::temp_dir().join(format!(
-            "cmux-tui-ghostty-helper-fallback-{}-{}",
-            std::process::id(),
-            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
-        let config = dir.join("config");
-        std::fs::write(&config, "foreground = #010203\nbackground = #040506\n").unwrap();
-
-        let defaults = ghostty_defaults_from_sources(
-            vec![config],
-            Vec::new(),
-            GhosttyHelperDefaults::Unavailable,
-        );
-
-        let _ = std::fs::remove_dir_all(dir);
-
-        assert_eq!(defaults.fg, Some(Rgb { r: 0x01, g: 0x02, b: 0x03 }));
-        assert_eq!(defaults.bg, Some(Rgb { r: 0x04, g: 0x05, b: 0x06 }));
-        assert_eq!(defaults.cursor_style, Some(CursorShape::Block));
-    }
-
-    #[test]
-    fn ghostty_defaults_use_helper_result_before_file_fallback() {
-        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
-        let dir = std::env::temp_dir().join(format!(
-            "cmux-tui-ghostty-helper-result-{}-{}",
-            std::process::id(),
-            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
-        let config = dir.join("config");
-        std::fs::write(&config, "foreground = #010203\nbackground = #040506\n").unwrap();
-        let helper = DefaultColors {
-            fg: Some(Rgb { r: 0xa0, g: 0xa1, b: 0xa2 }),
-            bg: Some(Rgb { r: 0xb0, g: 0xb1, b: 0xb2 }),
-            ..Default::default()
-        };
-
-        let defaults = ghostty_defaults_from_sources(
-            vec![config],
-            Vec::new(),
-            GhosttyHelperDefaults::Resolved(Box::new(helper)),
-        );
-
-        let _ = std::fs::remove_dir_all(dir);
-
-        assert_eq!(defaults.fg, Some(Rgb { r: 0xa0, g: 0xa1, b: 0xa2 }));
-        assert_eq!(defaults.bg, Some(Rgb { r: 0xb0, g: 0xb1, b: 0xb2 }));
-        assert_eq!(defaults.cursor_style, Some(CursorShape::Block));
-    }
-
-    #[test]
-    fn ghostty_defaults_do_not_retry_files_after_helper_timeout() {
-        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
-        let dir = std::env::temp_dir().join(format!(
-            "cmux-tui-ghostty-helper-timeout-{}-{}",
-            std::process::id(),
-            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
-        let config = dir.join("config");
-        std::fs::write(&config, "foreground = #010203\nbackground = #040506\n").unwrap();
-
-        let defaults = ghostty_defaults_from_sources(
-            vec![config],
-            Vec::new(),
-            GhosttyHelperDefaults::TimedOut,
-        );
-
-        let _ = std::fs::remove_dir_all(dir);
-
-        assert_eq!(defaults.fg, None);
-        assert_eq!(defaults.bg, None);
-        assert_eq!(defaults.cursor_style, Some(CursorShape::Block));
-    }
-
-    #[test]
-    fn ghostty_automatic_window_theme_uses_detected_dark_mode_for_conditional_theme() {
-        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
-        let old_apple_interface_style = std::env::var_os("AppleInterfaceStyle");
-        let dir = std::env::temp_dir().join(format!(
-            "cmux-tui-ghostty-theme-auto-{}-{}",
-            std::process::id(),
-            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
-        std::fs::write(
-            dir.join("Light Auto Theme"),
-            "background = #f0f1f2\nforeground = #f3f4f5\npalette = 1=#f6f7f8\n",
-        )
-        .unwrap();
-        std::fs::write(
-            dir.join("Dark Auto Theme"),
-            "background = #101112\nforeground = #131415\npalette = 1=#161718\n",
-        )
-        .unwrap();
-        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
-        unsafe { std::env::set_var("AppleInterfaceStyle", "Dark") };
-
-        let defaults = parse_ghostty_defaults_with_theme_dirs(
-            "window-theme = auto\n\
-             theme = light:Light Auto Theme,dark:Dark Auto Theme\n",
-            std::slice::from_ref(&dir),
-        );
-
-        restore_env_var("AppleInterfaceStyle", old_apple_interface_style);
-        let _ = std::fs::remove_dir_all(dir);
-
-        assert_eq!(defaults.bg, Some(Rgb { r: 0x10, g: 0x11, b: 0x12 }));
-        assert_eq!(defaults.fg, Some(Rgb { r: 0x13, g: 0x14, b: 0x15 }));
-        assert_eq!(defaults.palette[1], Some(Rgb { r: 0x16, g: 0x17, b: 0x18 }));
-    }
-
-    #[test]
-    fn ghostty_conditional_terminal_theme_ignores_ghostty_window_theme() {
-        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
-        let old_apple_interface_style = std::env::var_os("AppleInterfaceStyle");
-        let dir = std::env::temp_dir().join(format!(
-            "cmux-tui-ghostty-theme-window-ghostty-{}-{}",
-            std::process::id(),
-            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
-        std::fs::write(
-            dir.join("Light Window Theme"),
-            "background = #f0f1f2\nforeground = #f3f4f5\npalette = 1=#f6f7f8\n",
-        )
-        .unwrap();
-        std::fs::write(
-            dir.join("Dark Window Theme"),
-            "background = #101112\nforeground = #131415\npalette = 1=#161718\n",
-        )
-        .unwrap();
-        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
-        unsafe { std::env::set_var("AppleInterfaceStyle", "Dark") };
-
-        let defaults = parse_ghostty_defaults_with_theme_dirs(
-            "window-theme = ghostty\n\
-             theme = light:Light Window Theme,dark:Dark Window Theme\n",
-            std::slice::from_ref(&dir),
-        );
-
-        restore_env_var("AppleInterfaceStyle", old_apple_interface_style);
-        let _ = std::fs::remove_dir_all(dir);
-
-        assert_eq!(defaults.bg, Some(Rgb { r: 0x10, g: 0x11, b: 0x12 }));
-        assert_eq!(defaults.fg, Some(Rgb { r: 0x13, g: 0x14, b: 0x15 }));
-        assert_eq!(defaults.palette[1], Some(Rgb { r: 0x16, g: 0x17, b: 0x18 }));
-    }
-
-    #[test]
-    fn ghostty_fixed_theme_selection_does_not_require_appearance_budget() {
-        let expired = Instant::now().checked_sub(Duration::from_millis(1)).unwrap();
-        let mut theme_mode = None;
-
-        let selected = selected_ghostty_theme("Monokai", Some(expired), &mut theme_mode);
-
-        assert_eq!(selected, "Monokai");
-        assert_eq!(theme_mode, None);
-    }
-
-    #[test]
-    fn ghostty_conditional_theme_selection_reuses_cached_appearance_mode() {
-        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
-        let old_apple_interface_style = std::env::var_os("AppleInterfaceStyle");
-        let mut theme_mode = None;
-        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
-        unsafe { std::env::set_var("AppleInterfaceStyle", "Dark") };
-
-        let missing = selected_ghostty_theme(
-            "light:Missing Light Theme,dark:Missing Dark Theme",
-            None,
-            &mut theme_mode,
-        );
-        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
-        unsafe { std::env::set_var("AppleInterfaceStyle", "Light") };
-        let fallback = selected_ghostty_theme(
-            "light:Light Fallback Theme,dark:Dark Fallback Theme",
-            None,
-            &mut theme_mode,
-        );
-
-        restore_env_var("AppleInterfaceStyle", old_apple_interface_style);
-
-        assert_eq!(missing, "Missing Dark Theme");
-        assert_eq!(fallback, "Dark Fallback Theme");
-        assert_eq!(theme_mode, Some(GhosttyThemeMode::Dark));
-    }
-
-    #[test]
-    fn ghostty_system_theme_uses_platform_appearance() {
-        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
-        let old_apple_interface_style = std::env::var_os("AppleInterfaceStyle");
-        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
-        unsafe { std::env::remove_var("AppleInterfaceStyle") };
-
-        let mode = system_ghostty_theme_mode_with_platform(|| Some(GhosttyThemeMode::Light));
-
-        restore_env_var("AppleInterfaceStyle", old_apple_interface_style);
-
-        assert_eq!(mode, GhosttyThemeMode::Light);
-    }
-
-    #[test]
-    fn ghostty_system_theme_uses_environment_before_platform_probe() {
-        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
-        let old_apple_interface_style = std::env::var_os("AppleInterfaceStyle");
-        let mut platform_calls = 0;
-        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
-        unsafe { std::env::set_var("AppleInterfaceStyle", "Dark") };
-
-        let mode = system_ghostty_theme_mode_with_platform(|| {
-            platform_calls += 1;
-            Some(GhosttyThemeMode::Light)
-        });
-
-        restore_env_var("AppleInterfaceStyle", old_apple_interface_style);
-
-        assert_eq!(mode, GhosttyThemeMode::Dark);
-        assert_eq!(platform_calls, 0);
-    }
-
-    #[test]
-    fn ghostty_background_luminance_matches_ghostty_threshold() {
-        assert!(ghostty_background_is_light(Rgb { r: 255, g: 255, b: 255 }));
-        assert!(!ghostty_background_is_light(Rgb { r: 0, g: 0, b: 0 }));
-        assert!(!ghostty_background_is_light(Rgb { r: 0x28, g: 0x2c, b: 0x34 }));
-    }
-
-    #[test]
-    fn ghostty_non_macos_desktop_sources_detect_system_theme_mode() {
-        assert_eq!(
-            freedesktop_portal_color_scheme_theme_mode("(<'uint32 1'>,)"),
-            Some(GhosttyThemeMode::Dark)
-        );
-        assert_eq!(
-            freedesktop_portal_color_scheme_theme_mode("(<uint32 2>,)"),
-            Some(GhosttyThemeMode::Light)
-        );
-        assert_eq!(
-            gnome_color_scheme_output_theme_mode("'prefer-dark'\n"),
-            Some(GhosttyThemeMode::Dark)
-        );
-        assert_eq!(gnome_color_scheme_output_theme_mode("'default'\n"), None);
-        assert_eq!(
-            gtk_settings_theme_mode("[Settings]\ngtk-application-prefer-dark-theme=1\n"),
-            Some(GhosttyThemeMode::Dark)
-        );
-        assert_eq!(
-            gtk_settings_theme_mode(
-                "[Settings]\ngtk-application-prefer-dark-theme=false\ngtk-theme-name=Adwaita-dark\n"
-            ),
-            Some(GhosttyThemeMode::Dark)
-        );
-        assert_eq!(
-            gtk_settings_theme_mode("[Settings]\ngtk-application-prefer-dark-theme=0\n"),
-            None
-        );
-        assert_eq!(
-            gtk_settings_theme_mode("[Settings]\ngtk-theme-name=Adwaita-dark\n"),
-            Some(GhosttyThemeMode::Dark)
-        );
-        assert_eq!(gtk_theme_name_theme_mode("Adwaita:dark"), Some(GhosttyThemeMode::Dark));
-        assert_eq!(gtk_theme_name_theme_mode("Yaru-light"), Some(GhosttyThemeMode::Light));
-        assert_eq!(
-            kde_globals_text_theme_mode("[General]\nColorScheme=BreezeDark\n"),
-            Some(GhosttyThemeMode::Dark)
-        );
-    }
-
-    #[test]
-    fn ghostty_window_theme_does_not_use_resolved_background_for_terminal_theme() {
-        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
-        let old_apple_interface_style = std::env::var_os("AppleInterfaceStyle");
-        let dir = std::env::temp_dir().join(format!(
-            "cmux-tui-ghostty-theme-source-{}-{}",
-            std::process::id(),
-            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
-        std::fs::write(
-            dir.join("Light Source Theme"),
-            "background = #f0f1f2\nforeground = #f3f4f5\n",
-        )
-        .unwrap();
-        std::fs::write(
-            dir.join("Dark Source Theme"),
-            "background = #101112\nforeground = #131415\n",
-        )
-        .unwrap();
-        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
-        unsafe { std::env::set_var("AppleInterfaceStyle", "Light") };
-
-        let system = parse_ghostty_defaults_with_theme_dirs(
-            "window-theme = system\n\
-             background = #101112\n\
-             theme = light:Light Source Theme,dark:Dark Source Theme\n",
-            std::slice::from_ref(&dir),
-        );
-        let ghostty = parse_ghostty_defaults_with_theme_dirs(
-            "window-theme = ghostty\n\
-             background = #101112\n\
-             theme = light:Light Source Theme,dark:Dark Source Theme\n",
-            std::slice::from_ref(&dir),
-        );
-
-        restore_env_var("AppleInterfaceStyle", old_apple_interface_style);
-        let _ = std::fs::remove_dir_all(dir);
-
-        assert_eq!(system.bg, Some(Rgb { r: 0x10, g: 0x11, b: 0x12 }));
-        assert_eq!(system.fg, Some(Rgb { r: 0xf3, g: 0xf4, b: 0xf5 }));
-        assert_eq!(ghostty.bg, Some(Rgb { r: 0x10, g: 0x11, b: 0x12 }));
-        assert_eq!(ghostty.fg, Some(Rgb { r: 0xf3, g: 0xf4, b: 0xf5 }));
-    }
-
     #[test]
     fn omitted_ghostty_cursor_blink_remains_unspecified() {
         let _guard = CONFIG_ENV_LOCK.lock().unwrap();
@@ -7578,28 +2869,6 @@ mod tests {
         ] {
             assert!(serde_json::from_str::<RawConfig>(invalid).is_err(), "accepted {invalid}");
         }
-    }
-
-    #[test]
-    fn machine_provider_command_parses_and_requires_a_program() {
-        let raw: RawConfig = serde_json::from_str(
-            r#"{"machine_provider":{"command":["/opt/provider/run.sh","--profile","prod"]}}"#,
-        )
-        .unwrap();
-        assert_eq!(
-            raw.machine_provider.command.as_deref(),
-            Some(
-                ["/opt/provider/run.sh".to_string(), "--profile".into(), "prod".into()].as_slice()
-            )
-        );
-
-        // An empty argv or blank program is ignored at apply time.
-        let raw: RawConfig =
-            serde_json::from_str(r#"{"machine_provider":{"command":[]}}"#).unwrap();
-        assert!(raw.machine_provider.command.as_deref().is_some_and(|c| c.is_empty()));
-        let raw: RawConfig =
-            serde_json::from_str(r#"{"machine_provider":{"command":["  "]}}"#).unwrap();
-        assert!(raw.machine_provider.command.as_deref().is_some_and(|c| c[0].trim().is_empty()));
     }
 
     #[test]
@@ -7689,8 +2958,7 @@ mod tests {
                     "selection_background": "#101010",
                     "sidebar_rail": 42,
                     "sidebar_active_bg": "#202020",
-                    "tab_bg": 44,
-                    "border_style": "rounded"
+                    "tab_bg": 44
                 },
                 "tabs": {"min_width": 9, "solid_background": false},
                 "sidebar": {
@@ -7698,11 +2966,6 @@ mod tests {
                     "width": 30,
                     "compact_width": 12,
                     "max_width": 38,
-                    "columns": [
-                        {"kind": "machines", "width": 18},
-                        {"kind": "workspaces", "width": 24},
-                        {"kind": "tabs", "width": 26, "max_width": 40}
-                    ],
                     "plugin": {
                         "command": ["/tmp/sidebar-plugin", "--mode", "test"],
                         "cwd": "/tmp"
@@ -7711,11 +2974,7 @@ mod tests {
                 "machine_sidebar": {
                     "enabled": true,
                     "width": 26,
-                    "max_width": 34,
-                    "create_sources": [
-                        {"id": "docker", "name": "Docker", "subtitle": "container prototype"},
-                        {"id": "e2b", "name": "E2B"}
-                    ]
+                    "max_width": 34
                 },
                 "machine_provider": {
                     "cloud": {
@@ -7738,8 +2997,6 @@ mod tests {
                     }
                 ],
                 "scrollbar": {"position": "border"},
-                "pane": {"padding": 9},
-                "status_bar": {"visible": false},
                 "viewport": {"animation": false},
                 "keys": {
                     "alt_shortcuts": false,
@@ -7772,43 +3029,9 @@ mod tests {
         assert_eq!(config.sidebar.compact_width, 12);
         assert_eq!(config.sidebar.max_width, 38);
         assert_eq!(config.sidebar.view, SidebarView::Workspaces);
-        assert!(config.sidebar.columns_explicit);
-        assert_eq!(
-            config.sidebar.columns,
-            vec![
-                SidebarColumn { kind: SidebarColumnKind::Machines, width: 18, max_width: 34 },
-                SidebarColumn { kind: SidebarColumnKind::Workspaces, width: 24, max_width: 38 },
-                SidebarColumn { kind: SidebarColumnKind::Tabs, width: 26, max_width: 40 },
-            ]
-        );
-        assert!(config.sidebar.views_explicit);
-        assert_eq!(
-            config.sidebar.views,
-            vec![
-                SidebarViewSpec::legacy(SidebarColumnKind::Machines, 18, 34),
-                SidebarViewSpec::legacy(SidebarColumnKind::Workspaces, 24, 38),
-                SidebarViewSpec::legacy(SidebarColumnKind::Tabs, 26, 40),
-            ]
-        );
         assert_eq!(
             config.machine_sidebar,
-            MachineSidebar {
-                enabled: true,
-                width: 26,
-                max_width: 34,
-                create_sources: vec![
-                    MachineCreationSourceConfig {
-                        id: "docker".into(),
-                        name: "Docker".into(),
-                        subtitle: "container prototype".into(),
-                    },
-                    MachineCreationSourceConfig {
-                        id: "e2b".into(),
-                        name: "E2B".into(),
-                        subtitle: String::new(),
-                    },
-                ],
-            }
+            MachineSidebar { enabled: true, width: 26, max_width: 34 }
         );
         assert_eq!(
             config.machine_provider.cloud,
@@ -7825,19 +3048,13 @@ mod tests {
         assert_eq!(config.machines[0].name, "Mac mini");
         assert!(matches!(
             &config.machines[0].target,
-            MachineTargetConfig::Ssh { host, user: Some(user), session, binary, .. }
-                if host == "mini.local"
-                    && user == "lawrence"
-                    && session == "main"
-                    && binary == "~/.local/bin/cmux-tui"
+            MachineTargetConfig::Ssh { host, user: Some(user), session, .. }
+                if host == "mini.local" && user == "lawrence" && session == "main"
         ));
         let plugin = config.sidebar.plugin.as_ref().expect("sidebar plugin config");
         assert_eq!(plugin.command, vec!["/tmp/sidebar-plugin", "--mode", "test"]);
         assert_eq!(plugin.cwd.as_deref(), Some("/tmp"));
         assert_eq!(config.scrollbar.position, ScrollbarPosition::Border);
-        assert_eq!(config.theme.border_style, BorderStyle::Rounded);
-        assert_eq!(config.pane.padding, MAX_PANE_PADDING, "padding clamps to the maximum");
-        assert!(!config.status_bar.visible);
         assert!(!config.viewport.animation);
         assert_eq!(
             config.keys.action_for(&KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE)),
@@ -7869,169 +3086,6 @@ mod tests {
     }
 
     #[test]
-    fn sidebar_views_parse_flat_columns_and_nested_resource_trees() {
-        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
-        let old_mux_config = std::env::var_os("CMUX_MUX_CONFIG");
-        let dir =
-            std::env::temp_dir().join(format!("cmux-sidebar-views-config-{}", std::process::id()));
-        std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("cmux-tui.json");
-        std::fs::write(
-            &path,
-            r#"{
-                "sidebar": {
-                    "views": [
-                        {
-                            "id": "hosts",
-                            "levels": ["machines"],
-                            "width": 18,
-                            "collapse_priority": 7
-                        },
-                        {
-                            "id": "workspace-agents",
-                            "levels": ["workspaces", "agents"],
-                            "actions": ["new-workspace", "new-tab"],
-                            "width": 28
-                        },
-                        {
-                            "id": "workspace-pane-tabs",
-                            "levels": ["workspaces", "panes", "tabs"],
-                            "actions": [],
-                            "width": 32,
-                            "max_width": 44
-                        }
-                    ]
-                }
-            }"#,
-        )
-        .unwrap();
-        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
-        unsafe { std::env::set_var("CMUX_MUX_CONFIG", &path) };
-
-        let config = load();
-
-        restore_env_var("CMUX_MUX_CONFIG", old_mux_config);
-        let _ = std::fs::remove_dir_all(&dir);
-        assert!(config.sidebar.views_explicit);
-        assert!(!config.sidebar.columns_explicit);
-        assert_eq!(config.sidebar.views.len(), 3);
-        assert_eq!(config.sidebar.views[0].id, "hosts");
-        assert_eq!(config.sidebar.views[0].levels, vec![SidebarResourceKind::Machines]);
-        assert_eq!(config.sidebar.views[0].width, 18);
-        assert_eq!(config.sidebar.views[0].collapse_priority, 7);
-        assert_eq!(
-            config.sidebar.views[1].levels,
-            vec![SidebarResourceKind::Workspaces, SidebarResourceKind::Agents]
-        );
-        assert_eq!(config.sidebar.views[1].collapse_priority, 20);
-        assert_eq!(
-            config.sidebar.views[1].actions,
-            vec![
-                SidebarActionSpec::plain(Action::NewWorkspace),
-                SidebarActionSpec::plain(Action::NewTab)
-            ]
-        );
-        assert_eq!(
-            config.sidebar.views[2].levels,
-            vec![
-                SidebarResourceKind::Workspaces,
-                SidebarResourceKind::Panes,
-                SidebarResourceKind::Tabs,
-            ]
-        );
-        assert_eq!(config.sidebar.views[2].max_width, 44);
-        assert!(config.sidebar.views[2].actions.is_empty());
-        assert_eq!(
-            config.sidebar.columns,
-            vec![SidebarColumn { kind: SidebarColumnKind::Machines, width: 18, max_width: 0 }]
-        );
-    }
-
-    #[test]
-    fn sidebar_profiles_select_one_named_native_layout() {
-        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
-        let old_mux_config = std::env::var_os("CMUX_MUX_CONFIG");
-        let dir = std::env::temp_dir()
-            .join(format!("cmux-sidebar-profiles-config-{}", std::process::id()));
-        std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("cmux-tui.json");
-        std::fs::write(
-            &path,
-            r#"{
-                "sidebar": {
-                    "profile": "focused",
-                    "profiles": [
-                        {
-                            "id": "full",
-                            "name": "Full",
-                            "views": [
-                                {"id": "machines", "levels": ["machines"]},
-                                {"id": "workspaces", "levels": ["workspaces"]},
-                                {"id": "tabs", "levels": ["tabs"]}
-                            ]
-                        },
-                        {
-                            "id": "focused",
-                            "name": "Focused",
-                            "views": [
-                                {"id": "machines", "levels": ["machines"]},
-                                {
-                                    "id": "workspace-tree",
-                                    "levels": ["workspaces", "agents"]
-                                }
-                            ]
-                        }
-                    ]
-                }
-            }"#,
-        )
-        .unwrap();
-        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
-        unsafe { std::env::set_var("CMUX_MUX_CONFIG", &path) };
-
-        let config = load();
-
-        restore_env_var("CMUX_MUX_CONFIG", old_mux_config);
-        let _ = std::fs::remove_dir_all(&dir);
-        assert_eq!(
-            config.sidebar.views.iter().map(|view| view.id.as_str()).collect::<Vec<_>>(),
-            vec!["machines", "workspace-tree"]
-        );
-        assert!(config.sidebar.views.iter().all(|view| !view.includes(SidebarResourceKind::Tabs)));
-    }
-
-    #[test]
-    fn sidebar_resources_are_hidden_when_their_view_is_omitted() {
-        let sidebar = Sidebar::default();
-        assert!(sidebar.views.iter().all(|view| !view.includes(SidebarResourceKind::Agents)));
-        assert_eq!(sidebar.views[1].actions, vec![SidebarActionSpec::plain(Action::NewWorkspace)]);
-    }
-
-    #[test]
-    fn sidebar_view_paths_reject_ambiguous_hierarchies() {
-        assert!(validate_sidebar_levels(&[]).is_err());
-        assert!(
-            validate_sidebar_levels(&[
-                SidebarResourceKind::Machines,
-                SidebarResourceKind::Workspaces,
-            ])
-            .is_err()
-        );
-        assert!(
-            validate_sidebar_levels(&[SidebarResourceKind::Tabs, SidebarResourceKind::Workspaces,])
-                .is_err()
-        );
-        assert!(
-            validate_sidebar_levels(&[
-                SidebarResourceKind::Workspaces,
-                SidebarResourceKind::Tabs,
-                SidebarResourceKind::Panes,
-            ])
-            .is_err()
-        );
-    }
-
-    #[test]
     fn browser_mode_defaults_headful_parses_headless_and_rejects_invalid_values() {
         let raw: RawConfig = serde_json::from_str(r##"{}"##).unwrap();
         assert!(raw.browser.mode.is_none());
@@ -8045,37 +3099,6 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("unknown variant `stealth`"), "{err}");
-    }
-
-    #[test]
-    fn invalid_section_does_not_discard_valid_sections() {
-        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
-        let dir = TestDirectory::new("section-recovery");
-        let path = dir.path.join("cmux-tui.json");
-        std::fs::write(&path, r##"{"theme":{"sidebar_rail":42},"browser":{"mode":"stealth"}}"##)
-            .unwrap();
-        let old = std::env::var_os("CMUX_TUI_CONFIG");
-        unsafe { std::env::set_var("CMUX_TUI_CONFIG", &path) };
-        let config = load();
-        restore_env_var("CMUX_TUI_CONFIG", old);
-        assert_eq!(config.theme.sidebar_rail, Color::Indexed(42));
-        assert_eq!(config.browser.mode, BrowserMode::Headful);
-    }
-
-    #[test]
-    fn unknown_top_level_field_keeps_strict_rejection() {
-        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
-        let dir =
-            std::env::temp_dir().join(format!("cmux-tui-top-level-strict-{}", std::process::id()));
-        std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("cmux-tui.json");
-        std::fs::write(&path, r##"{"theme":{"sidebar_rail":42},"future":true}"##).unwrap();
-        let old = std::env::var_os("CMUX_TUI_CONFIG");
-        unsafe { std::env::set_var("CMUX_TUI_CONFIG", &path) };
-        let config = load();
-        restore_env_var("CMUX_TUI_CONFIG", old);
-        let _ = std::fs::remove_dir_all(&dir);
-        assert_eq!(config.theme.sidebar_rail, Theme::default().sidebar_rail);
     }
 
     #[test]
@@ -8379,7 +3402,6 @@ mod tests {
             ("swap-pane-next", Action::SwapPaneNext),
             ("scroll-up", Action::ScrollUp),
             ("toggle-sidebar-compact", Action::ToggleSidebarCompact),
-            ("provider-menu", Action::ProviderMenu),
             ("toggle-sidebar-view", Action::ToggleSidebarView),
             ("new-pane-right", Action::NewPaneRight),
             ("undo-layout", Action::UndoLayout),
@@ -8398,23 +3420,6 @@ mod tests {
                 Some(action),
                 "{name} did not parse"
             );
-        }
-    }
-
-    #[test]
-    fn provider_menu_override_requires_a_valid_chord_or_none() {
-        let cases = [
-            (Value::String("not a chord".to_string()), false),
-            (Value::String("ctrl+b".to_string()), false),
-            (Value::String("none".to_string()), true),
-            (Value::Array(vec![]), true),
-            (Value::String("x".to_string()), true),
-            (Value::Bool(true), false),
-        ];
-        for (value, expected) in cases {
-            let mut keys = Keys::default();
-            keys.apply(&HashMap::from([("provider-menu".to_string(), value)]));
-            assert_eq!(keys.provider_menu_overridden, expected);
         }
     }
 
@@ -8508,329 +3513,6 @@ mod tests {
     }
 
     #[test]
-    fn border_style_parses_every_name_and_defaults_to_single() {
-        assert_eq!(Theme::default().border_style, BorderStyle::Single);
-        for (name, style) in [
-            ("single", BorderStyle::Single),
-            ("rounded", BorderStyle::Rounded),
-            ("thick", BorderStyle::Thick),
-            ("double", BorderStyle::Double),
-            ("none", BorderStyle::None),
-        ] {
-            let raw: RawConfig =
-                serde_json::from_str(&format!(r#"{{"theme":{{"border_style":"{name}"}}}}"#))
-                    .unwrap();
-            assert_eq!(raw.theme.border_style, Some(style), "{name} did not parse");
-        }
-        let hidden = BorderStyle::None.glyphs();
-        for glyph in [
-            hidden.horizontal,
-            hidden.vertical,
-            hidden.top_left,
-            hidden.top_right,
-            hidden.bottom_left,
-            hidden.bottom_right,
-        ] {
-            assert_eq!(glyph, " ");
-        }
-    }
-
-    #[test]
-    fn status_bar_segments_parse_validate_and_cap() {
-        let raw: RawConfig = serde_json::from_value(json!({
-            "status_bar": {
-                "show_screens": false,
-                "show_session": false,
-                "left": [
-                    {"text": " {session} ", "fg": "#87d787", "bg": 236},
-                    {"text": "x", "run": ["true"]},
-                    {"run": []},
-                    {}
-                ],
-                "right": [
-                    {"run": ["date", "+%H:%M"], "interval": 0},
-                    {"text": "{workspace}"}
-                ]
-            }
-        }))
-        .unwrap();
-        let left = resolve_status_segments(raw.status_bar.left.unwrap(), "left");
-        assert_eq!(left.len(), 1, "text+run, empty run, and empty segments are rejected");
-        assert_eq!(left[0].content, StatusSegmentContent::Text(" {session} ".to_string()));
-        assert!(left[0].fg.is_some() && left[0].bg.is_some());
-        let right = resolve_status_segments(raw.status_bar.right.unwrap(), "right");
-        assert_eq!(right.len(), 2);
-        assert_eq!(
-            right[0].content,
-            StatusSegmentContent::Command {
-                argv: vec!["date".to_string(), "+%H:%M".to_string()],
-                interval: Duration::from_secs(1),
-            },
-            "interval clamps to at least one second"
-        );
-
-        let options = StatusBarOptions { left, right, ..StatusBarOptions::default() };
-        let commands = options.command_segments();
-        assert_eq!(commands.len(), 1);
-        assert_eq!(commands[0].0, 1, "command index counts left segments first");
-
-        let overflow: Vec<RawStatusSegment> = (0..MAX_STATUS_SEGMENTS + 3)
-            .map(|index| RawStatusSegment {
-                text: Some(format!("{index}")),
-                ..RawStatusSegment::default()
-            })
-            .collect();
-        assert_eq!(resolve_status_segments(overflow, "left").len(), MAX_STATUS_SEGMENTS);
-    }
-
-    #[test]
-    fn chip_styles_and_separators_parse() {
-        let raw: RawConfig = serde_json::from_value(json!({
-            "tabs": {"style": "pill"},
-            "status_bar": {
-                "left_separator": "\u{e0b0}",
-                "right_separator": "\u{e0b2}",
-                "screens_style": "slant"
-            }
-        }))
-        .unwrap();
-        assert_eq!(raw.tabs.style, Some(ChipStyle::Pill));
-        assert_eq!(raw.status_bar.screens_style, Some(ChipStyle::Slant));
-        assert_eq!(raw.status_bar.left_separator.as_deref(), Some("\u{e0b0}"));
-        assert!(ChipStyle::Block.caps().is_none());
-        let (left, right) = ChipStyle::Pill.caps().unwrap();
-        assert!(!left.is_empty() && !right.is_empty());
-    }
-
-    #[test]
-    fn sidebar_buttons_accept_labels_positions_and_command_references() {
-        let views = vec![RawSidebarView {
-            id: "ws".to_string(),
-            levels: vec!["workspaces".to_string()],
-            actions: Some(vec![
-                RawSidebarAction::Detailed {
-                    action: "new-workspace".to_string(),
-                    label: Some("new".to_string()),
-                },
-                RawSidebarAction::Name("command:lazygit".to_string()),
-                RawSidebarAction::Name("command:unknown".to_string()),
-                RawSidebarAction::Name("new-tab".to_string()),
-            ]),
-            actions_position: Some(ActionsPosition::Top),
-            width: None,
-            max_width: None,
-            collapse_priority: None,
-        }];
-        let command_ids = vec!["lazygit".to_string()];
-        let resolved = resolve_sidebar_view_specs(&views, 22, 0, 22, 0, "sidebar", &command_ids);
-        assert_eq!(resolved.len(), 1);
-        assert_eq!(resolved[0].actions_position, ActionsPosition::Top);
-        assert_eq!(
-            resolved[0].actions,
-            vec![
-                SidebarActionSpec { action: Action::NewWorkspace, label: Some("new".to_string()) },
-                SidebarActionSpec::plain(Action::user_command(0).unwrap()),
-                SidebarActionSpec::plain(Action::NewTab),
-            ],
-            "unknown command references drop, known ones bind by id"
-        );
-    }
-
-    #[test]
-    fn sidebar_row_metrics_glyph_and_label_template_parse() {
-        let raw: RawConfig = serde_json::from_value(json!({
-            "sidebar": {
-                "row_height": 1,
-                "row_gap": 0,
-                "rail_glyph": "none",
-                "workspace_label": "{index} · {name}"
-            }
-        }))
-        .unwrap();
-        assert_eq!(raw.sidebar.row_height, Some(1));
-        assert_eq!(raw.sidebar.row_gap, Some(0));
-        assert_eq!(raw.sidebar.rail_glyph.as_deref(), Some("none"));
-        assert_eq!(raw.sidebar.workspace_label.as_deref(), Some("{index} · {name}"));
-    }
-
-    #[test]
-    fn plus_buttons_parse_labels_actions_and_menus() {
-        let raw: RawConfig = serde_json::from_value(json!({
-            "tabs": {"plus": {
-                "label": " new ",
-                "action": "command:top",
-                "menu": [
-                    "new-tab",
-                    {"action": "new-browser-tab", "label": "browser"},
-                    "command:top",
-                    "command:unknown"
-                ]
-            }},
-            "status_bar": {"screens_plus": {"label": " ⊕ "}}
-        }))
-        .unwrap();
-        let command_ids = vec!["top".to_string()];
-        let plus = resolve_plus_button(raw.tabs.plus.unwrap(), &command_ids, "tabs");
-        assert_eq!(plus.label, " new ");
-        assert_eq!(plus.action, Action::user_command(0));
-        assert_eq!(
-            plus.menu,
-            vec![
-                SidebarActionSpec::plain(Action::NewTab),
-                SidebarActionSpec {
-                    action: Action::NewBrowserTab,
-                    label: Some("browser".to_string()),
-                },
-                SidebarActionSpec::plain(Action::user_command(0).unwrap()),
-            ],
-            "unknown command references drop from plus menus"
-        );
-        let screens =
-            resolve_plus_button(raw.status_bar.screens_plus.unwrap(), &command_ids, "status_bar");
-        assert_eq!(screens.label, " ⊕ ");
-        assert_eq!(screens.action, None);
-        assert!(screens.menu.is_empty());
-        // A blank label keeps the clickable default.
-        let blank = resolve_plus_button(
-            RawPlusButton { label: Some("   ".to_string()), action: None, menu: None },
-            &command_ids,
-            "tabs",
-        );
-        assert_eq!(blank.label, " + ");
-    }
-
-    #[test]
-    fn raw_config_accepts_commands_section() {
-        let raw: RawConfig = serde_json::from_value(json!({
-            "commands": [
-                {"id": "lazygit", "name": "LazyGit", "keys": "g", "run": ["lazygit"]},
-                {"id": "scratch", "keys": ["alt+s"], "run": ["nvim", "/tmp/scratch.md"], "cwd": "/tmp"}
-            ]
-        }))
-        .unwrap();
-        assert_eq!(raw.commands.len(), 2);
-    }
-
-    #[test]
-    fn user_commands_bind_chords_and_resolve() {
-        let mut keys = Keys::default();
-        let raw = vec![
-            RawUserCommand {
-                id: Some("lazygit".to_string()),
-                name: Some("LazyGit".to_string()),
-                keys: Some(Value::String("g".to_string())),
-                run: Some(vec!["lazygit".to_string()]),
-                cwd: None,
-            },
-            RawUserCommand {
-                id: Some("scratch".to_string()),
-                name: None,
-                // The prefix chord is reserved, so only alt+s binds.
-                keys: Some(json!(["alt+s", "ctrl+b"])),
-                run: Some(vec!["nvim".to_string(), "/tmp/scratch.md".to_string()]),
-                cwd: Some("/tmp".to_string()),
-            },
-            RawUserCommand {
-                id: Some("lazygit".to_string()),
-                name: None,
-                keys: Some(Value::String("y".to_string())),
-                run: Some(vec!["true".to_string()]),
-                cwd: None,
-            },
-            RawUserCommand {
-                id: Some("empty-run".to_string()),
-                name: None,
-                keys: Some(Value::String("e".to_string())),
-                run: Some(Vec::new()),
-                cwd: None,
-            },
-            RawUserCommand {
-                id: None,
-                name: None,
-                keys: Some(Value::String("i".to_string())),
-                run: Some(vec!["true".to_string()]),
-                cwd: None,
-            },
-        ];
-        let (commands, key_values) = resolve_user_command_specs(raw);
-        bind_user_command_chords(&mut keys, &commands, &key_values);
-        assert_eq!(commands.len(), 2);
-        assert_eq!(commands[0].id, "lazygit");
-        // An ignored invalid entry does not reserve its id: a later valid
-        // entry with the same id is accepted.
-        let mut keys_retry = Keys::default();
-        let retry = vec![
-            RawUserCommand {
-                id: Some("retry".to_string()),
-                name: None,
-                keys: None,
-                run: Some(Vec::new()),
-                cwd: None,
-            },
-            RawUserCommand {
-                id: Some("retry".to_string()),
-                name: None,
-                keys: None,
-                run: Some(vec!["true".to_string()]),
-                cwd: Some("   ".to_string()),
-            },
-        ];
-        let (retried, retried_keys) = resolve_user_command_specs(retry);
-        bind_user_command_chords(&mut keys_retry, &retried, &retried_keys);
-        assert_eq!(retried.len(), 1);
-        assert_eq!(retried[0].id, "retry");
-        assert_eq!(retried[0].cwd, None, "blank cwd is treated as absent");
-        assert_eq!(commands[0].name, "LazyGit");
-        assert_eq!(commands[0].run, ["lazygit"]);
-        assert_eq!(commands[1].name, "scratch");
-        assert_eq!(commands[1].cwd.as_deref(), Some("/tmp"));
-
-        let lazygit = Action::user_command(0).unwrap();
-        let scratch = Action::user_command(1).unwrap();
-        // An explicit command chord steals the default chord it collides with.
-        assert_eq!(
-            keys.action_for(&KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE)),
-            Some(lazygit)
-        );
-        assert_eq!(keys.shortcut_labels(Action::NewPaneRight), Vec::<String>::new());
-        // Alt chords are modeless, exactly like built-in Alt bindings.
-        assert_eq!(
-            keys.modeless_action_for(&KeyEvent::new(KeyCode::Char('s'), KeyModifiers::ALT)),
-            Some(scratch)
-        );
-        // The prefix chord stays reserved for send-prefix.
-        assert_eq!(
-            keys.action_for(&KeyEvent::new(KeyCode::Char('b'), KeyModifiers::CONTROL)),
-            Some(Action::SendPrefix)
-        );
-        // Rejected chords do not bind: `y`, `e`, and `i` keep their defaults.
-        assert_ne!(
-            keys.action_for(&KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE)),
-            Some(Action::user_command(2).unwrap())
-        );
-        assert_eq!(keys.shortcut_labels(lazygit), ["Ctrl-b g"]);
-        assert_eq!(keys.shortcut_labels(scratch), ["Alt-s"]);
-    }
-
-    #[test]
-    fn user_commands_stop_at_the_command_limit() {
-        let mut keys = Keys::default();
-        let raw = (0..MAX_USER_COMMANDS + 2)
-            .map(|index| RawUserCommand {
-                id: Some(format!("command-{index}")),
-                name: None,
-                keys: None,
-                run: Some(vec!["true".to_string()]),
-                cwd: None,
-            })
-            .collect();
-        let (commands, key_values) = resolve_user_command_specs(raw);
-        bind_user_command_chords(&mut keys, &commands, &key_values);
-        assert_eq!(commands.len(), MAX_USER_COMMANDS);
-        assert!(Action::user_command(MAX_USER_COMMANDS).is_none());
-    }
-
-    #[test]
     fn default_backtab_accepts_crossterm_implied_shift() {
         let keys = Keys::default();
         assert_eq!(
@@ -8849,20 +3531,6 @@ mod tests {
             assert!(!definition.label_en.is_empty());
             assert!(!definition.label_ja.is_empty());
             assert_eq!(definition.action.definition(), definition);
-            let metadata = definition.action.metadata();
-            let metadata_key = metadata.key;
-            let _execution = metadata.execution();
-            let resolved_metadata_key = match definition.action {
-                Action::SelectTab(index) | Action::SelectScreen(index) => {
-                    metadata_key.replace("{number}", &index.get().to_string())
-                }
-                _ => metadata_key.to_string(),
-            };
-            assert_eq!(
-                resolved_metadata_key, definition.config_key,
-                "action catalog and programmability metadata disagree for {:?}",
-                definition.action
-            );
         }
         for (_, action) in Keys::default().bindings {
             assert!(actions.contains(&action), "default binding is not registered: {action:?}");
@@ -8984,20 +3652,14 @@ mod tests {
         )
         .unwrap();
 
-        assert_committed(
-            write_sidebar_plugin_at_path(
-                &path,
-                Some(&SidebarPluginConfig {
-                    command: vec![
-                        "/tmp/plugin".to_string(),
-                        "--mode".to_string(),
-                        "test".to_string(),
-                    ],
-                    cwd: Some("/tmp".to_string()),
-                }),
-            )
-            .unwrap(),
-        );
+        write_sidebar_plugin_at_path(
+            &path,
+            Some(&SidebarPluginConfig {
+                command: vec!["/tmp/plugin".to_string(), "--mode".to_string(), "test".to_string()],
+                cwd: Some("/tmp".to_string()),
+            }),
+        )
+        .unwrap();
         let value: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(value["theme"]["sidebar_rail"], json!(42));
         assert_eq!(value["sidebar"]["width"], json!(31));
@@ -9005,173 +3667,11 @@ mod tests {
         assert_eq!(value["sidebar"]["plugin"]["command"][0], json!("/tmp/plugin"));
         assert_eq!(value["sidebar"]["plugin"]["cwd"], json!("/tmp"));
 
-        assert_committed(write_sidebar_plugin_at_path(&path, None).unwrap());
+        write_sidebar_plugin_at_path(&path, None).unwrap();
         let value: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(value["sidebar"]["width"], json!(31));
         assert!(value["sidebar"].get("plugin").is_none());
         assert_eq!(value["future"]["unknown"], json!(true));
         let _ = std::fs::remove_dir_all(&dir);
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn sidebar_plugin_write_replaces_config_with_private_permissions() {
-        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
-
-        let dir = TestDirectory::new("private-permissions");
-        let path = dir.path.join("cmux-tui.json");
-        let mut options = OpenOptions::new();
-        options.write(true).create_new(true).mode(0o644);
-        let file = options.open(&path).unwrap();
-        drop(file);
-
-        assert_committed(
-            write_sidebar_plugin_at_path(
-                &path,
-                Some(&SidebarPluginConfig { command: vec!["/tmp/plugin".to_string()], cwd: None }),
-            )
-            .unwrap(),
-        );
-
-        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
-        assert_eq!(mode, 0o600, "config permissions must not expose server.ws_token");
-    }
-
-    #[test]
-    fn config_write_failure_cleans_staging_file() {
-        let dir = TestDirectory::new("failure-cleanup");
-        let path = dir.path.join("cmux-tui.json");
-        std::fs::create_dir(&path).unwrap();
-
-        let error = write_config_value_atomic(&path, &json!({"server": {"ws_token": "secret"}}))
-            .expect_err("replacing a directory must fail");
-        assert!(!error.to_string().is_empty());
-
-        let entries = std::fs::read_dir(&dir.path).unwrap().collect::<Result<Vec<_>, _>>().unwrap();
-        assert_eq!(entries.len(), 1, "failed writes must remove their staging file");
-        assert_eq!(entries[0].path(), path);
-    }
-
-    #[test]
-    fn config_write_collision_preserves_existing_staging_file() {
-        let dir = TestDirectory::new("staging-collision");
-        let path = dir.path.join("cmux-tui.json");
-        let collision = dir.path.join("collision.tmp");
-        let replacement = dir.path.join("replacement.tmp");
-        std::fs::write(&collision, b"owned by another writer").unwrap();
-        let staging_paths = [collision.clone(), replacement.clone()];
-        let staging_path = |_: &Path, attempt: usize| staging_paths[attempt].clone();
-        let sync_parent = |_parent: &Path| -> anyhow::Result<ConfigParentSyncOutcome> {
-            Ok(ConfigParentSyncOutcome::Synced)
-        };
-
-        assert_committed(
-            write_config_value_atomic_with_sync_and_staging(
-                &path,
-                &json!({"server": {"ws_token": "secret"}}),
-                &sync_parent,
-                &staging_path,
-            )
-            .expect("a colliding staging path should be retried"),
-        );
-        assert_eq!(std::fs::read(&collision).unwrap(), b"owned by another writer");
-        assert!(!replacement.exists(), "the successful staging file must be renamed");
-    }
-
-    #[test]
-    fn config_parent_creation_handles_absolute_path_syntax() {
-        let dir = TestDirectory::new("absolute-parent");
-        let parent = dir.path.join("nested").join("config");
-
-        let created = ensure_config_parent_directory(&parent).unwrap();
-
-        assert!(parent.is_dir());
-        assert!(created.iter().any(|directory| directory == &parent));
-    }
-
-    #[test]
-    fn config_parent_directory_normalizes_relative_path() {
-        assert_eq!(config_parent_directory(Path::new("cmux-tui.json")), Path::new("."));
-        assert_eq!(config_parent_directory(Path::new("nested/cmux-tui.json")), Path::new("nested"));
-    }
-
-    #[test]
-    fn config_write_succeeds_after_parent_directory_sync() {
-        let dir = TestDirectory::new("parent-sync");
-        let path = dir.path.join("cmux-tui.json");
-        assert_committed(
-            write_config_value_atomic(&path, &json!({"server": {"ws_token": "secret"}})).unwrap(),
-        );
-
-        let value: Value = serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
-        assert_eq!(value["server"]["ws_token"], json!("secret"));
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn config_write_does_not_report_failure_after_parent_sync_error() {
-        let dir = TestDirectory::new("parent-sync-failure");
-        let path = dir.path.join("cmux-tui.json");
-        let sync_parent = |_parent: &Path| -> anyhow::Result<ConfigParentSyncOutcome> {
-            Err(anyhow::anyhow!("injected parent directory sync failure"))
-        };
-
-        let result = write_config_value_atomic_with_sync(
-            &path,
-            &json!({"server": {"ws_token": "secret"}}),
-            &sync_parent,
-        );
-
-        assert!(matches!(
-            result.expect("a committed rename must not be reported as a write failure"),
-            ConfigWriteOutcome::CommittedButUnsynced { .. }
-        ));
-        let value: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
-        assert_eq!(value["server"]["ws_token"], json!("secret"));
-    }
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn config_write_does_not_warn_for_unsupported_parent_sync() {
-        let dir = TestDirectory::new("unsupported-parent-sync");
-        let path = dir.path.join("cmux-tui.json");
-        let sync_parent = |_parent: &Path| -> anyhow::Result<ConfigParentSyncOutcome> {
-            Ok(ConfigParentSyncOutcome::Unsupported)
-        };
-
-        let outcome = write_config_value_atomic_with_sync(
-            &path,
-            &json!({"server": {"ws_token": "secret"}}),
-            &sync_parent,
-        )
-        .expect("a committed rename must not be reported as a write failure");
-        assert!(matches!(&outcome, ConfigWriteOutcome::CommittedWithoutDirectorySync));
-        assert!(outcome.into_unsynced_error().is_none());
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn config_write_syncs_parents_of_new_directories() {
-        let dir = TestDirectory::new("created-parent-sync");
-        let parent = dir.path.join("new").join("nested");
-        let path = parent.join("cmux-tui.json");
-        let synced = RefCell::new(Vec::new());
-        let sync_parent = |directory: &Path| -> anyhow::Result<ConfigParentSyncOutcome> {
-            synced.borrow_mut().push(directory.to_path_buf());
-            Ok(ConfigParentSyncOutcome::Synced)
-        };
-
-        assert_committed(
-            write_config_value_atomic_with_sync(
-                &path,
-                &json!({"server": {"ws_token": "secret"}}),
-                &sync_parent,
-            )
-            .unwrap(),
-        );
-
-        let synced = synced.into_inner();
-        assert!(synced.iter().any(|directory| directory == &parent));
-        assert!(synced.iter().any(|directory| directory == &dir.path));
     }
 }

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -2134,21 +2134,29 @@ fn parse_color(s: &str) -> Option<Color> {
 /// The user's relevant Ghostty settings with non-optional application defaults
 /// resolved for values that the low-level terminal otherwise leaves unset.
 fn ghostty_defaults() -> GhosttyApplicationDefaults {
-    let parsed = resolved_ghostty_defaults()
-        .or_else(|| {
-            let text = platform::ghostty_config_paths()
-                .iter()
-                .find_map(|path| std::fs::read_to_string(path).ok())?;
-            Some(GhosttyApplicationDefaults {
-                colors: parse_ghostty_defaults(&text),
-                scrollback_limit_bytes: parse_scrollback_limit_bytes(&text),
-            })
-        })
-        .unwrap_or_default();
+    let parsed = if let Some(mut resolved) = resolved_ghostty_defaults() {
+        if resolved.scrollback_limit_bytes.is_none() {
+            resolved.scrollback_limit_bytes =
+                ghostty_file_defaults().and_then(|defaults| defaults.scrollback_limit_bytes);
+        }
+        resolved
+    } else {
+        ghostty_file_defaults().unwrap_or_default()
+    };
     GhosttyApplicationDefaults {
         colors: resolve_ghostty_application_defaults(parsed.colors),
         ..parsed
     }
+}
+
+fn ghostty_file_defaults() -> Option<GhosttyApplicationDefaults> {
+    let text = platform::ghostty_config_paths()
+        .iter()
+        .find_map(|path| std::fs::read_to_string(path).ok())?;
+    Some(GhosttyApplicationDefaults {
+        colors: parse_ghostty_defaults(&text),
+        scrollback_limit_bytes: parse_scrollback_limit_bytes(&text),
+    })
 }
 
 fn resolve_ghostty_application_defaults(mut defaults: DefaultColors) -> DefaultColors {

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -2206,7 +2206,10 @@ fn parse_scrollback_limit_bytes(text: &str) -> Option<usize> {
     text.lines()
         .filter_map(|line| {
             let (key, value) = line.trim().split_once('=')?;
-            (key.trim() == "scrollback-limit")
+            // Ghostty 1.4 renamed the byte-based setting to make its units
+            // explicit. Keep accepting the legacy spelling for older
+            // installations and configs.
+            matches!(key.trim(), "scrollback-limit" | "scrollback-limit-bytes")
                 .then(|| value.trim().trim_matches('"').replace('_', "").parse::<usize>().ok())
                 .flatten()
         })
@@ -2498,6 +2501,21 @@ mod tests {
         );
         assert_eq!(parse_scrollback_limit_bytes("scrollback-limit = -1\n"), None);
         assert_eq!(Config::default().scrollback_limit_bytes(), DEFAULT_SCROLLBACK_LIMIT_BYTES);
+    }
+
+    #[test]
+    fn parses_canonical_scrollback_limit_bytes_without_line_limit_conversion() {
+        assert_eq!(
+            parse_scrollback_limit_bytes(
+                "scrollback-limit-lines = 12\n\
+                 scrollback-limit-bytes = 8_000_000\n"
+            ),
+            Some(8_000_000)
+        );
+        assert_eq!(
+            parse_scrollback_limit_bytes("scrollback-limit-lines = 12\n"),
+            None
+        );
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -1963,6 +1963,7 @@ fn run_server(
 
     let mut surface_options = SurfaceOptions::default();
     config::apply_browser_to_surface_options(&config, &mut surface_options);
+    surface_options.scrollback = config.scrollback_limit_bytes();
     if let Some(term) = args.term {
         surface_options.term = term;
     }


### PR DESCRIPTION
Replacement follow-up for external PR #9022.

Includes the original scrollback truncation fix from #9022 plus compatibility with Ghostty's canonical `scrollback-limit-bytes` key. Legacy `scrollback-limit` remains supported. `scrollback-limit-lines` is intentionally ignored because line-to-byte conversion is not principled.

Behavior tests cover canonical parsing and line-limit non-conversion.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790559248&installation_model_id=21920&pr_number=11169&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11169&signature=8cb7339a66e97df324e51367e36fd61d5ad439757e8ef3a48ba0e152c73f0cba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the TUI's scrollback limit so long agent transcripts are no longer truncated. The TUI now inherits Ghostty's `scrollback-limit-bytes` setting (legacy `scrollback-limit` still accepted) instead of a fixed 10,000 units, raising the default to 50 MB. `scrollback-limit-lines` stays ignored because line-to-byte conversion isn't principled.

- Resolves the limit via `+show-config`, falling back to parsing the Ghostty config file.
- Applies the configured limit to the surface so the renderer retains the full transcript.
- Tests cover canonical and legacy key parsing, later-valid-entry-wins semantics, and `scrollback-limit-lines` non-conversion.

<sup>Written for commit a23ad54b9df2959478386bf26a41f1792951c34d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * None.

* **Bug Fixes**
  * Improved server startup configuration so the configured scrollback limit is applied consistently.

* **Refactor**
  * Streamlined internal interfaces by removing obsolete journaling, resource-management, agent-hook, browser-provider, and remote protocol components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->