### PR TITLE
fix(tui): inherit Ghostty scrollback capacity safely

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/lib.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/lib.rs
@@ -75,7 +75,8 @@ pub use surface::{
     CLEAR_HISTORY_PRESERVATION_ERROR, CLEAR_HISTORY_STREAM_TIMEOUT_ERROR, ClearHistoryDelivery,
     ClearHistoryFailure, DefaultColors, GuardedMouseEncode, PointerSemanticProbe,
     PointerSnapshotProbe, RenderAttachFrame, RenderAttachStream, Surface, SurfaceKind,
-    SurfaceOptions, SurfaceRenderFrame, TerminalColors, TerminalHostConnectionState,
+    DEFAULT_SCROLLBACK_LIMIT_BYTES, SurfaceOptions, SurfaceRenderFrame, TerminalColors,
+    TerminalHostConnectionState,
     TerminalPointerSnapshot,
 };
 pub use workspace_registry::{

--- a/cmux-tui/crates/cmux-tui-core/src/lib.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/lib.rs
@@ -73,10 +73,9 @@ pub use surface::{
     BrowserFrameStream, BrowserFrameUpdate, BrowserSource, BrowserStatus,
     CLEAR_HISTORY_FALLBACK_UNREPRESENTABLE_ERROR, CLEAR_HISTORY_FALLBACK_WRITE_TIMEOUT_ERROR,
     CLEAR_HISTORY_PRESERVATION_ERROR, CLEAR_HISTORY_STREAM_TIMEOUT_ERROR, ClearHistoryDelivery,
-    ClearHistoryFailure, DefaultColors, GuardedMouseEncode, PointerSemanticProbe,
-    PointerSnapshotProbe, RenderAttachFrame, RenderAttachStream, Surface, SurfaceKind,
-    DEFAULT_SCROLLBACK_LIMIT_BYTES, SurfaceOptions, SurfaceRenderFrame, TerminalColors,
-    TerminalHostConnectionState,
+    ClearHistoryFailure, DEFAULT_SCROLLBACK_LIMIT_BYTES, DefaultColors, GuardedMouseEncode,
+    PointerSemanticProbe, PointerSnapshotProbe, RenderAttachFrame, RenderAttachStream, Surface,
+    SurfaceKind, SurfaceOptions, SurfaceRenderFrame, TerminalColors, TerminalHostConnectionState,
     TerminalPointerSnapshot,
 };
 pub use workspace_registry::{

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -387,8 +387,8 @@ fn ghostty_config_paths_from(
     // Ghostty resolves XDG_CONFIG_HOME to the user's XDG config root. When
     // it is unset, that root is HOME/.config. Do not search both roots: doing
     // so would make an unrelated legacy file override the active XDG file.
-    let config_root =
-        xdg_config_home.clone().or_else(|| home.as_ref().map(|home| home.join(".config")));
+    let has_xdg_config_home = xdg_config_home.is_some();
+    let config_root = xdg_config_home.or_else(|| home.as_ref().map(|home| home.join(".config")));
     if let Some(config_root) = config_root {
         let dir = config_root.join("ghostty");
         // Ghostty loads the legacy name first, then the current name when
@@ -397,9 +397,7 @@ fn ghostty_config_paths_from(
         push_unique(&mut candidates, dir.join("config.ghostty"));
     }
     #[cfg(target_os = "macos")]
-    if xdg_config_home.is_none()
-        && let Some(home) = home
-    {
+    if !has_xdg_config_home && let Some(home) = home {
         let dir = home.join("Library").join("Application Support").join("com.mitchellh.ghostty");
         push_unique(&mut candidates, dir.join("config"));
         push_unique(&mut candidates, dir.join("config.ghostty"));

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -376,12 +376,19 @@ pub fn chrome_candidates() -> Vec<PathBuf> {
 
 /// Candidate Ghostty config files used to seed selection colors.
 pub fn ghostty_config_paths() -> Vec<PathBuf> {
+    ghostty_config_paths_from(env_path("XDG_CONFIG_HOME"), home_dir())
+}
+
+fn ghostty_config_paths_from(
+    xdg_config_home: Option<PathBuf>,
+    home: Option<PathBuf>,
+) -> Vec<PathBuf> {
     let mut candidates = Vec::new();
     // Ghostty resolves XDG_CONFIG_HOME to the user's XDG config root. When
     // it is unset, that root is HOME/.config. Do not search both roots: doing
     // so would make an unrelated legacy file override the active XDG file.
     let config_root =
-        env_path("XDG_CONFIG_HOME").or_else(|| home_dir().map(|home| home.join(".config")));
+        xdg_config_home.clone().or_else(|| home.as_ref().map(|home| home.join(".config")));
     if let Some(config_root) = config_root {
         let dir = config_root.join("ghostty");
         // Ghostty loads the legacy name first, then the current name when
@@ -389,9 +396,9 @@ pub fn ghostty_config_paths() -> Vec<PathBuf> {
         push_unique(&mut candidates, dir.join("config"));
         push_unique(&mut candidates, dir.join("config.ghostty"));
     }
-    if let Some(home) = home_dir() {
+    if let Some(home) = home {
         #[cfg(target_os = "macos")]
-        {
+        if xdg_config_home.is_none() {
             let dir =
                 home.join("Library").join("Application Support").join("com.mitchellh.ghostty");
             push_unique(&mut candidates, dir.join("config"));
@@ -999,6 +1006,16 @@ fn restrict_permissions(_path: &Path, _mode: u32) -> std::io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn explicit_xdg_ghostty_config_does_not_add_application_support_candidates() {
+        let xdg = PathBuf::from("/tmp/cmux-test-xdg");
+        let home = PathBuf::from("/tmp/cmux-test-home");
+        let paths = ghostty_config_paths_from(Some(xdg.clone()), Some(home));
+
+        assert_eq!(paths, vec![xdg.join("ghostty/config"), xdg.join("ghostty/config.ghostty")]);
+    }
 
     #[test]
     fn default_terminal_cwd_prefers_a_live_launch_directory() {

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -377,17 +377,19 @@ pub fn chrome_candidates() -> Vec<PathBuf> {
 /// Candidate Ghostty config files used to seed selection colors.
 pub fn ghostty_config_paths() -> Vec<PathBuf> {
     let mut candidates = Vec::new();
-    if let Some(config_home) = env_path("XDG_CONFIG_HOME") {
-        let dir = config_home.join("ghostty");
+    // Ghostty resolves XDG_CONFIG_HOME to the user's XDG config root. When
+    // it is unset, that root is HOME/.config. Do not search both roots: doing
+    // so would make an unrelated legacy file override the active XDG file.
+    let config_root = env_path("XDG_CONFIG_HOME")
+        .or_else(|| home_dir().map(|home| home.join(".config")));
+    if let Some(config_root) = config_root {
+        let dir = config_root.join("ghostty");
         // Ghostty loads the legacy name first, then the current name when
         // both exist. Keep that order so later current-file settings win.
         push_unique(&mut candidates, dir.join("config"));
         push_unique(&mut candidates, dir.join("config.ghostty"));
     }
     if let Some(home) = home_dir() {
-        let dir = home.join(".config").join("ghostty");
-        push_unique(&mut candidates, dir.join("config"));
-        push_unique(&mut candidates, dir.join("config.ghostty"));
         #[cfg(target_os = "macos")]
         {
             let dir = home

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -387,6 +387,7 @@ fn ghostty_config_paths_from(
     // Ghostty resolves XDG_CONFIG_HOME to the user's XDG config root. When
     // it is unset, that root is HOME/.config. Do not search both roots: doing
     // so would make an unrelated legacy file override the active XDG file.
+    #[cfg(target_os = "macos")]
     let has_xdg_config_home = xdg_config_home.is_some();
     let config_root = xdg_config_home.or_else(|| home.as_ref().map(|home| home.join(".config")));
     if let Some(config_root) = config_root {

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -396,14 +396,13 @@ fn ghostty_config_paths_from(
         push_unique(&mut candidates, dir.join("config"));
         push_unique(&mut candidates, dir.join("config.ghostty"));
     }
-    if let Some(home) = home {
-        #[cfg(target_os = "macos")]
-        if xdg_config_home.is_none() {
-            let dir =
-                home.join("Library").join("Application Support").join("com.mitchellh.ghostty");
-            push_unique(&mut candidates, dir.join("config"));
-            push_unique(&mut candidates, dir.join("config.ghostty"));
-        }
+    #[cfg(target_os = "macos")]
+    if xdg_config_home.is_none()
+        && let Some(home) = home
+    {
+        let dir = home.join("Library").join("Application Support").join("com.mitchellh.ghostty");
+        push_unique(&mut candidates, dir.join("config"));
+        push_unique(&mut candidates, dir.join("config.ghostty"));
     }
     candidates
 }

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -380,8 +380,8 @@ pub fn ghostty_config_paths() -> Vec<PathBuf> {
     // Ghostty resolves XDG_CONFIG_HOME to the user's XDG config root. When
     // it is unset, that root is HOME/.config. Do not search both roots: doing
     // so would make an unrelated legacy file override the active XDG file.
-    let config_root = env_path("XDG_CONFIG_HOME")
-        .or_else(|| home_dir().map(|home| home.join(".config")));
+    let config_root =
+        env_path("XDG_CONFIG_HOME").or_else(|| home_dir().map(|home| home.join(".config")));
     if let Some(config_root) = config_root {
         let dir = config_root.join("ghostty");
         // Ghostty loads the legacy name first, then the current name when
@@ -392,10 +392,8 @@ pub fn ghostty_config_paths() -> Vec<PathBuf> {
     if let Some(home) = home_dir() {
         #[cfg(target_os = "macos")]
         {
-            let dir = home
-                .join("Library")
-                .join("Application Support")
-                .join("com.mitchellh.ghostty");
+            let dir =
+                home.join("Library").join("Application Support").join("com.mitchellh.ghostty");
             push_unique(&mut candidates, dir.join("config"));
             push_unique(&mut candidates, dir.join("config.ghostty"));
         }

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -378,18 +378,25 @@ pub fn chrome_candidates() -> Vec<PathBuf> {
 pub fn ghostty_config_paths() -> Vec<PathBuf> {
     let mut candidates = Vec::new();
     if let Some(config_home) = env_path("XDG_CONFIG_HOME") {
-        push_unique(&mut candidates, config_home.join("ghostty").join("config"));
+        let dir = config_home.join("ghostty");
+        // Ghostty loads the legacy name first, then the current name when
+        // both exist. Keep that order so later current-file settings win.
+        push_unique(&mut candidates, dir.join("config"));
+        push_unique(&mut candidates, dir.join("config.ghostty"));
     }
     if let Some(home) = home_dir() {
-        push_unique(&mut candidates, home.join(".config").join("ghostty").join("config"));
+        let dir = home.join(".config").join("ghostty");
+        push_unique(&mut candidates, dir.join("config"));
+        push_unique(&mut candidates, dir.join("config.ghostty"));
         #[cfg(target_os = "macos")]
-        push_unique(
-            &mut candidates,
-            home.join("Library")
+        {
+            let dir = home
+                .join("Library")
                 .join("Application Support")
-                .join("com.mitchellh.ghostty")
-                .join("config"),
-        );
+                .join("com.mitchellh.ghostty");
+            push_unique(&mut candidates, dir.join("config"));
+            push_unique(&mut candidates, dir.join("config.ghostty"));
+        }
     }
     candidates
 }

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -106,6 +106,8 @@ pub struct SurfaceOptions {
     pub term: String,
     pub cols: u16,
     pub rows: u16,
+    /// Maximum retained scrollback storage in bytes, matching Ghostty's
+    /// `max_scrollback` API. This is not a line count.
     pub scrollback: usize,
     /// Extra environment for children (e.g. CMUX_TUI_SOCKET).
     pub extra_env: Vec<(String, String)>,

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -49,6 +49,9 @@ use crate::terminal_host_protocol::{
 };
 use cmux_tui_cdp::BrowserMode;
 
+/// Ghostty's default maximum retained scrollback backing storage.
+pub const DEFAULT_SCROLLBACK_LIMIT_BYTES: usize = 50_000_000;
+
 /// Result of encoding terminal mouse input against a previously observed
 /// pointer snapshot without blocking on terminal parsing.
 #[derive(Debug)]
@@ -167,7 +170,7 @@ impl Default for SurfaceOptions {
                 .unwrap_or_else(|_| default_child_term()),
             cols: 80,
             rows: 24,
-            scrollback: 10_000,
+            scrollback: DEFAULT_SCROLLBACK_LIMIT_BYTES,
             extra_env: Vec::new(),
             chrome_binary: None,
             cdp_url: None,

--- a/cmux-tui/crates/cmux-tui/Cargo.toml
+++ b/cmux-tui/crates/cmux-tui/Cargo.toml
@@ -54,6 +54,7 @@ url.workspace = true
 async-trait.workspace = true
 
 [target.'cfg(windows)'.dependencies]
+tokio.workspace = true
 windows-sys.workspace = true
 
 [dev-dependencies]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -4925,17 +4925,14 @@ fn parse_ghostty_config_file_until(
     theme_candidates: &mut Vec<GhosttyThemeCandidate>,
     deadline_at: Option<Instant>,
 ) -> GhosttyConfigParseOutcome {
-    // Keep the same breadth-first order as Ghostty's loadRecursiveFiles:
-    // finish a parent, then process its includes in declaration order, with
-    // nested includes queued after existing siblings.
-    let mut queue = VecDeque::from([PendingGhosttyConfig { path: path.to_path_buf(), depth: 0 }]);
+    let mut stack = vec![PendingGhosttyConfig { path: path.to_path_buf(), depth: 0 }];
     let mut loaded = HashSet::new();
     let mut files_loaded = 0usize;
     let mut bytes_loaded = 0u64;
     let mut loaded_root = false;
     let mut overrides = DefaultColors::default();
 
-    while let Some(pending) = queue.pop_front() {
+    while let Some(pending) = stack.pop() {
         if files_loaded > 0 && ghostty_config_deadline_expired(deadline_at) {
             return GhosttyConfigParseOutcome::TimedOut;
         }
@@ -4962,9 +4959,10 @@ fn parse_ghostty_config_file_until(
         let parsed = parse_ghostty_config_text(&text, Some(base_dir), theme_candidates);
         overlay_ghostty_defaults(&mut overrides, parsed.overrides);
 
-        for include in parsed.config_files.into_iter().filter_map(|include| include.resolve(base_dir))
+        for include in
+            parsed.config_files.into_iter().rev().filter_map(|include| include.resolve(base_dir))
         {
-            queue.push_back(PendingGhosttyConfig { path: include, depth: pending.depth + 1 });
+            stack.push(PendingGhosttyConfig { path: include, depth: pending.depth + 1 });
         }
         if ghostty_config_deadline_expired(deadline_at) {
             return GhosttyConfigParseOutcome::TimedOut;

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -142,10 +142,10 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use cmux_tui_core::BrowserMode;
 use cmux_tui_core::SidebarPluginOptions;
-use cmux_tui_core::SurfaceOptions;
 use cmux_tui_core::TRANSPORT_SAFE_CAPTURE_MEGAPIXELS;
 use cmux_tui_core::platform;
 use cmux_tui_core::{CursorShape, DefaultColors, Rgb};
+use cmux_tui_core::{DEFAULT_SCROLLBACK_LIMIT_BYTES, SurfaceOptions};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::style::Color;
 use serde::{Deserialize, Deserializer};
@@ -3021,6 +3021,7 @@ pub struct Config {
     pub terminal_defaults: DefaultColors,
     pub cursor_style: Option<CursorShape>,
     pub cursor_blink: Option<bool>,
+    scrollback_limit_bytes: Option<usize>,
     pub chrome: ChromeMode,
     pub tabs: Tabs,
     pub sidebar: Sidebar,
@@ -3238,6 +3239,10 @@ pub struct ThemeOverrides {
 }
 
 impl Config {
+    pub fn scrollback_limit_bytes(&self) -> usize {
+        self.scrollback_limit_bytes.unwrap_or(DEFAULT_SCROLLBACK_LIMIT_BYTES)
+    }
+
     pub fn apply_chrome_defaults(&mut self, chrome: ChromeTheme) {
         if !self.theme_overrides.selection {
             self.theme.selection_bg = chrome.selection_bg;
@@ -3259,6 +3264,7 @@ pub fn load() -> Config {
 
     let defaults = ghostty_defaults();
     config.terminal_defaults = defaults;
+    config.scrollback_limit_bytes = ghostty_scrollback_limit_bytes();
     if let Some(bg) = defaults.selection_bg {
         config.theme.selection_bg = Color::Rgb(bg.r, bg.g, bg.b);
         config.theme_overrides.selection = true;
@@ -4359,6 +4365,82 @@ fn ghostty_defaults_from_sources(
         GhosttyHelperDefaults::TimedOut => DefaultColors::default(),
     };
     resolve_ghostty_application_defaults(parsed)
+}
+
+/// Read Ghostty's scrollback setting with the same bounded include traversal
+/// used for the other file-based defaults. Ghostty 1.4 renamed the setting to
+/// make the byte unit explicit, so both spellings are accepted.
+fn ghostty_scrollback_limit_bytes() -> Option<usize> {
+    let deadline_at = ghostty_config_deadline_from_now(GHOSTTY_CONFIG_PARSE_DEADLINE);
+    for path in platform::ghostty_config_paths() {
+        let Some(value) = parse_scrollback_limit_from_root(&path, deadline_at) else {
+            continue;
+        };
+        return value;
+    }
+    None
+}
+
+fn parse_scrollback_limit_from_root(path: &Path, deadline_at: Instant) -> Option<Option<usize>> {
+    let mut stack = vec![PendingGhosttyConfig { path: path.to_path_buf(), depth: 0 }];
+    let mut loaded = HashSet::new();
+    let mut files_loaded = 0usize;
+    let mut bytes_loaded = 0u64;
+    let mut value = None;
+    let mut loaded_root = false;
+
+    while let Some(pending) = stack.pop() {
+        if files_loaded > 0 && Instant::now() >= deadline_at {
+            break;
+        }
+        if pending.depth > GHOSTTY_CONFIG_MAX_DEPTH || files_loaded >= GHOSTTY_CONFIG_MAX_FILES {
+            continue;
+        }
+        let identity = pending.path.canonicalize().unwrap_or_else(|_| pending.path.clone());
+        if !loaded.insert(identity) {
+            continue;
+        }
+        let remaining_bytes = GHOSTTY_CONFIG_MAX_BYTES.saturating_sub(bytes_loaded);
+        let Some(text) = read_ghostty_regular_file(&pending.path, remaining_bytes) else {
+            if pending.depth == 0 && files_loaded == 0 {
+                return None;
+            }
+            continue;
+        };
+        bytes_loaded = bytes_loaded.saturating_add(text.len() as u64);
+        files_loaded += 1;
+        loaded_root |= pending.depth == 0;
+        if let Some(parsed) = parse_scrollback_limit_bytes(&text) {
+            value = Some(parsed);
+        }
+
+        let base_dir = pending.path.parent().unwrap_or_else(|| Path::new("."));
+        let mut theme_candidates = Vec::new();
+        let parsed = parse_ghostty_config_text(&text, Some(base_dir), &mut theme_candidates);
+        for include in parsed
+            .config_files
+            .into_iter()
+            .rev()
+            .filter_map(|include| include.resolve(base_dir))
+        {
+            stack.push(PendingGhosttyConfig { path: include, depth: pending.depth + 1 });
+        }
+    }
+
+    loaded_root.then_some(value)
+}
+
+fn parse_scrollback_limit_bytes(text: &str) -> Option<usize> {
+    text.lines()
+        .filter_map(|line| {
+            let (key, value) = line.trim().split_once('=')?;
+            if !matches!(key.trim(), "scrollback-limit" | "scrollback-limit-bytes") {
+                return None;
+            }
+            let value = value.split('#').next().unwrap_or(value).trim();
+            value.trim_matches('"').replace('_', "").parse::<usize>().ok()
+        })
+        .last()
 }
 
 fn resolve_ghostty_application_defaults(mut defaults: DefaultColors) -> DefaultColors {
@@ -5669,6 +5751,16 @@ mod tests {
         );
         assert_eq!(defaults.cursor_style, Some(CursorShape::Bar));
         assert_eq!(defaults.cursor_blink, Some(false));
+
+        assert_eq!(
+            parse_scrollback_limit_bytes(
+                "scrollback-limit-lines = 12\n\
+                 scrollback-limit = invalid\n\
+                 scrollback-limit-bytes = 8_000_000\n"
+            ),
+            Some(8_000_000)
+        );
+        assert_eq!(parse_scrollback_limit_bytes("scrollback-limit-lines = 12\n"), None);
 
         let invalid = parse_ghostty_defaults(
             "cursor-style = underline\n\

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -4372,16 +4372,41 @@ fn ghostty_defaults_from_sources(
 /// make the byte unit explicit, so both spellings are accepted.
 fn ghostty_scrollback_limit_bytes() -> Option<usize> {
     let deadline_at = ghostty_config_deadline_from_now(GHOSTTY_CONFIG_PARSE_DEADLINE);
+    let mut resolved = None;
     for path in platform::ghostty_config_paths() {
-        let Some(value) = parse_scrollback_limit_from_root(&path, deadline_at) else {
-            continue;
-        };
-        return value;
+        if ghostty_config_deadline_expired(Some(deadline_at)) {
+            // A partial traversal is not an authoritative configuration
+            // result. Falling back to the shared default avoids making
+            // startup timing change the selected security and memory limit.
+            return None;
+        }
+        match parse_scrollback_limit_from_root(&path, deadline_at) {
+            ScrollbackConfigOutcome::Missing => {}
+            ScrollbackConfigOutcome::TimedOut => return None,
+            ScrollbackConfigOutcome::Parsed(setting) => {
+                // A file with no setting does not mask another candidate.
+                // An explicit empty setting is represented as Some(None) and
+                // intentionally resets the accumulated value to the default.
+                if let Some(setting) = setting {
+                    resolved = setting;
+                }
+            }
+        }
     }
-    None
+    resolved
 }
 
-fn parse_scrollback_limit_from_root(path: &Path, deadline_at: Instant) -> Option<Option<usize>> {
+#[derive(Debug, PartialEq, Eq)]
+enum ScrollbackConfigOutcome {
+    Missing,
+    Parsed(Option<Option<usize>>),
+    TimedOut,
+}
+
+fn parse_scrollback_limit_from_root(
+    path: &Path,
+    deadline_at: Instant,
+) -> ScrollbackConfigOutcome {
     let mut stack = vec![PendingGhosttyConfig { path: path.to_path_buf(), depth: 0 }];
     let mut loaded = HashSet::new();
     let mut files_loaded = 0usize;
@@ -4390,8 +4415,8 @@ fn parse_scrollback_limit_from_root(path: &Path, deadline_at: Instant) -> Option
     let mut loaded_root = false;
 
     while let Some(pending) = stack.pop() {
-        if files_loaded > 0 && Instant::now() >= deadline_at {
-            break;
+        if Instant::now() >= deadline_at {
+            return ScrollbackConfigOutcome::TimedOut;
         }
         if pending.depth > GHOSTTY_CONFIG_MAX_DEPTH || files_loaded >= GHOSTTY_CONFIG_MAX_FILES {
             continue;
@@ -4403,7 +4428,7 @@ fn parse_scrollback_limit_from_root(path: &Path, deadline_at: Instant) -> Option
         let remaining_bytes = GHOSTTY_CONFIG_MAX_BYTES.saturating_sub(bytes_loaded);
         let Some(text) = read_ghostty_regular_file(&pending.path, remaining_bytes) else {
             if pending.depth == 0 && files_loaded == 0 {
-                return None;
+                return ScrollbackConfigOutcome::Missing;
             }
             continue;
         };
@@ -4422,12 +4447,22 @@ fn parse_scrollback_limit_from_root(path: &Path, deadline_at: Instant) -> Option
         {
             stack.push(PendingGhosttyConfig { path: include, depth: pending.depth + 1 });
         }
+        if Instant::now() >= deadline_at {
+            return ScrollbackConfigOutcome::TimedOut;
+        }
     }
 
-    loaded_root.then_some(value)
+    if loaded_root {
+        ScrollbackConfigOutcome::Parsed(value)
+    } else {
+        ScrollbackConfigOutcome::Missing
+    }
 }
 
-fn parse_scrollback_limit_bytes(text: &str) -> Option<usize> {
+/// Return the last scrollback setting in a file. The outer `Option` says
+/// whether a setting was present; the inner `Option` represents an explicit
+/// empty reset to the shared default.
+fn parse_scrollback_limit_bytes(text: &str) -> Option<Option<usize>> {
     text.lines()
         .filter_map(|line| {
             let (key, value) = line.trim().split_once('=')?;
@@ -4435,7 +4470,11 @@ fn parse_scrollback_limit_bytes(text: &str) -> Option<usize> {
                 return None;
             }
             let value = value.split('#').next().unwrap_or(value).trim();
-            value.trim_matches('"').replace('_', "").parse::<usize>().ok()
+            let value = value.trim_matches('"').trim();
+            if value.is_empty() {
+                return Some(None);
+            }
+            value.replace('_', "").parse::<usize>().ok().map(Some)
         })
         .last()
 }
@@ -5755,8 +5794,9 @@ mod tests {
                  scrollback-limit = invalid\n\
                  scrollback-limit-bytes = 8_000_000\n"
             ),
-            Some(8_000_000)
+            Some(Some(8_000_000))
         );
+        assert_eq!(parse_scrollback_limit_bytes("scrollback-limit = \"\"\n"), Some(None));
         assert_eq!(parse_scrollback_limit_bytes("scrollback-limit-lines = 12\n"), None);
 
         let invalid = parse_ghostty_defaults(
@@ -5777,6 +5817,34 @@ mod tests {
 
         let hollow = parse_ghostty_defaults("cursor-style = block_hollow\n");
         assert_eq!(hollow.cursor_style, Some(CursorShape::BlockHollow));
+    }
+
+    #[test]
+    fn scrollback_config_outcomes_preserve_precedence_and_timeout() {
+        let dir = TestDirectory::new("scrollback-outcomes");
+        let value_path = dir.path.join("value.conf");
+        let empty_path = dir.path.join("empty.conf");
+        let absent_path = dir.path.join("absent.conf");
+        std::fs::write(&value_path, "scrollback-limit = 123_456\n").unwrap();
+        std::fs::write(&empty_path, "scrollback-limit = \"\"\n").unwrap();
+        std::fs::write(&absent_path, "foreground = #010203\n").unwrap();
+
+        assert_eq!(
+            parse_scrollback_limit_from_root(&value_path, Instant::now() + Duration::from_secs(1)),
+            ScrollbackConfigOutcome::Parsed(Some(Some(123_456)))
+        );
+        assert_eq!(
+            parse_scrollback_limit_from_root(&absent_path, Instant::now() + Duration::from_secs(1)),
+            ScrollbackConfigOutcome::Parsed(None)
+        );
+        assert_eq!(
+            parse_scrollback_limit_from_root(&empty_path, Instant::now() + Duration::from_secs(1)),
+            ScrollbackConfigOutcome::Parsed(Some(None))
+        );
+        assert_eq!(
+            parse_scrollback_limit_from_root(&value_path, Instant::now() - Duration::from_secs(1)),
+            ScrollbackConfigOutcome::TimedOut
+        );
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -6096,26 +6096,14 @@ mod tests {
         let first = dir.path.join("first.conf");
         let second = dir.path.join("second.conf");
         let nested = dir.path.join("nested.conf");
-        std::fs::write(
-            &root,
-            "config-file = first.conf\nconfig-file = second.conf\n",
-        )
-        .unwrap();
+        std::fs::write(&root, "config-file = first.conf\nconfig-file = second.conf\n").unwrap();
         std::fs::write(
             &first,
             "foreground = #010203\nscrollback-limit-bytes = 2\nconfig-file = nested.conf\n",
         )
         .unwrap();
-        std::fs::write(
-            &second,
-            "foreground = #040506\nscrollback-limit-bytes = 3\n",
-        )
-        .unwrap();
-        std::fs::write(
-            &nested,
-            "foreground = #070809\nscrollback-limit-bytes = 4\n",
-        )
-        .unwrap();
+        std::fs::write(&second, "foreground = #040506\nscrollback-limit-bytes = 3\n").unwrap();
+        std::fs::write(&nested, "foreground = #070809\nscrollback-limit-bytes = 4\n").unwrap();
 
         let mut scrollback = None;
         let outcome = parse_ghostty_defaults_from_path_result_until_with_scrollback(

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -4406,10 +4406,7 @@ enum ScrollbackConfigOutcome {
     TimedOut,
 }
 
-fn parse_scrollback_limit_from_root(
-    path: &Path,
-    deadline_at: Instant,
-) -> ScrollbackConfigOutcome {
+fn parse_scrollback_limit_from_root(path: &Path, deadline_at: Instant) -> ScrollbackConfigOutcome {
     // Ghostty parses the complete parent file first, then loads its
     // config-file entries in declaration order. Nested entries are appended
     // after the already queued siblings. A FIFO queue preserves that
@@ -4449,7 +4446,8 @@ fn parse_scrollback_limit_from_root(
         let base_dir = pending.path.parent().unwrap_or_else(|| Path::new("."));
         let mut theme_candidates = Vec::new();
         let parsed = parse_ghostty_config_text(&text, Some(base_dir), &mut theme_candidates);
-        for include in parsed.config_files.into_iter().filter_map(|include| include.resolve(base_dir))
+        for include in
+            parsed.config_files.into_iter().filter_map(|include| include.resolve(base_dir))
         {
             queue.push_back(PendingGhosttyConfig { path: include, depth: pending.depth + 1 });
         }

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -4417,11 +4417,8 @@ fn parse_scrollback_limit_from_root(path: &Path, deadline_at: Instant) -> Option
         let base_dir = pending.path.parent().unwrap_or_else(|| Path::new("."));
         let mut theme_candidates = Vec::new();
         let parsed = parse_ghostty_config_text(&text, Some(base_dir), &mut theme_candidates);
-        for include in parsed
-            .config_files
-            .into_iter()
-            .rev()
-            .filter_map(|include| include.resolve(base_dir))
+        for include in
+            parsed.config_files.into_iter().rev().filter_map(|include| include.resolve(base_dir))
         {
             stack.push(PendingGhosttyConfig { path: include, depth: pending.depth + 1 });
         }

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -4378,14 +4378,15 @@ fn ghostty_defaults_from_sources(
     theme_dirs: Vec<PathBuf>,
     helper_defaults: GhosttyHelperDefaults,
 ) -> DefaultColors {
-    let parsed = match helper_defaults {
+    match helper_defaults {
         GhosttyHelperDefaults::Resolved(defaults) => defaults.colors,
         GhosttyHelperDefaults::Unavailable => {
-            parse_ghostty_defaults_from_paths(config_paths, theme_dirs).unwrap_or_default()
+            parse_ghostty_application_defaults_from_paths(config_paths, theme_dirs)
+                .map(|defaults| defaults.colors)
+                .unwrap_or_default()
         }
         GhosttyHelperDefaults::TimedOut => DefaultColors::default(),
-    };
-    resolve_ghostty_application_defaults(parsed)
+    }
 }
 
 /// Read Ghostty's scrollback setting with the same bounded include traversal
@@ -4843,19 +4844,23 @@ fn parse_ghostty_application_defaults_from_paths(
             &path,
             &theme_dirs,
             Some(deadline_at),
-            &mut path_scrollback,
+            Some(&mut path_scrollback),
         ) {
             GhosttyConfigParseOutcome::Missing => {}
             GhosttyConfigParseOutcome::TimedOut => return None,
             GhosttyConfigParseOutcome::Parsed(defaults) => {
-                resolved.get_or_insert(*defaults);
+                let merged = resolved.get_or_insert_with(DefaultColors::default);
+                overlay_ghostty_defaults(merged, *defaults);
                 if let Some(value) = path_scrollback {
                     scrollback_limit_bytes = value;
                 }
             }
         }
     }
-    resolved.map(|colors| GhosttyApplicationDefaults { colors, scrollback_limit_bytes })
+    resolved.map(|colors| GhosttyApplicationDefaults {
+        colors: resolve_ghostty_application_defaults(colors),
+        scrollback_limit_bytes,
+    })
 }
 
 enum GhosttyConfigParseOutcome {
@@ -4922,7 +4927,7 @@ fn parse_ghostty_defaults_from_path_result_until(
         path,
         theme_dirs,
         deadline_at,
-        &mut None,
+        None,
     )
 }
 
@@ -4930,7 +4935,7 @@ fn parse_ghostty_defaults_from_path_result_until_with_scrollback(
     path: &Path,
     theme_dirs: &[PathBuf],
     deadline_at: Option<Instant>,
-    scrollback_limit_bytes: &mut Option<Option<usize>>,
+    mut scrollback_limit_bytes: Option<&mut Option<Option<usize>>>,
 ) -> GhosttyConfigParseOutcome {
     let mut theme_candidates = Vec::new();
     let overrides = match parse_ghostty_config_file_until_with_scrollback(
@@ -4990,23 +4995,24 @@ fn parse_ghostty_config_file_until(
     theme_candidates: &mut Vec<GhosttyThemeCandidate>,
     deadline_at: Option<Instant>,
 ) -> GhosttyConfigParseOutcome {
-    parse_ghostty_config_file_until_with_scrollback(path, theme_candidates, deadline_at, &mut None)
+    parse_ghostty_config_file_until_with_scrollback(path, theme_candidates, deadline_at, None)
 }
 
 fn parse_ghostty_config_file_until_with_scrollback(
     path: &Path,
     theme_candidates: &mut Vec<GhosttyThemeCandidate>,
     deadline_at: Option<Instant>,
-    scrollback_limit_bytes: &mut Option<Option<usize>>,
+    mut scrollback_limit_bytes: Option<&mut Option<Option<usize>>>,
 ) -> GhosttyConfigParseOutcome {
-    let mut stack = vec![PendingGhosttyConfig { path: path.to_path_buf(), depth: 0 }];
+    let mut queue = VecDeque::from([PendingGhosttyConfig { path: path.to_path_buf(), depth: 0 }]);
     let mut loaded = HashSet::new();
     let mut files_loaded = 0usize;
     let mut bytes_loaded = 0u64;
     let mut loaded_root = false;
     let mut overrides = DefaultColors::default();
+    let collect_scrollback = scrollback_limit_bytes.is_some();
 
-    while let Some(pending) = stack.pop() {
+    while let Some(pending) = queue.pop_front() {
         if files_loaded > 0 && ghostty_config_deadline_expired(deadline_at) {
             return GhosttyConfigParseOutcome::TimedOut;
         }
@@ -5028,7 +5034,9 @@ fn parse_ghostty_config_file_until_with_scrollback(
         bytes_loaded = bytes_loaded.saturating_add(text.len() as u64);
         files_loaded += 1;
         loaded_root |= pending.depth == 0;
-        if let Some(parsed) = parse_scrollback_limit_bytes(&text) {
+        if let (Some(scrollback_limit_bytes), Some(parsed)) =
+            (scrollback_limit_bytes.as_deref_mut(), parse_scrollback_limit_bytes(&text))
+        {
             *scrollback_limit_bytes = Some(parsed);
         }
 
@@ -5036,10 +5044,16 @@ fn parse_ghostty_config_file_until_with_scrollback(
         let parsed = parse_ghostty_config_text(&text, Some(base_dir), theme_candidates);
         overlay_ghostty_defaults(&mut overrides, parsed.overrides);
 
-        for include in
-            parsed.config_files.into_iter().rev().filter_map(|include| include.resolve(base_dir))
-        {
-            stack.push(PendingGhosttyConfig { path: include, depth: pending.depth + 1 });
+        let includes =
+            parsed.config_files.into_iter().filter_map(|include| include.resolve(base_dir));
+        if collect_scrollback {
+            for include in includes {
+                queue.push_back(PendingGhosttyConfig { path: include, depth: pending.depth + 1 });
+            }
+        } else {
+            for include in includes.rev() {
+                queue.push_front(PendingGhosttyConfig { path: include, depth: pending.depth + 1 });
+            }
         }
         if ghostty_config_deadline_expired(deadline_at) {
             return GhosttyConfigParseOutcome::TimedOut;
@@ -5983,13 +5997,29 @@ mod tests {
             &root,
             &[],
             Some(Instant::now() + Duration::from_secs(1)),
-            &mut scrollback,
+            Some(&mut scrollback),
         );
         let GhosttyConfigParseOutcome::Parsed(colors) = outcome else {
             panic!("snapshot should parse");
         };
         assert_eq!(colors.fg, Some(Rgb { r: 1, g: 2, b: 3 }));
         assert_eq!(scrollback, Some(Some(654321)));
+    }
+
+    #[test]
+    fn application_defaults_overlay_later_config_and_resolve_fallbacks() {
+        let dir = TestDirectory::new("application-defaults-overlay");
+        let legacy = dir.path.join("config");
+        let current = dir.path.join("config.ghostty");
+        std::fs::write(&legacy, "foreground = #010203\n").unwrap();
+        std::fs::write(&current, "foreground = #070809\nbackground = #040506\n").unwrap();
+
+        let defaults =
+            parse_ghostty_application_defaults_from_paths(vec![legacy, current], Vec::new())
+                .expect("config files should parse");
+        assert_eq!(defaults.colors.fg, Some(Rgb { r: 7, g: 8, b: 9 }));
+        assert_eq!(defaults.colors.bg, Some(Rgb { r: 4, g: 5, b: 6 }));
+        assert_eq!(defaults.colors.cursor_style, Some(CursorShape::Block));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -4564,15 +4564,16 @@ pub(crate) fn is_ghostty_config_helper_invocation(args: &[String]) -> bool {
 }
 
 pub(crate) fn run_ghostty_config_helper() -> i32 {
-    match parse_ghostty_application_defaults_from_paths(
+    match parse_ghostty_application_defaults_from_paths_result(
         platform::ghostty_config_paths(),
         platform::ghostty_theme_dirs(),
     ) {
-        Some(defaults) => {
+        GhosttyApplicationDefaultsParseOutcome::Parsed(defaults) => {
             print!("{}", serialize_ghostty_application_defaults(&defaults));
             0
         }
-        None => 1,
+        GhosttyApplicationDefaultsParseOutcome::Missing => 1,
+        GhosttyApplicationDefaultsParseOutcome::TimedOut => 2,
     }
 }
 
@@ -4832,12 +4833,29 @@ fn parse_ghostty_application_defaults_from_paths(
     config_paths: Vec<PathBuf>,
     theme_dirs: Vec<PathBuf>,
 ) -> Option<GhosttyApplicationDefaults> {
+    match parse_ghostty_application_defaults_from_paths_result(config_paths, theme_dirs) {
+        GhosttyApplicationDefaultsParseOutcome::Parsed(defaults) => Some(defaults),
+        GhosttyApplicationDefaultsParseOutcome::Missing
+        | GhosttyApplicationDefaultsParseOutcome::TimedOut => None,
+    }
+}
+
+enum GhosttyApplicationDefaultsParseOutcome {
+    Parsed(GhosttyApplicationDefaults),
+    Missing,
+    TimedOut,
+}
+
+fn parse_ghostty_application_defaults_from_paths_result(
+    config_paths: Vec<PathBuf>,
+    theme_dirs: Vec<PathBuf>,
+) -> GhosttyApplicationDefaultsParseOutcome {
     let deadline_at = ghostty_config_deadline_from_now(GHOSTTY_CONFIG_PARSE_DEADLINE);
     let mut resolved = None;
     let mut scrollback_limit_bytes = None;
     for path in config_paths {
         if ghostty_config_deadline_expired(Some(deadline_at)) {
-            return None;
+            return GhosttyApplicationDefaultsParseOutcome::TimedOut;
         }
         let mut path_scrollback = None;
         match parse_ghostty_defaults_from_path_result_until_with_scrollback(
@@ -4847,7 +4865,9 @@ fn parse_ghostty_application_defaults_from_paths(
             Some(&mut path_scrollback),
         ) {
             GhosttyConfigParseOutcome::Missing => {}
-            GhosttyConfigParseOutcome::TimedOut => return None,
+            GhosttyConfigParseOutcome::TimedOut => {
+                return GhosttyApplicationDefaultsParseOutcome::TimedOut;
+            }
             GhosttyConfigParseOutcome::Parsed(defaults) => {
                 let merged = resolved.get_or_insert_with(DefaultColors::default);
                 overlay_ghostty_defaults(merged, *defaults);
@@ -4857,10 +4877,15 @@ fn parse_ghostty_application_defaults_from_paths(
             }
         }
     }
-    resolved.map(|colors| GhosttyApplicationDefaults {
-        colors: resolve_ghostty_application_defaults(colors),
-        scrollback_limit_bytes,
-    })
+    match resolved {
+        Some(colors) => {
+            GhosttyApplicationDefaultsParseOutcome::Parsed(GhosttyApplicationDefaults {
+                colors: resolve_ghostty_application_defaults(colors),
+                scrollback_limit_bytes,
+            })
+        }
+        None => GhosttyApplicationDefaultsParseOutcome::Missing,
+    }
 }
 
 enum GhosttyConfigParseOutcome {
@@ -5004,15 +5029,17 @@ fn parse_ghostty_config_file_until_with_scrollback(
     deadline_at: Option<Instant>,
     mut scrollback_limit_bytes: Option<&mut Option<Option<usize>>>,
 ) -> GhosttyConfigParseOutcome {
-    let mut queue = VecDeque::from([PendingGhosttyConfig { path: path.to_path_buf(), depth: 0 }]);
+    let mut stack = vec![PendingGhosttyConfig { path: path.to_path_buf(), depth: 0 }];
     let mut loaded = HashSet::new();
+    let mut snapshot = Vec::new();
     let mut files_loaded = 0usize;
     let mut bytes_loaded = 0u64;
     let mut loaded_root = false;
     let mut overrides = DefaultColors::default();
     let collect_scrollback = scrollback_limit_bytes.is_some();
+    let root_identity = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
 
-    while let Some(pending) = queue.pop_front() {
+    while let Some(pending) = stack.pop() {
         if files_loaded > 0 && ghostty_config_deadline_expired(deadline_at) {
             return GhosttyConfigParseOutcome::TimedOut;
         }
@@ -5034,26 +5061,20 @@ fn parse_ghostty_config_file_until_with_scrollback(
         bytes_loaded = bytes_loaded.saturating_add(text.len() as u64);
         files_loaded += 1;
         loaded_root |= pending.depth == 0;
-        if let (Some(scrollback_limit_bytes), Some(parsed)) =
-            (scrollback_limit_bytes.as_deref_mut(), parse_scrollback_limit_bytes(&text))
-        {
-            *scrollback_limit_bytes = Some(parsed);
-        }
-
         let base_dir = pending.path.parent().unwrap_or_else(|| Path::new("."));
         let parsed = parse_ghostty_config_text(&text, Some(base_dir), theme_candidates);
         overlay_ghostty_defaults(&mut overrides, parsed.overrides);
 
-        let includes =
-            parsed.config_files.into_iter().filter_map(|include| include.resolve(base_dir));
+        let includes: Vec<PathBuf> = parsed
+            .config_files
+            .into_iter()
+            .filter_map(|include| include.resolve(base_dir))
+            .collect();
         if collect_scrollback {
-            for include in includes {
-                queue.push_back(PendingGhosttyConfig { path: include, depth: pending.depth + 1 });
-            }
-        } else {
-            for include in includes.rev() {
-                queue.push_front(PendingGhosttyConfig { path: include, depth: pending.depth + 1 });
-            }
+            snapshot.push((identity, includes.clone(), parse_scrollback_limit_bytes(&text)));
+        }
+        for include in includes.into_iter().rev() {
+            stack.push(PendingGhosttyConfig { path: include, depth: pending.depth + 1 });
         }
         if ghostty_config_deadline_expired(deadline_at) {
             return GhosttyConfigParseOutcome::TimedOut;
@@ -5061,6 +5082,32 @@ fn parse_ghostty_config_file_until_with_scrollback(
     }
 
     if loaded_root {
+        if let Some(scrollback_limit_bytes) = scrollback_limit_bytes.as_deref_mut() {
+            let mut snapshot_by_identity = HashMap::new();
+            for (index, (identity, _, _)) in snapshot.iter().enumerate() {
+                snapshot_by_identity.insert(identity, index);
+            }
+            let mut queue = VecDeque::from([(root_identity, 0usize)]);
+            let mut seen = HashSet::new();
+            let mut resolved = None;
+            while let Some((identity, depth)) = queue.pop_front() {
+                if depth > GHOSTTY_CONFIG_MAX_DEPTH || !seen.insert(identity.clone()) {
+                    continue;
+                }
+                let Some(&index) = snapshot_by_identity.get(&identity) else {
+                    continue;
+                };
+                let (_, includes, value) = &snapshot[index];
+                if let Some(value) = value {
+                    resolved = Some(*value);
+                }
+                for include in includes {
+                    let identity = include.canonicalize().unwrap_or_else(|_| include.clone());
+                    queue.push_back((identity, depth + 1));
+                }
+            }
+            *scrollback_limit_bytes = resolved;
+        }
         GhosttyConfigParseOutcome::Parsed(Box::new(overrides))
     } else {
         GhosttyConfigParseOutcome::Missing
@@ -7338,8 +7385,8 @@ mod tests {
         let GhosttyHelperDefaults::Resolved(defaults) = defaults else {
             panic!("helper should resolve within parent startup margin");
         };
-        assert_eq!(defaults.fg, Some(Rgb { r: 0x01, g: 0x02, b: 0x03 }));
-        assert_eq!(defaults.bg, Some(Rgb { r: 0x04, g: 0x05, b: 0x06 }));
+        assert_eq!(defaults.colors.fg, Some(Rgb { r: 0x01, g: 0x02, b: 0x03 }));
+        assert_eq!(defaults.colors.bg, Some(Rgb { r: 0x04, g: 0x05, b: 0x06 }));
     }
 
     #[cfg(all(unix, not(target_os = "macos")))]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -146,6 +146,8 @@ use cmux_tui_core::TRANSPORT_SAFE_CAPTURE_MEGAPIXELS;
 use cmux_tui_core::platform;
 use cmux_tui_core::{CursorShape, DefaultColors, Rgb};
 use cmux_tui_core::{DEFAULT_SCROLLBACK_LIMIT_BYTES, SurfaceOptions};
+
+const MAX_SCROLLBACK_LIMIT_BYTES: usize = 1_000_000_000;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::style::Color;
 use serde::{Deserialize, Deserializer};
@@ -3243,7 +3245,9 @@ impl Config {
     /// surface API uses bytes, so this value must never be interpreted as a
     /// line count by callers.
     pub fn scrollback_limit_bytes(&self) -> usize {
-        self.scrollback_limit_bytes.unwrap_or(DEFAULT_SCROLLBACK_LIMIT_BYTES)
+        self.scrollback_limit_bytes
+            .unwrap_or(DEFAULT_SCROLLBACK_LIMIT_BYTES)
+            .min(MAX_SCROLLBACK_LIMIT_BYTES)
     }
 
     pub fn apply_chrome_defaults(&mut self, chrome: ChromeTheme) {
@@ -4344,10 +4348,18 @@ fn ghostty_defaults() -> DefaultColors {
     ghostty_application_defaults().colors
 }
 
-#[derive(Default)]
 struct GhosttyApplicationDefaults {
     colors: DefaultColors,
     scrollback_limit_bytes: Option<usize>,
+}
+
+impl Default for GhosttyApplicationDefaults {
+    fn default() -> Self {
+        Self {
+            colors: resolve_ghostty_application_defaults(DefaultColors::default()),
+            scrollback_limit_bytes: None,
+        }
+    }
 }
 
 fn ghostty_application_defaults() -> GhosttyApplicationDefaults {
@@ -4383,9 +4395,9 @@ fn ghostty_defaults_from_sources(
         GhosttyHelperDefaults::Unavailable => {
             parse_ghostty_application_defaults_from_paths(config_paths, theme_dirs)
                 .map(|defaults| defaults.colors)
-                .unwrap_or_default()
+                .unwrap_or_else(|| GhosttyApplicationDefaults::default().colors)
         }
-        GhosttyHelperDefaults::TimedOut => DefaultColors::default(),
+        GhosttyHelperDefaults::TimedOut => GhosttyApplicationDefaults::default().colors,
     }
 }
 
@@ -6067,6 +6079,18 @@ mod tests {
         assert_eq!(defaults.colors.fg, Some(Rgb { r: 7, g: 8, b: 9 }));
         assert_eq!(defaults.colors.bg, Some(Rgb { r: 4, g: 5, b: 6 }));
         assert_eq!(defaults.colors.cursor_style, Some(CursorShape::Block));
+    }
+
+    #[test]
+    fn effective_scrollback_limit_is_bounded() {
+        let mut config = Config::default();
+        assert_eq!(config.scrollback_limit_bytes(), DEFAULT_SCROLLBACK_LIMIT_BYTES);
+
+        config.scrollback_limit_bytes = Some(usize::MAX);
+        assert_eq!(config.scrollback_limit_bytes(), MAX_SCROLLBACK_LIMIT_BYTES);
+
+        config.scrollback_limit_bytes = Some(0);
+        assert_eq!(config.scrollback_limit_bytes(), 0);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -4445,7 +4445,7 @@ fn parse_scrollback_limit_from_root(path: &Path, deadline_at: Instant) -> Scroll
             continue;
         }
         let identity = pending.path.canonicalize().unwrap_or_else(|_| pending.path.clone());
-        if !loaded.insert(identity) {
+        if !loaded.insert(identity.clone()) {
             continue;
         }
         let remaining_bytes = GHOSTTY_CONFIG_MAX_BYTES.saturating_sub(bytes_loaded);

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -4841,7 +4841,9 @@ fn parse_ghostty_defaults_from_paths(
 ) -> Option<DefaultColors> {
     match parse_ghostty_defaults_from_paths_result(config_paths, theme_dirs) {
         GhosttyConfigParseOutcome::Parsed(defaults) => Some(*defaults),
-        GhosttyConfigParseOutcome::Missing | GhosttyConfigParseOutcome::TimedOut => None,
+        GhosttyConfigParseOutcome::Partial(_)
+        | GhosttyConfigParseOutcome::Missing
+        | GhosttyConfigParseOutcome::TimedOut => None,
     }
 }
 

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -4454,13 +4454,16 @@ fn parse_scrollback_limit_from_root(path: &Path, deadline_at: Instant) -> Scroll
             return ScrollbackConfigOutcome::TimedOut;
         }
         if pending.depth > GHOSTTY_CONFIG_MAX_DEPTH || files_loaded >= GHOSTTY_CONFIG_MAX_FILES {
-            continue;
+            return ScrollbackConfigOutcome::TimedOut;
         }
         let identity = pending.path.canonicalize().unwrap_or_else(|_| pending.path.clone());
         if !loaded.insert(identity.clone()) {
             continue;
         }
         let remaining_bytes = GHOSTTY_CONFIG_MAX_BYTES.saturating_sub(bytes_loaded);
+        if ghostty_regular_file_exceeds_limit(&pending.path, remaining_bytes) {
+            return ScrollbackConfigOutcome::TimedOut;
+        }
         let Some(text) = read_ghostty_regular_file(&pending.path, remaining_bytes) else {
             if pending.depth == 0 && files_loaded == 0 {
                 return ScrollbackConfigOutcome::Missing;
@@ -5056,6 +5059,9 @@ fn parse_ghostty_config_file_until_with_scrollback(
             return GhosttyConfigParseOutcome::TimedOut;
         }
         if pending.depth > GHOSTTY_CONFIG_MAX_DEPTH || files_loaded >= GHOSTTY_CONFIG_MAX_FILES {
+            if collect_scrollback {
+                return GhosttyConfigParseOutcome::TimedOut;
+            }
             continue;
         }
         let identity = pending.path.canonicalize().unwrap_or_else(|_| pending.path.clone());
@@ -5063,6 +5069,10 @@ fn parse_ghostty_config_file_until_with_scrollback(
             continue;
         }
         let remaining_bytes = GHOSTTY_CONFIG_MAX_BYTES.saturating_sub(bytes_loaded);
+        if collect_scrollback && ghostty_regular_file_exceeds_limit(&pending.path, remaining_bytes)
+        {
+            return GhosttyConfigParseOutcome::TimedOut;
+        }
         let text = match read_ghostty_regular_file(&pending.path, remaining_bytes) {
             Some(text) => text,
             None if pending.depth == 0 && files_loaded == 0 => {
@@ -5768,6 +5778,11 @@ fn read_ghostty_regular_file(path: &Path, max_bytes: u64) -> Option<String> {
     read_ghostty_limited_string(file, max_bytes)
 }
 
+fn ghostty_regular_file_exceeds_limit(path: &Path, max_bytes: u64) -> bool {
+    std::fs::metadata(path)
+        .is_ok_and(|metadata| metadata.file_type().is_file() && metadata.len() > max_bytes)
+}
+
 fn read_ghostty_limited_string(reader: impl Read, max_bytes: u64) -> Option<String> {
     let mut text = String::new();
     reader.take(max_bytes.saturating_add(1)).read_to_string(&mut text).ok()?;
@@ -6041,6 +6056,35 @@ mod tests {
             parse_scrollback_limit_from_root(&root, Instant::now() + Duration::from_secs(1)),
             ScrollbackConfigOutcome::Parsed(Some(Some(4)))
         );
+    }
+
+    #[test]
+    fn scrollback_config_rejects_truncated_include_snapshot() {
+        let dir = TestDirectory::new("scrollback-truncated-include");
+        for depth in 0..=GHOSTTY_CONFIG_MAX_DEPTH + 1 {
+            let path = dir.path.join(format!("config-{depth}"));
+            let include = if depth <= GHOSTTY_CONFIG_MAX_DEPTH {
+                format!("config-file = config-{}\n", depth + 1)
+            } else {
+                "scrollback-limit-bytes = 999999\n".to_owned()
+            };
+            std::fs::write(path, include).unwrap();
+        }
+        let root = dir.path.join("config-0");
+
+        assert_eq!(
+            parse_scrollback_limit_from_root(&root, Instant::now() + Duration::from_secs(1)),
+            ScrollbackConfigOutcome::TimedOut
+        );
+
+        let mut scrollback = None;
+        let outcome = parse_ghostty_defaults_from_path_result_until_with_scrollback(
+            &root,
+            &[],
+            Some(Instant::now() + Duration::from_secs(1)),
+            Some(&mut scrollback),
+        );
+        assert!(matches!(outcome, GhosttyConfigParseOutcome::TimedOut));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -4890,6 +4890,10 @@ fn parse_ghostty_application_defaults_from_paths_result(
                     scrollback_limit_bytes = value;
                 }
             }
+            GhosttyConfigParseOutcome::Partial(defaults) => {
+                let merged = resolved.get_or_insert_with(DefaultColors::default);
+                overlay_ghostty_defaults(merged, *defaults);
+            }
         }
     }
     match resolved {
@@ -4905,6 +4909,7 @@ fn parse_ghostty_application_defaults_from_paths_result(
 
 enum GhosttyConfigParseOutcome {
     Parsed(Box<DefaultColors>),
+    Partial(Box<DefaultColors>),
     Missing,
     TimedOut,
 }
@@ -5056,11 +5061,15 @@ fn parse_ghostty_config_file_until_with_scrollback(
 
     while let Some(pending) = stack.pop() {
         if files_loaded > 0 && ghostty_config_deadline_expired(deadline_at) {
-            return GhosttyConfigParseOutcome::TimedOut;
+            return if collect_scrollback {
+                GhosttyConfigParseOutcome::Partial(Box::new(overrides))
+            } else {
+                GhosttyConfigParseOutcome::TimedOut
+            };
         }
         if pending.depth > GHOSTTY_CONFIG_MAX_DEPTH || files_loaded >= GHOSTTY_CONFIG_MAX_FILES {
             if collect_scrollback {
-                return GhosttyConfigParseOutcome::TimedOut;
+                return GhosttyConfigParseOutcome::Partial(Box::new(overrides));
             }
             continue;
         }
@@ -5071,7 +5080,7 @@ fn parse_ghostty_config_file_until_with_scrollback(
         let remaining_bytes = GHOSTTY_CONFIG_MAX_BYTES.saturating_sub(bytes_loaded);
         if collect_scrollback && ghostty_regular_file_exceeds_limit(&pending.path, remaining_bytes)
         {
-            return GhosttyConfigParseOutcome::TimedOut;
+            return GhosttyConfigParseOutcome::Partial(Box::new(overrides));
         }
         let text = match read_ghostty_regular_file(&pending.path, remaining_bytes) {
             Some(text) => text,
@@ -5099,7 +5108,11 @@ fn parse_ghostty_config_file_until_with_scrollback(
             stack.push(PendingGhosttyConfig { path: include, depth: pending.depth + 1 });
         }
         if ghostty_config_deadline_expired(deadline_at) {
-            return GhosttyConfigParseOutcome::TimedOut;
+            return if collect_scrollback {
+                GhosttyConfigParseOutcome::Partial(Box::new(overrides))
+            } else {
+                GhosttyConfigParseOutcome::TimedOut
+            };
         }
     }
 
@@ -6071,6 +6084,7 @@ mod tests {
             std::fs::write(path, include).unwrap();
         }
         let root = dir.path.join("config-0");
+        std::fs::write(&root, "foreground = #010203\nconfig-file = config-1\n").unwrap();
 
         assert_eq!(
             parse_scrollback_limit_from_root(&root, Instant::now() + Duration::from_secs(1)),
@@ -6084,7 +6098,10 @@ mod tests {
             Some(Instant::now() + Duration::from_secs(1)),
             Some(&mut scrollback),
         );
-        assert!(matches!(outcome, GhosttyConfigParseOutcome::TimedOut));
+        let GhosttyConfigParseOutcome::Partial(colors) = outcome else {
+            panic!("truncated snapshot should preserve parsed colors");
+        };
+        assert_eq!(colors.fg, Some(Rgb { r: 1, g: 2, b: 3 }));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -127,7 +127,7 @@
 //! deliberate non-goal because they conflict with shell/editor control
 //! keys.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs::OpenOptions;
 use std::io::{Read, Write};
 use std::ops::Deref;
@@ -3239,6 +3239,9 @@ pub struct ThemeOverrides {
 }
 
 impl Config {
+    /// Effective Ghostty scrollback storage limit in bytes. Ghostty's VT
+    /// surface API uses bytes, so this value must never be interpreted as a
+    /// line count by callers.
     pub fn scrollback_limit_bytes(&self) -> usize {
         self.scrollback_limit_bytes.unwrap_or(DEFAULT_SCROLLBACK_LIMIT_BYTES)
     }
@@ -4407,14 +4410,18 @@ fn parse_scrollback_limit_from_root(
     path: &Path,
     deadline_at: Instant,
 ) -> ScrollbackConfigOutcome {
-    let mut stack = vec![PendingGhosttyConfig { path: path.to_path_buf(), depth: 0 }];
+    // Ghostty parses the complete parent file first, then loads its
+    // config-file entries in declaration order. Nested entries are appended
+    // after the already queued siblings. A FIFO queue preserves that
+    // precedence while keeping the traversal bounded below.
+    let mut queue = VecDeque::from([PendingGhosttyConfig { path: path.to_path_buf(), depth: 0 }]);
     let mut loaded = HashSet::new();
     let mut files_loaded = 0usize;
     let mut bytes_loaded = 0u64;
     let mut value = None;
     let mut loaded_root = false;
 
-    while let Some(pending) = stack.pop() {
+    while let Some(pending) = queue.pop_front() {
         if Instant::now() >= deadline_at {
             return ScrollbackConfigOutcome::TimedOut;
         }
@@ -4442,10 +4449,9 @@ fn parse_scrollback_limit_from_root(
         let base_dir = pending.path.parent().unwrap_or_else(|| Path::new("."));
         let mut theme_candidates = Vec::new();
         let parsed = parse_ghostty_config_text(&text, Some(base_dir), &mut theme_candidates);
-        for include in
-            parsed.config_files.into_iter().rev().filter_map(|include| include.resolve(base_dir))
+        for include in parsed.config_files.into_iter().filter_map(|include| include.resolve(base_dir))
         {
-            stack.push(PendingGhosttyConfig { path: include, depth: pending.depth + 1 });
+            queue.push_back(PendingGhosttyConfig { path: include, depth: pending.depth + 1 });
         }
         if Instant::now() >= deadline_at {
             return ScrollbackConfigOutcome::TimedOut;
@@ -4469,8 +4475,15 @@ fn parse_scrollback_limit_bytes(text: &str) -> Option<Option<usize>> {
             if !matches!(key.trim(), "scrollback-limit" | "scrollback-limit-bytes") {
                 return None;
             }
-            let value = value.split('#').next().unwrap_or(value).trim();
-            let value = value.trim_matches('"').trim();
+            // Ghostty treats comments as whole lines. Do not truncate a
+            // numeric value at '#', because that would accept malformed input
+            // that Ghostty rejects.
+            let value = value.trim();
+            let value = value
+                .strip_prefix('"')
+                .and_then(|value| value.strip_suffix('"'))
+                .unwrap_or(value)
+                .trim();
             if value.is_empty() {
                 return Some(None);
             }
@@ -4912,14 +4925,17 @@ fn parse_ghostty_config_file_until(
     theme_candidates: &mut Vec<GhosttyThemeCandidate>,
     deadline_at: Option<Instant>,
 ) -> GhosttyConfigParseOutcome {
-    let mut stack = vec![PendingGhosttyConfig { path: path.to_path_buf(), depth: 0 }];
+    // Keep the same breadth-first order as Ghostty's loadRecursiveFiles:
+    // finish a parent, then process its includes in declaration order, with
+    // nested includes queued after existing siblings.
+    let mut queue = VecDeque::from([PendingGhosttyConfig { path: path.to_path_buf(), depth: 0 }]);
     let mut loaded = HashSet::new();
     let mut files_loaded = 0usize;
     let mut bytes_loaded = 0u64;
     let mut loaded_root = false;
     let mut overrides = DefaultColors::default();
 
-    while let Some(pending) = stack.pop() {
+    while let Some(pending) = queue.pop_front() {
         if files_loaded > 0 && ghostty_config_deadline_expired(deadline_at) {
             return GhosttyConfigParseOutcome::TimedOut;
         }
@@ -4946,10 +4962,9 @@ fn parse_ghostty_config_file_until(
         let parsed = parse_ghostty_config_text(&text, Some(base_dir), theme_candidates);
         overlay_ghostty_defaults(&mut overrides, parsed.overrides);
 
-        for include in
-            parsed.config_files.into_iter().rev().filter_map(|include| include.resolve(base_dir))
+        for include in parsed.config_files.into_iter().filter_map(|include| include.resolve(base_dir))
         {
-            stack.push(PendingGhosttyConfig { path: include, depth: pending.depth + 1 });
+            queue.push_back(PendingGhosttyConfig { path: include, depth: pending.depth + 1 });
         }
         if ghostty_config_deadline_expired(deadline_at) {
             return GhosttyConfigParseOutcome::TimedOut;
@@ -5798,6 +5813,7 @@ mod tests {
         );
         assert_eq!(parse_scrollback_limit_bytes("scrollback-limit = \"\"\n"), Some(None));
         assert_eq!(parse_scrollback_limit_bytes("scrollback-limit-lines = 12\n"), None);
+        assert_eq!(parse_scrollback_limit_bytes("scrollback-limit = 4096#note\n"), None);
 
         let invalid = parse_ghostty_defaults(
             "cursor-style = underline\n\
@@ -5844,6 +5860,30 @@ mod tests {
         assert_eq!(
             parse_scrollback_limit_from_root(&value_path, Instant::now() - Duration::from_secs(1)),
             ScrollbackConfigOutcome::TimedOut
+        );
+    }
+
+    #[test]
+    fn scrollback_include_order_matches_ghostty_recursive_loading() {
+        let dir = TestDirectory::new("scrollback-include-order");
+        let root = dir.path.join("config");
+        let first = dir.path.join("first.conf");
+        let second = dir.path.join("second.conf");
+        let nested = dir.path.join("nested.conf");
+        std::fs::write(
+            &root,
+            "config-file = first.conf\n\
+             scrollback-limit = 1\n\
+             config-file = second.conf\n",
+        )
+        .unwrap();
+        std::fs::write(&first, "scrollback-limit = 2\nconfig-file = nested.conf\n").unwrap();
+        std::fs::write(&second, "scrollback-limit = 3\n").unwrap();
+        std::fs::write(&nested, "scrollback-limit = 4\n").unwrap();
+
+        assert_eq!(
+            parse_scrollback_limit_from_root(&root, Instant::now() + Duration::from_secs(1)),
+            ScrollbackConfigOutcome::Parsed(Some(Some(4)))
         );
     }
 

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -5047,7 +5047,7 @@ fn parse_ghostty_config_file_until_with_scrollback(
             continue;
         }
         let identity = pending.path.canonicalize().unwrap_or_else(|_| pending.path.clone());
-        if !loaded.insert(identity) {
+        if !loaded.insert(identity.clone()) {
             continue;
         }
         let remaining_bytes = GHOSTTY_CONFIG_MAX_BYTES.saturating_sub(bytes_loaded);

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -5073,6 +5073,10 @@ fn parse_ghostty_config_file_until_with_scrollback(
     let collect_scrollback = scrollback_limit_bytes.is_some();
     let root_identity = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
 
+    // Preserve cmux's existing depth-first precedence for colors and themes.
+    // Scrollback is replayed from this snapshot in Ghostty's declaration-order
+    // breadth-first traversal, so changing color precedence is out of scope.
+
     while let Some(pending) = stack.pop() {
         if files_loaded > 0 && ghostty_config_deadline_expired(deadline_at) {
             return if collect_scrollback {
@@ -6083,6 +6087,49 @@ mod tests {
             parse_scrollback_limit_from_root(&root, Instant::now() + Duration::from_secs(1)),
             ScrollbackConfigOutcome::Parsed(Some(Some(4)))
         );
+    }
+
+    #[test]
+    fn combined_snapshot_preserves_color_dfs_and_scrollback_bfs_precedence() {
+        let dir = TestDirectory::new("combined-include-precedence");
+        let root = dir.path.join("config");
+        let first = dir.path.join("first.conf");
+        let second = dir.path.join("second.conf");
+        let nested = dir.path.join("nested.conf");
+        std::fs::write(
+            &root,
+            "config-file = first.conf\nconfig-file = second.conf\n",
+        )
+        .unwrap();
+        std::fs::write(
+            &first,
+            "foreground = #010203\nscrollback-limit-bytes = 2\nconfig-file = nested.conf\n",
+        )
+        .unwrap();
+        std::fs::write(
+            &second,
+            "foreground = #040506\nscrollback-limit-bytes = 3\n",
+        )
+        .unwrap();
+        std::fs::write(
+            &nested,
+            "foreground = #070809\nscrollback-limit-bytes = 4\n",
+        )
+        .unwrap();
+
+        let mut scrollback = None;
+        let outcome = parse_ghostty_defaults_from_path_result_until_with_scrollback(
+            &root,
+            &[],
+            Some(Instant::now() + Duration::from_secs(1)),
+            Some(&mut scrollback),
+        );
+        let GhosttyConfigParseOutcome::Parsed(colors) = outcome else {
+            panic!("snapshot should parse");
+        };
+
+        assert_eq!(colors.fg, Some(Rgb { r: 4, g: 5, b: 6 }));
+        assert_eq!(scrollback, Some(Some(4)));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -4962,7 +4962,9 @@ fn parse_ghostty_defaults_with_theme_dirs(text: &str, theme_dirs: &[PathBuf]) ->
 fn parse_ghostty_defaults_from_path(path: &Path, theme_dirs: &[PathBuf]) -> Option<DefaultColors> {
     match parse_ghostty_defaults_from_path_result(path, theme_dirs) {
         GhosttyConfigParseOutcome::Parsed(defaults) => Some(*defaults),
-        GhosttyConfigParseOutcome::Missing | GhosttyConfigParseOutcome::TimedOut => None,
+        GhosttyConfigParseOutcome::Partial(_)
+        | GhosttyConfigParseOutcome::Missing
+        | GhosttyConfigParseOutcome::TimedOut => None,
     }
 }
 

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -3265,9 +3265,10 @@ pub struct SidebarPluginConfig {
 pub fn load() -> Config {
     let mut config = Config::default();
 
-    let defaults = ghostty_defaults();
+    let application_defaults = ghostty_application_defaults();
+    let defaults = application_defaults.colors;
     config.terminal_defaults = defaults;
-    config.scrollback_limit_bytes = ghostty_scrollback_limit_bytes();
+    config.scrollback_limit_bytes = application_defaults.scrollback_limit_bytes;
     if let Some(bg) = defaults.selection_bg {
         config.theme.selection_bg = Color::Rgb(bg.r, bg.g, bg.b);
         config.theme_overrides.selection = true;
@@ -4340,17 +4341,34 @@ fn parse_color(s: &str) -> Option<Color> {
 /// The user's relevant Ghostty settings with non-optional application defaults
 /// resolved for values that the low-level terminal otherwise leaves unset.
 fn ghostty_defaults() -> DefaultColors {
+    ghostty_application_defaults().colors
+}
+
+#[derive(Default)]
+struct GhosttyApplicationDefaults {
+    colors: DefaultColors,
+    scrollback_limit_bytes: Option<usize>,
+}
+
+fn ghostty_application_defaults() -> GhosttyApplicationDefaults {
     let config_paths = platform::ghostty_config_paths();
     let theme_dirs = platform::ghostty_theme_dirs();
     #[cfg(not(test))]
     let helper_defaults = ghostty_defaults_from_helper();
     #[cfg(test)]
     let helper_defaults = GhosttyHelperDefaults::Unavailable;
-    ghostty_defaults_from_sources(config_paths, theme_dirs, helper_defaults)
+    match helper_defaults {
+        GhosttyHelperDefaults::Resolved(defaults) => *defaults,
+        GhosttyHelperDefaults::Unavailable => {
+            parse_ghostty_application_defaults_from_paths(config_paths, theme_dirs)
+                .unwrap_or_default()
+        }
+        GhosttyHelperDefaults::TimedOut => GhosttyApplicationDefaults::default(),
+    }
 }
 
 enum GhosttyHelperDefaults {
-    Resolved(Box<DefaultColors>),
+    Resolved(Box<GhosttyApplicationDefaults>),
     Unavailable,
     TimedOut,
 }
@@ -4361,7 +4379,7 @@ fn ghostty_defaults_from_sources(
     helper_defaults: GhosttyHelperDefaults,
 ) -> DefaultColors {
     let parsed = match helper_defaults {
-        GhosttyHelperDefaults::Resolved(defaults) => *defaults,
+        GhosttyHelperDefaults::Resolved(defaults) => defaults.colors,
         GhosttyHelperDefaults::Unavailable => {
             parse_ghostty_defaults_from_paths(config_paths, theme_dirs).unwrap_or_default()
         }
@@ -4545,16 +4563,15 @@ pub(crate) fn is_ghostty_config_helper_invocation(args: &[String]) -> bool {
 }
 
 pub(crate) fn run_ghostty_config_helper() -> i32 {
-    match parse_ghostty_defaults_from_paths_result(
+    match parse_ghostty_application_defaults_from_paths(
         platform::ghostty_config_paths(),
         platform::ghostty_theme_dirs(),
     ) {
-        GhosttyConfigParseOutcome::Parsed(defaults) => {
-            print!("{}", serialize_ghostty_defaults(*defaults));
+        Some(defaults) => {
+            print!("{}", serialize_ghostty_application_defaults(&defaults));
             0
         }
-        GhosttyConfigParseOutcome::Missing => 1,
-        GhosttyConfigParseOutcome::TimedOut => 2,
+        None => 1,
     }
 }
 
@@ -4612,9 +4629,10 @@ fn ghostty_defaults_from_helper_command(
         return GhosttyHelperDefaults::Unavailable;
     }
     match output_reader.wait() {
-        Some(output) => {
-            GhosttyHelperDefaults::Resolved(Box::new(parse_resolved_ghostty_defaults(&output)))
-        }
+        Some(output) => GhosttyHelperDefaults::Resolved(Box::new(GhosttyApplicationDefaults {
+            colors: parse_resolved_ghostty_defaults(&output),
+            scrollback_limit_bytes: parse_scrollback_limit_bytes(&output).flatten(),
+        })),
         None => GhosttyHelperDefaults::Unavailable,
     }
 }
@@ -4809,6 +4827,37 @@ fn parse_ghostty_defaults_from_paths(
     }
 }
 
+fn parse_ghostty_application_defaults_from_paths(
+    config_paths: Vec<PathBuf>,
+    theme_dirs: Vec<PathBuf>,
+) -> Option<GhosttyApplicationDefaults> {
+    let deadline_at = ghostty_config_deadline_from_now(GHOSTTY_CONFIG_PARSE_DEADLINE);
+    let mut resolved = None;
+    let mut scrollback_limit_bytes = None;
+    for path in config_paths {
+        if ghostty_config_deadline_expired(Some(deadline_at)) {
+            return None;
+        }
+        let mut path_scrollback = None;
+        match parse_ghostty_defaults_from_path_result_until_with_scrollback(
+            &path,
+            &theme_dirs,
+            Some(deadline_at),
+            &mut path_scrollback,
+        ) {
+            GhosttyConfigParseOutcome::Missing => {}
+            GhosttyConfigParseOutcome::TimedOut => return None,
+            GhosttyConfigParseOutcome::Parsed(defaults) => {
+                resolved.get_or_insert(*defaults);
+                if let Some(value) = path_scrollback {
+                    scrollback_limit_bytes = value;
+                }
+            }
+        }
+    }
+    resolved.map(|colors| GhosttyApplicationDefaults { colors, scrollback_limit_bytes })
+}
+
 enum GhosttyConfigParseOutcome {
     Parsed(Box<DefaultColors>),
     Missing,
@@ -4869,9 +4918,27 @@ fn parse_ghostty_defaults_from_path_result_until(
     theme_dirs: &[PathBuf],
     deadline_at: Option<Instant>,
 ) -> GhosttyConfigParseOutcome {
+    parse_ghostty_defaults_from_path_result_until_with_scrollback(
+        path,
+        theme_dirs,
+        deadline_at,
+        &mut None,
+    )
+}
+
+fn parse_ghostty_defaults_from_path_result_until_with_scrollback(
+    path: &Path,
+    theme_dirs: &[PathBuf],
+    deadline_at: Option<Instant>,
+    scrollback_limit_bytes: &mut Option<Option<usize>>,
+) -> GhosttyConfigParseOutcome {
     let mut theme_candidates = Vec::new();
-    let overrides = match parse_ghostty_config_file_until(path, &mut theme_candidates, deadline_at)
-    {
+    let overrides = match parse_ghostty_config_file_until_with_scrollback(
+        path,
+        &mut theme_candidates,
+        deadline_at,
+        scrollback_limit_bytes,
+    ) {
         GhosttyConfigParseOutcome::Parsed(overrides) => *overrides,
         outcome => return outcome,
     };
@@ -4923,6 +4990,15 @@ fn parse_ghostty_config_file_until(
     theme_candidates: &mut Vec<GhosttyThemeCandidate>,
     deadline_at: Option<Instant>,
 ) -> GhosttyConfigParseOutcome {
+    parse_ghostty_config_file_until_with_scrollback(path, theme_candidates, deadline_at, &mut None)
+}
+
+fn parse_ghostty_config_file_until_with_scrollback(
+    path: &Path,
+    theme_candidates: &mut Vec<GhosttyThemeCandidate>,
+    deadline_at: Option<Instant>,
+    scrollback_limit_bytes: &mut Option<Option<usize>>,
+) -> GhosttyConfigParseOutcome {
     let mut stack = vec![PendingGhosttyConfig { path: path.to_path_buf(), depth: 0 }];
     let mut loaded = HashSet::new();
     let mut files_loaded = 0usize;
@@ -4952,6 +5028,9 @@ fn parse_ghostty_config_file_until(
         bytes_loaded = bytes_loaded.saturating_add(text.len() as u64);
         files_loaded += 1;
         loaded_root |= pending.depth == 0;
+        if let Some(parsed) = parse_scrollback_limit_bytes(&text) {
+            *scrollback_limit_bytes = Some(parsed);
+        }
 
         let base_dir = pending.path.parent().unwrap_or_else(|| Path::new("."));
         let parsed = parse_ghostty_config_text(&text, Some(base_dir), theme_candidates);
@@ -5522,6 +5601,14 @@ fn serialize_ghostty_defaults(defaults: DefaultColors) -> String {
     out
 }
 
+fn serialize_ghostty_application_defaults(defaults: &GhosttyApplicationDefaults) -> String {
+    let mut out = serialize_ghostty_defaults(defaults.colors);
+    if let Some(limit) = defaults.scrollback_limit_bytes {
+        out.push_str(&format!("scrollback-limit-bytes = {limit}\n"));
+    }
+    out
+}
+
 fn format_ghostty_rgb(color: Rgb) -> String {
     format!("#{:02x}{:02x}{:02x}", color.r, color.g, color.b)
 }
@@ -5884,6 +5971,28 @@ mod tests {
     }
 
     #[test]
+    fn application_defaults_snapshot_resolves_colors_and_scrollback_together() {
+        let dir = TestDirectory::new("application-defaults-snapshot");
+        let root = dir.path.join("config");
+        let include = dir.path.join("scrollback.conf");
+        std::fs::write(&root, "foreground = #010203\nconfig-file = scrollback.conf\n").unwrap();
+        std::fs::write(&include, "scrollback-limit-bytes = 654321\n").unwrap();
+
+        let mut scrollback = None;
+        let outcome = parse_ghostty_defaults_from_path_result_until_with_scrollback(
+            &root,
+            &[],
+            Some(Instant::now() + Duration::from_secs(1)),
+            &mut scrollback,
+        );
+        let GhosttyConfigParseOutcome::Parsed(colors) = outcome else {
+            panic!("snapshot should parse");
+        };
+        assert_eq!(colors.fg, Some(Rgb { r: 1, g: 2, b: 3 }));
+        assert_eq!(scrollback, Some(Some(654321)));
+    }
+
+    #[test]
     fn resolves_ghostty_cursor_defaults_without_erasing_nullable_blink_semantics() {
         let absent = resolve_ghostty_application_defaults(parse_ghostty_defaults(""));
         assert_eq!(absent.cursor_style, Some(CursorShape::Block));
@@ -6016,7 +6125,7 @@ mod tests {
         let mut command = Command::new(&binary);
         command.stdout(Stdio::piped()).stderr(Stdio::null());
         let defaults = match ghostty_defaults_from_helper_command(command, Duration::from_secs(2)) {
-            GhosttyHelperDefaults::Resolved(defaults) => defaults,
+            GhosttyHelperDefaults::Resolved(defaults) => defaults.colors,
             GhosttyHelperDefaults::Unavailable => panic!("helper output was not parsed"),
             GhosttyHelperDefaults::TimedOut => panic!("helper output timed out"),
         };
@@ -7420,7 +7529,10 @@ mod tests {
         let defaults = ghostty_defaults_from_sources(
             vec![config],
             Vec::new(),
-            GhosttyHelperDefaults::Resolved(Box::new(helper)),
+            GhosttyHelperDefaults::Resolved(Box::new(GhosttyApplicationDefaults {
+                colors: helper,
+                scrollback_limit_bytes: None,
+            })),
         );
 
         let _ = std::fs::remove_dir_all(dir);

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -4587,6 +4587,7 @@ pub(crate) fn run_ghostty_config_helper() -> i32 {
             print!("{}", serialize_ghostty_application_defaults(&defaults));
             0
         }
+        GhosttyApplicationDefaultsParseOutcome::Partial(_) => 2,
         GhosttyApplicationDefaultsParseOutcome::Missing => 1,
         GhosttyApplicationDefaultsParseOutcome::TimedOut => 2,
     }
@@ -4850,6 +4851,7 @@ fn parse_ghostty_application_defaults_from_paths(
 ) -> Option<GhosttyApplicationDefaults> {
     match parse_ghostty_application_defaults_from_paths_result(config_paths, theme_dirs) {
         GhosttyApplicationDefaultsParseOutcome::Parsed(defaults) => Some(defaults),
+        GhosttyApplicationDefaultsParseOutcome::Partial(defaults) => Some(defaults),
         GhosttyApplicationDefaultsParseOutcome::Missing
         | GhosttyApplicationDefaultsParseOutcome::TimedOut => None,
     }
@@ -4857,6 +4859,7 @@ fn parse_ghostty_application_defaults_from_paths(
 
 enum GhosttyApplicationDefaultsParseOutcome {
     Parsed(GhosttyApplicationDefaults),
+    Partial(GhosttyApplicationDefaults),
     Missing,
     TimedOut,
 }
@@ -4868,6 +4871,7 @@ fn parse_ghostty_application_defaults_from_paths_result(
     let deadline_at = ghostty_config_deadline_from_now(GHOSTTY_CONFIG_PARSE_DEADLINE);
     let mut resolved = None;
     let mut scrollback_limit_bytes = None;
+    let mut incomplete = false;
     for path in config_paths {
         if ghostty_config_deadline_expired(Some(deadline_at)) {
             return GhosttyApplicationDefaultsParseOutcome::TimedOut;
@@ -4893,15 +4897,21 @@ fn parse_ghostty_application_defaults_from_paths_result(
             GhosttyConfigParseOutcome::Partial(defaults) => {
                 let merged = resolved.get_or_insert_with(DefaultColors::default);
                 overlay_ghostty_defaults(merged, *defaults);
+                incomplete = true;
             }
         }
     }
     match resolved {
         Some(colors) => {
-            GhosttyApplicationDefaultsParseOutcome::Parsed(GhosttyApplicationDefaults {
+            let defaults = GhosttyApplicationDefaults {
                 colors: resolve_ghostty_application_defaults(colors),
-                scrollback_limit_bytes,
-            })
+                scrollback_limit_bytes: if incomplete { None } else { scrollback_limit_bytes },
+            };
+            if incomplete {
+                GhosttyApplicationDefaultsParseOutcome::Partial(defaults)
+            } else {
+                GhosttyApplicationDefaultsParseOutcome::Parsed(defaults)
+            }
         }
         None => GhosttyApplicationDefaultsParseOutcome::Missing,
     }
@@ -6102,6 +6112,12 @@ mod tests {
             panic!("truncated snapshot should preserve parsed colors");
         };
         assert_eq!(colors.fg, Some(Rgb { r: 1, g: 2, b: 3 }));
+
+        let outcome = parse_ghostty_application_defaults_from_paths_result(vec![root], Vec::new());
+        let GhosttyApplicationDefaultsParseOutcome::Partial(defaults) = outcome else {
+            panic!("truncated application snapshot should remain explicitly partial");
+        };
+        assert_eq!(defaults.scrollback_limit_bytes, None);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -1963,6 +1963,7 @@ fn run_server(
 
     let mut surface_options = SurfaceOptions::default();
     config::apply_browser_to_surface_options(&config, &mut surface_options);
+    surface_options.scrollback = config.scrollback_limit_bytes();
     if let Some(term) = args.term {
         surface_options.term = term;
     }


### PR DESCRIPTION
This is a clean replacement for #11169. The old branch included an unrelated large rewrite of cmux-tui core and is not safe to merge.

This patch keeps the existing TUI code and adds only the scrollback contract: Ghostty 50 MB default, both scrollback-limit and scrollback-limit-bytes, bounded include traversal, and propagation into every new surface. Invalid values fall back to the same default.

Verification: hosted Linux/macOS focused tests and the full cross-platform gate will run on this exact head.

Trade-off: the replacement has a new PR number, but it preserves reviewable history and avoids merging unrelated deletions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790561990&installation_model_id=21920&pr_number=11173&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11173&signature=3700dc174af6ff78c771ec3ac2cb803c65c0c16c4b9a4a168968b49641da2bea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the TUI's scrollback capacity match Ghostty: the default retained storage goes from 10,000 lines to 50 MB, and a user-configured `scrollback-limit` or `scrollback-limit-bytes` is inherited when present, capped at 1 GB.

**Config resolution**
- Searches only the active XDG config root, loading legacy `config` before `config.ghostty`; on macOS the Application Support fallback is used only when `XDG_CONFIG_HOME` is unset.
- Follows include files in declaration order with bounded traversal; truncated traversal keeps colors but drops the scrollback value, later values win, and an explicit empty value resets to the default.
- The Ghostty helper subprocess reports the scrollback limit alongside colors.
- Missing, invalid, or timed-out values fall back to the 50 MB default; quoted and underscore-formatted values are accepted, but `scrollback-limit-lines` and trailing-comment values are rejected.
- Adds `tokio` to fix Windows builds.

<sup>Written for commit 2566d34e0dbe8d362b33b891f551807cd5b13174. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring terminal scrollback limits through Ghostty settings.
  * Applied configured limits when starting the terminal server.
  * Increased the default retained scrollback capacity to 50 MB.

* **Bug Fixes**
  * Improved detection across supported Ghostty configuration files and included settings.
  * Preserved configuration precedence, explicit resets, and timeout behavior.
  * Added support for quoted and underscore-formatted values while ignoring invalid legacy settings.
  * Improved configured scrollback behavior across supported platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->