### PR TITLE
ios: make export signingCertificate overridable via IOS_SIGNING_CERTIFICATE

### DIFF
--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -1016,10 +1016,14 @@ if [[ "$SIGNING" == "automatic" ]]; then
   # naming a profile that isn't installed makes -exportArchive fail.
   plutil -insert signingStyle -string automatic "$EXPORT_OPTIONS"
 else
-  # Manual signing: requires the "Apple Distribution" certificate and the named
+  # Manual signing: requires the distribution certificate and the named
   # provisioning profile to already be present in the local keychain.
+  # IOS_SIGNING_CERTIFICATE selects the certificate TYPE name Xcode matches
+  # against ("Apple Distribution" default; set "iPhone Distribution" when the
+  # keychain only holds an iOS-only distribution cert, whose identity string
+  # uses the legacy prefix).
   plutil -insert signingStyle -string manual "$EXPORT_OPTIONS"
-  plutil -insert signingCertificate -string "Apple Distribution" "$EXPORT_OPTIONS"
+  plutil -insert signingCertificate -string "${IOS_SIGNING_CERTIFICATE:-Apple Distribution}" "$EXPORT_OPTIONS"
   "$PLISTBUDDY" -c "Add :provisioningProfiles dict" "$EXPORT_OPTIONS"
   "$PLISTBUDDY" -c "Add :provisioningProfiles:$PRODUCT_BUNDLE_IDENTIFIER string $PROVISIONING_PROFILE_NAME" "$EXPORT_OPTIONS"
 fi


### PR DESCRIPTION
The manual-signing export path in `ios/scripts/upload-testflight.sh` hardcoded `signingCertificate` to "Apple Distribution". When the local keychain only holds an iOS-only distribution certificate (ASC type `IOS_DISTRIBUTION`, identity prefix "iPhone Distribution"), `-exportArchive` fails to match a cert. Apple caps DISTRIBUTION-type certs per team, so an iOS-only cert can be the only mintable option; the 1.0.0 App Store upload on 2026-08-27 (build 20260826220456) shipped with exactly this override applied by hand in the worktree.

`IOS_SIGNING_CERTIFICATE` now overrides the certificate type name and defaults to the previous "Apple Distribution", so automatic signing and existing manual-signing setups behave identically. `IOS_DISTRIBUTION_IDENTITY` (the re-sign identity override) already existed; this completes the pair for the export step.

Script-only change, no runtime build needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11272"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790803774&installation_model_id=21920&pr_number=11272&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11272&signature=47ad749b26b41c0bc85fb1849b18edb265e7152522c215a2951073a7b395d434"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the manual-signing export step in `ios/scripts/upload-testflight.sh` accept an `IOS_SIGNING_CERTIFICATE` override, so uploads succeed when the keychain only holds an iOS-only distribution certificate. Defaults to "Apple Distribution", keeping existing automatic and manual signing setups unchanged. Script-only change, no runtime build needed.

<sup>Written for commit a8e6f056b6b4083d806a149c00aeffddf078364b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for overriding the iOS signing certificate during manual TestFlight exports.
  * Defaults to the standard Apple Distribution certificate when no override is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->