### PR TITLE
Add CLA Assistant + Manaflow Individual CLA

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -7,7 +7,8 @@ on:
 
 # Keep the token scoped to the GitHub API operations used by this action.
 permissions:
-  actions: write
+  # The action inspects prior runs; its optional rerun request is best-effort.
+  actions: read
   contents: write
   issues: write
   pull-requests: read

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -12,6 +12,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: read
+  statuses: write
 
 jobs:
   CLAAssistant:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -5,6 +5,11 @@ on:
   pull_request_target:
     types: [opened,closed,synchronize]
 
+# Signature updates share one file and must not race.
+concurrency:
+  group: cla-signatures
+  cancel-in-progress: false
+
 # Keep the token scoped to the GitHub API operations used by this action.
 permissions:
   # The action inspects prior runs; its optional rerun request is best-effort.

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,30 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened,closed,synchronize]
+
+# explicitly configure permissions, in case GITHUB_TOKEN workflow permissions are set to read-only in repository settings
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    name: "CLA Assistant"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/version1/cla.json'
+          path-to-document: 'https://github.com/manaflow-ai/cmux/blob/main/CLA.md'
+          # signatures live on the unprotected cla-signatures branch so required checks on main don't block the bot's signature commits
+          branch: 'cla-signatures'
+          allowlist: lawrencecchen,bot*

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -36,4 +36,6 @@ jobs:
           path-to-document: 'https://github.com/manaflow-ai/cmux/blob/main/CLA.md'
           # signatures live on the unprotected cla-signatures branch so required checks on main don't block the bot's signature commits
           branch: 'cla-signatures'
-          allowlist: lawrencecchen,bot*
+          # Keep this list explicit. A username prefix is not proof that an
+          # account is a GitHub bot and would let a human bypass the CLA.
+          allowlist: lawrencecchen,github-actions[bot],chatmux-connections[bot]

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -18,8 +18,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "CLA Assistant"
+        # The action locks every `closed` event, so only run that path for a
+        # merged pull request. This keeps declined pull requests unlockable.
         if: >-
