### PR TITLE
vm: delete Blaxel home volumes on destroy and create rollback

### DIFF
--- a/web/services/vms/drivers/blaxel.ts
+++ b/web/services/vms/drivers/blaxel.ts
@@ -434,15 +434,20 @@ export class BlaxelProvider implements VMProvider {
           // resolved name (never the template) is what lands in providerMetadata,
           // so resurrection finds the right volume.
           const homeVolumeSpec = options.homeVolume?.trim() || undefined;
+          // A `{machine}` volume is owned by exactly one machine, so failure paths
+          // may delete it; a fixed name is the user's shared volume and is never
+          // deleted by create/destroy paths.
+          const perMachineHomeVolume = !!homeVolumeSpec?.includes("{machine}");
           const resolveHomeVolume = (machineName: string): string | undefined =>
             homeVolumeSpec?.replace("{machine}", machineName);
           let name = friendlyVmName();
           let homeVolume = resolveHomeVolume(name);
           let created: BlaxelSandbox | null = null;
           for (let attempt = 0; attempt < 4 && !created; attempt += 1) {
+            let volumeCreated = false;
             if (homeVolume) {
               const volume = homeVolume;
-              await timedStep("ensure_home_volume", () => this.ensureHomeVolume(volume, homeVolumeMb));
+              volumeCreated = await timedStep("ensure_home_volume", () => this.ensureHomeVolume(volume, homeVolumeMb));
             }
             try {
               created = await timedStep("create_sandbox", () => blaxelFetch<BlaxelSandbox>("POST", `${CONTROL_PLANE_BASE}/sandboxes`, {
@@ -458,6 +463,17 @@ export class BlaxelProvider implements VMProvider {
                 },
               }));
             } catch (err) {
+              // A per-machine volume this call just created for a sandbox that never
+              // came to exist is already orphaned — a retried create picks a fresh
+              // name, so nothing ever reattaches it. Delete it before moving on. A
+              // pre-existing volume (409 on ensure) is left alone: it may belong to
+              // the live sandbox this name conflicted with.
+              if (homeVolume && perMachineHomeVolume && volumeCreated) {
+                const volume = homeVolume;
+                await this.deleteHomeVolume(volume).catch((cleanupErr) => {
+                  console.error(`[blaxel] create cleanup failed; volume ${volume} may be orphaned`, cleanupErr);
+                });
+              }
               const conflict = err instanceof ProviderError && /-> 409/.test(err.message);
               if (!conflict || attempt === 3) throw err;
               name = friendlyVmName(attempt >= 1);
@@ -484,15 +500,24 @@ export class BlaxelProvider implements VMProvider {
             timedStep("ensure_raw_preview", () => this.ensurePreview(name, CMUX_TUI_RAW_PREVIEW_NAME, CMUX_TUI_PORT, { branded: false })),
           ]);
           // A machine that failed to bootstrap must not survive as an orphaned
-          // sandbox (its previews die with it); the durable home volume is kept —
-          // a retried create with the same volume reattaches it.
-          // A rollback failure means the sandbox is now leaked on the provider:
-          // log it loudly (the original create error still propagates) so the
-          // orphan is findable instead of silently accumulating.
-          const rollback = () =>
-            this.destroy(name).catch((cleanupErr) => {
+          // sandbox (its previews die with it). A per-machine home volume dies with
+          // the machine: a retried create picks a fresh name, so nothing would ever
+          // reattach it while its storage keeps billing. A shared user volume is
+          // kept — a retried create reattaches it by name.
+          // A rollback failure means the sandbox or volume is now leaked on the
+          // provider: log it loudly (the original create error still propagates) so
+          // the orphan is findable instead of silently accumulating.
+          const rollback = async () => {
+            await this.destroy(name).catch((cleanupErr) => {
               console.error(`[blaxel] create rollback failed; sandbox ${name} may be orphaned`, cleanupErr);
             });
+            if (homeVolume && perMachineHomeVolume) {
+              const volume = homeVolume;
+              await this.deleteHomeVolume(volume).catch((cleanupErr) => {
+                console.error(`[blaxel] create rollback failed; volume ${volume} may be orphaned`, cleanupErr);
+              });
+            }
+          };
           if (bootstrapResult.status === "rejected") {
             await rollback();
             throw bootstrapResult.reason;
@@ -514,7 +539,17 @@ export class BlaxelProvider implements VMProvider {
             image,
             createdAt: Date.now(),
             providerMetadata: homeVolume
-              ? { sandboxUrl, previewUrl, homeVolume, homeVolumeMb, image, memoryMb }
+              ? {
+                  sandboxUrl,
+                  previewUrl,
+                  homeVolume,
+                  homeVolumeMb,
+                  image,
+                  memoryMb,
+                  // Destroy paths delete only volumes a machine owns exclusively;
+                  // this marker is that ownership record.
+                  ...(perMachineHomeVolume ? { homeVolumePerMachine: true } : {}),
+                }
               : { sandboxUrl, previewUrl, image, memoryMb },
           };
         } catch (err) {
@@ -933,17 +968,60 @@ export class BlaxelProvider implements VMProvider {
 
   // A size the volume API rejects surfaces as the provider's own message (non-409
   // responses propagate); there is no silent fallback to a smaller disk.
-  private async ensureHomeVolume(name: string, sizeMb: number): Promise<void> {
+  /** Returns true when this call created the volume, false when it already existed. */
+  private async ensureHomeVolume(name: string, sizeMb: number): Promise<boolean> {
     try {
       await blaxelFetch("POST", `${CONTROL_PLANE_BASE}/volumes`, {
         metadata: { name },
         spec: { size: sizeMb },
       });
+      return true;
     } catch (err) {
       // An existing volume is the expected steady state; anything else is fatal.
       const conflict = err instanceof ProviderError && /-> 409/.test(err.message);
       if (!conflict) throw err;
+      return false;
     }
+  }
+
+  // Blaxel deletes sandboxes asynchronously and keeps a volume's attachment record
+  // alive until that finishes, answering 409 in the window. ~7.5 s of backoff covers it.
+  private static readonly HOME_VOLUME_DELETE_RETRY_DELAYS_MS: readonly number[] = [500, 1000, 2000, 4000];
+
+  /**
+   * Delete a persistent home volume (`DELETE /volumes/{name}`). A 404 is success —
+   * the volume is already gone. A 409 (still attached while the owning sandbox
+   * finishes deleting) is retried with bounded backoff; anything else, or an
+   * exhausted retry budget, throws so the caller can record the leak. Ownership is
+   * the caller's judgment: only a volume owned solely by a destroyed machine may
+   * be passed here.
+   */
+  async deleteHomeVolume(volumeName: string, opts?: { retryDelaysMs?: readonly number[] }): Promise<void> {
+    const name = volumeName.trim();
+    if (!name) throw new ProviderError("blaxel", "deleteHomeVolume requires a volume name");
+    await withVmSpan(
+      "cmux.vm.provider.delete_home_volume",
+      { "cmux.vm.provider": "blaxel", "cmux.vm.operation": "delete_home_volume", "cmux.vm.volume": name },
+      async () => {
+        const delays = opts?.retryDelaysMs ?? BlaxelProvider.HOME_VOLUME_DELETE_RETRY_DELAYS_MS;
+        for (let attempt = 0; ; attempt += 1) {
+          try {
+            await blaxelFetch("DELETE", `${CONTROL_PLANE_BASE}/volumes/${encodeURIComponent(name)}`);
+            return;
+          } catch (err) {
+            const gone = err instanceof ProviderError && /-> 404/.test(err.message);
+            if (gone) return;
+            const attached = err instanceof ProviderError && /-> 409/.test(err.message);
+            if (!attached || attempt >= delays.length) {
+              throw err instanceof ProviderError
+                ? err
+                : new ProviderError("blaxel", `deleteHomeVolume(${name}) failed`, err);
+            }
+            await new Promise((resolve) => setTimeout(resolve, delays[attempt]));
+          }
+        }
+      },
+    );
   }
 
   /**

--- a/web/services/vms/drivers/types.ts
+++ b/web/services/vms/drivers/types.ts
@@ -207,6 +207,15 @@ export interface VMProvider {
   create(options: CreateOptions): Promise<VMHandle>;
   destroy(vmId: string): Promise<void>;
 
+  /**
+   * Optional: delete a persistent home volume by name. Implementations must treat
+   * an already-missing volume as success and absorb the provider's brief
+   * volume-still-attached window after the owning sandbox is deleted (bounded
+   * retry). Ownership is the caller's judgment: only a volume owned solely by a
+   * destroyed machine may be passed here.
+   */
+  deleteHomeVolume?(volumeName: string): Promise<void>;
+
   getStatus?(vmId: string): Promise<VMStatus>;
   /// Live CPU/memory/disk for the Cloud panel's activity view. Must not wake a
   /// sleeping machine.

--- a/web/services/vms/providerGateway.ts
+++ b/web/services/vms/providerGateway.ts
@@ -23,6 +23,11 @@ import { VmProviderOperationError } from "./errors";
 export type VmProviderGatewayShape = {
   readonly create: (provider: ProviderId, options: CreateOptions) => Effect.Effect<VMHandle, VmProviderOperationError>;
   readonly destroy: (provider: ProviderId, vmId: string) => Effect.Effect<void, VmProviderOperationError>;
+  /** Optional: delete a machine-owned persistent home volume after its machine is destroyed. */
+  readonly deleteHomeVolume?: (
+    provider: ProviderId,
+    volumeName: string,
+  ) => Effect.Effect<void, VmProviderOperationError>;
   readonly getStatus?: (provider: ProviderId, vmId: string) => Effect.Effect<VMStatus, VmProviderOperationError>;
   readonly resume?: (provider: ProviderId, vmId: string) => Effect.Effect<VMHandle, VmProviderOperationError>;
   readonly pause?: (provider: ProviderId, vmId: string) => Effect.Effect<void, VmProviderOperationError>;
@@ -97,6 +102,13 @@ export const VmProviderGatewayLive = Layer.succeed(VmProviderGateway, {
     providerEffect(provider, "create", () => getProvider(provider).create(options)),
   destroy: (provider, vmId) =>
     providerEffect(provider, "destroy", () => getProvider(provider).destroy(vmId)),
+  deleteHomeVolume: (provider, volumeName) =>
+    providerEffect(provider, "deleteHomeVolume", async () => {
+      const impl = getProvider(provider);
+      // Providers without persistent volumes have nothing to delete.
+      if (!impl.deleteHomeVolume) return;
+      await impl.deleteHomeVolume(volumeName);
+    }),
   getStatus: (provider, vmId) =>
     providerEffect(provider, "getStatus", async () => {
       const driver = getProvider(provider);

--- a/web/services/vms/workflows.ts
+++ b/web/services/vms/workflows.ts
@@ -7,6 +7,7 @@ import type {
   ExecResult,
   ProviderId,
   SSHEndpoint,
+  VMHandle,
   VMStatus,
 } from "./drivers";
 import {
@@ -229,6 +230,63 @@ export function homeVolumeTemplateForUser(userId: string): string {
   return `${homeVolumeNameForUser(userId)}-{machine}`;
 }
 
+/**
+ * The home volume a destroyed machine owns exclusively, or null when there is
+ * nothing safe to delete. Per-machine volumes are marked at create
+ * (`providerMetadata.homeVolumePerMachine`); rows created before that marker
+ * existed are recognized by the per-machine naming scheme
+ * (`<user-home>-<machine>`). The shared per-user volume never matches: other
+ * machines, including future ones, mount it.
+ */
+export function machineOwnedHomeVolume(
+  vm: Pick<CloudVmRow, "userId" | "providerMetadata">,
+  providerVmId: string,
+): string | null {
+  const metadata = vm.providerMetadata ?? {};
+  const homeVolume = metadata["homeVolume"];
+  if (typeof homeVolume !== "string" || homeVolume.length === 0) return null;
+  const sharedName = homeVolumeNameForUser(vm.userId);
+  if (homeVolume === sharedName) return null;
+  if (metadata["homeVolumePerMachine"] === true) return homeVolume;
+  return providerVmId && homeVolume === `${sharedName}-${providerVmId}` ? homeVolume : null;
+}
+
+/**
+ * Best-effort provider rollback of a just-created machine the workflow could
+ * not finalize: the sandbox, and any per-machine home volume the create
+ * provisioned (nothing ever reattaches it, but its storage keeps billing). A
+ * shared per-user home is never deleted here — the next create reattaches it
+ * by name.
+ */
+function rollbackProviderCreate(
+  providers: VmProviderGatewayShape,
+  provider: ProviderId,
+  handle: VMHandle,
+): Effect.Effect<void> {
+  return Effect.gen(function* () {
+    yield* providers.destroy(provider, handle.providerVmId).pipe(Effect.catchAll(() => Effect.void));
+    const metadata = handle.providerMetadata ?? {};
+    const homeVolume = metadata["homeVolume"];
+    if (
+      metadata["homeVolumePerMachine"] === true &&
+      typeof homeVolume === "string" &&
+      homeVolume.length > 0 &&
+      providers.deleteHomeVolume
+    ) {
+      yield* providers.deleteHomeVolume(provider, homeVolume).pipe(
+        Effect.catchAll((err) =>
+          Effect.sync(() => {
+            console.error(
+              `[vm] create rollback leaked home volume ${homeVolume} for ${handle.providerVmId}`,
+              errorMessage(err.cause),
+            );
+          }),
+        ),
+      );
+    }
+  });
+}
+
 export function createVm(input: {
   readonly userId: string;
   readonly billingCustomerType: BillingCustomerType;
@@ -345,7 +403,7 @@ export function createVm(input: {
     ).pipe(
       Effect.catchAll((err) =>
         Effect.gen(function* () {
-          yield* providers.destroy(input.provider, handle.providerVmId).pipe(Effect.catchAll(() => Effect.void));
+          yield* rollbackProviderCreate(providers, input.provider, handle);
           yield* refundCredit(billing, repo, create.vm, creditReservation);
           yield* repo.markCreateFailed({
             id: create.vm.id,
@@ -533,7 +591,7 @@ function finishBaseCreate(
     ).pipe(
       Effect.catchAll((err) =>
         Effect.gen(function* () {
-          yield* providers.destroy(input.provider, handle.providerVmId).pipe(Effect.catchAll(() => Effect.void));
+          yield* rollbackProviderCreate(providers, input.provider, handle);
           yield* refundCredit(billing, repo, create.vm, creditReservation);
           yield* repo.markBaseCreateFailed({
             baseId: create.base.id,
@@ -817,7 +875,7 @@ export function forkVm(input: {
       ).pipe(
         Effect.catchAll((err) =>
           Effect.gen(function* () {
-            yield* providers.destroy(source.provider, handle.providerVmId).pipe(Effect.catchAll(() => Effect.void));
+            yield* rollbackProviderCreate(providers, source.provider, handle);
             yield* refundCredit(billing, repo, create.vm, creditReservation);
             yield* repo.markCreateFailed({
               id: create.vm.id,
@@ -1354,7 +1412,41 @@ export function destroyVm(input: {
     yield* Effect.sync(() => {
       input.afterProviderDestroy?.();
     });
-    yield* repo.markDestroyed(vm.id);
+    // The sandbox is gone; a per-machine home volume must go with it or its
+    // storage bills forever. The volume delete never fails the destroy — the
+    // machine is already unrecoverable — but a failed delete is recorded as a
+    // usage event so the leaked volume is findable instead of silent.
+    const destroyedProviderVmId = vm.providerVmId ?? input.providerVmId;
+    const homeVolume = machineOwnedHomeVolume(vm, destroyedProviderVmId);
+    let homeVolumeDeleted = false;
+    if (homeVolume && providers.deleteHomeVolume) {
+      homeVolumeDeleted = yield* providers.deleteHomeVolume(vm.provider, homeVolume).pipe(
+        Effect.as(true),
+        Effect.catchAll((err) =>
+          Effect.gen(function* () {
+            console.error(
+              `[vm] home volume delete failed for ${destroyedProviderVmId} (${homeVolume})`,
+              errorMessage(err.cause),
+            );
+            yield* repo.recordUsageEvent({
+              userId: input.userId,
+              billingTeamId: vm.billingTeamId,
+              billingPlanId: vm.billingPlanId,
+              vmId: vm.id,
+              eventType: "vm.home_volume.delete_failed",
+              provider: vm.provider,
+              imageId: vm.imageId,
+              metadata: { homeVolume, message: errorMessage(err.cause) },
+            }).pipe(Effect.catchAll(() => Effect.void));
+            return false;
+          }),
+        ),
+      );
+    }
+    // The provider-side machine is gone at this point, so a lost DB write would
+    // leave a ghost row counting against the active-VM limit. Retry the write;
+    // the provider-status reconciler is the backstop if it still fails.
+    yield* repo.markDestroyed(vm.id).pipe(Effect.retry({ times: 2 }));
     yield* repo.recordUsageEvent({
       userId: input.userId,
       billingTeamId: vm.billingTeamId,
@@ -1363,6 +1455,7 @@ export function destroyVm(input: {
       eventType: "vm.destroyed",
       provider: vm.provider,
       imageId: vm.imageId,
+      ...(homeVolume ? { metadata: { homeVolume, homeVolumeDeleted } } : {}),
     }).pipe(Effect.catchAll(() => Effect.void));
   });
 }

--- a/web/services/vms/workflows.ts
+++ b/web/services/vms/workflows.ts
@@ -1409,14 +1409,35 @@ export function destroyVm(input: {
         return Effect.fail(err);
       }),
     );
-    yield* Effect.sync(() => {
+    const destroyedProviderVmId = vm.providerVmId ?? input.providerVmId;
+    // This callback is advisory progress reporting. A failure must not skip
+    // the mandatory volume cleanup or DB finalization now that the provider
+    // machine is gone. Keep the failure observable in the usage ledger, but
+    // leave destroy successful because those mandatory operations are the
+    // authoritative outcome.
+    try {
       input.afterProviderDestroy?.();
-    });
+    } catch (err) {
+      const message = errorMessage(err);
+      console.error(
+        `[vm] afterProviderDestroy hook failed for ${destroyedProviderVmId}`,
+        message,
+      );
+      yield* repo.recordUsageEvent({
+        userId: input.userId,
+        billingTeamId: vm.billingTeamId,
+        billingPlanId: vm.billingPlanId,
+        vmId: vm.id,
+        eventType: "vm.destroy.after_provider_destroy_failed",
+        provider: vm.provider,
+        imageId: vm.imageId,
+        metadata: { message },
+      }).pipe(Effect.catchAll(() => Effect.void));
+    }
     // The sandbox is gone; a per-machine home volume must go with it or its
     // storage bills forever. The volume delete never fails the destroy — the
     // machine is already unrecoverable — but a failed delete is recorded as a
     // usage event so the leaked volume is findable instead of silent.
-    const destroyedProviderVmId = vm.providerVmId ?? input.providerVmId;
     const homeVolume = machineOwnedHomeVolume(vm, destroyedProviderVmId);
     let homeVolumeDeleted = false;
     if (homeVolume && providers.deleteHomeVolume) {

--- a/web/tests/vm-blaxel-provider.test.ts
+++ b/web/tests/vm-blaxel-provider.test.ts
@@ -455,3 +455,70 @@ describe("background provisioning", () => {
     expect(CMUX_PROVISION_SCRIPT).toContain("/tmp/cmux/provision.log");
   });
 });
+
+describe("BlaxelProvider home volume lifecycle", () => {
+  test("create rollback deletes the per-machine home volume it provisioned", async () => {
+    const prevKey = process.env.BL_API_KEY;
+    const prevWs = process.env.BL_WORKSPACE;
+    const prevDomain = process.env.CMUX_VM_BLAXEL_CUSTOM_DOMAIN;
+    process.env.BL_API_KEY = "test-key";
+    process.env.BL_WORKSPACE = "cmux";
+    delete process.env.CMUX_VM_BLAXEL_CUSTOM_DOMAIN;
+    const originalFetch = globalThis.fetch;
+    const calls: Array<{ method: string; url: string }> = [];
+    let machineName = "";
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+      calls.push({ method, url });
+      const respond = (status: number, body?: unknown) =>
+        new Response(body === undefined ? "" : JSON.stringify(body), {
+          status,
+          headers: { "content-type": "application/json" },
+        });
+      if (method === "POST" && url.endsWith("/volumes")) return respond(200, {});
+      if (method === "POST" && url.endsWith("/sandboxes")) {
+        const parsed = JSON.parse(String(init?.body)) as { metadata?: { name?: string } };
+        machineName = parsed.metadata?.name ?? "";
+        return respond(200, { metadata: { name: machineName, url: "https://sandbox-api.test" } });
+      }
+      // The first bootstrap write fails hard (a non-404/503 status is not retried by
+      // awaitSandboxApi), which forces create's rollback path.
+      if (method === "PUT" && url.startsWith("https://sandbox-api.test/filesystem/")) return respond(500, { error: "boom" });
+      if (method === "GET" && url.includes("/previews/")) return respond(404, {});
+      if (method === "POST" && url.includes("/previews")) {
+        return respond(200, { spec: { url: "https://abc123.us-pdx-1.preview.bl.run", public: false } });
+      }
+      if (method === "DELETE" && url.includes("/sandboxes/")) return respond(200, {});
+      if (method === "DELETE" && url.includes("/volumes/")) return respond(200, {});
+      return respond(500, { error: `unexpected ${method} ${url}` });
+    }) as typeof fetch;
+    try {
+      const provider = new BlaxelProvider();
+      await expect(
+        provider.create({
+          image: "blaxel/base-image:latest",
+          homeVolume: "cmux-home-testuser-{machine}",
+          memoryMb: 4096,
+        }),
+      ).rejects.toThrow();
+      expect(machineName).not.toBe("");
+      const sandboxDelete = calls.findIndex((call) => call.method === "DELETE" && call.url.endsWith(`/sandboxes/${machineName}`));
+      const volumeDelete = calls.findIndex((call) => call.method === "DELETE" && call.url.endsWith(`/volumes/cmux-home-testuser-${machineName}`));
+      expect(sandboxDelete).toBeGreaterThan(-1);
+      // Without volume cleanup the per-machine volume leaks forever: a retried create
+      // generates a fresh machine name, so nothing ever reattaches (or frees) the old
+      // volume, and Blaxel bills per-volume storage monotonically.
+      expect(volumeDelete).toBeGreaterThan(-1);
+      expect(volumeDelete).toBeGreaterThan(sandboxDelete);
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (prevKey === undefined) delete process.env.BL_API_KEY;
+      else process.env.BL_API_KEY = prevKey;
+      if (prevWs === undefined) delete process.env.BL_WORKSPACE;
+      else process.env.BL_WORKSPACE = prevWs;
+      if (prevDomain === undefined) delete process.env.CMUX_VM_BLAXEL_CUSTOM_DOMAIN;
+      else process.env.CMUX_VM_BLAXEL_CUSTOM_DOMAIN = prevDomain;
+    }
+  });
+});

--- a/web/tests/vm-blaxel-provider.test.ts
+++ b/web/tests/vm-blaxel-provider.test.ts
@@ -522,3 +522,152 @@ describe("BlaxelProvider home volume lifecycle", () => {
     }
   });
 });
+
+describe("BlaxelProvider deleteHomeVolume", () => {
+  type VolumeCall = { method: string; url: string };
+
+  function withBlaxelFetch(handler: (call: VolumeCall) => { status: number; body?: unknown }) {
+    const prevKey = process.env.BL_API_KEY;
+    const prevWs = process.env.BL_WORKSPACE;
+    process.env.BL_API_KEY = "test-key";
+    process.env.BL_WORKSPACE = "cmux";
+    const originalFetch = globalThis.fetch;
+    const calls: VolumeCall[] = [];
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const call = { method: init?.method ?? "GET", url };
+      calls.push(call);
+      const result = handler(call);
+      return new Response(result.body === undefined ? "" : JSON.stringify(result.body), {
+        status: result.status,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+    return {
+      calls,
+      restore: () => {
+        globalThis.fetch = originalFetch;
+        if (prevKey === undefined) delete process.env.BL_API_KEY;
+        else process.env.BL_API_KEY = prevKey;
+        if (prevWs === undefined) delete process.env.BL_WORKSPACE;
+        else process.env.BL_WORKSPACE = prevWs;
+      },
+    };
+  }
+
+  test("deletes the volume by name", async () => {
+    const mock = withBlaxelFetch(() => ({ status: 200, body: {} }));
+    try {
+      await new BlaxelProvider().deleteHomeVolume("cmux-home-x-noble-wren");
+      expect(mock.calls).toEqual([
+        { method: "DELETE", url: "https://api.blaxel.ai/v0/volumes/cmux-home-x-noble-wren" },
+      ]);
+    } finally {
+      mock.restore();
+    }
+  });
+
+  test("an already-missing volume is success", async () => {
+    const mock = withBlaxelFetch(() => ({ status: 404, body: { error: "Volume does not exist" } }));
+    try {
+      await new BlaxelProvider().deleteHomeVolume("cmux-home-x-noble-wren");
+      expect(mock.calls).toHaveLength(1);
+    } finally {
+      mock.restore();
+    }
+  });
+
+  test("retries through the volume-still-attached window", async () => {
+    let attempts = 0;
+    const mock = withBlaxelFetch(() => {
+      attempts += 1;
+      return attempts <= 2
+        ? { status: 409, body: { error: "Volume is currently attached to a sandbox" } }
+        : { status: 200, body: {} };
+    });
+    try {
+      await new BlaxelProvider().deleteHomeVolume("cmux-home-x-noble-wren", { retryDelaysMs: [0, 0, 0] });
+      expect(mock.calls).toHaveLength(3);
+    } finally {
+      mock.restore();
+    }
+  });
+
+  test("gives up after the bounded retry budget", async () => {
+    const mock = withBlaxelFetch(() => ({ status: 409, body: { error: "Volume is currently attached to a sandbox" } }));
+    try {
+      await expect(
+        new BlaxelProvider().deleteHomeVolume("cmux-home-x-noble-wren", { retryDelaysMs: [0] }),
+      ).rejects.toThrow("409");
+      expect(mock.calls).toHaveLength(2);
+    } finally {
+      mock.restore();
+    }
+  });
+
+  test("does not retry non-conflict failures", async () => {
+    const mock = withBlaxelFetch(() => ({ status: 500, body: { error: "boom" } }));
+    try {
+      await expect(
+        new BlaxelProvider().deleteHomeVolume("cmux-home-x-noble-wren", { retryDelaysMs: [0, 0] }),
+      ).rejects.toThrow("500");
+      expect(mock.calls).toHaveLength(1);
+    } finally {
+      mock.restore();
+    }
+  });
+
+  test("create rollback keeps a shared (fixed-name) home volume", async () => {
+    const prevKey = process.env.BL_API_KEY;
+    const prevWs = process.env.BL_WORKSPACE;
+    const prevDomain = process.env.CMUX_VM_BLAXEL_CUSTOM_DOMAIN;
+    process.env.BL_API_KEY = "test-key";
+    process.env.BL_WORKSPACE = "cmux";
+    delete process.env.CMUX_VM_BLAXEL_CUSTOM_DOMAIN;
+    const originalFetch = globalThis.fetch;
+    const calls: VolumeCall[] = [];
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+      calls.push({ method, url });
+      const respond = (status: number, body?: unknown) =>
+        new Response(body === undefined ? "" : JSON.stringify(body), {
+          status,
+          headers: { "content-type": "application/json" },
+        });
+      if (method === "POST" && url.endsWith("/volumes")) return respond(200, {});
+      if (method === "POST" && url.endsWith("/sandboxes")) {
+        const parsed = JSON.parse(String(init?.body)) as { metadata?: { name?: string } };
+        return respond(200, { metadata: { name: parsed.metadata?.name ?? "", url: "https://sandbox-api.test" } });
+      }
+      if (method === "PUT" && url.startsWith("https://sandbox-api.test/filesystem/")) return respond(500, { error: "boom" });
+      if (method === "GET" && url.includes("/previews/")) return respond(404, {});
+      if (method === "POST" && url.includes("/previews")) {
+        return respond(200, { spec: { url: "https://abc123.us-pdx-1.preview.bl.run", public: false } });
+      }
+      if (method === "DELETE" && url.includes("/sandboxes/")) return respond(200, {});
+      return respond(500, { error: `unexpected ${method} ${url}` });
+    }) as typeof fetch;
+    try {
+      await expect(
+        new BlaxelProvider().create({
+          image: "blaxel/base-image:latest",
+          // No {machine} token: this is the user's shared durable home. A retried
+          // create reattaches it by name, so rollback must leave it alone.
+          homeVolume: "cmux-home-shared-user",
+          memoryMb: 4096,
+        }),
+      ).rejects.toThrow();
+      expect(calls.some((call) => call.method === "DELETE" && call.url.includes("/volumes/"))).toBe(false);
+      expect(calls.some((call) => call.method === "DELETE" && call.url.includes("/sandboxes/"))).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (prevKey === undefined) delete process.env.BL_API_KEY;
+      else process.env.BL_API_KEY = prevKey;
+      if (prevWs === undefined) delete process.env.BL_WORKSPACE;
+      else process.env.BL_WORKSPACE = prevWs;
+      if (prevDomain === undefined) delete process.env.CMUX_VM_BLAXEL_CUSTOM_DOMAIN;
+      else process.env.CMUX_VM_BLAXEL_CUSTOM_DOMAIN = prevDomain;
+    }
+  });
+});

--- a/web/tests/vm-workflows.test.ts
+++ b/web/tests/vm-workflows.test.ts
@@ -5141,6 +5141,43 @@ describe("destroyVm home volume cleanup", () => {
     expect(destroyedEvent?.metadata).toEqual({ homeVolume: volume, homeVolumeDeleted: false });
   });
 
+  test("still deletes the volume and finalizes the row when afterProviderDestroy throws", async () => {
+    const userId = "user-volume-hook-failure";
+    const volume = "cmux-home-abcdef123456-noble-wren";
+    const vm = testCloudVmRow({
+      id: "00000000-0000-4000-8000-000000000145",
+      userId,
+      provider: "blaxel",
+      providerVmId: "noble-wren",
+      status: "running",
+      providerMetadata: { homeVolume: volume, homeVolumePerMachine: true },
+    });
+    const usageEvents: RecordedUsageEvent[] = [];
+    const destroyedIds: string[] = [];
+    const deletedVolumes: string[] = [];
+    const repo = testWorkflowRepo({ vm, usageEvents, destroyedIds });
+    const provider = destroyGateway({ deletedVolumes });
+    const hookError = new Error("tombstone refresh failed");
+
+    await Effect.runPromise(
+      destroyVm({
+        userId,
+        providerVmId: "noble-wren",
+        afterProviderDestroy: () => {
+          throw hookError;
+        },
+      }).pipe(Effect.provide(workflowLayer(repo, provider))),
+    );
+
+    expect(provider.destroyedVmIds).toEqual(["noble-wren"]);
+    expect(deletedVolumes).toEqual([volume]);
+    expect(destroyedIds).toEqual([vm.id]);
+    const hookEvent = usageEvents.find(
+      (event) => event.eventType === "vm.destroy.after_provider_destroy_failed",
+    );
+    expect(hookEvent?.metadata).toEqual({ message: hookError.message });
+  });
+
   test("retries a transiently failing markDestroyed write", async () => {
     const userId = "user-volume-retry";
     const vm = testCloudVmRow({

--- a/web/tests/vm-workflows.test.ts
+++ b/web/tests/vm-workflows.test.ts
@@ -41,6 +41,7 @@ import {
   createVm,
   destroyVm,
   execVm,
+  homeVolumeNameForUser,
   listUserVms,
   openBaseVm,
   openAttachEndpoint,
@@ -4807,6 +4808,8 @@ function testWorkflowRepo(input: {
   readonly markProviderObservedStatus?: (
     update: ObservedStatusUpdate,
   ) => Effect.Effect<boolean, VmDatabaseError>;
+  readonly markDestroyed?: VmRepositoryShape["markDestroyed"];
+  readonly destroyedIds?: string[];
 }): VmRepositoryShape {
   return {
     listUserVms: () => Effect.succeed([]),
@@ -4842,7 +4845,10 @@ function testWorkflowRepo(input: {
         : null,
       ),
     hasOwnedSnapshot: () => Effect.succeed(false),
-    markDestroyed: () => Effect.void,
+    markDestroyed: input.markDestroyed ?? ((id) =>
+      Effect.sync(() => {
+        input.destroyedIds?.push(id);
+      })),
     recordLease: (lease) =>
       Effect.sync(() => {
         input.leases?.push(lease);
@@ -5007,3 +5013,161 @@ async function waitForBlockedAdvisoryLock(sql: Sql, billingTeamId: string): Prom
   }
   throw new Error("timed out waiting for blocked advisory lock");
 }
+
+describe("destroyVm home volume cleanup", () => {
+  function destroyGateway(input: {
+    readonly deletedVolumes?: string[];
+    readonly deleteHomeVolume?: NonNullable<VmProviderGatewayShape["deleteHomeVolume"]>;
+  } = {}): VmProviderGatewayShape & { readonly destroyedVmIds: string[] } {
+    const destroyedVmIds: string[] = [];
+    return {
+      ...unusedProviderGateway(),
+      destroy: (_provider, vmId) =>
+        Effect.sync(() => {
+          destroyedVmIds.push(vmId);
+        }),
+      deleteHomeVolume:
+        input.deleteHomeVolume ??
+        ((_provider, volumeName) =>
+          Effect.sync(() => {
+            input.deletedVolumes?.push(volumeName);
+          })),
+      destroyedVmIds,
+    };
+  }
+
+  test("deletes the per-machine home volume marked in providerMetadata", async () => {
+    const userId = "user-volume-marker";
+    const volume = "cmux-home-abcdef123456-noble-wren";
+    const vm = testCloudVmRow({
+      id: "00000000-0000-4000-8000-000000000140",
+      userId,
+      provider: "blaxel",
+      providerVmId: "noble-wren",
+      status: "running",
+      providerMetadata: { homeVolume: volume, homeVolumePerMachine: true },
+    });
+    const usageEvents: RecordedUsageEvent[] = [];
+    const destroyedIds: string[] = [];
+    const repo = testWorkflowRepo({ vm, usageEvents, destroyedIds });
+    const deletedVolumes: string[] = [];
+    const provider = destroyGateway({ deletedVolumes });
+
+    await Effect.runPromise(
+      destroyVm({ userId, providerVmId: "noble-wren" }).pipe(Effect.provide(workflowLayer(repo, provider))),
+    );
+
+    expect(provider.destroyedVmIds).toEqual(["noble-wren"]);
+    expect(deletedVolumes).toEqual([volume]);
+    expect(destroyedIds).toEqual([vm.id]);
+    const destroyedEvent = usageEvents.find((event) => event.eventType === "vm.destroyed");
+    expect(destroyedEvent?.metadata).toEqual({ homeVolume: volume, homeVolumeDeleted: true });
+  });
+
+  test("deletes a pre-marker per-machine volume recognized by its derived name", async () => {
+    const userId = "user-volume-legacy";
+    const volume = `${homeVolumeNameForUser(userId)}-noble-wren`;
+    const vm = testCloudVmRow({
+      id: "00000000-0000-4000-8000-000000000141",
+      userId,
+      provider: "blaxel",
+      providerVmId: "noble-wren",
+      status: "running",
+      providerMetadata: { homeVolume: volume },
+    });
+    const deletedVolumes: string[] = [];
+    const repo = testWorkflowRepo({ vm });
+    const provider = destroyGateway({ deletedVolumes });
+
+    await Effect.runPromise(
+      destroyVm({ userId, providerVmId: "noble-wren" }).pipe(Effect.provide(workflowLayer(repo, provider))),
+    );
+
+    expect(deletedVolumes).toEqual([volume]);
+  });
+
+  test("never deletes the shared per-user home volume", async () => {
+    const userId = "user-volume-shared";
+    const vm = testCloudVmRow({
+      id: "00000000-0000-4000-8000-000000000142",
+      userId,
+      provider: "blaxel",
+      providerVmId: "noble-wren",
+      status: "running",
+      providerMetadata: { homeVolume: homeVolumeNameForUser(userId) },
+    });
+    const usageEvents: RecordedUsageEvent[] = [];
+    const deletedVolumes: string[] = [];
+    const repo = testWorkflowRepo({ vm, usageEvents });
+    const provider = destroyGateway({ deletedVolumes });
+
+    await Effect.runPromise(
+      destroyVm({ userId, providerVmId: "noble-wren" }).pipe(Effect.provide(workflowLayer(repo, provider))),
+    );
+
+    expect(provider.destroyedVmIds).toEqual(["noble-wren"]);
+    expect(deletedVolumes).toEqual([]);
+    const destroyedEvent = usageEvents.find((event) => event.eventType === "vm.destroyed");
+    expect(destroyedEvent?.metadata).toBeUndefined();
+  });
+
+  test("records the leak and still destroys the row when the volume delete fails", async () => {
+    const userId = "user-volume-leak";
+    const volume = "cmux-home-abcdef123456-noble-wren";
+    const vm = testCloudVmRow({
+      id: "00000000-0000-4000-8000-000000000143",
+      userId,
+      provider: "blaxel",
+      providerVmId: "noble-wren",
+      status: "running",
+      providerMetadata: { homeVolume: volume, homeVolumePerMachine: true },
+    });
+    const usageEvents: RecordedUsageEvent[] = [];
+    const destroyedIds: string[] = [];
+    const repo = testWorkflowRepo({ vm, usageEvents, destroyedIds });
+    const provider = destroyGateway({
+      deleteHomeVolume: () =>
+        Effect.fail(providerOperationError("deleteHomeVolume", "volume still attached")),
+    });
+
+    await Effect.runPromise(
+      destroyVm({ userId, providerVmId: "noble-wren" }).pipe(Effect.provide(workflowLayer(repo, provider))),
+    );
+
+    expect(destroyedIds).toEqual([vm.id]);
+    const leakEvent = usageEvents.find((event) => event.eventType === "vm.home_volume.delete_failed");
+    expect(leakEvent?.metadata).toEqual({ homeVolume: volume, message: "volume still attached" });
+    const destroyedEvent = usageEvents.find((event) => event.eventType === "vm.destroyed");
+    expect(destroyedEvent?.metadata).toEqual({ homeVolume: volume, homeVolumeDeleted: false });
+  });
+
+  test("retries a transiently failing markDestroyed write", async () => {
+    const userId = "user-volume-retry";
+    const vm = testCloudVmRow({
+      id: "00000000-0000-4000-8000-000000000144",
+      userId,
+      provider: "blaxel",
+      providerVmId: "noble-wren",
+      status: "running",
+      providerMetadata: {},
+    });
+    let markCalls = 0;
+    const repo = testWorkflowRepo({
+      vm,
+      markDestroyed: () =>
+        Effect.suspend(() => {
+          markCalls += 1;
+          return markCalls === 1
+            ? Effect.fail(new VmDatabaseError({ operation: "markDestroyed", cause: new Error("transient") }))
+            : Effect.void;
+        }),
+    });
+    const provider = destroyGateway();
+
+    await Effect.runPromise(
+      destroyVm({ userId, providerVmId: "noble-wren" }).pipe(Effect.provide(workflowLayer(repo, provider))),
+    );
+
+    expect(markCalls).toBe(2);
+  });
+});


### PR DESCRIPTION
Blaxel bills per-volume storage, and no code path ever issued a volume DELETE: `destroy` removed only the sandbox, and a failed `create` kept the volume even though a retried create generates a fresh machine name and can never reattach it. Every destroyed or create-failed per-machine VM leaked its 8-16 GB home volume forever, a monotonic storage cost.

Mechanism:

- `BlaxelProvider.deleteHomeVolume` issues `DELETE /volumes/{name}` through the same `blaxelFetch` convention as `ensureHomeVolume`. 404 is success (already gone). 409 (Blaxel deletes sandboxes asynchronously and keeps the attachment record alive briefly) is retried with bounded backoff (0.5/1/2/4 s); anything else, or an exhausted budget, throws so the caller records the leak.
- `create` marks per-machine volumes with `providerMetadata.homeVolumePerMachine: true`. Rollback after a failed bootstrap/preview now deletes that volume after the sandbox. The name-conflict retry loop deletes an abandoned volume only when this call created it (a pre-existing volume may belong to the live sandbox the name collided with). A shared fixed-name volume is never deleted: a retried create reattaches it by name.
- `destroyVm` deletes the machine-owned home volume after the provider destroy succeeds. Ownership: the metadata marker, or (for rows created before the marker) the `<user-home>-<machine>` naming scheme via `machineOwnedHomeVolume`. The shared per-user volume never matches. A failed volume delete never fails the destroy; it is recorded as a `vm.home_volume.delete_failed` usage event, and `vm.destroyed` carries `{homeVolume, homeVolumeDeleted}` metadata.
- The three DB-finalize rollback sites (create, base create, fork) share `rollbackProviderCreate`, which destroys the sandbox and deletes a marked per-machine volume.
- Hardening: `markDestroyed` is retried twice, since at that point the provider-side machine is already gone and a lost write leaves a ghost row counting against the active-VM limit. The provider-status reconciler remains the backstop.

Pauses and standby never touch volumes: Blaxel pause is a no-op and standby/resurrection semantics are unchanged (destroy of a standby-expired machine 404s on the sandbox and still deletes the volume).

Tests: commit 1 adds the failing regression test (create rollback leaked the per-machine volume), commit 2 fixes it and adds driver tests for delete/404/409-retry/budget/non-retry and shared-volume-kept rollback, plus workflow tests for marker ownership, legacy-name ownership, shared-volume protection, leak-event visibility, and the markDestroyed retry. `bun test tests/vm-*.test.ts`: 304 pass, 0 fail. `tsgo --noEmit` clean.

Trade-offs:

- Volumes leaked before this fix are not reclaimed; an orphan reaper is a separate work item (volumes in `GET /volumes` with no referencing VM row and no sandbox attachment).
- The 409 backoff adds up to ~7.5 s to a destroy in the worst case; normally the first DELETE succeeds because the sandbox DELETE has completed.
- Legacy-row ownership is inferred from the naming scheme rather than a stored marker; both name derivations live in `workflows.ts`, and new rows carry the explicit marker.
- A crash between provider destroy and the volume DELETE still leaks silently; fixing that window needs a destroy-intent state machine, left as follow-up with the reaper.

Dictionary: home volume = the Blaxel persistent disk mounted at /root that survives sandbox deletion; sandbox = the disposable Blaxel micro-VM compute; standby = Blaxel freezing an idle sandbox to a memory snapshot at $0 compute; per-machine home = `perMachineHome` create mode where each machine gets its own volume, vs the single shared per-user volume; usage event = a `cloud_vm_usage_events` row used for billing/telemetry queries.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790760583&installation_model_id=21920&pr_number=11251&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11251&signature=4d9aebc2a06427345e3662116f75623a07dd707e86b9b7f3dbaa9b5f5905958c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blaxel bills per-volume storage, but no code path ever issued a volume `DELETE`: `destroy` removed only the sandbox, and a failed `create` kept the volume even though a retried create generates a fresh machine name and can never reattach it. This adds home-volume deletion so destroyed and create-failed per-machine VMs no longer leak their 8-16 GB volume forever.

**What changed**
- `deleteHomeVolume` issues `DELETE /volumes/{name}`; a 404 is success, and the 409 still-attached window after async sandbox deletion is retried with bounded backoff.
- Create rollback deletes per-machine volumes this call provisioned (`homeVolumePerMachine` marker); the shared per-user volume and pre-existing volumes are never deleted.
- `destroyVm` deletes a machine-owned volume after the sandbox; a failed delete records a `vm.home_volume.delete_failed` usage event instead of failing the destroy.
- A failing `afterProviderDestroy` hook records `vm.destroy.after_provider_destroy_failed` and the destroy continues with volume cleanup and DB finalization.
- Rows created before the marker are recognized by the `<user-home>-<machine>` naming scheme.
- Pauses and standby never touch volumes.
- `markDestroyed` is retried twice so a provider-side deletion no longer leaves a ghost row.

**Trade-offs**
- Volumes leaked before this fix are not reclaimed; an orphan reaper is follow-up.
- The 409 backoff adds up to ~7.5 s to a destroy worst-case.
- A crash between provider destroy and the volume `DELETE` still leaks silently; fixing that window needs a destroy-intent state machine.

<sup>Written for commit b21fe91fe98bebf51b40621f5b874457c2c56ced. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic cleanup for machine-specific home volumes when virtual machines are deleted.
  * Added cleanup during failed machine creation and rollback.
  * Shared home volumes are preserved.
  * Added support for providers that do not manage persistent volumes.
* **Bug Fixes**
  * Improved handling of missing volumes and temporary attachment conflicts during deletion.
  * Machine records are still marked destroyed if volume cleanup or post-destruction hooks fail.
  * Added retry handling for transient destruction updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->