### PR TITLE
ios: drop redundant Notifications nav title

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/NotificationFeedView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/NotificationFeedView.swift
@@ -44,8 +44,6 @@ struct NotificationFeedView: View {
                 }
             )
         }
-        .navigationTitle(L10n.string("mobile.notificationFeed.title", defaultValue: "Notifications"))
-        .navigationBarTitleDisplayMode(.large)
         .toolbar {
             if projection.sourceUnreadCount > 0 {
                 ToolbarItem(placement: .topBarTrailing) {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/NotificationFeedView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/NotificationFeedView.swift
@@ -44,6 +44,7 @@ struct NotificationFeedView: View {
                 }
             )
         }
+        .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             if projection.sourceUnreadCount > 0 {
                 ToolbarItem(placement: .topBarTrailing) {

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -4982,23 +4982,6 @@
         }
       }
     },
-    "mobile.notificationFeed.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Notifications"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "通知"
-          }
-        }
-      }
-    },
     "mobile.notificationFeed.unread": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
The Notifications tab showed a large "Notifications" navigation title directly under the toolbar row, duplicating the tab context; the Workspaces tab has no equivalent title. Remove the large title and the now-unused `mobile.notificationFeed.title` localization key (en, ja).

Localization audit: no new strings; removed one unused key from `ios/cmux/Resources/Localizable.xcstrings` (en + ja entries). No UI test references the nav-bar title (tab-bar button labels come from `mobile.tabs.*`).

Screenshot preview is being dogfooded via the tagged `shots` build before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790732801&installation_model_id=21920&pr_number=11233&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11233&signature=09a5b54735566310d65f4b296cd769fd789c622d372b72f85d378768594d68f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the large "Notifications" nav title from the Notifications tab so it no longer duplicates the tab context, matching the Workspaces tab. Pins the nav bar to inline display mode so the stack no longer reserves large-title height, which was leaving a dead band above the filter bar. Also deletes the now-unused `mobile.notificationFeed.title` localization key from `ios/cmux/Resources/Localizable.xcstrings` (en and ja). No UI tests reference the nav-bar title, and no new strings were introduced.

<sup>Written for commit f605dd3cda449f470b6aec4dcaa863160ca64a4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the notification feed screen to use a compact inline navigation layout instead of a large title.
  * Removed the separate notification feed title from the navigation bar.
  * Removed unused notification feed title localization entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->