### PR TITLE
fix: preserve automatic workspace titles across restart

### DIFF
--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomization.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomization.swift
@@ -46,4 +46,67 @@ public struct WorkspaceCustomization: Codable, Equatable, Sendable {
         self.customTitle = customTitle
         self.customColor = customColor
     }
+
+    private enum CodingKeys: String, CodingKey {
+        case customTitle
+        case customColor
+        // This key is intentionally additive. Older cmux versions ignore
+        // unknown keyed values and continue to decode `customTitle` as `.value`.
+        case customTitleSource
+    }
+
+    /// Decodes both the original field-only format and the provenance-aware
+    /// format. Automatic titles are represented as `.value` plus an additive
+    /// source key on disk so older binaries do not reject the whole journal.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let decodedTitle = try container.decode(
+            WorkspaceCustomizationField.self,
+            forKey: .customTitle
+        )
+        let decodedSource = try container.decodeIfPresent(
+            WorkspaceCustomizationTitleSource.self,
+            forKey: .customTitleSource
+        )
+        if decodedSource == .some(.auto),
+           case let .value(title) = decodedTitle {
+            self.customTitle = .autoValue(title)
+        } else {
+            self.customTitle = decodedTitle
+        }
+        self.customColor = try container.decode(
+            WorkspaceCustomizationField.self,
+            forKey: .customColor
+        )
+    }
+
+    /// Encodes automatic title provenance as an additive key while retaining
+    /// the old `.value` wire shape for downgrade compatibility.
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch customTitle {
+        case let .autoValue(title):
+            try container.encode(
+                WorkspaceCustomizationField.value(title),
+                forKey: .customTitle
+            )
+            try container.encode(
+                WorkspaceCustomizationTitleSource.auto,
+                forKey: .customTitleSource
+            )
+        default:
+            try container.encode(customTitle, forKey: .customTitle)
+        }
+        switch customColor {
+        case .autoValue:
+            // Automatic provenance is meaningful only for titles. Do not
+            // emit a new enum case in the color field that old decoders reject.
+            try container.encode(
+                WorkspaceCustomizationField.absent,
+                forKey: .customColor
+            )
+        default:
+            try container.encode(customColor, forKey: .customColor)
+        }
+    }
 }

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomization.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomization.swift
@@ -1,3 +1,9 @@
+/// Identifies who produced a workspace title for recovery ordering.
+public enum WorkspaceCustomizationTitleSource: String, Codable, Equatable, Sendable {
+    case user
+    case auto
+}
+
 /// One independently persisted workspace customization field.
 ///
 /// `absent` means the recovery journal has never observed a mutation for the
@@ -8,11 +14,16 @@ public enum WorkspaceCustomizationField: Codable, Equatable, Sendable {
     case absent
     /// The most recent user mutation assigned the associated value.
     case value(String)
+    /// The most recent automatic title mutation assigned the associated value.
+    ///
+    /// Automatic values are journaled so a clear followed by auto-naming has a
+    /// durable ordering relative to a stale session snapshot.
+    case autoValue(String)
     /// The most recent user mutation explicitly cleared the field.
     case cleared
 }
 
