### PR TITLE
fix(tests): reconcile current AppKit fixture APIs

### DIFF
--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -1737,9 +1737,13 @@ final class WindowBrowserHostViewTests: XCTestCase {
             ["began", "changed", "ended"],
             "A shared browser/Dock divider hit must follow the native sidebar drag lifecycle"
         )
+        guard let forwardedTranslation = changedTranslation else {
+            XCTFail("The forwarded drag must report a native sidebar translation")
+            return
+        }
         XCTAssertEqual(
-            changedTranslation,
-            32,
+            Double(forwardedTranslation),
+            32.0,
             accuracy: 0.5,
             "The forwarded drag must reach the native sidebar tracker"
         )
@@ -1794,9 +1798,13 @@ final class WindowBrowserHostViewTests: XCTestCase {
             ["began", "changed", "ended"],
             "A Dock divider handoff must survive a transient tracker reparent"
         )
+        guard let reparentedTranslation = changedTranslation else {
+            XCTFail("A reparented Dock divider must report a native drag translation")
+            return
+        }
         XCTAssertEqual(
-            changedTranslation,
-            28,
+            Double(reparentedTranslation),
+            28.0,
             accuracy: 0.5,
             "A reparented Dock divider must continue receiving native drag translation"
         )

--- a/cmuxTests/BrowserPanelViewIdentityTests.swift
+++ b/cmuxTests/BrowserPanelViewIdentityTests.swift
@@ -331,7 +331,8 @@ private struct BrowserPanelReplacementHarness: View {
             onRequestPanelFocus: {},
             onResumeAgentHibernation: {},
             onAutoResumeAgentHibernation: {},
-            onTriggerFlash: {}
+            onTriggerFlash: {},
+            onRequestDeferredBrowserMaterialization: {}
         )
     }
 }


### PR DESCRIPTION
Fixes current main test compilation under Xcode 26.3.

- Preserve CGFloat accuracy by unwrapping before XCTest Double assertion.
- Supply the new deferred browser materialization callback in the identity harness.

Verification: git diff --check. Hosted targeted test will run after opening.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790699358&installation_model_id=21920&pr_number=11217&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11217&signature=1b20d39120814f523ab6aea428d9f46273edf3c2f56e8eaf2518e42ba863921f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes test compilation under Xcode 26.3 by reconciling test code with the current AppKit fixture APIs.

- Unwraps the optional native drag translation before the XCTest `Double` assertion to preserve `CGFloat` accuracy.
- Supplies the new deferred browser materialization callback in the identity harness.

<sup>Written for commit adc3a51a9bb7190eab55676580d1da843e0c8cdb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test assertions for dock divider mouse translation values by explicitly validating that values are present before comparison.
  * Updated browser panel identity test setup to support deferred browser materialization callbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->