### PR TITLE
fix(relay): make session shutdown cancellation-safe

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -24,6 +24,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::sync::Notify;
+use tokio_util::sync::CancellationToken;
 
 use async_trait::async_trait;
 use base64::Engine as _;
@@ -227,6 +228,7 @@ pub struct SpawnSpec {
     pub rows: u16,
     pub cwd: PathBuf,
     pub env: HashMap<String, String>,
+    pub cancellation: CancellationToken,
 }
 
 /// A resolved cmux-tui binary: file plus an argv prefix.
@@ -277,6 +279,8 @@ pub struct FrameContext {
     /// detaches only its own attachments. `None` preserves the legacy
     /// owns-everything behavior for callers that own the whole manager.
     pub transport_id: Option<String>,
+    /// Raised when the transport that requested this work disconnects.
+    pub cancellation: CancellationToken,
 }
 
 #[derive(Clone)]
@@ -1076,6 +1080,7 @@ impl Inner {
                 rows,
                 cwd: cwd.to_path_buf(),
                 env: env.clone(),
+                cancellation: context.cancellation.clone(),
             })
             .await;
         let control = Arc::clone(&handle.control);
@@ -1159,6 +1164,7 @@ impl Inner {
                         rows,
                         cwd: cwd.to_path_buf(),
                         env: env.clone(),
+                        cancellation: context.cancellation.clone(),
                     })
                     .await;
                 let PtyHandle { control, output, banner } = handle;
