### PR TITLE
iOS: open newly created terminal tab

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/CreatedTerminalSelection.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/CreatedTerminalSelection.swift
@@ -68,10 +68,11 @@ struct CreatedTerminalSelection: Equatable {
         // A snapshot may omit the instance tag while the host is still
         // converging. A pinned tag remains authoritative, so a legacy/untagged
         // sibling cannot match accidentally while its owner is unknown.
-        let expectedTag = normalizedCreatedTerminalIdentity(macInstanceTag)
-        let actualTag = normalizedCreatedTerminalIdentity(workspace.macInstanceTag)
+        let tagAuthority = MobileMacInstanceTagAuthority()
+        let expectedTag = tagAuthority.normalize(macInstanceTag)
+        let actualTag = tagAuthority.normalize(workspace.macInstanceTag)
         if let expectedTag {
-            guard actualTag == expectedTag else { return false }
+            guard tagAuthority.sameStoredAuthority(expectedTag, actualTag) else { return false }
         } else {
             // A pin without a tag belongs to the legacy/untagged pairing only;
             // a tagged row is a distinct sibling until the pin learns that tag.
@@ -96,9 +97,11 @@ struct CreatedTerminalSelection: Equatable {
         default:
             break
         }
-        let expectedTag = normalizedCreatedTerminalIdentity(macInstanceTag)
-        let actualTag = normalizedCreatedTerminalIdentity(workspace.macInstanceTag)
-        if let expectedTag, let actualTag, expectedTag != actualTag {
+        let tagAuthority = MobileMacInstanceTagAuthority()
+        let expectedTag = tagAuthority.normalize(macInstanceTag)
+        let actualTag = tagAuthority.normalize(workspace.macInstanceTag)
+        if let expectedTag, let actualTag,
+           !tagAuthority.sameStoredAuthority(expectedTag, actualTag) {
             return false
         }
         // A pin with no owner metadata is safe to preserve only when the

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/CreatedTerminalSelection.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/CreatedTerminalSelection.swift
@@ -22,12 +22,36 @@ struct CreatedTerminalSelection: Equatable {
         self.terminalID = terminalID
     }
 
-    func matches(workspace: MobileWorkspacePreview) -> Bool {
-        guard workspace.rpcWorkspaceID == remoteWorkspaceID,
-              Self.deviceIDsMatch(macDeviceID, workspace.macDeviceID) else {
+    func matches(
+        workspace: MobileWorkspacePreview,
+        allowsAnonymousForeground: Bool
+    ) -> Bool {
+        guard workspace.rpcWorkspaceID == remoteWorkspaceID else {
             return false
         }
-        return Self.normalized(macInstanceTag) == Self.normalized(workspace.macInstanceTag)
+        switch (Self.normalized(macDeviceID), Self.normalized(workspace.macDeviceID)) {
+        case (nil, nil):
+            guard allowsAnonymousForeground else { return false }
+        case let (expected?, actual?):
+            guard cmxCanonicalDeviceID(expected) == cmxCanonicalDeviceID(actual) else {
+                return false
+            }
+        default:
+            return false
+        }
+        // A snapshot may omit the instance tag while the host is still
+        // converging. A present tag remains authoritative, so sibling builds
+        // cannot match accidentally; an absent tag is simply unknown.
+        let expectedTag = Self.normalized(macInstanceTag)
+        let actualTag = Self.normalized(workspace.macInstanceTag)
+        if let expectedTag {
+            guard actualTag == nil || expectedTag == actualTag else { return false }
+        } else {
+            // A pin without a tag belongs to the legacy/untagged pairing only;
+            // a tagged row is a distinct sibling until the pin learns that tag.
+            guard actualTag == nil else { return false }
+        }
+        return true
     }
 
     /// A legacy/anonymous workspace row can acquire its stable Mac identity
@@ -39,6 +63,13 @@ struct CreatedTerminalSelection: Equatable {
         if Self.normalized(macInstanceTag) == nil {
             self.macInstanceTag = Self.normalized(instanceTag)
         }
+    }
+
+    /// Learn a tag that was resolved after creation without replacing an
+    /// already-owned sibling identity.
+    mutating func adoptMacInstanceTagIfMissing(_ instanceTag: String) {
+        guard Self.normalized(macInstanceTag) == nil else { return }
+        macInstanceTag = Self.normalized(instanceTag)
     }
 
     static func deviceIDsMatch(_ lhs: String?, _ rhs: String?) -> Bool {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/CreatedTerminalSelection.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/CreatedTerminalSelection.swift
@@ -1,0 +1,62 @@
+import CMUXMobileCore
+import CmuxMobileShellModel
+
+/// Keeps a terminal created by the user selected while workspace snapshots
+/// catch up with the Mac. The UI row id is not stable across multi-Mac
+/// aggregation, so the pin is owned by the remote workspace and Mac identity.
+struct CreatedTerminalSelection: Equatable {
+    var remoteWorkspaceID: MobileWorkspacePreview.ID
+    var macDeviceID: String?
+    var macInstanceTag: String?
+    var terminalID: MobileTerminalPreview.ID
+
+    init(
+        workspace: MobileWorkspacePreview,
+        fallbackMacDeviceID: String? = nil,
+        fallbackInstanceTag: String? = nil,
+        terminalID: MobileTerminalPreview.ID
+    ) {
+        remoteWorkspaceID = workspace.rpcWorkspaceID
+        macDeviceID = Self.normalized(workspace.macDeviceID) ?? Self.normalized(fallbackMacDeviceID)
+        macInstanceTag = Self.normalized(workspace.macInstanceTag) ?? Self.normalized(fallbackInstanceTag)
+        self.terminalID = terminalID
+    }
+
+    func matches(workspace: MobileWorkspacePreview) -> Bool {
+        guard workspace.rpcWorkspaceID == remoteWorkspaceID,
+              Self.deviceIDsMatch(macDeviceID, workspace.macDeviceID) else {
+            return false
+        }
+        return Self.normalized(macInstanceTag) == Self.normalized(workspace.macInstanceTag)
+    }
+
+    /// A legacy/anonymous workspace row can acquire its stable Mac identity
+    /// after the create response. Adopt it without retargeting a pin that
+    /// already has an owner.
+    mutating func adoptMacDeviceIDIfMissing(_ macDeviceID: String, instanceTag: String? = nil) {
+        guard Self.normalized(self.macDeviceID) == nil else { return }
+        self.macDeviceID = Self.normalized(macDeviceID)
+        if Self.normalized(macInstanceTag) == nil {
+            self.macInstanceTag = Self.normalized(instanceTag)
+        }
+    }
+
+    static func deviceIDsMatch(_ lhs: String?, _ rhs: String?) -> Bool {
+        switch (normalized(lhs), normalized(rhs)) {
+        case (nil, nil):
+            return true
+        case let (lhs?, rhs?):
+            return cmxCanonicalDeviceID(lhs) == cmxCanonicalDeviceID(rhs)
+        default:
+            return false
+        }
+    }
+
+    private static func normalized(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty else {
+            return nil
+        }
+        return value
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/CreatedTerminalSelection.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/CreatedTerminalSelection.swift
@@ -10,7 +10,7 @@ func createdTerminalDeviceIDsMatch(_ lhs: String?, _ rhs: String?) -> Bool {
     }
 }
 
-private func normalizedCreatedTerminalIdentity(_ value: String?) -> String? {
+func normalizedCreatedTerminalIdentity(_ value: String?) -> String? {
     guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
           !value.isEmpty else {
         return nil

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/CreatedTerminalSelection.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/CreatedTerminalSelection.swift
@@ -1,6 +1,23 @@
 import CMUXMobileCore
 import CmuxMobileShellModel
 
+func createdTerminalDeviceIDsMatch(_ lhs: String?, _ rhs: String?) -> Bool {
+    switch (normalizedCreatedTerminalIdentity(lhs), normalizedCreatedTerminalIdentity(rhs)) {
+    case let (lhs?, rhs?):
+        return cmxCanonicalDeviceID(lhs) == cmxCanonicalDeviceID(rhs)
+    default:
+        return false
+    }
+}
+
+private func normalizedCreatedTerminalIdentity(_ value: String?) -> String? {
+    guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+          !value.isEmpty else {
+        return nil
+    }
+    return value
+}
+
 /// Keeps a terminal created by the user selected while workspace snapshots
 /// catch up with the Mac. The UI row id is not stable across multi-Mac
 /// aggregation, so the pin is owned by the remote workspace and Mac identity.
@@ -17,8 +34,10 @@ struct CreatedTerminalSelection: Equatable {
         terminalID: MobileTerminalPreview.ID
     ) {
         remoteWorkspaceID = workspace.rpcWorkspaceID
-        macDeviceID = Self.normalized(workspace.macDeviceID) ?? Self.normalized(fallbackMacDeviceID)
-        macInstanceTag = Self.normalized(workspace.macInstanceTag) ?? Self.normalized(fallbackInstanceTag)
+        macDeviceID = normalizedCreatedTerminalIdentity(workspace.macDeviceID)
+            ?? normalizedCreatedTerminalIdentity(fallbackMacDeviceID)
+        macInstanceTag = normalizedCreatedTerminalIdentity(workspace.macInstanceTag)
+            ?? normalizedCreatedTerminalIdentity(fallbackInstanceTag)
         self.terminalID = terminalID
     }
 
@@ -29,11 +48,11 @@ struct CreatedTerminalSelection: Equatable {
         guard workspace.rpcWorkspaceID == remoteWorkspaceID else {
             return false
         }
-        switch (Self.normalized(macDeviceID), Self.normalized(workspace.macDeviceID)) {
+        switch (normalizedCreatedTerminalIdentity(macDeviceID), normalizedCreatedTerminalIdentity(workspace.macDeviceID)) {
         case (nil, nil):
             guard allowsAnonymousForeground else { return false }
         case let (expected?, actual?):
-            guard cmxCanonicalDeviceID(expected) == cmxCanonicalDeviceID(actual) else {
+            guard createdTerminalDeviceIDsMatch(expected, actual) else {
                 return false
             }
         case (_, nil):
@@ -46,8 +65,8 @@ struct CreatedTerminalSelection: Equatable {
         // A snapshot may omit the instance tag while the host is still
         // converging. A pinned tag remains authoritative, so a legacy/untagged
         // sibling cannot match accidentally while its owner is unknown.
-        let expectedTag = Self.normalized(macInstanceTag)
-        let actualTag = Self.normalized(workspace.macInstanceTag)
+        let expectedTag = normalizedCreatedTerminalIdentity(macInstanceTag)
+        let actualTag = normalizedCreatedTerminalIdentity(workspace.macInstanceTag)
         if let expectedTag {
             guard actualTag == expectedTag else { return false }
         } else {
@@ -62,36 +81,17 @@ struct CreatedTerminalSelection: Equatable {
     /// after the create response. Adopt it without retargeting a pin that
     /// already has an owner.
     mutating func adoptMacDeviceIDIfMissing(_ macDeviceID: String, instanceTag: String? = nil) {
-        guard Self.normalized(self.macDeviceID) == nil else { return }
-        self.macDeviceID = Self.normalized(macDeviceID)
-        if Self.normalized(macInstanceTag) == nil {
-            self.macInstanceTag = Self.normalized(instanceTag)
+        guard normalizedCreatedTerminalIdentity(self.macDeviceID) == nil else { return }
+        self.macDeviceID = normalizedCreatedTerminalIdentity(macDeviceID)
+        if normalizedCreatedTerminalIdentity(macInstanceTag) == nil {
+            self.macInstanceTag = normalizedCreatedTerminalIdentity(instanceTag)
         }
     }
 
     /// Learn a tag that was resolved after creation without replacing an
     /// already-owned sibling identity.
     mutating func adoptMacInstanceTagIfMissing(_ instanceTag: String) {
-        guard Self.normalized(macInstanceTag) == nil else { return }
-        macInstanceTag = Self.normalized(instanceTag)
-    }
-
-    static func deviceIDsMatch(_ lhs: String?, _ rhs: String?) -> Bool {
-        switch (normalized(lhs), normalized(rhs)) {
-        case (nil, nil):
-            return true
-        case let (lhs?, rhs?):
-            return cmxCanonicalDeviceID(lhs) == cmxCanonicalDeviceID(rhs)
-        default:
-            return false
-        }
-    }
-
-    private static func normalized(_ value: String?) -> String? {
-        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !value.isEmpty else {
-            return nil
-        }
-        return value
+        guard normalizedCreatedTerminalIdentity(macInstanceTag) == nil else { return }
+        macInstanceTag = normalizedCreatedTerminalIdentity(instanceTag)
     }
 }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/CreatedTerminalSelection.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/CreatedTerminalSelection.swift
@@ -34,10 +34,17 @@ struct CreatedTerminalSelection: Equatable {
         terminalID: MobileTerminalPreview.ID
     ) {
         remoteWorkspaceID = workspace.rpcWorkspaceID
-        macDeviceID = normalizedCreatedTerminalIdentity(workspace.macDeviceID)
+        let workspaceMacDeviceID = normalizedCreatedTerminalIdentity(workspace.macDeviceID)
+        macDeviceID = workspaceMacDeviceID
             ?? normalizedCreatedTerminalIdentity(fallbackMacDeviceID)
-        macInstanceTag = normalizedCreatedTerminalIdentity(workspace.macInstanceTag)
-            ?? normalizedCreatedTerminalIdentity(fallbackInstanceTag)
+        if workspaceMacDeviceID == nil {
+            macInstanceTag = normalizedCreatedTerminalIdentity(workspace.macInstanceTag)
+                ?? normalizedCreatedTerminalIdentity(fallbackInstanceTag)
+        } else {
+            // A known workspace owner may omit its legacy instance tag. Do not
+            // borrow the global foreground tag from a different sibling.
+            macInstanceTag = normalizedCreatedTerminalIdentity(workspace.macInstanceTag)
+        }
         self.terminalID = terminalID
     }
 

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/CreatedTerminalSelection.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/CreatedTerminalSelection.swift
@@ -36,16 +36,20 @@ struct CreatedTerminalSelection: Equatable {
             guard cmxCanonicalDeviceID(expected) == cmxCanonicalDeviceID(actual) else {
                 return false
             }
+        case (_, nil):
+            // A converging anonymous foreground row can temporarily omit the
+            // device id, but only the caller can prove that this is that row.
+            guard allowsAnonymousForeground else { return false }
         default:
             return false
         }
         // A snapshot may omit the instance tag while the host is still
-        // converging. A present tag remains authoritative, so sibling builds
-        // cannot match accidentally; an absent tag is simply unknown.
+        // converging. A pinned tag remains authoritative, so a legacy/untagged
+        // sibling cannot match accidentally while its owner is unknown.
         let expectedTag = Self.normalized(macInstanceTag)
         let actualTag = Self.normalized(workspace.macInstanceTag)
         if let expectedTag {
-            guard actualTag == nil || expectedTag == actualTag else { return false }
+            guard actualTag == expectedTag else { return false }
         } else {
             // A pin without a tag belongs to the legacy/untagged pairing only;
             // a tagged row is a distinct sibling until the pin learns that tag.

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/CreatedTerminalSelection.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/CreatedTerminalSelection.swift
@@ -80,6 +80,33 @@ struct CreatedTerminalSelection: Equatable {
         return true
     }
 
+    /// Returns true when a snapshot has the same remote workspace but is
+    /// missing one of the pin's owner fields. A known conflicting owner is
+    /// never treated as convergence.
+    func identityMetadataIsIncomplete(in workspace: MobileWorkspacePreview) -> Bool {
+        guard workspace.rpcWorkspaceID == remoteWorkspaceID else { return false }
+        let expectedDevice = normalizedCreatedTerminalIdentity(macDeviceID)
+        let actualDevice = normalizedCreatedTerminalIdentity(workspace.macDeviceID)
+        switch (expectedDevice, actualDevice) {
+        case let (expected?, actual?):
+            guard createdTerminalDeviceIDsMatch(expected, actual) else { return false }
+        case (nil, nil):
+            break
+        default:
+            return true
+        }
+        let expectedTag = normalizedCreatedTerminalIdentity(macInstanceTag)
+        let actualTag = normalizedCreatedTerminalIdentity(workspace.macInstanceTag)
+        switch (expectedTag, actualTag) {
+        case let (expected?, actual?):
+            return expected != actual
+        case (nil, nil):
+            return expectedDevice == nil && actualDevice == nil
+        default:
+            return true
+        }
+    }
+
     /// A legacy/anonymous workspace row can acquire its stable Mac identity
     /// after the create response. Adopt it without retargeting a pin that
     /// already has an owner.

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/CreatedTerminalSelection.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/CreatedTerminalSelection.swift
@@ -55,10 +55,6 @@ struct CreatedTerminalSelection: Equatable {
             guard createdTerminalDeviceIDsMatch(expected, actual) else {
                 return false
             }
-        case (_, nil):
-            // A converging anonymous foreground row can temporarily omit the
-            // device id, but only the caller can prove that this is that row.
-            guard allowsAnonymousForeground else { return false }
         default:
             return false
         }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/CreatedTerminalSelection.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/CreatedTerminalSelection.swift
@@ -83,28 +83,31 @@ struct CreatedTerminalSelection: Equatable {
     /// Returns true when a snapshot has the same remote workspace but is
     /// missing one of the pin's owner fields. A known conflicting owner is
     /// never treated as convergence.
-    func identityMetadataIsIncomplete(in workspace: MobileWorkspacePreview) -> Bool {
+    func identityMetadataIsIncomplete(
+        in workspace: MobileWorkspacePreview,
+        allowsAnonymousForeground: Bool
+    ) -> Bool {
         guard workspace.rpcWorkspaceID == remoteWorkspaceID else { return false }
         let expectedDevice = normalizedCreatedTerminalIdentity(macDeviceID)
         let actualDevice = normalizedCreatedTerminalIdentity(workspace.macDeviceID)
         switch (expectedDevice, actualDevice) {
         case let (expected?, actual?):
             guard createdTerminalDeviceIDsMatch(expected, actual) else { return false }
-        case (nil, nil):
-            break
         default:
-            return true
+            break
         }
         let expectedTag = normalizedCreatedTerminalIdentity(macInstanceTag)
         let actualTag = normalizedCreatedTerminalIdentity(workspace.macInstanceTag)
-        switch (expectedTag, actualTag) {
-        case let (expected?, actual?):
-            return expected != actual
-        case (nil, nil):
-            return expectedDevice == nil && actualDevice == nil
-        default:
-            return true
+        if let expectedTag, let actualTag, expectedTag != actualTag {
+            return false
         }
+        // A pin with no owner metadata is safe to preserve only when the
+        // caller has proved this is the unique anonymous foreground row.
+        if expectedDevice == nil, expectedTag == nil {
+            return allowsAnonymousForeground
+        }
+        return (expectedDevice == nil) != (actualDevice == nil)
+            || (expectedTag == nil) != (actualTag == nil)
     }
 
     /// A legacy/anonymous workspace row can acquire its stable Mac identity

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -11970,11 +11970,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             applyRemoteWorkspaceList(response, mergeExistingWorkspaces: true)
             let selectedRow = explicitlySelectedWorkspace
             let selectedRowMatchesAnonymousRequest: Bool
-            if CreatedTerminalSelection.deviceIDsMatch(requestedRow?.macDeviceID, nil),
+            if requestedRow?.macDeviceID?.isEmpty != false,
                let foregroundMacDeviceID,
                let selectedRow,
                selectedRow.rpcWorkspaceID == requestedWorkspaceID,
-               CreatedTerminalSelection.deviceIDsMatch(
+               createdTerminalDeviceIDsMatch(
                    selectedRow.macDeviceID,
                    foregroundMacDeviceID
                ),
@@ -11986,16 +11986,27 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             } else {
                 selectedRowMatchesAnonymousRequest = false
             }
+            let selectedRowMatchesKnownOwnerRequest: Bool = {
+                guard let selectedRow,
+                      selectedRow.rpcWorkspaceID == requestedWorkspaceID,
+                      let selectedMacDeviceID = selectedRow.macDeviceID,
+                      let requestedMacDeviceID,
+                      createdTerminalDeviceIDsMatch(selectedMacDeviceID, requestedMacDeviceID) else {
+                    return false
+                }
+                let selectedTag = macInstanceTagAuthority.normalize(selectedRow.macInstanceTag)
+                let requestedTag = macInstanceTagAuthority.normalize(requestedInstanceTag)
+                switch (selectedTag, requestedTag) {
+                case (nil, nil):
+                    return true
+                case let (selectedTag?, requestedTag?):
+                    return macInstanceTagAuthority.sameStoredAuthority(selectedTag, requestedTag)
+                default:
+                    return false
+                }
+            }()
             let selectedRowMatchesRequest = selectedRow?.id == rowWorkspaceID
-                || (selectedRow?.rpcWorkspaceID == requestedWorkspaceID
-                    && CreatedTerminalSelection.deviceIDsMatch(
-                        selectedRow?.macDeviceID,
-                        requestedMacDeviceID
-                    )
-                    && macInstanceTagAuthority.sameStoredAuthority(
-                        selectedRow?.macInstanceTag,
-                        requestedInstanceTag
-                    ))
+                || selectedRowMatchesKnownOwnerRequest
                 || selectedRowMatchesAnonymousRequest
             if let selectedRow, selectedRowMatchesRequest,
                let createdID = response.createdTerminalID {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -8143,6 +8143,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         }
         createdTerminalSelection = CreatedTerminalSelection(
             workspace: workspace,
+            fallbackMacDeviceID: foregroundMacDeviceID,
+            fallbackInstanceTag: activeMacInstanceTag,
             terminalID: terminal.id
         )
         selectedTerminalID = terminal.id

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -11957,7 +11957,16 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         let requestedRow = workspaces.first { $0.id == rowWorkspaceID }
         let requestedWorkspaceID = remoteWorkspaceID(for: rowWorkspaceID)
         let requestedMacDeviceID = requestedRow?.macDeviceID ?? foregroundMacDeviceID
-        let requestedInstanceTag = requestedRow?.macInstanceTag ?? activeMacInstanceTag
+        // A known workspace owner may legitimately have no instance tag in a
+        // legacy snapshot. Keep that absence instead of borrowing the global
+        // foreground tag, which may belong to a different Mac instance.
+        let requestedInstanceTag: String? = {
+            guard let requestedRow else { return activeMacInstanceTag }
+            if requestedRow.macDeviceID?.isEmpty == false {
+                return requestedRow.macInstanceTag
+            }
+            return requestedRow.macInstanceTag ?? activeMacInstanceTag
+        }()
         let generation = connectionGeneration
         do {
             let resultData = try await client.sendRequest(

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -2106,6 +2106,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         composerFieldIsFocused = false
         composerFocusRequestPending = false
         composerFocusRequestTerminalID = nil
+        clearTerminalCreationError()
         clearPairingError()
         activeTicket = nil
         activeRoute = nil
@@ -8107,9 +8108,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// different workspace if the selection drifts before the async work runs.
     public func createTerminal(in workspaceID: MobileWorkspacePreview.ID? = nil) {
         let targetWorkspaceID = workspaceID ?? selectedWorkspace?.id
-        terminalCreationError = nil
-        terminalCreationErrorWorkspaceID = nil
-        terminalCreationErrorTerminalID = nil
+        clearTerminalCreationError()
         guard remoteClient == nil else {
             // Bail BEFORE pinning selection when a create is already in flight,
             // so a second "+" on another workspace can't strand the UI on that
@@ -11207,9 +11206,6 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// = nil`) so guidance cannot linger under a cleared headline.
     private func clearPairingError() {
         connectionError = nil
-        terminalCreationError = nil
-        terminalCreationErrorWorkspaceID = nil
-        terminalCreationErrorTerminalID = nil
         connectionErrorGuidance = nil
     }
 
@@ -11222,6 +11218,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
               }) else {
             return
         }
+        clearTerminalCreationError()
+    }
+
+    private func clearTerminalCreationError() {
         terminalCreationError = nil
         terminalCreationErrorWorkspaceID = nil
         terminalCreationErrorTerminalID = nil
@@ -11527,7 +11527,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     allowsAnonymousForeground: allowsAnonymousForeground
                 ) {
                     return
-                } else if selectedWorkspace.rpcWorkspaceID == created.remoteWorkspaceID {
+                } else if created.identityMetadataIsIncomplete(in: selectedWorkspace) {
                     // Preserve the pin while identity fields are temporarily
                     // absent during snapshot convergence. The expiry task is
                     // the bounded escape hatch for a genuinely stuck create.

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -281,6 +281,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// can be remapped while snapshots converge, so recovery UI keys off the
     /// stable RPC workspace identity.
     public private(set) var terminalCreationErrorWorkspaceID: MobileWorkspacePreview.ID?
+    @ObservationIgnored private var terminalCreationErrorTerminalID: MobileTerminalPreview.ID?
     /// Actionable next-step line shown beneath ``connectionError`` (for example
     /// "Check that both devices are on the same Tailscale"). Set and cleared
     /// together with the error by the pairing-failure classifier sink.
@@ -8108,6 +8109,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         let targetWorkspaceID = workspaceID ?? selectedWorkspace?.id
         terminalCreationError = nil
         terminalCreationErrorWorkspaceID = nil
+        terminalCreationErrorTerminalID = nil
         guard remoteClient == nil else {
             // Bail BEFORE pinning selection when a create is already in flight,
             // so a second "+" on another workspace can't strand the UI on that
@@ -8196,6 +8198,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 defaultValue: "The new terminal did not finish starting."
             )
             self.terminalCreationErrorWorkspaceID = failedWorkspaceID
+            self.terminalCreationErrorTerminalID = terminalID
             self.recordAppEvent(
                 .terminalCreateFailed,
                 correlationID: terminalID.rawValue,
@@ -11206,7 +11209,22 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         connectionError = nil
         terminalCreationError = nil
         terminalCreationErrorWorkspaceID = nil
+        terminalCreationErrorTerminalID = nil
         connectionErrorGuidance = nil
+    }
+
+    private func clearTerminalCreationErrorIfRecovered() {
+        guard let errorWorkspaceID = terminalCreationErrorWorkspaceID,
+              let errorTerminalID = terminalCreationErrorTerminalID,
+              workspaces.contains(where: {
+                  $0.rpcWorkspaceID == errorWorkspaceID
+                      && $0.terminals.contains { $0.id == errorTerminalID && $0.isReady }
+              }) else {
+            return
+        }
+        terminalCreationError = nil
+        terminalCreationErrorWorkspaceID = nil
+        terminalCreationErrorTerminalID = nil
     }
 
     private func clearPairingVersionWarning() {
@@ -11444,6 +11462,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     }
 
     func syncSelectedTerminalForWorkspace() {
+        clearTerminalCreationErrorIfRecovered()
         // A selection held across a degraded-connection window has no live
         // row, and ``selectedWorkspace`` would fall back to an arbitrary
         // first row: re-deriving from that would clobber the held terminal
@@ -12033,8 +12052,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     return false
                 }
             }()
-            let selectedRowMatchesRequest = selectedRow?.id == rowWorkspaceID
-                || selectedRowMatchesKnownOwnerRequest
+            let selectedRowMatchesRequest = selectedRowMatchesKnownOwnerRequest
                 || selectedRowMatchesAnonymousRequest
             if let selectedRow, selectedRowMatchesRequest,
                let createdID = response.createdTerminalID {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -277,6 +277,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// User-facing recovery copy for a terminal create that did not become
     /// ready within the bounded optimistic-selection window.
     public private(set) var terminalCreationError: String?
+    /// Remote workspace that owns ``terminalCreationError``. The local row id
+    /// can be remapped while snapshots converge, so recovery UI keys off the
+    /// stable RPC workspace identity.
+    public private(set) var terminalCreationErrorWorkspaceID: MobileWorkspacePreview.ID?
     /// Actionable next-step line shown beneath ``connectionError`` (for example
     /// "Check that both devices are on the same Tailscale"). Set and cleared
     /// together with the error by the pairing-failure classifier sink.
@@ -8103,6 +8107,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     public func createTerminal(in workspaceID: MobileWorkspacePreview.ID? = nil) {
         let targetWorkspaceID = workspaceID ?? selectedWorkspace?.id
         terminalCreationError = nil
+        terminalCreationErrorWorkspaceID = nil
         guard remoteClient == nil else {
             // Bail BEFORE pinning selection when a create is already in flight,
             // so a second "+" on another workspace can't strand the UI on that
@@ -8179,15 +8184,18 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 return
             }
             guard let self,
-                  self.createdTerminalSelection?.terminalID == terminalID,
+                  let selection = self.createdTerminalSelection,
+                  selection.terminalID == terminalID,
                   self.selectedTerminalID == terminalID else {
                 return
             }
+            let failedWorkspaceID = selection.remoteWorkspaceID
             self.clearCreatedTerminalSelection()
             self.terminalCreationError = L10n.string(
                 "mobile.terminal.creationTimeout",
                 defaultValue: "The new terminal did not finish starting."
             )
+            self.terminalCreationErrorWorkspaceID = failedWorkspaceID
             self.recordAppEvent(
                 .terminalCreateFailed,
                 correlationID: terminalID.rawValue,
@@ -11197,6 +11205,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     private func clearPairingError() {
         connectionError = nil
         terminalCreationError = nil
+        terminalCreationErrorWorkspaceID = nil
         connectionErrorGuidance = nil
     }
 

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -879,6 +879,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// observed: it gates async hand-backs, not view state.
     @ObservationIgnored var signInGeneration = 0
     @ObservationIgnored private var createdTerminalSelection: CreatedTerminalSelection?
+    @ObservationIgnored private var createdTerminalSelectionExpiryTask: Task<Void, Never>?
+    private static let createdTerminalSelectionTimeout = Duration.seconds(30)
     public var selectedWorkspaceID: MobileWorkspacePreview.ID? {
         didSet {
             if selectedWorkspaceID != oldValue {
@@ -925,7 +927,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         didSet {
             guard selectedTerminalID != oldValue else { return }
             if selectedTerminalID != createdTerminalSelection?.terminalID {
-                createdTerminalSelection = nil
+                clearCreatedTerminalSelection()
             }
             if let selectedTerminalID {
                 recordAppEvent(
@@ -1964,6 +1966,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         terminalSubscriptionRefreshTask?.cancel()
         createWorkspaceTask?.cancel()
         createTerminalTask?.cancel()
+        createdTerminalSelectionExpiryTask?.cancel()
         workspaceListRefreshTask?.cancel()
         workspaceChangesSummaryDebounceTask?.cancel()
         workspaceChangesSummaryFetchTask?.cancel()
@@ -8142,6 +8145,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 list[index].terminals.append(terminal)
             }
         }
+        clearCreatedTerminalSelection()
         createdTerminalSelection = CreatedTerminalSelection(
             workspace: workspace,
             fallbackMacDeviceID: foregroundMacDeviceID,
@@ -8150,10 +8154,44 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         )
         selectedTerminalID = terminal.id
         suppressTerminalAutoFocusOnNextAttach(for: terminal.id)
+        armCreatedTerminalSelectionExpiry(for: terminal.id)
         recordAppEvent(
             .terminalCreateSucceeded,
             correlationID: terminal.id.rawValue
         )
+    }
+
+    private func armCreatedTerminalSelectionExpiry(
+        for terminalID: MobileTerminalPreview.ID
+    ) {
+        createdTerminalSelectionExpiryTask?.cancel()
+        createdTerminalSelectionExpiryTask = Task { @MainActor [weak self] in
+            do {
+                try await ContinuousClock().sleep(
+                    for: Self.createdTerminalSelectionTimeout
+                )
+            } catch {
+                return
+            }
+            guard let self,
+                  self.createdTerminalSelection?.terminalID == terminalID,
+                  self.selectedTerminalID == terminalID else {
+                return
+            }
+            self.clearCreatedTerminalSelection()
+            self.recordAppEvent(
+                .terminalCreateFailed,
+                correlationID: terminalID.rawValue,
+                failure: .timedOut
+            )
+            self.syncSelectedTerminalForWorkspace()
+        }
+    }
+
+    private func clearCreatedTerminalSelection() {
+        createdTerminalSelection = nil
+        createdTerminalSelectionExpiryTask?.cancel()
+        createdTerminalSelectionExpiryTask = nil
     }
 
     /// Select the active terminal by id without changing workspace selection.
@@ -11448,7 +11486,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                let selectedTerminal = selectedWorkspace.terminals.first(where: { $0.id == created.terminalID }) {
                 guard selectedTerminal.isReady else { return }
             }
-            createdTerminalSelection = nil
+            clearCreatedTerminalSelection()
         }
         if let selectedTerminalID,
            let selectedTerminal = selectedWorkspace.terminals.first(where: { $0.id == selectedTerminalID }),
@@ -11970,6 +12008,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 )
                 selectedTerminalID = createdTerminalID
                 suppressTerminalAutoFocusOnNextAttach(for: createdTerminalID)
+                armCreatedTerminalSelectionExpiry(for: createdTerminalID)
             }
             recordAppEvent(
                 .terminalCreateSucceeded,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -878,6 +878,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// writing the previous user's state under ids the next account may reuse. Not
     /// observed: it gates async hand-backs, not view state.
     @ObservationIgnored var signInGeneration = 0
+    @ObservationIgnored private var createdTerminalSelection: CreatedTerminalSelection?
     public var selectedWorkspaceID: MobileWorkspacePreview.ID? {
         didSet {
             if selectedWorkspaceID != oldValue {
@@ -923,6 +924,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         }
         didSet {
             guard selectedTerminalID != oldValue else { return }
+            if selectedTerminalID != createdTerminalSelection?.terminalID {
+                createdTerminalSelection = nil
+            }
             if let selectedTerminalID {
                 recordAppEvent(
                     .surfaceFocused,
@@ -1329,6 +1333,12 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     }
     var foregroundMacDeviceID: String? {
         didSet {
+            if oldValue == nil, let foregroundMacDeviceID {
+                createdTerminalSelection?.adoptMacDeviceIDIfMissing(
+                    foregroundMacDeviceID,
+                    instanceTag: activeMacInstanceTag
+                )
+            }
             if let foregroundMacDeviceID {
                 recoveryTargetMacDeviceID = foregroundMacDeviceID
                 recoveryTargetInstanceTag = activeMacInstanceTag
@@ -8131,6 +8141,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 list[index].terminals.append(terminal)
             }
         }
+        createdTerminalSelection = CreatedTerminalSelection(
+            workspace: workspace,
+            terminalID: terminal.id
+        )
         selectedTerminalID = terminal.id
         suppressTerminalAutoFocusOnNextAttach(for: terminal.id)
         recordAppEvent(
@@ -11413,6 +11427,18 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 recordDisplayedTabAfterSync = true
             }
         }
+        // A create response is followed by one or more workspace snapshots.
+        // Keep the newly created terminal selected while it is still starting,
+        // even when the refresh contains another ready terminal that would
+        // otherwise win the fallback below. The pin is scoped to the remote
+        // workspace and owning Mac, so a row-id remap cannot retarget it.
+        if let created = createdTerminalSelection, selectedTerminalID == created.terminalID {
+            if created.matches(workspace: selectedWorkspace),
+               let selectedTerminal = selectedWorkspace.terminals.first(where: { $0.id == created.terminalID }) {
+                guard selectedTerminal.isReady else { return }
+            }
+            createdTerminalSelection = nil
+        }
         if let selectedTerminalID,
            let selectedTerminal = selectedWorkspace.terminals.first(where: { $0.id == selectedTerminalID }),
            selectedTerminal.isReady || !selectedWorkspace.hasReadyTerminal {
@@ -11869,7 +11895,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             .terminalCreateStarted,
             correlationID: rowWorkspaceID.rawValue
         )
+        let requestedRow = workspaces.first { $0.id == rowWorkspaceID }
         let requestedWorkspaceID = remoteWorkspaceID(for: rowWorkspaceID)
+        let requestedMacDeviceID = requestedRow?.macDeviceID ?? foregroundMacDeviceID
+        let requestedInstanceTag = requestedRow?.macInstanceTag ?? activeMacInstanceTag
         let generation = connectionGeneration
         do {
             let resultData = try await client.sendRequest(
@@ -11890,9 +11919,44 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 return
             }
             applyRemoteWorkspaceList(response, mergeExistingWorkspaces: true)
-            if selectedWorkspaceID == rowWorkspaceID,
+            let selectedRow = explicitlySelectedWorkspace
+            let selectedRowMatchesAnonymousRequest: Bool
+            if CreatedTerminalSelection.deviceIDsMatch(requestedRow?.macDeviceID, nil),
+               let foregroundMacDeviceID,
+               let selectedRow,
+               selectedRow.rpcWorkspaceID == requestedWorkspaceID,
+               CreatedTerminalSelection.deviceIDsMatch(
+                   selectedRow.macDeviceID,
+                   foregroundMacDeviceID
+               ),
+               macInstanceTagAuthority.sameStoredAuthority(
+                   selectedRow.macInstanceTag,
+                   activeMacInstanceTag
+               ) {
+                selectedRowMatchesAnonymousRequest = true
+            } else {
+                selectedRowMatchesAnonymousRequest = false
+            }
+            let selectedRowMatchesRequest = selectedRow?.id == rowWorkspaceID
+                || (selectedRow?.rpcWorkspaceID == requestedWorkspaceID
+                    && CreatedTerminalSelection.deviceIDsMatch(
+                        selectedRow?.macDeviceID,
+                        requestedMacDeviceID
+                    )
+                    && macInstanceTagAuthority.sameStoredAuthority(
+                        selectedRow?.macInstanceTag,
+                        requestedInstanceTag
+                    ))
+                || selectedRowMatchesAnonymousRequest
+            if let selectedRow, selectedRowMatchesRequest,
                let createdID = response.createdTerminalID {
                 let createdTerminalID = MobileTerminalPreview.ID(rawValue: createdID)
+                createdTerminalSelection = CreatedTerminalSelection(
+                    workspace: selectedRow,
+                    fallbackMacDeviceID: requestedMacDeviceID,
+                    fallbackInstanceTag: requestedInstanceTag,
+                    terminalID: createdTerminalID
+                )
                 selectedTerminalID = createdTerminalID
                 suppressTerminalAutoFocusOnNextAttach(for: createdTerminalID)
             }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -274,6 +274,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     }
     public internal(set) var connectedHostName: String
     public private(set) var connectionError: String?
+    /// User-facing recovery copy for a terminal create that did not become
+    /// ready within the bounded optimistic-selection window.
+    public private(set) var terminalCreationError: String?
     /// Actionable next-step line shown beneath ``connectionError`` (for example
     /// "Check that both devices are on the same Tailscale"). Set and cleared
     /// together with the error by the pairing-failure classifier sink.
@@ -1847,6 +1850,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         self.workspaces = workspaces
         self.terminalInputText = ""
         self.connectionError = nil
+        self.terminalCreationError = nil
         self.connectionErrorGuidance = nil
         self.pairingVersionWarning = nil
         self.activeTicket = nil
@@ -8098,6 +8102,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// different workspace if the selection drifts before the async work runs.
     public func createTerminal(in workspaceID: MobileWorkspacePreview.ID? = nil) {
         let targetWorkspaceID = workspaceID ?? selectedWorkspace?.id
+        terminalCreationError = nil
         guard remoteClient == nil else {
             // Bail BEFORE pinning selection when a create is already in flight,
             // so a second "+" on another workspace can't strand the UI on that
@@ -8179,6 +8184,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 return
             }
             self.clearCreatedTerminalSelection()
+            self.terminalCreationError = L10n.string(
+                "mobile.terminal.creationTimeout",
+                defaultValue: "The new terminal did not finish starting."
+            )
             self.recordAppEvent(
                 .terminalCreateFailed,
                 correlationID: terminalID.rawValue,
@@ -11187,6 +11196,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// = nil`) so guidance cannot linger under a cleared headline.
     private func clearPairingError() {
         connectionError = nil
+        terminalCreationError = nil
         connectionErrorGuidance = nil
     }
 

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -11527,7 +11527,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     allowsAnonymousForeground: allowsAnonymousForeground
                 ) {
                     return
-                } else if created.identityMetadataIsIncomplete(in: selectedWorkspace) {
+                } else if created.identityMetadataIsIncomplete(
+                    in: selectedWorkspace,
+                    allowsAnonymousForeground: allowsAnonymousForeground
+                ) {
                     // Preserve the pin while identity fields are temporarily
                     // absent during snapshot convergence. The expiry task is
                     // the bounded escape hatch for a genuinely stuck create.

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -11517,14 +11517,28 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 && workspacesByMac[.anonymousForeground]?.workspaces.contains {
                     $0.rpcWorkspaceID == selectedWorkspace.rpcWorkspaceID
                 } == true
-            if created.matches(
-                workspace: selectedWorkspace,
-                allowsAnonymousForeground: allowsAnonymousForeground
-            ),
-               let selectedTerminal = selectedWorkspace.terminals.first(where: { $0.id == created.terminalID }) {
-                guard selectedTerminal.isReady else { return }
+            if let selectedTerminal = selectedWorkspace.terminals.first(where: { $0.id == created.terminalID }) {
+                if selectedTerminal.isReady {
+                    clearCreatedTerminalSelection()
+                    // The timeout banner is cleared separately when a late
+                    // success arrives after the pin's expiry.
+                } else if created.matches(
+                    workspace: selectedWorkspace,
+                    allowsAnonymousForeground: allowsAnonymousForeground
+                ) {
+                    return
+                } else if selectedWorkspace.rpcWorkspaceID == created.remoteWorkspaceID {
+                    // Preserve the pin while identity fields are temporarily
+                    // absent during snapshot convergence. The expiry task is
+                    // the bounded escape hatch for a genuinely stuck create.
+                    return
+                } else {
+                    clearCreatedTerminalSelection()
+                }
+            } else {
+                // The host has confirmed that the created terminal vanished.
+                clearCreatedTerminalSelection()
             }
-            clearCreatedTerminalSelection()
         }
         if let selectedTerminalID,
            let selectedTerminal = selectedWorkspace.terminals.first(where: { $0.id == selectedTerminalID }),
@@ -11984,16 +11998,18 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         )
         let requestedRow = workspaces.first { $0.id == rowWorkspaceID }
         let requestedWorkspaceID = remoteWorkspaceID(for: rowWorkspaceID)
-        let requestedMacDeviceID = requestedRow?.macDeviceID ?? foregroundMacDeviceID
+        let requestedMacDeviceID = normalizedCreatedTerminalIdentity(requestedRow?.macDeviceID)
+            ?? normalizedCreatedTerminalIdentity(foregroundMacDeviceID)
         // A known workspace owner may legitimately have no instance tag in a
         // legacy snapshot. Keep that absence instead of borrowing the global
         // foreground tag, which may belong to a different Mac instance.
         let requestedInstanceTag: String? = {
-            guard let requestedRow else { return activeMacInstanceTag }
-            if requestedRow.macDeviceID?.isEmpty == false {
-                return requestedRow.macInstanceTag
+            guard let requestedRow else { return normalizedCreatedTerminalIdentity(activeMacInstanceTag) }
+            if normalizedCreatedTerminalIdentity(requestedRow.macDeviceID) != nil {
+                return normalizedCreatedTerminalIdentity(requestedRow.macInstanceTag)
             }
-            return requestedRow.macInstanceTag ?? activeMacInstanceTag
+            return normalizedCreatedTerminalIdentity(requestedRow.macInstanceTag)
+                ?? normalizedCreatedTerminalIdentity(activeMacInstanceTag)
         }()
         let generation = connectionGeneration
         do {
@@ -12017,7 +12033,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             applyRemoteWorkspaceList(response, mergeExistingWorkspaces: true)
             let selectedRow = explicitlySelectedWorkspace
             let selectedRowMatchesAnonymousRequest: Bool
-            if requestedRow?.macDeviceID?.isEmpty != false,
+            if normalizedCreatedTerminalIdentity(requestedRow?.macDeviceID) == nil,
                let foregroundMacDeviceID,
                let selectedRow,
                selectedRow.rpcWorkspaceID == requestedWorkspaceID,
@@ -12033,6 +12049,22 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             } else {
                 selectedRowMatchesAnonymousRequest = false
             }
+            let selectedRowMatchesUnidentifiedRequest: Bool = {
+                guard normalizedCreatedTerminalIdentity(requestedRow?.macDeviceID) == nil,
+                      normalizedCreatedTerminalIdentity(foregroundMacDeviceID) == nil,
+                      normalizedCreatedTerminalIdentity(requestedInstanceTag) == nil,
+                      let selectedRow,
+                      selectedRow.rpcWorkspaceID == requestedWorkspaceID,
+                      normalizedCreatedTerminalIdentity(selectedRow.macDeviceID) == nil,
+                      normalizedCreatedTerminalIdentity(selectedRow.macInstanceTag) == nil else {
+                    return false
+                }
+                return workspaces.filter {
+                    $0.rpcWorkspaceID == requestedWorkspaceID
+                        && normalizedCreatedTerminalIdentity($0.macDeviceID) == nil
+                        && normalizedCreatedTerminalIdentity($0.macInstanceTag) == nil
+                }.count == 1
+            }()
             let selectedRowMatchesKnownOwnerRequest: Bool = {
                 guard let selectedRow,
                       selectedRow.rpcWorkspaceID == requestedWorkspaceID,
@@ -12054,6 +12086,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             }()
             let selectedRowMatchesRequest = selectedRowMatchesKnownOwnerRequest
                 || selectedRowMatchesAnonymousRequest
+                || selectedRowMatchesUnidentifiedRequest
             if let selectedRow, selectedRowMatchesRequest,
                let createdID = response.createdTerminalID {
                 let createdTerminalID = MobileTerminalPreview.ID(rawValue: createdID)

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -4614,6 +4614,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         let foregroundKeyBeforeTagAdoption = foregroundMacKey
         if activeMacInstanceTag == nil, let resolvedTag, !resolvedTag.isEmpty {
             activeMacInstanceTag = resolvedTag
+            createdTerminalSelection?.adoptMacInstanceTagIfMissing(resolvedTag)
         }
         adoptForegroundMacIdentity(
             reportedID,
@@ -11435,7 +11436,15 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // otherwise win the fallback below. The pin is scoped to the remote
         // workspace and owning Mac, so a row-id remap cannot retarget it.
         if let created = createdTerminalSelection, selectedTerminalID == created.terminalID {
-            if created.matches(workspace: selectedWorkspace),
+            let allowsAnonymousForeground = foregroundMacDeviceID == nil
+                && selectedWorkspace.macDeviceID == nil
+                && workspacesByMac[.anonymousForeground]?.workspaces.contains {
+                    $0.rpcWorkspaceID == selectedWorkspace.rpcWorkspaceID
+                } == true
+            if created.matches(
+                workspace: selectedWorkspace,
+                allowsAnonymousForeground: allowsAnonymousForeground
+            ),
                let selectedTerminal = selectedWorkspace.terminals.first(where: { $0.id == created.terminalID }) {
                 guard selectedTerminal.isReady else { return }
             }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ComposerSubmitRoutingTestSupport.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ComposerSubmitRoutingTestSupport.swift
@@ -89,10 +89,13 @@ actor RoutingHostRouter {
     private var firstWorkspaceCreateHeld = false
     private var firstWorkspaceCreateContinuation: CheckedContinuation<Void, Never>?
     private var firstWorkspaceCreateReachedWaiters: [CheckedContinuation<Void, Never>] = []
+    private var createdTerminalExists = false
+    private var terminalCreateWaiters: [CheckedContinuation<Void, Never>] = []
 
     static let workspaceID = "ws-route"
     static let terminalA = "term-route-a"
     static let terminalB = "term-route-b"
+    static let createdTerminal = "term-route-created"
 
     /// Reject every terminal.paste_image with an error frame, modeling a host
     /// that cannot accept the image (the composer must keep the attachment).
@@ -125,6 +128,11 @@ actor RoutingHostRouter {
         let continuation = firstPasteImageContinuation
         firstPasteImageContinuation = nil
         continuation?.resume()
+    }
+
+    func awaitTerminalCreateRequested() async {
+        if createdTerminalExists { return }
+        await withCheckedContinuation { terminalCreateWaiters.append($0) }
     }
 
     func setRejectWorkspaceCreate(_ reject: Bool) {
@@ -247,32 +255,13 @@ actor RoutingHostRouter {
         let id = info.id
         switch method {
         case "workspace.list", "mobile.workspace.list":
-            return try? Self.resultFrame(id: id, result: [
-                "workspaces": [
-                    [
-                        "id": Self.workspaceID,
-                        "title": "Routing Workspace",
-                        "current_directory": "/tmp/route",
-                        "is_selected": true,
-                        "terminals": [
-                            [
-                                "id": Self.terminalA,
-                                "title": "A",
-                                "current_directory": "/tmp/route",
-                                "is_ready": true,
-                                "is_focused": true,
-                            ],
-                            [
-                                "id": Self.terminalB,
-                                "title": "B",
-                                "current_directory": "/tmp/route",
-                                "is_ready": true,
-                                "is_focused": false,
-                            ],
-                        ],
-                    ],
-                ],
-            ])
+            return try? workspaceListFrame(id: id)
+        case "terminal.create":
+            createdTerminalExists = true
+            let waiters = terminalCreateWaiters
+            terminalCreateWaiters = []
+            for waiter in waiters { waiter.resume() }
+            return try? workspaceListFrame(id: id, createdTerminalID: Self.createdTerminal)
         case "mobile.host.status":
             return try? Self.resultFrame(id: id, result: [
                 "terminal_fidelity": "render_grid",
@@ -496,6 +485,47 @@ actor RoutingHostRouter {
         default:
             return try? Self.errorFrame(id: id, message: "Unexpected method \(method ?? "nil")")
         }
+    }
+
+    private func workspaceListFrame(id: String?, createdTerminalID: String? = nil) throws -> Data {
+        var terminals: [[String: Any]] = [
+            [
+                "id": Self.terminalA,
+                "title": "A",
+                "current_directory": "/tmp/route",
+                "is_ready": true,
+                "is_focused": true,
+            ],
+            [
+                "id": Self.terminalB,
+                "title": "B",
+                "current_directory": "/tmp/route",
+                "is_ready": true,
+                "is_focused": false,
+            ],
+        ]
+        if createdTerminalExists {
+            terminals.append([
+                "id": Self.createdTerminal,
+                "title": "Created",
+                "current_directory": "/tmp/route",
+                "is_ready": false,
+                "is_focused": false,
+            ])
+        }
+        var result: [String: Any] = [
+            "workspaces": [[
+                "id": Self.workspaceID,
+                "title": "Routing Workspace",
+                "current_directory": "/tmp/route",
+                "is_selected": true,
+                "terminals": terminals,
+            ]],
+        ]
+        if let createdTerminalID {
+            result["created_terminal_id"] = createdTerminalID
+        }
+        return try Self.resultFrame(id: id, result: result)
     }
 
     static func resultFrame(id: String?, result: [String: Any]) throws -> Data {

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/CreatedTerminalSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/CreatedTerminalSelectionTests.swift
@@ -33,7 +33,7 @@ import Testing
             fallbackMacDeviceID: "mac-main",
             terminalID: "terminal-new"
         )
-        #expect(anonymousWithFallback.matches(workspace: anonymousWorkspace, allowsAnonymousForeground: true))
+        #expect(!anonymousWithFallback.matches(workspace: anonymousWorkspace, allowsAnonymousForeground: true))
         #expect(!anonymousWithFallback.matches(workspace: anonymousWorkspace, allowsAnonymousForeground: false))
 
         let anonymousSelection = CreatedTerminalSelection(

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/CreatedTerminalSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/CreatedTerminalSelectionTests.swift
@@ -48,6 +48,23 @@ import Testing
         #expect(!anonymousSelection.matches(workspace: taggedWorkspace, allowsAnonymousForeground: true))
     }
 
+    @Test func knownWorkspaceDoesNotBorrowFallbackInstanceTag() {
+        let workspace = MobileWorkspacePreview(
+            id: "workspace-main",
+            macDeviceID: "mac-main",
+            name: "cmux",
+            terminals: [MobileTerminalPreview(id: "terminal-new", name: "Terminal 2")]
+        )
+        let selection = CreatedTerminalSelection(
+            workspace: workspace,
+            fallbackMacDeviceID: "mac-main",
+            fallbackInstanceTag: "unrelated-sibling",
+            terminalID: "terminal-new"
+        )
+
+        #expect(selection.macInstanceTag == nil)
+    }
+
     @Test func remoteCreatedTerminalRemainsSelectedAfterRefresh() async throws {
         let router = RoutingHostRouter()
         let store = try await makeRoutingConnectedStore(router: router)

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/CreatedTerminalSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/CreatedTerminalSelectionTests.swift
@@ -24,7 +24,20 @@ import Testing
         )
         stampedWorkspace.macInstanceTag = "ntab"
 
-        #expect(selection.matches(workspace: stampedWorkspace))
+        #expect(selection.matches(workspace: stampedWorkspace, allowsAnonymousForeground: false))
+        stampedWorkspace.macInstanceTag = nil
+        #expect(selection.matches(workspace: stampedWorkspace, allowsAnonymousForeground: false))
+
+        let anonymousSelection = CreatedTerminalSelection(
+            workspace: anonymousWorkspace,
+            terminalID: "terminal-new"
+        )
+        #expect(anonymousSelection.matches(workspace: anonymousWorkspace, allowsAnonymousForeground: true))
+        #expect(!anonymousSelection.matches(workspace: anonymousWorkspace, allowsAnonymousForeground: false))
+
+        var taggedWorkspace = anonymousWorkspace
+        taggedWorkspace.macInstanceTag = "nightly"
+        #expect(!anonymousSelection.matches(workspace: taggedWorkspace, allowsAnonymousForeground: true))
     }
 
     @Test func remoteCreatedTerminalRemainsSelectedAfterRefresh() async throws {

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/CreatedTerminalSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/CreatedTerminalSelectionTests.swift
@@ -26,7 +26,15 @@ import Testing
 
         #expect(selection.matches(workspace: stampedWorkspace, allowsAnonymousForeground: false))
         stampedWorkspace.macInstanceTag = nil
-        #expect(selection.matches(workspace: stampedWorkspace, allowsAnonymousForeground: false))
+        #expect(!selection.matches(workspace: stampedWorkspace, allowsAnonymousForeground: false))
+
+        let anonymousWithFallback = CreatedTerminalSelection(
+            workspace: anonymousWorkspace,
+            fallbackMacDeviceID: "mac-main",
+            terminalID: "terminal-new"
+        )
+        #expect(anonymousWithFallback.matches(workspace: anonymousWorkspace, allowsAnonymousForeground: true))
+        #expect(!anonymousWithFallback.matches(workspace: anonymousWorkspace, allowsAnonymousForeground: false))
 
         let anonymousSelection = CreatedTerminalSelection(
             workspace: anonymousWorkspace,

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/CreatedTerminalSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/CreatedTerminalSelectionTests.swift
@@ -4,6 +4,29 @@ import Testing
 
 @MainActor
 @Suite struct CreatedTerminalSelectionTests {
+    @Test func localCreatedTerminalMatchesAfterAnonymousRowAdoptsMacIdentity() {
+        let anonymousWorkspace = MobileWorkspacePreview(
+            id: "workspace-main",
+            name: "cmux",
+            terminals: [MobileTerminalPreview(id: "terminal-new", name: "Terminal 2", isReady: false)]
+        )
+        let selection = CreatedTerminalSelection(
+            workspace: anonymousWorkspace,
+            fallbackMacDeviceID: "mac-main",
+            fallbackInstanceTag: "ntab",
+            terminalID: "terminal-new"
+        )
+        var stampedWorkspace = MobileWorkspacePreview(
+            id: "workspace-main",
+            macDeviceID: "mac-main",
+            name: "cmux",
+            terminals: [MobileTerminalPreview(id: "terminal-new", name: "Terminal 2", isReady: false)]
+        )
+        stampedWorkspace.macInstanceTag = "ntab"
+
+        #expect(selection.matches(workspace: stampedWorkspace))
+    }
+
     @Test func remoteCreatedTerminalRemainsSelectedAfterRefresh() async throws {
         let router = RoutingHostRouter()
         let store = try await makeRoutingConnectedStore(router: router)

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/CreatedTerminalSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/CreatedTerminalSelectionTests.swift
@@ -1,0 +1,30 @@
+import CmuxMobileShellModel
+import Testing
+@testable import CmuxMobileShell
+
+@MainActor
+@Suite struct CreatedTerminalSelectionTests {
+    @Test func remoteCreatedTerminalRemainsSelectedAfterRefresh() async throws {
+        let router = RoutingHostRouter()
+        let store = try await makeRoutingConnectedStore(router: router)
+        let created = MobileTerminalPreview.ID(rawValue: RoutingHostRouter.createdTerminal)
+
+        store.createTerminal(in: MobileWorkspacePreview.ID(rawValue: RoutingHostRouter.workspaceID))
+        await router.awaitTerminalCreateRequested()
+        await waitUntilSelectedTerminal(store, is: created)
+        #expect(store.selectedTerminalID == created)
+
+        await store.refreshWorkspaces()
+
+        #expect(store.selectedTerminalID == created)
+    }
+
+    private func waitUntilSelectedTerminal(
+        _ store: MobileShellComposite,
+        is terminalID: MobileTerminalPreview.ID
+    ) async {
+        for _ in 0..<50 where store.selectedTerminalID != terminalID {
+            await Task.yield()
+        }
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositePreviewTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositePreviewTests.swift
@@ -520,6 +520,48 @@ import Testing
         #expect(store.selectedTerminalID?.rawValue == "workspace-main-terminal-4")
     }
 
+    @Test func createTerminalRemainsSelectedWhileItStarts() throws {
+        let store = MobileShellComposite.preview()
+        store.signIn()
+        store.pairingCode = "debug"
+        store.connectPreviewHost()
+
+        store.createTerminal()
+        let created = try #require(store.selectedTerminalID)
+        let refreshedWorkspace = MobileWorkspacePreview(
+            id: "workspace-main",
+            name: "cmux",
+            terminals: [
+                MobileTerminalPreview(id: "terminal-build", name: "Build", isReady: true),
+                MobileTerminalPreview(id: created, name: "Terminal 4", isReady: false),
+            ]
+        )
+
+        store.replaceForegroundWorkspaceState([refreshedWorkspace])
+
+        #expect(store.selectedTerminalID == created)
+    }
+
+    @Test func createTerminalFallsBackWhenCreatedTerminalDisappears() throws {
+        let store = MobileShellComposite.preview()
+        store.signIn()
+        store.pairingCode = "debug"
+        store.connectPreviewHost()
+
+        store.createTerminal()
+        let created = try #require(store.selectedTerminalID)
+        store.replaceForegroundWorkspaceState([
+            MobileWorkspacePreview(
+                id: "workspace-main",
+                name: "cmux",
+                terminals: [MobileTerminalPreview(id: "terminal-build", name: "Build", isReady: true)]
+            )
+        ])
+
+        #expect(store.selectedTerminalID == "terminal-build")
+        #expect(store.selectedTerminalID != created)
+    }
+
     @Test func createTerminalUsesExplicitWorkspaceContextOverStaleSelection() {
         let store = MobileShellComposite.preview()
         store.signIn()

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -178,7 +178,15 @@ struct WorkspaceDetailView: View {
     }
     #endif
     var body: some View {
-        let content = Group { detailSurfaceContent }
+        let content = Group {
+            VStack(spacing: 0) {
+                if let message = store.terminalCreationError,
+                   store.selectedWorkspaceID == workspace.id {
+                    terminalCreationRecovery(message: message)
+                }
+                detailSurfaceContent
+            }
+        }
 
         #if os(iOS)
         content
@@ -286,6 +294,31 @@ struct WorkspaceDetailView: View {
             )
             .mobileConnectionRecoveryOverlay(store: store, signOut: signOut)
         #endif
+    }
+
+    private func terminalCreationRecovery(message: String) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+            VStack(alignment: .leading, spacing: 6) {
+                Text(message)
+                    .font(.subheadline)
+                    .fixedSize(horizontal: false, vertical: true)
+                Button {
+                    createTerminal()
+                } label: {
+                    Text(L10n.string("mobile.terminal.creationRetry", defaultValue: "Retry"))
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+                .accessibilityIdentifier("MobileTerminalCreationRetry")
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(.orange.opacity(0.14))
+        .accessibilityIdentifier("MobileTerminalCreationRecovery")
     }
 
     #if os(iOS)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -181,7 +181,8 @@ struct WorkspaceDetailView: View {
         let content = Group {
             VStack(spacing: 0) {
                 if let message = store.terminalCreationError,
-                   store.selectedWorkspaceID == workspace.id {
+                   store.selectedWorkspaceID == workspace.id,
+                   store.terminalCreationErrorWorkspaceID == workspace.rpcWorkspaceID {
                     terminalCreationRecovery(message: message)
                 }
                 detailSurfaceContent


### PR DESCRIPTION
## Summary
- keep a terminal created from iOS selected while workspace refreshes catch up
- scope the pending selection to the remote workspace and owning Mac
- cover local and RPC creation paths, refresh fallback, and identity matching

## Verification
- `swift test --package-path Packages/iOS/CmuxMobileShell --filter CreatedTerminalSelectionTests`
- `swift test --package-path Packages/iOS/CmuxMobileShell --filter MobileShellCompositePreviewTests.createTerminal`
- tagged macOS build `ntab` succeeded
- signed iOS archive succeeded; iPhone install is queued because device `4A52829D-6427-599F-A166-4058881D2DF4` was unreachable

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790809464&installation_model_id=21920&pr_number=11279&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11279&signature=eb558447a9102afdd029e0ff9db09842ab9acd05c86f0dbbbc6128f1e83a27c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps a terminal created from iOS selected while workspace refreshes catch up, so the refresh no longer jumps focus to an already-ready terminal.

- Pins the selection to the remote workspace and owning Mac identity so a row-id remap or sibling build can't retarget it, adopting the identity when a legacy row gains it after the create.
- Captures the requested row's Mac identity and instance tag at request time and rejects a create response that doesn't match them; instance tags are compared canonically through the tag authority, and an ownerless pin is kept only while it's the unique anonymous row in that workspace.
- Covers both the local preview path and the RPC create-response path.
- Releases the pin when the user selects another terminal, the created terminal disappears, or 30 seconds pass without it becoming ready.
- On that timeout, shows a recovery banner with a Retry button scoped to the workspace where creation failed and records `terminalCreateFailed`; a late successful start clears the banner.

<sup>Written for commit e4d783a1460ec6d13c5b63a7895432d9d8502e56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a recovery message when a newly created terminal does not become ready within the expected time.
  * Added a **Retry** option to attempt terminal creation again.

* **Bug Fixes**
  * Newly created terminals remain selected while starting, including after workspace refreshes.
  * Selection stays associated as workspace, device, or instance details become available.
  * If a created terminal disappears during refresh, selection falls back to an available ready terminal.
  * Selection clears when the created terminal becomes ready or another terminal is selected.

* **Tests**
  * Added coverage for terminal creation, refreshes, selection persistence, identity updates, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->