### PR TITLE
vm: cover fork/restore with kill switch + provision telemetry, set maxDuration, audit prod env, loud unconfigured alerts

### DIFF
--- a/web/app/api/cron/vm-alerts/route.ts
+++ b/web/app/api/cron/vm-alerts/route.ts
@@ -14,5 +14,7 @@ export async function GET(request: Request): Promise<Response> {
   }
 
   const checks = await runVmAlertChecks();
-  return jsonResponse({ checks });
+  // Top-level `configured` makes a sink-less production deployment visible to
+  // anything scraping the cron response, not only readers of the summary.
+  return jsonResponse({ configured: checks.alertSink.configured, checks });
 }

--- a/web/app/api/vm/[id]/exec/route.ts
+++ b/web/app/api/vm/[id]/exec/route.ts
@@ -9,6 +9,12 @@ import { setSpanAttributes } from "../../../../../services/telemetry";
 import { execVm, runVmWorkflow } from "../../../../../services/vms/workflows";
 
 
+// Exec accepts client timeouts up to 15 minutes (MAX_EXEC_TIMEOUT_MS below).
+// The function budget must outlive that ceiling or the platform kills the
+// invocation mid-command; 960s = the 900s command ceiling plus attach and
+// auth overhead.
+export const maxDuration = 960;
+
 export async function POST(
   request: Request,
   { params }: { params: Promise<{ id: string }> },

--- a/web/app/api/vm/[id]/fork/route.ts
+++ b/web/app/api/vm/[id]/fork/route.ts
@@ -9,6 +9,7 @@ import {
   vmRequiresProResponse,
 } from "../../../../../services/vms/routeHelpers";
 import { setSpanAttributes } from "../../../../../services/telemetry";
+import { captureVmProvisionOutcome } from "../../../../../services/vms/observability";
 import {
   isVmNotFoundError,
 } from "../../../../../services/vms/errors";
@@ -26,6 +27,10 @@ import {
   stringField,
 } from "../../../../../services/vms/routeInput";
 
+// Fork cold-provisions a machine (and may snapshot the source first); same
+// budget and rationale as POST /api/vm (see app/api/vm/route.ts).
+export const maxDuration = 600;
+
 export async function POST(
   request: Request,
   { params }: { params: Promise<{ id: string }> },
@@ -38,7 +43,10 @@ export async function POST(
     async ({ user: initialUser, span, authDurationMs, routeStartedAtMs, setResponseFinalizer }) => {
       const timing = new VmTimingRecorder(span, "fork", { startedAt: routeStartedAtMs });
       timing.record("auth", authDurationMs);
-      setResponseFinalizer((response) => timing.finish({ status: response.status }));
+      setResponseFinalizer((response) => {
+        timing.finish({ status: response.status });
+        captureVmProvisionOutcome({ userId: initialUser.id, operation: "fork", response, span });
+      });
       const parsedBody = await parseOptionalObjectBody(request, {
         operation: "fork",
         action: "Send `{}` or `{ \"name\": \"before-agent\" }`.",

--- a/web/app/api/vm/[id]/snapshot/route.ts
+++ b/web/app/api/vm/[id]/snapshot/route.ts
@@ -9,6 +9,10 @@ import { isVmNotFoundError } from "../../../../../services/vms/errors";
 import { runVmWorkflow, snapshotVm } from "../../../../../services/vms/workflows";
 import { parseOptionalObjectBody } from "../../../../../services/vms/routeInput";
 
+// Snapshot duration scales with the machine's dirty memory; give it the same
+// long-provisioning budget as create (see app/api/vm/route.ts).
+export const maxDuration = 600;
+
 export async function POST(
   request: Request,
   { params }: { params: Promise<{ id: string }> },

--- a/web/app/api/vm/base/open/route.ts
+++ b/web/app/api/vm/base/open/route.ts
@@ -6,6 +6,10 @@ import { VmTimingRecorder } from "../../../../../services/vms/timings";
 import { runBaseRoute } from "../routeShared";
 
 
+// Base open/reset cold-provisions a machine; same budget and rationale as
+// POST /api/vm (see app/api/vm/route.ts).
+export const maxDuration = 600;
+
 export async function POST(request: Request): Promise<Response> {
   return withAuthedVmApiRoute(
     request,

--- a/web/app/api/vm/base/reset/route.ts
+++ b/web/app/api/vm/base/reset/route.ts
@@ -6,6 +6,10 @@ import { VmTimingRecorder } from "../../../../../services/vms/timings";
 import { runBaseRoute } from "../routeShared";
 
 
+// Base open/reset cold-provisions a machine; same budget and rationale as
+// POST /api/vm (see app/api/vm/route.ts).
+export const maxDuration = 600;
+
 export async function POST(request: Request): Promise<Response> {
   return withAuthedVmApiRoute(
     request,

--- a/web/app/api/vm/restore/route.ts
+++ b/web/app/api/vm/restore/route.ts
@@ -1,5 +1,8 @@
 import { unauthorized, verifyRequest, type AuthedUser } from "../../../../services/vms/auth";
+import { assertVmCreateEnabled } from "../../../../services/vms/config";
 import { defaultProviderId } from "../../../../services/vms/drivers";
+import { isVmCreateDisabledError } from "../../../../services/vms/errors";
+import { captureVmProvisionOutcome } from "../../../../services/vms/observability";
 import {
   jsonResponse,
   requestedVmTeamIdFromRequest,
@@ -25,6 +28,10 @@ import {
   stringField,
 } from "../../../../services/vms/routeInput";
 
+// Restore cold-provisions a machine from a snapshot; same budget and
+// rationale as POST /api/vm (see app/api/vm/route.ts).
+export const maxDuration = 600;
+
 export async function POST(request: Request): Promise<Response> {
   return withAuthedVmApiRoute(
     request,
@@ -34,7 +41,10 @@ export async function POST(request: Request): Promise<Response> {
     async ({ user: initialUser, span, authDurationMs, routeStartedAtMs, setResponseFinalizer }) => {
       const timing = new VmTimingRecorder(span, "restore", { startedAt: routeStartedAtMs });
       timing.record("auth", authDurationMs);
-      setResponseFinalizer((response) => timing.finish({ status: response.status }));
+      setResponseFinalizer((response) => {
+        timing.finish({ status: response.status });
+        captureVmProvisionOutcome({ userId: initialUser.id, operation: "restore", response, span });
+      });
       const parsedBody = await parseRequiredObjectBody(request, {
         operation: "restore",
         action: "Send `{ \"snapshotId\": \"...\" }`.",
@@ -62,6 +72,25 @@ export async function POST(request: Request): Promise<Response> {
       const providerResult = providerField(body);
       if (!providerResult.ok) return providerResult.response;
       const provider = providerResult.provider ?? defaultProviderId();
+      // Kill-switch parity with POST /api/vm: restore provisions a brand-new
+      // machine on `provider`, so it must refuse before any team refresh or
+      // workflow work when creation is disabled.
+      try {
+        assertVmCreateEnabled(provider);
+      } catch (err) {
+        if (isVmCreateDisabledError(err)) {
+          return vmErrorResponse({
+            error: "vm_create_disabled",
+            status: 503,
+            message: "Cloud VM creation is disabled for this environment.",
+            action: "Ask an admin to enable Cloud VM creation, then retry.",
+            reason: "Cloud VM creation is disabled.",
+            phase: "create",
+            retryable: true,
+          });
+        }
+        throw err;
+      }
       let user: AuthedUser = initialUser;
       const requestedBillingTeamId = stringField(body, "billingTeamId") ?? stringField(body, "teamId") ?? requestedVmTeamIdFromRequest(request);
       if (requestedBillingTeamId && !user.teamIds.includes(requestedBillingTeamId)) {

--- a/web/app/api/vm/route.ts
+++ b/web/app/api/vm/route.ts
@@ -69,6 +69,13 @@ import {
 import { authProviderErrorResponse } from "../../../services/vms/authErrors";
 
 
+// Cold creates (provider VM boot, image pull, cmux-tui bootstrap) routinely
+// run minutes; without an explicit budget the platform default killed them
+// mid-provision. 600s caps a hung provider call well below the 20-minute
+// stuck-provisioning alert. The plan allows more (app/v1/responses/route.ts
+// uses 1800).
+export const maxDuration = 600;
+
 export async function GET(request: Request): Promise<Response> {
   return withAuthedVmApiRoute(
     request,

--- a/web/scripts/cloud-vm/projects.mjs
+++ b/web/scripts/cloud-vm/projects.mjs
@@ -25,6 +25,15 @@ export const projects = {
 export const requiredRuntimeEnvKeys = [
   "AWS_REGION",
   "AWS_ROLE_ARN",
+  // Blaxel is the production default provider (CMUX_VM_DEFAULT_PROVIDER):
+  // without credentials and an image selector every create 503s.
+  "BLAXEL_SANDBOX_IMAGE",
+  "BL_API_KEY",
+  "BL_WORKSPACE",
+  // Without the Slack sink every triggered VM alert drops silently while the
+  // alert cron keeps returning 200, so an unset webhook is an observability
+  // outage, not a tuning choice.
+  "CMUX_ALERTS_SLACK_WEBHOOK_URL",
   // The application can build without APNs credentials, but a promoted
   // runtime cannot deliver the Push Alerts feature without the complete set.
   "CMUX_APNS_KEY_ID",
@@ -35,6 +44,8 @@ export const requiredRuntimeEnvKeys = [
   "CMUX_VM_DEFAULT_PROVIDER",
   "CMUX_VM_E2B_ENABLED",
   "CMUX_VM_FREESTYLE_ENABLED",
+  // Every Vercel cron (VM alerts included) refuses to run without it.
+  "CRON_SECRET",
   "E2B_API_KEY",
   "E2B_CMUXD_WS_TEMPLATE",
   "FREESTYLE_API_KEY",
@@ -49,7 +60,14 @@ export const requiredRuntimeEnvKeys = [
 ];
 
 export const recommendedRuntimeEnvKeys = [
+  // Optional by design: when unset, desktop creates fall back to the generic
+  // BLAXEL_SANDBOX_IMAGE selector (services/vms/images/resolver.ts).
+  "BLAXEL_SANDBOX_DESKTOP_IMAGE",
   "CMUX_DB_POOL_MAX",
+  // Kill switches are off-only: unset means enabled, so requiring presence
+  // would fail a healthy deployment. Recommended for explicitness (the other
+  // provider flags are set in prod).
+  "CMUX_VM_BLAXEL_ENABLED",
   "CMUX_DB_SSL_REJECT_UNAUTHORIZED",
   "OTEL_EXPORTER_OTLP_ENDPOINT",
   "OTEL_EXPORTER_OTLP_HEADERS",

--- a/web/services/observability/alerts.ts
+++ b/web/services/observability/alerts.ts
@@ -11,6 +11,11 @@ export type AlertInput = {
 
 export type AlertResult = {
   readonly sent: boolean;
+  /**
+   * False only when no Slack webhook is configured at all: the alert fired
+   * and went nowhere. Callers use this to make the silent state loud.
+   */
+  readonly configured: boolean;
   readonly status?: number;
   readonly error?: string;
 };
@@ -29,7 +34,7 @@ export async function sendAlert(
 ): Promise<AlertResult> {
   const env = options.env ?? process.env;
   const webhookUrl = env.CMUX_ALERTS_SLACK_WEBHOOK_URL?.trim();
-  if (!webhookUrl) return { sent: false };
+  if (!webhookUrl) return { sent: false, configured: false };
 
   const fetchImpl = options.fetch ?? fetch;
   try {
@@ -46,16 +51,16 @@ export async function sendAlert(
         severity: input.severity,
         status: response.status,
       });
-      return { sent: false, status: response.status };
+      return { sent: false, configured: true, status: response.status };
     }
-    return { sent: true, status: response.status };
+    return { sent: true, configured: true, status: response.status };
   } catch (error) {
     reportError(error, {
       subsystem: "cloud_vm_alerts",
       alertKey: input.key,
       severity: input.severity,
     });
-    return { sent: false, error: errorMessage(error) };
+    return { sent: false, configured: true, error: errorMessage(error) };
   }
 }
 

--- a/web/services/observability/vmAlerts.ts
+++ b/web/services/observability/vmAlerts.ts
@@ -1,5 +1,5 @@
-import { randomUUID } from "node:crypto";
 import { and, count, eq, gte, inArray, isNull, lt, sql } from "drizzle-orm";
+import { after } from "next/server";
 import { POSTHOG_HOST, POSTHOG_PROJECT_KEY } from "../analytics/iosEventPolicy";
 import { cloudDb } from "../../db/client";
 import { cloudVmLeases, cloudVms, cloudVmUsageEvents } from "../../db/schema";
@@ -7,6 +7,10 @@ import { sendAlert, type AlertFetch, type AlertInput, type AlertResult } from ".
 import { reportError } from "./report";
 
 const CREATE_FAILURE_EVENT_TYPES = ["vm.create.failed", "vm.base.create.failed"] as const;
+const DROPPED_ALERT_REPORT_TIMEOUT_MS = 2_000;
+// The cron runs every five minutes. A daily bucket gives operators a reminder
+// without creating a new PostHog event for every tick of a persistent outage.
+const DROPPED_ALERT_DEDUPE_WINDOW_MS = 24 * 60 * 60 * 1_000;
 
 export type VmAlertCheckSummary = {
   readonly triggered: boolean;
@@ -96,7 +100,9 @@ export async function runVmAlertChecks(options: {
   }
 
   if (droppedAlerts.length > 0) {
-    reportDroppedVmAlerts(droppedAlerts, { env, fetch: options.fetch });
+    // reportDroppedVmAlerts bounds its capture task; await it so this cron
+    // cannot finish before the unconfigured-alert signal is handed off.
+    await reportDroppedVmAlerts(droppedAlerts, { env, fetch: options.fetch, now });
   }
 
   return {
@@ -127,16 +133,20 @@ export async function runVmAlertChecks(options: {
  * production only, so dev and preview stay quiet with no webhook set; the
  * daily env audit covers the config gap on quiet days.
  */
-export function reportDroppedVmAlerts(
+export async function reportDroppedVmAlerts(
   alerts: readonly AlertInput[],
   options: {
     readonly env?: Record<string, string | undefined>;
     readonly fetch?: AlertFetch;
+    readonly now?: Date;
   } = {},
-): void {
+): Promise<void> {
   const env = options.env ?? process.env;
   if (env.VERCEL_ENV !== "production" && env.CMUX_ALERTS_REPORT_FORCE !== "1") return;
-  const keys = alerts.map((alert) => alert.key);
+  const keys = [...new Set(alerts.map((alert) => alert.key))];
+  if (keys.length === 0) return;
+  const now = options.now ?? new Date();
+  const dedupeBucket = Math.floor(now.getTime() / DROPPED_ALERT_DEDUPE_WINDOW_MS);
   reportError(
     new Error(`cloud VM alerts fired with no Slack sink configured: ${keys.join(", ")}`),
     {
@@ -146,27 +156,74 @@ export function reportDroppedVmAlerts(
     },
     { fingerprint: ["cmux-vm-alerts", "alerts_unconfigured"] },
   );
-  const body = JSON.stringify({
-    api_key: POSTHOG_PROJECT_KEY,
-    event: "cloud_vm_alert_dropped",
-    distinct_id: "cmux-vm-alerts",
-    properties: {
-      alert_keys: keys,
-      alert_count: keys.length,
-      operator_fault: true,
-      schema_version: 1,
-      $insert_id: randomUUID(),
-      $geoip_disable: true,
-    },
-    timestamp: new Date().toISOString(),
-  });
   const fetchImpl = options.fetch ?? fetch;
-  void Promise.resolve(fetchImpl(`${POSTHOG_HOST}/capture/`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body,
-    signal: AbortSignal.timeout(2_000),
-  })).catch(() => undefined);
+  const captureTask = Promise.all(keys.map((key) => {
+    const body = JSON.stringify({
+      api_key: POSTHOG_PROJECT_KEY,
+      event: "cloud_vm_alert_dropped",
+      distinct_id: "cmux-vm-alerts",
+      properties: {
+        alert_key: key,
+        alert_keys: [key],
+        alert_count: 1,
+        operator_fault: true,
+        schema_version: 1,
+        // PostHog deduplicates matching distinct_id/$insert_id pairs. The
+        // bucket keeps one persistent alert from creating an event every five
+        // minutes while avoiding process-local state in serverless workers.
+        $insert_id: droppedAlertInsertId(key, dedupeBucket),
+        $geoip_disable: true,
+      },
+      timestamp: now.toISOString(),
+    });
+    return Promise.resolve()
+      .then(() => fetchImpl(`${POSTHOG_HOST}/capture/`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body,
+        signal: AbortSignal.timeout(DROPPED_ALERT_REPORT_TIMEOUT_MS),
+      }))
+      .then(() => undefined)
+      .catch(() => undefined);
+  })).then(() => undefined);
+  const boundedCaptureTask = waitForBoundedTask(
+    captureTask,
+    DROPPED_ALERT_REPORT_TIMEOUT_MS,
+  );
+  try {
+    // Keep the request alive on Vercel while also returning the promise to the
+    // cron caller. The fallback is needed for tests and non-request invocations
+    // where Next has no after() context.
+    after(boundedCaptureTask);
+  } catch {
+    // The caller still awaits boundedCaptureTask below.
+  }
+  await boundedCaptureTask;
+}
+
+/** Builds the deterministic PostHog identity for one alert and one day. */
+function droppedAlertInsertId(key: string, bucket: number): string {
+  return `cloud-vm-alert-dropped:${encodeURIComponent(key)}:${bucket}`;
+}
+
+/** Waits for telemetry briefly, then lets the alert check complete. */
+async function waitForBoundedTask(
+  task: Promise<void>,
+  timeoutMs: number,
+): Promise<void> {
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  const timeoutTask = new Promise<void>((resolve) => {
+    if (timeoutSignal.aborted) {
+      resolve();
+      return;
+    }
+    timeoutSignal.addEventListener("abort", () => resolve(), { once: true });
+  });
+  try {
+    await Promise.race([task, timeoutTask]);
+  } catch {
+    // Telemetry must never make the alert checks fail.
+  }
 }
 
 async function countCreateFailures(

--- a/web/services/observability/vmAlerts.ts
+++ b/web/services/observability/vmAlerts.ts
@@ -1,7 +1,10 @@
+import { randomUUID } from "node:crypto";
 import { and, count, eq, gte, inArray, isNull, lt, sql } from "drizzle-orm";
+import { POSTHOG_HOST, POSTHOG_PROJECT_KEY } from "../analytics/iosEventPolicy";
 import { cloudDb } from "../../db/client";
 import { cloudVmLeases, cloudVms, cloudVmUsageEvents } from "../../db/schema";
 import { sendAlert, type AlertFetch, type AlertInput, type AlertResult } from "./alerts";
+import { reportError } from "./report";
 
 const CREATE_FAILURE_EVENT_TYPES = ["vm.create.failed", "vm.base.create.failed"] as const;
 
@@ -14,6 +17,15 @@ export type VmAlertSummary = {
   readonly createFailures: VmAlertCheckSummary;
   readonly stuckProvisioning: VmAlertCheckSummary;
   readonly expiredUnrevokedLeases: VmAlertCheckSummary;
+  /**
+   * Whether a Slack sink exists at all, and how many triggered alerts were
+   * dropped for lack of one during this run. Surfaced in the cron response so
+   * an unconfigured production deployment is visible instead of a silent 200.
+   */
+  readonly alertSink: {
+    readonly configured: boolean;
+    readonly droppedAlerts: number;
+  };
 };
 
 type SendAlert = (input: AlertInput) => Promise<AlertResult>;
@@ -28,7 +40,17 @@ export async function runVmAlertChecks(options: {
   const db = options.db ?? cloudDb();
   const env = options.env ?? process.env;
   const now = options.now ?? new Date();
-  const send = options.sendAlert ?? ((input) => sendAlert(input, { fetch: options.fetch, env }));
+  const rawSend = options.sendAlert ?? ((input) => sendAlert(input, { fetch: options.fetch, env }));
+  const alertsConfigured = Boolean(env.CMUX_ALERTS_SLACK_WEBHOOK_URL?.trim());
+  const droppedAlerts: AlertInput[] = [];
+  const send: SendAlert = async (input) => {
+    const result = await rawSend(input);
+    // `configured: false` means the alert had no sink: it fired and went
+    // nowhere. Track it so the unconfigured state is loud exactly when it
+    // swallowed a real incident signal.
+    if (result.configured === false) droppedAlerts.push(input);
+    return result;
+  };
 
   const createFailureThreshold = positiveIntegerEnv(env.CMUX_VM_ALERT_CREATE_FAILURES_15M, 3);
   const expiredLeaseThreshold = positiveIntegerEnv(env.CMUX_VM_ALERT_EXPIRED_LEASES, 50);
@@ -73,6 +95,10 @@ export async function runVmAlertChecks(options: {
     });
   }
 
+  if (droppedAlerts.length > 0) {
+    reportDroppedVmAlerts(droppedAlerts, { env, fetch: options.fetch });
+  }
+
   return {
     createFailures: {
       triggered: createFailures.count >= createFailureThreshold,
@@ -86,7 +112,61 @@ export async function runVmAlertChecks(options: {
       triggered: expiredLeaseCount > expiredLeaseThreshold,
       count: expiredLeaseCount,
     },
+    alertSink: {
+      configured: alertsConfigured,
+      droppedAlerts: droppedAlerts.length,
+    },
   };
+}
+
+/**
+ * Operator-fault leg for alerts that fired with no Slack sink configured.
+ * Two sinks so at least one is watched: a scrubbed structured error in the
+ * runtime logs (plus Sentry when a DSN exists), and a PostHog
+ * `cloud_vm_alert_dropped` event insights and alerts can key on. Emits in
+ * production only, so dev and preview stay quiet with no webhook set; the
+ * daily env audit covers the config gap on quiet days.
+ */
+export function reportDroppedVmAlerts(
+  alerts: readonly AlertInput[],
+  options: {
+    readonly env?: Record<string, string | undefined>;
+    readonly fetch?: AlertFetch;
+  } = {},
+): void {
+  const env = options.env ?? process.env;
+  if (env.VERCEL_ENV !== "production" && env.CMUX_ALERTS_REPORT_FORCE !== "1") return;
+  const keys = alerts.map((alert) => alert.key);
+  reportError(
+    new Error(`cloud VM alerts fired with no Slack sink configured: ${keys.join(", ")}`),
+    {
+      subsystem: "cloud_vm_alerts",
+      code: "alerts_unconfigured",
+      droppedAlerts: keys,
+    },
+    { fingerprint: ["cmux-vm-alerts", "alerts_unconfigured"] },
+  );
+  const body = JSON.stringify({
+    api_key: POSTHOG_PROJECT_KEY,
+    event: "cloud_vm_alert_dropped",
+    distinct_id: "cmux-vm-alerts",
+    properties: {
+      alert_keys: keys,
+      alert_count: keys.length,
+      operator_fault: true,
+      schema_version: 1,
+      $insert_id: randomUUID(),
+      $geoip_disable: true,
+    },
+    timestamp: new Date().toISOString(),
+  });
+  const fetchImpl = options.fetch ?? fetch;
+  void Promise.resolve(fetchImpl(`${POSTHOG_HOST}/capture/`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body,
+    signal: AbortSignal.timeout(2_000),
+  })).catch(() => undefined);
 }
 
 async function countCreateFailures(

--- a/web/services/vms/config.ts
+++ b/web/services/vms/config.ts
@@ -7,20 +7,28 @@ export function assertVmCreateEnabled(
   provider: ProviderId,
   env: VmRuntimeEnv = process.env,
 ): void {
-  if (isFalseFlag(env.CMUX_VM_CREATE_ENABLED)) {
-    throw new VmCreateDisabledError({
-      provider,
-      reason: "Cloud VM creation is disabled",
-    });
+  const reason = vmCreateDisabledReason(provider, env);
+  if (reason) {
+    throw new VmCreateDisabledError({ provider, reason });
   }
+}
 
-  const providerKey = providerEnabledEnvKey(provider);
-  if (isFalseFlag(env[providerKey])) {
-    throw new VmCreateDisabledError({
-      provider,
-      reason: `${provider} VM creation is disabled`,
-    });
+/**
+ * Why creating a machine on `provider` is disabled, or null when creation is
+ * allowed. Workflow code (Effect) uses this instead of the throwing assert so
+ * a flipped kill switch is a typed failure, not a thrown defect.
+ */
+export function vmCreateDisabledReason(
+  provider: ProviderId,
+  env: VmRuntimeEnv = process.env,
+): string | null {
+  if (isFalseFlag(env.CMUX_VM_CREATE_ENABLED)) {
+    return "Cloud VM creation is disabled";
   }
+  if (isFalseFlag(env[providerEnabledEnvKey(provider)])) {
+    return `${provider} VM creation is disabled`;
+  }
+  return null;
 }
 
 export function providerEnabledEnvKey(provider: ProviderId): string {

--- a/web/services/vms/observability.ts
+++ b/web/services/vms/observability.ts
@@ -87,7 +87,7 @@ export function reportVmErrorResponse(input: VmErrorResponseInput): void {
   );
 }
 
-export type VmProvisionOperation = "create" | "base_open" | "base_reset";
+export type VmProvisionOperation = "create" | "fork" | "restore" | "base_open" | "base_reset";
 
 /**
  * Provisioning outcome choke point, run as a response finalizer. Two legs:

--- a/web/services/vms/workflows.ts
+++ b/web/services/vms/workflows.ts
@@ -17,10 +17,12 @@ import {
   type VmCreateCreditReservation,
   type VmBillingGatewayShape,
 } from "./billingGateway";
+import { vmCreateDisabledReason } from "./config";
 import {
   VmBillingError,
   VmAccountDeletionIdentityRevocationError,
   VmAttachTransportUnsupportedError,
+  VmCreateDisabledError,
   VmCreateFailedError,
   VmCreateInProgressError,
   VmFreeAccessExpiredError,
@@ -721,6 +723,17 @@ export function forkVm(input: {
     const providers = yield* VmProviderGateway;
     const billing = yield* VmBillingGateway;
     const source = yield* requireUserVm(input);
+    // Kill-switch parity with POST /api/vm: fork provisions a brand-new
+    // machine on the source VM's provider and spends the same provider money.
+    // The check lives here rather than in the route because the provider is
+    // only known once the source VM row is loaded.
+    const createDisabledReason = vmCreateDisabledReason(source.provider);
+    if (createDisabledReason) {
+      return yield* Effect.fail(new VmCreateDisabledError({
+        provider: source.provider,
+        reason: createDisabledReason,
+      }));
+    }
     yield* preflightResumeIfSuspended(repo, providers, source, input.providerVmId, "fork");
 
     if (source.provider === "freestyle" && providers.fork) {

--- a/web/tests/cloud-vm-env-audit.test.ts
+++ b/web/tests/cloud-vm-env-audit.test.ts
@@ -8,6 +8,10 @@ import {
   auditProviderReadiness,
   CODE_DEFAULT_PROVIDER,
 } from "../scripts/cloud-vm/defaultProviderAudit.mjs";
+import {
+  recommendedRuntimeEnvKeys,
+  requiredRuntimeEnvKeys,
+} from "../scripts/cloud-vm/projects.mjs";
 import { defaultProviderId } from "../services/vms/drivers";
 
 type Manifest = {
@@ -175,5 +179,29 @@ describe("audit constants stay tied to the runtime", () => {
       manifest,
     ) as { problems: string[] };
     expect(result.problems.join("\n")).toContain("no credential mapping");
+  });
+});
+
+describe("required runtime env keys cover the production provider path", () => {
+  test("blaxel credentials, cron auth, and the alert sink are required", () => {
+    for (const key of [
+      "BL_API_KEY",
+      "BL_WORKSPACE",
+      "BLAXEL_SANDBOX_IMAGE",
+      "CRON_SECRET",
+      "CMUX_ALERTS_SLACK_WEBHOOK_URL",
+    ]) {
+      expect(requiredRuntimeEnvKeys).toContain(key);
+    }
+  });
+
+  test("off-only kill switches and the desktop selector stay recommended, not required", () => {
+    // Unset means enabled for kill switches, and desktop creates fall back to
+    // the generic BLAXEL_SANDBOX_IMAGE selector, so requiring these would
+    // fail a healthy deployment.
+    for (const key of ["CMUX_VM_BLAXEL_ENABLED", "BLAXEL_SANDBOX_DESKTOP_IMAGE"]) {
+      expect(recommendedRuntimeEnvKeys).toContain(key);
+      expect(requiredRuntimeEnvKeys).not.toContain(key);
+    }
   });
 });

--- a/web/tests/observability-alerts.test.ts
+++ b/web/tests/observability-alerts.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
 import { sendAlert } from "../services/observability/alerts";
+import { reportDroppedVmAlerts } from "../services/observability/vmAlerts";
 import { GET as vmAlertsCronGET } from "../app/api/cron/vm-alerts/route";
 
 describe("observability alerts", () => {
@@ -18,7 +19,7 @@ describe("observability alerts", () => {
       fetch: fetchMock,
     });
 
-    expect(result).toEqual({ sent: false });
+    expect(result).toEqual({ sent: false, configured: false });
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -40,8 +41,40 @@ describe("observability alerts", () => {
       fetch: fetchMock,
     });
 
-    expect(result).toEqual({ sent: true, status: 200 });
+    expect(result).toEqual({ sent: true, configured: true, status: 200 });
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("dropped alerts emit a PostHog operator-fault event in production", () => {
+    const seen: { body: Record<string, unknown> | null } = { body: null };
+    const fetchMock = (async (...args: unknown[]) => {
+      const init = args[1] as RequestInit | undefined;
+      seen.body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return new Response("ok", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    reportDroppedVmAlerts(
+      [{ key: "vm-create-failure-spike", title: "t", body: "b", severity: "critical" }],
+      { env: { VERCEL_ENV: "production" }, fetch: fetchMock },
+    );
+
+    expect(seen.body?.event).toBe("cloud_vm_alert_dropped");
+    expect(seen.body?.distinct_id).toBe("cmux-vm-alerts");
+    const properties = seen.body?.properties as Record<string, unknown>;
+    expect(properties.operator_fault).toBe(true);
+    expect(properties.alert_keys).toEqual(["vm-create-failure-spike"]);
+    expect(properties.alert_count).toBe(1);
+  });
+
+  test("dropped alerts stay quiet outside production", () => {
+    const fetchMock = mock(async () => new Response("ok")) as unknown as typeof fetch;
+
+    reportDroppedVmAlerts(
+      [{ key: "k", title: "t", body: "b", severity: "warning" }],
+      { env: {}, fetch: fetchMock },
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   test("VM alerts cron requires CRON_SECRET and bearer auth before querying", async () => {

--- a/web/tests/observability-alerts.test.ts
+++ b/web/tests/observability-alerts.test.ts
@@ -1,7 +1,41 @@
 import { describe, expect, mock, test } from "bun:test";
-import { sendAlert } from "../services/observability/alerts";
-import { reportDroppedVmAlerts } from "../services/observability/vmAlerts";
+import { cloudDb } from "../db/client";
+import { sendAlert, type AlertInput, type AlertResult } from "../services/observability/alerts";
+import { reportDroppedVmAlerts, runVmAlertChecks } from "../services/observability/vmAlerts";
 import { GET as vmAlertsCronGET } from "../app/api/cron/vm-alerts/route";
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function fakeAlertDb(): ReturnType<typeof cloudDb> {
+  let queryNumber = 0;
+  return {
+    select: () => ({
+      from: () => ({
+        where: () => {
+          queryNumber += 1;
+          const rows = queryNumber === 1
+            ? [{ total: 1, providers: ["e2b"] }]
+            : queryNumber === 2
+              ? []
+              : [{ total: 0 }];
+          return Object.assign(Promise.resolve(rows), {
+            limit: async () => [],
+          });
+        },
+      }),
+    }),
+  } as unknown as ReturnType<typeof cloudDb>;
+}
+
+function alertInput(key: string): AlertInput {
+  return { key, title: "Test alert", body: "Test body", severity: "warning" };
+}
 
 describe("observability alerts", () => {
   test("sendAlert no-ops when the Slack webhook is unset", async () => {
@@ -45,7 +79,7 @@ describe("observability alerts", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  test("dropped alerts emit a PostHog operator-fault event in production", () => {
+  test("dropped alerts emit a PostHog operator-fault event in production", async () => {
     const seen: { body: Record<string, unknown> | null } = { body: null };
     const fetchMock = (async (...args: unknown[]) => {
       const init = args[1] as RequestInit | undefined;
@@ -53,7 +87,7 @@ describe("observability alerts", () => {
       return new Response("ok", { status: 200 });
     }) as unknown as typeof fetch;
 
-    reportDroppedVmAlerts(
+    await reportDroppedVmAlerts(
       [{ key: "vm-create-failure-spike", title: "t", body: "b", severity: "critical" }],
       { env: { VERCEL_ENV: "production" }, fetch: fetchMock },
     );
@@ -66,10 +100,119 @@ describe("observability alerts", () => {
     expect(properties.alert_count).toBe(1);
   });
 
-  test("dropped alerts stay quiet outside production", () => {
+  test("dropped alert reporting resolves after the PostHog request settles", async () => {
+    const request = deferred<Response>();
+    const started = deferred<void>();
+    const fetchMock = mock(async () => {
+      started.resolve();
+      return request.promise;
+    }) as unknown as typeof fetch;
+
+    const report = Promise.resolve(reportDroppedVmAlerts(
+      [alertInput("vm-create-failure-spike")],
+      { env: { VERCEL_ENV: "production" }, fetch: fetchMock },
+    ));
+    await started.promise;
+
+    let settled = false;
+    report.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    request.resolve(new Response("ok"));
+    await report;
+    expect(settled).toBe(true);
+  });
+
+  test("runVmAlertChecks waits for dropped-alert telemetry", async () => {
+    const request = deferred<Response>();
+    const started = deferred<void>();
+    const fetchMock = mock(async () => {
+      started.resolve();
+      return request.promise;
+    }) as unknown as typeof fetch;
+
+    const checks = runVmAlertChecks({
+      db: fakeAlertDb(),
+      now: new Date("2026-08-31T12:00:00.000Z"),
+      env: {
+        VERCEL_ENV: "production",
+        CMUX_VM_ALERT_CREATE_FAILURES_15M: "1",
+      },
+      fetch: fetchMock,
+      sendAlert: async (): Promise<AlertResult> => ({
+        sent: false,
+        configured: false,
+      }),
+    });
+    await started.promise;
+
+    let settled = false;
+    checks.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    request.resolve(new Response("ok"));
+    const summary = await checks;
+    expect(settled).toBe(true);
+    expect(summary.alertSink).toEqual({ configured: false, droppedAlerts: 1 });
+  });
+
+  test("dropped alerts use stable per-key insert IDs within a daily bucket", async () => {
+    const captures: Array<{ properties: Record<string, unknown> }> = [];
+    const fetchMock = mock(async (...args: unknown[]) => {
+      const init = args[1] as RequestInit | undefined;
+      const payload = JSON.parse(String(init?.body)) as {
+        properties: Record<string, unknown>;
+      };
+      captures.push(payload);
+      return new Response("ok");
+    }) as unknown as typeof fetch;
+    const firstNow = new Date("2026-08-31T12:00:00.000Z");
+
+    const firstOptions = { env: { VERCEL_ENV: "production" }, fetch: fetchMock, now: firstNow };
+    const secondOptions = {
+      env: { VERCEL_ENV: "production" },
+      fetch: fetchMock,
+      now: new Date(firstNow.getTime() + 60 * 60 * 1000),
+    };
+    const nextDayOptions = {
+      env: { VERCEL_ENV: "production" },
+      fetch: fetchMock,
+      now: new Date(firstNow.getTime() + 24 * 60 * 60 * 1000),
+    };
+    await reportDroppedVmAlerts(
+      [alertInput("vm-create-failure-spike"), alertInput("vm-stuck-provisioning"), alertInput("vm-create-failure-spike")],
+      firstOptions,
+    );
+    await reportDroppedVmAlerts(
+      [alertInput("vm-create-failure-spike"), alertInput("vm-stuck-provisioning")],
+      secondOptions,
+    );
+    await reportDroppedVmAlerts([alertInput("vm-create-failure-spike")], nextDayOptions);
+
+    const idsFor = (key: string) => captures
+      .filter((capture) => capture.properties.alert_key === key)
+      .map((capture) => capture.properties.$insert_id);
+    const createFailureIds = idsFor("vm-create-failure-spike");
+    const stuckIds = idsFor("vm-stuck-provisioning");
+    expect(createFailureIds).toHaveLength(3);
+    expect(stuckIds).toHaveLength(2);
+    expect(createFailureIds[0]).toBe(createFailureIds[1]);
+    expect(createFailureIds[1]).not.toBe(createFailureIds[2]);
+    expect(stuckIds[0]).toBe(stuckIds[1]);
+    expect(createFailureIds[0]).not.toBe(stuckIds[0]);
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+  });
+
+  test("dropped alerts stay quiet outside production", async () => {
     const fetchMock = mock(async () => new Response("ok")) as unknown as typeof fetch;
 
-    reportDroppedVmAlerts(
+    await reportDroppedVmAlerts(
       [{ key: "k", title: "t", body: "b", severity: "warning" }],
       { env: {}, fetch: fetchMock },
     );

--- a/web/tests/vm-alerts.test.ts
+++ b/web/tests/vm-alerts.test.ts
@@ -114,7 +114,7 @@ describe("VM alert checks", () => {
       },
       sendAlert: async (input): Promise<AlertResult> => {
         alerts.push(input);
-        return { sent: true, status: 200 };
+        return { sent: true, configured: true, status: 200 };
       },
     });
 
@@ -122,6 +122,7 @@ describe("VM alert checks", () => {
       createFailures: { triggered: true, count: 3 },
       stuckProvisioning: { triggered: true, count: 1 },
       expiredUnrevokedLeases: { triggered: true, count: 51 },
+      alertSink: { configured: false, droppedAlerts: 0 },
     });
     expect(alerts.map((alert) => alert.key)).toEqual([
       "vm-create-failure-spike",

--- a/web/tests/vm-create-kill-switch.test.ts
+++ b/web/tests/vm-create-kill-switch.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+
+import { assertVmCreateEnabled, vmCreateDisabledReason } from "../services/vms/config";
+import { isVmCreateDisabledError } from "../services/vms/errors";
+
+describe("VM create kill switch", () => {
+  test("unset flags mean enabled", () => {
+    expect(vmCreateDisabledReason("blaxel", {})).toBeNull();
+    expect(vmCreateDisabledReason("freestyle", {})).toBeNull();
+  });
+
+  test("the global flag disables every provider", () => {
+    expect(vmCreateDisabledReason("blaxel", { CMUX_VM_CREATE_ENABLED: "0" })).toContain("disabled");
+    expect(vmCreateDisabledReason("freestyle", { CMUX_VM_CREATE_ENABLED: "off" })).toContain("disabled");
+  });
+
+  test("a provider flag disables only that provider", () => {
+    const env = { CMUX_VM_BLAXEL_ENABLED: "false" };
+    expect(vmCreateDisabledReason("blaxel", env)).toContain("blaxel");
+    expect(vmCreateDisabledReason("freestyle", env)).toBeNull();
+  });
+
+  test("assertVmCreateEnabled throws the typed error", () => {
+    try {
+      assertVmCreateEnabled("e2b", { CMUX_VM_E2B_ENABLED: "0" });
+      throw new Error("expected VmCreateDisabledError");
+    } catch (err) {
+      expect(isVmCreateDisabledError(err)).toBe(true);
+    }
+  });
+});

--- a/web/tests/vm-observability.test.ts
+++ b/web/tests/vm-observability.test.ts
@@ -189,6 +189,34 @@ describe("cloud_vm_provision capture", () => {
     expect(properties.operator_fault).toBe(true);
   });
 
+  test("fork and restore failures carry their operation", () => {
+    for (const operation of ["fork", "restore"] as const) {
+      const seen: { body: Record<string, unknown> | null } = { body: null };
+      const fakeFetch = ((input: string | URL | Request, init?: RequestInit) => {
+        void input;
+        seen.body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        return Promise.resolve(new Response("ok"));
+      }) as typeof fetch;
+      captureVmProvisionOutcome(
+        {
+          userId: "user-1",
+          operation,
+          response: vmErrorResponse({
+            error: "vm_create_failed",
+            status: 500,
+            message: "boom",
+            action: "retry",
+            phase: "create",
+          }),
+        },
+        { fetch: fakeFetch, env: { CMUX_VM_ANALYTICS_FORCE: "1" } },
+      );
+      const properties = seen.body?.properties as Record<string, unknown>;
+      expect(properties.operation).toBe(operation);
+      expect(properties.operator_fault).toBe(true);
+    }
+  });
+
   test("capture is disabled outside production unless forced", () => {
     let called = false;
     const fakeFetch = (() => {

--- a/web/tests/vm-route-auth.test.ts
+++ b/web/tests/vm-route-auth.test.ts
@@ -163,7 +163,7 @@ const { DELETE } = vmIdRoute;
 const attachRoute = await import("../app/api/vm/[id]/attach-endpoint/route");
 const cmuxRemoteApproveRoute = await import("../app/api/vm/[id]/cmux-remote/approve/route");
 const execRoute = await import("../app/api/vm/[id]/exec/route");
-const _forkRoute = await import("../app/api/vm/[id]/fork/route");
+const forkRoute = await import("../app/api/vm/[id]/fork/route");
 const _snapshotRoute = await import("../app/api/vm/[id]/snapshot/route");
 const sshRoute = await import("../app/api/vm/[id]/ssh-endpoint/route");
 const restoreRoute = await import("../app/api/vm/restore/route");
@@ -1852,6 +1852,74 @@ describe("VM REST auth", () => {
     expectNoCloudVmImplementationLeaks(payload);
     expect(payload.action).toContain("enable Cloud VM creation");
     expect(runVmWorkflow).not.toHaveBeenCalled();
+  });
+
+  test("blocks VM restore kill switch before workflow", async () => {
+    process.env.CMUX_VM_CREATE_ENABLED = "0";
+    getUser.mockResolvedValue(authedStackUser());
+
+    const response = await restoreRoute.POST(
+      new Request("https://cmux.test/api/vm/restore", {
+        method: "POST",
+        headers: { origin: "https://cmux.test" },
+        body: JSON.stringify({ snapshotId: "snap-1", provider: "freestyle" }),
+      }),
+    );
+
+    expect(response.status).toBe(503);
+    const payload = await response.json();
+    expect(payload).toMatchObject({ error: "vm_create_disabled", phase: "create" });
+    expectNoCloudVmImplementationLeaks(payload);
+    expect(payload.action).toContain("enable Cloud VM creation");
+    expect(runVmWorkflow).not.toHaveBeenCalled();
+  });
+
+  test("blocks provider kill switch on restore before workflow", async () => {
+    process.env.CMUX_VM_E2B_ENABLED = "false";
+    getUser.mockResolvedValue(authedStackUser());
+
+    const response = await restoreRoute.POST(
+      new Request("https://cmux.test/api/vm/restore", {
+        method: "POST",
+        headers: { origin: "https://cmux.test" },
+        body: JSON.stringify({ snapshotId: "snap-1", provider: "e2b" }),
+      }),
+    );
+
+    expect(response.status).toBe(503);
+    const payload = await response.json();
+    expect(payload).toMatchObject({ error: "vm_create_disabled" });
+    expectNoCloudVmImplementationLeaks(payload);
+    expect(runVmWorkflow).not.toHaveBeenCalled();
+  });
+
+  test("maps the fork workflow kill switch without an internal error", async () => {
+    getUser.mockResolvedValue(authedStackUser());
+    rejectRunVmWorkflowWith(
+      new VmCreateDisabledError({
+        provider: "freestyle",
+        reason: "Cloud VM creation is disabled.",
+      }),
+    );
+
+    const response = await forkRoute.POST(
+      new Request("https://cmux.test/api/vm/provider-vm-1/fork", {
+        method: "POST",
+        headers: { origin: "https://cmux.test" },
+        body: JSON.stringify({}),
+      }),
+      { params: Promise.resolve({ id: "provider-vm-1" }) },
+    );
+
+    expect(response.status).toBe(503);
+    const payload = await response.json();
+    expect(payload).toMatchObject({
+      error: "vm_create_disabled",
+      reason: "Cloud VM creation is disabled.",
+      phase: "create",
+    });
+    expectNoCloudVmImplementationLeaks(payload);
+    expect(runVmWorkflow).toHaveBeenCalled();
   });
 
   test("requires manifest images in deployed environments before workflow", async () => {


### PR DESCRIPTION
Closes four incident-containment and observability holes in the Cloud VM API.

**Kill switch.** `POST /api/vm/restore` and `POST /api/vm/[id]/fork` provision machines but ignored `assertVmCreateEnabled`, so an operator flipping `CMUX_VM_CREATE_ENABLED=0` (or a provider flag) during an incident only stopped create and base open/reset. Restore now checks at the route, before any team refresh, since its provider is explicit in the body. Fork checks inside the workflow via a new non-throwing `vmCreateDisabledReason` helper, because its provider is only known once the source VM row loads; the existing `vmWorkflowErrorResponse` mapping turns that typed failure into the standard 503 `vm_create_disabled`.

**Provision telemetry.** `captureVmProvisionOutcome` now runs as a response finalizer on fork and restore (operations `fork` and `restore`), so their failures reach the `cloud_vm_provision` PostHog signal that feeds the create-failure alert instead of being invisible.

**maxDuration.** No route under `web/app/api/vm/**` exported `maxDuration`, so long provisioning and exec died at the platform default. Create, fork, restore, base open, base reset, and snapshot get 600s: cold provisioning runs minutes, and 600s caps a hung provider call below the 20-minute stuck-provisioning alert. Exec gets 960s because its client-facing `timeoutMs` ceiling is 900s and the budget must outlive it. The plan allows these values (`app/v1/responses/route.ts` already uses 1800).

**Env audit.** `requiredRuntimeEnvKeys` now includes what the prod Blaxel path depends on: `BL_API_KEY`, `BL_WORKSPACE`, `BLAXEL_SANDBOX_IMAGE`, `CRON_SECRET`, `CMUX_ALERTS_SLACK_WEBHOOK_URL`. Verified against the live prod env (`vercel env pull`): all are set except `CMUX_ALERTS_SLACK_WEBHOOK_URL`, so the daily audit goes red until an operator adds the Slack webhook. That red is the point of this PR: prod VM alerts currently drop silently. `CMUX_VM_BLAXEL_ENABLED` and `BLAXEL_SANDBOX_DESKTOP_IMAGE` are recommended, not required: unset is a valid enabled state for the off-only kill switches, and desktop creates fall back to the generic selector (`resolveByKind` in `services/vms/images/resolver.ts`), so requiring them would fail a healthy deployment.

**Loud unconfigured alerts.** `sendAlert` silently no-oped with no webhook and the cron returned a bare 200. `AlertResult` now carries `configured`, the cron response exposes `configured` at the top level, and when a triggered alert has no sink in production, `reportDroppedVmAlerts` emits a PostHog `cloud_vm_alert_dropped` operator-fault event plus a scrubbed structured error (Sentry when a DSN exists). Dev and preview stay quiet; the daily env audit covers the config gap on days with no incident.

Follow-up candidate (not in this PR): an async-create flow so create/fork/restore return early with a provisioning handle instead of holding a function invocation for the whole cold provision.

Tests: kill-switch route tests for restore, workflow-mapping test for fork, fork/restore capture tests, dropped-alert reporting tests, audit key-list guard tests, and a `vmCreateDisabledReason` unit test. `bun run typecheck` clean; 96 tests pass across the six touched files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790760647&installation_model_id=21920&pr_number=11252&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11252&signature=01ba5f0915bf788c854569e941baba26363c77b053e9db55c00eb5831cf4dfa1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four incident-containment and observability holes in the VM API: fork/restore now honor the create kill switch, provisioning telemetry covers them, route timeouts are explicit, and unconfigured alert sinks no longer fail silent.

**Bug Fixes**

- `POST /api/vm/restore` and `POST /api/vm/[id]/fork` kept provisioning machines when creation was disabled; both now return 503 `vm_create_disabled` (restore at the route, fork inside the workflow once the source provider is known).
- Every VM provisioning route and exec now exports `maxDuration` (600s, 960s for exec) so long cold provisions and commands no longer hit the platform default.

**Observability**

- Fork and restore failures now produce `cloud_vm_provision` PostHog events, so the create-failure alert sees them.
- Triggered alerts with no Slack webhook emit a `cloud_vm_alert_dropped` PostHog event plus a structured error in production instead of a silent 200; the cron response exposes sink config, the report is awaited before the cron returns and deduped per alert per day, and dev and preview stay quiet.
- The env audit now requires the prod Blaxel and alert keys (`BL_API_KEY`, `BL_WORKSPACE`, `BLAXEL_SANDBOX_IMAGE`, `CRON_SECRET`, `CMUX_ALERTS_SLACK_WEBHOOK_URL`); prod lacks the webhook, so the audit stays red until an operator adds it.

<sup>Written for commit 04b3c0fab573dd5f73063ca5acd5bb20b5ac7f81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added safeguards to disable VM creation globally or for specific providers, with clear service-unavailable responses.
  - Added visibility into alert delivery configuration and dropped alerts.
  - Extended provisioning monitoring to include VM forks and restores.
  - Added required and recommended environment settings for VM, desktop, alerting, and scheduled-task features.

- **Bug Fixes**
  - Increased execution limits for long-running VM operations and command execution.
  - Improved production reporting for undelivered alerts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->