### PR TITLE
fix(tui): report dimensionless terminal clients as passive

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -8006,7 +8006,6 @@ impl Mux {
 
     pub fn control_clients_json(&self, requesting_client: u64) -> Value {
         let mut clients = self.control_clients.list_json(requesting_client);
-        let sizing = self.client_sizing.lock().unwrap();
         if let Some(clients) = clients.as_array_mut() {
             for info in clients {
                 let id = info.get("client").and_then(Value::as_u64).unwrap_or_default();
@@ -8015,11 +8014,12 @@ impl Mux {
                         let surface =
                             size.get("surface").and_then(Value::as_u64).unwrap_or_default();
                         size["size_participating"] =
-                            serde_json::json!(sizing.report_participates(surface, id));
+                            serde_json::json!(self.client_size_participates(surface, id));
                     }
                 }
             }
         }
+        let sizing = self.client_sizing.lock().unwrap();
         let local_sizes = sizing
             .surfaces
             .iter()

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -20260,6 +20260,37 @@ mod tests {
     }
 
     #[test]
+    fn dimensionless_terminal_client_reports_disabled_sizing_participation() {
+        let mux = test_mux();
+        let surface = mux.new_workspace(None, Some((80, 24))).unwrap();
+        let writer = test_writer();
+        let client = mux.control_clients.register(ClientTransport::Unix, writer.clone());
+        let stream = writer.start_stream(&json!({"event": "test"})).unwrap();
+        let stream_id = stream.id;
+        mux.control_clients.attach_surface(client, surface.id, stream).unwrap();
+        mux.control_clients.commit_surface(client, surface.id, stream_id, None).unwrap();
+
+        handle_command(
+            &mux,
+            client,
+            Command::SetClientSizing {
+                surface: surface.id,
+                client: Some(client),
+                enabled: false,
+                exclusive: false,
+            },
+            &writer,
+        )
+        .unwrap();
+
+        let listed = handle_command(&mux, client, Command::ListClients, &writer).unwrap();
+        assert_eq!(listed[0]["attached"], json!([surface.id]));
+        assert_eq!(listed[0]["sizes"][0]["cols"], Value::Null);
+        assert_eq!(listed[0]["sizes"][0]["rows"], Value::Null);
+        assert_eq!(listed[0]["sizes"][0]["size_participating"], false);
+    }
+
+    #[test]
     fn client_sizing_command_applies_exclusive_and_all_modes_atomically() {
         let mux = test_mux();
         let surface = mux.new_workspace(None, Some((120, 40))).unwrap();


### PR DESCRIPTION
## Problem

A terminal client can successfully opt out of surface sizing before it has ever reported `cols`/`rows`. `list-clients` then incorrectly reports `size_participating: true`: the reporting helper only recognizes terminal ownership through the lazily populated placement map and falls back to the legacy default for dimensionless clients.

This makes a successful `set-client-sizing enabled:false` response contradict the next sizing inspection.

## Change

- Treat an existing local size record with no dimensions and `size_participating:false` as authoritative for reporting.
- Keep the normal geometry-owner path unchanged once dimensions exist.
- Snapshot local size entries after the report helper calls so sizing and mux-state locks remain sequential rather than nested.
- Add regressions at both the mux helper and command/list-clients boundary.

No protocol, schema, binding, or generated artifact changes.

## Verification

- `cargo test -p cmux-tui-core server::tests::dimensionless_terminal_client_reports_disabled_sizing_participation -- --exact --nocapture`
- `cargo test -p cmux-tui-core mux::tests::client_sizing_reports_dimensionless_terminal_client_as_passive -- --exact --nocapture`
- `cargo test -p cmux-tui-core client_sizing -- --test-threads=1` (4 passed)
- `cargo build -p cmux-tui --bin cmux-tui`
- focused OMP review: clean, no actionable findings

A full serial crate run also exposed nine failures in current-main agent-hook/schema snapshot tests; they do not exercise the changed sizing path. The focused sizing slice is green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790775372&installation_model_id=21920&pr_number=11260&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11260&signature=34634d0fbb40ab38d72f9b8922107d8a1ee44083c4d11aa3ce44a4dd31896bbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `list-clients` reporting `size_participating: true` for terminal clients that opted out of sizing before ever reporting dimensions, so their successful `set-client-sizing enabled:false` response no longer contradicts the next sizing inspection.

- Treats an existing dimensionless local size record with `size_participating: false` as authoritative; the geometry-owner path is unchanged once dimensions exist.
- Moves the sizing lock acquisition after the report helper loop so sizing and mux-state locks stay sequential rather than nested.
- Adds regression tests at both the mux helper and command/`list-clients` boundary.

<sup>Written for commit 646292738b56baa2d84a200aaf2cd006bb533403. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Client listings now accurately reflect when terminal sizing participation is disabled.
  * Disabled sizing clients report unavailable dimensions instead of stale or misleading size values.

* **Tests**
  * Added coverage verifying client attachment status, null dimensions, and disabled sizing participation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->