### PR TITLE
devbox image: bake ble.sh tput caches so first panes open clean

### DIFF
--- a/web/services/vms/images/blaxel/Dockerfile
+++ b/web/services/vms/images/blaxel/Dockerfile
@@ -22,7 +22,7 @@
 FROM debian:trixie-slim
 
 # Cache-buster: bump to force a full rebuild on Blaxel's builder.
-ENV CMUX_IMAGE_EPOCH=2026-08-28-r10
+ENV CMUX_IMAGE_EPOCH=2026-08-31-r11
 
 # Blaxel's sandbox API binary is mandatory in every custom image: it is the control
 # plane (port 8080) the driver uses for filesystem and process operations.
@@ -200,6 +200,35 @@ RUN printf '%s\n' '[ -f /etc/cmux/bashrc ] && . /etc/cmux/bashrc' >> /etc/bash.b
   && printf '%s\n' '[ -f /etc/cmux/bashrc ] && . /etc/cmux/bashrc' >> /root/.bashrc \
   && printf '%s\n' '[ -f /etc/cmux/bashrc ] && . /etc/cmux/bashrc' >> /home/cua/.bashrc \
   && echo 'set -g default-shell /bin/bash' >> /etc/tmux.conf
+
+# Pre-generate ble.sh's per-TERM tput caches for the terminals cmux panes use.
+# Without them the FIRST shell on a machine prints
+# "ble/term.sh: updating tput cache for TERM=... done" into the pane (and pays
+# the tput walk) before its first prompt. ble.sh resolves its cache dir in two
+# steps (verified live on a machine): ${XDG_CACHE_HOME:-~/.cache}/blesh/<ver>
+# only when that base dir ALREADY exists, else <blesh>/cache.d/<uid>. A fresh
+# home volume has no ~/.cache, so panes start on cache.d/<uid> and switch to
+# the XDG path once anything creates ~/.cache — both places are seeded:
+# cache.d here, the XDG copy by cmux-bashrc from /etc/cmux/blesh-cache-seed.
+# Generation runs ble.sh itself through the rc chain above under a pty
+# (`script`; ble.sh refuses `bash -c` and ttyless shells), so the cache layout
+# stays ble.sh's own business. The freshness test ble.sh applies is
+# "cache newer than lib/init-term.sh" — everything here is written after the
+# tarball unpack, and the hard `test` guards prove the bake produced files.
+RUN mkdir -p /etc/cmux/blesh-cache-seed \
+  && for term in xterm-256color screen-256color tmux-256color linux; do \
+       printf 'exit\n' | TERM="$term" HOME=/tmp/blesh-seed-home XDG_CACHE_HOME=/etc/cmux/blesh-cache-seed \
+         script -qec 'bash -i' /dev/null >/dev/null 2>&1 || true; \
+     done \
+  && rm -rf /tmp/blesh-seed-home \
+  && test -s /etc/cmux/blesh-cache-seed/blesh/*/term.xterm-256color \
+  && test -s /etc/cmux/blesh-cache-seed/blesh/*/term.screen-256color \
+  && mkdir -p /usr/local/share/blesh/cache.d/0 /usr/local/share/blesh/cache.d/1000 \
+  && chmod a+rwxt /usr/local/share/blesh/cache.d \
+  && cp /etc/cmux/blesh-cache-seed/blesh/*/term.* /usr/local/share/blesh/cache.d/0/ \
+  && cp /etc/cmux/blesh-cache-seed/blesh/*/term.* /usr/local/share/blesh/cache.d/1000/ \
+  && chmod 700 /usr/local/share/blesh/cache.d/0 /usr/local/share/blesh/cache.d/1000 \
+  && chown -R cua:cua /usr/local/share/blesh/cache.d/1000
 
 # Agent harness config: every shell materializes per-harness model-proxy
 # configs from the machine boot env (the coderouter model-plane vars minted at

