### PR TITLE
vm create: transient provider failures no longer poison the idempotency key

### DIFF
--- a/web/scripts/cloud-vm/smoke-vm-api.mjs
+++ b/web/scripts/cloud-vm/smoke-vm-api.mjs
@@ -13,13 +13,14 @@ import {
   requireEnvKeys,
 } from "./projects.mjs";
 
-const usage = "Usage: smoke-vm-api.mjs [web-dir] <staging|production> [--create] [--provider e2b|freestyle|daytona|blaxel|default] [--url https://preview.example] [--vercel-curl] [--skip-attach]";
+const usage = "Usage: smoke-vm-api.mjs [web-dir] <staging|production> [--create] [--provider e2b|freestyle|daytona|blaxel|default] [--image <manifest image id or version>] [--url https://preview.example] [--vercel-curl] [--skip-attach]";
 const args = process.argv.slice(2);
 const { webDir, target, project, rest } = parseWebDirAndTarget(args, usage);
 const shouldCreate = rest.includes("--create");
 const useVercelCurl = rest.includes("--vercel-curl");
 const skipAttach = rest.includes("--skip-attach");
 const provider = optionValue(rest, "--provider") ?? "e2b";
+const image = optionValue(rest, "--image");
 const targetUrl = optionValue(rest, "--url") ?? project.url;
 const REQUEST_TIMEOUT_MS = 45_000;
 
