### PR TITLE
fix(tui): harden roster cursor metadata and echo provenance

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/agent_hooks.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/agent_hooks.rs
@@ -17,6 +17,10 @@ const MAX_AGENT_REDACTION_DEPTH: usize = 32;
 const MAX_AGENT_REDACTION_NODES: usize = 4_096;
 const REDACTED_AGENT_VALUE: &str = "[redacted]";
 const STRUCTURE_LIMIT_REASON: &str = "structure_limit";
+// The socket report path writes this adapter directly after committing its
+// projection. Hook ingress must not be able to impersonate that internal
+// record and bypass source arbitration.
+const RESERVED_SOCKET_ADAPTER: &str = "socket";
 
 const AGENT_EVENT_KINDS: [&str; 12] = [
     "agent.session.started",
@@ -255,12 +259,14 @@ pub(crate) fn built_in_agent_producer_manifest() -> JournalProducerManifest {
 
 fn validate_agent_source(source: &str) -> anyhow::Result<()> {
     anyhow::ensure!(
+        source != RESERVED_SOCKET_ADAPTER
+            &&
         !source.is_empty()
             && source.len() <= MAX_AGENT_SOURCE_BYTES
             && source.bytes().all(|byte| {
                 byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'_' | b'-')
             }),
-        "agent source must contain 1 to {MAX_AGENT_SOURCE_BYTES} lowercase ASCII letters, digits, hyphens, or underscores"
+        "agent source must contain 1 to {MAX_AGENT_SOURCE_BYTES} lowercase ASCII letters, digits, hyphens, or underscores and cannot be reserved"
     );
     Ok(())
 }
@@ -823,6 +829,12 @@ fn semantic_key(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn socket_adapter_is_reserved_for_internal_projection_echoes() {
+        let error = agent_hook_journal_ingress("socket", "Stop", None, json!({})).unwrap_err();
+        assert!(error.to_string().contains("reserved"));
+    }
 
     #[test]
     fn completion_hooks_share_one_semantic_kind_and_keep_native_payload() {

--- a/cmux-tui/crates/cmux-tui-core/src/journal_reducers.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_reducers.rs
@@ -183,10 +183,10 @@ impl AgentRoster {
             let Some(state) = event.normalized("state").and_then(agent_state_from_str) else {
                 return Vec::new();
             };
-            let source = event
-                .normalized("source")
-                .and_then(agent_source_from_str)
-                .unwrap_or(AgentSource::Socket);
+            // The adapter id is the provenance marker. Do not trust the
+            // normalized source field here: it is a payload echo and a
+            // forged `source: hook` must not bypass hook precedence.
+            let source = AgentSource::Socket;
             let updated_at_ms = event
                 .normalized("updated_at_ms")
                 .and_then(|value| value.parse::<u64>().ok())

--- a/cmux-tui/crates/cmux-tui-core/src/journal_reducers.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_reducers.rs
@@ -360,6 +360,37 @@ mod tests {
     }
 
     #[test]
+    fn socket_echo_cannot_spoof_hook_precedence_through_normalized_source() {
+        let subjects = terminal_subject("term_a");
+        let hook_payload = json!({"adapter": {"id": "claude", "version": 1}});
+        let spoofed_socket_payload = json!({
+            "adapter": {"id": SOCKET_REPORT_ADAPTER, "version": 1},
+            "normalized": {
+                "state": "idle",
+                // A direct report rejected by hook arbitration can carry the
+                // winning projection source. It remains a socket echo for
+                // reducer precedence purposes.
+                "source": "hook",
+                "source_session": "spoof",
+            },
+        });
+        let mut roster = AgentRoster::default();
+
+        roster.apply(&stamped_event(10_000, "agent.turn.started", &subjects, &hook_payload));
+        let deltas = roster.apply(&stamped_event(
+            11_000,
+            "agent.state.changed",
+            &subjects,
+            &spoofed_socket_payload,
+        ));
+
+        assert!(deltas.is_empty());
+        assert_eq!(roster.entries["term_a"].source, "hook");
+        assert_eq!(roster.entries["term_a"].state, "working");
+        assert_eq!(roster.entries["term_a"].agent.as_deref(), Some("claude"));
+    }
+
+    #[test]
     fn folds_are_idempotent_per_state_and_deterministic_across_replays() {
         let subjects = terminal_subject("term_a");
         let payload = json!({});

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -1110,6 +1110,13 @@ struct AgentRosterHost {
     cursor: u64,
 }
 
+/// Only a cursor-range violation is safe to repair by replaying from the
+/// journal floor. I/O, decoding, and integrity failures must not be treated
+/// as derived-state damage because that could hide a broken source journal.
+fn is_recoverable_agent_roster_cursor_error(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| cause.to_string().starts_with("cursor.invalid:"))
+}
+
 /// Restore the roster from its persisted snapshot and fold the journal tail
 /// committed after the cursor. A reducer-version mismatch discards the
 /// snapshot and re-folds from the journal head. Deltas produced here are
@@ -1137,19 +1144,27 @@ fn restore_agent_roster(registry: &WorkspaceRegistry) -> anyhow::Result<AgentRos
     loop {
         let page = match registry.session_journal_after(host.cursor, 512) {
             Ok(page) => page,
-            Err(error) if !reset_after_error && host.cursor != 0 => {
+            Err(error)
+                if !reset_after_error
+                    && host.cursor != 0
+                    && is_recoverable_agent_roster_cursor_error(&error) =>
+            {
                 // A persisted cursor can point past the head or before the
                 // retained journal floor. Do not fail startup on corrupt
                 // derived state. Reset and make one best-effort replay from
                 // the journal head; if the journal itself has a gap, return
                 // an empty, safe roster and let future events rebuild it.
-                eprintln!("cmux-tui: resetting invalid agent roster cursor: {error}");
+                eprintln!("cmux-tui: resetting invalid agent roster cursor");
                 host = AgentRosterHost::default();
                 reset_after_error = true;
                 continue;
             }
-            Err(error) => {
-                eprintln!("cmux-tui: agent journal replay unavailable after cursor reset: {error}");
+            Err(_error) => {
+                // The roster is advisory, so a damaged journal must not
+                // prevent the terminal from starting. Keep this diagnostic
+                // class-only: database paths and decoded payloads are not
+                // safe to place in shared logs.
+                eprintln!("cmux-tui: agent journal replay unavailable");
                 return Ok(AgentRosterHost::default());
             }
         };
@@ -17429,6 +17444,19 @@ mod tests {
 
     fn test_mux() -> Arc<Mux> {
         Mux::new_for_test("test", SurfaceOptions::default())
+    }
+
+    #[test]
+    fn roster_cursor_recovery_accepts_only_explicit_cursor_errors() {
+        assert!(is_recoverable_agent_roster_cursor_error(&anyhow::anyhow!(
+            "cursor.invalid: journal sequence 9 is ahead of 2"
+        )));
+        assert!(!is_recoverable_agent_roster_cursor_error(&anyhow::anyhow!(
+            "journal segment digest is invalid"
+        )));
+        assert!(!is_recoverable_agent_roster_cursor_error(&anyhow::anyhow!(
+            "database is locked"
+        )));
     }
 
     /// A machine resume reconnects every hosted terminal at once. Checkpoint

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -1163,8 +1163,7 @@ fn restore_agent_roster(registry: &WorkspaceRegistry) -> anyhow::Result<AgentRos
                         // snapshot untouched and fail closed so the caller can
                         // surface the recovery failure and preserve evidence.
                         return Err(anyhow::anyhow!(
-                            "cannot restore agent roster: journal history before sequence {first_retained} "
-                                "was compacted (snapshot cursor {requested}); a complete reducer snapshot is required",
+                            "cannot restore agent roster: journal history before sequence {first_retained} was compacted (snapshot cursor {requested}); a complete reducer snapshot is required",
                         ));
                     }
                 }

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -22222,10 +22222,11 @@ mod tests {
         let first_surface = mux.new_workspace(None, None).unwrap();
         let second_surface = mux.new_workspace(None, None).unwrap();
         let terminal_id = |surface: &Surface| {
-            mux.with_state(|state| match state.resource_indexes.content_ids.get(&surface.id).unwrap()
-            {
-                ContentPublicId::Terminal(terminal_id) => terminal_id.clone(),
-                ContentPublicId::Browser(_) => panic!("workspace opened a browser"),
+            mux.with_state(|state| {
+                match state.resource_indexes.content_ids.get(&surface.id).unwrap() {
+                    ContentPublicId::Terminal(terminal_id) => terminal_id.clone(),
+                    ContentPublicId::Browser(_) => panic!("workspace opened a browser"),
+                }
             })
         };
         let first_terminal = terminal_id(&first_surface);
@@ -22679,10 +22680,8 @@ mod tests {
 
         let error = restore_agent_roster(&registry).unwrap_err();
         assert!(error.to_string().contains("complete reducer snapshot"));
-        let (_, cursor, _) = registry
-            .journal_reducer_state(AGENT_ROSTER_REDUCER_ID)
-            .unwrap()
-            .unwrap();
+        let (_, cursor, _) =
+            registry.journal_reducer_state(AGENT_ROSTER_REDUCER_ID).unwrap().unwrap();
         assert_eq!(cursor, 0, "failed recovery must leave the durable snapshot untouched");
     }
 

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -64,8 +64,10 @@ use crate::workspace_registry::{
     RegistryBrowser, RegistryBrowserReconnect, RegistryCommit, RegistryLayoutNode,
     RegistrySnapshot, RegistryTab, RegistryTerminal, RegistryViewport, RegistryWorkspace,
     ResourceChange, ResourceEffectOutcome, ResourceEffectPreparation, ResourcePatch,
-    ResourcePatchCommit, ResourceTopologySnapshot, ResourceWorkspaceLedger, TerminalLifecycle,
-    TerminalOnExit, TerminalRegistrySnapshot, WorkspaceMutation, WorkspaceRegistry,
+<<<<<<< HEAD
+    ResourcePatchCommit, ResourceTopologySnapshot, ResourceWorkspaceLedger, SessionJournalCursorError,
+    TerminalLifecycle, TerminalOnExit, TerminalRegistrySnapshot, WorkspaceMutation,
+    WorkspaceRegistry,
 };
 use crate::{
     PairingChallenge, PairingDecision, PairingError, PaneId, ScreenId, SplitDir, SplitId,
@@ -1110,13 +1112,6 @@ struct AgentRosterHost {
     cursor: u64,
 }
 
-/// Only a cursor-range violation is safe to repair by replaying from the
-/// journal floor. I/O, decoding, and integrity failures must not be treated
-/// as derived-state damage because that could hide a broken source journal.
-fn is_recoverable_agent_roster_cursor_error(error: &anyhow::Error) -> bool {
-    error.chain().any(|cause| cause.to_string().starts_with("cursor.invalid:"))
-}
-
 /// Restore the roster from its persisted snapshot and fold the journal tail
 /// committed after the cursor. A reducer-version mismatch discards the
 /// snapshot and re-folds from the journal head. Deltas produced here are
@@ -1147,26 +1142,25 @@ fn restore_agent_roster(registry: &WorkspaceRegistry) -> anyhow::Result<AgentRos
             Err(error)
                 if !reset_after_error
                     && host.cursor != 0
-                    && is_recoverable_agent_roster_cursor_error(&error) =>
+                    && error.downcast_ref::<SessionJournalCursorError>().is_some() =>
             {
                 // A persisted cursor can point past the head or before the
                 // retained journal floor. Do not fail startup on corrupt
                 // derived state. Reset and make one best-effort replay from
                 // the journal head; if the journal itself has a gap, return
                 // an empty, safe roster and let future events rebuild it.
-                eprintln!("cmux-tui: resetting invalid agent roster cursor");
+                eprintln!("cmux-tui: resetting invalid agent roster cursor: {error}");
                 host = AgentRosterHost::default();
                 reset_after_error = true;
                 continue;
             }
-            Err(_error) => {
-                // The roster is advisory, so a damaged journal must not
-                // prevent the terminal from starting. Keep this diagnostic
-                // class-only: database paths and decoded payloads are not
-                // safe to place in shared logs.
-                eprintln!("cmux-tui: agent journal replay unavailable");
+            Err(error)
+                if error.downcast_ref::<SessionJournalCursorError>().is_some() =>
+            {
+                eprintln!("cmux-tui: agent journal replay unavailable after cursor reset: {error}");
                 return Ok(AgentRosterHost::default());
             }
+            Err(error) => return Err(error.context("restore agent roster from session journal")),
         };
         if page.records.is_empty() {
             break;
@@ -17446,19 +17440,6 @@ mod tests {
         Mux::new_for_test("test", SurfaceOptions::default())
     }
 
-    #[test]
-    fn roster_cursor_recovery_accepts_only_explicit_cursor_errors() {
-        assert!(is_recoverable_agent_roster_cursor_error(&anyhow::anyhow!(
-            "cursor.invalid: journal sequence 9 is ahead of 2"
-        )));
-        assert!(!is_recoverable_agent_roster_cursor_error(&anyhow::anyhow!(
-            "journal segment digest is invalid"
-        )));
-        assert!(!is_recoverable_agent_roster_cursor_error(&anyhow::anyhow!(
-            "database is locked"
-        )));
-    }
-
     /// A machine resume reconnects every hosted terminal at once. Checkpoint
     /// capture can lose its consistency race while those reconnects append to
     /// the journal, but the skipped optimization is recovered by replaying
@@ -22485,6 +22466,28 @@ mod tests {
         assert_eq!(host.roster.entries.get(terminal_id.as_str()).unwrap().state, "idle");
 
         std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn agent_roster_ahead_cursor_rebuilds_from_retained_journal() {
+        use crate::journal_reducers::{
+            AGENT_ROSTER_REDUCER_ID, AGENT_ROSTER_REDUCER_VERSION, AgentRoster,
+        };
+
+        let registry = WorkspaceRegistry::in_memory("roster-ahead").unwrap();
+        let snapshot = AgentRoster::default().snapshot().to_string();
+        registry
+            .put_journal_reducer_state(
+                AGENT_ROSTER_REDUCER_ID,
+                AGENT_ROSTER_REDUCER_VERSION,
+                42,
+                &snapshot,
+            )
+            .unwrap();
+
+        let host = restore_agent_roster(&registry).unwrap();
+        assert_eq!(host.cursor, 0, "an ahead cursor must be repaired to the journal head");
+        assert!(host.roster.entries.is_empty());
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -65,9 +65,8 @@ use crate::workspace_registry::{
     RegistrySnapshot, RegistryTab, RegistryTerminal, RegistryViewport, RegistryWorkspace,
     ResourceChange, ResourceEffectOutcome, ResourceEffectPreparation, ResourcePatch,
     ResourcePatchCommit, ResourceTopologySnapshot, ResourceWorkspaceLedger,
-    SessionJournalCursorError,
-    TerminalLifecycle, TerminalOnExit, TerminalRegistrySnapshot, WorkspaceMutation,
-    WorkspaceRegistry,
+    SessionJournalCursorError, TerminalLifecycle, TerminalOnExit, TerminalRegistrySnapshot,
+    WorkspaceMutation, WorkspaceRegistry,
 };
 use crate::{
     PairingChallenge, PairingDecision, PairingError, PaneId, ScreenId, SplitDir, SplitId,

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -64,8 +64,8 @@ use crate::workspace_registry::{
     RegistryBrowser, RegistryBrowserReconnect, RegistryCommit, RegistryLayoutNode,
     RegistrySnapshot, RegistryTab, RegistryTerminal, RegistryViewport, RegistryWorkspace,
     ResourceChange, ResourceEffectOutcome, ResourceEffectPreparation, ResourcePatch,
-<<<<<<< HEAD
-    ResourcePatchCommit, ResourceTopologySnapshot, ResourceWorkspaceLedger, SessionJournalCursorError,
+    ResourcePatchCommit, ResourceTopologySnapshot, ResourceWorkspaceLedger,
+    SessionJournalCursorError,
     TerminalLifecycle, TerminalOnExit, TerminalRegistrySnapshot, WorkspaceMutation,
     WorkspaceRegistry,
 };
@@ -1135,32 +1135,31 @@ fn restore_agent_roster(registry: &WorkspaceRegistry) -> anyhow::Result<AgentRos
         _ => AgentRosterHost::default(),
     };
     let started_at = host.cursor;
-    let mut reset_after_error = false;
+    let mut recovered_cursor = false;
     loop {
         let page = match registry.session_journal_after(host.cursor, 512) {
             Ok(page) => page,
-            Err(error)
-                if !reset_after_error
-                    && host.cursor != 0
-                    && error.downcast_ref::<SessionJournalCursorError>().is_some() =>
-            {
+            Err(error) => {
+                let Some(cursor_error) = error.downcast_ref::<SessionJournalCursorError>() else {
+                    return Err(error.context("restore agent roster from session journal"));
+                };
+                if recovered_cursor {
+                    return Err(error.context("restore agent roster after cursor recovery"));
+                }
                 // A persisted cursor can point past the head or before the
-                // retained journal floor. Do not fail startup on corrupt
-                // derived state. Reset and make one best-effort replay from
-                // the journal head; if the journal itself has a gap, return
-                // an empty, safe roster and let future events rebuild it.
-                eprintln!("cmux-tui: resetting invalid agent roster cursor: {error}");
-                host = AgentRosterHost::default();
-                reset_after_error = true;
+                // retained journal floor. Rebuild from a valid boundary,
+                // preserving ordinary I/O, decode, and corruption errors.
+                host = match *cursor_error {
+                    SessionJournalCursorError::Ahead { .. } => AgentRosterHost::default(),
+                    SessionJournalCursorError::Gap { first_retained, .. } => AgentRosterHost {
+                        roster: AgentRoster::default(),
+                        cursor: first_retained.saturating_sub(1),
+                    },
+                };
+                recovered_cursor = true;
+                eprintln!("cmux-tui: recovering invalid agent roster cursor: {error}");
                 continue;
             }
-            Err(error)
-                if error.downcast_ref::<SessionJournalCursorError>().is_some() =>
-            {
-                eprintln!("cmux-tui: agent journal replay unavailable after cursor reset: {error}");
-                return Ok(AgentRosterHost::default());
-            }
-            Err(error) => return Err(error.context("restore agent roster from session journal")),
         };
         if page.records.is_empty() {
             break;

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -22499,6 +22499,58 @@ mod tests {
     }
 
     #[test]
+    fn agent_roster_legacy_numeric_ahead_cursor_rebuilds_from_retained_journal() {
+        use crate::journal_reducers::{
+            AGENT_ROSTER_REDUCER_ID, AGENT_ROSTER_REDUCER_VERSION, AgentRoster,
+        };
+
+        let registry = WorkspaceRegistry::in_memory("roster-ahead-legacy").unwrap();
+        let snapshot = AgentRoster::default().snapshot().to_string();
+        let metadata = serde_json::json!({
+            "version": AGENT_ROSTER_REDUCER_VERSION,
+            "cursor": 42,
+            "snapshot": snapshot,
+        });
+        registry
+            .connection
+            .execute(
+                "INSERT INTO meta(key, value) VALUES(?1, ?2)
+                 ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                rusqlite::params![
+                    format!("journal_reducer.{AGENT_ROSTER_REDUCER_ID}"),
+                    metadata.to_string()
+                ],
+            )
+            .unwrap();
+
+        let host = restore_agent_roster(&registry).unwrap();
+        assert_eq!(host.cursor, 0, "legacy numeric ahead cursors must be repaired");
+        assert!(host.roster.entries.is_empty());
+    }
+
+    #[test]
+    fn malformed_agent_roster_cursor_metadata_rebuilds_as_missing_state() {
+        use crate::journal_reducers::AGENT_ROSTER_REDUCER_ID;
+
+        let registry = WorkspaceRegistry::in_memory("roster-malformed-cursor").unwrap();
+        registry
+            .connection
+            .execute(
+                "INSERT INTO meta(key, value) VALUES(?1, ?2)
+                 ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                rusqlite::params![
+                    format!("journal_reducer.{AGENT_ROSTER_REDUCER_ID}"),
+                    r#"{"version":3,"cursor":{"bad":true},"snapshot":{}}"#
+                ],
+            )
+            .unwrap();
+
+        let host = restore_agent_roster(&registry).unwrap();
+        assert_eq!(host.cursor, 0);
+        assert!(host.roster.entries.is_empty());
+    }
+
+    #[test]
     fn agent_roster_gap_fails_closed_without_complete_snapshot() {
         use crate::journal_reducers::{
             AGENT_ROSTER_REDUCER_ID, AGENT_ROSTER_REDUCER_VERSION, AgentRoster,

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -1133,8 +1133,26 @@ fn restore_agent_roster(registry: &WorkspaceRegistry) -> anyhow::Result<AgentRos
         _ => AgentRosterHost::default(),
     };
     let started_at = host.cursor;
+    let mut reset_after_error = false;
     loop {
-        let page = registry.session_journal_after(host.cursor, 512)?;
+        let page = match registry.session_journal_after(host.cursor, 512) {
+            Ok(page) => page,
+            Err(error) if !reset_after_error && host.cursor != 0 => {
+                // A persisted cursor can point past the head or before the
+                // retained journal floor. Do not fail startup on corrupt
+                // derived state. Reset and make one best-effort replay from
+                // the journal head; if the journal itself has a gap, return
+                // an empty, safe roster and let future events rebuild it.
+                eprintln!("cmux-tui: resetting invalid agent roster cursor: {error}");
+                host = AgentRosterHost::default();
+                reset_after_error = true;
+                continue;
+            }
+            Err(error) => {
+                eprintln!("cmux-tui: agent journal replay unavailable after cursor reset: {error}");
+                return Ok(AgentRosterHost::default());
+            }
+        };
         if page.records.is_empty() {
             break;
         }

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -1164,7 +1164,7 @@ fn restore_agent_roster(registry: &WorkspaceRegistry) -> anyhow::Result<AgentRos
                         // surface the recovery failure and preserve evidence.
                         return Err(anyhow::anyhow!(
                             "cannot restore agent roster: journal history before sequence {first_retained} "
-                                "was compacted (snapshot cursor {requested}); a complete reducer snapshot is required"
+                                "was compacted (snapshot cursor {requested}); a complete reducer snapshot is required",
                         ));
                     }
                 }

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -22217,6 +22217,106 @@ mod tests {
     }
 
     #[test]
+    fn reverse_order_roster_folds_replay_the_complete_two_terminal_prefix() {
+        let mux = test_mux();
+        let first_surface = mux.new_workspace(None, None).unwrap();
+        let second_surface = mux.new_workspace(None, None).unwrap();
+        let terminal_id = |surface: &Surface| {
+            mux.with_state(|state| match state.resource_indexes.content_ids.get(&surface.id).unwrap()
+            {
+                ContentPublicId::Terminal(terminal_id) => terminal_id.clone(),
+                ContentPublicId::Browser(_) => panic!("workspace opened a browser"),
+            })
+        };
+        let first_terminal = terminal_id(&first_surface);
+        let second_terminal = terminal_id(&second_surface);
+        let first = crate::agent_hooks::agent_hook_journal_ingress(
+            "claude",
+            "SessionStart",
+            Some(&first_terminal.to_string()),
+            serde_json::json!({"session_id":"reverse-first"}),
+        )
+        .unwrap();
+        let second = crate::agent_hooks::agent_hook_journal_ingress(
+            "codex",
+            "UserPromptSubmit",
+            Some(&second_terminal.to_string()),
+            serde_json::json!({"session_id":"reverse-second"}),
+        )
+        .unwrap();
+        let append_without_fold = |ingress: &crate::JournalIngress, key: &str| {
+            let validated = mux.journal_kernel.validate_ingress(ingress).unwrap();
+            mux.workspace_registry
+                .lock()
+                .unwrap()
+                .append_journal_ingress(ingress, &validated, "reverse-fold-test", key)
+                .unwrap()
+        };
+        let first_commit = append_without_fold(&first, "reverse-fold-first");
+        let second_commit = append_without_fold(&second, "reverse-fold-second");
+        assert!(first_commit.sequence < second_commit.sequence);
+
+        // The later commit can be the first callback to reach the reducer.
+        // It must read the whole durable prefix instead of skipping the first
+        // terminal permanently.
+        mux.fold_agent_roster(&second, &second_commit);
+        mux.fold_agent_roster(&first, &first_commit);
+
+        let records = mux.list_agents(None, None);
+        assert_eq!(records.len(), 2);
+        assert!(records.iter().any(|record| {
+            record.terminal_id == first_terminal
+                && record.state == AgentState::Idle
+                && record.agent.as_deref() == Some("claude")
+        }));
+        assert!(records.iter().any(|record| {
+            record.terminal_id == second_terminal
+                && record.state == AgentState::Working
+                && record.agent.as_deref() == Some("codex")
+        }));
+    }
+
+    #[test]
+    fn failed_roster_projection_retries_from_the_unchanged_cursor() {
+        let mux = test_mux();
+        let surface = mux.new_workspace(None, None).unwrap();
+        let terminal_id = mux.with_state(|state| {
+            match state.resource_indexes.content_ids.get(&surface.id).unwrap() {
+                ContentPublicId::Terminal(terminal_id) => terminal_id.clone(),
+                ContentPublicId::Browser(_) => panic!("workspace opened a browser"),
+            }
+        });
+        let ingress = crate::agent_hooks::agent_hook_journal_ingress(
+            "claude",
+            "SessionStart",
+            Some(&terminal_id.to_string()),
+            serde_json::json!({"session_id":"retryable-fold"}),
+        )
+        .unwrap();
+        let validated = mux.journal_kernel.validate_ingress(&ingress).unwrap();
+        let commit = mux
+            .workspace_registry
+            .lock()
+            .unwrap()
+            .append_journal_ingress(&ingress, &validated, "retry-fold-test", "retry-fold-event")
+            .unwrap();
+        let starting_cursor = mux.agent_roster.lock().unwrap().cursor;
+
+        mux.workspace_registry.lock().unwrap().set_resource_patch_failure(true).unwrap();
+        mux.fold_agent_roster(&ingress, &commit);
+        assert_eq!(mux.agent_roster.lock().unwrap().cursor, starting_cursor);
+        assert!(mux.list_agents(Some(surface.id), None).is_empty());
+
+        mux.workspace_registry.lock().unwrap().set_resource_patch_failure(false).unwrap();
+        mux.fold_agent_roster(&ingress, &commit);
+        assert_eq!(mux.agent_roster.lock().unwrap().cursor, commit.sequence);
+        let records = mux.list_agents(Some(surface.id), None);
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].state, AgentState::Idle);
+        assert_eq!(records[0].source, AgentSource::Hook);
+    }
+
+    #[test]
     fn screen_detect_scan_drives_the_roster_through_journal_events() {
         use crate::screen_detect::manifest::ManifestSet;
         use crate::screen_detect::{ScreenDetectTracker, scanner};

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -22489,6 +22489,42 @@ mod tests {
     }
 
     #[test]
+    fn agent_roster_gap_fails_closed_without_complete_snapshot() {
+        use crate::journal_reducers::{
+            AGENT_ROSTER_REDUCER_ID, AGENT_ROSTER_REDUCER_VERSION, AgentRoster,
+        };
+
+        let registry = WorkspaceRegistry::in_memory("roster-gap").unwrap();
+        let snapshot = AgentRoster::default().snapshot().to_string();
+        registry
+            .put_journal_reducer_state(
+                AGENT_ROSTER_REDUCER_ID,
+                AGENT_ROSTER_REDUCER_VERSION,
+                0,
+                &snapshot,
+            )
+            .unwrap();
+        registry
+            .connection
+            .execute(
+                "INSERT INTO journal_segments(
+                   segment_id, start_sequence, end_sequence, record_count, codec, content,
+                   uncompressed_bytes, sha256, sealed_at_ms
+                 ) VALUES(?1, 3, 3, 1, 'test', ?2, 1, ?3, 1)",
+                rusqlite::params!["roster-gap-segment", vec![0_u8], vec![0_u8; 32]],
+            )
+            .unwrap();
+
+        let error = restore_agent_roster(&registry).unwrap_err();
+        assert!(error.to_string().contains("complete reducer snapshot"));
+        let (_, cursor, _) = registry
+            .journal_reducer_state(AGENT_ROSTER_REDUCER_ID)
+            .unwrap()
+            .unwrap();
+        assert_eq!(cursor, 0, "failed recovery must leave the durable snapshot untouched");
+    }
+
+    #[test]
     fn failed_raw_agent_report_rolls_back_projection_memory_revision_and_event() {
         let mux = test_mux();
         let surface = mux.new_workspace(None, None).unwrap();

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -1142,22 +1142,32 @@ fn restore_agent_roster(registry: &WorkspaceRegistry) -> anyhow::Result<AgentRos
                 let Some(cursor_error) = error.downcast_ref::<SessionJournalCursorError>() else {
                     return Err(error.context("restore agent roster from session journal"));
                 };
-                if recovered_cursor {
-                    return Err(error.context("restore agent roster after cursor recovery"));
+                match *cursor_error {
+                    SessionJournalCursorError::Ahead { .. } => {
+                        if recovered_cursor {
+                            return Err(error.context("restore agent roster after cursor recovery"));
+                        }
+                        // A persisted cursor can point past the head. Rebuild
+                        // from the journal head, preserving ordinary I/O,
+                        // decode, and corruption errors.
+                        host = AgentRosterHost::default();
+                        recovered_cursor = true;
+                        eprintln!("cmux-tui: recovering invalid agent roster cursor: {error}");
+                        continue;
+                    }
+                    SessionJournalCursorError::Gap { requested, first_retained } => {
+                        // A retained-history gap means the snapshot does not
+                        // cover the records needed to derive the roster. A
+                        // suffix-only replay would silently drop agents and
+                        // claim a successful recovery. Keep the durable
+                        // snapshot untouched and fail closed so the caller can
+                        // surface the recovery failure and preserve evidence.
+                        return Err(anyhow::anyhow!(
+                            "cannot restore agent roster: journal history before sequence {first_retained} "
+                                "was compacted (snapshot cursor {requested}); a complete reducer snapshot is required"
+                        ));
+                    }
                 }
-                // A persisted cursor can point past the head or before the
-                // retained journal floor. Rebuild from a valid boundary,
-                // preserving ordinary I/O, decode, and corruption errors.
-                host = match *cursor_error {
-                    SessionJournalCursorError::Ahead { .. } => AgentRosterHost::default(),
-                    SessionJournalCursorError::Gap { first_retained, .. } => AgentRosterHost {
-                        roster: AgentRoster::default(),
-                        cursor: first_retained.saturating_sub(1),
-                    },
-                };
-                recovered_cursor = true;
-                eprintln!("cmux-tui: recovering invalid agent roster cursor: {error}");
-                continue;
             }
         };
         if page.records.is_empty() {

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -84,7 +84,7 @@ use session_journal::{
     append_resource_journal_record, create_session_journal_schema,
     migrate_resource_events_to_session_journal,
 };
-pub(crate) use session_journal::{SessionJournalReader, unix_epoch_ms};
+pub(crate) use session_journal::{SessionJournalCursorError, SessionJournalReader, unix_epoch_ms};
 
 // Schema 9 shipped independently on the journal and multiview development
 // branches. Schema 10 shipped the journal extensions. Version 11 is the first

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
@@ -1348,7 +1348,7 @@ fn archived_records_after(
         } else {
             anyhow::ensure!(
                 start_sequence <= sequence.saturating_add(1),
-                "journal segments contain a gap before sequence {start_sequence}"
+                "cursor.invalid: journal retention begins at sequence {start_sequence}"
             );
         }
         previous_end = Some(end_sequence);

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
@@ -2100,6 +2100,27 @@ mod tests {
     }
 
     #[test]
+    fn malformed_retained_segment_is_not_classified_as_cursor_repairable() {
+        let registry = WorkspaceRegistry::in_memory("cursor-corrupt").unwrap();
+        registry
+            .connection
+            .execute(
+                "INSERT INTO journal_segments(
+                   segment_id, start_sequence, end_sequence, record_count, codec, content,
+                   uncompressed_bytes, sha256, sealed_at_ms
+                 ) VALUES(?1, 1, 1, 1, 'test', ?2, 1, ?3, 1)",
+                rusqlite::params!["corrupt-segment", vec![0_u8], vec![0_u8; 32]],
+            )
+            .unwrap();
+
+        let error = registry.session_journal_after(0, 1).unwrap_err();
+        assert!(
+            error.downcast_ref::<SessionJournalCursorError>().is_none(),
+            "segment corruption must propagate instead of triggering a cursor reset"
+        );
+    }
+
+    #[test]
     fn persistent_reader_observes_commits_on_an_independent_connection() {
         let root = std::env::temp_dir().join(format!("cmux-journal-reader-{}", new_uuid_v4()));
         let mut registry = WorkspaceRegistry::open(&root, "reader").unwrap();

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
@@ -1150,16 +1150,13 @@ pub(super) fn query_session_journal_after(
 fn first_retained_journal_sequence(connection: &Connection) -> anyhow::Result<Option<u64>> {
     // Keep each MIN over its indexed column. Wrapping both tables in one
     // UNION makes SQLite materialize the full history for every page read.
-    let active = connection.query_row(
-        "SELECT MIN(sequence) FROM session_journal",
-        [],
-        |row| row.get::<_, Option<i64>>(0),
-    )?;
-    let archived = connection.query_row(
-        "SELECT MIN(start_sequence) FROM journal_segments",
-        [],
-        |row| row.get::<_, Option<i64>>(0),
-    )?;
+    let active = connection.query_row("SELECT MIN(sequence) FROM session_journal", [], |row| {
+        row.get::<_, Option<i64>>(0)
+    })?;
+    let archived =
+        connection.query_row("SELECT MIN(start_sequence) FROM journal_segments", [], |row| {
+            row.get::<_, Option<i64>>(0)
+        })?;
     active
         .into_iter()
         .chain(archived)

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
@@ -927,17 +927,26 @@ impl WorkspaceRegistry {
             )
             .optional()?;
         let Some(raw) = raw else { return Ok(None) };
-        let value: Value = serde_json::from_str(&raw)
-            .with_context(|| format!("journal reducer state for {reducer_id} is not JSON"))?;
-        let version = value.get("version").and_then(Value::as_u64).unwrap_or(0) as u32;
-        let cursor = value
-            .get("cursor")
-            .and_then(Value::as_str)
-            .and_then(|cursor| cursor.parse::<u64>().ok())
-            .unwrap_or(0);
-        let snapshot =
-            value.get("snapshot").and_then(Value::as_str).map(str::to_string).unwrap_or_default();
-        Ok(Some((version, cursor, snapshot)))
+        // Reducer metadata is derived state. Treat malformed metadata as
+        // absent so startup can rebuild it from the journal, while keeping
+        // journal read/decode failures visible to the caller. Older writers
+        // stored the cursor as a JSON number; current writers use a decimal
+        // string to avoid losing 64-bit precision in JavaScript clients.
+        let Ok(value) = serde_json::from_str::<Value>(&raw) else { return Ok(None) };
+        let Some(version) = value
+            .get("version")
+            .and_then(Value::as_u64)
+            .and_then(|version| u32::try_from(version).ok())
+        else {
+            return Ok(None);
+        };
+        let Some(cursor) = value.get("cursor").and_then(parse_reducer_cursor) else {
+            return Ok(None);
+        };
+        let Some(snapshot) = value.get("snapshot").and_then(Value::as_str) else {
+            return Ok(None);
+        };
+        Ok(Some((version, cursor, snapshot.to_string())))
     }
 
     /// Durably record a reducer's fold position and state snapshot. Cursor
@@ -1157,6 +1166,17 @@ fn first_retained_journal_sequence(connection: &Connection) -> anyhow::Result<Op
         .min()
         .map(|value| u64::try_from(value).context("first retained journal sequence is negative"))
         .transpose()
+}
+
+/// Decode a reducer cursor from both the current decimal-string format and
+/// the legacy JSON-number format. JSON numbers that are negative, fractional,
+/// or outside `u64` are rejected instead of being coerced to zero.
+fn parse_reducer_cursor(value: &Value) -> Option<u64> {
+    match value {
+        Value::String(cursor) => cursor.parse::<u64>().ok(),
+        Value::Number(cursor) => cursor.as_u64(),
+        _ => None,
+    }
 }
 
 pub(super) fn query_session_journal_sequences(

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
@@ -131,6 +131,32 @@ pub struct SessionJournalPage {
     pub records: Vec<SessionJournalRecord>,
 }
 
+/// A journal cursor can be unrecoverable because it points beyond the
+/// current head or before the retained history. These are the only replay
+/// errors that a derived reducer may repair by rebuilding from the head.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SessionJournalCursorError {
+    Ahead { requested: u64, head: u64 },
+    Gap { requested: u64, first_retained: u64 },
+}
+
+impl std::fmt::Display for SessionJournalCursorError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Ahead { requested, head } => write!(
+                formatter,
+                "cursor.invalid: journal sequence {requested} is ahead of {head}"
+            ),
+            Self::Gap { requested, first_retained } => write!(
+                formatter,
+                "cursor.gap: journal history before sequence {first_retained} is no longer retained after {requested}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SessionJournalCursorError {}
+
 pub(crate) struct SessionJournalSubjectPage {
     pub(crate) head_sequence: u64,
     pub(crate) scanned_through: u64,
@@ -1054,10 +1080,20 @@ pub(super) fn query_session_journal_after(
     )?;
     let head_sequence =
         u64::try_from(head_sequence).context("journal head sequence is negative")?;
-    anyhow::ensure!(
-        sequence <= head_sequence,
-        "cursor.invalid: journal sequence {sequence} is ahead of {head_sequence}"
-    );
+    if sequence > head_sequence {
+        return Err(anyhow::Error::new(SessionJournalCursorError::Ahead {
+            requested: sequence,
+            head: head_sequence,
+        }));
+    }
+    if let Some(first_retained) = first_retained_journal_sequence(connection)?
+        && sequence.saturating_add(1) < first_retained
+    {
+        return Err(anyhow::Error::new(SessionJournalCursorError::Gap {
+            requested: sequence,
+            first_retained,
+        }));
+    }
     let mut records = archived_records_after(connection, sequence, limit)?;
     if records.len() >= limit {
         records.truncate(limit);
@@ -1101,6 +1137,21 @@ pub(super) fn query_session_journal_after(
         "session journal contains a gap after sequence {sequence}"
     );
     Ok(SessionJournalPage { head_sequence, records })
+}
+
+fn first_retained_journal_sequence(connection: &Connection) -> anyhow::Result<Option<u64>> {
+    let first = connection.query_row(
+        "SELECT MIN(sequence) FROM (
+           SELECT sequence FROM session_journal
+           UNION ALL
+           SELECT start_sequence FROM journal_segments
+         )",
+        [],
+        |row| row.get::<_, Option<i64>>(0),
+    )?;
+    first
+        .map(|value| u64::try_from(value).context("first retained journal sequence is negative"))
+        .transpose()
 }
 
 pub(super) fn query_session_journal_sequences(

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
@@ -143,10 +143,9 @@ pub(crate) enum SessionJournalCursorError {
 impl std::fmt::Display for SessionJournalCursorError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Ahead { requested, head } => write!(
-                formatter,
-                "cursor.invalid: journal sequence {requested} is ahead of {head}"
-            ),
+            Self::Ahead { requested, head } => {
+                write!(formatter, "cursor.invalid: journal sequence {requested} is ahead of {head}")
+            }
             Self::Gap { requested, first_retained } => write!(
                 formatter,
                 "cursor.gap: journal history before sequence {first_retained} is no longer retained after {requested}"

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
@@ -2084,6 +2084,64 @@ mod tests {
     }
 
     #[test]
+    fn reducer_state_accepts_legacy_numeric_cursor_without_precision_loss() {
+        let registry = WorkspaceRegistry::in_memory("reducer-cursor-legacy").unwrap();
+        let key = "journal_reducer.agent_roster";
+        for cursor in [42_u64, u64::MAX] {
+            let raw = serde_json::json!({
+                "version": 3,
+                "cursor": cursor,
+                "snapshot": "{\"entries\":{}}",
+            })
+            .to_string();
+            registry
+                .connection
+                .execute(
+                    "INSERT INTO meta(key, value) VALUES(?1, ?2)
+                     ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                    rusqlite::params![key, raw],
+                )
+                .unwrap();
+
+            assert_eq!(
+                registry.journal_reducer_state("agent_roster").unwrap(),
+                Some((3, cursor, "{\"entries\":{}}".to_string()))
+            );
+        }
+    }
+
+    #[test]
+    fn malformed_reducer_state_fields_are_treated_as_absent() {
+        let registry = WorkspaceRegistry::in_memory("reducer-cursor-malformed").unwrap();
+        let key = "journal_reducer.agent_roster";
+        let malformed = [
+            "not-json".to_string(),
+            serde_json::json!({"version": 3, "snapshot": "{}"}).to_string(),
+            serde_json::json!({"version": 3, "cursor": -1, "snapshot": "{}"}).to_string(),
+            serde_json::json!({"version": 3, "cursor": 1.5, "snapshot": "{}"}).to_string(),
+            serde_json::json!({
+                "version": 3,
+                "cursor": "18446744073709551616",
+                "snapshot": "{}",
+            })
+            .to_string(),
+            serde_json::json!({"version": "3", "cursor": 1, "snapshot": "{}"}).to_string(),
+            serde_json::json!({"version": 3, "cursor": 1, "snapshot": 7}).to_string(),
+        ];
+        for raw in malformed {
+            registry
+                .connection
+                .execute(
+                    "INSERT INTO meta(key, value) VALUES(?1, ?2)
+                     ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                    rusqlite::params![key, raw],
+                )
+                .unwrap();
+            assert_eq!(registry.journal_reducer_state("agent_roster").unwrap(), None);
+        }
+    }
+
+    #[test]
     fn retained_history_gap_is_a_typed_cursor_error() {
         let registry = WorkspaceRegistry::in_memory("cursor-gap").unwrap();
         registry

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
@@ -1399,7 +1399,7 @@ fn archived_records_after(
         } else {
             anyhow::ensure!(
                 start_sequence <= sequence.saturating_add(1),
-                "cursor.invalid: journal retention begins at sequence {start_sequence}"
+                "journal segments contain a gap before sequence {start_sequence}"
             );
         }
         previous_end = Some(end_sequence);
@@ -2062,7 +2062,12 @@ mod tests {
     #[test]
     fn journal_cursor_and_page_limits_fail_closed() {
         let registry = WorkspaceRegistry::in_memory("limits").unwrap();
-        assert!(registry.session_journal_after(1, 1).unwrap_err().to_string().contains("ahead"));
+        let ahead = registry.session_journal_after(1, 1).unwrap_err();
+        assert!(ahead.to_string().contains("ahead"));
+        assert_eq!(
+            ahead.downcast_ref::<SessionJournalCursorError>(),
+            Some(&SessionJournalCursorError::Ahead { requested: 1, head: 0 })
+        );
         assert!(registry.session_journal_after(0, 0).unwrap_err().to_string().contains("positive"));
         assert!(
             registry
@@ -2070,6 +2075,27 @@ mod tests {
                 .unwrap_err()
                 .to_string()
                 .contains("exceeds")
+        );
+    }
+
+    #[test]
+    fn retained_history_gap_is_a_typed_cursor_error() {
+        let registry = WorkspaceRegistry::in_memory("cursor-gap").unwrap();
+        registry
+            .connection
+            .execute(
+                "INSERT INTO journal_segments(
+                   segment_id, start_sequence, end_sequence, record_count, codec, content,
+                   uncompressed_bytes, sha256, sealed_at_ms
+                 ) VALUES(?1, 3, 3, 1, 'test', ?2, 1, ?3, 1)",
+                rusqlite::params!["gap-segment", vec![0_u8], vec![0_u8; 32]],
+            )
+            .unwrap();
+
+        let error = registry.session_journal_after(0, 1).unwrap_err();
+        assert_eq!(
+            error.downcast_ref::<SessionJournalCursorError>(),
+            Some(&SessionJournalCursorError::Gap { requested: 0, first_retained: 3 })
         );
     }
 

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
@@ -1139,16 +1139,22 @@ pub(super) fn query_session_journal_after(
 }
 
 fn first_retained_journal_sequence(connection: &Connection) -> anyhow::Result<Option<u64>> {
-    let first = connection.query_row(
-        "SELECT MIN(sequence) FROM (
-           SELECT sequence FROM session_journal
-           UNION ALL
-           SELECT start_sequence FROM journal_segments
-         )",
+    // Keep each MIN over its indexed column. Wrapping both tables in one
+    // UNION makes SQLite materialize the full history for every page read.
+    let active = connection.query_row(
+        "SELECT MIN(sequence) FROM session_journal",
         [],
         |row| row.get::<_, Option<i64>>(0),
     )?;
-    first
+    let archived = connection.query_row(
+        "SELECT MIN(start_sequence) FROM journal_segments",
+        [],
+        |row| row.get::<_, Option<i64>>(0),
+    )?;
+    active
+        .into_iter()
+        .chain(archived)
+        .min()
         .map(|value| u64::try_from(value).context("first retained journal sequence is negative"))
         .transpose()
 }

--- a/cmux-tui/crates/cmux-tui/src/ui/sidebar.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/sidebar.rs
@@ -404,11 +404,7 @@ pub fn draw_projection(app: &mut App, frame: &mut Frame, view_index: usize) {
         // context line (tab title, else the session/workspace subtitle),
         // then the agent type dim underneath. Single-line rows keep the
         // combined detail text.
-        let detail = if two_line {
-            String::new()
-        } else {
-            projection_detail(row).into_owned()
-        };
+        let detail = if two_line { String::new() } else { projection_detail(row).into_owned() };
         let title = if two_line && row.agent_label.as_deref() == Some(row.name.as_str()) {
             row.subtitle.as_str()
         } else {

--- a/cmux-tui/crates/cmux-tui/src/ui/sidebar.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/sidebar.rs
@@ -47,7 +47,7 @@ fn projection_detail<'a>(row: &'a crate::sidebar_projection::ProjectionRow) -> C
     if !row.subtitle.is_empty() {
         detail = format!("{detail} · {}", row.subtitle);
     }
-    detail
+    detail.into()
 }
 
 /// The color of a workspace's unread indicator, or `None` when nothing is
@@ -404,7 +404,11 @@ pub fn draw_projection(app: &mut App, frame: &mut Frame, view_index: usize) {
         // context line (tab title, else the session/workspace subtitle),
         // then the agent type dim underneath. Single-line rows keep the
         // combined detail text.
-        let detail = if two_line { String::new() } else { projection_detail(row) };
+        let detail = if two_line {
+            String::new()
+        } else {
+            projection_detail(row).into_owned()
+        };
         let title = if two_line && row.agent_label.as_deref() == Some(row.name.as_str()) {
             row.subtitle.as_str()
         } else {


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/cmux/pull/11148 and https://github.com/manaflow-ai/cmux/pull/11123.

- Parse reducer version and snapshot fields strictly; malformed metadata is treated as absent derived state.
- Accept legacy JSON-number cursors and current decimal-string cursors only when they are nonnegative values within `u64`.
- Keep ahead-cursor recovery bounded to one reset/replay attempt, and keep retained-history gaps fail-closed because the snapshot does not prove coverage of compacted events.
- Classify socket echoes by `adapter.id`, so a normalized `source` value cannot spoof hook precedence.
- Add behavior coverage for numeric and malformed metadata, ahead and gap recovery, reverse-order two-terminal folds, retry after projection failure, and spoofed socket source.

Focused hosted verification is pending.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790559794&installation_model_id=21920&pr_number=11170&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11170&signature=e70ed34512f8aecd0b0f1f20c5f7a68d4711c4267a5de59df9e3c25c8aee25a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens agent roster recovery in the TUI so corrupted or stale cursor metadata rebuilds safely instead of silently dropping agents, and reserves the `socket` adapter so a forged `source` value cannot take hook precedence over socket echoes.

- Treats malformed reducer metadata as absent derived state and rebuilds it from the journal, preserving real I/O and decode errors.
- Accepts legacy JSON-number and decimal-string cursors only when they are nonnegative `u64` values; invalid values rebuild from the journal head.
- Rebuilds ahead cursors from the journal head with at most one reset/replay attempt.
- Fails closed on retained-history gaps because the snapshot cannot prove coverage of compacted events, leaving the durable snapshot untouched.
- Retries failed projections from the unchanged cursor instead of advancing past unapplied records.
- Replays the complete durable prefix on reverse-order folds so no terminal is skipped permanently.
- Classifies socket echoes by adapter id; the `socket` adapter is reserved for internal projection writes.
- Fixes sidebar detail rendering to use the correct `Cow` type.

**Migration**
- No migration required; malformed persisted `journal_reducer.*` metadata is discarded safely on next startup.

<sup>Written for commit 42d085e69e866ee9bbf4ada5273570559fbd9e18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

