### PR TITLE
Accept mobile host TCP through a POSIX listener so Tailscale clients can reach the Mac

### DIFF
--- a/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxPOSIXByteTransport.swift
+++ b/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxPOSIXByteTransport.swift
@@ -1,0 +1,540 @@
+public import CMUXMobileCore
+public import Foundation
+import Dispatch
+
+/// Errors raised while operating a ``CmxPOSIXByteTransport``.
+public enum CmxPOSIXByteTransportError: Error, Equatable, Sendable {
+    /// An operation was attempted before the accepted socket became ready.
+    case notConnected
+    /// The transport was already closed.
+    case alreadyClosed
+    /// A receive was requested while another is still in flight.
+    case receiveAlreadyInProgress
+    /// A send was requested while another is still in flight.
+    case sendAlreadyInProgress
+    /// A receive failed; the associated value describes the cause.
+    case receiveFailed(String)
+    /// A send failed; the associated value describes the cause.
+    case sendFailed(String)
+}
+
+/// A ``CmxByteTransport`` over one already-connected POSIX socket.
+///
+/// The Mac pairing host accepts inbound TCP through a BSD listening socket
+/// instead of a Network.framework `NWListener`, because on macOS 26/27 with
+/// the Tailscale system extension the kernel drops inbound-delivered
+/// connections whose listener is an NWListener socket before `accept` ever
+/// runs. This transport carries the accepted file descriptor through the same
+/// byte contract the NW-based transport implements, so `MobileHostConnection`
+/// consumes both identically.
+///
+/// The actor owns the file descriptor, a private I/O queue, and every
+/// in-flight continuation, so receive/send/close serialize without locks.
+/// Readiness is driven by `DispatchSource` read and write events on the
+/// descriptor, the sanctioned carve-out for low-level socket I/O. Sources are
+/// created suspended and toggled with balanced `resume()`/`suspend()` guarded
+/// by `readSourceResumed`/`writeSourceResumed`, so the dispatch suspension
+/// count can never go negative. The descriptor is closed exactly once, on the
+/// I/O queue, by the read source's cancel handler.
+public actor CmxPOSIXByteTransport: CmxByteTransport {
+    /// Default per-receive byte cap, matching ``CmxNetworkByteTransport``.
+    public static let defaultMaximumReceiveLength = 64 * 1024
+
+    private enum TransportState {
+        case ready
+        case failed(CmxPOSIXByteTransportError)
+        case closed
+    }
+
+    private enum ReadOutcome: Sendable {
+        case bytes(Data)
+        case endOfStream
+        case wouldBlock
+        case failed(String)
+    }
+
+    private enum WriteOutcome: Sendable {
+        case progress(Int)
+        case wouldBlock
+        case failed(String)
+    }
+
+    private let fileDescriptor: Int32
+    private let ioQueue: DispatchQueue
+    private let maximumReceiveLength: Int
+    private var state: TransportState = .ready
+    private var remoteDidClose = false
+    private var receiveContinuation: (id: UUID, continuation: CheckedContinuation<Data?, any Error>)?
+    private var cancelledReceiveIDs: Set<UUID> = []
+    private var receiveBuffer: [Data] = []
+    private var sendContinuation: (id: UUID, continuation: CheckedContinuation<Void, any Error>?)?
+    private var cancelledSendIDs: Set<UUID> = []
+    private var sendBuffer = Data()
+    private var sendOffset = 0
+    private let readSource: any DispatchSourceRead
+    private let writeSource: any DispatchSourceWrite
+    private var readSourceResumed = false
+    private var writeSourceResumed = false
+    /// Set by ``tearDown(pendingError:resumeReceiveWithError:)`` so ``deinit``
+    /// can tell "already cancelled" from "never cleaned up".
+    private var sourcesCancelled = false
+
+    /// Wraps an accepted, connected socket.
+    ///
+    /// The transport takes ownership of `acceptedFileDescriptor`: it configures
+    /// nothing itself (the acceptor sets `O_NONBLOCK`, `TCP_NODELAY`, and
+    /// `SO_NOSIGPIPE`) and closes the descriptor exactly once on teardown.
+    /// - Parameters:
+    ///   - acceptedFileDescriptor: A connected, nonblocking socket descriptor.
+    ///   - maximumReceiveLength: Positive per-receive byte cap.
+    public init(
+        acceptedFileDescriptor: Int32,
+        maximumReceiveLength: Int = CmxPOSIXByteTransport.defaultMaximumReceiveLength
+    ) {
+        fileDescriptor = acceptedFileDescriptor
+        ioQueue = DispatchQueue(
+            label: "dev.cmux.mobile.posix-byte-transport.\(UUID().uuidString)"
+        )
+        self.maximumReceiveLength = maximumReceiveLength
+        // Handlers attach after every stored property is initialized, so the
+        // event closures may safely capture self.
+        readSource = DispatchSource.makeReadSource(
+            fileDescriptor: acceptedFileDescriptor,
+            queue: ioQueue
+        )
+        writeSource = DispatchSource.makeWriteSource(
+            fileDescriptor: acceptedFileDescriptor,
+            queue: ioQueue
+        )
+        readSource.setEventHandler { [weak self] in
+            guard let self else { return }
+            let outcome = Self.readOnce(
+                fileDescriptor: self.fileDescriptor,
+                maximumLength: self.maximumReceiveLength
+            )
+            Task { await self.handleReadOutcome(outcome) }
+        }
+        readSource.setCancelHandler {
+            Darwin.close(acceptedFileDescriptor)
+        }
+        writeSource.setEventHandler { [weak self] in
+            guard let self else { return }
+            Task { await self.pumpSend() }
+        }
+    }
+
+    deinit {
+        // A dispatch source released while suspended traps libdispatch, and a
+        // source cancelled while suspended never runs its cancel handler (the
+        // fd would leak). If teardown never ran (a caller dropped the transport
+        // without close(), or the process is shutting down before a pending
+        // close task runs), finish the same resume-then-cancel sequence here.
+        guard !sourcesCancelled else { return }
+        let readResumed = readSourceResumed
+        let writeResumed = writeSourceResumed
+        ioQueue.async { [readSource, writeSource] in
+            if !writeResumed { writeSource.resume() }
+            writeSource.cancel()
+            if !readResumed { readSource.resume() }
+            readSource.cancel()
+        }
+    }
+
+    /// No-op for an accepted socket: the connection already exists.
+    ///
+    /// Validates the transport is still usable so callers that symmetrically
+    /// `connect()` before use (as the NW transport requires) keep working.
+    /// - Throws: ``CmxPOSIXByteTransportError/alreadyClosed`` after close, or
+    ///   the recorded failure if the transport failed.
+    public func connect() async throws {
+        try Task.checkCancellation()
+        switch state {
+        case .ready:
+            return
+        case let .failed(error):
+            throw error
+        case .closed:
+            throw CmxPOSIXByteTransportError.alreadyClosed
+        }
+    }
+
+    /// Receives the next chunk of bytes, or `nil` at end of stream.
+    /// - Returns: The next received `Data`, or `nil` once the peer closed.
+    /// - Throws: ``CmxPOSIXByteTransportError`` or `CancellationError`.
+    public func receive() async throws -> Data? {
+        try Task.checkCancellation()
+        let operationID = UUID()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                Task {
+                    await self.startReceive(
+                        operationID: operationID,
+                        continuation: continuation
+                    )
+                }
+            }
+        } onCancel: {
+            Task { await self.cancelReceive(operationID: operationID) }
+        }
+    }
+
+    /// Sends bytes over the socket. Empty data is a no-op.
+    /// - Parameter data: The bytes to write.
+    /// - Throws: ``CmxPOSIXByteTransportError`` or `CancellationError`.
+    public func send(_ data: Data) async throws {
+        guard !data.isEmpty else {
+            return
+        }
+        try Task.checkCancellation()
+        let operationID = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+                Task {
+                    await self.startSend(
+                        data,
+                        operationID: operationID,
+                        continuation: continuation
+                    )
+                }
+            }
+        } onCancel: {
+            Task { await self.cancelSend(operationID: operationID) }
+        }
+    }
+
+    /// Closes the socket and completes any in-flight operations.
+    ///
+    /// A pending ``receive()`` resolves to `nil` (end of stream); a pending
+    /// ``send(_:)`` fails with ``CmxPOSIXByteTransportError/alreadyClosed``.
+    public func close() async {
+        tearDown(pendingError: CmxPOSIXByteTransportError.alreadyClosed, resumeReceiveWithError: false)
+    }
+
+    // MARK: - Receive path
+
+    private func startReceive(
+        operationID: UUID,
+        continuation: CheckedContinuation<Data?, any Error>
+    ) async {
+        guard !consumeCancelledReceive(operationID) else {
+            continuation.resume(throwing: CancellationError())
+            return
+        }
+        switch state {
+        case .ready:
+            break
+        case let .failed(error):
+            continuation.resume(throwing: error)
+            return
+        case .closed:
+            continuation.resume(returning: nil)
+            return
+        }
+
+        if !receiveBuffer.isEmpty {
+            continuation.resume(returning: receiveBuffer.removeFirst())
+            return
+        }
+        guard !remoteDidClose else {
+            continuation.resume(returning: nil)
+            return
+        }
+        guard receiveContinuation == nil else {
+            continuation.resume(throwing: CmxPOSIXByteTransportError.receiveAlreadyInProgress)
+            return
+        }
+
+        receiveContinuation = (operationID, continuation)
+        resumeReadSource()
+    }
+
+    private func handleReadOutcome(_ outcome: ReadOutcome) {
+        switch outcome {
+        case let .bytes(data):
+            // A late event after teardown still lands here; drop it silently
+            // rather than buffering data for a closed transport.
+            guard !isTerminal else { return }
+            if let pending = receiveContinuation {
+                receiveContinuation = nil
+                suspendReadSource()
+                pending.continuation.resume(returning: data)
+            } else {
+                suspendReadSource()
+                receiveBuffer.append(data)
+            }
+        case .endOfStream:
+            remoteDidClose = true
+            suspendReadSource()
+            if let pending = receiveContinuation {
+                receiveContinuation = nil
+                pending.continuation.resume(returning: nil)
+            }
+        case .wouldBlock:
+            // Spurious wakeup: leave the source resumed and the continuation
+            // armed; the next readable event carries the payload.
+            break
+        case let .failed(description):
+            guard !isTerminal else { return }
+            failTransport(.receiveFailed(description))
+        }
+    }
+
+    private func resumeReadSource() {
+        // After teardown the source is cancelled; resuming or suspending a
+        // cancelled source traps libdispatch, so every toggle is terminal-gated.
+        guard !readSourceResumed, !isTerminal else { return }
+        readSourceResumed = true
+        readSource.resume()
+    }
+
+    private func suspendReadSource() {
+        guard readSourceResumed, !isTerminal else { return }
+        readSourceResumed = false
+        readSource.suspend()
+    }
+
+    private func cancelReceive(operationID: UUID) {
+        if let pending = receiveContinuation, pending.id == operationID {
+            receiveContinuation = nil
+            suspendReadSource()
+            pending.continuation.resume(throwing: CancellationError())
+        } else {
+            cancelledReceiveIDs.insert(operationID)
+        }
+    }
+
+    private func consumeCancelledReceive(_ operationID: UUID) -> Bool {
+        cancelledReceiveIDs.remove(operationID) != nil
+    }
+
+    // MARK: - Send path
+
+    private func startSend(
+        _ data: Data,
+        operationID: UUID,
+        continuation: CheckedContinuation<Void, any Error>
+    ) async {
+        guard !consumeCancelledSend(operationID) else {
+            continuation.resume(throwing: CancellationError())
+            return
+        }
+        switch state {
+        case .ready:
+            break
+        case let .failed(error):
+            continuation.resume(throwing: error)
+            return
+        case .closed:
+            continuation.resume(throwing: CmxPOSIXByteTransportError.alreadyClosed)
+            return
+        }
+        guard sendContinuation == nil else {
+            continuation.resume(throwing: CmxPOSIXByteTransportError.sendAlreadyInProgress)
+            return
+        }
+
+        sendContinuation = (operationID, continuation)
+        sendBuffer = data
+        sendOffset = 0
+        pumpSend()
+    }
+
+    /// Writes what the nonblocking socket accepts now, completing the send when
+    /// the buffer drains or arming the write source on a would-block. Runs on
+    /// the actor; `write` on the nonblocking descriptor returns immediately.
+    private func pumpSend() {
+        guard !isTerminal else { return }
+        guard let pending = sendContinuation else { return }
+        let remaining = sendBuffer.count - sendOffset
+        guard remaining > 0 else {
+            sendContinuation = nil
+            suspendWriteSource()
+            pending.continuation?.resume()
+            return
+        }
+
+        var writeErrno: Int32 = 0
+        let written = sendBuffer.withUnsafeBytes { rawBuffer -> Int in
+            guard let base = rawBuffer.baseAddress else { return 0 }
+            let byteCount = write(fileDescriptor, base + sendOffset, remaining)
+            // Capture errno at the syscall site: any code between write()
+            // returning and the capture can clobber the thread-local errno.
+            if byteCount < 0 {
+                writeErrno = errno
+            }
+            return byteCount
+        }
+
+        if written > 0 {
+            sendOffset += written
+            if sendOffset >= sendBuffer.count {
+                sendContinuation = nil
+                suspendWriteSource()
+                pending.continuation?.resume()
+            } else {
+                // Partial write: the kernel buffer filled partway. Wait for
+                // writability (the event fires immediately if space remains)
+                // instead of spinning on write().
+                resumeWriteSource()
+            }
+            return
+        }
+        if written == 0 {
+            failTransport(.sendFailed("zero-length write"))
+            return
+        }
+
+        switch writeErrno {
+        case EAGAIN, EWOULDBLOCK, EINTR:
+            resumeWriteSource()
+        default:
+            failTransport(.sendFailed(String(cString: strerror(writeErrno))))
+        }
+    }
+
+    private func resumeWriteSource() {
+        guard !writeSourceResumed, !isTerminal else { return }
+        writeSourceResumed = true
+        writeSource.resume()
+    }
+
+    private func suspendWriteSource() {
+        guard writeSourceResumed, !isTerminal else { return }
+        writeSourceResumed = false
+        writeSource.suspend()
+    }
+
+    private func cancelSend(operationID: UUID) {
+        if let pending = sendContinuation, pending.id == operationID {
+            sendContinuation = nil
+            cancelledSendIDs.insert(operationID)
+            pending.continuation?.resume(throwing: CancellationError())
+        } else {
+            cancelledSendIDs.insert(operationID)
+        }
+    }
+
+    private func consumeCancelledSend(_ operationID: UUID) -> Bool {
+        cancelledSendIDs.remove(operationID) != nil
+    }
+
+    // MARK: - Teardown
+
+    private func failTransport(_ error: CmxPOSIXByteTransportError) {
+        guard !isTerminal else {
+            return
+        }
+        state = .failed(error)
+        tearDown(pendingError: error, resumeReceiveWithError: true)
+    }
+
+    private func tearDown(pendingError: any Error, resumeReceiveWithError: Bool) {
+        guard !isClosedState else {
+            return
+        }
+        state = .closed
+        cancelledReceiveIDs.removeAll()
+        cancelledSendIDs.removeAll()
+        receiveBuffer.removeAll()
+
+        // Cancel on the I/O queue so an in-flight read handler completes
+        // first; the read source's cancel handler closes the descriptor
+        // exactly once. Sources never resume after this point. A suspended
+        // source must be resumed before cancel: a cancelled suspended source
+        // never runs its cancel handler, and releasing it traps libdispatch.
+        let readWasResumed = readSourceResumed
+        let writeWasResumed = writeSourceResumed
+        readSourceResumed = false
+        writeSourceResumed = false
+        sourcesCancelled = true
+        ioQueue.async { [readSource, writeSource] in
+            if !writeWasResumed { writeSource.resume() }
+            writeSource.cancel()
+            if !readWasResumed { readSource.resume() }
+            readSource.cancel()
+        }
+
+        if let pending = receiveContinuation {
+            receiveContinuation = nil
+            if resumeReceiveWithError {
+                pending.continuation.resume(throwing: pendingError)
+            } else {
+                pending.continuation.resume(returning: nil)
+            }
+        }
+        if let pending = sendContinuation {
+            sendContinuation = nil
+            pending.continuation?.resume(throwing: pendingError)
+        }
+    }
+
+    private var isTerminal: Bool {
+        switch state {
+        case .failed, .closed:
+            return true
+        case .ready:
+            return false
+        }
+    }
+
+    private var isClosedState: Bool {
+        if case .closed = state {
+            return true
+        }
+        return false
+    }
+
+    // MARK: - Syscall helpers
+
+    /// Performs one `read` on the I/O queue, classifying the outcome while
+    /// `errno` is still bound to the syscall.
+    private nonisolated static func readOnce(
+        fileDescriptor: Int32,
+        maximumLength: Int
+    ) -> ReadOutcome {
+        var buffer = [UInt8](repeating: 0, count: maximumLength)
+        let byteCount = read(fileDescriptor, &buffer, maximumLength)
+        if byteCount > 0 {
+            return .bytes(Data(buffer[0..<byteCount]))
+        }
+        if byteCount == 0 {
+            return .endOfStream
+        }
+        let errnoValue = errno
+        switch errnoValue {
+        case EAGAIN, EWOULDBLOCK, EINTR:
+            return .wouldBlock
+        default:
+            return .failed(String(cString: strerror(errnoValue)))
+        }
+    }
+
+    private nonisolated static func makeReadSource(
+        fileDescriptor: Int32,
+        queue: DispatchQueue,
+        handler: @escaping @Sendable () -> Void
+    ) -> any DispatchSourceRead {
+        let source = DispatchSource.makeReadSource(
+            fileDescriptor: fileDescriptor,
+            queue: queue
+        )
+        source.setEventHandler(handler: handler)
+        source.setCancelHandler {
+            Darwin.close(fileDescriptor)
+        }
+        return source
+    }
+
+    private nonisolated static func makeWriteSource(
+        fileDescriptor: Int32,
+        queue: DispatchQueue,
+        handler: @escaping @Sendable () -> Void
+    ) -> any DispatchSourceWrite {
+        let source = DispatchSource.makeWriteSource(
+            fileDescriptor: fileDescriptor,
+            queue: queue
+        )
+        source.setEventHandler(handler: handler)
+        return source
+    }
+}

