### PR TITLE
cloud VM: user-scoped billing fallback when Stack returns no team; honest billing-team 409 title

### DIFF
--- a/web/app/api/vm/[id]/fork/route.ts
+++ b/web/app/api/vm/[id]/fork/route.ts
@@ -62,7 +62,6 @@ export async function POST(
       try {
         entitlements = resolveVmEntitlements(user, process.env, {
           requestedBillingTeamId,
-          requireTeam: true,
         });
       } catch (err) {
         if (isVmBillingTeamResolutionError(err)) return vmBillingTeamErrorResponse(err);

--- a/web/app/api/vm/base/routeShared.ts
+++ b/web/app/api/vm/base/routeShared.ts
@@ -58,7 +58,6 @@ export async function runBaseRoute(input: {
   try {
     entitlements = resolveVmEntitlements(input.user, process.env, {
       requestedBillingTeamId,
-      requireTeam: false,
     });
   } catch (err) {
     if (isVmBillingTeamResolutionError(err)) return vmBillingTeamErrorResponse(err);

--- a/web/app/api/vm/restore/route.ts
+++ b/web/app/api/vm/restore/route.ts
@@ -78,7 +78,6 @@ export async function POST(request: Request): Promise<Response> {
       try {
         entitlements = resolveVmEntitlements(user, process.env, {
           requestedBillingTeamId,
-          requireTeam: true,
         });
       } catch (err) {
         if (isVmBillingTeamResolutionError(err)) return vmBillingTeamErrorResponse(err);

--- a/web/app/api/vm/route.ts
+++ b/web/app/api/vm/route.ts
@@ -83,7 +83,6 @@ export async function GET(request: Request): Promise<Response> {
         if (requestedBillingTeamId || user.billingCustomerType === "team") {
           const entitlements = resolveVmEntitlements(user, process.env, {
             requestedBillingTeamId,
-            requireTeam: false,
           });
           listEntitlements = entitlements;
           billingTeamId = entitlements.billingTeamId;
@@ -109,7 +108,7 @@ export async function GET(request: Request): Promise<Response> {
       // resolution above, so resolve lazily here.
       if (!listEntitlements) {
         try {
-          listEntitlements = resolveVmEntitlements(user, process.env, { requireTeam: false });
+          listEntitlements = resolveVmEntitlements(user, process.env);
         } catch {
           listEntitlements = null;
         }
@@ -387,7 +386,6 @@ export async function POST(request: Request): Promise<Response> {
           entitlements = measureVmSync(timing, "entitlements", () =>
             resolveVmEntitlements(user, process.env, {
               requestedBillingTeamId,
-              requireTeam: true,
             })
           );
         } catch (err) {

--- a/web/app/api/vm/route.ts
+++ b/web/app/api/vm/route.ts
@@ -487,11 +487,16 @@ export async function POST(request: Request): Promise<Response> {
             });
           }
           if (isVmCreateCreditsInsufficientError(err)) {
+            const billsUser = entitlements.billingCustomerType === "user";
             return vmErrorResponse({
               error: "vm_create_credits_insufficient",
               status: 402,
-              message: "This team has no Cloud VM create credits left.",
-              action: "Upgrade the team's plan or ask an admin to add Cloud VM create credits, then retry.",
+              message: billsUser
+                ? "Your account has no Cloud VM create credits left."
+                : "This team has no Cloud VM create credits left.",
+              action: billsUser
+                ? "Upgrade your plan or add Cloud VM create credits, then retry."
+                : "Upgrade the team's plan or ask an admin to add Cloud VM create credits, then retry.",
               extra: { amount: err.amount },
               details: { amount: err.amount },
             });

--- a/web/services/vms/entitlements.ts
+++ b/web/services/vms/entitlements.ts
@@ -11,7 +11,6 @@ export type VmEntitlements = {
 
 export type VmEntitlementOptions = {
   readonly requestedBillingTeamId?: string | null;
-  readonly requireTeam?: boolean;
 };
 
 export type VmBillingTeamErrorCode =
@@ -94,14 +93,10 @@ function resolveBillingContext(
     });
   }
 
-  if (options.requireTeam) {
-    throw new VmBillingTeamResolutionError({
-      code: "vm_billing_team_required",
-      status: 409,
-      message: "Stack Auth did not return a team. Enable personal team creation on sign-up before creating Cloud VMs.",
-    });
-  }
-
+  // No team at all (accounts that predate personal-team auto-create): bill
+  // the user directly. Every billing surface (Stack items, credits, plan
+  // metadata) supports user-scoped customers, so provisioning verbs must not
+  // dead-end on a 409 the caller has no way to resolve.
   return {
     billingCustomerType: "user",
     billingTeamId: user.billingTeamId,

--- a/web/services/vms/routeHelpers.ts
+++ b/web/services/vms/routeHelpers.ts
@@ -270,7 +270,6 @@ export type VmRouteAccountScope =
 export function resolveVmRouteAccountScope(
   user: AuthedUser,
   request: Request,
-  options: { readonly requireTeam?: boolean } = {},
 ): VmRouteAccountScope {
   const requestedBillingTeamId = requestedVmTeamIdFromRequest(request);
   try {
@@ -279,7 +278,6 @@ export function resolveVmRouteAccountScope(
       requestedBillingTeamId,
       entitlements: resolveVmEntitlements(user, process.env, {
         requestedBillingTeamId,
-        requireTeam: options.requireTeam ?? false,
       }),
     };
   } catch (err) {
@@ -631,6 +629,12 @@ function cloudServiceAction(operation: string, retryAfterSeconds: number | undef
 }
 
 function defaultVmDisplayTitle(input: VmErrorResponseInput): string {
+  // Billing-team resolution shares the 409/403 statuses with unrelated
+  // failures; title it as the team problem it is instead of the generic
+  // "operation already running" that pure-status mapping would produce.
+  if (input.error === "vm_billing_team_required" || input.error === "vm_billing_team_not_found") {
+    return "Cloud VM team required";
+  }
   if (input.status === 409) return "Cloud VM operation already running";
   if (input.status === 404) return "Cloud VM not found";
   if (input.status === 401 || input.status === 403) return "Cloud VM authentication required";

--- a/web/tests/vm-route-auth.test.ts
+++ b/web/tests/vm-route-auth.test.ts
@@ -977,13 +977,25 @@ describe("VM REST auth", () => {
     expect(listTeams).toHaveBeenCalledTimes(1);
   });
 
-  test("rejects VM create when Stack Auth returns no teams", async () => {
+  test("creates a VM with user-scoped billing when Stack Auth returns no teams", async () => {
+    // Legacy accounts predate personal-team auto-create: Stack returns no
+    // team at all. Billing supports user-scoped customers everywhere else
+    // (list, entitlements, credits), so create must fall back to the user
+    // instead of dead-ending on a 409 the caller cannot fix.
     getUser.mockResolvedValue({
       id: "user-1",
       displayName: null,
       primaryEmail: "user@example.com",
+      clientReadOnlyMetadata: { cmuxPlan: "pro" },
       selectedTeam: null,
       listTeams: async () => [],
+    });
+    runVmWorkflow.mockResolvedValue({
+      providerVmId: "provider-vm-user-billing",
+      provider: "freestyle",
+      image: "snapshot-test",
+      imageVersion: null,
+      createdAt: 1_777_000_000_000,
     });
 
     const response = await POST(
@@ -994,15 +1006,14 @@ describe("VM REST auth", () => {
       }),
     );
 
-    expect(response.status).toBe(409);
-    const payload = await response.json();
-    expect(payload).toMatchObject({
-      error: "vm_billing_team_required",
-    });
-    expectNoCloudVmImplementationLeaks(payload);
-    expect(payload.message).toContain("team");
-    expect(payload.action).toContain("Select a team");
-    expect(runVmWorkflow).not.toHaveBeenCalled();
+    expect(response.status).toBe(200);
+    expect(createVm).toHaveBeenCalledWith(expect.objectContaining({
+      userId: "user-1",
+      billingCustomerType: "user",
+      billingTeamId: "user-1",
+      billingPlanId: "pro",
+    }));
+    expect(runVmWorkflow).toHaveBeenCalled();
   });
 
   test("uses the paid Stack team when multiple teams have no selected/requested team", async () => {
@@ -1073,6 +1084,10 @@ describe("VM REST auth", () => {
     expectNoCloudVmImplementationLeaks(payload);
     expect(payload.message).toContain("team");
     expect(payload.action).toContain("Select a team");
+    // The 409 must present as a team-selection problem, not the generic
+    // "operation already running" that defaultVmDisplayTitle maps 409 to.
+    const ui = payload.ui as { title?: string } | undefined;
+    expect(ui?.title).toBe("Cloud VM team required");
     expect(runVmWorkflow).not.toHaveBeenCalled();
   });
 

--- a/web/tests/vm-route-auth.test.ts
+++ b/web/tests/vm-route-auth.test.ts
@@ -770,7 +770,44 @@ describe("VM REST auth", () => {
       error: "vm_create_credits_insufficient",
       amount: 1,
       details: { amount: 1 },
+      message: "This team has no Cloud VM create credits left.",
     });
+  });
+
+  test("credit exhaustion on user-scoped billing names the account, not a team", async () => {
+    getUser.mockResolvedValue({
+      id: "user-1",
+      displayName: null,
+      primaryEmail: "user@example.com",
+      clientReadOnlyMetadata: { cmuxPlan: "pro" },
+      selectedTeam: null,
+      listTeams: async () => [],
+    });
+    rejectRunVmWorkflowWith(
+      new VmCreateCreditsInsufficientError({
+        itemId: "cmux-vm-create-credit",
+        billingCustomerId: "user-1",
+        amount: 1,
+      }),
+    );
+
+    const response = await POST(
+      new Request("https://cmux.test/api/vm", {
+        method: "POST",
+        headers: { "idempotency-key": "idem-credits-user", origin: "https://cmux.test" },
+        body: JSON.stringify({ provider: "freestyle", image: "snapshot-test" }),
+      }),
+    );
+
+    expect(response.status).toBe(402);
+    const payload = await response.json();
+    expect(payload).toMatchObject({
+      error: "vm_create_credits_insufficient",
+      amount: 1,
+      message: "Your account has no Cloud VM create credits left.",
+    });
+    expect(payload.message).not.toContain("team");
+    expect(payload.action).not.toContain("team");
   });
 
   test("uses the native client's requested Stack team for billing", async () => {


### PR DESCRIPTION
## What

`POST /api/vm` (and fork/restore) passed `requireTeam: true` into `resolveVmEntitlements`, so any Stack account with **zero teams** — accounts that predate personal-team auto-create — got a dead-end `vm_billing_team_required` 409 telling it to "select a team" it doesn't have. The same account lists machines fine with `limits.planId: "pro"` because the list route already resolves user-scoped billing.

- Drop the `requireTeam` option: a team-less account now falls back to user-scoped billing (`billingCustomerType: "user"`, `billingTeamId = userId`) on create/fork/restore, matching list/entitlements/credits, all of which already support user customers (`billingCustomer()`, user-scoped `stackItem`).
- Keep the genuine ambiguity 409 (multiple teams, none selected/requested).
- `defaultVmDisplayTitle` mapped 409 by status alone, so the billing-team error was titled **"Cloud VM operation already running"**. Billing-team codes now title as "Cloud VM team required".

## Repro

austin@manaflow.ai (Pro on user metadata, zero Stack teams) on 0.64.22-nightly:
`cmux vm ls` → `planId: "pro"`, `maxActiveVms: 10`; `cmux vm new` → `Cloud VM operation already running (HTTP 409: vm_billing_team_required)`.

## Commits

1. Red regression tests: team-less create must succeed with user billing; the remaining multi-team 409 must not wear the concurrency title.
2. The fix; `bun test tests/vm-route-auth.test.ts tests/vm-observability.test.ts` → 70 pass, `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q8M6wNCw6uLEvQaHGUo4SY

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790719684&installation_model_id=21920&pr_number=11225&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11225&signature=b0ff4854ed6902e448fa3f2b7cb99ceb6b5abcd08f31fa89d3b518d016dda60f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Cloud VM create/fork/restore for Stack accounts with zero teams (accounts that predate personal-team auto-create) so they fall back to user-scoped billing instead of dead-ending on a `vm_billing_team_required` 409. The credits-exhausted error now names the actual billing owner instead of always blaming a team.

- The remaining multi-team 409 now titles as "Cloud VM team required" instead of the generic "Cloud VM operation already running".
- The 402 credits message switches between "Your account" and "This team" depending on whether billing is user- or team-scoped.

<sup>Written for commit 4b820546d1a6f1b3951d394070e987e7664144be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users without a billing team can now create, fork, restore, and use Cloud VMs with user-scoped billing.
* **Bug Fixes**
  * Removed unnecessary billing-team requirements during VM entitlement resolution.
  * Improved messaging when a required or unavailable billing team prevents an operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->