-/// User-owned workspace identity persisted independently of session autosave.
+/// Workspace identity persisted independently of session autosave.
 ///
 /// Records are keyed by `Workspace.stableId`. Title and color are independent
 /// so mutating one field never makes the other field authoritative.

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomization.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomization.swift
@@ -19,7 +19,11 @@ public struct WorkspaceCustomizationPendingAutomaticTitle: Sendable, Equatable {
     /// title mutation from another manager cannot be overwritten by a stale queue.
     public let titleMutationRevision: UInt64
 
-    public init(stableId: UUID, title: String?, titleMutationRevision: UInt64) {
+    public init(
+        stableId: UUID,
+        title: String?,
+        titleMutationRevision: UInt64 = 0
+    ) {
         self.stableId = stableId
         self.title = title
         self.titleMutationRevision = titleMutationRevision

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomization.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomization.swift
@@ -18,15 +18,20 @@ public struct WorkspaceCustomizationPendingAutomaticTitle: Sendable, Equatable {
     /// valid only while this remains the current title revision, so a later
     /// title mutation from another manager cannot be overwritten by a stale queue.
     public let titleMutationRevision: UInt64
+    /// Process-local tie-breaker for queues created by separate managers at
+    /// the same title mutation revision.
+    public let automaticTitleOrdering: UInt64
 
     public init(
         stableId: UUID,
         title: String?,
-        titleMutationRevision: UInt64 = 0
+        titleMutationRevision: UInt64 = 0,
+        automaticTitleOrdering: UInt64 = 0
     ) {
         self.stableId = stableId
         self.title = title
         self.titleMutationRevision = titleMutationRevision
+        self.automaticTitleOrdering = automaticTitleOrdering
     }
 }
 

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomization.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomization.swift
@@ -1,7 +1,24 @@
+public import Foundation
+
 /// Identifies who produced a workspace title for recovery ordering.
 public enum WorkspaceCustomizationTitleSource: String, Codable, Equatable, Sendable {
     case user
     case auto
+}
+
+/// One automatic title mutation handed off from a workspace owner at teardown.
+///
+/// The title is optional because an automatic clear must be durable too. This
+/// value is `Sendable` so a nonisolated owner deinitializer can hand it to the
+/// store's synchronous persistence boundary without retaining the owner.
+public struct WorkspaceCustomizationPendingAutomaticTitle: Sendable, Equatable {
+    public let stableId: UUID
+    public let title: String?
+
+    public init(stableId: UUID, title: String?) {
+        self.stableId = stableId
+        self.title = title
+    }
 }
 
 /// One independently persisted workspace customization field.
@@ -19,7 +36,7 @@ public enum WorkspaceCustomizationField: Codable, Equatable, Sendable {
     /// Automatic values are journaled so a clear followed by auto-naming has a
     /// durable ordering relative to a stale session snapshot.
     case autoValue(String)
-    /// The most recent user mutation explicitly cleared the field.
+    /// The most recent title mutation explicitly cleared the field.
     case cleared
 }
 

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomization.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomization.swift
@@ -14,10 +14,15 @@ public enum WorkspaceCustomizationTitleSource: String, Codable, Equatable, Senda
 public struct WorkspaceCustomizationPendingAutomaticTitle: Sendable, Equatable {
     public let stableId: UUID
     public let title: String?
+    /// Title revision observed when the automatic title was queued. The write is
+    /// valid only while this remains the current title revision, so a later
+    /// title mutation from another manager cannot be overwritten by a stale queue.
+    public let titleMutationRevision: UInt64
 
-    public init(stableId: UUID, title: String?) {
+    public init(stableId: UUID, title: String?, titleMutationRevision: UInt64) {
         self.stableId = stableId
         self.title = title
+        self.titleMutationRevision = titleMutationRevision
     }
 }
 

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomization.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomization.swift
@@ -17,8 +17,8 @@ public struct WorkspaceCustomizationPendingAutomaticTitle: Sendable, Equatable {
     /// Title revision observed when the automatic title was queued. The write is
     /// valid only while this remains the current title revision, so a later
     /// title mutation from another manager cannot be overwritten by a stale queue.
-    /// Zero means that the revision is resolved at flush time. This keeps high-
-    /// frequency title notifications off the synchronous journal-read path.
+    /// Zero is retained for legacy callers that have no observed title fence;
+    /// such a record is accepted only when the durable revision is also zero.
     public let titleMutationRevision: UInt64
     /// Process-local tie-breaker for queues created by separate managers at
     /// the same title mutation revision.

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomization.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomization.swift
@@ -17,6 +17,8 @@ public struct WorkspaceCustomizationPendingAutomaticTitle: Sendable, Equatable {
     /// Title revision observed when the automatic title was queued. The write is
     /// valid only while this remains the current title revision, so a later
     /// title mutation from another manager cannot be overwritten by a stale queue.
+    /// Zero means that the revision is resolved at flush time. This keeps high-
+    /// frequency title notifications off the synchronous journal-read path.
     public let titleMutationRevision: UInt64
     /// Process-local tie-breaker for queues created by separate managers at
     /// the same title mutation revision.

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomizationPersistence.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomizationPersistence.swift
@@ -3,6 +3,38 @@ import Foundation
 struct WorkspaceCustomizationPersistenceEntry: Codable, Equatable, Sendable {
     let customization: WorkspaceCustomization
     let revision: UInt64
+    let titleMutationRevision: UInt64
+
+    init(
+        customization: WorkspaceCustomization,
+        revision: UInt64,
+        titleMutationRevision: UInt64 = 0
+    ) {
+        self.customization = customization
+        self.revision = revision
+        self.titleMutationRevision = titleMutationRevision
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case customization
+        case revision
+        case titleMutationRevision
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        customization = try container.decode(
+            WorkspaceCustomization.self,
+            forKey: .customization
+        )
+        revision = try container.decode(UInt64.self, forKey: .revision)
+        // Older journals have no title-specific revision. Zero is a safe
+        // compatibility value; the next title mutation advances it.
+        titleMutationRevision = try container.decodeIfPresent(
+            UInt64.self,
+            forKey: .titleMutationRevision
+        ) ?? 0
+    }
 }
 
 struct WorkspaceCustomizationPersistenceSnapshot: Codable, Sendable {
@@ -22,9 +54,17 @@ struct WorkspaceCustomizationPersistenceSnapshot: Codable, Sendable {
 
     mutating func set(_ customization: WorkspaceCustomization, for key: String) {
         nextRevision &+= 1
+        let previous = entries[key]
+        let titleMutationRevision: UInt64
+        if previous?.customization.customTitle != customization.customTitle {
+            titleMutationRevision = nextRevision
+        } else {
+            titleMutationRevision = previous?.titleMutationRevision ?? 0
+        }
         entries[key] = WorkspaceCustomizationPersistenceEntry(
             customization: customization,
-            revision: nextRevision
+            revision: nextRevision,
+            titleMutationRevision: titleMutationRevision
         )
     }
 
@@ -96,11 +136,19 @@ final class WorkspaceCustomizationSynchronousWriter: @unchecked Sendable {
                 lhs.stableId.uuidString < rhs.stableId.uuidString
             }) {
                 let key = item.stableId.uuidString
-                if let currentTitle = snapshot.entries[key]?.customization.customTitle,
-                   case .value = currentTitle {
-                    // A user write may have landed after this automatic
-                    // record was queued. Preserve the user-owned value even
-                    // when the queue belongs to another manager copy.
+                guard let currentEntry = snapshot.entries[key],
+                      currentEntry.titleMutationRevision == item.titleMutationRevision else {
+                    // Any mutation after the automatic title was queued makes
+                    // this record stale, including an explicit clear from a
+                    // different manager instance. Preserve that later state.
+                    continue
+                }
+                switch currentEntry.customization.customTitle {
+                case .cleared, .autoValue:
+                    break
+                case .absent, .value:
+                    // Keep the legacy user-value guard as a defense in depth
+                    // for journals written before title-specific revisions.
                     continue
                 }
                 let trimmed = item.title?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomizationPersistence.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomizationPersistence.swift
@@ -41,3 +41,132 @@ struct WorkspaceCustomizationPersistenceSnapshot: Codable, Sendable {
             .map { ($0.key, $0.value) })
     }
 }
+
+/// One process-wide lock keeps independent store values from racing a
+/// read-modify-write against the same UserDefaults database. Store values are
+/// copied into each window manager, so an instance-local lock would not cover
+/// all writers.
+private final class WorkspaceCustomizationPersistenceLock: @unchecked Sendable {
+    static let shared = WorkspaceCustomizationPersistenceLock()
+
+    let value = NSRecursiveLock()
+
+    private init() {}
+}
+
+/// Owns the synchronous persistence boundary shared by actor-isolated stores.
+///
+/// Normal callers reach this through ``WorkspaceCustomizationStore`` on the
+/// main actor. A workspace owner can also hand pending records here from its
+/// nonisolated deinitializer. The lock covers the complete read-modify-write
+/// transaction so that handoff cannot race another store mutation. UserDefaults
+/// is thread-safe for individual calls, but does not make this compound
+/// transaction atomic.
+final class WorkspaceCustomizationSynchronousWriter: @unchecked Sendable {
+    private let defaults: UserDefaults?
+    private let storageKey: String
+    private let capacity: Int
+    // UserDefaults posts didChangeNotification synchronously on the setter
+    // thread. A recursive lock lets an observer read this store during that
+    // callback without deadlocking the transaction that triggered it. The
+    // critical section is bounded to one snapshot decode/encode and defaults
+    // update because deinitializers cannot suspend for an actor hop.
+    private let lock = WorkspaceCustomizationPersistenceLock.shared.value
+
+    init(defaults: UserDefaults?, storageKey: String, capacity: Int) {
+        self.defaults = defaults
+        self.storageKey = storageKey
+        self.capacity = capacity
+    }
+
+    func withLock<T>(_ body: () -> T) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return body()
+    }
+
+    func persistPendingAutomaticTitles(
+        _ pending: [WorkspaceCustomizationPendingAutomaticTitle]
+    ) {
+        guard !pending.isEmpty else { return }
+        withLock {
+            guard let defaults else { return }
+            var snapshot = loadSnapshotUnlocked(defaults: defaults)
+            for item in pending.sorted(by: { lhs, rhs in
+                lhs.stableId.uuidString < rhs.stableId.uuidString
+            }) {
+                let key = item.stableId.uuidString
+                if let currentTitle = snapshot.entries[key]?.customization.customTitle,
+                   case .value = currentTitle {
+                    // A user write may have landed after this automatic
+                    // record was queued. Preserve the user-owned value even
+                    // when the queue belongs to another manager copy.
+                    continue
+                }
+                let trimmed = item.title?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                let field: WorkspaceCustomizationField = trimmed.isEmpty
+                    ? .cleared
+                    : .autoValue(trimmed)
+                snapshot.set(
+                    WorkspaceCustomization(
+                        customTitle: field,
+                        customColor: snapshot.entries[key]?.customization.customColor ?? .absent
+                    ),
+                    for: key
+                )
+            }
+            snapshot.trim(to: capacity)
+            persistSnapshotUnlocked(snapshot, defaults: defaults)
+        }
+    }
+
+    func loadSnapshot() -> WorkspaceCustomizationPersistenceSnapshot {
+        withLock {
+            guard let defaults else { return WorkspaceCustomizationPersistenceSnapshot() }
+            return loadSnapshotUnlocked(defaults: defaults)
+        }
+    }
+
+    func updateSnapshot(
+        _ update: (inout WorkspaceCustomizationPersistenceSnapshot) -> Void
+    ) {
+        withLock {
+            guard let defaults else { return }
+            var snapshot = loadSnapshotUnlocked(defaults: defaults)
+            update(&snapshot)
+            snapshot.trim(to: capacity)
+            persistSnapshotUnlocked(snapshot, defaults: defaults)
+        }
+    }
+
+    private func loadSnapshotUnlocked(
+        defaults: UserDefaults
+    ) -> WorkspaceCustomizationPersistenceSnapshot {
+        guard let data = defaults.data(forKey: storageKey),
+              var snapshot = try? JSONDecoder().decode(
+                  WorkspaceCustomizationPersistenceSnapshot.self,
+                  from: data
+              ),
+              snapshot.version == WorkspaceCustomizationPersistenceSnapshot.currentVersion else {
+            return WorkspaceCustomizationPersistenceSnapshot()
+        }
+        let previousCount = snapshot.entries.count
+        snapshot.trim(to: capacity)
+        if snapshot.entries.count != previousCount {
+            persistSnapshotUnlocked(snapshot, defaults: defaults)
+        }
+        return snapshot
+    }
+
+    private func persistSnapshotUnlocked(
+        _ snapshot: WorkspaceCustomizationPersistenceSnapshot,
+        defaults: UserDefaults
+    ) {
+        guard !snapshot.entries.isEmpty else {
+            defaults.removeObject(forKey: storageKey)
+            return
+        }
+        guard let data = try? JSONEncoder().encode(snapshot) else { return }
+        defaults.set(data, forKey: storageKey)
+    }
+}

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomizationPersistence.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomizationPersistence.swift
@@ -55,16 +55,19 @@ struct WorkspaceCustomizationPersistenceSnapshot: Codable, Sendable {
     mutating func set(_ customization: WorkspaceCustomization, for key: String) {
         nextRevision &+= 1
         let previous = entries[key]
-        let titleMutationRevision: UInt64
-        if previous?.customization.customTitle != customization.customTitle {
-            titleMutationRevision = nextRevision
-        } else {
-            titleMutationRevision = previous?.titleMutationRevision ?? 0
-        }
         entries[key] = WorkspaceCustomizationPersistenceEntry(
             customization: customization,
             revision: nextRevision,
-            titleMutationRevision: titleMutationRevision
+            titleMutationRevision: previous?.titleMutationRevision ?? 0
+        )
+    }
+
+    mutating func setTitle(_ customization: WorkspaceCustomization, for key: String) {
+        nextRevision &+= 1
+        entries[key] = WorkspaceCustomizationPersistenceEntry(
+            customization: customization,
+            revision: nextRevision,
+            titleMutationRevision: nextRevision
         )
     }
 

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomizationPersistence.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomizationPersistence.swift
@@ -106,6 +106,11 @@ private final class WorkspaceCustomizationPersistenceLock: @unchecked Sendable {
 /// is thread-safe for individual calls, but does not make this compound
 /// transaction atomic.
 final class WorkspaceCustomizationSynchronousWriter: @unchecked Sendable {
+    private struct CachedSnapshot {
+        let data: Data?
+        let snapshot: WorkspaceCustomizationPersistenceSnapshot
+    }
+
     private let defaults: UserDefaults?
     private let storageKey: String
     private let capacity: Int
@@ -115,11 +120,37 @@ final class WorkspaceCustomizationSynchronousWriter: @unchecked Sendable {
     // critical section is bounded to one snapshot decode/encode and defaults
     // update because deinitializers cannot suspend for an actor hop.
     private let lock = WorkspaceCustomizationPersistenceLock.shared.value
+    // This short lock protects only the cache reference. Notification
+    // callbacks must not take the transaction lock: another writer can be in a
+    // defaults setter that synchronously waits for this callback to return.
+    private let cacheLock = NSLock()
+    private var cachedSnapshot: CachedSnapshot?
+    private var defaultsChangeObserver: (any NSObjectProtocol)?
 
     init(defaults: UserDefaults?, storageKey: String, capacity: Int) {
         self.defaults = defaults
         self.storageKey = storageKey
         self.capacity = capacity
+        guard defaults != nil else { return }
+
+        // Observe every UserDefaults instance. The notification object identifies
+        // the instance that wrote the value, so filtering by object would leave
+        // separately-created stores for the same suite stale. This writer has a
+        // per-instance cache, and a process-wide notification invalidates all
+        // copies that may read the same defaults database.
+        self.defaultsChangeObserver = NotificationCenter.default.addObserver(
+            forName: UserDefaults.didChangeNotification,
+            object: nil,
+            queue: nil
+        ) { [weak self] _ in
+            self?.invalidateCachedSnapshot()
+        }
+    }
+
+    deinit {
+        if let defaultsChangeObserver {
+            NotificationCenter.default.removeObserver(defaultsChangeObserver)
+        }
     }
 
     func withLock<T>(_ body: () -> T) -> T {
@@ -193,18 +224,27 @@ final class WorkspaceCustomizationSynchronousWriter: @unchecked Sendable {
     private func loadSnapshotUnlocked(
         defaults: UserDefaults
     ) -> WorkspaceCustomizationPersistenceSnapshot {
-        guard let data = defaults.data(forKey: storageKey),
+        let data = defaults.data(forKey: storageKey)
+        if let cachedSnapshot = cachedSnapshot(matching: data) {
+            return cachedSnapshot
+        }
+
+        guard let data,
               var snapshot = try? JSONDecoder().decode(
                   WorkspaceCustomizationPersistenceSnapshot.self,
                   from: data
               ),
               snapshot.version == WorkspaceCustomizationPersistenceSnapshot.currentVersion else {
-            return WorkspaceCustomizationPersistenceSnapshot()
+            let empty = WorkspaceCustomizationPersistenceSnapshot()
+            setCachedSnapshot(CachedSnapshot(data: data, snapshot: empty))
+            return empty
         }
         let previousCount = snapshot.entries.count
         snapshot.trim(to: capacity)
         if snapshot.entries.count != previousCount {
             persistSnapshotUnlocked(snapshot, defaults: defaults)
+        } else {
+            setCachedSnapshot(CachedSnapshot(data: data, snapshot: snapshot))
         }
         return snapshot
     }
@@ -215,9 +255,32 @@ final class WorkspaceCustomizationSynchronousWriter: @unchecked Sendable {
     ) {
         guard !snapshot.entries.isEmpty else {
             defaults.removeObject(forKey: storageKey)
+            setCachedSnapshot(CachedSnapshot(data: nil, snapshot: snapshot))
             return
         }
         guard let data = try? JSONEncoder().encode(snapshot) else { return }
         defaults.set(data, forKey: storageKey)
+        setCachedSnapshot(CachedSnapshot(data: data, snapshot: snapshot))
+    }
+
+    private func invalidateCachedSnapshot() {
+        cacheLock.lock()
+        cachedSnapshot = nil
+        cacheLock.unlock()
+    }
+
+    private func cachedSnapshot(
+        matching data: Data?
+    ) -> WorkspaceCustomizationPersistenceSnapshot? {
+        cacheLock.lock()
+        defer { cacheLock.unlock() }
+        guard let cachedSnapshot, cachedSnapshot.data == data else { return nil }
+        return cachedSnapshot.snapshot
+    }
+
+    private func setCachedSnapshot(_ snapshot: CachedSnapshot) {
+        cacheLock.lock()
+        cachedSnapshot = snapshot
+        cacheLock.unlock()
     }
 }

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomizationPersistence.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomizationPersistence.swift
@@ -4,21 +4,25 @@ struct WorkspaceCustomizationPersistenceEntry: Codable, Equatable, Sendable {
     let customization: WorkspaceCustomization
     let revision: UInt64
     let titleMutationRevision: UInt64
+    let automaticTitleOrdering: UInt64
 
     init(
         customization: WorkspaceCustomization,
         revision: UInt64,
-        titleMutationRevision: UInt64 = 0
+        titleMutationRevision: UInt64 = 0,
+        automaticTitleOrdering: UInt64 = 0
     ) {
         self.customization = customization
         self.revision = revision
         self.titleMutationRevision = titleMutationRevision
+        self.automaticTitleOrdering = automaticTitleOrdering
     }
 
     private enum CodingKeys: String, CodingKey {
         case customization
         case revision
         case titleMutationRevision
+        case automaticTitleOrdering
     }
 
     init(from decoder: Decoder) throws {
@@ -33,6 +37,10 @@ struct WorkspaceCustomizationPersistenceEntry: Codable, Equatable, Sendable {
         titleMutationRevision = try container.decodeIfPresent(
             UInt64.self,
             forKey: .titleMutationRevision
+        ) ?? 0
+        automaticTitleOrdering = try container.decodeIfPresent(
+            UInt64.self,
+            forKey: .automaticTitleOrdering
         ) ?? 0
     }
 }
@@ -58,16 +66,22 @@ struct WorkspaceCustomizationPersistenceSnapshot: Codable, Sendable {
         entries[key] = WorkspaceCustomizationPersistenceEntry(
             customization: customization,
             revision: nextRevision,
-            titleMutationRevision: previous?.titleMutationRevision ?? 0
+            titleMutationRevision: previous?.titleMutationRevision ?? 0,
+            automaticTitleOrdering: previous?.automaticTitleOrdering ?? 0
         )
     }
 
-    mutating func setTitle(_ customization: WorkspaceCustomization, for key: String) {
+    mutating func setTitle(
+        _ customization: WorkspaceCustomization,
+        for key: String,
+        automaticTitleOrdering: UInt64 = 0
+    ) {
         nextRevision &+= 1
         entries[key] = WorkspaceCustomizationPersistenceEntry(
             customization: customization,
             revision: nextRevision,
-            titleMutationRevision: nextRevision
+            titleMutationRevision: nextRevision,
+            automaticTitleOrdering: automaticTitleOrdering
         )
     }
 
@@ -170,11 +184,17 @@ final class WorkspaceCustomizationSynchronousWriter: @unchecked Sendable {
                 lhs.stableId.uuidString < rhs.stableId.uuidString
             }) {
                 let key = item.stableId.uuidString
-                guard let currentEntry = snapshot.entries[key],
-                      currentEntry.titleMutationRevision == item.titleMutationRevision else {
+                guard let currentEntry = snapshot.entries[key] else { continue }
+                let sameRevision = currentEntry.titleMutationRevision == item.titleMutationRevision
+                let newerConcurrentAutomaticTitle =
+                    currentEntry.titleMutationRevision > item.titleMutationRevision
+                    && currentEntry.automaticTitleOrdering > 0
+                    && item.automaticTitleOrdering > currentEntry.automaticTitleOrdering
+                guard sameRevision || newerConcurrentAutomaticTitle else {
                     // Any mutation after the automatic title was queued makes
-                    // this record stale, including an explicit clear from a
-                    // different manager instance. Preserve that later state.
+                    // this record stale unless it is a later automatic title
+                    // queued by another manager at the same observed revision.
+                    // Explicit user mutations retain precedence.
                     continue
                 }
                 switch currentEntry.customization.customTitle {
@@ -194,7 +214,8 @@ final class WorkspaceCustomizationSynchronousWriter: @unchecked Sendable {
                         customTitle: field,
                         customColor: snapshot.entries[key]?.customization.customColor ?? .absent
                     ),
-                    for: key
+                    for: key,
+                    automaticTitleOrdering: item.automaticTitleOrdering
                 )
             }
             snapshot.trim(to: capacity)

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomizationPersistence.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomizationPersistence.swift
@@ -158,7 +158,7 @@ final class WorkspaceCustomizationSynchronousWriter: @unchecked Sendable {
                 let field: WorkspaceCustomizationField = trimmed.isEmpty
                     ? .cleared
                     : .autoValue(trimmed)
-                snapshot.set(
+                snapshot.setTitle(
                     WorkspaceCustomization(
                         customTitle: field,
                         customColor: snapshot.entries[key]?.customization.customColor ?? .absent

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomizationPersistence.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomizationPersistence.swift
@@ -139,6 +139,8 @@ final class WorkspaceCustomizationSynchronousWriter: @unchecked Sendable {
     // defaults setter that synchronously waits for this callback to return.
     private let cacheLock = NSLock()
     private var cachedSnapshot: CachedSnapshot?
+    private let changeGenerationLock = NSLock()
+    private var changeGenerationValue: UInt64 = 0
     private var defaultsChangeObserver: (any NSObjectProtocol)?
 
     init(defaults: UserDefaults?, storageKey: String, capacity: Int) {
@@ -173,6 +175,12 @@ final class WorkspaceCustomizationSynchronousWriter: @unchecked Sendable {
         return body()
     }
 
+    func changeGeneration() -> UInt64 {
+        changeGenerationLock.lock()
+        defer { changeGenerationLock.unlock() }
+        return changeGenerationValue
+    }
+
     func persistPendingAutomaticTitles(
         _ pending: [WorkspaceCustomizationPendingAutomaticTitle]
     ) {
@@ -186,40 +194,12 @@ final class WorkspaceCustomizationSynchronousWriter: @unchecked Sendable {
                 let key = item.stableId.uuidString
                 guard let currentEntry = snapshot.entries[key] else { continue }
                 let trimmed = item.title?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-                let sameRevision = item.titleMutationRevision != 0
-                    && currentEntry.titleMutationRevision == item.titleMutationRevision
+                let sameRevision = currentEntry.titleMutationRevision == item.titleMutationRevision
                 let newerConcurrentAutomaticTitle =
-                    item.titleMutationRevision != 0
-                    && currentEntry.titleMutationRevision > item.titleMutationRevision
+                    currentEntry.titleMutationRevision > item.titleMutationRevision
                     && currentEntry.automaticTitleOrdering > 0
                     && item.automaticTitleOrdering > currentEntry.automaticTitleOrdering
-                let deferredAutomaticTitleCanApply: Bool = {
-                    guard item.titleMutationRevision == 0 else { return false }
-                    switch currentEntry.customization.customTitle {
-                    case .cleared:
-                        // A clear is the authority handoff that enables auto
-                        // naming. It may have happened in another manager
-                        // after this notification was queued.
-                        return true
-                    case let .autoValue(currentTitle):
-                        if currentEntry.automaticTitleOrdering > 0 {
-                            return currentEntry.automaticTitleOrdering <= item.automaticTitleOrdering
-                        }
-                        // Legacy automatic records have no ordering. Never
-                        // replace a different value without a durable fence.
-                        return currentTitle == trimmed
-                    case .absent, .value:
-                        return false
-                    }
-                }()
-                let clearAfterQueuedAutomaticTitle =
-                    item.titleMutationRevision != 0
-                    && currentEntry.titleMutationRevision > item.titleMutationRevision
-                    && currentEntry.customization.customTitle == .cleared
-                guard sameRevision
-                    || newerConcurrentAutomaticTitle
-                    || deferredAutomaticTitleCanApply
-                    || clearAfterQueuedAutomaticTitle else {
+                guard sameRevision || newerConcurrentAutomaticTitle else {
                     // Any mutation after the automatic title was queued makes
                     // this record stale unless it is a later automatic title
                     // queued by another manager at the same observed revision.
@@ -316,6 +296,9 @@ final class WorkspaceCustomizationSynchronousWriter: @unchecked Sendable {
         cacheLock.lock()
         cachedSnapshot = nil
         cacheLock.unlock()
+        changeGenerationLock.lock()
+        changeGenerationValue &+= 1
+        changeGenerationLock.unlock()
     }
 
     private func cachedSnapshot(

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomizationPersistence.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomizationPersistence.swift
@@ -151,15 +151,15 @@ final class WorkspaceCustomizationSynchronousWriter: @unchecked Sendable {
 
         // Observe every UserDefaults instance. The notification object identifies
         // the instance that wrote the value, so filtering by object would leave
-        // separately-created stores for the same suite stale. This writer has a
-        // per-instance cache, and a process-wide notification invalidates all
-        // copies that may read the same defaults database.
+        // separately-created stores for the same suite stale. Read the one
+        // backing value before invalidating. This keeps cross-instance cache
+        // coherence without turning unrelated defaults writes into journal work.
         self.defaultsChangeObserver = NotificationCenter.default.addObserver(
             forName: UserDefaults.didChangeNotification,
             object: nil,
             queue: nil
         ) { [weak self] _ in
-            self?.invalidateCachedSnapshot()
+            self?.invalidateCachedSnapshotIfBackingValueChanged()
         }
     }
 
@@ -292,9 +292,15 @@ final class WorkspaceCustomizationSynchronousWriter: @unchecked Sendable {
         setCachedSnapshot(CachedSnapshot(data: data, snapshot: snapshot))
     }
 
-    private func invalidateCachedSnapshot() {
+    private func invalidateCachedSnapshotIfBackingValueChanged() {
+        guard let defaults else { return }
+        let data = defaults.data(forKey: storageKey)
         cacheLock.lock()
-        cachedSnapshot = nil
+        guard let cachedSnapshot, cachedSnapshot.data != data else {
+            cacheLock.unlock()
+            return
+        }
+        self.cachedSnapshot = nil
         cacheLock.unlock()
         changeGenerationLock.lock()
         changeGenerationValue &+= 1

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomizationPersistence.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomizationPersistence.swift
@@ -310,7 +310,7 @@ final class WorkspaceCustomizationSynchronousWriter: @unchecked Sendable {
         guard let defaults else { return }
         let data = defaults.data(forKey: storageKey)
         cacheLock.lock()
-        guard let cachedSnapshot, cachedSnapshot.data != data else {
+        if let cachedSnapshot, cachedSnapshot.data == data {
             cacheLock.unlock()
             return
         }

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomizationPersistence.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomizationPersistence.swift
@@ -192,8 +192,22 @@ final class WorkspaceCustomizationSynchronousWriter: @unchecked Sendable {
                 lhs.stableId.uuidString < rhs.stableId.uuidString
             }) {
                 let key = item.stableId.uuidString
-                guard let currentEntry = snapshot.entries[key] else { continue }
                 let trimmed = item.title?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                guard let currentEntry = snapshot.entries[key] else {
+                    guard trimmed.isEmpty else { continue }
+                    // A clear from an automatic title owner is meaningful even
+                    // when no earlier stable-ID record exists. Create the
+                    // field-specific tombstone and retain its new fence.
+                    snapshot.setTitle(
+                        WorkspaceCustomization(
+                            customTitle: .cleared,
+                            customColor: .absent
+                        ),
+                        for: key,
+                        automaticTitleOrdering: item.automaticTitleOrdering
+                    )
+                    continue
+                }
                 let sameRevision = currentEntry.titleMutationRevision == item.titleMutationRevision
                 let newerConcurrentAutomaticTitle =
                     currentEntry.titleMutationRevision > item.titleMutationRevision

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomizationPersistence.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomizationPersistence.swift
@@ -185,12 +185,41 @@ final class WorkspaceCustomizationSynchronousWriter: @unchecked Sendable {
             }) {
                 let key = item.stableId.uuidString
                 guard let currentEntry = snapshot.entries[key] else { continue }
-                let sameRevision = currentEntry.titleMutationRevision == item.titleMutationRevision
+                let trimmed = item.title?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                let sameRevision = item.titleMutationRevision != 0
+                    && currentEntry.titleMutationRevision == item.titleMutationRevision
                 let newerConcurrentAutomaticTitle =
-                    currentEntry.titleMutationRevision > item.titleMutationRevision
+                    item.titleMutationRevision != 0
+                    && currentEntry.titleMutationRevision > item.titleMutationRevision
                     && currentEntry.automaticTitleOrdering > 0
                     && item.automaticTitleOrdering > currentEntry.automaticTitleOrdering
-                guard sameRevision || newerConcurrentAutomaticTitle else {
+                let deferredAutomaticTitleCanApply: Bool = {
+                    guard item.titleMutationRevision == 0 else { return false }
+                    switch currentEntry.customization.customTitle {
+                    case .cleared:
+                        // A clear is the authority handoff that enables auto
+                        // naming. It may have happened in another manager
+                        // after this notification was queued.
+                        return true
+                    case let .autoValue(currentTitle):
+                        if currentEntry.automaticTitleOrdering > 0 {
+                            return currentEntry.automaticTitleOrdering <= item.automaticTitleOrdering
+                        }
+                        // Legacy automatic records have no ordering. Never
+                        // replace a different value without a durable fence.
+                        return currentTitle == trimmed
+                    case .absent, .value:
+                        return false
+                    }
+                }()
+                let clearAfterQueuedAutomaticTitle =
+                    item.titleMutationRevision != 0
+                    && currentEntry.titleMutationRevision > item.titleMutationRevision
+                    && currentEntry.customization.customTitle == .cleared
+                guard sameRevision
+                    || newerConcurrentAutomaticTitle
+                    || deferredAutomaticTitleCanApply
+                    || clearAfterQueuedAutomaticTitle else {
                     // Any mutation after the automatic title was queued makes
                     // this record stale unless it is a later automatic title
                     // queued by another manager at the same observed revision.
@@ -205,7 +234,6 @@ final class WorkspaceCustomizationSynchronousWriter: @unchecked Sendable {
                     // for journals written before title-specific revisions.
                     continue
                 }
-                let trimmed = item.title?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
                 let field: WorkspaceCustomizationField = trimmed.isEmpty
                     ? .cleared
                     : .autoValue(trimmed)

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomizationStore.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomizationStore.swift
@@ -100,7 +100,7 @@ public struct WorkspaceCustomizationStore {
         source: WorkspaceCustomizationTitleSource = .user
     ) {
         let field = normalizedTitleField(title, source: source)
-        updateCustomization(for: stableId) { current in
+        updateTitleCustomization(for: stableId) { current in
             WorkspaceCustomization(
                 customTitle: field,
                 customColor: current?.customColor ?? .absent
@@ -189,6 +189,19 @@ public struct WorkspaceCustomizationStore {
         updateCustomizations(forKeys: [stableId.uuidString]) { current in
             result = transform(current)
             return result
+        }
+        return result
+    }
+
+    @discardableResult
+    private func updateTitleCustomization(
+        for stableId: UUID,
+        _ transform: (WorkspaceCustomization?) -> WorkspaceCustomization
+    ) -> WorkspaceCustomization {
+        var result = WorkspaceCustomization()
+        synchronousWriter.updateSnapshot { snapshot in
+            result = transform(snapshot.entries[stableId.uuidString]?.customization)
+            snapshot.setTitle(result, for: stableId.uuidString)
         }
         return result
     }

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomizationStore.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomizationStore.swift
@@ -1,10 +1,10 @@
 public import Foundation
 
-/// Persists bounded user-owned identity recovery records by workspace identity.
+/// Persists bounded workspace identity recovery records by workspace identity.
 ///
 /// The session snapshot remains the baseline. This journal records immediate
-/// user mutations so a quit before the next autosave cannot lose a rename,
-/// recolor, or explicit clear.
+/// title and user mutations so a quit before the next autosave cannot lose a
+/// rename, recolor, or explicit clear.
 @MainActor
 public struct WorkspaceCustomizationStore {
     /// Production key for the stable-workspace-ID recovery journal.
@@ -65,13 +65,18 @@ public struct WorkspaceCustomizationStore {
         })
     }
 
-    /// Records the latest explicit workspace-title mutation.
+    /// Records the latest workspace-title mutation.
     ///
     /// - Parameters:
     ///   - title: The title to record, or `nil` to record an explicit clear.
+    ///   - source: Whether the title came from a user or automatic naming.
     ///   - stableId: The stable workspace identity.
-    public func setCustomTitle(_ title: String?, for stableId: UUID) {
-        let field = normalizedField(title)
+    public func setCustomTitle(
+        _ title: String?,
+        for stableId: UUID,
+        source: WorkspaceCustomizationTitleSource = .user
+    ) {
+        let field = normalizedTitleField(title, source: source)
         updateCustomization(for: stableId) { current in
             WorkspaceCustomization(
                 customTitle: field,
@@ -180,6 +185,15 @@ public struct WorkspaceCustomizationStore {
     private func normalizedField(_ value: String?) -> WorkspaceCustomizationField {
         let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         return trimmed.isEmpty ? .cleared : .value(trimmed)
+    }
+
+    private func normalizedTitleField(
+        _ value: String?,
+        source: WorkspaceCustomizationTitleSource
+    ) -> WorkspaceCustomizationField {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !trimmed.isEmpty else { return .cleared }
+        return source == .auto ? .autoValue(trimmed) : .value(trimmed)
     }
 
     private func migratedField(_ value: String?) -> WorkspaceCustomizationField {

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomizationStore.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomizationStore.swift
@@ -68,6 +68,13 @@ public struct WorkspaceCustomizationStore {
         loadSnapshot().entries[stableId.uuidString]?.customization
     }
 
+    /// Reads the monotonic title mutation revision for one stable workspace identity.
+    /// A caller can use this as a fence for deferred writes that must not
+    /// overwrite a later mutation made by another manager instance.
+    public func customizationTitleMutationRevision(for stableId: UUID) -> UInt64? {
+        loadSnapshot().entries[stableId.uuidString]?.titleMutationRevision
+    }
+
     /// Reads a batch of recovery records with one defaults decode.
     ///
     /// - Parameter stableIds: The stable workspace identities to read.

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomizationStore.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomizationStore.swift
@@ -75,6 +75,18 @@ public struct WorkspaceCustomizationStore {
         loadSnapshot().entries[stableId.uuidString]?.titleMutationRevision
     }
 
+    /// Reads the recovery value and its title-mutation fence from one snapshot.
+    ///
+    /// Automatic title notifications use this combined read because decoding
+    /// the complete journal is synchronous. Keeping the two fields together
+    /// avoids decoding the journal twice for one high-frequency notification.
+    public func customizationAndTitleMutationRevision(
+        for stableId: UUID
+    ) -> (customization: WorkspaceCustomization, titleMutationRevision: UInt64)? {
+        guard let entry = loadSnapshot().entries[stableId.uuidString] else { return nil }
+        return (entry.customization, entry.titleMutationRevision)
+    }
+
     /// Reads a batch of recovery records with one defaults decode.
     ///
     /// - Parameter stableIds: The stable workspace identities to read.

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomizationStore.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomizationStore.swift
@@ -21,6 +21,9 @@ public struct WorkspaceCustomizationStore {
     private let storageKey: String
     private let legacyStorageKey: String
     private let capacity: Int
+    /// Nonisolated so a workspace owner can synchronously hand off pending
+    /// records from its deinitializer without retaining the owner.
+    private nonisolated let synchronousWriter: WorkspaceCustomizationSynchronousWriter
 
     /// Creates a store backed by the supplied defaults suite.
     ///
@@ -42,6 +45,19 @@ public struct WorkspaceCustomizationStore {
         self.storageKey = storageKey
         self.legacyStorageKey = legacyStorageKey
         self.capacity = max(1, capacity)
+        self.synchronousWriter = WorkspaceCustomizationSynchronousWriter(
+            defaults: defaults,
+            storageKey: storageKey,
+            capacity: max(1, capacity)
+        )
+    }
+
+    /// Persists automatic title records synchronously from a nonisolated owner
+    /// teardown. The writer owns the lock and the complete snapshot transaction.
+    public nonisolated func persistPendingAutomaticTitlesSynchronously(
+        _ pending: [WorkspaceCustomizationPendingAutomaticTitle]
+    ) {
+        synchronousWriter.persistPendingAutomaticTitles(pending)
     }
 
     /// Reads the recovery record for one stable workspace identity.
@@ -174,12 +190,11 @@ public struct WorkspaceCustomizationStore {
         forKeys keys: Set<String>,
         transform: (WorkspaceCustomization?) -> WorkspaceCustomization
     ) {
-        var snapshot = loadSnapshot()
-        for key in keys.sorted() {
-            snapshot.set(transform(snapshot.entries[key]?.customization), for: key)
+        synchronousWriter.updateSnapshot { snapshot in
+            for key in keys.sorted() {
+                snapshot.set(transform(snapshot.entries[key]?.customization), for: key)
+            }
         }
-        snapshot.trim(to: capacity)
-        persist(snapshot)
     }
 
     private func normalizedField(_ value: String?) -> WorkspaceCustomizationField {
@@ -201,29 +216,6 @@ public struct WorkspaceCustomizationStore {
     }
 
     private func loadSnapshot() -> WorkspaceCustomizationPersistenceSnapshot {
-        guard let data = defaults?.data(forKey: storageKey),
-              var snapshot = try? JSONDecoder().decode(
-                  WorkspaceCustomizationPersistenceSnapshot.self,
-                  from: data
-              ),
-              snapshot.version == WorkspaceCustomizationPersistenceSnapshot.currentVersion else {
-            return WorkspaceCustomizationPersistenceSnapshot()
-        }
-        let previousCount = snapshot.entries.count
-        snapshot.trim(to: capacity)
-        if snapshot.entries.count != previousCount {
-            persist(snapshot)
-        }
-        return snapshot
-    }
-
-    private func persist(_ snapshot: WorkspaceCustomizationPersistenceSnapshot) {
-        guard let defaults else { return }
-        guard !snapshot.entries.isEmpty else {
-            defaults.removeObject(forKey: storageKey)
-            return
-        }
-        guard let data = try? JSONEncoder().encode(snapshot) else { return }
-        defaults.set(data, forKey: storageKey)
+        synchronousWriter.loadSnapshot()
     }
 }

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomizationStore.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomizationStore.swift
@@ -105,6 +105,31 @@ public struct WorkspaceCustomizationStore {
         })
     }
 
+    /// Reads recovery values and their title-mutation fences from one immutable
+    /// journal snapshot. The two dictionaries always describe the same
+    /// persisted state, even when another store writes immediately afterward.
+    ///
+    /// - Parameter stableIds: The stable workspace identities to read.
+    /// - Returns: Matching customization values and title fences.
+    public func customizationsAndTitleMutationRevisions(
+        for stableIds: [UUID]
+    ) -> (
+        customizations: [UUID: WorkspaceCustomization],
+        titleMutationRevisions: [UUID: UInt64]
+    ) {
+        let requested = Set(stableIds)
+        guard !requested.isEmpty else { return ([:], [:]) }
+        let entries = loadSnapshot().entries
+        var customizations: [UUID: WorkspaceCustomization] = [:]
+        var titleMutationRevisions: [UUID: UInt64] = [:]
+        for stableId in requested {
+            guard let entry = entries[stableId.uuidString] else { continue }
+            customizations[stableId] = entry.customization
+            titleMutationRevisions[stableId] = entry.titleMutationRevision
+        }
+        return (customizations, titleMutationRevisions)
+    }
+
     /// Reads a batch of recovery records with one defaults decode.
     ///
     /// - Parameter stableIds: The stable workspace identities to read.

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomizationStore.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomizationStore.swift
@@ -60,6 +60,13 @@ public struct WorkspaceCustomizationStore {
         synchronousWriter.persistPendingAutomaticTitles(pending)
     }
 
+    /// Returns a cheap process-local generation that changes whenever the
+    /// backing defaults value changes. Callers can cache a journal read until
+    /// this value changes without decoding the full snapshot for each event.
+    public nonisolated func changeGeneration() -> UInt64 {
+        synchronousWriter.changeGeneration()
+    }
+
     /// Reads the recovery record for one stable workspace identity.
     ///
     /// - Parameter stableId: The stable workspace identity.

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomizationStore.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceCustomizationStore.swift
@@ -87,6 +87,17 @@ public struct WorkspaceCustomizationStore {
         return (entry.customization, entry.titleMutationRevision)
     }
 
+    /// Reads title-mutation fences for several stable workspace identities with
+    /// one defaults decode. Missing identities are omitted.
+    public func titleMutationRevisions(for stableIds: [UUID]) -> [UUID: UInt64] {
+        let requested = Set(stableIds)
+        guard !requested.isEmpty else { return [:] }
+        let entries = loadSnapshot().entries
+        return Dictionary(uniqueKeysWithValues: requested.compactMap { stableId in
+            entries[stableId.uuidString].map { (stableId, $0.titleMutationRevision) }
+        })
+    }
+
     /// Reads a batch of recovery records with one defaults decode.
     ///
     /// - Parameter stableIds: The stable workspace identities to read.

--- a/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/Customization/WorkspaceCustomizationStoreTests.swift
+++ b/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/Customization/WorkspaceCustomizationStoreTests.swift
@@ -133,6 +133,50 @@ func titleRecoveryRecordIncludesMutationFence() throws {
     #expect(record.titleMutationRevision > 0)
 }
 
+    @Test("invalidates a cached snapshot when another store changes the defaults")
+    func snapshotCacheInvalidatesAcrossStoreInstances() throws {
+        let fixture = try makeFixture()
+        defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
+        let stableId = UUID()
+        let otherStore = WorkspaceCustomizationStore(
+            defaults: fixture.defaults,
+            storageKey: fixture.storageKey,
+            legacyStorageKey: fixture.legacyStorageKey
+        )
+
+        fixture.store.setCustomTitle("First", for: stableId)
+        #expect(fixture.store.customization(for: stableId)?.customTitle == .value("First"))
+
+        otherStore.setCustomTitle("Second", for: stableId)
+        #expect(fixture.store.customization(for: stableId)?.customTitle == .value("Second"))
+    }
+
+    @Test("invalidates when the backing UserDefaults value changes directly")
+    func snapshotCacheInvalidatesForDirectDefaultsMutation() throws {
+        let fixture = try makeFixture()
+        defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
+        let stableId = UUID()
+
+        fixture.store.setCustomTitle("First", for: stableId)
+        #expect(fixture.store.customization(for: stableId)?.customTitle == .value("First"))
+
+        let replacement = WorkspaceCustomizationPersistenceSnapshot(
+            nextRevision: 1,
+            entries: [
+                stableId.uuidString: WorkspaceCustomizationPersistenceEntry(
+                    customization: WorkspaceCustomization(
+                        customTitle: .value("Direct"),
+                        customColor: .absent
+                    ),
+                    revision: 1
+                ),
+            ]
+        )
+        fixture.defaults.set(try JSONEncoder().encode(replacement), forKey: fixture.storageKey)
+
+        #expect(fixture.store.customization(for: stableId)?.customTitle == .value("Direct"))
+    }
+
 private enum LegacyWorkspaceCustomizationField: Codable, Equatable {
     case absent
     case value(String)
@@ -180,4 +224,5 @@ private func makeFixture(capacity: Int = 512) throws -> (
             legacyStorageKey
         )
     }
+
 }

--- a/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/Customization/WorkspaceCustomizationStoreTests.swift
+++ b/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/Customization/WorkspaceCustomizationStoreTests.swift
@@ -177,6 +177,42 @@ func titleRecoveryRecordIncludesMutationFence() throws {
         #expect(fixture.store.customization(for: stableId)?.customTitle == .value("Direct"))
     }
 
+    @Test("preserves ordering for same-revision automatic titles from separate stores")
+    func sameRevisionAutomaticTitlesUseQueueOrdering() throws {
+        let fixture = try makeFixture()
+        defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
+        let otherStore = WorkspaceCustomizationStore(
+            defaults: fixture.defaults,
+            storageKey: fixture.storageKey,
+            legacyStorageKey: fixture.legacyStorageKey
+        )
+        let stableId = UUID()
+
+        fixture.store.setCustomTitle(nil, for: stableId)
+        let revision = try #require(
+            fixture.store.customizationAndTitleMutationRevision(for: stableId)
+        ).titleMutationRevision
+
+        fixture.store.persistPendingAutomaticTitlesSynchronously([
+            WorkspaceCustomizationPendingAutomaticTitle(
+                stableId: stableId,
+                title: "First",
+                titleMutationRevision: revision,
+                automaticTitleOrdering: 1
+            ),
+        ])
+        otherStore.persistPendingAutomaticTitlesSynchronously([
+            WorkspaceCustomizationPendingAutomaticTitle(
+                stableId: stableId,
+                title: "Second",
+                titleMutationRevision: revision,
+                automaticTitleOrdering: 2
+            ),
+        ])
+
+        #expect(fixture.store.customization(for: stableId)?.customTitle == .autoValue("Second"))
+    }
+
 private enum LegacyWorkspaceCustomizationField: Codable, Equatable {
     case absent
     case value(String)

--- a/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/Customization/WorkspaceCustomizationStoreTests.swift
+++ b/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/Customization/WorkspaceCustomizationStoreTests.swift
@@ -100,7 +100,47 @@ struct WorkspaceCustomizationStoreTests {
         #expect(fixture.defaults.object(forKey: fixture.legacyStorageKey) == nil)
     }
 
-    private func makeFixture(capacity: Int = 512) throws -> (
+@Test("automatic title records remain decodable by the previous schema")
+func automaticTitleRecordIsLegacyDecodable() throws {
+    let fixture = try makeFixture()
+    defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
+
+    let stableId = UUID()
+    fixture.store.setCustomTitle("Auto title", for: stableId, source: .auto)
+    let data = try #require(fixture.defaults.data(forKey: fixture.storageKey))
+    let legacy = try JSONDecoder().decode(LegacyWorkspaceCustomizationSnapshot.self, from: data)
+    let entry = try #require(legacy.entries[stableId.uuidString])
+
+    // The pre-provenance decoder must still read the record as a normal value.
+    // The new decoder retains automatic provenance through its extension key.
+    #expect(entry.customization.customTitle == .value("Auto title"))
+    #expect(entry.customization.customColor == .absent)
+    #expect(fixture.store.customization(for: stableId)?.customTitle == .autoValue("Auto title"))
+}
+
+private enum LegacyWorkspaceCustomizationField: Codable, Equatable {
+    case absent
+    case value(String)
+    case cleared
+}
+
+private struct LegacyWorkspaceCustomization: Codable, Equatable {
+    let customTitle: LegacyWorkspaceCustomizationField
+    let customColor: LegacyWorkspaceCustomizationField
+}
+
+private struct LegacyWorkspaceCustomizationPersistenceEntry: Codable, Equatable {
+    let customization: LegacyWorkspaceCustomization
+    let revision: UInt64
+}
+
+private struct LegacyWorkspaceCustomizationSnapshot: Codable, Equatable {
+    let version: Int
+    let nextRevision: UInt64
+    let entries: [String: LegacyWorkspaceCustomizationPersistenceEntry]
+}
+
+private func makeFixture(capacity: Int = 512) throws -> (
         store: WorkspaceCustomizationStore,
         defaults: UserDefaults,
         suiteName: String,

--- a/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/Customization/WorkspaceCustomizationStoreTests.swift
+++ b/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/Customization/WorkspaceCustomizationStoreTests.swift
@@ -118,6 +118,21 @@ func automaticTitleRecordIsLegacyDecodable() throws {
     #expect(fixture.store.customization(for: stableId)?.customTitle == .autoValue("Auto title"))
 }
 
+@Test("title recovery reads the value and mutation fence from one record")
+func titleRecoveryRecordIncludesMutationFence() throws {
+    let fixture = try makeFixture()
+    defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
+
+    let stableId = UUID()
+    fixture.store.setCustomTitle("Auto title", for: stableId, source: .auto)
+
+    let record = try #require(
+        fixture.store.customizationAndTitleMutationRevision(for: stableId)
+    )
+    #expect(record.customization.customTitle == .autoValue("Auto title"))
+    #expect(record.titleMutationRevision > 0)
+}
+
 private enum LegacyWorkspaceCustomizationField: Codable, Equatable {
     case absent
     case value(String)

--- a/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/Customization/WorkspaceCustomizationStoreTests.swift
+++ b/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/Customization/WorkspaceCustomizationStoreTests.swift
@@ -192,6 +192,21 @@ func titleRecoveryRecordIncludesMutationFence() throws {
         #expect(fixture.store.customization(for: stableId)?.customTitle == .value("Direct"))
     }
 
+    @Test("ignores unrelated UserDefaults changes")
+    func snapshotCacheIgnoresUnrelatedDefaultsChanges() throws {
+        let fixture = try makeFixture()
+        defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
+        let stableId = UUID()
+
+        fixture.store.setCustomTitle("First", for: stableId)
+        let generationBeforeUnrelatedChange = fixture.store.changeGeneration()
+
+        fixture.defaults.set("unrelated", forKey: "workspaceCustomizations.unrelated")
+
+        #expect(fixture.store.changeGeneration() == generationBeforeUnrelatedChange)
+        #expect(fixture.store.customization(for: stableId)?.customTitle == .value("First"))
+    }
+
     @Test("preserves ordering for same-revision automatic titles from separate stores")
     func sameRevisionAutomaticTitlesUseQueueOrdering() throws {
         let fixture = try makeFixture()

--- a/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/Customization/WorkspaceCustomizationStoreTests.swift
+++ b/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/Customization/WorkspaceCustomizationStoreTests.swift
@@ -197,6 +197,18 @@ func titleRecoveryRecordIncludesMutationFence() throws {
         #expect(fixture.store.customization(for: stableId)?.customTitle == .value("Direct"))
     }
 
+    @Test("advances generation when backing value changes before the cache is populated")
+    func backingMutationBeforeInitialLoadAdvancesGeneration() throws {
+        let fixture = try makeFixture()
+        defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
+
+        let generationBeforeMutation = fixture.store.changeGeneration()
+        let snapshot = WorkspaceCustomizationPersistenceSnapshot()
+        fixture.defaults.set(try JSONEncoder().encode(snapshot), forKey: fixture.storageKey)
+
+        #expect(fixture.store.changeGeneration() > generationBeforeMutation)
+    }
+
     @Test("ignores unrelated UserDefaults changes")
     func snapshotCacheIgnoresUnrelatedDefaultsChanges() throws {
         let fixture = try makeFixture()

--- a/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/Customization/WorkspaceCustomizationStoreTests.swift
+++ b/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/Customization/WorkspaceCustomizationStoreTests.swift
@@ -115,7 +115,12 @@ func automaticTitleRecordIsLegacyDecodable() throws {
     // The new decoder retains automatic provenance through its extension key.
     #expect(entry.customization.customTitle == .value("Auto title"))
     #expect(entry.customization.customColor == .absent)
-    #expect(fixture.store.customization(for: stableId)?.customTitle == .autoValue("Auto title"))
+    let reloaded = WorkspaceCustomizationStore(
+        defaults: fixture.defaults,
+        storageKey: fixture.storageKey,
+        legacyStorageKey: fixture.legacyStorageKey
+    )
+    #expect(reloaded.customization(for: stableId)?.customTitle == .autoValue("Auto title"))
 }
 
 @Test("title recovery reads the value and mutation fence from one record")

--- a/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/Customization/WorkspaceCustomizationStoreTests.swift
+++ b/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/Customization/WorkspaceCustomizationStoreTests.swift
@@ -133,6 +133,21 @@ func titleRecoveryRecordIncludesMutationFence() throws {
     #expect(record.titleMutationRevision > 0)
 }
 
+    @Test("batch title recovery returns values and fences from one snapshot")
+    func batchTitleRecoveryUsesOneSnapshot() throws {
+        let fixture = try makeFixture()
+        defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
+        let stableId = UUID()
+
+        fixture.store.setCustomTitle("Auto title", for: stableId, source: .auto)
+
+        let records = fixture.store.customizationsAndTitleMutationRevisions(for: [stableId])
+        let customization = try #require(records.customizations[stableId])
+        let revision = try #require(records.titleMutationRevisions[stableId])
+        #expect(customization.customTitle == .autoValue("Auto title"))
+        #expect(revision > 0)
+    }
+
     @Test("invalidates a cached snapshot when another store changes the defaults")
     func snapshotCacheInvalidatesAcrossStoreInstances() throws {
         let fixture = try makeFixture()

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2096,6 +2096,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                     ttyDeviceBindings: ttyDeviceBindings
                 )
                 guard !Task.isCancelled else { return }
+                self.flushPendingWorkspaceCustomizationWrites()
                 _ = self.saveSessionSnapshot(
                     includeScrollback: true,
                     removeWhenEmpty: false,
@@ -2134,6 +2135,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                     hasOwnedRuntimeCleanup: hasOwnedRuntimeCleanup
                 )
                 guard disposition == .cancelTerminationAfterRuntimeCleanupFailure else {
+                    self.flushPendingWorkspaceCustomizationWrites()
                     _ = self.saveSessionSnapshotUsingCachedProcessDetectedIndexes(
                         includeScrollback: true,
                         removeWhenEmpty: false
@@ -2205,6 +2207,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // The hard AppKit watchdog is armed immediately before the terminate
         // reply, after any owned asynchronous cleanup has finished. This keeps
         // the will-terminate gauntlet bounded without cutting rollback short.
+    }
+
+    private func flushPendingWorkspaceCustomizationWrites() {
+        var managers = mainWindowContexts.values.map(\.tabManager)
+        if let tabManager,
+           !managers.contains(where: { $0 === tabManager }) {
+            managers.append(tabManager)
+        }
+        for manager in managers {
+            manager.flushPendingWorkspaceCustomizationWrites()
+        }
     }
 
     private func presentQuitConfirmationAlert(
@@ -2322,6 +2335,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     func applicationWillTerminate(_ notification: Notification) {
         StartupBreadcrumbLog.append("appDelegate.willTerminate.begin")
+        flushPendingWorkspaceCustomizationWrites()
         // Backstop for any terminate path that did not route through
         // prepareForConfirmedAppTermination(). Normal confirmed termination has already
         // persisted a fresh index before AppKit receives its reply; do not overwrite that

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6775,6 +6775,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         rememberRecoverableRoute: Bool
     ) -> MainWindowContext? {
         guard mainWindowContexts.values.contains(where: { $0 === context }) else { return nil }
+        // Persist queued automatic titles before removing the context's strong
+        // manager owner. This handoff is synchronous, so a quit immediately
+        // after window teardown cannot lose the queued journal update.
+        context.tabManager.flushPendingWorkspaceCustomizationWrites()
         let sidebarSnapshot = sessionSidebarSnapshot(for: context)
         let recoverableWindowDock: DockSplitStore?
         if rememberRecoverableRoute {

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -1845,6 +1845,10 @@ struct SessionWorkspaceSnapshot: Codable, Sendable {
     var customTitle: String?
     /// Provenance of `customTitle`; absent provenance restores as user-set for compatibility.
     var customTitleSource: Workspace.CustomTitleSource? = nil
+    /// Title-mutation fence observed in the stable-ID customization journal
+    /// when this snapshot was written. It lets restore choose a newer session
+    /// snapshot over an automatic journal record that was still pending.
+    var customTitleMutationRevision: UInt64? = nil
     var customDescription: String?
     var customColor: String?
     var customizationDirectory: String? = nil

--- a/Sources/TabManager+WorkspaceCustomizationPersistence.swift
+++ b/Sources/TabManager+WorkspaceCustomizationPersistence.swift
@@ -108,7 +108,15 @@ extension TabManager {
         case let .value(title):
             workspace.setCustomTitle(title)
         case .cleared:
-            workspace.setCustomTitle(nil)
+            // A prior user clear re-enables auto-naming; it must not evict
+            // a subsequently auto-derived title restored from the session
+            // snapshot. Without this guard, the durable customization journal
+            // clobbers the snapshot's `.auto` title on every restore, so
+            // auto-named workspaces lose their title across restart until the
+            // next turn re-derives it.
+            if workspace.effectiveCustomTitleSource != .auto {
+                workspace.setCustomTitle(nil)
+            }
         }
 
         switch customization.customColor {

--- a/Sources/TabManager+WorkspaceCustomizationPersistence.swift
+++ b/Sources/TabManager+WorkspaceCustomizationPersistence.swift
@@ -80,10 +80,17 @@ extension TabManager {
         _ workspace: Workspace,
         source: Workspace.CustomTitleSource
     ) {
-        guard source == .user else { return }
+        // Automatic naming normally belongs to the session snapshot. Journal
+        // only the first auto title after an explicit clear, which advances the
+        // clear tombstone without turning every refresh into a durable write.
+        if source == .auto,
+           workspaceCustomizationStore.customization(for: workspace.stableId)?.customTitle != .cleared {
+            return
+        }
         workspaceCustomizationStore.setCustomTitle(
             workspace.customTitle,
-            for: workspace.stableId
+            for: workspace.stableId,
+            source: source == .auto ? .auto : .user
         )
     }
 
@@ -106,17 +113,14 @@ extension TabManager {
         case .absent:
             break
         case let .value(title):
-            workspace.setCustomTitle(title)
+            workspace.setCustomTitle(title, source: .user)
+        case let .autoValue(title):
+            // The journal is newer than the session snapshot. Clear any stale
+            // snapshot title before restoring the latest automatic value.
+            workspace.setCustomTitle(nil)
+            workspace.setCustomTitle(title, source: .auto)
         case .cleared:
-            // A prior user clear re-enables auto-naming; it must not evict
-            // a subsequently auto-derived title restored from the session
-            // snapshot. Without this guard, the durable customization journal
-            // clobbers the snapshot's `.auto` title on every restore, so
-            // auto-named workspaces lose their title across restart until the
-            // next turn re-derives it.
-            if workspace.effectiveCustomTitleSource != .auto {
-                workspace.setCustomTitle(nil)
-            }
+            workspace.setCustomTitle(nil)
         }
 
         switch customization.customColor {

--- a/Sources/TabManager+WorkspaceCustomizationPersistence.swift
+++ b/Sources/TabManager+WorkspaceCustomizationPersistence.swift
@@ -134,28 +134,23 @@ extension TabManager {
         // subsequent automatic value so a stale snapshot cannot roll the title
         // back to an earlier refresh.
         if source == .auto {
-            guard let field = workspaceCustomizationStore
-                .customization(for: workspace.stableId)?
-                .customTitle else {
+            guard let record = workspaceCustomizationStore
+                .customizationAndTitleMutationRevision(for: workspace.stableId) else {
                 return
             }
+            let field = record.customization.customTitle
             switch field {
             case .cleared, .autoValue:
                 break
             case .absent, .value:
                 return
             }
-            guard let titleMutationRevision = workspaceCustomizationStore
-                .customizationTitleMutationRevision(
-                for: workspace.stableId
-            ) else {
-                return
-            }
             let pending = pendingAutomaticWorkspaceTitles[workspace.stableId]
             pendingAutomaticWorkspaceTitles[workspace.stableId] =
                 PendingAutomaticWorkspaceTitle(
                     title: workspace.customTitle,
-                    titleMutationRevision: pending?.titleMutationRevision ?? titleMutationRevision
+                    titleMutationRevision: pending?.titleMutationRevision
+                        ?? record.titleMutationRevision
                 )
             scheduleAutomaticWorkspaceTitlePersistence()
             return

--- a/Sources/TabManager+WorkspaceCustomizationPersistence.swift
+++ b/Sources/TabManager+WorkspaceCustomizationPersistence.swift
@@ -2,6 +2,53 @@ import CmuxWorkspaces
 import Foundation
 
 extension TabManager {
+    /// Gives automatic title persistence a short coalescing window. Process
+    /// title notifications can arrive for every shell command, and each store
+    /// write encodes the complete recovery snapshot synchronously on the main
+    /// actor. A fixed window bounds durability lag while collapsing bursts.
+    private static let automaticWorkspaceTitlePersistenceDelay: Duration = .milliseconds(250)
+
+    /// Flushes all queued automatic title records. Lifecycle code calls this
+    /// before termination, while tests and restore boundaries can use it to
+    /// make the durability point explicit.
+    func flushPendingWorkspaceCustomizationWrites() {
+        automaticWorkspaceTitlePersistenceTask?.cancel()
+        automaticWorkspaceTitlePersistenceTask = nil
+        guard !pendingAutomaticWorkspaceTitles.isEmpty else { return }
+        let pending = pendingAutomaticWorkspaceTitles
+        pendingAutomaticWorkspaceTitles.removeAll(keepingCapacity: true)
+        for (stableId, title) in pending.sorted(by: { $0.key.uuidString < $1.key.uuidString }) {
+            workspaceCustomizationStore.setCustomTitle(
+                title,
+                for: stableId,
+                source: .auto
+            )
+        }
+    }
+
+    private func scheduleAutomaticWorkspaceTitlePersistence() {
+        guard automaticWorkspaceTitlePersistenceTask == nil else { return }
+        automaticWorkspaceTitlePersistenceTask = Task { [weak self] in
+            do {
+                try await ContinuousClock().sleep(
+                    for: Self.automaticWorkspaceTitlePersistenceDelay
+                )
+            } catch {
+                return
+            }
+            guard !Task.isCancelled else { return }
+            self?.flushPendingWorkspaceCustomizationWrites()
+        }
+    }
+
+    private func cancelPendingAutomaticWorkspaceTitle(for stableId: UUID) {
+        pendingAutomaticWorkspaceTitles.removeValue(forKey: stableId)
+        if pendingAutomaticWorkspaceTitles.isEmpty {
+            automaticWorkspaceTitlePersistenceTask?.cancel()
+            automaticWorkspaceTitlePersistenceTask = nil
+        }
+    }
+
     /// Migrates v1 directory records only when one restored workspace owns the directory.
     func prepareLegacyWorkspaceCustomizationMigration(
         afterRestoring snapshots: [SessionWorkspaceSnapshot]
@@ -96,7 +143,12 @@ extension TabManager {
             case .absent, .value:
                 return
             }
+            guard let title = workspace.customTitle else { return }
+            pendingAutomaticWorkspaceTitles[workspace.stableId] = title
+            scheduleAutomaticWorkspaceTitlePersistence()
+            return
         }
+        cancelPendingAutomaticWorkspaceTitle(for: workspace.stableId)
         workspaceCustomizationStore.setCustomTitle(
             workspace.customTitle,
             for: workspace.stableId,

--- a/Sources/TabManager+WorkspaceCustomizationPersistence.swift
+++ b/Sources/TabManager+WorkspaceCustomizationPersistence.swift
@@ -80,12 +80,22 @@ extension TabManager {
         _ workspace: Workspace,
         source: Workspace.CustomTitleSource
     ) {
-        // Automatic naming normally belongs to the session snapshot. Journal
-        // only the first auto title after an explicit clear, which advances the
-        // clear tombstone without turning every refresh into a durable write.
-        if source == .auto,
-           workspaceCustomizationStore.customization(for: workspace.stableId)?.customTitle != .cleared {
-            return
+        // Automatic naming normally belongs to the session snapshot. Once an
+        // explicit clear has made auto-naming authoritative, journal each
+        // subsequent automatic value so a stale snapshot cannot roll the title
+        // back to an earlier refresh.
+        if source == .auto {
+            guard let field = workspaceCustomizationStore
+                .customization(for: workspace.stableId)?
+                .customTitle else {
+                return
+            }
+            switch field {
+            case .cleared, .autoValue:
+                break
+            case .absent, .value:
+                return
+            }
         }
         workspaceCustomizationStore.setCustomTitle(
             workspace.customTitle,

--- a/Sources/TabManager+WorkspaceCustomizationPersistence.swift
+++ b/Sources/TabManager+WorkspaceCustomizationPersistence.swift
@@ -23,7 +23,7 @@ extension TabManager {
                     stableId: stableId,
                     title: pendingTitle.title,
                     titleMutationRevision: pendingTitle.titleMutationRevision,
-                    automaticTitleOrdering: pendingTitle.automaticTitleOrdering
+                automaticTitleOrdering: pendingTitle.automaticTitleOrdering
                 )
             }
         )

--- a/Sources/TabManager+WorkspaceCustomizationPersistence.swift
+++ b/Sources/TabManager+WorkspaceCustomizationPersistence.swift
@@ -138,6 +138,10 @@ extension TabManager {
             break
         case let .value(color):
             workspace.setCustomColor(color)
+        case .autoValue:
+            // Automatic provenance is valid only for titles. Ignore malformed
+            // color records rather than treating them as a user color.
+            break
         case .cleared:
             workspace.setCustomColor(nil)
         }

--- a/Sources/TabManager+WorkspaceCustomizationPersistence.swift
+++ b/Sources/TabManager+WorkspaceCustomizationPersistence.swift
@@ -17,13 +17,14 @@ extension TabManager {
         guard !pendingAutomaticWorkspaceTitles.isEmpty else { return }
         let pending = pendingAutomaticWorkspaceTitles
         pendingAutomaticWorkspaceTitles.removeAll(keepingCapacity: true)
-        for (stableId, title) in pending.sorted(by: { $0.key.uuidString < $1.key.uuidString }) {
-            workspaceCustomizationStore.setCustomTitle(
-                title,
-                for: stableId,
-                source: .auto
-            )
-        }
+        workspaceCustomizationStore.persistPendingAutomaticTitlesSynchronously(
+            pending.map { stableId, pendingTitle in
+                WorkspaceCustomizationPendingAutomaticTitle(
+                    stableId: stableId,
+                    title: pendingTitle.title
+                )
+            }
+        )
     }
 
     private func scheduleAutomaticWorkspaceTitlePersistence() {
@@ -143,8 +144,8 @@ extension TabManager {
             case .absent, .value:
                 return
             }
-            guard let title = workspace.customTitle else { return }
-            pendingAutomaticWorkspaceTitles[workspace.stableId] = title
+            pendingAutomaticWorkspaceTitles[workspace.stableId] =
+                PendingAutomaticWorkspaceTitle(title: workspace.customTitle)
             scheduleAutomaticWorkspaceTitlePersistence()
             return
         }

--- a/Sources/TabManager+WorkspaceCustomizationPersistence.swift
+++ b/Sources/TabManager+WorkspaceCustomizationPersistence.swift
@@ -22,7 +22,8 @@ extension TabManager {
                 WorkspaceCustomizationPendingAutomaticTitle(
                     stableId: stableId,
                     title: pendingTitle.title,
-                    titleMutationRevision: pendingTitle.titleMutationRevision
+                    titleMutationRevision: pendingTitle.titleMutationRevision,
+                    automaticTitleOrdering: pendingTitle.automaticTitleOrdering
                 )
             }
         )
@@ -146,11 +147,19 @@ extension TabManager {
                 return
             }
             let pending = pendingAutomaticWorkspaceTitles[workspace.stableId]
+            let automaticTitleOrdering: UInt64
+            if let pending {
+                automaticTitleOrdering = pending.automaticTitleOrdering
+            } else {
+                Self.nextAutomaticWorkspaceTitleOrdering &+= 1
+                automaticTitleOrdering = Self.nextAutomaticWorkspaceTitleOrdering
+            }
             pendingAutomaticWorkspaceTitles[workspace.stableId] =
                 PendingAutomaticWorkspaceTitle(
                     title: workspace.customTitle,
                     titleMutationRevision: pending?.titleMutationRevision
-                        ?? record.titleMutationRevision
+                        ?? record.titleMutationRevision,
+                    automaticTitleOrdering: automaticTitleOrdering
                 )
             scheduleAutomaticWorkspaceTitlePersistence()
             return

--- a/Sources/TabManager+WorkspaceCustomizationPersistence.swift
+++ b/Sources/TabManager+WorkspaceCustomizationPersistence.swift
@@ -21,7 +21,8 @@ extension TabManager {
             pending.map { stableId, pendingTitle in
                 WorkspaceCustomizationPendingAutomaticTitle(
                     stableId: stableId,
-                    title: pendingTitle.title
+                    title: pendingTitle.title,
+                    titleMutationRevision: pendingTitle.titleMutationRevision
                 )
             }
         )
@@ -144,8 +145,18 @@ extension TabManager {
             case .absent, .value:
                 return
             }
+            guard let titleMutationRevision = workspaceCustomizationStore
+                .customizationTitleMutationRevision(
+                for: workspace.stableId
+            ) else {
+                return
+            }
+            let pending = pendingAutomaticWorkspaceTitles[workspace.stableId]
             pendingAutomaticWorkspaceTitles[workspace.stableId] =
-                PendingAutomaticWorkspaceTitle(title: workspace.customTitle)
+                PendingAutomaticWorkspaceTitle(
+                    title: workspace.customTitle,
+                    titleMutationRevision: pending?.titleMutationRevision ?? titleMutationRevision
+                )
             scheduleAutomaticWorkspaceTitlePersistence()
             return
         }

--- a/Sources/TabManager+WorkspaceCustomizationPersistence.swift
+++ b/Sources/TabManager+WorkspaceCustomizationPersistence.swift
@@ -146,19 +146,16 @@ extension TabManager {
             case .absent, .value:
                 return
             }
-            let pending = pendingAutomaticWorkspaceTitles[workspace.stableId]
-            let automaticTitleOrdering: UInt64
-            if let pending {
-                automaticTitleOrdering = pending.automaticTitleOrdering
-            } else {
-                Self.nextAutomaticWorkspaceTitleOrdering &+= 1
-                automaticTitleOrdering = Self.nextAutomaticWorkspaceTitleOrdering
-            }
+            // Every notification is a new observation. A different manager
+            // may have persisted a newer automatic title since this manager
+            // queued its previous value, so retaining the pending fence
+            // would make the newest value look stale and drop it.
+            Self.nextAutomaticWorkspaceTitleOrdering &+= 1
+            let automaticTitleOrdering = Self.nextAutomaticWorkspaceTitleOrdering
             pendingAutomaticWorkspaceTitles[workspace.stableId] =
                 PendingAutomaticWorkspaceTitle(
                     title: workspace.customTitle,
-                    titleMutationRevision: pending?.titleMutationRevision
-                        ?? record.titleMutationRevision,
+                    titleMutationRevision: record.titleMutationRevision,
                     automaticTitleOrdering: automaticTitleOrdering
                 )
             scheduleAutomaticWorkspaceTitlePersistence()

--- a/Sources/TabManager+WorkspaceCustomizationPersistence.swift
+++ b/Sources/TabManager+WorkspaceCustomizationPersistence.swift
@@ -196,7 +196,13 @@ extension TabManager {
                 )
                 automaticWorkspaceTitleJournalState[stableId] = state
             }
-            guard state.automaticTitleAllowed else { return }
+            // Automatic title owners can clear a restored title before this
+            // workspace has ever written a stable-ID record. Keep that clear
+            // as a durable tombstone so a stale session snapshot cannot
+            // resurrect the title on restart.
+            let automaticTitleClear =
+                workspace.customTitle == nil && workspace.customTitleSource == nil
+            guard state.automaticTitleAllowed || automaticTitleClear else { return }
             // Every notification is a new observation. A different manager
             // may have persisted a newer automatic title since this manager
             // queued its previous value, so retaining the pending fence

--- a/Sources/TabManager+WorkspaceCustomizationPersistence.swift
+++ b/Sources/TabManager+WorkspaceCustomizationPersistence.swift
@@ -82,15 +82,6 @@ extension TabManager {
         )
     }
 
-    /// Reads recovery records needed by one restore with a single defaults decode.
-    func cachedWorkspaceCustomizations(
-        afterRestoring snapshots: [SessionWorkspaceSnapshot]
-    ) -> [UUID: WorkspaceCustomization] {
-        workspaceCustomizationStore.customizations(
-            for: snapshots.compactMap(\.stableId)
-        )
-    }
-
     /// Applies an explicit creation title without coupling identity to a directory.
     func applyCreationWorkspaceCustomization(
         to workspace: Workspace,

--- a/Sources/TabManager+WorkspaceCustomizationPersistence.swift
+++ b/Sources/TabManager+WorkspaceCustomizationPersistence.swift
@@ -17,6 +17,9 @@ extension TabManager {
         guard !pendingAutomaticWorkspaceTitles.isEmpty else { return }
         let pending = pendingAutomaticWorkspaceTitles
         pendingAutomaticWorkspaceTitles.removeAll(keepingCapacity: true)
+        for stableId in pending.keys {
+            automaticWorkspaceTitleJournalState.removeValue(forKey: stableId)
+        }
         workspaceCustomizationStore.persistPendingAutomaticTitlesSynchronously(
             pending.map { stableId, pendingTitle in
                 WorkspaceCustomizationPendingAutomaticTitle(
@@ -172,6 +175,35 @@ extension TabManager {
         // subsequent automatic value so a stale snapshot cannot roll the title
         // back to an earlier refresh.
         if source == .auto {
+            let stableId = workspace.stableId
+            let generation = workspaceCustomizationStore.changeGeneration()
+            let state: (
+                generation: UInt64,
+                titleMutationRevision: UInt64,
+                automaticTitleAllowed: Bool
+            )
+            if let cached = automaticWorkspaceTitleJournalState[stableId],
+               cached.generation == generation {
+                state = cached
+            } else {
+                let loaded = workspaceCustomizationStore
+                    .customizationAndTitleMutationRevision(for: stableId)
+                let automaticTitleAllowed = loaded.map { record in
+                    switch record.customization.customTitle {
+                    case .cleared, .autoValue:
+                        return true
+                    case .absent, .value:
+                        return false
+                    }
+                } ?? false
+                state = (
+                    generation: generation,
+                    titleMutationRevision: loaded?.titleMutationRevision ?? 0,
+                    automaticTitleAllowed: automaticTitleAllowed
+                )
+                automaticWorkspaceTitleJournalState[stableId] = state
+            }
+            guard state.automaticTitleAllowed else { return }
             // Every notification is a new observation. A different manager
             // may have persisted a newer automatic title since this manager
             // queued its previous value, so retaining the pending fence
@@ -181,16 +213,14 @@ extension TabManager {
             pendingAutomaticWorkspaceTitles[workspace.stableId] =
                 PendingAutomaticWorkspaceTitle(
                     title: workspace.customTitle,
-                    // Resolve the durable title fence in the synchronous
-                    // writer at flush time. Notification delivery stays
-                    // actor-local and never decodes the full journal.
-                    titleMutationRevision: 0,
+                    titleMutationRevision: state.titleMutationRevision,
                     automaticTitleOrdering: automaticTitleOrdering
                 )
             scheduleAutomaticWorkspaceTitlePersistence()
             return
         }
         cancelPendingAutomaticWorkspaceTitle(for: workspace.stableId)
+        automaticWorkspaceTitleJournalState.removeValue(forKey: workspace.stableId)
         workspaceCustomizationStore.setCustomTitle(
             workspace.customTitle,
             for: workspace.stableId,

--- a/Sources/TabManager+WorkspaceCustomizationPersistence.swift
+++ b/Sources/TabManager+WorkspaceCustomizationPersistence.swift
@@ -109,6 +109,14 @@ extension TabManager {
               let stored = workspaceCustomizationStore.customization(for: stableId) else {
             return
         }
+        guard shouldApplyWorkspaceCustomization(
+            stored,
+            to: snapshot,
+            titleMutationRevision: workspaceCustomizationStore
+                .customizationTitleMutationRevision(for: stableId)
+        ) else {
+            return
+        }
         applyWorkspaceCustomization(stored, to: workspace)
     }
 
@@ -116,14 +124,43 @@ extension TabManager {
     func reconcileWorkspaceCustomization(
         afterRestoring snapshot: SessionWorkspaceSnapshot,
         to workspace: Workspace,
-        cachedCustomizations: [UUID: WorkspaceCustomization]
+        cachedCustomizations: [UUID: WorkspaceCustomization],
+        cachedTitleMutationRevisions: [UUID: UInt64] = [:]
     ) {
         guard let stableId = snapshot.stableId,
               workspace.stableId == stableId,
               let stored = cachedCustomizations[stableId] else {
             return
         }
+        guard shouldApplyWorkspaceCustomization(
+            stored,
+            to: snapshot,
+            titleMutationRevision: cachedTitleMutationRevisions[stableId]
+        ) else {
+            return
+        }
         applyWorkspaceCustomization(stored, to: workspace)
+    }
+
+    private func shouldApplyWorkspaceCustomization(
+        _ customization: WorkspaceCustomization,
+        to snapshot: SessionWorkspaceSnapshot,
+        titleMutationRevision: UInt64?
+    ) -> Bool {
+        guard snapshot.customTitleSource == .auto,
+              let snapshotRevision = snapshot.customTitleMutationRevision,
+              let titleMutationRevision else {
+            // User records and legacy snapshots retain the established journal
+            // precedence. The fence is only comparable for provenance-aware
+            // automatic titles written by the new schema.
+            return true
+        }
+        switch customization.customTitle {
+        case .autoValue, .cleared:
+            return titleMutationRevision > snapshotRevision
+        case .absent, .value:
+            return true
+        }
     }
 
     func recordWorkspaceCustomTitle(
@@ -135,17 +172,6 @@ extension TabManager {
         // subsequent automatic value so a stale snapshot cannot roll the title
         // back to an earlier refresh.
         if source == .auto {
-            guard let record = workspaceCustomizationStore
-                .customizationAndTitleMutationRevision(for: workspace.stableId) else {
-                return
-            }
-            let field = record.customization.customTitle
-            switch field {
-            case .cleared, .autoValue:
-                break
-            case .absent, .value:
-                return
-            }
             // Every notification is a new observation. A different manager
             // may have persisted a newer automatic title since this manager
             // queued its previous value, so retaining the pending fence
@@ -155,7 +181,10 @@ extension TabManager {
             pendingAutomaticWorkspaceTitles[workspace.stableId] =
                 PendingAutomaticWorkspaceTitle(
                     title: workspace.customTitle,
-                    titleMutationRevision: record.titleMutationRevision,
+                    // Resolve the durable title fence in the synchronous
+                    // writer at flush time. Notification delivery stays
+                    // actor-local and never decodes the full journal.
+                    titleMutationRevision: 0,
                     automaticTitleOrdering: automaticTitleOrdering
                 )
             scheduleAutomaticWorkspaceTitlePersistence()

--- a/Sources/TabManager+WorkspaceCustomizationPersistence.swift
+++ b/Sources/TabManager+WorkspaceCustomizationPersistence.swift
@@ -34,7 +34,9 @@ extension TabManager {
 
     private func scheduleAutomaticWorkspaceTitlePersistence() {
         guard automaticWorkspaceTitlePersistenceTask == nil else { return }
-        automaticWorkspaceTitlePersistenceTask = Task { [weak self] in
+        // The delayed task may resume on any executor after its clock wait.
+        // Keep every access to TabManager's queued state on its owning actor.
+        automaticWorkspaceTitlePersistenceTask = Task { @MainActor [weak self] in
             do {
                 try await ContinuousClock().sleep(
                     for: Self.automaticWorkspaceTitlePersistenceDelay

--- a/Sources/TabManager+WorkspaceCustomizationPersistence.swift
+++ b/Sources/TabManager+WorkspaceCustomizationPersistence.swift
@@ -102,18 +102,20 @@ extension TabManager {
     ) {
         guard let stableId = snapshot.stableId,
               workspace.stableId == stableId,
-              let stored = workspaceCustomizationStore.customization(for: stableId) else {
+              let storedState = workspaceCustomizationStore
+                  .customizationAndTitleMutationRevision(for: stableId) else {
             return
         }
-        guard shouldApplyWorkspaceCustomization(
-            stored,
+        let shouldApplyTitle = shouldApplyWorkspaceTitle(
+            storedState.customization,
             to: snapshot,
-            titleMutationRevision: workspaceCustomizationStore
-                .customizationTitleMutationRevision(for: stableId)
-        ) else {
-            return
-        }
-        applyWorkspaceCustomization(stored, to: workspace)
+            titleMutationRevision: storedState.titleMutationRevision
+        )
+        applyWorkspaceCustomization(
+            storedState.customization,
+            to: workspace,
+            applyTitle: shouldApplyTitle
+        )
     }
 
     /// Applies one cached stable-ID recovery record.
@@ -128,17 +130,19 @@ extension TabManager {
               let stored = cachedCustomizations[stableId] else {
             return
         }
-        guard shouldApplyWorkspaceCustomization(
+        let shouldApplyTitle = shouldApplyWorkspaceTitle(
             stored,
             to: snapshot,
             titleMutationRevision: cachedTitleMutationRevisions[stableId]
-        ) else {
-            return
-        }
-        applyWorkspaceCustomization(stored, to: workspace)
+        )
+        applyWorkspaceCustomization(stored, to: workspace, applyTitle: shouldApplyTitle)
     }
 
-    private func shouldApplyWorkspaceCustomization(
+    /// Returns whether the journal title may replace the snapshot title.
+    ///
+    /// The title fence does not govern other customization fields. A stale or
+    /// equal automatic title must not prevent an independent color recovery.
+    private func shouldApplyWorkspaceTitle(
         _ customization: WorkspaceCustomization,
         to snapshot: SessionWorkspaceSnapshot,
         titleMutationRevision: UInt64?
@@ -156,6 +160,58 @@ extension TabManager {
             return titleMutationRevision > snapshotRevision
         case .absent, .value:
             return true
+        }
+    }
+
+    /// Pairs a session snapshot with the immutable journal state captured for
+    /// the same stable identity. A live workspace can lag another manager's
+    /// durable title, so the journal remains the source of truth unless a
+    /// queued local automatic write is newer and still pending.
+    func reconcileWorkspaceSnapshotCustomization(
+        _ snapshot: inout SessionWorkspaceSnapshot,
+        persistedCustomization: WorkspaceCustomization?,
+        persistedTitleMutationRevision: UInt64?,
+        pendingAutomaticTitle: PendingAutomaticWorkspaceTitle?
+    ) {
+        if let pendingAutomaticTitle {
+            switch pendingAutomaticTitle.title {
+            case let title?:
+                guard snapshot.customTitleSource != .user else { break }
+                snapshot.customTitle = title
+                snapshot.customTitleSource = .auto
+                snapshot.customTitleMutationRevision =
+                    pendingAutomaticTitle.titleMutationRevision
+                return
+            case nil:
+                guard snapshot.customTitleSource != .user else { break }
+                snapshot.customTitle = nil
+                snapshot.customTitleSource = nil
+                snapshot.customTitleMutationRevision =
+                    pendingAutomaticTitle.titleMutationRevision
+                return
+            }
+        }
+
+        guard let persistedCustomization,
+              let persistedTitleMutationRevision else {
+            return
+        }
+        switch persistedCustomization.customTitle {
+        case .absent:
+            break
+        case let .value(title):
+            snapshot.customTitle = title
+            snapshot.customTitleSource = .user
+            snapshot.customTitleMutationRevision = persistedTitleMutationRevision
+        case let .autoValue(title):
+            guard snapshot.customTitleSource != .user else { return }
+            snapshot.customTitle = title
+            snapshot.customTitleSource = .auto
+            snapshot.customTitleMutationRevision = persistedTitleMutationRevision
+        case .cleared:
+            snapshot.customTitle = nil
+            snapshot.customTitleSource = nil
+            snapshot.customTitleMutationRevision = persistedTitleMutationRevision
         }
     }
 
@@ -240,20 +296,23 @@ extension TabManager {
 
     private func applyWorkspaceCustomization(
         _ customization: WorkspaceCustomization,
-        to workspace: Workspace
+        to workspace: Workspace,
+        applyTitle: Bool = true
     ) {
-        switch customization.customTitle {
-        case .absent:
-            break
-        case let .value(title):
-            workspace.setCustomTitle(title, source: .user)
-        case let .autoValue(title):
-            // The journal is newer than the session snapshot. Clear any stale
-            // snapshot title before restoring the latest automatic value.
-            workspace.setCustomTitle(nil)
-            workspace.setCustomTitle(title, source: .auto)
-        case .cleared:
-            workspace.setCustomTitle(nil)
+        if applyTitle {
+            switch customization.customTitle {
+            case .absent:
+                break
+            case let .value(title):
+                workspace.setCustomTitle(title, source: .user)
+            case let .autoValue(title):
+                // The journal is newer than the session snapshot. Clear any stale
+                // snapshot title before restoring the latest automatic value.
+                workspace.setCustomTitle(nil)
+                workspace.setCustomTitle(title, source: .auto)
+            case .cleared:
+                workspace.setCustomTitle(nil)
+            }
         }
 
         switch customization.customColor {

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -462,11 +462,14 @@ class TabManager: ObservableObject {
     private var workspaceCycleCooldownTask: Task<Void, Never>?
     /// Coalesces automatic title journal writes so frequent process-title
     /// events do not encode the full customization snapshot on every event.
-    private struct PendingAutomaticWorkspaceTitle: Sendable {
+    struct PendingAutomaticWorkspaceTitle: Sendable {
         let title: String?
+        let titleMutationRevision: UInt64
     }
-    private var pendingAutomaticWorkspaceTitles: [UUID: PendingAutomaticWorkspaceTitle] = [:]
-    private var automaticWorkspaceTitlePersistenceTask: Task<Void, Never>?
+    // These members are internal because the persistence behavior is split
+    // across same-type extensions in separate source files.
+    var pendingAutomaticWorkspaceTitles: [UUID: PendingAutomaticWorkspaceTitle] = [:]
+    var automaticWorkspaceTitlePersistenceTask: Task<Void, Never>?
     private var pendingWorkspaceUnfocusTarget: (tabId: UUID, panelId: UUID)?
     var sidebarSelectedWorkspaceIds: Set<UUID> { sidebarMultiSelection.selectedWorkspaceIds }
     private var currentWindowTabBarLeadingInset: CGFloat?
@@ -740,7 +743,8 @@ class TabManager: ObservableObject {
         let pendingAutomaticTitles = pendingAutomaticWorkspaceTitles.map {
             WorkspaceCustomizationPendingAutomaticTitle(
                 stableId: $0.key,
-                title: $0.value.title
+                title: $0.value.title,
+                titleMutationRevision: $0.value.titleMutationRevision
             )
         }
         let workspaceCustomizationStore = workspaceCustomizationStore

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -734,22 +734,7 @@ class TabManager: ObservableObject {
         }
         observers.removeAll()
         workspaceCycleCooldownTask?.cancel()
-        let pendingAutomaticWorkspaceTitles = pendingAutomaticWorkspaceTitles
-        let workspaceCustomizationStore = workspaceCustomizationStore
         automaticWorkspaceTitlePersistenceTask?.cancel()
-        if !pendingAutomaticWorkspaceTitles.isEmpty {
-            Task { @MainActor in
-                for (stableId, title) in pendingAutomaticWorkspaceTitles.sorted(
-                    by: { $0.key.uuidString < $1.key.uuidString }
-                ) {
-                    workspaceCustomizationStore.setCustomTitle(
-                        title,
-                        for: stableId,
-                        source: .auto
-                    )
-                }
-            }
-        }
         agentPIDSweepTimer?.cancel()
         // The sidebar git/PR services cancel their own poll, probe, snapshot,
         // and refresh tasks in their deinits; they deallocate with this

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -734,8 +734,22 @@ class TabManager: ObservableObject {
         }
         observers.removeAll()
         workspaceCycleCooldownTask?.cancel()
-        flushPendingWorkspaceCustomizationWrites()
+        let pendingAutomaticWorkspaceTitles = pendingAutomaticWorkspaceTitles
+        let workspaceCustomizationStore = workspaceCustomizationStore
         automaticWorkspaceTitlePersistenceTask?.cancel()
+        if !pendingAutomaticWorkspaceTitles.isEmpty {
+            Task { @MainActor in
+                for (stableId, title) in pendingAutomaticWorkspaceTitles.sorted(
+                    by: { $0.key.uuidString < $1.key.uuidString }
+                ) {
+                    workspaceCustomizationStore.setCustomTitle(
+                        title,
+                        for: stableId,
+                        source: .auto
+                    )
+                }
+            }
+        }
         agentPIDSweepTimer?.cancel()
         // The sidebar git/PR services cancel their own poll, probe, snapshot,
         // and refresh tasks in their deinits; they deallocate with this

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -471,7 +471,10 @@ class TabManager: ObservableObject {
     // across same-type extensions in separate source files.
     var pendingAutomaticWorkspaceTitles: [UUID: PendingAutomaticWorkspaceTitle] = [:]
     var automaticWorkspaceTitlePersistenceTask: Task<Void, Never>?
-    private static var nextAutomaticWorkspaceTitleOrdering: UInt64 = 0
+    // This counter is shared with the persistence extension in this module.
+    // TabManager is main-actor isolated, so incrementing it does not need a
+    // second lock on the high-frequency title path.
+    static var nextAutomaticWorkspaceTitleOrdering: UInt64 = 0
     private var pendingWorkspaceUnfocusTarget: (tabId: UUID, panelId: UUID)?
     var sidebarSelectedWorkspaceIds: Set<UUID> { sidebarMultiSelection.selectedWorkspaceIds }
     private var currentWindowTabBarLeadingInset: CGFloat?
@@ -747,7 +750,7 @@ class TabManager: ObservableObject {
                 stableId: $0.key,
                 title: $0.value.title,
                 titleMutationRevision: $0.value.titleMutationRevision,
-                ordering: $0.value.ordering
+                automaticTitleOrdering: $0.value.automaticTitleOrdering
             )
         }
         let workspaceCustomizationStore = workspaceCustomizationStore

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -460,6 +460,10 @@ class TabManager: ObservableObject {
     private var selectionSideEffectsGeneration: UInt64 = 0
     private var workspaceCycleGeneration: UInt64 = 0
     private var workspaceCycleCooldownTask: Task<Void, Never>?
+    /// Coalesces automatic title journal writes so frequent process-title
+    /// events do not encode the full customization snapshot on every event.
+    private var pendingAutomaticWorkspaceTitles: [UUID: String] = [:]
+    private var automaticWorkspaceTitlePersistenceTask: Task<Void, Never>?
     private var pendingWorkspaceUnfocusTarget: (tabId: UUID, panelId: UUID)?
     var sidebarSelectedWorkspaceIds: Set<UUID> { sidebarMultiSelection.selectedWorkspaceIds }
     private var currentWindowTabBarLeadingInset: CGFloat?
@@ -730,6 +734,7 @@ class TabManager: ObservableObject {
         }
         observers.removeAll()
         workspaceCycleCooldownTask?.cancel()
+        automaticWorkspaceTitlePersistenceTask?.cancel()
         agentPIDSweepTimer?.cancel()
         // The sidebar git/PR services cancel their own poll, probe, snapshot,
         // and refresh tasks in their deinits; they deallocate with this

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -462,7 +462,10 @@ class TabManager: ObservableObject {
     private var workspaceCycleCooldownTask: Task<Void, Never>?
     /// Coalesces automatic title journal writes so frequent process-title
     /// events do not encode the full customization snapshot on every event.
-    private var pendingAutomaticWorkspaceTitles: [UUID: String] = [:]
+    private struct PendingAutomaticWorkspaceTitle: Sendable {
+        let title: String?
+    }
+    private var pendingAutomaticWorkspaceTitles: [UUID: PendingAutomaticWorkspaceTitle] = [:]
     private var automaticWorkspaceTitlePersistenceTask: Task<Void, Never>?
     private var pendingWorkspaceUnfocusTarget: (tabId: UUID, panelId: UUID)?
     var sidebarSelectedWorkspaceIds: Set<UUID> { sidebarMultiSelection.selectedWorkspaceIds }
@@ -734,7 +737,17 @@ class TabManager: ObservableObject {
         }
         observers.removeAll()
         workspaceCycleCooldownTask?.cancel()
+        let pendingAutomaticTitles = pendingAutomaticWorkspaceTitles.map {
+            WorkspaceCustomizationPendingAutomaticTitle(
+                stableId: $0.key,
+                title: $0.value.title
+            )
+        }
+        let workspaceCustomizationStore = workspaceCustomizationStore
         automaticWorkspaceTitlePersistenceTask?.cancel()
+        workspaceCustomizationStore.persistPendingAutomaticTitlesSynchronously(
+            pendingAutomaticTitles
+        )
         agentPIDSweepTimer?.cancel()
         // The sidebar git/PR services cancel their own poll, probe, snapshot,
         // and refresh tasks in their deinits; they deallocate with this

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -465,11 +465,13 @@ class TabManager: ObservableObject {
     struct PendingAutomaticWorkspaceTitle: Sendable {
         let title: String?
         let titleMutationRevision: UInt64
+        let automaticTitleOrdering: UInt64
     }
     // These members are internal because the persistence behavior is split
     // across same-type extensions in separate source files.
     var pendingAutomaticWorkspaceTitles: [UUID: PendingAutomaticWorkspaceTitle] = [:]
     var automaticWorkspaceTitlePersistenceTask: Task<Void, Never>?
+    private static var nextAutomaticWorkspaceTitleOrdering: UInt64 = 0
     private var pendingWorkspaceUnfocusTarget: (tabId: UUID, panelId: UUID)?
     var sidebarSelectedWorkspaceIds: Set<UUID> { sidebarMultiSelection.selectedWorkspaceIds }
     private var currentWindowTabBarLeadingInset: CGFloat?
@@ -744,7 +746,8 @@ class TabManager: ObservableObject {
             WorkspaceCustomizationPendingAutomaticTitle(
                 stableId: $0.key,
                 title: $0.value.title,
-                titleMutationRevision: $0.value.titleMutationRevision
+                titleMutationRevision: $0.value.titleMutationRevision,
+                ordering: $0.value.ordering
             )
         }
         let workspaceCustomizationStore = workspaceCustomizationStore

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -734,6 +734,7 @@ class TabManager: ObservableObject {
         }
         observers.removeAll()
         workspaceCycleCooldownTask?.cancel()
+        flushPendingWorkspaceCustomizationWrites()
         automaticWorkspaceTitlePersistenceTask?.cancel()
         agentPIDSweepTimer?.cancel()
         // The sidebar git/PR services cancel their own poll, probe, snapshot,

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2412,11 +2412,13 @@ class TabManager: ObservableObject {
             // RestorableAgentSessionIndex.load() (sysctl-per-record + disk) so closing a
             // workspace does not freeze the main thread; fall back to a fresh load only
             // while the cache has not loaded yet. See closedPanelHistoryEntry.
-            let snapshot = workspace.sessionSnapshot(
+            var snapshot = workspace.sessionSnapshot(
                 includeScrollback: true,
                 restorableAgentIndex: SharedLiveAgentIndex.shared.currentIndexSchedulingRefresh()
                     ?? RestorableAgentSessionIndex.load()
             )
+            snapshot.customTitleMutationRevision = workspaceCustomizationStore
+                .customizationTitleMutationRevision(for: workspace.stableId)
             ClosedItemHistoryStore.shared.push(.workspace(ClosedWorkspaceHistoryEntry(
                 workspaceId: workspace.id,
                 windowId: AppDelegate.shared?.windowId(for: self),
@@ -6438,7 +6440,7 @@ extension TabManager {
         let restorableTabs = tabs
             .filter(\.isRestorableInSessionSnapshot)
             .prefix(SessionPersistencePolicy.maxWorkspacesPerWindow)
-        let workspaceSnapshots = restorableTabs
+        var workspaceSnapshots = restorableTabs
             .map {
                 $0.sessionSnapshot(
                     includeScrollback: includeScrollback,
@@ -6446,6 +6448,13 @@ extension TabManager {
                     surfaceResumeBindingIndex: surfaceResumeBindingIndex
                 )
             }
+        let titleMutationRevisions = workspaceCustomizationStore.titleMutationRevisions(
+            for: workspaceSnapshots.compactMap(\.stableId)
+        )
+        for index in workspaceSnapshots.indices {
+            guard let stableId = workspaceSnapshots[index].stableId else { continue }
+            workspaceSnapshots[index].customTitleMutationRevision = titleMutationRevisions[stableId]
+        }
         let selectedWorkspaceIndex = selectedTabId.flatMap { selectedTabId in
             restorableTabs.firstIndex(where: { $0.id == selectedTabId })
         }
@@ -6598,6 +6607,9 @@ extension TabManager {
         let restoredCustomizations = cachedWorkspaceCustomizations(
             afterRestoring: Array(workspaceSnapshots)
         )
+        let restoredTitleMutationRevisions = workspaceCustomizationStore.titleMutationRevisions(
+            for: workspaceSnapshots.compactMap(\.stableId)
+        )
         var restoredOriginalWorkspaceIds: [UUID?] = []
         var reservedWorkspaceIds = excludingWorkspaceIds
         let identitySelector = WorkspaceSessionRestoreIdentity()
@@ -6631,7 +6643,8 @@ extension TabManager {
             reconcileWorkspaceCustomization(
                 afterRestoring: workspaceSnapshot,
                 to: workspace,
-                cachedCustomizations: restoredCustomizations
+                cachedCustomizations: restoredCustomizations,
+                cachedTitleMutationRevisions: restoredTitleMutationRevisions
             )
             Self.recordRestoredTaskCreateProvenance(for: workspace, in: workspaceCreateIdempotencyCache)
             wireClosedBrowserTracking(for: workspace)

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2420,14 +2420,22 @@ class TabManager: ObservableObject {
             // RestorableAgentSessionIndex.load() (sysctl-per-record + disk) so closing a
             // workspace does not freeze the main thread; fall back to a fresh load only
             // while the cache has not loaded yet. See closedPanelHistoryEntry.
-            let titleMutationRevision = workspaceCustomizationStore
-                .customizationTitleMutationRevision(for: workspace.stableId)
+            let persistedWorkspaceCustomizationState = workspaceCustomizationStore
+                .customizationsAndTitleMutationRevisions(for: [workspace.stableId])
+            let pendingAutomaticTitle = pendingAutomaticWorkspaceTitles[workspace.stableId]
             var snapshot = workspace.sessionSnapshot(
                 includeScrollback: true,
                 restorableAgentIndex: SharedLiveAgentIndex.shared.currentIndexSchedulingRefresh()
                     ?? RestorableAgentSessionIndex.load()
             )
-            snapshot.customTitleMutationRevision = titleMutationRevision
+            reconcileWorkspaceSnapshotCustomization(
+                &snapshot,
+                persistedCustomization: persistedWorkspaceCustomizationState
+                    .customizations[workspace.stableId],
+                persistedTitleMutationRevision: persistedWorkspaceCustomizationState
+                    .titleMutationRevisions[workspace.stableId],
+                pendingAutomaticTitle: pendingAutomaticTitle
+            )
             ClosedItemHistoryStore.shared.push(.workspace(ClosedWorkspaceHistoryEntry(
                 workspaceId: workspace.id,
                 windowId: AppDelegate.shared?.windowId(for: self),
@@ -6449,12 +6457,13 @@ extension TabManager {
         let restorableTabs = tabs
             .filter(\.isRestorableInSessionSnapshot)
             .prefix(SessionPersistencePolicy.maxWorkspacesPerWindow)
-        // Capture journal fences before projecting workspace state. A
-        // concurrent clear after this read must remain newer than the snapshot
-        // rather than being stamped onto its older title projection.
-        let titleMutationRevisions = workspaceCustomizationStore.titleMutationRevisions(
-            for: restorableTabs.compactMap(\.stableId)
-        )
+        // Capture the persisted state before projecting workspace state. The
+        // snapshot helper pairs each local title with this immutable read and
+        // uses the durable value when the live title is stale.
+        let stableIds = restorableTabs.compactMap(\.stableId)
+        let persistedWorkspaceCustomizationState = workspaceCustomizationStore
+            .customizationsAndTitleMutationRevisions(for: stableIds)
+        let pendingAutomaticTitles = pendingAutomaticWorkspaceTitles
         var workspaceSnapshots = restorableTabs
             .map {
                 $0.sessionSnapshot(
@@ -6462,11 +6471,17 @@ extension TabManager {
                     restorableAgentIndex: restorableAgentIndex,
                     surfaceResumeBindingIndex: surfaceResumeBindingIndex
                 )
-            }
+        }
         didCaptureWorkspaceSessionSnapshots()
         for index in workspaceSnapshots.indices {
             guard let stableId = workspaceSnapshots[index].stableId else { continue }
-            workspaceSnapshots[index].customTitleMutationRevision = titleMutationRevisions[stableId]
+            reconcileWorkspaceSnapshotCustomization(
+                &workspaceSnapshots[index],
+                persistedCustomization: persistedWorkspaceCustomizationState.customizations[stableId],
+                persistedTitleMutationRevision: persistedWorkspaceCustomizationState
+                    .titleMutationRevisions[stableId],
+                pendingAutomaticTitle: pendingAutomaticTitles[stableId]
+            )
         }
         let selectedWorkspaceIndex = selectedTabId.flatMap { selectedTabId in
             restorableTabs.firstIndex(where: { $0.id == selectedTabId })

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2420,13 +2420,14 @@ class TabManager: ObservableObject {
             // RestorableAgentSessionIndex.load() (sysctl-per-record + disk) so closing a
             // workspace does not freeze the main thread; fall back to a fresh load only
             // while the cache has not loaded yet. See closedPanelHistoryEntry.
+            let titleMutationRevision = workspaceCustomizationStore
+                .customizationTitleMutationRevision(for: workspace.stableId)
             var snapshot = workspace.sessionSnapshot(
                 includeScrollback: true,
                 restorableAgentIndex: SharedLiveAgentIndex.shared.currentIndexSchedulingRefresh()
                     ?? RestorableAgentSessionIndex.load()
             )
-            snapshot.customTitleMutationRevision = workspaceCustomizationStore
-                .customizationTitleMutationRevision(for: workspace.stableId)
+            snapshot.customTitleMutationRevision = titleMutationRevision
             ClosedItemHistoryStore.shared.push(.workspace(ClosedWorkspaceHistoryEntry(
                 workspaceId: workspace.id,
                 windowId: AppDelegate.shared?.windowId(for: self),
@@ -6448,6 +6449,12 @@ extension TabManager {
         let restorableTabs = tabs
             .filter(\.isRestorableInSessionSnapshot)
             .prefix(SessionPersistencePolicy.maxWorkspacesPerWindow)
+        // Capture journal fences before projecting workspace state. A
+        // concurrent clear after this read must remain newer than the snapshot
+        // rather than being stamped onto its older title projection.
+        let titleMutationRevisions = workspaceCustomizationStore.titleMutationRevisions(
+            for: restorableTabs.compactMap(\.stableId)
+        )
         var workspaceSnapshots = restorableTabs
             .map {
                 $0.sessionSnapshot(
@@ -6456,9 +6463,7 @@ extension TabManager {
                     surfaceResumeBindingIndex: surfaceResumeBindingIndex
                 )
             }
-        let titleMutationRevisions = workspaceCustomizationStore.titleMutationRevisions(
-            for: workspaceSnapshots.compactMap(\.stableId)
-        )
+        didCaptureWorkspaceSessionSnapshots()
         for index in workspaceSnapshots.indices {
             guard let stableId = workspaceSnapshots[index].stableId else { continue }
             workspaceSnapshots[index].customTitleMutationRevision = titleMutationRevisions[stableId]
@@ -6509,6 +6514,9 @@ extension TabManager {
             workspaceGroups: groupSnapshots
         )
     }
+
+    /// Test seam for mutating persisted workspace state after live snapshots are captured.
+    func didCaptureWorkspaceSessionSnapshots() {}
 
     func sessionSnapshotWorkspaceIds() -> [UUID] {
         Array(

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -470,6 +470,14 @@ class TabManager: ObservableObject {
     // These members are internal because the persistence behavior is split
     // across same-type extensions in separate source files.
     var pendingAutomaticWorkspaceTitles: [UUID: PendingAutomaticWorkspaceTitle] = [:]
+    /// One journal read is shared by all automatic-title notifications until
+    /// the backing defaults value changes. The writer still revalidates the
+    /// revision at flush time for cross-manager races.
+    var automaticWorkspaceTitleJournalState: [UUID: (
+        generation: UInt64,
+        titleMutationRevision: UInt64,
+        automaticTitleAllowed: Bool
+    )] = [:]
     var automaticWorkspaceTitlePersistenceTask: Task<Void, Never>?
     // This counter is shared with the persistence extension in this module.
     // TabManager is main-actor isolated, so incrementing it does not need a

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -6162,6 +6162,11 @@ class TabManager: ObservableObject {
         }
     }
 #endif
+    /// Test seam for mutating persisted workspace state after live snapshots are captured.
+    ///
+    /// This declaration lives in the class body so focused tests can override
+    /// it while production keeps the default no-op behavior.
+    func didCaptureWorkspaceSessionSnapshots() {}
 }
 
 extension TabManager {
@@ -6529,9 +6534,6 @@ extension TabManager {
             workspaceGroups: groupSnapshots
         )
     }
-
-    /// Test seam for mutating persisted workspace state after live snapshots are captured.
-    func didCaptureWorkspaceSessionSnapshots() {}
 
     func sessionSnapshotWorkspaceIds() -> [UUID] {
         Array(

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -6612,12 +6612,13 @@ extension TabManager {
         prepareLegacyWorkspaceCustomizationMigration(
             afterRestoring: Array(workspaceSnapshots)
         )
-        let restoredCustomizations = cachedWorkspaceCustomizations(
-            afterRestoring: Array(workspaceSnapshots)
-        )
-        let restoredTitleMutationRevisions = workspaceCustomizationStore.titleMutationRevisions(
-            for: workspaceSnapshots.compactMap(\.stableId)
-        )
+        let restoredWorkspaceCustomizationState = workspaceCustomizationStore
+            .customizationsAndTitleMutationRevisions(
+                for: workspaceSnapshots.compactMap(\.stableId)
+            )
+        let restoredCustomizations = restoredWorkspaceCustomizationState.customizations
+        let restoredTitleMutationRevisions =
+            restoredWorkspaceCustomizationState.titleMutationRevisions
         var restoredOriginalWorkspaceIds: [UUID?] = []
         var reservedWorkspaceIds = excludingWorkspaceIds
         let identitySelector = WorkspaceSessionRestoreIdentity()

--- a/cmuxTests/ClosedMainWindowRoutingTests.swift
+++ b/cmuxTests/ClosedMainWindowRoutingTests.swift
@@ -54,6 +54,51 @@ struct ClosedMainWindowRoutingTests {
         return window
     }
 
+    @Test("Window-context removal flushes queued automatic workspace titles")
+    func windowContextRemovalFlushesQueuedAutomaticWorkspaceTitle() throws {
+        _ = NSApplication.shared
+        let suiteName = "WorkspaceCustomizationStore.window-teardown.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = WorkspaceCustomizationStore(
+            defaults: defaults,
+            storageKey: "test.customizations",
+            legacyStorageKey: "test.legacy-customizations"
+        )
+
+        let previousAppDelegate = AppDelegate.shared
+        let app = AppDelegate()
+        defer {
+            AppDelegate.shared = previousAppDelegate
+        }
+
+        let manager = TabManager(
+            autoWelcomeIfNeeded: false,
+            workspaceCustomizationStore: store
+        )
+        let workspace = try #require(manager.selectedWorkspace)
+        let windowId = app.registerMainWindowContextForTesting(tabManager: manager)
+        defer { app.unregisterMainWindowContextForTesting(windowId: windowId) }
+
+        #expect(manager.setCustomTitle(tabId: workspace.id, title: "User Title"))
+        manager.clearCustomTitle(tabId: workspace.id)
+        #expect(manager.setCustomTitle(
+            tabId: workspace.id,
+            title: "Automatic Title",
+            source: .auto
+        ))
+        #expect(
+            store.customization(for: workspace.stableId)?.customTitle == .cleared
+        )
+
+        app.unregisterMainWindowContextForTesting(windowId: windowId)
+
+        #expect(
+            store.customization(for: workspace.stableId)?.customTitle ==
+                .autoValue("Automatic Title")
+        )
+    }
+
     @Test("Closed main window is not listed or focusable while its objects linger")
     func closedMainWindowIsNotListedOrFocusableWhileItsObjectsLinger() throws {
         _ = NSApplication.shared

--- a/cmuxTests/WorkspaceRecoveryTests.swift
+++ b/cmuxTests/WorkspaceRecoveryTests.swift
@@ -393,6 +393,52 @@ struct WorkspaceRecoveryTests {
     }
 
     @Test
+    func clearedUserTitleDoesNotEvictAutoTitleAcrossRestart() throws {
+        // Regression: a durable `.cleared` customization record (the user once
+        // cleared their title) must not clobber an `.auto` title restored from
+        // the session snapshot. Clearing re-enables auto-naming; it does not
+        // forbid it. Without the guard in applyWorkspaceCustomization, the
+        // reconcile pass that runs after restoreTitleState wipes the restored
+        // auto title on every restart.
+        let fixture = try makeCustomizationStore()
+        defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
+        let store = fixture.store
+
+        // Seed the durable journal with a `.cleared` record for a stable id by
+        // setting then clearing a user title in a source manager.
+        let sourceManager = TabManager(
+            initialWorkingDirectory: "/tmp/cleared-vs-auto",
+            autoWelcomeIfNeeded: false,
+            workspaceCustomizationStore: store
+        )
+        let sourceWorkspace = try #require(sourceManager.selectedWorkspace)
+        #expect(sourceManager.setCustomTitle(tabId: sourceWorkspace.id, title: "Old User Title"))
+        sourceManager.clearCustomTitle(tabId: sourceWorkspace.id)
+        #expect(
+            store.customization(for: sourceWorkspace.stableId) ==
+                WorkspaceCustomization(customTitle: .cleared, customColor: .absent)
+        )
+
+        // Simulate a later session where auto-naming derived a title for the
+        // same workspace; the snapshot persists it with `.auto` provenance.
+        var snapshot = sourceWorkspace.sessionSnapshot(includeScrollback: false)
+        snapshot.customTitle = "Auto Derived Title"
+        snapshot.customTitleSource = .auto
+
+        let restoredManager = TabManager(
+            autoWelcomeIfNeeded: false,
+            workspaceCustomizationStore: store
+        )
+        restoredManager.restoreSessionSnapshot(SessionTabManagerSnapshot(
+            selectedWorkspaceIndex: 0,
+            workspaces: [snapshot]
+        ))
+        let restoredWorkspace = try #require(restoredManager.selectedWorkspace)
+        #expect(restoredWorkspace.customTitle == "Auto Derived Title")
+        #expect(restoredWorkspace.effectiveCustomTitleSource == .auto)
+    }
+
+    @Test
     func titleAndColorRecoveryFieldsRemainIndependent() throws {
         let fixture = try makeCustomizationStore()
         defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }

--- a/cmuxTests/WorkspaceRecoveryTests.swift
+++ b/cmuxTests/WorkspaceRecoveryTests.swift
@@ -426,6 +426,7 @@ struct WorkspaceRecoveryTests {
             title: "Auto Derived Title",
             source: .auto
         ))
+        sourceManager.flushPendingWorkspaceCustomizationWrites()
         #expect(
             store.customization(for: sourceWorkspace.stableId) ==
                 WorkspaceCustomization(customTitle: .autoValue("Auto Derived Title"), customColor: .absent)
@@ -467,6 +468,7 @@ struct WorkspaceRecoveryTests {
             title: "Auto Before Clear",
             source: .auto
         ))
+        sourceManager.flushPendingWorkspaceCustomizationWrites()
         let staleSnapshot = sourceWorkspace.sessionSnapshot(includeScrollback: false)
         sourceManager.clearCustomTitle(tabId: sourceWorkspace.id)
         #expect(
@@ -516,6 +518,7 @@ struct WorkspaceRecoveryTests {
             title: "Latest Auto Title",
             source: .auto
         ))
+        sourceManager.flushPendingWorkspaceCustomizationWrites()
 
         let restoredManager = TabManager(
             autoWelcomeIfNeeded: false,
@@ -586,6 +589,7 @@ struct WorkspaceRecoveryTests {
             title: "Automatic Name",
             source: .auto
         ))
+        sourceManager.flushPendingWorkspaceCustomizationWrites()
         sourceManager.applyWorkspaceColor(
             "#123456",
             toWorkspaceIds: [sourceWorkspace.id]

--- a/cmuxTests/WorkspaceRecoveryTests.swift
+++ b/cmuxTests/WorkspaceRecoveryTests.swift
@@ -531,6 +531,40 @@ struct WorkspaceRecoveryTests {
     }
 
     @Test
+    func automaticTitleJournalWritesCoalesceUntilFlush() throws {
+        let fixture = try makeCustomizationStore()
+        defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
+
+        let manager = TabManager(
+            initialWorkingDirectory: "/tmp/coalesced-auto-title",
+            autoWelcomeIfNeeded: false,
+            workspaceCustomizationStore: fixture.store
+        )
+        let workspace = try #require(manager.selectedWorkspace)
+        #expect(manager.setCustomTitle(tabId: workspace.id, title: "User Name"))
+        manager.clearCustomTitle(tabId: workspace.id)
+        let dataBeforeAutomaticUpdates = fixture.defaults.data(forKey: "test.customizations")
+
+        #expect(manager.setCustomTitle(
+            tabId: workspace.id,
+            title: "First Auto Title",
+            source: .auto
+        ))
+        #expect(manager.setCustomTitle(
+            tabId: workspace.id,
+            title: "Latest Auto Title",
+            source: .auto
+        ))
+        #expect(fixture.defaults.data(forKey: "test.customizations") == dataBeforeAutomaticUpdates)
+
+        manager.flushPendingWorkspaceCustomizationWrites()
+        #expect(
+            fixture.store.customization(for: workspace.stableId)?.customTitle ==
+                .autoValue("Latest Auto Title")
+        )
+    }
+
+    @Test
     func autoTitleRecoveryPreservesIndependentColor() throws {
         let fixture = try makeCustomizationStore()
         defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }

--- a/cmuxTests/WorkspaceRecoveryTests.swift
+++ b/cmuxTests/WorkspaceRecoveryTests.swift
@@ -568,6 +568,33 @@ struct WorkspaceRecoveryTests {
     }
 
     @Test
+    func managerTeardownFlushesQueuedAutomaticTitle() async throws {
+        let fixture = try makeCustomizationStore()
+        defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
+
+        var manager: TabManager? = TabManager(
+            initialWorkingDirectory: "/tmp/teardown-auto-title",
+            autoWelcomeIfNeeded: false,
+            workspaceCustomizationStore: fixture.store
+        )
+        let workspace = try #require(manager?.selectedWorkspace)
+        #expect(manager?.setCustomTitle(tabId: workspace.id, title: "User Name") == true)
+        manager?.clearCustomTitle(tabId: workspace.id)
+        #expect(manager?.setCustomTitle(
+            tabId: workspace.id,
+            title: "Automatic Name",
+            source: .auto
+        ) == true)
+        manager = nil
+
+        for _ in 0..<3 { await Task.yield() }
+        #expect(
+            fixture.store.customization(for: workspace.stableId)?.customTitle ==
+                .autoValue("Automatic Name")
+        )
+    }
+
+    @Test
     func autoTitleRecoveryPreservesIndependentColor() throws {
         let fixture = try makeCustomizationStore()
         defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }

--- a/cmuxTests/WorkspaceRecoveryTests.swift
+++ b/cmuxTests/WorkspaceRecoveryTests.swift
@@ -568,7 +568,7 @@ struct WorkspaceRecoveryTests {
     }
 
     @Test
-    func managerTeardownFlushesQueuedAutomaticTitle() async throws {
+    func managerTeardownFlushesQueuedAutomaticTitle() throws {
         let fixture = try makeCustomizationStore()
         defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
 
@@ -585,12 +585,50 @@ struct WorkspaceRecoveryTests {
             title: "Automatic Name",
             source: .auto
         ) == true)
+        weak var weakManager = manager
         manager = nil
 
-        for _ in 0..<3 { await Task.yield() }
+        #expect(weakManager == nil)
         #expect(
             fixture.store.customization(for: workspace.stableId)?.customTitle ==
                 .autoValue("Automatic Name")
+        )
+    }
+
+    @Test
+    func automaticClearAfterAutoTitlePersistsClearedTombstone() throws {
+        let fixture = try makeCustomizationStore()
+        defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
+
+        let manager = TabManager(
+            initialWorkingDirectory: "/tmp/automatic-clear-title",
+            autoWelcomeIfNeeded: false,
+            workspaceCustomizationStore: fixture.store
+        )
+        let workspace = try #require(manager.selectedWorkspace)
+        #expect(manager.setCustomTitle(tabId: workspace.id, title: "User Title"))
+        manager.clearCustomTitle(tabId: workspace.id)
+        #expect(manager.setCustomTitle(
+            tabId: workspace.id,
+            title: "Automatic Title",
+            source: .auto
+        ))
+        manager.flushPendingWorkspaceCustomizationWrites()
+        #expect(
+            fixture.store.customization(for: workspace.stableId)?.customTitle ==
+                .autoValue("Automatic Title")
+        )
+
+        // Model an automatic clear from a title owner that has already
+        // persisted an automatic value. The journal must retain the clear as
+        // a tombstone instead of leaving the auto value authoritative.
+        workspace.customTitle = nil
+        workspace.customTitleSource = nil
+        manager.recordWorkspaceCustomTitle(workspace, source: .auto)
+        manager.flushPendingWorkspaceCustomizationWrites()
+        #expect(
+            fixture.store.customization(for: workspace.stableId)?.customTitle ==
+                .cleared
         )
     }
 

--- a/cmuxTests/WorkspaceRecoveryTests.swift
+++ b/cmuxTests/WorkspaceRecoveryTests.swift
@@ -633,6 +633,53 @@ struct WorkspaceRecoveryTests {
     }
 
     @Test
+    func queuedAutomaticTitleCannotOverwriteLaterExplicitClearAcrossManagers() throws {
+        let fixture = try makeCustomizationStore()
+        defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
+
+        let queuedManager = TabManager(
+            initialWorkingDirectory: "/tmp/queued-auto-title-manager",
+            autoWelcomeIfNeeded: false,
+            workspaceCustomizationStore: fixture.store
+        )
+        let queuedWorkspace = try #require(queuedManager.selectedWorkspace)
+        #expect(queuedManager.setCustomTitle(
+            tabId: queuedWorkspace.id,
+            title: "User Title"
+        ))
+        queuedManager.clearCustomTitle(tabId: queuedWorkspace.id)
+        #expect(queuedManager.setCustomTitle(
+            tabId: queuedWorkspace.id,
+            title: "Queued Automatic Title",
+            source: .auto
+        ))
+
+        // A second manager can make an explicit clear after the first manager
+        // queued its automatic write but before that write reaches the store.
+        let clearingManager = TabManager(
+            autoWelcomeIfNeeded: false,
+            workspaceCustomizationStore: fixture.store
+        )
+        clearingManager.restoreSessionSnapshot(SessionTabManagerSnapshot(
+            selectedWorkspaceIndex: 0,
+            workspaces: [queuedWorkspace.sessionSnapshot(includeScrollback: false)]
+        ))
+        let clearingWorkspace = try #require(clearingManager.selectedWorkspace)
+        #expect(clearingWorkspace.stableId == queuedWorkspace.stableId)
+        clearingManager.clearCustomTitle(tabId: clearingWorkspace.id)
+        #expect(
+            fixture.store.customization(for: queuedWorkspace.stableId)?.customTitle ==
+                .cleared
+        )
+
+        queuedManager.flushPendingWorkspaceCustomizationWrites()
+        #expect(
+            fixture.store.customization(for: queuedWorkspace.stableId)?.customTitle ==
+                .cleared
+        )
+    }
+
+    @Test
     func autoTitleRecoveryPreservesIndependentColor() throws {
         let fixture = try makeCustomizationStore()
         defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }

--- a/cmuxTests/WorkspaceRecoveryTests.swift
+++ b/cmuxTests/WorkspaceRecoveryTests.swift
@@ -531,6 +531,47 @@ struct WorkspaceRecoveryTests {
     }
 
     @Test
+    func autoTitleRecoveryPreservesIndependentColor() throws {
+        let fixture = try makeCustomizationStore()
+        defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
+        let store = fixture.store
+
+        let sourceManager = TabManager(
+            initialWorkingDirectory: "/tmp/auto-title-color",
+            autoWelcomeIfNeeded: false,
+            workspaceCustomizationStore: store
+        )
+        let sourceWorkspace = try #require(sourceManager.selectedWorkspace)
+        #expect(sourceManager.setCustomTitle(
+            tabId: sourceWorkspace.id,
+            title: "User Name"
+        ))
+        sourceManager.clearCustomTitle(tabId: sourceWorkspace.id)
+        #expect(sourceManager.setCustomTitle(
+            tabId: sourceWorkspace.id,
+            title: "Automatic Name",
+            source: .auto
+        ))
+        sourceManager.applyWorkspaceColor(
+            "#123456",
+            toWorkspaceIds: [sourceWorkspace.id]
+        )
+
+        let restoredManager = TabManager(
+            autoWelcomeIfNeeded: false,
+            workspaceCustomizationStore: store
+        )
+        restoredManager.restoreSessionSnapshot(SessionTabManagerSnapshot(
+            selectedWorkspaceIndex: 0,
+            workspaces: [sourceWorkspace.sessionSnapshot(includeScrollback: false)]
+        ))
+        let restoredWorkspace = try #require(restoredManager.selectedWorkspace)
+        #expect(restoredWorkspace.customTitle == "Automatic Name")
+        #expect(restoredWorkspace.effectiveCustomTitleSource == .auto)
+        #expect(restoredWorkspace.customColor == "#123456")
+    }
+
+    @Test
     func titleAndColorRecoveryFieldsRemainIndependent() throws {
         let fixture = try makeCustomizationStore()
         defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }

--- a/cmuxTests/WorkspaceRecoveryTests.swift
+++ b/cmuxTests/WorkspaceRecoveryTests.swift
@@ -488,6 +488,49 @@ struct WorkspaceRecoveryTests {
     }
 
     @Test
+    func latestAutoTitleAfterClearWinsOverOlderJournalAndSnapshot() throws {
+        let fixture = try makeCustomizationStore()
+        defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
+        let store = fixture.store
+
+        let sourceManager = TabManager(
+            initialWorkingDirectory: "/tmp/repeated-auto-title",
+            autoWelcomeIfNeeded: false,
+            workspaceCustomizationStore: store
+        )
+        let sourceWorkspace = try #require(sourceManager.selectedWorkspace)
+        #expect(sourceManager.setCustomTitle(tabId: sourceWorkspace.id, title: "User Name"))
+        sourceManager.clearCustomTitle(tabId: sourceWorkspace.id)
+        #expect(sourceManager.setCustomTitle(
+            tabId: sourceWorkspace.id,
+            title: "First Auto Title",
+            source: .auto
+        ))
+
+        // Autosave can lag behind a later automatic title refresh. The
+        // recovery journal must keep the latest automatic value, not only the
+        // first value that followed the explicit clear.
+        let staleSnapshot = sourceWorkspace.sessionSnapshot(includeScrollback: false)
+        #expect(sourceManager.setCustomTitle(
+            tabId: sourceWorkspace.id,
+            title: "Latest Auto Title",
+            source: .auto
+        ))
+
+        let restoredManager = TabManager(
+            autoWelcomeIfNeeded: false,
+            workspaceCustomizationStore: store
+        )
+        restoredManager.restoreSessionSnapshot(SessionTabManagerSnapshot(
+            selectedWorkspaceIndex: 0,
+            workspaces: [staleSnapshot]
+        ))
+        let restoredWorkspace = try #require(restoredManager.selectedWorkspace)
+        #expect(restoredWorkspace.customTitle == "Latest Auto Title")
+        #expect(restoredWorkspace.effectiveCustomTitleSource == .auto)
+    }
+
+    @Test
     func titleAndColorRecoveryFieldsRemainIndependent() throws {
         let fixture = try makeCustomizationStore()
         defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }

--- a/cmuxTests/WorkspaceRecoveryTests.swift
+++ b/cmuxTests/WorkspaceRecoveryTests.swift
@@ -419,10 +419,22 @@ struct WorkspaceRecoveryTests {
                 WorkspaceCustomization(customTitle: .cleared, customColor: .absent)
         )
 
-        // Simulate a later session where auto-naming derived a title for the
-        // same workspace; the snapshot persists it with `.auto` provenance.
+        // Simulate a later auto-naming pass. The journal must advance past the
+        // clear so the title remains recoverable even if autosave is stale.
+        #expect(sourceManager.setCustomTitle(
+            tabId: sourceWorkspace.id,
+            title: "Auto Derived Title",
+            source: .auto
+        ))
+        #expect(
+            store.customization(for: sourceWorkspace.stableId) ==
+                WorkspaceCustomization(customTitle: .autoValue("Auto Derived Title"), customColor: .absent)
+        )
+
+        // Restore an older snapshot to prove the journal, rather than snapshot
+        // timing, supplies the latest auto title.
         var snapshot = sourceWorkspace.sessionSnapshot(includeScrollback: false)
-        snapshot.customTitle = "Auto Derived Title"
+        snapshot.customTitle = "Stale Auto Title"
         snapshot.customTitleSource = .auto
 
         let restoredManager = TabManager(
@@ -436,6 +448,43 @@ struct WorkspaceRecoveryTests {
         let restoredWorkspace = try #require(restoredManager.selectedWorkspace)
         #expect(restoredWorkspace.customTitle == "Auto Derived Title")
         #expect(restoredWorkspace.effectiveCustomTitleSource == .auto)
+    }
+
+    @Test
+    func clearedJournalRemovesStaleAutoTitleBeforeAutosave() throws {
+        let fixture = try makeCustomizationStore()
+        defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
+        let store = fixture.store
+
+        let sourceManager = TabManager(
+            initialWorkingDirectory: "/tmp/cleared-stale-auto",
+            autoWelcomeIfNeeded: false,
+            workspaceCustomizationStore: store
+        )
+        let sourceWorkspace = try #require(sourceManager.selectedWorkspace)
+        #expect(sourceManager.setCustomTitle(
+            tabId: sourceWorkspace.id,
+            title: "Auto Before Clear",
+            source: .auto
+        ))
+        let staleSnapshot = sourceWorkspace.sessionSnapshot(includeScrollback: false)
+        sourceManager.clearCustomTitle(tabId: sourceWorkspace.id)
+        #expect(
+            store.customization(for: sourceWorkspace.stableId) ==
+                WorkspaceCustomization(customTitle: .cleared, customColor: .absent)
+        )
+
+        let restoredManager = TabManager(
+            autoWelcomeIfNeeded: false,
+            workspaceCustomizationStore: store
+        )
+        restoredManager.restoreSessionSnapshot(SessionTabManagerSnapshot(
+            selectedWorkspaceIndex: 0,
+            workspaces: [staleSnapshot]
+        ))
+        let restoredWorkspace = try #require(restoredManager.selectedWorkspace)
+        #expect(restoredWorkspace.customTitle == nil)
+        #expect(restoredWorkspace.effectiveCustomTitleSource == nil)
     }
 
     @Test

--- a/cmuxTests/WorkspaceRecoveryTests.swift
+++ b/cmuxTests/WorkspaceRecoveryTests.swift
@@ -779,6 +779,33 @@ struct WorkspaceRecoveryTests {
     }
 
     @Test
+    func automaticClearWithoutPriorJournalCreatesTombstone() throws {
+        let fixture = try makeCustomizationStore()
+        defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
+
+        let manager = TabManager(
+            initialWorkingDirectory: "/tmp/automatic-clear-without-journal",
+            autoWelcomeIfNeeded: false,
+            workspaceCustomizationStore: fixture.store
+        )
+        let workspace = try #require(manager.selectedWorkspace)
+        #expect(fixture.store.customization(for: workspace.stableId) == nil)
+
+        // A restored automatic title can be cleared before this workspace has
+        // ever written a stable-ID customization record. That clear must still
+        // fence a stale session snapshot on the next restart.
+        workspace.customTitle = nil
+        workspace.customTitleSource = nil
+        manager.recordWorkspaceCustomTitle(workspace, source: .auto)
+        manager.flushPendingWorkspaceCustomizationWrites()
+
+        #expect(
+            fixture.store.customization(for: workspace.stableId)?.customTitle ==
+                .cleared
+        )
+    }
+
+    @Test
     func queuedAutomaticTitleCannotOverwriteLaterExplicitClearAcrossManagers() throws {
         let fixture = try makeCustomizationStore()
         defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }

--- a/cmuxTests/WorkspaceRecoveryTests.swift
+++ b/cmuxTests/WorkspaceRecoveryTests.swift
@@ -11,6 +11,15 @@ import Testing
 @MainActor
 @Suite(.serialized)
 struct WorkspaceRecoveryTests {
+    @MainActor
+    private final class SnapshotRaceTabManager: TabManager {
+        var afterWorkspaceSnapshots: (() -> Void)?
+
+        override func didCaptureWorkspaceSessionSnapshots() {
+            afterWorkspaceSnapshots?()
+        }
+    }
+
     private func makeCustomizationStore() throws -> (
         store: WorkspaceCustomizationStore,
         defaults: UserDefaults,
@@ -573,6 +582,56 @@ struct WorkspaceRecoveryTests {
         let restoredWorkspace = try #require(restoredManager.selectedWorkspace)
         #expect(restoredWorkspace.customTitle == "Newer Session Title")
         #expect(restoredWorkspace.effectiveCustomTitleSource == .auto)
+    }
+
+    @Test
+    func snapshotFenceRemainsOlderThanAConcurrentClear() throws {
+        let fixture = try makeCustomizationStore()
+        defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
+
+        let sourceManager = SnapshotRaceTabManager(
+            initialWorkingDirectory: "/tmp/snapshot-fence-race",
+            autoWelcomeIfNeeded: false,
+            workspaceCustomizationStore: fixture.store
+        )
+        let sourceWorkspace = try #require(sourceManager.selectedWorkspace)
+        #expect(sourceManager.setCustomTitle(tabId: sourceWorkspace.id, title: "User Name"))
+        sourceManager.clearCustomTitle(tabId: sourceWorkspace.id)
+        #expect(sourceManager.setCustomTitle(
+            tabId: sourceWorkspace.id,
+            title: "Before Clear",
+            source: .auto
+        ))
+        sourceManager.flushPendingWorkspaceCustomizationWrites()
+
+        let clearingManager = TabManager(
+            autoWelcomeIfNeeded: false,
+            workspaceCustomizationStore: fixture.store
+        )
+        clearingManager.restoreSessionSnapshot(SessionTabManagerSnapshot(
+            selectedWorkspaceIndex: 0,
+            workspaces: [sourceWorkspace.sessionSnapshot(includeScrollback: false)]
+        ))
+        let clearingWorkspace = try #require(clearingManager.selectedWorkspace)
+        sourceManager.afterWorkspaceSnapshots = {
+            clearingManager.clearCustomTitle(tabId: clearingWorkspace.id)
+        }
+
+        let snapshot = sourceManager.sessionSnapshot(includeScrollback: false)
+        let snapshotWorkspace = try #require(snapshot.workspaces.first)
+        let currentRevision = try #require(
+            fixture.store.customizationAndTitleMutationRevision(for: sourceWorkspace.stableId)
+        ).titleMutationRevision
+        #expect(snapshotWorkspace.customTitleMutationRevision ?? 0 < currentRevision)
+
+        let restoredManager = TabManager(
+            autoWelcomeIfNeeded: false,
+            workspaceCustomizationStore: fixture.store
+        )
+        restoredManager.restoreSessionSnapshot(snapshot)
+        let restoredWorkspace = try #require(restoredManager.selectedWorkspace)
+        #expect(restoredWorkspace.customTitle == nil)
+        #expect(restoredWorkspace.effectiveCustomTitleSource == nil)
     }
 
     @Test

--- a/cmuxTests/WorkspaceRecoveryTests.swift
+++ b/cmuxTests/WorkspaceRecoveryTests.swift
@@ -680,6 +680,65 @@ struct WorkspaceRecoveryTests {
     }
 
     @Test
+    func newestAutomaticTitleReplacesStalePendingAcrossManagers() throws {
+        let fixture = try makeCustomizationStore()
+        defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
+
+        let firstManager = TabManager(
+            initialWorkingDirectory: "/tmp/newest-auto-title-manager",
+            autoWelcomeIfNeeded: false,
+            workspaceCustomizationStore: fixture.store
+        )
+        let firstWorkspace = try #require(firstManager.selectedWorkspace)
+        #expect(firstManager.setCustomTitle(
+            tabId: firstWorkspace.id,
+            title: "User Title"
+        ))
+        firstManager.clearCustomTitle(tabId: firstWorkspace.id)
+        #expect(firstManager.setCustomTitle(
+            tabId: firstWorkspace.id,
+            title: "Queued Automatic Title",
+            source: .auto
+        ))
+
+        // A second manager flushes a newer automatic title while the first
+        // manager still has its older title queued. The first manager must
+        // refresh both the durable revision and ordering when it receives the
+        // newest title, or its flush is incorrectly rejected as stale.
+        let secondManager = TabManager(
+            autoWelcomeIfNeeded: false,
+            workspaceCustomizationStore: fixture.store
+        )
+        secondManager.restoreSessionSnapshot(SessionTabManagerSnapshot(
+            selectedWorkspaceIndex: 0,
+            workspaces: [firstWorkspace.sessionSnapshot(includeScrollback: false)]
+        ))
+        let secondWorkspace = try #require(secondManager.selectedWorkspace)
+        #expect(secondWorkspace.stableId == firstWorkspace.stableId)
+        #expect(secondManager.setCustomTitle(
+            tabId: secondWorkspace.id,
+            title: "Newer Automatic Title",
+            source: .auto
+        ))
+        secondManager.flushPendingWorkspaceCustomizationWrites()
+        #expect(
+            fixture.store.customization(for: firstWorkspace.stableId)?.customTitle ==
+                .autoValue("Newer Automatic Title")
+        )
+
+        #expect(firstManager.setCustomTitle(
+            tabId: firstWorkspace.id,
+            title: "Newest Automatic Title",
+            source: .auto
+        ))
+        firstManager.flushPendingWorkspaceCustomizationWrites()
+        #expect(
+            fixture.store.customization(for: firstWorkspace.stableId)?.customTitle ==
+                .autoValue("Newest Automatic Title")
+        )
+    }
+
+    @Test
     func autoTitleRecoveryPreservesIndependentColor() throws {
         let fixture = try makeCustomizationStore()
         defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }

--- a/cmuxTests/WorkspaceRecoveryTests.swift
+++ b/cmuxTests/WorkspaceRecoveryTests.swift
@@ -534,6 +534,93 @@ struct WorkspaceRecoveryTests {
     }
 
     @Test
+    func newerSessionAutomaticTitleWinsOverOlderJournal() throws {
+        let fixture = try makeCustomizationStore()
+        defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
+        let store = fixture.store
+
+        let sourceManager = TabManager(
+            initialWorkingDirectory: "/tmp/newer-session-title",
+            autoWelcomeIfNeeded: false,
+            workspaceCustomizationStore: store
+        )
+        let sourceWorkspace = try #require(sourceManager.selectedWorkspace)
+        #expect(sourceManager.setCustomTitle(tabId: sourceWorkspace.id, title: "User Name"))
+        sourceManager.clearCustomTitle(tabId: sourceWorkspace.id)
+        #expect(sourceManager.setCustomTitle(
+            tabId: sourceWorkspace.id,
+            title: "Older Journal Title",
+            source: .auto
+        ))
+        sourceManager.flushPendingWorkspaceCustomizationWrites()
+        let olderRevision = try #require(
+            store.customizationAndTitleMutationRevision(for: sourceWorkspace.stableId)
+        ).titleMutationRevision
+
+        var snapshot = sourceWorkspace.sessionSnapshot(includeScrollback: false)
+        snapshot.customTitle = "Newer Session Title"
+        snapshot.customTitleSource = .auto
+        snapshot.customTitleMutationRevision = olderRevision &+ 1
+
+        let restoredManager = TabManager(
+            autoWelcomeIfNeeded: false,
+            workspaceCustomizationStore: store
+        )
+        restoredManager.restoreSessionSnapshot(SessionTabManagerSnapshot(
+            selectedWorkspaceIndex: 0,
+            workspaces: [snapshot]
+        ))
+        let restoredWorkspace = try #require(restoredManager.selectedWorkspace)
+        #expect(restoredWorkspace.customTitle == "Newer Session Title")
+        #expect(restoredWorkspace.effectiveCustomTitleSource == .auto)
+    }
+
+    @Test
+    func queuedAutomaticTitleSurvivesAConcurrentClearWithoutPerEventReads() throws {
+        let fixture = try makeCustomizationStore()
+        defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
+
+        let queuedManager = TabManager(
+            initialWorkingDirectory: "/tmp/concurrent-clear-title",
+            autoWelcomeIfNeeded: false,
+            workspaceCustomizationStore: fixture.store
+        )
+        let queuedWorkspace = try #require(queuedManager.selectedWorkspace)
+        #expect(queuedManager.setCustomTitle(tabId: queuedWorkspace.id, title: "User Name"))
+        queuedManager.clearCustomTitle(tabId: queuedWorkspace.id)
+        #expect(queuedManager.setCustomTitle(
+            tabId: queuedWorkspace.id,
+            title: "Queued Before Clear",
+            source: .auto
+        ))
+
+        // A second manager advances the durable clear after the first manager
+        // queued its automatic value. The queued writer must revalidate at
+        // flush without requiring another synchronous read for each event.
+        let clearingManager = TabManager(
+            autoWelcomeIfNeeded: false,
+            workspaceCustomizationStore: fixture.store
+        )
+        clearingManager.restoreSessionSnapshot(SessionTabManagerSnapshot(
+            selectedWorkspaceIndex: 0,
+            workspaces: [queuedWorkspace.sessionSnapshot(includeScrollback: false)]
+        ))
+        let clearingWorkspace = try #require(clearingManager.selectedWorkspace)
+        clearingManager.clearCustomTitle(tabId: clearingWorkspace.id)
+
+        #expect(queuedManager.setCustomTitle(
+            tabId: queuedWorkspace.id,
+            title: "Queued After Clear",
+            source: .auto
+        ))
+        queuedManager.flushPendingWorkspaceCustomizationWrites()
+        #expect(
+            fixture.store.customization(for: queuedWorkspace.stableId)?.customTitle ==
+                .autoValue("Queued After Clear")
+        )
+    }
+
+    @Test
     func automaticTitleJournalWritesCoalesceUntilFlush() throws {
         let fixture = try makeCustomizationStore()
         defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }

--- a/cmuxTests/WorkspaceRecoveryTests.swift
+++ b/cmuxTests/WorkspaceRecoveryTests.swift
@@ -635,6 +635,97 @@ struct WorkspaceRecoveryTests {
     }
 
     @Test
+    func sessionSnapshotUsesDurableAutomaticTitleWhenLiveTitleIsStale() throws {
+        let fixture = try makeCustomizationStore()
+        defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
+
+        let sourceManager = TabManager(
+            initialWorkingDirectory: "/tmp/durable-title-source",
+            autoWelcomeIfNeeded: false,
+            workspaceCustomizationStore: fixture.store
+        )
+        let sourceWorkspace = try #require(sourceManager.selectedWorkspace)
+        #expect(sourceManager.setCustomTitle(tabId: sourceWorkspace.id, title: "User Title"))
+        sourceManager.clearCustomTitle(tabId: sourceWorkspace.id)
+        #expect(sourceManager.setCustomTitle(
+            tabId: sourceWorkspace.id,
+            title: "Durable Automatic Title",
+            source: .auto
+        ))
+        sourceManager.flushPendingWorkspaceCustomizationWrites()
+
+        let staleManager = SnapshotRaceTabManager(
+            initialWorkingDirectory: "/tmp/stale-live-title",
+            autoWelcomeIfNeeded: false,
+            workspaceCustomizationStore: fixture.store
+        )
+        staleManager.restoreSessionSnapshot(SessionTabManagerSnapshot(
+            selectedWorkspaceIndex: 0,
+            workspaces: [sourceWorkspace.sessionSnapshot(includeScrollback: false)]
+        ))
+        let staleWorkspace = try #require(staleManager.selectedWorkspace)
+        staleWorkspace.customTitle = "Stale Live Title"
+        staleWorkspace.customTitleSource = .auto
+
+        let snapshot = staleManager.sessionSnapshot(includeScrollback: false)
+        let snapshotWorkspace = try #require(snapshot.workspaces.first)
+        #expect(snapshotWorkspace.customTitle == "Durable Automatic Title")
+        #expect(snapshotWorkspace.customTitleSource == .auto)
+
+        let restoredManager = TabManager(
+            autoWelcomeIfNeeded: false,
+            workspaceCustomizationStore: fixture.store
+        )
+        restoredManager.restoreSessionSnapshot(snapshot)
+        let restoredWorkspace = try #require(restoredManager.selectedWorkspace)
+        #expect(restoredWorkspace.customTitle == "Durable Automatic Title")
+        #expect(restoredWorkspace.effectiveCustomTitleSource == .auto)
+    }
+
+    @Test
+    func equalTitleFenceDoesNotSuppressIndependentColorRecovery() throws {
+        let fixture = try makeCustomizationStore()
+        defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
+
+        let sourceManager = TabManager(
+            initialWorkingDirectory: "/tmp/independent-color-recovery",
+            autoWelcomeIfNeeded: false,
+            workspaceCustomizationStore: fixture.store
+        )
+        let sourceWorkspace = try #require(sourceManager.selectedWorkspace)
+        #expect(sourceManager.setCustomTitle(tabId: sourceWorkspace.id, title: "User Title"))
+        sourceManager.clearCustomTitle(tabId: sourceWorkspace.id)
+        #expect(sourceManager.setCustomTitle(
+            tabId: sourceWorkspace.id,
+            title: "Automatic Title",
+            source: .auto
+        ))
+        sourceManager.flushPendingWorkspaceCustomizationWrites()
+        fixture.store.setCustomColor("#123456", for: sourceWorkspace.stableId)
+        let titleRevision = try #require(
+            fixture.store.customizationAndTitleMutationRevision(for: sourceWorkspace.stableId)
+        ).titleMutationRevision
+
+        var snapshot = sourceWorkspace.sessionSnapshot(includeScrollback: false)
+        snapshot.customTitle = "Automatic Title"
+        snapshot.customTitleSource = .auto
+        snapshot.customTitleMutationRevision = titleRevision
+        snapshot.customColor = nil
+
+        let restoredManager = TabManager(
+            autoWelcomeIfNeeded: false,
+            workspaceCustomizationStore: fixture.store
+        )
+        restoredManager.restoreSessionSnapshot(SessionTabManagerSnapshot(
+            selectedWorkspaceIndex: 0,
+            workspaces: [snapshot]
+        ))
+        let restoredWorkspace = try #require(restoredManager.selectedWorkspace)
+        #expect(restoredWorkspace.customTitle == "Automatic Title")
+        #expect(restoredWorkspace.customColor == "#123456")
+    }
+
+    @Test
     func queuedAutomaticTitleSurvivesAConcurrentClearWithoutPerEventReads() throws {
         let fixture = try makeCustomizationStore()
         defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }


### PR DESCRIPTION
Supersedes https://github.com/manaflow-ai/cmux/pull/11129.

Summary:
- Preserve an automatic workspace title after a user clears an explicit title.
- Order clear and automatic-title recovery records so a stale session snapshot cannot restore the removed title.
- Journal each later automatic title refresh so restart recovery uses the newest title.

Verification:
- Regression tests are in test-only commits before their fixes.
- Packages/macOS/CmuxWorkspaces: swift test --disable-sandbox, 213 tests passed.
- Changed Swift files pass swiftc parse checks.
- Local Xcode tests were not run, per repository policy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790660470&installation_model_id=21920&pr_number=11198&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11198&signature=dac6c21a09dfb926f154f3e3d88cd8a491f8d3505f2e782a336462b7e31c2927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes automatic workspace titles so the newest auto title (or explicit clear) survives restart, and colors are still recovered independently of the title fence.

**What changed**
- The journal records `customTitleSource` (user/auto) with an additive `autoValue` title field; older decoders still read it as `.value`, so existing journals stay backward-compatible.
- A per-title mutation revision plus process-local ordering lets the journal drop stale auto-title records that would overwrite a newer clear or user title.
- Auto-title writes coalesce in a 250 ms window and flush synchronously at terminate, manager teardown, window-context removal, and before session snapshot write/restore.
- Session snapshots carry the title-mutation fence, captured before workspace title projection, so restore prefers whichever auto title is newer; journal reads are deferred and batched to keep high-frequency title events off the synchronous decode path.
- Restore clears a stale snapshot title before applying a newer auto title, ignores auto-provenance color records, and records automatic clears as durable tombstones even when the workspace has no prior journal entry. Colors are applied independently of the title fence, so a stale or equal auto title never suppresses a stored color.

**Notes for review**
- Old behavior: auto title refreshes after a cleared title were not journaled, and pending auto titles were not flushed on quick quit or teardown, so restart could restore a stale or lost title.
- New behavior: the newest auto title (or explicit clear) is durable across restart; a concurrent clear captured after the snapshot fence still wins.
- Rollout is safe: no migration or user action, and revert is clean since the new keys are additive.
- Tests: Swift package tests pass; changed Swift files pass `swiftc` parse checks; local Xcode tests omitted per repo policy.

<sup>Written for commit 9432fcbf1695e3f99375889747b15ab532f04f4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace title recovery across restarts.
  * Explicitly cleared titles remain cleared instead of being replaced by older automatic titles.
  * Automatic titles restore correctly while preserving manual title changes and workspace colors.
  * Pending automatic title updates are reliably saved during app shutdown.

* **Enhancements**
  * Automatic and user-provided titles are distinguished for more reliable recovery.
  * Automatic title updates are coalesced to reduce redundant saves.
  * Automatic title data remains compatible with older saved workspace records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->