### PR TITLE
Fix unread notification badge on app icon

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2359,6 +2359,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         pendingCrashScanTask?.cancel()
         pendingCrashScanTask = nil
         notificationStore?.clearAll()
+        NotificationBadgeSettings.persistDockBadgeLabel(nil)
+        _ = AppIconSettings.updateRuntimeBadgeLabel(nil)
+        NSApp.dockTile.badgeLabel = nil
         GhosttyCrashBreadcrumb.markCleanExit()
         unregisterDisplayReconfigurationCallbackIfNeeded()
         StartupBreadcrumbLog.append("appDelegate.willTerminate.complete")

--- a/Sources/AppIconBadgeRenderer.swift
+++ b/Sources/AppIconBadgeRenderer.swift
@@ -1,0 +1,108 @@
+import AppKit
+
+/// Composes the unread-count badge into app-icon images when AppKit's native Dock badge is not rendered.
+enum AppIconBadgeRenderer {
+    static func normalizedBadgeLabel(_ rawLabel: String?) -> String? {
+        guard let label = rawLabel?.trimmingCharacters(in: .whitespacesAndNewlines), !label.isEmpty else {
+            return nil
+        }
+        return label
+    }
+
+    static func visibleBadgeLabel(_ rawLabel: String?, isAppRunning: Bool) -> String? {
+        guard isAppRunning else { return nil }
+        return normalizedBadgeLabel(rawLabel)
+    }
+
+    @MainActor
+    static func image(baseIcon: NSImage, badgeLabel rawBadgeLabel: String?) -> NSImage {
+        guard let badgeLabel = normalizedBadgeLabel(rawBadgeLabel) else {
+            return baseIcon
+        }
+
+        let size = normalizedIconSize(baseIcon.size)
+        let result = NSImage(size: size, flipped: false) { bounds in
+            NSGraphicsContext.current?.imageInterpolation = .high
+            baseIcon.draw(
+                in: bounds,
+                from: NSRect(origin: .zero, size: baseIcon.size),
+                operation: .sourceOver,
+                fraction: 1
+            )
+            drawBadge(badgeLabel, in: bounds)
+            return true
+        }
+        result.isTemplate = false
+        result.accessibilityDescription = badgeLabel
+        return result
+    }
+
+    @MainActor
+    private static func normalizedIconSize(_ size: NSSize) -> NSSize {
+        guard size.width > 0, size.height > 0 else {
+            return NSSize(width: 128, height: 128)
+        }
+        return size
+    }
+
+    @MainActor
+    private static func drawBadge(_ label: String, in bounds: NSRect) {
+        guard bounds.width > 0, bounds.height > 0 else { return }
+
+        NSGraphicsContext.current?.shouldAntialias = true
+
+        let iconEdge = min(bounds.width, bounds.height)
+        let badgeHeight = max(18, iconEdge * 0.34)
+        let horizontalPadding = badgeHeight * 0.28
+        let maxBadgeWidth = bounds.width * 0.86
+        let font = badgeFont(
+            fitting: label,
+            badgeHeight: badgeHeight,
+            horizontalPadding: horizontalPadding,
+            maxBadgeWidth: maxBadgeWidth
+        )
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: NSColor.white,
+        ]
+        let textSize = label.size(withAttributes: attributes)
+        let badgeWidth = min(maxBadgeWidth, max(badgeHeight, ceil(textSize.width + horizontalPadding * 2)))
+        let badgeRect = NSRect(
+            x: bounds.maxX - badgeWidth - iconEdge * 0.02,
+            y: bounds.maxY - badgeHeight - iconEdge * 0.02,
+            width: badgeWidth,
+            height: badgeHeight
+        )
+
+        NSColor(calibratedRed: 1.0, green: 0.12, blue: 0.16, alpha: 1.0).setFill()
+        NSBezierPath(roundedRect: badgeRect, xRadius: badgeHeight / 2, yRadius: badgeHeight / 2).fill()
+
+        let textRect = NSRect(
+            x: badgeRect.midX - textSize.width / 2,
+            y: badgeRect.midY - textSize.height / 2,
+            width: textSize.width,
+            height: textSize.height
+        )
+        label.draw(in: textRect, withAttributes: attributes)
+    }
+
+    @MainActor
+    private static func badgeFont(
+        fitting label: String,
+        badgeHeight: CGFloat,
+        horizontalPadding: CGFloat,
+        maxBadgeWidth: CGFloat
+    ) -> NSFont {
+        let baseSize = max(11, badgeHeight * 0.56)
+        let baseFont = NSFont.systemFont(ofSize: baseSize, weight: .bold)
+        let textWidth = label.size(withAttributes: [.font: baseFont]).width
+        let availableWidth = max(1, maxBadgeWidth - horizontalPadding * 2)
+        guard textWidth > availableWidth else {
+            return baseFont
+        }
+        return NSFont.systemFont(
+            ofSize: max(8, floor(baseSize * availableWidth / max(textWidth, 1))),
+            weight: .bold
+        )
+    }
+}

--- a/Sources/AppIconDockTilePlugin.swift
+++ b/Sources/AppIconDockTilePlugin.swift
@@ -3,6 +3,7 @@ import CoreServices
 
 private let cmuxAppIconDidChangeNotification = Notification.Name("com.cmuxterm.appIconDidChange")
 private let cmuxAppIconModeKey = "appIconMode"
+private let cmuxNotificationDockBadgeLabelKey = "notificationDockBadgeLabel"
 
 private enum DockTileAppIconMode: String {
     case automatic
@@ -30,11 +31,15 @@ final class CmuxDockTilePlugin: NSObject, NSDockTilePlugIn {
     // Keep the state minimal and derive everything from the enclosing app bundle.
     private let pluginBundle = Bundle(for: CmuxDockTilePlugin.self)
     private var iconChangeObserver: NSObjectProtocol?
+    private var appTerminationObserver: NSObjectProtocol?
     private var appearanceObservation: NSKeyValueObservation?
 
     deinit {
         if let iconChangeObserver {
             DistributedNotificationCenter.default().removeObserver(iconChangeObserver)
+        }
+        if let appTerminationObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(appTerminationObserver)
         }
         appearanceObservation?.invalidate()
     }
@@ -52,6 +57,10 @@ final class CmuxDockTilePlugin: NSObject, NSDockTilePlugIn {
             DistributedNotificationCenter.default().removeObserver(iconChangeObserver)
             self.iconChangeObserver = nil
         }
+        if let appTerminationObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(appTerminationObserver)
+            self.appTerminationObserver = nil
+        }
         appearanceObservation?.invalidate()
         appearanceObservation = nil
 
