### PR TITLE
fix(web): reload the document when the footer switches locale

### DIFF
--- a/web/app/[locale]/components/language-switcher.tsx
+++ b/web/app/[locale]/components/language-switcher.tsx
@@ -1,20 +1,30 @@
 "use client";
 
 import { useLocale } from "next-intl";
-import { useRouter, usePathname } from "../../../i18n/navigation";
-import { locales, localeNames, type Locale } from "../../../i18n/routing";
+import { usePathname } from "../../../i18n/navigation";
+import {
+  locales,
+  localeNames,
+  routing,
+  type Locale,
+} from "../../../i18n/routing";
 
 export function LanguageSwitcher() {
   const locale = useLocale() as Locale;
-  const router = useRouter();
   const pathname = usePathname();
 
   function onChange(e: React.ChangeEvent<HTMLSelectElement>) {
     const newLocale = e.target.value as Locale;
-    const qs = typeof window !== "undefined"
-      ? window.location.search + window.location.hash
-      : "";
-    router.replace(pathname + qs, { locale: newLocale });
+    if (newLocale === locale || typeof window === "undefined") return;
+    // The server only sets NEXT_LOCALE on a locale-prefixed URL, so the
+    // default locale needs it written here.
+    document.cookie = `NEXT_LOCALE=${newLocale};path=/;samesite=lax`;
+    const prefix = newLocale === routing.defaultLocale ? "" : `/${newLocale}`;
+    const qs = window.location.search + window.location.hash;
+    // A client transition reuses the cached RSC payload and skips
+    // generateMetadata, leaving the body and title in the old locale.
+    // eslint-disable-next-line @next/next/no-location-assign-relative-destination -- the reload is the fix
+    window.location.assign(`${prefix}${pathname}${qs}`);
   }
 
   return (

--- a/web/tests/language-switcher.test.tsx
+++ b/web/tests/language-switcher.test.tsx
@@ -1,0 +1,130 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { ReactElement } from "react";
+
+const replace = mock(() => undefined);
+const push = mock(() => undefined);
+const writtenCookies: string[] = [];
+let currentLocale = "en";
+
+// Spread the real modules: bun swaps a mocked module for the whole process,
+// and a partial mock breaks other suites in the shared run.
+const actualIntl = await import("next-intl");
+const actualNavigation = await import("../i18n/navigation");
+
+mock.module("next-intl", () => ({
+  ...actualIntl,
+  useLocale: () => currentLocale,
+}));
+
+mock.module("../i18n/navigation", () => ({
+  ...actualNavigation,
+  usePathname: () => "/pricing",
+  useRouter: () => ({ push, replace }),
+}));
+
+const { LanguageSwitcher } = await import(
+  "../app/[locale]/components/language-switcher"
+);
+
+describe("footer language switcher", () => {
+  test("navigates the document instead of a client-side transition", () => {
+    expect(switchLocaleTo("ja")).toEqual(["/ja/pricing"]);
+    expect(replace).not.toHaveBeenCalled();
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  test("keeps the current query string and hash on the new locale", () => {
+    const assigned = switchLocaleTo("zh-CN", {
+      search: "?plan=team",
+      hash: "#faq",
+    });
+
+    expect(assigned).toEqual(["/zh-CN/pricing?plan=team#faq"]);
+  });
+
+  test("drops the prefix when switching back to the default locale", () => {
+    expect(switchLocaleTo("en", { from: "zh-CN" })).toEqual(["/pricing"]);
+  });
+
+  test("persists the new locale so the unprefixed default path sticks", () => {
+    switchLocaleTo("en", { from: "ja" });
+
+    expect(writtenCookies).toEqual(["NEXT_LOCALE=en;path=/;samesite=lax"]);
+  });
+
+  test("ignores a selection of the locale already in use", () => {
+    expect(switchLocaleTo("en")).toEqual([]);
+    expect(writtenCookies).toEqual([]);
+  });
+});
+
+function switchLocaleTo(
+  locale: string,
+  location: { search?: string; hash?: string; from?: string } = {},
+): string[] {
+  const assigned: string[] = [];
+  writtenCookies.length = 0;
+  currentLocale = location.from ?? "en";
+  replace.mockClear();
+  push.mockClear();
+
+  const previousWindow = (globalThis as { window?: unknown }).window;
+  const previousDocument = (globalThis as { document?: unknown }).document;
+  (globalThis as { window?: unknown }).window = {
+    location: {
+      search: location.search ?? "",
+      hash: location.hash ?? "",
+      assign: (url: string) => {
+        assigned.push(url);
+      },
+    },
+  };
+  (globalThis as { document?: unknown }).document = {
+    set cookie(value: string) {
+      writtenCookies.push(value);
+    },
+  };
+
+  try {
+    findSelect(LanguageSwitcher()).props.onChange({ target: { value: locale } });
+  } finally {
+    (globalThis as { window?: unknown }).window = previousWindow;
+    (globalThis as { document?: unknown }).document = previousDocument;
+  }
+
+  return assigned;
+}
+
+function findSelect(node: unknown): ReactElement<{
+  onChange: (event: { target: { value: string } }) => void;
+}> {
+  if (!isElement(node)) {
+    throw new Error("language switcher did not render an element");
+  }
+  if (node.type === "select") {
+    return node as ReactElement<{
+      onChange: (event: { target: { value: string } }) => void;
+    }>;
+  }
+  const children = (node.props as { children?: unknown }).children;
+  for (const child of Array.isArray(children) ? children : [children]) {
+    if (!isElement(child)) {
+      continue;
+    }
+    try {
+      return findSelect(child);
+    } catch {
+      continue;
+    }
+  }
+  throw new Error("language switcher did not render a select");
+}
+
+function isElement(node: unknown): node is ReactElement {
+  return (
+    typeof node === "object" &&
+    node !== null &&
+    "type" in node &&
+    "props" in node
+  );
+}


### PR DESCRIPTION
## Summary

This PR fixes the footer language switcher leaving the page in the old locale.

- What changed? The switcher does a full document navigation instead of `router.replace(pathname, { locale })`, and writes the `NEXT_LOCALE` cookie itself.
- Why? The client-side transition reuses the cached RSC payload and skips `generateMetadata`, so the nav updated but the page body and tab title stayed in the old locale until a reload. The cookie is written manually because the server only sets `NEXT_LOCALE` on locale-prefixed URLs, so switching back to English would otherwise keep the old one.

## Testing

- How did you test this change? `bun test tests/language-switcher.test.tsx` — 5 pass, 4 fail with the fix reverted. Typecheck and eslint clean. Full suite has no new failures.
- What did you verify manually? Switched en → zh-CN → en on the dev server. Title follows the locale both ways, cookie ends as `en`, path goes `/zh-CN` → `/`.

## Video

--- Before 


https://github.com/user-attachments/assets/5454c7e7-e0c3-4835-8c7a-75d5a7ef60dc


--- After 


https://github.com/user-attachments/assets/678b82d1-f00e-415f-82b9-657e9524b507





## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790582333&installation_model_id=21920&pr_number=11178&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11178&signature=304e4ddf741c48379c43986f1c3b297a7479b1f749151b6c70d00c8e1413d3b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the footer language switcher so the page actually changes language instead of just updating the nav. The switcher now does a full document reload and writes the `NEXT_LOCALE` cookie itself, because the client-side transition reused the cached RSC payload and skipped `generateMetadata`, leaving the body and title in the old locale until reload. The cookie is needed because without it the unprefixed default locale would keep the old cookie value.

<sup>Written for commit 5736ee0af673690d35bad5c5f8526a1ad765cd5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved language switching with full-page navigation for more reliable locale changes.
  - Preserves the current query parameters and URL hash when changing languages.
  - Automatically handles locale prefixes, including removing the prefix for the default language.
  - Saves the selected language preference for future visits.
  - Selecting the currently active language has no effect.

- **Tests**
  - Added coverage for locale navigation, URL preservation, preference storage, and no-op selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->