### PR TITLE
Cloud pane: say the real auth problem, one sign-in header, honest CLI 401 guidance

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -127702,6 +127702,108 @@
         }
       }
     },
+    "machines.requiresPro.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This account\u2019s plan doesn\u2019t include Cloud machine access. Upgrade to create and reconnect machines."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このアカウントのプランでは Cloud マシンを利用できません。アップグレードするとマシンの作成と再接続ができます。"
+          }
+        }
+      }
+    },
+    "machines.requiresPro.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud machines need cmux Pro"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud マシンには cmux Pro が必要です"
+          }
+        }
+      }
+    },
+    "machines.requiresPro.upgrade": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Upgrade to Pro"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pro にアップグレード"
+          }
+        }
+      }
+    },
+    "machines.sessionRejected.signInAgain": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sign Out & Sign In Again"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サインアウトして再サインイン"
+          }
+        }
+      }
+    },
+    "machines.sessionRejected.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The Cloud service no longer accepts this Mac\u2019s saved session. Sign out and sign back in to reconnect."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud サービスがこの Mac に保存されたセッションを受け付けなくなりました。サインアウトして再度サインインすると再接続できます。"
+          }
+        }
+      }
+    },
+    "machines.sessionRejected.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sign-in needs a refresh"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再サインインが必要です"
+          }
+        }
+      }
+    },
     "machines.unavailable.retry": {
       "extractionState": "manual",
       "localizations": {
@@ -242669,6 +242771,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Cloud VMを利用するにはサインインが必要です。`cmux auth login`を実行してから再試行してください。"
+          }
+        }
+      }
+    },
+    "socket.cloudVM.sessionRejected": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The cmux Cloud service rejected this session. Run `cmux auth logout`, then `cmux auth login`, and retry."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux Cloud サービスがこのセッションを拒否しました。`cmux auth logout` を実行してから `cmux auth login` を実行し、再試行してください。"
           }
         }
       }

