### PR TITLE
fix(relay): restore TUI parent build after lifecycle hardening

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1412,7 +1412,6 @@ impl Inner {
                             server_roots.as_deref(),
                             context,
                             &cancellation,
-                            &open_permit,
                         )
                         .await
                 } else {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -852,7 +852,7 @@ impl PtyManager {
             changed
         };
         if changed {
-            self.inner.detach_matching(|candidate| candidate == &owner, false).retire();
+            self.detach_matching(|candidate| candidate == &owner, false).retire();
         }
         let _state = self.inner.tunnel_state.lock().expect("tunnel state lock");
         if !self.inner.tunnel_authority_generation_current(context) {
@@ -1383,7 +1383,6 @@ impl Inner {
                     server_roots.as_deref(),
                     context,
                     &cancellation,
-                    &open_permit,
                 )
                 .await
             {
@@ -2288,9 +2287,10 @@ impl Inner {
                 }
             };
             if !owner {
+                let cancellation_token = cancellation.token();
                 tokio::select! {
                     biased;
-                    _ = cancellation.token().cancelled() => {
+                    _ = cancellation_token.cancelled() => {
                         return Err("terminal open cancelled".to_owned());
                     }
                     _ = waiter.expect("shell waiter") => {}
@@ -2852,7 +2852,6 @@ impl Inner {
         server_roots: Option<&[String]>,
         context: &FrameContext,
         cancellation: &OpenCancellation,
-        open_permit: &OpenPermit,
     ) -> Result<Option<Opened>, (RelayPtyErrorCode, String)> {
         let socket_dir = self.deps.socket_dir();
         let ensured = self

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -3810,6 +3810,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cancelled_shell_waiter_does_not_claim_starting_session() {
+        let h = harness(None, None);
+        let cancellation = h.manager.new_open_cancellation().expect("open attempt token");
+        let context = h.context("supervised", h.owner.clone());
+        let env = env_map(&h.home);
+        let open_permit = OpenPermit::new(
+            h.manager.inner.open_slots.clone().try_acquire_owned().expect("open permit"),
+        );
+        let notify = Arc::new(Notify::new());
+        h.manager
+            .inner
+            .shell_starting
+            .lock()
+            .unwrap()
+            .insert("waiting".to_owned(), Arc::clone(&notify));
+
+        // Model a second opener that is waiting for the first owner. The
+        // cancellation branch must win without spawning or removing the
+        // owner's in-progress marker.
+        cancellation.cancel();
+        let result = Arc::clone(&h.manager.inner)
+            .open_shell(
+                "waiting",
+                80,
+                24,
+                &h.home,
+                &env,
+                "p1",
+                None,
+                &context,
+                &cancellation,
+                &open_permit,
+            )
+            .await;
+
+        assert_eq!(result.err().as_deref(), Some("terminal open cancelled"));
+        assert!(h.spawned().is_empty());
+        assert!(h.manager.inner.shell_starting.lock().unwrap().contains_key("waiting"));
+    }
+
+    #[tokio::test]
     async fn cancellation_during_shell_subscribe_is_not_cached_and_killed() {
         let h = harness(None, None);
         h.cancel_on_subscribe.store(true, Ordering::SeqCst);

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1412,6 +1412,7 @@ impl Inner {
                             server_roots.as_deref(),
                             context,
                             &cancellation,
+                            &open_permit,
                         )
                         .await
                 } else {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -4258,10 +4258,11 @@ mod tests {
         });
         let cancellation = h.manager.new_open_cancellation().expect("open attempt token");
         let task_manager = Arc::new(h.manager);
+        let spawned_task_manager = Arc::clone(&task_manager);
         let task_context = context.clone();
         let task_cancellation = cancellation.clone();
         let task = tokio::spawn(async move {
-            task_manager
+            spawned_task_manager
                 .handle_frame_with_open_cancellation(&frame, &task_context, Some(task_cancellation))
                 .await;
         });

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -814,8 +814,8 @@ fn spawn_real_pty(spec: &SpawnSpec, handoff: &SpawnHandoff) -> anyhow::Result<Pt
     let (completion, cancel_reader) =
         ProcessOutputCompletion::with_pty_cancellation(1, Arc::clone(&output))?;
     let spawned = pair.spawn(command)?;
-    let cmux_pty::SpawnedPty { mut master, child } = spawned;
-    let mut child_cleanup = SpawnedChildCleanup::new(child);
+    let cmux_pty::SpawnedPty { master, child } = spawned;
+    let child_cleanup = SpawnedChildCleanup::new(child);
     if handoff.is_cancelled() {
         return Err(anyhow::anyhow!("PTY spawn cancelled"));
     }


### PR DESCRIPTION
## Summary
- add a deterministic cancelled shell-waiter regression test
- fix the hosted Rust compile errors in the tunnel lifecycle branch
- keep the child-reaping fence before fallback wait, even when kill fails

This PR is stacked on https://github.com/manaflow-ai/cmux/pull/11119.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790696714&installation_model_id=21920&pr_number=11216&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11216&signature=3d3c1aa09a79949ea598cfa62e8863580582762f7177c0bca92626c89d172127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the hosted Rust compile errors in `chatmux-relay` that broke the TUI parent build after tunnel lifecycle hardening, and adds a regression test for the cancelled shell-waiter path.

- Keeps `open_permit` at the `open_shell` boundary to match the cmux opener signature but stops passing it into the spawn internals; routes `detach_matching` through the manager.
- Drops unneeded `mut` bindings in `spawn_real_pty`.
- The new test confirms a cancelled waiter returns `terminal open cancelled` without spawning a process or removing the owner's starting marker.

<sup>Written for commit b965613cd690589aa42a70b8f16b528c7b04836c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

