### PR TITLE
ci: update CLA Assistant — pin upstream master (v2.6.1+4) and silence Node deprecation noise

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -44,7 +44,10 @@ jobs:
               github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
             )
           )
-        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        # Pinned to master's head: the repo is archived, v2.6.1 is the final
+        # release, and master adds one real fix over it ($contributorName not
+        # replaced in the signing comment). SHA-pinned, so immutable.
+        uses: contributor-assistant/github-action@58daaf842ac3a5a064edeaebe5987b7e196a3f22 # master 2026-03-23, v2.6.1+4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # v2.6.1 (the newest release; upstream master still declares node20)

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -47,6 +47,11 @@ jobs:
         uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # v2.6.1 (the newest release; upstream master still declares node20)
+          # bundles deps that emit punycode/url.parse DeprecationWarnings under
+          # the runner's Node 24. Suppress deprecation noise; drop this when a
+          # release ships a node24 runtime with updated deps.
+          NODE_OPTIONS: --no-deprecation
         with:
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-document: 'https://github.com/manaflow-ai/cmux/blob/main/CLA.md'


### PR DESCRIPTION
## Summary
Two changes to the CLA Assistant step in `.github/workflows/cla.yml`:

1. **Update the action pin** — the upstream repo is archived and `v2.6.1` is its final release; master is 4 commits ahead with one real fix (the signing comment left `$contributorName` unreplaced). Pin master's head by SHA (`58daaf842ac3`, 2026-03-23), immutable.
2. **Silence Node deprecation noise** — every run prints `punycode` (DEP0040) and `url.parse` (DEP0169) DeprecationWarnings from the action's bundled deps under the runner's Node 24. `NODE_OPTIONS: --no-deprecation` on this one step drops them. The "Node 20 is being deprecated" banner comes from the action's `node20` manifest (unchanged even on master) and only a node24 upstream release removes it; the run already executes on Node 24, so nothing is functionally affected. `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` deliberately not used — it would pin back the deprecated Node 20.

## Test plan
- [ ] Next CLA Assistant run on any PR: no DeprecationWarnings in the step log, signing comment renders the contributor name

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the contributor license agreement workflow for improved compatibility with the current runtime.
  * Suppressed non-actionable dependency deprecation warnings during workflow execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->