### PR TITLE
test(web): update pricing color assertion

### DIFF
--- a/web/tests/app-pricing-page.test.tsx
+++ b/web/tests/app-pricing-page.test.tsx
@@ -184,9 +184,24 @@ describe("app pricing page", () => {
     expect(html).toContain("--cmux-product-blue-on-foreground:#006CBF");
     expect(html).toContain("mx-auto mt-6 flex w-fit");
     expect(html).toContain(
-      "var(--cmux-product-blue-on-foreground, var(--cmux-product-blue, #0088ff))",
+      '<span class="ml-1.5 text-xs font-medium" style="color:inherit">Save 20%</span>',
     );
     expect(html).toContain('href="/enterprise?cmux_external_browser=1"');
+  });
+
+  test("uses the product accent for the inactive annual savings label", async () => {
+    const element = await AppPricingPage({
+      searchParams: Promise.resolve({
+        cmux_app: "1",
+        cmux_scheme: "cmux-dev-test",
+        interval: "month",
+      }),
+    });
+    const html = renderToStaticMarkup(element);
+
+    expect(html).toContain(
+      '<span class="ml-1.5 text-xs font-medium" style="color:var(--cmux-product-blue-on-background, var(--cmux-product-blue, #0088ff))">Save 20%</span>',
+    );
   });
 
   test("removes external purchase links in App Store distribution mode", async () => {


### PR DESCRIPTION
The merged pricing change uses inherited text color for the selected annual label. Update its behavior test to assert the rendered result on current main.\n\nFocused check: bun test --isolate tests/app-pricing-page.test.tsx

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790809551&installation_model_id=21920&pr_number=11280&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11280&signature=e91a9e73cfd4481227680f51c4ec6660f2a14ca5741b034ce21ef928a74d25d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the pricing page tests to match the merged label styling behavior: the annual (selected) label now asserts `style="color:inherit"`, and a new test verifies the monthly (inactive) label still uses the product accent CSS variable fallback.

<sup>Written for commit 144d478319aab32c47027c7fe040b4ec78c04daa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated pricing page coverage to verify correct savings-label colors for annual and monthly billing views.
  * Confirmed the active annual savings label inherits the surrounding text color.
  * Added validation that the inactive annual savings label uses the product accent color.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->