@@ -2242,6 +2248,7 @@ mod tests {
                 local_roots: None,
                 owner_user_id: owner,
                 transport_id: None,
+                cancellation: CancellationToken::new(),
             }
         }
 

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -804,9 +804,25 @@ impl PtyDeps for RealPtyDeps {
         // On PTY allocation failure (ptmx exhaustion et al) degrade to a
         // pipe-mode shell so the terminal still functions, with a banner.
         let output = ThreadOutput::new();
-        tokio::task::spawn_blocking(move || match spawn_real_pty(&spec) {
-            Ok(handle) => handle,
-            Err(error) => spawn_pipe_mode(&spec, &error.to_string()),
+        tokio::task::spawn_blocking(move || {
+            if spec.cancellation.is_cancelled() {
+                output.push_exit(1);
+                return PtyHandle { control: Arc::new(DeadControl), output, banner: None };
+            }
+            let handle = match spawn_real_pty(&spec) {
+                Ok(handle) => handle,
+                Err(error) if !spec.cancellation.is_cancelled() => {
+                    spawn_pipe_mode(&spec, &error.to_string())
+                }
+                Err(_) => {
+                    output.push_exit(1);
+                    return PtyHandle { control: Arc::new(DeadControl), output, banner: None };
+                }
+            };
+            if spec.cancellation.is_cancelled() {
+                handle.control.kill();
+            }
+            handle
         })
         .await
         .unwrap_or_else(|_| {

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -804,10 +804,16 @@ impl PtyDeps for RealPtyDeps {
         // On PTY allocation failure (ptmx exhaustion et al) degrade to a
         // pipe-mode shell so the terminal still functions, with a banner.
         let output = ThreadOutput::new();
+        let task_output = Arc::clone(&output);
+        let fallback_output = Arc::clone(&output);
         tokio::task::spawn_blocking(move || {
             if spec.cancellation.is_cancelled() {
-                output.push_exit(1);
-                return PtyHandle { control: Arc::new(DeadControl), output, banner: None };
+                task_output.push_exit(1);
+                return PtyHandle {
+                    control: Arc::new(DeadControl),
+                    output: task_output,
+                    banner: None,
+                };
             }
             let handle = match spawn_real_pty(&spec) {
                 Ok(handle) => handle,
@@ -815,8 +821,12 @@ impl PtyDeps for RealPtyDeps {
                     spawn_pipe_mode(&spec, &error.to_string())
                 }
                 Err(_) => {
-                    output.push_exit(1);
-                    return PtyHandle { control: Arc::new(DeadControl), output, banner: None };
+                    task_output.push_exit(1);
+                    return PtyHandle {
+                        control: Arc::new(DeadControl),
+                        output: task_output,
+                        banner: None,
+                    };
                 }
             };
             if spec.cancellation.is_cancelled() {
@@ -826,8 +836,8 @@ impl PtyDeps for RealPtyDeps {
         })
         .await
         .unwrap_or_else(|_| {
-            output.push_exit(1);
-            PtyHandle { control: Arc::new(DeadControl), output, banner: None }
+            fallback_output.push_exit(1);
+            PtyHandle { control: Arc::new(DeadControl), output: fallback_output, banner: None }
         })
     }
 

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -403,7 +403,7 @@ async fn observe_connection_tasks(connection_tasks: &mut JoinSet<()>) {
         if let Err(error) = joined
             && error.is_panic()
         {
-            eprintln!("Relay connection task panicked during shutdown: {error}");
+            eprintln!("Relay cleanup encountered an internal error.");
         }
     }
 }
@@ -1217,9 +1217,7 @@ async fn relay_session(
     // deadline for the final await instead of letting reconnect or process
     // shutdown wait forever.
     if !shutdown_connection_tasks(&mut connection_tasks, &connection_cancellation).await {
-        eprintln!(
-            "Graceful relay connection task shutdown exceeded {CONNECTION_TASK_SHUTDOWN_TIMEOUT:?}; forced abort was applied to remaining handlers."
-        );
+        eprintln!("Relay cleanup did not finish before its safety deadline.");
     }
 
     // This socket's attachments die with it; sessions persist, and the

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -1106,7 +1106,7 @@ async fn relay_session(
                                     &pending,
                                     &snapshot,
                                     &transport_id,
-                                    &cancellation,
+                                    &connection_cancellation,
                                 );
                                 tokio::select! {
                                     biased;

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -766,7 +766,7 @@ async fn relay_session(
             Wake::Heartbeat => {
                 critical_burst = 0;
                 let frame = heartbeat_frame(now_ms()).to_string();
-                if send_socket_text(&socket, frame, cancellation).await.is_err() {
+                if send_socket_text(&socket, frame, &connection_cancellation).await.is_err() {
                     break Ok(connected);
                 }
             }
@@ -809,7 +809,7 @@ async fn relay_session(
                 }
                 let text = frame.text;
                 let size = text.len() as u64;
-                let sent = send_socket_text(&socket, text, cancellation).await;
+                let sent = send_socket_text(&socket, text, &connection_cancellation).await;
                 pending.fetch_sub(size.min(pending.load(Ordering::SeqCst)), Ordering::SeqCst);
                 if sent.is_err() {
                     break Ok(connected);
@@ -834,8 +834,12 @@ async fn relay_session(
                 let text = match message {
                     Message::Text(text) => text,
                     Message::Ping(payload) => {
-                        let _ = send_socket_message(&socket, Message::Pong(payload), cancellation)
-                            .await;
+                        let _ = send_socket_message(
+                            &socket,
+                            Message::Pong(payload),
+                            &connection_cancellation,
+                        )
+                        .await;
                         continue;
                     }
                     Message::Close(_) => break Ok(connected),
@@ -917,7 +921,10 @@ async fn relay_session(
                                 || local_trust == Trust::Autonomous)
                         {
                             let frame = set_trust_frame(local_trust.as_str()).to_string();
-                            if send_socket_text(&socket, frame, cancellation).await.is_err() {
+                            if send_socket_text(&socket, frame, &connection_cancellation)
+                                .await
+                                .is_err()
+                            {
                                 break Ok(connected);
                             }
                         } else if !state.managed {
@@ -976,7 +983,7 @@ async fn relay_session(
                                 save(config, config_path);
                             }
                             let frame = set_trust_frame(DEFAULT_RELAY_TRUST.as_str()).to_string();
-                            let _ = send_socket_text(&socket, frame, cancellation).await;
+                            let _ = send_socket_text(&socket, frame, &connection_cancellation).await;
                             workspace.set_local_observe(DEFAULT_RELAY_TRUST == Trust::Observe);
                             eprintln!(
                                 "Refused an autonomous trust acknowledgement without this \
@@ -1322,13 +1329,52 @@ mod liveness_tests {
 
 #[cfg(test)]
 mod cancellation_tests {
-    use super::{shutdown_connection_tasks, wait_for_reconnect};
+    use super::{send_socket_text, shutdown_connection_tasks, wait_for_reconnect};
+    use futures_util::Sink;
+    use std::pin::Pin;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
+    use std::task::{Context, Poll};
     use std::time::Duration;
 
+    use tokio::sync::{Mutex as AsyncMutex, Notify};
     use tokio::task::JoinSet;
+    use tokio_tungstenite::tungstenite::Message;
     use tokio_util::sync::CancellationToken;
+
+    struct PendingSink {
+        started: Arc<Notify>,
+    }
+
+    impl Sink<Message> for PendingSink {
+        type Error = ();
+
+        fn poll_ready(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            self.started.notify_one();
+            Poll::Pending
+        }
+
+        fn start_send(self: Pin<&mut Self>, _item: Message) -> Result<(), Self::Error> {
+            Ok(())
+        }
+
+        fn poll_flush(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_close(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+    }
 
     #[tokio::test]
     async fn reconnect_backoff_stops_when_process_is_cancelled() {
@@ -1375,6 +1421,24 @@ mod cancellation_tests {
         assert!(shutdown_connection_tasks(&mut tasks, &cancellation).await);
         assert!(completed.load(Ordering::Acquire));
         assert!(tasks.is_empty());
+    }
+
+    #[tokio::test]
+    async fn cancellation_unblocks_a_send_waiting_on_the_socket() {
+        let started = Arc::new(Notify::new());
+        let socket = Arc::new(AsyncMutex::new(PendingSink {
+            started: Arc::clone(&started),
+        }));
+        let cancellation = CancellationToken::new();
+        let task_socket = Arc::clone(&socket);
+        let task_cancellation = cancellation.clone();
+        let send = tokio::spawn(async move {
+            send_socket_text(&task_socket, "blocked".to_owned(), &task_cancellation).await
+        });
+
+        started.notified().await;
+        cancellation.cancel();
+        assert!(send.await.expect("send task joined").is_err());
     }
 }
 

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -1284,6 +1284,8 @@ mod liveness_tests {
 #[cfg(test)]
 mod cancellation_tests {
     use super::{shutdown_connection_tasks, wait_for_reconnect};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::time::Duration;
 
     use tokio::task::JoinSet;
@@ -1313,6 +1315,26 @@ mod cancellation_tests {
 
         assert!(shutdown_connection_tasks(&mut tasks, &cancellation).await);
         assert!(cancellation.is_cancelled());
+        assert!(tasks.is_empty());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn connection_shutdown_allows_cooperative_tasks_to_finish() {
+        let cancellation = CancellationToken::new();
+        let worker_cancellation = cancellation.clone();
+        let completed = Arc::new(AtomicBool::new(false));
+        let worker_completed = Arc::clone(&completed);
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let mut tasks = JoinSet::new();
+        tasks.spawn(async move {
+            started_tx.send(()).expect("test receiver is waiting");
+            worker_cancellation.cancelled().await;
+            worker_completed.store(true, Ordering::Release);
+        });
+        started_rx.await.expect("worker started");
+
+        assert!(shutdown_connection_tasks(&mut tasks, &cancellation).await);
+        assert!(completed.load(Ordering::Acquire));
         assert!(tasks.is_empty());
     }
 }

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -112,14 +112,16 @@ impl OutboundFrame {
 async fn send_socket_message<S>(
     socket: &Arc<AsyncMutex<S>>,
     message: Message,
-    cancellation: &CancellationToken,
+    process_cancellation: &CancellationToken,
+    connection_cancellation: &CancellationToken,
 ) -> Result<(), ()>
 where
     S: futures_util::Sink<Message> + Unpin,
 {
     tokio::select! {
         biased;
-        _ = cancellation.cancelled() => Err(()),
+        _ = process_cancellation.cancelled() => Err(()),
+        _ = connection_cancellation.cancelled() => Err(()),
         result = async {
             socket.lock().await.send(message).await
         } => result.map_err(|_| ()),
@@ -129,12 +131,19 @@ where
 async fn send_socket_text<S>(
     socket: &Arc<AsyncMutex<S>>,
     text: String,
-    cancellation: &CancellationToken,
+    process_cancellation: &CancellationToken,
+    connection_cancellation: &CancellationToken,
 ) -> Result<(), ()>
 where
     S: futures_util::Sink<Message> + Unpin,
 {
-    send_socket_message(socket, Message::Text(text.into()), cancellation).await
+    send_socket_message(
+        socket,
+        Message::Text(text.into()),
+        process_cancellation,
+        connection_cancellation,
+    )
+    .await
 }
 
 /// One socket's bounded outbound capacity. Critical request responses wait
@@ -614,7 +623,7 @@ async fn relay_session(
     };
     let hello_text =
         serde_json::to_string(&hello).map_err(|error| RelayError::transient(error.to_string()))?;
-    if send_socket_text(&socket, hello_text, cancellation).await.is_err() {
+    if send_socket_text(&socket, hello_text, cancellation, cancellation).await.is_err() {
         return Ok(false);
     }
 
@@ -766,7 +775,10 @@ async fn relay_session(
             Wake::Heartbeat => {
                 critical_burst = 0;
                 let frame = heartbeat_frame(now_ms()).to_string();
-                if send_socket_text(&socket, frame, &connection_cancellation).await.is_err() {
+                if send_socket_text(&socket, frame, cancellation, &connection_cancellation)
+                    .await
+                    .is_err()
+                {
                     break Ok(connected);
                 }
             }
@@ -809,7 +821,8 @@ async fn relay_session(
                 }
                 let text = frame.text;
                 let size = text.len() as u64;
-                let sent = send_socket_text(&socket, text, &connection_cancellation).await;
+                let sent =
+                    send_socket_text(&socket, text, cancellation, &connection_cancellation).await;
                 pending.fetch_sub(size.min(pending.load(Ordering::SeqCst)), Ordering::SeqCst);
                 if sent.is_err() {
                     break Ok(connected);
@@ -837,6 +850,7 @@ async fn relay_session(
                         let _ = send_socket_message(
                             &socket,
                             Message::Pong(payload),
+                            cancellation,
                             &connection_cancellation,
                         )
                         .await;
@@ -921,9 +935,14 @@ async fn relay_session(
                                 || local_trust == Trust::Autonomous)
                         {
                             let frame = set_trust_frame(local_trust.as_str()).to_string();
-                            if send_socket_text(&socket, frame, &connection_cancellation)
-                                .await
-                                .is_err()
+                            if send_socket_text(
+                                &socket,
+                                frame,
+                                cancellation,
+                                &connection_cancellation,
+                            )
+                            .await
+                            .is_err()
                             {
                                 break Ok(connected);
                             }
@@ -983,7 +1002,13 @@ async fn relay_session(
                                 save(config, config_path);
                             }
                             let frame = set_trust_frame(DEFAULT_RELAY_TRUST.as_str()).to_string();
-                            let _ = send_socket_text(&socket, frame, &connection_cancellation).await;
+                            let _ = send_socket_text(
+                                &socket,
+                                frame,
+                                cancellation,
+                                &connection_cancellation,
+                            )
+                            .await;
                             workspace.set_local_observe(DEFAULT_RELAY_TRUST == Trust::Observe);
                             eprintln!(
                                 "Refused an autonomous trust acknowledgement without this \
@@ -1156,6 +1181,7 @@ async fn relay_session(
                                         let sent = send_socket_text(
                                             &socket,
                                             text,
+                                            cancellation,
                                             &connection_cancellation,
                                         )
                                         .await;
@@ -1426,19 +1452,26 @@ mod cancellation_tests {
     #[tokio::test]
     async fn cancellation_unblocks_a_send_waiting_on_the_socket() {
         let started = Arc::new(Notify::new());
-        let socket = Arc::new(AsyncMutex::new(PendingSink {
-            started: Arc::clone(&started),
-        }));
-        let cancellation = CancellationToken::new();
+        let socket = Arc::new(AsyncMutex::new(PendingSink { started: Arc::clone(&started) }));
+        let process_cancellation = CancellationToken::new();
+        let connection_cancellation = CancellationToken::new();
         let task_socket = Arc::clone(&socket);
-        let task_cancellation = cancellation.clone();
+        let task_process_cancellation = process_cancellation.clone();
+        let task_connection_cancellation = connection_cancellation.clone();
         let send = tokio::spawn(async move {
-            send_socket_text(&task_socket, "blocked".to_owned(), &task_cancellation).await
+            send_socket_text(
+                &task_socket,
+                "blocked".to_owned(),
+                &task_process_cancellation,
+                &task_connection_cancellation,
+            )
+            .await
         });
 
         started.notified().await;
-        cancellation.cancel();
+        process_cancellation.cancel();
         assert!(send.await.expect("send task joined").is_err());
+        assert!(!connection_cancellation.is_cancelled());
     }
 }
 

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -538,6 +538,7 @@ fn make_context(
     pending: &Arc<AtomicU64>,
     auth: &AuthSnapshot,
     transport_id: &str,
+    cancellation: &CancellationToken,
 ) -> FrameContext {
     let sender = out.clone();
     let pending_send = Arc::clone(pending);
@@ -570,6 +571,7 @@ fn make_context(
         local_roots: auth.roots.clone(),
         owner_user_id: auth.owner.clone(),
         transport_id: Some(transport_id.to_owned()),
+        cancellation: cancellation.clone(),
     }
 }
 
@@ -661,7 +663,7 @@ async fn relay_session(
                     }
                 };
                 let snapshot = auth.lock().expect("auth lock").clone();
-                let context = make_context(&out, &pending, &snapshot, &transport);
+                let context = make_context(&out, &pending, &snapshot, &transport, &cancellation);
                 tokio::select! {
                     biased;
                     _ = cancellation.cancelled() => break,
@@ -1099,8 +1101,13 @@ async fn relay_session(
                                 // bounded work queue is saturated. The manager close path is
                                 // synchronous and short, so this cannot create an unbounded wait.
                                 let snapshot = auth_direct.lock().expect("auth lock").clone();
-                                let context =
-                                    make_context(&out_tx, &pending, &snapshot, &transport_id);
+                                let context = make_context(
+                                    &out_tx,
+                                    &pending,
+                                    &snapshot,
+                                    &transport_id,
+                                    &cancellation,
+                                );
                                 tokio::select! {
                                     biased;
                                     _ = cancellation.cancelled() => break Ok(connected),

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -61,6 +61,7 @@ const MAX_PTY_INGRESS_FRAMES: usize = 64;
 // Keep room for the workspace fs_write 2 MiB payload plus its JSON envelope.
 const MAX_INBOUND_FRAME_BYTES: usize = 4 << 20;
 const CONNECTION_TASK_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
+const CONNECTION_TASK_ABORT_TIMEOUT: Duration = Duration::from_secs(1);
 /// One suspend/read-liveness sample per period while a socket is open.
 const LIVENESS_CHECK_INTERVAL: Duration = Duration::from_secs(5);
 /// Wall clock moving more than this relative to the monotonic clock between
@@ -393,15 +394,40 @@ async fn wait_for_reconnect(cancellation: &CancellationToken, delay: Duration) -
     }
 }
 
-/// Cancel and await all work admitted by one physical socket. The timeout is
-/// a final guard for provider code that does not reach an async cancellation
-/// point; dropping the JoinSet after the timeout aborts the remaining handles.
+/// Observe every task result while a connection shuts down. `JoinSet::shutdown`
+/// would abort first and intentionally discard panic results, so keep the
+/// join loop explicit to preserve diagnostics for a task that fails while
+/// releasing its connection-owned resources.
+async fn observe_connection_tasks(connection_tasks: &mut JoinSet<()>) {
+    while let Some(joined) = connection_tasks.join_next().await {
+        if let Err(error) = joined
+            && error.is_panic()
+        {
+            eprintln!("Relay connection task panicked during shutdown: {error}");
+        }
+    }
+}
+
+/// Cancel and await all work admitted by one physical socket. Give handlers
+/// a cooperative window first, then abort and observe the remaining handles
+/// within a shorter final window. A started blocking provider may still outlive
+/// its async wrapper, so the JoinSet is dropped when the bounded cleanup ends.
 async fn shutdown_connection_tasks(
     connection_tasks: &mut JoinSet<()>,
     cancellation: &CancellationToken,
 ) -> bool {
     cancellation.cancel();
-    timeout(CONNECTION_TASK_SHUTDOWN_TIMEOUT, connection_tasks.shutdown()).await.is_ok()
+    if timeout(CONNECTION_TASK_SHUTDOWN_TIMEOUT, observe_connection_tasks(connection_tasks))
+        .await
+        .is_ok()
+    {
+        return true;
+    }
+
+    connection_tasks.abort_all();
+    let _ =
+        timeout(CONNECTION_TASK_ABORT_TIMEOUT, observe_connection_tasks(connection_tasks)).await;
+    false
 }
 
 /// Keep the machine online until the process cancellation token is raised.
@@ -697,6 +723,10 @@ async fn relay_session(
             if critical_burst >= 8 {
                 critical_burst = 0;
                 tokio::select! {
+                    // This arm is intentionally unbiased after each critical
+                    // burst. Keep cancellation as an explicit wake source so
+                    // it competes fairly with ready queues and timers.
+                    _ = cancellation.cancelled() => Wake::Shutdown,
                     frame = critical_rx.recv() => Wake::Outbound(true, frame),
                     frame = watch_rx.recv() => Wake::Outbound(false, frame),
                     _ = async {
@@ -706,12 +736,15 @@ async fn relay_session(
                         }
                     }, if heartbeat.is_some() => Wake::Heartbeat,
                     _ = liveness.tick() => Wake::Liveness,
-                    _ = cancellation.cancelled() => Wake::Shutdown,
                     incoming = guard.next() => Wake::Incoming(incoming),
                 }
             } else {
                 tokio::select! {
                     biased;
+                    // `biased` polls in source order. Cancellation must be
+                    // first or a continuously-ready queue/heartbeat can
+                    // starve process shutdown indefinitely.
+                    _ = cancellation.cancelled() => Wake::Shutdown,
                     frame = critical_rx.recv() => Wake::Outbound(true, frame),
                     frame = watch_rx.recv() => Wake::Outbound(false, frame),
                     _ = async {
@@ -721,7 +754,6 @@ async fn relay_session(
                         }
                     }, if heartbeat.is_some() => Wake::Heartbeat,
                     _ = liveness.tick() => Wake::Liveness,
-                    _ = cancellation.cancelled() => Wake::Shutdown,
                     incoming = guard.next() => Wake::Incoming(incoming),
                 }
             }
@@ -1106,11 +1138,12 @@ async fn relay_session(
                                         // outbound queue cannot block this loop and stop socket
                                         // ingress from being drained.
                                         let text = reply.to_string();
-                                        let sent = socket
-                                            .lock()
-                                            .await
-                                            .send(Message::Text(text.into()))
-                                            .await;
+                                        let sent = send_socket_text(
+                                            &socket,
+                                            text,
+                                            &connection_cancellation,
+                                        )
+                                        .await;
                                         if sent.is_err() {
                                             break Ok(connected);
                                         }
@@ -1185,7 +1218,7 @@ async fn relay_session(
     // shutdown wait forever.
     if !shutdown_connection_tasks(&mut connection_tasks, &connection_cancellation).await {
         eprintln!(
-            "Relay connection task shutdown exceeded {CONNECTION_TASK_SHUTDOWN_TIMEOUT:?}; abandoning remaining handlers."
+            "Graceful relay connection task shutdown exceeded {CONNECTION_TASK_SHUTDOWN_TIMEOUT:?}; forced abort was applied to remaining handlers."
         );
     }
 

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -650,23 +650,24 @@ async fn relay_session(
         let out = out_tx.clone();
         let pending = Arc::clone(&pending);
         let auth = Arc::clone(&auth);
-        let cancellation = connection_cancellation.clone();
+        let connection_token = connection_cancellation.clone();
         let transport = transport_id.clone();
         connection_tasks.spawn(async move {
             loop {
                 let frame = tokio::select! {
                     biased;
-                    _ = cancellation.cancelled() => break,
+                    _ = connection_token.cancelled() => break,
                     frame = pty_rx.recv() => {
                         let Some(frame) = frame else { break };
                         frame
                     }
                 };
                 let snapshot = auth.lock().expect("auth lock").clone();
-                let context = make_context(&out, &pending, &snapshot, &transport, &cancellation);
+                let context =
+                    make_context(&out, &pending, &snapshot, &transport, &connection_token);
                 tokio::select! {
                     biased;
-                    _ = cancellation.cancelled() => break,
+                    _ = connection_token.cancelled() => break,
                     _ = manager.handle_frame(&frame, &context) => {}
                 }
             }

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -379,6 +379,7 @@ impl Connection {
             local_roots: None,
             owner_user_id: None,
             transport_id: Some(self.pty_id.clone()),
+            cancellation: self.done.clone(),
         }
     }
 }

--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -10,7 +10,6 @@ use std::sync::mpsc::{
 use std::sync::{Arc, Condvar, Mutex, Weak};
 use std::time::{Duration, Instant};
 
-use anyhow::Context;
 use base64::Engine;
 use serde_json::{Value, json};
 use tungstenite::client::IntoClientRequest;


### PR DESCRIPTION
## Summary

- Put cancellation first in the biased relay wake selector so continuously-ready outbound sources cannot starve shutdown.
- Route PTY ingress busy replies through the connection cancellation-aware socket helper while keeping the direct path for mandatory responses.
- Replace immediate `JoinSet::shutdown` with cooperative `join_next` observation, then bounded abort and drain fallback; preserve the existing private boolean contract and queue behavior.

## Verification

- `rustfmt --check` passed for `cmux-tui/crates/chatmux-relay/src/session.rs`.
- `git diff --check` passed.
- No local Cargo tests were run, per `cmux-tui/CLAUDE.md`; hosted focused verification is required.

## Commit narrative

1. `20e8c0ec585` adds the failing behavior test requiring a token-aware connection task to finish during shutdown.
2. `a641474096f` implements the shutdown, selector, and direct-send fixes.

Changed file: `cmux-tui/crates/chatmux-relay/src/session.rs`.

Residual risk: a started `spawn_blocking` or non-cooperative provider can outlive its async wrapper after the bounded abort fallback.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790601693&installation_model_id=21920&pr_number=11183&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11183&signature=5c505359c90a939549adcaaa03297bf9563f6404d776e6f93417cb69ae4a0fe3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes relay session shutdown so cooperative work gets a window to finish before being aborted.

- Puts cancellation first in the relay wake selectors so continuously-ready outbound sources cannot starve shutdown.
- Replaces `JoinSet::shutdown` with an explicit join loop that preserves panic diagnostics, then falls back to a bounded abort with a shorter timeout.
- Routes connection-owned socket sends through the cancellation-aware send path so outbound frames, pongs, heartbeats, and busy replies stop on connection or process cancellation.
- Propagates connection cancellation into PTY setup so canceled spawns don't fall back to pipe mode and a spawned PTY is killed.
- Preserves the exit-1 output when the PTY setup task fails.
- Renames the per-connection PTY cancellation token for clarity.
- Adds a test proving a cooperative connection task finishes during shutdown.
- Residual risk: a started `spawn_blocking` work item can outlive its async wrapper after the bounded abort fallback.

<sup>Written for commit b774111d1dd194ef6cb25e5789b21ea6e0443329. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection shutdown handling so tasks can finish cleanly before forced termination.
  * Prevented cancellation signals from being delayed while processing socket activity.
  * Ensured busy responses and PTY operations can be interrupted during shutdown.
  * Prevented new PTY sessions from starting after cancellation.
  * Improved reporting of task failures and panics during connection cleanup.

* **Tests**
  * Added coverage verifying cooperative tasks complete successfully during shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->