--- a/Packages/iOS/CmuxMobileTransport/Tests/CmuxMobileTransportTests/CmxPOSIXByteTransportTests.swift
+++ b/Packages/iOS/CmuxMobileTransport/Tests/CmuxMobileTransportTests/CmxPOSIXByteTransportTests.swift
@@ -1,0 +1,157 @@
+import CMUXMobileCore
+import Foundation
+import Testing
+@testable import CmuxMobileTransport
+
+/// Drives the raw peer side of a socketpair with blocking syscalls so the
+/// transport under test sees genuine kernel buffering, partial reads, and EOF.
+private struct SocketPair {
+    let transportfd: Int32
+    let peerfd: Int32
+
+    /// Creates a connected `SOCK_STREAM` pair. The transport descriptor is
+    /// switched to nonblocking (matching what a real acceptor hands off); the
+    /// peer descriptor stays blocking for simple test I/O.
+    init() throws {
+        var fds: [Int32] = [0, 0]
+        let result = fds.withUnsafeMutableBufferPointer { buffer -> Int32 in
+            guard let base = buffer.baseAddress else { return -1 }
+            return socketpair(Int32(AF_UNIX), Int32(SOCK_STREAM), 0, base)
+        }
+        guard result == 0 else {
+            throw NSError(domain: "socketpair", code: Int(result))
+        }
+        transportfd = fds[0]
+        peerfd = fds[1]
+        let flags = fcntl(fds[0], F_GETFL)
+        guard flags >= 0, fcntl(fds[0], F_SETFL, flags | O_NONBLOCK) == 0 else {
+            throw NSError(domain: "fcntl", code: Int(errno))
+        }
+        var yes: Int32 = 1
+        _ = setsockopt(fds[0], SOL_SOCKET, SO_NOSIGPIPE, &yes, socklen_t(MemoryLayout<Int32>.size))
+    }
+
+    func peerWrite(_ data: Data) throws {
+        try data.withUnsafeBytes { raw in
+            guard let base = raw.baseAddress else { return }
+            var offset = 0
+            while offset < data.count {
+                let written = write(peerfd, base + offset, data.count - offset)
+                try #require(written > 0)
+                offset += written
+            }
+        }
+    }
+
+    /// Reads exactly `count` bytes from the peer side.
+    func peerRead(count: Int) throws -> Data {
+        var buffer = [UInt8](repeating: 0, count: count)
+        var filled = 0
+        while filled < count {
+            let n = buffer.withUnsafeMutableBufferPointer { raw -> Int in
+                read(peerfd, raw.baseAddress! + filled, count - filled)
+            }
+            try #require(n > 0)
+            filled += n
+        }
+        return Data(buffer)
+    }
+
+    func closePeer() {
+        close(peerfd)
+    }
+
+    func closeTransportSide() {
+        close(transportfd)
+    }
+}
+
+@Test func posixTransportExchangesBytesBidirectionally() async throws {
+    let pair = try SocketPair()
+    let transport = CmxPOSIXByteTransport(acceptedFileDescriptor: pair.transportfd)
+    defer { Task { await transport.close() } }
+
+    try await transport.connect()
+    try pair.peerWrite(Data("request".utf8))
+    #expect(try await transport.receive() == Data("request".utf8))
+
+    try await transport.send(Data("response".utf8))
+    #expect(try pair.peerRead(count: "response".utf8.count) == Data("response".utf8))
+}
+
+@Test func posixTransportCarriesLargeMultiChunkPayloads() async throws {
+    let pair = try SocketPair()
+    let transport = CmxPOSIXByteTransport(acceptedFileDescriptor: pair.transportfd)
+    defer { Task { await transport.close() } }
+
+    try await transport.connect()
+    // 192 KiB forces several 64 KiB receive chunks and a send larger than the
+    // typical socket buffer, exercising the partial-write path.
+    let payload = Data((0..<192 * 1024).map { UInt8($0 % 251) })
+    let writeTask = Task { try pair.peerWrite(payload) }
+    var received = Data()
+    while received.count < payload.count {
+        guard let chunk = try await transport.receive() else {
+            Issue.record("stream ended early after \(received.count) bytes")
+            break
+        }
+        received.append(chunk)
+    }
+    try await writeTask.value
+    #expect(received == payload)
+
+    // The peer must drain concurrently with the transport's send: a
+    // socketpair buffers far less than 192 KiB, so a send that suspends the
+    // test task until completion would deadlock against a later read.
+    let echoTask = Task { () -> Data in
+        var echoed = Data()
+        while echoed.count < payload.count {
+            echoed.append(try pair.peerRead(count: 32 * 1024))
+        }
+        return echoed
+    }
+    try await transport.send(payload)
+    #expect(try await echoTask.value == payload)
+}
+
+@Test func posixTransportSurfacesPeerCloseAsEndOfStream() async throws {
+    let pair = try SocketPair()
+    let transport = CmxPOSIXByteTransport(acceptedFileDescriptor: pair.transportfd)
+
+    try await transport.connect()
+    try pair.peerWrite(Data("last-bytes".utf8))
+    pair.closePeer()
+    // Buffered bytes arrive before the end-of-stream nil.
+    #expect(try await transport.receive() == Data("last-bytes".utf8))
+    #expect(try await transport.receive() == nil)
+    #expect(try await transport.receive() == nil)
+}
+
+@Test func posixTransportCloseCompletesInFlightReceiveWithEndOfStream() async throws {
+    let pair = try SocketPair()
+    let transport = CmxPOSIXByteTransport(acceptedFileDescriptor: pair.transportfd)
+
+    try await transport.connect()
+    let receiveTask = Task { try await transport.receive() }
+    await Task.yield()
+    await transport.close()
+
+    #expect(try await receiveTask.value == nil)
+    #expect(try await transport.receive() == nil)
+    pair.closePeer()
+}
+
+@Test func posixTransportRejectsUseAfterClose() async throws {
+    let pair = try SocketPair()
+    let transport = CmxPOSIXByteTransport(acceptedFileDescriptor: pair.transportfd)
+    try await transport.connect()
+    await transport.close()
+
+    await #expect(throws: CmxPOSIXByteTransportError.alreadyClosed) {
+        try await transport.connect()
+    }
+    await #expect(throws: CmxPOSIXByteTransportError.alreadyClosed) {
+        try await transport.send(Data("x".utf8))
+    }
+    pair.closePeer()
+}

