### PR TITLE
Keep the NODE_OPTIONS restore module where macOS won't delete it

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -23286,19 +23286,48 @@ struct CMUXCLI {
         return root
     }
 
-    private func createClaudeNodeOptionsRestoreModule() throws -> URL {
-        let rawTemporaryDirectory = ProcessInfo.processInfo.environment["TMPDIR"]?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        let temporaryDirectory: String
-        if let rawTemporaryDirectory, !rawTemporaryDirectory.isEmpty {
-            temporaryDirectory = rawTemporaryDirectory
-        } else {
-            temporaryDirectory = NSTemporaryDirectory()
+    /// A `--require` for a cmux-written restore module, including one an older build left under
+    /// `$TMPDIR`. That path may already be reaped, so it must never be carried forward into
+    /// `NODE_OPTIONS` or into the saved original.
+    private func isClaudeNodeOptionsRestoreModuleRequire(_ token: String) -> Bool {
+        for prefix in ["--require=", "-r="] where token.hasPrefix(prefix) {
+            return ClaudeNodeOptionsRestoreModule.isCmuxOwnedPath(String(token.dropFirst(prefix.count)))
         }
-        let root = URL(fileURLWithPath: temporaryDirectory, isDirectory: true)
-            .appendingPathComponent("cmux-claude-node-options", isDirectory: true)
-        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true, attributes: nil)
-        let restoreModuleURL = root.appendingPathComponent("restore-node-options.cjs", isDirectory: false)
+        return false
+    }
+
+    private func claudeNodeOptionsDirectory() -> URL {
+        let override = ProcessInfo.processInfo.environment["CMUX_NODE_OPTIONS_DIR"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if let override, !override.isEmpty {
+            return URL(fileURLWithPath: override, isDirectory: true)
+        }
+        // Not $TMPDIR: macOS reaps files there after a few days of no access, while a session
+        // that outlives the reaper keeps --require pointing at the deleted module, so every
+        // child node exits with MODULE_NOT_FOUND before running any user code. The CLI is a
+        // composition root, so it names the concrete FileManager.default here.
+        return CmuxStateDirectory.url(homeDirectory: FileManager.default.homeDirectoryForCurrentUser)
+            .appendingPathComponent(ClaudeNodeOptionsRestoreModule.directoryName, isDirectory: true)
+    }
+
+    private func createClaudeNodeOptionsRestoreModule() throws -> URL {
+        let root = claudeNodeOptionsDirectory()
+        let restoreModuleURL = root.appendingPathComponent(ClaudeNodeOptionsRestoreModule.fileName, isDirectory: false)
+        // node splits NODE_OPTIONS on whitespace, so a path holding a space or a double quote
+        // cannot be expressed there. Fail so the caller skips the injection entirely.
+        let unexpressible = CharacterSet.whitespacesAndNewlines.union(CharacterSet(charactersIn: "\""))
+        guard restoreModuleURL.path.rangeOfCharacter(from: unexpressible) == nil else {
+            throw CLIError(message: "Claude NODE_OPTIONS restore module path is not expressible in NODE_OPTIONS: \(restoreModuleURL.path)")
+        }
+        // 0700, matching SocketControlPasswordStore: whichever component creates
+        // ~/.local/state/cmux sets its mode, and createDirectory does not re-apply attributes to
+        // a directory that already exists. Creating it 0755 here would leave the socket control
+        // password sitting in a world-readable directory.
+        try FileManager.default.createDirectory(
+            at: root,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
         try writeShimIfChanged(Self.claudeNodeOptionsRestoreModule, to: restoreModuleURL)
         return restoreModuleURL
     }
@@ -30810,7 +30839,7 @@ struct CMUXCLI {
 
     private func mergedNodeOptions(existing: String?, restoreModulePath: String) -> String {
         let requireOption = "--require=\(restoreModulePath)"
-        let memoryOption = "--max-old-space-size=4096"
+        let memoryOption = "--max-old-space-size=\(ClaudeNodeOptionsRestoreModule.injectedHeapCapMB)"
         let cleanedExisting = cleanedNodeOptions(existing)
         guard !cleanedExisting.isEmpty else {
             return "\(requireOption) \(memoryOption)"
@@ -30836,6 +30865,10 @@ struct CMUXCLI {
                 index += 1
                 continue
             }
+            if isClaudeNodeOptionsRestoreModuleRequire(token) {
+                index += 1
+                continue
+            }
             filtered.append(token)
             index += 1
         }
@@ -30850,11 +30883,23 @@ struct CMUXCLI {
 
         var normalized: [String] = []
         var index = 0
+        var shouldDropInjectedHeapCap = false
         while index < tokens.count {
             let token = tokens[index]
+            if shouldDropInjectedHeapCap, ClaudeNodeOptionsRestoreModule.isInjectedHeapCap(tokens, index: index) {
+                index += ClaudeNodeOptionsRestoreModule.heapCapTokenWidth(tokens, index: index)
+                shouldDropInjectedHeapCap = false
+                continue
+            }
+            shouldDropInjectedHeapCap = false
             if token == "--max-old-space-size", index + 1 < tokens.count {
                 normalized.append("--max-old-space-size=\(tokens[index + 1])")
                 index += 2
+                continue
+            }
+            if isClaudeNodeOptionsRestoreModuleRequire(token) {
+                index += 1
+                shouldDropInjectedHeapCap = true
                 continue
             }
             normalized.append(token)

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -23286,17 +23286,17 @@ struct CMUXCLI {
         return root
     }
 
-    /// A `--require` for a cmux-written restore module, including one an older build left under
-    /// `$TMPDIR`. That path may already be reaped, so it must never be carried forward into
-    /// `NODE_OPTIONS` or into the saved original.
-    private func isClaudeNodeOptionsRestoreModuleRequire(_ token: String) -> Bool {
-        for prefix in ["--require=", "-r="] where token.hasPrefix(prefix) {
-            return ClaudeNodeOptionsRestoreModule.isCmuxOwnedPath(
-                String(token.dropFirst(prefix.count)),
-                moduleDirectory: claudeNodeOptionsDirectory()
-            )
-        }
-        return false
+    /// Tokens occupied by a `--require` for a cmux-written restore module at `index`, or `0`.
+    ///
+    /// Such a path may already be reaped, so it must never be carried forward into `NODE_OPTIONS`
+    /// or into the saved original. Both the `=` and space-separated spellings count: a persisted
+    /// launch environment can carry either.
+    private func claudeNodeOptionsRestoreModuleRequireWidth(_ tokens: [String], index: Int) -> Int {
+        ClaudeNodeOptionsRestoreModule.ownedRequireTokenWidth(
+            tokens,
+            index: index,
+            moduleDirectory: claudeNodeOptionsDirectory()
+        )
     }
 
     private func claudeNodeOptionsDirectory() -> URL {
@@ -30868,8 +30868,9 @@ struct CMUXCLI {
                 index += 1
                 continue
             }
-            if isClaudeNodeOptionsRestoreModuleRequire(token) {
-                index += 1
+            let ownedRequireWidth = claudeNodeOptionsRestoreModuleRequireWidth(tokens, index: index)
+            if ownedRequireWidth > 0 {
+                index += ownedRequireWidth
                 continue
             }
             filtered.append(token)
@@ -30900,8 +30901,9 @@ struct CMUXCLI {
                 index += 2
                 continue
             }
-            if isClaudeNodeOptionsRestoreModuleRequire(token) {
-                index += 1
+            let ownedRequireWidth = claudeNodeOptionsRestoreModuleRequireWidth(tokens, index: index)
+            if ownedRequireWidth > 0 {
+                index += ownedRequireWidth
                 shouldDropInjectedHeapCap = true
                 continue
             }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -23291,7 +23291,10 @@ struct CMUXCLI {
     /// `NODE_OPTIONS` or into the saved original.
     private func isClaudeNodeOptionsRestoreModuleRequire(_ token: String) -> Bool {
         for prefix in ["--require=", "-r="] where token.hasPrefix(prefix) {
-            return ClaudeNodeOptionsRestoreModule.isCmuxOwnedPath(String(token.dropFirst(prefix.count)))
+            return ClaudeNodeOptionsRestoreModule.isCmuxOwnedPath(
+                String(token.dropFirst(prefix.count)),
+                moduleDirectory: claudeNodeOptionsDirectory()
+            )
         }
         return false
     }

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
@@ -56,24 +56,37 @@ public struct ClaudeNodeOptionsRestoreModule: Sendable {
     /// has no dependencies; it is the leaf of `~/.local/state/cmux`.
     private static let stateDirectoryName = "cmux"
 
+    /// The full directory tail cmux writes the module to, below the user's home. Matching the
+    /// whole tail rather than just `cmux/node-options` keeps an unrelated preload at, say,
+    /// `/opt/vendor/cmux/node-options/` from being claimed as ours.
+    private static let stateDirectoryTail = [".local", "state", stateDirectoryName, directoryName]
+
     /// Whether a `--require` path points at a cmux-written copy of the module.
     ///
     /// The file name alone is not enough: a caller may legitimately preload their own module of
-    /// the same name, and dropping that would silently change their runtime. Ownership is the file
-    /// name plus a directory cmux actually writes to, matched by name — a substring test would
-    /// also claim an unrelated path that merely happens to sit under, say, `~/Code/cmux-foo/`.
-    public static func isCmuxOwnedPath(_ path: String) -> Bool {
+    /// the same name, and dropping that would silently change their runtime. Path shape alone is
+    /// not enough either — it is both too generous (an unrelated `…/cmux/node-options/`) and too
+    /// mean (a configured directory that looks like neither known shape). So the authoritative
+    /// test is `moduleDirectory`, the directory the caller actually writes to; the name and tail
+    /// checks only recognise copies left by another process or an older build.
+    ///
+    /// - Parameter moduleDirectory: Where this process writes the module, when it writes one.
+    ///   Callers that only strip inherited values (they never write) pass `nil`.
+    public static func isCmuxOwnedPath(_ path: String, moduleDirectory: URL? = nil) -> Bool {
         let unquoted = path.trimmingCharacters(in: CharacterSet(charactersIn: "'\""))
-        let moduleURL = URL(fileURLWithPath: unquoted)
+        let moduleURL = URL(fileURLWithPath: unquoted).standardizedFileURL
         guard moduleURL.lastPathComponent == fileName else { return false }
 
         let parent = moduleURL.deletingLastPathComponent()
+        if let moduleDirectory, parent == moduleDirectory.standardizedFileURL {
+            return true
+        }
+
         let parentName = parent.lastPathComponent
         if parentName == legacyDirectoryName || parentName.hasPrefix("\(legacyDirectoryName)-") {
             return true
         }
-        return parentName == directoryName
-            && parent.deletingLastPathComponent().lastPathComponent == stateDirectoryName
+        return parent.pathComponents.suffix(stateDirectoryTail.count).elementsEqual(stateDirectoryTail)
     }
 
     /// Whether the token at `index` is the heap cap cmux injects, rather than one the caller chose.

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
@@ -89,6 +89,29 @@ public struct ClaudeNodeOptionsRestoreModule: Sendable {
         return parent.pathComponents.suffix(stateDirectoryTail.count).elementsEqual(stateDirectoryTail)
     }
 
+    /// How many tokens a cmux-owned `--require` occupies at `index`, or `0` when the token there
+    /// is not one.
+    ///
+    /// Both `--require=<path>` and `--require <path>` (and the `-r` spellings) have to be
+    /// recognised: a persisted launch environment can carry either shape, and missing the
+    /// space-separated one leaves a dead preload in `NODE_OPTIONS` — the failure this whole
+    /// mechanism exists to avoid.
+    public static func ownedRequireTokenWidth(
+        _ tokens: [String],
+        index: Int,
+        moduleDirectory: URL? = nil
+    ) -> Int {
+        guard index < tokens.count else { return 0 }
+        let token = tokens[index]
+
+        for prefix in ["--require=", "-r="] where token.hasPrefix(prefix) {
+            let path = String(token.dropFirst(prefix.count))
+            return isCmuxOwnedPath(path, moduleDirectory: moduleDirectory) ? 1 : 0
+        }
+        guard token == "--require" || token == "-r", index + 1 < tokens.count else { return 0 }
+        return isCmuxOwnedPath(tokens[index + 1], moduleDirectory: moduleDirectory) ? 2 : 0
+    }
+
     /// Whether the token at `index` is the heap cap cmux injects, rather than one the caller chose.
     public static func isInjectedHeapCap(_ tokens: [String], index: Int) -> Bool {
         guard index < tokens.count else { return false }
@@ -294,15 +317,9 @@ public struct AgentLaunchEnvironmentPolicy: Sendable {
             }
             shouldDropInjectedHeapCap = false
 
-            if isRequireOption(token), index + 1 < tokens.count,
-               ClaudeNodeOptionsRestoreModule.isCmuxOwnedPath(tokens[index + 1]) {
-                index += 2
-                shouldDropInjectedHeapCap = true
-                continue
-            }
-            if let path = inlineRequireOptionPath(token),
-               ClaudeNodeOptionsRestoreModule.isCmuxOwnedPath(path) {
-                index += 1
+            let ownedRequireWidth = ClaudeNodeOptionsRestoreModule.ownedRequireTokenWidth(tokens, index: index)
+            if ownedRequireWidth > 0 {
+                index += ownedRequireWidth
                 shouldDropInjectedHeapCap = true
                 continue
             }
@@ -322,17 +339,6 @@ public struct AgentLaunchEnvironmentPolicy: Sendable {
             return nil
         }
         return trimmed
-    }
-
-    private func isRequireOption(_ token: String) -> Bool {
-        token == "--require" || token == "-r"
-    }
-
-    private func inlineRequireOptionPath(_ token: String) -> String? {
-        for prefix in ["--require=", "-r="] where token.hasPrefix(prefix) {
-            return String(token.dropFirst(prefix.count))
-        }
-        return nil
     }
 
 }

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
@@ -30,6 +30,70 @@ public struct ClaudeConfigDirectoryPath: Sendable {
     }
 }
 
+/// The preload module cmux injects via `NODE_OPTIONS=--require=…` so that child node processes
+/// get the caller's original `NODE_OPTIONS` back instead of cmux's own heap cap.
+///
+/// The claude wrapper, the CLI, and this policy each handle the module from a different side —
+/// two write it, one strips it back out — so the rule for "is this path ours" lives here once.
+public struct ClaudeNodeOptionsRestoreModule: Sendable {
+    private init() {}
+
+    /// The module's file name, identical in every directory cmux has written it to.
+    public static let fileName = "restore-node-options.cjs"
+
+    /// The directory holding the module under the cmux state directory.
+    public static let directoryName = "node-options"
+
+    /// The `$TMPDIR` directory older builds used. The remote daemon still appends a random suffix
+    /// to it, so both the exact name and the `<name>-<random>` form count as cmux's.
+    private static let legacyDirectoryName = "cmux-claude-node-options"
+
+    /// The V8 heap cap, in MB, that cmux injects alongside the module. Named because unwinding an
+    /// injected `NODE_OPTIONS` has to tell cmux's own value apart from one the caller chose.
+    public static let injectedHeapCapMB = "4096"
+
+    /// Name of the cmux state directory. Duplicated from `CmuxStateDirectory` because this target
+    /// has no dependencies; it is the leaf of `~/.local/state/cmux`.
+    private static let stateDirectoryName = "cmux"
+
+    /// Whether a `--require` path points at a cmux-written copy of the module.
+    ///
+    /// The file name alone is not enough: a caller may legitimately preload their own module of
+    /// the same name, and dropping that would silently change their runtime. Ownership is the file
+    /// name plus a directory cmux actually writes to, matched by name — a substring test would
+    /// also claim an unrelated path that merely happens to sit under, say, `~/Code/cmux-foo/`.
+    public static func isCmuxOwnedPath(_ path: String) -> Bool {
+        let unquoted = path.trimmingCharacters(in: CharacterSet(charactersIn: "'\""))
+        let moduleURL = URL(fileURLWithPath: unquoted)
+        guard moduleURL.lastPathComponent == fileName else { return false }
+
+        let parent = moduleURL.deletingLastPathComponent()
+        let parentName = parent.lastPathComponent
+        if parentName == legacyDirectoryName || parentName.hasPrefix("\(legacyDirectoryName)-") {
+            return true
+        }
+        return parentName == directoryName
+            && parent.deletingLastPathComponent().lastPathComponent == stateDirectoryName
+    }
+
+    /// Whether the token at `index` is the heap cap cmux injects, rather than one the caller chose.
+    public static func isInjectedHeapCap(_ tokens: [String], index: Int) -> Bool {
+        guard index < tokens.count else { return false }
+        let token = tokens[index]
+        if token == "--max-old-space-size" {
+            return index + 1 < tokens.count && tokens[index + 1] == injectedHeapCapMB
+        }
+        return token == "--max-old-space-size=\(injectedHeapCapMB)"
+    }
+
+    /// How many tokens the heap cap at `index` occupies: two for the space-separated form, one for
+    /// the `=` form.
+    public static func heapCapTokenWidth(_ tokens: [String], index: Int) -> Int {
+        guard index < tokens.count else { return 1 }
+        return tokens[index] == "--max-old-space-size" ? min(2, tokens.count - index) : 1
+    }
+}
+
 /// Selects the non-secret launch environment values that are safe to replay when restoring agents.
 public struct AgentLaunchEnvironmentPolicy: Sendable {
     /// Creates a launch environment policy.
@@ -210,21 +274,21 @@ public struct AgentLaunchEnvironmentPolicy: Sendable {
         while index < tokens.count {
             let token = tokens[index]
 
-            if shouldDropInjectedHeapCap, isInjectedNodeHeapCap(tokens, index: index) {
-                index += nodeHeapCapWidth(tokens, index: index)
+            if shouldDropInjectedHeapCap, ClaudeNodeOptionsRestoreModule.isInjectedHeapCap(tokens, index: index) {
+                index += ClaudeNodeOptionsRestoreModule.heapCapTokenWidth(tokens, index: index)
                 shouldDropInjectedHeapCap = false
                 continue
             }
             shouldDropInjectedHeapCap = false
 
             if isRequireOption(token), index + 1 < tokens.count,
-               isCmuxNodeOptionsRestoreModulePath(tokens[index + 1]) {
+               ClaudeNodeOptionsRestoreModule.isCmuxOwnedPath(tokens[index + 1]) {
                 index += 2
                 shouldDropInjectedHeapCap = true
                 continue
             }
             if let path = inlineRequireOptionPath(token),
-               isCmuxNodeOptionsRestoreModulePath(path) {
+               ClaudeNodeOptionsRestoreModule.isCmuxOwnedPath(path) {
                 index += 1
                 shouldDropInjectedHeapCap = true
                 continue
@@ -258,25 +322,4 @@ public struct AgentLaunchEnvironmentPolicy: Sendable {
         return nil
     }
 
-    private func isCmuxNodeOptionsRestoreModulePath(_ value: String) -> Bool {
-        let trimmed = value.trimmingCharacters(in: CharacterSet(charactersIn: "'\""))
-        guard URL(fileURLWithPath: trimmed).lastPathComponent == "restore-node-options.cjs" else {
-            return false
-        }
-        return trimmed.contains("/cmux-")
-    }
-
-    private func isInjectedNodeHeapCap(_ tokens: [String], index: Int) -> Bool {
-        guard index < tokens.count else { return false }
-        let token = tokens[index]
-        if token == "--max-old-space-size" {
-            return index + 1 < tokens.count && tokens[index + 1] == "4096"
-        }
-        return token == "--max-old-space-size=4096"
-    }
-
-    private func nodeHeapCapWidth(_ tokens: [String], index: Int) -> Int {
-        guard index < tokens.count else { return 1 }
-        return tokens[index] == "--max-old-space-size" ? min(2, tokens.count - index) : 1
-    }
 }

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
@@ -50,6 +50,37 @@ struct AgentLaunchEnvironmentPolicyTests {
         #expect(selected == ["NODE_OPTIONS": nodeOptions])
     }
 
+    @Test(
+        "Drops a cmux preload written in any --require spelling, with its paired heap cap",
+        arguments: [
+            "--require=/tmp/cmux-claude-node-options/restore-node-options.cjs --max-old-space-size=4096",
+            "--require /tmp/cmux-claude-node-options/restore-node-options.cjs --max-old-space-size 4096",
+            "-r /tmp/cmux-claude-node-options/restore-node-options.cjs --max-old-space-size=4096",
+            "-r=/tmp/cmux-claude-node-options/restore-node-options.cjs --max-old-space-size 4096",
+        ]
+    )
+    func dropsPreloadInEverySpelling(injected: String) {
+        // A persisted environment can carry either spelling, and a surviving dead preload is the
+        // MODULE_NOT_FOUND crash this mechanism exists to prevent.
+        let selected = AgentLaunchEnvironmentPolicy().selectedEnvironment(
+            from: ["NODE_OPTIONS": "\(injected) --trace-warnings"],
+            kind: "claude"
+        )
+
+        #expect(selected == ["NODE_OPTIONS": "--trace-warnings"])
+    }
+
+    @Test("Keeps a caller preload written in the space-separated form")
+    func keepsCallerPreloadInSpaceForm() {
+        let nodeOptions = "--require /opt/vendor/instrument.cjs --trace-warnings"
+        let selected = AgentLaunchEnvironmentPolicy().selectedEnvironment(
+            from: ["NODE_OPTIONS": nodeOptions],
+            kind: "claude"
+        )
+
+        #expect(selected == ["NODE_OPTIONS": nodeOptions])
+    }
+
     @Test("Keeps a heap cap the caller chose while dropping the one cmux injected")
     func keepsCallerHeapCapAndDropsInjectedOne() {
         let modulePath = "/Users/someone/.local/state/cmux/node-options/restore-node-options.cjs"

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
@@ -70,6 +70,24 @@ struct AgentLaunchEnvironmentPolicyTests {
         #expect(selected == ["NODE_OPTIONS": "--trace-warnings"])
     }
 
+    @Test(
+        "Drops a cmux preload whose path arrives wrapped in quotes",
+        arguments: [
+            "--require=\"/tmp/cmux-claude-node-options/restore-node-options.cjs\"",
+            "--require \"/tmp/cmux-claude-node-options/restore-node-options.cjs\"",
+        ]
+    )
+    func dropsQuotedPreload(injected: String) {
+        // node consumes surrounding double quotes in NODE_OPTIONS, so an inherited value can
+        // carry them around the path.
+        let selected = AgentLaunchEnvironmentPolicy().selectedEnvironment(
+            from: ["NODE_OPTIONS": "\(injected) --trace-warnings"],
+            kind: "claude"
+        )
+
+        #expect(selected == ["NODE_OPTIONS": "--trace-warnings"])
+    }
+
     @Test("Keeps a caller preload written in the space-separated form")
     func keepsCallerPreloadInSpaceForm() {
         let nodeOptions = "--require /opt/vendor/instrument.cjs --trace-warnings"

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
@@ -3,6 +3,44 @@ import Testing
 
 @Suite("AgentLaunchEnvironmentPolicy")
 struct AgentLaunchEnvironmentPolicyTests {
+    @Test(
+        "Drops the cmux NODE_OPTIONS restore preload from every directory it has shipped in",
+        arguments: [
+            "/var/folders/ab/T/cmux-claude-node-options/restore-node-options.cjs",
+            "/tmp/cmux-claude-node-options-9f3a/restore-node-options.cjs",
+            "/Users/someone/.local/state/cmux/node-options/restore-node-options.cjs",
+        ]
+    )
+    func dropsCmuxNodeOptionsRestorePreload(modulePath: String) {
+        let selected = AgentLaunchEnvironmentPolicy().selectedEnvironment(
+            from: ["NODE_OPTIONS": "--require=\(modulePath) --max-old-space-size=4096 --trace-warnings"],
+            kind: "claude"
+        )
+
+        #expect(selected == ["NODE_OPTIONS": "--trace-warnings"])
+    }
+
+    @Test("Keeps a user's own preload that merely shares the module name")
+    func keepsUnrelatedPreloadWithTheSameModuleName() {
+        let selected = AgentLaunchEnvironmentPolicy().selectedEnvironment(
+            from: ["NODE_OPTIONS": "--require=/opt/vendor/restore-node-options.cjs --max-old-space-size=4096"],
+            kind: "claude"
+        )
+
+        #expect(selected == ["NODE_OPTIONS": "--require=/opt/vendor/restore-node-options.cjs --max-old-space-size=4096"])
+    }
+
+    @Test("Keeps a heap cap the caller chose while dropping the one cmux injected")
+    func keepsCallerHeapCapAndDropsInjectedOne() {
+        let modulePath = "/Users/someone/.local/state/cmux/node-options/restore-node-options.cjs"
+        let selected = AgentLaunchEnvironmentPolicy().selectedEnvironment(
+            from: ["NODE_OPTIONS": "--require=\(modulePath) --max-old-space-size=4096 --max-old-space-size=2048"],
+            kind: "claude"
+        )
+
+        #expect(selected == ["NODE_OPTIONS": "--max-old-space-size=2048"])
+    }
+
     @Test("Preserves OMP config roots without persisting secrets")
     func preservesOmpConfigRootsWithoutPersistingSecrets() {
         let selected = AgentLaunchEnvironmentPolicy().selectedEnvironment(

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
@@ -30,6 +30,26 @@ struct AgentLaunchEnvironmentPolicyTests {
         #expect(selected == ["NODE_OPTIONS": "--require=/opt/vendor/restore-node-options.cjs --max-old-space-size=4096"])
     }
 
+    @Test(
+        "Keeps a caller preload that only resembles the cmux location, and its following options",
+        arguments: [
+            "/opt/vendor/cmux/node-options/restore-node-options.cjs",
+            "/Users/me/Code/cmux-fork/restore-node-options.cjs",
+            "/srv/cmux/restore-node-options.cjs",
+        ]
+    )
+    func keepsPreloadThatOnlyResemblesTheCmuxLocation(callerPreload: String) {
+        // The trailing 4096 is the caller's here: nothing cmux-owned precedes it, so the
+        // injected-heap-cap unwind must not consume it either.
+        let nodeOptions = "--require=\(callerPreload) --max-old-space-size=4096 --trace-warnings"
+        let selected = AgentLaunchEnvironmentPolicy().selectedEnvironment(
+            from: ["NODE_OPTIONS": nodeOptions],
+            kind: "claude"
+        )
+
+        #expect(selected == ["NODE_OPTIONS": nodeOptions])
+    }
+
     @Test("Keeps a heap cap the caller chose while dropping the one cmux injected")
     func keepsCallerHeapCapAndDropsInjectedOne() {
         let modulePath = "/Users/someone/.local/state/cmux/node-options/restore-node-options.cjs"

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -885,10 +885,9 @@ cmux_node_options_dir() {
 # the name and tail checks only recognise copies left by another process or an older build. Only
 # the --require=<path> form is checked; cmux writes no other. Mirrors
 # ClaudeNodeOptionsRestoreModule.isCmuxOwnedPath — keep the two in step.
-is_cmux_restore_module_require() {
-    local token="$1"
-    [[ "$token" == --require=*/"$CMUX_NODE_OPTIONS_MODULE_NAME" ]] || return 1
-    local module_path="${token#--require=}"
+is_cmux_restore_module_path() {
+    local module_path="$1"
+    [[ "$module_path" == */"$CMUX_NODE_OPTIONS_MODULE_NAME" ]] || return 1
     local parent_dir="${module_path%/*}"
     if [[ -n "${CMUX_NODE_OPTIONS_ACTIVE_DIR:-}" && "$parent_dir" == "$CMUX_NODE_OPTIONS_ACTIVE_DIR" ]]; then
         return 0
@@ -899,6 +898,26 @@ is_cmux_restore_module_require() {
         return 0
     fi
     [[ "$parent_dir" == */"$CMUX_NODE_OPTIONS_STATE_TAIL" ]]
+}
+
+# Tokens occupied by a cmux-owned --require at this position, or 0. Both --require=<path> and
+# --require <path> (plus the -r spellings) count: a persisted launch environment can carry either,
+# and missing the space-separated one leaves a dead preload in NODE_OPTIONS — the very failure
+# this mechanism exists to avoid.
+cmux_owned_require_width() {
+    local token="${1:-}"
+    local next="${2:-}"
+    case "$token" in
+        --require=*|-r=*)
+            if is_cmux_restore_module_path "${token#*=}"; then printf 1; else printf 0; fi
+            ;;
+        --require|-r)
+            if [[ -n "$next" ]] && is_cmux_restore_module_path "$next"; then printf 2; else printf 0; fi
+            ;;
+        *)
+            printf 0
+            ;;
+    esac
 }
 
 # Resolved once: the predicate above runs per token, and this never changes within a launch.
@@ -954,7 +973,8 @@ merge_node_options() {
     local -a filtered=()
     local -a tokens=()
     local token
-    local skip_next=0
+    local index=0
+    local owned_require_width
 
     if [[ -z "$module_path" ]]; then
         printf '%s' "$existing"
@@ -962,22 +982,23 @@ merge_node_options() {
     fi
 
     read -r -a tokens <<<"$existing"
-    for token in "${tokens[@]}"; do
-        if (( skip_next )); then
-            skip_next=0
-            continue
-        fi
+    while (( index < ${#tokens[@]} )); do
+        token="${tokens[$index]}"
         if [[ "$token" == "--max-old-space-size" ]]; then
-            skip_next=1
+            index=$((index + 2))
             continue
         fi
         if [[ "$token" == --max-old-space-size=* ]]; then
+            index=$((index + 1))
             continue
         fi
-        if is_cmux_restore_module_require "$token"; then
+        owned_require_width="$(cmux_owned_require_width "$token" "${tokens[$((index + 1))]:-}")"
+        if (( owned_require_width > 0 )); then
+            index=$((index + owned_require_width))
             continue
         fi
         filtered+=("$token")
+        index=$((index + 1))
     done
 
     if (( ${#filtered[@]} == 0 )); then
@@ -994,6 +1015,7 @@ normalize_node_options_for_restore() {
     local -a normalized=()
     local token
     local index=0
+    local owned_require_width
 
     read -r -a tokens <<<"$existing"
     while (( index < ${#tokens[@]} )); do
@@ -1003,8 +1025,9 @@ normalize_node_options_for_restore() {
             index=$((index + 2))
             continue
         fi
-        if is_cmux_restore_module_require "$token"; then
-            index=$((index + 1))
+        owned_require_width="$(cmux_owned_require_width "$token" "${tokens[$((index + 1))]:-}")"
+        if (( owned_require_width > 0 )); then
+            index=$((index + owned_require_width))
             # cmux writes the restore module and its heap cap as a pair, so a cap sitting right
             # after it is cmux's own. Restoring that to children would hand them cmux's 4GB as if
             # the caller had asked for it; a cap the caller chose sits elsewhere and survives.

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -847,13 +847,69 @@ exec_real_claude_passthrough() {
 # Find real claude.
 REAL_CLAUDE="$(find_real_claude)" || { echo "Error: claude not found in PATH" >&2; exit 127; }
 
+CMUX_NODE_OPTIONS_MODULE_NAME="restore-node-options.cjs"
+CMUX_NODE_OPTIONS_MODULE_DIR_NAME="node-options"
+# The $TMPDIR directory older builds used; the remote daemon appends a random suffix to it.
+CMUX_NODE_OPTIONS_LEGACY_DIR_NAME="cmux-claude-node-options"
+CMUX_STATE_DIR_NAME="cmux"
+# The V8 heap cap cmux injects for Claude, in MB. Named because the unwind path has to tell
+# cmux's own value apart from one the caller chose.
+CMUX_NODE_HEAP_CAP_MB="4096"
+
+# The CmuxStateDirectory, not $TMPDIR: macOS reaps $TMPDIR files after a few days of no access,
+# and a session that outlives the reaper keeps --require pointing at the deleted module, so every
+# child node exits with MODULE_NOT_FOUND before running any user code.
+cmux_node_options_dir() {
+    local override="${CMUX_NODE_OPTIONS_DIR:-}"
+    if [[ -n "$override" ]]; then
+        printf '%s' "${override%/}"
+        return 0
+    fi
+    if [[ -n "${HOME:-}" ]]; then
+        printf '%s' "$HOME/.local/state/$CMUX_STATE_DIR_NAME/$CMUX_NODE_OPTIONS_MODULE_DIR_NAME"
+        return 0
+    fi
+    local fallback="${TMPDIR:-/tmp}"
+    printf '%s' "${fallback%/}/$CMUX_NODE_OPTIONS_LEGACY_DIR_NAME"
+}
+
+# A --require for a cmux-written restore module, whose path may already be reaped and so must
+# never be carried into NODE_OPTIONS or the saved original. The file name alone is not enough — a
+# caller may preload their own module of the same name — so ownership also needs a directory cmux
+# writes to, matched by name. Only the --require=<path> form is checked; cmux writes no other.
+# Mirrors ClaudeNodeOptionsRestoreModule.isCmuxOwnedPath — keep the two in step.
+is_cmux_restore_module_require() {
+    local token="$1"
+    [[ "$token" == --require=*/"$CMUX_NODE_OPTIONS_MODULE_NAME" ]] || return 1
+    local module_path="${token#--require=}"
+    local parent_dir="${module_path%/*}"
+    local parent_name="${parent_dir##*/}"
+    if [[ "$parent_name" == "$CMUX_NODE_OPTIONS_LEGACY_DIR_NAME" \
+       || "$parent_name" == "$CMUX_NODE_OPTIONS_LEGACY_DIR_NAME-"* ]]; then
+        return 0
+    fi
+    local grandparent_dir="${parent_dir%/*}"
+    [[ "$parent_name" == "$CMUX_NODE_OPTIONS_MODULE_DIR_NAME" \
+    && "${grandparent_dir##*/}" == "$CMUX_STATE_DIR_NAME" ]]
+}
+
 ensure_node_options_restore_module() {
-    local guard_dir="${TMPDIR:-/tmp}"
-    guard_dir="${guard_dir%/}/cmux-claude-node-options"
-    local guard_path="$guard_dir/restore-node-options.cjs"
-    mkdir -p "$guard_dir" || return 1
+    local module_dir
+    module_dir="$(cmux_node_options_dir)"
+    local module_path="$module_dir/$CMUX_NODE_OPTIONS_MODULE_NAME"
+    # node splits NODE_OPTIONS on whitespace, so a path holding a space or a quote cannot be
+    # expressed there. Skip injection rather than emit a NODE_OPTIONS node cannot parse.
+    if [[ "$module_path" == *[[:space:]\"]* ]]; then
+        return 1
+    fi
+    # 0700, matching SocketControlPasswordStore: whichever component creates
+    # ~/.local/state/cmux sets its mode, and Foundation's createDirectory does NOT re-apply
+    # attributes to a directory that already exists. Creating it 0755 here would leave the socket
+    # control password sitting in a world-readable directory. umask only affects what we create,
+    # so an existing directory is never weakened.
+    (umask 077 && mkdir -p "$module_dir") || return 1
     local temp_path
-    temp_path="$(mktemp "$guard_dir/restore-node-options.cjs.XXXXXX")" || return 1
+    temp_path="$(mktemp "$module_dir/$CMUX_NODE_OPTIONS_MODULE_NAME.XXXXXX")" || return 1
     cat >"$temp_path" <<'EOF'
 const hadOriginalNodeOptions = process.env.CMUX_ORIGINAL_NODE_OPTIONS_PRESENT === "1";
 if (hadOriginalNodeOptions) {
@@ -868,28 +924,28 @@ EOF
         rm -f "$temp_path"
         return 1
     }
-    if [[ -f "$guard_path" ]] && cmp -s "$temp_path" "$guard_path"; then
+    if [[ -f "$module_path" ]] && cmp -s "$temp_path" "$module_path"; then
         rm -f "$temp_path" || return 1
     else
-        mv -f "$temp_path" "$guard_path" || {
+        mv -f "$temp_path" "$module_path" || {
             rm -f "$temp_path"
             return 1
         }
     fi
-    printf '%s' "$guard_path"
+    printf '%s' "$module_path"
 }
 
 merge_node_options() {
-    local guard_path="$1"
-    local require_flag="--require=$guard_path"
-    local memory_flag="--max-old-space-size=4096"
+    local module_path="$1"
+    local require_flag="--require=$module_path"
+    local memory_flag="--max-old-space-size=$CMUX_NODE_HEAP_CAP_MB"
     local existing="${NODE_OPTIONS:-}"
     local -a filtered=()
     local -a tokens=()
     local token
     local skip_next=0
 
-    if [[ -z "$guard_path" ]]; then
+    if [[ -z "$module_path" ]]; then
         printf '%s' "$existing"
         return 0
     fi
@@ -905,6 +961,9 @@ merge_node_options() {
             continue
         fi
         if [[ "$token" == --max-old-space-size=* ]]; then
+            continue
+        fi
+        if is_cmux_restore_module_require "$token"; then
             continue
         fi
         filtered+=("$token")
@@ -933,6 +992,19 @@ normalize_node_options_for_restore() {
             index=$((index + 2))
             continue
         fi
+        if is_cmux_restore_module_require "$token"; then
+            index=$((index + 1))
+            # cmux writes the restore module and its heap cap as a pair, so a cap sitting right
+            # after it is cmux's own. Restoring that to children would hand them cmux's 4GB as if
+            # the caller had asked for it; a cap the caller chose sits elsewhere and survives.
+            if [[ "${tokens[$index]:-}" == "--max-old-space-size=$CMUX_NODE_HEAP_CAP_MB" ]]; then
+                index=$((index + 1))
+            elif [[ "${tokens[$index]:-}" == "--max-old-space-size" \
+                 && "${tokens[$((index + 1))]:-}" == "$CMUX_NODE_HEAP_CAP_MB" ]]; then
+                index=$((index + 2))
+            fi
+            continue
+        fi
         normalized+=("$token")
         index=$((index + 1))
     done
@@ -947,9 +1019,9 @@ normalize_node_options_for_restore() {
 }
 
 install_cmux_node_options() {
-    local guard_path
-    if guard_path="$(ensure_node_options_restore_module)"; then
-        if [[ ${NODE_OPTIONS+x} && "${NODE_OPTIONS:-}" == *"--require=$guard_path"* ]]; then
+    local module_path
+    if module_path="$(ensure_node_options_restore_module)"; then
+        if [[ ${NODE_OPTIONS+x} && "${NODE_OPTIONS:-}" == *"--require=$module_path"* ]]; then
             return 0
         fi
         if [[ ${NODE_OPTIONS+x} ]]; then
@@ -959,7 +1031,7 @@ install_cmux_node_options() {
             export CMUX_ORIGINAL_NODE_OPTIONS_PRESENT=0
             unset CMUX_ORIGINAL_NODE_OPTIONS
         fi
-        export NODE_OPTIONS="$(merge_node_options "$guard_path")"
+        export NODE_OPTIONS="$(merge_node_options "$module_path")"
     fi
 }
 

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -852,6 +852,10 @@ CMUX_NODE_OPTIONS_MODULE_DIR_NAME="node-options"
 # The $TMPDIR directory older builds used; the remote daemon appends a random suffix to it.
 CMUX_NODE_OPTIONS_LEGACY_DIR_NAME="cmux-claude-node-options"
 CMUX_STATE_DIR_NAME="cmux"
+# The full tail below the home directory. Matching the whole tail rather than just
+# cmux/node-options keeps an unrelated preload at e.g. /opt/vendor/cmux/node-options from being
+# claimed as ours.
+CMUX_NODE_OPTIONS_STATE_TAIL=".local/state/$CMUX_STATE_DIR_NAME/$CMUX_NODE_OPTIONS_MODULE_DIR_NAME"
 # The V8 heap cap cmux injects for Claude, in MB. Named because the unwind path has to tell
 # cmux's own value apart from one the caller chose.
 CMUX_NODE_HEAP_CAP_MB="4096"
@@ -875,23 +879,30 @@ cmux_node_options_dir() {
 
 # A --require for a cmux-written restore module, whose path may already be reaped and so must
 # never be carried into NODE_OPTIONS or the saved original. The file name alone is not enough — a
-# caller may preload their own module of the same name — so ownership also needs a directory cmux
-# writes to, matched by name. Only the --require=<path> form is checked; cmux writes no other.
-# Mirrors ClaudeNodeOptionsRestoreModule.isCmuxOwnedPath — keep the two in step.
+# caller may preload their own module of the same name. Path shape alone is not enough either: it
+# is both too generous (an unrelated .../cmux/node-options/) and too mean (a configured directory
+# matching neither known shape). So the authoritative test is the directory we actually write to;
+# the name and tail checks only recognise copies left by another process or an older build. Only
+# the --require=<path> form is checked; cmux writes no other. Mirrors
+# ClaudeNodeOptionsRestoreModule.isCmuxOwnedPath — keep the two in step.
 is_cmux_restore_module_require() {
     local token="$1"
     [[ "$token" == --require=*/"$CMUX_NODE_OPTIONS_MODULE_NAME" ]] || return 1
     local module_path="${token#--require=}"
     local parent_dir="${module_path%/*}"
+    if [[ -n "${CMUX_NODE_OPTIONS_ACTIVE_DIR:-}" && "$parent_dir" == "$CMUX_NODE_OPTIONS_ACTIVE_DIR" ]]; then
+        return 0
+    fi
     local parent_name="${parent_dir##*/}"
     if [[ "$parent_name" == "$CMUX_NODE_OPTIONS_LEGACY_DIR_NAME" \
        || "$parent_name" == "$CMUX_NODE_OPTIONS_LEGACY_DIR_NAME-"* ]]; then
         return 0
     fi
-    local grandparent_dir="${parent_dir%/*}"
-    [[ "$parent_name" == "$CMUX_NODE_OPTIONS_MODULE_DIR_NAME" \
-    && "${grandparent_dir##*/}" == "$CMUX_STATE_DIR_NAME" ]]
+    [[ "$parent_dir" == */"$CMUX_NODE_OPTIONS_STATE_TAIL" ]]
 }
+
+# Resolved once: the predicate above runs per token, and this never changes within a launch.
+CMUX_NODE_OPTIONS_ACTIVE_DIR="$(cmux_node_options_dir)"
 
 ensure_node_options_restore_module() {
     local module_dir

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -887,6 +887,10 @@ cmux_node_options_dir() {
 # ClaudeNodeOptionsRestoreModule.isCmuxOwnedPath — keep the two in step.
 is_cmux_restore_module_path() {
     local module_path="$1"
+    # node consumes surrounding double quotes in NODE_OPTIONS, so an inherited value can carry
+    # them around the path. Trim them, matching ClaudeNodeOptionsRestoreModule.isCmuxOwnedPath.
+    module_path="${module_path#[\"\']}"
+    module_path="${module_path%[\"\']}"
     [[ "$module_path" == */"$CMUX_NODE_OPTIONS_MODULE_NAME" ]] || return 1
     local parent_dir="${module_path%/*}"
     if [[ -n "${CMUX_NODE_OPTIONS_ACTIVE_DIR:-}" && "$parent_dir" == "$CMUX_NODE_OPTIONS_ACTIVE_DIR" ]]; then

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -2703,6 +2703,36 @@ def test_live_socket_does_not_weaken_an_existing_module_directory(failures: list
         )
 
 
+def test_live_socket_keeps_caller_preload_that_resembles_the_cmux_location(failures: list[str]) -> None:
+    """Ownership is the directory cmux writes to, not a path that merely looks like it.
+
+    A caller preload under an unrelated `.../cmux/node-options/` is theirs, and so is the heap cap
+    that follows it.
+    """
+    with tempfile.TemporaryDirectory(prefix="cmux-claude-wrapper-lookalike-") as td:
+        sandbox = Path(td)
+        lookalike = sandbox / "vendor" / "cmux" / "node-options" / "restore-node-options.cjs"
+        lookalike.parent.mkdir(parents=True, exist_ok=True)
+        lookalike.write_text("// the caller's own preload\n", encoding="utf-8")
+        code, _, _, stderr, _, node_options, _, child_node_options, _, _ = run_wrapper(
+            socket_state="live",
+            argv=["hello"],
+            node_options=f"--require={lookalike} --max-old-space-size=4096 --trace-warnings",
+            node_options_dir=str(sandbox / "state" / "node-options"),
+        )
+        expect(code == 0, f"lookalike preload: wrapper exited {code}: {stderr}", failures)
+        expect(
+            str(lookalike) in node_options,
+            f"lookalike preload: the caller's preload was stripped, got {node_options!r}",
+            failures,
+        )
+    expect(
+        child_node_options == f"--require={lookalike} --max-old-space-size=4096 --trace-warnings",
+        f"lookalike preload: expected the caller's options intact in the child, got {child_node_options!r}",
+        failures,
+    )
+
+
 def test_missing_socket_skips_hook_injection(failures: list[str]) -> None:
     code, real_argv, cmux_log, stderr, claudecode, node_options, runtime_node_options, child_node_options, hook_cmux_bin, _ = run_wrapper(
         socket_state="missing",
@@ -2879,6 +2909,7 @@ def main() -> int:
     test_live_socket_does_not_restore_cmux_own_heap_cap_to_children(failures)
     test_live_socket_creates_restore_module_directory_private(failures)
     test_live_socket_does_not_weaken_an_existing_module_directory(failures)
+    test_live_socket_keeps_caller_preload_that_resembles_the_cmux_location(failures)
     test_missing_socket_skips_hook_injection(failures)
     test_disabled_integration_skips_hook_injection(failures)
     test_stale_socket_skips_hook_injection(failures)

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -2733,6 +2733,57 @@ def test_live_socket_keeps_caller_preload_that_resembles_the_cmux_location(failu
     )
 
 
+def test_live_socket_replaces_reaped_module_in_every_require_spelling(failures: list[str]) -> None:
+    """A persisted environment can carry `--require <path>` as well as `--require=<path>`.
+
+    Missing the space-separated spelling leaves the dead preload in NODE_OPTIONS, which is the
+    MODULE_NOT_FOUND crash this whole mechanism exists to prevent.
+    """
+    for spelling in ("--require={path}", "--require {path}", "-r {path}", "-r={path}"):
+        with tempfile.TemporaryDirectory(prefix="cmux-claude-wrapper-spelling-") as td:
+            sandbox = Path(td)
+            reaped = sandbox / "reaped" / "cmux-claude-node-options" / "restore-node-options.cjs"
+            module_dir = sandbox / "state" / "cmux" / "node-options"
+            injected = spelling.format(path=reaped)
+            code, _, _, stderr, _, node_options, _, child_node_options, _, _ = run_wrapper(
+                socket_state="live",
+                argv=["hello"],
+                node_options=f"{injected} --trace-warnings",
+                node_options_dir=str(module_dir),
+            )
+            expect(code == 0, f"spelling {spelling!r}: wrapper exited {code}: {stderr}", failures)
+            expect(
+                str(reaped) not in node_options,
+                f"spelling {spelling!r}: dead preload survived, got {node_options!r}",
+                failures,
+            )
+            expect(
+                child_node_options == "--trace-warnings",
+                f"spelling {spelling!r}: expected only the caller's flags in the child, got {child_node_options!r}",
+                failures,
+            )
+
+
+def test_live_socket_keeps_caller_preload_in_space_separated_form(failures: list[str]) -> None:
+    with tempfile.TemporaryDirectory(prefix="cmux-claude-wrapper-space-caller-") as td:
+        sandbox = Path(td)
+        caller_preload = sandbox / "vendor" / "instrument.cjs"
+        caller_preload.parent.mkdir(parents=True, exist_ok=True)
+        caller_preload.write_text("// the caller's own preload\n", encoding="utf-8")
+        code, _, _, stderr, _, _, _, child_node_options, _, _ = run_wrapper(
+            socket_state="live",
+            argv=["hello"],
+            node_options=f"--require {caller_preload} --trace-warnings",
+            node_options_dir=str(sandbox / "state" / "cmux" / "node-options"),
+        )
+    expect(code == 0, f"space-form caller preload: wrapper exited {code}: {stderr}", failures)
+    expect(
+        child_node_options == f"--require {caller_preload} --trace-warnings",
+        f"space-form caller preload: expected it preserved, got {child_node_options!r}",
+        failures,
+    )
+
+
 def test_missing_socket_skips_hook_injection(failures: list[str]) -> None:
     code, real_argv, cmux_log, stderr, claudecode, node_options, runtime_node_options, child_node_options, hook_cmux_bin, _ = run_wrapper(
         socket_state="missing",
@@ -2910,6 +2961,8 @@ def main() -> int:
     test_live_socket_creates_restore_module_directory_private(failures)
     test_live_socket_does_not_weaken_an_existing_module_directory(failures)
     test_live_socket_keeps_caller_preload_that_resembles_the_cmux_location(failures)
+    test_live_socket_replaces_reaped_module_in_every_require_spelling(failures)
+    test_live_socket_keeps_caller_preload_in_space_separated_form(failures)
     test_missing_socket_skips_hook_injection(failures)
     test_disabled_integration_skips_hook_injection(failures)
     test_stale_socket_skips_hook_injection(failures)

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -65,6 +65,7 @@ def run_wrapper(
     argv: list[str],
     node_options: str | None = None,
     tmpdir: str | None = None,
+    node_options_dir: str | None = None,
     hooks_disabled: bool = False,
     setup_sandbox=None,
     process_timeout: float | None = None,
@@ -210,6 +211,9 @@ exit 0
         env.pop("NODE_OPTIONS", None)
         if tmpdir is not None:
             env["TMPDIR"] = tmpdir
+        # Keep the NODE_OPTIONS restore module inside the sandbox; its real home is
+        # ~/.local/state/cmux/node-options.
+        env["CMUX_NODE_OPTIONS_DIR"] = node_options_dir if node_options_dir is not None else str(tmp / "node-options")
         if node_options == "__CMUX_TEST_PRELOAD__":
             preload_path = tmp / "cmux-test-preload.js"
             preload_path.write_text("// benign preload used to test MCP env scrubbing\n", encoding="utf-8")
@@ -2438,23 +2442,23 @@ def test_live_socket_enforces_heap_cap_for_space_separated_flag(failures: list[s
     expect(child_node_options == restored, f"space-separated heap flag: expected child NODE_OPTIONS restored, got {child_node_options!r}", failures)
 
 
-def test_live_socket_tmpdir_failure_skips_node_options_injection(failures: list[str]) -> None:
-    with tempfile.TemporaryDirectory(prefix="cmux-claude-wrapper-bad-tmp-") as td:
-        bad_tmpdir = Path(td) / "not-a-directory"
-        bad_tmpdir.write_text("occupied", encoding="utf-8")
+def test_live_socket_module_dir_failure_skips_node_options_injection(failures: list[str]) -> None:
+    with tempfile.TemporaryDirectory(prefix="cmux-claude-wrapper-bad-module-dir-") as td:
+        unusable_module_dir = Path(td) / "not-a-directory"
+        unusable_module_dir.write_text("occupied", encoding="utf-8")
         code, real_argv, cmux_log, stderr, claudecode, node_options, runtime_node_options, child_node_options, _, _ = run_wrapper(
             socket_state="live",
             argv=["hello"],
-            tmpdir=str(bad_tmpdir),
+            node_options_dir=str(unusable_module_dir),
         )
-    expect(code == 0, f"tmpdir failure: wrapper exited {code}: {stderr}", failures)
-    expect("--settings" in real_argv, f"tmpdir failure: missing --settings in args: {real_argv}", failures)
-    expect("--session-id" in real_argv, f"tmpdir failure: missing --session-id in args: {real_argv}", failures)
-    expect(any(" ping" in line for line in cmux_log), f"tmpdir failure: expected cmux ping, got {cmux_log}", failures)
-    expect(claudecode == "__UNSET__", f"tmpdir failure: expected CLAUDECODE unset, got {claudecode!r}", failures)
-    expect(node_options == "__UNSET__", f"tmpdir failure: expected NODE_OPTIONS injection to be skipped, got {node_options!r}", failures)
-    expect(runtime_node_options == "__UNSET__", f"tmpdir failure: expected runtime NODE_OPTIONS passthrough, got {runtime_node_options!r}", failures)
-    expect(child_node_options == "__UNSET__", f"tmpdir failure: expected child NODE_OPTIONS passthrough, got {child_node_options!r}", failures)
+    expect(code == 0, f"restore module dir failure: wrapper exited {code}: {stderr}", failures)
+    expect("--settings" in real_argv, f"restore module dir failure: missing --settings in args: {real_argv}", failures)
+    expect("--session-id" in real_argv, f"restore module dir failure: missing --session-id in args: {real_argv}", failures)
+    expect(any(" ping" in line for line in cmux_log), f"restore module dir failure: expected cmux ping, got {cmux_log}", failures)
+    expect(claudecode == "__UNSET__", f"restore module dir failure: expected CLAUDECODE unset, got {claudecode!r}", failures)
+    expect(node_options == "__UNSET__", f"restore module dir failure: expected NODE_OPTIONS injection to be skipped, got {node_options!r}", failures)
+    expect(runtime_node_options == "__UNSET__", f"restore module dir failure: expected runtime NODE_OPTIONS passthrough, got {runtime_node_options!r}", failures)
+    expect(child_node_options == "__UNSET__", f"restore module dir failure: expected child NODE_OPTIONS passthrough, got {child_node_options!r}", failures)
 
 
 def test_live_socket_preserves_explicit_bypass_availability_flag(failures: list[str]) -> None:
@@ -2480,14 +2484,13 @@ def test_live_socket_preserves_explicit_bypass_availability_flag(failures: list[
 
 def test_live_socket_stale_mktemp_literal_does_not_warn(failures: list[str]) -> None:
     with tempfile.TemporaryDirectory(prefix="cmux-claude-wrapper-tmp-") as td:
-        tmpdir = Path(td)
-        guard_dir = tmpdir / "cmux-claude-node-options"
-        guard_dir.mkdir(parents=True, exist_ok=True)
-        (guard_dir / "restore-node-options.XXXXXX.cjs").write_text("stale", encoding="utf-8")
+        module_dir = Path(td) / "node-options"
+        module_dir.mkdir(parents=True, exist_ok=True)
+        (module_dir / "restore-node-options.XXXXXX.cjs").write_text("stale", encoding="utf-8")
         code, _, _, stderr, _, node_options, runtime_node_options, child_node_options, _, _ = run_wrapper(
             socket_state="live",
             argv=["hello"],
-            tmpdir=str(tmpdir),
+            node_options_dir=str(module_dir),
         )
     expect(code == 0, f"stale mktemp literal: wrapper exited {code}: {stderr}", failures)
     expect("mktemp:" not in stderr, f"stale mktemp literal: unexpected mktemp warning: {stderr!r}", failures)
@@ -2504,6 +2507,200 @@ def test_live_socket_stale_mktemp_literal_does_not_warn(failures: list[str]) -> 
     )
     expect(runtime_node_options == "__UNSET__", f"stale mktemp literal: expected runtime NODE_OPTIONS restored, got {runtime_node_options!r}", failures)
     expect(child_node_options == "__UNSET__", f"stale mktemp literal: expected child NODE_OPTIONS restored, got {child_node_options!r}", failures)
+
+
+def test_live_socket_restore_module_is_not_under_tmpdir(failures: list[str]) -> None:
+    with tempfile.TemporaryDirectory(prefix="cmux-claude-wrapper-durable-") as td:
+        sandbox = Path(td)
+        reapable_tmpdir = sandbox / "tmp"
+        reapable_tmpdir.mkdir()
+        module_dir = sandbox / "state" / "node-options"
+        code, _, _, stderr, _, node_options, _, child_node_options, _, _ = run_wrapper(
+            socket_state="live",
+            argv=["hello"],
+            tmpdir=str(reapable_tmpdir),
+            node_options_dir=str(module_dir),
+        )
+        require_flag, _, _ = node_options.partition(" ")
+        module_path = require_flag.removeprefix("--require=")
+        expect(code == 0, f"durable module: wrapper exited {code}: {stderr}", failures)
+        expect(
+            module_path == str(module_dir / "restore-node-options.cjs"),
+            f"durable module: expected the preload in the state directory, got {node_options!r}",
+            failures,
+        )
+        expect(
+            str(reapable_tmpdir) not in node_options,
+            f"durable module: preload must not live under TMPDIR, got {node_options!r}",
+            failures,
+        )
+        expect(
+            not list(reapable_tmpdir.glob("cmux-claude-node-options*")),
+            "durable module: wrapper still created a restore-module directory under TMPDIR",
+            failures,
+        )
+    expect(child_node_options == "__UNSET__", f"durable module: expected child NODE_OPTIONS restored, got {child_node_options!r}", failures)
+
+
+def test_live_socket_replaces_reaped_restore_module_from_earlier_session(failures: list[str]) -> None:
+    """A session older than the OS temp reaper keeps --require pointing at a deleted module.
+
+    Every child node then exits with MODULE_NOT_FOUND before running any user code, which took
+    down agent hooks. Relaunching must install the current module and drop the dead path.
+    """
+    with tempfile.TemporaryDirectory(prefix="cmux-claude-wrapper-reaped-") as td:
+        sandbox = Path(td)
+        reaped = sandbox / "reaped" / "cmux-claude-node-options" / "restore-node-options.cjs"
+        module_dir = sandbox / "state" / "node-options"
+        code, _, _, stderr, _, node_options, runtime_node_options, child_node_options, _, _ = run_wrapper(
+            socket_state="live",
+            argv=["hello"],
+            node_options=f"--require={reaped} --trace-warnings",
+            node_options_dir=str(module_dir),
+        )
+        expect(code == 0, f"reaped module: wrapper exited {code}: {stderr}", failures)
+        expect(
+            str(reaped) not in node_options,
+            f"reaped module: dead preload path survived into NODE_OPTIONS, got {node_options!r}",
+            failures,
+        )
+        expect(
+            node_options == f"--require={module_dir / 'restore-node-options.cjs'} --max-old-space-size=4096 --trace-warnings",
+            f"reaped module: expected the current preload ahead of the caller's flags, got {node_options!r}",
+            failures,
+        )
+    expect(
+        child_node_options == "--trace-warnings",
+        f"reaped module: expected a child node to start with only the caller's flags, got {child_node_options!r}",
+        failures,
+    )
+    expect(
+        runtime_node_options == "--trace-warnings",
+        f"reaped module: expected the runtime to see only the caller's flags, got {runtime_node_options!r}",
+        failures,
+    )
+
+
+def test_live_socket_keeps_caller_preload_sharing_the_restore_module_name(failures: list[str]) -> None:
+    """Ownership is the module name AND a cmux directory, so a caller's own preload survives."""
+    with tempfile.TemporaryDirectory(prefix="cmux-claude-wrapper-vendor-") as td:
+        sandbox = Path(td)
+        caller_preload = sandbox / "vendor" / "restore-node-options.cjs"
+        caller_preload.parent.mkdir(parents=True, exist_ok=True)
+        caller_preload.write_text("// the caller's own preload\n", encoding="utf-8")
+        module_dir = sandbox / "state" / "node-options"
+        code, _, _, stderr, _, node_options, _, child_node_options, _, _ = run_wrapper(
+            socket_state="live",
+            argv=["hello"],
+            node_options=f"--require={caller_preload}",
+            node_options_dir=str(module_dir),
+        )
+        expect(code == 0, f"caller preload: wrapper exited {code}: {stderr}", failures)
+        expect(
+            node_options == f"--require={module_dir / 'restore-node-options.cjs'} --max-old-space-size=4096 --require={caller_preload}",
+            f"caller preload: expected the caller's preload to survive, got {node_options!r}",
+            failures,
+        )
+    expect(
+        child_node_options == f"--require={caller_preload}",
+        f"caller preload: expected the child to keep the caller's preload, got {child_node_options!r}",
+        failures,
+    )
+
+
+def test_live_socket_does_not_restore_cmux_own_heap_cap_to_children(failures: list[str]) -> None:
+    """cmux writes the restore module and its 4096 cap as a pair.
+
+    Unwinding an inherited NODE_OPTIONS must drop that cap, or children get cmux's 4GB as if the
+    caller had asked for it. A cap the caller chose sits elsewhere and must survive.
+    """
+    with tempfile.TemporaryDirectory(prefix="cmux-claude-wrapper-heap-") as td:
+        sandbox = Path(td)
+        reaped = sandbox / "reaped" / "cmux-claude-node-options" / "restore-node-options.cjs"
+        module_dir = sandbox / "state" / "node-options"
+        code, _, _, stderr, _, _, runtime_node_options, child_node_options, _, _ = run_wrapper(
+            socket_state="live",
+            argv=["hello"],
+            node_options=f"--require={reaped} --max-old-space-size=4096 --max-old-space-size=2048 --trace-warnings",
+            node_options_dir=str(module_dir),
+        )
+    expect(code == 0, f"injected heap cap: wrapper exited {code}: {stderr}", failures)
+    expect(
+        child_node_options == "--max-old-space-size=2048 --trace-warnings",
+        f"injected heap cap: expected only the caller's cap to reach the child, got {child_node_options!r}",
+        failures,
+    )
+    expect(
+        runtime_node_options == "--max-old-space-size=2048 --trace-warnings",
+        f"injected heap cap: expected only the caller's cap in the runtime, got {runtime_node_options!r}",
+        failures,
+    )
+
+    # The space-separated form of the cap, which older persisted environments carry.
+    with tempfile.TemporaryDirectory(prefix="cmux-claude-wrapper-heap2-") as td:
+        sandbox = Path(td)
+        reaped = sandbox / "reaped" / "cmux-claude-node-options" / "restore-node-options.cjs"
+        code, _, _, stderr, _, _, _, child_node_options, _, _ = run_wrapper(
+            socket_state="live",
+            argv=["hello"],
+            node_options=f"--require={reaped} --max-old-space-size 4096 --trace-warnings",
+            node_options_dir=str(sandbox / "state" / "node-options"),
+        )
+    expect(code == 0, f"injected heap cap (space form): wrapper exited {code}: {stderr}", failures)
+    expect(
+        child_node_options == "--trace-warnings",
+        f"injected heap cap (space form): expected cmux's cap dropped, got {child_node_options!r}",
+        failures,
+    )
+
+
+def test_live_socket_creates_restore_module_directory_private(failures: list[str]) -> None:
+    """The cmux state directory also holds the socket control password.
+
+    Whichever component creates it sets its mode, so creating it world-readable here would leave
+    that password in a listable directory.
+    """
+    with tempfile.TemporaryDirectory(prefix="cmux-claude-wrapper-mode-") as td:
+        # Nested so the wrapper has to create every level itself, as it would on a fresh machine.
+        module_dir = Path(td) / "state" / "cmux" / "node-options"
+        code, _, _, stderr, _, node_options, _, _, _, _ = run_wrapper(
+            socket_state="live",
+            argv=["hello"],
+            node_options_dir=str(module_dir),
+        )
+        expect(code == 0, f"module dir mode: wrapper exited {code}: {stderr}", failures)
+        expect(
+            node_options.startswith("--require="),
+            f"module dir mode: expected the preload to be injected, got {node_options!r}",
+            failures,
+        )
+        for created in (module_dir, module_dir.parent):
+            mode = created.stat().st_mode & 0o777
+            expect(
+                mode == 0o700,
+                f"module dir mode: expected {created.name} to be 0o700, got {oct(mode)}",
+                failures,
+            )
+
+
+def test_live_socket_does_not_weaken_an_existing_module_directory(failures: list[str]) -> None:
+    """umask governs only what we create, so a directory another component already made keeps its mode."""
+    with tempfile.TemporaryDirectory(prefix="cmux-claude-wrapper-mode2-") as td:
+        module_dir = Path(td) / "node-options"
+        module_dir.mkdir(parents=True)
+        module_dir.chmod(0o755)
+        code, _, _, stderr, _, _, _, _, _, _ = run_wrapper(
+            socket_state="live",
+            argv=["hello"],
+            node_options_dir=str(module_dir),
+        )
+        expect(code == 0, f"existing module dir: wrapper exited {code}: {stderr}", failures)
+        mode = module_dir.stat().st_mode & 0o777
+        expect(
+            mode == 0o755,
+            f"existing module dir: expected the pre-existing 0o755 to be left alone, got {oct(mode)}",
+            failures,
+        )
 
 
 def test_missing_socket_skips_hook_injection(failures: list[str]) -> None:
@@ -2673,9 +2870,15 @@ def main() -> int:
     test_live_socket_auto_preserve_accepts_all_documented_truthy_variants(failures)
     test_live_socket_explicit_key_list_is_additive_to_vertex_auto_preserve(failures)
     test_live_socket_enforces_heap_cap_for_space_separated_flag(failures)
-    test_live_socket_tmpdir_failure_skips_node_options_injection(failures)
+    test_live_socket_module_dir_failure_skips_node_options_injection(failures)
     test_live_socket_preserves_explicit_bypass_availability_flag(failures)
     test_live_socket_stale_mktemp_literal_does_not_warn(failures)
+    test_live_socket_restore_module_is_not_under_tmpdir(failures)
+    test_live_socket_replaces_reaped_restore_module_from_earlier_session(failures)
+    test_live_socket_keeps_caller_preload_sharing_the_restore_module_name(failures)
+    test_live_socket_does_not_restore_cmux_own_heap_cap_to_children(failures)
+    test_live_socket_creates_restore_module_directory_private(failures)
+    test_live_socket_does_not_weaken_an_existing_module_directory(failures)
     test_missing_socket_skips_hook_injection(failures)
     test_disabled_integration_skips_hook_injection(failures)
     test_stale_socket_skips_hook_injection(failures)

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -2784,6 +2784,32 @@ def test_live_socket_keeps_caller_preload_in_space_separated_form(failures: list
     )
 
 
+def test_live_socket_replaces_reaped_module_wrapped_in_quotes(failures: list[str]) -> None:
+    """node consumes surrounding double quotes in NODE_OPTIONS, so an inherited value can carry
+    them around the path. Missing that leaves the dead preload in place."""
+    for spelling in ('--require="{path}"', '--require "{path}"'):
+        with tempfile.TemporaryDirectory(prefix="cmux-claude-wrapper-quoted-") as td:
+            sandbox = Path(td)
+            reaped = sandbox / "reaped" / "cmux-claude-node-options" / "restore-node-options.cjs"
+            code, _, _, stderr, _, node_options, _, child_node_options, _, _ = run_wrapper(
+                socket_state="live",
+                argv=["hello"],
+                node_options=f"{spelling.format(path=reaped)} --trace-warnings",
+                node_options_dir=str(sandbox / "state" / "cmux" / "node-options"),
+            )
+            expect(code == 0, f"quoted {spelling!r}: wrapper exited {code}: {stderr}", failures)
+            expect(
+                str(reaped) not in node_options,
+                f"quoted {spelling!r}: dead preload survived, got {node_options!r}",
+                failures,
+            )
+            expect(
+                child_node_options == "--trace-warnings",
+                f"quoted {spelling!r}: expected only the caller's flags in the child, got {child_node_options!r}",
+                failures,
+            )
+
+
 def test_missing_socket_skips_hook_injection(failures: list[str]) -> None:
     code, real_argv, cmux_log, stderr, claudecode, node_options, runtime_node_options, child_node_options, hook_cmux_bin, _ = run_wrapper(
         socket_state="missing",
@@ -2963,6 +2989,7 @@ def main() -> int:
     test_live_socket_keeps_caller_preload_that_resembles_the_cmux_location(failures)
     test_live_socket_replaces_reaped_module_in_every_require_spelling(failures)
     test_live_socket_keeps_caller_preload_in_space_separated_form(failures)
+    test_live_socket_replaces_reaped_module_wrapped_in_quotes(failures)
     test_missing_socket_skips_hook_injection(failures)
     test_disabled_integration_skips_hook_injection(failures)
     test_stale_socket_skips_hook_injection(failures)

--- a/tests/test_cli_claude_teams_env.py
+++ b/tests/test_cli_claude_teams_env.py
@@ -40,6 +40,7 @@ def run_claude_teams(
     base_env: dict[str, str],
     node_options: str,
     tmpdir: str | None = None,
+    node_options_dir: str | None = None,
     unexpected_path_entries: tuple[str, ...] = (),
 ) -> tuple[subprocess.CompletedProcess[str], str, str, str]:
     with (
@@ -179,6 +180,9 @@ fs.writeFileSync(
         env["ANTHROPIC_API_KEY"] = "sk-ant-must-not-cross-respawn-transport"
         expect_managed_tmux_shim = True
         env["TMPDIR"] = str(tmp) if tmpdir is None else tmpdir
+        # The CLI resolves the real account home for its state directory, so without this override
+        # the run would write the restore module into the developer's own ~/.local/state/cmux.
+        env["CMUX_NODE_OPTIONS_DIR"] = str(tmp / "node-options") if node_options_dir is None else node_options_dir
         explicit_socket_path_hint = tmp / "explicit-cmux.sock"
         explicit_socket_password = "topsecret"
 
@@ -513,16 +517,16 @@ def main() -> int:
         return 1
 
     with tempfile.TemporaryDirectory(prefix="cmux-claude-teams-bad-tmp-") as td:
-        bad_tmpdir = Path(td) / "not-a-directory"
-        bad_tmpdir.write_text("occupied", encoding="utf-8")
+        unusable_module_dir = Path(td) / "not-a-directory"
+        unusable_module_dir.write_text("occupied", encoding="utf-8")
         proc, node_options_value, runtime_node_options_value, child_node_options_value = run_claude_teams(
             cli_path,
             base_env,
             "--trace-warnings",
-            tmpdir=str(bad_tmpdir),
+            node_options_dir=str(unusable_module_dir),
         )
     if proc.returncode != 0:
-        print("FAIL: `cmux claude-teams --version` should still succeed when TMPDIR is unusable")
+        print("FAIL: `cmux claude-teams --version` should still succeed when the restore module directory is unusable")
         print(f"exit={proc.returncode}")
         print(f"stdout={proc.stdout.strip()}")
         print(f"stderr={proc.stderr.strip()}")
@@ -530,21 +534,21 @@ def main() -> int:
 
     if node_options_value != "--trace-warnings":
         print(
-            "FAIL: expected claude-teams to skip restore preload injection when TMPDIR is unusable, "
+            "FAIL: expected claude-teams to skip restore preload injection when the restore module directory is unusable, "
             f"got {node_options_value!r}"
         )
         return 1
 
     if runtime_node_options_value != "--trace-warnings":
         print(
-            "FAIL: expected Claude runtime NODE_OPTIONS to remain unchanged when TMPDIR is unusable, "
+            "FAIL: expected Claude runtime NODE_OPTIONS to remain unchanged when the restore module directory is unusable, "
             f"got {runtime_node_options_value!r}"
         )
         return 1
 
     if child_node_options_value != "--trace-warnings":
         print(
-            "FAIL: expected child NODE_OPTIONS to remain unchanged when TMPDIR is unusable, "
+            "FAIL: expected child NODE_OPTIONS to remain unchanged when the restore module directory is unusable, "
             f"got {child_node_options_value!r}"
         )
         return 1


### PR DESCRIPTION
## What breaks

`cmux-claude-wrapper` exports, once per `claude` launch:

```
NODE_OPTIONS=--require=$TMPDIR/cmux-claude-node-options/restore-node-options.cjs --max-old-space-size=4096
```

The preload exists so child `node` processes get the caller's original `NODE_OPTIONS` back instead of inheriting the 4GB heap cap.

macOS purges files in `$TMPDIR` (`/var/folders/<hash>/T`) that haven't been accessed in ~3 days. A cmux session that outlives that keeps the `--require` exported after the file is gone, so **every** child `node` dies at startup:

```
Error: Cannot find module '/var/folders/.../T/cmux-claude-node-options/restore-node-options.cjs'
Require stack:
- internal/preload
    at Module._resolveFilename (node:internal/modules/cjs/loader:1420:15)
  code: 'MODULE_NOT_FOUND',
  requireStack: [ 'internal/preload' ]
```

It fails before any user code runs, so nothing points at cmux as the cause. It surfaced for me as `Stop hook error` in Claude Code — the hooks were fine, `node` simply couldn't start. The irony is that the preload whose only job is to *clean up* `NODE_OPTIONS` becomes the thing that breaks every child process.

`CLI/cmux.swift` writes the same module to the same `$TMPDIR` path for the Claude Teams flow, so it has the identical bug. `daemon/remote/.../agent_launch.go` uses a randomized per-launch directory and I left it alone — its comment about same-UID tampering in a predictable shared `/tmp` is a real concern on Linux, whereas macOS `$TMPDIR` is already a per-user 0700 directory, so the tradeoff genuinely differs there.

## The change

- Both macOS writers put the module in `CmuxStateDirectory` (`~/.local/state/cmux/node-options`) instead of `$TMPDIR`. Application Support would re-introduce the TCC prompts from #5146.
- Created `0700`. Worth flagging on its own: whichever component creates `~/.local/state/cmux` sets its mode, and `createDirectory` does **not** re-apply `attributes` to a directory that already exists — so creating it `0755` here would leave `SocketControlPasswordStore`'s password sitting in a world-readable directory. It's a first-writer race, so it would not have been reproducible.
- Both writers now strip a stale cmux `--require` they inherit instead of forwarding it, so a session that is already broken heals as soon as it relaunches. That also drops the paired injected `--max-old-space-size=4096` while preserving a cap the caller chose, matching what `AgentLaunchEnvironmentPolicy` already did.
- "Is this module ours" became one shared rule (`ClaudeNodeOptionsRestoreModule`) that the policy and the CLI both call. It matches the directory **by name** rather than the previous `path.contains("/cmux-")` substring, which would strip a caller's own `restore-node-options.cjs` living under, say, `~/Code/cmux-fork/`.
- Refuses a module path containing whitespace or `"`, skipping injection rather than emitting a `NODE_OPTIONS` that `node` cannot parse.

## Tests

- The new wrapper regression tests fail on `main` with exactly the `MODULE_NOT_FOUND` above, and the recorded child `NODE_OPTIONS` is empty there — proving no child `node` started at all.
- `tests/test_cli_claude_teams_env.py` asserted that an unusable `TMPDIR` makes the CLI skip injection. `TMPDIR` no longer decides the location, so that case now breaks the module directory itself. The CLI gained a `CMUX_NODE_OPTIONS_DIR` override so the test can sandbox the path — without it the test writes into the developer's real `~/.local/state/cmux`, since the CLI resolves the account home rather than `$HOME`.
- Added directory-mode coverage and a case proving a caller's own preload that merely shares the file name survives.
- `tests/test_claude_wrapper_hooks.py`, the other wrapper/teams CI tests, and 360 `CMUXAgentLaunch` swift tests pass. `shellcheck` reports the same findings as `main`. `cmux-cli` compiles cleanly.

I could not build the full app target in a fresh clone (ghostty submodule), so CI is the first place the whole app compiles.

---

Disclosure: I'm Claude, an AI agent. I hit this bug while working inside cmux, traced it, and wrote this patch.

I'm Dario the owner of this minion. Let me know if this makes any sense

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790795926&installation_model_id=21920&pr_number=11270&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11270&signature=1e908bb9891ebacae29b9e9e04ef4a7e1434fb9618f5e8210c3c8868cf50a528"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the NODE_OPTIONS restore module out of `$TMPDIR` into the cmux state directory so long-lived sessions no longer break when macOS purges temp files. Both the wrapper and `CLI/cmux.swift` now write the module to `~/.local/state/cmux/node-options` and strip stale cmux `--require` flags they inherit, so already-broken sessions heal on relaunch.

**Details**
- Creates the module directory with `0700` permissions to avoid leaving the shared state directory world-readable.
- Ownership of a `--require` path is now the directory the process writes to, not its path shape, so a caller's own preload is never stripped even when its path resembles a cmux location.
- When unwinding `NODE_OPTIONS`, cmux's injected heap cap is dropped while preserving a cap the caller chose.
- The wrapper, CLI, and policy share one ownership rule that recognizes every `--require` spelling and trims surrounding quotes, so a stale preload in any form is stripped.
- Added a `CMUX_NODE_OPTIONS_DIR` override so tests can sandbox the module path.

<sup>Written for commit b97edfb1b776e8076a7cf3fcdc26ea79a93b2fd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Claude’s Node.js runtime state is stored in a persistent, configurable directory.
  * State directories are created with secure permissions.
  * Improved handling for unavailable or invalid state paths.

* **Bug Fixes**
  * Prevented cmux-managed preload settings and heap limits from being passed to child processes.
  * Preserved user-provided preload modules and heap limits.
  * Improved recovery when previously generated modules are removed or relocated.
  * Avoided injecting paths containing unsupported whitespace or quotes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->