### PR TITLE
Fix main compile: duplicate exactEntry + processLiveness memberwise init

### DIFF
--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -1058,15 +1058,7 @@ struct RestorableAgentSessionIndex: Sendable {
     ///
     /// Security-sensitive callers use this instead of the compatibility lookup
     /// below so a stale workspace cannot adopt a same-panel entry from another
-    /// restored workspace.
-    func exactEntry(workspaceId: UUID, panelId: UUID) -> Entry? {
-        entriesByPanel[PanelKey(workspaceId: workspaceId, panelId: panelId)]
-    }
-
-    /// Returns only the process entry keyed by this exact workspace/panel pair.
-    ///
-    /// Unlike ``entry(workspaceId:panelId:)``, this does not use the panel-ID
-    /// compatibility fallback. Process teardown safety must never borrow a
+    /// restored workspace. Process teardown safety likewise must never borrow a
     /// live scope from a panel's previous workspace after the surface moves.
     func exactEntry(workspaceId: UUID, panelId: UUID) -> Entry? {
         entriesByPanel[PanelKey(workspaceId: workspaceId, panelId: panelId)]


### PR DESCRIPTION
## Summary
`main` fails to build the app target for two remaining reasons (the third, the bonsplit pointer regression from #11163, was already restored by #11187); this PR fixes both so one merge turns the build lanes green:

1. **duplicate `exactEntry`** — #10658 and #7151 each added an identical `exactEntry(workspaceId:panelId:)` to `RestorableAgentSession` → `invalid redeclaration`. Keep one copy, fold the doc comments.
2. **`processLiveness` memberwise init** — #10658 declared `let processLiveness: RestorableAgentProcessLiveness = .unknown` on `AgentHibernationRecord` and passes `processLiveness:` at the record's only construction site (`AgentHibernationController+Records.swift:123`); a `let` with an initial value is excluded from the synthesized memberwise init → `extra argument 'processLiveness' in call`. Make it a defaulted `var`. No behavior change.

Note: submodule-pointer-only diffs short-circuit the Swift build lanes in `ci.yml`, which is why the now-closed #11190 showed green while main was unbuildable; this PR's Swift diff exercises the real build. The app-host unit-test shard failures are the known pre-existing storm on main and appear identically on every run.

## Test plan
- [x] `ci.yml` dispatch on this branch: `tests-build-and-lag` and `release-build` green (they fail on current main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
