### PR TITLE
cloud-vm smoke: retry retryable 502 attaches within a bounded budget

### DIFF
--- a/web/scripts/cloud-vm/smoke-vm-api.mjs
+++ b/web/scripts/cloud-vm/smoke-vm-api.mjs
@@ -187,14 +187,35 @@ try {
       const attachBody = expectedTransport === "cmux-remote"
         ? { transport: "cmux-remote" }
         : { requireDaemon: true };
+      // First attach after create races the in-VM daemon boot; the API says
+      // retryable with retryAfterSeconds and real clients loop. Retry 502s
+      // within a bounded budget so the smoke measures the client contract,
+      // not the race.
       const attachStartedAt = performance.now();
-      const attach = await fetchWithTimeout(`${targetUrl}/api/vm/${encodeURIComponent(vmId)}/attach-endpoint`, {
-        method: "POST",
-        headers: { ...authHeaders, "content-type": "application/json" },
-        body: JSON.stringify(attachBody),
-      });
+      const attachBudgetMs = 120_000;
+      let attach;
+      let attachText;
+      for (;;) {
+        attach = await fetchWithTimeout(`${targetUrl}/api/vm/${encodeURIComponent(vmId)}/attach-endpoint`, {
+          method: "POST",
+          headers: { ...authHeaders, "content-type": "application/json" },
+          body: JSON.stringify(attachBody),
+        });
+        attachText = await attach.text();
+        if (attach.status !== 502) break;
+        const elapsed = performance.now() - attachStartedAt;
+        if (elapsed >= attachBudgetMs) break;
+        let retryAfterSeconds = 2;
+        try {
+          const parsed = JSON.parse(attachText);
+          if (typeof parsed.retryAfterSeconds === "number") retryAfterSeconds = parsed.retryAfterSeconds;
+          if (parsed.retryable !== true) break;
+        } catch {
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, Math.max(1, retryAfterSeconds) * 1000));
+      }
       attachDurationMs = Math.round(performance.now() - attachStartedAt);
-      const attachText = await attach.text();
       if (attach.status !== 200) throw new Error(`POST attach-endpoint expected 200, got ${attach.status}: ${attachText}`);
       const attached = JSON.parse(attachText);
       if (attached.transport !== expectedTransport) {


### PR DESCRIPTION
The first attach after create races the in-VM daemon boot; the API answers 502 `vm_cloud_service_unavailable` with `retryable: true` and `retryAfterSeconds`, and real clients loop on that contract. The smoke tried attach exactly once and reported boot races as failures (seen while diagnosing the 2026-08-29 freestyle incident). It now retries retryable 502s, honoring `retryAfterSeconds`, bounded at 120 seconds. Operator script only; verified against production (blaxel default create+attach+destroy green).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790563681&installation_model_id=21920&pr_number=11175&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11175&signature=a2b4278293f6e562187c6b674534a066b7eddb4bceda3e0f2846c8c45131b9bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the cloud-VM smoke script so a race between VM creation and in-VM daemon boot no longer fails the attach check. The smoke now retries 502 responses that declare `retryable: true`, sleeping `retryAfterSeconds` between attempts, and stops after a 120-second budget.

<sup>Written for commit d3a1b8a8832152d19fee7a3feccce64835d97fc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved virtual machine attachment handling by retrying temporary HTTP 502 errors.
  * Retries now respect server-provided wait times and stop safely when the retry window expires or the response is not retryable.
  * Attachment timing now reflects the complete operation, including retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->