### PR TITLE
ios: fade accessory shortcut row incrementally at its leading edge

### DIFF
--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/AccessoryEdgeFadeScrollView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/AccessoryEdgeFadeScrollView.swift
@@ -28,8 +28,11 @@ final class AccessoryEdgeFadeScrollView: UIScrollView {
     /// fade) while the row rests at its origin, ramping linearly to 0 (fully
     /// faded) once the content has scrolled a full ``fadeWidth`` past the
     /// edge. The ramp is what makes the fade INCREMENTAL: a 1pt scroll barely
-    /// dims the edge instead of snapping a full gradient on, and rubber-band
-    /// bounce (negative offsets) stays fully opaque.
+    /// dims the edge instead of snapping a full gradient on. Negative offsets
+    /// stay fully opaque, which covers both rubber-band bounce and the at-rest
+    /// position when the host carries the inter-button gap as a leading
+    /// content inset (rest offset -gap): the fade begins only once a key
+    /// actually reaches the viewport's leading edge.
     nonisolated static func leadingEdgeAlpha(contentOffsetX: CGFloat, fadeWidth: CGFloat = fadeWidth) -> CGFloat {
         guard fadeWidth > 0 else { return 0 }
         return 1 - min(1, max(0, contentOffsetX / fadeWidth))

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/AccessoryEdgeFadeScrollView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/AccessoryEdgeFadeScrollView.swift
@@ -1,0 +1,86 @@
+import UIKit
+
+/// The accessory button row's horizontal scroll view, with a leading-edge fade
+/// that ramps in as the row scrolls.
+///
+/// The row is clipped on its left by the pinned composer button, so without a
+/// mask the Ctrl/Esc/Tab keys shear off abruptly against it mid-scroll. This
+/// masks the leading ``fadeWidth`` points with an alpha gradient whose edge
+/// opacity tracks ``leadingEdgeAlpha(contentOffsetX:fadeWidth:)``: invisible
+/// at rest (the first key renders fully), strengthening with the first points
+/// of scroll, and a full transparent→opaque ramp once scrolled past a band
+/// width. Buttons therefore dissolve under the composer button instead of
+/// hard-clipping, which also signals that scrolled-away keys exist to the
+/// left (HIG scroll-view guidance: imply continuation past the edge).
+///
+/// The mask is updated from `layoutSubviews`, which UIKit invokes for every
+/// `contentOffset` change, so no scroll-view delegate is consumed; the
+/// gradient's frame tracks `bounds` (whose origin IS the content offset) to
+/// stay glued to the visible viewport rather than scrolling with the content.
+final class AccessoryEdgeFadeScrollView: UIScrollView {
+    /// Width in points of the leading fade band, and the scroll distance over
+    /// which the fade ramps from nothing to full strength. Sized near one
+    /// button width (`accessoryButtonMinWidth` is 32) so a key dissolves over
+    /// roughly its own width as it slides under the row's leading edge.
+    nonisolated static let fadeWidth: CGFloat = 24
+
+    /// Opacity at the row's leading edge for a given scroll offset. 1 (no
+    /// fade) while the row rests at its origin, ramping linearly to 0 (fully
+    /// faded) once the content has scrolled a full ``fadeWidth`` past the
+    /// edge. The ramp is what makes the fade INCREMENTAL: a 1pt scroll barely
+    /// dims the edge instead of snapping a full gradient on, and rubber-band
+    /// bounce (negative offsets) stays fully opaque.
+    nonisolated static func leadingEdgeAlpha(contentOffsetX: CGFloat, fadeWidth: CGFloat = fadeWidth) -> CGFloat {
+        guard fadeWidth > 0 else { return 0 }
+        return 1 - min(1, max(0, contentOffsetX / fadeWidth))
+    }
+
+    /// The fade band's end position as a fraction of the viewport width, for a
+    /// gradient whose coordinate space spans the visible bounds. Clamped to 1
+    /// so a degenerate (narrower-than-band) viewport fades across its whole
+    /// width instead of placing a gradient stop out of range.
+    nonisolated static func fadeBandFraction(viewportWidth: CGFloat, fadeWidth: CGFloat = fadeWidth) -> CGFloat {
+        guard viewportWidth > 0 else { return 0 }
+        return min(1, fadeWidth / viewportWidth)
+    }
+
+    private let fadeMask: CAGradientLayer = {
+        let gradient = CAGradientLayer()
+        gradient.startPoint = CGPoint(x: 0, y: 0.5)
+        gradient.endPoint = CGPoint(x: 1, y: 0.5)
+        return gradient
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        layer.mask = fadeMask
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not supported")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        updateFadeMask()
+    }
+
+    private func updateFadeMask() {
+        guard bounds.width > 0 else { return }
+        let edgeAlpha = Self.leadingEdgeAlpha(contentOffsetX: contentOffset.x)
+        let bandEnd = Self.fadeBandFraction(viewportWidth: bounds.width)
+        // Mask layers read only the alpha channel; disable implicit animations
+        // so the gradient tracks finger-driven scrolling without trailing.
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        fadeMask.frame = bounds
+        fadeMask.colors = [
+            UIColor(white: 0, alpha: edgeAlpha).cgColor,
+            UIColor(white: 0, alpha: 1).cgColor,
+            UIColor(white: 0, alpha: 1).cgColor,
+        ]
+        fadeMask.locations = [0, NSNumber(value: Double(bandEnd)), 1]
+        CATransaction.commit()
+    }
+}

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
@@ -365,8 +365,10 @@ final class TerminalInputTextView: UIView, UIKeyInput, UITextInput {
         dismissButton.translatesAutoresizingMaskIntoConstraints = false
         self.dismissButton = dismissButton
 
-        // Scrollable action buttons
-        let scrollView = UIScrollView()
+        // Scrollable action buttons. The fade subclass dissolves keys under
+        // the leading edge (against the pinned composer button) incrementally
+        // as the row scrolls, instead of hard-clipping them.
+        let scrollView = AccessoryEdgeFadeScrollView()
         scrollView.showsHorizontalScrollIndicator = false
         scrollView.showsVerticalScrollIndicator = false
         scrollView.alwaysBounceHorizontal = true

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
@@ -373,6 +373,16 @@ final class TerminalInputTextView: UIView, UIKeyInput, UITextInput {
         scrollView.showsVerticalScrollIndicator = false
         scrollView.alwaysBounceHorizontal = true
         scrollView.translatesAutoresizingMaskIntoConstraints = false
+        // The scroll view's FRAME starts flush at the composer button's
+        // trailing edge; the 4pt visual gap the frame constant used to carry
+        // lives INSIDE the scroll view as a leading content inset. At rest the
+        // bar reads identically (first key sits 4pt after the composer, offset
+        // -4), but a scrolled key now travels through that gap and dissolves
+        // AT the composer's edge, fading into the empty gap instead of
+        // clipping against an invisible line 4pt short of the button.
+        scrollView.contentInsetAdjustmentBehavior = .never
+        scrollView.contentInset.left = 4
+        scrollView.contentOffset = CGPoint(x: -4, y: 0)
 
         let stack = UIStackView()
         stack.axis = .horizontal
@@ -469,13 +479,13 @@ final class TerminalInputTextView: UIView, UIKeyInput, UITextInput {
 
             // Pinned composer toggle: directly after the nub (same 6pt gap the
             // scroll view used to take), centered on the shared strip line. The
-            // scroll view starts after it with the 4pt inter-button spacing the
-            // stack uses, so the bar reads identically to before — only now the
-            // composer can never scroll away.
+            // scroll view starts FLUSH after it; the 4pt inter-button gap is a
+            // leading content inset (see above) so scrolled keys fade out at
+            // the composer's edge rather than at a line 4pt short of it.
             composerButton.leadingAnchor.constraint(equalTo: nub.trailingAnchor, constant: 6),
             composerButton.centerYAnchor.constraint(equalTo: buttonRow.centerYAnchor),
 
-            scrollView.leadingAnchor.constraint(equalTo: composerButton.trailingAnchor, constant: 4),
+            scrollView.leadingAnchor.constraint(equalTo: composerButton.trailingAnchor),
             scrollTrailingConstraint,
             scrollView.topAnchor.constraint(equalTo: buttonRow.topAnchor),
             scrollView.bottomAnchor.constraint(equalTo: buttonRow.bottomAnchor),

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/AccessoryEdgeFadeTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/AccessoryEdgeFadeTests.swift
@@ -1,0 +1,33 @@
+import Testing
+
+@testable import CmuxMobileTerminal
+
+@Suite("Accessory leading-edge scroll fade")
+struct AccessoryEdgeFadeTests {
+    @Test("edge stays fully opaque at rest and during leading bounce")
+    func opaqueAtRest() {
+        #expect(AccessoryEdgeFadeScrollView.leadingEdgeAlpha(contentOffsetX: 0) == 1)
+        #expect(AccessoryEdgeFadeScrollView.leadingEdgeAlpha(contentOffsetX: -30) == 1)
+    }
+
+    @Test("fade ramps linearly with the first points of scroll")
+    func incrementalRamp() {
+        let quarter = AccessoryEdgeFadeScrollView.leadingEdgeAlpha(contentOffsetX: 6, fadeWidth: 24)
+        let half = AccessoryEdgeFadeScrollView.leadingEdgeAlpha(contentOffsetX: 12, fadeWidth: 24)
+        #expect(abs(quarter - 0.75) < 0.0001)
+        #expect(abs(half - 0.5) < 0.0001)
+    }
+
+    @Test("fade saturates once scrolled a full band width")
+    func saturates() {
+        #expect(AccessoryEdgeFadeScrollView.leadingEdgeAlpha(contentOffsetX: 24, fadeWidth: 24) == 0)
+        #expect(AccessoryEdgeFadeScrollView.leadingEdgeAlpha(contentOffsetX: 500, fadeWidth: 24) == 0)
+    }
+
+    @Test("band fraction spans the band, clamped to degenerate viewports")
+    func bandFraction() {
+        #expect(abs(AccessoryEdgeFadeScrollView.fadeBandFraction(viewportWidth: 240, fadeWidth: 24) - 0.1) < 0.0001)
+        #expect(AccessoryEdgeFadeScrollView.fadeBandFraction(viewportWidth: 10, fadeWidth: 24) == 1)
+        #expect(AccessoryEdgeFadeScrollView.fadeBandFraction(viewportWidth: 0, fadeWidth: 24) == 0)
+    }
+}

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/AccessoryEdgeFadeTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/AccessoryEdgeFadeTests.swift
@@ -7,6 +7,9 @@ struct AccessoryEdgeFadeTests {
     @Test("edge stays fully opaque at rest and during leading bounce")
     func opaqueAtRest() {
         #expect(AccessoryEdgeFadeScrollView.leadingEdgeAlpha(contentOffsetX: 0) == 1)
+        // Rest position when the host carries the 4pt inter-button gap as a
+        // leading content inset: still no fade until a key reaches the edge.
+        #expect(AccessoryEdgeFadeScrollView.leadingEdgeAlpha(contentOffsetX: -4) == 1)
         #expect(AccessoryEdgeFadeScrollView.leadingEdgeAlpha(contentOffsetX: -30) == 1)
     }
 


### PR DESCRIPTION
The keyboard accessory's scrollable shortcut row (Ctrl/Esc/Tab/…) hard-clips against the pinned composer button on its left while scrolling. This adds `AccessoryEdgeFadeScrollView`, a `UIScrollView` subclass that masks the row's leading 24pt with an alpha gradient whose edge opacity ramps with `contentOffset.x`: no fade at rest (the first key renders fully), a 1pt scroll barely dims the edge, and the ramp saturates to a full transparent→opaque band once the row has scrolled one band width. Keys dissolve under the left edge instead of shearing off, and the fade doubles as a cue that scrolled-away keys exist to the left.

The mask updates from `layoutSubviews` (UIKit invokes it for every `contentOffset` change), so no scroll-view delegate is consumed; the gradient frame tracks `bounds` to stay glued to the viewport. Rubber-band bounce stays fully opaque, and the band clamps to degenerate viewport widths. The ramp math lives as `nonisolated` statics on the view (namespace-enum lint disallows a caseless helper enum) with unit tests in `CmuxMobileTerminalTests/AccessoryEdgeFadeTests`.

HIG: checked https://developer.apple.com/design/human-interface-guidelines/scroll-views — fading near an edge to imply continuation beyond the visible region is consistent with its guidance to make additional content apparent; no deliberate deviation.

Localization audit: no user-facing strings added or changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790800310&installation_model_id=21920&pr_number=11271&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11271&signature=265964001bc84c84951d8cceb2fa2f010fe99f68869ddb14f8850b2a351c5250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fades the keyboard accessory's scrollable shortcut row at its leading edge so Ctrl/Esc/Tab keys dissolve under the pinned composer button instead of hard-clipping mid-scroll. The fade is invisible at rest and ramps in with `contentOffset.x`; the row's 4pt leading gap now lives as a content inset so scrolled keys fade into empty space at the composer's edge rather than clipping at a line 4pt short of it.

<sup>Written for commit 0ff436a64b4e8515ebc1301ac361dc432b77944f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Accessory buttons in the terminal toolbar now fade smoothly as they scroll beneath the pinned composer button, replacing the previous hard-clipping effect.
  * Scrolling behavior is aligned more closely with the composer button for a cleaner transition.

* **Tests**
  * Added coverage to verify fading behavior at rest, during bounce states, across the fade area, and in narrow or zero-width layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->