### PR TITLE
Add red/green regression tests for the sidebar height-cache close fix

### DIFF
--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2212,6 +2212,7 @@
 		B804A02B000000000000002B /* SidebarWorkspaceRowChecklistSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B02B000000000000002B /* SidebarWorkspaceRowChecklistSection.swift */; };
 		970900020000000000000001 /* SidebarWorkspaceRowColorMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 970900020000000000000002 /* SidebarWorkspaceRowColorMenu.swift */; };
 		B804A0220000000000000022 /* SidebarWorkspaceRowCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0220000000000000022 /* SidebarWorkspaceRowCommands.swift */; };
+		B8624C9A000000000000009A /* SidebarWorkspaceRowHeightCacheRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8624D9A000000000000009A /* SidebarWorkspaceRowHeightCacheRegressionTests.swift */; };
 		B8624C990000000000000099 /* SidebarWorkspaceRowHeightInvariantTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8624D990000000000000099 /* SidebarWorkspaceRowHeightInvariantTests.swift */; };
 		B8624C0294950000000000A1 /* SidebarWorkspaceRowInlineRenameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8624D0294950000000000A1 /* SidebarWorkspaceRowInlineRenameTests.swift */; };
 		6707F0116707F0116707F011 /* SidebarWorkspaceRowInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6707F0126707F0126707F012 /* SidebarWorkspaceRowInput.swift */; };
@@ -5162,6 +5163,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		B804B02B000000000000002B /* SidebarWorkspaceRowChecklistSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/Cells/SidebarWorkspaceRowChecklistSection.swift; sourceTree = "<group>"; };
 		970900020000000000000002 /* SidebarWorkspaceRowColorMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/Cells/SidebarWorkspaceRowColorMenu.swift; sourceTree = "<group>"; };
 		B804B0220000000000000022 /* SidebarWorkspaceRowCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/Cells/SidebarWorkspaceRowCommands.swift; sourceTree = "<group>"; };
+		B8624D9A000000000000009A /* SidebarWorkspaceRowHeightCacheRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceRowHeightCacheRegressionTests.swift; sourceTree = "<group>"; };
 		B8624D990000000000000099 /* SidebarWorkspaceRowHeightInvariantTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceRowHeightInvariantTests.swift; sourceTree = "<group>"; };
 		B8624D0294950000000000A1 /* SidebarWorkspaceRowInlineRenameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceRowInlineRenameTests.swift; sourceTree = "<group>"; };
 		6707F0126707F0126707F012 /* SidebarWorkspaceRowInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceRowInput.swift; sourceTree = "<group>"; };
@@ -8883,6 +8885,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				B8624D050000000000000005 /* SidebarWorkspaceDropTargetSuspensionTests.swift */,
 				B8624D040000000000000004 /* SidebarWorkspaceRowRetirementTests.swift */,
 				B8624D990000000000000099 /* SidebarWorkspaceRowHeightInvariantTests.swift */,
+				B8624D9A000000000000009A /* SidebarWorkspaceRowHeightCacheRegressionTests.swift */,
 				B8624D030000000000000003 /* SidebarWorkspaceTableSuspensionTests.swift */,
 				D7AB34300000000000000106 /* SidebarTabDropIndicatorPredicateTests.swift */,
 				D73440010000000000000002 /* SidebarTabDragPayloadProviderTests.swift */,
@@ -12237,6 +12240,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C9A57303C9A57303C9A57303 /* SidebarWorkspaceGroupHeaderMetricsTests.swift in Sources */,
 				6707F0236707F0236707F023 /* SidebarWorkspaceNotificationIndexTests.swift in Sources */,
 				C9A57305C9A57305C9A57305 /* SidebarWorkspaceReorderDropOverlayHitTestingTests.swift in Sources */,
+				B8624C9A000000000000009A /* SidebarWorkspaceRowHeightCacheRegressionTests.swift in Sources */,
 				B8624C990000000000000099 /* SidebarWorkspaceRowHeightInvariantTests.swift in Sources */,
 				B8624C0294950000000000A1 /* SidebarWorkspaceRowInlineRenameTests.swift in Sources */,
 				B8624C040000000000000004 /* SidebarWorkspaceRowRetirementTests.swift in Sources */,

--- a/cmuxTests/HiddenRightSidebarContentMountingTests.swift
+++ b/cmuxTests/HiddenRightSidebarContentMountingTests.swift
@@ -73,7 +73,8 @@ struct HiddenRightSidebarContentMountingTests {
             onResumeSession: nil,
             onOpenFilePreview: { _ in },
             onOpenAsPane: { _ in },
-            onClose: {}
+            onClose: {},
+            customSidebarDataContext: { _ in [:] }
         )
         let hostingView = NSHostingView(rootView: rootView)
         hostingView.frame = window.contentRect(forFrameRect: window.frame)