@@ -60,10 +69,25 @@ final class CmuxDockTilePlugin: NSObject, NSDockTilePlugIn {
 
         iconChangeObserver = DistributedNotificationCenter.default().addObserver(
             forName: cmuxAppIconDidChangeNotification,
+            object: appBundle?.bundleIdentifier,
+            queue: .main
+        ) { [weak self] notification in
+            guard let self else { return }
+            self.updateDockTile(
+                dockTile,
+                badgeLabelOverride: notification.userInfo?[cmuxNotificationDockBadgeLabelKey] as? String
+            )
+        }
+
+        appTerminationObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didTerminateApplicationNotification,
             object: nil,
             queue: .main
-        ) { [weak self] _ in
-            guard let self else { return }
+        ) { [weak self] notification in
+            guard let self,
+                  let application = notification.userInfo?[NSWorkspace.applicationUserInfoKey]
+                    as? NSRunningApplication,
+                  application.bundleIdentifier == self.appBundle?.bundleIdentifier else { return }
             self.updateDockTile(dockTile)
         }
 
@@ -102,10 +126,19 @@ final class CmuxDockTilePlugin: NSObject, NSDockTilePlugIn {
         return UserDefaults(suiteName: bundleIdentifier)
     }
 
-    private func updateDockTile(_ dockTile: NSDockTile) {
+    private var isAppRunning: Bool {
+        guard let bundleIdentifier = appBundle?.bundleIdentifier else { return false }
+        return !NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier).isEmpty
+    }
+
+    private func updateDockTile(_ dockTile: NSDockTile, badgeLabelOverride: String? = nil) {
         Self.assertMainQueue()
 
         let mode = DockTileAppIconMode(defaultsValue: appDefaults?.string(forKey: cmuxAppIconModeKey))
+        let badgeLabel = AppIconBadgeRenderer.visibleBadgeLabel(
+            badgeLabelOverride ?? appDefaults?.string(forKey: cmuxNotificationDockBadgeLabelKey),
+            isAppRunning: isAppRunning
+        )
         let isDarkAppearance = NSApp?.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
         guard let appBundleURL else {
             dockTile.showDefaultAppIcon()
@@ -128,7 +161,7 @@ final class CmuxDockTilePlugin: NSObject, NSDockTilePlugIn {
             NSWorkspace.shared.noteFileSystemChanged(appBundleURL.path)
             _ = LSRegisterURL(appBundleURL as CFURL, true)
         }
-        dockTile.showIcon(icon)
+        dockTile.showIcon(icon, badgeLabel: badgeLabel)
     }
 
     private static func performOnMain(_ work: @escaping () -> Void) {
@@ -171,13 +204,17 @@ private extension NSDockTile {
         display()
     }
 
-    func showIcon(_ newIcon: NSImage) {
+    func showIcon(_ newIcon: NSImage, badgeLabel: String?) {
         CmuxDockTilePlugin.assertMainQueue()
 
         let iconView = NSImageView(frame: CGRect(origin: .zero, size: size))
         iconView.wantsLayer = true
-        iconView.image = newIcon
+        MainActor.assumeIsolated {
+            iconView.image = AppIconBadgeRenderer.image(baseIcon: newIcon, badgeLabel: badgeLabel)
+            iconView.setAccessibilityValue(badgeLabel)
+        }
         contentView = iconView
+        self.badgeLabel = nil
         display()
     }
 }

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -1608,7 +1608,7 @@ final class CmuxSettingsFileStore {
         let userDefaults = userDefaults
         let languageSettingsStore = languageSettingsStore
         let changes = sideEffects.changes
-        let apply = {
+        let apply: @MainActor () -> Void = {
             var agentSessionAutoResumeDidChange = false
             var agentHibernationDidChange = false
             var rendererRealizationDidChange = false
@@ -1677,9 +1677,11 @@ final class CmuxSettingsFileStore {
             }
         }
         if Thread.isMainThread {
-            apply()
+            MainActor.assumeIsolated { apply() }
         } else {
-            DispatchQueue.main.async { apply() }
+            DispatchQueue.main.async {
+                MainActor.assumeIsolated { apply() }
+            }
         }
     }
 

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -25,6 +25,7 @@ extension TerminalNotificationStore {
 }
 enum NotificationBadgeSettings {
     static let dockBadgeEnabledKey = "notificationDockBadgeEnabled"
+    static let dockBadgeLabelKey = "notificationDockBadgeLabel"
     static let defaultDockBadgeEnabled = true
 
     static func isDockBadgeEnabled(defaults: UserDefaults = .standard) -> Bool {
@@ -32,6 +33,22 @@ enum NotificationBadgeSettings {
             return defaultDockBadgeEnabled
         }
         return defaults.bool(forKey: dockBadgeEnabledKey)
+    }
+
+    @discardableResult
+    static func persistDockBadgeLabel(_ label: String?, defaults: UserDefaults = .standard) -> Bool {
+        let normalizedLabel = AppIconBadgeRenderer.normalizedBadgeLabel(label)
+        guard defaults.string(forKey: dockBadgeLabelKey) != normalizedLabel else { return false }
+        if let normalizedLabel {
+            defaults.set(normalizedLabel, forKey: dockBadgeLabelKey)
+        } else {
+            defaults.removeObject(forKey: dockBadgeLabelKey)
+        }
+        return true
+    }
+
+    static func nativeDockBadgeLabel(_ label: String?, runtimeIconIncludesBadge: Bool) -> String? {
+        runtimeIconIncludesBadge ? nil : label
     }
 }
 
@@ -469,6 +486,7 @@ final class TerminalNotificationStore: ObservableObject {
                 self?.refreshDockBadge()
             }
         }
+        // Reconcile any label left by an unclean prior exit before the Dock plugin can reuse it.
         refreshDockBadge()
         refreshAuthorizationStatus()
     }
@@ -2658,6 +2676,14 @@ final class TerminalNotificationStore: ObservableObject {
             isEnabled: NotificationBadgeSettings.isDockBadgeEnabled(),
             runTag: TaggedRunBadgeSettings.normalizedTag()
         )
-        NSApp?.dockTile.badgeLabel = label
+        let persistedLabelChanged = NotificationBadgeSettings.persistDockBadgeLabel(label)
+        let runtimeIconIncludesBadge = AppIconSettings.updateRuntimeBadgeLabel(
+            label,
+            forceDockTileRefresh: persistedLabelChanged
+        )
+        NSApp?.dockTile.badgeLabel = NotificationBadgeSettings.nativeDockBadgeLabel(
+            label,
+            runtimeIconIncludesBadge: runtimeIconIncludesBadge
+        )
     }
 }

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -5365,10 +5365,15 @@ enum AppIconLaunchState {
 enum AppIconSettings {
     static let modeKey = "appIconMode"
     static let defaultMode: AppIconMode = .automatic
-    private static let dockTileIconDidChangeNotification = Notification.Name("com.cmuxterm.appIconDidChange")
+    fileprivate static let dockTileIconDidChangeNotification = Notification.Name("com.cmuxterm.appIconDidChange")
+    @MainActor
     private static var liveEnvironmentProvider: () -> Environment = { .live() }
+    @MainActor
+    private static var runtimeBaseIcon: NSImage?
+    @MainActor
+    private static var runtimeBadgeLabel: String?
 
-    private static func isRunningUnderXCTest(_ env: [String: String] = ProcessInfo.processInfo.environment) -> Bool {
+    fileprivate static func isRunningUnderXCTest(_ env: [String: String] = ProcessInfo.processInfo.environment) -> Bool {
         if env["CMUX_TEST_PROCESS"] == "1" { return true }
         if env["XCTestConfigurationFilePath"] != nil { return true }
         if env["XCTestBundlePath"] != nil { return true }
@@ -5383,10 +5388,11 @@ enum AppIconSettings {
     struct Environment {
         let isApplicationFinishedLaunching: () -> Bool
         let imageForMode: (AppIconMode) -> NSImage?
-        let setApplicationIconImage: (NSImage) -> Void
-        let startAppearanceObservation: () -> Void
-        let stopAppearanceObservation: () -> Void
-        let notifyDockTilePlugin: () -> Void
+        let setApplicationIconImage: @MainActor (NSImage) -> Void
+        let setNativeDockBadgeLabel: @MainActor (String?) -> Void
+        let startAppearanceObservation: @MainActor () -> Void
+        let stopAppearanceObservation: @MainActor () -> Void
+        let notifyDockTilePlugin: @MainActor (String?) -> Void
 
         static func live() -> Self {
             Self(
@@ -5400,18 +5406,21 @@ enum AppIconSettings {
                 setApplicationIconImage: { icon in
                     NSApplication.shared.applicationIconImage = icon
                 },
+                setNativeDockBadgeLabel: { label in
+                    NSApp?.dockTile.badgeLabel = label
+                },
                 startAppearanceObservation: {
                     AppIconAppearanceObserver.shared.startObserving()
                 },
                 stopAppearanceObservation: {
                     AppIconAppearanceObserver.shared.stopObserving()
                 },
-                notifyDockTilePlugin: {
+                notifyDockTilePlugin: { badgeLabel in
                     guard !AppIconSettings.isRunningUnderXCTest() else { return }
                     DistributedNotificationCenter.default().postNotificationName(
                         AppIconSettings.dockTileIconDidChangeNotification,
-                        object: nil,
-                        userInfo: nil,
+                        object: Bundle.main.bundleIdentifier,
+                        userInfo: [NotificationBadgeSettings.dockBadgeLabelKey: badgeLabel ?? ""],
                         deliverImmediately: true
                     )
                 }
@@ -5427,6 +5436,7 @@ enum AppIconSettings {
         return mode
     }
 
+    @MainActor
     static func applyIcon(_ mode: AppIconMode, environment: Environment? = nil) {
         let environment = environment ?? liveEnvironmentProvider()
         // Tahoe can crash or wedge when app icon work runs during App.init(),
@@ -5437,28 +5447,85 @@ enum AppIconSettings {
         switch mode {
         case .automatic:
             environment.startAppearanceObservation()
+            environment.notifyDockTilePlugin(runtimeBaseIcon == nil ? nil : runtimeBadgeLabel)
         case .light:
             environment.stopAppearanceObservation()
             guard let icon = environment.imageForMode(.light) else { return }
-            environment.setApplicationIconImage(icon)
+            if !setRuntimeBaseIcon(icon, environment: environment) {
+                environment.notifyDockTilePlugin(runtimeBadgeLabel)
+            }
         case .dark:
             environment.stopAppearanceObservation()
             guard let icon = environment.imageForMode(.dark) else { return }
-            environment.setApplicationIconImage(icon)
+            if !setRuntimeBaseIcon(icon, environment: environment) {
+                environment.notifyDockTilePlugin(runtimeBadgeLabel)
+            }
         }
-
-        environment.notifyDockTilePlugin()
     }
 
+    @MainActor
+    @discardableResult
+    static func updateRuntimeBadgeLabel(
+        _ label: String?,
+        forceDockTileRefresh: Bool = false,
+        environment: Environment? = nil
+    ) -> Bool {
+        let normalizedLabel = AppIconBadgeRenderer.normalizedBadgeLabel(label)
+        let labelChanged = normalizedLabel != runtimeBadgeLabel
+        runtimeBadgeLabel = normalizedLabel
+        let environment = environment ?? liveEnvironmentProvider()
+        guard environment.isApplicationFinishedLaunching() else {
+            if forceDockTileRefresh { environment.notifyDockTilePlugin(nil) }
+            return false
+        }
+        guard labelChanged else {
+            if forceDockTileRefresh {
+                environment.notifyDockTilePlugin(runtimeBaseIcon == nil ? nil : runtimeBadgeLabel)
+            }
+            return runtimeBaseIcon != nil
+        }
+        if let runtimeBaseIcon {
+            environment.setApplicationIconImage(runtimeIcon(for: runtimeBaseIcon))
+            environment.setNativeDockBadgeLabel(nil)
+            environment.notifyDockTilePlugin(runtimeBadgeLabel)
+            return true
+        }
+        environment.notifyDockTilePlugin(nil)
+        return false
+    }
+
+    @MainActor
+    @discardableResult
+    static func setRuntimeBaseIcon(_ icon: NSImage, environment: Environment? = nil) -> Bool {
+        let iconChanged = runtimeBaseIcon !== icon
+        runtimeBaseIcon = icon
+        let environment = environment ?? liveEnvironmentProvider()
+        environment.setNativeDockBadgeLabel(nil)
+        guard iconChanged else { return false }
+        environment.setApplicationIconImage(runtimeIcon(for: icon))
+        environment.notifyDockTilePlugin(runtimeBadgeLabel)
+        return true
+    }
+
+    @MainActor
+    private static func runtimeIcon(for baseIcon: NSImage) -> NSImage {
+        AppIconBadgeRenderer.image(baseIcon: baseIcon, badgeLabel: runtimeBadgeLabel)
+    }
+
+    @MainActor
     static func setLiveEnvironmentProviderForTesting(_ provider: @escaping () -> Environment) {
         liveEnvironmentProvider = provider
     }
 
+    @MainActor
     static func resetLiveEnvironmentProviderForTesting() {
         liveEnvironmentProvider = { .live() }
+        runtimeBaseIcon = nil
+        runtimeBadgeLabel = nil
     }
 }
 
+@MainActor
 final class AppIconAppearanceObserver: NSObject {
     struct Environment {
         let isApplicationFinishedLaunching: () -> Bool
@@ -5468,6 +5535,8 @@ final class AppIconAppearanceObserver: NSObject {
         let currentAppearanceIsDark: () -> Bool?
         let imageForName: (String) -> NSImage?
         let setApplicationIconImage: (NSImage) -> Void
+        let setNativeDockBadgeLabel: (String?) -> Void
+        let notifyDockTilePlugin: (String?) -> Void
 
         static func live() -> Self {
             Self(
@@ -5503,6 +5572,18 @@ final class AppIconAppearanceObserver: NSObject {
                 },
                 setApplicationIconImage: { icon in
                     NSApplication.shared.applicationIconImage = icon
+                },
+                setNativeDockBadgeLabel: { label in
+                    NSApp?.dockTile.badgeLabel = label
+                },
+                notifyDockTilePlugin: { badgeLabel in
+                    guard !AppIconSettings.isRunningUnderXCTest() else { return }
+                    DistributedNotificationCenter.default().postNotificationName(
+                        AppIconSettings.dockTileIconDidChangeNotification,
+                        object: Bundle.main.bundleIdentifier,
+                        userInfo: [NotificationBadgeSettings.dockBadgeLabelKey: badgeLabel ?? ""],
+                        deliverImmediately: true
+                    )
                 }
             )
         }
@@ -5562,9 +5643,19 @@ final class AppIconAppearanceObserver: NSObject {
         guard environment.isApplicationFinishedLaunching() else { return }
         guard let isDark = environment.currentAppearanceIsDark() else { return }
         let imageName = isDark ? "AppIconDark" : "AppIconLight"
-        guard imageName != lastAppliedImageName,
-              let icon = environment.imageForName(imageName) else { return }
-        environment.setApplicationIconImage(icon)
+        if imageName == lastAppliedImageName {
+            return
+        }
+        guard let icon = environment.imageForName(imageName) else { return }
+        AppIconSettings.setRuntimeBaseIcon(icon, environment: AppIconSettings.Environment(
+            isApplicationFinishedLaunching: environment.isApplicationFinishedLaunching,
+            imageForMode: { _ in nil },
+            setApplicationIconImage: environment.setApplicationIconImage,
+            setNativeDockBadgeLabel: environment.setNativeDockBadgeLabel,
+            startAppearanceObservation: {},
+            stopAppearanceObservation: {},
+            notifyDockTilePlugin: environment.notifyDockTilePlugin
+        ))
         lastAppliedImageName = imageName
     }
 }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -255,6 +255,7 @@
 		C97160000000000000000001 /* AppHostProcessReceipt.swift in Sources */ = {isa = PBXBuildFile; fileRef = C97160000000000000000002 /* AppHostProcessReceipt.swift */; };
 		C8046FF15781CC7E4F8EAEA6 /* AppHostWindowReleaseGuardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3FAA194471B7BA157FB4660 /* AppHostWindowReleaseGuardTests.swift */; };
 		A7206E010000000000000001 /* AppIconAppearanceObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7206E020000000000000001 /* AppIconAppearanceObserverTests.swift */; };
+		DBAD00010000000000000001 /* AppIconDockBadgeRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBAD00010000000000000002 /* AppIconDockBadgeRegressionTests.swift */; };
 		D1320AA0D1320AA0D1320AA1 /* AppIconDockTilePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1320AA0D1320AA0D1320AA4 /* AppIconDockTilePlugin.swift */; };
 		A5001621 /* AppleScriptSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001620 /* AppleScriptSupport.swift */; };
 		A5001A02A1B2C3D4E5F60718 /* AppWindowBackdropControllerDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001A03A1B2C3D4E5F60718 /* AppWindowBackdropControllerDependencies.swift */; };
@@ -3297,6 +3298,7 @@
 		B3FAA194471B7BA157FB4660 /* AppHostWindowReleaseGuardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppHostWindowReleaseGuardTests.swift; sourceTree = "<group>"; };
 		IC000002 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = folder; path = AppIcon.icon; sourceTree = "<group>"; };
 		A7206E020000000000000001 /* AppIconAppearanceObserverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconAppearanceObserverTests.swift; sourceTree = "<group>"; };
+		DBAD00010000000000000002 /* AppIconDockBadgeRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconDockBadgeRegressionTests.swift; sourceTree = "<group>"; };
 		D1320AA0D1320AA0D1320AA4 /* AppIconDockTilePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconDockTilePlugin.swift; sourceTree = "<group>"; };
 		A5001620 /* AppleScriptSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleScriptSupport.swift; sourceTree = "<group>"; };
 		A5001A03A1B2C3D4E5F60718 /* AppWindowBackdropControllerDependencies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Windowing/AppWindowBackdropControllerDependencies.swift; sourceTree = "<group>"; };
@@ -8740,6 +8742,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				1055FA010000000000000002 /* MobileSurfaceKindMappingTests.swift */,
 				645645000000000000000001 /* NumberedShortcutSwapTests.swift */,
 					B09C007F42697761B5F1A2AB /* OmnibarAndToolsTests.swift */,
+					DBAD00010000000000000002 /* AppIconDockBadgeRegressionTests.swift */,
 					D2C075029771815DD5DA1332 /* NotificationAndMenuBarTests.swift */,
 					C0DE70520000000000000001 /* MenuBarProfilingLauncherTests.swift */,
 					596100000000000000000002 /* NativeNotificationFallbackCommandTests.swift */,
@@ -11732,6 +11735,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				A11EAA000000000000000000 /* AppearanceSettingsTests.swift in Sources */,
 				C8046FF15781CC7E4F8EAEA6 /* AppHostWindowReleaseGuardTests.swift in Sources */,
 				A7206E010000000000000001 /* AppIconAppearanceObserverTests.swift in Sources */,
+				DBAD00010000000000000001 /* AppIconDockBadgeRegressionTests.swift in Sources */,
 				A47E00010000000000000001 /* AuthEnvironmentTests.swift in Sources */,
 				AA9457BF0000000000000001 /* AutoNamingClaudeArgumentsTests.swift in Sources */,
 				FF068325E8A04E51A30AE9BA /* AutoNamingCodexAdapterTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -255,6 +255,8 @@
 		C97160000000000000000001 /* AppHostProcessReceipt.swift in Sources */ = {isa = PBXBuildFile; fileRef = C97160000000000000000002 /* AppHostProcessReceipt.swift */; };
 		C8046FF15781CC7E4F8EAEA6 /* AppHostWindowReleaseGuardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3FAA194471B7BA157FB4660 /* AppHostWindowReleaseGuardTests.swift */; };
 		A7206E010000000000000001 /* AppIconAppearanceObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7206E020000000000000001 /* AppIconAppearanceObserverTests.swift */; };
+		D0BADGE0000000000000002 /* AppIconBadgeRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0BADGE0000000000000001 /* AppIconBadgeRenderer.swift */; };
+		D0BADGE0000000000000003 /* AppIconBadgeRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0BADGE0000000000000001 /* AppIconBadgeRenderer.swift */; };
 		DBAD00010000000000000001 /* AppIconDockBadgeRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBAD00010000000000000002 /* AppIconDockBadgeRegressionTests.swift */; };
 		D1320AA0D1320AA0D1320AA1 /* AppIconDockTilePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1320AA0D1320AA0D1320AA4 /* AppIconDockTilePlugin.swift */; };
 		A5001621 /* AppleScriptSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001620 /* AppleScriptSupport.swift */; };