--- a/web/services/vms/images/blaxel/Dockerfile
+++ b/web/services/vms/images/blaxel/Dockerfile
@@ -223,6 +223,8 @@ RUN mkdir -p /etc/cmux/blesh-cache-seed \
   && rm -rf /tmp/blesh-seed-home \
   && test -s /etc/cmux/blesh-cache-seed/blesh/*/term.xterm-256color \
   && test -s /etc/cmux/blesh-cache-seed/blesh/*/term.screen-256color \
+  && test -s /etc/cmux/blesh-cache-seed/blesh/*/term.tmux-256color \
+  && test -s /etc/cmux/blesh-cache-seed/blesh/*/term.linux \
   && mkdir -p /usr/local/share/blesh/cache.d/0 /usr/local/share/blesh/cache.d/1000 \
   && chmod a+rwxt /usr/local/share/blesh/cache.d \
   && cp /etc/cmux/blesh-cache-seed/blesh/*/term.* /usr/local/share/blesh/cache.d/0/ \

--- a/web/services/vms/images/blaxel/cmux-bashrc
+++ b/web/services/vms/images/blaxel/cmux-bashrc
@@ -18,16 +18,23 @@ fi
 # cmux uses) so no shell prints "ble/term.sh: updating tput cache ... done"
 # into the pane before its first prompt. ble.sh uses ~/.cache only when it
 # already exists (else it falls back to <blesh>/cache.d/<uid>, seeded in the
-# image), so create it and copy the XDG layout; plain cp (not -a) stamps now,
-# satisfying ble.sh's "cache newer than lib/init-term.sh" freshness test.
+# image). Per file, not per directory: a durable home carries the cache dir of
+# an older image (other ble version dir, or entries stale against a newer
+# lib/init-term.sh — ble.sh regenerates and prints unless the cache file is
+# NEWER than that file), so copy each seed entry that is missing or stale.
+# Plain cp (not -a) stamps now, which always beats init-term.sh.
 if [ -d /etc/cmux/blesh-cache-seed/blesh ]; then
   __cmux_cache_base="${XDG_CACHE_HOME:-$HOME/.cache}"
-  if [ ! -d "$__cmux_cache_base/blesh" ]; then
-    mkdir -p "$__cmux_cache_base" 2>/dev/null \
-      && cp -R /etc/cmux/blesh-cache-seed/blesh "$__cmux_cache_base/" 2>/dev/null \
-      || true
-  fi
-  unset __cmux_cache_base
+  for __cmux_seed in /etc/cmux/blesh-cache-seed/blesh/*/term.*; do
+    [ -f "$__cmux_seed" ] || continue
+    __cmux_dst="$__cmux_cache_base/${__cmux_seed#/etc/cmux/blesh-cache-seed/}"
+    if [ ! -f "$__cmux_dst" ] || [ /usr/local/share/blesh/lib/init-term.sh -nt "$__cmux_dst" ]; then
+      mkdir -p "${__cmux_dst%/*}" 2>/dev/null \
+        && cp "$__cmux_seed" "$__cmux_dst" 2>/dev/null \
+        || true
+    fi
+  done
+  unset __cmux_cache_base __cmux_seed __cmux_dst
 fi
 
 if [ -f /usr/local/share/blesh/ble.sh ] && [ -z "${BLE_VERSION:-}" ]; then

--- a/web/services/vms/images/blaxel/cmux-bashrc
+++ b/web/services/vms/images/blaxel/cmux-bashrc
@@ -14,6 +14,22 @@ if [ ! -f "$HOME/.bash_history" ] && [ -f /etc/cmux/seed-history ]; then
   cp /etc/cmux/seed-history "$HOME/.bash_history" 2>/dev/null || true
 fi
 
