### PR TITLE
iOS: reach the keyboard-clipped top rows in alt-screen TUIs (Claude Code)

### DIFF
--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+LocalPixelScroll.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+LocalPixelScroll.swift
@@ -280,8 +280,8 @@ extension GhosttySurfaceView {
             remainder = 0
         }
         // Two mismatches in one batch: same units the legacy line path derives
-        // from `enqueueScrollMechanicsDelta` (points = px/scale, divisor 3x
-        // cell height), so the fallback scrolls the same distance in rows.
+        // from `enqueueScrollMechanicsDelta` (one line per cell-height of
+        // travel), so the fallback scrolls the same distance in rows.
         let shouldLog = pixelState.withLock { state -> Bool in
             if state.epoch == operation.pixelStateEpoch {
                 state.remainderPx = 0
@@ -301,7 +301,7 @@ extension GhosttySurfaceView {
         ghostty_surface_mouse_scroll(
             operation.surface,
             0,
-            -deltaPixels / (cellHeightPx * 3),
+            -deltaPixels / cellHeightPx,
             0
         )
     }

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -340,13 +340,16 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         /// hijacking the gesture. Cleared on dock/typing snaps and surface
         /// replacement, where the live viewport becomes the truth again.
         var lastApplied: Held?
-        /// Device pixels of scroll-top reveal: how far past scrollback-top
-        /// the gesture has pulled, realized by the host sliding the
+        /// Device pixels of scroll-top reveal: how far the gesture has pulled
+        /// into the clipped-top zone, realized by the host sliding the
         /// bottom-pinned render back down to uncover the rows the keyboard-up
-        /// presentation clips above the screen. Only ever nonzero while the
-        /// grid sits at scrollback top; cleared everywhere `lastApplied` is,
-        /// plus on every keyboard leg (the budget it was granted against
-        /// changes with the keyboard).
+        /// presentation clips above the screen. On the primary screen it is
+        /// the pixel axis's continuation past scrollback-top (only nonzero at
+        /// position 0); on the line path (alt screens) it resolves before
+        /// wheel dispatch. Presentation-space, so the line path's routing
+        /// clear preserves it while dropping `lastApplied`; bottom snaps,
+        /// surface replacement, and every keyboard leg (the budget it was
+        /// granted against changes with the keyboard) still zero it.
         var topRevealPx: Double = 0
         #if DEBUG
         /// Rate-limits slow-batch perf log lines (scroll-hitch investigation).
@@ -2419,12 +2422,32 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
                 // carry a held anchor or re-assert into the TUI's screen.
                 pendingLocalScrollPixels = 0
                 pendingLocalPixelScrollReassert = false
+                // The keyboard-up bottom-pin clips the render's top above the
+                // screen on alt screens too, and wheel lines cannot reach it:
+                // a short TUI transcript has nothing to scroll, and a long one
+                // exhausts its history with the grid's top rows still hidden.
+                // Resolve the same top-reveal zone the pixel path owns before
+                // dispatching wheel lines (reveal-first in both directions —
+                // see `lineScrollTopRevealResolution`); the host's content cap
+                // follows the reveal on its display link, exactly as it does
+                // for the pixel path. The reveal is presentation-space, so
+                // unlike the held anchor it survives the routing flip.
+                let revealBudgetPx = hostedScrollTopRevealBudgetPx
+                let deltaPixels = pixels
+                var wheelDeltaPixels = deltaPixels
                 localPixelScrollState.withLock {
                     $0.epoch &+= 1
                     $0.remainderPx = 0
                     $0.lastApplied = nil
-                    $0.topRevealPx = 0
+                    let resolved = TerminalLetterboxGeometry.lineScrollTopRevealResolution(
+                        currentRevealPx: $0.topRevealPx,
+                        deltaPixels: deltaPixels,
+                        maxRevealPx: revealBudgetPx
+                    )
+                    $0.topRevealPx = resolved.revealPx
+                    wheelDeltaPixels = resolved.leftoverDeltaPixels
                 }
+                let wheelFraction = deltaPixels != 0 ? wheelDeltaPixels / deltaPixels : 1
                 // TUI scroll feel: dispatch whole lines only, carrying the
                 // fraction in its own accumulator, so the app sees clean
                 // steps instead of a 120Hz fragment stream; and cap the
@@ -2432,7 +2455,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
                 // full-screen app for seconds. The carry lives OUTSIDE
                 // pendingScrollLines so a sub-line leftover cannot re-trigger
                 // the flush every frame and churn interaction generations.
-                let totalLines = linePathFractionCarry + lines
+                let totalLines = linePathFractionCarry + lines * wheelFraction
                 let wholeLines = totalLines < 0
                     ? totalLines.rounded(.up)
                     : totalLines.rounded(.down)

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -2304,8 +2304,13 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // User-driven movement reveals the chip; this is guard-only work per
         // frame (the linger is armed by the gesture-end callbacks).
         noteArtifactChipScrollActivity()
+        // One wheel line per cell-height of finger travel: alt-screen content
+        // tracks the finger 1:1 in row units, the same pixels/cell-height
+        // conversion macOS ghostty applies to precise trackpad deltas. The
+        // 14pt fallback stands in for a typical cell height until metrics
+        // land.
         let cellHeightPt = cellPixelSize.height / max(preferredScreenScale, 1)
-        let divisor = cellHeightPt > 1 ? Double(cellHeightPt) * 3 : 42
+        let divisor = cellHeightPt > 1 ? Double(cellHeightPt) : 14
         pendingScrollLines += -Double(deltaY) / divisor
         // Same direction in device pixels: the pixel position is the viewport
         // top's distance from the top of scrollback, so a finger drag DOWN

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -2434,18 +2434,17 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
                 // unlike the held anchor it survives the routing flip.
                 let revealBudgetPx = hostedScrollTopRevealBudgetPx
                 let deltaPixels = pixels
-                var wheelDeltaPixels = deltaPixels
-                localPixelScrollState.withLock {
-                    $0.epoch &+= 1
-                    $0.remainderPx = 0
-                    $0.lastApplied = nil
+                let wheelDeltaPixels = localPixelScrollState.withLock { state -> Double in
+                    state.epoch &+= 1
+                    state.remainderPx = 0
+                    state.lastApplied = nil
                     let resolved = TerminalLetterboxGeometry.lineScrollTopRevealResolution(
-                        currentRevealPx: $0.topRevealPx,
+                        currentRevealPx: state.topRevealPx,
                         deltaPixels: deltaPixels,
                         maxRevealPx: revealBudgetPx
                     )
-                    $0.topRevealPx = resolved.revealPx
-                    wheelDeltaPixels = resolved.leftoverDeltaPixels
+                    state.topRevealPx = resolved.revealPx
+                    return resolved.leftoverDeltaPixels
                 }
                 let wheelFraction = deltaPixels != 0 ? wheelDeltaPixels / deltaPixels : 1
                 // TUI scroll feel: dispatch whole lines only, carrying the

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/LineScrollTopRevealTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/LineScrollTopRevealTests.swift
@@ -1,0 +1,144 @@
+#if canImport(UIKit)
+import CMUXMobileCore
+import CoreGraphics
+import Foundation
+import Testing
+@testable import CmuxMobileTerminal
+
+/// The keyboard-up top-reveal zone on the LINE scroll path (alternate-screen
+/// TUIs). The bottom-pinned full-height render clips its top rows above the
+/// screen while the keyboard is up; wheel lines are input for the TUI and can
+/// never reach those rows — a short transcript has nothing to scroll at all,
+/// and a long one exhausts its history with the grid's top rows still hidden.
+/// The line path must resolve the same reveal the pixel path owns: toward
+/// older content the reveal fills before any wheel lines dispatch, toward
+/// newer it drains first, and with the keyboard down every line reaches the
+/// TUI unchanged.
+@Suite("Line-path scroll top reveal")
+struct LineScrollTopRevealTests {
+    @MainActor
+    @Test("keyboard-up TUI scroll grants the reveal before any wheel lines")
+    func keyboardUpScrollGrantsRevealBeforeWheelLines() async throws {
+        let runtime = try GhosttyRuntime.shared()
+        let delegate = LineScrollDelegate()
+        let view = GhosttySurfaceView(runtime: runtime, delegate: delegate, fontSize: 10)
+        defer { view.prepareForDismantle() }
+        view.hostedAltScreenActive = true
+        view.setHostedKeyboardState(height: 300, isVisible: true)
+        #expect(view.hostedScrollTopRevealBudget == 300)
+
+        // Toward older content (negative deltaY), within the clipped-top
+        // budget: the render slides, the TUI sees nothing.
+        view.enqueueScrollMechanicsDelta(-120, touchPoint: CGPoint(x: 12, y: 18))
+        _ = await view.drainPendingScrollForVerifiedReplayReveal()
+
+        #expect(abs(view.hostedScrollTopReveal - 120) < 0.001)
+        #expect(delegate.scrollEvents.isEmpty)
+
+        // Past the budget: the reveal clamps full and only the leftover
+        // becomes wheel lines (positive = toward older content).
+        view.enqueueScrollMechanicsDelta(-300, touchPoint: CGPoint(x: 12, y: 18))
+        _ = await view.drainPendingScrollForVerifiedReplayReveal()
+
+        #expect(abs(view.hostedScrollTopReveal - 300) < 0.001)
+        #expect(!delegate.scrollEvents.isEmpty)
+        #expect(delegate.scrollEvents.allSatisfy { $0 > 0 })
+    }
+
+    @MainActor
+    @Test("scrolling toward newer content drains the reveal before wheeling the TUI")
+    func scrollTowardNewerDrainsRevealFirst() async throws {
+        let runtime = try GhosttyRuntime.shared()
+        let delegate = LineScrollDelegate()
+        let view = GhosttySurfaceView(runtime: runtime, delegate: delegate, fontSize: 10)
+        defer { view.prepareForDismantle() }
+        view.hostedAltScreenActive = true
+        view.setHostedKeyboardState(height: 300, isVisible: true)
+
+        view.enqueueScrollMechanicsDelta(-250, touchPoint: CGPoint(x: 12, y: 18))
+        _ = await view.drainPendingScrollForVerifiedReplayReveal()
+        #expect(abs(view.hostedScrollTopReveal - 250) < 0.001)
+        #expect(delegate.scrollEvents.isEmpty)
+
+        // Back toward newer: the granted reveal absorbs the delta; the TUI
+        // still sees nothing.
+        view.enqueueScrollMechanicsDelta(150, touchPoint: CGPoint(x: 12, y: 18))
+        _ = await view.drainPendingScrollForVerifiedReplayReveal()
+
+        #expect(abs(view.hostedScrollTopReveal - 100) < 0.001)
+        #expect(delegate.scrollEvents.isEmpty)
+    }
+
+    @MainActor
+    @Test("keyboard-down TUI scrolling is unchanged: every line reaches the app")
+    func keyboardDownForwardsAllLines() async throws {
+        let runtime = try GhosttyRuntime.shared()
+        let delegate = LineScrollDelegate()
+        let view = GhosttySurfaceView(runtime: runtime, delegate: delegate, fontSize: 10)
+        defer { view.prepareForDismantle() }
+        view.hostedAltScreenActive = true
+        #expect(view.hostedScrollTopRevealBudget == 0)
+
+        view.enqueueScrollMechanicsDelta(-120, touchPoint: CGPoint(x: 12, y: 18))
+        _ = await view.drainPendingScrollForVerifiedReplayReveal()
+
+        #expect(view.hostedScrollTopReveal == 0)
+        #expect(!delegate.scrollEvents.isEmpty)
+        #expect(delegate.scrollEvents.allSatisfy { $0 > 0 })
+    }
+
+    @MainActor
+    @Test("the routing clear still drops the held anchor but preserves the reveal")
+    func routingClearPreservesRevealWhileDroppingHeldAnchor() async throws {
+        let runtime = try GhosttyRuntime.shared()
+        let delegate = LineScrollDelegate()
+        let view = GhosttySurfaceView(runtime: runtime, delegate: delegate, fontSize: 10)
+        defer { view.prepareForDismantle() }
+        view.hostedAltScreenActive = true
+        view.setHostedKeyboardState(height: 300, isVisible: true)
+
+        view.enqueueScrollMechanicsDelta(-100, touchPoint: CGPoint(x: 12, y: 18))
+        _ = await view.drainPendingScrollForVerifiedReplayReveal()
+        #expect(abs(view.hostedScrollTopReveal - 100) < 0.001)
+
+        // A primary->alt flip mid-scroll leaves a held pixel anchor behind;
+        // the next line-path flush must drop it (it must never drive alt
+        // renders) without snapping the presentation-space reveal to zero.
+        view.localPixelScrollState.withLock {
+            $0.remainderPx = 3
+            $0.lastApplied = .init(
+                row: 12, remainderPx: 3, positionPx: 245, revision: 7,
+                total: 90, rowsPushed: 0, dockedAtTail: false
+            )
+        }
+        view.enqueueScrollMechanicsDelta(-50, touchPoint: CGPoint(x: 12, y: 18))
+        _ = await view.drainPendingScrollForVerifiedReplayReveal()
+
+        let state = view.localPixelScrollState.withLock {
+            (held: $0.lastApplied, remainder: $0.remainderPx)
+        }
+        #expect(state.held == nil)
+        #expect(state.remainder == 0)
+        #expect(abs(view.hostedScrollTopReveal - 150) < 0.001)
+    }
+}
+
+private final class LineScrollDelegate: NSObject, GhosttySurfaceViewDelegate {
+    private(set) var scrollEvents: [Double] = []
+
+    func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didProduceInput data: Data) {}
+    func ghosttySurfaceView(
+        _ surfaceView: GhosttySurfaceView,
+        didResize size: TerminalGridSize,
+        reportID: UInt64
+    ) {}
+    func ghosttySurfaceView(
+        _ surfaceView: GhosttySurfaceView,
+        didScrollLines lines: Double,
+        atCol col: Int,
+        row: Int
+    ) {
+        scrollEvents.append(lines)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalLetterboxGeometry.swift
+++ b/Packages/iOS/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalLetterboxGeometry.swift
@@ -266,6 +266,46 @@ public struct TerminalLetterboxGeometry {
         return (max(0, next), max(0, -next))
     }
 
+    /// Resolves one line-path (alternate-screen / TUI) scroll delta against
+    /// the keyboard top-reveal zone, returning the leftover delta that should
+    /// become mouse-wheel input for the app.
+    ///
+    /// The keyboard-up bottom-pin clips the render's top above the screen on
+    /// alternate screens too, but unlike the grid axis there is no scrollback
+    /// position to order the reveal against: wheel lines are input for the
+    /// TUI, and how much of them it consumes (or whether it scrolls at all)
+    /// is invisible to the phone. The reveal therefore resolves FIRST in both
+    /// directions — pulling toward older content grows it until the clipped
+    /// top is fully visible (those rows are the content adjacent above the
+    /// viewport), pushing toward newer drains it until the render is
+    /// re-pinned (bringing the TUI's bottom rows back from under the
+    /// keyboard) — and only the leftover is dispatched as wheel lines. Any
+    /// other ordering would need the TUI's scroll extent, which the wheel
+    /// protocol cannot report.
+    ///
+    /// - Parameters:
+    ///   - currentRevealPx: The reveal already granted, in device pixels; a
+    ///     value beyond the current budget is clamped before the delta
+    ///     applies (dropped entirely on a zero budget), never converted into
+    ///     wheel input.
+    ///   - deltaPixels: The gesture delta in device pixels (negative = toward
+    ///     older content).
+    ///   - maxRevealPx: The clipped-top budget in device pixels (0 whenever
+    ///     the keyboard is down).
+    /// - Returns: The next reveal, and the delta remaining for wheel
+    ///   dispatch (same sign as `deltaPixels`, or 0 when the reveal absorbed
+    ///   all of it).
+    public static func lineScrollTopRevealResolution(
+        currentRevealPx: Double,
+        deltaPixels: Double,
+        maxRevealPx: Double
+    ) -> (revealPx: Double, leftoverDeltaPixels: Double) {
+        let maxReveal = max(0, maxRevealPx)
+        let reveal = maxReveal > 0 ? min(max(0, currentRevealPx), maxReveal) : 0
+        let next = min(max(reveal - deltaPixels, 0), maxReveal)
+        return (next, deltaPixels + (next - reveal))
+    }
+
     /// The cell size in device pixels derived from a measured surface size.
     ///
     /// Returns `.zero` when any measured dimension is non-positive, matching the

--- a/Packages/iOS/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/ScrollTopRevealResolutionTests.swift
+++ b/Packages/iOS/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/ScrollTopRevealResolutionTests.swift
@@ -97,3 +97,69 @@ struct ScrollTopRevealResolutionTests {
         #expect(resolved.revealPx == 0)
     }
 }
+
+/// The line-path variant of the reveal axis: no grid position exists (wheel
+/// lines are TUI input with an unknowable extent), so the reveal resolves
+/// FIRST in both directions and the leftover delta is what reaches the app.
+@Suite("Line-path scroll top-reveal resolution")
+struct LineScrollTopRevealResolutionTests {
+    @Test("toward older content the reveal fills before any wheel delta leaks")
+    func olderFillsRevealFirst() {
+        let within = TerminalLetterboxGeometry.lineScrollTopRevealResolution(
+            currentRevealPx: 0,
+            deltaPixels: -180,
+            maxRevealPx: 250
+        )
+        #expect(within.revealPx == 180)
+        #expect(within.leftoverDeltaPixels == 0)
+
+        let past = TerminalLetterboxGeometry.lineScrollTopRevealResolution(
+            currentRevealPx: 180,
+            deltaPixels: -200,
+            maxRevealPx: 250
+        )
+        #expect(past.revealPx == 250)
+        #expect(past.leftoverDeltaPixels == -130)
+    }
+
+    @Test("toward newer content the reveal drains before any wheel delta leaks")
+    func newerDrainsRevealFirst() {
+        let within = TerminalLetterboxGeometry.lineScrollTopRevealResolution(
+            currentRevealPx: 250,
+            deltaPixels: 100,
+            maxRevealPx: 250
+        )
+        #expect(within.revealPx == 150)
+        #expect(within.leftoverDeltaPixels == 0)
+
+        let past = TerminalLetterboxGeometry.lineScrollTopRevealResolution(
+            currentRevealPx: 150,
+            deltaPixels: 400,
+            maxRevealPx: 250
+        )
+        #expect(past.revealPx == 0)
+        #expect(past.leftoverDeltaPixels == 250)
+    }
+
+    @Test("a zero budget drops a stale reveal without converting it into wheel delta")
+    func zeroBudgetDropsStaleReveal() {
+        let resolved = TerminalLetterboxGeometry.lineScrollTopRevealResolution(
+            currentRevealPx: 120,
+            deltaPixels: -100,
+            maxRevealPx: 0
+        )
+        #expect(resolved.revealPx == 0)
+        #expect(resolved.leftoverDeltaPixels == -100)
+    }
+
+    @Test("a shrunken budget clamps a held reveal before the delta applies")
+    func shrunkenBudgetClampsHeldReveal() {
+        let resolved = TerminalLetterboxGeometry.lineScrollTopRevealResolution(
+            currentRevealPx: 250,
+            deltaPixels: 0,
+            maxRevealPx: 100
+        )
+        #expect(resolved.revealPx == 100)
+        #expect(resolved.leftoverDeltaPixels == 0)
+    }
+}


### PR DESCRIPTION
With the keyboard up, the iOS terminal bottom-pins the keyboard-invariant grid and clips its top rows above the screen. The primary screen recovers them through the pixel-scroll top-reveal zone (https://github.com/manaflow-ai/cmux/pull/10885), but the alt-screen line path turned every gesture into mouse-wheel lines for the TUI and zeroed the reveal. In Claude Code that meant a short transcript could not scroll up at all, and a long one stopped with the top rows still hidden (Claude's history hits its top while the grid top stays clipped above the screen).

The line path now resolves the same top-reveal zone before dispatching wheel lines, via a pure resolver in `TerminalLetterboxGeometry.lineScrollTopRevealResolution`. The TUI's wheel consumption is invisible to the phone, so the reveal resolves first in both directions: scrolling toward older content fills it until the clipped top is visible, scrolling toward newer drains it until the render re-pins and the TUI's input row returns from under the keyboard; only the leftover delta becomes wheel lines. The reveal is presentation-space, so the line path's routing clear now preserves it while still dropping the held pixel anchor. Typing snaps and keyboard legs reset it as before, and the host's existing display-link content-cap follow does the actual render slide, unanimated while the finger owns the gesture.

Commit 1 adds the failing regression tests (line path granted no reveal and leaked every line to the TUI), commit 2 the fix plus resolver unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11265"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790793526&installation_model_id=21920&pr_number=11265&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11265&signature=8f012334c148e130973467c1f3cd39c5fd2c7d961050c24e1fdac2b9dcb80461"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the iOS alt-screen (TUI) scroll path so keyboard-clipped top rows are reachable in apps like Claude Code, and makes wheel lines track the finger 1:1 in row units.

- The top-reveal zone now resolves before wheel dispatch in both directions, so older content reveals the clipped top and newer drains until the input row returns; only leftover delta becomes wheel lines.
- Wheel lines now map one per cell-height of finger travel instead of three, matching macOS ghostty's precise trackpad conversion; the pixel-path fallback uses the same units.
- The presentation-space reveal survives the line path's routing clear while the held pixel anchor is still dropped; typing snaps and keyboard legs reset it as before.
- Keyboard-down scrolling is unchanged — every line still reaches the TUI.
- Adds regression tests for the unreachable rows and unit tests for `TerminalLetterboxGeometry.lineScrollTopRevealResolution`.

<sup>Written for commit 6f4c1f6b28db6a2291640d4497a30ca4ae4db1b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scrolling in alternate-screen and legacy terminal views when the on-screen keyboard clips the top rows.
  * Scrolling now reveals hidden content before forwarding remaining movement to the terminal, providing smoother and more accurate behavior.
  * Improved scroll sensitivity and handling when the keyboard is dismissed or the reveal area changes, preventing stale offsets.

* **Tests**
  * Added coverage for reveal, reverse scrolling, hidden-keyboard, and routing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Follow-up in the same PR: alt-screen wheel mapping is now finger-true — one wheel line per cell-height of travel instead of three, matching how macOS ghostty converts precise trackpad deltas, so TUI content tracks the finger 1:1 in row units and flicks cover 3x the distance within the same bounded momentum tail.
