### PR TITLE
Fix sidebar rows clipping to stale heights after workspace closes

### DIFF
--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowModel.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowModel.swift
@@ -11,7 +11,9 @@ import SwiftUI
 /// these values only (snapshot-boundary discipline in AppKit form).
 struct SidebarWorkspaceRowModel: Equatable {
     let workspaceId: UUID
-    let index: Int
+    // `var` only so `hasHeightEquivalentContent` can compare
+    // position-neutralized copies; the stored value stays authoritative.
+    var index: Int
     let snapshot: SidebarWorkspaceSnapshotBuilder.Snapshot
     let settings: SidebarTabItemSettingsSnapshot
     // `var` (not `let`) so the optimistic press/deselect paint can apply a
@@ -34,7 +36,8 @@ struct SidebarWorkspaceRowModel: Equatable {
     let topDropIndicatorVisible: Bool
     let bottomDropIndicatorVisible: Bool
     let isGrouped: Bool
-    let isFirstRow: Bool
+    // `var` only for `hasHeightEquivalentContent` (see `index`).
+    var isFirstRow: Bool
     /// Resolved modifier-hold hint text (nil hides the pill).
     let shortcutHintText: String?
     let showsShortcutHints: Bool
@@ -67,6 +70,24 @@ struct SidebarWorkspaceRowModel: Equatable {
 
     func scaled(_ base: CGFloat) -> CGFloat {
         GlobalFontMagnification.scaledSize(base * fontScale, percent: globalFontMagnificationPercent)
+    }
+
+    /// Equality over every field that can influence the measured row height.
+    /// `index` feeds only the accessibility label and `isFirstRow` only the
+    /// drop-indicator frame in the apply pass (`layoutContent(apply: true)`),
+    /// so neither changes what `layoutContent(apply: false)` returns. Closing
+    /// a workspace shifts both for every row below it; height caching keyed on
+    /// full equality would re-measure that whole tail and lose its entries
+    /// exactly when a stale-width fallback needs them.
+    func hasHeightEquivalentContent(to other: Self) -> Bool {
+        if self == other { return true }
+        var normalizedSelf = self
+        var normalizedOther = other
+        normalizedSelf.index = 0
+        normalizedOther.index = 0
+        normalizedSelf.isFirstRow = false
+        normalizedOther.isFirstRow = false
+        return normalizedSelf == normalizedOther
     }
 }
 

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
@@ -232,6 +232,7 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
         appliedUnreadSnapshot = SidebarUnreadSnapshot()
         hasPendingContentRefresh = false
         pumpHeightOverrides.removeAll(keepingCapacity: false)
+        servedRowHeights.removeAll(keepingCapacity: false)
         rows.removeAll(keepingCapacity: false)
         workspaceIds.removeAll(keepingCapacity: false)
         selectedScrollTargetWorkspaceId = nil
@@ -616,6 +617,10 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
             )
             : nil
         rows = nextRows
+        if hasStructuralChanges {
+            let liveIds = Set(nextRows.map(\.id))
+            servedRowHeights = servedRowHeights.filter { liveIds.contains($0.key) }
+        }
 
 #if DEBUG
         if hasStructuralChanges || !contentChanges.isEmpty {
@@ -701,6 +706,8 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
                 )
             }
         }
+
+        noteServedHeightDivergence(in: containerView.tableView)
 
 #if DEBUG
         // Height-drift probe (row clipping reports): the height the cache