-          github.event_name == 'pull_request_target' ||
+          (
+            github.event_name == 'pull_request_target' &&
+            (
+              github.event.action != 'closed' ||
+              github.event.pull_request.merged == true
+            )
+          ) ||
           (
             github.event_name == 'issue_comment' &&
             github.event.issue.pull_request &&

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -5,12 +5,12 @@ on:
   pull_request_target:
     types: [opened,closed,synchronize]
 
-# explicitly configure permissions, in case GITHUB_TOKEN workflow permissions are set to read-only in repository settings
+# Keep the token scoped to the GitHub API operations used by this action.
 permissions:
   actions: write
   contents: write
-  pull-requests: write
-  statuses: write
+  issues: write
+  pull-requests: read
 
 jobs:
   CLAAssistant:
@@ -18,8 +18,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "CLA Assistant"
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.6.1
+        if: >-
+          github.event_name == 'pull_request_target' ||
+          (
+            github.event_name == 'issue_comment' &&
+            github.event.issue.pull_request &&
+            (
+              github.event.comment.body == 'recheck' ||
+              github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
+            )
+          )
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,41 @@
+# Individual Contributor License Agreement ("Agreement") v2.2
+
+Thank you for your interest in cmux, an open-source project of Manaflow, Inc. (the "Company"). To clarify the intellectual property license granted with Contributions from any person or entity, the Company must have on file a signed Contributor License Agreement ("CLA") from each Contributor, indicating agreement with the license terms below. This agreement is for your protection as a Contributor as well as the protection of the Company and its users. It does not change your rights to use your own Contributions for any other purpose.
+
+Please complete and sign this Agreement, and return a signed copy to Manaflow, Inc. Read this document carefully before signing and keep a copy for your records.
+
+| | |
+|---|---|
+| Full name: | _________________________________________________ |
+| Public name (optional): | _________________________________________________ |
+| Mailing address: | _________________________________________________ |
+| | _________________________________________________ |
+| Country: | _________________________________________________ |
+| E-Mail: | _________________________________________________ |
+| GitHub username (optional): | _________________________________________________ |
+
+You accept and agree to the following terms and conditions for Your Contributions (present and future) that you submit to the Company. Except for the license granted herein to the Company and recipients of software distributed by the Company, You reserve all right, title, and interest in and to Your Contributions.
+
+1. **Definitions.**
+
+   "You" (or "Your") shall mean the copyright owner or legal entity authorized by the copyright owner that is making this Agreement with the Company. For legal entities, the entity making a Contribution and all other entities that control, are controlled by, or are under common control with that entity are considered to be a single Contributor. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "Contribution" shall mean any original work of authorship, including any modifications or additions to an existing work, that is intentionally submitted by You to the Company for inclusion in, or documentation of, any of the products owned or managed by the Company (the "Work"). For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Company or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Company for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by You as "Not a Contribution."
+
+2. **Grant of Copyright License.** Subject to the terms and conditions of this Agreement, You hereby grant to the Company and to recipients of software distributed by the Company a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute Your Contributions and such derivative works.
+
+3. **Grant of Patent License.** Subject to the terms and conditions of this Agreement, You hereby grant to the Company and to recipients of software distributed by the Company a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by You that are necessarily infringed by Your Contribution(s) alone or by combination of Your Contribution(s) with the Work to which such Contribution(s) was submitted. If any entity institutes patent litigation against You or any other entity (including a cross-claim or counterclaim in a lawsuit) alleging that your Contribution, or the Work to which you have contributed, constitutes direct or contributory patent infringement, then any patent licenses granted to that entity under this Agreement for that Contribution or Work shall terminate as of the date such litigation is filed.
+
+4. You represent that you are legally entitled to grant the above license. If your employer(s) has rights to intellectual property that you create that includes your Contributions, you represent that you have received permission to make Contributions on behalf of that employer, that your employer has waived such rights for your Contributions to the Company, or that your employer has executed a separate Corporate CLA with the Company.
+
+5. You represent that each of Your Contributions is Your original creation (see section 7 for submissions on behalf of others). You represent that Your Contribution submissions include complete details of any third-party license or other restriction (including, but not limited to, related patents and trademarks) of which you are personally aware and which are associated with any part of Your Contributions.
+
+6. You are not expected to provide support for Your Contributions, except to the extent You desire to provide support. You may provide support for free, for a fee, or not at all. Unless required by applicable law or agreed to in writing, You provide Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+7. Should You wish to submit work that is not Your original creation, You may submit it to the Company separately from any Contribution, identifying the complete details of its source and of any license or other restriction (including, but not limited to, related patents, trademarks, and license agreements) of which you are personally aware, and conspicuously marking the work as "Submitted on behalf of a third-party: [named here]".
+
+8. You agree to notify the Company of any facts or circumstances of which you become aware that would make these representations inaccurate in any respect.
+
+&nbsp;
+
+Please sign: __________________________________  Date: ____________________

--- a/CLA.md
+++ b/CLA.md
@@ -4,6 +4,8 @@ Thank you for your interest in cmux, an open-source project of Manaflow, Inc. (t
 
 Please complete and sign this Agreement, and return a signed copy to Manaflow, Inc. Read this document carefully before signing and keep a copy for your records.
 
+This Agreement is maintained in English and the English version controls. Any translation is provided for convenience only and does not change the terms of this Agreement.
+
 | | |
 |---|---|
 | Full name: | _________________________________________________ |


### PR DESCRIPTION
Adds a Contributor License Agreement gate for outside contributions to cmux (covers cmux-browser and all other directories in this repo).

**What is in this PR**
- `CLA.md` - the Manaflow, Inc. Individual Contributor License Agreement (adapted from the Apache Software Foundation ICLA v2.2). Contributors keep copyright and grant Manaflow the perpetual license needed for the dual-licensing model described in `LICENSE`/`CONTRIBUTING.md`.
- `.github/workflows/cla.yml` - the official CLA Assistant lite GitHub Action (`contributor-assistant/github-action@v2.6.1`). On every PR it checks whether all committers have signed; unsigned contributors get a PR comment asking them to sign by commenting `I have read the CLA Document and I hereby sign the CLA`. The PR status check fails until everyone has signed.

**How it works**
- Signatures are recorded in `signatures/version1/cla.json` on the `cla-signatures` branch (kept off `main`, and unprotected so the bot can commit them even after `main` gets required checks).
- `lawrencecchen` and bots (`bot*`) are allowlisted; other maintainers can be added to the `allowlist` input.

**After merging**
- Mark the `CLA Assistant` check as required in the `main` branch protection so unsigned PRs cannot be merged. (Not done in this PR - setting it before the workflow exists on `main` would block this PR itself.)
- Backup copy of the CLA text also lives at https://gist.github.com/lawrencecchen/81d1304ce4c640b4ab87d8ce254f029c

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790746689&installation_model_id=21920&pr_number=11244&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11244&signature=6eb818e82ccbb26d75de7d9fdc63269f85cf50bbda79067127ec6ae5ea42482c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Contributor License Agreement gate so outside contributors must sign before their cmux PRs can merge.

Previously any contributor could merge freely; now the `CLA Assistant` check blocks PRs until all committers sign by commenting on the PR. Signatures are written to the unprotected `cla-signatures` branch, the action is pinned to a specific commit, and the workflow token is scoped to minimum permissions with `statuses` write restored for the status check. Signature commits are serialized by a concurrency group, and the CLA states that the English text controls over any translation. Only `lawrencecchen`, `github-actions[bot]`, and `chatmux-connections[bot]` are allowlisted, since a `bot*` prefix pattern would let a human bypass the CLA. Declined PRs stay unlockable because the close path only runs on merged PRs.

**After merging**
- Mark the `CLA Assistant` check as required in `main` branch protection so unsigned PRs can't merge.

<sup>Written for commit 08fee46fed53f97a986cac86a1133f3a66948995. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added an Individual Contributor License Agreement covering contribution rights, licensing terms, representations, warranties, and third-party materials.
  - Clarified requirements for original contributions and reporting inaccurate representations.

- **Chores**
  - Added automated agreement checks for pull requests and related comments.
  - Added contributor signature tracking and workflow permissions.
  - Contributors can complete or update their agreement through the contribution workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->