@@ -162,7 +163,10 @@ try {
     const create = await fetchWithTimeout(`${targetUrl}/api/vm`, {
       method: "POST",
       headers: { ...authHeaders, "content-type": "application/json", "idempotency-key": `smoke-${suffix}` },
-      body: JSON.stringify(provider === "default" ? {} : { provider }),
+      body: JSON.stringify({
+        ...(provider === "default" ? {} : { provider }),
+        ...(image ? { image } : {}),
+      }),
     });
     const createDurationMs = Math.round(performance.now() - createStartedAt);
     const createText = await create.text();

--- a/web/services/vms/repository.ts
+++ b/web/services/vms/repository.ts
@@ -315,9 +315,21 @@ async function findByIdempotencyKey(
 
 export const FAILED_CREATE_RETRY_WINDOW_MS = 15 * 60 * 1000;
 
+/**
+ * failureCode stored when the provider itself failed the create. The HTTP
+ * layer reports these as vm_cloud_service_unavailable with retryable: true
+ * and retryAfterSeconds ~5, so the idempotency key must honor that contract
+ * and let the retry reach the provider again instead of replaying the stored
+ * failure for FAILED_CREATE_RETRY_WINDOW_MS (a client with a stable key, like
+ * the CLI pinned-slot flow, was bricked for 15 minutes by one transient
+ * provider failure).
+ */
+export const PROVIDER_CREATE_UNAVAILABLE_FAILURE_CODE = "provider_create_unavailable";
+
 const RETRYABLE_FAILED_CREATE_CODES = new Set([
   "billing_credits_insufficient",
   "billing_reserve_failed",
+  PROVIDER_CREATE_UNAVAILABLE_FAILURE_CODE,
 ]);
 
 function isRetryableFailedCreate(vm: CloudVmRow, now: Date): boolean {

--- a/web/services/vms/workflows.ts
+++ b/web/services/vms/workflows.ts
@@ -37,6 +37,7 @@ import { isVmFreeAccessExpired, maxActiveVmsForPlan, vmFreeAccessWindowDays } fr
 import { isProviderIdentityNotFoundError, isProviderNotFoundError } from "./providerErrors";
 import { VmProviderGateway, VmProviderGatewayLive, type VmProviderGatewayShape } from "./providerGateway";
 import {
+  PROVIDER_CREATE_UNAVAILABLE_FAILURE_CODE,
   VmRepository,
   VmRepositoryLive,
   type BeginCreateResult,
@@ -310,7 +311,11 @@ export function createVm(input: {
           refundCredit(billing, repo, create.vm, creditReservation),
           repo.markCreateFailed({
             id: create.vm.id,
-            code: err.operation,
+            // providers.create fails only with VmProviderOperationError, and
+            // the caller is told it is retryable (vm_cloud_service_unavailable,
+            // retryAfterSeconds ~5), so store the code that lets a same-key
+            // retry reach the provider again immediately.
+            code: PROVIDER_CREATE_UNAVAILABLE_FAILURE_CODE,
             message: errorMessage(err.cause),
           }),
           repo.recordUsageEvent({

--- a/web/tests/vm-workflows.test.ts
+++ b/web/tests/vm-workflows.test.ts
@@ -4376,12 +4376,12 @@ describe("VM Effect workflows", () => {
         Effect.provide(providerLayer(provider, billing)),
       ),
     );
-    expect(retryError).toBeInstanceOf(VmCreateFailedError);
-    expect(retryError).toMatchObject({
-      code: "create",
-      message: "provider unavailable",
-    });
-    expect(createCalls).toBe(1);
+    // Provider create failures are reported to the caller as retryable, so a
+    // same-key retry reaches the provider again (and fails again here, since
+    // this provider always fails) instead of replaying vm_create_failed.
+    expect(retryError).toBeInstanceOf(VmProviderOperationError);
+    expect(createCalls).toBe(2);
+    expect(refundCalls).toBe(2);
 
     const usageEvents = await sql<{ eventType: string }[]>`
       select event_type as "eventType" from cloud_vm_usage_events
@@ -4390,8 +4390,12 @@ describe("VM Effect workflows", () => {
     `;
     expect(usageEvents.map((event) => event.eventType).sort()).toEqual([
       "vm.create.credit.refunded",
+      "vm.create.credit.refunded",
+      "vm.create.credit.reserved",
       "vm.create.credit.reserved",
       "vm.create.failed",
+      "vm.create.failed",
+      "vm.create.requested",
       "vm.create.requested",
     ]);
   });

--- a/web/tests/vm-workflows.test.ts
+++ b/web/tests/vm-workflows.test.ts
@@ -4147,6 +4147,65 @@ describe("VM Effect workflows", () => {
     expect(rows).toHaveLength(1);
   });
 
+  dbTest("a transient provider create failure does not poison the idempotency key", async () => {
+    if (!sql) throw new Error("test database not initialized");
+    await sql`truncate cloud_vm_billing_grants, cloud_vm_usage_events, cloud_vm_leases, cloud_vms restart identity cascade`;
+
+    // The HTTP layer reports every provider create failure as
+    // vm_cloud_service_unavailable with retryable: true and retryAfterSeconds
+    // ~5, so a client retrying the SAME stable idempotency key (the CLI's
+    // pinned-slot flow) must reach the provider again, not get the stored
+    // failure replayed as vm_create_failed for FAILED_CREATE_RETRY_WINDOW_MS.
+    let createCalls = 0;
+    const flakyProvider: VmProviderGatewayShape = {
+      create: () => {
+        createCalls += 1;
+        if (createCalls === 1) {
+          return Effect.fail(new VmProviderOperationError({
+            provider: "freestyle",
+            operation: "create",
+            cause: new Error("VM setup failed: agent connection lost"),
+          }));
+        }
+        return Effect.succeed({
+          provider: "freestyle" as const,
+          providerVmId: "provider-vm-transient-recovered",
+          status: "running" as const,
+          image: "snapshot-transient",
+          createdAt: Date.now(),
+        });
+      },
+      destroy: () => Effect.void,
+      exec: () => Effect.succeed({ exitCode: 0, stdout: "", stderr: "" }),
+      openAttach: () => Effect.fail(new Error("unused") as never),
+      openSSH: () => Effect.fail(new Error("unused") as never),
+      revokeSSHIdentity: () => Effect.void,
+    };
+
+    const createInput = {
+      userId: "user-workflow-transient",
+      billingCustomerType: "team" as const,
+      billingTeamId: "team-workflow-transient",
+      billingPlanId: "free",
+      maxActiveVms: 1,
+      provider: "freestyle" as const,
+      image: "snapshot-transient",
+      idempotencyKey: "stable-slot-1",
+    };
+
+    const firstError = await Effect.runPromise(
+      createVm(createInput).pipe(Effect.flip, Effect.provide(providerLayer(flakyProvider))),
+    );
+    expect(firstError).toBeInstanceOf(VmProviderOperationError);
+    expect(createCalls).toBe(1);
+
+    const retried = await Effect.runPromise(
+      createVm(createInput).pipe(Effect.provide(providerLayer(flakyProvider))),
+    );
+    expect(createCalls).toBe(2);
+    expect(retried.providerVmId).toBe("provider-vm-transient-recovered");
+  });
+
   dbTest("retries a stale failed create record after the retry window", async () => {
     if (!sql) throw new Error("test database not initialized");
     await sql`truncate cloud_vm_billing_grants, cloud_vm_usage_events, cloud_vm_leases, cloud_vms restart identity cascade`;


### PR DESCRIPTION
During the 2026-08-29 01:18 UTC provisioning incident (freestyle post-boot config failing with `AgentUnavailable`), the failing user's first create returned 502 `vm_cloud_service_unavailable` with `retryable: true, retryAfterSeconds: 5`, and their retries 30-60 seconds later returned 500 `vm_create_failed` ("The previous Cloud VM create attempt failed."). The two layers contradict each other: the response invites a retry, the idempotency layer replays the stored failure for `FAILED_CREATE_RETRY_WINDOW_MS` (15 minutes) because the stored `failureCode` is the operation name (`create`), which is not in `RETRYABLE_FAILED_CREATE_CODES`. A client with a stable idempotency key (the CLI pinned-slot flow uses one per slot) is bricked by a single transient provider failure.

Fix: store provider create failures as `provider_create_unavailable` and add that code to the immediately-retryable set, matching the existing billing codes. `providers.create` fails only with `VmProviderOperationError`, so the classification is total.

Two commits per regression policy: commit 1 adds the failing test (same-key retry after a transient provider failure must reach the provider again), commit 2 the fix. The existing refund test asserted the old replay behavior and now asserts the new contract, including the second credit reserve/refund cycle on retry.

Tests: `bun run db:test` (vm-workflows: 78 pass), `bun run typecheck`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790560640&installation_model_id=21920&pr_number=11172&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11172&signature=dca25a9a8b7a9220268f5818cb750e73438bd928222793d85b104b672d8ce19d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes VM create idempotency so a single transient provider failure no longer bricks the idempotency key for 15 minutes. Previously, provider create failures stored the operation name (`create`) as the failure code, which wasn't retryable, so a same-key retry replayed the stored failure as `vm_create_failed` even though the original HTTP response said `retryable: true` with `retryAfterSeconds: 5`. Now these failures store `provider_create_unavailable`, an immediately retryable code, so a same-key retry reaches the provider again.

**Bug Fixes**
- Provider create failures now store `provider_create_unavailable` and honor the retry contract the HTTP layer already advertises.
- The refund test was updated to assert the new behavior: a retry triggers a second credit reserve and refund cycle.

**New Features**
- The Cloud VM smoke script accepts `--image` for reproducing image-specific create failures.

<sup>Written for commit 0f83b946c009a18d521111210448dad8c52a511b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional image parameter to VM API smoke tests, allowing creation requests to target a specific image.

* **Bug Fixes**
  * VM creation failures caused by temporarily unavailable providers can now be retried immediately with the same idempotency key.
  * Retried creation attempts correctly reprocess billing credits and usage records instead of replaying the previous failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->