### PR TITLE
fix(tui): retry failed screen detection reads

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/screen_detect/mod.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/screen_detect/mod.rs
@@ -116,6 +116,14 @@ impl ScreenDetectTracker {
         true
     }
 
+    /// Let a failed screen read retry on the next scan instead of waiting for
+    /// the max-evaluation interval or another output revision.
+    pub(crate) fn note_evaluation_failure(&mut self, terminal_id: &str) {
+        if let Some(entry) = self.terminals.get_mut(terminal_id) {
+            entry.last_evaluated_at = None;
+        }
+    }
+
     /// Fold one evaluated detection. `None` detection means the foreground
     /// process is not a supported agent (or is gone): a live screen-derived
     /// entry is closed with a session-ended-equivalent `Done` emission.
@@ -323,6 +331,15 @@ mod tests {
         // Swapping agents in place is an edge, and so is exiting.
         assert!(tracker.note_foreground_agent("term_a", Some("claude")));
         assert!(tracker.note_foreground_agent("term_a", None));
+    }
+
+    #[test]
+    fn screen_detect_tracker_retries_after_failed_screen_read() {
+        let mut tracker = ScreenDetectTracker::default();
+        let t0 = Instant::now();
+        assert!(tracker.observe_revision("term_a", 1, t0));
+        tracker.note_evaluation_failure("term_a");
+        assert!(tracker.observe_revision("term_a", 1, t0 + Duration::from_millis(1)));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/screen_detect/mod.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/screen_detect/mod.rs
@@ -392,7 +392,7 @@ mod tests {
         live.extend(live_ids.iter().map(String::as_str));
         builds.store(0, Ordering::Relaxed);
 
-        tracker.retain_terminals(&live);
+        tracker.retain_terminals(|terminal_id| live.contains(terminal_id));
 
         assert_eq!(
             builds.load(Ordering::Relaxed),

--- a/cmux-tui/crates/cmux-tui-core/src/screen_detect/scanner.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/screen_detect/scanner.rs
@@ -98,6 +98,7 @@ pub(crate) fn scan(
             Some(manifest) if quiesced || identity_edge => {
                 let Ok(Ok(screen)) = surface.try_with_terminal(|terminal| terminal.viewport_text())
                 else {
+                    tracker.note_evaluation_failure(terminal_id);
                     continue;
                 };
                 let title = surface.title();


### PR DESCRIPTION
## Summary
- Retry screen detection immediately when terminal viewport reads fail.
- Add a tracker regression test covering failed-read retry behavior.

## Testing
- cargo fmt --all -- --check
- git diff --check
- cargo test -p cmux-tui-core screen_detect_tracker_retries_after_failed_screen_read

## Issues
- Related: https://github.com/manaflow-ai/cmux/pull/11068

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790714823&installation_model_id=21920&pr_number=11222&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11222&signature=aebd6b007a31db21d06b6a7b4f6e13bf64d5e7ccc70b7ff2a6fd7f2bba5aa7bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries failed terminal viewport reads immediately so screen detection no longer waits for the next max-evaluation interval or output revision. Previously a failed read would stall detection; now the tracker resets the terminal's last-evaluated timestamp to allow a retry on the next scan, and a regression test covers the retry behavior.

<sup>Written for commit 5c97aefda368aefecf5e793790460ddae56dae29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