--- a/Sources/Auth/AccountSignInView.swift
+++ b/Sources/Auth/AccountSignInView.swift
@@ -5,12 +5,24 @@ import SwiftUI
 struct AccountSignInView: View {
     let model: AccountSignInModel
     let automaticallyStartsSignIn: Bool
+    /// Idle-state heading; hosts embed their own context (e.g. the Cloud
+    /// machines pane) so they never stack a second header above this view.
+    var idleTitle = String(localized: "account.signIn.heading", defaultValue: "Sign in to cmux")
+    /// Idle-state supporting line under ``idleTitle``.
+    var idleSubtitle = String(
+        localized: "account.signIn.prompt",
+        defaultValue: "Continue with your cmux account."
+    )
 
     var body: some View {
         VStack(spacing: 16) {
             switch model.phase {
             case .idle:
-                AccountSignInIdleView(onSignIn: model.presentSignIn)
+                AccountSignInIdleView(
+                    title: idleTitle,
+                    subtitle: idleSubtitle,
+                    onSignIn: model.presentSignIn
+                )
             case let .loading(stage):
                 AccountSignInLoadingView(
                     stage: stage,
@@ -45,6 +57,8 @@ struct AccountSignInView: View {
 }
 
 private struct AccountSignInIdleView: View {
+    let title: String
+    let subtitle: String
     let onSignIn: () -> Void
 
     var body: some View {
@@ -52,12 +66,9 @@ private struct AccountSignInIdleView: View {
             Image(systemName: "person.crop.circle.badge.plus")
                 .cmuxFont(size: 34)
                 .foregroundStyle(.tint)
-            Text(String(localized: "account.signIn.heading", defaultValue: "Sign in to cmux"))
+            Text(title)
                 .cmuxFont(.title2, weight: .semibold)
-            Text(String(
-                localized: "account.signIn.prompt",
-                defaultValue: "Continue with your cmux account."
-            ))
+            Text(subtitle)
             .foregroundStyle(.secondary)
             .multilineTextAlignment(.center)
             Button(String(localized: "account.signIn.start", defaultValue: "Sign In"), action: onSignIn)

--- a/Sources/Cloud/MachinesPanelView.swift
+++ b/Sources/Cloud/MachinesPanelView.swift
@@ -234,26 +234,120 @@ struct MachinesPanelView: View {
         }
 
         var body: some View {
-            VStack(spacing: 8) {
-                Text(String(
+            // One header only: the shared sign-in view carries the pane's
+            // copy through its idle state, and its later stages (waiting,
+            // failed, signed in) stand alone instead of stacking under a
+            // second title.
+            AccountSignInView(
+                model: signInModel,
+                automaticallyStartsSignIn: false,
+                idleTitle: String(
                     localized: "machines.auth.title",
                     defaultValue: "Sign in to use Cloud Machines"
-                ))
-                .cmuxFont(size: 13, weight: .semibold)
-                Text(String(
+                ),
+                idleSubtitle: String(
                     localized: "machines.auth.subtitle",
                     defaultValue: "Sign in to see and manage the machines in your cmux account."
-                ))
-                .cmuxFont(size: 12)
-                .foregroundColor(.secondary)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, 20)
-                AccountSignInView(model: signInModel, automaticallyStartsSignIn: false)
-                    .frame(maxWidth: 440)
-            }
+                )
+            )
+            .frame(maxWidth: 440)
+            .padding(24)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .accessibilityIdentifier("CloudMachinesSignInView")
         }
+    }
+
+    @ViewBuilder
+    private var unreachableState: some View {
+        Image(systemName: "cloud.slash")
+            .font(.system(size: 26, weight: .light))
+            .foregroundColor(.secondary.opacity(0.55))
+        Text(String(localized: "machines.unavailable.title", defaultValue: "Cloud is unreachable"))
+            .cmuxFont(size: 13)
+            .foregroundColor(.primary.opacity(0.85))
+        Text(String(
+            localized: "machines.unavailable.subtitle",
+            defaultValue: "Your machines are still there. cmux couldn\u{2019}t reach the Cloud service just now; it retries on its own."
+        ))
+        .cmuxFont(size: 12)
+        .foregroundColor(.secondary)
+        .multilineTextAlignment(.center)
+        .padding(.horizontal, 24)
+        Button {
+            viewModel.refresh()
+        } label: {
+            Text(String(localized: "machines.unavailable.retry", defaultValue: "Retry"))
+                .cmuxFont(size: 12)
+        }
+        .padding(.top, 2)
+    }
+
+    /// HTTP 401 from the Cloud service while the app still holds a session:
+    /// retrying can never fix it, so route straight to a fresh sign-in.
+    @ViewBuilder
+    private var sessionRejectedState: some View {
+        Image(systemName: "person.crop.circle.badge.exclamationmark")
+            .font(.system(size: 26, weight: .light))
+            .foregroundColor(.secondary.opacity(0.55))
+        Text(String(localized: "machines.sessionRejected.title", defaultValue: "Sign-in needs a refresh"))
+            .cmuxFont(size: 13, weight: .semibold)
+            .foregroundColor(.primary.opacity(0.85))
+        Text(String(
+            localized: "machines.sessionRejected.subtitle",
+            defaultValue: "The Cloud service no longer accepts this Mac\u{2019}s saved session. Sign out and sign back in to reconnect."
+        ))
+        .cmuxFont(size: 12)
+        .foregroundColor(.secondary)
+        .multilineTextAlignment(.center)
+        .padding(.horizontal, 24)
+        Button {
+            signOutForFreshSignIn()
+        } label: {
+            Text(String(localized: "machines.sessionRejected.signInAgain", defaultValue: "Sign Out & Sign In Again"))
+                .cmuxFont(size: 12)
+        }
+        .buttonStyle(.borderedProminent)
+        .controlSize(.small)
+        .padding(.top, 2)
+        .accessibilityIdentifier("CloudMachinesSessionRejectedSignInButton")
+    }
+
+    /// HTTP 402: the plan gates Cloud access, so the fix is an upgrade, not a
+    /// retry and not a sign-in.
+    @ViewBuilder
+    private var requiresProState: some View {
+        Image(systemName: "sparkles")
+            .font(.system(size: 26, weight: .light))
+            .foregroundColor(.secondary.opacity(0.55))
+        Text(String(localized: "machines.requiresPro.title", defaultValue: "Cloud machines need cmux Pro"))
+            .cmuxFont(size: 13, weight: .semibold)
+            .foregroundColor(.primary.opacity(0.85))
+        Text(String(
+            localized: "machines.requiresPro.subtitle",
+            defaultValue: "This account\u{2019}s plan doesn\u{2019}t include Cloud machine access. Upgrade to create and reconnect machines."
+        ))
+        .cmuxFont(size: 12)
+        .foregroundColor(.secondary)
+        .multilineTextAlignment(.center)
+        .padding(.horizontal, 24)
+        Button {
+            ProUpgradePresenter.present()
+        } label: {
+            Text(String(localized: "machines.requiresPro.upgrade", defaultValue: "Upgrade to Pro"))
+                .cmuxFont(size: 12)
+        }
+        .buttonStyle(.borderedProminent)
+        .controlSize(.small)
+        .padding(.top, 2)
+        .accessibilityIdentifier("CloudMachinesRequiresProUpgradeButton")
+    }
+
+    /// Server-rejected sessions can only be fixed by re-authenticating; the
+    /// sign-out flips the pane to the sign-in gate, whose flow mints a fresh
+    /// session.
+    private func signOutForFreshSignIn() {
+        guard let accountFlow else { return }
+        Task { await accountFlow.signOut() }
     }
 
     /// Cloud-agent launcher: each agent entry opens a local terminal running
@@ -364,29 +458,18 @@ struct MachinesPanelView: View {
         VStack(spacing: 10) {
             Spacer()
             if viewModel.hasLoadedOnce, viewModel.lastErrorDescription != nil {
-                // The list failed to load: say so instead of pretending the fleet is
-                // empty, and make retry one click.
-                Image(systemName: "cloud.slash")
-                    .font(.system(size: 26, weight: .light))
-                    .foregroundColor(.secondary.opacity(0.55))
-                Text(String(localized: "machines.unavailable.title", defaultValue: "Cloud is unreachable"))
-                    .cmuxFont(size: 13)
-                    .foregroundColor(.primary.opacity(0.85))
-                Text(String(
-                    localized: "machines.unavailable.subtitle",
-                    defaultValue: "Your machines are still there. cmux couldn\u{2019}t reach the Cloud service just now; it retries on its own."
-                ))
-                .cmuxFont(size: 12)
-                .foregroundColor(.secondary)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, 24)
-                Button {
-                    viewModel.refresh()
-                } label: {
-                    Text(String(localized: "machines.unavailable.retry", defaultValue: "Retry"))
-                        .cmuxFont(size: 12)
+                // The list failed to load: say the true thing instead of
+                // pretending the fleet is empty. A server-rejected session and
+                // a plan gate each get their real fix; only transient-shaped
+                // failures keep the retry-first "unreachable" copy.
+                switch viewModel.listProblem ?? .unreachable {
+                case .sessionRejected:
+                    sessionRejectedState
+                case .requiresPro:
+                    requiresProState
+                case .unreachable:
+                    unreachableState
                 }
-                .padding(.top, 2)
             } else if viewModel.hasLoadedOnce {
                 Image(systemName: "cloud")
                     .font(.system(size: 30, weight: .light))

--- a/Sources/Cloud/MachinesPanelViewModel.swift
+++ b/Sources/Cloud/MachinesPanelViewModel.swift
@@ -304,6 +304,33 @@ final class MachinesPanelViewModel: ObservableObject {
     @Published private(set) var isLoading = false
     @Published private(set) var hasLoadedOnce = false
     @Published private(set) var lastErrorDescription: String?
+    /// Why the machine list could not load, classified so the empty state can
+    /// say the true thing: a server-rejected session needs a fresh sign-in, a
+    /// plan gate needs an upgrade, and only genuinely transient failures get
+    /// the retry-first "unreachable" presentation.
+    @Published private(set) var listProblem: CloudListProblem?
+
+    enum CloudListProblem: Equatable {
+        /// HTTP 401: the Cloud service no longer accepts this session.
+        case sessionRejected
+        /// HTTP 402: the plan gates Cloud access.
+        case requiresPro
+        /// Everything else — retrying may help.
+        case unreachable
+    }
+
+    /// Classify a list failure for ``listProblem``. Pure so tests can pin the
+    /// mapping without a live client.
+    nonisolated static func classifyListFailure(_ error: VMClientError) -> CloudListProblem {
+        switch error {
+        case .httpStatus(401, _):
+            return .sessionRejected
+        case .httpStatus(402, _):
+            return .requiresPro
+        case .notSignedIn, .sessionRefreshFailed, .backendUnreachable, .httpStatus, .malformedResponse:
+            return .unreachable
+        }
+    }
     /// Human-readable label of the Cloud VM action currently running from this
     /// panel ("Checkpointing noble-wren…"). Replaces the plan meter in the
     /// header while set — the in-app substitute for a floating progress HUD.
@@ -552,6 +579,7 @@ final class MachinesPanelViewModel: ObservableObject {
         plan = nil
         activeOperation = nil
         lastErrorDescription = nil
+        listProblem = nil
         hasLoadedOnce = false
         isLoading = false
     }
@@ -579,6 +607,7 @@ final class MachinesPanelViewModel: ObservableObject {
             readCatalog()
             plan = MachineSnapshotBuilder.planSnapshot(activeCount: snapshots.count, limits: page.limits, machines: snapshots)
             lastErrorDescription = nil
+            listProblem = nil
         } catch let error as VMClientError {
             if case .notSignedIn = error {
                 // A request can race sign-out before the auth observation or
@@ -589,13 +618,16 @@ final class MachinesPanelViewModel: ObservableObject {
                 plan = nil
                 activeOperation = nil
                 lastErrorDescription = nil
+                listProblem = nil
                 hasLoadedOnce = false
                 isLoading = false
                 return
             }
             lastErrorDescription = String(describing: error)
+            listProblem = Self.classifyListFailure(error)
         } catch {
             lastErrorDescription = String(describing: error)
+            listProblem = .unreachable
         }
         isLoading = false
         hasLoadedOnce = true

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3891,14 +3891,26 @@ class TerminalController {
                Self.isCloudVMAuthenticationError(vmError) {
                 // Keep the auth boundary explicit for every VM verb. The CLI
                 // can then return a stable non-zero auth-required failure
-                // instead of presenting a generic backend error.
-                return v2Error(
-                    id: id,
-                    code: "auth_required",
-                    message: String(
+                // instead of presenting a generic backend error. A server 401
+                // means the app still holds a session the service rejects, so
+                // `cmux auth login` alone would short-circuit on "already
+                // signed in" — the fix is sign out, then sign in.
+                let message: String
+                if case .httpStatus = vmError {
+                    message = String(
+                        localized: "socket.cloudVM.sessionRejected",
+                        defaultValue: "The cmux Cloud service rejected this session. Run `cmux auth logout`, then `cmux auth login`, and retry."
+                    )
+                } else {
+                    message = String(
                         localized: "socket.cloudVM.authRequired",
                         defaultValue: "Cloud VM access requires sign-in. Run `cmux auth login`, then retry."
                     )
+                }
+                return v2Error(
+                    id: id,
+                    code: "auth_required",
+                    message: message
                 )
             }
             return v2Error(

--- a/cmuxTests/MachinesPanelModelTests.swift
+++ b/cmuxTests/MachinesPanelModelTests.swift
@@ -901,3 +901,46 @@ struct CloudTreeMachineInlineFactTests {
         #expect(CloudTreeMachineRowContent.inlineFact(snapshot(stats: nil), style: .compact) == nil)
     }
 }
+
+/// Pins the mapping from Cloud VM list failures to the machines pane's empty
+/// state. A server-rejected session (401) must route to re-auth and a plan
+/// gate (402) to the Pro upsell — neither may fall back to the retry-first
+/// "Cloud is unreachable" copy that misled the nightly's 401 storm.
+@Suite("Cloud machines list problem classification")
+struct MachinesPanelListProblemTests {
+    @Test("A server-rejected session (401) routes to a fresh sign-in")
+    func rejectedSessionRoutesToReauth() {
+        #expect(
+            MachinesPanelViewModel.classifyListFailure(
+                .httpStatus(401, #"{"error":"unauthorized"}"#)
+            ) == .sessionRejected
+        )
+    }
+
+    @Test("A plan gate (402) routes to the Pro upsell")
+    func planGateRoutesToPro() {
+        #expect(
+            MachinesPanelViewModel.classifyListFailure(
+                .httpStatus(402, #"{"error":"vm_requires_pro"}"#)
+            ) == .requiresPro
+        )
+    }
+
+    @Test("Transient-shaped failures keep the retry-first unreachable state")
+    func transientFailuresStayUnreachable() {
+        #expect(
+            MachinesPanelViewModel.classifyListFailure(.httpStatus(503, "{}")) == .unreachable
+        )
+        #expect(
+            MachinesPanelViewModel.classifyListFailure(
+                .backendUnreachable(url: "https://cmux.com", detail: "offline")
+            ) == .unreachable
+        )
+        #expect(
+            MachinesPanelViewModel.classifyListFailure(.sessionRefreshFailed) == .unreachable
+        )
+        #expect(
+            MachinesPanelViewModel.classifyListFailure(.malformedResponse("bad")) == .unreachable
+        )
+    }
+}


### PR DESCRIPTION
## What

During the nightly's 401 storm (dead Stack session the app refused to give up), every surface pointed away from the fix:

- The machines pane said **"Cloud is unreachable"** for *any* list failure — including HTTP 401 (server rejected the session) and 402 (plan gate), where retrying can never help.
- The CLI said `auth_required: … Run cmux auth login` — which short-circuits with **"Already signed in"** exactly when the server has rejected the session.
- The signed-out cloud pane stacked its own "Sign in to use Cloud Machines" header above `AccountSignInView`'s idle header and every later stage ("Waiting for sign-in…"), with no padding.

## Changes

- `MachinesPanelViewModel.classifyListFailure` (pure, tested): 401 → `sessionRejected`, 402 → `requiresPro`, everything else → `unreachable`.
- Empty state renders the true state: **Sign Out & Sign In Again** for rejected sessions (sign-out flips the pane to the sign-in gate), **Upgrade to Pro** for plan gates, retry-first "unreachable" only for transient-shaped failures.
- `AccountSignInView` gains idle title/subtitle overrides; the cloud pane passes its copy through, so there is exactly one header in every stage, plus real padding/centering.
- Socket `v2VmCall` 401 message now prescribes `cmux auth logout`, then `cmux auth login`.

## Localization audit

New surfaces: 6 machines-pane strings + 1 socket message. All via `String(localized:)` with keys added to `Resources/Localizable.xcstrings` carrying both **en and ja** `translated` entries (verified by parsing the file). No new bare English literals in the touched Swift files.

## Validation

- Debug build: **BUILD SUCCEEDED** (isolated derived data, arm64).
- `cmuxTests/MachinesPanelListProblemTests` pins the classification (wired in the existing `MachinesPanelModelTests.swift`; `scripts/lint-pbxproj-test-wiring.sh` ok).

Companion backend PR: #11225 (user-scoped billing fallback + honest 409 title).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q8M6wNCw6uLEvQaHGUo4SY

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790721268&installation_model_id=21920&pr_number=11229&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11229&signature=eb9b46999f7f1337117a1c98f95427ef626108aa5458ead70f3cf19b4f28730b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Cloud machines pane and CLI so auth failures point at the real fix instead of misleading copy. Previously every list failure showed "Cloud is unreachable", and a rejected session suggested `cmux auth login` — which short-circuits with "Already signed in".

**Bug Fixes**
- Classifies list failures by HTTP status: 401 routes to a fresh sign-in, 402 to the Pro upgrade, everything else keeps the retry-first "unreachable" state.
- The rejected-session state shows a "Sign Out & Sign In Again" button that flips the pane to the sign-in gate.
- The plan-gate state shows an "Upgrade to Pro" button.
- CLI 401 messages now prescribe `cmux auth logout`, then `cmux auth login`.
- The signed-out pane shows exactly one header: `AccountSignInView` takes idle title and subtitle overrides instead of stacking a second header.

<sup>Written for commit a1aed0bde705f00768ebe95e3cf1f3e130548657. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer Cloud machine states for authentication failures, Pro requirements, and unavailable services.
  * Added guidance for signing out and back in when a Cloud session is rejected.
  * Added English and Japanese translations for new Cloud machine messages.

* **Bug Fixes**
  * Cloud VM authentication errors now provide more specific recovery instructions.
  * Cloud machine failures are routed to the appropriate user-facing state instead of displaying a generic error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->