### PR TITLE
chore(cmux-tui): remove unused hook retry re-export

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -62,8 +62,7 @@ pub use public_projection_store::RegistryPublicProjections;
 pub use public_projection_store::{RegistryAgentProjection, RegistryNotificationProjection};
 pub(crate) use resource_store::validate_registry_screen_projection;
 pub(crate) use resource_store::{
-    AGENT_HOOK_MAX_ATTEMPTS, AGENT_HOOK_MAX_RETRY_PAGES_PER_WAKE, AgentHookProjectionState,
-    AgentHookRetryClass,
+    AGENT_HOOK_MAX_RETRY_PAGES_PER_WAKE, AgentHookProjectionState, AgentHookRetryClass,
 };
 #[allow(unused_imports)]
 pub use resource_store::{


### PR DESCRIPTION
## Summary
- remove the unused AGENT_HOOK_MAX_ATTEMPTS re-export from cmux-tui-core
- keep the clippy baseline clean after the CDP import repair

## Verification
- standalone rustfmt --check --edition 2024
- git diff --check

This is a mechanical baseline repair. No runtime behavior changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790670593&installation_model_id=21920&pr_number=11203&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11203&signature=d285a1efe07d23194485408b2ec36f7cf815f58aa1731e57796c4684c7f8c3ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the unused `AGENT_HOOK_MAX_ATTEMPTS` re-export from `cmux-tui-core` to keep the clippy baseline clean after the CDP import repair. No runtime behavior changes.

<sup>Written for commit 45f40a3eedb2abb166737c965a8a6f87250987ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed an internal retry-related constant from the module’s exported interface.
  * No user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->