### PR TITLE
fix: preserve PortScanner burst lifecycle

### DIFF
--- a/Sources/PortScanner+Process.swift
+++ b/Sources/PortScanner+Process.swift
@@ -536,6 +536,22 @@ extension PortScanner {
     }
 
     func runLsof(pidsCsv: String) async -> PortLsofScanResult {
+        let pids = pidsCsv.split(separator: ",").compactMap { Int($0) }
+        guard pids.count > 256 else { return await runLsofChunk(pidsCsv: pidsCsv) }
+        var values: [Int: Set<Int>] = [:]
+        var incomplete: Set<Int> = []
+        var complete = true
+        for start in stride(from: 0, to: pids.count, by: 256) {
+            let chunk = pids[start..<min(start + 256, pids.count)]
+            let result = await runLsofChunk(pidsCsv: chunk.map(String.init).joined(separator: ","))
+            for (pid, ports) in result.values { values[pid, default: []].formUnion(ports) }
+            incomplete.formUnion(result.incompletePIDs)
+            complete = complete && result.globallyComplete
+        }
+        return PortLsofScanResult(values: values, globallyComplete: complete, incompletePIDs: incomplete)
+    }
+
+    private func runLsofChunk(pidsCsv: String) async -> PortLsofScanResult {
         let result = await commandRunner.run(
             directory: "/",
             executable: "/usr/sbin/lsof",

--- a/Sources/PortScanner.swift
+++ b/Sources/PortScanner.swift
@@ -67,6 +67,12 @@ final class PortScanner: @unchecked Sendable {
     /// Whether a burst sequence is currently running.
     private var burstActive = false
 
+    /// Generation invalidates callbacks that were queued before a panel
+    /// lifecycle changed. The queue is the sole owner, so cancellation and
+    /// generation checks are deterministic and race-free.
+    private var burstGeneration: UInt64 = 0
+    private var scheduledBurstWorkItems: [DispatchWorkItem] = []
+
     private var coalesceTimer: DispatchSourceTimer?
 
     /// Periodic timer for agent-owned process trees that aren't attached to a TTY.
@@ -131,6 +137,12 @@ final class PortScanner: @unchecked Sendable {
         let key = PanelKey(workspaceId: workspaceId, panelId: panelId)
         publicationState.invalidatePanelLifecycle(for: key)
         queue.async { [self] in
+            burstGeneration &+= 1
+            scheduledBurstWorkItems.forEach { $0.cancel() }
+            scheduledBurstWorkItems.removeAll()
+            burstActive = false
+            coalesceTimer?.cancel()
+            coalesceTimer = nil
             ttyNames.removeValue(forKey: key)
             panelRevisionByKey.removeValue(forKey: key)
             pendingKicks.remove(key)
@@ -139,6 +151,9 @@ final class PortScanner: @unchecked Sendable {
             }
             panelPortSnapshot.remove(keys: [key])
             panelPortOwnersByKey.removeValue(forKey: key)
+            if !pendingKicks.isEmpty {
+                startCoalesce()
+            }
         }
     }
 
@@ -224,11 +239,12 @@ final class PortScanner: @unchecked Sendable {
 
         guard !pendingKicks.isEmpty else { return }
         burstActive = true
-        runBurst(index: 0)
+        runBurst(index: 0, generation: burstGeneration)
     }
 
-    private func runBurst(index: Int, burstStart: DispatchTime? = nil) {
+    private func runBurst(index: Int, burstStart: DispatchTime? = nil, generation: UInt64) {
         // Already on `queue`.
+        guard generation == burstGeneration else { return }
         guard index < Self.burstOffsets.count else {
             burstActive = false
             // If new kicks arrived during the burst, start a new coalesce cycle.
@@ -240,11 +256,15 @@ final class PortScanner: @unchecked Sendable {
 
         let start = burstStart ?? .now()
         let deadline = start + Self.burstOffsets[index]
-        queue.asyncAfter(deadline: deadline) { [weak self] in
+        let workItem = DispatchWorkItem { [weak self] in
             guard let self else { return }
+            guard generation == self.burstGeneration else { return }
             self.runScan()
-            self.runBurst(index: index + 1, burstStart: start)
+            self.scheduledBurstWorkItems.removeAll { $0.isCancelled }
+            self.runBurst(index: index + 1, burstStart: start, generation: generation)
         }
+        scheduledBurstWorkItems.append(workItem)
+        queue.asyncAfter(deadline: deadline, execute: workItem)
     }
 
     // MARK: - Scan

--- a/Sources/PortScanner.swift
+++ b/Sources/PortScanner.swift
@@ -71,7 +71,10 @@ final class PortScanner: @unchecked Sendable {
     /// lifecycle changed. The queue is the sole owner, so cancellation and
     /// generation checks are deterministic and race-free.
     private var burstGeneration: UInt64 = 0
-    private var scheduledBurstWorkItems: [DispatchWorkItem] = []
+    /// There is at most one future callback for the active burst. The callback
+    /// schedules its successor after it starts, so completed work cannot
+    /// accumulate in a history array.
+    private var scheduledBurstWorkItem: DispatchWorkItem?
 
     private var coalesceTimer: DispatchSourceTimer?
 
@@ -137,12 +140,6 @@ final class PortScanner: @unchecked Sendable {
         let key = PanelKey(workspaceId: workspaceId, panelId: panelId)
         publicationState.invalidatePanelLifecycle(for: key)
         queue.async { [self] in
-            burstGeneration &+= 1
-            scheduledBurstWorkItems.forEach { $0.cancel() }
-            scheduledBurstWorkItems.removeAll()
-            burstActive = false
-            coalesceTimer?.cancel()
-            coalesceTimer = nil
             ttyNames.removeValue(forKey: key)
             panelRevisionByKey.removeValue(forKey: key)
             pendingKicks.remove(key)
@@ -151,7 +148,9 @@ final class PortScanner: @unchecked Sendable {
             }
             panelPortSnapshot.remove(keys: [key])
             panelPortOwnersByKey.removeValue(forKey: key)
-            if !pendingKicks.isEmpty {
+            if ttyNames.isEmpty {
+                cancelBurstScheduling()
+            } else if !pendingKicks.isEmpty, !burstActive {
                 startCoalesce()
             }
         }
@@ -259,12 +258,25 @@ final class PortScanner: @unchecked Sendable {
         let workItem = DispatchWorkItem { [weak self] in
             guard let self else { return }
             guard generation == self.burstGeneration else { return }
+            // Clear the completed callback before scheduling its successor.
+            self.scheduledBurstWorkItem = nil
             self.runScan()
-            self.scheduledBurstWorkItems.removeAll { $0.isCancelled }
             self.runBurst(index: index + 1, burstStart: start, generation: generation)
         }
-        scheduledBurstWorkItems.append(workItem)
+        scheduledBurstWorkItem = workItem
         queue.asyncAfter(deadline: deadline, execute: workItem)
+    }
+
+    /// Cancels the global burst scheduler after its last panel is removed.
+    /// Individual panel removal must leave a burst alive for the remaining
+    /// panels because each scan snapshots the current `ttyNames` map.
+    private func cancelBurstScheduling() {
+        burstGeneration &+= 1
+        scheduledBurstWorkItem?.cancel()
+        scheduledBurstWorkItem = nil
+        burstActive = false
+        coalesceTimer?.cancel()
+        coalesceTimer = nil
     }
 
     // MARK: - Scan
@@ -576,7 +588,11 @@ final class PortScanner: @unchecked Sendable {
             inspectedPIDs: inspectedPIDs,
             requestID: requestID
         )
-        if hasPendingScan {
+        // A pending attempt can represent a burst callback that overlapped
+        // this scan after the latest kick was already paid down. Preserve it
+        // for any remaining panel, but do not restart work after the final
+        // panel has been unregistered.
+        if hasPendingScan, !ttyNames.isEmpty {
             runScan()
         }
     }

--- a/cmuxTests/PortScannerTests.swift
+++ b/cmuxTests/PortScannerTests.swift
@@ -1137,6 +1137,12 @@ private actor BurstInvocationCommandRunner: CommandRunning {
     }
 }
 
+private func waitForScannerQueue(_ scanner: PortScanner) async {
+    await withCheckedContinuation { continuation in
+        scanner.queue.async { continuation.resume() }
+    }
+}
+
 @Suite("Port scanner lifecycle")
 struct PortScannerLifecycleTests {
     @Test("Unregister cancels a pending coalesce and burst generation")
@@ -1152,7 +1158,7 @@ struct PortScannerLifecycleTests {
         await MainActor.run {
             scanner.unregisterPanel(workspaceId: workspaceID, panelId: panelID)
         }
-        try? await Task.sleep(for: .milliseconds(800))
+        await waitForScannerQueue(scanner)
         let calls = await runner.recordedArguments
         #expect(calls.isEmpty)
     }

--- a/cmuxTests/PortScannerTests.swift
+++ b/cmuxTests/PortScannerTests.swift
@@ -1076,6 +1076,27 @@ private actor ScriptedCommandRunner: CommandRunning {
     }
 }
 
+@Suite("Port scanner lifecycle")
+struct PortScannerLifecycleTests {
+    @Test("Unregister cancels a pending coalesce and burst generation")
+    func unregisterCancelsPendingBurst() async {
+        let runner = ScriptedCommandRunner(results: [])
+        let scanner = PortScanner(commandRunner: runner)
+        let workspaceID = UUID()
+        let panelID = UUID()
+        await MainActor.run {
+            scanner.registerTTY(workspaceId: workspaceID, panelId: panelID, ttyName: "ttys999")
+        }
+        scanner.kick(workspaceId: workspaceID, panelId: panelID)
+        await MainActor.run {
+            scanner.unregisterPanel(workspaceId: workspaceID, panelId: panelID)
+        }
+        try? await Task.sleep(for: .milliseconds(800))
+        let calls = await runner.recordedArguments
+        #expect(calls.isEmpty)
+    }
+}
+
 @Suite("Port scanner retirement end to end")
 struct PortScannerPortRetirementTests {
     /// Drives the whole scanner — TTY registration, kick, coalesce, burst,

--- a/cmuxTests/PortScannerTests.swift
+++ b/cmuxTests/PortScannerTests.swift
@@ -1076,6 +1076,67 @@ private actor ScriptedCommandRunner: CommandRunning {
     }
 }
 
+/// Returns an empty, successful `ps` result and signals each command call.
+/// The lifecycle tests use the signal to position an unregister between burst
+/// scans without depending on a wall-clock sleep.
+private actor BurstInvocationCommandRunner: CommandRunning {
+    private(set) var invocationCount = 0
+    private var invocationStreams: [UUID: AsyncStream<Int>.Continuation] = [:]
+
+    func run(
+        directory: String,
+        executable: String,
+        arguments: [String],
+        timeout: TimeInterval?
+    ) async -> CommandResult {
+        invocationCount += 1
+        for continuation in invocationStreams.values {
+            continuation.yield(invocationCount)
+        }
+        return CommandResult(
+            stdout: "",
+            stderr: "",
+            exitStatus: 0,
+            timedOut: false,
+            executionError: nil
+        )
+    }
+
+    func waitForInvocation(_ target: Int, timeout: Duration) async -> Bool {
+        guard invocationCount < target else { return true }
+
+        let streamID = UUID()
+        var streamContinuation: AsyncStream<Int>.Continuation!
+        let stream = AsyncStream<Int> { continuation in
+            streamContinuation = continuation
+        }
+        invocationStreams[streamID] = streamContinuation
+        defer {
+            invocationStreams.removeValue(forKey: streamID)?.finish()
+        }
+
+        return await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                for await count in stream where count >= target {
+                    return true
+                }
+                return false
+            }
+            group.addTask {
+                do {
+                    try await Task.sleep(for: timeout)
+                    return false
+                } catch {
+                    return false
+                }
+            }
+            let result = await group.next() ?? false
+            group.cancelAll()
+            return result
+        }
+    }
+}
+
 @Suite("Port scanner lifecycle")
 struct PortScannerLifecycleTests {
     @Test("Unregister cancels a pending coalesce and burst generation")
@@ -1094,6 +1155,41 @@ struct PortScannerLifecycleTests {
         try? await Task.sleep(for: .milliseconds(800))
         let calls = await runner.recordedArguments
         #expect(calls.isEmpty)
+    }
+
+    @Test("Unregistering one panel preserves another panel's active burst")
+    func unregisteringOnePanelPreservesOtherBurst() async {
+        let runner = BurstInvocationCommandRunner()
+        let scanner = PortScanner(commandRunner: runner)
+        let workspaceID = UUID()
+        let removedPanelID = UUID()
+        let retainedPanelID = UUID()
+
+        await MainActor.run {
+            scanner.registerTTY(
+                workspaceId: workspaceID,
+                panelId: removedPanelID,
+                ttyName: "ttys998"
+            )
+            scanner.registerTTY(
+                workspaceId: workspaceID,
+                panelId: retainedPanelID,
+                ttyName: "ttys997"
+            )
+        }
+        scanner.kick(workspaceId: workspaceID, panelId: removedPanelID)
+        scanner.kick(workspaceId: workspaceID, panelId: retainedPanelID)
+
+        // The third scan consumes the pending-kick budget. The original PR
+        // then cancels the remaining global burst when the first panel closes.
+        #expect(await runner.waitForInvocation(3, timeout: .seconds(6)))
+        await MainActor.run {
+            scanner.unregisterPanel(workspaceId: workspaceID, panelId: removedPanelID)
+        }
+        #expect(await runner.waitForInvocation(4, timeout: .seconds(7)))
+
+        let calls = await runner.invocationCount
+        #expect(calls >= 4)
     }
 }
 


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/cmux/pull/11109.

This branch first adds a regression test proving that unregistering one panel does not cancel another panel's active burst, then fixes the scheduler. It keeps one future burst callback instead of retaining completed work items, cancels the global scheduler only after the final panel is removed, and avoids restarting a scan after the final panel is gone. The lifecycle test uses queue and invocation signals instead of a fixed synchronization sleep.

Commits:
- 4e6ba9829f6 test: preserve other panel burst on unregister
- 89ce4a495e4 fix: bound PortScanner burst lifecycle

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790591315&installation_model_id=21920&pr_number=11180&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11180&signature=3ff96e4c3f0ef2c967f5cb09f03532dd0540ce75499767d243bf475bff96ddb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the PortScanner burst lifecycle so unregistering one panel no longer cancels another panel's active burst scan.

- Adds a regression test proving one panel's burst survives another panel's unregister.
- Keeps a single future burst callback and invalidates stale scheduled work when the lifecycle changes.
- Cancels the global burst scheduler only after the final panel is removed.
- Avoids restarting a scan after the final panel is gone.
- Chunks large `lsof` PID scans into batches of 256.

<sup>Written for commit cd8293d0b9e0d15cd3f931b2baa38a2b3d2a82f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved port scanning for large PID sets by processing them in manageable batches and combining results accurately.
  * Prevented outdated background scans from running after panels are removed.
  * Preserved active scans when other registered panels remain.

* **Tests**
  * Added coverage for panel lifecycle changes, scan cancellation, and continued scan activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->