### PR TITLE
Fail closed when notification pane identity is unproven

### DIFF
--- a/CLI/CMUXCLI+ClaudePushNotificationHook.swift
+++ b/CLI/CMUXCLI+ClaudePushNotificationHook.swift
@@ -36,21 +36,20 @@ extension CMUXCLI {
             mappedSession: mappedSession,
             routing: routing,
             client: client
-        ) else {
+        ), resolvedTarget.isAuthoritative else {
             markFeedTelemetryHandled()
             telemetry.breadcrumb("claude-hook.push-notification.unresolved")
             printClaudeHookAck()
             return
         }
         let workspaceId = resolvedTarget.workspaceId
-        let resolvedSurface = resolvedTarget
-        let surfaceId = resolvedSurface.surfaceId
+        let surfaceId = resolvedTarget.surfaceId
         sendFeedTelemetry(workspaceId, surfaceId)
         guard shouldApplyClaudeHookVisibleMutation(
             sessionStore: sessionStore,
             parsedInput: parsedInput,
             workspaceId: workspaceId,
-            surfaceId: resolvedSurface.isAuthoritative ? surfaceId : nil,
+            surfaceId: surfaceId,
             telemetry: telemetry
         ) else {
             telemetry.breadcrumb("claude-hook.push-notification.stale")

--- a/CLI/CMUXCLI+CodexFireAndForgetHooks.swift
+++ b/CLI/CMUXCLI+CodexFireAndForgetHooks.swift
@@ -21,7 +21,7 @@ extension CMUXCLI {
             telemetry.breadcrumb("codex-hook.settled-stop.retry-limit-reached")
             return
         }
-        let retryDelay = [0.25, 0.5, 1.0][min(retryCount, 2)]
+        let retryDelay = [0.0, 0.5, 1.0][min(retryCount, 2)]
         let selfPath: String = {
             if let first = ProcessInfo.processInfo.arguments.first,
                first.hasPrefix("/"),

--- a/CLI/CMUXCLI+CodexFireAndForgetHooks.swift
+++ b/CLI/CMUXCLI+CodexFireAndForgetHooks.swift
@@ -2,6 +2,8 @@ import CMUXAgentLaunch
 import Foundation
 
 extension CMUXCLI {
+    private static let codexSettledStopMaximumRetries = 3
+
     /// Schedules the normal Codex Stop path after the final child exits.
     ///
     /// Native child hooks must acknowledge the lifecycle write quickly, so the
@@ -13,6 +15,11 @@ extension CMUXCLI {
         environment: [String: String],
         telemetry: CLISocketSentryTelemetry
     ) {
+        let retryCount = Int(environment["CMUX_CODEX_SETTLED_STOP_RETRY_COUNT"] ?? "0") ?? 0
+        guard retryCount < Self.codexSettledStopMaximumRetries else {
+            telemetry.breadcrumb("codex-hook.settled-stop.retry-limit-reached")
+            return
+        }
         let selfPath: String = {
             if let first = ProcessInfo.processInfo.arguments.first,
                first.hasPrefix("/"),
@@ -49,6 +56,7 @@ extension CMUXCLI {
         ]
         var childEnvironment = environment
         childEnvironment["CMUX_CODEX_SETTLED_CHILD_STOP"] = "1"
+        childEnvironment["CMUX_CODEX_SETTLED_STOP_RETRY_COUNT"] = String(retryCount + 1)
         process.environment = childEnvironment
         process.standardInput = FileHandle.nullDevice
         process.standardOutput = FileHandle.nullDevice

--- a/CLI/CMUXCLI+CodexFireAndForgetHooks.swift
+++ b/CLI/CMUXCLI+CodexFireAndForgetHooks.swift
@@ -15,11 +15,12 @@ extension CMUXCLI {
         environment: [String: String],
         telemetry: CLISocketSentryTelemetry
     ) {
-        let retryCount = Int(environment["CMUX_CODEX_SETTLED_STOP_RETRY_COUNT"] ?? "0") ?? 0
+        let retryCount = max(0, Int(environment["CMUX_CODEX_SETTLED_STOP_RETRY_COUNT"] ?? "0") ?? 0)
         guard retryCount < Self.codexSettledStopMaximumRetries else {
             telemetry.breadcrumb("codex-hook.settled-stop.retry-limit-reached")
             return
         }
+        let retryDelay = [0.25, 0.5, 1.0][min(retryCount, 2)]
         let selfPath: String = {
             if let first = ProcessInfo.processInfo.arguments.first,
                first.hasPrefix("/"),
@@ -50,9 +51,10 @@ extension CMUXCLI {
         process.executableURL = URL(fileURLWithPath: "/bin/sh")
         process.arguments = [
             "-c",
-            "nohup /bin/sh -c '\"$0\" hooks codex stop < \"$1\" >/dev/null 2>&1; rm -f \"$1\"' \"$0\" \"$1\" >/dev/null 2>&1 &",
+            "nohup /bin/sh -c 'sleep \"$2\"; \"$0\" hooks codex stop < \"$1\" >/dev/null 2>&1; rm -f \"$1\"' \"$0\" \"$1\" \"$2\" >/dev/null 2>&1 &",
             selfPath,
             payloadURL.path,
+            String(retryDelay),
         ]
         var childEnvironment = environment
         childEnvironment["CMUX_CODEX_SETTLED_CHILD_STOP"] = "1"

--- a/CLI/CMUXCLI+CodexFireAndForgetHooks.swift
+++ b/CLI/CMUXCLI+CodexFireAndForgetHooks.swift
@@ -13,7 +13,8 @@ extension CMUXCLI {
     func spawnDetachedCodexSettledStop(
         payload: String,
         environment: [String: String],
-        telemetry: CLISocketSentryTelemetry
+        telemetry: CLISocketSentryTelemetry,
+        turnID: String? = nil
     ) {
         let retryCount = max(0, Int(environment["CMUX_CODEX_SETTLED_STOP_RETRY_COUNT"] ?? "0") ?? 0)
         guard retryCount < Self.codexSettledStopMaximumRetries else {
@@ -59,6 +60,11 @@ extension CMUXCLI {
         var childEnvironment = environment
         childEnvironment["CMUX_CODEX_SETTLED_CHILD_STOP"] = "1"
         childEnvironment["CMUX_CODEX_SETTLED_STOP_RETRY_COUNT"] = String(retryCount + 1)
+        if let turnID = turnID?.trimmingCharacters(in: .whitespacesAndNewlines), !turnID.isEmpty {
+            childEnvironment["CMUX_CODEX_SETTLED_STOP_TURN_ID"] = turnID
+        } else {
+            childEnvironment.removeValue(forKey: "CMUX_CODEX_SETTLED_STOP_TURN_ID")
+        }
         process.environment = childEnvironment
         process.standardInput = FileHandle.nullDevice
         process.standardOutput = FileHandle.nullDevice

--- a/CLI/CodexTurnLedger.swift
+++ b/CLI/CodexTurnLedger.swift
@@ -308,16 +308,19 @@ final class CodexTurnLedger {
                 }
             case .stop(let turnID, let claimNotification, let requireCurrentTurn):
                 let key = self.turnKey(turnID ?? record.activeTurnID)
-                if requireCurrentTurn, let incomingTurnID = Self.normalized(turnID) {
-                    if let activeTurnID = Self.normalized(record.activeTurnID) {
+                if requireCurrentTurn {
+                    if Self.normalized(record.activeTurnID) == nil,
+                       record.pendingTurns[key] == nil,
+                       !claimNotification {
+                        // An unattributed stop must not invent the @current
+                        // turn when the ledger has no current identity.
+                        return .ignored
+                    }
+                    if let incomingTurnID = Self.normalized(turnID),
+                       let activeTurnID = Self.normalized(record.activeTurnID) {
                         if incomingTurnID != activeTurnID, record.pendingTurns[key] == nil {
                             return .ignored
                         }
-                    } else if !claimNotification, record.pendingTurns[key] == nil {
-                        // An unattributed stop cannot invent a turn when the
-                        // ledger has no current identity. Authoritative stops
-                        // keep the legacy unseen-turn compatibility behavior.
-                        return .ignored
                     }
                 }
                 let active = self.activeChildCount(record)

--- a/CLI/CodexTurnLedger.swift
+++ b/CLI/CodexTurnLedger.swift
@@ -13,7 +13,7 @@ final class CodexTurnLedger {
         case promptSubmit(turnID: String?)
         case subagentStart(id: String?, turnID: String?)
         case subagentStop(id: String?, turnID: String?)
-        case stop(turnID: String?)
+        case stop(turnID: String?, claimNotification: Bool)
         case sessionEnd
         case observation
     }
@@ -95,47 +95,46 @@ final class CodexTurnLedger {
         turnID: String?,
         workspaceID: String?,
         surfaceID: String?,
-        invocation: CodexHookInvocation
+        invocation: CodexHookInvocation, allowCreate: Bool = true
     ) throws -> CodexTurnLedgerDecision {
         try apply(
             .subagentStart(id: agentID, turnID: turnID),
             sessionID: sessionID,
             workspaceID: workspaceID,
             surfaceID: surfaceID,
-            invocation: invocation
+            invocation: invocation, allowCreate: allowCreate
         )
     }
-
     func subagentStop(
         sessionID: String,
         agentID: String?,
         turnID: String?,
         workspaceID: String?,
         surfaceID: String?,
-        invocation: CodexHookInvocation
+        invocation: CodexHookInvocation, allowCreate: Bool = true
     ) throws -> CodexTurnLedgerDecision {
         try apply(
             .subagentStop(id: agentID, turnID: turnID),
             sessionID: sessionID,
             workspaceID: workspaceID,
             surfaceID: surfaceID,
-            invocation: invocation
+            invocation: invocation, allowCreate: allowCreate
         )
     }
-
     func stop(
         sessionID: String,
         turnID: String?,
         workspaceID: String?,
         surfaceID: String?,
-        invocation: CodexHookInvocation
+        invocation: CodexHookInvocation,
+        claimNotification: Bool = true, allowCreate: Bool = true
     ) throws -> CodexTurnLedgerDecision {
         try apply(
-            .stop(turnID: turnID),
+            .stop(turnID: turnID, claimNotification: claimNotification),
             sessionID: sessionID,
             workspaceID: workspaceID,
             surfaceID: surfaceID,
-            invocation: invocation
+            invocation: invocation, allowCreate: allowCreate
         )
     }
 
@@ -158,14 +157,14 @@ final class CodexTurnLedger {
         sessionID: String,
         workspaceID: String?,
         surfaceID: String?,
-        invocation: CodexHookInvocation
+        invocation: CodexHookInvocation, allowCreate: Bool = true
     ) throws -> CodexTurnLedgerDecision {
         try apply(
             .observation,
             sessionID: sessionID,
             workspaceID: workspaceID,
             surfaceID: surfaceID,
-            invocation: invocation
+            invocation: invocation, allowCreate: allowCreate
         )
     }
 
@@ -174,7 +173,7 @@ final class CodexTurnLedger {
         sessionID: String,
         workspaceID: String?,
         surfaceID: String?,
-        invocation: CodexHookInvocation
+        invocation: CodexHookInvocation, allowCreate: Bool = true
     ) throws -> CodexTurnLedgerDecision {
         let normalizedSessionID = Self.normalized(sessionID) ?? ""
         guard !normalizedSessionID.isEmpty else { return .ignored }
@@ -186,6 +185,7 @@ final class CodexTurnLedger {
             let ownerRecord = normalizedSurfaceID.isEmpty
                 ? nil
                 : state.surfaceOwners[normalizedSurfaceID].flatMap { state.records[$0] }
+            if !allowCreate, existing == nil, ownerRecord == nil { return .ignored }
             let ownership = self.ownership(
                 event: event,
                 sessionID: normalizedSessionID,
@@ -311,7 +311,7 @@ final class CodexTurnLedger {
                         shouldNotify: false
                     )
                 }
-            case .stop(let turnID):
+            case .stop(let turnID, let claimNotification):
                 let key = self.turnKey(turnID ?? record.activeTurnID)
                 let active = self.activeChildCount(record)
                 if active > 0 {
@@ -325,7 +325,7 @@ final class CodexTurnLedger {
                     )
                 } else if record.settledTurnIDs.contains(key) {
                     let shouldNotify = !record.notifiedTurnIDs.contains(key)
-                    if shouldNotify {
+                    if claimNotification, shouldNotify {
                         record.notifiedTurnIDs.append(key)
                     }
                     decision = self.decision(
@@ -339,7 +339,7 @@ final class CodexTurnLedger {
                     record.pendingTurns.removeValue(forKey: key)
                     record.settledTurnIDs.append(key)
                     let shouldNotify = !record.notifiedTurnIDs.contains(key)
-                    if shouldNotify { record.notifiedTurnIDs.append(key) }
+                    if claimNotification, shouldNotify { record.notifiedTurnIDs.append(key) }
                     decision = self.decision(
                         ownership: .foreground,
                         settlement: .settled,

--- a/CLI/CodexTurnLedger.swift
+++ b/CLI/CodexTurnLedger.swift
@@ -13,7 +13,7 @@ final class CodexTurnLedger {
         case promptSubmit(turnID: String?)
         case subagentStart(id: String?, turnID: String?)
         case subagentStop(id: String?, turnID: String?)
-        case stop(turnID: String?, claimNotification: Bool)
+        case stop(turnID: String?, claimNotification: Bool, requireCurrentTurn: Bool)
         case sessionEnd
         case observation
     }
@@ -127,10 +127,10 @@ final class CodexTurnLedger {
         workspaceID: String?,
         surfaceID: String?,
         invocation: CodexHookInvocation,
-        claimNotification: Bool = true, allowCreate: Bool = true
+        claimNotification: Bool = true, allowCreate: Bool = true, requireCurrentTurn: Bool = false
     ) throws -> CodexTurnLedgerDecision {
         try apply(
-            .stop(turnID: turnID, claimNotification: claimNotification),
+            .stop(turnID: turnID, claimNotification: claimNotification, requireCurrentTurn: requireCurrentTurn),
             sessionID: sessionID,
             workspaceID: workspaceID,
             surfaceID: surfaceID,
@@ -311,8 +311,14 @@ final class CodexTurnLedger {
                         shouldNotify: false
                     )
                 }
-            case .stop(let turnID, let claimNotification):
+            case .stop(let turnID, let claimNotification, let requireCurrentTurn):
                 let key = self.turnKey(turnID ?? record.activeTurnID)
+                if requireCurrentTurn,
+                   let incomingTurnID = Self.normalized(turnID),
+                   incomingTurnID != Self.normalized(record.activeTurnID),
+                   record.pendingTurns[key] == nil {
+                    return .ignored
+                }
                 let active = self.activeChildCount(record)
                 if active > 0 {
                     record.pendingTurns[key] = CodexTurnLedgerPending(turnID: Self.normalized(turnID ?? record.activeTurnID))

--- a/CLI/CodexTurnLedger.swift
+++ b/CLI/CodexTurnLedger.swift
@@ -55,9 +55,7 @@ final class CodexTurnLedger {
         self.fileManager = fileManager
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
     }
-
     deinit {}
-
     func sessionStart(
         sessionID: String,
         workspaceID: String?,
@@ -72,7 +70,6 @@ final class CodexTurnLedger {
             invocation: invocation
         )
     }
-
     func promptSubmit(
         sessionID: String,
         turnID: String?,
@@ -88,7 +85,6 @@ final class CodexTurnLedger {
             invocation: invocation
         )
     }
-
     func subagentStart(
         sessionID: String,
         agentID: String?,
@@ -137,7 +133,6 @@ final class CodexTurnLedger {
             invocation: invocation, allowCreate: allowCreate
         )
     }
-
     func sessionEnd(
         sessionID: String,
         workspaceID: String?,
@@ -152,7 +147,6 @@ final class CodexTurnLedger {
             invocation: invocation
         )
     }
-
     func observe(
         sessionID: String,
         workspaceID: String?,
@@ -167,7 +161,6 @@ final class CodexTurnLedger {
             invocation: invocation, allowCreate: allowCreate
         )
     }
-
     private func apply(
         _ event: Event,
         sessionID: String,
@@ -315,7 +308,8 @@ final class CodexTurnLedger {
                 let key = self.turnKey(turnID ?? record.activeTurnID)
                 if requireCurrentTurn,
                    let incomingTurnID = Self.normalized(turnID),
-                   incomingTurnID != Self.normalized(record.activeTurnID),
+                   let activeTurnID = Self.normalized(record.activeTurnID),
+                   incomingTurnID != activeTurnID,
                    record.pendingTurns[key] == nil {
                     return .ignored
                 }

--- a/CLI/CodexTurnLedger.swift
+++ b/CLI/CodexTurnLedger.swift
@@ -75,14 +75,16 @@ final class CodexTurnLedger {
         turnID: String?,
         workspaceID: String?,
         surfaceID: String?,
-        invocation: CodexHookInvocation
+        invocation: CodexHookInvocation,
+        allowCreate: Bool = true
     ) throws -> CodexTurnLedgerDecision {
         try apply(
             .promptSubmit(turnID: turnID),
             sessionID: sessionID,
             workspaceID: workspaceID,
             surfaceID: surfaceID,
-            invocation: invocation
+            invocation: invocation,
+            allowCreate: allowCreate
         )
     }
     func subagentStart(

--- a/CLI/CodexTurnLedger.swift
+++ b/CLI/CodexTurnLedger.swift
@@ -308,12 +308,17 @@ final class CodexTurnLedger {
                 }
             case .stop(let turnID, let claimNotification, let requireCurrentTurn):
                 let key = self.turnKey(turnID ?? record.activeTurnID)
-                if requireCurrentTurn,
-                   let incomingTurnID = Self.normalized(turnID),
-                   let activeTurnID = Self.normalized(record.activeTurnID),
-                   incomingTurnID != activeTurnID,
-                   record.pendingTurns[key] == nil {
-                    return .ignored
+                if requireCurrentTurn, let incomingTurnID = Self.normalized(turnID) {
+                    if let activeTurnID = Self.normalized(record.activeTurnID) {
+                        if incomingTurnID != activeTurnID, record.pendingTurns[key] == nil {
+                            return .ignored
+                        }
+                    } else if !claimNotification, record.pendingTurns[key] == nil {
+                        // An unattributed stop cannot invent a turn when the
+                        // ledger has no current identity. Authoritative stops
+                        // keep the legacy unseen-turn compatibility behavior.
+                        return .ignored
+                    }
                 }
                 let active = self.activeChildCount(record)
                 if active > 0 {

--- a/CLI/CodexTurnLifecycleCoordinator.swift
+++ b/CLI/CodexTurnLifecycleCoordinator.swift
@@ -18,6 +18,17 @@ struct CodexTurnLifecycleCoordinator {
         ledger = cli.codexTurnLedger(environment: environment)
     }
 
+    /// Read-only admission check used when a hook cannot prove a pane. An
+    /// unattributed callback may update an existing session's lifecycle, but
+    /// it must not create a durable ledger record with no owner or surface.
+    func hasRecord(sessionID: String) -> Bool {
+        guard let normalizedSessionID = CodexTurnLedger.normalized(sessionID),
+              let state = try? ledger.load() else {
+            return false
+        }
+        return state.records[normalizedSessionID] != nil
+    }
+
     func sessionStart(
         sessionID: String,
         workspaceID: String?,

--- a/CLI/CodexTurnLifecycleCoordinator.swift
+++ b/CLI/CodexTurnLifecycleCoordinator.swift
@@ -142,7 +142,8 @@ struct CodexTurnLifecycleCoordinator {
         agentID: String?,
         turnID: String?,
         workspaceID: String?,
-        surfaceID: String?
+        surfaceID: String?,
+        allowCreate: Bool = true
     ) -> CodexTurnLedgerDecision {
         let starts: Bool
         switch eventName {
@@ -156,7 +157,8 @@ struct CodexTurnLifecycleCoordinator {
             turnID: turnID,
             workspaceID: workspaceID,
             surfaceID: surfaceID,
-            starts: starts
+            starts: starts,
+            allowCreate: allowCreate
         )
     }
 }

--- a/CLI/CodexTurnLifecycleCoordinator.swift
+++ b/CLI/CodexTurnLifecycleCoordinator.swift
@@ -18,17 +18,6 @@ struct CodexTurnLifecycleCoordinator {
         ledger = cli.codexTurnLedger(environment: environment)
     }
 
-    /// Read-only admission check used when a hook cannot prove a pane. An
-    /// unattributed callback may update an existing session's lifecycle, but
-    /// it must not create a durable ledger record with no owner or surface.
-    func hasRecord(sessionID: String) -> Bool {
-        guard let normalizedSessionID = CodexTurnLedger.normalized(sessionID),
-              let state = try? ledger.load() else {
-            return false
-        }
-        return state.records[normalizedSessionID] != nil
-    }
-
     func sessionStart(
         sessionID: String,
         workspaceID: String?,
@@ -63,7 +52,8 @@ struct CodexTurnLifecycleCoordinator {
         turnID: String?,
         workspaceID: String?,
         surfaceID: String?,
-        starts: Bool
+        starts: Bool,
+        allowCreate: Bool = true
     ) -> CodexTurnLedgerDecision {
         let result: Result<CodexTurnLedgerDecision, Error>
         if starts {
@@ -74,7 +64,8 @@ struct CodexTurnLifecycleCoordinator {
                     turnID: turnID,
                     workspaceID: workspaceID,
                     surfaceID: surfaceID,
-                    invocation: invocation
+                    invocation: invocation,
+                    allowCreate: allowCreate
                 )
             }
         } else {
@@ -85,7 +76,8 @@ struct CodexTurnLifecycleCoordinator {
                     turnID: turnID,
                     workspaceID: workspaceID,
                     surfaceID: surfaceID,
-                    invocation: invocation
+                    invocation: invocation,
+                    allowCreate: allowCreate
                 )
             }
         }
@@ -96,27 +88,33 @@ struct CodexTurnLifecycleCoordinator {
         sessionID: String,
         turnID: String?,
         workspaceID: String?,
-        surfaceID: String?
+        surfaceID: String?,
+        claimNotification: Bool = true,
+        allowCreate: Bool = true
     ) -> CodexTurnLedgerDecision {
         (try? ledger.stop(
             sessionID: sessionID,
             turnID: turnID,
             workspaceID: workspaceID,
             surfaceID: surfaceID,
-            invocation: invocation
+            invocation: invocation,
+            claimNotification: claimNotification,
+            allowCreate: allowCreate
         )) ?? .ignored
     }
 
     func observe(
         sessionID: String,
         workspaceID: String?,
-        surfaceID: String?
+        surfaceID: String?,
+        allowCreate: Bool = true
     ) -> CodexTurnLedgerDecision {
         (try? ledger.observe(
             sessionID: sessionID,
             workspaceID: workspaceID,
             surfaceID: surfaceID,
-            invocation: invocation
+            invocation: invocation,
+            allowCreate: allowCreate
         )) ?? .ignored
     }
 

--- a/CLI/CodexTurnLifecycleCoordinator.swift
+++ b/CLI/CodexTurnLifecycleCoordinator.swift
@@ -35,14 +35,16 @@ struct CodexTurnLifecycleCoordinator {
         sessionID: String,
         turnID: String?,
         workspaceID: String?,
-        surfaceID: String?
+        surfaceID: String?,
+        allowCreate: Bool = true
     ) -> CodexTurnLedgerDecision {
         (try? ledger.promptSubmit(
             sessionID: sessionID,
             turnID: turnID,
             workspaceID: workspaceID,
             surfaceID: surfaceID,
-            invocation: invocation
+            invocation: invocation,
+            allowCreate: allowCreate
         )) ?? .ignored
     }
 

--- a/CLI/CodexTurnLifecycleCoordinator.swift
+++ b/CLI/CodexTurnLifecycleCoordinator.swift
@@ -90,7 +90,8 @@ struct CodexTurnLifecycleCoordinator {
         workspaceID: String?,
         surfaceID: String?,
         claimNotification: Bool = true,
-        allowCreate: Bool = true
+        allowCreate: Bool = true,
+        requireCurrentTurn: Bool = false
     ) -> CodexTurnLedgerDecision {
         (try? ledger.stop(
             sessionID: sessionID,
@@ -99,7 +100,8 @@ struct CodexTurnLifecycleCoordinator {
             surfaceID: surfaceID,
             invocation: invocation,
             claimNotification: claimNotification,
-            allowCreate: allowCreate
+            allowCreate: allowCreate,
+            requireCurrentTurn: requireCurrentTurn
         )) ?? .ignored
     }
 

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -38831,6 +38831,14 @@ export default CMUXSessionRestore;
                     guard let workspaceId else { return nil }
                     return resolveFromSurfaceList(workspaceId: workspaceId)
                 }
+                // Relay authorization intentionally exposes only the scoped
+                // `surface.list` path for remote callers; use it directly
+                // rather than asking the local PID/surface resolver, which is
+                // outside the remote trust boundary.
+                if activeClient.isRelayBacked {
+                    guard let workspaceId else { return nil }
+                    return resolveFromSurfaceList(workspaceId: workspaceId)
+                }
                 var params: [String: Any] = ["surface_id": rawSurfaceId]
                 if let workspaceId { params["workspace_id"] = workspaceId }
                 do {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -38635,6 +38635,27 @@ export default CMUXSessionRestore;
         guard !source.isEmpty else {
             throw CLIError(message: "cmux hooks feed requires --source <agent-name>")
         }
+        var lifecycleProbeClient: SocketClient?
+        defer { lifecycleProbeClient?.close() }
+
+        func makeLifecycleProbeClient() -> SocketClient? {
+            guard let socketPath else { return nil }
+            let probe = SocketClient(path: socketPath)
+            do {
+                try probe.connectWithoutRetry(responseTimeout: 0.25)
+                try authenticateClientIfNeeded(
+                    probe,
+                    explicitPassword: socketPassword,
+                    socketPath: socketPath,
+                    responseTimeout: 0.25
+                )
+                lifecycleProbeClient = probe
+                return probe
+            } catch {
+                probe.close()
+                return nil
+            }
+        }
 
         // Outside a cmux terminal (no CMUX_SURFACE_ID) → silently no-op.
         // Also matches the graceful-fallback pattern of the other hooks.
@@ -38740,7 +38761,7 @@ export default CMUXSessionRestore;
                       isUUID(workspaceId),
                       let rawSurfaceId = firstString(in: stdinObj, keys: ["surface_id", "surfaceId"])
                           ?? env["CMUX_SURFACE_ID"],
-                      let activeClient = client,
+                      let activeClient = client ?? makeLifecycleProbeClient(),
                       let listed = try? activeClient.sendV2(
                           method: "surface.list",
                           params: ["workspace_id": workspaceId]

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -7405,7 +7405,10 @@ struct CMUXCLI {
                     if let workspaceArg, isUUID(workspaceArg) || explicitWorkspaceArg != nil {
                         params["preferred_workspace_id"] = isUUID(workspaceArg) ? workspaceArg : try resolveWorkspaceId(workspaceArg, client: client)
                     }
-                    if windowRaw == nil, let surfaceId = env["CMUX_SURFACE_ID"], isUUID(surfaceId) { params["preferred_surface_id"] = surfaceId }
+                    if windowRaw == nil, explicitWorkspaceArg == nil,
+                       let surfaceId = env["CMUX_SURFACE_ID"], isUUID(surfaceId) {
+                        params["preferred_surface_id"] = surfaceId
+                    }
                     if let callerTTY = resolveCallerTTYName() { params["caller_tty"] = callerTTY }
                 }
             }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -35215,7 +35215,7 @@ export default CMUXSessionRestore;
                         surfaceID: nil,
                         claimNotification: false,
                         allowCreate: false,
-                        requireCurrentTurn: true
+                        requireCurrentTurn: codexLifecycle.usesLegacyIdentity == false
                     )
                     if codexStopDecision?.settlement == .settled,
                        codexStopDecision?.shouldNotify == true {
@@ -38735,17 +38735,35 @@ export default CMUXSessionRestore;
         if source == "codex",
            hookEventName == "SubagentStart" || hookEventName == "SubagentStop" {
             let lifecycle = CodexTurnLifecycleCoordinator(environment: env, cli: self)
+            let feedLifecycleTarget: (workspaceId: String, surfaceId: String)? = {
+                guard let workspaceId = feedWorkspaceId(rawObject: stdinObj, fallback: env["CMUX_WORKSPACE_ID"]),
+                      isUUID(workspaceId),
+                      let rawSurfaceId = firstString(in: stdinObj, keys: ["surface_id", "surfaceId"])
+                          ?? env["CMUX_SURFACE_ID"],
+                      let activeClient = client,
+                      let listed = try? activeClient.sendV2(
+                          method: "surface.list",
+                          params: ["workspace_id": workspaceId]
+                      ),
+                      let surfaces = listed["surfaces"] as? [[String: Any]],
+                      let surface = surfaces.first(where: {
+                          ($0["id"] as? String) == rawSurfaceId
+                              || ($0["ref"] as? String) == rawSurfaceId
+                      }),
+                      let surfaceId = surface["id"] as? String,
+                      isUUID(surfaceId) else {
+                    return nil
+                }
+                return (workspaceId, surfaceId)
+            }()
             let decision = lifecycle.recordFeedLifecycle(
                 sessionID: sessionId,
                 eventName: hookEventName,
                 agentID: firstString(in: stdinObj, keys: ["agent_id", "agentId"]),
                 turnID: firstString(in: stdinObj, keys: ["turn_id", "turnId"]),
-                workspaceID: feedWorkspaceId(
-                    rawObject: stdinObj,
-                    fallback: env["CMUX_WORKSPACE_ID"]
-                ),
-                surfaceID: firstString(in: stdinObj, keys: ["surface_id", "surfaceId"])
-                    ?? env["CMUX_SURFACE_ID"]
+                workspaceID: feedLifecycleTarget?.workspaceId,
+                surfaceID: feedLifecycleTarget?.surfaceId,
+                allowCreate: feedLifecycleTarget != nil
             )
             if hookEventName == "SubagentStop",
                decision.ownership == .foreground,

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -2439,6 +2439,13 @@ final class ClaudeHookSessionStore {
         _ body: (inout ClaudeHookSessionStoreFile) throws -> T
     ) throws -> T {
         let lockPath = statePath + ".lock"
+        // The lock file is opened before the state is ever saved, so the first
+        // store access on a fresh HOME must create the state directory itself.
+        try fileManager.createDirectory(
+            at: URL(fileURLWithPath: lockPath).deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: NSNumber(value: Int16(0o700))]
+        )
         let fd = open(lockPath, O_CREAT | O_RDWR, mode_t(S_IRUSR | S_IWUSR))
         if fd < 0 {
             throw CLIError(message: "Failed to open Claude hook state lock: \(lockPath)")
@@ -38638,6 +38645,7 @@ export default CMUXSessionRestore;
         guard !source.isEmpty else {
             throw CLIError(message: "cmux hooks feed requires --source <agent-name>")
         }
+        let lifecycleProbeDeadline = Date.now.addingTimeInterval(0.75)
         var lifecycleProbeClient: SocketClient?
         defer { lifecycleProbeClient?.close() }
 
@@ -38767,7 +38775,9 @@ export default CMUXSessionRestore;
                       let activeClient = client ?? makeLifecycleProbeClient(),
                       let listed = try? activeClient.sendV2(
                           method: "surface.list",
-                          params: ["workspace_id": workspaceId]
+                          params: ["workspace_id": workspaceId],
+                          responseTimeout: max(0.01, lifecycleProbeDeadline.timeIntervalSinceNow),
+                          deadline: lifecycleProbeDeadline
                       ),
                       let surfaces = listed["surfaces"] as? [[String: Any]],
                       let surface = surfaces.first(where: {
@@ -38804,6 +38814,13 @@ export default CMUXSessionRestore;
                     environment: env,
                     telemetry: telemetry
                 )
+            }
+            // A rejected lifecycle identity is intentionally diagnostic-only.
+            // Do not let the generic feed frame below reuse stale ambient
+            // workspace/surface metadata after this decision.
+            guard feedLifecycleTarget != nil else {
+                print("{}")
+                return
             }
         }
 

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -7412,9 +7412,7 @@ struct CMUXCLI {
                     if let workspaceArg, isUUID(workspaceArg) || explicitWorkspaceArg != nil {
                         params["preferred_workspace_id"] = isUUID(workspaceArg) ? workspaceArg : try resolveWorkspaceId(workspaceArg, client: client)
                     }
-                    if windowRaw == nil,
-                       (explicitWorkspaceArg == nil || client.isRelayBacked),
-                       let surfaceId = env["CMUX_SURFACE_ID"], isUUID(surfaceId) {
+                    if windowRaw == nil, let surfaceId = env["CMUX_SURFACE_ID"], isUUID(surfaceId) {
                         params["preferred_surface_id"] = surfaceId
                     }
                     if let callerTTY = resolveCallerTTYName() { params["caller_tty"] = callerTTY }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -34505,32 +34505,17 @@ export default CMUXSessionRestore;
                 break
             }
             let mapped = sessionId.isEmpty ? nil : (try? store.lookup(sessionId: sessionId))
-            guard let target = resolveAgentHookTarget(mapped: mapped) else {
+            let target = resolveAgentHookTarget(mapped: mapped)
+            let workspaceId = target?.workspaceId
+            let surfaceId = target?.surfaceId
+            if target == nil {
                 // Child lifecycle state participates in Codex settlement just
-                // like the parent stop path. Never pass a rejected/stale
-                // mapped surface back into the ledger after target resolution
-                // has failed; keep this callback explicitly unattributed.
+                // like the parent stop path. Keep the visible event
+                // unattributed, but still apply it to the durable ledger by
+                // session identity; passing a rejected/stale surface back
+                // would reintroduce the wrong-pane state we are closing.
                 reportTargetResolutionFailure()
-                let childJournalKind: AgentJournalEventKind = {
-                    if case .codexSubagentStart = action {
-                        return .childSpawned
-                    }
-                    return .childCompleted
-                }()
-                emitJournal(
-                    childJournalKind,
-                    workspaceId: nil,
-                    surfaceId: nil,
-                    unattributedReason: "target-unresolved",
-                    isSubagent: true,
-                    detail: "child-lifecycle"
-                )
-                didSendFeedTelemetry = true
-                print("{}")
-                return
             }
-            let workspaceId = target.workspaceId
-            let surfaceId = target.surfaceId
             let agentId = input.rawObject.flatMap {
                 firstString(in: $0, keys: ["agent_id", "agentId"])
             } ?? input.object.flatMap {
@@ -34559,6 +34544,7 @@ export default CMUXSessionRestore;
                 childJournalKind,
                 workspaceId: workspaceId,
                 surfaceId: surfaceId,
+                unattributedReason: target == nil ? "target-unresolved" : nil,
                 isSubagent: true,
                 detail: decision.ownership == .foreground ? nil : "child-lifecycle-nested"
             )

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -34515,6 +34515,10 @@ export default CMUXSessionRestore;
                 // session identity; passing a rejected/stale surface back
                 // would reintroduce the wrong-pane state we are closing.
                 reportTargetResolutionFailure()
+                // The unattributed journal below is the diagnostic record for
+                // this event. Do not let the function-level telemetry defer
+                // reuse a stale ambient workspace claim.
+                didSendFeedTelemetry = true
             }
             let agentId = input.rawObject.flatMap {
                 firstString(in: $0, keys: ["agent_id", "agentId"])

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -7411,6 +7411,9 @@ struct CMUXCLI {
                     let workspaceArg = explicitWorkspaceArg ?? (windowRaw == nil ? env["CMUX_WORKSPACE_ID"] : nil)
                     if let workspaceArg, isUUID(workspaceArg) || explicitWorkspaceArg != nil {
                         params["preferred_workspace_id"] = isUUID(workspaceArg) ? workspaceArg : try resolveWorkspaceId(workspaceArg, client: client)
+                        if explicitWorkspaceArg == nil {
+                            params["preferred_workspace_is_explicit"] = false
+                        }
                     }
                     if windowRaw == nil, let surfaceId = env["CMUX_SURFACE_ID"], isUUID(surfaceId) {
                         params["preferred_surface_id"] = surfaceId
@@ -34560,7 +34563,8 @@ export default CMUXSessionRestore;
                 surfaceId: surfaceId,
                 unattributedReason: target == nil ? "target-unresolved" : nil,
                 isSubagent: true,
-                detail: decision.ownership == .foreground ? nil : "child-lifecycle-nested"
+                detail: decision.ownership == .foreground ? nil : "child-lifecycle-nested",
+                responseTimeout: target == nil ? 0.5 : nil
             )
             if case .codexSubagentStop = action,
                decision.ownership == .foreground,
@@ -38781,8 +38785,11 @@ export default CMUXSessionRestore;
                       isUUID(workspaceId),
                       let rawSurfaceId = firstString(in: stdinObj, keys: ["surface_id", "surfaceId"])
                           ?? env["CMUX_SURFACE_ID"],
-                      let activeClient = client ?? makeLifecycleProbeClient(),
-                      let listed = try? activeClient.sendV2(
+                      let activeClient = client ?? makeLifecycleProbeClient() else {
+                    return nil
+                }
+                func resolveFromSurfaceList() -> (workspaceId: String, surfaceId: String)? {
+                    guard let listed = try? activeClient.sendV2(
                           method: "surface.list",
                           params: ["workspace_id": workspaceId],
                           responseTimeout: max(0.01, lifecycleProbeDeadline.timeIntervalSinceNow),
@@ -38795,9 +38802,37 @@ export default CMUXSessionRestore;
                       }),
                       let surfaceId = surface["id"] as? String,
                       isUUID(surfaceId) else {
+                        return nil
+                    }
+                    return (workspaceId, surfaceId)
+                }
+
+                guard isUUID(rawSurfaceId) else {
+                    return resolveFromSurfaceList()
+                }
+                do {
+                    var params: [String: Any] = ["surface_id": rawSurfaceId]
+                    params["workspace_id"] = workspaceId
+                    let target = try activeClient.sendV2(
+                        method: "agent.resolve_delivery_target",
+                        params: params,
+                        responseTimeout: max(0.01, lifecycleProbeDeadline.timeIntervalSinceNow),
+                        deadline: lifecycleProbeDeadline
+                    )
+                    guard (target["source"] as? String) == "surface",
+                          let liveWorkspaceId = normalizedHandleValue(target["workspace_id"] as? String),
+                          isUUID(liveWorkspaceId),
+                          let liveSurfaceId = normalizedHandleValue(target["surface_id"] as? String),
+                          isUUID(liveSurfaceId) else {
+                        return nil
+                    }
+                    return (liveWorkspaceId, liveSurfaceId)
+                } catch let error as CLIError where error.v2Code == "method_not_found"
+                        || error.v2Code == "unrecognized_method" {
+                    return resolveFromSurfaceList()
+                } catch {
                     return nil
                 }
-                return (workspaceId, surfaceId)
             }()
             validatedCodexFeedTarget = feedLifecycleTarget
             let decision = lifecycle.recordFeedLifecycle(

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -38759,6 +38759,7 @@ export default CMUXSessionRestore;
             in: stdinObj,
             keys: ["session_id", "sessionId", "conversation_id", "conversationId"]
         ) ?? stableFallbackFeedSessionId(source: source, rawObject: stdinObj, agentPid: agentPid)
+        var validatedCodexFeedTarget: (workspaceId: String, surfaceId: String)?
 
         // Native Codex child events are committed before their telemetry frame
         // is sent. This is the only source used by the Stop path to decide
@@ -38790,6 +38791,7 @@ export default CMUXSessionRestore;
                 }
                 return (workspaceId, surfaceId)
             }()
+            validatedCodexFeedTarget = feedLifecycleTarget
             let decision = lifecycle.recordFeedLifecycle(
                 sessionID: sessionId,
                 eventName: hookEventName,
@@ -38819,6 +38821,37 @@ export default CMUXSessionRestore;
             // Do not let the generic feed frame below reuse stale ambient
             // workspace/surface metadata after this decision.
             guard feedLifecycleTarget != nil else {
+                let diagnosticStore = ClaudeHookSessionStore(processEnv: env)
+                let diagnosticKind: AgentJournalEventKind = hookEventName == "SubagentStart"
+                    ? .childSpawned
+                    : .childCompleted
+                reportAgentHookFailure(
+                    stage: .targetResolution,
+                    agentName: source,
+                    sessionId: sessionId,
+                    event: hookEventName,
+                    store: diagnosticStore,
+                    telemetry: telemetry
+                )
+                if let diagnosticClient = client ?? lifecycleProbeClient {
+                    emitAgentJournalEvent(
+                        client: diagnosticClient,
+                        kind: diagnosticKind,
+                        source: source,
+                        agentKey: "codex",
+                        sessionId: sessionId,
+                        workspaceId: nil,
+                        surfaceId: nil,
+                        unattributedReason: "target-unresolved",
+                        isSubagent: true,
+                        nativeEvent: hookEventName,
+                        detail: "feed-child-lifecycle",
+                        responseTimeout: max(0.01, lifecycleProbeDeadline.timeIntervalSinceNow),
+                        deadline: lifecycleProbeDeadline,
+                        store: diagnosticStore,
+                        telemetry: telemetry
+                    )
+                }
                 print("{}")
                 return
             }
@@ -38832,6 +38865,10 @@ export default CMUXSessionRestore;
         ]
         if let workspaceId = feedWorkspaceId(rawObject: stdinObj, fallback: env["CMUX_WORKSPACE_ID"]) {
             eventDict["workspace_id"] = workspaceId
+        }
+        if let validatedCodexFeedTarget {
+            eventDict["workspace_id"] = validatedCodexFeedTarget.workspaceId
+            eventDict["surface_id"] = validatedCodexFeedTarget.surfaceId
         }
         let toolRequestInput = stdinObj["tool_input"] ?? stdinObj["toolInput"] ?? toolCall?["args"]
         let postToolUseResponseInput = stdinObj["tool_response"]

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -34530,17 +34530,15 @@ export default CMUXSessionRestore;
                 if case .codexSubagentStart = action { return true }
                 return false
             }()
-            let canApplyLedger = target != nil || codexLifecycle.hasRecord(sessionID: sessionId)
-            let decision = canApplyLedger
-                ? codexLifecycle.subagent(
-                    sessionID: sessionId,
-                    agentID: agentId,
-                    turnID: turnId,
-                    workspaceID: workspaceId,
-                    surfaceID: surfaceId,
-                    starts: starts
-                )
-                : .ignored
+            let decision = codexLifecycle.subagent(
+                sessionID: sessionId,
+                agentID: agentId,
+                turnID: turnId,
+                workspaceID: workspaceId,
+                surfaceID: surfaceId,
+                starts: starts,
+                allowCreate: target != nil
+            )
             let childJournalKind: AgentJournalEventKind = {
                 if case .codexSubagentStart = action {
                     return .childSpawned
@@ -34558,7 +34556,8 @@ export default CMUXSessionRestore;
             if case .codexSubagentStop = action,
                decision.ownership == .foreground,
                decision.settlement == .settled,
-               decision.shouldNotify {
+               decision.shouldNotify,
+               !skipCodexLegacyPromptStop {
                 spawnDetachedCodexSettledStop(
                     payload: rawInput,
                     environment: env,
@@ -35170,33 +35169,25 @@ export default CMUXSessionRestore;
             let resolvedTarget = resolveAgentHookTarget(mapped: mapped)
             let resolvedWorkspaceId = resolvedTarget?.workspaceId
             let resolvedSurfaceId = resolvedTarget?.surfaceId
-            let codexLedgerRecordExists: Bool = {
-                guard def.name == "codex",
-                      !sessionId.isEmpty,
-                      let codexLifecycle else {
-                    return false
-                }
-                return codexLifecycle.hasRecord(sessionID: sessionId)
-            }()
             // Admit ownership before touching the legacy prompt-depth store.
             // A nested reviewer must not be able to create or mutate a generic
             // session record merely because it inherited the foreground PID.
             let codexStopOwnership: CodexTurnLedgerDecision? = {
                 guard def.name == "codex",
                       !sessionId.isEmpty,
-                      let codexLifecycle,
-                      resolvedTarget != nil || codexLedgerRecordExists else {
+                      let codexLifecycle else {
                     return nil
                 }
                 return codexLifecycle.observe(
                     sessionID: sessionId,
                     workspaceID: resolvedWorkspaceId,
-                    surfaceID: resolvedSurfaceId
+                    surfaceID: resolvedSurfaceId,
+                    allowCreate: resolvedTarget != nil
                 )
             }()
             var codexStopDecision = codexStopOwnership
             if def.name == "codex", !sessionId.isEmpty,
-               resolvedTarget != nil || codexLedgerRecordExists {
+               resolvedTarget != nil || codexStopOwnership?.ownership == .foreground {
                 guard codexStopDecision?.ownership == .foreground else {
                     telemetry.breadcrumb("codex-hook.stop.nested-or-unknown")
                     print("{}")
@@ -35216,17 +35207,19 @@ export default CMUXSessionRestore;
             guard let target = resolvedTarget else {
                 if def.name == "codex",
                    !sessionId.isEmpty,
-                   codexLedgerRecordExists,
                    let codexLifecycle,
                    codexStopDecision?.ownership == .foreground {
                     codexStopDecision = codexLifecycle.stop(
                         sessionID: sessionId,
                         turnID: input.turnID,
                         workspaceID: nil,
-                        surfaceID: nil
+                        surfaceID: nil,
+                        claimNotification: false,
+                        allowCreate: false
                     )
                     if codexStopDecision?.settlement == .settled,
-                       codexStopDecision?.shouldNotify == true {
+                       codexStopDecision?.shouldNotify == true,
+                       !skipCodexLegacyPromptStop {
                         // Re-run the normal projection out of band; it will
                         // re-resolve the pane and still fail closed if proof
                         // remains unavailable.

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -33345,6 +33345,7 @@ export default CMUXSessionRestore;
         let env = ProcessInfo.processInfo.environment
         let skipCodexLegacyPromptStop = env["CMUX_CODEX_SETTLED_CHILD_STOP"] == "1"
         let isCodexSettledStopRetry = skipCodexLegacyPromptStop
+        let settledStopTurnID = normalizedHookValue(env["CMUX_CODEX_SETTLED_STOP_TURN_ID"])
         let subcommand = commandArgs.first?.lowercased() ?? ""
         let hookArgs = Array(commandArgs.dropFirst())
         let cursorShellEvent = def.name == "cursor" && subcommand == "shell-exec"
@@ -34572,7 +34573,8 @@ export default CMUXSessionRestore;
                 spawnDetachedCodexSettledStop(
                     payload: rawInput,
                     environment: env,
-                    telemetry: telemetry
+                    telemetry: telemetry,
+                    turnID: decision.turnID
                 )
             }
 
@@ -35186,6 +35188,9 @@ export default CMUXSessionRestore;
 
         case .stop:
             let mapped = sessionId.isEmpty ? nil : (try? store.lookup(sessionId: sessionId))
+            let effectiveCodexStopTurnID = def.name == "codex" && isCodexSettledStopRetry
+                ? (normalizedHookValue(input.turnId) ?? settledStopTurnID)
+                : input.turnId
             let resolvedTarget = resolveAgentHookTarget(mapped: mapped)
             let resolvedWorkspaceId = resolvedTarget?.workspaceId
             let resolvedSurfaceId = resolvedTarget?.surfaceId
@@ -35219,7 +35224,7 @@ export default CMUXSessionRestore;
             // foreground Codex transcript monitor while it inherits its PID.
             if def.name == "codex", !sessionId.isEmpty,
                codexStopDecision?.ownership == .foreground {
-                let stopTurnId = input.turnId?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                let stopTurnId = normalizedHookValue(effectiveCodexStopTurnID) ?? ""
                 if !stopTurnId.isEmpty {
                     retireCodexMonitorLeases(sessionId: sessionId, turnId: stopTurnId, env: env)
                 }
@@ -35231,7 +35236,7 @@ export default CMUXSessionRestore;
                    codexStopDecision?.ownership == .foreground {
                     codexStopDecision = codexLifecycle.stop(
                         sessionID: sessionId,
-                        turnID: input.turnID,
+                        turnID: effectiveCodexStopTurnID,
                         workspaceID: nil,
                         surfaceID: nil,
                         claimNotification: false,
@@ -35246,7 +35251,8 @@ export default CMUXSessionRestore;
                         spawnDetachedCodexSettledStop(
                             payload: rawInput,
                             environment: env,
-                            telemetry: telemetry
+                            telemetry: telemetry,
+                            turnID: codexStopDecision?.turnID
                         )
                     }
                 }
@@ -35426,7 +35432,7 @@ export default CMUXSessionRestore;
                let codexLifecycle {
                 codexStopDecision = codexLifecycle.stop(
                     sessionID: sessionId,
-                    turnID: input.turnId,
+                    turnID: effectiveCodexStopTurnID,
                     workspaceID: workspaceId,
                     surfaceID: surfaceId,
                     // Tokenized Codex launches must not let a delayed Stop
@@ -38780,14 +38786,29 @@ export default CMUXSessionRestore;
            hookEventName == "SubagentStart" || hookEventName == "SubagentStop" {
             let lifecycle = CodexTurnLifecycleCoordinator(environment: env, cli: self)
             let feedLifecycleTarget: (workspaceId: String, surfaceId: String)? = {
-                guard let workspaceId = feedWorkspaceId(rawObject: stdinObj, fallback: env["CMUX_WORKSPACE_ID"]),
-                      isUUID(workspaceId),
-                      let rawSurfaceId = firstString(in: stdinObj, keys: ["surface_id", "surfaceId"])
+                guard let rawSurfaceId = firstString(in: stdinObj, keys: ["surface_id", "surfaceId"])
                           ?? env["CMUX_SURFACE_ID"],
                       let activeClient = client ?? makeLifecycleProbeClient() else {
                     return nil
                 }
-                func resolveFromSurfaceList() -> (workspaceId: String, surfaceId: String)? {
+                let rawWorkspaceId = feedWorkspaceId(
+                    rawObject: stdinObj,
+                    fallback: env["CMUX_WORKSPACE_ID"]
+                )
+                let workspaceId = rawWorkspaceId.flatMap { raw in
+                    guard isUUID(raw) else {
+                        return try? resolveWorkspaceId(
+                            raw,
+                            client: activeClient,
+                            responseTimeout: max(0.01, lifecycleProbeDeadline.timeIntervalSinceNow),
+                            deadline: lifecycleProbeDeadline
+                        )
+                    }
+                    return raw
+                }
+                func resolveFromSurfaceList(
+                    workspaceId: String
+                ) -> (workspaceId: String, surfaceId: String)? {
                     guard let listed = try? activeClient.sendV2(
                           method: "surface.list",
                           params: ["workspace_id": workspaceId],
@@ -38807,11 +38828,12 @@ export default CMUXSessionRestore;
                 }
 
                 guard isUUID(rawSurfaceId) else {
-                    return resolveFromSurfaceList()
+                    guard let workspaceId else { return nil }
+                    return resolveFromSurfaceList(workspaceId: workspaceId)
                 }
+                var params: [String: Any] = ["surface_id": rawSurfaceId]
+                if let workspaceId { params["workspace_id"] = workspaceId }
                 do {
-                    var params: [String: Any] = ["surface_id": rawSurfaceId]
-                    params["workspace_id"] = workspaceId
                     let target = try activeClient.sendV2(
                         method: "agent.resolve_delivery_target",
                         params: params,
@@ -38828,7 +38850,8 @@ export default CMUXSessionRestore;
                     return (liveWorkspaceId, liveSurfaceId)
                 } catch let error as CLIError where error.v2Code == "method_not_found"
                         || error.v2Code == "unrecognized_method" {
-                    return resolveFromSurfaceList()
+                    guard let workspaceId else { return nil }
+                    return resolveFromSurfaceList(workspaceId: workspaceId)
                 } catch {
                     return nil
                 }
@@ -38856,7 +38879,8 @@ export default CMUXSessionRestore;
                 spawnDetachedCodexSettledStop(
                     payload: payload,
                     environment: env,
-                    telemetry: telemetry
+                    telemetry: telemetry,
+                    turnID: decision.turnID
                 )
             }
             // A rejected lifecycle identity is intentionally diagnostic-only.

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -34556,8 +34556,7 @@ export default CMUXSessionRestore;
             if case .codexSubagentStop = action,
                decision.ownership == .foreground,
                decision.settlement == .settled,
-               decision.shouldNotify,
-               !skipCodexLegacyPromptStop {
+               decision.shouldNotify {
                 spawnDetachedCodexSettledStop(
                     payload: rawInput,
                     environment: env,
@@ -35219,8 +35218,7 @@ export default CMUXSessionRestore;
                         requireCurrentTurn: true
                     )
                     if codexStopDecision?.settlement == .settled,
-                       codexStopDecision?.shouldNotify == true,
-                       !skipCodexLegacyPromptStop {
+                       codexStopDecision?.shouldNotify == true {
                         // Re-run the normal projection out of band; it will
                         // re-resolve the pane and still fail closed if proof
                         // remains unavailable.
@@ -35409,7 +35407,12 @@ export default CMUXSessionRestore;
                     sessionID: sessionId,
                     turnID: input.turnId,
                     workspaceID: workspaceId,
-                    surfaceID: surfaceId
+                    surfaceID: surfaceId,
+                    // Tokenized Codex launches must not let a delayed Stop
+                    // for an older turn settle the currently active turn.
+                    // Legacy unwrapped launches retain their historical
+                    // unseen-turn compatibility path.
+                    requireCurrentTurn: codexLifecycle.usesLegacyIdentity == false
                 )
             }
             if def.name == "codex",

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -7411,9 +7411,7 @@ struct CMUXCLI {
                     let workspaceArg = explicitWorkspaceArg ?? (windowRaw == nil ? env["CMUX_WORKSPACE_ID"] : nil)
                     if let workspaceArg, isUUID(workspaceArg) || explicitWorkspaceArg != nil {
                         params["preferred_workspace_id"] = isUUID(workspaceArg) ? workspaceArg : try resolveWorkspaceId(workspaceArg, client: client)
-                        if explicitWorkspaceArg == nil {
-                            params["preferred_workspace_is_explicit"] = false
-                        }
+                        params["preferred_workspace_is_explicit"] = explicitWorkspaceArg != nil
                     }
                     if windowRaw == nil, let surfaceId = env["CMUX_SURFACE_ID"], isUUID(surfaceId) {
                         params["preferred_surface_id"] = surfaceId
@@ -33346,6 +33344,7 @@ export default CMUXSessionRestore;
     ) throws {
         let env = ProcessInfo.processInfo.environment
         let skipCodexLegacyPromptStop = env["CMUX_CODEX_SETTLED_CHILD_STOP"] == "1"
+        let isCodexSettledStopRetry = skipCodexLegacyPromptStop
         let subcommand = commandArgs.first?.lowercased() ?? ""
         let hookArgs = Array(commandArgs.dropFirst())
         let cursorShellEvent = def.name == "cursor" && subcommand == "shell-exec"
@@ -35434,7 +35433,7 @@ export default CMUXSessionRestore;
                     // for an older turn settle the currently active turn.
                     // Legacy unwrapped launches retain their historical
                     // unseen-turn compatibility path.
-                    requireCurrentTurn: codexLifecycle.usesLegacyIdentity == false
+                    requireCurrentTurn: codexLifecycle.usesLegacyIdentity == false || isCodexSettledStopRetry
                 )
             }
             if def.name == "codex",

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -34505,9 +34505,32 @@ export default CMUXSessionRestore;
                 break
             }
             let mapped = sessionId.isEmpty ? nil : (try? store.lookup(sessionId: sessionId))
-            let target = resolveAgentHookTarget(mapped: mapped)
-            let workspaceId = target?.workspaceId ?? resolvedDirectWorkspaceArg ?? mapped?.workspaceId
-            let surfaceId = target?.surfaceId ?? resolvedDirectSurfaceArg ?? mapped?.surfaceId
+            guard let target = resolveAgentHookTarget(mapped: mapped) else {
+                // Child lifecycle state participates in Codex settlement just
+                // like the parent stop path. Never pass a rejected/stale
+                // mapped surface back into the ledger after target resolution
+                // has failed; keep this callback explicitly unattributed.
+                reportTargetResolutionFailure()
+                let childJournalKind: AgentJournalEventKind = {
+                    if case .codexSubagentStart = action {
+                        return .childSpawned
+                    }
+                    return .childCompleted
+                }()
+                emitJournal(
+                    childJournalKind,
+                    workspaceId: nil,
+                    surfaceId: nil,
+                    unattributedReason: "target-unresolved",
+                    isSubagent: true,
+                    detail: "child-lifecycle"
+                )
+                didSendFeedTelemetry = true
+                print("{}")
+                return
+            }
+            let workspaceId = target.workspaceId
+            let surfaceId = target.surfaceId
             let agentId = input.rawObject.flatMap {
                 firstString(in: $0, keys: ["agent_id", "agentId"])
             } ?? input.object.flatMap {
@@ -34526,21 +34549,19 @@ export default CMUXSessionRestore;
                 surfaceID: surfaceId,
                 starts: starts
             )
-            if let workspaceId, let surfaceId {
-                let childJournalKind: AgentJournalEventKind = {
-                    if case .codexSubagentStart = action {
-                        return .childSpawned
-                    }
-                    return .childCompleted
-                }()
-                emitJournal(
-                    childJournalKind,
-                    workspaceId: workspaceId,
-                    surfaceId: surfaceId,
-                    isSubagent: true,
-                    detail: decision.ownership == .foreground ? nil : "child-lifecycle-nested"
-                )
-            }
+            let childJournalKind: AgentJournalEventKind = {
+                if case .codexSubagentStart = action {
+                    return .childSpawned
+                }
+                return .childCompleted
+            }()
+            emitJournal(
+                childJournalKind,
+                workspaceId: workspaceId,
+                surfaceId: surfaceId,
+                isSubagent: true,
+                detail: decision.ownership == .foreground ? nil : "child-lifecycle-nested"
+            )
             if case .codexSubagentStop = action,
                decision.ownership == .foreground,
                decision.settlement == .settled,

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -34746,6 +34746,15 @@ export default CMUXSessionRestore;
         case .promptSubmit:
             let mapped = sessionId.isEmpty ? nil : (try? store.lookup(sessionId: sessionId))
             guard let target = resolveAgentHookTarget(mapped: mapped) else {
+                if def.name == "codex", !sessionId.isEmpty, let codexLifecycle {
+                    _ = codexLifecycle.promptSubmit(
+                        sessionID: sessionId,
+                        turnID: input.turnId,
+                        workspaceID: nil,
+                        surfaceID: nil,
+                        allowCreate: false
+                    )
+                }
                 reportTargetResolutionFailure()
                 emitJournal(.turnStarted, workspaceId: nil, surfaceId: nil, unattributedReason: "target-unresolved")
                 didSendFeedTelemetry = true

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -33441,15 +33441,6 @@ export default CMUXSessionRestore;
                 ($0["id"] as? String) == candidate || ($0["ref"] as? String) == candidate
             }) ? candidate : nil
         }
-        func resolveDefaultSurfaceId(workspaceId: String) -> String? {
-            try? resolveSurfaceId(
-                nil,
-                workspaceId: workspaceId,
-                client: client,
-                responseTimeout: cursorShellRemainingTimeout(),
-                deadline: cursorShellDeadline
-            )
-        }
         let resolvedDirectWorkspaceArg = strictPiTarget?.workspaceId
             ?? resolveAccessibleWorkspaceId(directWorkspaceArg)
         // Only an EXPLICIT --workspace flag that fails to resolve is a hard, hook-dropping error. A
@@ -34084,10 +34075,19 @@ export default CMUXSessionRestore;
                     return (workspaceId, surfaceId)
                 }
 
-                guard let surfaceId = resolveDefaultSurfaceId(workspaceId: workspaceId) else {
-                    return nil
-                }
-                return (workspaceId, surfaceId)
+                // A workspace's focused surface is mutable UI state, not
+                // evidence about which agent emitted this hook. Returning it
+                // here would recreate the wrong-pane notification bug whenever
+                // the caller's pane identity is stale or unavailable.
+                telemetry.breadcrumb("\(def.name)-hook.target.no-authoritative-surface")
+#if DEBUG
+                agentHookDebugLog(
+                    "agentHook.target.nil agent=\(def.name) subcommand=\(subcommand) session=\(agentHookDebugShort(sessionId)) reason=noAuthoritativeSurface mapped=\(mapped == nil ? 0 : 1)",
+                    socketPath: client.socketPath,
+                    env: env
+                )
+#endif
+                return nil
             }
 
             // Only live-process evidence may replace an ambient workspace; an ambient TTY stays inside it.

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -34530,14 +34530,17 @@ export default CMUXSessionRestore;
                 if case .codexSubagentStart = action { return true }
                 return false
             }()
-            let decision = codexLifecycle.subagent(
-                sessionID: sessionId,
-                agentID: agentId,
-                turnID: turnId,
-                workspaceID: workspaceId,
-                surfaceID: surfaceId,
-                starts: starts
-            )
+            let canApplyLedger = target != nil || codexLifecycle.hasRecord(sessionID: sessionId)
+            let decision = canApplyLedger
+                ? codexLifecycle.subagent(
+                    sessionID: sessionId,
+                    agentID: agentId,
+                    turnID: turnId,
+                    workspaceID: workspaceId,
+                    surfaceID: surfaceId,
+                    starts: starts
+                )
+                : .ignored
             let childJournalKind: AgentJournalEventKind = {
                 if case .codexSubagentStart = action {
                     return .childSpawned
@@ -35164,23 +35167,36 @@ export default CMUXSessionRestore;
 
         case .stop:
             let mapped = sessionId.isEmpty ? nil : (try? store.lookup(sessionId: sessionId))
+            let resolvedTarget = resolveAgentHookTarget(mapped: mapped)
+            let resolvedWorkspaceId = resolvedTarget?.workspaceId
+            let resolvedSurfaceId = resolvedTarget?.surfaceId
+            let codexLedgerRecordExists: Bool = {
+                guard def.name == "codex",
+                      !sessionId.isEmpty,
+                      let codexLifecycle else {
+                    return false
+                }
+                return codexLifecycle.hasRecord(sessionID: sessionId)
+            }()
             // Admit ownership before touching the legacy prompt-depth store.
             // A nested reviewer must not be able to create or mutate a generic
             // session record merely because it inherited the foreground PID.
             let codexStopOwnership: CodexTurnLedgerDecision? = {
                 guard def.name == "codex",
                       !sessionId.isEmpty,
-                      let codexLifecycle else {
+                      let codexLifecycle,
+                      resolvedTarget != nil || codexLedgerRecordExists else {
                     return nil
                 }
                 return codexLifecycle.observe(
                     sessionID: sessionId,
-                    workspaceID: resolvedDirectWorkspaceArg ?? mapped?.workspaceId,
-                    surfaceID: resolvedDirectSurfaceArg ?? mapped?.surfaceId
+                    workspaceID: resolvedWorkspaceId,
+                    surfaceID: resolvedSurfaceId
                 )
             }()
             var codexStopDecision = codexStopOwnership
-            if def.name == "codex", !sessionId.isEmpty {
+            if def.name == "codex", !sessionId.isEmpty,
+               resolvedTarget != nil || codexLedgerRecordExists {
                 guard codexStopDecision?.ownership == .foreground else {
                     telemetry.breadcrumb("codex-hook.stop.nested-or-unknown")
                     print("{}")
@@ -35190,13 +35206,37 @@ export default CMUXSessionRestore;
             // Retire only after the ledger admits this callback as the
             // foreground owner. A nested reviewer must not tear down the
             // foreground Codex transcript monitor while it inherits its PID.
-            if def.name == "codex", !sessionId.isEmpty {
+            if def.name == "codex", !sessionId.isEmpty,
+               codexStopDecision?.ownership == .foreground {
                 let stopTurnId = input.turnId?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
                 if !stopTurnId.isEmpty {
                     retireCodexMonitorLeases(sessionId: sessionId, turnId: stopTurnId, env: env)
                 }
             }
-            guard let target = resolveAgentHookTarget(mapped: mapped) else {
+            guard let target = resolvedTarget else {
+                if def.name == "codex",
+                   !sessionId.isEmpty,
+                   codexLedgerRecordExists,
+                   let codexLifecycle,
+                   codexStopDecision?.ownership == .foreground {
+                    codexStopDecision = codexLifecycle.stop(
+                        sessionID: sessionId,
+                        turnID: input.turnID,
+                        workspaceID: nil,
+                        surfaceID: nil
+                    )
+                    if codexStopDecision?.settlement == .settled,
+                       codexStopDecision?.shouldNotify == true {
+                        // Re-run the normal projection out of band; it will
+                        // re-resolve the pane and still fail closed if proof
+                        // remains unavailable.
+                        spawnDetachedCodexSettledStop(
+                            payload: rawInput,
+                            environment: env,
+                            telemetry: telemetry
+                        )
+                    }
+                }
                 reportTargetResolutionFailure()
                 emitJournal(.turnCompleted, workspaceId: nil, surfaceId: nil, unattributedReason: "target-unresolved")
                 didSendFeedTelemetry = true

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -35215,7 +35215,8 @@ export default CMUXSessionRestore;
                         workspaceID: nil,
                         surfaceID: nil,
                         claimNotification: false,
-                        allowCreate: false
+                        allowCreate: false,
+                        requireCurrentTurn: true
                     )
                     if codexStopDecision?.settlement == .settled,
                        codexStopDecision?.shouldNotify == true,

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -7412,7 +7412,8 @@ struct CMUXCLI {
                     if let workspaceArg, isUUID(workspaceArg) || explicitWorkspaceArg != nil {
                         params["preferred_workspace_id"] = isUUID(workspaceArg) ? workspaceArg : try resolveWorkspaceId(workspaceArg, client: client)
                     }
-                    if windowRaw == nil, explicitWorkspaceArg == nil,
+                    if windowRaw == nil,
+                       (explicitWorkspaceArg == nil || client.isRelayBacked),
                        let surfaceId = env["CMUX_SURFACE_ID"], isUUID(surfaceId) {
                         params["preferred_surface_id"] = surfaceId
                     }
@@ -35225,7 +35226,7 @@ export default CMUXSessionRestore;
                         surfaceID: nil,
                         claimNotification: false,
                         allowCreate: false,
-                        requireCurrentTurn: codexLifecycle.usesLegacyIdentity == false
+                        requireCurrentTurn: true
                     )
                     if codexStopDecision?.settlement == .settled,
                        codexStopDecision?.shouldNotify == true {

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+PortalLease.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+PortalLease.swift
@@ -35,6 +35,16 @@ extension TerminalSurface {
         portalLifecycleGeneration
     }
 
+    /// Returns whether this host and incarnation currently own the portal
+    /// lease, including while the host is detached from its window.
+    public func ownsPortalHost(
+        hostId: ObjectIdentifier,
+        instanceSerial: UInt64
+    ) -> Bool {
+        guard let lease = activePortalHostLease else { return false }
+        return lease.hostId == hostId && lease.instanceSerial == instanceSerial
+    }
+
     /// Keeps retired representable hosts from reclaiming the surface after a
     /// newer host has taken authority. The model epoch supersedes host creation
     /// order so a legitimate rollback can still return to an older host.

--- a/Sources/AgentDeliveryTargetResolution.swift
+++ b/Sources/AgentDeliveryTargetResolution.swift
@@ -178,6 +178,10 @@ extension Workspace {
             panelId: transfer.panelId,
             ttyName: ttyName
         )
+        PortScanner.shared.kick(
+            workspaceId: id,
+            panelId: transfer.panelId
+        )
     }
 
     /// Host-local TTY bindings eligible to identify a process running on this

--- a/Sources/AgentDeliveryTargetResolution.swift
+++ b/Sources/AgentDeliveryTargetResolution.swift
@@ -147,7 +147,6 @@ extension Workspace {
             return
         }
         if transfer.ttyNameWasReportedByCurrentRuntime,
-           !transfer.isRemoteTerminal,
            let terminal = panels[transfer.panelId] as? TerminalPanel,
            transfer.ttyReportRuntimeSurfaceGeneration ==
             terminal.surface.runtimeSurfaceGeneration {
@@ -158,8 +157,7 @@ extension Workspace {
     }
 
     func restoreTransferredSurfaceTTYRuntimeProofIfNeeded(from transfer: DetachedSurfaceTransfer) {
-        guard transfer.ttyNameWasReportedByCurrentRuntime,
-              !transfer.isRemoteTerminal else { return }
+        guard transfer.ttyNameWasReportedByCurrentRuntime else { return }
         if !surfaceRegistry.runtimeReportedTTYSurfaceIDs.contains(transfer.panelId) {
             adoptTransferredSurfaceTTYName(from: transfer)
         }
@@ -167,7 +165,8 @@ extension Workspace {
         // preserved current-generation report under the destination key so
         // strict caller-TTY resolution keeps its freshness check after a
         // local surface move.
-        guard !isRemoteWorkspace,
+        guard !transfer.isRemoteTerminal,
+              !isRemoteWorkspace,
               !isRemoteTmuxMirror,
               let terminal = panels[transfer.panelId] as? TerminalPanel,
               hasCurrentRuntimeReportedTTY(panelId: transfer.panelId, terminal: terminal),

--- a/Sources/AgentDeliveryTargetResolution.swift
+++ b/Sources/AgentDeliveryTargetResolution.swift
@@ -157,11 +157,26 @@ extension Workspace {
     }
 
     func restoreTransferredSurfaceTTYRuntimeProofIfNeeded(from transfer: DetachedSurfaceTransfer) {
-        guard transfer.ttyNameWasReportedByCurrentRuntime,
-              !surfaceRegistry.runtimeReportedTTYSurfaceIDs.contains(transfer.panelId) else {
+        guard transfer.ttyNameWasReportedByCurrentRuntime else { return }
+        if !surfaceRegistry.runtimeReportedTTYSurfaceIDs.contains(transfer.panelId) {
+            adoptTransferredSurfaceTTYName(from: transfer)
+        }
+        // Detaching retires the source PortScanner key. Re-register the
+        // preserved current-generation report under the destination key so
+        // strict caller-TTY resolution keeps its freshness check after a
+        // local surface move.
+        guard !isRemoteWorkspace,
+              !isRemoteTmuxMirror,
+              let terminal = panels[transfer.panelId] as? TerminalPanel,
+              hasCurrentRuntimeReportedTTY(panelId: transfer.panelId, terminal: terminal),
+              let ttyName = surfaceTTYNames[transfer.panelId] else {
             return
         }
-        adoptTransferredSurfaceTTYName(from: transfer)
+        PortScanner.shared.registerTTY(
+            workspaceId: id,
+            panelId: transfer.panelId,
+            ttyName: ttyName
+        )
     }
 
     /// Host-local TTY bindings eligible to identify a process running on this

--- a/Sources/AgentDeliveryTargetResolution.swift
+++ b/Sources/AgentDeliveryTargetResolution.swift
@@ -147,6 +147,7 @@ extension Workspace {
             return
         }
         if transfer.ttyNameWasReportedByCurrentRuntime,
+           !transfer.isRemoteTerminal,
            let terminal = panels[transfer.panelId] as? TerminalPanel,
            transfer.ttyReportRuntimeSurfaceGeneration ==
             terminal.surface.runtimeSurfaceGeneration {
@@ -157,7 +158,8 @@ extension Workspace {
     }
 
     func restoreTransferredSurfaceTTYRuntimeProofIfNeeded(from transfer: DetachedSurfaceTransfer) {
-        guard transfer.ttyNameWasReportedByCurrentRuntime else { return }
+        guard transfer.ttyNameWasReportedByCurrentRuntime,
+              !transfer.isRemoteTerminal else { return }
         if !surfaceRegistry.runtimeReportedTTYSurfaceIDs.contains(transfer.panelId) {
             adoptTransferredSurfaceTTYName(from: transfer)
         }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -13567,6 +13567,11 @@ struct GhosttyTerminalView: NSViewRepresentable {
         coordinator.lastBoundHostId = nil
         coordinator.portalReconciliationScheduler.cancel()
         let hostedView = coordinator.hostedView
+        let host = nsView as? HostContainerView
+        let wasBoundToDismantledHost: Bool = {
+            guard let host, let hostedView else { return false }
+            return TerminalWindowPortalRegistry.hasEntry(for: hostedView, boundTo: host)
+        }()
 #if DEBUG
         if let hostedView {
             if let snapshot = AppDelegate.shared?.tabManager?.debugCurrentWorkspaceSwitchSnapshot() {
@@ -13585,7 +13590,14 @@ struct GhosttyTerminalView: NSViewRepresentable {
         }
 #endif
 
-        if let host = nsView as? HostContainerView {
+        // Only the host that is still bound to this surface may clear the
+        // shared ring. Do this before preparing a replacement so a synchronous
+        // hand-off cannot let the old teardown hide the new owner's ring.
+        if wasBoundToDismantledHost {
+            hostedView?.setNotificationRing(visible: false)
+        }
+
+        if let host {
             host.onDidMoveToWindow = nil
             host.onGeometryChanged = nil
             // The owner's vacate path drops its own wake-up; a candidate that
@@ -13603,7 +13615,6 @@ struct GhosttyTerminalView: NSViewRepresentable {
 
         // Preserve the portal lease across transient rebuilds, but reset the
         // surface-local ring; the next reconciliation reapplies current state.
-        hostedView?.setNotificationRing(visible: false)
         hostedView?.setFocusHandler(nil)
         hostedView?.setTriggerFlashHandler(nil)
         hostedView?.setDropZoneOverlay(zone: nil)

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -13601,9 +13601,9 @@ struct GhosttyTerminalView: NSViewRepresentable {
             )
         }
 
-        // SwiftUI can transiently dismantle/rebuild NSViewRepresentable instances during split
-        // tree updates. Do not drop the portal lease or force visible/active false here; that
-        // causes avoidable blackouts when the same hosted view is rebound moments later.
+        // Preserve the portal lease across transient rebuilds, but reset the
+        // surface-local ring; the next reconciliation reapplies current state.
+        hostedView?.setNotificationRing(visible: false)
         hostedView?.setFocusHandler(nil)
         hostedView?.setTriggerFlashHandler(nil)
         hostedView?.setDropZoneOverlay(zone: nil)

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -13570,7 +13570,14 @@ struct GhosttyTerminalView: NSViewRepresentable {
         let host = nsView as? HostContainerView
         let wasBoundToDismantledHost: Bool = {
             guard let host, let hostedView else { return false }
-            return TerminalWindowPortalRegistry.hasEntry(for: hostedView, boundTo: host)
+            guard TerminalWindowPortalRegistry.hasEntry(for: hostedView, boundTo: host),
+                  let terminalSurface = hostedView.terminalSurface else {
+                return false
+            }
+            return terminalSurface.ownsPortalHost(
+                hostId: ObjectIdentifier(host),
+                instanceSerial: host.instanceSerial
+            )
         }()
 #if DEBUG
         if let hostedView {

--- a/Sources/NotificationDebugEmitter.swift
+++ b/Sources/NotificationDebugEmitter.swift
@@ -275,6 +275,13 @@ final class NotificationDebugEmitter {
         )
     }
 
+    /// Synthetic debug notifications without caller selectors intentionally
+    /// target the focused pane; production caller resolution never uses this
+    /// debug-only default.
+    func defaultTargetForDebugEmission() -> NotificationDebugTarget? {
+        focusedTarget()
+    }
+
     private func displayName(for kind: String) -> String {
         switch kind {
         case "turn-complete":

--- a/Sources/NotificationDebugTarget.swift
+++ b/Sources/NotificationDebugTarget.swift
@@ -15,6 +15,20 @@ struct NotificationDebugTarget: Sendable {
 @MainActor
 extension TerminalController {
     func notificationDebugCallerTarget(params: [String: Any]) -> NotificationDebugTarget? {
+        let hasCallerSelector = [
+            "preferred_workspace_id",
+            "preferred_surface_id",
+            "caller_tty",
+        ].contains { key in
+            guard let value = params[key] else { return false }
+            return !(value is NSNull)
+        }
+        // Keep the long-standing synthetic-debug default explicit and outside
+        // the production caller resolver. A real caller request with any
+        // selector still fails closed when that selector cannot be proven.
+        guard hasCallerSelector else {
+            return NotificationDebugEmitter.shared.defaultTargetForDebugEmission()
+        }
         guard let target = resolvedCallerNotificationTarget(
             preferredWorkspaceId: v2UUID(params, "preferred_workspace_id"),
             preferredSurfaceId: v2UUID(params, "preferred_surface_id"),

--- a/Sources/NotificationDebugTarget.swift
+++ b/Sources/NotificationDebugTarget.swift
@@ -15,6 +15,9 @@ struct NotificationDebugTarget: Sendable {
 @MainActor
 extension TerminalController {
     func notificationDebugCallerTarget(params: [String: Any]) -> NotificationDebugTarget? {
+        let preferredWorkspaceId = v2UUID(params, "preferred_workspace_id")
+        let preferredSurfaceId = v2UUID(params, "preferred_surface_id")
+        let callerTTY = notificationDebugStringParam(params, "caller_tty")
         let hasCallerSelector = [
             "preferred_workspace_id",
             "preferred_surface_id",
@@ -29,10 +32,17 @@ extension TerminalController {
         guard hasCallerSelector else {
             return NotificationDebugEmitter.shared.defaultTargetForDebugEmission()
         }
+        // A non-null selector is an assertion about caller identity. If it is
+        // malformed (or an unknown handle), reject the request rather than
+        // treating it as selector-free and borrowing the focused surface.
+        guard !v2HasNonNullParam(params, "preferred_workspace_id") || preferredWorkspaceId != nil,
+              !v2HasNonNullParam(params, "preferred_surface_id") || preferredSurfaceId != nil,
+              !v2HasNonNullParam(params, "caller_tty") || callerTTY != nil
+        else { return nil }
         guard let target = resolvedCallerNotificationTarget(
-            preferredWorkspaceId: v2UUID(params, "preferred_workspace_id"),
-            preferredSurfaceId: v2UUID(params, "preferred_surface_id"),
-            callerTTY: notificationDebugStringParam(params, "caller_tty"),
+            preferredWorkspaceId: preferredWorkspaceId,
+            preferredSurfaceId: preferredSurfaceId,
+            callerTTY: callerTTY,
             preferTTY: notificationDebugBoolParam(params, "prefer_tty") ?? false,
             preferredWorkspaceIsExplicit: true
         ) else { return nil }

--- a/Sources/NotificationDebugTarget.swift
+++ b/Sources/NotificationDebugTarget.swift
@@ -33,7 +33,8 @@ extension TerminalController {
             preferredWorkspaceId: v2UUID(params, "preferred_workspace_id"),
             preferredSurfaceId: v2UUID(params, "preferred_surface_id"),
             callerTTY: notificationDebugStringParam(params, "caller_tty"),
-            preferTTY: notificationDebugBoolParam(params, "prefer_tty") ?? false
+            preferTTY: notificationDebugBoolParam(params, "prefer_tty") ?? false,
+            preferredWorkspaceIsExplicit: true
         ) else { return nil }
         return NotificationDebugTarget(
             workspaceId: target.workspaceId,

--- a/Sources/TerminalNotificationCallerResolver.swift
+++ b/Sources/TerminalNotificationCallerResolver.swift
@@ -198,6 +198,13 @@ extension TerminalController {
             return TerminalCallerTarget(workspace: workspace, surfaceId: nil)
         }
 
+        // An explicit workspace selector that no longer resolves is a hard
+        // scope failure. Never let a globally resolvable surface or TTY cross
+        // that boundary after the workspace disappears.
+        if preferredWorkspaceIsExplicit, preferredWorkspaceId != nil {
+            return nil
+        }
+
         // With no live workspace selector, a stable surface UUID is stronger
         // than an ordinary (non-preferred) TTY claim and may re-home a pane
         // after a workspace move.

--- a/Sources/TerminalNotificationCallerResolver.swift
+++ b/Sources/TerminalNotificationCallerResolver.swift
@@ -81,7 +81,10 @@ extension TerminalController {
         }
 
         let preferredWorkspaceId = v2UUID(params, "preferred_workspace_id")
-        let preferredWorkspaceIsExplicit = boolParam(params, "preferred_workspace_is_explicit") ?? true
+        // Old clients do not send the provenance bit; preserve their moved-
+        // surface behavior and treat the workspace claim as ambient. New CLI
+        // callers set it explicitly when `--workspace` was supplied.
+        let preferredWorkspaceIsExplicit = boolParam(params, "preferred_workspace_is_explicit") ?? false
         let preferredSurfaceId = v2UUID(params, "preferred_surface_id")
         let callerTTY = stringParam(params, "caller_tty")
         let preferTTY = boolParam(params, "prefer_tty") ?? false

--- a/Sources/TerminalNotificationCallerResolver.swift
+++ b/Sources/TerminalNotificationCallerResolver.swift
@@ -174,11 +174,6 @@ extension TerminalController {
             cachedTTYTarget = callerTTY.flatMap { liveTargetForTTY($0, tabManagers: managers) }
             return cachedTTYTarget
         }
-        // `prefer_tty` is an explicit caller contract used by tmux/PTY
-        // wrappers. Honor it when the caller TTY is proven; otherwise fall
-        // through to the stable preferred surface identity.
-        if preferTTY, let ttyTarget = resolveTTYTarget() { return ttyTarget }
-
         if let preferredWorkspaceId,
            let workspace = workspace(id: preferredWorkspaceId, tabManagers: managers) {
             // An explicit workspace selector is a hard scope. An ambient
@@ -210,6 +205,10 @@ extension TerminalController {
         // after a workspace move.
         if let preferredSurfaceTarget { return preferredSurfaceTarget }
 
+        // `prefer_tty` is an explicit caller contract used by tmux/PTY
+        // wrappers. At this point there is no stronger pane identity or
+        // explicit workspace scope left to protect, so a proven TTY may win.
+        if preferTTY, let ttyTarget = resolveTTYTarget() { return ttyTarget }
         let ttyTarget = resolveTTYTarget()
         if let ttyTarget { return ttyTarget }
 

--- a/Sources/TerminalNotificationCallerResolver.swift
+++ b/Sources/TerminalNotificationCallerResolver.swift
@@ -155,16 +155,18 @@ extension TerminalController {
             preferredWorkspaceId: preferredWorkspaceId,
             preferredSurfaceId: preferredSurfaceId
         )
-        // A stable surface UUID is stronger evidence than a caller TTY. The
-        // workspace claim can be stale after a pane move, so resolve the
-        // surface globally before considering any weaker TTY evidence.
-        if let preferredSurfaceId,
-           let surfaceTarget = targetForSurface(preferredSurfaceId, tabManagers: managers) {
-            return surfaceTarget
+        let preferredSurfaceTarget = preferredSurfaceId.flatMap {
+            targetForSurface($0, tabManagers: managers)
         }
-
         let ttyTarget = callerTTY.flatMap { liveTargetForTTY($0, tabManagers: managers) }
+        // `prefer_tty` is an explicit caller contract used by tmux/PTY
+        // wrappers. Honor it when the caller TTY is proven; otherwise fall
+        // through to the stable preferred surface identity.
         if preferTTY, let ttyTarget { return ttyTarget }
+        // A stable surface UUID is stronger than an ordinary (non-preferred)
+        // TTY claim. The workspace claim can be stale after a pane move, so
+        // resolve the surface globally before the non-preferred TTY fallback.
+        if let preferredSurfaceTarget { return preferredSurfaceTarget }
 
         if let preferredWorkspaceId,
            let workspace = workspace(id: preferredWorkspaceId, tabManagers: managers) {

--- a/Sources/TerminalNotificationCallerResolver.swift
+++ b/Sources/TerminalNotificationCallerResolver.swift
@@ -158,11 +158,18 @@ extension TerminalController {
         let preferredSurfaceTarget = preferredSurfaceId.flatMap {
             targetForSurface($0, tabManagers: managers)
         }
-        let ttyTarget = callerTTY.flatMap { liveTargetForTTY($0, tabManagers: managers) }
+        var didResolveTTY = false
+        var cachedTTYTarget: TerminalCallerTarget?
+        func resolveTTYTarget() -> TerminalCallerTarget? {
+            guard !didResolveTTY else { return cachedTTYTarget }
+            didResolveTTY = true
+            cachedTTYTarget = callerTTY.flatMap { liveTargetForTTY($0, tabManagers: managers) }
+            return cachedTTYTarget
+        }
         // `prefer_tty` is an explicit caller contract used by tmux/PTY
         // wrappers. Honor it when the caller TTY is proven; otherwise fall
         // through to the stable preferred surface identity.
-        if preferTTY, let ttyTarget { return ttyTarget }
+        if preferTTY, let ttyTarget = resolveTTYTarget() { return ttyTarget }
         // A stable surface UUID is stronger than an ordinary (non-preferred)
         // TTY claim. The workspace claim can be stale after a pane move, so
         // resolve the surface globally before the non-preferred TTY fallback.
@@ -170,6 +177,7 @@ extension TerminalController {
 
         if let preferredWorkspaceId,
            let workspace = workspace(id: preferredWorkspaceId, tabManagers: managers) {
+            let ttyTarget = resolveTTYTarget()
             if let ttyTarget, ttyTarget.workspace.id == workspace.id { return ttyTarget }
             // The workspace itself is still a valid delivery scope, but no
             // pane has been proven. Keep the notification workspace-level
@@ -177,6 +185,7 @@ extension TerminalController {
             return TerminalCallerTarget(workspace: workspace, surfaceId: nil)
         }
 
+        let ttyTarget = resolveTTYTarget()
         if let ttyTarget { return ttyTarget }
 
         // A supplied caller TTY or surface that did not resolve is an

--- a/Sources/TerminalNotificationCallerResolver.swift
+++ b/Sources/TerminalNotificationCallerResolver.swift
@@ -170,13 +170,18 @@ extension TerminalController {
         // wrappers. Honor it when the caller TTY is proven; otherwise fall
         // through to the stable preferred surface identity.
         if preferTTY, let ttyTarget = resolveTTYTarget() { return ttyTarget }
-        // A stable surface UUID is stronger than an ordinary (non-preferred)
-        // TTY claim. The workspace claim can be stale after a pane move, so
-        // resolve the surface globally before the non-preferred TTY fallback.
-        if let preferredSurfaceTarget { return preferredSurfaceTarget }
 
         if let preferredWorkspaceId,
            let workspace = workspace(id: preferredWorkspaceId, tabManagers: managers) {
+            // An explicit workspace selector is a hard scope. An ambient
+            // surface claim can belong to a different workspace after a pane
+            // move; do not let that claim override the requested workspace.
+            // A surface identity still outranks TTY evidence when it resolves
+            // inside the requested workspace.
+            if let preferredSurfaceTarget,
+               preferredSurfaceTarget.workspace.id == workspace.id {
+                return preferredSurfaceTarget
+            }
             let ttyTarget = resolveTTYTarget()
             if let ttyTarget, ttyTarget.workspace.id == workspace.id { return ttyTarget }
             // The workspace itself is still a valid delivery scope, but no
@@ -184,6 +189,11 @@ extension TerminalController {
             // instead of borrowing mutable focus state.
             return TerminalCallerTarget(workspace: workspace, surfaceId: nil)
         }
+
+        // With no live workspace selector, a stable surface UUID is stronger
+        // than an ordinary (non-preferred) TTY claim and may re-home a pane
+        // after a workspace move.
+        if let preferredSurfaceTarget { return preferredSurfaceTarget }
 
         let ttyTarget = resolveTTYTarget()
         if let ttyTarget { return ttyTarget }

--- a/Sources/TerminalNotificationCallerResolver.swift
+++ b/Sources/TerminalNotificationCallerResolver.swift
@@ -155,45 +155,40 @@ extension TerminalController {
             preferredWorkspaceId: preferredWorkspaceId,
             preferredSurfaceId: preferredSurfaceId
         )
-        let ttyTarget = callerTTY.flatMap { targetForTTY($0, tabManagers: managers) }
-        if preferTTY, let ttyTarget { return ttyTarget }
-
-        if let preferredWorkspaceId,
-           let workspace = workspace(id: preferredWorkspaceId, tabManagers: managers) {
-            if let preferredSurfaceId,
-               let target = workspace.surfaceOwnershipTarget(for: preferredSurfaceId) {
-                return TerminalCallerTarget(workspace: workspace, surfaceId: target.surfaceID)
-            }
-            // Moved pane (issue #7939): the explicit surface identity outranks
-            // the stale spawn-time workspace claim — follow the surface to the
-            // workspace that owns it NOW instead of falling back to the old
-            // workspace's focused pane.
-            if let preferredSurfaceId,
-               let surfaceTarget = targetForSurface(preferredSurfaceId, tabManagers: managers) {
-                return surfaceTarget
-            }
-            if let ttyTarget, ttyTarget.workspace.id == workspace.id { return ttyTarget }
-            let focusedSurfaceID = workspace.focusedPanelId.flatMap {
-                workspace.surfaceOwnershipTarget(for: $0)?.surfaceID
-            }
-            return TerminalCallerTarget(workspace: workspace, surfaceId: focusedSurfaceID)
-        }
-
-        if let ttyTarget { return ttyTarget }
+        // A stable surface UUID is stronger evidence than a caller TTY. The
+        // workspace claim can be stale after a pane move, so resolve the
+        // surface globally before considering any weaker TTY evidence.
         if let preferredSurfaceId,
            let surfaceTarget = targetForSurface(preferredSurfaceId, tabManagers: managers) {
             return surfaceTarget
         }
-        if let preferredSurfaceId,
-           let selected = selectedWorkspace(in: managers),
-           let target = selected.surfaceOwnershipTarget(for: preferredSurfaceId) {
-            return TerminalCallerTarget(workspace: selected, surfaceId: target.surfaceID)
+
+        let ttyTarget = callerTTY.flatMap { liveTargetForTTY($0, tabManagers: managers) }
+        if preferTTY, let ttyTarget { return ttyTarget }
+
+        if let preferredWorkspaceId,
+           let workspace = workspace(id: preferredWorkspaceId, tabManagers: managers) {
+            if let ttyTarget, ttyTarget.workspace.id == workspace.id { return ttyTarget }
+            // The workspace itself is still a valid delivery scope, but no
+            // pane has been proven. Keep the notification workspace-level
+            // instead of borrowing mutable focus state.
+            return TerminalCallerTarget(workspace: workspace, surfaceId: nil)
+        }
+
+        if let ttyTarget { return ttyTarget }
+
+        // A supplied caller TTY or surface that did not resolve is an
+        // attribution failure. With no authoritative pane (and no valid
+        // workspace claim), selecting the focused workspace would still be a
+        // guess and can put the ring on an unrelated pane.
+        guard preferredWorkspaceId == nil, preferredSurfaceId == nil, callerTTY == nil else {
+            return nil
         }
         guard let selected = selectedWorkspace(in: managers) else { return nil }
-        let focusedSurfaceID = selected.focusedPanelId.flatMap {
-            selected.surfaceOwnershipTarget(for: $0)?.surfaceID
-        }
-        return TerminalCallerTarget(workspace: selected, surfaceId: focusedSurfaceID)
+        // A selector-free caller may still receive a workspace-level
+        // notification, but it must never inherit the workspace's focused
+        // surface as if that were pane evidence.
+        return TerminalCallerTarget(workspace: selected, surfaceId: nil)
     }
 
     private static func candidateManagers(
@@ -232,21 +227,6 @@ extension TerminalController {
         return nil
     }
 
-    private static func targetForTTY(
-        _ ttyName: String,
-        tabManagers: [TabManager]
-    ) -> TerminalCallerTarget? {
-        for manager in tabManagers {
-            for workspace in manager.tabs {
-                for (surfaceId, candidateTTY) in workspace.surfaceTTYNames
-                    where workspace.panels[surfaceId] != nil && normalizedTTYName(candidateTTY) == ttyName {
-                    return TerminalCallerTarget(workspace: workspace, surfaceId: surfaceId)
-                }
-            }
-        }
-        return nil
-    }
-
     /// Resolve local callers from Ghostty's current runtime PTYs first. Shell-
     /// reported TTYs are a unique-only fallback for nested multiplexers such as
     /// tmux, where the pane TTY necessarily differs from Ghostty's outer PTY.
@@ -275,7 +255,15 @@ extension TerminalController {
                     if let liveTTYName = terminalPanel.surface.controllingTTYName() {
                         liveCandidates.append((binding: binding, ttyName: liveTTYName))
                     }
-                    if let reportedTTYName = workspace.surfaceTTYNames[surfaceId] {
+                    // Restored TTY metadata is display context only. Include a
+                    // shell-reported name in the resolver only while this
+                    // terminal generation has an explicit runtime report;
+                    // otherwise stale duplicate names can shadow the live pane.
+                    if let reportedTTYName = workspace.surfaceTTYNames[surfaceId],
+                       workspace.hasCurrentRuntimeReportedTTY(
+                           panelId: surfaceId,
+                           terminal: terminalPanel
+                       ) {
                         reportedCandidates.append((binding: binding, ttyName: reportedTTYName))
                     }
                 }

--- a/Sources/TerminalNotificationCallerResolver.swift
+++ b/Sources/TerminalNotificationCallerResolver.swift
@@ -81,6 +81,7 @@ extension TerminalController {
         }
 
         let preferredWorkspaceId = v2UUID(params, "preferred_workspace_id")
+        let preferredWorkspaceIsExplicit = boolParam(params, "preferred_workspace_is_explicit") ?? true
         let preferredSurfaceId = v2UUID(params, "preferred_surface_id")
         let callerTTY = stringParam(params, "caller_tty")
         let preferTTY = boolParam(params, "prefer_tty") ?? false
@@ -95,7 +96,8 @@ extension TerminalController {
                 preferredWorkspaceId: preferredWorkspaceId,
                 preferredSurfaceId: preferredSurfaceId,
                 callerTTY: callerTTY,
-                preferTTY: preferTTY
+                preferTTY: preferTTY,
+                preferredWorkspaceIsExplicit: preferredWorkspaceIsExplicit
             )
             guard let target else {
                 result = .err(code: "not_found", message: "Workspace not found", data: nil)
@@ -127,7 +129,8 @@ extension TerminalController {
         preferredWorkspaceId: UUID?,
         preferredSurfaceId: UUID?,
         callerTTY: String?,
-        preferTTY: Bool
+        preferTTY: Bool,
+        preferredWorkspaceIsExplicit: Bool = true
     ) -> TerminalCallerNotificationTarget? {
         guard let fallback = activeTabManagerForCallerNotification() else { return nil }
         guard let target = Self.callerNotificationTarget(
@@ -135,7 +138,8 @@ extension TerminalController {
             preferredWorkspaceId: preferredWorkspaceId,
             preferredSurfaceId: preferredSurfaceId,
             callerTTY: Self.normalizedTTYName(callerTTY),
-            preferTTY: preferTTY
+            preferTTY: preferTTY,
+            preferredWorkspaceIsExplicit: preferredWorkspaceIsExplicit
         ) else { return nil }
         return TerminalCallerNotificationTarget(
             workspaceId: target.workspace.id,
@@ -148,7 +152,8 @@ extension TerminalController {
         preferredWorkspaceId: UUID?,
         preferredSurfaceId: UUID?,
         callerTTY: String?,
-        preferTTY: Bool
+        preferTTY: Bool,
+        preferredWorkspaceIsExplicit: Bool
     ) -> TerminalCallerTarget? {
         let managers = candidateManagers(
             fallback: fallback,
@@ -179,7 +184,7 @@ extension TerminalController {
             // A surface identity still outranks TTY evidence when it resolves
             // inside the requested workspace.
             if let preferredSurfaceTarget,
-               preferredSurfaceTarget.workspace.id == workspace.id {
+               (!preferredWorkspaceIsExplicit || preferredSurfaceTarget.workspace.id == workspace.id) {
                 return preferredSurfaceTarget
             }
             let ttyTarget = resolveTTYTarget()

--- a/Sources/TerminalPortalReconciliation.swift
+++ b/Sources/TerminalPortalReconciliation.swift
@@ -184,7 +184,6 @@ extension GhosttyTerminalView {
             // to resurrect one on the replacement host.
             if hostOwnsPortal || (
                 !coordinator.desiredShowsUnreadNotificationRing
-                    && hasCurrentHostEntry
                     && isCurrentPortalHost
             ) {
                 hostedView.setNotificationRing(visible: coordinator.desiredShowsUnreadNotificationRing)

--- a/Sources/TerminalPortalReconciliation.swift
+++ b/Sources/TerminalPortalReconciliation.swift
@@ -190,7 +190,7 @@ extension GhosttyTerminalView {
                 hostedView.setNotificationRing(visible: coordinator.desiredShowsUnreadNotificationRing)
             }
 
-            if !coordinator.desiredVisibleInUI,
+            if !coordinator.desiredIsVisibleInUI,
                hasCurrentHostEntry,
                isCurrentPortalHost {
                 TerminalWindowPortalRegistry.updateEntryVisibility(

--- a/Sources/TerminalPortalReconciliation.swift
+++ b/Sources/TerminalPortalReconciliation.swift
@@ -120,6 +120,13 @@ extension GhosttyTerminalView {
                     reason: reason
                 )
 
+            // Notification-ring visibility is a projection of the latest
+            // surface store snapshot, not a portal-ownership side effect. A
+            // hosted view can remain mounted while its host loses ownership;
+            // applying the projection on every pass prevents stale rings from
+            // surviving a pane/workspace transfer.
+            hostedView.setNotificationRing(visible: coordinator.desiredShowsUnreadNotificationRing)
+
             if hostOwnsPortal {
                 configureHostedView(
                     hostedView,
@@ -222,7 +229,6 @@ extension GhosttyTerminalView {
             opacity: CGFloat(snapshot.inactiveOverlayOpacity),
             visible: snapshot.showsInactiveOverlay
         )
-        hostedView.setNotificationRing(visible: coordinator.desiredShowsUnreadNotificationRing)
         hostedView.setSearchOverlay(searchState: snapshot.searchState)
         hostedView.syncKeyStateIndicator(text: terminalSurface.currentKeyStateIndicatorText)
         hostedView.setDropZoneOverlay(zone: snapshot.dropZone)

--- a/Sources/TerminalPortalReconciliation.swift
+++ b/Sources/TerminalPortalReconciliation.swift
@@ -174,12 +174,29 @@ extension GhosttyTerminalView {
                 for: hostedView,
                 boundTo: host
             )
+            let isCurrentPortalHost = terminalSurface.ownsPortalHost(
+                hostId: hostId,
+                instanceSerial: host.instanceSerial
+            )
             // Only the current portal owner may publish a ring. A host that is
             // still the bound owner may also publish a hide, which clears a
             // stale ring during a hand-off without allowing an old coordinator
             // to resurrect one on the replacement host.
-            if hostOwnsPortal || (!coordinator.desiredShowsUnreadNotificationRing && hasCurrentHostEntry) {
+            if hostOwnsPortal || (
+                !coordinator.desiredShowsUnreadNotificationRing
+                    && hasCurrentHostEntry
+                    && isCurrentPortalHost
+            ) {
                 hostedView.setNotificationRing(visible: coordinator.desiredShowsUnreadNotificationRing)
+            }
+
+            if !coordinator.desiredVisibleInUI,
+               hasCurrentHostEntry,
+               isCurrentPortalHost {
+                TerminalWindowPortalRegistry.updateEntryVisibility(
+                    for: hostedView,
+                    visibleInUI: false
+                )
             }
 
             switch immediateHostedStateAction(

--- a/Sources/TerminalPortalReconciliation.swift
+++ b/Sources/TerminalPortalReconciliation.swift
@@ -120,13 +120,6 @@ extension GhosttyTerminalView {
                     reason: reason
                 )
 
-            // Notification-ring visibility is a projection of the latest
-            // surface store snapshot, not a portal-ownership side effect. A
-            // hosted view can remain mounted while its host loses ownership;
-            // applying the projection on every pass prevents stale rings from
-            // surviving a pane/workspace transfer.
-            hostedView.setNotificationRing(visible: coordinator.desiredShowsUnreadNotificationRing)
-
             if hostOwnsPortal {
                 configureHostedView(
                     hostedView,
@@ -177,6 +170,18 @@ extension GhosttyTerminalView {
                 hostedView,
                 boundTo: host
             )
+            let hasCurrentHostEntry = TerminalWindowPortalRegistry.hasEntry(
+                for: hostedView,
+                boundTo: host
+            )
+            // Only the current portal owner may publish a ring. A host that is
+            // still the bound owner may also publish a hide, which clears a
+            // stale ring during a hand-off without allowing an old coordinator
+            // to resurrect one on the replacement host.
+            if hostOwnsPortal || (!coordinator.desiredShowsUnreadNotificationRing && hasCurrentHostEntry) {
+                hostedView.setNotificationRing(visible: coordinator.desiredShowsUnreadNotificationRing)
+            }
+
             switch immediateHostedStateAction(
                 hostOwnsPortal: hostOwnsPortal,
                 portalBindingLive: portalBindingLive,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2559,6 +2559,7 @@
 		A5A5A503A1B2C3D4E5F60718 /* TerminalNotificationQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A5A504A1B2C3D4E5F60718 /* TerminalNotificationQueueTests.swift */; };
 		A5001098 /* TerminalNotificationScrollPosition.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001099 /* TerminalNotificationScrollPosition.swift */; };
 		A5E380700000000000000001 /* TerminalNotificationSocketActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E380700000000000000002 /* TerminalNotificationSocketActionTests.swift */; };
+		11189010A1B2C3D4E5F60718 /* TerminalNotificationSocketAttributionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11189011A1B2C3D4E5F60718 /* TerminalNotificationSocketAttributionTests.swift */; };
 		468120000000000000000005 /* TerminalNotificationStore+HookResolution.swift in Sources */ = {isa = PBXBuildFile; fileRef = 468120000000000000000006 /* TerminalNotificationStore+HookResolution.swift */; };
 		7490C0107490C0107490C010 /* TerminalNotificationStore+MemoryPressure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7490D0107490D0107490D010 /* TerminalNotificationStore+MemoryPressure.swift */; };
 		596100000000000000000007 /* TerminalNotificationStore+NativeNotificationDeliveryTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596100000000000000000006 /* TerminalNotificationStore+NativeNotificationDeliveryTesting.swift */; };
@@ -5489,6 +5490,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		A5A5A504A1B2C3D4E5F60718 /* TerminalNotificationQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalNotificationQueueTests.swift; sourceTree = "<group>"; };
 		A5001099 /* TerminalNotificationScrollPosition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalNotificationScrollPosition.swift; sourceTree = "<group>"; };
 		A5E380700000000000000002 /* TerminalNotificationSocketActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalNotificationSocketActionTests.swift; sourceTree = "<group>"; };
+		11189011A1B2C3D4E5F60718 /* TerminalNotificationSocketAttributionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalNotificationSocketAttributionTests.swift; sourceTree = "<group>"; };
 		468120000000000000000006 /* TerminalNotificationStore+HookResolution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalNotificationStore+HookResolution.swift"; sourceTree = "<group>"; };
 		7490D0107490D0107490D010 /* TerminalNotificationStore+MemoryPressure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalNotificationStore+MemoryPressure.swift"; sourceTree = "<group>"; };
 		596100000000000000000006 /* TerminalNotificationStore+NativeNotificationDeliveryTesting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalNotificationStore+NativeNotificationDeliveryTesting.swift"; sourceTree = "<group>"; };
@@ -8867,6 +8869,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				A5E380700000000000000002 /* TerminalNotificationSocketActionTests.swift */,
 				A5A5A506A1B2C3D4E5F60718 /* TerminalNotificationDirectInteractionTests.swift */,
 				A5C41104A1B2C3D4E5F60718 /* TerminalNotificationCallerTests.swift */,
+				11189011A1B2C3D4E5F60718 /* TerminalNotificationSocketAttributionTests.swift */,
 				8362B0020000000000000002 /* TerminalCallerTTYResolverTests.swift */,
 				A5D41221A1B2C3D4E5F60718 /* ClaudeHookSurfaceResolutionSwiftTests.swift */,
 				79390002AA11BB22CC33DD02 /* ClaudeHookLiveDeliveryTargetTests.swift */,
@@ -12259,6 +12262,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				A5E380710000000000000001 /* TerminalNotificationOpenPanelFallbackTests.swift in Sources */,
 				A5A5A503A1B2C3D4E5F60718 /* TerminalNotificationQueueTests.swift in Sources */,
 				A5E380700000000000000001 /* TerminalNotificationSocketActionTests.swift in Sources */,
+				11189010A1B2C3D4E5F60718 /* TerminalNotificationSocketAttributionTests.swift in Sources */,
 				596100000000000000000007 /* TerminalNotificationStore+NativeNotificationDeliveryTesting.swift in Sources */,
 				C7261F020000000000000001 /* TerminalPointerFocusActivationPolicyTests.swift in Sources */,
 				D5671101D5671101D5671101 /* TerminalScrollSpeedSettingsFileStoreTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -571,6 +571,7 @@
 		A5D41211A1B2C3D4E5F60718 /* CLIHookNoResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D41212A1B2C3D4E5F60718 /* CLIHookNoResponseTests.swift */; };
 		A5D4120BA1B2C3D4E5F60718 /* CLILegacyHookAliasTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D4120CA1B2C3D4E5F60718 /* CLILegacyHookAliasTests.swift */; };
 		A5D41330A1B2C3D4E5F60718 /* CLIMockSocketServerSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D41331A1B2C3D4E5F60718 /* CLIMockSocketServerSupport.swift */; };
+		11189000A1B2C3D4E5F60718 /* CLINotificationPaneAttributionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11189001A1B2C3D4E5F60718 /* CLINotificationPaneAttributionTests.swift */; };
 		F0F0CF0E0000000000000001 /* CLINotifyClaudeForkOfForkRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0F0CF0E0000000000000002 /* CLINotifyClaudeForkOfForkRegressionTests.swift */; };
 		C72280000000000000000004 /* CLINotifyClaudeHookWorkspaceRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72280000000000000000003 /* CLINotifyClaudeHookWorkspaceRoutingTests.swift */; };
 		A5D41203A1B2C3D4E5F60718 /* CLINotifyProcessIntegrationRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D41204A1B2C3D4E5F60718 /* CLINotifyProcessIntegrationRegressionTests.swift */; };
@@ -3598,6 +3599,7 @@
 		A5D41212A1B2C3D4E5F60718 /* CLIHookNoResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIHookNoResponseTests.swift; sourceTree = "<group>"; };
 		A5D4120CA1B2C3D4E5F60718 /* CLILegacyHookAliasTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLILegacyHookAliasTests.swift; sourceTree = "<group>"; };
 		A5D41331A1B2C3D4E5F60718 /* CLIMockSocketServerSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIMockSocketServerSupport.swift; sourceTree = "<group>"; };
+		11189001A1B2C3D4E5F60718 /* CLINotificationPaneAttributionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLINotificationPaneAttributionTests.swift; sourceTree = "<group>"; };
 		F0F0CF0E0000000000000002 /* CLINotifyClaudeForkOfForkRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLINotifyClaudeForkOfForkRegressionTests.swift; sourceTree = "<group>"; };
 		C72280000000000000000003 /* CLINotifyClaudeHookWorkspaceRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLINotifyClaudeHookWorkspaceRoutingTests.swift; sourceTree = "<group>"; };
 		A5D41204A1B2C3D4E5F60718 /* CLINotifyProcessIntegrationRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLINotifyProcessIntegrationRegressionTests.swift; sourceTree = "<group>"; };
@@ -8888,6 +8890,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				F0F0CF0E0000000000000002 /* CLINotifyClaudeForkOfForkRegressionTests.swift */,
 				C72280000000000000000003 /* CLINotifyClaudeHookWorkspaceRoutingTests.swift */,
 				A5D41204A1B2C3D4E5F60718 /* CLINotifyProcessIntegrationRegressionTests.swift */,
+				11189001A1B2C3D4E5F60718 /* CLINotificationPaneAttributionTests.swift */,
 				A76110030000000000000002 /* CLIGrokNotificationNoiseTests.swift */,
 				6379A0026379A0026379A002 /* CLISSHPTYResizeInputTests.swift */,
 				C0F16B000000000000000002 /* CLIRemoteShellStartupPerformanceTests.swift */,
@@ -11772,6 +11775,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				A5D41211A1B2C3D4E5F60718 /* CLIHookNoResponseTests.swift in Sources */,
 				A5D4120BA1B2C3D4E5F60718 /* CLILegacyHookAliasTests.swift in Sources */,
 				A5D41330A1B2C3D4E5F60718 /* CLIMockSocketServerSupport.swift in Sources */,
+				11189000A1B2C3D4E5F60718 /* CLINotificationPaneAttributionTests.swift in Sources */,
 				F0F0CF0E0000000000000001 /* CLINotifyClaudeForkOfForkRegressionTests.swift in Sources */,
 				C72280000000000000000004 /* CLINotifyClaudeHookWorkspaceRoutingTests.swift in Sources */,
 				A5D41203A1B2C3D4E5F60718 /* CLINotifyProcessIntegrationRegressionTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2519,6 +2519,7 @@
 		9C1BEA3D2E6F49709A71C020 /* TerminalControllerTerminalTextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C1BEA3D2E6F49709A71C021 /* TerminalControllerTerminalTextTests.swift */; };
 		C7A505000000000000000002 /* TerminalControllerTopSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A505000000000000000001 /* TerminalControllerTopSupport.swift */; };
 		C7A50B000000000000000002 /* TerminalControllerV2ParamParsingSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A50B000000000000000001 /* TerminalControllerV2ParamParsingSupport.swift */; };
+		A5C41105A1B2C3D4E5F60718 /* TerminalControllingTTYWaiter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C41106A1B2C3D4E5F60718 /* TerminalControllingTTYWaiter.swift */; };
 		6190C0126190C0126190C012 /* TerminalCopyOnSelectManagedConfigLayeringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6190C0116190C0116190C011 /* TerminalCopyOnSelectManagedConfigLayeringTests.swift */; };
 		EC010B01 /* TerminalCustomUploadRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC010B02 /* TerminalCustomUploadRunner.swift */; };
 		0D56BE882EAD4B67AC44F96D /* TerminalDirectoryOpenSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8E2E03F4A64C61B729CF19 /* TerminalDirectoryOpenSupport.swift */; };
@@ -5450,6 +5451,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		9C1BEA3D2E6F49709A71C021 /* TerminalControllerTerminalTextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalControllerTerminalTextTests.swift; sourceTree = "<group>"; };
 		C7A505000000000000000001 /* TerminalControllerTopSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalControllerTopSupport.swift; sourceTree = "<group>"; };
 		C7A50B000000000000000001 /* TerminalControllerV2ParamParsingSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalControllerV2ParamParsingSupport.swift; sourceTree = "<group>"; };
+		A5C41106A1B2C3D4E5F60718 /* TerminalControllingTTYWaiter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalControllingTTYWaiter.swift; sourceTree = "<group>"; };
 		6190C0116190C0116190C011 /* TerminalCopyOnSelectManagedConfigLayeringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalCopyOnSelectManagedConfigLayeringTests.swift; sourceTree = "<group>"; };
 		EC010B02 /* TerminalCustomUploadRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalCustomUploadRunner.swift; sourceTree = "<group>"; };
 		6B8E2E03F4A64C61B729CF19 /* TerminalDirectoryOpenSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/TerminalDirectoryOpenSupport.swift; sourceTree = "<group>"; };
@@ -8869,6 +8871,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				A5E380700000000000000002 /* TerminalNotificationSocketActionTests.swift */,
 				A5A5A506A1B2C3D4E5F60718 /* TerminalNotificationDirectInteractionTests.swift */,
 				A5C41104A1B2C3D4E5F60718 /* TerminalNotificationCallerTests.swift */,
+				A5C41106A1B2C3D4E5F60718 /* TerminalControllingTTYWaiter.swift */,
 				11189011A1B2C3D4E5F60718 /* TerminalNotificationSocketAttributionTests.swift */,
 				8362B0020000000000000002 /* TerminalCallerTTYResolverTests.swift */,
 				A5D41221A1B2C3D4E5F60718 /* ClaudeHookSurfaceResolutionSwiftTests.swift */,
@@ -12251,6 +12254,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				B8835700000000000000000D /* TerminalClipboardInputSequencerTests.swift in Sources */,
 				8C4BBF2DEF6DF93F395A9EE7 /* TerminalControllerSocketSecurityTests.swift in Sources */,
 				9C1BEA3D2E6F49709A71C020 /* TerminalControllerTerminalTextTests.swift in Sources */,
+				A5C41105A1B2C3D4E5F60718 /* TerminalControllingTTYWaiter.swift in Sources */,
 				6190C0126190C0126190C012 /* TerminalCopyOnSelectManagedConfigLayeringTests.swift in Sources */,
 				851500000000000000000001 /* TerminalFontZoomSessionPersistenceTests.swift in Sources */,
 				B8835A000000000000000005 /* TerminalImageTransferConcurrencyTests+Timeouts.swift in Sources */,

--- a/cmuxTests/AgentDeliveryTTYBindingTests.swift
+++ b/cmuxTests/AgentDeliveryTTYBindingTests.swift
@@ -31,7 +31,10 @@ extension AgentNotificationRegressionTests {
             hostedView.removeFromSuperview()
             window.orderOut(nil)
         }
-        let liveTTYName = try #require(await waitForControllingTTYName(for: terminal))
+        let liveTTYName = try await TerminalControllingTTYWaiter().wait(
+            for: terminal,
+            timeout: .seconds(15)
+        )
         let liveTTYDevice = try #require(
             CmuxTopProcessSnapshot.deviceIdentifier(forTTYName: liveTTYName)
         )
@@ -410,17 +413,6 @@ extension AgentNotificationRegressionTests {
             dock.attachDetachedSurface(transfer, inPane: rootPane, focus: false)
                 == fixture.panelId
         )
-    }
-
-    private func waitForControllingTTYName(for terminal: TerminalPanel) async -> String? {
-        let deadline = ContinuousClock.now + .seconds(15)
-        while ContinuousClock.now < deadline {
-            if let ttyName = terminal.surface.controllingTTYName() {
-                return ttyName
-            }
-            try? await Task.sleep(for: .milliseconds(10))
-        }
-        return terminal.surface.controllingTTYName()
     }
 
     private func assertRelayTTYTarget(

--- a/cmuxTests/AgentRelayTTYOwnershipTests.swift
+++ b/cmuxTests/AgentRelayTTYOwnershipTests.swift
@@ -379,7 +379,10 @@ extension AgentNotificationRegressionTests {
             hostedView.removeFromSuperview()
             window.orderOut(nil)
         }
-        let ttyName = try #require(await waitForControllingTTYName(for: terminal))
+        let ttyName = try await TerminalControllingTTYWaiter().wait(
+            for: terminal,
+            timeout: .seconds(15)
+        )
         fixture.source.registerReportedSurfaceTTYName(
             ttyName,
             panelId: fixture.panelId
@@ -458,14 +461,4 @@ extension AgentNotificationRegressionTests {
         #expect(code == "not_found")
     }
 
-    private func waitForControllingTTYName(for terminal: TerminalPanel) async -> String? {
-        let deadline = ContinuousClock.now + .seconds(15)
-        while ContinuousClock.now < deadline {
-            if let ttyName = terminal.surface.controllingTTYName() {
-                return ttyName
-            }
-            try? await Task.sleep(for: .milliseconds(10))
-        }
-        return terminal.surface.controllingTTYName()
-    }
 }

--- a/cmuxTests/CLINotificationPaneAttributionTests.swift
+++ b/cmuxTests/CLINotificationPaneAttributionTests.swift
@@ -140,7 +140,9 @@ extension CLINotifyProcessIntegrationRegressionTests {
             try? FileManager.default.removeItem(at: root)
         }
 
-        let now = Date().timeIntervalSince1970
+        // These values are fixture metadata only; keep them independent of the
+        // host clock because this test does not exercise freshness boundaries.
+        let now: TimeInterval = 4_000_000_000
         let storedSessions = Dictionary(uniqueKeysWithValues: sessionIds.map { sessionId in
             (
                 sessionId,

--- a/cmuxTests/CLINotificationPaneAttributionTests.swift
+++ b/cmuxTests/CLINotificationPaneAttributionTests.swift
@@ -19,6 +19,7 @@ extension CLINotifyProcessIntegrationRegressionTests {
         let workspaceId = "11111111-1111-1111-1111-111111111111"
         let staleSurfaceId = "22222222-2222-2222-2222-222222222222"
         let focusedSurfaceId = "33333333-3333-3333-3333-333333333333"
+        let ledgerPath = root.appendingPathComponent("codex-turn-ledger.json")
 
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         defer {
@@ -26,6 +27,24 @@ extension CLINotifyProcessIntegrationRegressionTests {
             unlink(socketPath)
             try? FileManager.default.removeItem(at: root)
         }
+
+        let ledgerRecord: [String: Any] = [
+            "workspaceID": workspaceId,
+            "surfaceID": staleSurfaceId,
+            "owner": [:],
+            "activeTurnID": "turn-before",
+            "activeChildrenByTurn": [:],
+            "unknownChildrenByTurn": [:],
+            "terminalChildrenByTurn": [:],
+            "pendingTurns": [:],
+            "settledTurnIDs": [],
+            "notifiedTurnIDs": [],
+            "updatedAt": 4_000_000_000,
+        ]
+        try JSONSerialization.data(
+            withJSONObject: ["records": ["codex-stale-no-live": ledgerRecord], "surfaceOwners": [:]],
+            options: [.prettyPrinted]
+        ).write(to: ledgerPath, options: .atomic)
 
         let serverHandled = startMockServer(listenerFD: listenerFD, state: state) { line in
             guard let payload = self.jsonObject(line) else {
@@ -90,13 +109,14 @@ extension CLINotifyProcessIntegrationRegressionTests {
         environment["CMUX_AGENT_HOOK_STATE_DIR"] = root.path
         environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
         environment["CODEX_HOME"] = root.appendingPathComponent("codex-home", isDirectory: true).path
+        environment["CMUX_CODEX_TURN_LEDGER_PATH"] = ledgerPath.path
         environment.removeValue(forKey: "CMUX_CODEX_PID")
 
         let result = runProcess(
             executablePath: cliPath,
             arguments: ["hooks", "codex", "prompt-submit"],
             environment: environment,
-            standardInput: #"{"session_id":"codex-stale-no-live","cwd":"\#(root.path)","hook_event_name":"UserPromptSubmit","prompt":"continue"}"#,
+            standardInput: #"{"session_id":"codex-stale-no-live","turn_id":"turn-after","cwd":"\#(root.path)","hook_event_name":"UserPromptSubmit","prompt":"continue"}"#,
             timeout: 5
         )
 
@@ -113,6 +133,17 @@ extension CLINotifyProcessIntegrationRegressionTests {
                 $0.unattributedReason == "target-unresolved" && $0.surfaceId == nil
             },
             "Fail-closed target resolution must leave an unattributed journal diagnostic, saw \(state.commands)"
+        )
+        let ledger = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: Data(contentsOf: ledgerPath)) as? [String: Any]
+        )
+        let record = try XCTUnwrap(
+            (ledger["records"] as? [String: Any])?["codex-stale-no-live"] as? [String: Any]
+        )
+        XCTAssertEqual(
+            record["activeTurnID"] as? String,
+            "turn-after",
+            "An unresolved prompt must still advance an existing Codex turn record"
         )
     }
 

--- a/cmuxTests/CLINotificationPaneAttributionTests.swift
+++ b/cmuxTests/CLINotificationPaneAttributionTests.swift
@@ -127,7 +127,10 @@ extension CLINotifyProcessIntegrationRegressionTests {
         let staleSurfaceId = "22222222-2222-2222-2222-222222222222"
         let focusedSurfaceId = "33333333-3333-3333-3333-333333333333"
         let sessionIds = ["codex-stale-subagent-start", "codex-stale-subagent-stop"]
+        let settledSessionId = sessionIds[1]
+        let settledTurnId = "turn-1"
         let probePath = root.appendingPathComponent("target-resolution-error.txt", isDirectory: false)
+        let ledgerPath = root.appendingPathComponent("codex-turn-ledger.json")
 
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         defer {
@@ -153,6 +156,25 @@ extension CLINotifyProcessIntegrationRegressionTests {
         let storeObject: [String: Any] = ["version": 1, "sessions": storedSessions]
         try JSONSerialization.data(withJSONObject: storeObject, options: [.prettyPrinted])
             .write(to: root.appendingPathComponent("codex-hook-sessions.json"), options: .atomic)
+        let ledgerRecord: [String: Any] = [
+            "workspaceID": workspaceId,
+            "surfaceID": staleSurfaceId,
+            "owner": [:],
+            "activeTurnID": settledTurnId,
+            "activeChildrenByTurn": [settledTurnId: ["child-1"]],
+            "unknownChildrenByTurn": [:],
+            "terminalChildrenByTurn": [:],
+            "pendingTurns": [settledTurnId: ["turnID": settledTurnId]],
+            "settledTurnIDs": [],
+            "notifiedTurnIDs": [],
+            "updatedAt": now,
+        ]
+        let ledgerObject: [String: Any] = [
+            "records": [settledSessionId: ledgerRecord],
+            "surfaceOwners": [:],
+        ]
+        try JSONSerialization.data(withJSONObject: ledgerObject, options: [.prettyPrinted])
+            .write(to: ledgerPath, options: .atomic)
 
         let serverHandled = startMockServer(listenerFD: listenerFD, state: state) { line in
             guard let payload = self.jsonObject(line) else {
@@ -206,6 +228,7 @@ extension CLINotifyProcessIntegrationRegressionTests {
         environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
         environment["CMUX_CLI_SENTRY_CAPTURE_PROBE_PATH"] = probePath.path
         environment["CODEX_HOME"] = root.appendingPathComponent("codex-home", isDirectory: true).path
+        environment["CMUX_CODEX_TURN_LEDGER_PATH"] = ledgerPath.path
         environment.removeValue(forKey: "CMUX_CODEX_PID")
 
         for (index, subcommand) in ["subagent-start", "subagent-stop"].enumerated() {
@@ -213,7 +236,7 @@ extension CLINotifyProcessIntegrationRegressionTests {
                 executablePath: cliPath,
                 arguments: ["hooks", "codex", subcommand],
                 environment: environment,
-                standardInput: #"{"session_id":"\#(sessionIds[index])","cwd":"\#(root.path)","hook_event_name":"SubagentStart","agent_id":"child-\#(index)","turn_id":"turn-\#(index)"}"#,
+                standardInput: #"{"session_id":"\#(sessionIds[index])","cwd":"\#(root.path)","hook_event_name":"\#(index == 0 ? "SubagentStart" : "SubagentStop")","agent_id":"child-\#(index)","turn_id":"turn-\#(index)"}"#,
                 timeout: 5
             )
             XCTAssertFalse(result.timedOut, result.stderr)
@@ -230,6 +253,21 @@ extension CLINotifyProcessIntegrationRegressionTests {
         XCTAssertFalse(
             state.commands.contains { $0.contains("notify_target_async") },
             "Rejected child targets must not trigger a settled-stop notification, saw \(state.commands)"
+        )
+        let ledgerData = try Data(contentsOf: ledgerPath)
+        let ledger = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: ledgerData) as? [String: Any]
+        )
+        let records = try XCTUnwrap(ledger["records"] as? [String: Any])
+        let settledRecord = try XCTUnwrap(records[settledSessionId] as? [String: Any])
+        let activeChildren = (settledRecord["activeChildrenByTurn"] as? [String: [String]]) ?? [:]
+        XCTAssertTrue(
+            activeChildren[settledTurnId]?.isEmpty != false,
+            "An unresolved SubagentStop must still remove the durable child"
+        )
+        XCTAssertTrue(
+            (settledRecord["settledTurnIDs"] as? [String])?.contains(settledTurnId) == true,
+            "An unresolved SubagentStop must still settle the pending turn by session identity"
         )
         XCTAssertTrue(FileManager.default.fileExists(atPath: probePath.path))
     }

--- a/cmuxTests/CLINotificationPaneAttributionTests.swift
+++ b/cmuxTests/CLINotificationPaneAttributionTests.swift
@@ -268,6 +268,9 @@ extension CLINotifyProcessIntegrationRegressionTests {
         environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
         environment["CODEX_HOME"] = root.appendingPathComponent("codex-home", isDirectory: true).path
         environment["CMUX_CODEX_TURN_LEDGER_PATH"] = ledgerPath.path
+        // Keep this deterministic fixture in-process; retry scheduling is
+        // covered by the production retry-limit path separately.
+        environment["CMUX_CODEX_SETTLED_STOP_RETRY_COUNT"] = "3"
         environment.removeValue(forKey: "CMUX_CODEX_PID")
 
         for (index, subcommand) in ["subagent-start", "subagent-stop"].enumerated() {

--- a/cmuxTests/CLINotificationPaneAttributionTests.swift
+++ b/cmuxTests/CLINotificationPaneAttributionTests.swift
@@ -254,6 +254,10 @@ extension CLINotifyProcessIntegrationRegressionTests {
             state.commands.contains { $0.contains("notify_target_async") },
             "Rejected child targets must not trigger a settled-stop notification, saw \(state.commands)"
         )
+        XCTAssertFalse(
+            state.commands.contains { $0.contains(#""method":"feed.push""#) },
+            "Rejected child targets must not emit Feed activity under a stale ambient workspace, saw \(state.commands)"
+        )
         let ledgerData = try Data(contentsOf: ledgerPath)
         let ledger = try XCTUnwrap(
             try JSONSerialization.jsonObject(with: ledgerData) as? [String: Any]

--- a/cmuxTests/CLINotificationPaneAttributionTests.swift
+++ b/cmuxTests/CLINotificationPaneAttributionTests.swift
@@ -1,7 +1,10 @@
 import Darwin
 import Foundation
-import XCTest
+@preconcurrency import XCTest
 
+// Stays on XCTest deliberately: this extends the existing bundled-CLI socket
+// harness (`CLINotifyProcessIntegrationRegressionTests`), whose process runner
+// and mock server lifecycle are shared with the surrounding integration suite.
 extension CLINotifyProcessIntegrationRegressionTests {
     /// Regression for https://github.com/manaflow-ai/cmux/issues/11189: when
     /// the ambient surface is stale and the live resolver cannot prove a pane,

--- a/cmuxTests/CLINotificationPaneAttributionTests.swift
+++ b/cmuxTests/CLINotificationPaneAttributionTests.swift
@@ -131,6 +131,8 @@ extension CLINotifyProcessIntegrationRegressionTests {
         let sessionIds = ["codex-stale-subagent-start", "codex-stale-subagent-stop"]
         let settledSessionId = sessionIds[1]
         let settledTurnId = "turn-1"
+        let parentStopSessionId = "codex-stale-parent-stop"
+        let parentStopTurnId = "turn-parent-stop"
         let ledgerPath = root.appendingPathComponent("codex-turn-ledger.json")
 
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
@@ -143,7 +145,7 @@ extension CLINotifyProcessIntegrationRegressionTests {
         // These values are fixture metadata only; keep them independent of the
         // host clock because this test does not exercise freshness boundaries.
         let now: TimeInterval = 4_000_000_000
-        let storedSessions = Dictionary(uniqueKeysWithValues: sessionIds.map { sessionId in
+        let storedSessions = Dictionary(uniqueKeysWithValues: (sessionIds + [parentStopSessionId]).map { sessionId in
             (
                 sessionId,
                 [
@@ -172,8 +174,24 @@ extension CLINotifyProcessIntegrationRegressionTests {
             "notifiedTurnIDs": [],
             "updatedAt": now,
         ]
+        let parentStopLedgerRecord: [String: Any] = [
+            "workspaceID": workspaceId,
+            "surfaceID": staleSurfaceId,
+            "owner": [:],
+            "activeTurnID": parentStopTurnId,
+            "activeChildrenByTurn": [:],
+            "unknownChildrenByTurn": [:],
+            "terminalChildrenByTurn": [:],
+            "pendingTurns": [parentStopTurnId: ["turnID": parentStopTurnId]],
+            "settledTurnIDs": [],
+            "notifiedTurnIDs": [],
+            "updatedAt": now,
+        ]
         let ledgerObject: [String: Any] = [
-            "records": [settledSessionId: ledgerRecord],
+            "records": [
+                settledSessionId: ledgerRecord,
+                parentStopSessionId: parentStopLedgerRecord,
+            ],
             "surfaceOwners": [:],
         ]
         try JSONSerialization.data(withJSONObject: ledgerObject, options: [.prettyPrinted])
@@ -248,6 +266,17 @@ extension CLINotifyProcessIntegrationRegressionTests {
             XCTAssertEqual(result.stdout, "{}\n")
         }
 
+        let parentStopResult = runProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "codex", "stop"],
+            environment: environment,
+            standardInput: #"{"session_id":"\#(parentStopSessionId)","cwd":"\#(root.path)","hook_event_name":"Stop","turn_id":"\#(parentStopTurnId)","last_assistant_message":"done"}"#,
+            timeout: 5
+        )
+        XCTAssertFalse(parentStopResult.timedOut, parentStopResult.stderr)
+        XCTAssertEqual(parentStopResult.status, 0, parentStopResult.stderr)
+        XCTAssertEqual(parentStopResult.stdout, "{}\n")
+
         wait(for: [serverHandled], timeout: 5)
         let journalCommands = state.commands.filter { $0.contains("agent_journal_append") }
         XCTAssertFalse(
@@ -267,6 +296,10 @@ extension CLINotifyProcessIntegrationRegressionTests {
             try JSONSerialization.jsonObject(with: ledgerData) as? [String: Any]
         )
         let records = try XCTUnwrap(ledger["records"] as? [String: Any])
+        XCTAssertNil(
+            records[sessionIds[0]],
+            "An unresolved child start without an existing ledger session must stay diagnostic-only"
+        )
         let settledRecord = try XCTUnwrap(records[settledSessionId] as? [String: Any])
         let activeChildren = (settledRecord["activeChildrenByTurn"] as? [String: [String]]) ?? [:]
         XCTAssertTrue(
@@ -276,6 +309,11 @@ extension CLINotifyProcessIntegrationRegressionTests {
         XCTAssertTrue(
             (settledRecord["settledTurnIDs"] as? [String])?.contains(settledTurnId) == true,
             "An unresolved SubagentStop must still settle the pending turn by session identity"
+        )
+        let parentStopRecord = try XCTUnwrap(records[parentStopSessionId] as? [String: Any])
+        XCTAssertTrue(
+            (parentStopRecord["settledTurnIDs"] as? [String])?.contains(parentStopTurnId) == true,
+            "An unresolved parent Stop must still settle the ledger by session identity"
         )
         XCTAssertTrue(
             AgentJournalAppendCapture.captures(in: state.commands).contains {

--- a/cmuxTests/CLINotificationPaneAttributionTests.swift
+++ b/cmuxTests/CLINotificationPaneAttributionTests.swift
@@ -133,6 +133,9 @@ extension CLINotifyProcessIntegrationRegressionTests {
         let settledTurnId = "turn-1"
         let parentStopSessionId = "codex-stale-parent-stop"
         let parentStopTurnId = "turn-parent-stop"
+        let staleStopSessionId = "codex-stale-old-turn-stop"
+        let staleCurrentTurnId = "turn-new"
+        let staleIncomingTurnId = "turn-old"
         let ledgerPath = root.appendingPathComponent("codex-turn-ledger.json")
 
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
@@ -145,7 +148,7 @@ extension CLINotifyProcessIntegrationRegressionTests {
         // These values are fixture metadata only; keep them independent of the
         // host clock because this test does not exercise freshness boundaries.
         let now: TimeInterval = 4_000_000_000
-        let storedSessions = Dictionary(uniqueKeysWithValues: (sessionIds + [parentStopSessionId]).map { sessionId in
+        let storedSessions = Dictionary(uniqueKeysWithValues: (sessionIds + [parentStopSessionId, staleStopSessionId]).map { sessionId in
             (
                 sessionId,
                 [
@@ -187,10 +190,24 @@ extension CLINotifyProcessIntegrationRegressionTests {
             "notifiedTurnIDs": [],
             "updatedAt": now,
         ]
+        let staleStopLedgerRecord: [String: Any] = [
+            "workspaceID": workspaceId,
+            "surfaceID": staleSurfaceId,
+            "owner": [:],
+            "activeTurnID": staleCurrentTurnId,
+            "activeChildrenByTurn": [:],
+            "unknownChildrenByTurn": [:],
+            "terminalChildrenByTurn": [:],
+            "pendingTurns": [staleCurrentTurnId: ["turnID": staleCurrentTurnId]],
+            "settledTurnIDs": [],
+            "notifiedTurnIDs": [],
+            "updatedAt": now,
+        ]
         let ledgerObject: [String: Any] = [
             "records": [
                 settledSessionId: ledgerRecord,
                 parentStopSessionId: parentStopLedgerRecord,
+                staleStopSessionId: staleStopLedgerRecord,
             ],
             "surfaceOwners": [:],
         ]
@@ -277,6 +294,17 @@ extension CLINotifyProcessIntegrationRegressionTests {
         XCTAssertEqual(parentStopResult.status, 0, parentStopResult.stderr)
         XCTAssertEqual(parentStopResult.stdout, "{}\n")
 
+        let staleStopResult = runProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "codex", "stop"],
+            environment: environment,
+            standardInput: #"{"session_id":"\#(staleStopSessionId)","cwd":"\#(root.path)","hook_event_name":"Stop","turn_id":"\#(staleIncomingTurnId)","last_assistant_message":"late"}"#,
+            timeout: 5
+        )
+        XCTAssertFalse(staleStopResult.timedOut, staleStopResult.stderr)
+        XCTAssertEqual(staleStopResult.status, 0, staleStopResult.stderr)
+        XCTAssertEqual(staleStopResult.stdout, "{}\n")
+
         wait(for: [serverHandled], timeout: 5)
         let journalCommands = state.commands.filter { $0.contains("agent_journal_append") }
         XCTAssertFalse(
@@ -318,6 +346,15 @@ extension CLINotifyProcessIntegrationRegressionTests {
         XCTAssertFalse(
             (parentStopRecord["notifiedTurnIDs"] as? [String])?.contains(parentStopTurnId) == true,
             "An unresolved parent Stop must leave notification claiming retryable until a pane is proven"
+        )
+        let staleStopRecord = try XCTUnwrap(records[staleStopSessionId] as? [String: Any])
+        XCTAssertFalse(
+            (staleStopRecord["settledTurnIDs"] as? [String])?.contains(staleIncomingTurnId) == true,
+            "An unresolved Stop for an older non-pending turn must not settle over the current turn"
+        )
+        XCTAssertTrue(
+            (staleStopRecord["pendingTurns"] as? [String: Any])?[staleCurrentTurnId] != nil,
+            "An unresolved stale Stop must preserve the newer pending turn"
         )
         XCTAssertTrue(
             AgentJournalAppendCapture.captures(in: state.commands).contains {

--- a/cmuxTests/CLINotificationPaneAttributionTests.swift
+++ b/cmuxTests/CLINotificationPaneAttributionTests.swift
@@ -315,6 +315,10 @@ extension CLINotifyProcessIntegrationRegressionTests {
             (parentStopRecord["settledTurnIDs"] as? [String])?.contains(parentStopTurnId) == true,
             "An unresolved parent Stop must still settle the ledger by session identity"
         )
+        XCTAssertFalse(
+            (parentStopRecord["notifiedTurnIDs"] as? [String])?.contains(parentStopTurnId) == true,
+            "An unresolved parent Stop must leave notification claiming retryable until a pane is proven"
+        )
         XCTAssertTrue(
             AgentJournalAppendCapture.captures(in: state.commands).contains {
                 $0.unattributedReason == "target-unresolved" && $0.surfaceId == nil

--- a/cmuxTests/CLINotificationPaneAttributionTests.swift
+++ b/cmuxTests/CLINotificationPaneAttributionTests.swift
@@ -113,4 +113,124 @@ extension CLINotifyProcessIntegrationRegressionTests {
             "Fail-closed target resolution must leave a diagnostic"
         )
     }
+
+    /// A rejected generic target must not be reintroduced by the Codex child
+    /// lifecycle adapter after `resolveAgentHookTarget` returns nil.
+    func testCodexSubagentLifecycleDoesNotReuseRejectedMappedSurface() throws {
+        let cliPath = try bundledCLIPath()
+        let socketPath = makeSocketPath("codex-stale-subagent")
+        let listenerFD = try bindUnixSocket(at: socketPath)
+        let state = MockSocketServerState()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-codex-stale-subagent-\(UUID().uuidString)", isDirectory: true)
+        let workspaceId = "11111111-1111-1111-1111-111111111111"
+        let staleSurfaceId = "22222222-2222-2222-2222-222222222222"
+        let focusedSurfaceId = "33333333-3333-3333-3333-333333333333"
+        let sessionIds = ["codex-stale-subagent-start", "codex-stale-subagent-stop"]
+        let probePath = root.appendingPathComponent("target-resolution-error.txt", isDirectory: false)
+
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        let now = Date().timeIntervalSince1970
+        let storedSessions = Dictionary(uniqueKeysWithValues: sessionIds.map { sessionId in
+            (
+                sessionId,
+                [
+                    "sessionId": sessionId,
+                    "workspaceId": workspaceId,
+                    "surfaceId": staleSurfaceId,
+                    "cwd": root.path,
+                    "startedAt": now,
+                    "updatedAt": now,
+                ] as [String: Any]
+            )
+        })
+        let storeObject: [String: Any] = ["version": 1, "sessions": storedSessions]
+        try JSONSerialization.data(withJSONObject: storeObject, options: [.prettyPrinted])
+            .write(to: root.appendingPathComponent("codex-hook-sessions.json"), options: .atomic)
+
+        let serverHandled = startMockServer(listenerFD: listenerFD, state: state) { line in
+            guard let payload = self.jsonObject(line) else {
+                return "OK"
+            }
+            guard let id = payload["id"] as? String,
+                  let method = payload["method"] as? String else {
+                return self.malformedRequestResponse(id: payload["id"] as? String, raw: line)
+            }
+            switch method {
+            case "agent.resolve_delivery_target":
+                return self.v2Response(
+                    id: id,
+                    ok: false,
+                    error: ["code": "method_not_found", "message": "Legacy app without live resolver"]
+                )
+            case "system.top":
+                return self.v2Response(id: id, ok: true, result: ["windows": []])
+            case "surface.list":
+                let params = payload["params"] as? [String: Any] ?? [:]
+                guard params["workspace_id"] as? String == workspaceId else {
+                    return self.v2Response(
+                        id: id,
+                        ok: false,
+                        error: ["code": "not_found", "message": "Workspace not found"]
+                    )
+                }
+                return self.v2Response(
+                    id: id,
+                    ok: true,
+                    result: [
+                        "surfaces": [["id": focusedSurfaceId, "ref": "surface:1", "focused": true]],
+                    ]
+                )
+            case "workspace.current", "feed.push":
+                return self.v2Response(id: id, ok: true, result: ["workspace_id": workspaceId])
+            default:
+                return self.v2Response(
+                    id: id,
+                    ok: false,
+                    error: ["code": "unrecognized_method", "message": "unexpected method: \(method)"]
+                )
+            }
+        }
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_WORKSPACE_ID"] = workspaceId
+        environment["CMUX_SURFACE_ID"] = staleSurfaceId
+        environment["CMUX_AGENT_HOOK_STATE_DIR"] = root.path
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+        environment["CMUX_CLI_SENTRY_CAPTURE_PROBE_PATH"] = probePath.path
+        environment["CODEX_HOME"] = root.appendingPathComponent("codex-home", isDirectory: true).path
+        environment.removeValue(forKey: "CMUX_CODEX_PID")
+
+        for (index, subcommand) in ["subagent-start", "subagent-stop"].enumerated() {
+            let result = runProcess(
+                executablePath: cliPath,
+                arguments: ["hooks", "codex", subcommand],
+                environment: environment,
+                standardInput: #"{"session_id":"\#(sessionIds[index])","cwd":"\#(root.path)","hook_event_name":"SubagentStart","agent_id":"child-\#(index)","turn_id":"turn-\#(index)"}"#,
+                timeout: 5
+            )
+            XCTAssertFalse(result.timedOut, result.stderr)
+            XCTAssertEqual(result.status, 0, result.stderr)
+            XCTAssertEqual(result.stdout, "{}\n")
+        }
+
+        wait(for: [serverHandled], timeout: 5)
+        let journalCommands = state.commands.filter { $0.contains("agent_journal_append") }
+        XCTAssertFalse(
+            journalCommands.contains { $0.contains(staleSurfaceId) || $0.contains(focusedSurfaceId) },
+            "Rejected child targets must not journal activity under either stale or focused surface, saw \(journalCommands)"
+        )
+        XCTAssertFalse(
+            state.commands.contains { $0.contains("notify_target_async") },
+            "Rejected child targets must not trigger a settled-stop notification, saw \(state.commands)"
+        )
+        XCTAssertTrue(FileManager.default.fileExists(atPath: probePath.path))
+    }
 }

--- a/cmuxTests/CLINotificationPaneAttributionTests.swift
+++ b/cmuxTests/CLINotificationPaneAttributionTests.swift
@@ -1,0 +1,113 @@
+import Darwin
+import Foundation
+import XCTest
+
+extension CLINotifyProcessIntegrationRegressionTests {
+    /// Regression for https://github.com/manaflow-ai/cmux/issues/11189: when
+    /// the ambient surface is stale and the live resolver cannot prove a pane,
+    /// a generic hook must no-op instead of using the workspace's focused tab.
+    func testCodexPromptSubmitWithStaleSurfaceAndNoLiveEvidenceFailsClosed() throws {
+        let cliPath = try bundledCLIPath()
+        let socketPath = makeSocketPath("codex-stale-no-live")
+        let listenerFD = try bindUnixSocket(at: socketPath)
+        let state = MockSocketServerState()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-codex-stale-no-live-\(UUID().uuidString)", isDirectory: true)
+        let workspaceId = "11111111-1111-1111-1111-111111111111"
+        let staleSurfaceId = "22222222-2222-2222-2222-222222222222"
+        let focusedSurfaceId = "33333333-3333-3333-3333-333333333333"
+        let probePath = root.appendingPathComponent("target-resolution-error.txt", isDirectory: false)
+
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        let serverHandled = startMockServer(listenerFD: listenerFD, state: state) { line in
+            guard let payload = self.jsonObject(line) else {
+                return line.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("{")
+                    ? self.malformedRequestResponse(raw: line)
+                    : "OK"
+            }
+            guard let id = payload["id"] as? String,
+                  let method = payload["method"] as? String else {
+                return self.malformedRequestResponse(id: payload["id"] as? String, raw: line)
+            }
+            switch method {
+            case "agent.resolve_delivery_target":
+                return self.v2Response(
+                    id: id,
+                    ok: false,
+                    error: ["code": "method_not_found", "message": "Legacy app without live resolver"]
+                )
+            case "system.top":
+                return self.v2Response(id: id, ok: true, result: ["windows": []])
+            case "surface.list":
+                let params = payload["params"] as? [String: Any] ?? [:]
+                guard params["workspace_id"] as? String == workspaceId else {
+                    return self.v2Response(
+                        id: id,
+                        ok: false,
+                        error: ["code": "not_found", "message": "Workspace not found"]
+                    )
+                }
+                return self.v2Response(
+                    id: id,
+                    ok: true,
+                    result: [
+                        "surfaces": [
+                            [
+                                "id": focusedSurfaceId,
+                                "ref": "surface:1",
+                                "focused": true,
+                            ],
+                        ],
+                    ]
+                )
+            case "workspace.current":
+                return self.v2Response(id: id, ok: true, result: ["workspace_id": workspaceId])
+            case "feed.push":
+                return self.v2Response(id: id, ok: true, result: [:])
+            default:
+                return self.v2Response(
+                    id: id,
+                    ok: false,
+                    error: ["code": "unrecognized_method", "message": "unexpected method: \(method)"]
+                )
+            }
+        }
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_WORKSPACE_ID"] = workspaceId
+        environment["CMUX_SURFACE_ID"] = staleSurfaceId
+        environment["CMUX_AGENT_HOOK_STATE_DIR"] = root.path
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+        environment["CMUX_CLI_SENTRY_CAPTURE_PROBE_PATH"] = probePath.path
+        environment["CODEX_HOME"] = root.appendingPathComponent("codex-home", isDirectory: true).path
+        environment.removeValue(forKey: "CMUX_CODEX_PID")
+
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "codex", "prompt-submit"],
+            environment: environment,
+            standardInput: #"{"session_id":"codex-stale-no-live","cwd":"\#(root.path)","hook_event_name":"UserPromptSubmit","prompt":"continue"}"#,
+            timeout: 5
+        )
+
+        wait(for: [serverHandled], timeout: 5)
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+        XCTAssertEqual(result.stdout, "{}\n")
+        XCTAssertFalse(
+            state.commands.contains { $0.contains("notify_target_async") || $0.contains("set_status codex") },
+            "A stale surface with no live proof must not mutate the focused pane, saw \(state.commands)"
+        )
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: probePath.path),
+            "Fail-closed target resolution must leave a diagnostic"
+        )
+    }
+}

--- a/cmuxTests/CLINotificationPaneAttributionTests.swift
+++ b/cmuxTests/CLINotificationPaneAttributionTests.swift
@@ -19,7 +19,6 @@ extension CLINotifyProcessIntegrationRegressionTests {
         let workspaceId = "11111111-1111-1111-1111-111111111111"
         let staleSurfaceId = "22222222-2222-2222-2222-222222222222"
         let focusedSurfaceId = "33333333-3333-3333-3333-333333333333"
-        let probePath = root.appendingPathComponent("target-resolution-error.txt", isDirectory: false)
 
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         defer {
@@ -73,6 +72,8 @@ extension CLINotifyProcessIntegrationRegressionTests {
                 return self.v2Response(id: id, ok: true, result: ["workspace_id": workspaceId])
             case "feed.push":
                 return self.v2Response(id: id, ok: true, result: [:])
+            case "agent_journal_append":
+                return "OK 1"
             default:
                 return self.v2Response(
                     id: id,
@@ -88,7 +89,6 @@ extension CLINotifyProcessIntegrationRegressionTests {
         environment["CMUX_SURFACE_ID"] = staleSurfaceId
         environment["CMUX_AGENT_HOOK_STATE_DIR"] = root.path
         environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
-        environment["CMUX_CLI_SENTRY_CAPTURE_PROBE_PATH"] = probePath.path
         environment["CODEX_HOME"] = root.appendingPathComponent("codex-home", isDirectory: true).path
         environment.removeValue(forKey: "CMUX_CODEX_PID")
 
@@ -109,8 +109,10 @@ extension CLINotifyProcessIntegrationRegressionTests {
             "A stale surface with no live proof must not mutate the focused pane, saw \(state.commands)"
         )
         XCTAssertTrue(
-            FileManager.default.fileExists(atPath: probePath.path),
-            "Fail-closed target resolution must leave a diagnostic"
+            AgentJournalAppendCapture.captures(in: state.commands).contains {
+                $0.unattributedReason == "target-unresolved" && $0.surfaceId == nil
+            },
+            "Fail-closed target resolution must leave an unattributed journal diagnostic, saw \(state.commands)"
         )
     }
 
@@ -129,7 +131,6 @@ extension CLINotifyProcessIntegrationRegressionTests {
         let sessionIds = ["codex-stale-subagent-start", "codex-stale-subagent-stop"]
         let settledSessionId = sessionIds[1]
         let settledTurnId = "turn-1"
-        let probePath = root.appendingPathComponent("target-resolution-error.txt", isDirectory: false)
         let ledgerPath = root.appendingPathComponent("codex-turn-ledger.json")
 
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
@@ -211,6 +212,8 @@ extension CLINotifyProcessIntegrationRegressionTests {
                 )
             case "workspace.current", "feed.push":
                 return self.v2Response(id: id, ok: true, result: ["workspace_id": workspaceId])
+            case "agent_journal_append":
+                return "OK 1"
             default:
                 return self.v2Response(
                     id: id,
@@ -226,7 +229,6 @@ extension CLINotifyProcessIntegrationRegressionTests {
         environment["CMUX_SURFACE_ID"] = staleSurfaceId
         environment["CMUX_AGENT_HOOK_STATE_DIR"] = root.path
         environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
-        environment["CMUX_CLI_SENTRY_CAPTURE_PROBE_PATH"] = probePath.path
         environment["CODEX_HOME"] = root.appendingPathComponent("codex-home", isDirectory: true).path
         environment["CMUX_CODEX_TURN_LEDGER_PATH"] = ledgerPath.path
         environment.removeValue(forKey: "CMUX_CODEX_PID")
@@ -273,6 +275,11 @@ extension CLINotifyProcessIntegrationRegressionTests {
             (settledRecord["settledTurnIDs"] as? [String])?.contains(settledTurnId) == true,
             "An unresolved SubagentStop must still settle the pending turn by session identity"
         )
-        XCTAssertTrue(FileManager.default.fileExists(atPath: probePath.path))
+        XCTAssertTrue(
+            AgentJournalAppendCapture.captures(in: state.commands).contains {
+                $0.unattributedReason == "target-unresolved" && $0.surfaceId == nil
+            },
+            "Fail-closed child lifecycle must leave an unattributed journal diagnostic, saw \(state.commands)"
+        )
     }
 }

--- a/cmuxTests/GhosttyTerminalViewVisibilityPolicyTests.swift
+++ b/cmuxTests/GhosttyTerminalViewVisibilityPolicyTests.swift
@@ -259,16 +259,18 @@ struct GhosttyTerminalViewVisibilityPolicyTests {
 
         let panel = TerminalPanel(workspaceId: UUID())
         let coordinator = GhosttyTerminalView.Coordinator()
+        var ownsPane = true
         coordinator.attachGeneration = 1
         coordinator.hostedView = panel.hostedView
         coordinator.desiredIsVisibleInUI = true
+        coordinator.desiredShowsUnreadNotificationRing = true
         let snapshot = TerminalPortalReconciliationSnapshot(
             attachGeneration: coordinator.attachGeneration,
             expectedSurfaceId: panel.surface.id,
             expectedSurfaceGeneration: panel.surface.portalBindingGeneration(),
             paneId: PaneID(),
             ownershipGeneration: 1,
-            isCurrentPaneOwner: { true },
+            isCurrentPaneOwner: { ownsPane },
             workspaceAttentionColor: WorkspaceAttentionColor(configuredHex: "#FF69B4"),
             sessionContentWidthPresentation: .disabled,
             onFocus: nil,
@@ -300,10 +302,13 @@ struct GhosttyTerminalViewVisibilityPolicyTests {
         await flushPortalReconciliationPasses()
         #expect(TerminalWindowPortalRegistry.isHostedView(panel.hostedView, boundTo: host))
         #expect(!panel.hostedView.isHidden)
+        #expect(!panel.hostedView.debugNotificationRingState().isHidden)
 
         host.removeFromSuperview()
         #expect(host.window == nil)
+        ownsPane = false
         coordinator.desiredIsVisibleInUI = false
+        coordinator.desiredShowsUnreadNotificationRing = false
         GhosttyTerminalView.stagePortalReconciliation(
             hostedView: panel.hostedView,
             host: host,
@@ -314,6 +319,10 @@ struct GhosttyTerminalViewVisibilityPolicyTests {
             reason: "test.detachedHide"
         )
         coordinator.portalReconciliationScheduler.flushPendingReconciliation()
+        #expect(
+            panel.hostedView.debugNotificationRingState().isHidden,
+            "A reconciliation that no longer owns the portal must still project the latest ring state"
+        )
 
         // Reattach before the queued geometry pass can prune the detached,
         // hidden entry. Synchronizing now distinguishes persisted visibility

--- a/cmuxTests/TerminalCallerTTYResolverTests.swift
+++ b/cmuxTests/TerminalCallerTTYResolverTests.swift
@@ -59,6 +59,7 @@ struct TerminalCallerTTYResolverTests {
         // always choose the live proof, independent of candidate order.
         let liveCandidates = [
             (binding: runtime, ttyName: "/dev/ttys777"),
+            (binding: TerminalCallerTTYBinding(workspaceId: UUID(), surfaceId: UUID()), ttyName: "ttys888"),
         ]
         let restoredCandidates = [
             (binding: restored, ttyName: "ttys777"),

--- a/cmuxTests/TerminalCallerTTYResolverTests.swift
+++ b/cmuxTests/TerminalCallerTTYResolverTests.swift
@@ -32,14 +32,48 @@ struct TerminalCallerTTYResolverTests {
     @Test func duplicateReportedBindingsFailClosed() {
         let first = TerminalCallerTTYBinding(workspaceId: UUID(), surfaceId: UUID())
         let second = TerminalCallerTTYBinding(workspaceId: UUID(), surfaceId: UUID())
-        let resolver = TerminalCallerTTYResolver(
-            reportedCandidates: [
-                (binding: first, ttyName: "ttys8362"),
-                (binding: second, ttyName: "/dev/ttys8362"),
-            ]
-        )
+        let candidates = [
+            (binding: first, ttyName: "ttys8362"),
+            (binding: second, ttyName: "/dev/ttys8362"),
+        ]
 
-        #expect(resolver.binding(for: "ttys8362") == nil)
+        // Dictionary-backed TTY metadata has no stable iteration order. Every
+        // permutation must remain ambiguous instead of selecting whichever row
+        // happens to be visited first.
+        let permutations: [[(binding: TerminalCallerTTYBinding, ttyName: String)]] = [
+            candidates,
+            Array(candidates.reversed()),
+        ]
+        for permutation in permutations {
+            let resolver = TerminalCallerTTYResolver(reportedCandidates: permutation)
+            #expect(resolver.binding(for: "ttys8362") == nil)
+        }
+    }
+
+    @Test func currentRuntimeBindingWinsOverRestoredDuplicateRegardlessOfOrder() {
+        let runtime = TerminalCallerTTYBinding(workspaceId: UUID(), surfaceId: UUID())
+        let restored = TerminalCallerTTYBinding(workspaceId: UUID(), surfaceId: UUID())
+
+        // The app resolver places a current Ghostty PTY in the live tier and a
+        // restored shell report in the fallback tier. The strict resolver must
+        // always choose the live proof, independent of candidate order.
+        let liveCandidates = [
+            (binding: runtime, ttyName: "/dev/ttys777"),
+        ]
+        let restoredCandidates = [
+            (binding: restored, ttyName: "ttys777"),
+        ]
+        let livePermutations: [[(binding: TerminalCallerTTYBinding, ttyName: String)]] = [
+            liveCandidates,
+            Array(liveCandidates.reversed()),
+        ]
+        for live in livePermutations {
+            let resolver = TerminalCallerTTYResolver(
+                liveCandidates: live,
+                reportedCandidates: restoredCandidates
+            )
+            #expect(resolver.binding(for: "ttys777") == runtime)
+        }
     }
 
     @Test func ambiguousLiveBindingsDoNotFallBackToReportedBinding() {

--- a/cmuxTests/TerminalControllingTTYWaiter.swift
+++ b/cmuxTests/TerminalControllingTTYWaiter.swift
@@ -1,0 +1,43 @@
+import Darwin
+import Foundation
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Polls a terminal runtime for its controlling TTY with one shared timeout policy.
+struct TerminalControllingTTYWaiter {
+    private let clock: ContinuousClock
+    private let pollInterval: Duration
+
+    init(
+        clock: ContinuousClock = ContinuousClock(),
+        pollInterval: Duration = .milliseconds(10)
+    ) {
+        self.clock = clock
+        self.pollInterval = pollInterval
+    }
+
+    func wait(
+        for terminal: TerminalPanel,
+        timeout: Duration = .seconds(5)
+    ) async throws -> String {
+        let deadline = clock.now + timeout
+        while clock.now < deadline {
+            if let ttyName = terminal.surface.controllingTTYName() {
+                return ttyName
+            }
+            try await clock.sleep(for: pollInterval)
+        }
+        if let ttyName = terminal.surface.controllingTTYName() {
+            return ttyName
+        }
+        throw NSError(
+            domain: NSPOSIXErrorDomain,
+            code: Int(ENODEV),
+            userInfo: [NSLocalizedDescriptionKey: "Terminal surface did not expose a controlling TTY"]
+        )
+    }
+}

--- a/cmuxTests/TerminalNotificationCallerTests.swift
+++ b/cmuxTests/TerminalNotificationCallerTests.swift
@@ -7,6 +7,8 @@ import Darwin
 @testable import cmux
 #endif
 
+// This existing socket suite stays on XCTest because its lifecycle uses
+// XCTestCase setUp/tearDown and XCTestExpectation-backed socket delivery.
 @MainActor
 final class TerminalNotificationCallerTests: XCTestCase {
     override func setUp() {
@@ -41,7 +43,7 @@ final class TerminalNotificationCallerTests: XCTestCase {
         appDelegate.notificationStore = store
         AppFocusState.overrideIsFocused = false
 
-        let workspace = manager.addWorkspace(select: true)
+        let workspace = manager.addWorkspace(select: true, eagerLoadTerminal: true)
         defer {
             if manager.tabs.contains(where: { $0.id == workspace.id }) {
                 manager.closeWorkspace(workspace)
@@ -56,7 +58,7 @@ final class TerminalNotificationCallerTests: XCTestCase {
 
         let focusedPanelId = try XCTUnwrap(workspace.focusedPanelId)
         let focusedTerminal = try XCTUnwrap(workspace.panels[focusedPanelId] as? TerminalPanel)
-        let callerTTY = try XCTUnwrap(focusedTerminal.surface.controllingTTYName())
+        let callerTTY = try await waitForControllingTTYName(focusedTerminal)
         workspace.surfaceTTYNames[focusedPanelId] = callerTTY
 
         TerminalController.shared.start(
@@ -229,76 +231,6 @@ final class TerminalNotificationCallerTests: XCTestCase {
         XCTAssertFalse(store.hasUnreadNotification(forTabId: fallbackWorkspace.id, surfaceId: fallbackWorkspace.focusedPanelId))
     }
 
-    func testNotificationCreateForCallerPrefersPreferredSurfaceOverConflictingTTY() async throws {
-        let fixture = try makeSocketFixture(name: "notify-surface-over-tty")
-        defer { fixture.cleanup() }
-
-        let fallbackWorkspace = fixture.workspace
-        let targetWorkspace = fixture.manager.addWorkspace(title: "Preferred Surface", select: false)
-        let targetSurfaceId = try XCTUnwrap(targetWorkspace.focusedPanelId)
-
-        // This is deliberately stale/unproven metadata. The old dictionary
-        // scan returned the focused fallback pane before considering the
-        // preferred surface; strict resolution must let the surface identity
-        // win even when the claimed workspace is dead and prefer_tty is true.
-        fallbackWorkspace.surfaceTTYNames[fixture.surfaceId] = "/dev/ttys777"
-        let response = try await sendV2RequestAsync(
-            method: "notification.create_for_caller",
-            params: [
-                "preferred_workspace_id": UUID().uuidString,
-                "preferred_surface_id": targetSurfaceId.uuidString,
-                "caller_tty": "/dev/ttys777",
-                "prefer_tty": true,
-                "title": "Preferred surface",
-                "subtitle": "Evidence",
-                "body": "Surface identity wins"
-            ],
-            to: fixture.socketPath
-        )
-
-        XCTAssertEqual(response["ok"] as? Bool, true, "\(response)")
-        let result = try XCTUnwrap(response["result"] as? [String: Any])
-        XCTAssertEqual(result["workspace_id"] as? String, targetWorkspace.id.uuidString)
-        XCTAssertEqual(result["surface_id"] as? String, targetSurfaceId.uuidString)
-        XCTAssertTrue(fixture.store.hasUnreadNotification(forTabId: targetWorkspace.id, surfaceId: targetSurfaceId))
-        XCTAssertFalse(fixture.store.hasUnreadNotification(forTabId: fallbackWorkspace.id, surfaceId: fixture.surfaceId))
-    }
-
-    func testNotificationCreateForCallerRejectsAmbiguousReportedTTY() async throws {
-        let fixture = try makeSocketFixture(name: "notify-ambiguous-tty")
-        defer { fixture.cleanup() }
-
-        let focusedSurfaceId = fixture.surfaceId
-        let siblingPanel = try XCTUnwrap(
-            fixture.workspace.newTerminalSplit(
-                from: focusedSurfaceId,
-                orientation: .horizontal,
-                focus: false
-            )
-        )
-        let ambiguousTTY = "/dev/ttys777"
-        fixture.workspace.surfaceTTYNames[focusedSurfaceId] = ambiguousTTY
-        fixture.workspace.surfaceTTYNames[siblingPanel.id] = ambiguousTTY
-
-        let response = try await sendV2RequestAsync(
-            method: "notification.create_for_caller",
-            params: [
-                "caller_tty": ambiguousTTY,
-                "prefer_tty": false,
-                "title": "Ambiguous",
-                "subtitle": "TTY",
-                "body": "Must fail closed"
-            ],
-            to: fixture.socketPath
-        )
-
-        XCTAssertEqual(response["ok"] as? Bool, false, "\(response)")
-        let error = try XCTUnwrap(response["error"] as? [String: Any])
-        XCTAssertEqual(error["code"] as? String, "not_found")
-        XCTAssertFalse(fixture.store.hasUnreadNotification(forTabId: fixture.workspace.id, surfaceId: focusedSurfaceId))
-        XCTAssertFalse(fixture.store.hasUnreadNotification(forTabId: fixture.workspace.id, surfaceId: siblingPanel.id))
-    }
-
     func testNotifyTargetUpdatesStoreBeforeResponseWhenAsyncDrainsAreSuspended() async throws {
         let socketPath = makeSocketPath("notify-sync")
         let store = TerminalNotificationStore.shared
@@ -378,6 +310,21 @@ final class TerminalNotificationCallerTests: XCTestCase {
         return URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("tnc-\(name.prefix(4))-\(shortID).sock")
             .path
+    }
+
+    private func waitForControllingTTYName(_ terminal: TerminalPanel) async throws -> String {
+        let deadline = Date().addingTimeInterval(5)
+        while Date() < deadline {
+            if let ttyName = terminal.surface.controllingTTYName() {
+                return ttyName
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        throw NSError(
+            domain: NSPOSIXErrorDomain,
+            code: Int(ENODEV),
+            userInfo: [NSLocalizedDescriptionKey: "Terminal surface did not expose a controlling TTY"]
+        )
     }
 
     private func waitForSocket(at path: String, timeout: TimeInterval = 5.0) throws {

--- a/cmuxTests/TerminalNotificationCallerTests.swift
+++ b/cmuxTests/TerminalNotificationCallerTests.swift
@@ -58,7 +58,7 @@ final class TerminalNotificationCallerTests: XCTestCase {
 
         let focusedPanelId = try XCTUnwrap(workspace.focusedPanelId)
         let focusedTerminal = try XCTUnwrap(workspace.panels[focusedPanelId] as? TerminalPanel)
-        let callerTTY = try await waitForControllingTTYName(focusedTerminal)
+        let callerTTY = try await TerminalControllingTTYWaiter().wait(for: focusedTerminal)
         workspace.surfaceTTYNames[focusedPanelId] = callerTTY
 
         TerminalController.shared.start(
@@ -310,21 +310,6 @@ final class TerminalNotificationCallerTests: XCTestCase {
         return URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("tnc-\(name.prefix(4))-\(shortID).sock")
             .path
-    }
-
-    private func waitForControllingTTYName(_ terminal: TerminalPanel) async throws -> String {
-        let deadline = Date().addingTimeInterval(5)
-        while Date() < deadline {
-            if let ttyName = terminal.surface.controllingTTYName() {
-                return ttyName
-            }
-            try await Task.sleep(for: .milliseconds(10))
-        }
-        throw NSError(
-            domain: NSPOSIXErrorDomain,
-            code: Int(ENODEV),
-            userInfo: [NSLocalizedDescriptionKey: "Terminal surface did not expose a controlling TTY"]
-        )
     }
 
     private func waitForSocket(at path: String, timeout: TimeInterval = 5.0) throws {

--- a/cmuxTests/TerminalNotificationCallerTests.swift
+++ b/cmuxTests/TerminalNotificationCallerTests.swift
@@ -1,4 +1,4 @@
-import XCTest
+@preconcurrency import XCTest
 import AppKit
 import Darwin
 #if canImport(cmux_DEV)

--- a/cmuxTests/TerminalNotificationCallerTests.swift
+++ b/cmuxTests/TerminalNotificationCallerTests.swift
@@ -55,7 +55,9 @@ final class TerminalNotificationCallerTests: XCTestCase {
         }
 
         let focusedPanelId = try XCTUnwrap(workspace.focusedPanelId)
-        workspace.surfaceTTYNames[focusedPanelId] = "/dev/ttys777"
+        let focusedTerminal = try XCTUnwrap(workspace.panels[focusedPanelId] as? TerminalPanel)
+        let callerTTY = try XCTUnwrap(focusedTerminal.surface.controllingTTYName())
+        workspace.surfaceTTYNames[focusedPanelId] = callerTTY
 
         TerminalController.shared.start(
             tabManager: manager,
@@ -69,7 +71,7 @@ final class TerminalNotificationCallerTests: XCTestCase {
             params: [
                 "preferred_workspace_id": UUID().uuidString,
                 "preferred_surface_id": UUID().uuidString,
-                "caller_tty": "/dev/ttys777",
+                "caller_tty": callerTTY,
                 "prefer_tty": false,
                 "title": "Caller",
                 "subtitle": "TTY",
@@ -225,6 +227,76 @@ final class TerminalNotificationCallerTests: XCTestCase {
         await fulfillment(of: [notificationQueued], timeout: 1.0)
         XCTAssertTrue(store.hasUnreadNotification(forTabId: targetWorkspace.id, surfaceId: targetSurfaceId))
         XCTAssertFalse(store.hasUnreadNotification(forTabId: fallbackWorkspace.id, surfaceId: fallbackWorkspace.focusedPanelId))
+    }
+
+    func testNotificationCreateForCallerPrefersPreferredSurfaceOverConflictingTTY() async throws {
+        let fixture = try makeSocketFixture(name: "notify-surface-over-tty")
+        defer { fixture.cleanup() }
+
+        let fallbackWorkspace = fixture.workspace
+        let targetWorkspace = fixture.manager.addWorkspace(title: "Preferred Surface", select: false)
+        let targetSurfaceId = try XCTUnwrap(targetWorkspace.focusedPanelId)
+
+        // This is deliberately stale/unproven metadata. The old dictionary
+        // scan returned the focused fallback pane before considering the
+        // preferred surface; strict resolution must let the surface identity
+        // win even when the claimed workspace is dead and prefer_tty is true.
+        fallbackWorkspace.surfaceTTYNames[fixture.surfaceId] = "/dev/ttys777"
+        let response = try await sendV2RequestAsync(
+            method: "notification.create_for_caller",
+            params: [
+                "preferred_workspace_id": UUID().uuidString,
+                "preferred_surface_id": targetSurfaceId.uuidString,
+                "caller_tty": "/dev/ttys777",
+                "prefer_tty": true,
+                "title": "Preferred surface",
+                "subtitle": "Evidence",
+                "body": "Surface identity wins"
+            ],
+            to: fixture.socketPath
+        )
+
+        XCTAssertEqual(response["ok"] as? Bool, true, "\(response)")
+        let result = try XCTUnwrap(response["result"] as? [String: Any])
+        XCTAssertEqual(result["workspace_id"] as? String, targetWorkspace.id.uuidString)
+        XCTAssertEqual(result["surface_id"] as? String, targetSurfaceId.uuidString)
+        XCTAssertTrue(fixture.store.hasUnreadNotification(forTabId: targetWorkspace.id, surfaceId: targetSurfaceId))
+        XCTAssertFalse(fixture.store.hasUnreadNotification(forTabId: fallbackWorkspace.id, surfaceId: fixture.surfaceId))
+    }
+
+    func testNotificationCreateForCallerRejectsAmbiguousReportedTTY() async throws {
+        let fixture = try makeSocketFixture(name: "notify-ambiguous-tty")
+        defer { fixture.cleanup() }
+
+        let focusedSurfaceId = fixture.surfaceId
+        let siblingPanel = try XCTUnwrap(
+            fixture.workspace.newTerminalSplit(
+                from: focusedSurfaceId,
+                orientation: .horizontal,
+                focus: false
+            )
+        )
+        let ambiguousTTY = "/dev/ttys777"
+        fixture.workspace.surfaceTTYNames[focusedSurfaceId] = ambiguousTTY
+        fixture.workspace.surfaceTTYNames[siblingPanel.id] = ambiguousTTY
+
+        let response = try await sendV2RequestAsync(
+            method: "notification.create_for_caller",
+            params: [
+                "caller_tty": ambiguousTTY,
+                "prefer_tty": false,
+                "title": "Ambiguous",
+                "subtitle": "TTY",
+                "body": "Must fail closed"
+            ],
+            to: fixture.socketPath
+        )
+
+        XCTAssertEqual(response["ok"] as? Bool, false, "\(response)")
+        let error = try XCTUnwrap(response["error"] as? [String: Any])
+        XCTAssertEqual(error["code"] as? String, "not_found")
+        XCTAssertFalse(fixture.store.hasUnreadNotification(forTabId: fixture.workspace.id, surfaceId: focusedSurfaceId))
+        XCTAssertFalse(fixture.store.hasUnreadNotification(forTabId: fixture.workspace.id, surfaceId: siblingPanel.id))
     }
 
     func testNotifyTargetUpdatesStoreBeforeResponseWhenAsyncDrainsAreSuspended() async throws {

--- a/cmuxTests/TerminalNotificationSocketActionTests.swift
+++ b/cmuxTests/TerminalNotificationSocketActionTests.swift
@@ -1,4 +1,4 @@
-import XCTest
+@preconcurrency import XCTest
 import AppKit
 import Darwin
 #if canImport(cmux_DEV)
@@ -7,6 +7,8 @@ import Darwin
 @testable import cmux
 #endif
 
+// This existing socket suite remains on XCTest because its tests share the
+// XCTestCase setup/teardown and socket fixture lifecycle below.
 @MainActor
 final class TerminalNotificationSocketActionTests: XCTestCase {
     override func setUp() {
@@ -234,7 +236,7 @@ final class TerminalNotificationSocketActionTests: XCTestCase {
         XCTAssertEqual(fixture.notification(openable.id)?.isRead, true)
     }
 
-    private struct SocketFixture {
+    struct SocketFixture {
         let socketPath: String
         let store: TerminalNotificationStore
         let appDelegate: AppDelegate
@@ -274,7 +276,7 @@ final class TerminalNotificationSocketActionTests: XCTestCase {
         }
     }
 
-    private func makeSocketFixture(name: String, includeWindow: Bool = false) throws -> SocketFixture {
+    func makeSocketFixture(name: String, includeWindow: Bool = false) throws -> SocketFixture {
         let socketPath = makeSocketPath(name)
         let store = TerminalNotificationStore.shared
         let previousShared = AppDelegate.shared
@@ -384,7 +386,7 @@ final class TerminalNotificationSocketActionTests: XCTestCase {
         )
     }
 
-    private func sendV2RequestAsync(
+    func sendV2RequestAsync(
         method: String,
         params: [String: Any] = [:],
         to socketPath: String

--- a/cmuxTests/TerminalNotificationSocketActionTests.swift
+++ b/cmuxTests/TerminalNotificationSocketActionTests.swift
@@ -276,7 +276,11 @@ final class TerminalNotificationSocketActionTests: XCTestCase {
         }
     }
 
-    func makeSocketFixture(name: String, includeWindow: Bool = false) throws -> SocketFixture {
+    func makeSocketFixture(
+        name: String,
+        includeWindow: Bool = false,
+        eagerLoadTerminal: Bool = false
+    ) throws -> SocketFixture {
         let socketPath = makeSocketPath(name)
         let store = TerminalNotificationStore.shared
         let previousShared = AppDelegate.shared
@@ -294,7 +298,11 @@ final class TerminalNotificationSocketActionTests: XCTestCase {
         appDelegate.notificationStore = store
         AppFocusState.overrideIsFocused = false
 
-        let workspace = manager.addWorkspace(title: "Socket Notifications", select: true)
+        let workspace = manager.addWorkspace(
+            title: "Socket Notifications",
+            select: true,
+            eagerLoadTerminal: eagerLoadTerminal
+        )
         let surfaceId = try XCTUnwrap(workspace.focusedPanelId)
 
         let windowId: UUID?

--- a/cmuxTests/TerminalNotificationSocketActionTests.swift
+++ b/cmuxTests/TerminalNotificationSocketActionTests.swift
@@ -275,12 +275,7 @@ final class TerminalNotificationSocketActionTests: XCTestCase {
             unlink(socketPath)
         }
     }
-
-    func makeSocketFixture(
-        name: String,
-        includeWindow: Bool = false,
-        eagerLoadTerminal: Bool = false
-    ) throws -> SocketFixture {
+    func makeSocketFixture(name: String, includeWindow: Bool = false, eagerLoadTerminal: Bool = false) throws -> SocketFixture {
         let socketPath = makeSocketPath(name)
         let store = TerminalNotificationStore.shared
         let previousShared = AppDelegate.shared
@@ -298,11 +293,7 @@ final class TerminalNotificationSocketActionTests: XCTestCase {
         appDelegate.notificationStore = store
         AppFocusState.overrideIsFocused = false
 
-        let workspace = manager.addWorkspace(
-            title: "Socket Notifications",
-            select: true,
-            eagerLoadTerminal: eagerLoadTerminal
-        )
+        let workspace = manager.addWorkspace(title: "Socket Notifications", select: true, eagerLoadTerminal: eagerLoadTerminal)
         let surfaceId = try XCTUnwrap(workspace.focusedPanelId)
 
         let windowId: UUID?
@@ -351,7 +342,6 @@ final class TerminalNotificationSocketActionTests: XCTestCase {
             originalAppFocusOverride: originalAppFocusOverride
         )
     }
-
     private func makeNotification(
         tabId: UUID,
         surfaceId: UUID?,

--- a/cmuxTests/TerminalNotificationSocketAttributionTests.swift
+++ b/cmuxTests/TerminalNotificationSocketAttributionTests.swift
@@ -1,5 +1,10 @@
 @preconcurrency import XCTest
 import Foundation
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
 
 // Stays on XCTest deliberately: these cases extend the existing socket-action
 // suite and reuse its process-safe fixture/server lifecycle.
@@ -54,10 +59,21 @@ extension TerminalNotificationSocketActionTests {
                 focus: false
             )
         )
-        let focusedTerminal = try XCTUnwrap(
-            fixture.workspace.panels[focusedSurfaceId] as? TerminalPanel
+        let temporaryPanel = try XCTUnwrap(
+            fixture.workspace.newTerminalSplit(
+                from: siblingPanel.id,
+                orientation: .horizontal,
+                focus: false
+            )
         )
-        let ambiguousTTY = try XCTUnwrap(focusedTerminal.surface.controllingTTYName())
+        // Keep a real, session-valid TTY name for PortScanner freshness, but
+        // detach its panel so no live runtime candidate owns that name. The
+        // two remaining panels then exercise the reported-TTY ambiguity tier.
+        let temporaryTransfer = try XCTUnwrap(
+            fixture.workspace.detachSurface(panelId: temporaryPanel.id)
+        )
+        let temporaryTerminal = try XCTUnwrap(temporaryTransfer.panel as? TerminalPanel)
+        let ambiguousTTY = try await waitForControllingTTYName(temporaryTerminal)
         fixture.workspace.registerReportedSurfaceTTYName(ambiguousTTY, panelId: focusedSurfaceId)
         fixture.workspace.registerReportedSurfaceTTYName(ambiguousTTY, panelId: siblingPanel.id)
         PortScanner.shared.registerTTY(
@@ -88,5 +104,23 @@ extension TerminalNotificationSocketActionTests {
         XCTAssertEqual(error["code"] as? String, "not_found")
         XCTAssertFalse(fixture.store.hasUnreadNotification(forTabId: fixture.workspace.id, surfaceId: focusedSurfaceId))
         XCTAssertFalse(fixture.store.hasUnreadNotification(forTabId: fixture.workspace.id, surfaceId: siblingPanel.id))
+    }
+
+    private func waitForControllingTTYName(
+        _ terminal: TerminalPanel,
+        timeout: TimeInterval = 5
+    ) async throws -> String {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if let ttyName = terminal.surface.controllingTTYName() {
+                return ttyName
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        throw NSError(
+            domain: "TerminalNotificationSocketAttributionTests",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "Terminal surface did not expose a controlling TTY"]
+        )
     }
 }

--- a/cmuxTests/TerminalNotificationSocketAttributionTests.swift
+++ b/cmuxTests/TerminalNotificationSocketAttributionTests.swift
@@ -9,6 +9,33 @@ import Foundation
 // Stays on XCTest deliberately: these cases extend the existing socket-action
 // suite and reuse its process-safe fixture/server lifecycle.
 extension TerminalNotificationSocketActionTests {
+    func testNotificationCreateForCallerKeepsExplicitWorkspaceOverForeignAmbientSurface() async throws {
+        let fixture = try makeSocketFixture(name: "notify-workspace-scope")
+        defer { fixture.cleanup() }
+
+        let foreignWorkspace = fixture.manager.addWorkspace(title: "Foreign Surface", select: false)
+        let foreignSurfaceId = try XCTUnwrap(foreignWorkspace.focusedPanelId)
+        let response = try await sendV2RequestAsync(
+            method: "notification.create_for_caller",
+            params: [
+                "preferred_workspace_id": fixture.workspace.id.uuidString,
+                "preferred_surface_id": foreignSurfaceId.uuidString,
+                "prefer_tty": false,
+                "title": "Workspace scope",
+                "subtitle": "Evidence",
+                "body": "No foreign pane ring"
+            ],
+            to: fixture.socketPath
+        )
+
+        XCTAssertEqual(response["ok"] as? Bool, true, "\(response)")
+        let result = try XCTUnwrap(response["result"] as? [String: Any])
+        XCTAssertEqual(result["workspace_id"] as? String, fixture.workspace.id.uuidString)
+        XCTAssertTrue(result["surface_id"] is NSNull)
+        XCTAssertTrue(fixture.store.hasUnreadNotification(forTabId: fixture.workspace.id))
+        XCTAssertFalse(fixture.store.hasUnreadNotification(forTabId: foreignWorkspace.id, surfaceId: foreignSurfaceId))
+    }
+
     func testNotificationCreateForCallerPrefersPreferredSurfaceOverConflictingTTY() async throws {
         let fixture = try makeSocketFixture(name: "notify-surface-over-tty")
         defer { fixture.cleanup() }

--- a/cmuxTests/TerminalNotificationSocketAttributionTests.swift
+++ b/cmuxTests/TerminalNotificationSocketAttributionTests.swift
@@ -40,7 +40,10 @@ extension TerminalNotificationSocketActionTests {
     }
 
     func testNotificationCreateForCallerRejectsAmbiguousReportedTTY() async throws {
-        let fixture = try makeSocketFixture(name: "notify-ambiguous-tty")
+        let fixture = try makeSocketFixture(
+            name: "notify-ambiguous-tty",
+            eagerLoadTerminal: true
+        )
         defer { fixture.cleanup() }
 
         let focusedSurfaceId = fixture.surfaceId

--- a/cmuxTests/TerminalNotificationSocketAttributionTests.swift
+++ b/cmuxTests/TerminalNotificationSocketAttributionTests.swift
@@ -52,8 +52,8 @@ extension TerminalNotificationSocketActionTests {
             )
         )
         let ambiguousTTY = "/dev/ttys777"
-        fixture.workspace.surfaceTTYNames[focusedSurfaceId] = ambiguousTTY
-        fixture.workspace.surfaceTTYNames[siblingPanel.id] = ambiguousTTY
+        fixture.workspace.registerReportedSurfaceTTYName(ambiguousTTY, panelId: focusedSurfaceId)
+        fixture.workspace.registerReportedSurfaceTTYName(ambiguousTTY, panelId: siblingPanel.id)
 
         let response = try await sendV2RequestAsync(
             method: "notification.create_for_caller",

--- a/cmuxTests/TerminalNotificationSocketAttributionTests.swift
+++ b/cmuxTests/TerminalNotificationSocketAttributionTests.swift
@@ -51,9 +51,22 @@ extension TerminalNotificationSocketActionTests {
                 focus: false
             )
         )
-        let ambiguousTTY = "/dev/ttys777"
+        let focusedTerminal = try XCTUnwrap(
+            fixture.workspace.panels[focusedSurfaceId] as? TerminalPanel
+        )
+        let ambiguousTTY = try XCTUnwrap(focusedTerminal.surface.controllingTTYName())
         fixture.workspace.registerReportedSurfaceTTYName(ambiguousTTY, panelId: focusedSurfaceId)
         fixture.workspace.registerReportedSurfaceTTYName(ambiguousTTY, panelId: siblingPanel.id)
+        PortScanner.shared.registerTTY(
+            workspaceId: fixture.workspace.id,
+            panelId: focusedSurfaceId,
+            ttyName: ambiguousTTY
+        )
+        PortScanner.shared.registerTTY(
+            workspaceId: fixture.workspace.id,
+            panelId: siblingPanel.id,
+            ttyName: ambiguousTTY
+        )
 
         let response = try await sendV2RequestAsync(
             method: "notification.create_for_caller",

--- a/cmuxTests/TerminalNotificationSocketAttributionTests.swift
+++ b/cmuxTests/TerminalNotificationSocketAttributionTests.swift
@@ -19,6 +19,7 @@ extension TerminalNotificationSocketActionTests {
             method: "notification.create_for_caller",
             params: [
                 "preferred_workspace_id": fixture.workspace.id.uuidString,
+                "preferred_workspace_is_explicit": true,
                 "preferred_surface_id": foreignSurfaceId.uuidString,
                 "prefer_tty": false,
                 "title": "Workspace scope",

--- a/cmuxTests/TerminalNotificationSocketAttributionTests.swift
+++ b/cmuxTests/TerminalNotificationSocketAttributionTests.swift
@@ -129,7 +129,7 @@ extension TerminalNotificationSocketActionTests {
             fixture.workspace.detachSurface(panelId: temporaryPanel.id)
         )
         let temporaryTerminal = try XCTUnwrap(temporaryTransfer.panel as? TerminalPanel)
-        let ambiguousTTY = try await waitForControllingTTYName(temporaryTerminal)
+        let ambiguousTTY = try await TerminalControllingTTYWaiter().wait(for: temporaryTerminal)
         fixture.workspace.registerReportedSurfaceTTYName(ambiguousTTY, panelId: focusedSurfaceId)
         fixture.workspace.registerReportedSurfaceTTYName(ambiguousTTY, panelId: siblingPanel.id)
         PortScanner.shared.registerTTY(
@@ -162,21 +162,69 @@ extension TerminalNotificationSocketActionTests {
         XCTAssertFalse(fixture.store.hasUnreadNotification(forTabId: fixture.workspace.id, surfaceId: siblingPanel.id))
     }
 
-    private func waitForControllingTTYName(
-        _ terminal: TerminalPanel,
-        timeout: TimeInterval = 5
-    ) async throws -> String {
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            if let ttyName = terminal.surface.controllingTTYName() {
-                return ttyName
-            }
-            try await Task.sleep(for: .milliseconds(10))
-        }
-        throw NSError(
-            domain: "TerminalNotificationSocketAttributionTests",
-            code: 1,
-            userInfo: [NSLocalizedDescriptionKey: "Terminal surface did not expose a controlling TTY"]
+    func testNotificationCreateForCallerKeepsExplicitWorkspaceWhenPreferredTTYIsForeign() async throws {
+        let fixture = try makeSocketFixture(
+            name: "notify-explicit-tty-scope",
+            eagerLoadTerminal: true
+        )
+        defer { fixture.cleanup() }
+
+        let foreignWorkspace = fixture.manager.addWorkspace(
+            title: "Foreign TTY",
+            select: false,
+            eagerLoadTerminal: true
+        )
+        let foreignSurfaceId = try XCTUnwrap(foreignWorkspace.focusedPanelId)
+        let foreignTerminal = try XCTUnwrap(
+            foreignWorkspace.panels[foreignSurfaceId] as? TerminalPanel
+        )
+        let foreignTTY = try await TerminalControllingTTYWaiter().wait(for: foreignTerminal)
+
+        let response = try await sendV2RequestAsync(
+            method: "notification.create_for_caller",
+            params: [
+                "preferred_workspace_id": fixture.workspace.id.uuidString,
+                "preferred_workspace_is_explicit": true,
+                "caller_tty": foreignTTY,
+                "prefer_tty": true,
+                "title": "Explicit workspace",
+                "subtitle": "TTY scope",
+                "body": "Do not cross the requested workspace"
+            ],
+            to: fixture.socketPath
+        )
+
+        XCTAssertEqual(response["ok"] as? Bool, true, "\(response)")
+        let result = try XCTUnwrap(response["result"] as? [String: Any])
+        XCTAssertEqual(result["workspace_id"] as? String, fixture.workspace.id.uuidString)
+        XCTAssertTrue(result["surface_id"] is NSNull)
+        XCTAssertTrue(fixture.store.hasUnreadNotification(forTabId: fixture.workspace.id))
+        XCTAssertFalse(
+            fixture.store.hasUnreadNotification(
+                forTabId: foreignWorkspace.id,
+                surfaceId: foreignSurfaceId
+            )
         )
     }
+
+    #if DEBUG
+    func testDebugNotificationRejectsMalformedCallerSelector() async throws {
+        let fixture = try makeSocketFixture(name: "notify-debug-selector")
+        defer { fixture.cleanup() }
+
+        let response = try await sendV2RequestAsync(
+            method: "debug.notification.emit",
+            params: [
+                "kind": "feed-question",
+                "preferred_surface_id": "not-a-surface-ref"
+            ],
+            to: fixture.socketPath
+        )
+
+        XCTAssertEqual(response["ok"] as? Bool, false, "\(response)")
+        let error = try XCTUnwrap(response["error"] as? [String: Any])
+        XCTAssertEqual(error["code"] as? String, "invalid_params")
+        XCTAssertTrue(fixture.store.notifications.isEmpty)
+    }
+    #endif
 }

--- a/cmuxTests/TerminalNotificationSocketAttributionTests.swift
+++ b/cmuxTests/TerminalNotificationSocketAttributionTests.swift
@@ -1,0 +1,76 @@
+@preconcurrency import XCTest
+import Foundation
+
+// Stays on XCTest deliberately: these cases extend the existing socket-action
+// suite and reuse its process-safe fixture/server lifecycle.
+extension TerminalNotificationSocketActionTests {
+    func testNotificationCreateForCallerPrefersPreferredSurfaceOverConflictingTTY() async throws {
+        let fixture = try makeSocketFixture(name: "notify-surface-over-tty")
+        defer { fixture.cleanup() }
+
+        let fallbackWorkspace = fixture.workspace
+        let targetWorkspace = fixture.manager.addWorkspace(title: "Preferred Surface", select: false)
+        let targetSurfaceId = try XCTUnwrap(targetWorkspace.focusedPanelId)
+
+        // This is deliberately stale/unproven metadata. The old dictionary
+        // scan returned the focused fallback pane before considering the
+        // preferred surface; strict resolution must let the surface identity
+        // win when no explicit TTY preference is requested.
+        fallbackWorkspace.surfaceTTYNames[fixture.surfaceId] = "/dev/ttys777"
+        let response = try await sendV2RequestAsync(
+            method: "notification.create_for_caller",
+            params: [
+                "preferred_workspace_id": UUID().uuidString,
+                "preferred_surface_id": targetSurfaceId.uuidString,
+                "caller_tty": "/dev/ttys777",
+                "prefer_tty": false,
+                "title": "Preferred surface",
+                "subtitle": "Evidence",
+                "body": "Surface identity wins"
+            ],
+            to: fixture.socketPath
+        )
+
+        XCTAssertEqual(response["ok"] as? Bool, true, "\(response)")
+        let result = try XCTUnwrap(response["result"] as? [String: Any])
+        XCTAssertEqual(result["workspace_id"] as? String, targetWorkspace.id.uuidString)
+        XCTAssertEqual(result["surface_id"] as? String, targetSurfaceId.uuidString)
+        XCTAssertTrue(fixture.store.hasUnreadNotification(forTabId: targetWorkspace.id, surfaceId: targetSurfaceId))
+        XCTAssertFalse(fixture.store.hasUnreadNotification(forTabId: fallbackWorkspace.id, surfaceId: fixture.surfaceId))
+    }
+
+    func testNotificationCreateForCallerRejectsAmbiguousReportedTTY() async throws {
+        let fixture = try makeSocketFixture(name: "notify-ambiguous-tty")
+        defer { fixture.cleanup() }
+
+        let focusedSurfaceId = fixture.surfaceId
+        let siblingPanel = try XCTUnwrap(
+            fixture.workspace.newTerminalSplit(
+                from: focusedSurfaceId,
+                orientation: .horizontal,
+                focus: false
+            )
+        )
+        let ambiguousTTY = "/dev/ttys777"
+        fixture.workspace.surfaceTTYNames[focusedSurfaceId] = ambiguousTTY
+        fixture.workspace.surfaceTTYNames[siblingPanel.id] = ambiguousTTY
+
+        let response = try await sendV2RequestAsync(
+            method: "notification.create_for_caller",
+            params: [
+                "caller_tty": ambiguousTTY,
+                "prefer_tty": false,
+                "title": "Ambiguous",
+                "subtitle": "TTY",
+                "body": "Must fail closed"
+            ],
+            to: fixture.socketPath
+        )
+
+        XCTAssertEqual(response["ok"] as? Bool, false, "\(response)")
+        let error = try XCTUnwrap(response["error"] as? [String: Any])
+        XCTAssertEqual(error["code"] as? String, "not_found")
+        XCTAssertFalse(fixture.store.hasUnreadNotification(forTabId: fixture.workspace.id, surfaceId: focusedSurfaceId))
+        XCTAssertFalse(fixture.store.hasUnreadNotification(forTabId: fixture.workspace.id, surfaceId: siblingPanel.id))
+    }
+}

--- a/cmuxTests/TerminalNotificationSocketAttributionTests.swift
+++ b/cmuxTests/TerminalNotificationSocketAttributionTests.swift
@@ -36,6 +36,34 @@ extension TerminalNotificationSocketActionTests {
         XCTAssertFalse(fixture.store.hasUnreadNotification(forTabId: foreignWorkspace.id, surfaceId: foreignSurfaceId))
     }
 
+    func testNotificationCreateForCallerRehomesSurfacePastAmbientWorkspaceClaim() async throws {
+        let fixture = try makeSocketFixture(name: "notify-ambient-rehome")
+        defer { fixture.cleanup() }
+
+        let movedWorkspace = fixture.manager.addWorkspace(title: "Moved Surface", select: false)
+        let movedSurfaceId = try XCTUnwrap(movedWorkspace.focusedPanelId)
+        let response = try await sendV2RequestAsync(
+            method: "notification.create_for_caller",
+            params: [
+                "preferred_workspace_id": fixture.workspace.id.uuidString,
+                "preferred_workspace_is_explicit": false,
+                "preferred_surface_id": movedSurfaceId.uuidString,
+                "prefer_tty": false,
+                "title": "Ambient rehome",
+                "subtitle": "Evidence",
+                "body": "Follow the stable pane"
+            ],
+            to: fixture.socketPath
+        )
+
+        XCTAssertEqual(response["ok"] as? Bool, true, "\(response)")
+        let result = try XCTUnwrap(response["result"] as? [String: Any])
+        XCTAssertEqual(result["workspace_id"] as? String, movedWorkspace.id.uuidString)
+        XCTAssertEqual(result["surface_id"] as? String, movedSurfaceId.uuidString)
+        XCTAssertTrue(fixture.store.hasUnreadNotification(forTabId: movedWorkspace.id, surfaceId: movedSurfaceId))
+        XCTAssertFalse(fixture.store.hasUnreadNotification(forTabId: fixture.workspace.id, surfaceId: fixture.surfaceId))
+    }
+
     func testNotificationCreateForCallerPrefersPreferredSurfaceOverConflictingTTY() async throws {
         let fixture = try makeSocketFixture(name: "notify-surface-over-tty")
         defer { fixture.cleanup() }

--- a/cmuxTests/WorkspaceRemoteConnectionTests.swift
+++ b/cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -6109,7 +6109,7 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
     }
 
     @MainActor
-    func testNotifyWithWorkspaceHandleKeepsCallerSurfaceFallback() throws {
+    func testNotifyWithWorkspaceHandleOmitsAmbientSurfaceFallback() throws {
         let cliPath = try bundledCLIPath()
         let socketPath = makeSocketPath("notify")
         let listenerFD = try bindUnixSocket(at: socketPath)
@@ -6132,7 +6132,7 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
                 if method == "notification.create_for_caller" {
                     let params = payload["params"] as? [String: Any] ?? [:]
                     XCTAssertEqual(params["preferred_workspace_id"] as? String, currentWorkspace)
-                    XCTAssertEqual(params["preferred_surface_id"] as? String, staleSurface)
+                    XCTAssertNil(params["preferred_surface_id"])
                     XCTAssertEqual(params["prefer_tty"] as? Bool, false)
                     return self.v2Response(
                         id: id,

--- a/cmuxTests/WorkspaceRemoteConnectionTests.swift
+++ b/cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -6109,7 +6109,7 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
     }
 
     @MainActor
-    func testNotifyWithWorkspaceHandleOmitsAmbientSurfaceFallback() throws {
+    func testNotifyWithWorkspaceHandleKeepsCallerSurfaceFallback() throws {
         let cliPath = try bundledCLIPath()
         let socketPath = makeSocketPath("notify")
         let listenerFD = try bindUnixSocket(at: socketPath)
@@ -6132,7 +6132,7 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
                 if method == "notification.create_for_caller" {
                     let params = payload["params"] as? [String: Any] ?? [:]
                     XCTAssertEqual(params["preferred_workspace_id"] as? String, currentWorkspace)
-                    XCTAssertNil(params["preferred_surface_id"])
+                    XCTAssertEqual(params["preferred_surface_id"] as? String, staleSurface)
                     XCTAssertEqual(params["prefer_tty"] as? Bool, false)
                     return self.v2Response(
                         id: id,

--- a/tests/test_claude_hook_push_notification.py
+++ b/tests/test_claude_hook_push_notification.py
@@ -143,7 +143,7 @@ class CapturingSocketServer:
                 if "id" not in request:
                     return None
                 if request.get("method") == "surface.list":
-                    surfaces = self.surfaces or [
+                    surfaces = self.surfaces if self.surfaces is not None else [
                         {
                             "id": self.surface_id,
                             "ref": self.surface_id,

--- a/tests/test_claude_hook_push_notification.py
+++ b/tests/test_claude_hook_push_notification.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import glob
 import json
 import os
+from pathlib import Path
 import shutil
 import socket
 import subprocess
@@ -48,10 +49,19 @@ def resolve_cmux_cli() -> str:
 
 
 class CapturingSocketServer:
-    def __init__(self, workspace_id: str, surface_id: str) -> None:
+    def __init__(
+        self,
+        workspace_id: str,
+        surface_id: str,
+        *,
+        surfaces: list[dict[str, object]] | None = None,
+        resolver_error: bool = False,
+    ) -> None:
         self.commands: list[str] = []
         self.workspace_id = workspace_id
         self.surface_id = surface_id
+        self.surfaces = surfaces
+        self.resolver_error = resolver_error
         self.ready = threading.Event()
         self.stop = threading.Event()
         self.error: Exception | None = None
@@ -114,6 +124,9 @@ class CapturingSocketServer:
                     if not raw_line:
                         continue
                     line = raw_line.decode("utf-8", errors="replace")
+                    if line.startswith("_cmux_capability_v1 "):
+                        parts = line.split(" ", 2)
+                        line = parts[2] if len(parts) == 3 else line
                     self.commands.append(line)
                     response = self._response_for(line)
                     if response is None:
@@ -130,18 +143,40 @@ class CapturingSocketServer:
                 if "id" not in request:
                     return None
                 if request.get("method") == "surface.list":
+                    surfaces = self.surfaces or [
+                        {
+                            "id": self.surface_id,
+                            "ref": self.surface_id,
+                            "workspace_id": self.workspace_id,
+                        }
+                    ]
                     return json.dumps(
                         {
                             "id": request.get("id"),
                             "ok": True,
                             "result": {
-                                "surfaces": [
-                                    {
-                                        "id": self.surface_id,
-                                        "ref": self.surface_id,
-                                        "workspace_id": self.workspace_id,
-                                    }
-                                ]
+                                "surfaces": surfaces
+                            },
+                        }
+                    )
+                if request.get("method") == "agent.resolve_delivery_target" and self.resolver_error:
+                    return json.dumps(
+                        {
+                            "id": request.get("id"),
+                            "ok": False,
+                            "error": {"code": "not_found", "message": "No live delivery target"},
+                        }
+                    )
+                if request.get("method") == "agent.resolve_delivery_target":
+                    params = request.get("params") or {}
+                    return json.dumps(
+                        {
+                            "id": request.get("id"),
+                            "ok": True,
+                            "result": {
+                                "source": "surface",
+                                "workspace_id": params.get("workspace_id", self.workspace_id),
+                                "surface_id": params.get("surface_id", self.surface_id),
                             },
                         }
                     )
@@ -177,6 +212,87 @@ def run_push_notification_hook(
         )
         commands = list(server.commands)
     return proc, commands, workspace_id, surface_id
+
+
+def run_unresolved_push_notification_hook(
+    cli_path: str,
+) -> tuple[subprocess.CompletedProcess, list[str], str, str, str]:
+    """Run PushNotification with a stale recorded pane and a focused sibling.
+
+    The app-side live resolver deliberately rejects the invocation. Before the
+    fail-closed guard this made the legacy chain return the focused sibling,
+    which is the wrong-pane regression from #11189.
+    """
+
+    workspace_id = str(uuid.uuid4()).upper()
+    recorded_surface_id = str(uuid.uuid4()).upper()
+    other_surface_id = str(uuid.uuid4()).upper()
+    focused_surface_id = str(uuid.uuid4()).upper()
+    session_id = f"stale-{uuid.uuid4().hex}"
+    with CapturingSocketServer(
+        workspace_id=workspace_id,
+        surface_id=focused_surface_id,
+        surfaces=[
+            {
+                "id": other_surface_id,
+                "ref": other_surface_id,
+                "workspace_id": workspace_id,
+                "focused": False,
+            },
+            {
+                "id": focused_surface_id,
+                "ref": focused_surface_id,
+                "workspace_id": workspace_id,
+                "focused": True,
+            },
+        ],
+        resolver_error=True,
+    ) as server:
+        state_path = Path(server.root.name) / "state.json"
+        now = time.time()
+        state_path.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "sessions": {
+                        session_id: {
+                            "sessionId": session_id,
+                            "workspaceId": workspace_id,
+                            "surfaceId": recorded_surface_id,
+                            "startedAt": now,
+                            "updatedAt": now,
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        env = os.environ.copy()
+        env["CMUX_SOCKET_PATH"] = server.socket_path
+        env["CMUX_WORKSPACE_ID"] = workspace_id
+        env["CMUX_SURFACE_ID"] = recorded_surface_id
+        env["CMUX_CLAUDE_HOOK_STATE_PATH"] = str(state_path)
+        env["CMUX_CLI_SENTRY_DISABLED"] = "1"
+        env["CMUX_CLAUDE_HOOK_SENTRY_DISABLED"] = "1"
+        env.pop("CMUX_CLAUDE_PID", None)
+
+        proc = subprocess.run(
+            [cli_path, "--socket", server.socket_path, "hooks", "claude", "push-notification"],
+            input=json.dumps(
+                push_payload(
+                    "stale target must not ring the focused pane",
+                    {"message": "stale target must not ring the focused pane", "localSent": True},
+                )
+                | {"session_id": session_id}
+            ),
+            text=True,
+            capture_output=True,
+            env=env,
+            timeout=8,
+            check=False,
+        )
+        commands = list(server.commands)
+    return proc, commands, workspace_id, recorded_surface_id, focused_surface_id
 
 
 def push_payload(message: str, tool_response: object) -> dict:
@@ -316,7 +432,22 @@ def main() -> int:
         print(f"commands={commands!r}")
         return 1
 
-    # 7. Oversized message -> normalized and truncated like every other hook
+    # 7. A stale recorded surface with no live identity must fail closed. In
+    # particular, the focused sibling (B) is not an acceptable substitute for
+    # the unlisted recorded pane (A).
+    proc, commands, workspace_id, recorded_surface_id, focused_surface_id = run_unresolved_push_notification_hook(cli_path)
+    if proc.returncode != 0:
+        print("FAIL: unresolved push-notification hook exited nonzero")
+        print(f"stdout={proc.stdout!r} stderr={proc.stderr!r} commands={commands!r}")
+        return 1
+    notify_commands = [line for line in commands if line.startswith("notify_target_async ")]
+    if notify_commands:
+        print("FAIL: unresolved PushNotification must not notify a focused fallback surface")
+        print(f"workspace={workspace_id!r} recorded={recorded_surface_id!r} focused={focused_surface_id!r}")
+        print(f"notify_commands={notify_commands!r} commands={commands!r}")
+        return 1
+
+    # 8. Oversized message -> normalized and truncated like every other hook
     #    notification body (240-char cap with a trailing ellipsis), so a model
     #    cannot grow the notification store/UI with arbitrarily large pushes.
     oversized = "x" * 5000

--- a/tests/test_claude_hook_push_notification.py
+++ b/tests/test_claude_hook_push_notification.py
@@ -194,6 +194,8 @@ def run_push_notification_hook(
     surface_id = str(uuid.uuid4()).upper()
     with CapturingSocketServer(workspace_id=workspace_id, surface_id=surface_id) as server:
         env = os.environ.copy()
+        env["HOME"] = server.root.name
+        env["CFFIXED_USER_HOME"] = server.root.name
         env["CMUX_SOCKET_PATH"] = server.socket_path
         env["CMUX_WORKSPACE_ID"] = workspace_id
         env["CMUX_SURFACE_ID"] = surface_id
@@ -268,6 +270,8 @@ def run_unresolved_push_notification_hook(
             encoding="utf-8",
         )
         env = os.environ.copy()
+        env["HOME"] = server.root.name
+        env["CFFIXED_USER_HOME"] = server.root.name
         env["CMUX_SOCKET_PATH"] = server.socket_path
         env["CMUX_WORKSPACE_ID"] = workspace_id
         env["CMUX_SURFACE_ID"] = recorded_surface_id


### PR DESCRIPTION
Closes #11189

## Summary
- Require authoritative Claude PushNotification targets before feed/notification delivery.
- Remove generic agent-hook focused-surface fallback and leave a resolution diagnostic.
- Route caller TTY attribution through strict live/runtime evidence, prefer a valid surface identity, and remove focused-pane guesses.
- Project notification-ring state on every portal reconciliation and hide it on dismantle.

## Tests
- Added deterministic Python socket regression for stale Claude PushNotification attribution.
- Added generic-hook, TTY ambiguity/provenance, preferred-surface ordering, and portal ring lifecycle regressions.
- First commit is tests-only (`7d19970534`); second commit is the fix (`f51e160052`).
- Local checks: Python compile, Swift parse, PBX test wiring, package-resolved policy, workspace grouping, and `swift test` for CmuxNotifications/CmuxControlSocket.
- Full cmux XCTest/XCUITest execution is delegated to CI per the repository focus-safety rule.

## Notes
- No user-facing strings or localization catalogs changed.
- No Swift budget TSV changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790717843&installation_model_id=21920&pr_number=11224&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11224&signature=163dd25883bde2172cf5bb3b6d5b0910ae36dba2a02be040d84a8f2aec25f49f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #11189 by failing closed when a notification's target pane can't be proven. Previously an unproven caller fell back to the workspace's focused pane and could ring the wrong pane; now delivery requires authoritative surface evidence and otherwise stays workspace-level or is dropped with a diagnostic.

- Caller TTY attribution resolves lazily from live runtime evidence only; an explicit workspace is a hard scope, a valid surface outranks conflicting TTY claims, and freshness proof survives local surface moves.
- Notification-ring publishing and teardown honor portal ownership so a dismantled view can't hide or override the replacement host's ring.
- Codex settles stop by session identity without claiming the notification, rejects stale-turn stops, retries pending settlements with a bounded retry limit, validates persistent feed targets, journals unresolved targets as unattributed diagnostics, and uses a scoped resolver for relay feed hooks.
- Synthetic debug notifications without caller selectors keep the focused-pane default; production caller resolution never uses it.
- Added regression coverage for stale attribution, ambiguous TTY bindings, portal ring hand-off, and unresolved Codex lifecycle targets.

<sup>Written for commit 023c7db1cded61b1b4257c73d7247851149f46f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification delivery accuracy by requiring a verified target before sending notifications.
  * Prevented notifications from reaching focused panes when the originating pane cannot be identified.
  * Ensured stale notification indicators are hidden after panes or workspaces move.
  * Improved terminal attribution using current runtime information and safely handled ambiguous matches.
  * Ensured preferred surface identity takes precedence over conflicting terminal metadata.
  * Preserved child lifecycle cleanup when notification targets cannot be resolved.

* **Tests**
  * Added regression coverage for unresolved targets, ambiguous attribution, stale metadata, lifecycle cleanup, and detached-pane notification visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->