### PR TITLE
docs(tui): clarify bounded startup probe debt

### DIFF
--- a/cmux-tui/docs/TECH-DEBT-BOARD.md
+++ b/cmux-tui/docs/TECH-DEBT-BOARD.md
@@ -324,13 +324,13 @@ tail then adds protocol v7 operational PTY error gating (`29145d800c`,
 | [#10395](https://github.com/manaflow-ai/cmux/issues/10395) | `eprintln!` can corrupt TUI frames. Route diagnostics through the client log and prove raw-terminal bytes stay unchanged during attach, resize, and close. |
 | [#10431](https://github.com/manaflow-ai/cmux/issues/10431) | OSC-11 heredoc smoke input can drop bytes. Reproduce under parallel load and prove byte-for-byte paste delivery with bounded writes. |
 | [#10384](https://github.com/manaflow-ai/cmux/issues/10384) | SSH timeout kill/reap flakes in full suites. Prove process-group kill, reap, and no-child-leak behavior repeatedly. |
-| [#10426](https://github.com/manaflow-ai/cmux/issues/10426) | Paint-before-pointer flakes on cold parallel runs. Make ordering deterministic without hiding a rendering race. |
+| [#10426](https://github.com/manaflow-ai/cmux/issues/10426) | Paint-before-pointer ordering was fixed by merged [PR #11019](https://github.com/manaflow-ai/cmux/pull/11019). Keep a regression proof if this path changes; do not reopen the old race without a new failure. |
 | [#7126](https://github.com/manaflow-ai/cmux/issues/7126) | Cmd-V can send one character. Prove complete Unicode paste in bracketed and non-bracketed modes. |
 | [#8346](https://github.com/manaflow-ai/cmux/issues/8346) | Open-file-in-editor feature request. Define launch, focus, save/close, and reconnect behavior first. |
 | [#10034](https://github.com/manaflow-ai/cmux/issues/10034) | `preferredEditor` can leak editor and Node children. Prove process-group cleanup on success, cancel, crash, and app exit. |
 | [#4890](https://github.com/manaflow-ai/cmux/issues/4890), [#4733](https://github.com/manaflow-ai/cmux/issues/4733) | SSH loss/reconnect can leak mouse, focus, or Kitty bytes. Prove protocol-state reset on both paths. |
 | [#8285](https://github.com/manaflow-ai/cmux/issues/8285) | Width shrinks but may not widen. Prove bidirectional resize through daemon, PTY, and TUI under rapid changes. |
-| [#2688](https://github.com/manaflow-ai/cmux/issues/2688) | Crossterm startup can block on DSR. Define timeout/cancellation and prove startup without a reply. |
+| [#2688](https://github.com/manaflow-ai/cmux/issues/2688) | Child PTYs can still wait on DSR replies. cmux-tui's own startup probe is single-reader and bounded to 180 ms, but no-reply first-frame latency lacks hosted wall-clock proof. Add that behavior proof before tuning; do not add a second stdin reader. |
 | [#1059](https://github.com/manaflow-ai/cmux/issues/1059) | OSC-11 is not passed through. Prove request/reply forwarding and missing-color behavior. |
 | [#5490](https://github.com/manaflow-ai/cmux/issues/5490) | CSI 996/997/2031 theme protocol is missing. Add protocol behavior tests before claiming support. |
 | [#2396](https://github.com/manaflow-ai/cmux/issues/2396) | Large `cmux send` can freeze. Bound admission and prove completion under backpressure and bracketed paste. |


### PR DESCRIPTION
## Summary
- record that the cmux-tui startup probe has one bounded reader and a 180 ms deadline
- separate that latency debt from child-PTY DSR hangs
- mark the merged paint-before-pointer fix as regression-only debt

## Verification
- git diff --check
- source audit of app.rs and ui/graphics.rs
- official Ratatui and Crossterm behavior reviewed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790672785&installation_model_id=21920&pr_number=11207&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11207&signature=9b0f7598871a00735537d30aa213d5f8c421b740a0b1954a89c8e23afe5fc24c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the TUI tech-debt board to separate the bounded startup probe from child-PTY DSR hangs and to mark the paint-before-pointer fix as regression-only debt. The startup probe is now recorded as single-reader with a 180 ms deadline, and the DSR entry is scoped to child PTYs.

<sup>Written for commit e9e0cc2bc15c3181379e7e5a9d4ce5718d35d804. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the open issue inventory with the latest status for issues `#10426` and `#2688`.
  * Clarified regression-proof requirements and startup probe behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->