@@ -891,10 +898,20 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
     func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat {
         guard rows.indices.contains(row) else { return tableView.rowHeight }
         let configuration = rows[row]
-        let columnWidth = lastMeasuredWidth > 0 ? lastMeasuredWidth : currentColumnWidth()
+        let height = authoritativeRowHeight(for: configuration)
+        servedRowHeights[configuration.id] = height
+        return height
+    }
+
+    /// The exact answer `heightOfRow` gives for this row right now:
+    /// pump override, then cache, then the single-line estimate.
+    private func authoritativeRowHeight(
+        for configuration: SidebarWorkspaceTableRowConfiguration
+    ) -> CGFloat {
         if let override = effectivePumpHeightOverride(for: configuration.id) {
             return override
         }
+        let columnWidth = lastMeasuredWidth > 0 ? lastMeasuredWidth : currentColumnWidth()
         return rowHeightCache.height(
             for: configuration,
             columnWidth: columnWidth
@@ -1674,6 +1691,38 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
     private var lastLiveMeasuredWidth: CGFloat = 0
     private var hasLiveMeasuredRows = false
 
+    /// The height most recently returned to NSTableView per row id.
+    /// `heightOfRow` is the only point where row geometry enters the table,
+    /// and the table re-asks only after a note or reload — so any row whose
+    /// authoritative answer drifts from this ledger has a missed
+    /// `noteHeightOfRows` and paints clipped (or padded) until an unrelated
+    /// reload. The measure passes diff new heights against the cache's own
+    /// previous entry, not against what the table displays, so they cannot
+    /// catch every such miss themselves (the DEBUG drift probe in
+    /// `flushApply` logs exactly this class). `noteServedHeightDivergence`
+    /// turns the ledger into the corrective pass.
+    private var servedRowHeights: [SidebarWorkspaceRenderItemID: CGFloat] = [:]
+
+    /// Re-notes every row whose authoritative height no longer matches the
+    /// height the table was last served. Runs at the end of each apply and
+    /// settle pass; the triggered `heightOfRow` re-query updates the ledger,
+    /// so a corrected row converges in the same pass.
+    private func noteServedHeightDivergence(in table: NSTableView) {
+        guard !servedRowHeights.isEmpty else { return }
+        var diverged = IndexSet()
+        for (index, row) in rows.enumerated() {
+            guard let served = servedRowHeights[row.id] else { continue }
+            if abs(served - authoritativeRowHeight(for: row)) >= 0.5 {
+                diverged.insert(index)
+            }
+        }
+        guard !diverged.isEmpty else { return }
+#if DEBUG
+        cmuxDebugLog("sidebar.heightDrift.corrected rows=\(diverged.count)")
+#endif
+        noteHeightOfRowsWithoutAnimation(table, diverged)
+    }
+
     /// Legacy parity: rows re-wrap continuously while the divider or window
     /// edge is dragged instead of keeping last-width heights until mouse-up.
     /// Only the visible pure-AppKit rows (plus a small buffer) re-measure per
@@ -1785,6 +1834,7 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
             if !changed.isEmpty {
                 noteHeightOfRowsWithoutAnimation(table, changed)
             }
+            noteServedHeightDivergence(in: table)
         }
         hasLiveMeasuredRows = false
         lastLiveMeasuredWidth = 0

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableRowConfiguration.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableRowConfiguration.swift
@@ -41,6 +41,7 @@ struct SidebarWorkspaceTableRowConfiguration {
     private let environment: SidebarWorkspaceTableEnvironmentSnapshot
     private let equivalenceValue: Any
     private let isEquivalentValue: (Any) -> Bool
+    private let isHeightEquivalentValue: (Any) -> Bool
 
     private init(
         id: SidebarWorkspaceRenderItemID,
@@ -53,7 +54,8 @@ struct SidebarWorkspaceTableRowConfiguration {
         appKitWorkspaceRowModel: SidebarWorkspaceRowModel?,
         environment: SidebarWorkspaceTableEnvironmentSnapshot,
         equivalenceValue: Any,
-        isEquivalentValue: @escaping (Any) -> Bool
+        isEquivalentValue: @escaping (Any) -> Bool,
+        isHeightEquivalentValue: ((Any) -> Bool)? = nil
     ) {
         self.id = id
         self.workspaceId = workspaceId
@@ -73,6 +75,7 @@ struct SidebarWorkspaceTableRowConfiguration {
         self.environment = environment
         self.equivalenceValue = equivalenceValue
         self.isEquivalentValue = isEquivalentValue
+        self.isHeightEquivalentValue = isHeightEquivalentValue ?? isEquivalentValue
     }
 
     init<Content: View & Equatable>(
@@ -106,6 +109,7 @@ struct SidebarWorkspaceTableRowConfiguration {
             guard let value = value as? Content else { return false }
             return value == equivalenceValue
         }
+        self.isHeightEquivalentValue = self.isEquivalentValue
     }
 
     init(
@@ -136,6 +140,7 @@ struct SidebarWorkspaceTableRowConfiguration {
             guard let value = value as? SidebarGroupHeaderRowModel else { return false }
             return value == groupHeaderModel
         }
+        self.isHeightEquivalentValue = self.isEquivalentValue
     }
 
     init(
@@ -169,11 +174,25 @@ struct SidebarWorkspaceTableRowConfiguration {
             guard let value = value as? SidebarWorkspaceRowModel else { return false }
             return value == workspaceRowModel
         }
+        self.isHeightEquivalentValue = { value in
+            guard let value = value as? SidebarWorkspaceRowModel else { return false }
+            return value.hasHeightEquivalentContent(to: workspaceRowModel)
+        }
     }
 
     func hasEquivalentContent(to other: Self) -> Bool {
         environment.hasEquivalentPresentation(to: other.environment)
             && isEquivalentValue(other.equivalenceValue)
+    }
+
+    /// Content equality restricted to fields that can change the measured row
+    /// height. The height cache keys on this: a close shifts `index` /
+    /// `isFirstRow` for every row below it, and treating those rows as changed
+    /// would both re-measure the whole tail and drop the content-matched
+    /// entries the stale-width `height(for:)` fallback depends on.
+    func hasEquivalentHeightContent(to other: Self) -> Bool {
+        environment.hasEquivalentPresentation(to: other.environment)
+            && isHeightEquivalentValue(other.equivalenceValue)
     }
 
     func applyingUnreadSnapshot(_ snapshot: SidebarUnreadSnapshot) -> Self {

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableRowHeightCache.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableRowHeightCache.swift
@@ -20,7 +20,7 @@ final class SidebarWorkspaceTableRowHeightCache {
             row candidate: SidebarWorkspaceTableRowConfiguration,
             columnWidth candidateWidth: CGFloat
         ) -> Bool {
-            columnWidth == candidateWidth && row.hasEquivalentContent(to: candidate)
+            columnWidth == candidateWidth && row.hasEquivalentHeightContent(to: candidate)
         }
     }
 
@@ -164,7 +164,7 @@ final class SidebarWorkspaceTableRowHeightCache {
         // the lookup still uses the last settled width; a content-matched
         // entry at another width is that fresher measurement, and the settle
         // pass re-measures every width-mismatched entry afterward.
-        guard entry.row.hasEquivalentContent(to: row) else { return nil }
+        guard entry.row.hasEquivalentHeightContent(to: row) else { return nil }
         return entry.height
     }
 

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2210,6 +2210,7 @@
 		B804A02B000000000000002B /* SidebarWorkspaceRowChecklistSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B02B000000000000002B /* SidebarWorkspaceRowChecklistSection.swift */; };
 		970900020000000000000001 /* SidebarWorkspaceRowColorMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 970900020000000000000002 /* SidebarWorkspaceRowColorMenu.swift */; };
 		B804A0220000000000000022 /* SidebarWorkspaceRowCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0220000000000000022 /* SidebarWorkspaceRowCommands.swift */; };
+		B8624C990000000000000099 /* SidebarWorkspaceRowHeightInvariantTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8624D990000000000000099 /* SidebarWorkspaceRowHeightInvariantTests.swift */; };
 		B8624C0294950000000000A1 /* SidebarWorkspaceRowInlineRenameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8624D0294950000000000A1 /* SidebarWorkspaceRowInlineRenameTests.swift */; };
 		6707F0116707F0116707F011 /* SidebarWorkspaceRowInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6707F0126707F0126707F012 /* SidebarWorkspaceRowInput.swift */; };
 		B804A0230000000000000023 /* SidebarWorkspaceRowModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0230000000000000023 /* SidebarWorkspaceRowModel.swift */; };
