### PR TITLE
ci: route cla.yml through vars.LINUX_RUNNER

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   CLAAssistant:
     name: "CLA Assistant"
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     steps:
       - name: "CLA Assistant"
         # The action handles signing and status updates. Merged pull requests


### PR DESCRIPTION
workflow-guard-tests fails on main because .github/workflows/cla.yml:28 pins bare ubuntu-latest; the guard requires every job to route through vars.LINUX_RUNNER / vars.MACOS_RUNNER_IOS so the Blacksmith/overflow choice stays a repo-variable flip. One line: adopt the same expression ci.yml uses. ./tests/test_ci_self_hosted_guard.sh passes locally with the change (30/30). Last remaining red job on main after https://github.com/manaflow-ai/cmux/pull/11093 (web) and https://github.com/manaflow-ai/cmux/pull/11115 (CmuxGit build, by its author).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790810211&installation_model_id=21920&pr_number=11281&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11281&signature=018dcb6cede2bad41e68e1e20845c0b2ab2c4105cfa628c7cd1d2c60f14138bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes `cla.yml` through `vars.LINUX_RUNNER` (with the same fallback as `ci.yml`) so the workflow-guard test stops failing on main.

<sup>Written for commit 339b35b723ae843fed68f8b7317d41def155962f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated contribution checks to run on a configurable build environment.
  * Added a default runner option to maintain reliable execution when no custom setting is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->