@@ -3298,6 +3300,7 @@
 		B3FAA194471B7BA157FB4660 /* AppHostWindowReleaseGuardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppHostWindowReleaseGuardTests.swift; sourceTree = "<group>"; };
 		IC000002 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = folder; path = AppIcon.icon; sourceTree = "<group>"; };
 		A7206E020000000000000001 /* AppIconAppearanceObserverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconAppearanceObserverTests.swift; sourceTree = "<group>"; };
+		D0BADGE0000000000000001 /* AppIconBadgeRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconBadgeRenderer.swift; sourceTree = "<group>"; };
 		DBAD00010000000000000002 /* AppIconDockBadgeRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconDockBadgeRegressionTests.swift; sourceTree = "<group>"; };
 		D1320AA0D1320AA0D1320AA4 /* AppIconDockTilePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconDockTilePlugin.swift; sourceTree = "<group>"; };
 		A5001620 /* AppleScriptSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleScriptSupport.swift; sourceTree = "<group>"; };
@@ -6419,6 +6422,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				A11EAD000000000000000001 /* WorkspaceAppearanceResolution.swift */,
 				C97160000000000000000002 /* AppHostProcessReceipt.swift */,
 				A5001011 /* cmuxApp.swift */,
+				D0BADGE0000000000000001 /* AppIconBadgeRenderer.swift */,
 				875200000000000000000002 /* cmuxApp+SurfaceNavigationMenu.swift */,
 				C51A73000000000000000014 /* CmuxWorkerEntrypoint.swift */,
 				80410000000000000000000E /* cmuxApp+WorkspaceCommandHelpers.swift */,
