### PR TITLE
iOS: opening a workspace restores its last opened tab

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -483,6 +483,12 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// Mac, then phone-owned. `@ObservationIgnored` (views read `workspaceGroups`);
     /// injected so tests/previews can pass a suite-scoped `UserDefaults`.
     @ObservationIgnored var groupCollapseStore: MobileWorkspaceGroupCollapseStore
+    /// Device-local last-opened-tab memory per workspace, so opening a
+    /// workspace restores the tab the phone last showed there instead of
+    /// re-deriving from the Mac's moving focus. `@ObservationIgnored` (views
+    /// read the selection properties); injected so tests/previews can pass a
+    /// suite-scoped `UserDefaults` or ``MobileWorkspaceLastTabStore/inMemory``.
+    @ObservationIgnored var lastTabStore: MobileWorkspaceLastTabStore
     /// Device-local sort preference for the aggregated All Computers list
     /// (mode + user computer order). `@ObservationIgnored`: views read the
     /// observable ``workspaceSortMode`` / ``workspaceComputerPriority``
@@ -857,7 +863,12 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// terminal, or nil when the terminal is visible. Independent of
     /// ``selectedTerminalID`` (so dismissing the surface returns to the same
     /// terminal and composer draft) and cleared when the workspace changes.
-    public var selectedMacSurfaceID: MobileSurfacePreview.ID?
+    public var selectedMacSurfaceID: MobileSurfacePreview.ID? {
+        didSet {
+            guard selectedMacSurfaceID != oldValue, let selectedMacSurfaceID else { return }
+            recordLastOpenedMacSurfaceTab(selectedMacSurfaceID)
+        }
+    }
     /// The terminal whose surface (and composer draft) is currently shown.
     ///
     /// Changing it swaps the composer draft: `willSet` captures the outgoing
@@ -879,6 +890,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     .surfaceFocused,
                     correlationID: selectedTerminalID.rawValue
                 )
+                recordLastOpenedTerminalTab(selectedTerminalID)
             }
             swapDraft(from: draftedOutgoingTerminalID, outgoingText: draftedOutgoingText, to: selectedTerminalID)
             draftedOutgoingTerminalID = nil
@@ -1689,6 +1701,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         feedbackStampProvider: @escaping @MainActor () -> MobileFeedbackStamp = { MobileShellComposite.emptyFeedbackStamp },
         draftStore: (any TerminalDraftStoring)? = nil,
         groupCollapseStore: MobileWorkspaceGroupCollapseStore = MobileWorkspaceGroupCollapseStore(),
+        // In-memory by default so tests and previews that construct the
+        // composite directly never leak last-tab state through `.standard`
+        // (persisted restore would make selection tests history-dependent);
+        // the app's composition root injects the persistent store.
+        lastTabStore: MobileWorkspaceLastTabStore = .inMemory,
         workspaceSortStore: MobileWorkspaceSortStore = MobileWorkspaceSortStore(),
         workspaceChangesHintDismissalStore: MobileWorkspaceChangesHintDismissalStore = MobileWorkspaceChangesHintDismissalStore(),
         workspaceChangesSchedulingClock: any Clock<Duration> = ContinuousClock(),
@@ -1705,6 +1722,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         self.runtime = runtime
         self.draftStore = draftStore
         self.groupCollapseStore = groupCollapseStore
+        self.lastTabStore = lastTabStore
         self.workspaceSortStore = workspaceSortStore
         self.workspaceSortMode = workspaceSortStore.mode
         self.workspaceComputerPriority = workspaceSortStore.computerPriority
@@ -1912,6 +1930,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
 
     public static func preview(
         runtime: (any MobileSyncRuntime)? = nil,
+        // In-memory so previews and package tests never share persisted
+        // last-tab state through `.standard` (the app injects a persistent
+        // store through the composite initializer instead).
+        lastTabStore: MobileWorkspaceLastTabStore = .inMemory,
         terminalInputAckResubscribeClock: any Clock<Duration> = ContinuousClock(),
         controlPlaneSchedulingClock: any Clock<Duration> = ContinuousClock()
     ) -> CMUXMobileShellStore {
@@ -1919,6 +1941,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             runtime: runtime,
             workspaces: PreviewMobileHost.workspaces,
             deliveredNotificationClearer: NoopDeliveredNotificationClearer(),
+            lastTabStore: lastTabStore,
             controlPlaneSchedulingClock: controlPlaneSchedulingClock,
             terminalInputAckResubscribeClock: terminalInputAckResubscribeClock
         )
@@ -8002,6 +8025,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         if id != selectedTerminalID {
             terminalAutoFocusSuppressedSurfaceIDs.insert(id.rawValue)
         }
+        // Re-confirming the already-selected terminal is still an explicit tab
+        // open (returning from a Mac surface to the terminal picker's checked
+        // row), so the last-opened-tab memory must move off the surface even
+        // though the selection below is unchanged.
+        recordLastOpenedTerminalTab(id)
         guard selectedTerminalID != id else { return }
         selectedTerminalID = id
         recordAppEvent(
@@ -11181,6 +11209,20 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         if let selectedTerminalID,
            let selectedTerminal = selectedWorkspace.terminals.first(where: { $0.id == selectedTerminalID }),
            selectedTerminal.isReady || !selectedWorkspace.hasReadyTerminal {
+            // A held valid selection is the workspace's displayed tab; keep the
+            // last-opened-tab memory tracking it (selections that landed before
+            // the workspace id, like push deep links, only become attributable
+            // here). Skip while a stream or Mac surface owns the frame: the
+            // terminal selection is then background state, not the shown tab.
+            if !nonTerminalTabOwnsFrame(in: selectedWorkspace) {
+                recordLastOpenedTerminalTab(selectedTerminalID)
+            }
+            return
+        }
+        // The workspace needs a fresh tab decision (it was just opened, or its
+        // held tab disappeared): the tab this device last opened there wins
+        // over every Mac-focus heuristic below.
+        if restoreLastOpenedTab(in: selectedWorkspace) {
             return
         }
         // Clear stale Mac selections and promote an active or Mac-focused
@@ -11265,6 +11307,83 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
            let browserPanelID = browserStore.panels(in: workspaceID).first?.panelID {
             _ = browserStore.activate(panelID: browserPanelID, in: workspaceID)
             return
+        }
+    }
+
+    // MARK: - Last opened tab per workspace
+
+    /// True when a live stream or still-valid Mac surface owns the workspace
+    /// frame, so the selected terminal is background state rather than the
+    /// displayed tab.
+    private func nonTerminalTabOwnsFrame(in workspace: MobileWorkspacePreview) -> Bool {
+        let workspaceID = workspace.rpcWorkspaceID.rawValue
+        if simulatorStreamStore?.activeState(in: workspaceID) != nil { return true }
+        if let browserStore = browserStreamEvents as? BrowserStreamStore,
+           browserStore.activeState(in: workspaceID) != nil {
+            return true
+        }
+        if let selectedMacSurfaceID,
+           workspace.surfaces.contains(where: { $0.id == selectedMacSurfaceID && !$0.kind.isTerminal }) {
+            return true
+        }
+        return false
+    }
+
+    /// Records `terminalID` as the last opened tab of the explicitly selected
+    /// workspace. Every selection entrypoint (picker, push deep link, create
+    /// flows, the open-workspace synchronizer) funnels here through the
+    /// selection property observers, so the memory always tracks the tab the
+    /// user actually saw. Membership is checked so a selection that races a
+    /// workspace switch can never stamp another workspace's memory.
+    private func recordLastOpenedTerminalTab(_ terminalID: MobileTerminalPreview.ID) {
+        guard let workspace = explicitlySelectedWorkspace,
+              workspace.terminals.contains(where: { $0.id == terminalID }) else { return }
+        lastTabStore.set(
+            MobileWorkspaceLastTab(kind: .terminal, tabID: terminalID.rawValue),
+            for: workspace.lastTabStateID
+        )
+    }
+
+    /// Records `surfaceID` as the last opened tab of the explicitly selected
+    /// workspace; the Mac-surface sibling of ``recordLastOpenedTerminalTab(_:)``.
+    private func recordLastOpenedMacSurfaceTab(_ surfaceID: MobileSurfacePreview.ID) {
+        guard let workspace = explicitlySelectedWorkspace,
+              workspace.surfaces.contains(where: { $0.id == surfaceID && !$0.kind.isTerminal }) else { return }
+        lastTabStore.set(
+            MobileWorkspaceLastTab(kind: .macSurface, tabID: surfaceID.rawValue),
+            for: workspace.lastTabStateID
+        )
+    }
+
+    /// Restores the workspace's remembered last-opened tab, if it still
+    /// exists there. Called only from ``syncSelectedTerminalForWorkspace()``
+    /// after the keep-current check, so it runs exactly when a workspace
+    /// needs a fresh tab decision (open/reopen, or the held tab disappeared)
+    /// and never yanks a live stream or still-valid Mac surface the user is
+    /// looking at. Returns false when nothing restorable is remembered, so
+    /// the caller falls back to the Mac-focus heuristics.
+    private func restoreLastOpenedTab(in workspace: MobileWorkspacePreview) -> Bool {
+        guard !nonTerminalTabOwnsFrame(in: workspace),
+              let remembered = lastTabStore.lastTab(for: workspace.lastTabStateID) else { return false }
+        switch remembered.kind {
+        case .terminal:
+            let id = MobileTerminalPreview.ID(rawValue: remembered.tabID)
+            // Same readiness policy as the keep-current check above: a
+            // remembered tab that is not ready loses to a ready sibling.
+            guard let terminal = workspace.terminals.first(where: { $0.id == id }),
+                  terminal.isReady || !workspace.hasReadyTerminal else { return false }
+            if selectedTerminalID != id {
+                // Restoring is chrome navigation, not a typing intent: the
+                // surface must not grab the keyboard when it attaches.
+                suppressTerminalAutoFocusOnNextAttach(for: id)
+                selectedTerminalID = id
+            }
+            return true
+        case .macSurface:
+            let id = MobileSurfacePreview.ID(rawValue: remembered.tabID)
+            guard workspace.surfaces.contains(where: { $0.id == id && !$0.kind.isTerminal }) else { return false }
+            selectedMacSurfaceID = id
+            return true
         }
     }
 

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -489,6 +489,25 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// read the selection properties); injected so tests/previews can pass a
     /// suite-scoped `UserDefaults` or ``MobileWorkspaceLastTabStore/inMemory``.
     @ObservationIgnored var lastTabStore: MobileWorkspaceLastTabStore