+# Seed ble.sh's per-TERM tput caches (baked by the Dockerfile for the TERMs
+# cmux uses) so no shell prints "ble/term.sh: updating tput cache ... done"
+# into the pane before its first prompt. ble.sh uses ~/.cache only when it
+# already exists (else it falls back to <blesh>/cache.d/<uid>, seeded in the
+# image), so create it and copy the XDG layout; plain cp (not -a) stamps now,
+# satisfying ble.sh's "cache newer than lib/init-term.sh" freshness test.
+if [ -d /etc/cmux/blesh-cache-seed/blesh ]; then
+  __cmux_cache_base="${XDG_CACHE_HOME:-$HOME/.cache}"
+  if [ ! -d "$__cmux_cache_base/blesh" ]; then
+    mkdir -p "$__cmux_cache_base" 2>/dev/null \
+      && cp -R /etc/cmux/blesh-cache-seed/blesh "$__cmux_cache_base/" 2>/dev/null \
+      || true
+  fi
+  unset __cmux_cache_base
+fi
+
 if [ -f /usr/local/share/blesh/ble.sh ] && [ -z "${BLE_VERSION:-}" ]; then
   source /usr/local/share/blesh/ble.sh --noattach
   bleopt prompt_eol_mark= exec_errexit_mark= exec_elapsed_mark= exec_exit_mark=

