### PR TITLE
CmuxGit: fix two compile errors in the reftable metadata change

### DIFF
--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/GitMetadataService.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/GitMetadataService.swift
@@ -123,27 +123,27 @@ public struct GitMetadataService: Sendable {
             repository: repository,
             trackedPathEventGeneration: trackedPathEventGeneration
         )
-        let initialReferences = await initialReferences
+        let startReferences = await initialReferences
         var trackedChanges = await initialTrackedChanges
         // HEAD and index updates are separate filesystem operations. Reconcile
         // the reference signature after the index scan for every backend; the
         // files implementation uses a cheap bounded direct revalidation.
         let resolvedReferences: GitReferenceSnapshot
         let latestReferences: GitReferenceSnapshot
-        if initialReferences.usesGitPlumbing {
+        if startReferences.usesGitPlumbing {
             // Plumbing snapshots already perform a stable symbolic-ref/commit
             // read under the shared limiter. Repeating that full probe after
             // the index scan doubles process work for reftable repositories;
             // the watcher will schedule a new snapshot when ref metadata
             // changes.
-            latestReferences = initialReferences
+            latestReferences = startReferences
         } else {
             latestReferences = await gitReferenceSnapshot(
                 repository: repository,
                 revalidateFileBackedHead: true
             )
         }
-        if latestReferences.headSignature != initialReferences.headSignature {
+        if latestReferences.headSignature != startReferences.headSignature {
             trackedChanges = await gitTrackedChangesSnapshot(repository: repository)
         }
         resolvedReferences = latestReferences

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+WatchFallback.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+WatchFallback.swift
@@ -3,7 +3,7 @@ import Foundation
 
 extension GitMetadataService {
     /// Keeps a conservative root watcher when an index format cannot be parsed.
-    private nonisolated func applyingForcedWorkTreeRoots(
+    nonisolated func applyingForcedWorkTreeRoots(
         _ descriptor: GitWorkspaceMetadataWatchDescriptor,
         repositories: Set<String>
     ) -> GitWorkspaceMetadataWatchDescriptor {


### PR DESCRIPTION
Two constructs in #10326 do not compile (checked against Swift 6.2.3 and 6.3.3, in both language modes):

- `GitMetadataService.refreshMetadata` rebinds the `async let initialReferences` with a same-name `let` in the same scope. An `async let` stays bound for its whole lexical scope after awaiting, so the second binding is an invalid redeclaration. The awaited value now lands in `startReferences`.

- `GitMetadataService.swift` calls `applyingForcedWorkTreeRoots`, which is declared `private` in `GitMetadataService+WatchFallback.swift`. `private` does not permit access from another source file, so the cross-file call cannot see it. The method drops `private`; module-internal is the narrowest access that works without relocating the code.

No intended behavior change: a rename and an access-level widening only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790576893&installation_model_id=21920&pr_number=11176&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11176&signature=12608a1ea2b93be7eec1f6d433f368a0a6f5b6db98329ba6075d6a7e7f036b5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two compile errors in the reftable metadata change for `CmuxGit` without changing behavior.

- Renames the awaited `async let initialReferences` value to `startReferences` to avoid an invalid same-scope redeclaration.
- Widens `applyingForcedWorkTreeRoots` from `private` to module-internal so `GitMetadataService.swift` can call it across source files.

<sup>Written for commit f11a17e2355e7f84f7cb448f9d84840c5966fad3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

