### PR TITLE
Fix Swift Testing calls for middle-button event fixtures

### DIFF
--- a/cmuxTests/FileDropOverlayViewTests.swift
+++ b/cmuxTests/FileDropOverlayViewTests.swift
@@ -451,11 +451,26 @@ struct FileDropOverlayViewTests {
         let leftDown = try #require(Self.mouseEvent(type: .leftMouseDown, location: leftPoint, window: window))
         let rightDown = try #require(Self.mouseEvent(type: .rightMouseDown, location: rightPoint, window: window))
         let rightDrag = try #require(Self.mouseEvent(type: .rightMouseDragged, location: leftPoint, window: window))
-        let middleDown = try #require(Self.otherMouseEvent(type: .otherMouseDown, location: leftPoint, window: window, buttonNumber: 2))
-        let middleDrag = try #require(Self.otherMouseEvent(type: .otherMouseDragged, location: rightPoint, window: window, buttonNumber: 2))
+        let middleDown = try Self.otherMouseEvent(
+            type: .otherMouseDown,
+            location: leftPoint,
+            window: window,
+            buttonNumber: 2
+        )
+        let middleDrag = try Self.otherMouseEvent(
+            type: .otherMouseDragged,
+            location: rightPoint,
+            window: window,
+            buttonNumber: 2
+        )
         let leftUp = try #require(Self.mouseEvent(type: .leftMouseUp, location: rightPoint, window: window))
         let rightUp = try #require(Self.mouseEvent(type: .rightMouseUp, location: leftPoint, window: window))
-        let middleUp = try #require(Self.otherMouseEvent(type: .otherMouseUp, location: rightPoint, window: window, buttonNumber: 2))
+        let middleUp = try Self.otherMouseEvent(
+            type: .otherMouseUp,
+            location: rightPoint,
+            window: window,
+            buttonNumber: 2
+        )
 
         overlay.mouseDown(with: leftDown)
         overlay.rightMouseDown(with: rightDown)


### PR DESCRIPTION
## Summary
- Call the throwing, non-optional middle-button event fixture directly with `try`.
- Preserve the existing behavior test for independent left, right, and middle button capture.

## Testing
- `swiftformat --lint --swift-version 6 --line-range 451,473 cmuxTests/FileDropOverlayViewTests.swift`
- `git diff --check`
- Hosted failure reference: https://github.com/manaflow-ai/cmux/actions/runs/33298069078

The existing behavior test is the regression test. No local Xcode tests were run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified test event setup while preserving the existing event sequence and assertions.
  * No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->