### PR TITLE
refactor(cmux-tui): normalize crossterm poll timeout

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -100,18 +100,20 @@ use crate::ui::{
 };
 
 const DEFERRED_INPUT_CAPACITY: usize = 512;
+const CROSSTERM_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 fn read_crossterm_event(
     timeout: Option<Duration>,
     mut poll: impl FnMut(Duration) -> std::io::Result<bool>,
     mut read: impl FnMut() -> std::io::Result<Event>,
 ) -> std::io::Result<Option<Event>> {
-    if let Some(timeout) = timeout.map(|timeout| timeout.min(Duration::from_millis(100)))
-        && !poll(timeout)?
-    {
-        return Ok(None);
-    }
-    if timeout.is_none() && !poll(Duration::from_millis(100))? {
+    // Keep the input thread interruptible even when no graphics response is
+    // pending. A single normalized poll avoids separate timed and untimed
+    // branches drifting apart as the reader evolves.
+    let poll_timeout = timeout.map_or(CROSSTERM_POLL_INTERVAL, |timeout| {
+        timeout.min(CROSSTERM_POLL_INTERVAL)
+    });
+    if !poll(poll_timeout)? {
         return Ok(None);
     }
     read().map(Some)
@@ -23848,6 +23850,24 @@ mod tests {
             poll_durations,
             vec![Duration::from_millis(100), Duration::from_millis(10), Duration::from_millis(10),]
         );
+    }
+
+    #[test]
+    fn crossterm_reader_propagates_poll_errors_without_reading() {
+        let mut read_calls = 0;
+        let error = std::io::Error::new(std::io::ErrorKind::Interrupted, "poll interrupted");
+
+        let result = super::read_crossterm_event(
+            None,
+            |_| Err(std::io::Error::new(error.kind(), error.to_string())),
+            || {
+                read_calls += 1;
+                Ok(Event::Resize(80, 24))
+            },
+        );
+
+        assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::Interrupted);
+        assert_eq!(read_calls, 0);
     }
 
     use super::{

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -110,9 +110,8 @@ fn read_crossterm_event(
     // Keep the input thread interruptible even when no graphics response is
     // pending. A single normalized poll avoids separate timed and untimed
     // branches drifting apart as the reader evolves.
-    let poll_timeout = timeout.map_or(CROSSTERM_POLL_INTERVAL, |timeout| {
-        timeout.min(CROSSTERM_POLL_INTERVAL)
-    });
+    let poll_timeout =
+        timeout.map_or(CROSSTERM_POLL_INTERVAL, |timeout| timeout.min(CROSSTERM_POLL_INTERVAL));
     if !poll(poll_timeout)? {
         return Ok(None);
     }


### PR DESCRIPTION
Normalize the crossterm input poll timeout into one capped path for both timed and untimed reads. This keeps the input thread interruptible at 100 ms while removing duplicate branches that could drift.

Adds a behavior test covering poll-error propagation and ensuring read is not called after poll failure.

Local Rust tests were not run per cmux-tui AGENTS.md. Hosted cmux-tui workflow runs are dispatched separately.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790694802&installation_model_id=21920&pr_number=11214&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11214&signature=5d12aebb81ff15c1e92462e974900a05f8aa1a856836b109c92c0dbbe3386cd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes the crossterm poll timeout in the input reader to a single capped 100 ms interval, keeping the thread interruptible and removing duplicate timed/untimed branches that could drift. Adds a behavior test covering poll-error propagation and ensuring read is not called after poll failure.

Local Rust tests were not run per cmux-tui AGENTS.md; hosted cmux-tui workflow runs are dispatched separately.

<sup>Written for commit 989640277f4c86ec97d050c4eec9101f006ea475. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event handling responsiveness by standardizing polling intervals.
  * Polling errors are now surfaced correctly instead of being silently ignored.
  * Improved consistency when processing timed and untimed input events.
  * Prevented event processing from continuing after an input polling failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->