### PR TITLE
test: avoid throwing Swift Testing key-path expansion

### DIFF
--- a/cmuxTests/KeyboardShortcutContextSwiftTests.swift
+++ b/cmuxTests/KeyboardShortcutContextSwiftTests.swift
@@ -313,7 +313,7 @@ struct KeyboardShortcutContextSwiftTests {
                     notifications: notifications
                 )
                 #expect(updated.count == notifications.count)
-                #expect(updated.allSatisfy(\.isRead))
+                #expect(updated.allSatisfy { $0.isRead })
             }
         }
     }


### PR DESCRIPTION
## Summary
- use an explicit predicate in the notification all-read assertion
- avoid Swift 6.3 parsing the key-path predicate as a throwing macro expression

## Verification
- git diff --check
- official Swift Testing and Sequence.allSatisfy semantics reviewed
- hosted cmux test workflow pending

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790672039&installation_model_id=21920&pr_number=11205&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11205&signature=0bda6cea744e1dbae5cad808e11173612330c998f30b3016ad6829dcb5a736e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the key-path predicate in the notification all-read assertion with an explicit closure so Swift 6.3 no longer expands it as a throwing macro expression.

<sup>Written for commit 35175fbdd35fe0f657c3490f2620b94a983ba1b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated notification read-status test syntax without changing behavior or coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->