@@ -5157,6 +5158,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		B804B02B000000000000002B /* SidebarWorkspaceRowChecklistSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/Cells/SidebarWorkspaceRowChecklistSection.swift; sourceTree = "<group>"; };
 		970900020000000000000002 /* SidebarWorkspaceRowColorMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/Cells/SidebarWorkspaceRowColorMenu.swift; sourceTree = "<group>"; };
 		B804B0220000000000000022 /* SidebarWorkspaceRowCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/Cells/SidebarWorkspaceRowCommands.swift; sourceTree = "<group>"; };
+		B8624D990000000000000099 /* SidebarWorkspaceRowHeightInvariantTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceRowHeightInvariantTests.swift; sourceTree = "<group>"; };
 		B8624D0294950000000000A1 /* SidebarWorkspaceRowInlineRenameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceRowInlineRenameTests.swift; sourceTree = "<group>"; };
 		6707F0126707F0126707F012 /* SidebarWorkspaceRowInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceRowInput.swift; sourceTree = "<group>"; };
 		B804B0230000000000000023 /* SidebarWorkspaceRowModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/Cells/SidebarWorkspaceRowModel.swift; sourceTree = "<group>"; };
@@ -8874,6 +8876,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				B8624D0294950000000000A1 /* SidebarWorkspaceRowInlineRenameTests.swift */,
 				B8624D050000000000000005 /* SidebarWorkspaceDropTargetSuspensionTests.swift */,
 				B8624D040000000000000004 /* SidebarWorkspaceRowRetirementTests.swift */,
