### PR TITLE
fix(relay): fence fallback child reap after wait error

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -852,7 +852,7 @@ impl PtyManager {
             changed
         };
         if changed {
-            self.inner.detach_matching(|candidate| candidate == &owner, false).retire();
+            self.detach_matching(|candidate| candidate == &owner, false).retire();
         }
         let _state = self.inner.tunnel_state.lock().expect("tunnel state lock");
         if !self.inner.tunnel_authority_generation_current(context) {
@@ -1383,7 +1383,6 @@ impl Inner {
                     server_roots.as_deref(),
                     context,
                     &cancellation,
-                    &open_permit,
                 )
                 .await
             {
@@ -2288,9 +2287,10 @@ impl Inner {
                 }
             };
             if !owner {
+                let cancellation_token = cancellation.token();
                 tokio::select! {
                     biased;
-                    _ = cancellation.token().cancelled() => {
+                    _ = cancellation_token.cancelled() => {
                         return Err("terminal open cancelled".to_owned());
                     }
                     _ = waiter.expect("shell waiter") => {}
@@ -2852,7 +2852,6 @@ impl Inner {
         server_roots: Option<&[String]>,
         context: &FrameContext,
         cancellation: &OpenCancellation,
-        open_permit: &OpenPermit,
     ) -> Result<Option<Opened>, (RelayPtyErrorCode, String)> {
         let socket_dir = self.deps.socket_dir();
         let ensured = self

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -3810,6 +3810,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cancelled_shell_waiter_does_not_claim_starting_session() {
+        let h = harness(None, None);
+        let cancellation = h.manager.new_open_cancellation().expect("open attempt token");
+        let context = h.context("supervised", h.owner.clone());
+        let env = env_map(&h.home);
+        let open_permit = OpenPermit::new(
+            h.manager.inner.open_slots.clone().try_acquire_owned().expect("open permit"),
+        );
+        let notify = Arc::new(Notify::new());
+        h.manager
+            .inner
+            .shell_starting
+            .lock()
+            .unwrap()
+            .insert("waiting".to_owned(), Arc::clone(&notify));
+
+        // Model a second opener that is waiting for the first owner. The
+        // cancellation branch must win without spawning or removing the
+        // owner's in-progress marker.
+        cancellation.cancel();
+        let result = Arc::clone(&h.manager.inner)
+            .open_shell(
+                "waiting",
+                80,
+                24,
+                &h.home,
+                &env,
+                "p1",
+                None,
+                &context,
+                &cancellation,
+                &open_permit,
+            )
+            .await;
+
+        assert_eq!(result.err().as_deref(), Some("terminal open cancelled"));
+        assert!(h.spawned().is_empty());
+        assert!(h.manager.inner.shell_starting.lock().unwrap().contains_key("waiting"));
+    }
+
+    #[tokio::test]
     async fn cancellation_during_shell_subscribe_is_not_cached_and_killed() {
         let h = harness(None, None);
         h.cancel_on_subscribe.store(true, Ordering::SeqCst);

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -814,8 +814,8 @@ fn spawn_real_pty(spec: &SpawnSpec, handoff: &SpawnHandoff) -> anyhow::Result<Pt
     let (completion, cancel_reader) =
         ProcessOutputCompletion::with_pty_cancellation(1, Arc::clone(&output))?;
     let spawned = pair.spawn(command)?;
-    let cmux_pty::SpawnedPty { mut master, child } = spawned;
-    let mut child_cleanup = SpawnedChildCleanup::new(child);
+    let cmux_pty::SpawnedPty { master, child } = spawned;
+    let child_cleanup = SpawnedChildCleanup::new(child);
     if handoff.is_cancelled() {
         return Err(anyhow::anyhow!("PTY spawn cancelled"));
     }

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -815,7 +815,7 @@ fn spawn_real_pty(spec: &SpawnSpec, handoff: &SpawnHandoff) -> anyhow::Result<Pt
         ProcessOutputCompletion::with_pty_cancellation(1, Arc::clone(&output))?;
     let spawned = pair.spawn(command)?;
     let cmux_pty::SpawnedPty { master, child } = spawned;
-    let child_cleanup = SpawnedChildCleanup::new(child);
+    let mut child_cleanup = SpawnedChildCleanup::new(child);
     if handoff.is_cancelled() {
         return Err(anyhow::anyhow!("PTY spawn cancelled"));
     }
@@ -850,7 +850,6 @@ fn spawn_real_pty(spec: &SpawnSpec, handoff: &SpawnHandoff) -> anyhow::Result<Pt
         return Err(anyhow::anyhow!("PTY reader thread spawn failed"));
     }
     // Blocking wait thread -> exit.
-    let mut child_cleanup = child_cleanup;
     let exit_completion = Arc::clone(&completion);
     let wait_lifecycle = Arc::clone(&lifecycle);
     if std::thread::Builder::new()

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -1485,6 +1485,22 @@ mod tests {
     }
 
     #[derive(Debug)]
+    struct FailingTestChildKiller {
+        kills: TestArc<AtomicUsize>,
+    }
+
+    impl cmux_pty::ChildKiller for FailingTestChildKiller {
+        fn kill(&mut self) -> std::io::Result<()> {
+            self.kills.fetch_add(1, AtomicOrdering::Relaxed);
+            Err(std::io::Error::other("injected kill failure"))
+        }
+
+        fn clone_killer(&self) -> Box<dyn cmux_pty::ChildKiller + Send + Sync> {
+            Box::new(Self { kills: TestArc::clone(&self.kills) })
+        }
+    }
+
+    #[derive(Debug)]
     struct TestMaster;
 
     impl MasterPty for TestMaster {
@@ -1562,6 +1578,47 @@ mod tests {
         let state = lifecycle.lock().expect("lifecycle lock");
         assert!(state.reaping);
         assert!(state.termination_started);
+    }
+
+    #[test]
+    fn fallback_kill_error_keeps_reaping_fence_during_concurrent_master_drop() {
+        let kills = TestArc::new(AtomicUsize::new(0));
+        let lifecycle = ChildLifecycle::new(Some(42));
+        let (ready_tx, ready_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let wait_lifecycle = TestArc::clone(&lifecycle);
+        let wait_kills = TestArc::clone(&kills);
+        let wait_thread = thread::spawn(move || {
+            let claimed = ChildLifecycle::begin_reaping(&wait_lifecycle);
+            let kill_failed = {
+                let mut killer = FailingTestChildKiller { kills: wait_kills };
+                killer.kill().is_err()
+            };
+            ready_tx.send((claimed, kill_failed)).expect("fallback result");
+            release_rx.recv().expect("fallback wait release");
+            wait_lifecycle.lock().expect("lifecycle lock").exited = true;
+        });
+
+        let (claimed, kill_failed) = ready_rx.recv().expect("fallback result");
+        assert!(claimed, "fallback wait must claim the lifecycle");
+        assert!(kill_failed, "test child kill must exercise the error path");
+
+        let control = MasterControl {
+            master: Mutex::new(Box::new(TestMaster)),
+            writer: Mutex::new(Box::new(std::io::sink())),
+            killer: Mutex::new(Box::new(FailingTestChildKiller { kills: TestArc::clone(&kills) })),
+            lifecycle: TestArc::clone(&lifecycle),
+        };
+        let drop_thread = thread::spawn(move || drop(control));
+        drop_thread.join().expect("master control drop");
+
+        assert_eq!(kills.load(AtomicOrdering::Relaxed), 1);
+        release_tx.send(()).expect("release fallback wait");
+        wait_thread.join().expect("fallback wait thread");
+
+        let state = lifecycle.lock().expect("lifecycle lock");
+        assert!(state.exited);
+        assert!(state.reaping);
     }
 
     #[test]

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -877,11 +877,13 @@ fn spawn_real_pty(spec: &SpawnSpec, handoff: &SpawnHandoff) -> anyhow::Result<Pt
                 }
             };
             let wait_result = wait_result.or_else(|_| {
-                // Keep the old error path: a failed wait requests termination
-                // through the lifecycle gate, then retries the blocking reap.
-                let _ = ChildLifecycle::terminate(&wait_lifecycle, |_| {
-                    child_cleanup.child_mut().kill()
-                });
+                // A failed first wait still falls back to a blocking reap.
+                // Claim the reaping fence before asking the child to die so
+                // a kill error cannot reopen the lifecycle while `wait`
+                // releases the PID for reuse.
+                if ChildLifecycle::begin_reaping(&wait_lifecycle) {
+                    let _ = child_cleanup.child_mut().kill();
+                }
                 child_cleanup.wait()
             });
             let code = wait_result.map(|status| i64::from(status.exit_code() as i32)).unwrap_or(0);


### PR DESCRIPTION
## Summary
- claim the child lifecycle reaping fence before the fallback wait after a wait error
- keep the fence set when child kill reports an error, preventing late PID-reuse signals
- add a behavior regression test for concurrent MasterControl drop

## Verification
- Not run locally per cmux-tui instructions.
- Hosted focused workflow: `./scripts/verify-cmux-tui-hosted.sh --filter fallback_kill_error_keeps_reaping_fence_during_concurrent_master_drop`

Regression commits:
- `2369fefa41` test first
- `39b4890acd` fix

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790694972&installation_model_id=21920&pr_number=11215&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11215&signature=39aa75417c26d918e7d7570a7cf560bfa45a1a4070d36e31306025c46d1e5f1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in the relay fallback path where a failed `wait` could release the child PID for reuse before the reaping fence was claimed, allowing late signals to hit a recycled PID.

- Claims the reaping fence before killing the child on the fallback wait error path.
- Keeps the fence set even when the kill fails, closing the PID-reuse window.
- Adds regression tests for a failing fallback kill during concurrent `MasterControl` drop and a cancelled shell waiter not claiming an in-progress starting session.
- Removes the now-unused `open_permit` argument from the open-session path.

<sup>Written for commit 6d59bb8cd017ae5a47aa4b0b6c4c4fff7f9298d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

