### PR TITLE
ci: route cla.yml through vars.LINUX_RUNNER

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   CLAAssistant:
     name: "CLA Assistant"
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     steps:
       - name: "CLA Assistant"
         # The action handles signing and status updates. Merged pull requests


### PR DESCRIPTION
Rebased resubmission of https://github.com/manaflow-ai/cmux/pull/11281 (closed by an accidental branch deletion on my side). workflow-guard-tests fails on main because .github/workflows/cla.yml:28 pins bare ubuntu-latest; the guard requires vars.LINUX_RUNNER routing. One line, same expression ci.yml uses. ./tests/test_ci_self_hosted_guard.sh passes locally (30/30). Codex review on the identical diff was clean (https://github.com/manaflow-ai/cmux/pull/11281): patch correct 0.98, no findings.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790813129&installation_model_id=21920&pr_number=11284&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11284&signature=6064d05322e50558419936c4d4fa9f372cc1d58fd1c3d39403b6ad47c5f51faa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes the CLA workflow through the configured Linux runner so `workflow-guard-tests` stops failing on main.

<sup>Written for commit de4ce1800d2560337abb2f6b9d54d8fc0ef69969. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated contributor agreement workflow to use a configurable Linux runner, with a default fallback for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->