### PR TITLE
chore(cmux-tui-core): remove unused hook retry re-export

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -61,6 +61,8 @@ pub use public_projection_store::RegistryPublicProjections;
 #[cfg(test)]
 pub use public_projection_store::{RegistryAgentProjection, RegistryNotificationProjection};
 pub(crate) use resource_store::validate_registry_screen_projection;
+#[cfg(test)]
+pub(crate) use resource_store::AGENT_HOOK_MAX_ATTEMPTS;
 pub(crate) use resource_store::{
     AGENT_HOOK_MAX_RETRY_PAGES_PER_WAKE, AgentHookProjectionState, AgentHookRetryClass,
 };

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -60,9 +60,9 @@ pub(crate) use journal_extensions::{
 pub use public_projection_store::RegistryPublicProjections;
 #[cfg(test)]
 pub use public_projection_store::{RegistryAgentProjection, RegistryNotificationProjection};
-pub(crate) use resource_store::validate_registry_screen_projection;
 #[cfg(test)]
 pub(crate) use resource_store::AGENT_HOOK_MAX_ATTEMPTS;
+pub(crate) use resource_store::validate_registry_screen_projection;
 pub(crate) use resource_store::{
     AGENT_HOOK_MAX_RETRY_PAGES_PER_WAKE, AgentHookProjectionState, AgentHookRetryClass,
 };

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -62,8 +62,7 @@ pub use public_projection_store::RegistryPublicProjections;
 pub use public_projection_store::{RegistryAgentProjection, RegistryNotificationProjection};
 pub(crate) use resource_store::validate_registry_screen_projection;
 pub(crate) use resource_store::{
-    AGENT_HOOK_MAX_ATTEMPTS, AGENT_HOOK_MAX_RETRY_PAGES_PER_WAKE, AgentHookProjectionState,
-    AgentHookRetryClass,
+    AGENT_HOOK_MAX_RETRY_PAGES_PER_WAKE, AgentHookProjectionState, AgentHookRetryClass,
 };
 #[allow(unused_imports)]
 pub use resource_store::{


### PR DESCRIPTION
## Summary
- remove the unused `AGENT_HOOK_MAX_ATTEMPTS` re-export from `workspace_registry.rs`
- keep the constant defined and used by `resource_store`

## Verification
- `git diff --check`
- `rustfmt --edition 2024 --check cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs`
- hosted cmux-tui focused and full runs will be dispatched after this exact head is confirmed

No runtime behavior changes. No test-first commit is needed for an import-only cleanup.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790670962&installation_model_id=21920&pr_number=11204&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11204&signature=c760d2d01e22854ea447891196e6daf8e0da303cd62ed02511005a9003bcee88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the production re-export of `AGENT_HOOK_MAX_ATTEMPTS` from `workspace_registry.rs`, leaving it available only under `#[cfg(test)]` for test visibility. No runtime behavior changes.

<sup>Written for commit a0e6123a56aba7176435af3c913ba5406c5ee665. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of test-only retry configuration.
  * Kept production behavior unchanged while limiting test-specific settings to test builds.
  * No changes to runtime behavior, user-facing functionality, or application workflows.

* **Tests**
  * Updated build-time visibility for test-only configuration to support cleaner separation between testing and production environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->