### PR TITLE
fix(tui): cfg-gate macOS Ghostty config roots

### DIFF
--- a/cmux-tui/crates/cmux-pty/src/lib.rs
+++ b/cmux-tui/crates/cmux-pty/src/lib.rs
@@ -10,7 +10,7 @@ use std::fmt;
 use std::fs::File;
 use std::io;
 #[cfg(unix)]
-use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+use std::os::fd::{FromRawFd, OwnedFd};
 use std::path::{Path, PathBuf};
 #[cfg(unix)]
 use std::sync::Arc;

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -398,10 +398,13 @@ fn ghostty_config_paths_from(
         push_unique(&mut candidates, dir.join("config.ghostty"));
     }
     #[cfg(target_os = "macos")]
-    if !has_xdg_config_home && let Some(home) = home {
-        let dir = home.join("Library").join("Application Support").join("com.mitchellh.ghostty");
-        push_unique(&mut candidates, dir.join("config"));
-        push_unique(&mut candidates, dir.join("config.ghostty"));
+    {
+        if !has_xdg_config_home && let Some(home) = home {
+            let dir =
+                home.join("Library").join("Application Support").join("com.mitchellh.ghostty");
+            push_unique(&mut candidates, dir.join("config"));
+            push_unique(&mut candidates, dir.join("config.ghostty"));
+        }
     }
     candidates
 }


### PR DESCRIPTION
## Summary
- Keep the macOS-only HOME configuration-root block inside a macOS cfg block.
- Prevent the non-macOS Clippy `unused variable: home` error without changing path selection.

## Testing
- `cargo fmt --manifest-path cmux-tui/Cargo.toml --all`
- `git diff --check`

## Issues
- Related: https://github.com/manaflow-ai/cmux/pull/11173

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790657378&installation_model_id=21920&pr_number=11196&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11196&signature=f3ca1c478c7c01f05f19ded06da3c2a90daef7734fdfb44f42859df90f866642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Clippy warnings on non-macOS builds by cfg-gating the macOS-only Ghostty config roots block and removing an unused `AsRawFd` import. Ghostty path selection is unchanged.

<sup>Written for commit 9b4852aab5bf36e75fcc2dabd7d20e559c044dc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Ghostty configuration discovery on non-macOS platforms.
  * macOS-specific configuration locations are now considered only on macOS.
  * macOS configuration behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->