+				B8624D990000000000000099 /* SidebarWorkspaceRowHeightInvariantTests.swift */,
 				B8624D030000000000000003 /* SidebarWorkspaceTableSuspensionTests.swift */,
 				D7AB34300000000000000106 /* SidebarTabDropIndicatorPredicateTests.swift */,
 				D73440010000000000000002 /* SidebarTabDragPayloadProviderTests.swift */,
@@ -12226,6 +12229,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C9A57303C9A57303C9A57303 /* SidebarWorkspaceGroupHeaderMetricsTests.swift in Sources */,
 				6707F0236707F0236707F023 /* SidebarWorkspaceNotificationIndexTests.swift in Sources */,
 				C9A57305C9A57305C9A57305 /* SidebarWorkspaceReorderDropOverlayHitTestingTests.swift in Sources */,
+				B8624C990000000000000099 /* SidebarWorkspaceRowHeightInvariantTests.swift in Sources */,
 				B8624C0294950000000000A1 /* SidebarWorkspaceRowInlineRenameTests.swift in Sources */,
 				B8624C040000000000000004 /* SidebarWorkspaceRowRetirementTests.swift in Sources */,
 				2E057C19B76F8034F30969BF /* SidebarWorkspaceRowStatusGlyphRemovalTests.swift in Sources */,

