### PR TITLE
Apply the macOS 26 icon appearances to the Dock icon

### DIFF
--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/AppCatalogSection.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/AppCatalogSection.swift
@@ -17,7 +17,7 @@ public struct AppCatalogSection: SettingCatalogSection {
 
     public let appIcon = DefaultsKey<AppIconMode>(
         id: "app.appIcon",
-        defaultValue: .automatic,
+        defaultValue: .system,
         userDefaultsKey: "appIconMode"
     )
 

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Stores/AppIconSettingsStore.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Stores/AppIconSettingsStore.swift
@@ -22,7 +22,7 @@ public struct AppIconSettingsStore: Sendable {
     }
 
     /// The persisted icon mode; unrecognized stored values read as
-    /// ``AppIconMode/automatic``.
+    /// ``AppIconMode/system``.
     public var resolvedMode: AppIconMode {
         keys.appIcon.value(in: defaults)
     }

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/AppIconMode.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/AppIconMode.swift
@@ -1,6 +1,8 @@
 import Foundation
 
-/// Dock icon variant. `automatic` follows the system appearance.
+/// Dock icon variant. `system` leaves the bundle's layered icon alone so macOS
+/// can apply its Dark, Tinted and Clear appearances; `automatic` follows the
+/// system appearance with cmux's own light/dark bitmaps.
 public enum AppIconMode: String, CaseIterable, Sendable, SettingCodable {
-    case automatic, light, dark
+    case system, automatic, light, dark
 }

--- a/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/DomainSettingsStoreTests.swift
+++ b/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/DomainSettingsStoreTests.swift
@@ -331,12 +331,19 @@ struct PreferredEditorSettingsStoreTests {
 
 @Suite("AppIconSettingsStore")
 struct AppIconSettingsStoreTests {
-    @Test func unsetAndInvalidReadAutomatic() {
+    @Test func unsetAndInvalidReadSystem() {
         let defaults = makeScratchDefaults()
         let store = AppIconSettingsStore(defaults: defaults)
-        #expect(store.resolvedMode == .automatic)
+        #expect(store.resolvedMode == .system)
 
         defaults.set("neon", forKey: "appIconMode")
+        #expect(store.resolvedMode == .system)
+    }
+
+    @Test func readsAutomaticWhenStored() {
+        let defaults = makeScratchDefaults()
+        defaults.set("automatic", forKey: "appIconMode")
+        let store = AppIconSettingsStore(defaults: defaults)
         #expect(store.resolvedMode == .automatic)
     }
 

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Rows/AppIconPickerRow.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Rows/AppIconPickerRow.swift
@@ -39,7 +39,14 @@ struct AppIconPickerRow: View {
                     } label: {
                         VStack(spacing: 4) {
                             Group {
-                                if mode == .automatic {
+                                if mode == .system {
+                                    // Already shaped and appearance-treated by the
+                                    // system, so it needs no clipShape of its own.
+                                    Image(nsImage: NSApplication.shared.applicationIconImage)
+                                        .resizable()
+                                        .interpolation(.high)
+                                        .frame(width: iconSize, height: iconSize)
+                                } else if mode == .automatic {
                                     ZStack {
                                         Image("AppIconLight", bundle: .main)
                                             .resizable()
@@ -96,6 +103,7 @@ struct AppIconPickerRow: View {
 
     private func iconAssetName(for mode: AppIconMode) -> String {
         switch mode {
+        case .system: return "AppIconLight"
         case .automatic: return "AppIconLight"
         case .light: return "AppIconLight"
         case .dark: return "AppIconDark"
@@ -104,6 +112,7 @@ struct AppIconPickerRow: View {
 
     private func iconDisplayName(_ mode: AppIconMode) -> String {
         switch mode {
+        case .system: return String(localized: "appIcon.system", defaultValue: "System")
         case .automatic: return String(localized: "appIcon.automatic", defaultValue: "Automatic")
         case .light: return String(localized: "appIcon.light", defaultValue: "Light")
         case .dark: return String(localized: "appIcon.dark", defaultValue: "Dark")

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -20213,6 +20213,23 @@
         }
       }
     },
+    "appIcon.system": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "システム"
+          }
+        }
+      }
+    },
     "appearance.auto": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/AppIconDockTilePlugin.swift
+++ b/Sources/AppIconDockTilePlugin.swift
@@ -5,16 +5,22 @@ private let cmuxAppIconDidChangeNotification = Notification.Name("com.cmuxterm.a
 private let cmuxAppIconModeKey = "appIconMode"
 
 private enum DockTileAppIconMode: String {
+    case system
     case automatic
     case light
     case dark
 
     init(defaultsValue: String?) {
-        self = Self(rawValue: defaultsValue ?? "") ?? .automatic
+        self = Self(rawValue: defaultsValue ?? "") ?? .system
     }
 
     func imageName(isDarkAppearance: Bool) -> NSImage.Name? {
         switch self {
+        case .system:
+            // Returning nil routes updateDockTile through showDefaultAppIcon(),
+            // which leaves the bundle's layered icon and its appearance
+            // treatment in place.
+            return nil
         case .automatic:
             return isDarkAppearance ? NSImage.Name("AppIconDark") : NSImage.Name("AppIconLight")
         case .light:

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -5321,6 +5321,7 @@ private struct AboutVisualEffectBackground: NSViewRepresentable {
 }
 
 enum AppIconMode: String, CaseIterable, Identifiable {
+    case system
     case automatic
     case light
     case dark
@@ -5329,6 +5330,7 @@ enum AppIconMode: String, CaseIterable, Identifiable {
 
     var displayName: String {
         switch self {
+        case .system: return String(localized: "appIcon.system", defaultValue: "System")
         case .automatic: return String(localized: "appIcon.automatic", defaultValue: "Automatic")
         case .light: return String(localized: "appIcon.light", defaultValue: "Light")
         case .dark: return String(localized: "appIcon.dark", defaultValue: "Dark")
@@ -5337,6 +5339,7 @@ enum AppIconMode: String, CaseIterable, Identifiable {
 
     var imageName: String? {
         switch self {
+        case .system: return nil
         case .automatic: return nil
         case .light: return "AppIconLight"
         case .dark: return "AppIconDark"
@@ -5364,7 +5367,7 @@ enum AppIconLaunchState {
 
 enum AppIconSettings {
     static let modeKey = "appIconMode"
-    static let defaultMode: AppIconMode = .automatic
+    static let defaultMode: AppIconMode = .system
     private static let dockTileIconDidChangeNotification = Notification.Name("com.cmuxterm.appIconDidChange")
     private static var liveEnvironmentProvider: () -> Environment = { .live() }
 
@@ -5435,6 +5438,11 @@ enum AppIconSettings {
         guard environment.isApplicationFinishedLaunching() else { return }
 
         switch mode {
+        case .system:
+            // macOS applies Dark, Tinted and Clear treatment to the bundle's
+            // layered icon only. Assigning any NSImage here forfeits it, so
+            // this mode deliberately leaves applicationIconImage untouched.
+            environment.stopAppearanceObservation()
         case .automatic:
             environment.startAppearanceObservation()
         case .light:

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -5387,6 +5387,7 @@ enum AppIconSettings {
         let isApplicationFinishedLaunching: () -> Bool
         let imageForMode: (AppIconMode) -> NSImage?
         let setApplicationIconImage: (NSImage) -> Void
+        let restoreBundleIconImage: () -> Void
         let startAppearanceObservation: () -> Void
         let stopAppearanceObservation: () -> Void
         let notifyDockTilePlugin: () -> Void
@@ -5402,6 +5403,11 @@ enum AppIconSettings {
                 },
                 setApplicationIconImage: { icon in
                     NSApplication.shared.applicationIconImage = icon
+                },
+                restoreBundleIconImage: {
+                    // nil restores the bundle's own icon, which is the layered
+                    // one macOS applies its appearance treatment to.
+                    NSApplication.shared.applicationIconImage = nil
                 },
                 startAppearanceObservation: {
                     AppIconAppearanceObserver.shared.startObserving()
@@ -5440,9 +5446,11 @@ enum AppIconSettings {
         switch mode {
         case .system:
             // macOS applies Dark, Tinted and Clear treatment to the bundle's
-            // layered icon only. Assigning any NSImage here forfeits it, so
-            // this mode deliberately leaves applicationIconImage untouched.
+            // layered icon only, never to an NSImage assigned at runtime.
+            // A previous light/dark/automatic selection may have left one
+            // installed, so drop it rather than merely stopping observation.
             environment.stopAppearanceObservation()
+            environment.restoreBundleIconImage()
         case .automatic:
             environment.startAppearanceObservation()
         case .light:

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -252,6 +252,7 @@
 		A11EAA000000000000000000 /* AppearanceSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11EAA000000000000000001 /* AppearanceSettingsTests.swift */; };
 		C97160000000000000000001 /* AppHostProcessReceipt.swift in Sources */ = {isa = PBXBuildFile; fileRef = C97160000000000000000002 /* AppHostProcessReceipt.swift */; };
 		C8046FF15781CC7E4F8EAEA6 /* AppHostWindowReleaseGuardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3FAA194471B7BA157FB4660 /* AppHostWindowReleaseGuardTests.swift */; };
+		IC000003 /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = IC000002 /* AppIcon.icon */; };
 		A7206E010000000000000001 /* AppIconAppearanceObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7206E020000000000000001 /* AppIconAppearanceObserverTests.swift */; };
 		D1320AA0D1320AA0D1320AA1 /* AppIconDockTilePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1320AA0D1320AA0D1320AA4 /* AppIconDockTilePlugin.swift */; };
 		A5001621 /* AppleScriptSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001620 /* AppleScriptSupport.swift */; };
@@ -3290,7 +3291,7 @@
 		A11EAA000000000000000001 /* AppearanceSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceSettingsTests.swift; sourceTree = "<group>"; };
 		C97160000000000000000002 /* AppHostProcessReceipt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppHostProcessReceipt.swift; sourceTree = "<group>"; };
 		B3FAA194471B7BA157FB4660 /* AppHostWindowReleaseGuardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppHostWindowReleaseGuardTests.swift; sourceTree = "<group>"; };
-		IC000002 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = folder; path = AppIcon.icon; sourceTree = "<group>"; };
+		IC000002 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; path = AppIcon.icon; sourceTree = "<group>"; };
 		A7206E020000000000000001 /* AppIconAppearanceObserverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconAppearanceObserverTests.swift; sourceTree = "<group>"; };
 		D1320AA0D1320AA0D1320AA4 /* AppIconDockTilePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconDockTilePlugin.swift; sourceTree = "<group>"; };
 		A5001620 /* AppleScriptSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleScriptSupport.swift; sourceTree = "<group>"; };
@@ -9331,6 +9332,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 			files = (
 				A9E020000000000000000006 /* agent-session-react in Resources */,
 				A9E020000000000000000007 /* agent-session-solid in Resources */,
+				IC000003 /* AppIcon.icon in Resources */,
 				A5001100 /* Assets.xcassets in Resources */,
 				EF840DF6D022042F7E57B482 /* cloud-agent-skill.md in Resources */,
 				C0DEC0DE0000000000000011 /* cmux-cua in Resources */,

--- a/cmuxTests/KeyboardShortcutSettingsFileStoreStartupTests.swift
+++ b/cmuxTests/KeyboardShortcutSettingsFileStoreStartupTests.swift
@@ -165,6 +165,7 @@ final class KeyboardShortcutSettingsFileStoreStartupTests: XCTestCase {
                 setApplicationIconImage: { _ in
                     runtimeIconSetCount += 1
                 },
+                restoreBundleIconImage: {},
                 startAppearanceObservation: {
                     startObservationCallCount += 1
                 },

--- a/cmuxTests/NotificationAndMenuBarTests.swift
+++ b/cmuxTests/NotificationAndMenuBarTests.swift
@@ -494,6 +494,7 @@ final class AppIconSettingsTests: XCTestCase {
             setApplicationIconImage: { icon in
                 receivedRuntimeIcon = icon
             },
+            restoreBundleIconImage: {},
             startAppearanceObservation: {
                 startObservationCallCount += 1
             },
@@ -517,6 +518,7 @@ final class AppIconSettingsTests: XCTestCase {
         var dockTileNotificationCount = 0
         var startObservationCallCount = 0
         var stopObservationCallCount = 0
+        var restoreBundleIconCallCount = 0
 
         let environment = AppIconSettings.Environment(
             isApplicationFinishedLaunching: { true },
@@ -526,6 +528,9 @@ final class AppIconSettingsTests: XCTestCase {
             },
             setApplicationIconImage: { _ in
                 XCTFail("System mode must not assign applicationIconImage, or macOS drops the layered icon's appearance treatment")
+            },
+            restoreBundleIconImage: {
+                restoreBundleIconCallCount += 1
             },
             startAppearanceObservation: {
                 startObservationCallCount += 1
@@ -543,6 +548,44 @@ final class AppIconSettingsTests: XCTestCase {
         XCTAssertEqual(dockTileNotificationCount, 1)
         XCTAssertEqual(startObservationCallCount, 0)
         XCTAssertEqual(stopObservationCallCount, 1)
+        // A previous light/dark selection leaves a runtime icon installed;
+        // switching to system has to drop it, not just stop observing.
+        XCTAssertEqual(restoreBundleIconCallCount, 1)
+    }
+
+    func testSwitchingFromLightToSystemClearsTheRuntimeOverride() {
+        let lightIcon = NSImage(size: NSSize(width: 16, height: 16))
+        var runtimeIcon: NSImage?
+        var restoreCallCount = 0
+        var stopObservationCallCount = 0
+
+        let environment = AppIconSettings.Environment(
+            isApplicationFinishedLaunching: { true },
+            imageForMode: { _ in lightIcon },
+            setApplicationIconImage: { icon in
+                runtimeIcon = icon
+            },
+            restoreBundleIconImage: {
+                runtimeIcon = nil
+                restoreCallCount += 1
+            },
+            startAppearanceObservation: {},
+            stopAppearanceObservation: {
+                stopObservationCallCount += 1
+            },
+            notifyDockTilePlugin: {}
+        )
+
+        AppIconSettings.applyIcon(.light, environment: environment)
+        XCTAssertTrue(runtimeIcon === lightIcon)
+
+        AppIconSettings.applyIcon(.system, environment: environment)
+
+        // Without the reset the app keeps the flat light bitmap and macOS has
+        // nothing layered to treat until the next launch.
+        XCTAssertNil(runtimeIcon)
+        XCTAssertEqual(restoreCallCount, 1)
+        XCTAssertEqual(stopObservationCallCount, 2)
     }
 
     func testApplyAutomaticStartsObservationAndNotifiesDockTilePlugin() {
@@ -559,6 +602,7 @@ final class AppIconSettingsTests: XCTestCase {
             setApplicationIconImage: { _ in
                 XCTFail("Automatic mode should delegate live updates to the appearance observer")
             },
+            restoreBundleIconImage: {},
             startAppearanceObservation: {
                 startObservationCallCount += 1
             },
@@ -593,6 +637,7 @@ final class AppIconSettingsTests: XCTestCase {
             setApplicationIconImage: { _ in
                 runtimeIconSetCount += 1
             },
+            restoreBundleIconImage: {},
             startAppearanceObservation: {
                 startObservationCallCount += 1
             },

--- a/cmuxTests/NotificationAndMenuBarTests.swift
+++ b/cmuxTests/NotificationAndMenuBarTests.swift
@@ -513,6 +513,38 @@ final class AppIconSettingsTests: XCTestCase {
         XCTAssertEqual(stopObservationCallCount, 1)
     }
 
+    func testApplySystemLeavesRuntimeIconUntouched() {
+        var dockTileNotificationCount = 0
+        var startObservationCallCount = 0
+        var stopObservationCallCount = 0
+
+        let environment = AppIconSettings.Environment(
+            isApplicationFinishedLaunching: { true },
+            imageForMode: { mode in
+                XCTFail("System mode should not request an icon image: \(mode.rawValue)")
+                return nil
+            },
+            setApplicationIconImage: { _ in
+                XCTFail("System mode must not assign applicationIconImage, or macOS drops the layered icon's appearance treatment")
+            },
+            startAppearanceObservation: {
+                startObservationCallCount += 1
+            },
+            stopAppearanceObservation: {
+                stopObservationCallCount += 1
+            },
+            notifyDockTilePlugin: {
+                dockTileNotificationCount += 1
+            }
+        )
+
+        AppIconSettings.applyIcon(.system, environment: environment)
+
+        XCTAssertEqual(dockTileNotificationCount, 1)
+        XCTAssertEqual(startObservationCallCount, 0)
+        XCTAssertEqual(stopObservationCallCount, 1)
+    }
+
     func testApplyAutomaticStartsObservationAndNotifiesDockTilePlugin() {
         var dockTileNotificationCount = 0
         var startObservationCallCount = 0

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -1430,6 +1430,7 @@ final class KeyboardShortcutSettingsFileStoreTests: XCTestCase {
                 setApplicationIconImage: { _ in
                     runtimeIconSetCount += 1
                 },
+                restoreBundleIconImage: {},
                 startAppearanceObservation: {
                     startObservationCallCount += 1
                 },
@@ -1507,6 +1508,7 @@ final class KeyboardShortcutSettingsFileStoreTests: XCTestCase {
                 setApplicationIconImage: { _ in
                     runtimeIconSetCount += 1
                 },
+                restoreBundleIconImage: {},
                 startAppearanceObservation: {
                     startObservationCallCount += 1
                 },


### PR DESCRIPTION
Fixes #8517
Fixes #2873

macOS 26 never applies its Dark, Tinted or Clear appearance to the cmux Dock icon, for two reasons.

The bundle ships no layered icon. `AppIcon.icon` exists in the project only as a `PBXFileReference` inside a group, with no `PBXBuildFile` and no entry in any Resources phase, so `actool` never receives it. The compiled icon comes from `Assets.xcassets/AppIcon.appiconset`, a flat PNG set.

The running app then overwrites the Dock icon. `light` and `dark` assign `NSApplication.shared.applicationIconImage` directly, `automatic` through `AppIconAppearanceObserver`. macOS applies its appearance treatment to a bundle's layered icon, never to an `NSImage` assigned at runtime ([WWDC25 220](https://developer.apple.com/videos/play/wwdc2025/220/)).

One commit per cause. Three lines in `project.pbxproj` add `AppIcon.icon` to the cmux target's Resources phase and correct its file type to `folder.iconcomposer.icon`. A new `AppIconMode.system`, now the default, assigns no icon and stops the appearance observation; the dock tile plugin returns `nil` for it, routing through the existing `showDefaultAppIcon()` path. `light` and `dark` stay as explicit overrides.

Verification: `IconImageStack` entries in the built `Assets.car`, Xcode 26.6.

| build | stacks |
| --- | --- |
| this branch | 3 |
| same tree, only the three pbxproj lines reverted | 0 |
| shipped 0.64.22 | 0 |

```
assetutil --info "<app>/Contents/Resources/Assets.car" | grep -c IconImageStack
```

Needs a Release build; Debug compiles `AppIcon-Debug` instead.

With the icon style set to Clear, both builds running side by side: the shipped 0.64.22 on the left stays opaque while every neighbouring app goes translucent, and this branch on the right picks up the same treatment as the rest of the Dock.

<img width="747" height="440" alt="Screenshot 2026-08-30 at 15 10 23" src="https://github.com/user-attachments/assets/d070bb11-8850-467b-955a-f27c4f11c079" />

`AppIcon.icns` is still emitted at the same four sizes for older systems.

One open question: `system` and `automatic` are hard to tell apart from their labels, now that both sound like "follow the system". Renaming `automatic`, or dropping it since `system` covers that intent better, may be the right call. I left it alone because it reads as a product decision rather than part of a bug fix, but happy to fold it in here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **System** app icon mode that preserves macOS-managed Dark, Tinted, and Clear appearances.
  * Updated the app icon picker with a localized **System** option and preview.
  * Bundled the app’s layered icon resource for system-managed rendering.

* **Bug Fixes**
  * Unset or invalid app icon settings now default to **System** instead of **Automatic**.
  * Switching to **System** clears custom runtime icon overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->