--- a/cmuxTests/SidebarWorkspaceRowHeightCacheRegressionTests.swift
+++ b/cmuxTests/SidebarWorkspaceRowHeightCacheRegressionTests.swift
@@ -1,0 +1,159 @@
+import AppKit
+import Testing
+@testable import cmux_DEV
+
+/// Red/green regression coverage for the sidebar close-clipping fix
+/// (https://github.com/manaflow-ai/cmux/pull/11242). Closing a workspace
+/// shifts `index` and `isFirstRow` for every row below it; before the fix the
+/// height cache keyed on full model equality, so a close both forgot the
+/// cached height of the entire tail (losing the content-matched entries the
+/// stale-width `height(for:)` fallback depends on) and re-measured every
+/// surviving row through hosted layout. These tests fail on the pre-fix
+/// cache (`hasEquivalentContent` keying) and pass on
+/// `hasEquivalentHeightContent`.
+@Suite
+@MainActor
+struct SidebarWorkspaceRowHeightCacheRegressionTests {
+    @Test
+    func cacheServesCachedHeightAcrossTheIndexShiftACloseCauses() {
+        let cache = SidebarWorkspaceTableRowHeightCache()
+        var model = SidebarWorkspaceRowSuspensionTests.makeModel(
+            customDescription: "This workspace description wraps across several sidebar lines"
+        )
+        model.index = 3
+        model.isFirstRow = false
+        let prepared = cache.prepare(
+            rows: [makeConfiguration(model: model)],
+            columnWidth: 300
+        ) { _, _ in 57 }
+        #expect(prepared == IndexSet(integer: 0))
+
+        // A close above this row shifts it up one slot; nothing that affects
+        // its measured height changed, so the cached height must survive.
+        var shifted = model
+        shifted.index = 2
+        #expect(cache.height(for: makeConfiguration(model: shifted), columnWidth: 300) == 57)
+
+        // Promotion to first row is the same shift for the head's successor.
+        var promoted = model
+        promoted.index = 0
+        promoted.isFirstRow = true
+        #expect(cache.height(for: makeConfiguration(model: promoted), columnWidth: 300) == 57)
+    }
+
+    @Test
+    func closeDoesNotRemeasureTheSurvivingTail() {
+        let cache = SidebarWorkspaceTableRowHeightCache()
+        let models = (0..<5).map { index in
+            var model = SidebarWorkspaceRowSuspensionTests.makeModel(
+                customDescription: "This workspace description wraps across several sidebar lines"
+            )
+            model.index = index
+            model.isFirstRow = index == 0
+            return model
+        }
+        var measured = 0
+        _ = cache.prepare(
+            rows: models.map(makeConfiguration),
+            columnWidth: 300
+        ) { _, _ in
+            measured += 1
+            return 57
+        }
+        #expect(measured == 5)
+
+        // Close the first workspace: the four survivors shift up one index
+        // and the new head becomes the first row.
+        let survivors = models.dropFirst().enumerated().map { index, model in
+            var shifted = model
+            shifted.index = index
+            shifted.isFirstRow = index == 0
+            return makeConfiguration(model: shifted)
+        }
+        measured = 0
+        let changed = cache.prepare(rows: survivors, columnWidth: 300) { _, _ in
+            measured += 1
+            return 57
+        }
+        #expect(measured == 0, "a close must not re-measure position-only changes")
+        #expect(changed.isEmpty)
+    }
+
+    @Test
+    func contentChangesStillRemeasureAndReportHeightChanges() {
+        let cache = SidebarWorkspaceTableRowHeightCache()
+        var model = SidebarWorkspaceRowSuspensionTests.makeModel(
+            customDescription: "This workspace description wraps across several sidebar lines"
+        )
+        model.index = 0
+        model.isFirstRow = true
+        _ = cache.prepare(
+            rows: [makeConfiguration(model: model)],
+            columnWidth: 300
+        ) { _, _ in 57 }
+
+        // A notification line is real content: it must re-measure even though
+        // the row's position did not move.
+        var updated = model
+        updated.latestNotificationText = "latest agent message"
+        var measured = 0
+        let updatedRow = makeConfiguration(model: updated)
+        let changed = cache.prepare(rows: [updatedRow], columnWidth: 300) { _, _ in
+            measured += 1
+            return 88
+        }
+        #expect(measured == 1)
+        #expect(changed == IndexSet(integer: 0))
+        #expect(cache.height(for: updatedRow, columnWidth: 300) == 88)
+    }
+
+    /// Pins the premise the cache keying relies on: `index` feeds only the
+    /// accessibility label and `isFirstRow` only the drop-indicator frame in
+    /// the apply pass, so neither may change what the measurement pass
+    /// (`layoutContent(apply: false)`) returns. If a future change makes
+    /// either field height-relevant, this fails and
+    /// `hasHeightEquivalentContent` must stop neutralizing that field.
+    @Test
+    func positionFieldsDoNotAffectMeasuredCellHeight() {
+        var tailModel = SidebarWorkspaceRowSuspensionTests.makeModel(
+            customDescription: Array(
+                repeating: "wraps across several sidebar lines to exceed the estimate",
+                count: 4
+            ).joined(separator: " ")
+        )
+        tailModel.index = 7
+        tailModel.isFirstRow = false
+        var headModel = tailModel
+        headModel.index = 0
+        headModel.isFirstRow = true
+
+        let cell = SidebarWorkspaceRowTableCellView()
+        cell.configure(
+            model: tailModel,
+            actions: SidebarWorkspaceRowSuspensionTests.makeActions(model: tailModel),
+            isPointerHovering: false,
+            contextMenuDidOpen: {},
+            contextMenuDidClose: {}
+        )
+        let tailHeight = cell.layoutContent(model: tailModel, width: 300, apply: false)
+        let headHeight = cell.layoutContent(model: headModel, width: 300, apply: false)
+        #expect(tailHeight == headHeight)
+        #expect(tailModel.hasHeightEquivalentContent(to: headModel))
+    }
+
+    private func makeConfiguration(
+        model: SidebarWorkspaceRowModel
+    ) -> SidebarWorkspaceTableRowConfiguration {
+        SidebarWorkspaceTableRowConfiguration(
+            workspaceRowModel: model,
+            actions: SidebarWorkspaceRowSuspensionTests.makeActions(model: model),
+            groupId: nil,
+            isPinned: false,
+            environment: SidebarWorkspaceTableEnvironmentSnapshot(
+                colorScheme: .light,
+                globalFontMagnificationPercent: 100,
+                lazyContractProbe: SidebarLazyContractProbe()
+            )
+        )
+    }
+}

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -1897,7 +1897,8 @@ final class WindowDragHandleHitTests: XCTestCase {
             onResumeSession: nil,
             onOpenFilePreview: { _ in },
             onOpenAsPane: { _ in },
-            onClose: {}
+            onClose: {},
+            customSidebarDataContext: { _ in [:] }
         )
         let hostingView = NSHostingView(rootView: rootView)
         hostingView.frame = window.contentRect(forFrameRect: window.frame)