+    /// The workspace whose last-opened tab should be restored by the next
+    /// selection sync. Armed by every workspace open (selection change or
+    /// ``openWorkspace(_:)`` on a remount) and disarmed by a successful or
+    /// definitively failed restore, or by any explicit tab selection. Stays
+    /// armed across syncs while the remembered tab's backing data (stream
+    /// panel discovery) is still loading. Not observed: it gates selection
+    /// writes, not view state.
+    @ObservationIgnored var pendingLastTabRestoreWorkspaceID: MobileWorkspacePreview.ID?
+    /// True while ``syncSelectedTerminalForWorkspace()`` applies derived
+    /// fallback selections, so the selection observers treat those writes as
+    /// churn (no recording, no restore disarm) instead of explicit tab opens.
+    /// Not observed: it gates recording, not view state.
+    @ObservationIgnored private var isSyncingDerivedTabSelection = false
+    /// One-shot intent for the workspace detail view to reopen the
+    /// phone-local browser tab. The local browser lives in the view-layer
+    /// `BrowserSurfaceStore`, which this store cannot reach, so restoring
+    /// that tab kind is handed off to the detail view. Observable so the
+    /// mounted detail reacts when a restore arms it after the view's task.
+    public private(set) var pendingLocalBrowserTabRestoreWorkspaceID: MobileWorkspacePreview.ID?
     /// Device-local sort preference for the aggregated All Computers list
     /// (mode + user computer order). `@ObservationIgnored`: views read the
     /// observable ``workspaceSortMode`` / ``workspaceComputerPriority``
@@ -855,6 +874,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         didSet {
             if selectedWorkspaceID != oldValue {
                 selectedMacSurfaceID = nil
+                // Selecting a workspace is an "open": arm the last-opened-tab
+                // restore so the synchronizer below (and later data-arrival
+                // syncs) put back the tab this device last showed there.
+                pendingLastTabRestoreWorkspaceID = selectedWorkspaceID
+                pendingLocalBrowserTabRestoreWorkspaceID = nil
             }
             syncSelectedTerminalForWorkspace()
         }
@@ -865,7 +889,13 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// terminal and composer draft) and cleared when the workspace changes.
     public var selectedMacSurfaceID: MobileSurfacePreview.ID? {
         didSet {
-            guard selectedMacSurfaceID != oldValue, let selectedMacSurfaceID else { return }
+            guard selectedMacSurfaceID != oldValue, let selectedMacSurfaceID,
+                  !isSyncingDerivedTabSelection else { return }
+            // An unsuppressed non-nil change is an explicit tab open (the
+            // picker or a deep link), so it both wins over a pending restore
+            // and becomes the remembered tab. Derived promotions inside the
+            // synchronizer are suppressed and recorded only at open time.
+            pendingLastTabRestoreWorkspaceID = nil
             recordLastOpenedMacSurfaceTab(selectedMacSurfaceID)
         }
     }
@@ -890,7 +920,17 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     .surfaceFocused,
                     correlationID: selectedTerminalID.rawValue
                 )
-                recordLastOpenedTerminalTab(selectedTerminalID)
+                // An unsuppressed non-nil change is an explicit tab open
+                // (picker, push deep link, attach ticket, create flow): it
+                // wins over a pending restore and becomes the remembered tab.
+                // The synchronizer's derived fallbacks are suppressed and
+                // recorded only at open time, so background churn (a terminal
+                // closing while the user is on the list) cannot clobber the
+                // remembered stream or surface tab.
+                if !isSyncingDerivedTabSelection {
+                    pendingLastTabRestoreWorkspaceID = nil
+                    recordLastOpenedTerminalTab(selectedTerminalID)
+                }
             }
             swapDraft(from: draftedOutgoingTerminalID, outgoingText: draftedOutgoingText, to: selectedTerminalID)
             draftedOutgoingTerminalID = nil
@@ -1934,6 +1974,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // last-tab state through `.standard` (the app injects a persistent
         // store through the composite initializer instead).
         lastTabStore: MobileWorkspaceLastTabStore = .inMemory,
+        browserStreamEvents: (any BrowserStreamEventReceiving)? = nil,
+        simulatorStreamStore: MobileSimulatorStreamStore? = nil,
         terminalInputAckResubscribeClock: any Clock<Duration> = ContinuousClock(),
         controlPlaneSchedulingClock: any Clock<Duration> = ContinuousClock()
     ) -> CMUXMobileShellStore {
@@ -1943,7 +1985,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             deliveredNotificationClearer: NoopDeliveredNotificationClearer(),
             lastTabStore: lastTabStore,
             controlPlaneSchedulingClock: controlPlaneSchedulingClock,
-            terminalInputAckResubscribeClock: terminalInputAckResubscribeClock
+            terminalInputAckResubscribeClock: terminalInputAckResubscribeClock,
+            browserStreamEvents: browserStreamEvents,
+            simulatorStreamStore: simulatorStreamStore
         )
     }
 
@@ -8026,9 +8070,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             terminalAutoFocusSuppressedSurfaceIDs.insert(id.rawValue)
         }
         // Re-confirming the already-selected terminal is still an explicit tab
-        // open (returning from a Mac surface to the terminal picker's checked
-        // row), so the last-opened-tab memory must move off the surface even
-        // though the selection below is unchanged.
+        // open (returning from a stream or Mac surface to the terminal
+        // picker's checked row), so it disarms a pending restore and moves the
+        // last-opened-tab memory even though the selection below is unchanged.
+        pendingLastTabRestoreWorkspaceID = nil
         recordLastOpenedTerminalTab(id)
         guard selectedTerminalID != id else { return }
         selectedTerminalID = id