@@ -9697,6 +9701,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				D37777040000000000000001 /* AppDelegateSettingsPresentation.swift in Sources */,
 				A11EAB000000000000000000 /* AppearanceSettings.swift in Sources */,
 				C97160000000000000000001 /* AppHostProcessReceipt.swift in Sources */,
+				D0BADGE0000000000000002 /* AppIconBadgeRenderer.swift in Sources */,
 				A5001621 /* AppleScriptSupport.swift in Sources */,
 				A5001A02A1B2C3D4E5F60718 /* AppWindowBackdropControllerDependencies.swift in Sources */,
 				A5001A00A1B2C3D4E5F60718 /* AppWindowChromeComposition.swift in Sources */,
@@ -11602,6 +11607,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 			buildActionMask = 2147483647;
 			files = (
 				F4350A120000000000000001 /* AppBundleIconPersistencePolicy.swift in Sources */,
+				D0BADGE0000000000000003 /* AppIconBadgeRenderer.swift in Sources */,
 				D1320AA0D1320AA0D1320AA1 /* AppIconDockTilePlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/cmuxTests/AppIconAppearanceObserverTests.swift
+++ b/cmuxTests/AppIconAppearanceObserverTests.swift
@@ -16,6 +16,7 @@ private func checkTrue(_ condition: @autoclosure () -> Bool, _ message: String =
 }
 
 @Suite
+@MainActor
 struct AppIconAppearanceObserverTests {
     private final class ObservationToken: EffectiveAppearanceObservation {
         private(set) var invalidateCallCount = 0
@@ -32,6 +33,7 @@ struct AppIconAppearanceObserverTests {
         var currentAppearanceIsDarkCallCount = 0
         var imageRequests: [String] = []
         var appliedIconCount = 0
+        var dockTileNotificationCount = 0
         var didFinishLaunchingObserverCount = 0
         private(set) var didFinishLaunchingHandler: (() -> Void)?
         private(set) var appearanceHandler: (() -> Void)?
@@ -62,6 +64,10 @@ struct AppIconAppearanceObserverTests {
             },
             setApplicationIconImage: { [unowned self] _ in
                 self.appliedIconCount += 1
+            },
+            setNativeDockBadgeLabel: { _ in },
+            notifyDockTilePlugin: { [unowned self] _ in
+                self.dockTileNotificationCount += 1
             }
         )
 
@@ -93,6 +99,7 @@ struct AppIconAppearanceObserverTests {
         checkEqual(harness.currentAppearanceIsDarkCallCount, 1)
         checkEqual(harness.imageRequests, ["AppIconLight"])
         checkEqual(harness.appliedIconCount, 1)
+        checkEqual(harness.dockTileNotificationCount, 1)
     }
 
     @Test
@@ -136,6 +143,23 @@ struct AppIconAppearanceObserverTests {
         checkEqual(harness.currentAppearanceIsDarkCallCount, 2)
         checkEqual(harness.imageRequests, ["AppIconLight"])
         checkEqual(harness.appliedIconCount, 1)
+        checkEqual(harness.dockTileNotificationCount, 1)
+    }
+
+    @Test
+    func testRestartingAutomaticModeReappliesCurrentAppearance() {
+        let harness = Harness()
+        harness.isFinishedLaunching = true
+        harness.isDark = true
+        let observer = AppIconAppearanceObserver(environment: harness.environment)
+
+        observer.startObserving()
+        observer.stopObserving()
+        observer.startObserving()
+
+        checkEqual(harness.imageRequests, ["AppIconDark", "AppIconDark"])
+        checkEqual(harness.appliedIconCount, 2)
+        checkEqual(harness.dockTileNotificationCount, 2)
     }
 
     @Test
@@ -150,5 +174,6 @@ struct AppIconAppearanceObserverTests {
 
         checkEqual(harness.imageRequests, ["AppIconLight", "AppIconDark"])
         checkEqual(harness.appliedIconCount, 2)
+        checkEqual(harness.dockTileNotificationCount, 2)
     }
 }

--- a/cmuxTests/AppIconDockBadgeRegressionTests.swift
+++ b/cmuxTests/AppIconDockBadgeRegressionTests.swift
@@ -1,0 +1,69 @@
+import AppKit
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite(.serialized)
+@MainActor
+struct AppIconDockBadgeRegressionTests {
+    @Test("Unread notification updates the runtime app icon with a badge")
+    func unreadNotificationUpdatesRuntimeAppIcon() {
+        let baseIcon = NSImage(size: NSSize(width: 64, height: 64))
+        baseIcon.lockFocus()
+        NSColor.systemBlue.setFill()
+        NSBezierPath(rect: NSRect(origin: .zero, size: baseIcon.size)).fill()
+        baseIcon.unlockFocus()
+
+        var receivedRuntimeIcon: NSImage?
+        let store = TerminalNotificationStore.shared
+        let previousBadgeLabel = NSApplication.shared.dockTile.badgeLabel
+        let environment = AppIconSettings.Environment(
+            isApplicationFinishedLaunching: { true },
+            imageForMode: { mode in
+                #expect(mode == .dark)
+                return baseIcon
+            },
+            setApplicationIconImage: { icon in
+                receivedRuntimeIcon = icon
+            },
+            startAppearanceObservation: {},
+            stopAppearanceObservation: {},
+            notifyDockTilePlugin: {}
+        )
+
+        store.replaceNotificationsForTesting([])
+        AppIconSettings.resetLiveEnvironmentProviderForTesting()
+        AppIconSettings.setLiveEnvironmentProviderForTesting { environment }
+        defer {
+            store.replaceNotificationsForTesting([])
+            NSApplication.shared.dockTile.badgeLabel = previousBadgeLabel
+            AppIconSettings.resetLiveEnvironmentProviderForTesting()
+        }
+
+        AppIconSettings.applyIcon(.dark, environment: environment)
+        #expect(receivedRuntimeIcon === baseIcon)
+
+        store.replaceNotificationsForTesting([
+            TerminalNotification(
+                id: UUID(),
+                tabId: UUID(),
+                surfaceId: nil,
+                title: "Done",
+                subtitle: "",
+                body: "Needs attention",
+                createdAt: Date(),
+                isRead: false
+            )
+        ])
+
+        #expect(receivedRuntimeIcon != nil)
+        #expect(
+            receivedRuntimeIcon !== baseIcon,
+            "The runtime app icon must include the unread count instead of reusing the unbadged base icon"
+        )
+    }
+}

--- a/cmuxTests/AppIconDockBadgeRegressionTests.swift
+++ b/cmuxTests/AppIconDockBadgeRegressionTests.swift
@@ -30,9 +30,10 @@ struct AppIconDockBadgeRegressionTests {
             setApplicationIconImage: { icon in
                 receivedRuntimeIcon = icon
             },
+            setNativeDockBadgeLabel: { _ in },
             startAppearanceObservation: {},
             stopAppearanceObservation: {},
-            notifyDockTilePlugin: {}
+            notifyDockTilePlugin: { _ in }
         )
 
         store.replaceNotificationsForTesting([])
@@ -64,6 +65,160 @@ struct AppIconDockBadgeRegressionTests {
         #expect(
             receivedRuntimeIcon !== baseIcon,
             "The runtime app icon must include the unread count instead of reusing the unbadged base icon"
+        )
+    }
+
+    @Test("Launch transition clears the native badge after composing it into the runtime icon")
+    func launchTransitionAvoidsDuplicateDockBadge() {
+        let baseIcon = NSImage(size: NSSize(width: 64, height: 64))
+        var isFinishedLaunching = false
+        var nativeBadgeLabel: String? = "3"
+        var receivedRuntimeIcon: NSImage?
+        let environment = AppIconSettings.Environment(
+            isApplicationFinishedLaunching: { isFinishedLaunching },
+            imageForMode: { _ in baseIcon },
+            setApplicationIconImage: { icon in
+                receivedRuntimeIcon = icon
+            },
+            setNativeDockBadgeLabel: { label in
+                nativeBadgeLabel = label
+            },
+            startAppearanceObservation: {},
+            stopAppearanceObservation: {},
+            notifyDockTilePlugin: { _ in }
+        )
+
+        AppIconSettings.resetLiveEnvironmentProviderForTesting()
+        defer { AppIconSettings.resetLiveEnvironmentProviderForTesting() }
+
+        #expect(AppIconSettings.updateRuntimeBadgeLabel("3", environment: environment) == false)
+        #expect(nativeBadgeLabel == "3")
+
+        isFinishedLaunching = true
+        AppIconSettings.setRuntimeBaseIcon(baseIcon, environment: environment)
+
+        #expect(receivedRuntimeIcon !== baseIcon)
+        #expect(nativeBadgeLabel == nil)
+    }
+
+    @Test("Unchanged badge label does not recompose or renotify the runtime icon")
+    func unchangedBadgeLabelSkipsRuntimeWork() {
+        let baseIcon = NSImage(size: NSSize(width: 64, height: 64))
+        var runtimeIconSetCount = 0
+        var nativeBadgeSetCount = 0
+        var dockTileNotificationCount = 0
+        let environment = AppIconSettings.Environment(
+            isApplicationFinishedLaunching: { true },
+            imageForMode: { _ in baseIcon },
+            setApplicationIconImage: { _ in runtimeIconSetCount += 1 },
+            setNativeDockBadgeLabel: { _ in nativeBadgeSetCount += 1 },
+            startAppearanceObservation: {},
+            stopAppearanceObservation: {},
+            notifyDockTilePlugin: { _ in dockTileNotificationCount += 1 }
+        )
+
+        AppIconSettings.resetLiveEnvironmentProviderForTesting()
+        defer { AppIconSettings.resetLiveEnvironmentProviderForTesting() }
+
+        AppIconSettings.setRuntimeBaseIcon(baseIcon, environment: environment)
+        #expect(AppIconSettings.updateRuntimeBadgeLabel("3", environment: environment))
+        #expect(AppIconSettings.updateRuntimeBadgeLabel("3", environment: environment))
+
+        #expect(runtimeIconSetCount == 2)
+        #expect(nativeBadgeSetCount == 2)
+        #expect(dockTileNotificationCount == 2)
+    }
+
+    @Test("Composed badge icon stays scale-aware and exposes its unread value")
+    func composedBadgeIconPreservesRenderingAndAccessibilitySemantics() {
+        let baseIcon = NSImage(size: NSSize(width: 64, height: 64))
+        let rendered = AppIconBadgeRenderer.image(baseIcon: baseIcon, badgeLabel: "3")
+
+        #expect(rendered.representations.contains { $0 is NSCustomImageRep })
+        #expect(rendered.accessibilityDescription == "3")
+    }
+
+    @Test("Dock plugin hides persisted unread count while cmux is not running")
+    func dockPluginSuppressesStaleBadgeAfterUncleanExit() {
+        #expect(AppIconBadgeRenderer.visibleBadgeLabel("3", isAppRunning: false) == nil)
+        #expect(AppIconBadgeRenderer.visibleBadgeLabel("3", isAppRunning: true) == "3")
+    }
+
+    @Test("Persisted-label cleanup refreshes the Dock plugin before launch completes")
+    func persistedLabelCleanupForcesDockPluginRefresh() {
+        var dockTileLabels: [String?] = []
+        let environment = AppIconSettings.Environment(
+            isApplicationFinishedLaunching: { false },
+            imageForMode: { _ in nil },
+            setApplicationIconImage: { _ in },
+            setNativeDockBadgeLabel: { _ in },
+            startAppearanceObservation: {},
+            stopAppearanceObservation: {},
+            notifyDockTilePlugin: { dockTileLabels.append($0) }
+        )
+
+        AppIconSettings.resetLiveEnvironmentProviderForTesting()
+        defer { AppIconSettings.resetLiveEnvironmentProviderForTesting() }
+
+        #expect(
+            AppIconSettings.updateRuntimeBadgeLabel(
+                nil,
+                forceDockTileRefresh: true,
+                environment: environment
+            ) == false
+        )
+        #expect(dockTileLabels.count == 1)
+        #expect(dockTileLabels[0] == nil)
+    }
+
+    @Test("Native fallback suppresses plugin composition until a runtime icon exists")
+    func nativeFallbackUsesOnlyOneBadgeRenderer() {
+        var dockTileLabels: [String?] = []
+        let environment = AppIconSettings.Environment(
+            isApplicationFinishedLaunching: { true },
+            imageForMode: { _ in nil },
+            setApplicationIconImage: { _ in },
+            setNativeDockBadgeLabel: { _ in },
+            startAppearanceObservation: {},
+            stopAppearanceObservation: {},
+            notifyDockTilePlugin: { dockTileLabels.append($0) }
+        )
+
+        AppIconSettings.resetLiveEnvironmentProviderForTesting()
+        defer { AppIconSettings.resetLiveEnvironmentProviderForTesting() }
+
+        #expect(AppIconSettings.updateRuntimeBadgeLabel("3", environment: environment) == false)
+        #expect(dockTileLabels.count == 1)
+        #expect(dockTileLabels[0] == nil)
+    }
+
+    @Test("Persisted Dock badge label can be cleared before app termination")
+    func persistedDockBadgeCanBeCleared() throws {
+        let suiteName = "AppIconDockBadgeRegressionTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        #expect(NotificationBadgeSettings.persistDockBadgeLabel("3", defaults: defaults))
+        #expect(defaults.string(forKey: NotificationBadgeSettings.dockBadgeLabelKey) == "3")
+        #expect(NotificationBadgeSettings.persistDockBadgeLabel("3", defaults: defaults) == false)
+
+        #expect(NotificationBadgeSettings.persistDockBadgeLabel(nil, defaults: defaults))
+        #expect(defaults.string(forKey: NotificationBadgeSettings.dockBadgeLabelKey) == nil)
+    }
+
+    @Test("Native Dock badge is suppressed when the runtime icon already contains it")
+    func nativeDockBadgeAvoidsDuplicateRendering() {
+        #expect(
+            NotificationBadgeSettings.nativeDockBadgeLabel(
+                "3",
+                runtimeIconIncludesBadge: true
+            ) == nil
+        )
+        #expect(
+            NotificationBadgeSettings.nativeDockBadgeLabel(
+                "3",
+                runtimeIconIncludesBadge: false
+            ) == "3"
         )
     }
 }

--- a/cmuxTests/KeyboardShortcutSettingsFileStoreStartupTests.swift
+++ b/cmuxTests/KeyboardShortcutSettingsFileStoreStartupTests.swift
@@ -15,6 +15,7 @@ import struct CmuxSettings.BrowserSearchSettingsStore
 @testable import cmux
 #endif
 
+@MainActor
 final class KeyboardShortcutSettingsFileStoreStartupTests: XCTestCase {
     private var originalSettingsFileStore: KeyboardShortcutSettingsFileStore!
     private let settingsFileBackupsDefaultsKey = "cmux.settingsFile.backups.v1"
@@ -165,13 +166,14 @@ final class KeyboardShortcutSettingsFileStoreStartupTests: XCTestCase {
                 setApplicationIconImage: { _ in
                     runtimeIconSetCount += 1
                 },
+                setNativeDockBadgeLabel: { _ in },
                 startAppearanceObservation: {
                     startObservationCallCount += 1
                 },
                 stopAppearanceObservation: {
                     stopObservationCallCount += 1
                 },
-                notifyDockTilePlugin: {
+                notifyDockTilePlugin: { _ in
                     dockTileNotificationCount += 1
                 }
             )

--- a/cmuxTests/NotificationAndMenuBarTests.swift
+++ b/cmuxTests/NotificationAndMenuBarTests.swift
@@ -478,6 +478,16 @@ final class TerminalNotificationPolicyEngineTests: XCTestCase {
 
 @MainActor
 final class AppIconSettingsTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        AppIconSettings.resetLiveEnvironmentProviderForTesting()
+    }
+
+    override func tearDown() {
+        AppIconSettings.resetLiveEnvironmentProviderForTesting()
+        super.tearDown()
+    }
+
     func testApplyDarkSetsRuntimeIconAndNotifiesDockTilePlugin() {
         let expectedIcon = NSImage(size: NSSize(width: 16, height: 16))
         var receivedRuntimeIcon: NSImage?
@@ -494,13 +504,14 @@ final class AppIconSettingsTests: XCTestCase {
             setApplicationIconImage: { icon in
                 receivedRuntimeIcon = icon
             },
+            setNativeDockBadgeLabel: { _ in },
             startAppearanceObservation: {
                 startObservationCallCount += 1
             },
             stopAppearanceObservation: {
                 stopObservationCallCount += 1
             },
-            notifyDockTilePlugin: {
+            notifyDockTilePlugin: { _ in
                 dockTileNotificationCount += 1
             }
         )
@@ -514,7 +525,7 @@ final class AppIconSettingsTests: XCTestCase {
     }
 
     func testApplyAutomaticStartsObservationAndNotifiesDockTilePlugin() {
-        var dockTileNotificationCount = 0
+        var dockTileLabels: [String?] = []
         var startObservationCallCount = 0
         var stopObservationCallCount = 0
 
@@ -527,20 +538,20 @@ final class AppIconSettingsTests: XCTestCase {
             setApplicationIconImage: { _ in
                 XCTFail("Automatic mode should delegate live updates to the appearance observer")
             },
+            setNativeDockBadgeLabel: { _ in },
             startAppearanceObservation: {
                 startObservationCallCount += 1
             },
             stopAppearanceObservation: {
                 stopObservationCallCount += 1
             },
-            notifyDockTilePlugin: {
-                dockTileNotificationCount += 1
-            }
+            notifyDockTilePlugin: { dockTileLabels.append($0) }
         )
 
         AppIconSettings.applyIcon(.automatic, environment: environment)
 
-        XCTAssertEqual(dockTileNotificationCount, 1)
+        XCTAssertEqual(dockTileLabels.count, 1)
+        XCTAssertNil(dockTileLabels[0])
         XCTAssertEqual(startObservationCallCount, 1)
         XCTAssertEqual(stopObservationCallCount, 0)
     }
@@ -561,13 +572,14 @@ final class AppIconSettingsTests: XCTestCase {
             setApplicationIconImage: { _ in
                 runtimeIconSetCount += 1
             },
+            setNativeDockBadgeLabel: { _ in },
             startAppearanceObservation: {
                 startObservationCallCount += 1
             },
             stopAppearanceObservation: {
                 stopObservationCallCount += 1
             },
-            notifyDockTilePlugin: {
+            notifyDockTilePlugin: { _ in
                 dockTileNotificationCount += 1
             }
         )

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -842,6 +842,7 @@ final class WorkspaceRenameShortcutDefaultsTests: XCTestCase {
     }
 }
 
+@MainActor
 final class KeyboardShortcutSettingsFileStoreTests: XCTestCase {
     private var originalSettingsFileStore: KeyboardShortcutSettingsFileStore!
     private let settingsFileBackupsDefaultsKey = "cmux.settingsFile.backups.v1"
@@ -1430,13 +1431,14 @@ final class KeyboardShortcutSettingsFileStoreTests: XCTestCase {
                 setApplicationIconImage: { _ in
                     runtimeIconSetCount += 1
                 },
+                setNativeDockBadgeLabel: { _ in },
                 startAppearanceObservation: {
                     startObservationCallCount += 1
                 },
                 stopAppearanceObservation: {
                     stopObservationCallCount += 1
                 },
-                notifyDockTilePlugin: {
+                notifyDockTilePlugin: { _ in
                     dockTileNotificationCount += 1
                 }
             )
@@ -1507,13 +1509,14 @@ final class KeyboardShortcutSettingsFileStoreTests: XCTestCase {
                 setApplicationIconImage: { _ in
                     runtimeIconSetCount += 1
                 },
+                setNativeDockBadgeLabel: { _ in },
                 startAppearanceObservation: {
                     startObservationCallCount += 1
                 },
                 stopAppearanceObservation: {
                     stopObservationCallCount += 1
                 },
-                notifyDockTilePlugin: {
+                notifyDockTilePlugin: { _ in
                     dockTileNotificationCount += 1
                 }
             )


### PR DESCRIPTION
## Why

cmux tracks unread notifications correctly, but the macOS Dock icon does not display the unread badge reported in #1764 and #2718.

This updates and rebases the proven approach from #4336 onto current main.

## What

- Compose the unread count into the runtime and custom Dock icons.
- Keep exactly one badge source active to prevent duplicate bubbles.
- Synchronize badge state with the Dock tile plugin.
- Deduplicate unchanged badge refreshes.
- Clear or suppress stale badges after clean and unclean exits.
- Preserve app-icon mode and appearance updates.

## Verification

- Regression test added in a separate first commit.
- `lint-pbxproj-test-wiring.sh` passed.
- `check-pbxproj.sh` passed.
- Swift parsing and focused AppKit typechecks passed.
- Standalone rendering probe confirmed the badge changes icon bytes.
- Full Xcode build was not run locally because Xcode is not installed; CI is required.

Co-authored implementation credit: Lawrence Chen / PR #4336.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790750272&installation_model_id=21920&pr_number=11246&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11246&signature=672815c4faa817b3cd216617829ee7492bd47846085d0b8980647e9759d1d5f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the macOS Dock icon to show the unread notification count, resolving #1764 and #2718. Previously the Dock icon did not reflect unread state even though cmux tracked it; now the unread count is composed into the app icon and the custom Dock Tile icon.

**Changes**
- Composes the unread count into the runtime app icon and the Dock Tile plugin icon.
- Keeps exactly one badge source active to prevent duplicate bubbles.
- Persists the badge label across launches; clears it on clean exit and suppresses stale labels after unclean exits.
- Adds regression tests covering badge rendering and state synchronization.

<sup>Written for commit f433384a83214000976a805d8646219070a571d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unread notification counts now appear directly on the app icon when native Dock badges aren’t displayed.
  * Badge rendering adapts to icon size and clears when notifications are no longer active.
  * Dock badge state refreshes correctly when the app launches, quits, or restarts.

* **Bug Fixes**
  * Prevented duplicate or stale badges from remaining on the Dock icon.
  * Improved icon updates when switching appearance modes.

* **Tests**
  * Added regression coverage for app-icon badges, Dock refreshes, and termination behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->