### PR TITLE
fix(ios): content-true viewport anchoring while scrollback evicts at the cap

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -640,7 +640,8 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
                     if !chunk.data.isEmpty || chunk.terminalConfigTheme != nil {
                         let applied = await surfaceView.processOutputAndWait(
                             chunk.data,
-                            terminalConfigTheme: chunk.terminalConfigTheme
+                            terminalConfigTheme: chunk.terminalConfigTheme,
+                            pushesLocalScrollbackRows: chunk.sourceRenderGridFrame?.scrolledRows ?? 0
                         )
                         guard applied else {
                             store.terminalOutputDidReset(
@@ -1089,7 +1090,8 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             if !chunk.data.isEmpty || chunk.terminalConfigTheme != nil {
                 let applied = await surfaceView.processOutputAndWait(
                     chunk.data,
-                    terminalConfigTheme: chunk.terminalConfigTheme
+                    terminalConfigTheme: chunk.terminalConfigTheme,
+                    pushesLocalScrollbackRows: chunk.sourceRenderGridFrame?.scrolledRows ?? 0
                 )
                 guard !Task.isCancelled else { return false }
                 guard applied else {

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+LocalPixelScroll.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+LocalPixelScroll.swift
@@ -85,6 +85,7 @@ extension GhosttySurfaceView {
         let workQueue = outputQueue
         let gate = viewportRestoreGate
         let pixelState = localPixelScrollState
+        let pushedRowsCounter = localScrollbackRowsPushed
         #if DEBUG
         let enqueuedAt = CACurrentMediaTime()
         #endif
@@ -96,7 +97,8 @@ extension GhosttySurfaceView {
                 operation: operation,
                 deltaPixels: deltaPixels,
                 rebaseFromHeldPosition: rebaseFromHeldPosition,
-                pixelState: pixelState
+                pixelState: pixelState,
+                pushedRowsCounter: pushedRowsCounter
             )
             gate.withLock {
                 $0.appliedInteractionGeneration = max(
@@ -167,7 +169,10 @@ extension GhosttySurfaceView {
         operation: LocalPixelScrollSurfaceOperation,
         deltaPixels: Double,
         rebaseFromHeldPosition: Bool,
-        pixelState: OSAllocatedUnfairLock<LocalPixelScrollState>
+        pixelState: OSAllocatedUnfairLock<LocalPixelScrollState>,
+        // lint:allow lock - the view's cumulative push counter threaded to the
+        // serial batch; same discipline as pixelState above.
+        pushedRowsCounter: OSAllocatedUnfairLock<UInt64>
     ) {
         let size = ghostty_surface_size(operation.surface)
         let cellHeightPx = Double(size.cell_height_px)
@@ -187,18 +192,30 @@ extension GhosttySurfaceView {
             let total = scrollbar.total
             let len = min(scrollbar.len, total)
             let maxPosition = Double(total - len) * cellHeightPx
+            let rowsPushedNow = pushedRowsCounter.withLock { $0 }
             // Mid-gesture the held position is the authority: a verified
             // replay may have reset the live viewport to the bottom between
             // batches, and deriving from it would make the reset hijack the
             // gesture. The exact (unrounded) position carries sub-pixel
-            // deltas across batches, and the anchor is only trusted while
-            // its row space is unchanged: replays repaint in place and keep
-            // the revision, while eviction or reflow renumber rows, so a
-            // revision change falls back to the live viewport.
+            // deltas across batches. A held position from an older row-space
+            // revision is first rebased content-true: pushes beyond growth
+            // evicted rows from the top of a capped scrollback, so the same
+            // content sits that many rows higher. Only an unreconcilable
+            // space (rebuilt, shrunk) falls back to the live viewport.
             let current: Double
             if rebaseFromHeldPosition, let held,
                held.revision == scrollbar.row_space_revision {
                 current = min(held.positionPx, maxPosition)
+            } else if rebaseFromHeldPosition, let held,
+                      let corrected = GhosttySurfaceView.LocalPixelScrollState.rebasedHeldPositionPx(
+                          heldPositionPx: held.positionPx,
+                          heldTotal: held.total,
+                          heldRowsPushed: held.rowsPushed,
+                          scrollbarTotal: total,
+                          rowsPushedNow: rowsPushedNow,
+                          cellHeightPx: cellHeightPx
+                      ) {
+                current = min(corrected, maxPosition)
             } else {
                 current = min(Double(scrollbar.offset) * cellHeightPx + remainder, maxPosition)
             }
@@ -256,18 +273,19 @@ extension GhosttySurfaceView {
                         remainderPx: appliedOffset,
                         positionPx: appliedPosition,
                         revision: appliedRevision,
-                        total: appliedTotal
+                        total: appliedTotal,
+                        rowsPushed: rowsPushedNow
                     )
                 }
                 return
             }
-            // Content changed shape mid-batch; rebase once from the live
-            // viewport with a zeroed remainder (held row numbers are no
-            // longer trustworthy in the new row space). The reveal survives:
-            // it is presentation-space, not row-space, so a reflow does not
+            // Content changed shape mid-batch; retry once with a zeroed
+            // remainder. The held position stays: the next iteration's fresh
+            // scrollbar and push counter rebase it content-true, or reject it
+            // and fall back to the live viewport. The reveal survives: it is
+            // presentation-space, not row-space, so a reflow does not
             // invalidate how far the render has slid.
             remainder = 0
-            held = nil
         }
         // Two mismatches in one batch: same units the legacy line path derives
         // from `enqueueScrollMechanicsDelta` (points = px/scale, divisor 3x

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+ThemeOutput.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+ThemeOutput.swift
@@ -25,19 +25,27 @@ extension GhosttySurfaceView {
     /// - Parameters:
     ///   - data: VT or PTY bytes to feed into the surface.
     ///   - terminalConfigTheme: Raw Ghostty defaults captured with these bytes.
+    ///   - pushesLocalScrollbackRows: Rows this chunk's scroll prologue pushes
+    ///     into local scrollback (a screen-anchored delta's `scrolledRows`),
+    ///     accounted into the view's cumulative push counter as the bytes apply.
     /// - Returns: `true` when the operation reached the current surface generation,
     ///   or `false` when the caller should reset its delivery queue and replay.
     @discardableResult
     public func processOutputAndWait(
         _ data: Data,
-        terminalConfigTheme: TerminalTheme?
+        terminalConfigTheme: TerminalTheme?,
+        pushesLocalScrollbackRows: Int = 0
     ) async -> Bool {
         await withCheckedContinuation { continuation in
             let operationID = registerPendingOutputApply(
                 byteCount: data.count,
                 continuation: continuation
             )
-            processOutput(data, terminalConfigTheme: terminalConfigTheme) { [weak self] applied in
+            processOutput(
+                data,
+                terminalConfigTheme: terminalConfigTheme,
+                pushesLocalScrollbackRows: pushesLocalScrollbackRows
+            ) { [weak self] applied in
                 self?.completePendingOutputApply(id: operationID, returning: applied)
             }
         }

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+VerifiedReplay.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+VerifiedReplay.swift
@@ -35,6 +35,7 @@ extension GhosttySurfaceView {
         )
         let workQueue = outputQueue
         let gate = viewportRestoreGate
+        let pushedRowsCounter = localScrollbackRowsPushed
         return await withCheckedContinuation { continuation in
             let operationID = registerPendingVerifiedReplayViewportAnchorCapture(
                 continuation: continuation
@@ -53,7 +54,8 @@ extension GhosttySurfaceView {
                         captured = VerifiedReplayViewportAnchor(
                             scrollbarTotal: scrollbar.total,
                             offset: scrollbar.offset,
-                            len: scrollbar.len
+                            len: scrollbar.len,
+                            rowsPushedAtCapture: pushedRowsCounter.withLock { $0 }
                         ).map {
                             VerifiedReplayCapturedViewportAnchor(
                                 anchor: $0,
@@ -110,6 +112,7 @@ extension GhosttySurfaceView {
         )
         let workQueue = outputQueue
         let gate = viewportRestoreGate
+        let pushedRowsCounter = localScrollbackRowsPushed
         return await withCheckedContinuation { continuation in
             let operationID = registerPendingVerifiedReplayViewportAnchorRestore(
                 continuation: continuation
@@ -120,10 +123,15 @@ extension GhosttySurfaceView {
                     operation.surface,
                     &postReplay
                 )
+                let rowsPushedNow = pushedRowsCounter.withLock { $0 }
+                let rowsPushedSinceCapture = rowsPushedNow >= anchor.rowsPushedAtCapture
+                    ? rowsPushedNow - anchor.rowsPushedAtCapture
+                    : 0
                 let targetTopRow = readPostReplay
                     ? anchor.targetTopRow(
                         postReplayTotalRows: postReplay.total,
-                        postReplayVisibleRows: postReplay.len
+                        postReplayVisibleRows: postReplay.len,
+                        rowsPushedSinceCapture: rowsPushedSinceCapture
                     )
                     : nil
                 let postReplayRevision = postReplay.row_space_revision
@@ -155,7 +163,7 @@ extension GhosttySurfaceView {
                 }
                 if readPostReplay {
                     MobileDebugLog.anchormux(
-                        "verified_replay.viewport_restore preTotal=\(anchor.totalRows) preTopDistance=\(anchor.topRowDistanceFromBottom) postTotal=\(postReplay.total) postOffset=\(postReplay.offset) postLen=\(postReplay.len) targetTop=\(targetTopRow.map(String.init) ?? "nil") restored=\(restored)"
+                        "verified_replay.viewport_restore preTotal=\(anchor.totalRows) preTopDistance=\(anchor.topRowDistanceFromBottom) postTotal=\(postReplay.total) postOffset=\(postReplay.offset) postLen=\(postReplay.len) pushed=\(rowsPushedSinceCapture) targetTop=\(targetTopRow.map(String.init) ?? "nil") restored=\(restored)"
                     )
                 }
                 Task { @MainActor [weak self] in

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -319,7 +319,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         /// sub-pixel deltas accumulate across batches; `remainderPx` is the
         /// whole-pixel offset actually applied to Ghostty. `revision` guards
         /// the row space: the held anchor is only valid while it matches.
-        var lastApplied: (row: UInt64, remainderPx: Double, positionPx: Double, revision: UInt64, total: UInt64)?
+        var lastApplied: (row: UInt64, remainderPx: Double, positionPx: Double, revision: UInt64, total: UInt64, rowsPushed: UInt64)?
         /// Device pixels of scroll-top reveal: how far past scrollback-top
         /// the gesture has pulled, realized by the host sliding the
         /// bottom-pinned render back down to uncover the rows the keyboard-up
@@ -335,9 +335,20 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     }
     nonisolated let localPixelScrollState =
         OSAllocatedUnfairLock<LocalPixelScrollState>(initialState: .init())
+    /// Cumulative rows this view has pushed into its local mirror's scrollback
+    /// (the line feeds of screen-anchored delta prologues). Incremented on the
+    /// serial output queue as each chunk applies, and read there by viewport
+    /// anchor capture/restore and pixel-scroll batches, so reads are exactly
+    /// ordered against the pushes they account for. Below the scrollback cap a
+    /// push grows the row space; at the cap it evicts a retained top row, which
+    /// totals alone cannot distinguish — this counter can.
+    // lint:allow lock - one cumulative row counter shared between the main
+    // actor and the serial output queue; same discipline as viewportRestoreGate.
+    nonisolated let localScrollbackRowsPushed =
+        OSAllocatedUnfairLock<UInt64>(initialState: 0)
     #if DEBUG
     /// Last pixel-precise viewport position the pixel pump applied.
-    var debugLastPixelScroll: (row: UInt64, remainderPx: Double, positionPx: Double, revision: UInt64, total: UInt64)? {
+    var debugLastPixelScroll: (row: UInt64, remainderPx: Double, positionPx: Double, revision: UInt64, total: UInt64, rowsPushed: UInt64)? {
         localPixelScrollState.withLock { $0.lastApplied }
     }
     #endif
@@ -3030,6 +3041,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     func processOutput(
         _ data: Data,
         terminalConfigTheme outputConfigTheme: TerminalTheme? = nil,
+        pushesLocalScrollbackRows: Int = 0,
         completion: (@MainActor @Sendable (Bool) -> Void)?
     ) {
         guard !renderPipelineRecoveryPaused else {
@@ -3078,6 +3090,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // the main thread. Feed it on a serial background queue (order
         // preserved) and hop back to main only for the Swift-side UI state.
         let workQueue = outputQueue
+        let pushedRowsCounter = localScrollbackRowsPushed
         workQueue.async { [weak self] in
             if let preparedConfigBits,
                let preparedConfig = ghostty_config_t(bitPattern: preparedConfigBits) {
@@ -3091,6 +3104,13 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
                 guard let baseAddress = buffer.baseAddress else { return }
                 let pointer = baseAddress.assumingMemoryBound(to: CChar.self)
                 ghostty_surface_process_output(surface, pointer, UInt(buffer.count))
+            }
+            // Account for this chunk's scroll-prologue pushes at the exact
+            // queue position they landed, so an anchor capture or pixel batch
+            // queued before/after this block reads a counter consistent with
+            // the row space it observes.
+            if pushesLocalScrollbackRows > 0 {
+                pushedRowsCounter.withLock { $0 &+= UInt64(pushesLocalScrollbackRows) }
             }
             #if DEBUG
             // Perf probe for the scroll-hitch investigation: a VT apply on this

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/LocalPixelScrollHeldRebase.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/LocalPixelScrollHeldRebase.swift
@@ -36,7 +36,19 @@ extension GhosttySurfaceView.LocalPixelScrollState {
         rowsPushedNow: UInt64,
         cellHeightPx: Double
     ) -> Double? {
-        nil
+        guard cellHeightPx > 0 else { return nil }
+        // A shrunk total means the row space was rebuilt (hydration, reset);
+        // held row numbers do not survive it. A rewound counter means the
+        // held value belongs to another counting epoch.
+        guard scrollbarTotal >= heldTotal else { return nil }
+        guard rowsPushedNow >= heldRowsPushed else { return nil }
+        let growth = scrollbarTotal - heldTotal
+        let pushed = rowsPushedNow - heldRowsPushed
+        // Pushes absorbed as growth leave top offsets unchanged; only the
+        // remainder evicted retained rows and shifted content upward.
+        guard pushed > growth else { return heldPositionPx }
+        let evicted = pushed - growth
+        return max(0, heldPositionPx - Double(evicted) * cellHeightPx)
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/LocalPixelScrollHeldRebase.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/LocalPixelScrollHeldRebase.swift
@@ -1,0 +1,42 @@
+#if canImport(UIKit)
+
+/// Content-true rebase for a gesture's held pixel-scroll position after the
+/// row space changed underneath it.
+///
+/// A held position is an offset from the top of local scrollback. While the
+/// scrollback is below its cap that offset is content-stable, but once the cap
+/// is reached every pushed row evicts retained rows from the top and the same
+/// offset names newer content. `row_space_revision` changes on eviction, so a
+/// revision-mismatched held position must not be re-applied verbatim; falling
+/// back to the live viewport is also wrong mid-gesture, because a verified
+/// replay may have just reset the live viewport to the bottom.
+///
+/// This decision is pure so the rebase arithmetic is unit-testable without a
+/// Ghostty surface.
+extension GhosttySurfaceView.LocalPixelScrollState {
+    /// Rebases a revision-mismatched held position onto the current row space.
+    ///
+    /// - Parameters:
+    ///   - heldPositionPx: The held content-space position (offset from
+    ///     scrollback top, in device pixels).
+    ///   - heldTotal: The row-space total when the held position was applied.
+    ///   - heldRowsPushed: Cumulative local scrollback pushes when the held
+    ///     position was applied.
+    ///   - scrollbarTotal: The live row-space total.
+    ///   - rowsPushedNow: Cumulative local scrollback pushes now.
+    ///   - cellHeightPx: Cell height in device pixels.
+    /// - Returns: The content-true position in the current row space, or `nil`
+    ///   when the row spaces cannot be reconciled (rebuilt or shrunk space,
+    ///   incoherent counters) and the live viewport must be trusted instead.
+    static func rebasedHeldPositionPx(
+        heldPositionPx: Double,
+        heldTotal: UInt64,
+        heldRowsPushed: UInt64,
+        scrollbarTotal: UInt64,
+        rowsPushedNow: UInt64,
+        cellHeightPx: Double
+    ) -> Double? {
+        nil
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/VerifiedReplayViewportAnchor.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/VerifiedReplayViewportAnchor.swift
@@ -4,15 +4,25 @@ public struct VerifiedReplayViewportAnchor: Equatable, Sendable {
     public let topRowDistanceFromBottom: UInt64
     /// The total row-space size when the viewport was captured.
     public let totalRows: UInt64
+    /// Cumulative rows the consumer had pushed into local scrollback when the
+    /// viewport was captured. Restores diff this against the live counter to
+    /// recover eviction the scrollback cap hides from ``totalRows``.
+    public let rowsPushedAtCapture: UInt64
 
     /// Creates a viewport anchor from content-relative row-space values.
     ///
     /// - Parameters:
     ///   - topRowDistanceFromBottom: Rows from the viewport top to content bottom.
     ///   - totalRows: Total row-space size at capture time.
-    public init(topRowDistanceFromBottom: UInt64, totalRows: UInt64) {
+    ///   - rowsPushedAtCapture: Cumulative local scrollback pushes at capture time.
+    public init(
+        topRowDistanceFromBottom: UInt64,
+        totalRows: UInt64,
+        rowsPushedAtCapture: UInt64 = 0
+    ) {
         self.topRowDistanceFromBottom = topRowDistanceFromBottom
         self.totalRows = totalRows
+        self.rowsPushedAtCapture = rowsPushedAtCapture
     }
 
     /// Creates an anchor when a scrollbar snapshot is above the content bottom.
@@ -24,14 +34,21 @@ public struct VerifiedReplayViewportAnchor: Equatable, Sendable {
     ///   - scrollbarTotal: Total row-space size at capture time.
     ///   - offset: Top visible row at capture time.
     ///   - len: Number of visible rows at capture time.
+    ///   - rowsPushedAtCapture: Cumulative local scrollback pushes at capture time.
     /// - Returns: An anchor above bottom, or `nil` at or below bottom.
-    public init?(scrollbarTotal: UInt64, offset: UInt64, len: UInt64) {
+    public init?(
+        scrollbarTotal: UInt64,
+        offset: UInt64,
+        len: UInt64,
+        rowsPushedAtCapture: UInt64 = 0
+    ) {
         guard offset < scrollbarTotal else { return nil }
         let rowsAfterOffset = scrollbarTotal - offset
         guard len < rowsAfterOffset else { return nil }
         self.init(
             topRowDistanceFromBottom: rowsAfterOffset,
-            totalRows: scrollbarTotal
+            totalRows: scrollbarTotal,
+            rowsPushedAtCapture: rowsPushedAtCapture
         )
     }
 
@@ -48,6 +65,27 @@ public struct VerifiedReplayViewportAnchor: Equatable, Sendable {
     public func targetTopRow(
         postReplayTotalRows: UInt64,
         postReplayVisibleRows: UInt64
+    ) -> UInt64? {
+        targetTopRow(
+            postReplayTotalRows: postReplayTotalRows,
+            postReplayVisibleRows: postReplayVisibleRows,
+            rowsPushedSinceCapture: 0
+        )
+    }
+
+    /// Computes the post-replay top row that preserves the captured content,
+    /// including content the scrollback cap evicted while rows were pushed.
+    ///
+    /// - Parameters:
+    ///   - postReplayTotalRows: Total row-space size after replay.
+    ///   - postReplayVisibleRows: Number of rows visible after replay.
+    ///   - rowsPushedSinceCapture: Rows pushed into local scrollback between
+    ///     this anchor's capture and the restore.
+    /// - Returns: The clamped target top row, or `nil` for natural bottom follow.
+    public func targetTopRow(
+        postReplayTotalRows: UInt64,
+        postReplayVisibleRows: UInt64,
+        rowsPushedSinceCapture: UInt64
     ) -> UInt64? {
         guard topRowDistanceFromBottom > 0 else { return nil }
 

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/VerifiedReplayViewportAnchor.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/VerifiedReplayViewportAnchor.swift
@@ -76,6 +76,13 @@ public struct VerifiedReplayViewportAnchor: Equatable, Sendable {
     /// Computes the post-replay top row that preserves the captured content,
     /// including content the scrollback cap evicted while rows were pushed.
     ///
+    /// Every row pushed through the grid either grows the row space (below the
+    /// cap) or evicts a retained row from the top (at the cap), so the total
+    /// drift between capture and restore is `max(growth, rowsPushed)`. A row
+    /// space that shrank below the captured total was rebuilt (hydration), and
+    /// local push accounting cannot place content in it; that case keeps the
+    /// growth-canceled distance-from-bottom fallback.
+    ///
     /// - Parameters:
     ///   - postReplayTotalRows: Total row-space size after replay.
     ///   - postReplayVisibleRows: Number of rows visible after replay.
@@ -92,9 +99,13 @@ public struct VerifiedReplayViewportAnchor: Equatable, Sendable {
         let maximumTopRow = postReplayTotalRows > postReplayVisibleRows
             ? postReplayTotalRows - postReplayVisibleRows
             : 0
-        let drift = postReplayTotalRows > totalRows
-            ? postReplayTotalRows - totalRows
-            : 0
+        let drift: UInt64
+        if postReplayTotalRows >= totalRows {
+            let growth = postReplayTotalRows - totalRows
+            drift = max(growth, rowsPushedSinceCapture)
+        } else {
+            drift = 0
+        }
 
         guard topRowDistanceFromBottom <= postReplayTotalRows else { return 0 }
         let topRowBeforeDrift = postReplayTotalRows - topRowDistanceFromBottom

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/LocalPixelScrollHeldRebaseTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/LocalPixelScrollHeldRebaseTests.swift
@@ -1,0 +1,109 @@
+import Testing
+
+@testable import CmuxMobileTerminal
+
+@Suite("Local pixel scroll held rebase")
+struct LocalPixelScrollHeldRebaseTests {
+    private let cellHeightPx = 20.0
+
+    @Test("eviction at the cap slides the held position up by the evicted rows")
+    func evictionAtCapFollowsContent() {
+        // Pegged at the cap: 30 rows pushed with zero growth means 30 rows
+        // evicted from the top, so the same content is 30 rows (600px) higher.
+        let corrected = GhosttySurfaceView.LocalPixelScrollState.rebasedHeldPositionPx(
+            heldPositionPx: 20_000,
+            heldTotal: 4_000,
+            heldRowsPushed: 100,
+            scrollbarTotal: 4_000,
+            rowsPushedNow: 130,
+            cellHeightPx: cellHeightPx
+        )
+
+        #expect(corrected == 20_000 - 30 * cellHeightPx)
+    }
+
+    @Test("growth below the cap keeps the held position unchanged")
+    func growthBelowCapKeepsPosition() {
+        let corrected = GhosttySurfaceView.LocalPixelScrollState.rebasedHeldPositionPx(
+            heldPositionPx: 20_000,
+            heldTotal: 3_000,
+            heldRowsPushed: 100,
+            scrollbarTotal: 3_050,
+            rowsPushedNow: 150,
+            cellHeightPx: cellHeightPx
+        )
+
+        #expect(corrected == 20_000)
+    }
+
+    @Test("partial eviction subtracts only the pushes beyond growth")
+    func partialEvictionSubtractsRemainder() {
+        // 50 pushed, 20 absorbed as growth to the cap, 30 evicted.
+        let corrected = GhosttySurfaceView.LocalPixelScrollState.rebasedHeldPositionPx(
+            heldPositionPx: 20_000,
+            heldTotal: 3_980,
+            heldRowsPushed: 100,
+            scrollbarTotal: 4_000,
+            rowsPushedNow: 150,
+            cellHeightPx: cellHeightPx
+        )
+
+        #expect(corrected == 20_000 - 30 * cellHeightPx)
+    }
+
+    @Test("eviction past the held content clamps to the scrollback top")
+    func evictionPastHeldContentClampsToTop() {
+        let corrected = GhosttySurfaceView.LocalPixelScrollState.rebasedHeldPositionPx(
+            heldPositionPx: 100,
+            heldTotal: 4_000,
+            heldRowsPushed: 0,
+            scrollbarTotal: 4_000,
+            rowsPushedNow: 50,
+            cellHeightPx: cellHeightPx
+        )
+
+        #expect(corrected == 0)
+    }
+
+    @Test("a shrunk row space cannot be reconciled")
+    func shrunkRowSpaceIsUntrusted() {
+        let corrected = GhosttySurfaceView.LocalPixelScrollState.rebasedHeldPositionPx(
+            heldPositionPx: 20_000,
+            heldTotal: 4_000,
+            heldRowsPushed: 100,
+            scrollbarTotal: 200,
+            rowsPushedNow: 150,
+            cellHeightPx: cellHeightPx
+        )
+
+        #expect(corrected == nil)
+    }
+
+    @Test("a rewound push counter cannot be reconciled")
+    func rewoundCounterIsUntrusted() {
+        let corrected = GhosttySurfaceView.LocalPixelScrollState.rebasedHeldPositionPx(
+            heldPositionPx: 20_000,
+            heldTotal: 4_000,
+            heldRowsPushed: 100,
+            scrollbarTotal: 4_000,
+            rowsPushedNow: 50,
+            cellHeightPx: cellHeightPx
+        )
+
+        #expect(corrected == nil)
+    }
+
+    @Test("a degenerate cell height cannot be reconciled")
+    func degenerateCellHeightIsUntrusted() {
+        let corrected = GhosttySurfaceView.LocalPixelScrollState.rebasedHeldPositionPx(
+            heldPositionPx: 20_000,
+            heldTotal: 4_000,
+            heldRowsPushed: 100,
+            scrollbarTotal: 4_000,
+            rowsPushedNow: 130,
+            cellHeightPx: 0
+        )
+
+        #expect(corrected == nil)
+    }
+}

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/ScrollTopRevealClearTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/ScrollTopRevealClearTests.swift
@@ -23,7 +23,7 @@ struct ScrollTopRevealClearTests {
         let staleEpoch = view.localPixelScrollState.withLock { state -> UInt64 in
             state.topRevealPx = 240
             state.remainderPx = 3
-            state.lastApplied = (row: 0, remainderPx: 0, positionPx: 0, revision: 7, total: 90)
+            state.lastApplied = (row: 0, remainderPx: 0, positionPx: 0, revision: 7, total: 90, rowsPushed: 0)
             return state.epoch
         }
 
@@ -49,7 +49,7 @@ struct ScrollTopRevealClearTests {
 
         let seeded = view.localPixelScrollState.withLock { state -> UInt64 in
             state.remainderPx = 5
-            state.lastApplied = (row: 12, remainderPx: 5, positionPx: 245, revision: 7, total: 90)
+            state.lastApplied = (row: 12, remainderPx: 5, positionPx: 245, revision: 7, total: 90, rowsPushed: 0)
             return state.epoch
         }
 

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/VerifiedReplayViewportAnchorTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/VerifiedReplayViewportAnchorTests.swift
@@ -92,7 +92,7 @@ struct VerifiedReplayViewportAnchorTests {
         #expect(anchor.targetTopRow(postReplayTotalRows: 115, postReplayVisibleRows: 20) == 50)
     }
 
-    @Test("a capped row space preserves distance from bottom")
+    @Test("a capped row space without push accounting preserves distance from bottom")
     func cappedHistoryDegradesToDistanceFromBottom() {
         let anchor = VerifiedReplayViewportAnchor(
             topRowDistanceFromBottom: 55,
@@ -100,6 +100,100 @@ struct VerifiedReplayViewportAnchorTests {
         )
 
         #expect(anchor.targetTopRow(postReplayTotalRows: 200, postReplayVisibleRows: 25) == 145)
+    }
+
+    @Test("pushes at the scrollback cap follow the evicted content upward")
+    func cappedEvictionFollowsContent() {
+        // Pegged at a 4,000-row cap: 250 rows pushed through the grid while
+        // the total stayed flat means 250 retained rows were evicted from the
+        // top, so the captured content now lives 250 rows higher.
+        let anchor = VerifiedReplayViewportAnchor(
+            topRowDistanceFromBottom: 3_000,
+            totalRows: 4_000,
+            rowsPushedAtCapture: 1_000
+        )
+
+        #expect(
+            anchor.targetTopRow(
+                postReplayTotalRows: 4_000,
+                postReplayVisibleRows: 54,
+                rowsPushedSinceCapture: 250
+            ) == 750
+        )
+    }
+
+    @Test("below the cap, pushes equal growth and the target is unchanged")
+    func belowCapPushesMatchGrowth() {
+        let anchor = VerifiedReplayViewportAnchor(
+            topRowDistanceFromBottom: 50,
+            totalRows: 100,
+            rowsPushedAtCapture: 500
+        )
+
+        #expect(
+            anchor.targetTopRow(
+                postReplayTotalRows: 115,
+                postReplayVisibleRows: 20,
+                rowsPushedSinceCapture: 15
+            ) == 50
+        )
+    }
+
+    @Test("reaching the cap mid-window follows content by the evicted remainder")
+    func reachingCapMidWindowFollowsContent() {
+        // 400 rows pushed while the total only grew by 100: the last 300
+        // pushes evicted retained rows, so the content sits 300 rows higher
+        // than the pure growth-canceled target.
+        let anchor = VerifiedReplayViewportAnchor(
+            topRowDistanceFromBottom: 3_000,
+            totalRows: 3_900,
+            rowsPushedAtCapture: 0
+        )
+
+        #expect(
+            anchor.targetTopRow(
+                postReplayTotalRows: 4_000,
+                postReplayVisibleRows: 54,
+                rowsPushedSinceCapture: 400
+            ) == 600
+        )
+    }
+
+    @Test("evicting past the captured content clamps to the scrollback top")
+    func evictionPastCapturedContentClampsToTop() {
+        let anchor = VerifiedReplayViewportAnchor(
+            topRowDistanceFromBottom: 3_900,
+            totalRows: 4_000,
+            rowsPushedAtCapture: 0
+        )
+
+        #expect(
+            anchor.targetTopRow(
+                postReplayTotalRows: 4_000,
+                postReplayVisibleRows: 54,
+                rowsPushedSinceCapture: 500
+            ) == 0
+        )
+    }
+
+    @Test("a rebuilt shorter row space keeps the growth-canceled fallback")
+    func rebuiltRowSpaceKeepsFallback() {
+        // Hydration collapsed the row space below the captured total; the
+        // pushed-rows correction cannot place content in a rebuilt space, so
+        // the target degrades to the growth-canceled distance from bottom.
+        let anchor = VerifiedReplayViewportAnchor(
+            topRowDistanceFromBottom: 55,
+            totalRows: 4_000,
+            rowsPushedAtCapture: 100
+        )
+
+        #expect(
+            anchor.targetTopRow(
+                postReplayTotalRows: 200,
+                postReplayVisibleRows: 25,
+                rowsPushedSinceCapture: 40
+            ) == 145
+        )
     }
 
     @Test("a distance beyond available history clamps to the top")


### PR DESCRIPTION
Fixes item 1 of https://github.com/manaflow-ai/cmux/issues/9143: with the local mirror's scrollback pegged at its cap, a scrolled-up viewport was pushed down over newer content as output streamed, both while idle and mid-gesture.

Every row a screen-anchored delta pushes through the grid either grows the local row space (below the cap) or evicts a retained row from the top (at the cap). Two paths only accounted for growth:

- The verified-replay anchor restore canceled growth but preserved distance-from-bottom at the cap, so each replay restored the viewport `scrolledRows` lower in content space. Observed in the issue as lines 4,354,666 → 4,362,346 at one offset over a 20s hold.
- Mid-gesture, eviction bumps `row_space_revision`, the held pixel-scroll position fails the revision gate, and the batch rebased from the live viewport that a full replay's alternate-screen roundtrip had just reset to the bottom.

The fix keeps a per-surface cumulative counter of rows pushed into local scrollback, incremented on the serial output queue as each chunk's scroll prologue applies (`frame.scrolledRows`), so counter reads by anchor capture/restore and pixel batches on the same queue are exactly ordered against the pushes they account for. Anchor restores now subtract `max(growth, pushedSinceCapture)`; a revision-mismatched held gesture position is rebased by the same arithmetic through the pure `LocalPixelScrollState.rebasedHeldPositionPx` decision. Rebuilt row spaces (hydration collapse) and rewound counters are detected and keep the previous growth-canceled fallback, since local push accounting cannot place content in a rebuilt space; content-true anchoring across hydration still needs the producer-side counter tracked in the issue.

This is a principled fix: it reconstructs the producer's monotonic scrolled-rows counter client-side (the approach the issue proposed) rather than patching a symptom. Residual risk: windows that span a hydrating full keep today's distance-from-bottom behavior.

Commit 1 adds the failing tests plus the inert API they compile against (stubs preserve old behavior so the new expectations are red); commit 2 adds the fix. The hosted `iOS simulator tests` lane cannot prove this right now: it is red on current main before any test runs (`cmuxFeatureTests/MobileIrohRuntimeComposition*Tests` no longer conform to the current broker protocols, and `package-conventions-lint` has 43 pre-existing violations). Red/green was instead proven on a leased fleet Mac (cmux-app-review-mac, iPhone 17 / iOS 26.3 simulator, `xcodebuild test` scoped to the CmuxMobileTerminal package): commit 1 (2107bdae8e) fails with 7 issues, all of them the new content-true expectations; commit 2 (6fca0a311a) passes the full `Test run with 21 tests in 2 suites`. This branch adds zero lint violations (43 before and after; the new lock and helper are annotated/scoped per convention).

Builds of this branch also need https://github.com/manaflow-ai/cmux/pull/11187 (main's macOS compile is broken by an unrelated bonsplit pin revert); the tagged dogfood build uses a throwaway `ctru-build` branch = this head + that pin bump.

HIG: scroll views must keep content stable under the user's finger and not move it unexpectedly while new content arrives (https://developer.apple.com/design/human-interface-guidelines/scroll-views).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