--- a/cmuxTests/SidebarWorkspaceRowHeightInvariantTests.swift
+++ b/cmuxTests/SidebarWorkspaceRowHeightInvariantTests.swift
@@ -1,0 +1,251 @@
+import AppKit
+import CmuxWorkspaces
+import Testing
+@testable import cmux_DEV
+
+/// Regression coverage for sidebar rows painting clipped after workspace
+/// closes (https://github.com/manaflow-ai/cmux — "multiple closes leave rows
+/// short of their content height"). The invariant under test is the one the
+/// controller's DEBUG drift probe documents: for every row, the rect the
+/// table lays out must equal the height its delegate answers, and closes must
+/// never change a surviving row's height.
+@Suite(.serialized)
+@MainActor
+struct SidebarWorkspaceRowHeightInvariantTests {
+    private let tallDescription = Array(
+        repeating: "wraps across several sidebar lines to exceed the estimate",
+        count: 4
+    ).joined(separator: " ")
+
+    @Test
+    func rapidClosesKeepSurvivingRowsAtFullContentHeight() async throws {
+        let mounted = try await mount(rowCount: 6, width: 300)
+        defer { mounted.window.close() }
+
+        let initialHeights = rectHeightsById(mounted, appliedRows: mounted.rows)
+        for (id, height) in initialHeights {
+            #expect(
+                height > estimatedHeightCeiling,
+                "row \(id) must start taller than the single-line estimate"
+            )
+        }
+
+        // Two closes in separate apply turns, then two coalesced into one
+        // turn (rapid clicking collapses into a single staged apply).
+        var surviving = mounted.rows
+        surviving.remove(at: 0)
+        applyRows(surviving, mounted)
+        await flushStagedTableMutations()
+
+        surviving.remove(at: 1)
+        applyRows(surviving, mounted)
+        var twiceSurviving = surviving
+        twiceSurviving.remove(at: 2)
+        applyRows(twiceSurviving, mounted)
+        await flushStagedTableMutations()
+        surviving = twiceSurviving
+        mounted.container.tableView.layoutSubtreeIfNeeded()
+
+        assertRectsMatchDelegate(mounted)
+        let survivingHeights = rectHeightsById(mounted, appliedRows: surviving)
+        #expect(survivingHeights.count == surviving.count)
+        for (id, height) in survivingHeights {
+            let initial = try #require(initialHeights[id])
+            #expect(
+                abs(height - initial) < 0.5,
+                "closing other rows must not change row \(id): \(initial) -> \(height)"
+            )
+        }
+    }
+
+    @Test
+    func closeDuringUnsettledWidthChangeSettlesToFullContentHeight() async throws {
+        let mounted = try await mount(rowCount: 6, width: 300)
+        defer { mounted.window.close() }
+
+        // Narrow the sidebar and close two rows before the trailing width
+        // settle can run — the historical clipped-row window (structural
+        // reload while measured width and live width disagree).
+        mounted.window.setContentSize(NSSize(width: 220, height: 900))
+        mounted.container.layoutSubtreeIfNeeded()
+
+        var surviving = mounted.rows
+        surviving.remove(at: 0)
+        applyRows(surviving, mounted)
+        await flushStagedTableMutations()
+        surviving.remove(at: 2)
+        applyRows(surviving, mounted)
+        await flushStagedTableMutations()
+
+        mounted.controller.performWidthRemeasureNow()
+        mounted.container.tableView.layoutSubtreeIfNeeded()
+
+        assertRectsMatchDelegate(mounted)
+        for (id, height) in rectHeightsById(mounted, appliedRows: surviving) {
+            #expect(
+                height > estimatedHeightCeiling,
+                "row \(id) settled clipped after close during width change"
+            )
+        }
+    }
+
+    @Test
+    func closingLastRowThenWidthSettleKeepsUnchangedRowsConsistent() async throws {
+        let mounted = try await mount(rowCount: 6, width: 300)
+        defer { mounted.window.close() }
+
+        // Closing the trailing row leaves every surviving row content- and
+        // index-identical, so no apply-time re-measure runs for them; the
+        // width change then settles through the cache-diff path alone.
+        mounted.window.setContentSize(NSSize(width: 240, height: 900))
+        mounted.container.layoutSubtreeIfNeeded()
+
+        var surviving = mounted.rows
+        surviving.removeLast()
+        applyRows(surviving, mounted)
+        await flushStagedTableMutations()
+
+        mounted.controller.performWidthRemeasureNow()
+        mounted.container.tableView.layoutSubtreeIfNeeded()
+
+        assertRectsMatchDelegate(mounted)
+        for (id, height) in rectHeightsById(mounted, appliedRows: surviving) {
+            #expect(
+                height > estimatedHeightCeiling,
+                "row \(id) stuck at the estimate after trailing close + settle"
+            )
+        }
+    }
+
+    // MARK: - Harness
+
+    /// Ceiling for the 1-title-line / 0-auxiliary-line estimate every clipped
+    /// row collapses to; the tall description keeps real rows well above it.
+    private var estimatedHeightCeiling: CGFloat { 40 }
+
+    private struct Mounted {
+        let controller: SidebarWorkspaceTableController
+        let container: SidebarWorkspaceTableContainerView
+        let window: NSWindow
+        let tableActions: SidebarWorkspaceTableActions
+        var rows: [SidebarWorkspaceTableRowConfiguration]
+    }
+
+    private func mount(rowCount: Int, width: CGFloat) async throws -> Mounted {
+        let controller = SidebarWorkspaceTableController()
+        let container = controller.makeContainerView()
+        let tableActions = makeTableActions()
+        let rows = (0..<rowCount).map { index in
+            makeRowConfiguration(index: index, rowCount: rowCount)
+        }
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: width, height: 900),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = container
+        window.orderFront(nil)
+        container.layoutSubtreeIfNeeded()
+        let mounted = Mounted(
+            controller: controller,
+            container: container,
+            window: window,
+            tableActions: tableActions,
+            rows: rows
+        )
+        applyRows(rows, mounted)
+        await flushStagedTableMutations()
+        container.tableView.layoutSubtreeIfNeeded()
+        #expect(container.tableView.numberOfRows == rowCount)
+        return mounted
+    }
+
+    private func applyRows(
+        _ rows: [SidebarWorkspaceTableRowConfiguration],
+        _ mounted: Mounted
+    ) {
+        mounted.controller.apply(
+            rows: rows,
+            actions: mounted.tableActions,
+            workspaceIds: rows.map(\.workspaceId),
+            selectedWorkspaceId: nil,
+            selectedScrollTargetWorkspaceId: nil
+        )
+    }
+
+    private func makeRowConfiguration(
+        index: Int,
+        rowCount: Int
+    ) -> SidebarWorkspaceTableRowConfiguration {
+        var model = SidebarWorkspaceRowSuspensionTests.makeModel(
+            customDescription: tallDescription
+        )
+        model.index = index
+        model.isFirstRow = index == 0
+        return SidebarWorkspaceTableRowConfiguration(
+            workspaceRowModel: model,
+            actions: SidebarWorkspaceRowSuspensionTests.makeActions(model: model),
+            groupId: nil,
+            isPinned: false,
+            environment: SidebarWorkspaceTableEnvironmentSnapshot(
+                colorScheme: .light,
+                globalFontMagnificationPercent: 100,
+                lazyContractProbe: SidebarLazyContractProbe()
+            )
+        )
+    }
+
+    /// The drift-probe invariant: the rect NSTableView laid out for each row
+    /// equals the height its delegate currently answers.
+    private func assertRectsMatchDelegate(_ mounted: Mounted) {
+        let table = mounted.container.tableView
+        let spacing = table.intercellSpacing.height
+        for row in 0..<table.numberOfRows {
+            let laidOut = table.rect(ofRow: row).height - spacing
+            let served = mounted.controller.tableView(table, heightOfRow: row)
+            #expect(
+                abs(laidOut - served) < 0.5,
+                "row \(row) rect \(laidOut) != delegate answer \(served)"
+            )
+        }
+    }
+
+    /// Heights keyed by workspace id; `appliedRows` is the row array most
+    /// recently passed to `apply`, whose order is the table's row order.
+    private func rectHeightsById(
+        _ mounted: Mounted,
+        appliedRows: [SidebarWorkspaceTableRowConfiguration]
+    ) -> [UUID: CGFloat] {
+        let table = mounted.container.tableView
+        let spacing = table.intercellSpacing.height
+        #expect(table.numberOfRows == appliedRows.count)
+        var heights: [UUID: CGFloat] = [:]
+        for row in 0..<min(table.numberOfRows, appliedRows.count) {
+            heights[appliedRows[row].workspaceId] = table.rect(ofRow: row).height - spacing
+        }
+        return heights
+    }
+
+    private func makeTableActions() -> SidebarWorkspaceTableActions {
+        SidebarWorkspaceTableActions(
+            attachScrollView: { _ in }, closeWorkspace: { _ in }, createWorkspaceAtEnd: {},
+            createEmptyWorkspaceGroup: {}, beginWorkspaceDrag: { _ in },
+            movingWorkspaceCount: { _ in 1 }, endWorkspaceDrag: {},
+            isValidWorkspaceDrag: { true }, updateWorkspaceDrag: { _, _, _ in nil },
+            performWorkspaceDrop: { _, _, _ in false }, commitWorkspaceDropPlan: { _ in false },
+            clearWorkspaceDropIndicator: {}, currentDropIndicator: { nil },
+            currentDropIndicatorScope: { .raw }, canPerformBonsplitAction: { _, _ in false },
+            moveBonsplitToExistingWorkspace: { _, _ in false },
+            moveBonsplitToNewWorkspace: { _, _ in nil }, didMoveBonsplitToWorkspace: { _ in },
+            updateDragAutoscroll: {}, setBonsplitDropTargetCollectionActive: { _ in },
+            setBonsplitDropIndicator: { _ in }
+        )
+    }
+
+    private func flushStagedTableMutations() async {
+        await withCheckedContinuation { continuation in
+            RunLoop.main.perform(inModes: [.common]) { continuation.resume() }
+        }
+    }
+}