@@ -8077,6 +8122,15 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
 
     /// Open the workspace preview, switching the foreground Mac first when the workspace belongs to another paired Mac.
     public func openWorkspace(_ id: MobileWorkspacePreview.ID) async {
+        // Re-arm the last-opened-tab restore even when the selection is
+        // unchanged: reopening the SAME workspace from the list remounts the
+        // detail without a selection change, and its streams were stopped on
+        // the previous leave. Synchronous, before the first await, so no
+        // derived recording can slip in between the open and the arm.
+        pendingLastTabRestoreWorkspaceID = id
+        if explicitlySelectedWorkspace?.id == id {
+            syncSelectedTerminalForWorkspace()
+        }
         let diagnosticStartedAt = appDiagnosticNow()
         recordAppEvent(
             .workspaceOpenStarted,
@@ -11202,27 +11256,44 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         if selectedWorkspaceID != nil, explicitlySelectedWorkspace == nil {
             return
         }
+        // Everything this synchronizer assigns is derived churn, not an
+        // explicit tab open: the selection observers must neither record it
+        // nor disarm a pending restore for it.
+        isSyncingDerivedTabSelection = true
+        var recordDisplayedTabAfterSync = false
+        defer {
+            isSyncingDerivedTabSelection = false
+            // A completed open with nothing (left) to restore records the tab
+            // that actually got displayed, so the NEXT open reproduces it.
+            if recordDisplayedTabAfterSync, let workspace = explicitlySelectedWorkspace {
+                recordDisplayedTab(in: workspace)
+            }
+        }
         guard let selectedWorkspace else {
             selectedTerminalID = nil
             return
         }
+        // Opening a workspace restores its last opened tab — any kind, ahead
+        // of every keep-current and Mac-focus heuristic below.
+        if pendingLastTabRestoreWorkspaceID == selectedWorkspace.id {
+            switch restoreLastOpenedTab(in: selectedWorkspace) {
+            case .restored:
+                pendingLastTabRestoreWorkspaceID = nil
+                return
+            case .waiting:
+                // The remembered tab's backing data (stream panel discovery)
+                // has not arrived: stay armed for the next sync and fall
+                // through WITHOUT recording, so the interim fallback cannot
+                // clobber the remembered tab.
+                break
+            case .unavailable:
+                pendingLastTabRestoreWorkspaceID = nil
+                recordDisplayedTabAfterSync = true
+            }
+        }
         if let selectedTerminalID,
            let selectedTerminal = selectedWorkspace.terminals.first(where: { $0.id == selectedTerminalID }),
            selectedTerminal.isReady || !selectedWorkspace.hasReadyTerminal {
-            // A held valid selection is the workspace's displayed tab; keep the
-            // last-opened-tab memory tracking it (selections that landed before
-            // the workspace id, like push deep links, only become attributable
-            // here). Skip while a stream or Mac surface owns the frame: the
-            // terminal selection is then background state, not the shown tab.
-            if !nonTerminalTabOwnsFrame(in: selectedWorkspace) {
-                recordLastOpenedTerminalTab(selectedTerminalID)
-            }
-            return
-        }
-        // The workspace needs a fresh tab decision (it was just opened, or its
-        // held tab disappeared): the tab this device last opened there wins
-        // over every Mac-focus heuristic below.
-        if restoreLastOpenedTab(in: selectedWorkspace) {
             return
         }
         // Clear stale Mac selections and promote an active or Mac-focused
@@ -11312,29 +11383,23 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
 
     // MARK: - Last opened tab per workspace
 
-    /// True when a live stream or still-valid Mac surface owns the workspace
-    /// frame, so the selected terminal is background state rather than the
-    /// displayed tab.
-    private func nonTerminalTabOwnsFrame(in workspace: MobileWorkspacePreview) -> Bool {
-        let workspaceID = workspace.rpcWorkspaceID.rawValue
-        if simulatorStreamStore?.activeState(in: workspaceID) != nil { return true }
-        if let browserStore = browserStreamEvents as? BrowserStreamStore,
-           browserStore.activeState(in: workspaceID) != nil {
-            return true
-        }
-        if let selectedMacSurfaceID,
-           workspace.surfaces.contains(where: { $0.id == selectedMacSurfaceID && !$0.kind.isTerminal }) {
-            return true
-        }
-        return false
+    /// Outcome of one armed restore attempt.
+    enum LastTabRestoreOutcome {
+        /// The remembered tab is showing (or was just reselected); disarm.
+        case restored
+        /// The remembered tab's backing data has not loaded yet (stream panel
+        /// discovery, cross-Mac row hydration); stay armed for the next sync.
+        case waiting
+        /// Nothing is remembered, or the remembered tab no longer exists;
+        /// disarm and let the fallback heuristics pick a tab.
+        case unavailable
     }
 
     /// Records `terminalID` as the last opened tab of the explicitly selected
-    /// workspace. Every selection entrypoint (picker, push deep link, create
-    /// flows, the open-workspace synchronizer) funnels here through the
-    /// selection property observers, so the memory always tracks the tab the
-    /// user actually saw. Membership is checked so a selection that races a
-    /// workspace switch can never stamp another workspace's memory.
+    /// workspace. Explicit selection entrypoints (picker, push deep link,
+    /// attach ticket, create flows) funnel here through the selection
+    /// observers. Membership is checked so a selection that races a workspace
+    /// switch can never stamp another workspace's memory.
     private func recordLastOpenedTerminalTab(_ terminalID: MobileTerminalPreview.ID) {
         guard let workspace = explicitlySelectedWorkspace,
               workspace.terminals.contains(where: { $0.id == terminalID }) else { return }
@@ -11355,35 +11420,176 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         )
     }
 
-    /// Restores the workspace's remembered last-opened tab, if it still
-    /// exists there. Called only from ``syncSelectedTerminalForWorkspace()``
-    /// after the keep-current check, so it runs exactly when a workspace
-    /// needs a fresh tab decision (open/reopen, or the held tab disappeared)
-    /// and never yanks a live stream or still-valid Mac surface the user is
-    /// looking at. Returns false when nothing restorable is remembered, so
-    /// the caller falls back to the Mac-focus heuristics.
-    private func restoreLastOpenedTab(in workspace: MobileWorkspacePreview) -> Bool {
-        guard !nonTerminalTabOwnsFrame(in: workspace),
-              let remembered = lastTabStore.lastTab(for: workspace.lastTabStateID) else { return false }
+    /// Records a Mac browser stream pick as the workspace's last opened tab.
+    /// Called by the detail view's picker action, which owns stream
+    /// activation; an explicit pick also disarms a pending restore.
+    public func recordLastOpenedBrowserStreamTab(
+        panelID: String,
+        in workspaceID: MobileWorkspacePreview.ID
+    ) {
+        pendingLastTabRestoreWorkspaceID = nil
+        guard let workspace = workspaces.first(where: { $0.id == workspaceID }) else { return }
+        lastTabStore.set(
+            MobileWorkspaceLastTab(kind: .browserStream, tabID: panelID),
+            for: workspace.lastTabStateID
+        )
+    }
+
+    /// Records a Mac Simulator stream pick as the workspace's last opened
+    /// tab; the Simulator sibling of ``recordLastOpenedBrowserStreamTab(panelID:in:)``.
+    public func recordLastOpenedSimulatorStreamTab(
+        panelID: String,
+        in workspaceID: MobileWorkspacePreview.ID
+    ) {
+        pendingLastTabRestoreWorkspaceID = nil
+        guard let workspace = workspaces.first(where: { $0.id == workspaceID }) else { return }
+        lastTabStore.set(
+            MobileWorkspaceLastTab(kind: .simulatorStream, tabID: panelID),
+            for: workspace.lastTabStateID
+        )
+    }
+
+    /// Records the phone-local browser as the workspace's last opened tab.
+    /// Called by the detail view when it opens the local browser pane.
+    public func recordLastOpenedLocalBrowserTab(in workspaceID: MobileWorkspacePreview.ID) {
+        pendingLastTabRestoreWorkspaceID = nil
+        guard let workspace = workspaces.first(where: { $0.id == workspaceID }) else { return }
+        lastTabStore.set(
+            MobileWorkspaceLastTab(
+                kind: .localBrowser,
+                tabID: MobileWorkspaceLastTab.localBrowserTabID
+            ),
+            for: workspace.lastTabStateID
+        )
+    }
+
+    /// Consumes the one-shot local-browser restore intent for `workspaceID`.
+    /// The detail view calls this and reopens its local browser pane when it
+    /// returns true; the local browser lives in the view-layer store this
+    /// composite cannot reach.
+    public func consumeLocalBrowserTabRestore(for workspaceID: MobileWorkspacePreview.ID) -> Bool {
+        guard pendingLocalBrowserTabRestoreWorkspaceID == workspaceID else { return false }
+        pendingLocalBrowserTabRestoreWorkspaceID = nil
+        return true
+    }
+
+    /// Records whatever tab the workspace is actually displaying, used once
+    /// per completed open (when nothing was restorable) so the next open
+    /// reproduces this one. The phone-local browser is view-owned and
+    /// invisible here; its open action records itself.
+    private func recordDisplayedTab(in workspace: MobileWorkspacePreview) {
+        let workspaceID = workspace.rpcWorkspaceID.rawValue
+        if let simulator = simulatorStreamStore?.activeState(in: workspaceID) {
+            lastTabStore.set(
+                MobileWorkspaceLastTab(kind: .simulatorStream, tabID: simulator.id),
+                for: workspace.lastTabStateID
+            )
+            return
+        }
+        if let browserStore = browserStreamEvents as? BrowserStreamStore,
+           let browser = browserStore.activeState(in: workspaceID) {
+            lastTabStore.set(
+                MobileWorkspaceLastTab(kind: .browserStream, tabID: browser.id),
+                for: workspace.lastTabStateID
+            )
+            return
+        }
+        if let surfaceID = selectedMacSurfaceID,
+           workspace.surfaces.contains(where: { $0.id == surfaceID && !$0.kind.isTerminal }) {
+            lastTabStore.set(
+                MobileWorkspaceLastTab(kind: .macSurface, tabID: surfaceID.rawValue),
+                for: workspace.lastTabStateID
+            )
+            return
+        }
+        if let terminalID = selectedTerminalID {
+            recordLastOpenedTerminalTab(terminalID)
+        }
+    }
+
+    /// Attempts to restore the workspace's remembered last-opened tab. Called
+    /// only from ``syncSelectedTerminalForWorkspace()`` while a restore is
+    /// armed for this workspace, ahead of every fallback heuristic, so every
+    /// tab kind is restored on equal footing.
+    private func restoreLastOpenedTab(in workspace: MobileWorkspacePreview) -> LastTabRestoreOutcome {
+        guard let remembered = lastTabStore.lastTab(for: workspace.lastTabStateID) else {
+            return .unavailable
+        }
+        let workspaceID = workspace.rpcWorkspaceID.rawValue
+        let browserStore = browserStreamEvents as? BrowserStreamStore
+        // A stream already live in this workspace: matching memory means the
+        // open landed on the remembered tab; a different live stream is newer
+        // user-visible state than the memory and wins.
+        if let activeSimulator = simulatorStreamStore?.activeState(in: workspaceID) {
+            return remembered.kind == .simulatorStream && remembered.tabID == activeSimulator.id
+                ? .restored : .unavailable
+        }
+        if let activeBrowser = browserStore?.activeState(in: workspaceID) {
+            return remembered.kind == .browserStream && remembered.tabID == activeBrowser.id
+                ? .restored : .unavailable
+        }
         switch remembered.kind {
         case .terminal:
             let id = MobileTerminalPreview.ID(rawValue: remembered.tabID)
-            // Same readiness policy as the keep-current check above: a
-            // remembered tab that is not ready loses to a ready sibling.
-            guard let terminal = workspace.terminals.first(where: { $0.id == id }),
-                  terminal.isReady || !workspace.hasReadyTerminal else { return false }
+            guard let terminal = workspace.terminals.first(where: { $0.id == id }) else {
+                // An empty row usually means the workspace's data has not
+                // hydrated yet (cross-Mac open); a populated row without the
+                // tab means it was closed on the Mac.
+                return workspace.terminals.isEmpty && workspace.surfaces.isEmpty
+                    ? .waiting : .unavailable
+            }
+            // Same readiness policy as the keep-current check: a remembered
+            // tab that is not ready yet keeps the restore armed rather than
+            // losing permanently to a ready sibling.
+            guard terminal.isReady || !workspace.hasReadyTerminal else { return .waiting }
+            selectedMacSurfaceID = nil
             if selectedTerminalID != id {
                 // Restoring is chrome navigation, not a typing intent: the
                 // surface must not grab the keyboard when it attaches.
                 suppressTerminalAutoFocusOnNextAttach(for: id)
                 selectedTerminalID = id
             }
-            return true
+            return .restored
         case .macSurface:
             let id = MobileSurfacePreview.ID(rawValue: remembered.tabID)
-            guard workspace.surfaces.contains(where: { $0.id == id && !$0.kind.isTerminal }) else { return false }
+            guard workspace.surfaces.contains(where: { $0.id == id && !$0.kind.isTerminal }) else {
+                return workspace.terminals.isEmpty && workspace.surfaces.isEmpty
+                    ? .waiting : .unavailable
+            }
             selectedMacSurfaceID = id
-            return true
+            return .restored
+        case .browserStream:
+            guard let browserStore else { return .unavailable }
+            if browserStore.panels(in: workspaceID).contains(where: { $0.panelID == remembered.tabID }) {
+                _ = browserStore.activate(panelID: remembered.tabID, in: workspaceID)
+                let panelID = remembered.tabID
+                Task { await startMobileBrowserStream(panelID: panelID) }
+                return .restored
+            }
+            // Not discovered yet: the Mac row still lists the pane, or panel
+            // discovery has never completed for this workspace — the detail
+            // view's refresh will re-run this sync.
+            if workspace.surfaces.contains(where: { $0.id.rawValue == remembered.tabID && $0.kind == .browser })
+                || browserStore.panelDiscoveryRevision(in: workspaceID) == 0 {
+                return .waiting
+            }
+            return .unavailable
+        case .simulatorStream:
+            guard let simulatorStreamStore else { return .unavailable }
+            guard workspace.simulators.contains(where: { $0.panelID == remembered.tabID }) else {
+                return .unavailable
+            }
+            // Seed panel state from the workspace row: the detail view's own
+            // panel sync arrives only after it mounts.
+            simulatorStreamStore.replaceSimulatorPanels(in: workspaceID, with: workspace.simulators)
+            _ = simulatorStreamStore.activate(panelID: remembered.tabID, in: workspaceID)
+            let panelID = remembered.tabID
+            Task { await startMobileSimulatorStream(panelID: panelID, workspaceID: workspaceID) }
+            return .restored
+        case .localBrowser:
+            // View-owned tab: hand the reopen to the mounted detail view.
+            pendingLocalBrowserTabRestoreWorkspaceID = workspace.id
+            return .restored
         }
     }
 

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositePreviewTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositePreviewTests.swift
@@ -755,6 +755,44 @@ import Testing
         #expect(store.selectedTerminalID?.rawValue == "a1")
     }
 
+    @Test func lastOpenedTabIsRestoredAcrossStoreInstances() {
+        let suiteName = "MobileShellCompositeLastTabTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let workspaceA = MobileWorkspacePreview(
+            id: "ws-a",
+            name: "A",
+            terminals: [
+                MobileTerminalPreview(id: "a1", name: "First", isFocused: true),
+                MobileTerminalPreview(id: "a2", name: "Second"),
+            ]
+        )
+        let workspaceB = MobileWorkspacePreview(
+            id: "ws-b",
+            name: "B",
+            terminals: [MobileTerminalPreview(id: "b1", name: "Other")]
+        )
+
+        let first = MobileShellComposite.preview(
+            lastTabStore: MobileWorkspaceLastTabStore(defaults: defaults)
+        )
+        first.signIn()
+        first.replaceForegroundWorkspaceState([workspaceA, workspaceB])
+        first.selectedWorkspaceID = workspaceA.id
+        first.selectTerminalFromChrome("a2")
+
+        // A relaunch constructs a fresh store over the same defaults; opening
+        // the workspace restores the tab the previous session last opened.
+        let second = MobileShellComposite.preview(
+            lastTabStore: MobileWorkspaceLastTabStore(defaults: defaults)
+        )
+        second.signIn()
+        second.replaceForegroundWorkspaceState([workspaceA, workspaceB])
+        second.selectedWorkspaceID = workspaceA.id
+        #expect(second.selectedTerminalID?.rawValue == "a2")
+    }
+
     @Test func anonymousForegroundRowsDoNotExposeAggregateSentinel() {
         let store = MobileShellComposite.preview()
         store.signIn()

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositePreviewTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositePreviewTests.swift
@@ -662,6 +662,99 @@ import Testing
         #expect(store.selectedTerminalID?.rawValue == "terminal-selected")
     }
 
+    @Test func reopeningWorkspaceRestoresLastOpenedTerminalTab() {
+        let store = MobileShellComposite.preview()
+        store.signIn()
+        let workspaceA = MobileWorkspacePreview(
+            id: "ws-a",
+            name: "A",
+            terminals: [
+                MobileTerminalPreview(id: "a1", name: "First", isFocused: true),
+                MobileTerminalPreview(id: "a2", name: "Second"),
+            ]
+        )
+        let workspaceB = MobileWorkspacePreview(
+            id: "ws-b",
+            name: "B",
+            terminals: [MobileTerminalPreview(id: "b1", name: "Other")]
+        )
+        store.replaceForegroundWorkspaceState([workspaceA, workspaceB])
+        store.selectedWorkspaceID = workspaceA.id
+        #expect(store.selectedTerminalID?.rawValue == "a1")
+
+        store.selectTerminalFromChrome("a2")
+        store.selectedWorkspaceID = workspaceB.id
+        #expect(store.selectedTerminalID?.rawValue == "b1")
+
+        store.selectedWorkspaceID = workspaceA.id
+
+        // Reopening the workspace shows the tab the user last opened there,
+        // not the Mac-focused fallback.
+        #expect(store.selectedTerminalID?.rawValue == "a2")
+    }
+
+    @Test func reopeningWorkspaceRestoresLastOpenedMacSurfaceTab() {
+        let store = MobileShellComposite.preview()
+        store.signIn()
+        let workspaceA = MobileWorkspacePreview(
+            id: "ws-a",
+            name: "A",
+            terminals: [MobileTerminalPreview(id: "a1", name: "Shell", isFocused: true)],
+            surfaces: [MobileSurfacePreview(id: "s1", kind: .markdown, title: "README")]
+        )
+        let workspaceB = MobileWorkspacePreview(
+            id: "ws-b",
+            name: "B",
+            terminals: [MobileTerminalPreview(id: "b1", name: "Other")]
+        )
+        store.replaceForegroundWorkspaceState([workspaceA, workspaceB])
+        store.selectedWorkspaceID = workspaceA.id
+        #expect(store.selectedTerminalID?.rawValue == "a1")
+
+        store.selectMacSurface("s1")
+        store.selectedWorkspaceID = workspaceB.id
+        #expect(store.selectedMacSurfaceID == nil)
+
+        store.selectedWorkspaceID = workspaceA.id
+
+        // The last opened tab in ws-a was the Mac surface, so reopening the
+        // workspace shows it again instead of falling back to the terminal.
+        #expect(store.selectedMacSurfaceID?.rawValue == "s1")
+    }
+
+    @Test func reopeningWorkspaceFallsBackWhenLastOpenedTabIsGone() {
+        let store = MobileShellComposite.preview()
+        store.signIn()
+        let workspaceA = MobileWorkspacePreview(
+            id: "ws-a",
+            name: "A",
+            terminals: [
+                MobileTerminalPreview(id: "a1", name: "First", isFocused: true),
+                MobileTerminalPreview(id: "a2", name: "Second"),
+            ]
+        )
+        let workspaceB = MobileWorkspacePreview(
+            id: "ws-b",
+            name: "B",
+            terminals: [MobileTerminalPreview(id: "b1", name: "Other")]
+        )
+        store.replaceForegroundWorkspaceState([workspaceA, workspaceB])
+        store.selectedWorkspaceID = workspaceA.id
+        store.selectTerminalFromChrome("a2")
+        store.selectedWorkspaceID = workspaceB.id
+
+        // The remembered tab is closed on the Mac while the user is away.
+        let workspaceAWithoutA2 = MobileWorkspacePreview(
+            id: "ws-a",
+            name: "A",
+            terminals: [MobileTerminalPreview(id: "a1", name: "First", isFocused: true)]
+        )
+        store.replaceForegroundWorkspaceState([workspaceAWithoutA2, workspaceB])
+        store.selectedWorkspaceID = workspaceA.id
+
+        #expect(store.selectedTerminalID?.rawValue == "a1")
+    }
+
     @Test func anonymousForegroundRowsDoNotExposeAggregateSentinel() {
         let store = MobileShellComposite.preview()
         store.signIn()

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositePreviewTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositePreviewTests.swift
@@ -1,4 +1,5 @@
 import CMUXMobileCore
+import CmuxMobileBrowserStream
 import CmuxMobilePairedMac
 import CmuxMobileRPC
 import CmuxMobileShellModel
@@ -753,6 +754,159 @@ import Testing
         store.selectedWorkspaceID = workspaceA.id
 
         #expect(store.selectedTerminalID?.rawValue == "a1")
+    }
+
+    @Test func reopeningSameWorkspaceRestoresBrowserStreamTab() async {
+        let browserStreams = BrowserStreamStore()
+        let store = MobileShellComposite.preview(browserStreamEvents: browserStreams)
+        store.signIn()
+        let workspaceB = MobileWorkspacePreview(
+            id: "ws-b",
+            name: "Beta",
+            terminals: [MobileTerminalPreview(id: "b1", name: "Shell", isFocused: true)],
+            surfaces: [MobileSurfacePreview(id: "panel-1", kind: .browser, title: "Web")]
+        )
+        store.replaceForegroundWorkspaceState([workspaceB])
+        store.selectedWorkspaceID = workspaceB.id
+        browserStreams.replacePanels(in: "ws-b", with: [
+            MobileBrowserPanelDescriptor(
+                panelID: "panel-1", workspaceID: "ws-b", url: nil, title: "Web",
+                pageWidth: 900, pageHeight: 600,
+                canGoBack: false, canGoForward: false, isLoading: false
+            ),
+        ])
+
+        // The user opens the browser stream tab from the picker.
+        _ = browserStreams.activate(panelID: "panel-1", in: "ws-b")
+        store.recordLastOpenedBrowserStreamTab(panelID: "panel-1", in: workspaceB.id)
+
+        // Leaving the workspace unmounts the stream surface, which stops and
+        // deactivates the stream (`onDisappear` in the detail view).
+        browserStreams.deactivate(in: "ws-b")
+        #expect(browserStreams.activeState(in: "ws-b") == nil)
+
+        // Reopening the SAME workspace from the list remounts the detail with
+        // an unchanged selection; only `openWorkspace` marks the open.
+        await store.openWorkspace(workspaceB.id)
+
+        #expect(browserStreams.activeState(in: "ws-b")?.id == "panel-1")
+    }
+
+    @Test func listRefreshWhileAwayDoesNotClobberBrowserStreamMemory() async {
+        let browserStreams = BrowserStreamStore()
+        let store = MobileShellComposite.preview(browserStreamEvents: browserStreams)
+        store.signIn()
+        let workspaceB = MobileWorkspacePreview(
+            id: "ws-b",
+            name: "Beta",
+            terminals: [MobileTerminalPreview(id: "b1", name: "Shell", isFocused: true)],
+            surfaces: [MobileSurfacePreview(id: "panel-1", kind: .browser, title: "Web")]
+        )
+        store.replaceForegroundWorkspaceState([workspaceB])
+        store.selectedWorkspaceID = workspaceB.id
+        browserStreams.replacePanels(in: "ws-b", with: [
+            MobileBrowserPanelDescriptor(
+                panelID: "panel-1", workspaceID: "ws-b", url: nil, title: "Web",
+                pageWidth: 900, pageHeight: 600,
+                canGoBack: false, canGoForward: false, isLoading: false
+            ),
+        ])
+        _ = browserStreams.activate(panelID: "panel-1", in: "ws-b")
+        store.recordLastOpenedBrowserStreamTab(panelID: "panel-1", in: workspaceB.id)
+        browserStreams.deactivate(in: "ws-b")
+
+        // While the user sits on the workspace list (selection retained, the
+        // stream stopped), workspace list refreshes re-run the selection
+        // synchronizer. That churn must not overwrite the remembered tab.
+        store.replaceForegroundWorkspaceState([workspaceB])
+        store.replaceForegroundWorkspaceState([workspaceB])
+
+        await store.openWorkspace(workspaceB.id)
+        #expect(browserStreams.activeState(in: "ws-b")?.id == "panel-1")
+    }
+
+    @Test func reopeningSameWorkspaceRestoresSimulatorStreamTab() async {
+        let simulatorStreams = MobileSimulatorStreamStore()
+        let store = MobileShellComposite.preview(simulatorStreamStore: simulatorStreams)
+        store.signIn()
+        let simulator = MobileSimulatorPanelDescriptor(
+            panelID: "sim-1", workspaceID: "ws-b", title: "iPhone",
+            selectedDeviceName: "iPhone 17", selectedDeviceState: "Booted",
+            status: "ready", isReady: true,
+            supportsTouch: true, supportsKeyboard: true,
+            supportsHardwareButtons: true, supportsRotation: true
+        )
+        let workspaceB = MobileWorkspacePreview(
+            id: "ws-b",
+            name: "Beta",
+            terminals: [MobileTerminalPreview(id: "b1", name: "Shell", isFocused: true)],
+            simulators: [simulator]
+        )
+        store.replaceForegroundWorkspaceState([workspaceB])
+        store.selectedWorkspaceID = workspaceB.id
+        simulatorStreams.replaceSimulatorPanels(in: "ws-b", with: [simulator])
+        _ = simulatorStreams.activate(panelID: "sim-1", in: "ws-b")
+        store.recordLastOpenedSimulatorStreamTab(panelID: "sim-1", in: workspaceB.id)
+
+        simulatorStreams.deactivate(in: "ws-b")
+        #expect(simulatorStreams.activeState(in: "ws-b") == nil)
+
+        await store.openWorkspace(workspaceB.id)
+        #expect(simulatorStreams.activeState(in: "ws-b")?.id == "sim-1")
+    }
+
+    @Test func reopeningSameWorkspaceRestoresLocalBrowserTab() async {
+        let store = MobileShellComposite.preview()
+        store.signIn()
+        let workspaceB = MobileWorkspacePreview(
+            id: "ws-b",
+            name: "Beta",
+            terminals: [MobileTerminalPreview(id: "b1", name: "Shell", isFocused: true)]
+        )
+        store.replaceForegroundWorkspaceState([workspaceB])
+        store.selectedWorkspaceID = workspaceB.id
+        store.recordLastOpenedLocalBrowserTab(in: workspaceB.id)
+
+        await store.openWorkspace(workspaceB.id)
+
+        // The composite hands the phone-local browser reopen to the detail
+        // view as a one-shot intent.
+        #expect(store.consumeLocalBrowserTabRestore(for: workspaceB.id))
+        #expect(!store.consumeLocalBrowserTabRestore(for: workspaceB.id))
+    }
+
+    @Test func explicitTerminalPickWinsOverPendingStreamRestore() async {
+        let browserStreams = BrowserStreamStore()
+        let store = MobileShellComposite.preview(browserStreamEvents: browserStreams)
+        store.signIn()
+        let workspaceB = MobileWorkspacePreview(
+            id: "ws-b",
+            name: "Beta",
+            terminals: [
+                MobileTerminalPreview(id: "b1", name: "Shell", isFocused: true),
+                MobileTerminalPreview(id: "b2", name: "Second"),
+            ],
+            surfaces: [MobileSurfacePreview(id: "panel-1", kind: .browser, title: "Web")]
+        )
+        store.replaceForegroundWorkspaceState([workspaceB])
+        store.selectedWorkspaceID = workspaceB.id
+        store.recordLastOpenedBrowserStreamTab(panelID: "panel-1", in: workspaceB.id)
+        // The stream panel is never discovered (Mac unreachable), so a reopen
+        // keeps the restore armed. An explicit pick must disarm it and win.
+        await store.openWorkspace(workspaceB.id)
+        store.selectTerminalFromChrome("b2")
+
+        browserStreams.replacePanels(in: "ws-b", with: [
+            MobileBrowserPanelDescriptor(
+                panelID: "panel-1", workspaceID: "ws-b", url: nil, title: "Web",
+                pageWidth: 900, pageHeight: 600,
+                canGoBack: false, canGoForward: false, isLoading: false
+            ),
+        ])
+        store.refreshWorkspaceSelection()
+
+        #expect(browserStreams.activeState(in: "ws-b") == nil)
+        #expect(store.selectedTerminalID?.rawValue == "b2")
     }
 
     @Test func lastOpenedTabIsRestoredAcrossStoreInstances() {

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceLastTabStore.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceLastTabStore.swift
@@ -1,0 +1,115 @@
+public import Foundation
+
+/// The tab a workspace last showed on this device: a terminal, or a
+/// non-terminal Mac surface.
+public struct MobileWorkspaceLastTab: Hashable, Sendable {
+    /// Which selection axis the remembered tab lives on.
+    public enum Kind: String, Codable, Sendable {
+        case terminal
+        case macSurface
+    }
+
+    /// The remembered tab's selection axis.
+    public var kind: Kind
+    /// The raw terminal or surface identifier, Mac-local like the ids inside
+    /// a workspace preview.
+    public var tabID: String
+
+    /// Creates a remembered tab.
+    /// - Parameters:
+    ///   - kind: Which selection axis the tab lives on.
+    ///   - tabID: The raw terminal or surface identifier.
+    public init(kind: Kind, tabID: String) {
+        self.kind = kind
+        self.tabID = tabID
+    }
+}
+
+/// Device-local "last opened tab" memory per workspace, persisted in an
+/// injected `UserDefaults`.
+///
+/// Which tab a workspace shows is a per-device UI preference, not shared
+/// state: the Mac's focused pane keeps moving with Mac usage, and following
+/// it on every open is exactly the behavior this store exists to override.
+/// The map is keyed by ``MobileWorkspacePreview/lastTabStateID`` (Mac-scoped,
+/// unlike the aggregate row id, which is only scoped while several Macs are
+/// live) and bounded to ``maxEntries`` by dropping the least recently
+/// updated workspaces.
+///
+/// The backing `UserDefaults` is injected so the store is testable without
+/// touching `.standard` (mirroring `MobileWorkspaceGroupCollapseStore`); the
+/// app constructs it at the composition root with `UserDefaults.standard`,
+/// previews and tests use ``inMemory``.
+public struct MobileWorkspaceLastTabStore: Sendable {
+    /// The defaults key under which the `[lastTabStateID: entry]` map is stored.
+    public static let defaultsKey = "dev.cmux.mobile.workspace.lastTab.v1"
+    /// Upper bound on remembered workspaces; the least recently updated
+    /// entries are dropped first.
+    public static let maxEntries = 512
+
+    private struct Entry: Codable, Sendable {
+        var kind: MobileWorkspaceLastTab.Kind
+        var tabID: String
+        /// Monotonic recency stamp (not wall-clock), so pruning order is
+        /// deterministic even for writes within one instant.
+        var seq: UInt64
+    }
+
+    // UserDefaults is Apple-documented thread-safe; OK to hold nonisolated.
+    // `nil` = in-memory only (previews/tests).
+    private nonisolated(unsafe) let defaults: UserDefaults?
+    private var map: [String: Entry]
+    private var nextSeq: UInt64
+
+    /// Create a store backed by the given defaults.
+    /// - Parameter defaults: The persistence store for the last-tab map.
+    ///   Inject a suite-scoped `UserDefaults` in tests; the app passes
+    ///   `.standard`; `nil` keeps the map in memory only.
+    public init(defaults: UserDefaults? = .standard) {
+        self.defaults = defaults
+        if let data = defaults?.data(forKey: Self.defaultsKey),
+           let decoded = try? JSONDecoder().decode([String: Entry].self, from: data) {
+            map = decoded
+        } else {
+            map = [:]
+        }
+        nextSeq = (map.values.map(\.seq).max() ?? 0) &+ 1
+    }
+
+    /// A store that never persists, for previews and tests.
+    public static var inMemory: Self { .init(defaults: nil) }
+
+    /// The tab this workspace last showed on this device, or `nil` if none
+    /// was recorded (or it was pruned).
+    public func lastTab(for workspaceStateID: String) -> MobileWorkspaceLastTab? {
+        guard let entry = map[workspaceStateID] else { return nil }
+        return MobileWorkspaceLastTab(kind: entry.kind, tabID: entry.tabID)
+    }
+
+    /// Record the tab a workspace currently shows. Persists immediately;
+    /// re-recording the unchanged tab is a no-op (no write, no recency bump).
+    public mutating func set(_ tab: MobileWorkspaceLastTab, for workspaceStateID: String) {
+        if let existing = map[workspaceStateID],
+           existing.kind == tab.kind, existing.tabID == tab.tabID {
+            return
+        }
+        map[workspaceStateID] = Entry(kind: tab.kind, tabID: tab.tabID, seq: nextSeq)
+        nextSeq &+= 1
+        if map.count > Self.maxEntries {
+            let oldestKeys = map.sorted { $0.value.seq < $1.value.seq }
+                .prefix(map.count - Self.maxEntries)
+                .map(\.key)
+            for key in oldestKeys {
+                map.removeValue(forKey: key)
+            }
+        }
+        persist()
+    }
+
+    private func persist() {
+        guard let defaults else { return }
+        if let data = try? JSONEncoder().encode(map) {
+            defaults.set(data, forKey: Self.defaultsKey)
+        }
+    }
+}

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceLastTabStore.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceLastTabStore.swift
@@ -1,24 +1,31 @@
 public import Foundation
 
-/// The tab a workspace last showed on this device: a terminal, or a
-/// non-terminal Mac surface.
+/// The tab a workspace last showed on this device. Every tab kind the
+/// workspace detail can present is remembered on equal footing.
 public struct MobileWorkspaceLastTab: Hashable, Sendable {
     /// Which selection axis the remembered tab lives on.
     public enum Kind: String, Codable, Sendable {
         case terminal
         case macSurface
+        case browserStream
+        case simulatorStream
+        case localBrowser
     }
 
     /// The remembered tab's selection axis.
     public var kind: Kind
-    /// The raw terminal or surface identifier, Mac-local like the ids inside
-    /// a workspace preview.
+    /// The raw terminal, surface, or stream-panel identifier, Mac-local like
+    /// the ids inside a workspace preview. ``Kind/localBrowser`` has no
+    /// Mac-side identity; its ``tabID`` is a fixed placeholder.
     public var tabID: String
+
+    /// The placeholder ``tabID`` for the phone-local browser tab.
+    public static let localBrowserTabID = "local"
 
     /// Creates a remembered tab.
     /// - Parameters:
     ///   - kind: Which selection axis the tab lives on.
-    ///   - tabID: The raw terminal or surface identifier.
+    ///   - tabID: The raw terminal, surface, or stream-panel identifier.
     public init(kind: Kind, tabID: String) {
         self.kind = kind
         self.tabID = tabID
@@ -48,7 +55,10 @@ public struct MobileWorkspaceLastTabStore: Sendable {
     public static let maxEntries = 512
 
     private struct Entry: Codable, Sendable {
-        var kind: MobileWorkspaceLastTab.Kind
+        /// Stored as the kind's raw string so an entry written by a NEWER
+        /// build with a kind this build does not know decodes (and is
+        /// ignored) instead of failing the whole map.
+        var kind: String
         var tabID: String
         /// Monotonic recency stamp (not wall-clock), so pruning order is
         /// deterministic even for writes within one instant.
@@ -80,20 +90,22 @@ public struct MobileWorkspaceLastTabStore: Sendable {
     public static var inMemory: Self { .init(defaults: nil) }
 
     /// The tab this workspace last showed on this device, or `nil` if none
-    /// was recorded (or it was pruned).
+    /// was recorded, it was pruned, or it was written by a newer build with
+    /// an unknown kind.
     public func lastTab(for workspaceStateID: String) -> MobileWorkspaceLastTab? {
-        guard let entry = map[workspaceStateID] else { return nil }
-        return MobileWorkspaceLastTab(kind: entry.kind, tabID: entry.tabID)
+        guard let entry = map[workspaceStateID],
+              let kind = MobileWorkspaceLastTab.Kind(rawValue: entry.kind) else { return nil }
+        return MobileWorkspaceLastTab(kind: kind, tabID: entry.tabID)
     }
 
     /// Record the tab a workspace currently shows. Persists immediately;
     /// re-recording the unchanged tab is a no-op (no write, no recency bump).
     public mutating func set(_ tab: MobileWorkspaceLastTab, for workspaceStateID: String) {
         if let existing = map[workspaceStateID],
-           existing.kind == tab.kind, existing.tabID == tab.tabID {
+           existing.kind == tab.kind.rawValue, existing.tabID == tab.tabID {
             return
         }
-        map[workspaceStateID] = Entry(kind: tab.kind, tabID: tab.tabID, seq: nextSeq)
+        map[workspaceStateID] = Entry(kind: tab.kind.rawValue, tabID: tab.tabID, seq: nextSeq)
         nextSeq &+= 1
         if map.count > Self.maxEntries {
             let oldestKeys = map.sorted { $0.value.seq < $1.value.seq }

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspacePreview.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspacePreview.swift
@@ -186,6 +186,24 @@ public struct MobileWorkspacePreview: Identifiable, Equatable, Sendable {
 }
 
 extension MobileWorkspacePreview {
+    /// Stable key for device-local per-workspace UI state (the last opened
+    /// tab), mirroring ``MobileWorkspaceGroupPreview/collapseStateID``.
+    ///
+    /// ``id`` cannot key persisted state: aggregation Mac-scopes row ids only
+    /// while more than one Mac is live, so the same workspace flips between a
+    /// plain and a scoped id. This key is always owner-scoped when the owning
+    /// Mac is known, and falls back to the Mac-local id otherwise.
+    public var lastTabStateID: String {
+        guard let macDeviceID, !macDeviceID.isEmpty else {
+            return rpcWorkspaceID.rawValue
+        }
+        let ownerID = CmxMacAppInstanceIdentity(
+            macDeviceID: macDeviceID,
+            instanceTag: macInstanceTag
+        ).id
+        return "\(ownerID)\u{1F}\(rpcWorkspaceID.rawValue)"
+    }
+
     /// The non-terminal surface the owning Mac currently has focused, when it
     /// reports one. This is separate from the terminal fallback because an
     /// explicitly selected terminal on iOS must remain authoritative.

--- a/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileWorkspaceLastTabStoreTests.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileWorkspaceLastTabStoreTests.swift
@@ -1,0 +1,113 @@
+import CMUXMobileCore
+import Foundation
+import Testing
+
+@testable import CmuxMobileShellModel
+
+/// Behavior tests for ``MobileWorkspaceLastTabStore`` using a suite-scoped
+/// `UserDefaults` so they never touch `UserDefaults.standard`.
+///
+/// The store's contract: the tab a workspace last showed on this device is
+/// device-local memory, persisted immediately, bounded by dropping the least
+/// recently updated workspaces, and keyed by the owner-scoped
+/// ``MobileWorkspacePreview/lastTabStateID`` so it survives the aggregate
+/// list flipping between plain and Mac-scoped row ids.
+@Suite struct MobileWorkspaceLastTabStoreTests {
+    private func makeDefaults() -> UserDefaults {
+        let suite = "MobileWorkspaceLastTabStoreTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return defaults
+    }
+
+    @Test func roundTripsThroughInjectedDefaults() {
+        let defaults = makeDefaults()
+        var store = MobileWorkspaceLastTabStore(defaults: defaults)
+        store.set(MobileWorkspaceLastTab(kind: .terminal, tabID: "t-2"), for: "ws-a")
+        store.set(MobileWorkspaceLastTab(kind: .macSurface, tabID: "s-1"), for: "ws-b")
+
+        let reloaded = MobileWorkspaceLastTabStore(defaults: defaults)
+        #expect(reloaded.lastTab(for: "ws-a") == MobileWorkspaceLastTab(kind: .terminal, tabID: "t-2"))
+        #expect(reloaded.lastTab(for: "ws-b") == MobileWorkspaceLastTab(kind: .macSurface, tabID: "s-1"))
+        #expect(reloaded.lastTab(for: "ws-c") == nil)
+    }
+
+    @Test func inMemoryStoreDoesNotPersist() {
+        var store = MobileWorkspaceLastTabStore.inMemory
+        store.set(MobileWorkspaceLastTab(kind: .terminal, tabID: "t-1"), for: "ws-a")
+        #expect(store.lastTab(for: "ws-a") == MobileWorkspaceLastTab(kind: .terminal, tabID: "t-1"))
+        #expect(MobileWorkspaceLastTabStore.inMemory.lastTab(for: "ws-a") == nil)
+    }
+
+    @Test func reRecordingTheUnchangedTabDoesNotRewriteDefaults() {
+        let defaults = makeDefaults()
+        var store = MobileWorkspaceLastTabStore(defaults: defaults)
+        store.set(MobileWorkspaceLastTab(kind: .terminal, tabID: "t-1"), for: "ws-a")
+        let persisted = defaults.data(forKey: MobileWorkspaceLastTabStore.defaultsKey)
+        #expect(persisted != nil)
+
+        // The synchronizer re-records the displayed tab on every workspace
+        // list refresh; an unchanged tab must be a no-op write.
+        defaults.removeObject(forKey: MobileWorkspaceLastTabStore.defaultsKey)
+        store.set(MobileWorkspaceLastTab(kind: .terminal, tabID: "t-1"), for: "ws-a")
+        #expect(defaults.data(forKey: MobileWorkspaceLastTabStore.defaultsKey) == nil)
+    }
+
+    @Test func prunesLeastRecentlyUpdatedWorkspacesBeyondCap() {
+        var store = MobileWorkspaceLastTabStore.inMemory
+        let overflow = 10
+        for index in 0..<(MobileWorkspaceLastTabStore.maxEntries + overflow) {
+            store.set(MobileWorkspaceLastTab(kind: .terminal, tabID: "t-\(index)"), for: "ws-\(index)")
+        }
+        for index in 0..<overflow {
+            #expect(store.lastTab(for: "ws-\(index)") == nil)
+        }
+        #expect(store.lastTab(for: "ws-\(overflow)") != nil)
+        #expect(store.lastTab(for: "ws-\(MobileWorkspaceLastTabStore.maxEntries + overflow - 1)") != nil)
+    }
+
+    @Test func lastTabStateIDIsPlainForAnonymousWorkspaces() {
+        let workspace = MobileWorkspacePreview(
+            id: "workspace-1",
+            name: "Plain",
+            terminals: []
+        )
+        #expect(workspace.lastTabStateID == "workspace-1")
+    }
+
+    @Test func lastTabStateIDIsStableAcrossAggregateRowScoping() {
+        // Single-Mac list: the row id is the Mac-local id.
+        let plainRow = MobileWorkspacePreview(
+            id: "workspace-1",
+            macDeviceID: "mac-a",
+            name: "Same workspace",
+            terminals: []
+        )
+        // Multi-Mac aggregate: the row id is owner-scoped and the Mac-local id
+        // moves to `remoteWorkspaceID`.
+        var scopedRow = MobileWorkspacePreview(
+            id: MobileWorkspaceAggregation().rowID(
+                macDeviceID: "mac-a",
+                workspaceID: "workspace-1"
+            ),
+            macDeviceID: "mac-a",
+            name: "Same workspace",
+            terminals: []
+        )
+        scopedRow.remoteWorkspaceID = "workspace-1"
+
+        #expect(plainRow.lastTabStateID == scopedRow.lastTabStateID)
+        let expectedOwner = CmxMacAppInstanceIdentity(macDeviceID: "mac-a", instanceTag: nil).id
+        #expect(plainRow.lastTabStateID == "\(expectedOwner)\u{1F}workspace-1")
+    }
+
+    @Test func lastTabStateIDDistinguishesMacsSharingWorkspaceIDs() {
+        let onMacA = MobileWorkspacePreview(
+            id: "workspace-1", macDeviceID: "mac-a", name: "A", terminals: []
+        )
+        let onMacB = MobileWorkspacePreview(
+            id: "workspace-1", macDeviceID: "mac-b", name: "B", terminals: []
+        )
+        #expect(onMacA.lastTabStateID != onMacB.lastTabStateID)
+    }
+}

--- a/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileWorkspaceLastTabStoreTests.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileWorkspaceLastTabStoreTests.swift
@@ -53,6 +53,18 @@ import Testing
         #expect(defaults.data(forKey: MobileWorkspaceLastTabStore.defaultsKey) == nil)
     }
 
+    @Test func unknownKindEntriesFromNewerBuildsAreIgnoredNotFatal() {
+        let defaults = makeDefaults()
+        let json = """
+        {"ws-a":{"kind":"browserStream","tabID":"p1","seq":1},\
+        "ws-b":{"kind":"holographicPane","tabID":"x","seq":2}}
+        """
+        defaults.set(json.data(using: .utf8), forKey: MobileWorkspaceLastTabStore.defaultsKey)
+        let store = MobileWorkspaceLastTabStore(defaults: defaults)
+        #expect(store.lastTab(for: "ws-a") == MobileWorkspaceLastTab(kind: .browserStream, tabID: "p1"))
+        #expect(store.lastTab(for: "ws-b") == nil)
+    }
+
     @Test func prunesLeastRecentlyUpdatedWorkspacesBeyondCap() {
         var store = MobileWorkspaceLastTabStore.inMemory
         let overflow = 10

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -195,6 +195,10 @@ struct WorkspaceDetailView: View {
                 await store.refreshMobileBrowserPanels(workspaceID: workspace.rpcWorkspaceID.rawValue)
                 syncSimulatorStreamPanels()
                 store.refreshWorkspaceSelection()
+                restoreLocalBrowserTabIfRequested()
+            }
+            .onChange(of: store.pendingLocalBrowserTabRestoreWorkspaceID) { _, _ in
+                restoreLocalBrowserTabIfRequested()
             }
             .onChange(of: browserStreamStore.panelDiscoveryRevision(in: workspace.rpcWorkspaceID.rawValue)) { _, _ in
                 store.refreshWorkspaceSelection()
@@ -1082,6 +1086,7 @@ struct WorkspaceDetailView: View {
         store.recordAppEvent(.browserCreateStarted, correlationID: workspaceID)
         _ = browserStore.openBrowser(for: workspaceID)
         store.recordAppEvent(.browserCreateSucceeded, correlationID: workspaceID)
+        store.recordLastOpenedLocalBrowserTab(in: workspace.id)
         stopActiveBrowserStream()
         stopActiveSimulatorStream()
         store.selectedMacSurfaceID = nil
@@ -1099,6 +1104,7 @@ struct WorkspaceDetailView: View {
             Task { await store.stopMobileBrowserStream(panelID: previous.id) }
         }
         _ = browserStreamStore.activate(panelID: panelID, in: workspace.rpcWorkspaceID.rawValue)
+        store.recordLastOpenedBrowserStreamTab(panelID: panelID, in: workspace.id)
         Task { await store.startMobileBrowserStream(panelID: panelID) }
     }
 
@@ -1118,6 +1124,7 @@ struct WorkspaceDetailView: View {
             simulatorStreamStore.deactivate(panelID: previousPanelID, in: workspaceID)
         }
         _ = simulatorStreamStore.activate(panelID: panelID, in: workspaceID)
+        store.recordLastOpenedSimulatorStreamTab(panelID: panelID, in: workspace.id)
         // One task, stop awaited before start: two independent tasks have no
         // ordering guarantee, and the reversed order would tear down the new
         // stream (or churn host sessions) right after it started.
@@ -1133,6 +1140,15 @@ struct WorkspaceDetailView: View {
                 workspaceID: workspaceID
             )
         }
+    }
+
+    /// Reopens the phone-local browser pane when the store's last-opened-tab
+    /// restore asked for it. The local browser lives in this view layer's
+    /// `BrowserSurfaceStore`, so the composite hands the reopen here as a
+    /// one-shot intent; opening is idempotent for an already-open pane.
+    private func restoreLocalBrowserTabIfRequested() {
+        guard store.consumeLocalBrowserTabRestore(for: workspace.id) else { return }
+        _ = browserStore.openBrowser(for: workspace.id.rawValue)
     }
 
     private func stopActiveBrowserStream() {

--- a/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRootScene.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRootScene.swift
@@ -511,6 +511,9 @@ public struct CMUXMobileRootScene: View {
             feedbackEmailSubmitter: feedbackEmailSubmitter,
             feedbackStampProvider: feedbackStampProvider,
             draftStore: draftStore,
+            // Persistent, unlike the composite's in-memory default: opening a
+            // workspace must restore its last opened tab across app relaunches.
+            lastTabStore: MobileWorkspaceLastTabStore(defaults: .standard),
             taskTemplateStore: UserDefaultsMobileTaskTemplateStore(
                 defaults: .standard,
                 diagnosticLog: diagnosticLog


### PR DESCRIPTION
Opening a workspace on iOS re-derived the shown tab from the Mac's moving focus (`preferredTerminal` / focused-surface promotion), so returning to a workspace lost the tab you last had open there. Now every open (list tap, same-workspace reopen, reconnect selection, cross-Mac switch, fresh launch) restores the workspace's last opened tab, for every tab kind on equal footing: terminals, Mac surfaces, Mac browser streams, Mac Simulator streams, and the phone-local browser.

Mechanism: a new `MobileWorkspaceLastTabStore` (CmuxMobileShellModel) remembers the last opened tab per workspace, persisted in UserDefaults and keyed by an owner-scoped `lastTabStateID` (mirroring `collapseStateID`) that stays stable whether or not the aggregate list Mac-scopes row ids. A restore is armed by every open — workspace-selection change and `openWorkspace(_:)`, which fires on each detail remount, covering the reopen-same-workspace case where streams were stopped by the surface's `onDisappear` — and attempted in `syncSelectedTerminalForWorkspace()` ahead of the keep-current and Mac-focus heuristics. Stream kinds reactivate their panel and restart the stream; the phone-local browser is handed to the detail view as a one-shot intent since its store is view-owned; a remembered stream whose panel discovery hasn't completed keeps the restore armed instead of losing to the interim fallback. Explicit picks of any kind (picker, push deep links, attach tickets, create flows) record immediately and disarm a pending restore, so they always win; the synchronizer's derived fallback churn is suppressed and the displayed tab is recorded once per completed open, so background terminal churn can never clobber a remembered stream tab. A remembered tab that no longer exists falls back to the previous behavior; unknown persisted kinds from newer builds decode as absent.

Commits: the first two are red/green for the terminal/Mac-surface reopen behavior (commit 1 failing tests, commit 2 fix). The stream-kind round (`29baceaa58`) lands with its regression tests in the same commit because the failing tests require the new recording entrypoints. The `vendor/bonsplit` pointer commit duplicates https://github.com/manaflow-ai/cmux/pull/11187 (main pins a bonsplit SHA that predates `clearResidualCapability` and does not compile for macOS); it collapses to no diff once that merges.

HIG: reviewed the Tab bars page (https://developer.apple.com/design/human-interface-guidelines/tab-bars), which calls for switching sections "while preserving the current navigation state within each section"; restoring the last opened tab follows that guidance. Localization audit: no user-facing strings were added or changed (state and selection logic only; the picker UI is untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)