### PR TITLE
Bound cmux TUI tunnel terminal writer queues

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -1027,7 +1027,6 @@ mod tests {
             WRITER_QUEUE_BYTE_CAP
         );
         assert!(writer_queue_byte_limit(false) < writer_queue_byte_limit(true));
-        assert!(WRITER_CONTROL_BYTE_RESERVE > 0);
     }
 
     /// Wait until the fake spawn landed (open settles asynchronously).
@@ -1196,7 +1195,7 @@ mod tests {
     #[tokio::test]
     async fn stalled_peer_hits_the_byte_budget_and_pauses_before_close() {
         let rig = rig().await;
-        let (connection, mut writer_rx, mut flow_rx) = test_connection(&rig);
+        let (connection, mut writer_rx, flow_rx) = test_connection(&rig);
         let frame_len = (WRITER_QUEUE_BYTE_CAP - WRITER_CONTROL_BYTE_RESERVE) as usize / 2;
         assert!(connection.enqueue(WriterMessage::Frame(vec![1; frame_len])));
         assert!(connection.enqueue(WriterMessage::Frame(vec![2; frame_len])));
@@ -1207,7 +1206,7 @@ mod tests {
             (frame_len * 2) as u64,
             "a rejected frame must release its byte reservation"
         );
-        assert_eq!(*flow_rx.borrow(), true);
+        assert!(*flow_rx.borrow());
         assert!(connection.done.is_cancelled());
         match writer_rx.recv().await.expect("first admitted frame") {
             WriterMessage::Frame(frame) => assert_eq!(frame[0], 1),
@@ -1296,9 +1295,11 @@ mod tests {
             .expect("flow worker drain")
             .expect("flow worker join");
 
-        let state = pty.state.lock().unwrap();
-        assert_eq!(state.pause_calls, 1, "shutdown must pause the live attachment");
-        assert_eq!(state.resume_calls, 0);
+        {
+            let state = pty.state.lock().unwrap();
+            assert_eq!(state.pause_calls, 1, "shutdown must pause the live attachment");
+            assert_eq!(state.resume_calls, 0);
+        }
         assert!(connection.finished.load(Ordering::SeqCst));
 
         let close = json!({
@@ -1327,14 +1328,14 @@ mod tests {
     #[tokio::test]
     async fn full_writer_queue_closes_without_growing_beyond_message_budget() {
         let rig = rig().await;
-        let (connection, mut writer_rx, mut flow_rx) = test_connection(&rig);
+        let (connection, mut writer_rx, flow_rx) = test_connection(&rig);
         let data_capacity = WRITER_QUEUE_CAPACITY - WRITER_CONTROL_MESSAGE_RESERVE - 1;
         for index in 0..data_capacity {
             assert!(connection.enqueue(WriterMessage::Frame(vec![index as u8])));
         }
         assert!(!connection.enqueue(WriterMessage::Frame(vec![0])));
         assert!(connection.finished.load(Ordering::SeqCst));
-        assert_eq!(*flow_rx.borrow(), true);
+        assert!(*flow_rx.borrow());
         assert!(connection.done.is_cancelled());
         for index in 0..data_capacity {
             match writer_rx.recv().await.expect("admitted frame") {

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -48,7 +48,7 @@ use base64::engine::general_purpose::STANDARD as BASE64;
 use serde_json::{Value, json};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
 
 use crate::pty::{
@@ -263,8 +263,11 @@ struct Connection {
     /// Serializes queue admission with the End marker so no frame can be
     /// inserted after shutdown and silently be dropped by the writer.
     queue_gate: Mutex<()>,
-    /// pty_flow requests from the writer's water marks (true = pause).
-    flow_tx: mpsc::Sender<bool>,
+    /// Latest pty_flow state from the writer's water marks (true = pause).
+    /// A watch channel cannot lose the current state when its consumer is
+    /// busy. Pause and resume are idempotent, so retaining only the newest
+    /// state is the correct flow-control contract.
+    flow_tx: watch::Sender<bool>,
     /// Bytes queued toward the socket and not yet written.
     pending_out: AtomicU64,
     paused: AtomicBool,
@@ -306,10 +309,14 @@ impl Connection {
         self.pending_out.fetch_sub(amount, Ordering::SeqCst);
     }
 
+    fn publish_flow(&self, pause: bool) {
+        let _ = self.flow_tx.send(pause);
+    }
+
     /// Pause the source before closing when a stalled peer exhausts admission.
     fn reject_due_to_backpressure(&self) {
         if !self.paused.swap(true, Ordering::SeqCst) {
-            let _ = self.flow_tx.try_send(true);
+            self.publish_flow(true);
         }
         self.finish();
     }
@@ -406,7 +413,7 @@ impl Connection {
                 if self.pending_out.load(Ordering::SeqCst) > FLOW_PAUSE_BYTES
                     && !self.paused.swap(true, Ordering::SeqCst)
                 {
-                    let _ = self.flow_tx.try_send(true);
+                    self.publish_flow(true);
                 }
             }
             Some("pty_exit") => {
@@ -513,7 +520,7 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
     let _ = stream.set_nodelay(true);
     let (mut read_half, mut write_half) = stream.into_split();
     let (writer_tx, mut writer_rx) = mpsc::channel::<WriterMessage>(WRITER_QUEUE_CAPACITY);
-    let (flow_tx, mut flow_rx) = mpsc::channel::<bool>(4);
+    let (flow_tx, mut flow_rx) = watch::channel(false);
     let connection = Arc::new(Connection {
         pty_id: format!("tunnel-{}", random_hex(8)),
         manager: Arc::clone(&manager),
@@ -549,7 +556,7 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
                         if previous.saturating_sub(length) < FLOW_RESUME_BYTES
                             && connection.paused.swap(false, Ordering::SeqCst)
                         {
-                            let _ = connection.flow_tx.try_send(false);
+                            connection.publish_flow(false);
                         }
                         // `finish` may race with a full queue, so End is only
                         // best effort. Once all admitted frames drain, stop
@@ -571,12 +578,8 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
         let connection = Arc::clone(&connection);
         let context = context.clone();
         tokio::spawn(async move {
-            while let Some(pause) = flow_rx.recv().await {
-                // Deliver a final pause even when shutdown has started. This
-                // keeps PTY flow semantics intact for a queue-overflow close.
-                if connection.finished.load(Ordering::SeqCst) && !pause {
-                    break;
-                }
+            while flow_rx.changed().await.is_ok() {
+                let pause = *flow_rx.borrow_and_update();
                 let frame = json!({
                     "version": PTY_PROTOCOL_VERSION,
                     "type": "pty_flow",
@@ -990,9 +993,9 @@ mod tests {
 
     fn test_connection(
         rig: &Rig,
-    ) -> (Arc<Connection>, mpsc::Receiver<WriterMessage>, mpsc::Receiver<bool>) {
+    ) -> (Arc<Connection>, mpsc::Receiver<WriterMessage>, watch::Receiver<bool>) {
         let (writer_tx, writer_rx) = mpsc::channel(WRITER_QUEUE_CAPACITY);
-        let (flow_tx, flow_rx) = mpsc::channel(4);
+        let (flow_tx, flow_rx) = watch::channel(false);
         let connection = Arc::new(Connection {
             pty_id: "test-pty".to_owned(),
             manager: Arc::clone(&rig.manager),
@@ -1019,7 +1022,7 @@ mod tests {
         assert!(!connection.enqueue(WriterMessage::Frame(vec![3])));
         assert!(connection.finished.load(Ordering::SeqCst));
         assert!(connection.pending_out.load(Ordering::SeqCst) <= WRITER_QUEUE_BYTE_CAP);
-        assert_eq!(flow_rx.try_recv(), Ok(true));
+        assert_eq!(*flow_rx.borrow(), true);
         match writer_rx.recv().await.expect("first admitted frame") {
             WriterMessage::Frame(frame) => assert_eq!(frame[0], 1),
             WriterMessage::End => panic!("queue order changed"),
@@ -1032,6 +1035,20 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn flow_state_keeps_resume_after_consumer_lag() {
+        let rig = rig().await;
+        let (connection, _writer_rx, mut flow_rx) = test_connection(&rig);
+        connection.publish_flow(true);
+        connection.publish_flow(true);
+        connection.publish_flow(true);
+        connection.publish_flow(true);
+        connection.publish_flow(false);
+        assert!(flow_rx.changed().await.is_ok());
+        assert!(!*flow_rx.borrow_and_update());
+        rig.cancel.cancel();
+    }
+
+    #[tokio::test]
     async fn full_writer_queue_closes_without_growing_beyond_message_budget() {
         let rig = rig().await;
         let (connection, mut writer_rx, mut flow_rx) = test_connection(&rig);
@@ -1040,7 +1057,7 @@ mod tests {
         }
         assert!(!connection.enqueue(WriterMessage::Frame(vec![0])));
         assert!(connection.finished.load(Ordering::SeqCst));
-        assert_eq!(flow_rx.try_recv(), Ok(true));
+        assert_eq!(*flow_rx.borrow(), true);
         for index in 0..WRITER_QUEUE_CAPACITY {
             match writer_rx.recv().await.expect("admitted frame") {
                 WriterMessage::Frame(frame) => assert_eq!(frame, vec![index as u8]),

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -915,6 +915,69 @@ mod tests {
         }
     }
 
+    fn test_connection(
+        rig: &Rig,
+    ) -> (Arc<Connection>, mpsc::Receiver<WriterMessage>, mpsc::Receiver<bool>) {
+        let (writer_tx, writer_rx) = mpsc::channel(WRITER_QUEUE_CAPACITY);
+        let (flow_tx, flow_rx) = mpsc::channel(4);
+        let connection = Arc::new(Connection {
+            pty_id: "test-pty".to_owned(),
+            manager: Arc::clone(&rig.manager),
+            writer_tx,
+            queue_gate: Mutex::new(()),
+            flow_tx,
+            pending_out: AtomicU64::new(0),
+            paused: AtomicBool::new(false),
+            open_sent: AtomicBool::new(false),
+            opened_seen: AtomicBool::new(false),
+            finished: AtomicBool::new(false),
+            done: CancellationToken::new(),
+        });
+        (connection, writer_rx, flow_rx)
+    }
+
+    #[tokio::test]
+    async fn stalled_peer_hits_the_byte_budget_and_pauses_before_close() {
+        let rig = rig().await;
+        let (connection, mut writer_rx, mut flow_rx) = test_connection(&rig);
+        let frame_len = WRITER_QUEUE_BYTE_CAP as usize / 2;
+        assert!(connection.enqueue(WriterMessage::Frame(vec![1; frame_len])));
+        assert!(connection.enqueue(WriterMessage::Frame(vec![2; frame_len])));
+        assert!(!connection.enqueue(WriterMessage::Frame(vec![3])));
+        assert!(connection.finished.load(Ordering::SeqCst));
+        assert!(connection.pending_out.load(Ordering::SeqCst) <= WRITER_QUEUE_BYTE_CAP);
+        assert_eq!(flow_rx.try_recv(), Ok(true));
+        match writer_rx.recv().await.expect("first admitted frame") {
+            WriterMessage::Frame(frame) => assert_eq!(frame[0], 1),
+            WriterMessage::End => panic!("queue order changed"),
+        }
+        match writer_rx.recv().await.expect("second admitted frame") {
+            WriterMessage::Frame(frame) => assert_eq!(frame[0], 2),
+            WriterMessage::End => panic!("queue order changed"),
+        }
+        rig.cancel.cancel();
+    }
+
+    #[tokio::test]
+    async fn full_writer_queue_closes_without_growing_beyond_message_budget() {
+        let rig = rig().await;
+        let (connection, mut writer_rx, mut flow_rx) = test_connection(&rig);
+        for index in 0..WRITER_QUEUE_CAPACITY {
+            assert!(connection.enqueue(WriterMessage::Frame(vec![index as u8])));
+        }
+        assert!(!connection.enqueue(WriterMessage::Frame(vec![0])));
+        assert!(connection.finished.load(Ordering::SeqCst));
+        assert_eq!(flow_rx.try_recv(), Ok(true));
+        for index in 0..WRITER_QUEUE_CAPACITY {
+            match writer_rx.recv().await.expect("admitted frame") {
+                WriterMessage::Frame(frame) => assert_eq!(frame, vec![index as u8]),
+                WriterMessage::End => panic!("queue order changed"),
+            }
+        }
+        assert!(writer_rx.try_recv().is_err());
+        rig.cancel.cancel();
+    }
+
     // -- live listener ------------------------------------------------------
 
     #[tokio::test]

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -48,7 +48,7 @@ use base64::engine::general_purpose::STANDARD as BASE64;
 use serde_json::{Value, json};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::{mpsc, watch};
+use tokio::sync::{Notify, mpsc, watch};
 use tokio_util::sync::CancellationToken;
 
 use crate::pty::{
@@ -74,6 +74,9 @@ const OPEN_TIMEOUT: Duration = Duration::from_secs(10);
 /// manager's own 1 MiB output cap stays the hard boundary above this.
 const FLOW_PAUSE_BYTES: u64 = 262_144;
 const FLOW_RESUME_BYTES: u64 = 32_768;
+/// The flow worker is local and normally drains synchronously. Keep shutdown
+/// bounded if a future manager implementation blocks unexpectedly.
+const FLOW_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 /// Admission is synchronous from the manager callback, so the writer queue
 /// uses non-blocking sends with both message and byte budgets. The byte cap
 /// leaves room for a maximum PTY frame and a follow-up control/error frame.
@@ -268,6 +271,11 @@ struct Connection {
     /// busy. Pause and resume are idempotent, so retaining only the newest
     /// state is the correct flow-control contract.
     flow_tx: watch::Sender<bool>,
+    /// Coalesced flow state and shutdown marker. The flow worker drains this
+    /// state before it exits, so a required pause cannot be lost to task
+    /// cancellation.
+    flow_state: Mutex<FlowState>,
+    flow_notify: Arc<Notify>,
     /// Bytes queued toward the socket and not yet written.
     pending_out: AtomicU64,
     paused: AtomicBool,
@@ -277,6 +285,18 @@ struct Connection {
     opened_seen: AtomicBool,
     finished: AtomicBool,
     done: CancellationToken,
+}
+
+#[derive(Debug, Default)]
+struct FlowState {
+    desired_pause: bool,
+    stopping: bool,
+}
+
+enum FlowAction {
+    Apply(bool),
+    Wait,
+    Stop,
 }
 
 impl Connection {
@@ -310,15 +330,46 @@ impl Connection {
     }
 
     fn publish_flow(&self, pause: bool) {
-        let _ = self.flow_tx.send(pause);
+        let changed = {
+            let mut state = self.flow_state.lock().expect("flow state lock");
+            if state.stopping || state.desired_pause == pause {
+                false
+            } else {
+                state.desired_pause = pause;
+                true
+            }
+        };
+        if changed {
+            let _ = self.flow_tx.send(pause);
+            self.flow_notify.notify_one();
+        }
     }
 
     /// Pause the source before closing when a stalled peer exhausts admission.
     fn reject_due_to_backpressure(&self) {
-        if !self.paused.swap(true, Ordering::SeqCst) {
-            self.publish_flow(true);
+        let notify_flow = {
+            let _gate = self.queue_gate.lock().expect("writer queue lock");
+            if self.finished.load(Ordering::SeqCst) {
+                false
+            } else {
+                self.paused.store(true, Ordering::SeqCst);
+                let mut state = self.flow_state.lock().expect("flow state lock");
+                let notify = !state.desired_pause;
+                state.desired_pause = true;
+                state.stopping = true;
+                self.finished.store(true, Ordering::SeqCst);
+                let _ = self.writer_tx.try_send(WriterMessage::End);
+                self.done.cancel();
+                notify
+            }
+        };
+        // The state transition and End marker are serialized by queue_gate.
+        // Notify after releasing it so the worker can observe the complete
+        // pause-before-stop state in one read.
+        if notify_flow {
+            let _ = self.flow_tx.send(true);
         }
-        self.finish();
+        self.flow_notify.notify_one();
     }
 
     fn enqueue(&self, message: WriterMessage) -> bool {
@@ -355,12 +406,21 @@ impl Connection {
     /// session lives on for a later re-attach, the same rule a dropped
     /// relay-socket viewer follows).
     fn finish(&self) {
-        let _gate = self.queue_gate.lock().expect("writer queue lock");
-        if self.finished.swap(true, Ordering::SeqCst) {
-            return;
+        let should_notify = {
+            let _gate = self.queue_gate.lock().expect("writer queue lock");
+            if self.finished.swap(true, Ordering::SeqCst) {
+                false
+            } else {
+                let mut state = self.flow_state.lock().expect("flow state lock");
+                state.stopping = true;
+                let _ = self.writer_tx.try_send(WriterMessage::End);
+                self.done.cancel();
+                true
+            }
+        };
+        if should_notify {
+            self.flow_notify.notify_one();
         }
-        let _ = self.writer_tx.try_send(WriterMessage::End);
-        self.done.cancel();
     }
 
     fn protocol_error(&self, code: &str, message: &str) {
@@ -516,17 +576,58 @@ async fn handle_client_frame(
     }
 }
 
+fn spawn_flow_worker(
+    connection: Arc<Connection>,
+    context: FrameContext,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut applied_pause = false;
+        loop {
+            // Create the notification future before inspecting state. Tokio
+            // retains a notification permit, so a concurrent transition
+            // cannot be lost between the read and the await.
+            let notified = connection.flow_notify.notified();
+            let action = {
+                let state = connection.flow_state.lock().expect("flow state lock");
+                if state.desired_pause != applied_pause {
+                    FlowAction::Apply(state.desired_pause)
+                } else if state.stopping {
+                    FlowAction::Stop
+                } else {
+                    FlowAction::Wait
+                }
+            };
+            match action {
+                FlowAction::Apply(pause) => {
+                    let frame = json!({
+                        "version": PTY_PROTOCOL_VERSION,
+                        "type": "pty_flow",
+                        "ptyId": connection.pty_id,
+                        "pause": pause,
+                    });
+                    connection.manager.handle_frame(&frame, &context).await;
+                    applied_pause = pause;
+                }
+                FlowAction::Wait => notified.await,
+                FlowAction::Stop => break,
+            }
+        }
+    })
+}
+
 async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: CancellationToken) {
     let _ = stream.set_nodelay(true);
     let (mut read_half, mut write_half) = stream.into_split();
     let (writer_tx, mut writer_rx) = mpsc::channel::<WriterMessage>(WRITER_QUEUE_CAPACITY);
-    let (flow_tx, mut flow_rx) = watch::channel(false);
+    let (flow_tx, _flow_rx) = watch::channel(false);
     let connection = Arc::new(Connection {
         pty_id: format!("tunnel-{}", random_hex(8)),
         manager: Arc::clone(&manager),
         writer_tx,
         queue_gate: Mutex::new(()),
         flow_tx,
+        flow_state: Mutex::new(FlowState::default()),
+        flow_notify: Arc::new(Notify::new()),
         pending_out: AtomicU64::new(0),
         paused: AtomicBool::new(false),
         open_sent: AtomicBool::new(false),
@@ -573,32 +674,9 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
     };
 
     // Flow verbs need the async manager; drain them on their own task so a
-    // slow open never delays a pause.
-    let flow = {
-        let connection = Arc::clone(&connection);
-        let context = context.clone();
-        tokio::spawn(async move {
-            loop {
-                tokio::select! {
-                    biased;
-                    _ = connection.done.cancelled() => break,
-                    changed = flow_rx.changed() => {
-                        if changed.is_err() || connection.finished.load(Ordering::SeqCst) {
-                            break;
-                        }
-                        let pause = *flow_rx.borrow_and_update();
-                        let frame = json!({
-                            "version": PTY_PROTOCOL_VERSION,
-                            "type": "pty_flow",
-                            "ptyId": connection.pty_id,
-                            "pause": pause,
-                        });
-                        connection.manager.handle_frame(&frame, &context).await;
-                    }
-                }
-            }
-        })
-    };
+    // slow open never delays a pause. Its state is drained during shutdown
+    // before the attachment is released.
+    let mut flow = spawn_flow_worker(Arc::clone(&connection), context.clone());
 
     // Reader: strictly in arrival order, so input received while an open
     // settles lands after the attachment exists. Awaiting each frame is the
@@ -644,6 +722,13 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
         }
     }
     connection.finish();
+    // Drain the flow state before releasing the attachment. In particular,
+    // backpressure shutdown must deliver pty_flow(true) while authorization
+    // still sees this connection's live attachment.
+    if tokio::time::timeout(FLOW_DRAIN_TIMEOUT, &mut flow).await.is_err() {
+        flow.abort();
+        let _ = flow.await;
+    }
     // Detach, never kill: the owed close releases only this connection's
     // attachment (transport-fenced), and the session lives on.
     if connection.open_sent.load(Ordering::SeqCst) {
@@ -654,13 +739,12 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
         });
         manager.handle_frame(&close, &context).await;
     }
-    flow.abort();
     // A peer that stopped reading can wedge the final flush forever; the
     // attachment is already released above, so cap the flush and reap.
     if tokio::time::timeout(Duration::from_secs(30), &mut writer).await.is_err() {
         writer.abort();
+        let _ = writer.await;
     }
-    let _ = flow.await;
 }
 
 /// Start the loopback listener. Managed mode only — the caller's managed
@@ -724,6 +808,8 @@ mod tests {
         on_exit: Option<ExitSink>,
         written: Vec<Vec<u8>>,
         resized: Vec<(u16, u16)>,
+        pause_calls: usize,
+        resume_calls: usize,
         killed: bool,
     }
 
@@ -754,8 +840,12 @@ mod tests {
         fn resize(&self, cols: u16, rows: u16) {
             self.state.lock().unwrap().resized.push((cols, rows));
         }
-        fn pause(&self) {}
-        fn resume(&self) {}
+        fn pause(&self) {
+            self.state.lock().unwrap().pause_calls += 1;
+        }
+        fn resume(&self) {
+            self.state.lock().unwrap().resume_calls += 1;
+        }
         fn kill(&self) {
             self.state.lock().unwrap().killed = true;
         }
@@ -1011,6 +1101,8 @@ mod tests {
             writer_tx,
             queue_gate: Mutex::new(()),
             flow_tx,
+            flow_state: Mutex::new(FlowState::default()),
+            flow_notify: Arc::new(Notify::new()),
             pending_out: AtomicU64::new(0),
             paused: AtomicBool::new(false),
             open_sent: AtomicBool::new(false),
@@ -1019,6 +1111,21 @@ mod tests {
             done: CancellationToken::new(),
         });
         (connection, writer_rx, flow_rx)
+    }
+
+    async fn attach_test_pty(rig: &Rig, connection: &Arc<Connection>) -> FakePty {
+        connection.open_sent.store(true, Ordering::SeqCst);
+        let context = connection.frame_context();
+        let open = json!({
+            "version": PTY_PROTOCOL_VERSION,
+            "type": "pty_open",
+            "ptyId": connection.pty_id,
+            "session": "flow-test",
+            "cols": 80,
+            "rows": 24,
+        });
+        rig.manager.handle_frame(&open, &context).await;
+        spawned_pty(rig).await
     }
 
     #[tokio::test]
@@ -1040,6 +1147,33 @@ mod tests {
             WriterMessage::Frame(frame) => assert_eq!(frame[0], 2),
             WriterMessage::End => panic!("queue order changed"),
         }
+        rig.cancel.cancel();
+    }
+
+    #[tokio::test]
+    async fn backpressure_delivers_pause_before_flow_worker_stops() {
+        let rig = rig().await;
+        let (connection, _writer_rx, _flow_rx) = test_connection(&rig);
+        let pty = attach_test_pty(&rig, &connection).await;
+        let flow = spawn_flow_worker(Arc::clone(&connection), connection.frame_context());
+
+        connection.reject_due_to_backpressure();
+        tokio::time::timeout(FLOW_DRAIN_TIMEOUT, flow)
+            .await
+            .expect("flow worker drain")
+            .expect("flow worker join");
+
+        let state = pty.state.lock().unwrap();
+        assert_eq!(state.pause_calls, 1, "shutdown must pause the live attachment");
+        assert_eq!(state.resume_calls, 0);
+        assert!(connection.finished.load(Ordering::SeqCst));
+
+        let close = json!({
+            "version": PTY_PROTOCOL_VERSION,
+            "type": "pty_close",
+            "ptyId": connection.pty_id,
+        });
+        rig.manager.handle_frame(&close, &connection.frame_context()).await;
         rig.cancel.cancel();
     }
 

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -78,10 +78,28 @@ const FLOW_RESUME_BYTES: u64 = 32_768;
 /// bounded if a future manager implementation blocks unexpectedly.
 const FLOW_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 /// Admission is synchronous from the manager callback, so the writer queue
-/// uses non-blocking sends with both message and byte budgets. The byte cap
-/// leaves room for a maximum PTY frame and a follow-up control/error frame.
+/// uses non-blocking sends with both message and byte budgets. Keep part of
+/// each budget available for control/error frames after PTY data saturates.
 const WRITER_QUEUE_CAPACITY: usize = 128;
 const WRITER_QUEUE_BYTE_CAP: u64 = (MAX_TUNNEL_FRAME_BYTES as u64 + HEADER_BYTES as u64) * 2;
+const WRITER_CONTROL_MESSAGE_RESERVE: usize = 8;
+const WRITER_CONTROL_BYTE_RESERVE: u64 = 64 * 1024;
+
+fn writer_queue_byte_limit(control: bool) -> u64 {
+    if control {
+        WRITER_QUEUE_BYTE_CAP
+    } else {
+        WRITER_QUEUE_BYTE_CAP.saturating_sub(WRITER_CONTROL_BYTE_RESERVE)
+    }
+}
+
+fn is_encoded_control_frame(frame: &[u8]) -> bool {
+    if frame.len() < HEADER_BYTES {
+        return false;
+    }
+    let payload_len = u32::from_be_bytes([frame[0], frame[1], frame[2], frame[3]]) as usize;
+    frame[4] == FRAME_KIND_CONTROL && payload_len == frame.len() - HEADER_BYTES
+}
 
 /// Relay pty_error codes -> browser wire codes. Mirrors the Worker's
 /// browserErrorCode map (apps/backend/src/terminal/relay-pty.ts). KEEP IN
@@ -263,6 +281,9 @@ struct Connection {
     pty_id: String,
     manager: Arc<PtyManager>,
     writer_tx: mpsc::Sender<WriterMessage>,
+    /// A permanently reserved channel slot for shutdown. `finish` is
+    /// synchronous, so it cannot wait for queue capacity.
+    end_permit: Mutex<Option<mpsc::OwnedPermit<WriterMessage>>>,
     /// Serializes queue admission with the End marker so no frame can be
     /// inserted after shutdown and silently be dropped by the writer.
     queue_gate: Mutex<()>,
@@ -301,16 +322,17 @@ enum FlowAction {
 
 impl Connection {
     fn send_control(&self, frame: &Value) {
-        let _ = self.enqueue(WriterMessage::Frame(encode_control_frame(frame)));
+        let _ = self.enqueue_frame(encode_control_frame(frame), true);
     }
 
-    fn reserve_bytes(&self, amount: u64) -> bool {
+    fn reserve_bytes(&self, amount: u64, control: bool) -> bool {
         let mut current = self.pending_out.load(Ordering::SeqCst);
         loop {
             let Some(next) = current.checked_add(amount) else {
                 return false;
             };
-            if next > WRITER_QUEUE_BYTE_CAP {
+            let limit = writer_queue_byte_limit(control);
+            if next > limit {
                 return false;
             }
             match self.pending_out.compare_exchange(
@@ -327,6 +349,50 @@ impl Connection {
 
     fn release_bytes(&self, amount: u64) {
         self.pending_out.fetch_sub(amount, Ordering::SeqCst);
+    }
+
+    /// Preserve the existing message-shaped queue API for tests and callers
+    /// that already build `WriterMessage::Frame`. Production paths use the
+    /// explicit class-aware helper below so a control frame cannot consume
+    /// the reserved data budget.
+    fn enqueue(&self, message: WriterMessage) -> bool {
+        match message {
+            WriterMessage::Frame(frame) => {
+                let control = is_encoded_control_frame(&frame);
+                self.enqueue_frame(frame, control)
+            }
+            // End is sent only through its reserved permit in `finish`.
+            WriterMessage::End => false,
+        }
+    }
+
+    fn enqueue_frame(&self, frame: Vec<u8>, control: bool) -> bool {
+        let frame_bytes = frame.len() as u64;
+        let mut reserved = false;
+        let admitted = {
+            let _gate = self.queue_gate.lock().expect("writer queue lock");
+            let queue_has_room =
+                control || self.writer_tx.capacity() > WRITER_CONTROL_MESSAGE_RESERVE;
+            if self.finished.load(Ordering::SeqCst)
+                || !queue_has_room
+                || !self.reserve_bytes(frame_bytes, control)
+            {
+                false
+            } else {
+                reserved = frame_bytes != 0;
+                self.writer_tx.try_send(WriterMessage::Frame(frame)).is_ok()
+            }
+        };
+        if admitted {
+            return true;
+        }
+        if reserved {
+            self.release_bytes(frame_bytes);
+        }
+        if !self.finished.load(Ordering::SeqCst) {
+            self.reject_due_to_backpressure();
+        }
+        false
     }
 
     fn publish_flow(&self, pause: bool) {
@@ -358,7 +424,10 @@ impl Connection {
                 state.desired_pause = true;
                 state.stopping = true;
                 self.finished.store(true, Ordering::SeqCst);
-                let _ = self.writer_tx.try_send(WriterMessage::End);
+                if let Some(permit) = self.end_permit.lock().expect("tunnel end permit lock").take()
+                {
+                    permit.send(WriterMessage::End);
+                }
                 self.done.cancel();
                 notify
             }
@@ -370,35 +439,6 @@ impl Connection {
             let _ = self.flow_tx.send(true);
         }
         self.flow_notify.notify_one();
-    }
-
-    fn enqueue(&self, message: WriterMessage) -> bool {
-        let frame_bytes = match &message {
-            WriterMessage::Frame(frame) => frame.len() as u64,
-            WriterMessage::End => 0,
-        };
-        let mut reserved = false;
-        let admitted = {
-            let _gate = self.queue_gate.lock().expect("writer queue lock");
-            if self.finished.load(Ordering::SeqCst) {
-                false
-            } else if frame_bytes != 0 && !self.reserve_bytes(frame_bytes) {
-                false
-            } else {
-                reserved = frame_bytes != 0;
-                self.writer_tx.try_send(message).is_ok()
-            }
-        };
-        if admitted {
-            return true;
-        }
-        if reserved {
-            self.release_bytes(frame_bytes);
-        }
-        if !self.finished.load(Ordering::SeqCst) {
-            self.reject_due_to_backpressure();
-        }
-        false
     }
 
     /// Idempotent shutdown: flush queued frames, close the socket, and let
@@ -413,7 +453,10 @@ impl Connection {
             } else {
                 let mut state = self.flow_state.lock().expect("flow state lock");
                 state.stopping = true;
-                let _ = self.writer_tx.try_send(WriterMessage::End);
+                if let Some(permit) = self.end_permit.lock().expect("tunnel end permit lock").take()
+                {
+                    permit.send(WriterMessage::End);
+                }
                 self.done.cancel();
                 true
             }
@@ -464,7 +507,7 @@ impl Connection {
                 else {
                     return;
                 };
-                if !self.enqueue(WriterMessage::Frame(encode_pty_frame(&bytes))) {
+                if !self.enqueue_frame(encode_pty_frame(&bytes), false) {
                     return;
                 }
                 // Socket-side congestion: pause the source through the
@@ -619,11 +662,22 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
     let _ = stream.set_nodelay(true);
     let (mut read_half, mut write_half) = stream.into_split();
     let (writer_tx, mut writer_rx) = mpsc::channel::<WriterMessage>(WRITER_QUEUE_CAPACITY);
+    // Reserve one item before any producer can fill the queue. The owned
+    // permit keeps End available to the synchronous shutdown path without
+    // waiting for a stalled peer or an already-full queue.
+    let end_permit = match writer_tx.clone().try_reserve_owned() {
+        Ok(permit) => permit,
+        Err(_) => {
+            let _ = write_half.shutdown().await;
+            return;
+        }
+    };
     let (flow_tx, _flow_rx) = watch::channel(false);
     let connection = Arc::new(Connection {
         pty_id: format!("tunnel-{}", random_hex(8)),
         manager: Arc::clone(&manager),
         writer_tx,
+        end_permit: Mutex::new(Some(end_permit)),
         queue_gate: Mutex::new(()),
         flow_tx,
         flow_state: Mutex::new(FlowState::default()),
@@ -658,12 +712,6 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
                             && connection.paused.swap(false, Ordering::SeqCst)
                         {
                             connection.publish_flow(false);
-                        }
-                        // `finish` may race with a full queue, so End is only
-                        // best effort. Once all admitted frames drain, stop
-                        // without waiting for another sender-side message.
-                        if connection.finished.load(Ordering::SeqCst) && writer_rx.is_empty() {
-                            break;
                         }
                     }
                     WriterMessage::End => break,
@@ -967,6 +1015,16 @@ mod tests {
         serde_json::from_slice(&frame.payload).expect("control json")
     }
 
+    #[test]
+    fn data_budget_leaves_byte_reserve_for_control_frames() {
+        assert_eq!(
+            writer_queue_byte_limit(false) + WRITER_CONTROL_BYTE_RESERVE,
+            WRITER_QUEUE_BYTE_CAP
+        );
+        assert!(writer_queue_byte_limit(false) < writer_queue_byte_limit(true));
+        assert!(WRITER_CONTROL_BYTE_RESERVE > 0);
+    }
+
     /// Wait until the fake spawn landed (open settles asynchronously).
     async fn spawned_pty(rig: &Rig) -> FakePty {
         for _ in 0..100 {
@@ -1094,11 +1152,13 @@ mod tests {
         rig: &Rig,
     ) -> (Arc<Connection>, mpsc::Receiver<WriterMessage>, watch::Receiver<bool>) {
         let (writer_tx, writer_rx) = mpsc::channel(WRITER_QUEUE_CAPACITY);
+        let end_permit = writer_tx.clone().try_reserve_owned().expect("reserve End slot");
         let (flow_tx, flow_rx) = watch::channel(false);
         let connection = Arc::new(Connection {
             pty_id: "test-pty".to_owned(),
             manager: Arc::clone(&rig.manager),
             writer_tx,
+            end_permit: Mutex::new(Some(end_permit)),
             queue_gate: Mutex::new(()),
             flow_tx,
             flow_state: Mutex::new(FlowState::default()),
@@ -1132,13 +1192,18 @@ mod tests {
     async fn stalled_peer_hits_the_byte_budget_and_pauses_before_close() {
         let rig = rig().await;
         let (connection, mut writer_rx, mut flow_rx) = test_connection(&rig);
-        let frame_len = WRITER_QUEUE_BYTE_CAP as usize / 2;
+        let frame_len = (WRITER_QUEUE_BYTE_CAP - WRITER_CONTROL_BYTE_RESERVE) as usize / 2;
         assert!(connection.enqueue(WriterMessage::Frame(vec![1; frame_len])));
         assert!(connection.enqueue(WriterMessage::Frame(vec![2; frame_len])));
         assert!(!connection.enqueue(WriterMessage::Frame(vec![3])));
         assert!(connection.finished.load(Ordering::SeqCst));
-        assert!(connection.pending_out.load(Ordering::SeqCst) <= WRITER_QUEUE_BYTE_CAP);
+        assert_eq!(
+            connection.pending_out.load(Ordering::SeqCst),
+            (frame_len * 2) as u64,
+            "a rejected frame must release its byte reservation"
+        );
         assert_eq!(*flow_rx.borrow(), true);
+        assert!(connection.done.is_cancelled());
         match writer_rx.recv().await.expect("first admitted frame") {
             WriterMessage::Frame(frame) => assert_eq!(frame[0], 1),
             WriterMessage::End => panic!("queue order changed"),
@@ -1147,6 +1212,69 @@ mod tests {
             WriterMessage::Frame(frame) => assert_eq!(frame[0], 2),
             WriterMessage::End => panic!("queue order changed"),
         }
+        assert!(matches!(writer_rx.recv().await, Some(WriterMessage::End)));
+        rig.cancel.cancel();
+    }
+
+    #[tokio::test]
+    async fn control_frame_uses_reserved_byte_budget_and_end_stays_fifo() {
+        let rig = rig().await;
+        let (connection, mut writer_rx, _flow_rx) = test_connection(&rig);
+        let data_limit = writer_queue_byte_limit(false) as usize;
+        let frame_len = data_limit / 2;
+        assert!(connection.enqueue_frame(vec![1; frame_len], false));
+        assert!(connection.enqueue_frame(vec![2; data_limit - frame_len], false));
+        assert_eq!(connection.pending_out.load(Ordering::SeqCst), data_limit as u64);
+
+        let control = encode_control_frame(&json!({ "t": "error", "code": "failed" }));
+        let control_len = control.len() as u64;
+        assert!(connection.enqueue_frame(control, true));
+        assert_eq!(connection.pending_out.load(Ordering::SeqCst), data_limit as u64 + control_len);
+
+        connection.finish();
+        match writer_rx.recv().await.expect("first data frame") {
+            WriterMessage::Frame(frame) => assert_eq!(frame[0], 1),
+            WriterMessage::End => panic!("End overtook queued data"),
+        }
+        match writer_rx.recv().await.expect("second data frame") {
+            WriterMessage::Frame(frame) => assert_eq!(frame[0], 2),
+            WriterMessage::End => panic!("End overtook queued data"),
+        }
+        match writer_rx.recv().await.expect("control frame") {
+            WriterMessage::Frame(frame) => {
+                assert_eq!(frame.get(HEADER_BYTES - 1), Some(&FRAME_KIND_CONTROL));
+            }
+            WriterMessage::End => panic!("End overtook control"),
+        }
+        assert!(matches!(writer_rx.recv().await, Some(WriterMessage::End)));
+        rig.cancel.cancel();
+    }
+
+    #[tokio::test]
+    async fn control_frame_survives_message_reserve_before_end() {
+        let rig = rig().await;
+        let (connection, mut writer_rx, _flow_rx) = test_connection(&rig);
+        let data_capacity = WRITER_QUEUE_CAPACITY - WRITER_CONTROL_MESSAGE_RESERVE - 1;
+        for index in 0..data_capacity {
+            assert!(connection.enqueue(WriterMessage::Frame(vec![index as u8])));
+        }
+        let control = encode_control_frame(&json!({ "t": "error", "code": "failed" }));
+        assert!(connection.enqueue_frame(control, true));
+        connection.finish();
+
+        for index in 0..data_capacity {
+            match writer_rx.recv().await.expect("admitted data frame") {
+                WriterMessage::Frame(frame) => assert_eq!(frame, vec![index as u8]),
+                WriterMessage::End => panic!("End overtook queued data"),
+            }
+        }
+        match writer_rx.recv().await.expect("control frame") {
+            WriterMessage::Frame(frame) => {
+                assert_eq!(frame.get(HEADER_BYTES - 1), Some(&FRAME_KIND_CONTROL));
+            }
+            WriterMessage::End => panic!("End overtook control"),
+        }
+        assert!(matches!(writer_rx.recv().await, Some(WriterMessage::End)));
         rig.cancel.cancel();
     }
 
@@ -1195,19 +1323,21 @@ mod tests {
     async fn full_writer_queue_closes_without_growing_beyond_message_budget() {
         let rig = rig().await;
         let (connection, mut writer_rx, mut flow_rx) = test_connection(&rig);
-        for index in 0..WRITER_QUEUE_CAPACITY {
+        let data_capacity = WRITER_QUEUE_CAPACITY - WRITER_CONTROL_MESSAGE_RESERVE - 1;
+        for index in 0..data_capacity {
             assert!(connection.enqueue(WriterMessage::Frame(vec![index as u8])));
         }
         assert!(!connection.enqueue(WriterMessage::Frame(vec![0])));
         assert!(connection.finished.load(Ordering::SeqCst));
         assert_eq!(*flow_rx.borrow(), true);
-        for index in 0..WRITER_QUEUE_CAPACITY {
+        assert!(connection.done.is_cancelled());
+        for index in 0..data_capacity {
             match writer_rx.recv().await.expect("admitted frame") {
                 WriterMessage::Frame(frame) => assert_eq!(frame, vec![index as u8]),
                 WriterMessage::End => panic!("queue order changed"),
             }
         }
-        assert!(writer_rx.try_recv().is_err());
+        assert!(matches!(writer_rx.recv().await, Some(WriterMessage::End)));
         rig.cancel.cancel();
     }
 

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -361,8 +361,13 @@ impl Connection {
                 let control = is_encoded_control_frame(&frame);
                 self.enqueue_frame(frame, control)
             }
-            // End is sent only through its reserved permit in `finish`.
-            WriterMessage::End => false,
+            // Preserve the old End-shaped call site while routing the marker
+            // through the reserved permit and the idempotent shutdown path.
+            WriterMessage::End => {
+                let was_finished = self.finished.load(Ordering::SeqCst);
+                self.finish();
+                !was_finished
+            }
         }
     }
 

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -578,15 +578,24 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
         let connection = Arc::clone(&connection);
         let context = context.clone();
         tokio::spawn(async move {
-            while flow_rx.changed().await.is_ok() {
-                let pause = *flow_rx.borrow_and_update();
-                let frame = json!({
-                    "version": PTY_PROTOCOL_VERSION,
-                    "type": "pty_flow",
-                    "ptyId": connection.pty_id,
-                    "pause": pause,
-                });
-                connection.manager.handle_frame(&frame, &context).await;
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = connection.done.cancelled() => break,
+                    changed = flow_rx.changed() => {
+                        if changed.is_err() || connection.finished.load(Ordering::SeqCst) {
+                            break;
+                        }
+                        let pause = *flow_rx.borrow_and_update();
+                        let frame = json!({
+                            "version": PTY_PROTOCOL_VERSION,
+                            "type": "pty_flow",
+                            "ptyId": connection.pty_id,
+                            "pause": pause,
+                        });
+                        connection.manager.handle_frame(&frame, &context).await;
+                    }
+                }
             }
         })
     };

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -39,7 +39,8 @@
 //! never run this listener: it starts from the managed branch only.
 
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use std::sync::Mutex;
 use std::time::Duration;
 
 use base64::engine::general_purpose::STANDARD as BASE64;

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -322,7 +322,7 @@ enum FlowAction {
 
 impl Connection {
     fn send_control(&self, frame: &Value) {
-        let _ = self.enqueue_frame(encode_control_frame(frame), true);
+        let _ = self.enqueue(WriterMessage::Frame(encode_control_frame(frame)));
     }
 
     fn reserve_bytes(&self, amount: u64, control: bool) -> bool {

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -38,20 +38,20 @@
 //! already attach terminals through the cmux CLI. Paired human machines
 //! never run this listener: it starts from the managed branch only.
 
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64;
-use serde_json::{Value, json};
+use base64::Engine as _;
+use serde_json::{json, Value};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 use crate::pty::{
-    FrameContext, PTY_PROTOCOL_VERSION, PtyManager, random_hex, session_name_ok, surface_ref_ok,
+    random_hex, session_name_ok, surface_ref_ok, FrameContext, PtyManager, PTY_PROTOCOL_VERSION,
 };
 
 /// Loopback port the gateway's spliced streams dial. The chatmux Worker
@@ -73,6 +73,11 @@ const OPEN_TIMEOUT: Duration = Duration::from_secs(10);
 /// manager's own 1 MiB output cap stays the hard boundary above this.
 const FLOW_PAUSE_BYTES: u64 = 262_144;
 const FLOW_RESUME_BYTES: u64 = 32_768;
+/// Admission is synchronous from the manager callback, so the writer queue
+/// uses non-blocking sends with both message and byte budgets. The byte cap
+/// leaves room for a maximum PTY frame and a follow-up control/error frame.
+const WRITER_QUEUE_CAPACITY: usize = 128;
+const WRITER_QUEUE_BYTE_CAP: u64 = (MAX_TUNNEL_FRAME_BYTES as u64 + HEADER_BYTES as u64) * 2;
 
 /// Relay pty_error codes -> browser wire codes. Mirrors the Worker's
 /// browserErrorCode map (apps/backend/src/terminal/relay-pty.ts). KEEP IN
@@ -253,9 +258,12 @@ enum WriterMessage {
 struct Connection {
     pty_id: String,
     manager: Arc<PtyManager>,
-    writer_tx: mpsc::UnboundedSender<WriterMessage>,
+    writer_tx: mpsc::Sender<WriterMessage>,
+    /// Serializes queue admission with the End marker so no frame can be
+    /// inserted after shutdown and silently be dropped by the writer.
+    queue_gate: Mutex<()>,
     /// pty_flow requests from the writer's water marks (true = pause).
-    flow_tx: mpsc::UnboundedSender<bool>,
+    flow_tx: mpsc::Sender<bool>,
     /// Bytes queued toward the socket and not yet written.
     pending_out: AtomicU64,
     paused: AtomicBool,
@@ -269,17 +277,69 @@ struct Connection {
 
 impl Connection {
     fn send_control(&self, frame: &Value) {
-        self.enqueue(WriterMessage::Frame(encode_control_frame(frame)));
+        let _ = self.enqueue(WriterMessage::Frame(encode_control_frame(frame)));
     }
 
-    fn enqueue(&self, message: WriterMessage) {
-        if self.finished.load(Ordering::SeqCst) {
-            return;
+    fn reserve_bytes(&self, amount: u64) -> bool {
+        let mut current = self.pending_out.load(Ordering::SeqCst);
+        loop {
+            let Some(next) = current.checked_add(amount) else {
+                return false;
+            };
+            if next > WRITER_QUEUE_BYTE_CAP {
+                return false;
+            }
+            match self.pending_out.compare_exchange(
+                current,
+                next,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            ) {
+                Ok(_) => return true,
+                Err(actual) => current = actual,
+            }
         }
-        if let WriterMessage::Frame(frame) = &message {
-            self.pending_out.fetch_add(frame.len() as u64, Ordering::SeqCst);
+    }
+
+    fn release_bytes(&self, amount: u64) {
+        self.pending_out.fetch_sub(amount, Ordering::SeqCst);
+    }
+
+    /// Pause the source before closing when a stalled peer exhausts admission.
+    fn reject_due_to_backpressure(&self) {
+        if !self.paused.swap(true, Ordering::SeqCst) {
+            let _ = self.flow_tx.try_send(true);
         }
-        let _ = self.writer_tx.send(message);
+        self.finish();
+    }
+
+    fn enqueue(&self, message: WriterMessage) -> bool {
+        let frame_bytes = match &message {
+            WriterMessage::Frame(frame) => frame.len() as u64,
+            WriterMessage::End => 0,
+        };
+        let mut reserved = false;
+        let admitted = {
+            let _gate = self.queue_gate.lock().expect("writer queue lock");
+            if self.finished.load(Ordering::SeqCst) {
+                false
+            } else if frame_bytes != 0 && !self.reserve_bytes(frame_bytes) {
+                false
+            } else {
+                reserved = frame_bytes != 0;
+                self.writer_tx.try_send(message).is_ok()
+            }
+        };
+        if admitted {
+            return true;
+        }
+        if reserved {
+            self.release_bytes(frame_bytes);
+        }
+        if !self.finished.load(Ordering::SeqCst) {
+            self.reject_due_to_backpressure();
+        }
+        false
     }
 
     /// Idempotent shutdown: flush queued frames, close the socket, and let
@@ -287,10 +347,11 @@ impl Connection {
     /// session lives on for a later re-attach, the same rule a dropped
     /// relay-socket viewer follows).
     fn finish(&self) {
+        let _gate = self.queue_gate.lock().expect("writer queue lock");
         if self.finished.swap(true, Ordering::SeqCst) {
             return;
         }
-        let _ = self.writer_tx.send(WriterMessage::End);
+        let _ = self.writer_tx.try_send(WriterMessage::End);
         self.done.cancel();
     }
 
@@ -335,14 +396,16 @@ impl Connection {
                 else {
                     return;
                 };
-                self.enqueue(WriterMessage::Frame(encode_pty_frame(&bytes)));
+                if !self.enqueue(WriterMessage::Frame(encode_pty_frame(&bytes))) {
+                    return;
+                }
                 // Socket-side congestion: pause the source through the
                 // manager's own flow verb; the writer resumes it below the
                 // low-water mark.
                 if self.pending_out.load(Ordering::SeqCst) > FLOW_PAUSE_BYTES
                     && !self.paused.swap(true, Ordering::SeqCst)
                 {
-                    let _ = self.flow_tx.send(true);
+                    let _ = self.flow_tx.try_send(true);
                 }
             }
             Some("pty_exit") => {
@@ -448,12 +511,13 @@ async fn handle_client_frame(
 async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: CancellationToken) {
     let _ = stream.set_nodelay(true);
     let (mut read_half, mut write_half) = stream.into_split();
-    let (writer_tx, mut writer_rx) = mpsc::unbounded_channel::<WriterMessage>();
-    let (flow_tx, mut flow_rx) = mpsc::unbounded_channel::<bool>();
+    let (writer_tx, mut writer_rx) = mpsc::channel::<WriterMessage>(WRITER_QUEUE_CAPACITY);
+    let (flow_tx, mut flow_rx) = mpsc::channel::<bool>(4);
     let connection = Arc::new(Connection {
         pty_id: format!("tunnel-{}", random_hex(8)),
         manager: Arc::clone(&manager),
         writer_tx,
+        queue_gate: Mutex::new(()),
         flow_tx,
         pending_out: AtomicU64::new(0),
         paused: AtomicBool::new(false),
@@ -484,7 +548,13 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
                         if previous.saturating_sub(length) < FLOW_RESUME_BYTES
                             && connection.paused.swap(false, Ordering::SeqCst)
                         {
-                            let _ = connection.flow_tx.send(false);
+                            let _ = connection.flow_tx.try_send(false);
+                        }
+                        // `finish` may race with a full queue, so End is only
+                        // best effort. Once all admitted frames drain, stop
+                        // without waiting for another sender-side message.
+                        if connection.finished.load(Ordering::SeqCst) && writer_rx.is_empty() {
+                            break;
                         }
                     }
                     WriterMessage::End => break,
@@ -501,7 +571,9 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
         let context = context.clone();
         tokio::spawn(async move {
             while let Some(pause) = flow_rx.recv().await {
-                if connection.finished.load(Ordering::SeqCst) {
+                // Deliver a final pause even when shutdown has started. This
+                // keeps PTY flow semantics intact for a queue-overflow close.
+                if connection.finished.load(Ordering::SeqCst) && !pause {
                     break;
                 }
                 let frame = json!({

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -38,21 +38,21 @@
 //! already attach terminals through the cmux CLI. Paired human machines
 //! never run this listener: it starts from the managed branch only.
 
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
 
-use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine as _;
-use serde_json::{json, Value};
+use base64::engine::general_purpose::STANDARD as BASE64;
+use serde_json::{Value, json};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 use crate::pty::{
-    random_hex, session_name_ok, surface_ref_ok, FrameContext, PtyManager, PTY_PROTOCOL_VERSION,
+    FrameContext, PTY_PROTOCOL_VERSION, PtyManager, random_hex, session_name_ok, surface_ref_ok,
 };
 
 /// Loopback port the gateway's spliced streams dial. The chatmux Worker

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -1330,10 +1330,13 @@ mod tests {
         let rig = rig().await;
         let (connection, _writer_rx, _flow_rx) = test_connection(&rig);
         let pty = attach_test_pty(&rig, &connection).await;
-        let data_capacity = WRITER_QUEUE_CAPACITY - WRITER_CONTROL_MESSAGE_RESERVE - 1;
-        for index in 0..data_capacity {
-            assert!(connection.enqueue(WriterMessage::Frame(vec![index as u8])));
+        let mut frame_index = 0_usize;
+        while connection.writer_tx.capacity() > WRITER_CONTROL_MESSAGE_RESERVE {
+            assert!(connection.enqueue(WriterMessage::Frame(vec![(frame_index % 256) as u8])));
+            frame_index += 1;
         }
+        assert!(frame_index > 0);
+        assert!(connection.writer_tx.capacity() <= WRITER_CONTROL_MESSAGE_RESERVE);
 
         let flow = spawn_flow_worker(Arc::clone(&connection), connection.frame_context());
         connection.publish_flow(true);

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -101,6 +101,14 @@ fn is_encoded_control_frame(frame: &[u8]) -> bool {
     frame[4] == FRAME_KIND_CONTROL && payload_len == frame.len() - HEADER_BYTES
 }
 
+fn encode_overflow_frame() -> Vec<u8> {
+    encode_control_frame(&json!({
+        "t": "error",
+        "code": "overflow",
+        "message": "terminal output queue is full; reconnect to resume",
+    }))
+}
+
 /// Relay pty_error codes -> browser wire codes. Mirrors the Worker's
 /// browserErrorCode map (apps/backend/src/terminal/relay-pty.ts). KEEP IN
 /// SYNC; `wire_error_codes_match_the_worker_map` pins the shape here.
@@ -423,6 +431,16 @@ impl Connection {
             if self.finished.load(Ordering::SeqCst) {
                 false
             } else {
+                // Keep the client informed before closing. Data admission
+                // leaves a message and byte reserve for this bounded control
+                // frame, and the End permit remains last in FIFO order.
+                let overflow = encode_overflow_frame();
+                let overflow_bytes = overflow.len() as u64;
+                if self.reserve_bytes(overflow_bytes, true) {
+                    if self.writer_tx.try_send(WriterMessage::Frame(overflow)).is_err() {
+                        self.release_bytes(overflow_bytes);
+                    }
+                }
                 self.paused.store(true, Ordering::SeqCst);
                 let mut state = self.flow_state.lock().expect("flow state lock");
                 let notify = !state.desired_pause;
@@ -1020,6 +1038,11 @@ mod tests {
         serde_json::from_slice(&frame.payload).expect("control json")
     }
 
+    fn encoded_control_json(frame: &[u8]) -> Value {
+        assert!(is_encoded_control_frame(frame));
+        serde_json::from_slice(&frame[HEADER_BYTES..]).expect("encoded control json")
+    }
+
     #[test]
     fn data_budget_leaves_byte_reserve_for_control_frames() {
         assert_eq!(
@@ -1203,8 +1226,8 @@ mod tests {
         assert!(connection.finished.load(Ordering::SeqCst));
         assert_eq!(
             connection.pending_out.load(Ordering::SeqCst),
-            (frame_len * 2) as u64,
-            "a rejected frame must release its byte reservation"
+            (frame_len * 2) as u64 + encode_overflow_frame().len() as u64,
+            "a rejected frame must release its byte reservation while retaining the error"
         );
         assert!(*flow_rx.borrow());
         assert!(connection.done.is_cancelled());
@@ -1215,6 +1238,14 @@ mod tests {
         match writer_rx.recv().await.expect("second admitted frame") {
             WriterMessage::Frame(frame) => assert_eq!(frame[0], 2),
             WriterMessage::End => panic!("queue order changed"),
+        }
+        match writer_rx.recv().await.expect("overflow control frame") {
+            WriterMessage::Frame(frame) => {
+                let error = encoded_control_json(&frame);
+                assert_eq!(error["t"], "error");
+                assert_eq!(error["code"], "overflow");
+            }
+            WriterMessage::End => panic!("End overtook overflow error"),
         }
         assert!(matches!(writer_rx.recv().await, Some(WriterMessage::End)));
         rig.cancel.cancel();
@@ -1390,6 +1421,14 @@ mod tests {
                 WriterMessage::Frame(frame) => assert_eq!(frame, vec![index as u8]),
                 WriterMessage::End => panic!("queue order changed"),
             }
+        }
+        match writer_rx.recv().await.expect("overflow control frame") {
+            WriterMessage::Frame(frame) => {
+                let error = encoded_control_json(&frame);
+                assert_eq!(error["t"], "error");
+                assert_eq!(error["code"], "overflow");
+            }
+            WriterMessage::End => panic!("End overtook overflow error"),
         }
         assert!(matches!(writer_rx.recv().await, Some(WriterMessage::End)));
         rig.cancel.cancel();

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -1326,6 +1326,51 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn full_writer_queue_keeps_flow_resume_and_worker_completion() {
+        let rig = rig().await;
+        let (connection, _writer_rx, _flow_rx) = test_connection(&rig);
+        let pty = attach_test_pty(&rig, &connection).await;
+        let data_capacity = WRITER_QUEUE_CAPACITY - WRITER_CONTROL_MESSAGE_RESERVE - 1;
+        for index in 0..data_capacity {
+            assert!(connection.enqueue(WriterMessage::Frame(vec![index as u8])));
+        }
+
+        let flow = spawn_flow_worker(Arc::clone(&connection), connection.frame_context());
+        connection.publish_flow(true);
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if pty.state.lock().unwrap().pause_calls == 1 {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("pause should reach the live attachment");
+
+        // A resume published after the queue is full must not be dropped.
+        connection.publish_flow(false);
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if pty.state.lock().unwrap().resume_calls == 1 {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("resume should reach the live attachment");
+
+        connection.finish();
+        tokio::time::timeout(FLOW_DRAIN_TIMEOUT, flow)
+            .await
+            .expect("flow worker completion")
+            .expect("flow worker join");
+        assert!(connection.finished.load(Ordering::SeqCst));
+        rig.cancel.cancel();
+    }
+
+    #[tokio::test]
     async fn full_writer_queue_closes_without_growing_beyond_message_budget() {
         let rig = rig().await;
         let (connection, mut writer_rx, flow_rx) = test_connection(&rig);

--- a/cmux-tui/crates/cmux-tui/Cargo.toml
+++ b/cmux-tui/crates/cmux-tui/Cargo.toml
@@ -46,11 +46,11 @@ sha2.workspace = true
 uuid.workspace = true
 wait-timeout.workspace = true
 fs4.workspace = true
+tokio.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 cmux-remote.workspace = true
 cmux-remote-protocol.workspace = true
-tokio.workspace = true
 url.workspace = true
 async-trait.workspace = true
 


### PR DESCRIPTION
Replace unbounded Tokio mpsc queues in tunnel_terminal with bounded message and byte admission. Queue overflow pauses PTY flow and closes the connection after preserving admitted FIFO frames. Add behavior tests for stalled peers and full queues.

Regression commits: test first, fix second.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790563190&installation_model_id=21920&pr_number=11174&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11174&signature=61bfe56c2534ce213132a1144c87eff096a35f5e59ebaccd0d0283f4a5b6ab7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the tunnel terminal writer queues to fixed message and byte capacities so a stalled peer can no longer cause unbounded memory growth. Control frames and the shutdown marker get reserved capacity so error and flow signals survive a full data queue; when queues fill, the relay sends an overflow error frame, pauses PTY flow, and closes the connection after admitted frames flush in FIFO order.

- Flow control coalesces on a watch channel so the latest pause/resume survives consumer lag, and shutdown drains the final pause before releasing the attachment.
- Behavior tests cover stalled peers, full queues, resume after saturation, queue ordering, and the overflow report; the tests landed before the fix (regression commits).
- Promotes `tokio` to a top-level `cmux-tui` dependency so signal handling works on Windows.

<sup>Written for commit 3ae97624cd3f1b01c11474d17969e5012283838f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal data flow control to prevent excessive buffering during high-volume sessions.
  * Added backpressure handling so terminal input pauses safely when capacity is reached and resumes when available.
  * Ensured connections shut down cleanly after queued data has been processed.
  * Improved shutdown behavior by reliably delivering the final pause signal.

* **Tests**
  * Added coverage for message- and byte-limit backpressure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->