### PR DESCRIPTION
Reported by Lawrence (cmux group screenshot, 08-27): after closing several workspaces, surviving sidebar rows painted clipped, short of their full content height, until an unrelated reload.

Root cause: row heights enter NSTableView only through `heightOfRow`, and the table re-asks only after `noteHeightOfRows` or a reload. Every measure pass diffs new measurements against the height cache's own previous entry, not against the height the table actually displays. Any divergence whose measured number happens not to change is never re-noted, so the row stays clipped. `flushContentRefresh` and the DEBUG heightDrift probe each already worked around one strand of this class locally (as did #9189 and #8626 for two others).

Fix (class-level, not per-strand): a served-height ledger records what `heightOfRow` returned per row id, and `noteServedHeightDivergence` re-notes any row whose authoritative answer (pump override / cache / estimate) no longer matches the ledger, at the end of every apply and width settle. The existing DEBUG probe now doubles as verification that the ledger holds.

Second fix: `index` and `isFirstRow` participated in row-model equality, which the height cache keyed on, yet `index` feeds only the accessibility label and `isFirstRow` only the drop-indicator frame in the apply pass. Closing one workspace therefore invalidated cache equivalence for every row below it: an O(tail) hosted re-measure per close, and the loss of exactly the content-matched entries the stale-width `height(for:)` fallback needs during width transitions. The cache now compares position-neutralized models.