--- a/web/tests/vm-blaxel-image.test.ts
+++ b/web/tests/vm-blaxel-image.test.ts
@@ -123,8 +123,14 @@ describe("Blaxel baked image template", () => {
     expect(dockerfile).toContain("/etc/cmux/blesh-cache-seed");
     expect(dockerfile).toContain("/usr/local/share/blesh/cache.d/0");
     expect(dockerfile).toContain("/usr/local/share/blesh/cache.d/1000");
-    expect(bashrc).toContain("/etc/cmux/blesh-cache-seed/blesh");
-    expect(bashrc).toContain('cp -R /etc/cmux/blesh-cache-seed/blesh "$__cmux_cache_base/"');
+    // The bake must prove every seeded TERM generated, not just the first two.
+    for (const term of ["xterm-256color", "screen-256color", "tmux-256color", "linux"]) {
+      expect(dockerfile).toContain(`test -s /etc/cmux/blesh-cache-seed/blesh/*/term.${term}`);
+    }
+    // Per-file seeding with the same freshness rule ble.sh applies, so durable
+    // homes from older images (stale or missing entries) reseed too.
+    expect(bashrc).toContain("/etc/cmux/blesh-cache-seed/blesh/*/term.*");
+    expect(bashrc).toContain('[ /usr/local/share/blesh/lib/init-term.sh -nt "$__cmux_dst" ]');
     expect(bashrc.indexOf("blesh-cache-seed")).toBeLessThan(
       bashrc.indexOf("source /usr/local/share/blesh/ble.sh"),
     );

--- a/web/tests/vm-blaxel-image.test.ts
+++ b/web/tests/vm-blaxel-image.test.ts
@@ -113,6 +113,21 @@ describe("Blaxel baked image template", () => {
     expect(read("seed-history")).toBe("claude --dangerously-skip-permissions\ncodex --yolo\n");
     expect(bashrc).toContain("source /usr/local/share/blesh/ble.sh --noattach");
     expect(bashrc).toContain("ble-attach");
+    // ble.sh tput caches are baked and seeded, so no pane ever opens on
+    // "ble/term.sh: updating tput cache ... done". Both cache homes are
+    // covered: <blesh>/cache.d/<uid> (what a shell uses while ~/.cache does
+    // not exist yet) bakes in the image; the XDG copy seeds per HOME from
+    // /etc/cmux/blesh-cache-seed. The runtime copy must NOT preserve seed
+    // mtimes (ble.sh loads the cache only when it is newer than
+    // lib/init-term.sh), so it is a plain cp -R.
+    expect(dockerfile).toContain("/etc/cmux/blesh-cache-seed");
+    expect(dockerfile).toContain("/usr/local/share/blesh/cache.d/0");
+    expect(dockerfile).toContain("/usr/local/share/blesh/cache.d/1000");
+    expect(bashrc).toContain("/etc/cmux/blesh-cache-seed/blesh");
+    expect(bashrc).toContain('cp -R /etc/cmux/blesh-cache-seed/blesh "$__cmux_cache_base/"');
+    expect(bashrc.indexOf("blesh-cache-seed")).toBeLessThan(
+      bashrc.indexOf("source /usr/local/share/blesh/ble.sh"),
+    );
     // half-life prompt with the machine name kept (\h): machines are addressed by name.
     expect(bashrc).toContain("PS1='\\[\\e[38;5;135m\\]\\u@\\h");
     expect(dockerfile).toContain("echo 'set -g default-shell /bin/bash' >> /etc/tmux.conf");


### PR DESCRIPTION
Reported while dogfooding https://github.com/manaflow-ai/cmux/pull/11108: the first terminal on a cloud machine opens on

```
ble/term.sh: updating tput cache for TERM=xterm-256color... done
```

before its first prompt.

Mechanism, verified live on a dev machine (quiet-seal): ble.sh resolves its cache dir in two steps — `${XDG_CACHE_HOME:-~/.cache}/blesh/<ver>` only when that base directory already exists, else `<blesh>/cache.d/<uid>`. A fresh home volume has no `~/.cache`, so the machine's first shells use `cache.d`, and later shells switch to the XDG path once anything creates `~/.cache` — each empty location regenerates the tput cache and prints the message. ble.sh loads a cache silently only when `term.$TERM` is newer than `lib/init-term.sh` (mtime test).

The image now pre-generates the caches for `xterm-256color`, `screen-256color`, `tmux-256color`, and `linux` at bake time by running ble.sh itself under a pty (`script`; ble.sh refuses `bash -c` and ttyless shells), bakes them into `cache.d/0` and `cache.d/1000` (root panes and the `cua` desktop), and keeps an XDG-layout seed at `/etc/cmux/blesh-cache-seed` that `cmux-bashrc` copies into each fresh HOME — with a plain `cp -R`, so the copy's mtime always beats `init-term.sh`. Same pattern as the existing seed-history materialization.

Live A/B on the real pane path (`workspace run -- bash -l` through the machine link): bare cache reproduces the message as the pane's first line; the seeded state opens straight at the prompt.

Rollout: epoch bumped to `2026-08-31-r11`; the fix reaches new machines after a rebake with `web/scripts/build-blaxel-image.sh` (not run here — it publishes `sandbox/cmux-devbox:latest`). Existing machines only pay the message once per TERM per cache location. The e2b/daytona devbox image (`services/vms/images/devbox`) shares the ble.sh setup lineage and likely wants the same seed; left for the shared-image owner to confirm.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790808354&installation_model_id=21920&pr_number=11277&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11277&signature=c7b16723be026b9474ccc91205c9a481e9e963ebf87e25fbee185f1afe8db785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
First shells in devbox panes used to print `ble/term.sh: updating tput cache ... done` before the first prompt. The image now bakes and seeds `ble.sh`'s per-TERM tput caches so panes open straight at the prompt.

**Changes**
- Generates caches for `xterm-256color`, `screen-256color`, `tmux-256color`, and `linux` at bake time by running `ble.sh` under a pty, with bake-time checks that all four were produced.
- Seeds the `cache.d/<uid>` locations (`cache.d/0` and `cache.d/1000`) and an XDG-layout seed that `cmux-bashrc` copies into each HOME.
- The per-HOME copy is per file with ble.sh's own freshness rule (missing or older than `lib/init-term.sh`), so durable homes from older images reseed too; plain `cp` keeps the copy newer than `init-term.sh`.

**Rollout**
- Image epoch bumped to `2026-08-31-r11`; new machines get the fix after a rebake with `web/scripts/build-blaxel-image.sh`.
- Existing machines may still print the message once per TERM per cache location.
- The e2b/daytona devbox image (`services/vms/images/devbox`) shares the `ble.sh` setup and likely needs the same seed; left for its owner to confirm.

<sup>Written for commit 2d35c87d0399846987a974dbef1e9ca97e8e8144. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced terminal startup output and delays by preloading shell terminal caches.
  * Improved first-prompt readiness across supported terminal environments and terminal types.
  * Ensured cached terminal data is refreshed when outdated and applied consistently for interactive shells.

* **Tests**
  * Added validation to confirm terminal cache data is included in images and applied before shell initialization.
  * Verified cache support for common terminal environments, including xterm, screen, tmux, and Linux terminals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->