### PR TITLE
vm images: kind requests survive a generic env selector of the other kind

### DIFF
--- a/web/services/vms/images/manifest.json
+++ b/web/services/vms/images/manifest.json
@@ -192,7 +192,9 @@
       "builtAt": "2026-08-24T23:07:01.000Z",
       "builderScriptVersion": "bootstrap-on-create",
       "validationStatus": "passed",
-      "notes": "Stock Blaxel Alpine shell image, no desktop; `cmux vm new --base` and `vm run` pool provisioning send this id explicitly. Nothing is baked: the driver bootstraps every image at create time, installing the pinned cmux-tui build onto the persistent home volume (the installer adds curl via apk first, since the stock image ships without it). Validated live in #10478 in us-pdx-1: create + bootstrap, cmux-remote attach (route + enrollment), exec, and standby/wake process preservation. Listed so deployed runtimes accept the id the CLI sends; it was missing from the manifest between #10478 and this entry, so `vm new --base` failed closed in production."
+      "notes": "Stock Blaxel Alpine shell image, no desktop; `cmux vm new --base` and `vm run` pool provisioning send this id explicitly. Nothing is baked: the driver bootstraps every image at create time, installing the pinned cmux-tui build onto the persistent home volume (the installer adds curl via apk first, since the stock image ships without it). Validated live in #10478 in us-pdx-1: create + bootstrap, cmux-remote attach (route + enrollment), exec, and standby/wake process preservation. Listed so deployed runtimes accept the id the CLI sends; it was missing from the manifest between #10478 and this entry, so `vm new --base` failed closed in production.",
+      "kind": "base",
+      "defaultForKind": true
     },
     {
       "provider": "e2b",

--- a/web/services/vms/images/resolver.ts
+++ b/web/services/vms/images/resolver.ts
@@ -206,6 +206,17 @@ export function resolveVmImage(
   const envVar = providerImageEnvKey(provider, kind);
   const configured = env[envVar]?.trim();
   if (configured) {
+    // An operator's generic selector naming an image of another kind is not a
+    // misconfiguration for this request: deployments from before image kinds
+    // existed set the single selector to the desktop image. Serve the
+    // requested kind from the manifest defaults instead of failing the
+    // create on the mismatch. Client-requested images keep the strict check.
+    if (kind !== undefined) {
+      const entry = findVmImageManifestEntry(provider, configured);
+      if (entry && deriveVmImageKind(entry, configured) !== kind) {
+        return resolveByKind(provider, kind, envVar, env);
+      }
+    }
     return resolveKnownOrAllowed(provider, configured, envVar, env, kind);
   }
 

--- a/web/tests/vm-image-resolver.test.ts
+++ b/web/tests/vm-image-resolver.test.ts
@@ -54,6 +54,42 @@ describe("VM image resolver: request by kind", () => {
     ).toMatchObject({ image: "blaxel/base-image:latest", imageVersion: "blaxel-base-bootstrap-20260824a", kind: "base" });
   });
 
+  test("a generic env selector of the other kind falls through to the kind default", () => {
+    // Production reality before kinds existed: BLAXEL_SANDBOX_IMAGE names the
+    // desktop devbox and no desktop-specific selector is set. A kind=base
+    // request must resolve the manifest base default, not 503 on the desktop
+    // image's kind mismatch (seen in prod 2026-08-30 21:58 UTC).
+    expect(
+      resolveVmImage("blaxel", undefined, {
+        ...deployed,
+        BLAXEL_SANDBOX_IMAGE: "sandbox/cmux-devbox:latest",
+      }, { kind: "base" }),
+    ).toMatchObject({
+      image: "blaxel/base-image:latest",
+      imageVersion: "blaxel-base-bootstrap-20260824a",
+      kind: "base",
+    });
+    // The same env still serves desktop and kind-less requests unchanged.
+    expect(
+      resolveVmImage("blaxel", undefined, {
+        ...deployed,
+        BLAXEL_SANDBOX_IMAGE: "sandbox/cmux-devbox:latest",
+      }, { kind: "desktop" }),
+    ).toMatchObject({ image: "sandbox/cmux-devbox:latest", kind: "desktop" });
+    expect(
+      resolveVmImage("blaxel", undefined, {
+        ...deployed,
+        BLAXEL_SANDBOX_IMAGE: "sandbox/cmux-devbox:latest",
+      }),
+    ).toMatchObject({ image: "sandbox/cmux-devbox:latest" });
+  });
+
+  test("an explicitly requested image of the wrong kind still errors", () => {
+    const err = captureImageConfigError(() =>
+      resolveVmImage("blaxel", "sandbox/cmux-devbox:latest", deployed, { kind: "base" }));
+    expect(err.reason).toMatch(/desktop image, not a base image/);
+  });
+
   test("deployed runtimes fall back to the manifest kind default instead of throwing", () => {
     // The nightly app's `vm base open` with no image and nothing configured for
     // desktop used to 503; now the manifest default desktop image serves it.

--- a/web/tests/vm-image-resolver.test.ts
+++ b/web/tests/vm-image-resolver.test.ts
@@ -136,37 +136,39 @@ describe("VM image resolver: request by kind", () => {
     expect(err.allowedImages).toEqual(["sandbox/cmux-devbox:latest", "blaxel/xfce-vnc:latest", "blaxel/base-image:latest"]);
     expect(reportVmImageConfigError(err, deployed)).toMatchObject({
       message: 'Cloud VM image kind "gpu" is not supported.',
-      details: { imageRequested: false, kind: "gpu", source: "request", allowedKinds: ["desktop"] },
+      details: { imageRequested: false, kind: "gpu", source: "request", allowedKinds: ["desktop", "base"] },
     });
   });
 
   test("a kind with nothing configured names the env var and the allowed images", () => {
+    // freestyle ships no desktop image, so it exercises the unresolvable-kind
+    // error shape (blaxel base resolves from the manifest default now).
     const err = captureImageConfigError(() =>
-      resolveVmImage("blaxel", undefined, deployed, { kind: "base" }),
+      resolveVmImage("freestyle", undefined, deployed, { kind: "desktop" }),
     );
     expect(err).toMatchObject({
-      provider: "blaxel",
-      envVar: "BLAXEL_SANDBOX_IMAGE",
-      kind: "base",
+      provider: "freestyle",
+      envVar: "FREESTYLE_SANDBOX_SNAPSHOT",
+      kind: "desktop",
       source: "default",
-      reason: "no base image is configured for blaxel: set BLAXEL_SANDBOX_IMAGE or record a base manifest default",
+      reason: "no desktop image is configured for freestyle: set FREESTYLE_SANDBOX_SNAPSHOT or record a desktop manifest default",
     });
     const report = reportVmImageConfigError(err, deployed);
-    expect(report.message).toBe("No base Cloud VM image is available in this environment.");
-    expect(report.action).toContain("available: desktop");
+    expect(report.message).toBe("No desktop Cloud VM image is available in this environment.");
+    // Deployed freestyle with no env selector serves no kind at all.
+    expect(report.action).toContain("available: none");
     // Client-safe details name the kind and the source, never the env var or image ids.
     expect(report.details).toEqual({
       imageRequested: false,
-      kind: "base",
+      kind: "desktop",
       source: "default",
-      allowedKinds: ["desktop"],
+      allowedKinds: [],
     });
-    expect(JSON.stringify(report.details)).not.toMatch(/BLAXEL_|manifest\.json|cmux-devbox/);
+    expect(JSON.stringify(report.details)).not.toMatch(/FREESTYLE_|manifest\.json|sh-[a-z0-9]/);
     // The operator log carries what the response may not.
     expect(report.operator).toMatchObject({
-      provider: "blaxel",
-      envVar: "BLAXEL_SANDBOX_IMAGE",
-      allowedImages: ["sandbox/cmux-devbox:latest", "blaxel/xfce-vnc:latest", "blaxel/base-image:latest"],
+      provider: "freestyle",
+      envVar: "FREESTYLE_SANDBOX_SNAPSHOT",
     });
   });
 
@@ -176,9 +178,9 @@ describe("VM image resolver: request by kind", () => {
     );
     expect(err).toMatchObject({ image: "blaxel/unlisted:latest", source: "request" });
     const report = reportVmImageConfigError(err, deployed);
-    expect(report.details).toEqual({ imageRequested: true, kind: undefined, source: "request", allowedKinds: ["desktop"] });
+    expect(report.details).toEqual({ imageRequested: true, kind: undefined, source: "request", allowedKinds: ["desktop", "base"] });
     expect(report.message).toBe("The requested Cloud VM image is not available in this environment.");
-    expect(report.action).toContain("`kind`: desktop");
+    expect(report.action).toContain("`kind`: desktop, base");
     expect(report.operator).toMatchObject({ image: "blaxel/unlisted:latest", allowedImages: ["sandbox/cmux-devbox:latest", "blaxel/xfce-vnc:latest", "blaxel/base-image:latest"] });
   });
 
@@ -202,6 +204,7 @@ describe("VM image resolver: request by kind", () => {
 
     expect(listVmImageKinds("blaxel", deployed)).toEqual([
       { kind: "desktop", image: "sandbox/cmux-devbox:latest" },
+      { kind: "base", image: "blaxel/base-image:latest" },
     ]);
     expect(listVmImageKinds("blaxel", { ...deployed, BLAXEL_SANDBOX_IMAGE: "blaxel/base-image:latest" })).toEqual([
       { kind: "desktop", image: "sandbox/cmux-devbox:latest" },


### PR DESCRIPTION
@austinpower1258 this touches the image-kind feature you shipped; the default-image choice is yours to swap if a newer base bake is coming.

Production predates image kinds: `BLAXEL_SANDBOX_IMAGE` names the desktop devbox and no desktop selector is set. A `kind: base` create consulted that env value, hard-failed on the kind mismatch, and returned 503 `vm_image_config_error` before `resolveByKind` could run, so kind=base was unservable in production. Hit live at 2026-08-30 21:57-21:58 UTC (trace `fae6abbe62a947d4b5dca218fdd3a2f9`), caught by the provisioning-failure watch.

- `resolveVmImage`: an env-selected image of another kind falls through to the manifest kind default. Client-requested images keep the strict mismatch error (test covers both).
- Manifest: `blaxel-base-bootstrap-20260824a` becomes the blaxel base default (`kind: base, defaultForKind: true`), the same image the CLI pins for `vm new --base`. Your own unresolvable-kind error text names "record a base manifest default" as the intended action.
- Tests that documented the no-base-default state (unresolvable-kind error shape, `listVmImageKinds`, allowedKinds) move to freestyle desktop, which stays unresolvable.

Two commits per regression policy (failing test, then fix). Tests: `vm-image-resolver` (25 pass), `vm-route-auth` + `vm-observability` (70 pass), typecheck.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790720648&installation_model_id=21920&pr_number=11227&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11227&signature=8be40c7753a19311753886eedff65c4f88d727733cf2abee9571238619a81eba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes VM image kind resolution so kind-based requests fall back to the manifest default when a generic env selector points to an image of another kind, instead of failing with a 503. Explicitly requested images still error on mismatched kind.

- Records `blaxel-base-bootstrap-20260824a` as the blaxel base default in the image manifest.
- Moves tests that assumed no base default to the freestyle provider, which remains unresolvable.

<sup>Written for commit e034f098f0c754ea38d7745f487aa867354e6487. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved VM image selection when a configured generic image belongs to a different image type.
  - VM creation now falls back to the appropriate type-specific default instead of failing.
  - Explicitly requested images of an incompatible type continue to be rejected with a clear validation error.

- **Improvements**
  - Added support for recognizing the designated default base image during automatic image resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->