### PR TITLE
ios: closing search with the X resets the query

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimarySearchCoordinator.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimarySearchCoordinator.swift
@@ -36,7 +36,7 @@ final class MobilePrimarySearchCoordinator {
 
     func setPresentation(_ presented: Bool) {
         if isPresented, !presented {
-            commitNativeDraft(for: scope)
+            resetSearchQuery(for: scope)
             beginDeactivation(for: scope)
         }
         isPresented = presented
@@ -65,7 +65,7 @@ final class MobilePrimarySearchCoordinator {
             platformSearchingScope = scope
         } else if phase == .active(scope) {
             guard platformSearchingScope == scope else { return }
-            commitNativeDraft(for: scope)
+            resetSearchQuery(for: scope)
             beginDeactivation(for: scope)
         }
     }
@@ -178,6 +178,16 @@ final class MobilePrimarySearchCoordinator {
             searchQueryBounds.normalizedFilterText(nativeSearchText(for: scope)).value,
             for: scope
         )
+    }
+
+    /// Dismissing search without submitting (the search tab's round X, or a
+    /// platform-driven end of searching) cancels the query outright: draft and
+    /// committed text both clear so the scope returns to its unfiltered list
+    /// and the next activation starts empty. Submit and in-search navigation
+    /// keep committing through ``commitNativeDraft(for:)``.
+    private func resetSearchQuery(for scope: MobilePrimarySearchScope) {
+        setCommittedSearchText("", for: scope)
+        setNativeSearchText("", for: scope)
     }
 
     private func syncNativeSearchText(fromCommittedQueryFor scope: MobilePrimarySearchScope) {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimarySearchCoordinator.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimarySearchCoordinator.swift
@@ -59,6 +59,18 @@ final class MobilePrimarySearchCoordinator {
         isPresented = false
     }
 
+    /// A TabView-driven selection change away from a presented search is the
+    /// search tab's round X: while search is presented the tab bar is the
+    /// search field, so no other tab control can move selection. The X
+    /// cancels the query instead of committing it. Programmatic transitions
+    /// (result taps, deep links) keep committing through
+    /// ``deactivateCurrentSearch()``.
+    func cancelPresentedSearch() {
+        resetSearchQuery(for: scope)
+        beginDeactivation(for: scope)
+        isPresented = false
+    }
+
     func updateLifecycle(scope: MobilePrimarySearchScope, isSearching: Bool) {
         if isSearching {
             activate(scope: scope)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimaryTabScaffold.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimaryTabScaffold.swift
@@ -109,9 +109,15 @@ struct MobilePrimaryTabScaffold<
         Binding(
             get: { selection },
             set: { newValue in
-                if (selection == .search || searchCoordinator.isPresented),
-                   newValue.searchScope != nil {
-                    searchCoordinator.deactivateCurrentSearch()
+                if newValue.searchScope != nil {
+                    if searchCoordinator.isPresented {
+                        // The round X returns selection to the previous tab
+                        // while search is still presented; it cancels the
+                        // query rather than committing it as a filter.
+                        searchCoordinator.cancelPresentedSearch()
+                    } else if selection == .search {
+                        searchCoordinator.deactivateCurrentSearch()
+                    }
                 }
                 selection = newValue
             }

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobilePrimarySearchCoordinatorTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobilePrimarySearchCoordinatorTests.swift
@@ -61,6 +61,41 @@ import Testing
         #expect(coordinator.searchDestinationText(for: .notifications) == "")
     }
 
+    @Test func cancelPresentedSearchResetsQueryAndDismisses() {
+        let coordinator = MobilePrimarySearchCoordinator()
+        coordinator.synchronizeSelection(.workspaces)
+        coordinator.setPresentation(true)
+        coordinator.updateNativeSearchText(
+            "docs",
+            for: .workspaces,
+            activationGeneration: coordinator.activationGeneration
+        )
+
+        coordinator.cancelPresentedSearch()
+
+        #expect(coordinator.isPresented == false)
+        #expect(coordinator.workspaces == "")
+        #expect(coordinator.activeNativeSearchText() == "")
+        #expect(coordinator.searchDestinationText(for: .workspaces) == "")
+    }
+
+    @Test func deactivateCurrentSearchStillCommitsDraftForResultNavigation() {
+        let coordinator = MobilePrimarySearchCoordinator()
+        coordinator.synchronizeSelection(.workspaces)
+        coordinator.setPresentation(true)
+        coordinator.updateNativeSearchText(
+            "docs",
+            for: .workspaces,
+            activationGeneration: coordinator.activationGeneration
+        )
+
+        coordinator.deactivateCurrentSearch()
+
+        #expect(coordinator.isPresented == false)
+        #expect(coordinator.workspaces == "docs")
+        #expect(coordinator.searchDestinationText(for: .workspaces) == "docs")
+    }
+
     @Test func dismissedSearchClearsPreviouslySubmittedQuery() {
         let coordinator = MobilePrimarySearchCoordinator()
         coordinator.synchronizeSelection(.workspaces)

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobilePrimarySearchCoordinatorTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobilePrimarySearchCoordinatorTests.swift
@@ -44,7 +44,7 @@ import Testing
         #expect(coordinator.activeNativeSearchText() == "release")
     }
 
-    @Test func dismissedSearchCommitsNativeDraft() {
+    @Test func dismissedSearchResetsDraftAndCommittedQuery() {
         let coordinator = MobilePrimarySearchCoordinator(initialScope: .notifications)
         coordinator.synchronizeSelection(.notifications)
         coordinator.setPresentation(true)
@@ -56,9 +56,31 @@ import Testing
 
         coordinator.setPresentation(false)
 
-        #expect(coordinator.notifications == "alerts")
-        #expect(coordinator.activeNativeSearchText() == "alerts")
-        #expect(coordinator.searchDestinationText(for: .notifications) == "alerts")
+        #expect(coordinator.notifications == "")
+        #expect(coordinator.activeNativeSearchText() == "")
+        #expect(coordinator.searchDestinationText(for: .notifications) == "")
+    }
+
+    @Test func dismissedSearchClearsPreviouslySubmittedQuery() {
+        let coordinator = MobilePrimarySearchCoordinator()
+        coordinator.synchronizeSelection(.workspaces)
+        coordinator.setPresentation(true)
+        coordinator.updateNativeSearchText(
+            "docs",
+            for: .workspaces,
+            activationGeneration: coordinator.activationGeneration
+        )
+        #expect(coordinator.commitSubmit() == .workspaces)
+        #expect(coordinator.workspaces == "docs")
+
+        coordinator.setPresentation(true)
+        #expect(coordinator.activeNativeSearchText() == "docs")
+
+        coordinator.setPresentation(false)
+
+        #expect(coordinator.workspaces == "")
+        #expect(coordinator.activeNativeSearchText() == "")
+        #expect(coordinator.searchDestinationText(for: .workspaces) == "")
     }
 
     @Test func nativeNotificationSearchBoundsDisplayedDraftAndCommittedQuery() {
@@ -181,7 +203,7 @@ import Testing
         #expect(coordinator.searchDestinationText(for: .notifications) == "alerts")
     }
 
-    @Test func falseLifecycleCallbackAfterObservedSearchDismissesAndCommitsDraft() {
+    @Test func falseLifecycleCallbackAfterObservedSearchDismissesAndResetsQuery() {
         let coordinator = MobilePrimarySearchCoordinator(initialScope: .notifications)
         coordinator.synchronizeSelection(.notifications)
         coordinator.setPresentation(true)
@@ -195,14 +217,14 @@ import Testing
 
         coordinator.updateLifecycle(scope: .notifications, isSearching: false)
         coordinator.updateNativeSearchText(
-            "",
+            "late platform write",
             for: .notifications,
             activationGeneration: activation
         )
 
-        #expect(coordinator.notifications == "alerts")
-        #expect(coordinator.activeNativeSearchText() == "alerts")
-        #expect(coordinator.searchDestinationText(for: .notifications) == "alerts")
+        #expect(coordinator.notifications == "")
+        #expect(coordinator.activeNativeSearchText() == "")
+        #expect(coordinator.searchDestinationText(for: .notifications) == "")
     }
 
     @Test func notificationDeepLinkUsesNotificationSearchOnlyWhenThatSearchScopeIsMounted() {


### PR DESCRIPTION
Closing the iOS 26 search tab via the round X previously kept the query: the draft was committed as the active scope's filter, so the workspaces or notifications list stayed filtered by text the user had just dismissed, and reopening search restored the old text. Dismissing search without submitting now clears both the native draft and the committed query, so the X cancels the search outright. Submit (return key) and result-tap navigation still commit the query.

Simulator preflight showed the X never reaches `setPresentation(false)` while search is presented: the system first moves the TabView selection back to the previous tab, and the scaffold's selection binding ran `deactivateCurrentSearch()`, committing the draft before the presentation binding fired. The fix is in three commits:

1. failing coordinator tests encoding the reset-on-dismiss contract (red)
2. `MobilePrimarySearchCoordinator` resets on the presentation-binding and platform-lifecycle dismissal paths (green for those paths)
3. the scaffold's tab-selection binding routes a selection change away from a presented search through the new `cancelPresentedSearch()`, which is the path the X actually takes; `deactivateCurrentSearch()` keeps committing for result taps and deep links, covered by a regression test

Verified in the tagged `sxrst` build on an isolated iPhone 17 simulator: type in search, tap the X, the workspaces list is unfiltered again and reopening search shows an empty field. Before commit 3 the same drive left the list filtered and the text restored.

The manual-only `test-ios.yml` lane currently fails on main for unrelated pre-existing reasons (package-conventions lint errors and `ios/cmuxPackage` test targets that no longer compile against updated Iroh broker protocols), so the red/green runs were also demonstrated by compiling the coordinator plus its value-type dependencies and this test file as a standalone SwiftPM package: 9 expectation failures at commit 1, 19/19 pass at head.

HIG note (Packages/iOS/AGENTS.md): the [Searching](https://developer.apple.com/design/human-interface-guidelines/searching) page was fetched but rendered title-only in this sandbox; the change follows the system-app convention that canceling search clears the query and returns to the pre-search state, while the field's small in-field clear button still handles clearing without dismissal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)