--- a/Sources/Mobile/MobileHostPOSIXListener.swift
+++ b/Sources/Mobile/MobileHostPOSIXListener.swift
@@ -1,0 +1,250 @@
+import Dispatch
+import Foundation
+
+/// One inbound connection accepted by ``MobileHostPOSIXListener``.
+///
+/// The file descriptor is a connected, nonblocking TCP socket with
+/// `TCP_NODELAY` and `SO_NOSIGPIPE` already applied. The receiver owns the
+/// descriptor and must close it (usually by wrapping it in a transport that
+/// closes on teardown).
+struct MobileHostPOSIXAcceptedConnection: Sendable {
+    let fileDescriptor: Int32
+    let peerIsLoopback: Bool
+}
+
+/// BSD-socket TCP listener for the legacy mobile pairing host.
+///
+/// Replaces the previous Network.framework `NWListener`: on macOS 26/27 with
+/// the Tailscale system extension active, inbound-delivered connections whose
+/// listener socket is an NWListener socket are dropped by NECP policy before
+/// `accept` runs, so an iOS client dialing the Mac's Tailscale address can
+/// never reach the host. A POSIX listening socket receives those same
+/// connections (verified side by side on macOS 27.0 + Tailscale 1.103.85:
+/// identical NWListener and BSD listeners on this Mac, NW unreachable via the
+/// Tailscale address, BSD accepting).
+///
+/// The listener binds an IPv6 dual-stack wildcard (`[::]` with
+/// `IPV6_V6ONLY=0`, mirroring the old `tcp6 *.<port>` shape), so IPv4 and
+/// IPv6 clients both reach it. `bind` and `listen` complete synchronously in
+/// ``init(preferredPort:queue:)``, so a successfully constructed listener is
+/// already accepting into its backlog; ``start(onAccepted:onCancelled:)``
+/// only arms the event handler that drains accepted sockets.
+///
+/// All mutable state is confined to `queue` (the DispatchSource event queue,
+/// the sanctioned carve-out for low-level socket I/O), which is what makes the
+/// class `@unchecked Sendable`: `init` finishes before the instance escapes,
+/// and every later mutation happens on `queue`.
+final class MobileHostPOSIXListener: @unchecked Sendable {
+    enum ListenerError: Error, Equatable, Sendable {
+        case socketCreationFailed(Int32)
+        case optionFailed(Int32)
+        case bindFailed(Int32)
+        case listenFailed(Int32)
+    }
+
+    private let queue: DispatchQueue
+    private let fileDescriptor: Int32
+    private let source: any DispatchSourceRead
+    private var onAccepted: ((MobileHostPOSIXAcceptedConnection) -> Void)?
+    private var onCancelled: (() -> Void)?
+    private var didCancel = false
+    /// The bound port, resolved from the kernel (ephemeral when
+    /// `preferredPort` is nil or 0). Immutable after init.
+    let boundPort: UInt16
+
+    /// Binds and listens immediately.
+    ///
+    /// - Parameters:
+    ///   - preferredPort: The port to bind, or nil for an OS-assigned
+    ///     ephemeral port. Binding a busy port throws
+    ///     ``ListenerError/bindFailed`` with `EADDRINUSE`.
+    ///   - queue: The dispatch queue that receives accepted connections and
+    ///     the cancellation callback. The service passes the shared
+    ///     `dev.cmux.mobile.host-listener` queue.
+    /// - Throws: ``ListenerError`` when the socket cannot be created, bound,
+    ///   or switched to listening.
+    init(preferredPort: UInt16?, queue: DispatchQueue) throws {
+        self.queue = queue
+        let fd = socket(AF_INET6, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            throw ListenerError.socketCreationFailed(errno)
+        }
+        fileDescriptor = fd
+
+        do {
+            var yes: Int32 = 1
+            guard setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &yes, socklen_t(MemoryLayout<Int32>.size)) == 0 else {
+                throw ListenerError.optionFailed(errno)
+            }
+            var no: Int32 = 0
+            guard setsockopt(fd, Int32(IPPROTO_IPV6), IPV6_V6ONLY, &no, socklen_t(MemoryLayout<Int32>.size)) == 0 else {
+                throw ListenerError.optionFailed(errno)
+            }
+
+            var address = sockaddr_in6()
+            address.sin6_family = sa_family_t(AF_INET6)
+            address.sin6_port = (preferredPort ?? 0).bigEndian
+            address.sin6_addr = in6addr_any
+            let bindResult = withUnsafePointer(to: &address) { pointer in
+                pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                    bind(fd, $0, socklen_t(MemoryLayout<sockaddr_in6>.size))
+                }
+            }
+            guard bindResult == 0 else {
+                throw ListenerError.bindFailed(errno)
+            }
+            guard listen(fd, 128) == 0 else {
+                throw ListenerError.listenFailed(errno)
+            }
+
+            var bound = sockaddr_in6()
+            var boundLength = socklen_t(MemoryLayout<sockaddr_in6>.size)
+            let nameResult = withUnsafeMutablePointer(to: &bound) { pointer in
+                pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                    getsockname(fd, $0, &boundLength)
+                }
+            }
+            guard nameResult == 0 else {
+                throw ListenerError.bindFailed(errno)
+            }
+            boundPort = bound.sin6_port.bigEndian
+        } catch {
+            close(fd)
+            throw error
+        }
+
+        source = DispatchSource.makeReadSource(fileDescriptor: fd, queue: queue)
+        source.setEventHandler { [weak self] in
+            self?.acceptPendingConnections()
+        }
+        source.setCancelHandler { [weak self] in
+            guard let self else { return }
+            self.closeFileDescriptor()
+            self.onCancelled?()
+            self.onCancelled = nil
+        }
+        source.resume()
+    }
+
+    /// Arms the accept callback. Idempotent: the latest handlers win.
+    ///
+    /// - Parameters:
+    ///   - onAccepted: Invoked on `queue` once per accepted connection. The
+    ///     receiver owns the handed-off file descriptor.
+    ///   - onCancelled: Invoked on `queue` when the listener stops for any
+    ///     reason other than an intentional ``disarm()`` followed by
+    ///     ``cancel()``.
+    func start(
+        onAccepted: @escaping (MobileHostPOSIXAcceptedConnection) -> Void,
+        onCancelled: @escaping () -> Void
+    ) {
+        queue.async { [weak self] in
+            guard let self, !self.didCancel else { return }
+            self.onAccepted = onAccepted
+            self.onCancelled = onCancelled
+        }
+    }
+
+    /// Clears the callbacks so a subsequent ``cancel()`` stays silent.
+    ///
+    /// Intentional teardown paths (settings stop, port change, adoption of a
+    /// replacement listener) call this before ``cancel()``; spontaneous
+    /// cancellation keeps its callback.
+    func disarm() {
+        queue.async { [weak self] in
+            guard let self else { return }
+            self.onAccepted = nil
+            self.onCancelled = nil
+        }
+    }
+
+    /// Stops listening and releases the bound port. Safe to call twice.
+    func cancel() {
+        queue.async { [weak self] in
+            guard let self, !self.didCancel else { return }
+            self.didCancel = true
+            self.source.cancel()
+        }
+    }
+
+    /// Whether `address` is a loopback peer: IPv4 `127.0.0.0/8`, IPv6 `::1`,
+    /// or an IPv4-mapped loopback address carried in an IPv6 sockaddr.
+    ///
+    /// Release builds reject loopback peers on the legacy listener (a real
+    /// phone always arrives over a network interface), so this classification
+    /// must match the old `NWEndpoint`-based check exactly.
+    static func isLoopbackPeer(_ address: sockaddr_storage) -> Bool {
+        switch Int32(address.ss_family) {
+        case AF_INET:
+            return withUnsafeBytes(of: address) { raw in
+                guard raw.count >= MemoryLayout<sockaddr_in>.size else { return false }
+                let sin = raw.loadUnaligned(as: sockaddr_in.self)
+                return (sin.sin_addr.s_addr.bigEndian & 0xFF00_0000) == 0x7F00_0000
+            }
+        case AF_INET6:
+            return withUnsafeBytes(of: address) { raw in
+                guard raw.count >= MemoryLayout<sockaddr_in6>.size else { return false }
+                let sin6 = raw.loadUnaligned(as: sockaddr_in6.self)
+                let bytes = withUnsafeBytes(of: sin6.sin6_addr) { Array($0) }
+                // ::1
+                if bytes[0..<15].allSatisfy({ $0 == 0 }) && bytes[15] == 1 {
+                    return true
+                }
+                // ::ffff:127.0.0.0/8 (IPv4-mapped)
+                if bytes[0..<10].allSatisfy({ $0 == 0 }), bytes[10] == 0xFF, bytes[11] == 0xFF,
+                   bytes[12] == 127 {
+                    return true
+                }
+                return false
+            }
+        default:
+            return false
+        }
+    }
+
+    // MARK: - Private
+
+    /// Runs on `queue`: drains every pending connection, then returns; the
+    /// nonblocking listener socket makes `accept` return `EAGAIN` when the
+    /// backlog is empty, which ends the drain without blocking the queue.
+    private func acceptPendingConnections() {
+        guard let onAccepted else { return }
+        while true {
+            var peer = sockaddr_storage()
+            var peerLength = socklen_t(MemoryLayout<sockaddr_storage>.size)
+            let client = withUnsafeMutablePointer(to: &peer) { pointer in
+                pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                    accept(fileDescriptor, $0, &peerLength)
+                }
+            }
+            guard client >= 0 else {
+                return
+            }
+            configure(client)
+            onAccepted(
+                MobileHostPOSIXAcceptedConnection(
+                    fileDescriptor: client,
+                    peerIsLoopback: Self.isLoopbackPeer(peer)
+                )
+            )
+        }
+    }
+
+    /// Applies the socket options every accepted connection needs:
+    /// nonblocking for the dispatch-source event loop, `TCP_NODELAY` to match
+    /// the interactive RPC latency of the old NW listener, and `SO_NOSIGPIPE`
+    /// so a peer reset surfaces as an error instead of a fatal signal.
+    private func configure(_ client: Int32) {
+        let flags = fcntl(client, F_GETFL)
+        if flags >= 0 {
+            _ = fcntl(client, F_SETFL, flags | O_NONBLOCK)
+        }
+        var yes: Int32 = 1
+        _ = setsockopt(client, Int32(IPPROTO_TCP), TCP_NODELAY, &yes, socklen_t(MemoryLayout<Int32>.size))
+        _ = setsockopt(client, SOL_SOCKET, SO_NOSIGPIPE, &yes, socklen_t(MemoryLayout<Int32>.size))
+    }
+
+    private func closeFileDescriptor() {
+        close(fileDescriptor)
+    }
+}

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -370,7 +370,7 @@ final class MobileHostService {
     private let callbackQueue = DispatchQueue(label: "dev.cmux.mobile.host-listener")
     private let routeResolver = MobileRouteResolver()
     private let ticketStore = MobileAttachTicketStore()
-    private var listener: NWListener?
+    private var listener: MobileHostPOSIXListener?
     private var listenerGeneration = UUID()
     private var listenerUsesEphemeralFallback = false
     private var listenerPort: Int?
@@ -784,15 +784,6 @@ final class MobileHostService {
         return nil
     }
 
-    /// Whether `error` means the address/port cannot be bound (in use, not
-    /// available, or permission denied) versus a transient waiting reason.
-    nonisolated static func isAddressUnavailable(_ error: NWError) -> Bool {
-        if case let .posix(code) = error {
-            return code == .EADDRINUSE || code == .EADDRNOTAVAIL || code == .EACCES
-        }
-        return false
-    }
-
     /// Applies an explicitly-requested pairing port.
     ///
     /// Make-before-break: when a running listener must move to a different port, a
@@ -817,8 +808,8 @@ final class MobileHostService {
             return preBind
         }
         // A real bind is required (pairing on, valid port, different from bound).
-        guard let endpointPort = NWEndpoint.Port(rawValue: UInt16(port)) else { return .invalid }
-        guard let candidate = await bindReadyCandidate(on: endpointPort, generation: UUID()) else {
+        guard (1...65535).contains(port) else { return .invalid }
+        guard let candidate = bindReadyCandidate(on: UInt16(port), generation: UUID()) else {
             return .portInUse
         }
         adoptCandidateListener(candidate.listener, generation: candidate.generation, port: port)
@@ -826,70 +817,15 @@ final class MobileHostService {
         return .applied(port)
     }
 
-    /// Binds a candidate `NWListener` on `endpointPort` while the current listener
-    /// keeps running, returning it (with `generation`) once it reaches `.ready`,
-    /// or `nil` when the port is unavailable. A bounded, cancellable deadline
-    /// guarantees the call can't hang; on timeout/failure the candidate is torn
-    /// down and `nil` returned, leaving the live listener untouched.
-    private func bindReadyCandidate(on endpointPort: NWEndpoint.Port, generation: UUID) async -> (listener: NWListener, generation: UUID)? {
-        let tcpOptions = NWProtocolTCP.Options()
-        tcpOptions.noDelay = true
-        let candidate: NWListener
-        do {
-            candidate = try NWListener(using: NWParameters(tls: nil, tcp: tcpOptions), on: endpointPort)
-        } catch {
-            return nil
-        }
-        let queue = callbackQueue
-        let didBind: Bool = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
-            // One-shot resume guard + deadline holder (lock carve-out): the state
-            // handler and the timeout race to resume the continuation exactly once.
-            let resumed = OSAllocatedUnfairLock(initialState: false)
-            let timeoutHolder = OSAllocatedUnfairLock<Task<Void, Never>?>(initialState: nil)
-            let finish: @Sendable (Bool) -> Void = { ready in
-                let alreadyResumed = resumed.withLock { state -> Bool in
-                    if state { return true }
-                    state = true
-                    return false
-                }
-                guard !alreadyResumed else { return }
-                timeoutHolder.withLock { task in
-                    task?.cancel()
-                    task = nil
-                }
-                continuation.resume(returning: ready)
-            }
-            candidate.stateUpdateHandler = { state in
-                switch state {
-                case .ready:
-                    finish(true)
-                case .failed, .cancelled:
-                    finish(false)
-                case let .waiting(error):
-                    if Self.isAddressUnavailable(error) { finish(false) }
-                default:
-                    break
-                }
-            }
-            // NWListener needs a newConnectionHandler set before `start()` or it
-            // never reaches `.ready`; wiring the real accept path (with this
-            // generation) also means no connection is dropped once it's adopted.
-            candidate.newConnectionHandler = { connection in
-                Self.acceptConnectionOffMain(connection, generation: generation)
-            }
-            candidate.start(queue: queue)
-            // Bounded, cancellable safety deadline (check-timeout carve-out) so an
-            // unclassified/stuck listener state can never hang the Apply flow.
-            let timeout = Task {
-                try? await Task.sleep(for: .seconds(2))
-                finish(false)
-            }
-            timeoutHolder.withLock { $0 = timeout }
-        }
-        guard didBind else {
-            candidate.stateUpdateHandler = nil
-            candidate.newConnectionHandler = nil
-            candidate.cancel()
+    /// Binds a candidate POSIX listener on `port` while the current listener
+    /// keeps running, returning it (with `generation`), or nil when the port
+    /// is unavailable. `bind` and `listen` complete synchronously in the
+    /// listener's init, so a successfully constructed candidate is already
+    /// accepting into its backlog; the caller adopts it (arming the accept
+    /// callback) or cancels it, and an in-use port leaves the live listener
+    /// untouched.
+    private func bindReadyCandidate(on port: UInt16, generation: UUID) -> (listener: MobileHostPOSIXListener, generation: UUID)? {
+        guard let candidate = try? MobileHostPOSIXListener(preferredPort: port, queue: callbackQueue) else {
             return nil
         }
         return (candidate, generation)
@@ -897,11 +833,9 @@ final class MobileHostService {
 
     /// Cuts over to a freshly-bound `candidate`: tears down the old listener and
     /// its connections (they reconnect on the new port), then adopts the candidate
-    /// as the live listener, routes future state changes through the normal
-    /// handler, and republishes routes.
-    private func adoptCandidateListener(_ candidate: NWListener, generation: UUID, port: Int) {
-        listener?.stateUpdateHandler = nil
-        listener?.newConnectionHandler = nil
+    /// as the live listener, arms its accept path, and republishes routes.
+    private func adoptCandidateListener(_ candidate: MobileHostPOSIXListener, generation: UUID, port: Int) {
+        listener?.disarm()
         listener?.cancel()
         for connection in activeConnections.values {
             Task { await connection.close(reason: "pairing port changed") }
@@ -917,12 +851,17 @@ final class MobileHostService {
         listenerPort = port
         appliedPreferredPort = port
         lastErrorDescription = nil
-        // The candidate is already `.ready`; route only *future* states normally.
-        candidate.stateUpdateHandler = { state in
-            Task { @MainActor in
-                MobileHostService.shared.handleListenerState(state, generation: generation)
+        // The candidate is already bound and listening; arm its accept path.
+        candidate.start(
+            onAccepted: { accepted in
+                Self.acceptPOSIXConnection(accepted, generation: generation)
+            },
+            onCancelled: {
+                Task { @MainActor in
+                    MobileHostService.shared.handleListenerCancelled(generation: generation)
+                }
             }
-        }
+        )
         routeResolver.refreshTailscaleRoutes(onResolvedHosts: { [weak self] hosts in
             Task { @MainActor [weak self] in
                 self?.updatePublicStatusRoutes(port: port, generation: generation, tailscaleHosts: hosts)
@@ -983,54 +922,86 @@ final class MobileHostService {
         let desiredPort = Self.configuredPort()
         appliedPreferredPort = desiredPort
         do {
-            let tcpOptions = NWProtocolTCP.Options()
-            tcpOptions.noDelay = true
-            let parameters = NWParameters(tls: nil, tcp: tcpOptions)
-            let nextListener = try makeListener(
-                parameters: parameters,
-                usePreferredPort: usePreferredPort,
-                port: desiredPort
+            let nextListener = try MobileHostPOSIXListener(
+                preferredPort: usePreferredPort ? UInt16(exactly: desiredPort) : nil,
+                queue: callbackQueue
             )
             let generation = UUID()
             listenerGeneration = generation
-            nextListener.stateUpdateHandler = { state in
-                Task { @MainActor in
-                    MobileHostService.shared.handleListenerState(state, generation: generation)
-                }
-            }
-            nextListener.newConnectionHandler = { connection in
-                Self.acceptConnectionOffMain(connection, generation: generation)
-            }
             listener = nextListener
             listenerUsesEphemeralFallback = !usePreferredPort
-            listenerPort = nil
-            nextListener.start(queue: callbackQueue)
-            startNetworkPathMonitorIfNeeded()
+            nextListener.start(
+                onAccepted: { accepted in
+                    Self.acceptPOSIXConnection(accepted, generation: generation)
+                },
+                onCancelled: {
+                    Task { @MainActor in
+                        MobileHostService.shared.handleListenerCancelled(generation: generation)
+                    }
+                }
+            )
+            handleListenerReady(port: Int(nextListener.boundPort), generation: generation)
         } catch {
-            if usePreferredPort {
-                mobileHostLog.info("mobile host preferred port unavailable before listener start, falling back to an ephemeral port")
-                startListener(usePreferredPort: false)
-                return
+            handleListenerBindFailure(error: error, context: "bind failed")
+        }
+    }
+
+    /// Publishes routes for a freshly bound listener and unblocks readiness
+    /// waiters. POSIX `bind` is synchronous, so this replaces the old
+    /// `NWListener.State.ready` transition.
+    private func handleListenerReady(port: Int, generation: UUID) {
+        guard generation == listenerGeneration else { return }
+        listenerPort = port
+        lastErrorDescription = nil
+        routeResolver.refreshTailscaleRoutes(onResolvedHosts: { [weak self] hosts in
+            Task { @MainActor [weak self] in
+                self?.updatePublicStatusRoutes(
+                    port: port,
+                    generation: generation,
+                    tailscaleHosts: hosts
+                )
             }
-            lastErrorDescription = String(describing: error)
-            mobileHostLog.error("mobile host listener failed to start: \(String(describing: error), privacy: .public)")
-            // No listener was registered, so no state callback will fire to drain
-            // readiness waiters; resolve them now instead of waiting for the deadline.
+        })
+        MobileHostPublicStatusCache.update(routes: routeResolver.routes(port: port).routes)
+        mobileHostLog.info("mobile host listener ready on port \(port)")
+        startNetworkPathMonitorIfNeeded()
+        drainReadinessWaiters()
+    }
+
+    /// Tears down a listener that could not bind its port and, unless it was
+    /// already on the ephemeral fallback, retries on an OS-assigned port.
+    private func handleListenerBindFailure(error: any Error, context: String) {
+        lastErrorDescription = String(describing: error)
+        MobileHostPublicStatusCache.update(routes: [])
+        let shouldRetryWithEphemeralPort = !listenerUsesEphemeralFallback
+        listener?.disarm()
+        listener?.cancel()
+        listenerGeneration = UUID()
+        listener = nil
+        listenerUsesEphemeralFallback = false
+        listenerPort = nil
+        if shouldRetryWithEphemeralPort {
+            mobileHostLog.info("mobile host preferred port \(context, privacy: .public), falling back to an ephemeral port")
+            startListener(usePreferredPort: false)
+        } else {
+            mobileHostLog.error("mobile host listener bind failed on ephemeral port: \(String(describing: error), privacy: .public)")
+            // No retry left: unblock any readiness waiters (the retry path drains
+            // them when the ephemeral listener becomes ready).
             drainReadinessWaiters()
         }
     }
 
-    private func makeListener(
-        parameters: NWParameters,
-        usePreferredPort: Bool,
-        port: Int
-    ) throws -> NWListener {
-        if usePreferredPort,
-           let rawPort = UInt16(exactly: port),
-           let endpointPort = NWEndpoint.Port(rawValue: rawPort) {
-            return try NWListener(using: parameters, on: endpointPort)
-        }
-        return try NWListener(using: parameters, on: .any)
+    /// Mirrors the old `NWListener.State.cancelled` transition: a listener
+    /// that stops for any reason other than intentional teardown clears its
+    /// routes and unblocks readiness waiters.
+    private func handleListenerCancelled(generation: UUID) {
+        guard generation == listenerGeneration else { return }
+        listenerGeneration = UUID()
+        listener = nil
+        listenerUsesEphemeralFallback = false
+        listenerPort = nil
+        MobileHostPublicStatusCache.update(routes: [])
+        drainReadinessWaiters()
     }
 
     func stop() {
@@ -1049,8 +1020,7 @@ final class MobileHostService {
         stopNetworkPathMonitor()
         listenerGeneration = UUID()
         listenerUsesEphemeralFallback = false
-        listener?.stateUpdateHandler = nil
-        listener?.newConnectionHandler = nil
+        listener?.disarm()
         listener?.cancel()
         listener = nil
         listenerPort = nil
@@ -1209,15 +1179,15 @@ final class MobileHostService {
         start()
     }
 
-    nonisolated private static func acceptConnectionOffMain(
-        _ connection: NWConnection,
+    nonisolated private static func acceptPOSIXConnection(
+        _ accepted: MobileHostPOSIXAcceptedConnection,
         generation: UUID
     ) {
         Task.detached(priority: .userInitiated) {
             let canAccept = await MobileHostService.shared.canAcceptConnection(generation: generation)
             guard canAccept else {
                 mobileHostLog.info("mobile host rejected stale listener connection")
-                connection.cancel()
+                close(accepted.fileDescriptor)
                 return
             }
 
@@ -1229,14 +1199,14 @@ final class MobileHostService {
             // process (or a browser that somehow framed the binary protocol), never
             // the real client, so refuse it outright. DEBUG keeps loopback so the
             // iOS Simulator (which reaches the Mac via 127.0.0.1) can still pair.
-            if Self.isLoopbackConnection(connection) {
+            if accepted.peerIsLoopback {
                 mobileHostLog.error("mobile host rejected loopback connection in release build")
-                connection.cancel()
+                close(accepted.fileDescriptor)
                 return
             }
             #endif
 
-            let transport = CmxNetworkByteTransport(acceptedConnection: connection)
+            let transport = CmxPOSIXByteTransport(acceptedFileDescriptor: accepted.fileDescriptor)
             await Self.acceptTransport(
                 transport,
                 authorization: .legacyPrivateNetworkListener,
@@ -1457,37 +1427,6 @@ final class MobileHostService {
         return filtered
     }
 
-    /// Whether an incoming connection's remote peer is on the loopback interface.
-    ///
-    /// Used to refuse local connections in release builds, where no legitimate
-    /// client ever connects via `127.0.0.1`/`::1`.
-    nonisolated static func isLoopbackConnection(_ connection: NWConnection) -> Bool {
-        isLoopbackEndpoint(connection.endpoint) || isLoopbackEndpoint(connection.currentPath?.remoteEndpoint)
-    }
-
-    nonisolated static func isLoopbackEndpoint(_ endpoint: NWEndpoint?) -> Bool {
-        guard case let .hostPort(host, _)? = endpoint else { return false }
-        switch host {
-        case let .ipv4(address):
-            // 127.0.0.0/8
-            return address.rawValue.first == 127
-        case let .ipv6(address):
-            let bytes = Array(address.rawValue)
-            guard bytes.count == 16 else { return false }
-            // ::1
-            let isV6Loopback = bytes[0..<15].allSatisfy { $0 == 0 } && bytes[15] == 1
-            // IPv4-mapped loopback ::ffff:127.0.0.0/8
-            let isV4MappedLoopback = bytes[0..<10].allSatisfy { $0 == 0 }
-                && bytes[10] == 0xff && bytes[11] == 0xff && bytes[12] == 127
-            return isV6Loopback || isV4MappedLoopback
-        case let .name(name, _):
-            let lowered = name.lowercased()
-            return lowered == "localhost" || lowered.hasSuffix(".localhost")
-        @unknown default:
-            return false
-        }
-    }
-
     private func removeConnection(id: UUID) {
         MobileHostConnectionRegistry.shared.remove(id: id)
         activeConnections.removeValue(forKey: id)
@@ -1690,84 +1629,6 @@ final class MobileHostService {
         }
     }
 
-    private func handleListenerState(_ state: NWListener.State, generation: UUID) {
-        guard generation == listenerGeneration else {
-            return
-        }
-
-        switch state {
-        case .ready:
-            listenerPort = listener?.port.map { Int($0.rawValue) }
-            lastErrorDescription = nil
-            if let listenerPort {
-                routeResolver.refreshTailscaleRoutes(onResolvedHosts: { [weak self] hosts in
-                    Task { @MainActor [weak self] in
-                        self?.updatePublicStatusRoutes(
-                            port: listenerPort,
-                            generation: generation,
-                            tailscaleHosts: hosts
-                        )
-                    }
-                })
-                MobileHostPublicStatusCache.update(routes: routeResolver.routes(port: listenerPort).routes)
-            } else {
-                MobileHostPublicStatusCache.update(routes: [])
-            }
-            mobileHostLog.info("mobile host listener ready on port \(self.listenerPort ?? 0)")
-            drainReadinessWaiters()
-        case let .failed(error):
-            handleListenerBindFailure(error: error, context: "failed after start")
-        case .cancelled:
-            listenerGeneration = UUID()
-            listener = nil
-            listenerUsesEphemeralFallback = false
-            listenerPort = nil
-            MobileHostPublicStatusCache.update(routes: [])
-            drainReadinessWaiters()
-        case let .waiting(error):
-            // A preferred-port bind blocked by another listener surfaces as
-            // `.waiting(.posix(.EADDRINUSE))` rather than `.failed`, and NWListener
-            // would otherwise wait forever; treat address-unavailable the same as
-            // a failure so the ephemeral fallback (and bound-port warning) fire.
-            if Self.isAddressUnavailable(error) {
-                handleListenerBindFailure(error: error, context: "in use (waiting)")
-            } else {
-                listenerPort = nil
-                MobileHostPublicStatusCache.update(routes: [])
-            }
-        case .setup:
-            listenerPort = nil
-            MobileHostPublicStatusCache.update(routes: [])
-        @unknown default:
-            break
-        }
-    }
-
-    /// Tears down a listener that could not bind its preferred port and, unless
-    /// it was already on the ephemeral fallback, retries on an OS-assigned port.
-    /// Shared by the `.failed` and `.waiting(addressUnavailable)` paths.
-    private func handleListenerBindFailure(error: NWError, context: String) {
-        lastErrorDescription = String(describing: error)
-        MobileHostPublicStatusCache.update(routes: [])
-        let shouldRetryWithEphemeralPort = !listenerUsesEphemeralFallback
-        listener?.stateUpdateHandler = nil
-        listener?.newConnectionHandler = nil
-        listener?.cancel()
-        listenerGeneration = UUID()
-        listener = nil
-        listenerUsesEphemeralFallback = false
-        listenerPort = nil
-        if shouldRetryWithEphemeralPort {
-            mobileHostLog.info("mobile host preferred port \(context, privacy: .public), falling back to an ephemeral port")
-            startListener(usePreferredPort: false)
-        } else {
-            mobileHostLog.error("mobile host listener bind failed on ephemeral port: \(String(describing: error), privacy: .public)")
-            // No retry left: unblock any readiness waiters (the retry path drains
-            // them when the ephemeral listener reaches `.ready`).
-            drainReadinessWaiters()
-        }
-    }
-
     private func updatePublicStatusRoutes(
         port: Int,
         generation: UUID,
@@ -1868,8 +1729,12 @@ extension MobileHostService {
         listenerPort = port
     }
 
-    func debugHandleListenerStateForTesting(_ state: NWListener.State, generation: UUID) {
-        handleListenerState(state, generation: generation)
+    func debugHandleListenerCancelledForTesting(generation: UUID) {
+        handleListenerCancelled(generation: generation)
+    }
+
+    func debugStartListenerForTesting(usePreferredPort: Bool) {
+        startListener(usePreferredPort: usePreferredPort)
     }
 
     func debugListenerGenerationForTesting() -> UUID {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1420,6 +1420,8 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		DE71CE000000000000000006 /* MobileHostNetworkPathRefreshTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE71CE000000000000000005 /* MobileHostNetworkPathRefreshTests.swift */; };
 		A1B2C3D4E5F60718293A4C03 /* MobileHostOrderedInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A4C04 /* MobileHostOrderedInputTests.swift */; };
 		A1B2C3D4E5F60718293A4C01 /* MobileHostOrderedRequestQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A4C02 /* MobileHostOrderedRequestQueue.swift */; };
+		DD6FA290AA945703B703DAEE /* MobileHostPOSIXListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5516FEB938854A487B9BBF1 /* MobileHostPOSIXListener.swift */; };
+		CC2A61F0CB995783B5AAD0B3 /* MobileHostPOSIXListenerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FC76FBF26DF532895CA454F /* MobileHostPOSIXListenerTests.swift */; };
 		4E673EDE464BF3AB80E94C1D /* MobileHostRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BDC06F004C02A52B05E4A0 /* MobileHostRPC.swift */; };
 		C7A50B000000000000000014 /* MobileHostService+Capabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A50B000000000000000013 /* MobileHostService+Capabilities.swift */; };
 		C0DE00000000000000000C8D /* MobileHostService+TicketAuthorization.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000C8C /* MobileHostService+TicketAuthorization.swift */; };
@@ -4178,6 +4180,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		DE71CE000000000000000005 /* MobileHostNetworkPathRefreshTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileHostNetworkPathRefreshTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60718293A4C04 /* MobileHostOrderedInputTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostOrderedInputTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60718293A4C02 /* MobileHostOrderedRequestQueue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostOrderedRequestQueue.swift; sourceTree = "<group>"; };
+		A5516FEB938854A487B9BBF1 /* MobileHostPOSIXListener.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostPOSIXListener.swift; sourceTree = "<group>"; };
+		8FC76FBF26DF532895CA454F /* MobileHostPOSIXListenerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostPOSIXListenerTests.swift; sourceTree = "<group>"; };
 		47BDC06F004C02A52B05E4A0 /* MobileHostRPC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostRPC.swift; sourceTree = "<group>"; };
 		C7A50B000000000000000013 /* MobileHostService+Capabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MobileHostService+Capabilities.swift"; sourceTree = "<group>"; };
 		C0DE00000000000000000C8C /* MobileHostService+TicketAuthorization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MobileHostService+TicketAuthorization.swift"; sourceTree = "<group>"; };
@@ -5835,6 +5839,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D1A700000000000000000004 /* MobileTaskDirectorySearchService.swift */,
 				F5A700000000000000000012 /* MobileTaskFilesystemJobQuota.swift */,
 				DE71CE000000000000000007 /* MobileHostNetworkPathMonitor.swift */,
+				A5516FEB938854A487B9BBF1 /* MobileHostPOSIXListener.swift */,
 				7A956C76162B79EC74AF9965 /* MobileRouteResolver.swift */,
 				04CE82AE8B39EA0C1395F696 /* MobilePairingModel.swift */,
 				B76EC5E03C345BEAC25828A7 /* MobilePairingQRImageView.swift */,
@@ -8374,6 +8379,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				FE002010 /* FileExplorerDoubleClickActionTests.swift */,
 				FE002003 /* FileSearchRipgrepParserTests.swift */,
 				9BD519CFE74530A46DF0925D /* MobileHostAuthorizationTests.swift */,
+				8FC76FBF26DF532895CA454F /* MobileHostPOSIXListenerTests.swift */,
 				D1B800000000000000000015 /* MobileTaskDirectoryListServiceTests.swift */,
 				D1A700000000000000000006 /* MobileTaskDirectorySearchServiceTests.swift */,
 				F5A700000000000000000011 /* MobileTaskFilesystemJobQuotaTests.swift */,
@@ -9706,6 +9712,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C1A070000000000000000004 /* MobileHostIrohServerEventWriter.swift in Sources */,
 				DE71CE000000000000000008 /* MobileHostNetworkPathMonitor.swift in Sources */,
 				A1B2C3D4E5F60718293A4C01 /* MobileHostOrderedRequestQueue.swift in Sources */,
+				DD6FA290AA945703B703DAEE /* MobileHostPOSIXListener.swift in Sources */,
 				4E673EDE464BF3AB80E94C1D /* MobileHostRPC.swift in Sources */,
 				C7A50B000000000000000014 /* MobileHostService+Capabilities.swift in Sources */,
 				C0DE00000000000000000C8D /* MobileHostService+TicketAuthorization.swift in Sources */,
@@ -11237,6 +11244,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C1A071000000000000000001 /* MobileHostIrohAdmissionTests.swift in Sources */,
 				DE71CE000000000000000006 /* MobileHostNetworkPathRefreshTests.swift in Sources */,
 				A1B2C3D4E5F60718293A4C03 /* MobileHostOrderedInputTests.swift in Sources */,
+				CC2A61F0CB995783B5AAD0B3 /* MobileHostPOSIXListenerTests.swift in Sources */,
 				C0DE10510000000000000001 /* MobileHostServiceSettingsTests.swift in Sources */,
 				4C1A7E10B2D34F56A8C90013 /* MobileHostStatusVerificationLimiterTests.swift in Sources */,
 				7A1B2C3D4E5F60718293A4B6 /* MobileHostTerminalThemeTests.swift in Sources */,

--- a/cmuxTests/MobileHostAuthorizationTests.swift
+++ b/cmuxTests/MobileHostAuthorizationTests.swift
@@ -835,7 +835,7 @@ struct MobileHostAuthorizationTests {
         )
         terminalController.debugResetMobileViewportReportsForTesting()
     }
-    @Test func testMobileHostIgnoresStaleListenerStateCallbacks() {
+    @Test func testMobileHostIgnoresStaleListenerCancelledCallbacks() {
         let service = MobileHostService.shared
         let currentGeneration = UUID()
         let staleGeneration = UUID()
@@ -845,34 +845,41 @@ struct MobileHostAuthorizationTests {
             usesEphemeralFallback: true,
             port: 61234
         )
-        service.debugHandleListenerStateForTesting(
-            .failed(.posix(.ECONNRESET)),
-            generation: staleGeneration
-        )
-        #expect(service.debugListenerGenerationForTesting() == currentGeneration)
-        #expect(service.debugListenerUsesEphemeralFallbackForTesting())
-        #expect(service.debugListenerPortForTesting() == 61234)
-        service.debugHandleListenerStateForTesting(.cancelled, generation: staleGeneration)
+        service.debugHandleListenerCancelledForTesting(generation: staleGeneration)
         #expect(service.debugListenerGenerationForTesting() == currentGeneration)
         #expect(service.debugListenerUsesEphemeralFallbackForTesting())
         #expect(service.debugListenerPortForTesting() == 61234)
     }
-    @Test func testMobileHostWaitingListenerDoesNotPublishRoutes() {
+    @Test func testMobileHostFallsBackToEphemeralWhenPreferredPortIsInUse() throws {
         let service = MobileHostService.shared
-        let generation = UUID()
         service.stop()
         service.debugResetMobileLifecycleStateForTesting()
-        service.debugSetListenerStateForTesting(
-            generation: generation,
-            usesEphemeralFallback: false,
-            port: 61234
+
+        // Occupy a real port so the service's preferred-port bind must fail.
+        let blocker = try MobileHostPOSIXListener(
+            preferredPort: nil,
+            queue: DispatchQueue(label: "dev.cmux.mobile.test-port-blocker")
         )
-        service.debugHandleListenerStateForTesting(.waiting(.posix(.EADDRINUSE)), generation: generation)
+        let blockedPort = Int(blocker.boundPort)
+        let originalPort = UserDefaults.standard.object(forKey: MobileHostService.portDefaultsKey)
+        UserDefaults.standard.set(blockedPort, forKey: MobileHostService.portDefaultsKey)
+        defer {
+            if let originalPort {
+                UserDefaults.standard.set(originalPort, forKey: MobileHostService.portDefaultsKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: MobileHostService.portDefaultsKey)
+            }
+            service.stop()
+            blocker.cancel()
+        }
+
+        service.debugStartListenerForTesting(usePreferredPort: true)
+
         let status = service.statusSnapshot()
-        #expect(!status.isRunning)
-        #expect(status.port == nil)
-        #expect(status.routes.isEmpty)
-        #expect(service.debugListenerPortForTesting() == nil)
+        #expect(status.isRunning)
+        #expect(status.port != blockedPort)
+        #expect(service.debugListenerUsesEphemeralFallbackForTesting())
+        #expect(service.debugListenerPortForTesting() == status.port)
     }
     private func scopedAttachTicket(workspaceID: String, terminalID: String?) throws -> CmxAttachTicket {
         let route = try CmxAttachRoute(id: "debug", kind: .debugLoopback, endpoint: .hostPort(host: "127.0.0.1", port: 58465))

--- a/cmuxTests/MobileHostPOSIXListenerTests.swift
+++ b/cmuxTests/MobileHostPOSIXListenerTests.swift
@@ -1,0 +1,239 @@
+import Foundation
+import os
+import Testing
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite(.serialized)
+struct MobileHostPOSIXListenerTests {
+    /// One-shot bridge from the listener's queue callbacks to async test code.
+    /// The watchdog resumes the waiter instead of leaving a cancelled task
+    /// suspended in a continuation, so a broken listener fails the test rather
+    /// than hanging it.
+    private final class AcceptAwaiter: @unchecked Sendable {
+        private let queue = DispatchQueue(label: "dev.cmux.mobile.test.accept-awaiter")
+        private var continuation: CheckedContinuation<MobileHostPOSIXAcceptedConnection?, Never>?
+        private var delivered = false
+
+        func arm(_ listener: MobileHostPOSIXListener) {
+            listener.start(
+                onAccepted: { [weak self] accepted in
+                    self?.deliver(accepted)
+                },
+                onCancelled: { [weak self] in
+                    self?.deliver(nil)
+                }
+            )
+        }
+
+        func awaitConnection(timeout: TimeInterval = 5) async throws -> MobileHostPOSIXAcceptedConnection {
+            let watchdog = Task { [weak self] in
+                try? await Task.sleep(for: .seconds(timeout))
+                self?.deliver(nil)
+            }
+            let result: MobileHostPOSIXAcceptedConnection? = await withCheckedContinuation { continuation in
+                queue.async {
+                    guard !self.delivered else {
+                        continuation.resume(returning: nil)
+                        return
+                    }
+                    self.continuation = continuation
+                }
+            }
+            watchdog.cancel()
+            guard let result else {
+                throw NSError(
+                    domain: "dev.cmux.mobile.test.accept-awaiter",
+                    code: 1,
+                    userInfo: [
+                        NSLocalizedDescriptionKey: "listener did not accept within \(timeout)s"
+                    ]
+                )
+            }
+            return result
+        }
+
+        private func deliver(_ accepted: MobileHostPOSIXAcceptedConnection?) {
+            queue.async {
+                guard !self.delivered else { return }
+                self.delivered = true
+                self.continuation?.resume(returning: accepted)
+                self.continuation = nil
+            }
+        }
+    }
+
+    /// Dials `port` on loopback with a blocking client socket and returns the
+    /// connected descriptor.
+    private func dialLoopback(port: UInt16) throws -> Int32 {
+        let fd = socket(AF_INET, SOCK_STREAM, 0)
+        #require(fd >= 0)
+        var address = sockaddr_in()
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = port.bigEndian
+        address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+        let result = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                connect(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard result == 0 else {
+            close(fd)
+            throw NSError(
+                domain: "dev.cmux.mobile.test.dial",
+                code: Int(errno),
+                userInfo: [NSLocalizedDescriptionKey: "connect to 127.0.0.1:\(port) failed"]
+            )
+        }
+        return fd
+    }
+
+    @Test func listenerAcceptsLoopbackConnectionWithLiveDescriptor() async throws {
+        let listener = try MobileHostPOSIXListener(
+            preferredPort: nil,
+            queue: DispatchQueue(label: "dev.cmux.mobile.test-listener-accept")
+        )
+        defer { listener.cancel() }
+        let awaiter = AcceptAwaiter()
+        awaiter.arm(listener)
+
+        let client = try dialLoopback(port: listener.boundPort)
+        defer { close(client) }
+
+        let accepted = try await awaiter.awaitConnection()
+        #expect(accepted.fileDescriptor >= 0)
+        #expect(accepted.peerIsLoopback)
+
+        // The accepted descriptor is a live, connected socket: a round-trip
+        // through the client proves the kernel wired both halves.
+        let message = Data("ping".utf8)
+        try message.withUnsafeBytes { raw in
+            guard let base = raw.baseAddress else { return }
+            var offset = 0
+            while offset < message.count {
+                let written = write(client, base + offset, message.count - offset)
+                if written <= 0 { throw NSError(domain: "write", code: Int(errno)) }
+                offset += written
+            }
+        }
+        var buffer = [UInt8](repeating: 0, count: message.count)
+        var filled = 0
+        while filled < message.count {
+            let n = read(accepted.fileDescriptor, &buffer, message.count - filled)
+            if n <= 0 { throw NSError(domain: "read", code: Int(errno)) }
+            filled += n
+        }
+        #expect(Data(buffer) == message)
+        close(accepted.fileDescriptor)
+    }
+
+    @Test func listenerBindFailsWhenPreferredPortIsOccupied() throws {
+        let blocker = try MobileHostPOSIXListener(
+            preferredPort: nil,
+            queue: DispatchQueue(label: "dev.cmux.mobile.test-listener-blocker")
+        )
+        defer { blocker.cancel() }
+
+        #expect(throws: MobileHostPOSIXListener.ListenerError.bindFailed(Int32(EADDRINUSE))) {
+            _ = try MobileHostPOSIXListener(
+                preferredPort: blocker.boundPort,
+                queue: DispatchQueue(label: "dev.cmux.mobile.test-listener-conflict")
+            )
+        }
+    }
+
+    @Test func listenerCancelStopsAcceptingAndFiresCancelledOnce() async throws {
+        let listener = try MobileHostPOSIXListener(
+            preferredPort: nil,
+            queue: DispatchQueue(label: "dev.cmux.mobile.test-listener-cancel")
+        )
+        let cancelledCount = OSAllocatedUnfairLock(initialState: 0)
+        listener.start(
+            onAccepted: { accepted in close(accepted.fileDescriptor) },
+            onCancelled: {
+                _ = cancelledCount.withLock { $0 += 1 }
+            }
+        )
+        listener.cancel()
+        listener.cancel()
+
+        // The cancel handler runs on the listener queue; poll for it with a
+        // bounded deadline instead of a fixed sleep.
+        for _ in 0..<300 {
+            if cancelledCount.withLock({ $0 }) == 1 { break }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(cancelledCount.withLock { $0 } == 1)
+
+        // The port is released: a fresh listener can bind it.
+        let replacement = try MobileHostPOSIXListener(
+            preferredPort: listener.boundPort,
+            queue: DispatchQueue(label: "dev.cmux.mobile.test-listener-replacement")
+        )
+        replacement.cancel()
+    }
+
+    @Test func listenerDisarmKeepsIntentionalTeardownSilent() async throws {
+        let listener = try MobileHostPOSIXListener(
+            preferredPort: nil,
+            queue: DispatchQueue(label: "dev.cmux.mobile.test-listener-disarm")
+        )
+        let cancelledCount = OSAllocatedUnfairLock(initialState: 0)
+        listener.start(
+            onAccepted: { accepted in close(accepted.fileDescriptor) },
+            onCancelled: {
+                _ = cancelledCount.withLock { $0 += 1 }
+            }
+        )
+        listener.disarm()
+        listener.cancel()
+        for _ in 0..<50 {
+            if cancelledCount.withLock({ $0 }) > 0 { break }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(cancelledCount.withLock { $0 } == 0)
+    }
+
+    @Test func loopbackPeerClassificationMatchesOldEndpointSemantics() {
+        func ipv4(_ a: UInt8, _ b: UInt8, _ c: UInt8, _ d: UInt8) -> sockaddr_storage {
+            var storage = sockaddr_storage()
+            withUnsafeMutableBytes(of: &storage) { raw in
+                let sin = raw.bindMemory(to: sockaddr_in.self).baseAddress!
+                sin.pointee.sin_family = sa_family_t(AF_INET)
+                sin.pointee.sin_addr = in_addr(
+                    s_addr: UInt32(a) << 24 | UInt32(b) << 16 | UInt32(c) << 8 | UInt32(d)
+                )
+            }
+            return storage
+        }
+
+        func ipv6(_ bytes: [UInt8]) -> sockaddr_storage {
+            var storage = sockaddr_storage()
+            withUnsafeMutableBytes(of: &storage) { raw in
+                let sin6 = raw.bindMemory(to: sockaddr_in6.self).baseAddress!
+                sin6.pointee.sin6_family = sa_family_t(AF_INET6)
+                _ = withUnsafeMutableBytes(of: &sin6.pointee.sin6_addr) { addr in
+                    for (index, byte) in bytes.enumerated() {
+                        addr[index] = byte
+                    }
+                }
+            }
+            return storage
+        }
+
+        let mappedLoopback: [UInt8] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF, 127, 0, 0, 1]
+        var v6Loopback: [UInt8] = Array(repeating: 0, count: 16)
+        v6Loopback[15] = 1
+
+        #expect(MobileHostPOSIXListener.isLoopbackPeer(ipv4(127, 0, 0, 1)))
+        #expect(MobileHostPOSIXListener.isLoopbackPeer(ipv4(127, 255, 255, 254)))
+        #expect(MobileHostPOSIXListener.isLoopbackPeer(ipv6(v6Loopback)))
+        #expect(MobileHostPOSIXListener.isLoopbackPeer(ipv6(mappedLoopback)))
+        #expect(!MobileHostPOSIXListener.isLoopbackPeer(ipv4(100, 88, 118, 71)))
+        #expect(!MobileHostPOSIXListener.isLoopbackPeer(ipv4(192, 168, 0, 3)))
+        #expect(!MobileHostPOSIXListener.isLoopbackPeer(ipv4(8, 8, 8, 8)))
+    }
+}


### PR DESCRIPTION
## Problem

With Tailscale (macOS system extension) active on macOS 26/27, an iOS client dialing the Mac's Tailscale address can never reach the legacy mobile pairing listener. On that OS/VPN combination the kernel drops inbound-delivered connections whose listener socket is a Network.framework NWListener, before accept ever runs. The phone's Tailscale compatibility path therefore dies in the kernel while every other transport keeps working, and the Mac logs nothing.

Verified side by side on macOS 27.0 (26A5388g) + Tailscale 1.103.85 (system extension), same machine, same moment:

| Listener | loopback | LAN IP | Tailscale IP |
| --- | --- | --- | --- |
| NWListener (old) | OK | OK | timeout |
| BSD socket (new) | OK | OK | OK |

A BSD-socket listener bound identically receives the exact connections the NWListener never sees. After this change, a framed mobile.host.status request over the Mac's Tailscale address completes end to end against a tagged dev build (it times out against the Stable app running the old listener on the same machine).

## Change

- CmxPOSIXByteTransport (CmuxMobileTransport): a CmxByteTransport over one accepted nonblocking socket, driven by DispatchSource read/write events (the sanctioned low-level socket I/O carve-out). Balanced resume/suspend bookkeeping, errno captured at the syscall site, deterministic teardown and deinit so suspended sources are never released or double-resumed.
- MobileHostPOSIXListener (app target): BSD-socket IPv6 dual-stack wildcard listener with SO_REUSEADDR, TCP_NODELAY, SO_NOSIGPIPE, peer loopback classification matching the old NWEndpoint check, and disarm-then-cancel for intentional teardown.
- MobileHostService: the legacy TCP listener swaps from NWListener to the POSIX listener; accepted descriptors flow through the existing acceptTransport seam unchanged. POSIX bind is synchronous, so the NW ready/waiting/cancelled state machine collapses into direct success, bind-failure (ephemeral fallback), and cancelled handling. The apply-port flow keeps make-before-break semantics with a synchronous bind probe.

## Tests

- Package: 5 new CmxPOSIXByteTransport tests (bidirectional round trip, 192 KiB multi-chunk both directions, peer-close end-of-stream ordering, close completing in-flight receive, use-after-close) plus the full suite: 47/47 green via swift test --package-path Packages/iOS/CmuxMobileTransport.
- App: new MobileHostPOSIXListenerTests (accept hands off a live descriptor, occupied-port bind failure, cancel fires once and releases the port, disarm keeps teardown silent, loopback classification) and the NW state-machine service tests ported to the POSIX flow (stale-generation guard, occupied-port ephemeral fallback through the real bind path).
- The kernel-level NECP drop is only reproducible on the affected OS/VPN combination, so there is deliberately no red/green CI test for it; the PR Commits tab shows components plus tests landing before the service switch instead.

Note: cmux-unit currently fails to plan on Xcode 27 beta local runs with pre-existing duplicate Sentry copy tasks (reproduces on main without these changes); CI's Xcode 26 lane is the gate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790596240&installation_model_id=21920&pr_number=11181&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11181&signature=0b67283ac3cd1684af75c884db47421a35c567e93051ac1b9dc078993c146d06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the mobile host's legacy NWListener with a POSIX socket listener and matching `CmxPOSIXByteTransport`, so iOS clients can reach the Mac over its Tailscale IP on macOS 26/27 with the Tailscale system extension. Previously the kernel dropped inbound-delivered connections to NWListener sockets before accept (Tailscale IP timed out while loopback and LAN worked); BSD listeners receive those connections, and a framed `mobile.host.status` request now completes over the Tailscale address.

**Notes**
- Synchronous POSIX bind collapses the NW ready/waiting/cancelled state machine; the apply-port flow keeps make-before-break semantics with a synchronous bind probe.
- Release-build loopback rejection now classifies the accepted peer address directly rather than the NW endpoint.
- Added transport and listener tests: round trips, peer close, use-after-close, bind conflict, cancel-once, disarm silence, and loopback classification. The kernel-level drop is only reproducible on the affected OS/VPN combination, so there is no CI test for it.

<sup>Written for commit 4dc5ac5f3be9a039885e283c05a213f79024f4b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added POSIX socket transport for reliable asynchronous byte send and receive operations.
  * Added a TCP listener for mobile host connections with loopback detection and connection lifecycle controls.
  * Mobile host pairing now supports preferred-port fallback when the requested port is unavailable.

* **Bug Fixes**
  * Improved connection shutdown, cancellation, end-of-stream handling, and stale listener callback handling.

* **Tests**
  * Added coverage for socket communication, large payloads, listener behavior, cancellation, and port fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->