### PR TITLE
fix(ios): pin the viewport to the tail through streaming output mid-gesture

### DIFF
--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+LocalPixelScroll.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+LocalPixelScroll.swift
@@ -193,32 +193,22 @@ extension GhosttySurfaceView {
             let len = min(scrollbar.len, total)
             let maxPosition = Double(total - len) * cellHeightPx
             let rowsPushedNow = pushedRowsCounter.withLock { $0 }
-            // Mid-gesture the held position is the authority: a verified
-            // replay may have reset the live viewport to the bottom between
-            // batches, and deriving from it would make the reset hijack the
-            // gesture. The exact (unrounded) position carries sub-pixel
-            // deltas across batches. A held position from an older row-space
-            // revision is first rebased content-true: pushes beyond growth
-            // evicted rows from the top of a capped scrollback, so the same
-            // content sits that many rows higher. Only an unreconcilable
-            // space (rebuilt, shrunk) falls back to the live viewport.
-            let current: Double
-            if rebaseFromHeldPosition, let held,
-               held.revision == scrollbar.row_space_revision {
-                current = min(held.positionPx, maxPosition)
-            } else if rebaseFromHeldPosition, let held,
-                      let corrected = GhosttySurfaceView.LocalPixelScrollState.rebasedHeldPositionPx(
-                          heldPositionPx: held.positionPx,
-                          heldTotal: held.total,
-                          heldRowsPushed: held.rowsPushed,
-                          scrollbarTotal: total,
-                          rowsPushedNow: rowsPushedNow,
-                          cellHeightPx: cellHeightPx
-                      ) {
-                current = min(corrected, maxPosition)
-            } else {
-                current = min(Double(scrollbar.offset) * cellHeightPx + remainder, maxPosition)
-            }
+            // Mid-gesture the held position is the authority; see
+            // `gestureBasePositionPx` for the anchoring contract (docked
+            // holds target the live tail, undocked holds keep their content,
+            // revision changes rebase content-true, unreconcilable spaces
+            // fall back to the live viewport).
+            let current = GhosttySurfaceView.LocalPixelScrollState.gestureBasePositionPx(
+                rebaseFromHeldPosition: rebaseFromHeldPosition,
+                held: held,
+                scrollbarOffset: scrollbar.offset,
+                scrollbarRevision: scrollbar.row_space_revision,
+                scrollbarTotal: total,
+                rowsPushedNow: rowsPushedNow,
+                remainderPx: remainder,
+                cellHeightPx: cellHeightPx,
+                maxPositionPx: maxPosition
+            )
             // The axis continues past scrollback-top into the top-reveal
             // zone (the keyboard-up presentation's clipped top), so the
             // oldest rows stay reachable while the keyboard is up. The grid
@@ -241,7 +231,8 @@ extension GhosttySurfaceView {
                 row += 1
                 pixelOffset = 0
             }
-            if next >= maxPosition - 0.5 {
+            let dockedAtTail = next >= maxPosition - 0.5
+            if dockedAtTail {
                 // Docked at the tail: target the absolute bottom and let
                 // Ghostty clamp the row into the active area.
                 row = total
@@ -268,13 +259,14 @@ extension GhosttySurfaceView {
                     guard $0.epoch == operation.pixelStateEpoch else { return }
                     $0.remainderPx = appliedOffset
                     $0.topRevealPx = appliedReveal
-                    $0.lastApplied = (
+                    $0.lastApplied = LocalPixelScrollState.Held(
                         row: appliedRow,
                         remainderPx: appliedOffset,
                         positionPx: appliedPosition,
                         revision: appliedRevision,
                         total: appliedTotal,
-                        rowsPushed: rowsPushedNow
+                        rowsPushed: rowsPushedNow,
+                        dockedAtTail: dockedAtTail
                     )
                 }
                 return

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -309,17 +309,37 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         var epoch: UInt64 = 0
         var remainderPx: Double = 0
         var lastFallbackLogTime: CFTimeInterval = 0
-        /// The last (row, remainder) the pixel pump applied. While a gesture
-        /// is active this is the position AUTHORITY: batches rebase from it
+        /// One applied pixel-pump position, remembered as the gesture's
+        /// authority between batches.
+        nonisolated struct Held: Equatable, Sendable {
+            /// The viewport top row applied to Ghostty.
+            var row: UInt64
+            /// The whole-pixel offset actually applied to Ghostty.
+            var remainderPx: Double
+            /// The exact (unrounded) content-space position, so sub-pixel
+            /// deltas accumulate across batches.
+            var positionPx: Double
+            /// Row-space revision at apply time; the held content anchor is
+            /// only valid verbatim while it matches.
+            var revision: UInt64
+            /// Row-space total at apply time.
+            var total: UInt64
+            /// Cumulative local scrollback pushes at apply time.
+            var rowsPushed: UInt64
+            /// True when this batch docked at the tail (`row == total`).
+            /// A docked hold is BOTTOM-anchored, not content-anchored: while
+            /// it stands, batches target the LIVE tail so streaming output
+            /// cannot leave the viewport a few rows behind the bottom.
+            var dockedAtTail: Bool
+        }
+
+        /// The last position the pixel pump applied. While a gesture is
+        /// active this is the position AUTHORITY: batches rebase from it
         /// instead of the live viewport, so a verified-replay bottom-reset
         /// between batches is overwritten on the next frame instead of
         /// hijacking the gesture. Cleared on dock/typing snaps and surface
         /// replacement, where the live viewport becomes the truth again.
-        /// `positionPx` is the exact (unrounded) content-space position so
-        /// sub-pixel deltas accumulate across batches; `remainderPx` is the
-        /// whole-pixel offset actually applied to Ghostty. `revision` guards
-        /// the row space: the held anchor is only valid while it matches.
-        var lastApplied: (row: UInt64, remainderPx: Double, positionPx: Double, revision: UInt64, total: UInt64, rowsPushed: UInt64)?
+        var lastApplied: Held?
         /// Device pixels of scroll-top reveal: how far past scrollback-top
         /// the gesture has pulled, realized by the host sliding the
         /// bottom-pinned render back down to uncover the rows the keyboard-up
@@ -348,7 +368,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         OSAllocatedUnfairLock<UInt64>(initialState: 0)
     #if DEBUG
     /// Last pixel-precise viewport position the pixel pump applied.
-    var debugLastPixelScroll: (row: UInt64, remainderPx: Double, positionPx: Double, revision: UInt64, total: UInt64, rowsPushed: UInt64)? {
+    var debugLastPixelScroll: LocalPixelScrollState.Held? {
         localPixelScrollState.withLock { $0.lastApplied }
     }
     #endif

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/LocalPixelScrollHeldRebase.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/LocalPixelScrollHeldRebase.swift
@@ -14,6 +14,59 @@
 /// This decision is pure so the rebase arithmetic is unit-testable without a
 /// Ghostty surface.
 extension GhosttySurfaceView.LocalPixelScrollState {
+    /// Resolves the content-space base position for one gesture batch.
+    ///
+    /// Mid-gesture the held position is the authority: a verified replay may
+    /// have reset the live viewport to the bottom between batches, and
+    /// deriving from it would make the reset hijack the gesture. The hold has
+    /// two anchoring modes: a hold docked at the tail is BOTTOM-anchored and
+    /// targets the LIVE tail, so output appended between batches cannot leave
+    /// the viewport a row behind the bottom (the pin-to-bottom contract of
+    /// messaging apps); an undocked hold is CONTENT-anchored and keeps the
+    /// same rows visible, rebased content-true across a row-space revision
+    /// change. Only an unreconcilable space falls back to the live viewport.
+    ///
+    /// - Parameters:
+    ///   - rebaseFromHeldPosition: Whether a gesture (or its deceleration)
+    ///     owns the axis; idle batches always trust the live viewport.
+    ///   - held: The last applied position, or `nil` before the first apply.
+    ///   - scrollbarOffset: The live viewport top row.
+    ///   - scrollbarRevision: The live row-space revision.
+    ///   - scrollbarTotal: The live row-space total.
+    ///   - rowsPushedNow: Cumulative local scrollback pushes now.
+    ///   - remainderPx: The fractional pixel carried between batches.
+    ///   - cellHeightPx: Cell height in device pixels.
+    ///   - maxPositionPx: The tail position (`(total - len) * cellHeightPx`).
+    /// - Returns: The batch's base position in content-space device pixels.
+    static func gestureBasePositionPx(
+        rebaseFromHeldPosition: Bool,
+        held: Held?,
+        scrollbarOffset: UInt64,
+        scrollbarRevision: UInt64,
+        scrollbarTotal: UInt64,
+        rowsPushedNow: UInt64,
+        remainderPx: Double,
+        cellHeightPx: Double,
+        maxPositionPx: Double
+    ) -> Double {
+        if rebaseFromHeldPosition, let held {
+            if held.revision == scrollbarRevision {
+                return min(held.positionPx, maxPositionPx)
+            }
+            if let corrected = rebasedHeldPositionPx(
+                heldPositionPx: held.positionPx,
+                heldTotal: held.total,
+                heldRowsPushed: held.rowsPushed,
+                scrollbarTotal: scrollbarTotal,
+                rowsPushedNow: rowsPushedNow,
+                cellHeightPx: cellHeightPx
+            ) {
+                return min(corrected, maxPositionPx)
+            }
+        }
+        return min(Double(scrollbarOffset) * cellHeightPx + remainderPx, maxPositionPx)
+    }
+
     /// Rebases a revision-mismatched held position onto the current row space.
     ///
     /// - Parameters:

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/LocalPixelScrollHeldRebase.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/LocalPixelScrollHeldRebase.swift
@@ -50,6 +50,14 @@ extension GhosttySurfaceView.LocalPixelScrollState {
         maxPositionPx: Double
     ) -> Double {
         if rebaseFromHeldPosition, let held {
+            // A docked hold is bottom-anchored: the tail is the tail in every
+            // row space, so it needs no revision match and no content rebase.
+            // The gesture undocks it by actually moving up (the batch's dock
+            // check stores dockedAtTail=false the moment the resolved
+            // position leaves the tail).
+            if held.dockedAtTail {
+                return maxPositionPx
+            }
             if held.revision == scrollbarRevision {
                 return min(held.positionPx, maxPositionPx)
             }

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/LocalPixelScrollHeldRebaseTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/LocalPixelScrollHeldRebaseTests.swift
@@ -107,3 +107,118 @@ struct LocalPixelScrollHeldRebaseTests {
         #expect(corrected == nil)
     }
 }
+
+@Suite("Gesture base position")
+struct GestureBasePositionTests {
+    private let cellHeightPx = 20.0
+
+    private func held(
+        positionPx: Double,
+        revision: UInt64,
+        total: UInt64,
+        rowsPushed: UInt64 = 0,
+        dockedAtTail: Bool
+    ) -> GhosttySurfaceView.LocalPixelScrollState.Held {
+        .init(
+            row: UInt64(positionPx / cellHeightPx),
+            remainderPx: 0,
+            positionPx: positionPx,
+            revision: revision,
+            total: total,
+            rowsPushed: rowsPushed,
+            dockedAtTail: dockedAtTail
+        )
+    }
+
+    @Test("a docked hold targets the live tail after output grew the row space")
+    func dockedHoldFollowsGrownTail() {
+        // Docked at total=1000 (position 18,800); 12 rows arrived since the
+        // batch. Content anchoring would leave the viewport 12 rows behind
+        // the new bottom; the docked hold must target the LIVE tail.
+        let base = GhosttySurfaceView.LocalPixelScrollState.gestureBasePositionPx(
+            rebaseFromHeldPosition: true,
+            held: held(positionPx: 18_800, revision: 3, total: 1_000, dockedAtTail: true),
+            scrollbarOffset: 952,
+            scrollbarRevision: 3,
+            scrollbarTotal: 1_012,
+            rowsPushedNow: 12,
+            remainderPx: 0,
+            cellHeightPx: cellHeightPx,
+            maxPositionPx: 19_040
+        )
+
+        #expect(base == 19_040)
+    }
+
+    @Test("a docked hold survives a row-space revision change at the cap")
+    func dockedHoldSurvivesEviction() {
+        // Eviction at the cap bumps the revision; the tail is still the
+        // tail, so a docked hold keeps targeting the live bottom instead of
+        // rebasing content-true away from it.
+        let base = GhosttySurfaceView.LocalPixelScrollState.gestureBasePositionPx(
+            rebaseFromHeldPosition: true,
+            held: held(positionPx: 78_800, revision: 3, total: 4_000, rowsPushed: 100, dockedAtTail: true),
+            scrollbarOffset: 3_940,
+            scrollbarRevision: 4,
+            scrollbarTotal: 4_000,
+            rowsPushedNow: 130,
+            remainderPx: 0,
+            cellHeightPx: cellHeightPx,
+            maxPositionPx: 78_800
+        )
+
+        #expect(base == 78_800)
+    }
+
+    @Test("an undocked hold keeps its content while output grows")
+    func undockedHoldKeepsContent() {
+        let base = GhosttySurfaceView.LocalPixelScrollState.gestureBasePositionPx(
+            rebaseFromHeldPosition: true,
+            held: held(positionPx: 10_000, revision: 3, total: 1_000, dockedAtTail: false),
+            scrollbarOffset: 952,
+            scrollbarRevision: 3,
+            scrollbarTotal: 1_012,
+            rowsPushedNow: 12,
+            remainderPx: 0,
+            cellHeightPx: cellHeightPx,
+            maxPositionPx: 19_040
+        )
+
+        #expect(base == 10_000)
+    }
+
+    @Test("an undocked hold rebases content-true across eviction")
+    func undockedHoldRebasesAcrossEviction() {
+        // 30 pushed with zero growth at the cap: same content is 30 rows up.
+        let base = GhosttySurfaceView.LocalPixelScrollState.gestureBasePositionPx(
+            rebaseFromHeldPosition: true,
+            held: held(positionPx: 20_000, revision: 3, total: 4_000, rowsPushed: 100, dockedAtTail: false),
+            scrollbarOffset: 900,
+            scrollbarRevision: 4,
+            scrollbarTotal: 4_000,
+            rowsPushedNow: 130,
+            remainderPx: 0,
+            cellHeightPx: cellHeightPx,
+            maxPositionPx: 78_800
+        )
+
+        #expect(base == 20_000 - 30 * cellHeightPx)
+    }
+
+    @Test("an idle batch trusts the live viewport")
+    func idleBatchTrustsLiveViewport() {
+        let base = GhosttySurfaceView.LocalPixelScrollState.gestureBasePositionPx(
+            rebaseFromHeldPosition: false,
+            held: held(positionPx: 10_000, revision: 3, total: 1_000, dockedAtTail: true),
+            scrollbarOffset: 100,
+            scrollbarRevision: 3,
+            scrollbarTotal: 1_000,
+            rowsPushedNow: 0,
+            remainderPx: 4,
+            cellHeightPx: cellHeightPx,
+            maxPositionPx: 18_800
+        )
+
+        #expect(base == 100 * cellHeightPx + 4)
+    }
+}

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/ScrollTopRevealClearTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/ScrollTopRevealClearTests.swift
@@ -23,7 +23,7 @@ struct ScrollTopRevealClearTests {
         let staleEpoch = view.localPixelScrollState.withLock { state -> UInt64 in
             state.topRevealPx = 240
             state.remainderPx = 3
-            state.lastApplied = (row: 0, remainderPx: 0, positionPx: 0, revision: 7, total: 90, rowsPushed: 0)
+            state.lastApplied = .init(row: 0, remainderPx: 0, positionPx: 0, revision: 7, total: 90, rowsPushed: 0, dockedAtTail: false)
             return state.epoch
         }
 
@@ -49,7 +49,7 @@ struct ScrollTopRevealClearTests {
 
         let seeded = view.localPixelScrollState.withLock { state -> UInt64 in
             state.remainderPx = 5
-            state.lastApplied = (row: 12, remainderPx: 5, positionPx: 245, revision: 7, total: 90, rowsPushed: 0)
+            state.lastApplied = .init(row: 12, remainderPx: 5, positionPx: 245, revision: 7, total: 90, rowsPushed: 0, dockedAtTail: false)
             return state.epoch
         }
 


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/cmux/pull/11185, from Aziz's recording: at the very bottom of a streaming terminal the viewport "tries to stay pinned but struggles".

Device log evidence (tag ctru, offsets 1042-1047s): `scroll.bar` offset flaps one row around the tail many times per second (`total=1054 offset=994 -> 993 -> 994`) and periodically falls 12+ rows behind before a catch-up jump. Mechanism: while a gesture (or its deceleration) owns the scroll axis, the held pixel position is content-anchored, so each batch re-applies the position of the OLD tail - one row short of the bottom that output just grew - and the next batch's dock check re-bottoms it. Ghostty itself follows the tail natively between batches (`scroll .row >= total-rows` sets `viewport = .active`); the pump was the only fighter.

Fix: the held position now records `dockedAtTail`. A docked hold is bottom-anchored - `gestureBasePositionPx` targets the LIVE tail regardless of row-space revision (the tail is the tail in every row space) - so streaming output cannot leave the viewport behind and the bounce loop disappears, matching the messaging-app pin-at-newest contract. The gesture undocks by actually moving up: the dock check stores `dockedAtTail=false` the moment the resolved position leaves the tail, and the hold returns to the content anchoring #11185 shipped (scrolled-up behavior unchanged).

Commit 1 promotes the held tuple to `LocalPixelScrollState.Held`, extracts the batch's base-position decision into the pure `gestureBasePositionPx` (behavior preserved), and adds the failing bottom-anchored tests; commit 2 adds the docked branch. The hosted `iOS simulator tests` lane is still red on main before any test runs (`cmuxFeatureTests` broker-protocol rot), so red/green is proven on a leased fleet Mac with `xcodebuild test` scoped to the CmuxMobileTerminal package - run links in comments once complete.

HIG: scroll views should keep content anchored to the user's position and move predictably as content changes (https://developer.apple.com/design/human-interface-guidelines/scroll-views).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790735021&installation_model_id=21920&pr_number=11237&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11237&signature=60aa4d9809112523b868fb318f4b7588dc1a40638a88ce56954ccba6aa510107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the streaming terminal viewport oscillating around the tail mid-gesture, so it stays pinned to the last line while output streams.

Before, a gesture hold was content-anchored: each batch re-applied the old tail position (one row short of the new bottom), and the next batch's dock check re-bottomed it, so the viewport flapped around the tail and periodically fell screens behind.

Now a hold docked at the tail is bottom-anchored and targets the live tail regardless of row-space revision, matching the pin-at-newest contract of messaging apps. The gesture undocks by actually moving up: when the resolved position leaves the tail, `dockedAtTail` is set to false and the hold returns to content anchoring, so scrolled-up behavior is unchanged.

**Bug Fixes**
- Docked holds now target the live tail instead of the stale content position.
- Extracted the batch base-position decision into pure `gestureBasePositionPx`; held positions are now `LocalPixelScrollState.Held` with a `dockedAtTail` flag.
- Added tests for docked-held growth/eviction, undocked content anchoring, and idle fallback to the live viewport.

The hosted iOS simulator tests lane is red on `main` before tests run (broker-protocol rot); red/green was proven locally with `xcodebuild test` scoped to the `CmuxMobileTerminal` package.

<sup>Written for commit 296c9b162dabc1db3b7f9e7a3121eeb03ef7a8d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pixel scrolling during content updates, including terminal growth and scrollback changes.
  * Preserved bottom-of-content positioning more reliably during gestures.
  * Improved handling of idle scroll batches and partial-pixel movement.

* **Tests**
  * Added coverage for anchored scrolling, content changes, scrollback eviction, and pixel remainders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->