Tests: `SidebarWorkspaceRowHeightInvariantTests` (real controller + NSTableView) covers rapid closes, a close during an unsettled width change, and a trailing close + width settle; each asserts every surviving row's laid-out rect equals its delegate answer at full content height. Passed on hosted CI: 3/3 in https://github.com/manaflow-ai/cmux/actions/runs/33356874488; neighboring `SidebarWorkspaceTableTests` dispatched in https://github.com/manaflow-ai/cmux/actions/runs/33358530355.

Preflight on tagged build `sbclip`: seeded 5 workspaces with wrapping descriptions + checklists, closed 3 concurrently (coalesced into one structural apply), surviving rows rendered at full height and the drift probe logged nothing.

Dictionary:
- **note (noteHeightOfRows)**: the AppKit call that tells NSTableView a row's height changed so it re-asks the delegate.
- **pump override**: a per-row height installed by the streaming update path between container applies.
- **width settle**: the full re-measure pass after a sidebar width change stops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11242"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790743980&installation_model_id=21920&pr_number=11242&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11242&signature=0bca49556716db6fc0dcbb2532a52e2a5eb370b97241d0fc8416e00ce4da88e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sidebar rows clipping to stale heights after workspace closes. The table now re-notes any row whose authoritative height diverges from the last served height, and the height cache stops treating position-only fields as content changes.

- Records the height served per row and re-notes divergences at the end of every apply and width settle.
- Excludes `index` and `isFirstRow` from height-cache equivalence so closing a workspace no longer forces a tail re-measure or drops content-matched entries.
- Adds `SidebarWorkspaceRowHeightInvariantTests` covering rapid closes, close during an unsettled width change, and trailing close + settle.

<sup>Written for commit f0df08c55e73131458ea6a3ddb08596efe18d7de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented sidebar rows from becoming clipped or visually inconsistent after workspaces are closed.
  * Preserved the heights of remaining rows during rapid closures and width changes.
  * Improved reuse of cached row heights when only position-related content changes.

* **Tests**
  * Added regression coverage for row-height consistency during workspace closures and layout updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->