### PR DESCRIPTION
Regression coverage for https://github.com/manaflow-ai/cmux/pull/11242 (sidebar rows clipping after workspace closes), pinning the cache-keying mechanism at the unit level.

`SidebarWorkspaceRowHeightCacheRegressionTests`, four tests:
- an index shift from a close (including first-row promotion) must not evict a row's cached height
- a close must not re-measure the surviving tail (zero measure-closure invocations)
- a real content change (notification line) must still re-measure and report the height change
- premise pin: `index`/`isFirstRow` must not affect `layoutContent(apply: false)` — if a future change makes either height-relevant, this fails and `hasHeightEquivalentContent` must stop neutralizing that field

Red/green proven on hosted CI. On a control branch with only the two cache-keying lines reverted to pre-fix (`hasEquivalentContent`), the first two tests fail exactly as the bug predicts (`cache.height → nil` across the shift; `measured → 4`): https://github.com/manaflow-ai/cmux/actions/runs/33426230608. On this branch all four pass: https://github.com/manaflow-ai/cmux/actions/runs/33426138146. The fix is already merged, so the red proof lives on the control run instead of a first red commit.

Also fixes the cmuxTests target compile on main: https://github.com/manaflow-ai/cmux/pull/10401 added `customSidebarDataContext` to `RightSidebarPanelView` without updating the `WindowAndDragTests` and `HiddenRightSidebarContentMountingTests` call sites, so every cmuxTests dispatch on current main fails to build (the PR lane has no macOS compile gate). Both call sites now pass an empty context.

Dictionary:
- **control branch**: a throwaway branch identical to this one except the fix under test is reverted, used to prove the tests go red without it.
- **measure closure**: the cache's injected measurement function; counting its invocations detects unnecessary re-measures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790794501&installation_model_id=21920&pr_number=11268&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11268&signature=96effce2011ef2dd5290bebe73bf78405521295f653cbd8cb36f24f533a42f00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for sidebar workspace row height caching when rows are closed, reordered, or updated.
  * Added checks to ensure unchanged content reuses cached measurements while content changes trigger recalculation.
  * Updated sidebar-related tests to provide the required test context and maintain coverage for hidden content and title-bar interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->