### PR TITLE
web: keep test-suite analytics out of production PostHog; real principal ids on checkout events

### DIFF
--- a/web/app/api/billing/checkout/route.ts
+++ b/web/app/api/billing/checkout/route.ts
@@ -142,6 +142,9 @@ async function stripeProCheckout(
     if (isAccountDeletionInProgress(user)) {
       return accountDeletionCheckoutRedirect(request);
     }
+    // `or: "anonymous"` creates/returns the real Stack anonymous principal.
+    // Keep that id as the source of truth for Stripe and checkout analytics.
+    const stackUserId = checkoutPrincipalId(user.id, "user");
 
     const status = await resolveProPlanStatus(user);
     if (status.isPro) {
@@ -154,7 +157,7 @@ async function stripeProCheckout(
     const cancelUrl = new URL("/pricing?billing=cancelled", request.nextUrl.origin);
     cancelUrl.searchParams.set("interval", interval);
     const metadata = {
-      stackUserId: user.id,
+      stackUserId,
       plan: "pro",
       app: "cmux",
       billingInterval: interval,
@@ -169,7 +172,7 @@ async function stripeProCheckout(
           quantity: 1,
         },
       ],
-      client_reference_id: user.id,
+      client_reference_id: stackUserId,
       metadata,
       subscription_data: { metadata },
       customer_email: !user.isAnonymous && user.primaryEmail ? user.primaryEmail : undefined,
@@ -177,10 +180,12 @@ async function stripeProCheckout(
       success_url: successUrl,
       cancel_url: cancelUrl.toString(),
     });
-    if (!session.url) throw new Error("Stripe Checkout Session did not include a URL");
+    if (!usableCheckoutSession(session)) {
+      throw new Error("Stripe Checkout Session did not include an id and URL");
+    }
     deferCheckoutAnalytics(() => captureBillingCheckoutStarted({
       sessionId: session.id,
-      subject: { scope: "user", stackUserId: user.id },
+      subject: { scope: "user", stackUserId },
       plan: "pro",
       billingInterval: interval,
     }));
@@ -209,11 +214,9 @@ async function stripeTeamCheckout(
     if (isAccountDeletionInProgress(user)) {
       return accountDeletionCheckoutRedirect(request);
     }
+    const stackUserId = checkoutPrincipalId(user.id, "user");
     const team = await checkoutTeamCustomer(user);
-    const resolvedTeamId = team.id;
-    if (!resolvedTeamId) {
-      throw new Error("Stack team checkout customer is missing an id");
-    }
+    const resolvedTeamId = checkoutPrincipalId(team.id, "team");
     teamId = resolvedTeamId;
 
     const successUrl =
@@ -229,7 +232,7 @@ async function stripeTeamCheckout(
       nativeCallbackScheme: callbackScheme,
     };
 
-    const customerId = await stripeCustomerForTeam(team, user.id);
+    const customerId = await stripeCustomerForTeam(team, stackUserId);
     const session = await stripe().checkout.sessions.create({
       mode: "subscription",
       line_items: [
@@ -250,7 +253,9 @@ async function stripeTeamCheckout(
       success_url: successUrl,
       cancel_url: cancelUrl.toString(),
     });
-    if (!session.url) throw new Error("Stripe Checkout Session did not include a URL");
+    if (!usableCheckoutSession(session)) {
+      throw new Error("Stripe Checkout Session did not include an id and URL");
+    }
     deferCheckoutAnalytics(() => captureBillingCheckoutStarted({
       sessionId: session.id,
       subject: { scope: "team", stackTeamId: resolvedTeamId },
@@ -272,6 +277,26 @@ async function stripeTeamCheckout(
 function accountDeletionCheckoutRedirect(request: NextRequest) {
   return NextResponse.redirect(
     new URL("/pricing?billing=account_deletion_in_progress", request.url),
+  );
+}
+
+function checkoutPrincipalId(value: unknown, kind: "user" | "team"): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`Stack ${kind} checkout principal is missing an id`);
+  }
+  return value;
+}
+
+function usableCheckoutSession(
+  value: unknown,
+): value is { readonly id: string; readonly url: string } {
+  if (!value || typeof value !== "object") return false;
+  const session = value as { readonly id?: unknown; readonly url?: unknown };
+  return (
+    typeof session.id === "string" &&
+    session.id.trim().length > 0 &&
+    typeof session.url === "string" &&
+    session.url.trim().length > 0
   );
 }
 

--- a/web/services/analytics/iosEventPolicy.ts
+++ b/web/services/analytics/iosEventPolicy.ts
@@ -9,6 +9,22 @@ export const POSTHOG_PROJECT_KEY =
 /** The PostHog capture host (no trailing slash). */
 export const POSTHOG_HOST = (process.env.POSTHOG_HOST ?? "https://r.cmux.com").replace(/\/$/, "");
 
+/**
+ * Test runners must never use the production PostHog transport by default.
+ * The explicit marker is set by the web test preload; NODE_ENV and VITEST
+ * also cover direct module tests that do not load that preload.
+ */
+export function isAnalyticsTestRun(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  return (
+    env.CMUX_ANALYTICS_TEST_MODE === "1" ||
+    env.NODE_ENV === "test" ||
+    env.VITEST === "true" ||
+    env.VITEST === "1"
+  );
+}
+
 /** Max request size for an analytics batch. */
 export const MAX_ANALYTICS_REQUEST_BYTES = 64 * 1024;
 

--- a/web/services/analytics/stripeBilling.ts
+++ b/web/services/analytics/stripeBilling.ts
@@ -1,6 +1,7 @@
 import type Stripe from "stripe";
 
 import {
+  isAnalyticsTestRun,
   POSTHOG_HOST,
   POSTHOG_PROJECT_KEY,
 } from "./iosEventPolicy";
@@ -29,7 +30,7 @@ export type StripeBillingAnalyticsSubject =
 export async function captureStripeBillingEvent(
   event: Stripe.Event,
   subject: StripeBillingAnalyticsSubject,
-  postHogFetch: typeof fetch = fetch,
+  postHogFetch?: typeof fetch,
 ): Promise<void> {
   const mapped = mappedBillingEvent(event, subject);
   if (!mapped) return;
@@ -49,7 +50,7 @@ export async function captureBillingCheckoutStarted(
     readonly plan: "pro" | "team";
     readonly billingInterval: "month" | "year";
   },
-  postHogFetch: typeof fetch = fetch,
+  postHogFetch?: typeof fetch,
 ): Promise<void> {
   await captureBillingPayload({
     name: "cmux_billing_checkout_started",
@@ -160,10 +161,12 @@ function mappedBillingEvent(
   }
 }
 
-function subjectDistinctId(subject: StripeBillingAnalyticsSubject): string {
-  return subject.scope === "user"
+function subjectDistinctId(subject: StripeBillingAnalyticsSubject): string | null {
+  const principalId = subject.scope === "user"
     ? subject.stackUserId
-    : `stack-team:${subject.stackTeamId}`;
+    : subject.stackTeamId;
+  if (typeof principalId !== "string" || principalId.trim().length === 0) return null;
+  return subject.scope === "user" ? principalId : `stack-team:${principalId}`;
 }
 
 async function captureBillingPayload(
@@ -173,13 +176,21 @@ async function captureBillingPayload(
     readonly subject: StripeBillingAnalyticsSubject;
     readonly properties: Record<string, unknown>;
   },
-  postHogFetch: typeof fetch,
+  postHogFetch?: typeof fetch,
 ): Promise<void> {
+  // The production transport is unavailable in test runs. An explicitly
+  // injected fetch remains a deliberate unit-test seam for payload mapping;
+  // normal callers omit it and fail closed here.
+  if (isAnalyticsTestRun() && !postHogFetch) return;
+  const fetchImpl = postHogFetch ?? fetch;
+  const distinctId = subjectDistinctId(input.subject);
+  if (!distinctId) return;
+
   const body = JSON.stringify({
     api_key: POSTHOG_PROJECT_KEY,
     event: input.name,
     properties: {
-      distinct_id: subjectDistinctId(input.subject),
+      distinct_id: distinctId,
       $insert_id: input.insertId,
       ...(input.subject.scope === "team"
         ? { $groups: { stack_team: input.subject.stackTeamId } }
@@ -189,7 +200,7 @@ async function captureBillingPayload(
   });
   for (let attempt = 0; attempt < 2; attempt += 1) {
     try {
-      const response = await postHogFetch(`${POSTHOG_HOST}/capture/`, {
+      const response = await fetchImpl(`${POSTHOG_HOST}/capture/`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body,

--- a/web/tests/billing-checkout-route.test.ts
+++ b/web/tests/billing-checkout-route.test.ts
@@ -121,7 +121,7 @@ mock.module("../services/billing/stripe", () => ({
 // Checkout tests must never exercise the real PostHog transport. The analytics
 // module has its own test-mode guard, but this route seam also lets these tests
 // assert the exact event contract without starting a background request.
-const captureBillingCheckoutStarted = mock(async (_input: unknown) => undefined);
+const captureBillingCheckoutStarted = mock(async () => undefined);
 mock.module("../services/analytics/stripeBilling", () => ({
   captureBillingCheckoutStarted,
 }));

--- a/web/tests/billing-checkout-route.test.ts
+++ b/web/tests/billing-checkout-route.test.ts
@@ -11,20 +11,25 @@ const realCloudDb = dbClientModule.cloudDb;
 const realCloseCloudDbForTests = dbClientModule.closeCloudDbForTests;
 const realCreateAwsRdsIamPool = dbClientModule.createAwsRdsIamPool;
 
+const SIGNED_IN_USER_ID = "7f5e4e80-3d96-4f6a-8f2e-3c1e4a4d0d01";
+const ANONYMOUS_USER_ID = "5a0f6f7a-7d9f-4bc5-a3be-2d11f7a6c902";
+const TEAM_ID = "9b6e2d4c-1a73-4f05-b8d9-6c0e2a5f3b14";
+const CHECKOUT_SESSION_ID = "cs_test_checkout";
+
 const teamCustomer = {
-  id: "team-signed-in",
+  id: TEAM_ID,
   displayName: "Signed Team",
   listUsers: mock(async () => [{ id: "member-1" }, { id: "member-2" }]),
 };
 const signedInUser = {
-  id: "user-signed-in",
+  id: SIGNED_IN_USER_ID,
   isAnonymous: false,
   primaryEmail: "signed@example.com",
   update: mock(async () => undefined),
   selectedTeam: null as null | typeof teamCustomer,
 };
 const anonymousUser = {
-  id: "user-anonymous",
+  id: ANONYMOUS_USER_ID,
   isAnonymous: true,
   primaryEmail: null,
   update: mock(async () => undefined),
@@ -41,9 +46,13 @@ const createdStripeSessions: unknown[] = [];
 const createdStripeCustomers: unknown[] = [];
 const insertedStripeCustomers: Record<string, unknown>[] = [];
 let stripeCustomerRows: { id: string }[] = [];
+let stripeSessionResponse: { readonly id?: string; readonly url?: string } = {
+  id: CHECKOUT_SESSION_ID,
+  url: "https://checkout.stripe.com/c/session",
+};
 const createStripeSession = mock(async (params: unknown) => {
   createdStripeSessions.push(params);
-  return { url: "https://checkout.stripe.com/c/session" };
+  return stripeSessionResponse;
 });
 const createStripeCustomer = mock(async (params: unknown) => {
   createdStripeCustomers.push(params);
@@ -109,6 +118,14 @@ mock.module("../services/billing/stripe", () => ({
   }),
 }));
 
+// Checkout tests must never exercise the real PostHog transport. The analytics
+// module has its own test-mode guard, but this route seam also lets these tests
+// assert the exact event contract without starting a background request.
+const captureBillingCheckoutStarted = mock(async (_input: unknown) => undefined);
+mock.module("../services/analytics/stripeBilling", () => ({
+  captureBillingCheckoutStarted,
+}));
+
 const { GET } = await import("../app/api/billing/checkout/route");
 
 beforeAll(() => {
@@ -136,10 +153,15 @@ describe("billing checkout route", () => {
     createdStripeCustomers.length = 0;
     insertedStripeCustomers.length = 0;
     stripeCustomerRows = [];
+    stripeSessionResponse = {
+      id: CHECKOUT_SESSION_ID,
+      url: "https://checkout.stripe.com/c/session",
+    };
     createStripeSession.mockClear();
     createStripeCustomer.mockClear();
     resolveProPrice.mockClear();
     resolveTeamPrice.mockClear();
+    captureBillingCheckoutStarted.mockClear();
     stripeLimit.mockClear();
     stripeLimit.mockResolvedValue([]);
   });
@@ -384,16 +406,16 @@ describe("billing checkout route", () => {
     expect(createdStripeSessions[0]).toMatchObject({
       mode: "subscription",
       line_items: [{ price: "price_month", quantity: 1 }],
-      client_reference_id: "user-anonymous",
+      client_reference_id: ANONYMOUS_USER_ID,
       metadata: {
-        stackUserId: "user-anonymous",
+        stackUserId: ANONYMOUS_USER_ID,
         plan: "pro",
         app: "cmux",
         billingInterval: "month",
       },
       subscription_data: {
         metadata: {
-          stackUserId: "user-anonymous",
+          stackUserId: ANONYMOUS_USER_ID,
           plan: "pro",
           app: "cmux",
           billingInterval: "month",
@@ -405,6 +427,30 @@ describe("billing checkout route", () => {
         "https://cmux.test/api/billing/complete?session_id={CHECKOUT_SESSION_ID}&cmux_scheme=cmux",
       cancel_url: "https://cmux.test/pricing?billing=cancelled&interval=month",
     });
+    expect(captureBillingCheckoutStarted).toHaveBeenCalledTimes(1);
+    expect(captureBillingCheckoutStarted).toHaveBeenCalledWith({
+      sessionId: CHECKOUT_SESSION_ID,
+      subject: { scope: "user", stackUserId: ANONYMOUS_USER_ID },
+      plan: "pro",
+      billingInterval: "month",
+    });
+  });
+
+  test("does not capture checkout analytics when Stripe returns no session id", async () => {
+    stripeConfigured = true;
+    stripeSessionResponse = {
+      url: "https://checkout.stripe.com/c/session",
+    };
+    userResponses = [null, anonymousUser];
+
+    const response = await GET(
+      new NextRequest("https://cmux.test/api/billing/checkout"),
+    );
+
+    expect(response.headers.get("location")).toBe(
+      "https://cmux.test/pricing?billing=error",
+    );
+    expect(captureBillingCheckoutStarted).not.toHaveBeenCalled();
   });
 
   test("bounds Stack Auth failures before creating a checkout", async () => {
@@ -467,6 +513,13 @@ describe("billing checkout route", () => {
       subscription_data: { metadata: { billingInterval: "year" } },
       cancel_url: "https://cmux.test/pricing?billing=cancelled&interval=year",
     });
+    expect(captureBillingCheckoutStarted).toHaveBeenCalledTimes(1);
+    expect(captureBillingCheckoutStarted).toHaveBeenCalledWith({
+      sessionId: CHECKOUT_SESSION_ID,
+      subject: { scope: "user", stackUserId: SIGNED_IN_USER_ID },
+      plan: "pro",
+      billingInterval: "year",
+    });
   });
 
   test("rejects dev callback schemes on non-local Stripe checkout hosts", async () => {
@@ -497,12 +550,12 @@ describe("billing checkout route", () => {
     expect(resolveTeamPrice).toHaveBeenCalledWith("month");
     expect(createStripeCustomer).toHaveBeenCalledWith({
       name: "Signed Team",
-      metadata: { stackTeamId: "team-signed-in", app: "cmux" },
+      metadata: { stackTeamId: TEAM_ID, app: "cmux" },
     });
     expect(insertedStripeCustomers).toContainEqual({
       id: "cus_team",
-      stackUserId: "user-signed-in",
-      stackTeamId: "team-signed-in",
+      stackUserId: SIGNED_IN_USER_ID,
+      stackTeamId: TEAM_ID,
       email: null,
     });
     expect(createdStripeSessions[0]).toMatchObject({
@@ -515,16 +568,16 @@ describe("billing checkout route", () => {
         },
       ],
       customer: "cus_team",
-      client_reference_id: "team-signed-in",
+      client_reference_id: TEAM_ID,
       metadata: {
-        stackTeamId: "team-signed-in",
+        stackTeamId: TEAM_ID,
         plan: "team",
         app: "cmux",
         billingInterval: "month",
       },
       subscription_data: {
         metadata: {
-          stackTeamId: "team-signed-in",
+          stackTeamId: TEAM_ID,
           plan: "team",
           app: "cmux",
           billingInterval: "month",
@@ -534,6 +587,13 @@ describe("billing checkout route", () => {
       success_url:
         "https://cmux.test/api/billing/complete?session_id={CHECKOUT_SESSION_ID}&cmux_scheme=cmux",
       cancel_url: "https://cmux.test/pricing?billing=cancelled&interval=month",
+    });
+    expect(captureBillingCheckoutStarted).toHaveBeenCalledTimes(1);
+    expect(captureBillingCheckoutStarted).toHaveBeenCalledWith({
+      sessionId: CHECKOUT_SESSION_ID,
+      subject: { scope: "team", stackTeamId: TEAM_ID },
+      plan: "team",
+      billingInterval: "month",
     });
   });
 

--- a/web/tests/stripe-billing-analytics.test.ts
+++ b/web/tests/stripe-billing-analytics.test.ts
@@ -7,6 +7,27 @@ import {
 } from "../services/analytics/stripeBilling";
 
 describe("Stripe billing analytics", () => {
+  test("does not use the real transport in a test process", async () => {
+    const originalFetch = globalThis.fetch;
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls += 1;
+      return new Response(null, { status: 200 });
+    }) as typeof fetch;
+    try {
+      await captureBillingCheckoutStarted({
+        sessionId: "cs_test_guard",
+        subject: { scope: "user", stackUserId: "stack-user-test" },
+        plan: "pro",
+        billingInterval: "month",
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(calls).toBe(0);
+  });
+
   test("joins paid checkout events to the Stack PostHog identity", async () => {
     let capturedInit: RequestInit | undefined;
     const postHogFetch = (async (_input: string | URL | Request, init?: RequestInit) => {

--- a/web/tests/test-preload.ts
+++ b/web/tests/test-preload.ts
@@ -8,6 +8,13 @@
 // removes the ordering dependency. Individual suites may still override these
 // at their own top level.
 process.env.SKIP_ENV_VALIDATION = "1";
+// Billing analytics has a production key/host fallback. Mark every Bun test
+// process so the analytics transport fails closed before any test module loads.
+process.env.CMUX_ANALYTICS_TEST_MODE = "1";
+// Also replace the fallback credentials and host. This protects analytics
+// senders that do not yet use the module-level test guard.
+process.env.POSTHOG_PROJECT_KEY = "phc_test_only";
+process.env.POSTHOG_HOST = "http://127.0.0.1:1";
 process.env.RESEND_API_KEY ??= "re_test";
 process.env.STRIPE_FOUNDERS_WEBHOOK_SECRET ??= "whsec_founders_test";
 process.env.CMUX_FEEDBACK_FROM_EMAIL ??= "founders@manaflow.com";


### PR DESCRIPTION
## Summary

- Prevent billing analytics from using the PostHog network transport in test runs.
- Hard-pin test PostHog credentials to a dummy key and loopback host.
- Require a non-empty Stack principal and a real Stripe Checkout Session id and URL before emitting `cmux_billing_checkout_started`.
- Keep one best-effort capture after each successful Pro or Team session creation.

## Root cause

The sender was `web/services/analytics/stripeBilling.ts`. It imported `POSTHOG_PROJECT_KEY` and `POSTHOG_HOST` from `web/services/analytics/iosEventPolicy.ts`. When the variables were absent, that module used the live project key literal and the production proxy host `https://r.cmux.com`.

`web/tests/billing-checkout-route.test.ts` imported the real checkout route and did not mock the analytics module. In a Bun test there is no Next request work store, so `deferCheckoutAnalytics` caught the synchronous `after()` error and immediately ran `captureBillingCheckoutStarted`. The capture function then used the process global `fetch`. The Stripe test double returned a checkout URL but no `session.id`, which also produced `checkout-started:undefined`. The old test fixtures supplied the literal principals `user-anonymous`, `user-signed-in`, and `team-signed-in`.

A safe reproduction set `POSTHOG_HOST` to a loopback sink and ran the checkout test. One run generated seven `cmux_billing_checkout_started` payloads with `source: "checkout_route"`; the sink received them through the route fallback described above. The sink prevented any production request during reproduction.

Local direct `bun test` and `bun run test` use `web/bunfig.toml` and do not source `web/scripts/load-dev-env.sh`. With no `POSTHOG_PROJECT_KEY` or `POSTHOG_HOST` in the local test environment, the module defaults were therefore selected. A caller-provided value still wins over the default.

CI has the same path. The `web-typecheck` job in `.github/workflows/ci.yml` runs `bun install --frozen-lockfile`, `bun run typecheck`, and `bun run test`, with no PostHog override. It therefore had the same default key and host unless an ambient runner variable was present. The repository uses Bun tests, not Vitest; the guard also recognizes `NODE_ENV=test` and common `VITEST` values for direct Vitest invocation.

## Runtime identity and ordering

Stack `getUser({ or: "anonymous" })` creates or returns the real anonymous Stack user before Stripe session creation. The route now preserves and validates that `user.id` for Stripe metadata, `client_reference_id`, and the checkout-start subject. Team checkout validates both the initiating Stack user id and team id. Both branches require a non-empty Stripe session id and URL before scheduling analytics. The shared billing payload path now rejects missing principals, so the sibling Stripe webhook events receive the same identity and test-transport protection.

## Verification

- `bun run typecheck`
- `bun run test -- tests/stripe-billing-analytics.test.ts tests/billing-checkout-route.test.ts`: 26 passed
- Focused ESLint: clean
- Full `bun run test`: 1,600 passed, 175 skipped; four existing Stripe catalog process tests failed and two related errors occurred after their temporary curl log was missing following a 5-second timeout. No changed test failed.

## Trade-offs

- The test preload sets `CMUX_ANALYTICS_TEST_MODE=1` and hard-pins `POSTHOG_PROJECT_KEY=phc_test_only` plus `POSTHOG_HOST=http://127.0.0.1:1`. The billing module also checks `NODE_ENV` and `VITEST`. This is defense in depth for Bun preload, direct module tests, future test runners, and any sender that does not yet use the module guard.
- The module refuses its default transport in test mode. An explicitly injected `fetch` remains available as a unit-test seam for payload assertions; those tests provide an in-memory stub, not the production transport.
- The checkout route test mocks the analytics module as well as the module-level guard. This keeps route assertions synchronous and makes the exact once-per-session contract visible.
- IDs are validated as non-empty strings, rather than forced to a UUID format, because Stack is the authority and may use valid non-UUID identifiers.
- A Stripe session must have both `id` and `url`. A malformed provider response is treated as a checkout error, and no start event is sent.
- Analytics remains best effort and asynchronous after the Stripe mutation. An analytics outage cannot fail or retry a valid billing session.
- The test preload intentionally prevents developers from sending analytics to a local or staging PostHog project while tests run. Safety has priority over that use case.
- No production PostHog key or host was changed. The fix fences test execution and preserves the existing production transport configuration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved billing checkout reliability by validating checkout sessions before redirecting.
  - Ensured billing analytics use the correct checkout identity for user and team purchases.
  - Prevented analytics events from being sent when required identifiers or session data are missing.

- **Tests**
  - Expanded coverage for user and team checkout flows.
  - Added safeguards verifying analytics tests cannot trigger real network requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->