### PR TITLE
Fix SSH recovery, large ssh-tmux pastes, and Codex hook cleanup

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -32606,6 +32606,12 @@ export default CMUXSessionRestore;
         }
 
         var hooks = existing["hooks"] as? [String: Any] ?? [:]
+        let previousCodexHookTrustEntries = Self.codexHookTrustEntries(
+            hooks: hooks,
+            hooksFilePath: filePath,
+            def: def,
+            includeLegacyOwnedCommands: true
+        )
         let newHooks = buildHooksDict(for: def)
 
         // Remove existing cmux-owned entries (both the per-agent hook
@@ -32729,7 +32735,9 @@ export default CMUXSessionRestore;
             hooksFilePath: filePath,
             def: def
         )
-        let codexLegacyHookTrustHashes = Self.codexLegacyHookTrustHashes(def: def)
+        let codexHookTrustHashesToRemove = Set(
+            previousCodexHookTrustEntries.map(\.trustedHash)
+        ).union(Self.codexLegacyHookTrustHashes(def: def))
 
         let newData = try JSONSerialization.data(withJSONObject: existing, options: [.prettyPrinted, .sortedKeys])
         let newString = String(data: newData, encoding: .utf8) ?? "{}"
@@ -32787,8 +32795,9 @@ export default CMUXSessionRestore;
                 let trustInstall = CmuxCodexConfigEditor().installingHooks(
                     in: existingContent,
                     trustEntries: codexHookTrustEntries,
+                    removingHookTrustEntries: previousCodexHookTrustEntries,
                     removingKeyPrefixes: codexHookTrustKeyPrefixes,
-                    removingTrustedHashes: codexLegacyHookTrustHashes
+                    removingTrustedHashes: codexHookTrustHashesToRemove
                 )
                 let newContent = trustInstall.content
                 if newContent != existingContent {

--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/ConfigPaths/CmuxCodexConfigEditor+Feature.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/ConfigPaths/CmuxCodexConfigEditor+Feature.swift
@@ -26,6 +26,7 @@ extension CmuxCodexConfigEditor {
             "features.hooks = true",
             Self.cmuxCodexHooksFeatureEnd,
         ]
+        let rootEnd = lines.firstIndex(where: { tomlLineIsAnyTableHeader($0) }) ?? lines.endIndex
 
         if let featuresStart = lines.firstIndex(where: { tomlLineIsTable("features", line: $0) }) {
             let featuresEnd = tomlTableEndIndex(in: lines, after: featuresStart)
@@ -43,7 +44,8 @@ extension CmuxCodexConfigEditor {
             } else {
                 lines.insert(contentsOf: insertedLines, at: featuresStart + 1)
             }
-        } else if let dottedHooksIndex = lines.firstIndex(where: { tomlLineDefinesDottedFeaturesKey("hooks", line: $0) }) {
+        } else if let dottedHooksIndex = lines[..<rootEnd]
+            .firstIndex(where: { tomlLineDefinesDottedFeaturesKey("hooks", line: $0) }) {
             if !tomlLineDefinesDottedFeaturesTrueKey("hooks", line: lines[dottedHooksIndex]) {
                 let previousLine = lines[dottedHooksIndex]
                 lines.replaceSubrange(
@@ -51,7 +53,8 @@ extension CmuxCodexConfigEditor {
                     with: codexHooksFeatureLines(settingLine: "features.hooks = true", previousLine: previousLine)
                 )
             }
-        } else if let firstDottedFeaturesIndex = lines.firstIndex(where: { tomlLineDefinesAnyDottedFeaturesKey($0) }) {
+        } else if let firstDottedFeaturesIndex = lines[..<rootEnd]
+            .firstIndex(where: { tomlLineDefinesAnyDottedFeaturesKey($0) }) {
             lines.insert(contentsOf: insertedDottedLines, at: firstDottedFeaturesIndex)
         } else {
             if !lines.isEmpty, lines.last?.isEmpty == false {

--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/ConfigPaths/CmuxCodexConfigEditor+Feature.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/ConfigPaths/CmuxCodexConfigEditor+Feature.swift
@@ -14,8 +14,7 @@ extension CmuxCodexConfigEditor {
         let lineEnding = CmuxConfigLines().lineEnding(of: existingContent)
         var lines = tomlLines(from: existingContent)
         removeCmuxCodexHooksFeatureBlock(from: &lines)
-        lines.removeAll { tomlLineDefinesKey("codex_hooks", line: $0) }
-        lines.removeAll { tomlLineDefinesDottedFeaturesKey("codex_hooks", line: $0) }
+        removeLegacyCodexHooksSettings(from: &lines)
 
         let insertedLines = [
             Self.cmuxCodexHooksFeatureBegin,

--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/ConfigPaths/CmuxCodexConfigEditor+TOML.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/ConfigPaths/CmuxCodexConfigEditor+TOML.swift
@@ -43,6 +43,33 @@ extension CmuxCodexConfigEditor {
         CmuxConfigLines().joined(lines, lineEnding: lineEnding)
     }
 
+    func removeLegacyCodexHooksSettings(from lines: inout [String]) {
+        var index = 0
+        var isRoot = true
+        var isFeaturesTable = false
+
+        while index < lines.count {
+            if tomlLineIsAnyTableHeader(lines[index]) {
+                isRoot = false
+                isFeaturesTable = tomlLineIsTable("features", line: lines[index])
+                index += 1
+                continue
+            }
+
+            let removesRootSetting = isRoot && (
+                tomlLineDefinesKey("codex_hooks", line: lines[index])
+                    || tomlLineDefinesDottedFeaturesKey("codex_hooks", line: lines[index])
+            )
+            let removesFeaturesSetting = isFeaturesTable
+                && tomlLineDefinesKey("codex_hooks", line: lines[index])
+            if removesRootSetting || removesFeaturesSetting {
+                lines.remove(at: index)
+            } else {
+                index += 1
+            }
+        }
+    }
+
     func tomlLineDefinesKey(_ key: String, line: String) -> Bool {
         let escapedKey = NSRegularExpression.escapedPattern(for: key)
         return line.range(
@@ -91,7 +118,7 @@ extension CmuxCodexConfigEditor {
     }
 
     func tomlLineIsAnyTableHeader(_ line: String) -> Bool {
-        let tomlKey = #"(?:[A-Za-z0-9_-]+|"[^"\n]*"|'[^'\n]*')"#
+        let tomlKey = #"(?:[A-Za-z0-9_-]+|"(?:[^"\\\n]|\\.)*"|'[^'\n]*')"#
         let tomlKeyPath = tomlKey + #"(?:\s*\.\s*"# + tomlKey + ")*"
         let pattern = #"^\s*(?:\[\s*"# + tomlKeyPath + #"\s*\]|\[\[\s*"# + tomlKeyPath
             + #"\s*\]\])\s*(#.*)?$"#

--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/ConfigPaths/CmuxCodexConfigEditor.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/ConfigPaths/CmuxCodexConfigEditor.swift
@@ -54,6 +54,8 @@ public struct CmuxCodexConfigEditor: Sendable {
     /// - Parameters:
     ///   - existingContent: The current `config.toml` body.
     ///   - trustEntries: The cmux-owned hook trust tables to install.
+    ///   - removingHookTrustEntries: Prior cmux-owned trust identities whose exact
+    ///     keys and hashes should be removed without reinstalling them.
     ///   - removingKeyPrefixes: Raw key prefixes whose stale trust tables may be
     ///     removed during reinstall. The editor applies TOML basic-string
     ///     escaping before matching them.
@@ -63,13 +65,14 @@ public struct CmuxCodexConfigEditor: Sendable {
     public func installingHooks(
         in existingContent: String,
         trustEntries: [HookTrustEntry],
+        removingHookTrustEntries: [HookTrustEntry] = [],
         removingKeyPrefixes: Set<String> = [],
         removingTrustedHashes: Set<String> = []
     ) -> HookInstallResult {
         let removingEscapedKeyPrefixes = Set(removingKeyPrefixes.map { tomlBasicStringContent($0) })
         let trustClean = removingHookTrust(
             in: existingContent,
-            entries: trustEntries,
+            entries: trustEntries + removingHookTrustEntries,
             removingEscapedKeyPrefixes: removingEscapedKeyPrefixes,
             removingTrustedHashes: removingTrustedHashes
         )
@@ -116,8 +119,7 @@ public struct CmuxCodexConfigEditor: Sendable {
             stripMalformedCmuxCodexHookTrustMarker(from: &lines)
         }
         removeCodexHookTrustTables(withEscapedKeys: escapedKeys, from: &lines)
-        lines.removeAll { tomlLineDefinesKey("codex_hooks", line: $0) }
-        lines.removeAll { tomlLineDefinesDottedFeaturesKey("codex_hooks", line: $0) }
+        removeLegacyCodexHooksSettings(from: &lines)
         removeEmptyFeaturesTable(from: &lines)
         return tomlContent(from: lines, lineEnding: lineEnding)
     }

--- a/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/CmuxCodexConfigEditorTests.swift
+++ b/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/CmuxCodexConfigEditorTests.swift
@@ -90,6 +90,60 @@ struct CmuxCodexConfigEditorTests {
         #expect(result.content.contains(Self.featureBegin))
     }
 
+    @Test("Legacy codex hooks cleanup stays scoped to root and features")
+    func legacyCodexHooksCleanupPreservesCustomTables() {
+        let original = #"""
+        codex_hooks = true
+        features.codex_hooks = true
+        [features]
+        codex_hooks = true
+        [custom]
+        codex_hooks = "keep"
+        features.codex_hooks = "keep"
+        [custom.nested]
+        codex_hooks = "keep"
+        features.codex_hooks = "keep"
+        """# + "\n"
+        let installed = editor.installingHooks(in: original, trustEntries: [])
+        let uninstalled = editor.uninstallingHooks(from: installed.content)
+
+        let expected = #"""
+        [custom]
+        codex_hooks = "keep"
+        features.codex_hooks = "keep"
+        [custom.nested]
+        codex_hooks = "keep"
+        features.codex_hooks = "keep"
+        """# + "\n"
+        #expect(uninstalled == expected)
+    }
+
+    @Test("Stale trust cleanup preserves escaped quoted user table headers")
+    func staleTrustCleanupStopsAtEscapedQuotedUserTableHeader() {
+        let original = #"""
+        # cmux-codex-hook-trust-f5cc24da-7a09-4b20-a756-89e7786f6738 begin
+        [hooks.state."/tmp/cmux-hooks:stale"]
+        trusted_hash = "sha256:stale-hook"
+        ["custom\"quote\\slash"]
+        value = "keep"
+        enabled = true
+        # cmux-codex-hook-trust-f5cc24da-7a09-4b20-a756-89e7786f6738 end
+        """# + "\n"
+
+        let uninstalled = editor.uninstallingHooks(
+            from: original,
+            removingKeyPrefixes: ["/tmp/cmux-hooks:"],
+            removingTrustedHashes: ["sha256:stale-hook"]
+        )
+
+        let expected = #"""
+        ["custom\"quote\\slash"]
+        value = "keep"
+        enabled = true
+        """# + "\n"
+        #expect(uninstalled == expected)
+    }
+
     private static func occurrences(of needle: String, in haystack: String) -> Int {
         haystack.components(separatedBy: needle).count - 1
     }

--- a/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/CmuxCodexConfigEditorTests.swift
+++ b/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/CmuxCodexConfigEditorTests.swift
@@ -118,6 +118,32 @@ struct CmuxCodexConfigEditorTests {
         #expect(uninstalled == expected)
     }
 
+    @Test("Custom dotted features settings stay inside their table")
+    func customDottedFeaturesSettingsRemainUnchanged() {
+        let original = #"""
+        [custom]
+        features.hooks = "keep"
+        features.codex_hooks = "keep"
+        """# + "\n"
+
+        let installed = editor.installingHooks(in: original, trustEntries: [])
+
+        let expectedInstalled = #"""
+        [custom]
+        features.hooks = "keep"
+        features.codex_hooks = "keep"
+
+        [features]
+        # cmux-codex-hooks-feature-78f1e4ba-66df-4d35-93c1-67fdf1cbb7df begin
+        hooks = true
+        # cmux-codex-hooks-feature-78f1e4ba-66df-4d35-93c1-67fdf1cbb7df end
+        """# + "\n"
+        #expect(installed.content == expectedInstalled)
+
+        let uninstalled = editor.uninstallingHooks(from: installed.content)
+        #expect(uninstalled == original)
+    }
+
     @Test("Stale trust cleanup preserves escaped quoted user table headers")
     func staleTrustCleanupStopsAtEscapedQuotedUserTableHeader() {
         let original = #"""

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/RemoteTmux/RemoteTmuxSendKeysBatchBuilder.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/RemoteTmux/RemoteTmuxSendKeysBatchBuilder.swift
@@ -1,0 +1,58 @@
+public import Foundation
+
+/// Builds bounded, ordered tmux `send-keys -H` command batches for literal input.
+///
+/// The builder owns the raw-input admission limit and encoded writer budget so
+/// app adapters, input forwarders, and package tests cannot drift independently.
+public enum RemoteTmuxSendKeysBatchBuilder {
+    /// Largest logical manual-input event accepted by the remote tmux path.
+    public static let maximumInputBytes = 256 * 1024
+
+    /// Pending writer capacity required for one fully encoded maximum-size batch.
+    public static let writerPendingByteLimit = maximumInputBytes * 4
+
+    private static let maximumBytesPerCommand = 8 * 1024
+    private static let lowercaseHexDigits = Array("0123456789abcdef".utf8)
+
+    /// Encodes one logical input event as an ordered atomic command batch.
+    ///
+    /// - Parameters:
+    ///   - paneID: Target tmux pane identifier without the leading `%`.
+    ///   - data: Literal bytes to deliver in order.
+    /// - Returns: Empty commands for empty input, `nil` above the admission
+    ///   limit, or commands whose encoded lines remain below tmux's control-mode
+    ///   command ceiling.
+    public static func commands(paneID: Int, data: Data) -> [String]? {
+        guard data.count <= maximumInputBytes else { return nil }
+        guard !data.isEmpty else { return [] }
+
+        var commands: [String] = []
+        commands.reserveCapacity(
+            (data.count + maximumBytesPerCommand - 1) / maximumBytesPerCommand
+        )
+
+        var chunkStart = data.startIndex
+        while chunkStart < data.endIndex {
+            let chunkEnd = data.index(
+                chunkStart,
+                offsetBy: maximumBytesPerCommand,
+                limitedBy: data.endIndex
+            ) ?? data.endIndex
+            let hex = hexByteArguments(data[chunkStart ..< chunkEnd])
+            commands.append("send-keys -t %\(paneID) -H \(hex)")
+            chunkStart = chunkEnd
+        }
+        return commands
+    }
+
+    private static func hexByteArguments(_ data: Data.SubSequence) -> String {
+        var bytes: [UInt8] = []
+        bytes.reserveCapacity(data.count * 3 - 1)
+        for byte in data {
+            if !bytes.isEmpty { bytes.append(UInt8(ascii: " ")) }
+            bytes.append(lowercaseHexDigits[Int(byte >> 4)])
+            bytes.append(lowercaseHexDigits[Int(byte & 0x0f)])
+        }
+        return String(decoding: bytes, as: UTF8.self)
+    }
+}

--- a/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteTmuxSendKeysBatchBuilderTests.swift
+++ b/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteTmuxSendKeysBatchBuilderTests.swift
@@ -1,0 +1,79 @@
+import CmuxRemoteSession
+import Foundation
+import Testing
+
+@Suite struct RemoteTmuxSendKeysBatchBuilderTests {
+    @Test func emptyInputProducesNoCommands() throws {
+        let commands = try #require(
+            RemoteTmuxSendKeysBatchBuilder.commands(paneID: 42, data: Data())
+        )
+
+        #expect(commands.isEmpty)
+    }
+
+    @Test func encodesLowercaseSpaceSeparatedHexBytes() throws {
+        let commands = try #require(
+            RemoteTmuxSendKeysBatchBuilder.commands(
+                paneID: 42,
+                data: Data([0x00, 0x0F, 0x10, 0xFF])
+            )
+        )
+
+        #expect(commands == ["send-keys -t %42 -H 00 0f 10 ff"])
+    }
+
+    @Test func preservesAChunkedNonzeroBasedDataSliceInOrder() throws {
+        let backing = Data((0..<8_205).map { UInt8($0 % 251) })
+        let payloadStart = backing.index(backing.startIndex, offsetBy: 11)
+        let payload = backing[payloadStart..<backing.endIndex]
+        #expect(payload.startIndex == payloadStart)
+
+        let commands = try #require(
+            RemoteTmuxSendKeysBatchBuilder.commands(paneID: 7, data: payload)
+        )
+
+        #expect(commands.count > 1)
+        #expect(commands.allSatisfy { $0.utf8.count < 30_000 })
+        #expect(try decodedBytes(from: commands, paneID: 7) == Data(payload))
+    }
+
+    @Test func maximumInputFitsTheProductionWriterBudgetIncludingTerminators() throws {
+        let maximumInput = Data(
+            repeating: 0xFF,
+            count: RemoteTmuxSendKeysBatchBuilder.maximumInputBytes
+        )
+        let commands = try #require(
+            RemoteTmuxSendKeysBatchBuilder.commands(paneID: 7, data: maximumInput)
+        )
+        let encodedByteCount = commands.reduce(into: 0) { total, command in
+            total += command.utf8.count + 1
+        }
+
+        #expect(!commands.isEmpty)
+        #expect(encodedByteCount <= RemoteTmuxSendKeysBatchBuilder.writerPendingByteLimit)
+        #expect(try decodedBytes(from: commands, paneID: 7) == maximumInput)
+    }
+
+    @Test func rejectsOneByteAboveMaximumInput() {
+        let oversizedInput = Data(
+            repeating: 0xFF,
+            count: RemoteTmuxSendKeysBatchBuilder.maximumInputBytes + 1
+        )
+
+        #expect(
+            RemoteTmuxSendKeysBatchBuilder.commands(paneID: 7, data: oversizedInput) == nil
+        )
+    }
+}
+
+private func decodedBytes(from commands: [String], paneID: Int) throws -> Data {
+    let prefix = "send-keys -t %\(paneID) -H "
+    var decoded = Data()
+    for command in commands {
+        #expect(command.hasPrefix(prefix))
+        for argument in command.dropFirst(prefix.count).split(separator: " ") {
+            decoded.append(try #require(UInt8(argument, radix: 16)))
+        }
+    }
+    return decoded
+}

--- a/Sources/RemoteTmuxControlConnection+Commands.swift
+++ b/Sources/RemoteTmuxControlConnection+Commands.swift
@@ -443,31 +443,17 @@ extension RemoteTmuxControlConnection {
         notifyReconnectReadyIfSeedBatchDrained()
     }
 
-    /// Sends literal key bytes to a pane via tmux `send-keys -H` (hex-encoded),
-    /// which is binary-safe and needs no shell quoting. The control client drops
-    /// command lines above 30,000 characters, so keep each encoded command below
-    /// that ceiling while preserving byte order across commands.
+    /// Sends literal key bytes through the package-owned tmux framing policy.
+    ///
+    /// One logical input is admitted and enqueued as a complete ordered batch,
+    /// so writer backpressure cannot expose a partially delivered paste.
     @discardableResult
     func sendKeys(paneId: Int, data: Data) -> Bool {
-        guard !data.isEmpty else { return true }
-        guard data.count <= RemoteTmuxPaneInputForwarder.defaultMaximumPendingBytes else { return false }
-
-        let maxBytesPerCommand = 8 * 1024
-        var commands: [String] = []
-        commands.reserveCapacity((data.count + maxBytesPerCommand - 1) / maxBytesPerCommand)
-
-        var chunkStart = data.startIndex
-        while chunkStart < data.endIndex {
-            let chunkEnd = data.index(
-                chunkStart,
-                offsetBy: maxBytesPerCommand,
-                limitedBy: data.endIndex
-            ) ?? data.endIndex
-            let hex = Self.hexByteArguments(data[chunkStart ..< chunkEnd])
-            commands.append("send-keys -t %\(paneId) -H \(hex)")
-            chunkStart = chunkEnd
-        }
-
+        guard let commands = RemoteTmuxSendKeysBatchBuilder.commands(
+            paneID: paneId,
+            data: data
+        ) else { return false }
+        guard !commands.isEmpty else { return true }
         return sendBatchInternal(
             commands,
             kinds: Array(repeating: .other, count: commands.count)
@@ -479,19 +465,6 @@ extension RemoteTmuxControlConnection {
     @discardableResult
     func sendKey(paneId: Int, key: RemoteTmuxKeyName) -> Bool {
         sendInternal("send-keys -t %\(paneId) \(key.value)", kind: .other)
-    }
-
-    nonisolated static func hexByteArguments(_ data: Data) -> String {
-        guard !data.isEmpty else { return "" }
-        let digits = Array("0123456789abcdef".utf8)
-        var bytes: [UInt8] = []
-        bytes.reserveCapacity(data.count * 3 - 1)
-        for byte in data {
-            if !bytes.isEmpty { bytes.append(UInt8(ascii: " ")) }
-            bytes.append(digits[Int(byte >> 4)])
-            bytes.append(digits[Int(byte & 0x0f)])
-        }
-        return String(decoding: bytes, as: UTF8.self)
     }
 
     /// Pastes `text` into `paneId` as a tmux paste (`paste-buffer -p`), which wraps

--- a/Sources/RemoteTmuxControlConnection+Commands.swift
+++ b/Sources/RemoteTmuxControlConnection+Commands.swift
@@ -444,12 +444,34 @@ extension RemoteTmuxControlConnection {
     }
 
     /// Sends literal key bytes to a pane via tmux `send-keys -H` (hex-encoded),
-    /// which is binary-safe and needs no shell quoting.
+    /// which is binary-safe and needs no shell quoting. The control client drops
+    /// command lines above 30,000 characters, so keep each encoded command below
+    /// that ceiling while preserving byte order across commands.
     @discardableResult
     func sendKeys(paneId: Int, data: Data) -> Bool {
         guard !data.isEmpty else { return true }
-        let hex = Self.hexByteArguments(data)
-        return sendInternal("send-keys -t %\(paneId) -H \(hex)", kind: .other)
+        guard data.count <= RemoteTmuxPaneInputForwarder.defaultMaximumPendingBytes else { return false }
+
+        let maxBytesPerCommand = 8 * 1024
+        var commands: [String] = []
+        commands.reserveCapacity((data.count + maxBytesPerCommand - 1) / maxBytesPerCommand)
+
+        var chunkStart = data.startIndex
+        while chunkStart < data.endIndex {
+            let chunkEnd = data.index(
+                chunkStart,
+                offsetBy: maxBytesPerCommand,
+                limitedBy: data.endIndex
+            ) ?? data.endIndex
+            let hex = Self.hexByteArguments(data[chunkStart ..< chunkEnd])
+            commands.append("send-keys -t %\(paneId) -H \(hex)")
+            chunkStart = chunkEnd
+        }
+
+        return sendBatchInternal(
+            commands,
+            kinds: Array(repeating: .other, count: commands.count)
+        )
     }
 
     /// Sends a physical named key and lets tmux encode it for the target pane's

--- a/Sources/RemoteTmuxControlConnection.swift
+++ b/Sources/RemoteTmuxControlConnection.swift
@@ -265,12 +265,10 @@ final class RemoteTmuxControlConnection {
     private static let reconnectMaxDelaySeconds: Double = 10
     /// Cap on captured stderr (bytes) so a noisy/hostile remote can't grow it unbounded.
     private static let maxStderrBytes = 8 * 1024
-    /// Cap queued stdin bytes while the dedicated writer is backpressured. One
-    /// accepted manual-input event may contain 256 KiB of raw bytes; `send-keys -H`
-    /// expands that to roughly three times its size, so retain bounded framing
-    /// headroom for the complete atomic batch.
-    static let maxPendingStdinBytes =
-        RemoteTmuxPaneInputForwarder.defaultMaximumPendingBytes * 4
+    /// Cap queued stdin bytes while the dedicated writer is backpressured.
+    /// The package-owned framing policy sizes this for one complete maximum
+    /// logical input after `send-keys -H` encoding and command framing.
+    static let maxPendingStdinBytes = RemoteTmuxSendKeysBatchBuilder.writerPendingByteLimit
     /// Cap pending stdout between SSH's pipe callback and the main-actor parser.
     /// Initial attach can legitimately burst one `capture-pane -S 5000` block per
     /// mirrored pane, so the chunk cap absorbs pipe delivery jitter while the byte

--- a/Sources/RemoteTmuxControlConnection.swift
+++ b/Sources/RemoteTmuxControlConnection.swift
@@ -265,10 +265,12 @@ final class RemoteTmuxControlConnection {
     private static let reconnectMaxDelaySeconds: Double = 10
     /// Cap on captured stderr (bytes) so a noisy/hostile remote can't grow it unbounded.
     private static let maxStderrBytes = 8 * 1024
-    /// Cap queued stdin bytes while the dedicated writer is backpressured. Above
-    /// this, mutations are rejected and the connection reconnects instead of
-    /// accepting unbounded user input that may never reach tmux.
-    private static let maxPendingStdinBytes = 256 * 1024
+    /// Cap queued stdin bytes while the dedicated writer is backpressured. One
+    /// accepted manual-input event may contain 256 KiB of raw bytes; `send-keys -H`
+    /// expands that to roughly three times its size, so retain bounded framing
+    /// headroom for the complete atomic batch.
+    static let maxPendingStdinBytes =
+        RemoteTmuxPaneInputForwarder.defaultMaximumPendingBytes * 4
     /// Cap pending stdout between SSH's pipe callback and the main-actor parser.
     /// Initial attach can legitimately burst one `capture-pane -S 5000` block per
     /// mirrored pane, so the chunk cap absorbs pipe delivery jitter while the byte

--- a/Sources/RemoteTmuxPaneInputForwarder.swift
+++ b/Sources/RemoteTmuxPaneInputForwarder.swift
@@ -1,3 +1,4 @@
+import CmuxRemoteSession
 import CmuxTerminal
 import os
 
@@ -25,7 +26,7 @@ final class RemoteTmuxPaneInputForwarder: Sendable {
     /// Matches the control connection's bounded stdin budget. The byte
     /// reservation happens before the MainActor hop, where that later budget
     /// cannot protect a stalled consumer.
-    static let defaultMaximumPendingBytes = 256 * 1024
+    static let defaultMaximumPendingBytes = RemoteTmuxSendKeysBatchBuilder.maximumInputBytes
 
     // Ghostty's synchronous callback needs a non-blocking byte/epoch reservation before the actor hop.
     private let state: OSAllocatedUnfairLock<State>

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -446,7 +446,7 @@ final class TerminalNotificationStore: ObservableObject {
     var lastNotificationHookFailureDateByKey: [NotificationHookFailureThrottleKey: Date] = [:]
     private var indexes = NotificationIndexes()
     private let inFlightPolicyRequests = TerminalNotificationPolicyInFlightStore()
-    private init(userNotificationCenter: UserNotificationCenterService) {
+    init(userNotificationCenter: UserNotificationCenterService) {
         self.userNotificationCenter = userNotificationCenter
         nativeNotificationDeliveryHooks = NativeNotificationDeliveryHooks(
             userNotificationCenter: userNotificationCenter
@@ -2631,7 +2631,9 @@ final class TerminalNotificationStore: ObservableObject {
     }
 
     func replaceNotificationsForTesting(_ notifications: [TerminalNotification]) {
-        TerminalMutationBus.shared.discardPendingNotifications()
+        if self === Self.shared {
+            TerminalMutationBus.shared.discardPendingNotifications()
+        }
         self.notifications = notifications
         notificationFeedHistory = NotificationFeedHistoryStore(fileURL: nil) { revision in
             MobileHostService.emitEvent(

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -1947,13 +1947,53 @@ final class TerminalNotificationStore: ObservableObject {
         emitNotificationsDismissed(ids: [id.uuidString], drainedSuperseded: supersededDrained)
     }
 
+    /// Clears every notification produced by one workspace correlation key in
+    /// a single collection pass and publishes one coherent index update.
     func clearNotifications(forTabId tabId: UUID, correlationKey: String) {
         inFlightPolicyRequests.discard(forTabId: tabId, correlationKey: correlationKey)
-        let ids = notifications.compactMap {
-            $0.tabId == tabId && $0.correlationKey == correlationKey ? $0.id : nil
+        var remaining: [TerminalNotification] = []
+        remaining.reserveCapacity(notifications.count)
+        var removed: [TerminalNotification] = []
+        for notification in notifications {
+            if notification.tabId == tabId,
+               notification.correlationKey == correlationKey {
+                removed.append(notification)
+            } else {
+                remaining.append(notification)
+            }
         }
-        ids.forEach(remove)
-        removePendingNotificationRequests(withIdentifiers: ids.map(\.uuidString))
+        guard !removed.isEmpty else { return }
+
+        notifications = remaining
+        let removedIDs = Set(removed.map(\.id))
+        notificationFeedHistory.markRead(ids: removedIDs)
+        var clearedIndicators = Set<TabSurfaceKey>()
+        var supersededDrained: [String] = []
+        for notification in removed {
+            let indicator = TabSurfaceKey(
+                tabId: notification.tabId,
+                surfaceId: notification.surfaceId
+            )
+            if clearedIndicators.insert(indicator).inserted {
+                clearFocusedReadIndicator(
+                    forTabId: notification.tabId,
+                    surfaceId: notification.surfaceId
+                )
+            }
+            supersededDrained.append(contentsOf: supersededPhoneDismissBuffer.flush(
+                forKey: SupersededPhoneDismissBuffer.key(
+                    tabId: notification.tabId,
+                    surfaceId: notification.surfaceId
+                )
+            ))
+        }
+        let identifierStrings = removed.map { $0.id.uuidString }
+        removeDeliveredNotifications(withIdentifiers: identifierStrings)
+        removePendingNotificationRequests(withIdentifiers: identifierStrings)
+        emitNotificationsDismissed(
+            ids: identifierStrings,
+            drainedSuperseded: supersededDrained
+        )
     }
 
     /// Clears one surface notification by its producer correlation key. This

--- a/Sources/Workspace+RemoteTerminalLiveness.swift
+++ b/Sources/Workspace+RemoteTerminalLiveness.swift
@@ -370,12 +370,20 @@ extension Workspace {
         return true
     }
 
+    /// Applies one authoritative terminal recovery to workspace presentation.
+    ///
+    /// Artifact cleanup runs once for each non-connected-to-connected transition;
+    /// additional terminals joining an already connected workspace still publish
+    /// their state without repeatedly scanning workspace logs and notifications.
     private func applyRemoteTerminalConnectedPresentation() {
+        let isRecoveryTransition = remoteConnectionState != .connected
         remoteConnectionState = .connected
         remoteConnectionDetail = nil
-        clearProxyOnlyRemoteSidebarArtifacts()
-        clearRecoveredRemoteConnectionSidebarArtifacts()
-        clearRecoveredRemoteDaemonSidebarArtifacts()
+        if isRecoveryTransition {
+            clearProxyOnlyRemoteSidebarArtifacts()
+            clearRecoveredRemoteConnectionSidebarArtifacts()
+            clearRecoveredRemoteDaemonSidebarArtifacts()
+        }
         applyBrowserRemoteWorkspaceStatusToPanels()
         postRemoteConnectionPresentationDidChange()
     }

--- a/Sources/Workspace+RemoteTerminalLiveness.swift
+++ b/Sources/Workspace+RemoteTerminalLiveness.swift
@@ -374,6 +374,7 @@ extension Workspace {
         remoteConnectionState = .connected
         remoteConnectionDetail = nil
         clearProxyOnlyRemoteSidebarArtifacts()
+        clearRecoveredRemoteConnectionSidebarArtifacts()
         clearRecoveredRemoteDaemonSidebarArtifacts()
         applyBrowserRemoteWorkspaceStatusToPanels()
         postRemoteConnectionPresentationDidChange()

--- a/cmuxTests/CLICodexHookTimeoutRegressionTests.swift
+++ b/cmuxTests/CLICodexHookTimeoutRegressionTests.swift
@@ -1,3 +1,5 @@
+import CMUXAgentLaunch
+import CryptoKit
 import Darwin
 import Foundation
 import Testing
@@ -553,6 +555,137 @@ struct CLICodexHookTimeoutRegressionTests {
         #expect(stopHooks.first?.body.contains("cat >/dev/null") == true)
     }
 
+    @Test func codexHookInstallRemovesDisplacedContentAddressedTrustAndIsIdempotent() throws {
+        let cliPath = try bundledCLIPath()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-codex-content-addressed-trust-\(UUID().uuidString)", isDirectory: true)
+        let codexHome = root.appendingPathComponent(".codex", isDirectory: true)
+        let hooksDirectory = root
+            .appendingPathComponent(".cmux", isDirectory: true)
+            .appendingPathComponent("hooks", isDirectory: true)
+        let hooksURL = codexHome.appendingPathComponent("hooks.json", isDirectory: false)
+        let configURL = codexHome.appendingPathComponent("config.toml", isDirectory: false)
+        try FileManager.default.createDirectory(at: codexHome, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: hooksDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let oldScriptContents = "#!/bin/sh\ncmux hooks codex stop\n"
+        let oldScriptName = try #require(CodexHookScriptName(
+            contents: oldScriptContents,
+            subcommand: "persistent-stop"
+        ))
+        let oldScript = hooksDirectory.appendingPathComponent(oldScriptName.filename, isDirectory: false)
+        try oldScriptContents.write(to: oldScript, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: oldScript.path)
+
+        let oldTrustKey = "\(hooksURL.resolvingSymlinksInPath().path):stop:1:1"
+        let oldTrustHash = try codexHookTrustedHash(
+            eventLabel: "stop",
+            matcher: nil,
+            command: oldScript.path,
+            timeout: 5,
+            statusMessage: nil
+        )
+        let userTrustKey = "/tmp/user-codex-hooks.json:stop:0:0"
+        let userTrustHash = "sha256:user-hook-trust"
+        let seededHooks: [String: Any] = [
+            "hooks": [
+                "Stop": [
+                    ["hooks": [["command": "/usr/local/bin/user-first", "timeout": 42, "type": "command"]]],
+                    [
+                        "hooks": [
+                            ["command": "/usr/local/bin/user-stop", "timeout": 42, "type": "command"],
+                            ["command": oldScript.path, "timeout": 5, "type": "command"],
+                        ],
+                    ],
+                ],
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: seededHooks, options: [.prettyPrinted, .sortedKeys])
+            .write(to: hooksURL, options: .atomic)
+        try """
+        model = "user-selected"
+
+        [custom]
+        preserve = "exactly"
+
+        # cmux-codex-hook-trust-f5cc24da-7a09-4b20-a756-89e7786f6738 begin
+        [hooks.state."\(oldTrustKey)"]
+        trusted_hash = "\(oldTrustHash)"
+        # cmux-codex-hook-trust-f5cc24da-7a09-4b20-a756-89e7786f6738 end
+
+        [hooks.state."\(userTrustKey)"]
+        trusted_hash = "\(userTrustHash)"
+        """.write(to: configURL, atomically: true, encoding: .utf8)
+
+        let environment = codexHookTestEnvironment(root: root, codexHome: codexHome)
+        let install = runCodexHookProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "codex", "install", "--yes"],
+            environment: environment,
+            timeout: 10
+        )
+        #expect(!install.timedOut, Comment(rawValue: install.stderr))
+        #expect(install.status == 0, Comment(rawValue: install.stderr))
+
+        let stopHooks = try codexHookEntries(in: codexHome)
+            .filter { $0.eventName == "Stop" }
+        let currentStopHooks = stopHooks.filter { $0.body.contains("hooks codex stop") }
+        #expect(currentStopHooks.count == 1, "The replaced Stop event must retain one current cmux producer")
+        #expect(!stopHooks.contains { $0.command == oldScript.path })
+        #expect(stopHooks.contains { $0.command == "/usr/local/bin/user-stop" })
+
+        let installedRoot = try #require(
+            JSONSerialization.jsonObject(with: Data(contentsOf: hooksURL)) as? [String: Any]
+        )
+        let installedHooks = try #require(installedRoot["hooks"] as? [String: Any])
+        let installedStopGroups = try #require(installedHooks["Stop"] as? [[String: Any]])
+        var currentStopPositions: [(command: String, groupIndex: Int, handlerIndex: Int)] = []
+        for (groupIndex, group) in installedStopGroups.enumerated() {
+            guard let handlers = group["hooks"] as? [[String: Any]] else { continue }
+            for (handlerIndex, handler) in handlers.enumerated() {
+                guard let command = handler["command"] as? String,
+                      command.hasPrefix(hooksDirectory.path + "/"),
+                      command != oldScript.path,
+                      let body = try? String(contentsOfFile: command, encoding: .utf8),
+                      body.contains("hooks codex stop") else {
+                    continue
+                }
+                currentStopPositions.append((command, groupIndex, handlerIndex))
+            }
+        }
+        #expect(currentStopPositions.count == 1)
+        let currentStop = try #require(currentStopPositions.first)
+        let currentTrustKey = "\(hooksURL.resolvingSymlinksInPath().path):stop:\(currentStop.groupIndex):\(currentStop.handlerIndex)"
+        let currentTrustHash = try codexHookTrustedHash(
+            eventLabel: "stop",
+            matcher: nil,
+            command: currentStop.command,
+            timeout: 5,
+            statusMessage: nil
+        )
+        let configAfterFirstInstall = try String(contentsOf: configURL, encoding: .utf8)
+        #expect(configAfterFirstInstall.contains("model = \"user-selected\""))
+        #expect(configAfterFirstInstall.contains("preserve = \"exactly\""))
+        #expect(configAfterFirstInstall.contains("[hooks.state.\"\(userTrustKey)\"]\ntrusted_hash = \"\(userTrustHash)\""))
+        #expect(!configAfterFirstInstall.contains(oldTrustKey))
+        #expect(!configAfterFirstInstall.contains(oldTrustHash))
+        #expect(configAfterFirstInstall.contains("[hooks.state.\"\(currentTrustKey)\"]\ntrusted_hash = \"\(currentTrustHash)\""))
+
+        let hooksAfterFirstInstall = try Data(contentsOf: hooksURL)
+        let configDataAfterFirstInstall = try Data(contentsOf: configURL)
+        let reinstall = runCodexHookProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "codex", "install", "--yes"],
+            environment: environment,
+            timeout: 10
+        )
+        #expect(!reinstall.timedOut, Comment(rawValue: reinstall.stderr))
+        #expect(reinstall.status == 0, Comment(rawValue: reinstall.stderr))
+        #expect(try Data(contentsOf: hooksURL) == hooksAfterFirstInstall)
+        #expect(try Data(contentsOf: configURL) == configDataAfterFirstInstall)
+    }
+
     @Test func codexHookInstallPreservesUnrecognizedGeneratedLookingScriptPath() throws {
         let cliPath = try bundledCLIPath()
         let root = FileManager.default.temporaryDirectory
@@ -1088,5 +1221,38 @@ struct CLICodexHookTimeoutRegressionTests {
             }
             return String(argument[argument.index(argument.startIndex, offsetBy: "hooks.".count)..<equals])
         }
+    }
+
+    private func codexHookTrustedHash(
+        eventLabel: String,
+        matcher: String?,
+        command: String,
+        timeout: Int,
+        statusMessage: String?
+    ) throws -> String {
+        var handler: [String: Any] = [
+            "async": false,
+            "command": command,
+            "timeout": max(timeout, 1),
+            "type": "command",
+        ]
+        if let statusMessage {
+            handler["statusMessage"] = statusMessage
+        }
+        var identity: [String: Any] = [
+            "event_name": eventLabel,
+            "hooks": [handler],
+        ]
+        if let matcher {
+            identity["matcher"] = matcher
+        }
+        let data = try JSONSerialization.data(
+            withJSONObject: identity,
+            options: [.sortedKeys, .withoutEscapingSlashes]
+        )
+        let digest = SHA256.hash(data: data)
+            .map { String(format: "%02x", $0) }
+            .joined()
+        return "sha256:\(digest)"
     }
 }

--- a/cmuxTests/RemoteTmuxAuthTests.swift
+++ b/cmuxTests/RemoteTmuxAuthTests.swift
@@ -272,43 +272,6 @@ import Testing
         #expect(RemoteTmuxHost.controlModeLineSafeName("work\nbad") == nil)
     }
 
-    @Test func sendKeysHexArgumentsAreLowercaseSpaceSeparatedBytes() {
-        #expect(RemoteTmuxControlConnection.hexByteArguments(Data([0x00, 0x0f, 0x10, 0xff])) == "00 0f 10 ff")
-        #expect(RemoteTmuxControlConnection.hexByteArguments(Data()) == "")
-    }
-
-    @Test @MainActor func sendKeysPreserves9994BytePayload() async throws {
-        let data = Data((0 ..< 9_994).map { UInt8($0 % 251) })
-        let emission = try await captureSendKeysWire(paneId: 7, data: data)
-
-        #expect(emission.accepted)
-        #expect(emission.commands.allSatisfy { $0.utf8.count < 30_000 })
-        #expect(try decodeHexArguments(from: emission.commands, paneId: 7) == data)
-    }
-
-    @Test @MainActor func sendKeysSplits9995BytePayloadBelowControlCommandLimit() async throws {
-        let data = Data((0 ..< 9_995).map { UInt8($0 % 251) })
-        let emission = try await captureSendKeysWire(paneId: 7, data: data)
-
-        #expect(emission.accepted)
-        #expect(emission.commands.count > 1)
-        #expect(emission.commands.allSatisfy { $0.utf8.count < 30_000 })
-        #expect(try decodeHexArguments(from: emission.commands, paneId: 7) == data)
-    }
-
-    @Test @MainActor func sendKeysPreservesNonzeroBasedDataSlice() async throws {
-        let backing = Data((0 ..< 10_006).map { UInt8($0 % 251) })
-        let firstPayloadIndex = backing.index(backing.startIndex, offsetBy: 11)
-        let data = backing[firstPayloadIndex..<backing.endIndex]
-        #expect(data.startIndex == firstPayloadIndex)
-
-        let emission = try await captureSendKeysWire(paneId: 7, data: data)
-
-        #expect(emission.accepted)
-        #expect(emission.commands.allSatisfy { $0.utf8.count < 30_000 })
-        #expect(try decodeHexArguments(from: emission.commands, paneId: 7) == data)
-    }
-
     @Test @MainActor func sendKeysRejectsOverBudgetLogicalInputWithoutPartialDelivery() async throws {
         let data = Data((0 ..< 9_995).map { UInt8($0 % 251) })
         let writerBudget = 30_000
@@ -335,27 +298,6 @@ import Testing
 
         #expect(emission.accepted)
         #expect(try decodeHexArguments(from: emission.commands, paneId: 7) == data)
-    }
-
-    @Test @MainActor func sendKeysRejectsOneByteAboveRawAdmissionWithoutWireEmission() async throws {
-        let rawAdmissionLimit = RemoteTmuxPaneInputForwarder.defaultMaximumPendingBytes
-        let data = Data(repeating: 0xa5, count: rawAdmissionLimit + 1)
-
-        let emission = try await captureSendKeysWire(
-            paneId: 7,
-            data: data,
-            maxPendingBytes: RemoteTmuxControlConnection.maxPendingStdinBytes
-        )
-
-        #expect(!emission.accepted)
-        #expect(emission.commands.isEmpty)
-    }
-
-    @Test @MainActor func sendKeysAcceptsEmptyPayloadWithoutWritingACommand() async throws {
-        let emission = try await captureSendKeysWire(paneId: 7, data: Data())
-
-        #expect(emission.accepted)
-        #expect(emission.commands.isEmpty)
     }
 
     @Test @MainActor func pastePaneRejectsDisconnectedControlStream() {
@@ -523,7 +465,7 @@ import Testing
     private func captureSendKeysWire(
         paneId: Int,
         data: Data,
-        maxPendingBytes: Int = 1 << 16
+        maxPendingBytes: Int
     ) async throws -> (accepted: Bool, commands: [String]) {
         let connection = RemoteTmuxControlConnection(
             host: RemoteTmuxHost(destination: "user@input-transport"),

--- a/cmuxTests/RemoteTmuxAuthTests.swift
+++ b/cmuxTests/RemoteTmuxAuthTests.swift
@@ -277,6 +277,87 @@ import Testing
         #expect(RemoteTmuxControlConnection.hexByteArguments(Data()) == "")
     }
 
+    @Test @MainActor func sendKeysPreserves9994BytePayload() async throws {
+        let data = Data((0 ..< 9_994).map { UInt8($0 % 251) })
+        let emission = try await captureSendKeysWire(paneId: 7, data: data)
+
+        #expect(emission.accepted)
+        #expect(emission.commands.allSatisfy { $0.utf8.count < 30_000 })
+        #expect(try decodeHexArguments(from: emission.commands, paneId: 7) == data)
+    }
+
+    @Test @MainActor func sendKeysSplits9995BytePayloadBelowControlCommandLimit() async throws {
+        let data = Data((0 ..< 9_995).map { UInt8($0 % 251) })
+        let emission = try await captureSendKeysWire(paneId: 7, data: data)
+
+        #expect(emission.accepted)
+        #expect(emission.commands.count > 1)
+        #expect(emission.commands.allSatisfy { $0.utf8.count < 30_000 })
+        #expect(try decodeHexArguments(from: emission.commands, paneId: 7) == data)
+    }
+
+    @Test @MainActor func sendKeysPreservesNonzeroBasedDataSlice() async throws {
+        let backing = Data((0 ..< 10_006).map { UInt8($0 % 251) })
+        let firstPayloadIndex = backing.index(backing.startIndex, offsetBy: 11)
+        let data = backing[firstPayloadIndex..<backing.endIndex]
+        #expect(data.startIndex == firstPayloadIndex)
+
+        let emission = try await captureSendKeysWire(paneId: 7, data: data)
+
+        #expect(emission.accepted)
+        #expect(emission.commands.allSatisfy { $0.utf8.count < 30_000 })
+        #expect(try decodeHexArguments(from: emission.commands, paneId: 7) == data)
+    }
+
+    @Test @MainActor func sendKeysRejectsOverBudgetLogicalInputWithoutPartialDelivery() async throws {
+        let data = Data((0 ..< 9_995).map { UInt8($0 % 251) })
+        let writerBudget = 30_000
+
+        let emission = try await captureSendKeysWire(
+            paneId: 7,
+            data: data,
+            maxPendingBytes: writerBudget
+        )
+
+        #expect(!emission.accepted)
+        #expect(emission.commands.isEmpty)
+    }
+
+    @Test @MainActor func sendKeysAcceptsRawAdmissionLimitWithProductionWriterBudget() async throws {
+        let rawAdmissionLimit = RemoteTmuxPaneInputForwarder.defaultMaximumPendingBytes
+        let data = Data((0 ..< rawAdmissionLimit).map { UInt8($0 % 251) })
+
+        let emission = try await captureSendKeysWire(
+            paneId: 7,
+            data: data,
+            maxPendingBytes: RemoteTmuxControlConnection.maxPendingStdinBytes
+        )
+
+        #expect(emission.accepted)
+        #expect(try decodeHexArguments(from: emission.commands, paneId: 7) == data)
+    }
+
+    @Test @MainActor func sendKeysRejectsOneByteAboveRawAdmissionWithoutWireEmission() async throws {
+        let rawAdmissionLimit = RemoteTmuxPaneInputForwarder.defaultMaximumPendingBytes
+        let data = Data(repeating: 0xa5, count: rawAdmissionLimit + 1)
+
+        let emission = try await captureSendKeysWire(
+            paneId: 7,
+            data: data,
+            maxPendingBytes: RemoteTmuxControlConnection.maxPendingStdinBytes
+        )
+
+        #expect(!emission.accepted)
+        #expect(emission.commands.isEmpty)
+    }
+
+    @Test @MainActor func sendKeysAcceptsEmptyPayloadWithoutWritingACommand() async throws {
+        let emission = try await captureSendKeysWire(paneId: 7, data: Data())
+
+        #expect(emission.accepted)
+        #expect(emission.commands.isEmpty)
+    }
+
     @Test @MainActor func pastePaneRejectsDisconnectedControlStream() {
         let connection = RemoteTmuxControlConnection(host: RemoteTmuxHost(destination: "user@host"), sessionName: "work")
         #expect(connection.pastePane(paneId: 1, text: "/tmp/image.png") == false)
@@ -436,6 +517,70 @@ import Testing
         let argv = host.interactiveAuthInvocation()
         #expect(consecutive(argv, "-p", "2222"))
         #expect(consecutive(argv, "-i", "/keys/id"))
+    }
+
+    @MainActor
+    private func captureSendKeysWire(
+        paneId: Int,
+        data: Data,
+        maxPendingBytes: Int = 1 << 16
+    ) async throws -> (accepted: Bool, commands: [String]) {
+        let connection = RemoteTmuxControlConnection(
+            host: RemoteTmuxHost(destination: "user@input-transport"),
+            sessionName: "input-transport"
+        )
+        let bootstrapPipe = Pipe()
+        let bootstrapWriter = RemoteTmuxControlPipeWriter(
+            handle: bootstrapPipe.fileHandleForWriting,
+            label: "remote-tmux-send-keys-bootstrap-test",
+            maxPendingBytes: 1 << 16,
+            onFailure: {}
+        )
+        let pipe = Pipe()
+        let writer = RemoteTmuxControlPipeWriter(
+            handle: pipe.fileHandleForWriting,
+            label: "remote-tmux-send-keys-wire-test",
+            maxPendingBytes: maxPendingBytes,
+            onFailure: {}
+        )
+        defer {
+            bootstrapWriter.close()
+            try? bootstrapPipe.fileHandleForReading.close()
+            writer.close()
+            try? pipe.fileHandleForReading.close()
+        }
+
+        connection.installStdinWriterForTesting(bootstrapWriter)
+        connection.handleMessageForTesting(.enter)
+        connection.handleMessageForTesting(.commandResult(commandNumber: 0, lines: [], isError: false))
+        connection.installStdinWriterForTesting(writer)
+
+        let accepted = connection.sendKeys(paneId: paneId, data: data)
+        writer.close()
+        var lineData = Data()
+        var commands: [String] = []
+        for try await byte in pipe.fileHandleForReading.bytes {
+            guard byte == UInt8(ascii: "\n") else {
+                lineData.append(byte)
+                continue
+            }
+            commands.append(String(decoding: lineData, as: UTF8.self))
+            lineData.removeAll(keepingCapacity: true)
+        }
+        #expect(lineData.isEmpty)
+        return (accepted, commands)
+    }
+
+    private func decodeHexArguments(from commands: [String], paneId: Int) throws -> Data {
+        let prefix = "send-keys -t %\(paneId) -H "
+        var decoded = Data()
+        for command in commands {
+            #expect(command.hasPrefix(prefix))
+            for argument in command.dropFirst(prefix.count).split(separator: " ") {
+                decoded.append(try #require(UInt8(argument, radix: 16)))
+            }
+        }
+        return decoded
     }
 
     /// True when `a` is immediately followed by `b` in `args` — i.e. an ssh

--- a/cmuxTests/WorkspaceRemoteDaemonRecoveryTests.swift
+++ b/cmuxTests/WorkspaceRemoteDaemonRecoveryTests.swift
@@ -327,7 +327,9 @@ struct WorkspaceRemoteDaemonRecoveryTests {
                     timestamp: Date()
                 )
             )
+            let remoteNotificationKey = "remote-host:\(host)"
             let unrelatedNotificationID = UUID()
+            let matchingNotificationIDs = [UUID(), UUID()]
             store.replaceNotificationsForTesting([
                 TerminalNotification(
                     id: unrelatedNotificationID,
@@ -340,9 +342,32 @@ struct WorkspaceRemoteDaemonRecoveryTests {
                     createdAt: Date(),
                     isRead: false
                 ),
+                TerminalNotification(
+                    id: matchingNotificationIDs[0],
+                    tabId: workspace.id,
+                    surfaceId: nil,
+                    correlationKey: remoteNotificationKey,
+                    title: "Recovered remote error",
+                    subtitle: "Remove",
+                    body: "First stale remote failure",
+                    createdAt: Date(),
+                    isRead: false
+                ),
+                TerminalNotification(
+                    id: matchingNotificationIDs[1],
+                    tabId: workspace.id,
+                    surfaceId: nil,
+                    correlationKey: remoteNotificationKey,
+                    title: "Recovered remote error",
+                    subtitle: "Remove",
+                    body: "Second stale remote failure",
+                    createdAt: Date(),
+                    isRead: false
+                ),
             ])
+            #expect(store.notifications.contains { $0.id == matchingNotificationIDs[0] })
+            #expect(store.notifications.contains { $0.id == matchingNotificationIDs[1] })
 
-            let remoteNotificationKey = "remote-host:\(host)"
             let failureDetail = "ssh: connect to host example.com port 22: Operation timed out"
             workspace.applyRemoteConnectionStateUpdate(.error, detail: failureDetail, target: target)
 

--- a/cmuxTests/WorkspaceRemoteDaemonRecoveryTests.swift
+++ b/cmuxTests/WorkspaceRemoteDaemonRecoveryTests.swift
@@ -1,7 +1,9 @@
 import CmuxCore
+import CmuxNotifications
 import CmuxSidebar
 import Foundation
 import Testing
+import UserNotifications
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -270,5 +272,138 @@ struct WorkspaceRemoteDaemonRecoveryTests {
             workspace.logEntries.count == logCountAfterRecovery + 1,
             "Recovery must reset the suspended connection fingerprint"
         )
+    }
+
+    /// https://github.com/manaflow-ai/cmux/issues/9584: an SSH error may be
+    /// recorded before the terminal transport proves it is connected. The
+    /// authoritative terminal-connected path must retract that recovered
+    /// failure even before the controller emits a separate `.connected`.
+    @Test
+    func terminalConnectionRetractsRecoveredNormalSSHFailure() async throws {
+        try await AppContextSerialGate.withExclusiveAppContext {
+            let store = TerminalNotificationStore(
+                userNotificationCenter: UserNotificationCenterService(
+                    center: UNUserNotificationCenter.current()
+                )
+            )
+            let previousAppDelegate = AppDelegate.shared
+            let appDelegate = AppDelegate()
+            let previousNotificationStore = appDelegate.notificationStore
+            AppDelegate.shared = appDelegate
+            appDelegate.notificationStore = store
+            store.configureNotificationDeliveryHandlerForTesting { _, _ in }
+            defer {
+                store.resetNotificationDeliveryHandlerForTesting()
+                appDelegate.notificationStore = previousNotificationStore
+                AppDelegate.shared = previousAppDelegate
+            }
+
+            let workspace = Workspace()
+            let host = "issue9584-\(UUID().uuidString.lowercased()).example"
+            let target = "dev@\(host)"
+            let config = WorkspaceRemoteConfiguration(
+                destination: target,
+                port: 22,
+                identityFile: nil,
+                sshOptions: [],
+                localProxyPort: nil,
+                relayPort: 64_025,
+                relayID: String(repeating: "3", count: 16),
+                relayToken: String(repeating: "4", count: 64),
+                localSocketPath: "/tmp/cmux-debug-test-terminal-connected.sock",
+                terminalStartupCommand: "ssh \(target)",
+                preserveAfterTerminalExit: true,
+                skipDaemonBootstrap: true
+            )
+            workspace.configureRemoteConnection(config, autoConnect: false)
+            let terminal = try #require(workspace.focusedTerminalPanel)
+
+            let unrelatedLogMessage = "User-visible note"
+            workspace.logEntries.append(
+                SidebarLogEntry(
+                    message: unrelatedLogMessage,
+                    level: .info,
+                    source: "user",
+                    timestamp: Date()
+                )
+            )
+            let unrelatedNotificationID = UUID()
+            store.replaceNotificationsForTesting([
+                TerminalNotification(
+                    id: unrelatedNotificationID,
+                    tabId: workspace.id,
+                    surfaceId: nil,
+                    correlationKey: "user-visible",
+                    title: "Unrelated notification",
+                    subtitle: "Keep",
+                    body: "Must survive remote recovery",
+                    createdAt: Date(),
+                    isRead: false
+                ),
+            ])
+
+            let remoteNotificationKey = "remote-host:\(host)"
+            let failureDetail = "ssh: connect to host example.com port 22: Operation timed out"
+            workspace.applyRemoteConnectionStateUpdate(.error, detail: failureDetail, target: target)
+
+            let remoteNotificationArrived = await waitForNotification(
+                in: store,
+                tabID: workspace.id,
+                correlationKey: remoteNotificationKey,
+                body: failureDetail
+            )
+            #expect(remoteNotificationArrived)
+
+            #expect(workspace.remoteConnectionState == .error)
+            #expect(workspace.statusEntries["remote.error"] != nil)
+            #expect(workspace.logEntries.contains { $0.source == "remote" && $0.message.contains(failureDetail) })
+            #expect(store.notifications.contains {
+                $0.tabId == workspace.id &&
+                    $0.correlationKey == remoteNotificationKey &&
+                    $0.body == failureDetail
+            })
+
+            #expect(
+                workspace.markRemoteTerminalSessionConnected(
+                    surfaceId: terminal.id,
+                    authority: .persistentTransport(
+                        config.scopedToOwnerWorkspace(workspace.id).proxyBrokerTransportKey
+                    )
+                )
+            )
+
+            #expect(workspace.remoteConnectionState == .connected)
+            #expect(workspace.remoteConnectionDetail == nil)
+            #expect(workspace.statusEntries["remote.error"] == nil)
+            #expect(!workspace.logEntries.contains { $0.source == "remote" })
+            #expect(workspace.logEntries.contains { $0.message == unrelatedLogMessage })
+            #expect(!store.notifications.contains {
+                $0.tabId == workspace.id && $0.correlationKey == remoteNotificationKey
+            })
+            #expect(store.notifications.contains { $0.id == unrelatedNotificationID })
+
+            workspace.applyRemoteConnectionStateUpdate(.error, detail: failureDetail, target: target)
+
+            #expect(workspace.logEntries.filter { $0.source == "remote" && $0.message.contains(failureDetail) }.count == 1)
+        }
+    }
+
+    private func waitForNotification(
+        in store: TerminalNotificationStore,
+        tabID: UUID,
+        correlationKey: String,
+        body: String
+    ) async -> Bool {
+        for _ in 0..<200 {
+            if store.notifications.contains(where: { notification in
+                notification.tabId == tabID
+                    && notification.correlationKey == correlationKey
+                    && notification.body == body
+            }) {
+                return true
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return false
     }
 }


### PR DESCRIPTION
## Summary

- Retract normal SSH error logs, status, and correlated notifications when an authoritative remote terminal reconnects before the controller reports `.connected`.
- Split ssh-tmux literal input into sub-30,000-byte `send-keys -H` commands, admit one logical paste atomically, and size the bounded writer for the existing 256 KiB raw-input contract.
- Replace Codex hooks across content-addressed generations while pruning their exact stale trust identities; preserve unrelated hooks and TOML tables, including escaped quoted headers.

Closes #9584.
Closes #10943.
Closes #9748.

## Testing

- `swift test --package-path Packages/macOS/CmuxFoundation --filter CmuxCodexConfigEditorTests` — 7 tests passed, including root-scoped dotted-feature insertion.
- `swift test --package-path Packages/macOS/CmuxRemoteSession --filter RemoteTmuxSendKeysBatchBuilderTests` — 5 tests passed, covering empty input, lowercase hex framing, sliced `Data`, command/writer budgets, exact 256 KiB admission, and over-limit rejection.
- Focused `cmux-unit` build-for-testing passed with `CMUX_SKIP_ZIG_BUILD=1`; two unrelated existing browser test sources (`BrowserPanelTests.swift`, `BrowserPanelViewIdentityTests.swift`) were excluded after their compiler batch failed independently of this diff.
- Focused `test-without-building` passed for #9584 authoritative recovery, atomic tmux writer-backpressure rejection, full production writer budget, and #9748 displaced-trust/idempotency.

Manual verification: not applicable; these are state/transport/configuration fixes covered at their behavioral seams.

The two Vercel preview statuses (`cmux41`, `cmux166`) require Manaflow Team authorization for fork deployments; they are not code/test failures and cannot be authorized by an external contributor.

## Demo Video

- Video URL or attachment: N/A — no visual UI change.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed — not needed for regression fixes
- [x] I requested bot reviews after my latest commit
- [ ] All code review bot comments are resolved
- [x] All human review comments are resolved — none received


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Codex hook reinstallation and removal while preserving user-defined settings and trust entries.
  - Improved remote terminal input handling for large payloads, preventing partial writes and preserving input order.
  - Fixed recovered remote connections so stale sidebar errors and notifications are cleared promptly.

- **Reliability**
  - Added safeguards for escaped configuration entries, custom settings, and repeated hook installations.
  - Improved notification cleanup to remove stale pending and delivered alerts during recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->