### PR TITLE
Fix concurrent tmux-compatible set-buffer writes

### DIFF
--- a/CLI/CMUXCLI+TmuxCompatStore.swift
+++ b/CLI/CMUXCLI+TmuxCompatStore.swift
@@ -49,8 +49,9 @@ extension CMUXCLI {
             data = try Data(contentsOf: url)
         } catch {
             let nsError = error as NSError
-            let isMissing = nsError.domain == NSCocoaErrorDomain
-                && (nsError.code == NSFileNoSuchFileError || nsError.code == NSFileReadNoSuchFileError)
+            let isMissing = (nsError.domain == NSCocoaErrorDomain
+                && (nsError.code == NSFileNoSuchFileError || nsError.code == NSFileReadNoSuchFileError))
+                || (nsError.domain == NSPOSIXErrorDomain && nsError.code == ENOENT)
                 || (error as? POSIXError)?.code == .ENOENT
             if isMissing {
                 return TmuxCompatStore()

--- a/CLI/CMUXCLI+TmuxCompatStore.swift
+++ b/CLI/CMUXCLI+TmuxCompatStore.swift
@@ -51,6 +51,7 @@ extension CMUXCLI {
     }
 
     private func readTmuxCompatStoreData(at url: URL) throws -> Data? {
+        try validateTmuxCompatStoreDirectory(at: url.deletingLastPathComponent())
         let descriptor = Darwin.open(url.path, O_RDONLY | O_CLOEXEC | O_NOFOLLOW)
         guard descriptor >= 0 else {
             if errno == ENOENT {
@@ -59,6 +60,13 @@ extension CMUXCLI {
             throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
         }
         defer { Darwin.close(descriptor) }
+        var metadata = stat()
+        guard Darwin.fstat(descriptor, &metadata) == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        guard (metadata.st_mode & S_IFMT) == S_IFREG else {
+            throw POSIXError(.EINVAL)
+        }
         guard Darwin.fchmod(descriptor, mode_t(S_IRUSR | S_IWUSR)) == 0 else {
             throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
         }
@@ -120,8 +128,22 @@ extension CMUXCLI {
             withIntermediateDirectories: true,
             attributes: [.posixPermissions: 0o700]
         )
+        try validateTmuxCompatStoreDirectory(at: parent)
         // Also tighten an existing directory created by an older CLI.
         try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: parent.path)
+    }
+
+    private func validateTmuxCompatStoreDirectory(at parent: URL) throws {
+        var metadata = stat()
+        guard Darwin.lstat(parent.path, &metadata) == 0 else {
+            if errno == ENOENT {
+                return
+            }
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        guard (metadata.st_mode & S_IFMT) == S_IFDIR else {
+            throw POSIXError(.ENOTDIR)
+        }
     }
 
     /// Serializes cross-process mutations of a tmux compatibility store.

--- a/CLI/CMUXCLI+TmuxCompatStore.swift
+++ b/CLI/CMUXCLI+TmuxCompatStore.swift
@@ -256,8 +256,12 @@ extension CMUXCLI {
     }
 
     private func loadTmuxCompatStore(from directory: TmuxCompatStoreDirectory) throws -> TmuxCompatStore {
-        let data = try readTmuxCompatStoreData(in: directory)
-        return try JSONDecoder().decode(TmuxCompatStore.self, from: data)
+        do {
+            let data = try readTmuxCompatStoreData(in: directory)
+            return try JSONDecoder().decode(TmuxCompatStore.self, from: data)
+        } catch let error as POSIXError where error.code == .ENOENT {
+            return TmuxCompatStore()
+        }
     }
 
     func withLockedTmuxCompatStoreIfChanged(

--- a/CLI/CMUXCLI+TmuxCompatStore.swift
+++ b/CLI/CMUXCLI+TmuxCompatStore.swift
@@ -64,9 +64,45 @@ extension CMUXCLI {
     func saveTmuxCompatStore(_ store: TmuxCompatStore) throws {
         let url = tmuxCompatStoreURL()
         let parent = url.deletingLastPathComponent()
-        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true, attributes: nil)
+        try ensureTmuxCompatStoreDirectory(at: parent)
         let data = try JSONEncoder().encode(store)
-        try data.write(to: url, options: .atomic)
+        let tempURL = parent.appendingPathComponent(".tmux-compat-store-\(UUID().uuidString).tmp")
+        let fileManager = FileManager.default
+        guard fileManager.createFile(
+            atPath: tempURL.path,
+            contents: data,
+            attributes: [.posixPermissions: 0o600]
+        ) else {
+            throw CocoaError(.fileWriteUnknown, userInfo: [NSFilePathErrorKey: tempURL.path])
+        }
+        var didReplace = false
+        defer {
+            if !didReplace {
+                try? fileManager.removeItem(at: tempURL)
+            }
+        }
+        // Keep the replacement owner-only even when the process umask is lax.
+        try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: tempURL.path)
+        let renameResult = tempURL.path.withCString { source in
+            url.path.withCString { destination in
+                Darwin.rename(source, destination)
+            }
+        }
+        guard renameResult == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        didReplace = true
+    }
+
+    private func ensureTmuxCompatStoreDirectory(at parent: URL) throws {
+        let fileManager = FileManager.default
+        try fileManager.createDirectory(
+            at: parent,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        // Also tighten an existing directory created by an older CLI.
+        try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: parent.path)
     }
 
     /// Serializes cross-process mutations of a tmux compatibility store.
@@ -76,7 +112,7 @@ extension CMUXCLI {
     /// atomically replaced by its writer.
     func withTmuxCompatStoreFileLock<T>(at storeURL: URL, _ body: () throws -> T) throws -> T {
         let parent = storeURL.deletingLastPathComponent()
-        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true, attributes: nil)
+        try ensureTmuxCompatStoreDirectory(at: parent)
 
         let lockURL = URL(fileURLWithPath: storeURL.path + ".lock")
         let descriptor = open(
@@ -88,6 +124,9 @@ extension CMUXCLI {
             throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
         }
         defer { Darwin.close(descriptor) }
+        guard Darwin.fchmod(descriptor, mode_t(S_IRUSR | S_IWUSR)) == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
 
         while flock(descriptor, LOCK_EX) != 0 {
             if errno == EINTR {

--- a/CLI/CMUXCLI+TmuxCompatStore.swift
+++ b/CLI/CMUXCLI+TmuxCompatStore.swift
@@ -44,24 +44,40 @@ extension CMUXCLI {
 
     func loadTmuxCompatStore() throws -> TmuxCompatStore {
         let url = tmuxCompatStoreURL()
-        let data: Data
-        do {
-            data = try Data(contentsOf: url)
-        } catch {
-            let nsError = error as NSError
-            let isMissing = (nsError.domain == NSCocoaErrorDomain
-                && (nsError.code == NSFileNoSuchFileError || nsError.code == NSFileReadNoSuchFileError))
-                || (nsError.domain == NSPOSIXErrorDomain && nsError.code == ENOENT)
-                || (error as? POSIXError)?.code == .ENOENT
-            if isMissing {
-                return TmuxCompatStore()
-            }
-            throw error
+        guard let data = try readTmuxCompatStoreData(at: url) else {
+            return TmuxCompatStore()
         }
-        // Heal stores created by older versions before exposing their contents
-        // to read-only commands (including malformed stores).
-        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
         return try JSONDecoder().decode(TmuxCompatStore.self, from: data)
+    }
+
+    private func readTmuxCompatStoreData(at url: URL) throws -> Data? {
+        let descriptor = Darwin.open(url.path, O_RDONLY | O_CLOEXEC | O_NOFOLLOW)
+        guard descriptor >= 0 else {
+            if errno == ENOENT {
+                return nil
+            }
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        defer { Darwin.close(descriptor) }
+        guard Darwin.fchmod(descriptor, mode_t(S_IRUSR | S_IWUSR)) == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 16 * 1024)
+        while true {
+            let count = buffer.withUnsafeMutableBytes { rawBuffer -> Int in
+                guard let baseAddress = rawBuffer.baseAddress else { return 0 }
+                return Darwin.read(descriptor, baseAddress, rawBuffer.count)
+            }
+            if count > 0 {
+                data.append(contentsOf: buffer.prefix(count))
+            } else if count == 0 {
+                return data
+            } else if errno != EINTR {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+        }
     }
 
     func saveTmuxCompatStore(_ store: TmuxCompatStore) throws {

--- a/CLI/CMUXCLI+TmuxCompatStore.swift
+++ b/CLI/CMUXCLI+TmuxCompatStore.swift
@@ -1,0 +1,115 @@
+import Darwin
+import Foundation
+
+extension CMUXCLI {
+    struct MainVerticalState: Codable {
+        /// The surface ID of the "main" (leader) pane on the left side.
+        var mainSurfaceId: String
+        /// The surface ID of the bottom-most pane in the right column.
+        /// Subsequent teammate splits target this pane with direction "down".
+        var lastColumnSurfaceId: String?
+    }
+
+    struct TmuxCompatStore: Codable {
+        var buffers: [String: String] = [:]
+        var hooks: [String: String] = [:]
+        /// Tracks main-vertical layout state per workspace, keyed by workspace ID.
+        var mainVerticalLayouts: [String: MainVerticalState] = [:]
+        /// Tracks the last surface created by split-window per workspace.
+        /// Used to seed lastColumnSurfaceId when select-layout main-vertical
+        /// is called after the first split.
+        var lastSplitSurface: [String: String] = [:]
+
+        /// Custom decoder so older store files missing newer keys
+        /// (mainVerticalLayouts, lastSplitSurface) decode gracefully
+        /// instead of throwing and resetting the entire store.
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            buffers = try container.decodeIfPresent([String: String].self, forKey: .buffers) ?? [:]
+            hooks = try container.decodeIfPresent([String: String].self, forKey: .hooks) ?? [:]
+            mainVerticalLayouts = try container.decodeIfPresent([String: MainVerticalState].self, forKey: .mainVerticalLayouts) ?? [:]
+            lastSplitSurface = try container.decodeIfPresent([String: String].self, forKey: .lastSplitSurface) ?? [:]
+        }
+
+        init() {}
+    }
+
+    func tmuxCompatStoreURL() -> URL {
+        let homePath = ProcessInfo.processInfo.environment["HOME"]
+            ?? NSString(string: "~").expandingTildeInPath
+        return URL(fileURLWithPath: homePath)
+            .appendingPathComponent(".cmuxterm")
+            .appendingPathComponent("tmux-compat-store.json")
+    }
+
+    func loadTmuxCompatStore() -> TmuxCompatStore {
+        let url = tmuxCompatStoreURL()
+        guard let data = try? Data(contentsOf: url),
+              let decoded = try? JSONDecoder().decode(TmuxCompatStore.self, from: data) else {
+            return TmuxCompatStore()
+        }
+        return decoded
+    }
+
+    func saveTmuxCompatStore(_ store: TmuxCompatStore) throws {
+        let url = tmuxCompatStoreURL()
+        let parent = url.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true, attributes: nil)
+        let data = try JSONEncoder().encode(store)
+        try data.write(to: url, options: .atomic)
+    }
+
+    /// Serializes cross-process mutations of a tmux compatibility store.
+    ///
+    /// Each CLI invocation is a separate process, so an in-memory lock cannot
+    /// protect the store. The lock file remains stable while the JSON file is
+    /// atomically replaced by its writer.
+    func withTmuxCompatStoreFileLock<T>(at storeURL: URL, _ body: () throws -> T) throws -> T {
+        let parent = storeURL.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true, attributes: nil)
+
+        let lockURL = URL(fileURLWithPath: storeURL.path + ".lock")
+        let descriptor = open(
+            lockURL.path,
+            O_CREAT | O_RDWR | O_CLOEXEC | O_NOFOLLOW,
+            mode_t(S_IRUSR | S_IWUSR)
+        )
+        guard descriptor >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        defer { Darwin.close(descriptor) }
+
+        while flock(descriptor, LOCK_EX) != 0 {
+            if errno == EINTR {
+                continue
+            }
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        defer { _ = flock(descriptor, LOCK_UN) }
+        return try body()
+    }
+
+    /// Performs one complete tmux compatibility store read-modify-write while
+    /// holding the cross-process lock.
+    func withLockedTmuxCompatStore<T>(
+        _ body: (inout TmuxCompatStore) throws -> T
+    ) throws -> T {
+        try withTmuxCompatStoreFileLock(at: tmuxCompatStoreURL()) {
+            var store = loadTmuxCompatStore()
+            let result = try body(&store)
+            try saveTmuxCompatStore(store)
+            return result
+        }
+    }
+
+    func withLockedTmuxCompatStoreIfChanged(
+        _ body: (inout TmuxCompatStore) throws -> Bool
+    ) throws {
+        try withTmuxCompatStoreFileLock(at: tmuxCompatStoreURL()) {
+            var store = loadTmuxCompatStore()
+            if try body(&store) {
+                try saveTmuxCompatStore(store)
+            }
+        }
+    }
+}

--- a/CLI/CMUXCLI+TmuxCompatStore.swift
+++ b/CLI/CMUXCLI+TmuxCompatStore.swift
@@ -58,6 +58,9 @@ extension CMUXCLI {
             }
             throw error
         }
+        // Heal stores created by older versions before exposing their contents
+        // to read-only commands (including malformed stores).
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
         return try JSONDecoder().decode(TmuxCompatStore.self, from: data)
     }
 

--- a/CLI/CMUXCLI+TmuxCompatStore.swift
+++ b/CLI/CMUXCLI+TmuxCompatStore.swift
@@ -42,23 +42,91 @@ extension CMUXCLI {
             .appendingPathComponent("tmux-compat-store.json")
     }
 
-    func loadTmuxCompatStore() throws -> TmuxCompatStore {
-        let url = tmuxCompatStoreURL()
-        guard let data = try readTmuxCompatStoreData(at: url) else {
-            return TmuxCompatStore()
+    private final class TmuxCompatStoreDirectory {
+        let descriptor: Int32
+        let storeName: String
+        let lockName: String
+
+        init(storeURL: URL, createIfMissing: Bool) throws {
+            let parent = storeURL.deletingLastPathComponent()
+            if createIfMissing {
+                try FileManager.default.createDirectory(
+                    at: parent,
+                    withIntermediateDirectories: true,
+                    attributes: [.posixPermissions: 0o700]
+                )
+            }
+            let fd = parent.path.withCString {
+                Darwin.open($0, O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW)
+            }
+            guard fd >= 0 else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+            var metadata = stat()
+            guard Darwin.fstat(fd, &metadata) == 0 else {
+                let error = POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+                Darwin.close(fd)
+                throw error
+            }
+            guard (metadata.st_mode & S_IFMT) == S_IFDIR else {
+                Darwin.close(fd)
+                throw POSIXError(.ENOTDIR)
+            }
+            guard Darwin.fchmod(fd, mode_t(S_IRUSR | S_IWUSR | S_IXUSR)) == 0 else {
+                let error = POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+                Darwin.close(fd)
+                throw error
+            }
+            descriptor = fd
+            storeName = storeURL.lastPathComponent
+            lockName = storeURL.lastPathComponent + ".lock"
         }
-        return try JSONDecoder().decode(TmuxCompatStore.self, from: data)
+
+        deinit {
+            Darwin.close(descriptor)
+        }
+
+        func open(_ name: String, flags: Int32, mode: mode_t = 0) throws -> Int32 {
+            let fd = name.withCString { Darwin.openat(descriptor, $0, flags, mode) }
+            guard fd >= 0 else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+            return fd
+        }
+
+        func rename(_ source: String, to destination: String) throws {
+            let result = source.withCString { sourcePointer in
+                destination.withCString { destinationPointer in
+                    Darwin.renameat(descriptor, sourcePointer, descriptor, destinationPointer)
+                }
+            }
+            guard result == 0 else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+        }
+
+        func unlink(_ name: String) {
+            _ = name.withCString { Darwin.unlinkat(descriptor, $0, 0) }
+        }
     }
 
-    private func readTmuxCompatStoreData(at url: URL) throws -> Data? {
-        try validateTmuxCompatStoreDirectory(at: url.deletingLastPathComponent())
-        let descriptor = Darwin.open(url.path, O_RDONLY | O_CLOEXEC | O_NOFOLLOW)
-        guard descriptor >= 0 else {
-            if errno == ENOENT {
-                return nil
-            }
-            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+    func loadTmuxCompatStore() throws -> TmuxCompatStore {
+        let directory: TmuxCompatStoreDirectory
+        do {
+            directory = try TmuxCompatStoreDirectory(storeURL: tmuxCompatStoreURL(), createIfMissing: false)
+        } catch let error as POSIXError where error.code == .ENOENT {
+            return TmuxCompatStore()
         }
+        do {
+            let data = try readTmuxCompatStoreData(in: directory)
+            return try JSONDecoder().decode(TmuxCompatStore.self, from: data)
+        } catch let error as POSIXError where error.code == .ENOENT {
+            return TmuxCompatStore()
+        }
+    }
+
+    private func readTmuxCompatStoreData(in directory: TmuxCompatStoreDirectory) throws -> Data {
+        let descriptor = try directory.open(directory.storeName, flags: O_RDONLY | O_CLOEXEC | O_NOFOLLOW)
         defer { Darwin.close(descriptor) }
         var metadata = stat()
         guard Darwin.fstat(descriptor, &metadata) == 0 else {
@@ -89,61 +157,58 @@ extension CMUXCLI {
     }
 
     func saveTmuxCompatStore(_ store: TmuxCompatStore) throws {
-        let url = tmuxCompatStoreURL()
-        let parent = url.deletingLastPathComponent()
-        try ensureTmuxCompatStoreDirectory(at: parent)
-        let data = try JSONEncoder().encode(store)
-        let tempURL = parent.appendingPathComponent(".tmux-compat-store-\(UUID().uuidString).tmp")
-        let fileManager = FileManager.default
-        guard fileManager.createFile(
-            atPath: tempURL.path,
-            contents: data,
-            attributes: [.posixPermissions: 0o600]
-        ) else {
-            throw CocoaError(.fileWriteUnknown, userInfo: [NSFilePathErrorKey: tempURL.path])
+        try withLockedTmuxCompatStore { current in
+            current = store
         }
+    }
+
+    private func saveTmuxCompatStore(
+        _ store: TmuxCompatStore,
+        in directory: TmuxCompatStoreDirectory
+    ) throws {
+        let data = try JSONEncoder().encode(store)
+        let tempName = ".tmux-compat-store-\(UUID().uuidString).tmp"
+        let descriptor = try directory.open(
+            tempName,
+            flags: O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC | O_NOFOLLOW,
+            mode: mode_t(S_IRUSR | S_IWUSR)
+        )
+        var isOpen = true
         var didReplace = false
         defer {
+            if isOpen {
+                Darwin.close(descriptor)
+            }
             if !didReplace {
-                try? fileManager.removeItem(at: tempURL)
+                directory.unlink(tempName)
             }
         }
-        // Keep the replacement owner-only even when the process umask is lax.
-        try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: tempURL.path)
-        let renameResult = tempURL.path.withCString { source in
-            url.path.withCString { destination in
-                Darwin.rename(source, destination)
+        try data.withUnsafeBytes { rawBuffer in
+            guard let baseAddress = rawBuffer.baseAddress else { return }
+            var offset = 0
+            while offset < rawBuffer.count {
+                let written = Darwin.write(descriptor, baseAddress.advanced(by: offset), rawBuffer.count - offset)
+                if written < 0 {
+                    if errno == EINTR { continue }
+                    throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+                }
+                guard written > 0 else { throw POSIXError(.EIO) }
+                offset += written
             }
         }
-        guard renameResult == 0 else {
+        guard Darwin.fchmod(descriptor, mode_t(S_IRUSR | S_IWUSR)) == 0 else {
             throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
         }
+        guard Darwin.fsync(descriptor) == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        guard Darwin.close(descriptor) == 0 else {
+            isOpen = false
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        isOpen = false
+        try directory.rename(tempName, to: directory.storeName)
         didReplace = true
-    }
-
-    private func ensureTmuxCompatStoreDirectory(at parent: URL) throws {
-        let fileManager = FileManager.default
-        try fileManager.createDirectory(
-            at: parent,
-            withIntermediateDirectories: true,
-            attributes: [.posixPermissions: 0o700]
-        )
-        try validateTmuxCompatStoreDirectory(at: parent)
-        // Also tighten an existing directory created by an older CLI.
-        try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: parent.path)
-    }
-
-    private func validateTmuxCompatStoreDirectory(at parent: URL) throws {
-        var metadata = stat()
-        guard Darwin.lstat(parent.path, &metadata) == 0 else {
-            if errno == ENOENT {
-                return
-            }
-            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
-        }
-        guard (metadata.st_mode & S_IFMT) == S_IFDIR else {
-            throw POSIXError(.ENOTDIR)
-        }
     }
 
     /// Serializes cross-process mutations of a tmux compatibility store.
@@ -152,31 +217,29 @@ extension CMUXCLI {
     /// protect the store. The lock file remains stable while the JSON file is
     /// atomically replaced by its writer.
     func withTmuxCompatStoreFileLock<T>(at storeURL: URL, _ body: () throws -> T) throws -> T {
-        let parent = storeURL.deletingLastPathComponent()
-        try ensureTmuxCompatStoreDirectory(at: parent)
+        try withLockedStoreDirectory(at: storeURL) { _ in try body() }
+    }
 
-        let lockURL = URL(fileURLWithPath: storeURL.path + ".lock")
-        let descriptor = open(
-            lockURL.path,
-            O_CREAT | O_RDWR | O_CLOEXEC | O_NOFOLLOW,
-            mode_t(S_IRUSR | S_IWUSR)
+    private func withLockedStoreDirectory<T>(
+        at storeURL: URL,
+        _ body: (TmuxCompatStoreDirectory) throws -> T
+    ) throws -> T {
+        let directory = try TmuxCompatStoreDirectory(storeURL: storeURL, createIfMissing: true)
+        let lockDescriptor = try directory.open(
+            directory.lockName,
+            flags: O_CREAT | O_RDWR | O_CLOEXEC | O_NOFOLLOW,
+            mode: mode_t(S_IRUSR | S_IWUSR)
         )
-        guard descriptor >= 0 else {
+        defer { Darwin.close(lockDescriptor) }
+        guard Darwin.fchmod(lockDescriptor, mode_t(S_IRUSR | S_IWUSR)) == 0 else {
             throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
         }
-        defer { Darwin.close(descriptor) }
-        guard Darwin.fchmod(descriptor, mode_t(S_IRUSR | S_IWUSR)) == 0 else {
+        while flock(lockDescriptor, LOCK_EX) != 0 {
+            if errno == EINTR { continue }
             throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
         }
-
-        while flock(descriptor, LOCK_EX) != 0 {
-            if errno == EINTR {
-                continue
-            }
-            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
-        }
-        defer { _ = flock(descriptor, LOCK_UN) }
-        return try body()
+        defer { _ = flock(lockDescriptor, LOCK_UN) }
+        return try body(directory)
     }
 
     /// Performs one complete tmux compatibility store read-modify-write while
@@ -184,21 +247,26 @@ extension CMUXCLI {
     func withLockedTmuxCompatStore<T>(
         _ body: (inout TmuxCompatStore) throws -> T
     ) throws -> T {
-        try withTmuxCompatStoreFileLock(at: tmuxCompatStoreURL()) {
-            var store = try loadTmuxCompatStore()
+        try withLockedStoreDirectory(at: tmuxCompatStoreURL()) { directory in
+            var store = try loadTmuxCompatStore(from: directory)
             let result = try body(&store)
-            try saveTmuxCompatStore(store)
+            try saveTmuxCompatStore(store, in: directory)
             return result
         }
+    }
+
+    private func loadTmuxCompatStore(from directory: TmuxCompatStoreDirectory) throws -> TmuxCompatStore {
+        let data = try readTmuxCompatStoreData(in: directory)
+        return try JSONDecoder().decode(TmuxCompatStore.self, from: data)
     }
 
     func withLockedTmuxCompatStoreIfChanged(
         _ body: (inout TmuxCompatStore) throws -> Bool
     ) throws {
-        try withTmuxCompatStoreFileLock(at: tmuxCompatStoreURL()) {
-            var store = try loadTmuxCompatStore()
+        try withLockedStoreDirectory(at: tmuxCompatStoreURL()) { directory in
+            var store = try loadTmuxCompatStore(from: directory)
             if try body(&store) {
-                try saveTmuxCompatStore(store)
+                try saveTmuxCompatStore(store, in: directory)
             }
         }
     }

--- a/CLI/CMUXCLI+TmuxCompatStore.swift
+++ b/CLI/CMUXCLI+TmuxCompatStore.swift
@@ -42,13 +42,22 @@ extension CMUXCLI {
             .appendingPathComponent("tmux-compat-store.json")
     }
 
-    func loadTmuxCompatStore() -> TmuxCompatStore {
+    func loadTmuxCompatStore() throws -> TmuxCompatStore {
         let url = tmuxCompatStoreURL()
-        guard let data = try? Data(contentsOf: url),
-              let decoded = try? JSONDecoder().decode(TmuxCompatStore.self, from: data) else {
-            return TmuxCompatStore()
+        let data: Data
+        do {
+            data = try Data(contentsOf: url)
+        } catch {
+            let nsError = error as NSError
+            let isMissing = nsError.domain == NSCocoaErrorDomain
+                && (nsError.code == NSFileNoSuchFileError || nsError.code == NSFileReadNoSuchFileError)
+                || (error as? POSIXError)?.code == .ENOENT
+            if isMissing {
+                return TmuxCompatStore()
+            }
+            throw error
         }
-        return decoded
+        return try JSONDecoder().decode(TmuxCompatStore.self, from: data)
     }
 
     func saveTmuxCompatStore(_ store: TmuxCompatStore) throws {
@@ -95,7 +104,7 @@ extension CMUXCLI {
         _ body: (inout TmuxCompatStore) throws -> T
     ) throws -> T {
         try withTmuxCompatStoreFileLock(at: tmuxCompatStoreURL()) {
-            var store = loadTmuxCompatStore()
+            var store = try loadTmuxCompatStore()
             let result = try body(&store)
             try saveTmuxCompatStore(store)
             return result
@@ -106,7 +115,7 @@ extension CMUXCLI {
         _ body: (inout TmuxCompatStore) throws -> Bool
     ) throws {
         try withTmuxCompatStoreFileLock(at: tmuxCompatStoreURL()) {
-            var store = loadTmuxCompatStore()
+            var store = try loadTmuxCompatStore()
             if try body(&store) {
                 try saveTmuxCompatStore(store)
             }

--- a/CLI/CMUXCLI+TmuxCompatSupport.swift
+++ b/CLI/CMUXCLI+TmuxCompatSupport.swift
@@ -462,4 +462,28 @@ extension CMUXCLI {
         return try body()
     }
 
+    /// Performs one complete tmux compatibility store read-modify-write while
+    /// holding the cross-process lock.
+    func withLockedTmuxCompatStore<T>(
+        _ body: (inout TmuxCompatStore) throws -> T
+    ) throws -> T {
+        try withTmuxCompatStoreFileLock(at: tmuxCompatStoreURL()) {
+            var store = loadTmuxCompatStore()
+            let result = try body(&store)
+            try saveTmuxCompatStore(store)
+            return result
+        }
+    }
+
+    func withLockedTmuxCompatStoreIfChanged(
+        _ body: (inout TmuxCompatStore) throws -> Bool
+    ) throws {
+        try withTmuxCompatStoreFileLock(at: tmuxCompatStoreURL()) {
+            var store = loadTmuxCompatStore()
+            if try body(&store) {
+                try saveTmuxCompatStore(store)
+            }
+        }
+    }
+
 }

--- a/CLI/CMUXCLI+TmuxCompatSupport.swift
+++ b/CLI/CMUXCLI+TmuxCompatSupport.swift
@@ -1,5 +1,4 @@
 import CMUXAgentLaunch
-import Darwin
 import Foundation
 
 extension CMUXCLI {
@@ -430,60 +429,6 @@ extension CMUXCLI {
             }
         }
         return ordered.joined(separator: ":")
-    }
-
-    /// Serializes cross-process mutations of a tmux compatibility store.
-    ///
-    /// Each CLI invocation is a separate process, so an in-memory lock cannot
-    /// protect the store. The lock file remains stable while the JSON file is
-    /// atomically replaced by its writer.
-    func withTmuxCompatStoreFileLock<T>(at storeURL: URL, _ body: () throws -> T) throws -> T {
-        let parent = storeURL.deletingLastPathComponent()
-        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true, attributes: nil)
-
-        let lockURL = URL(fileURLWithPath: storeURL.path + ".lock")
-        let descriptor = open(
-            lockURL.path,
-            O_CREAT | O_RDWR | O_CLOEXEC | O_NOFOLLOW,
-            mode_t(S_IRUSR | S_IWUSR)
-        )
-        guard descriptor >= 0 else {
-            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
-        }
-        defer { Darwin.close(descriptor) }
-
-        while flock(descriptor, LOCK_EX) != 0 {
-            if errno == EINTR {
-                continue
-            }
-            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
-        }
-        defer { _ = flock(descriptor, LOCK_UN) }
-        return try body()
-    }
-
-    /// Performs one complete tmux compatibility store read-modify-write while
-    /// holding the cross-process lock.
-    func withLockedTmuxCompatStore<T>(
-        _ body: (inout TmuxCompatStore) throws -> T
-    ) throws -> T {
-        try withTmuxCompatStoreFileLock(at: tmuxCompatStoreURL()) {
-            var store = loadTmuxCompatStore()
-            let result = try body(&store)
-            try saveTmuxCompatStore(store)
-            return result
-        }
-    }
-
-    func withLockedTmuxCompatStoreIfChanged(
-        _ body: (inout TmuxCompatStore) throws -> Bool
-    ) throws {
-        try withTmuxCompatStoreFileLock(at: tmuxCompatStoreURL()) {
-            var store = loadTmuxCompatStore()
-            if try body(&store) {
-                try saveTmuxCompatStore(store)
-            }
-        }
     }
 
 }

--- a/CLI/CMUXCLI+TmuxCompatSupport.swift
+++ b/CLI/CMUXCLI+TmuxCompatSupport.swift
@@ -1,4 +1,5 @@
 import CMUXAgentLaunch
+import Darwin
 import Foundation
 
 extension CMUXCLI {
@@ -429,6 +430,36 @@ extension CMUXCLI {
             }
         }
         return ordered.joined(separator: ":")
+    }
+
+    /// Serializes cross-process mutations of a tmux compatibility store.
+    ///
+    /// Each CLI invocation is a separate process, so an in-memory lock cannot
+    /// protect the store. The lock file remains stable while the JSON file is
+    /// atomically replaced by its writer.
+    func withTmuxCompatStoreFileLock<T>(at storeURL: URL, _ body: () throws -> T) throws -> T {
+        let parent = storeURL.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true, attributes: nil)
+
+        let lockURL = URL(fileURLWithPath: storeURL.path + ".lock")
+        let descriptor = open(
+            lockURL.path,
+            O_CREAT | O_RDWR | O_CLOEXEC | O_NOFOLLOW,
+            mode_t(S_IRUSR | S_IWUSR)
+        )
+        guard descriptor >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        defer { Darwin.close(descriptor) }
+
+        while flock(descriptor, LOCK_EX) != 0 {
+            if errno == EINTR {
+                continue
+            }
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        defer { _ = flock(descriptor, LOCK_UN) }
+        return try body()
     }
 
 }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -22889,8 +22889,8 @@ struct CMUXCLI {
     private func tmuxAnchoredSplitTarget(
         workspaceId: String,
         client: SocketClient
-    ) -> (targetSurfaceId: String, callerSurfaceId: String?, direction: String)? {
-        var store = loadTmuxCompatStore()
+    ) throws -> (targetSurfaceId: String, callerSurfaceId: String?, direction: String)? {
+        var store = try loadTmuxCompatStore()
         if let lastColumn = store.mainVerticalLayouts[workspaceId]?.lastColumnSurfaceId {
             if let lastColumnId = try? tmuxCanonicalSurfaceId(
                 lastColumn,
@@ -22913,7 +22913,7 @@ struct CMUXCLI {
                 store.lastSplitSurface.removeValue(forKey: workspaceId)
                 return true
             }
-            store = loadTmuxCompatStore()
+            store = try loadTmuxCompatStore()
         }
 
         let candidateAnchors = [
@@ -25998,11 +25998,12 @@ struct CMUXCLI {
             // invalid cross-workspace split.
             if parsed.hasFlag("-h"),
                let callerWorkspace = tmuxCallerWorkspaceHandle(),
-               let wsId = try? resolveWorkspaceId(callerWorkspace, client: client),
-               let anchoredTarget = tmuxAnchoredSplitTarget(workspaceId: wsId, client: client) {
-                target = (wsId, nil, anchoredTarget.targetSurfaceId)
-                direction = anchoredTarget.direction
-                anchoredCallerSurfaceId = anchoredTarget.callerSurfaceId
+               let wsId = try? resolveWorkspaceId(callerWorkspace, client: client) {
+                if let anchoredTarget = try tmuxAnchoredSplitTarget(workspaceId: wsId, client: client) {
+                    target = (wsId, nil, anchoredTarget.targetSurfaceId)
+                    direction = anchoredTarget.direction
+                    anchoredCallerSurfaceId = anchoredTarget.callerSurfaceId
+                }
             }
 
             // Keep the leader pane focused while agents spawn beside it.
@@ -26386,7 +26387,7 @@ struct CMUXCLI {
         case "show-buffer", "showb":
             let parsed = try parseTmuxArguments(rawArgs, valueFlags: ["-b"], boolFlags: [])
             let name = parsed.value("-b") ?? "default"
-            let store = loadTmuxCompatStore()
+            let store = try loadTmuxCompatStore()
             if let buffer = store.buffers[name] {
                 print(buffer)
             }
@@ -26411,7 +26412,7 @@ struct CMUXCLI {
         case "save-buffer", "saveb":
             let parsed = try parseTmuxArguments(rawArgs, valueFlags: ["-b"], boolFlags: [])
             let name = parsed.value("-b") ?? "default"
-            let store = loadTmuxCompatStore()
+            let store = try loadTmuxCompatStore()
             guard let buffer = store.buffers[name] else {
                 throw CLIError(message: "Buffer not found: \(name)")
             }
@@ -26587,7 +26588,7 @@ struct CMUXCLI {
         // between that RPC and the locked mutation, retry from a fresh snapshot
         // so a replacement selected for an old main pane is never persisted.
         while true {
-            let snapshot = loadTmuxCompatStore()
+            let snapshot = try loadTmuxCompatStore()
             let snapshotLayout = snapshot.mainVerticalLayouts[workspaceId]
             let replacementWasResolved: Bool
             let replacementSurfaceId: String?
@@ -26998,7 +26999,7 @@ struct CMUXCLI {
 
         case "set-hook":
             if commandArgs.contains("--list") {
-                let store = loadTmuxCompatStore()
+                let store = try loadTmuxCompatStore()
                 if jsonOutput {
                     print(jsonString(["hooks": store.hooks]))
                 } else if store.hooks.isEmpty {
@@ -27051,7 +27052,7 @@ struct CMUXCLI {
             print("OK")
 
         case "list-buffers":
-            let store = loadTmuxCompatStore()
+            let store = try loadTmuxCompatStore()
             if jsonOutput {
                 let payload = store.buffers.map { key, value in ["name": key, "size": value.count] }
                 print(jsonString(["buffers": payload.sorted { ($0["name"] as? String ?? "") < ($1["name"] as? String ?? "") }]))
@@ -27068,7 +27069,7 @@ struct CMUXCLI {
             let workspaceArg = workspaceFromArgsOrEnv(commandArgs, windowOverride: windowOverride)
             let surfaceArg = optionValue(commandArgs, name: "--surface")
             let name = optionValue(commandArgs, name: "--name") ?? "default"
-            let store = loadTmuxCompatStore()
+            let store = try loadTmuxCompatStore()
             guard let buffer = store.buffers[name] else {
                 throw CLIError(message: "Buffer not found: \(name)")
             }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -22904,9 +22904,16 @@ struct CMUXCLI {
 
             // Right-column anchors can outlive the pane they pointed at.
             // Drop stale state and rebuild from the caller surface instead.
-            store.mainVerticalLayouts[workspaceId]?.lastColumnSurfaceId = nil
-            store.lastSplitSurface.removeValue(forKey: workspaceId)
-            try? saveTmuxCompatStore(store)
+            try? withLockedTmuxCompatStoreIfChanged { store in
+                guard let layout = store.mainVerticalLayouts[workspaceId],
+                      layout.lastColumnSurfaceId == lastColumn else { return false }
+                var updatedLayout = layout
+                updatedLayout.lastColumnSurfaceId = nil
+                store.mainVerticalLayouts[workspaceId] = updatedLayout
+                store.lastSplitSurface.removeValue(forKey: workspaceId)
+                return true
+            }
+            store = loadTmuxCompatStore()
         }
 
         let candidateAnchors = [
@@ -22923,10 +22930,21 @@ struct CMUXCLI {
             }
         }
 
-        let removedLayout = store.mainVerticalLayouts.removeValue(forKey: workspaceId) != nil
-        let removedSplit = store.lastSplitSurface.removeValue(forKey: workspaceId) != nil
-        if removedLayout || removedSplit {
-            try? saveTmuxCompatStore(store)
+        let observedLayout = store.mainVerticalLayouts[workspaceId]
+        if observedLayout != nil || store.lastSplitSurface[workspaceId] != nil {
+            try? withLockedTmuxCompatStoreIfChanged { store in
+                if let observedLayout,
+                   let currentLayout = store.mainVerticalLayouts[workspaceId],
+                   currentLayout.mainSurfaceId == observedLayout.mainSurfaceId,
+                   currentLayout.lastColumnSurfaceId == observedLayout.lastColumnSurfaceId {
+                    store.mainVerticalLayouts.removeValue(forKey: workspaceId)
+                    store.lastSplitSurface.removeValue(forKey: workspaceId)
+                    return true
+                } else if observedLayout == nil {
+                    return store.lastSplitSurface.removeValue(forKey: workspaceId) != nil
+                }
+                return false
+            }
         }
         return nil
     }
@@ -26048,19 +26066,19 @@ struct CMUXCLI {
 
             // Track the newly created pane for main-vertical layout.
             if !isOMXHud {
-                var updatedStore = loadTmuxCompatStore()
-                updatedStore.lastSplitSurface[target.workspaceId] = surfaceId
-                if updatedStore.mainVerticalLayouts[target.workspaceId] != nil {
-                    updatedStore.mainVerticalLayouts[target.workspaceId]?.lastColumnSurfaceId = surfaceId
-                } else if direction == "right", let anchoredCallerSurfaceId {
-                    // First right split created the column; seed main-vertical
-                    // state so subsequent splits stack downward.
-                    updatedStore.mainVerticalLayouts[target.workspaceId] = MainVerticalState(
-                        mainSurfaceId: anchoredCallerSurfaceId,
-                        lastColumnSurfaceId: surfaceId
-                    )
+                try withLockedTmuxCompatStore { store in
+                    store.lastSplitSurface[target.workspaceId] = surfaceId
+                    if store.mainVerticalLayouts[target.workspaceId] != nil {
+                        store.mainVerticalLayouts[target.workspaceId]?.lastColumnSurfaceId = surfaceId
+                    } else if direction == "right", let anchoredCallerSurfaceId {
+                        // First right split created the column; seed main-vertical
+                        // state so subsequent splits stack downward.
+                        store.mainVerticalLayouts[target.workspaceId] = MainVerticalState(
+                            mainSurfaceId: anchoredCallerSurfaceId,
+                            lastColumnSurfaceId: surfaceId
+                        )
+                    }
                 }
-                try saveTmuxCompatStore(updatedStore)
 
                 // Equalize vertical splits so teammate panes are evenly distributed.
                 // Use orientation: "vertical" to only equalize the agent column,
@@ -26197,9 +26215,9 @@ struct CMUXCLI {
             if parsed.hasFlag("-p") {
                 print(text)
             } else {
-                var store = loadTmuxCompatStore()
-                store.buffers["default"] = text
-                try saveTmuxCompatStore(store)
+                try withLockedTmuxCompatStore { store in
+                    store.buffers["default"] = text
+                }
             }
 
         case "display-message", "display", "displayp":
@@ -26451,14 +26469,14 @@ struct CMUXCLI {
             }
             if layoutName == "main-vertical" {
                 if let callerSurface = tmuxCallerSurfaceHandle() {
-                    var store = loadTmuxCompatStore()
-                    let existingColumn = store.mainVerticalLayouts[workspaceId]?.lastColumnSurfaceId
-                    let seedColumn = existingColumn ?? store.lastSplitSurface[workspaceId]
-                    store.mainVerticalLayouts[workspaceId] = MainVerticalState(
-                        mainSurfaceId: callerSurface,
-                        lastColumnSurfaceId: seedColumn
-                    )
-                    try saveTmuxCompatStore(store)
+                    try withLockedTmuxCompatStore { store in
+                        let existingColumn = store.mainVerticalLayouts[workspaceId]?.lastColumnSurfaceId
+                        let seedColumn = existingColumn ?? store.lastSplitSurface[workspaceId]
+                        store.mainVerticalLayouts[workspaceId] = MainVerticalState(
+                            mainSurfaceId: callerSurface,
+                            lastColumnSurfaceId: seedColumn
+                        )
+                    }
                 }
             } else if !layoutName.isEmpty {
                 // Non-main-vertical layout selected: clear stale state so
@@ -26535,12 +26553,35 @@ struct CMUXCLI {
         try data.write(to: url, options: .atomic)
     }
 
-    private func tmuxPruneCompatWorkspaceState(workspaceId: String) throws {
-        var store = loadTmuxCompatStore()
-        let removedLayout = store.mainVerticalLayouts.removeValue(forKey: workspaceId) != nil
-        let removedSplit = store.lastSplitSurface.removeValue(forKey: workspaceId) != nil
-        if removedLayout || removedSplit {
+    /// Performs one complete store read-modify-write while holding the
+    /// cross-process lock. Callers must use this for every mutating path.
+    private func withLockedTmuxCompatStore<T>(
+        _ body: (inout TmuxCompatStore) throws -> T
+    ) throws -> T {
+        try withTmuxCompatStoreFileLock(at: tmuxCompatStoreURL()) {
+            var store = loadTmuxCompatStore()
+            let result = try body(&store)
             try saveTmuxCompatStore(store)
+            return result
+        }
+    }
+
+    private func withLockedTmuxCompatStoreIfChanged(
+        _ body: (inout TmuxCompatStore) throws -> Bool
+    ) throws {
+        try withTmuxCompatStoreFileLock(at: tmuxCompatStoreURL()) {
+            var store = loadTmuxCompatStore()
+            if try body(&store) {
+                try saveTmuxCompatStore(store)
+            }
+        }
+    }
+
+    private func tmuxPruneCompatWorkspaceState(workspaceId: String) throws {
+        try withLockedTmuxCompatStoreIfChanged { store in
+            let removedLayout = store.mainVerticalLayouts.removeValue(forKey: workspaceId) != nil
+            let removedSplit = store.lastSplitSurface.removeValue(forKey: workspaceId) != nil
+            return removedLayout || removedSplit
         }
     }
 
@@ -26623,15 +26664,14 @@ struct CMUXCLI {
         surfaceId: String,
         client: SocketClient
     ) throws {
-        var store = loadTmuxCompatStore()
-        var changed = false
+        try withLockedTmuxCompatStoreIfChanged { store in
+            var changed = false
+            if store.lastSplitSurface[workspaceId] == surfaceId {
+                store.lastSplitSurface.removeValue(forKey: workspaceId)
+                changed = true
+            }
 
-        if store.lastSplitSurface[workspaceId] == surfaceId {
-            store.lastSplitSurface.removeValue(forKey: workspaceId)
-            changed = true
-        }
-
-        if let layout = store.mainVerticalLayouts[workspaceId] {
+            guard let layout = store.mainVerticalLayouts[workspaceId] else { return changed }
             if layout.mainSurfaceId == surfaceId {
                 store.mainVerticalLayouts.removeValue(forKey: workspaceId)
                 store.lastSplitSurface.removeValue(forKey: workspaceId)
@@ -26652,10 +26692,7 @@ struct CMUXCLI {
                 }
                 changed = true
             }
-        }
-
-        if changed {
-            try saveTmuxCompatStore(store)
+            return changed
         }
     }
 
@@ -27006,8 +27043,8 @@ struct CMUXCLI {
             printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat))
 
         case "set-hook":
-            var store = loadTmuxCompatStore()
             if commandArgs.contains("--list") {
+                let store = loadTmuxCompatStore()
                 if jsonOutput {
                     print(jsonString(["hooks": store.hooks]))
                 } else if store.hooks.isEmpty {
@@ -27023,8 +27060,9 @@ struct CMUXCLI {
                 guard let event = commandArgs.last else {
                     throw CLIError(message: "set-hook --unset requires an event name")
                 }
-                store.hooks.removeValue(forKey: event)
-                try saveTmuxCompatStore(store)
+                try withLockedTmuxCompatStore { store in
+                    store.hooks.removeValue(forKey: event)
+                }
                 print("OK")
                 return
             }
@@ -27035,8 +27073,9 @@ struct CMUXCLI {
             guard !commandText.isEmpty else {
                 throw CLIError(message: "set-hook requires <event> <command>")
             }
-            store.hooks[event] = commandText
-            try saveTmuxCompatStore(store)
+            try withLockedTmuxCompatStore { store in
+                store.hooks[event] = commandText
+            }
             print("OK")
 
         case "popup":
@@ -27052,9 +27091,9 @@ struct CMUXCLI {
             guard !content.isEmpty else {
                 throw CLIError(message: "set-buffer requires text")
             }
-            var store = loadTmuxCompatStore()
-            store.buffers[name] = content
-            try saveTmuxCompatStore(store)
+            try withLockedTmuxCompatStore { store in
+                store.buffers[name] = content
+            }
             print("OK")
 
         case "list-buffers":

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -26640,6 +26640,25 @@ struct CMUXCLI {
         surfaceId: String,
         client: SocketClient
     ) throws {
+        // Resolve the replacement pane before taking the file lock. The RPC can
+        // block on the app socket; holding the lock across it would stall every
+        // unrelated tmux-compatible writer for the socket timeout.
+        let snapshot = loadTmuxCompatStore()
+        let snapshotLayout = snapshot.mainVerticalLayouts[workspaceId]
+        let replacementWasResolved: Bool
+        let replacementSurfaceId: String?
+        if let snapshotLayout, snapshotLayout.lastColumnSurfaceId == surfaceId {
+            replacementWasResolved = true
+            replacementSurfaceId = tmuxReplacementColumnSurfaceId(
+                workspaceId: workspaceId,
+                layout: snapshotLayout,
+                client: client
+            )
+        } else {
+            replacementWasResolved = false
+            replacementSurfaceId = nil
+        }
+
         try withLockedTmuxCompatStoreIfChanged { store in
             var changed = false
             if store.lastSplitSurface[workspaceId] == surfaceId {
@@ -26652,13 +26671,8 @@ struct CMUXCLI {
                 store.mainVerticalLayouts.removeValue(forKey: workspaceId)
                 store.lastSplitSurface.removeValue(forKey: workspaceId)
                 changed = true
-            } else if layout.lastColumnSurfaceId == surfaceId {
+            } else if layout.lastColumnSurfaceId == surfaceId, replacementWasResolved {
                 var updatedLayout = layout
-                let replacementSurfaceId = tmuxReplacementColumnSurfaceId(
-                    workspaceId: workspaceId,
-                    layout: layout,
-                    client: client
-                )
                 updatedLayout.lastColumnSurfaceId = replacementSurfaceId
                 store.mainVerticalLayouts[workspaceId] = updatedLayout
                 if let replacementSurfaceId {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -26496,63 +26496,6 @@ struct CMUXCLI {
         }
     }
 
-    struct MainVerticalState: Codable {
-        /// The surface ID of the "main" (leader) pane on the left side.
-        var mainSurfaceId: String
-        /// The surface ID of the bottom-most pane in the right column.
-        /// Subsequent teammate splits target this pane with direction "down".
-        var lastColumnSurfaceId: String?
-    }
-
-    struct TmuxCompatStore: Codable {
-        var buffers: [String: String] = [:]
-        var hooks: [String: String] = [:]
-        /// Tracks main-vertical layout state per workspace, keyed by workspace ID.
-        var mainVerticalLayouts: [String: MainVerticalState] = [:]
-        /// Tracks the last surface created by split-window per workspace.
-        /// Used to seed lastColumnSurfaceId when select-layout main-vertical
-        /// is called after the first split.
-        var lastSplitSurface: [String: String] = [:]
-
-        /// Custom decoder so older store files missing newer keys
-        /// (mainVerticalLayouts, lastSplitSurface) decode gracefully
-        /// instead of throwing and resetting the entire store.
-        init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            buffers = try container.decodeIfPresent([String: String].self, forKey: .buffers) ?? [:]
-            hooks = try container.decodeIfPresent([String: String].self, forKey: .hooks) ?? [:]
-            mainVerticalLayouts = try container.decodeIfPresent([String: MainVerticalState].self, forKey: .mainVerticalLayouts) ?? [:]
-            lastSplitSurface = try container.decodeIfPresent([String: String].self, forKey: .lastSplitSurface) ?? [:]
-        }
-
-        init() {}
-    }
-
-    func tmuxCompatStoreURL() -> URL {
-        let homePath = ProcessInfo.processInfo.environment["HOME"]
-            ?? NSString(string: "~").expandingTildeInPath
-        return URL(fileURLWithPath: homePath)
-            .appendingPathComponent(".cmuxterm")
-            .appendingPathComponent("tmux-compat-store.json")
-    }
-
-    func loadTmuxCompatStore() -> TmuxCompatStore {
-        let url = tmuxCompatStoreURL()
-        guard let data = try? Data(contentsOf: url),
-              let decoded = try? JSONDecoder().decode(TmuxCompatStore.self, from: data) else {
-            return TmuxCompatStore()
-        }
-        return decoded
-    }
-
-    func saveTmuxCompatStore(_ store: TmuxCompatStore) throws {
-        let url = tmuxCompatStoreURL()
-        let parent = url.deletingLastPathComponent()
-        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true, attributes: nil)
-        let data = try JSONEncoder().encode(store)
-        try data.write(to: url, options: .atomic)
-    }
-
     private func tmuxPruneCompatWorkspaceState(workspaceId: String) throws {
         try withLockedTmuxCompatStoreIfChanged { store in
             let removedLayout = store.mainVerticalLayouts.removeValue(forKey: workspaceId) != nil

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -26586,7 +26586,7 @@ struct CMUXCLI {
         // Resolve pane geometry outside the file lock. If layout state changes
         // between that RPC and the locked mutation, retry from a fresh snapshot
         // so a replacement selected for an old main pane is never persisted.
-        for _ in 0..<4 {
+        while true {
             let snapshot = loadTmuxCompatStore()
             let snapshotLayout = snapshot.mainVerticalLayouts[workspaceId]
             let replacementWasResolved: Bool

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -26587,7 +26587,7 @@ struct CMUXCLI {
         // Resolve pane geometry outside the file lock. If layout state changes
         // between that RPC and the locked mutation, retry from a fresh snapshot
         // so a replacement selected for an old main pane is never persisted.
-        while true {
+        for _ in 0..<8 {
             let snapshot = try loadTmuxCompatStore()
             let snapshotLayout = snapshot.mainVerticalLayouts[workspaceId]
             let replacementWasResolved: Bool
@@ -26649,6 +26649,9 @@ struct CMUXCLI {
                 return
             }
         }
+        // A continuously changing layout should be retried by the caller rather
+        // than leaving a closed surface's metadata silently stale.
+        throw POSIXError(.EAGAIN)
     }
 
     private func runShellCommand(_ command: String, stdinText: String) throws -> (status: Int32, stdout: String, stderr: String) {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -26640,49 +26640,70 @@ struct CMUXCLI {
         surfaceId: String,
         client: SocketClient
     ) throws {
-        // Resolve the replacement pane before taking the file lock. The RPC can
-        // block on the app socket; holding the lock across it would stall every
-        // unrelated tmux-compatible writer for the socket timeout.
-        let snapshot = loadTmuxCompatStore()
-        let snapshotLayout = snapshot.mainVerticalLayouts[workspaceId]
-        let replacementWasResolved: Bool
-        let replacementSurfaceId: String?
-        if let snapshotLayout, snapshotLayout.lastColumnSurfaceId == surfaceId {
-            replacementWasResolved = true
-            replacementSurfaceId = tmuxReplacementColumnSurfaceId(
-                workspaceId: workspaceId,
-                layout: snapshotLayout,
-                client: client
-            )
-        } else {
-            replacementWasResolved = false
-            replacementSurfaceId = nil
-        }
-
-        try withLockedTmuxCompatStoreIfChanged { store in
-            var changed = false
-            if store.lastSplitSurface[workspaceId] == surfaceId {
-                store.lastSplitSurface.removeValue(forKey: workspaceId)
-                changed = true
+        // Resolve pane geometry outside the file lock. If layout state changes
+        // between that RPC and the locked mutation, retry from a fresh snapshot
+        // so a replacement selected for an old main pane is never persisted.
+        for _ in 0..<4 {
+            let snapshot = loadTmuxCompatStore()
+            let snapshotLayout = snapshot.mainVerticalLayouts[workspaceId]
+            let replacementWasResolved: Bool
+            let replacementSurfaceId: String?
+            if let snapshotLayout, snapshotLayout.lastColumnSurfaceId == surfaceId {
+                replacementWasResolved = true
+                replacementSurfaceId = tmuxReplacementColumnSurfaceId(
+                    workspaceId: workspaceId,
+                    layout: snapshotLayout,
+                    client: client
+                )
+            } else {
+                replacementWasResolved = false
+                replacementSurfaceId = nil
             }
 
-            guard let layout = store.mainVerticalLayouts[workspaceId] else { return changed }
-            if layout.mainSurfaceId == surfaceId {
-                store.mainVerticalLayouts.removeValue(forKey: workspaceId)
-                store.lastSplitSurface.removeValue(forKey: workspaceId)
-                changed = true
-            } else if layout.lastColumnSurfaceId == surfaceId, replacementWasResolved {
-                var updatedLayout = layout
-                updatedLayout.lastColumnSurfaceId = replacementSurfaceId
-                store.mainVerticalLayouts[workspaceId] = updatedLayout
-                if let replacementSurfaceId {
-                    store.lastSplitSurface[workspaceId] = replacementSurfaceId
-                } else {
-                    store.lastSplitSurface.removeValue(forKey: workspaceId)
+            var retry = false
+            try withLockedTmuxCompatStoreIfChanged { store in
+                let currentLayout = store.mainVerticalLayouts[workspaceId]
+                let layoutsMatch: Bool = switch (snapshotLayout, currentLayout) {
+                case (nil, nil):
+                    true
+                case let (.some(snapshot), .some(current)):
+                    snapshot.mainSurfaceId == current.mainSurfaceId
+                        && snapshot.lastColumnSurfaceId == current.lastColumnSurfaceId
+                default:
+                    false
                 }
-                changed = true
+                guard layoutsMatch else {
+                    retry = true
+                    return false
+                }
+
+                var changed = false
+                if store.lastSplitSurface[workspaceId] == surfaceId {
+                    store.lastSplitSurface.removeValue(forKey: workspaceId)
+                    changed = true
+                }
+
+                guard let layout = currentLayout else { return changed }
+                if layout.mainSurfaceId == surfaceId {
+                    store.mainVerticalLayouts.removeValue(forKey: workspaceId)
+                    store.lastSplitSurface.removeValue(forKey: workspaceId)
+                    changed = true
+                } else if layout.lastColumnSurfaceId == surfaceId, replacementWasResolved {
+                    var updatedLayout = layout
+                    updatedLayout.lastColumnSurfaceId = replacementSurfaceId
+                    store.mainVerticalLayouts[workspaceId] = updatedLayout
+                    if let replacementSurfaceId {
+                        store.lastSplitSurface[workspaceId] = replacementSurfaceId
+                    } else {
+                        store.lastSplitSurface.removeValue(forKey: workspaceId)
+                    }
+                    changed = true
+                }
+                return changed
             }
-            return changed
+            if !retry {
+                return
+            }
         }
     }
 

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -7002,7 +7002,7 @@ struct CMUXCLI {
             let payload = try client.sendV2(method: "surface.close", params: params)
             if let closedWorkspaceId = (payload["workspace_id"] as? String) ?? wsId,
                let closedSurfaceId = (payload["surface_id"] as? String) ?? sfId {
-                try? tmuxPruneCompatSurfaceState(
+                try tmuxPruneCompatSurfaceState(
                     workspaceId: closedWorkspaceId,
                     surfaceId: closedSurfaceId,
                     client: client
@@ -25999,7 +25999,7 @@ struct CMUXCLI {
             if parsed.hasFlag("-h"),
                let callerWorkspace = tmuxCallerWorkspaceHandle(),
                let wsId = try? resolveWorkspaceId(callerWorkspace, client: client) {
-                if let anchoredTarget = try tmuxAnchoredSplitTarget(workspaceId: wsId, client: client) {
+                if let anchoredTarget = try? tmuxAnchoredSplitTarget(workspaceId: wsId, client: client) {
                     target = (wsId, nil, anchoredTarget.targetSurfaceId)
                     direction = anchoredTarget.direction
                     anchoredCallerSurfaceId = anchoredTarget.callerSurfaceId
@@ -26138,7 +26138,7 @@ struct CMUXCLI {
                 "workspace_id": target.workspaceId,
                 "surface_id": target.surfaceId
             ])
-            try? tmuxPruneCompatSurfaceState(
+            try tmuxPruneCompatSurfaceState(
                 workspaceId: target.workspaceId,
                 surfaceId: target.surfaceId,
                 client: client

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -26496,7 +26496,7 @@ struct CMUXCLI {
         }
     }
 
-    private struct MainVerticalState: Codable {
+    struct MainVerticalState: Codable {
         /// The surface ID of the "main" (leader) pane on the left side.
         var mainSurfaceId: String
         /// The surface ID of the bottom-most pane in the right column.
@@ -26504,7 +26504,7 @@ struct CMUXCLI {
         var lastColumnSurfaceId: String?
     }
 
-    private struct TmuxCompatStore: Codable {
+    struct TmuxCompatStore: Codable {
         var buffers: [String: String] = [:]
         var hooks: [String: String] = [:]
         /// Tracks main-vertical layout state per workspace, keyed by workspace ID.
@@ -26528,7 +26528,7 @@ struct CMUXCLI {
         init() {}
     }
 
-    private func tmuxCompatStoreURL() -> URL {
+    func tmuxCompatStoreURL() -> URL {
         let homePath = ProcessInfo.processInfo.environment["HOME"]
             ?? NSString(string: "~").expandingTildeInPath
         return URL(fileURLWithPath: homePath)
@@ -26536,7 +26536,7 @@ struct CMUXCLI {
             .appendingPathComponent("tmux-compat-store.json")
     }
 
-    private func loadTmuxCompatStore() -> TmuxCompatStore {
+    func loadTmuxCompatStore() -> TmuxCompatStore {
         let url = tmuxCompatStoreURL()
         guard let data = try? Data(contentsOf: url),
               let decoded = try? JSONDecoder().decode(TmuxCompatStore.self, from: data) else {
@@ -26545,36 +26545,12 @@ struct CMUXCLI {
         return decoded
     }
 
-    private func saveTmuxCompatStore(_ store: TmuxCompatStore) throws {
+    func saveTmuxCompatStore(_ store: TmuxCompatStore) throws {
         let url = tmuxCompatStoreURL()
         let parent = url.deletingLastPathComponent()
         try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true, attributes: nil)
         let data = try JSONEncoder().encode(store)
         try data.write(to: url, options: .atomic)
-    }
-
-    /// Performs one complete store read-modify-write while holding the
-    /// cross-process lock. Callers must use this for every mutating path.
-    private func withLockedTmuxCompatStore<T>(
-        _ body: (inout TmuxCompatStore) throws -> T
-    ) throws -> T {
-        try withTmuxCompatStoreFileLock(at: tmuxCompatStoreURL()) {
-            var store = loadTmuxCompatStore()
-            let result = try body(&store)
-            try saveTmuxCompatStore(store)
-            return result
-        }
-    }
-
-    private func withLockedTmuxCompatStoreIfChanged(
-        _ body: (inout TmuxCompatStore) throws -> Bool
-    ) throws {
-        try withTmuxCompatStoreFileLock(at: tmuxCompatStoreURL()) {
-            var store = loadTmuxCompatStore()
-            if try body(&store) {
-                try saveTmuxCompatStore(store)
-            }
-        }
     }
 
     private func tmuxPruneCompatWorkspaceState(workspaceId: String) throws {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -759,6 +759,7 @@
 		B9000048A1B2C3D4E5F60719 /* CMUXCLI+TmuxCompatHUDSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000049A1B2C3D4E5F60719 /* CMUXCLI+TmuxCompatHUDSupport.swift */; };
 		9009A0019009A0019009A001 /* CMUXCLI+TmuxCompatLaunchContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9009A0019009A0019009A002 /* CMUXCLI+TmuxCompatLaunchContext.swift */; };
 		7837A0017837A0017837A001 /* CMUXCLI+TmuxCompatResizePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7837A0027837A0027837A002 /* CMUXCLI+TmuxCompatResizePane.swift */; };
+		C0DE11260000000000000021 /* CMUXCLI+TmuxCompatStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE11260000000000000022 /* CMUXCLI+TmuxCompatStore.swift */; };
 		B9000044A1B2C3D4E5F60719 /* CMUXCLI+TmuxCompatSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000045A1B2C3D4E5F60719 /* CMUXCLI+TmuxCompatSupport.swift */; };
 		B9000033A1B2C3D4E5F60719 /* CMUXCLI+TopRendering.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000032A1B2C3D4E5F60719 /* CMUXCLI+TopRendering.swift */; };
 		D1FF52000000000000000001 /* CMUXCLI+TypedDiffViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1FF52000000000000000002 /* CMUXCLI+TypedDiffViewer.swift */; };
@@ -3786,6 +3787,7 @@
 		B9000049A1B2C3D4E5F60719 /* CMUXCLI+TmuxCompatHUDSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+TmuxCompatHUDSupport.swift"; sourceTree = "<group>"; };
 		9009A0019009A0019009A002 /* CMUXCLI+TmuxCompatLaunchContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+TmuxCompatLaunchContext.swift"; sourceTree = "<group>"; };
 		7837A0027837A0027837A002 /* CMUXCLI+TmuxCompatResizePane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+TmuxCompatResizePane.swift"; sourceTree = "<group>"; };
+		C0DE11260000000000000022 /* CMUXCLI+TmuxCompatStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+TmuxCompatStore.swift"; sourceTree = "<group>"; };
 		B9000045A1B2C3D4E5F60719 /* CMUXCLI+TmuxCompatSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+TmuxCompatSupport.swift"; sourceTree = "<group>"; };
 		B9000032A1B2C3D4E5F60719 /* CMUXCLI+TopRendering.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+TopRendering.swift"; sourceTree = "<group>"; };
 		D1FF52000000000000000002 /* CMUXCLI+TypedDiffViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+TypedDiffViewer.swift"; sourceTree = "<group>"; };
@@ -8176,6 +8178,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				D7AB0000000000000000000E /* CMUXCLI+MoveTabToNewWorkspace.swift */,
 				B9000047A1B2C3D4E5F60719 /* CMUXCLI+ExecutableResolution.swift */,
 				7837A0027837A0027837A002 /* CMUXCLI+TmuxCompatResizePane.swift */,
+				C0DE11260000000000000022 /* CMUXCLI+TmuxCompatStore.swift */,
 				9009A0019009A0019009A002 /* CMUXCLI+TmuxCompatLaunchContext.swift */,
 				9009A0029009A0029009A002 /* TmuxCompatLaunchContextError.swift */,
 				B9000045A1B2C3D4E5F60719 /* CMUXCLI+TmuxCompatSupport.swift */,
@@ -11550,6 +11553,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				B9000048A1B2C3D4E5F60719 /* CMUXCLI+TmuxCompatHUDSupport.swift in Sources */,
 				9009A0019009A0019009A001 /* CMUXCLI+TmuxCompatLaunchContext.swift in Sources */,
 				7837A0017837A0017837A001 /* CMUXCLI+TmuxCompatResizePane.swift in Sources */,
+				C0DE11260000000000000021 /* CMUXCLI+TmuxCompatStore.swift in Sources */,
 				B9000044A1B2C3D4E5F60719 /* CMUXCLI+TmuxCompatSupport.swift in Sources */,
 				B9000033A1B2C3D4E5F60719 /* CMUXCLI+TopRendering.swift in Sources */,
 				D1FF52000000000000000001 /* CMUXCLI+TypedDiffViewer.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -594,6 +594,7 @@
 		C12984000000000000000004 /* CLIStdioSIGPIPERegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12984000000000000000003 /* CLIStdioSIGPIPERegressionTests.swift */; };
 		B05553B10000000000000001 /* CLITmuxCompatRemoteSplitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B05553B10000000000000002 /* CLITmuxCompatRemoteSplitTests.swift */; };
 		7837E0057837E0057837E005 /* CLITmuxCompatResizePaneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7837E0067837E0067837E006 /* CLITmuxCompatResizePaneTests.swift */; };
+		C0DE11260000000000000001 /* CLITmuxCompatStoreConcurrencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE11260000000000000002 /* CLITmuxCompatStoreConcurrencyTests.swift */; };
 		A5D4120DA1B2C3D4E5F60F01 /* CLIVMTransferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D4120EA1B2C3D4E5F60F02 /* CLIVMTransferTests.swift */; };
 		773600000000000000000001 /* CLIWindowCommandMockServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 773600000000000000000002 /* CLIWindowCommandMockServer.swift */; };
 		773600000000000000000003 /* CLIWindowHandleRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 773600000000000000000004 /* CLIWindowHandleRoutingTests.swift */; };
@@ -3634,6 +3635,7 @@
 		C12984000000000000000003 /* CLIStdioSIGPIPERegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIStdioSIGPIPERegressionTests.swift; sourceTree = "<group>"; };
 		B05553B10000000000000002 /* CLITmuxCompatRemoteSplitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLITmuxCompatRemoteSplitTests.swift; sourceTree = "<group>"; };
 		7837E0067837E0067837E006 /* CLITmuxCompatResizePaneTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLITmuxCompatResizePaneTests.swift; sourceTree = "<group>"; };
+		C0DE11260000000000000002 /* CLITmuxCompatStoreConcurrencyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLITmuxCompatStoreConcurrencyTests.swift; sourceTree = "<group>"; };
 		A5D4120EA1B2C3D4E5F60F02 /* CLIVMTransferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIVMTransferTests.swift; sourceTree = "<group>"; };
 		773600000000000000000002 /* CLIWindowCommandMockServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIWindowCommandMockServer.swift; sourceTree = "<group>"; };
 		773600000000000000000004 /* CLIWindowHandleRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIWindowHandleRoutingTests.swift; sourceTree = "<group>"; };
@@ -8942,6 +8944,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				CD3B5F249DECAB446CC71D32 /* MockBridgeInputCapture.swift */,
 				C12984000000000000000003 /* CLIStdioSIGPIPERegressionTests.swift */,
 				B05553B10000000000000002 /* CLITmuxCompatRemoteSplitTests.swift */,
+				C0DE11260000000000000002 /* CLITmuxCompatStoreConcurrencyTests.swift */,
 				7837E0067837E0067837E006 /* CLITmuxCompatResizePaneTests.swift */,
 				C0D3F1F00000000000000104 /* CLICodexHookTimeoutRegressionTests.swift */,
 				C0D3F1F20000000000000104 /* CLICodexYoloResumePersistenceTests.swift */,
@@ -11844,6 +11847,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C12984000000000000000004 /* CLIStdioSIGPIPERegressionTests.swift in Sources */,
 				B05553B10000000000000001 /* CLITmuxCompatRemoteSplitTests.swift in Sources */,
 				7837E0057837E0057837E005 /* CLITmuxCompatResizePaneTests.swift in Sources */,
+				C0DE11260000000000000001 /* CLITmuxCompatStoreConcurrencyTests.swift in Sources */,
 				A5D4120DA1B2C3D4E5F60F01 /* CLIVMTransferTests.swift in Sources */,
 					773600000000000000000001 /* CLIWindowCommandMockServer.swift in Sources */,
 					773600000000000000000003 /* CLIWindowHandleRoutingTests.swift in Sources */,

--- a/cmuxTests/CLITmuxCompatStoreConcurrencyTests.swift
+++ b/cmuxTests/CLITmuxCompatStoreConcurrencyTests.swift
@@ -28,7 +28,9 @@ struct CLITmuxCompatStoreConcurrencyTests {
         let initialData = try JSONSerialization.data(withJSONObject: initialStore, options: [])
         try initialData.write(to: storeURL, options: .atomic)
 
-        let socketPath = root.appendingPathComponent("test.sock").path
+        // Keep the socket name short: macOS limits sockaddr_un.sun_path to
+        // 104 bytes, while XCTest temporary-directory paths can be long.
+        let socketPath = "/tmp/cmux-11262-\(UUID().uuidString.prefix(8)).sock"
         let listenerFD = try Self.bindUnixSocket(at: socketPath)
         defer {
             Darwin.close(listenerFD)
@@ -171,7 +173,10 @@ struct CLITmuxCompatStoreConcurrencyTests {
         let timedOut = exited.wait(timeout: .now() + timeout) == .timedOut
         if timedOut {
             process.terminate()
-            _ = exited.wait(timeout: .now() + 1)
+            if exited.wait(timeout: .now() + 1) == .timedOut {
+                kill(process.processIdentifier, SIGKILL)
+                _ = exited.wait(timeout: .now() + 1)
+            }
         }
         let stderr = String(
             data: stderrPipe.fileHandleForReading.readDataToEndOfFile(),

--- a/cmuxTests/CLITmuxCompatStoreConcurrencyTests.swift
+++ b/cmuxTests/CLITmuxCompatStoreConcurrencyTests.swift
@@ -115,7 +115,9 @@ struct CLITmuxCompatStoreConcurrencyTests {
             timeout: 30
         )
         #expect(serverDone.wait(timeout: .now() + 30) == .success)
+        #expect(!result.timedOut, Comment(rawValue: result.stderr))
         #expect(result.status != 0)
+        #expect(result.stderr.contains("dataCorrupted"), Comment(rawValue: result.stderr))
         #expect(try Data(contentsOf: storeURL) == malformed)
     }
 

--- a/cmuxTests/CLITmuxCompatStoreConcurrencyTests.swift
+++ b/cmuxTests/CLITmuxCompatStoreConcurrencyTests.swift
@@ -1,0 +1,186 @@
+import Darwin
+import Foundation
+import Testing
+
+/// Exercises the on-disk tmux compatibility store through separate CLI
+/// processes, which is the boundary where concurrent writers can overwrite one
+/// another.
+@Suite(.serialized)
+struct CLITmuxCompatStoreConcurrencyTests {
+    private static let writerCount = 20
+
+    @Test func concurrentSetBufferCallsRetainEveryBuffer() throws {
+        let cliPath = try BundledCLITestSupport.bundledCLIPath(for: BundleToken.self)
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-tmux-store-concurrency-\(UUID().uuidString)", isDirectory: true)
+        let home = root.appendingPathComponent("home", isDirectory: true)
+        let storeURL = home
+            .appendingPathComponent(".cmuxterm", isDirectory: true)
+            .appendingPathComponent("tmux-compat-store.json", isDirectory: false)
+        try FileManager.default.createDirectory(at: storeURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        // A non-empty store widens the decode/encode window and keeps this a
+        // deterministic repro of a read-modify-write race, rather than a test
+        // that happens to depend on process startup ordering.
+        let seed = String(repeating: "seed", count: 32_768)
+        let initialStore: [String: Any] = ["buffers": ["seed": seed]]
+        let initialData = try JSONSerialization.data(withJSONObject: initialStore, options: [])
+        try initialData.write(to: storeURL, options: .atomic)
+
+        let socketPath = root.appendingPathComponent("test.sock").path
+        let listenerFD = try Self.bindUnixSocket(at: socketPath)
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+        }
+        let serverDone = Self.startClientDrain(listenerFD: listenerFD, expectedClients: Self.writerCount)
+
+        let environment = [
+            "CMUX_SOCKET_PATH": socketPath,
+            "CMUX_SOCKET_PASSWORD": "",
+            "CMUX_CLI_SENTRY_DISABLED": "1",
+            "CFFIXED_USER_HOME": home.path,
+            "HOME": home.path,
+            "PATH": ProcessInfo.processInfo.environment["PATH"] ?? "/usr/bin:/bin",
+        ]
+        let resultLock = NSLock()
+        var results: [ProcessRunResult] = []
+        DispatchQueue.concurrentPerform(iterations: Self.writerCount) { index in
+            let result = Self.runProcess(
+                executablePath: cliPath,
+                arguments: [
+                    "set-buffer",
+                    "--name", "buf-\(index)",
+                    "--",
+                    "payload-\(index)",
+                ],
+                environment: environment,
+                timeout: 30
+            )
+            resultLock.lock()
+            results.append(result)
+            resultLock.unlock()
+        }
+
+        #expect(serverDone.wait(timeout: .now() + 30) == .success)
+        #expect(results.count == Self.writerCount)
+        #expect(results.allSatisfy { $0.status == 0 && !$0.timedOut }, Comment(rawValue: results.map(\.stderr).joined()))
+
+        let persistedData = try Data(contentsOf: storeURL)
+        let persistedObject = try #require(
+            JSONSerialization.jsonObject(with: persistedData, options: []) as? [String: Any]
+        )
+        let buffers = try #require(persistedObject["buffers"] as? [String: String])
+        #expect(buffers["seed"] == seed)
+        #expect(buffers.count == Self.writerCount + 1)
+        for index in 0..<Self.writerCount {
+            #expect(buffers["buf-\(index)"] == "payload-\(index)")
+        }
+    }
+
+    private struct ProcessRunResult {
+        let status: Int32
+        let stderr: String
+        let timedOut: Bool
+    }
+
+    private final class BundleToken {}
+
+    private static func bindUnixSocket(at path: String) throws -> Int32 {
+        let fd = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let bytes = Array(path.utf8)
+        let capacity = MemoryLayout.size(ofValue: address.sun_path)
+        guard bytes.count < capacity else {
+            Darwin.close(fd)
+            throw POSIXError(.ENAMETOOLONG)
+        }
+        withUnsafeMutablePointer(to: &address.sun_path) { pointer in
+            pointer.withMemoryRebound(to: CChar.self, capacity: capacity) { buffer in
+                for (index, byte) in bytes.enumerated() {
+                    buffer[index] = CChar(bitPattern: byte)
+                }
+                buffer[bytes.count] = 0
+            }
+        }
+        let bindResult = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.bind(fd, $0, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard bindResult == 0 else {
+            let error = POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            Darwin.close(fd)
+            throw error
+        }
+        guard Darwin.listen(fd, 128) == 0 else {
+            let error = POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            Darwin.close(fd)
+            throw error
+        }
+        return fd
+    }
+
+    private static func startClientDrain(listenerFD: Int32, expectedClients: Int) -> DispatchSemaphore {
+        let done = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .userInitiated).async {
+            defer { done.signal() }
+            for _ in 0..<expectedClients {
+                var descriptor = pollfd(fd: listenerFD, events: Int16(POLLIN), revents: 0)
+                guard Darwin.poll(&descriptor, 1, 30_000) > 0 else { return }
+                let clientFD = Darwin.accept(listenerFD, nil, nil)
+                guard clientFD >= 0 else { return }
+                Darwin.close(clientFD)
+            }
+        }
+        return done
+    }
+
+    private static func runProcess(
+        executablePath: String,
+        arguments: [String],
+        environment: [String: String],
+        timeout: TimeInterval
+    ) -> ProcessRunResult {
+        let process = Process()
+        let stderrPipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = arguments
+        process.environment = environment
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = stderrPipe
+
+        do {
+            try process.run()
+        } catch {
+            return ProcessRunResult(status: -1, stderr: String(describing: error), timedOut: false)
+        }
+
+        let exited = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .userInitiated).async {
+            process.waitUntilExit()
+            exited.signal()
+        }
+        let timedOut = exited.wait(timeout: .now() + timeout) == .timedOut
+        if timedOut {
+            process.terminate()
+            _ = exited.wait(timeout: .now() + 1)
+        }
+        let stderr = String(
+            data: stderrPipe.fileHandleForReading.readDataToEndOfFile(),
+            encoding: .utf8
+        ) ?? ""
+        return ProcessRunResult(
+            status: process.isRunning ? SIGKILL : process.terminationStatus,
+            stderr: stderr,
+            timedOut: timedOut
+        )
+    }
+}

--- a/cmuxTests/CLITmuxCompatStoreConcurrencyTests.swift
+++ b/cmuxTests/CLITmuxCompatStoreConcurrencyTests.swift
@@ -81,6 +81,44 @@ struct CLITmuxCompatStoreConcurrencyTests {
         }
     }
 
+    @Test func malformedStoreIsNotReplacedBySetBuffer() throws {
+        let cliPath = try BundledCLITestSupport.bundledCLIPath(for: BundleToken.self)
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-tmux-store-malformed-\(UUID().uuidString)", isDirectory: true)
+        let home = root.appendingPathComponent("home", isDirectory: true)
+        let storeURL = home
+            .appendingPathComponent(".cmuxterm", isDirectory: true)
+            .appendingPathComponent("tmux-compat-store.json", isDirectory: false)
+        try FileManager.default.createDirectory(at: storeURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let malformed = Data("{not-json".utf8)
+        try malformed.write(to: storeURL, options: .atomic)
+        let socketPath = "/tmp/cmux-11262-\(UUID().uuidString.prefix(8)).sock"
+        let listenerFD = try Self.bindUnixSocket(at: socketPath)
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+        }
+        let serverDone = Self.startClientDrain(listenerFD: listenerFD, expectedClients: 1)
+        let result = Self.runProcess(
+            executablePath: cliPath,
+            arguments: ["set-buffer", "--name", "buf", "--", "payload"],
+            environment: [
+                "CMUX_SOCKET_PATH": socketPath,
+                "CMUX_SOCKET_PASSWORD": "",
+                "CMUX_CLI_SENTRY_DISABLED": "1",
+                "CFFIXED_USER_HOME": home.path,
+                "HOME": home.path,
+                "PATH": ProcessInfo.processInfo.environment["PATH"] ?? "/usr/bin:/bin",
+            ],
+            timeout: 30
+        )
+        #expect(serverDone.wait(timeout: .now() + 30) == .success)
+        #expect(result.status != 0)
+        #expect(try Data(contentsOf: storeURL) == malformed)
+    }
+
     private struct ProcessRunResult {
         let status: Int32
         let stderr: String

--- a/cmuxTests/CLITmuxCompatStoreConcurrencyTests.swift
+++ b/cmuxTests/CLITmuxCompatStoreConcurrencyTests.swift
@@ -29,7 +29,7 @@ struct CLITmuxCompatStoreConcurrencyTests {
         try initialData.write(to: storeURL, options: .atomic)
 
         // Keep the socket name short: macOS limits sockaddr_un.sun_path to
-        // 104 bytes, while XCTest temporary-directory paths can be long.
+        // 104 bytes, while FileManager.default.temporaryDirectory paths can be long.
         let socketPath = "/tmp/cmux-11262-\(UUID().uuidString.prefix(8)).sock"
         let listenerFD = try Self.bindUnixSocket(at: socketPath)
         defer {
@@ -90,6 +90,7 @@ struct CLITmuxCompatStoreConcurrencyTests {
     private final class BundleToken {}
 
     private static func bindUnixSocket(at path: String) throws -> Int32 {
+        unlink(path)
         let fd = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
         guard fd >= 0 else {
             throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)

--- a/cmuxTests/CLITmuxCompatStoreConcurrencyTests.swift
+++ b/cmuxTests/CLITmuxCompatStoreConcurrencyTests.swift
@@ -117,7 +117,7 @@ struct CLITmuxCompatStoreConcurrencyTests {
         #expect(serverDone.wait(timeout: .now() + 30) == .success)
         #expect(!result.timedOut, Comment(rawValue: result.stderr))
         #expect(result.status != 0)
-        #expect(result.stderr.contains("dataCorrupted"), Comment(rawValue: result.stderr))
+        #expect(result.stderr.hasPrefix("Error:"), Comment(rawValue: result.stderr))
         #expect(try Data(contentsOf: storeURL) == malformed)
     }
 

--- a/daemon/remote/cmd/cmuxd-remote/tmux_compat.go
+++ b/daemon/remote/cmd/cmuxd-remote/tmux_compat.go
@@ -1256,6 +1256,15 @@ func saveTmuxCompatStore(store tmuxCompatStore) error {
 // across independent cmuxd processes. The lock file is separate from the JSON
 // path because writers replace the JSON atomically.
 func withLockedTmuxCompatStore(mutate func(*tmuxCompatStore) error) error {
+	return withLockedTmuxCompatStoreIfChanged(func(store *tmuxCompatStore) (bool, error) {
+		if err := mutate(store); err != nil {
+			return false, err
+		}
+		return true, nil
+	})
+}
+
+func withLockedTmuxCompatStoreIfChanged(mutate func(*tmuxCompatStore) (bool, error)) error {
 	path := tmuxCompatStoreURL()
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err
@@ -1271,8 +1280,12 @@ func withLockedTmuxCompatStore(mutate func(*tmuxCompatStore) error) error {
 	defer syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
 
 	store := loadTmuxCompatStore()
-	if err := mutate(&store); err != nil {
+	changed, err := mutate(&store)
+	if err != nil {
 		return err
+	}
+	if !changed {
+		return nil
 	}
 	return saveTmuxCompatStoreUnlocked(store)
 }
@@ -1320,28 +1333,38 @@ func saveTmuxCompatStoreUnlocked(store tmuxCompatStore) error {
 }
 
 func tmuxPruneCompatWorkspaceState(workspaceId string) error {
-	return withLockedTmuxCompatStore(func(store *tmuxCompatStore) error {
-		delete(store.MainVerticalLayouts, workspaceId)
-		delete(store.LastSplitSurface, workspaceId)
-		return nil
+	return withLockedTmuxCompatStoreIfChanged(func(store *tmuxCompatStore) (bool, error) {
+		_, removedLayout := store.MainVerticalLayouts[workspaceId]
+		_, removedSplit := store.LastSplitSurface[workspaceId]
+		if removedLayout {
+			delete(store.MainVerticalLayouts, workspaceId)
+		}
+		if removedSplit {
+			delete(store.LastSplitSurface, workspaceId)
+		}
+		return removedLayout || removedSplit, nil
 	})
 }
 
 func tmuxPruneCompatSurfaceState(workspaceId string, surfaceId string) error {
-	return withLockedTmuxCompatStore(func(store *tmuxCompatStore) error {
+	return withLockedTmuxCompatStoreIfChanged(func(store *tmuxCompatStore) (bool, error) {
+		changed := false
 		if lastSplit := store.LastSplitSurface[workspaceId]; lastSplit == surfaceId {
 			delete(store.LastSplitSurface, workspaceId)
+			changed = true
 		}
 		if layout, ok := store.MainVerticalLayouts[workspaceId]; ok {
 			if layout.MainSurfaceId == surfaceId {
 				delete(store.MainVerticalLayouts, workspaceId)
 				delete(store.LastSplitSurface, workspaceId)
+				changed = true
 			} else if layout.LastColumnSurfaceId == surfaceId {
 				layout.LastColumnSurfaceId = ""
 				store.MainVerticalLayouts[workspaceId] = layout
+				changed = true
 			}
 		}
-		return nil
+		return changed, nil
 	})
 }
 

--- a/daemon/remote/cmd/cmuxd-remote/tmux_compat.go
+++ b/daemon/remote/cmd/cmuxd-remote/tmux_compat.go
@@ -1220,8 +1220,28 @@ func ensureTmuxCompatStoreDirectory() error {
 	if err := os.MkdirAll(directory, 0700); err != nil {
 		return err
 	}
+	if err := validateTmuxCompatStoreDirectory(directory); err != nil {
+		return err
+	}
 	// Tighten directories created by older versions (or a permissive umask).
 	return os.Chmod(directory, 0700)
+}
+
+func validateTmuxCompatStoreDirectory(directory string) error {
+	info, err := os.Lstat(directory)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("tmux compatibility store directory is a symlink: %s", directory)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("tmux compatibility store path is not a directory: %s", directory)
+	}
+	return nil
 }
 
 func emptyTmuxCompatStore() tmuxCompatStore {
@@ -1235,6 +1255,9 @@ func emptyTmuxCompatStore() tmuxCompatStore {
 
 func loadTmuxCompatStore() (tmuxCompatStore, error) {
 	path := tmuxCompatStoreURL()
+	if err := validateTmuxCompatStoreDirectory(filepath.Dir(path)); err != nil {
+		return tmuxCompatStore{}, err
+	}
 	file, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -1243,6 +1266,13 @@ func loadTmuxCompatStore() (tmuxCompatStore, error) {
 		return tmuxCompatStore{}, err
 	}
 	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return tmuxCompatStore{}, err
+	}
+	if !info.Mode().IsRegular() {
+		return tmuxCompatStore{}, fmt.Errorf("tmux compatibility store is not a regular file")
+	}
 	// Heal stores created by older versions even when this is a read-only
 	// command, so buffer contents are never left world-readable.
 	if err := file.Chmod(0600); err != nil {

--- a/daemon/remote/cmd/cmuxd-remote/tmux_compat.go
+++ b/daemon/remote/cmd/cmuxd-remote/tmux_compat.go
@@ -10,8 +10,9 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"syscall"
 	"time"
+
+	"golang.org/x/sys/unix"
 )
 
 // runTmuxCompat handles `cmux __tmux-compat <args...>`, translating tmux
@@ -1215,33 +1216,53 @@ func tmuxCompatStoreURL() string {
 	return filepath.Join(home, ".cmuxterm", "tmux-compat-store.json")
 }
 
-func ensureTmuxCompatStoreDirectory() error {
-	directory := filepath.Dir(tmuxCompatStoreURL())
-	if err := os.MkdirAll(directory, 0700); err != nil {
-		return err
-	}
-	if err := validateTmuxCompatStoreDirectory(directory); err != nil {
-		return err
-	}
-	// Tighten directories created by older versions (or a permissive umask).
-	return os.Chmod(directory, 0700)
+type tmuxCompatStoreDirectory struct {
+	file      *os.File
+	storeName string
+	lockName  string
 }
 
-func validateTmuxCompatStoreDirectory(directory string) error {
-	info, err := os.Lstat(directory)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
+func openTmuxCompatStoreDirectory(createIfMissing bool) (*tmuxCompatStoreDirectory, error) {
+	directory := filepath.Dir(tmuxCompatStoreURL())
+	if createIfMissing {
+		if err := os.MkdirAll(directory, 0700); err != nil {
+			return nil, err
 		}
-		return err
 	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("tmux compatibility store directory is a symlink: %s", directory)
+	fd, err := unix.Open(
+		directory,
+		unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+		0,
+	)
+	if err != nil {
+		return nil, err
 	}
-	if !info.IsDir() {
-		return fmt.Errorf("tmux compatibility store path is not a directory: %s", directory)
+	directoryFile := os.NewFile(uintptr(fd), directory)
+	if err := unix.Fchmod(fd, 0700); err != nil {
+		_ = directoryFile.Close()
+		return nil, err
 	}
-	return nil
+	return &tmuxCompatStoreDirectory{
+		file:      directoryFile,
+		storeName: filepath.Base(tmuxCompatStoreURL()),
+		lockName:  filepath.Base(tmuxCompatStoreURL()) + ".lock",
+	}, nil
+}
+
+func (directory *tmuxCompatStoreDirectory) open(name string, flags int, mode uint32) (*os.File, error) {
+	fd, err := unix.Openat(int(directory.file.Fd()), name, flags, mode)
+	if err != nil {
+		return nil, err
+	}
+	return os.NewFile(uintptr(fd), name), nil
+}
+
+func (directory *tmuxCompatStoreDirectory) rename(source string, destination string) error {
+	return unix.Renameat(int(directory.file.Fd()), source, int(directory.file.Fd()), destination)
+}
+
+func (directory *tmuxCompatStoreDirectory) unlink(name string) {
+	_ = unix.Unlinkat(int(directory.file.Fd()), name, 0)
 }
 
 func emptyTmuxCompatStore() tmuxCompatStore {
@@ -1254,11 +1275,19 @@ func emptyTmuxCompatStore() tmuxCompatStore {
 }
 
 func loadTmuxCompatStore() (tmuxCompatStore, error) {
-	path := tmuxCompatStoreURL()
-	if err := validateTmuxCompatStoreDirectory(filepath.Dir(path)); err != nil {
+	directory, err := openTmuxCompatStoreDirectory(false)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return emptyTmuxCompatStore(), nil
+		}
 		return tmuxCompatStore{}, err
 	}
-	file, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
+	defer directory.file.Close()
+	return loadTmuxCompatStoreFromDirectory(directory)
+}
+
+func loadTmuxCompatStoreFromDirectory(directory *tmuxCompatStoreDirectory) (tmuxCompatStore, error) {
+	file, err := directory.open(directory.storeName, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return emptyTmuxCompatStore(), nil
@@ -1275,7 +1304,7 @@ func loadTmuxCompatStore() (tmuxCompatStore, error) {
 	}
 	// Heal stores created by older versions even when this is a read-only
 	// command, so buffer contents are never left world-readable.
-	if err := file.Chmod(0600); err != nil {
+	if err := unix.Fchmod(int(file.Fd()), 0600); err != nil {
 		return tmuxCompatStore{}, err
 	}
 	data, err := io.ReadAll(file)
@@ -1321,21 +1350,29 @@ func withLockedTmuxCompatStore(mutate func(*tmuxCompatStore) error) error {
 }
 
 func withLockedTmuxCompatStoreIfChanged(mutate func(*tmuxCompatStore) (bool, error)) error {
-	path := tmuxCompatStoreURL()
-	if err := ensureTmuxCompatStoreDirectory(); err != nil {
+	directory, err := openTmuxCompatStoreDirectory(true)
+	if err != nil {
 		return err
 	}
-	lockFile, err := os.OpenFile(path+".lock", os.O_CREATE|os.O_RDWR, 0600)
+	defer directory.file.Close()
+	lockFile, err := directory.open(
+		directory.lockName,
+		unix.O_CREAT|unix.O_RDWR|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+		0600,
+	)
 	if err != nil {
 		return err
 	}
 	defer lockFile.Close()
-	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX); err != nil {
+	if err := unix.Fchmod(int(lockFile.Fd()), 0600); err != nil {
 		return err
 	}
-	defer syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
+	if err := unix.Flock(int(lockFile.Fd()), unix.LOCK_EX); err != nil {
+		return err
+	}
+	defer unix.Flock(int(lockFile.Fd()), unix.LOCK_UN)
 
-	store, err := loadTmuxCompatStore()
+	store, err := loadTmuxCompatStoreFromDirectory(directory)
 	if err != nil {
 		return err
 	}
@@ -1346,30 +1383,30 @@ func withLockedTmuxCompatStoreIfChanged(mutate func(*tmuxCompatStore) (bool, err
 	if !changed {
 		return nil
 	}
-	return saveTmuxCompatStoreUnlocked(store)
+	return saveTmuxCompatStoreUnlocked(directory, store)
 }
 
-func saveTmuxCompatStoreUnlocked(store tmuxCompatStore) error {
-	path := tmuxCompatStoreURL()
-	if err := ensureTmuxCompatStoreDirectory(); err != nil {
-		return err
-	}
+func saveTmuxCompatStoreUnlocked(directory *tmuxCompatStoreDirectory, store tmuxCompatStore) error {
 	data, err := json.Marshal(store)
 	if err != nil {
 		return err
 	}
-	tmp, err := os.CreateTemp(filepath.Dir(path), ".tmux-compat-store-*.tmp")
+	tmpName := fmt.Sprintf(".tmux-compat-store-%d-%d.tmp", os.Getpid(), time.Now().UnixNano())
+	tmp, err := directory.open(
+		tmpName,
+		unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+		0600,
+	)
 	if err != nil {
 		return err
 	}
-	tmpPath := tmp.Name()
 	removeTemp := true
 	defer func() {
 		if removeTemp {
-			_ = os.Remove(tmpPath)
+			directory.unlink(tmpName)
 		}
 	}()
-	if err := tmp.Chmod(0600); err != nil {
+	if err := unix.Fchmod(int(tmp.Fd()), 0600); err != nil {
 		_ = tmp.Close()
 		return err
 	}
@@ -1384,7 +1421,7 @@ func saveTmuxCompatStoreUnlocked(store tmuxCompatStore) error {
 	if err := tmp.Close(); err != nil {
 		return err
 	}
-	if err := os.Rename(tmpPath, path); err != nil {
+	if err := directory.rename(tmpName, directory.storeName); err != nil {
 		return err
 	}
 	removeTemp = false

--- a/daemon/remote/cmd/cmuxd-remote/tmux_compat.go
+++ b/daemon/remote/cmd/cmuxd-remote/tmux_compat.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
+	"io"
 	"math"
 	"os"
 	"path/filepath"
@@ -1234,16 +1235,21 @@ func emptyTmuxCompatStore() tmuxCompatStore {
 
 func loadTmuxCompatStore() (tmuxCompatStore, error) {
 	path := tmuxCompatStoreURL()
-	data, err := os.ReadFile(path)
+	file, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return emptyTmuxCompatStore(), nil
 		}
 		return tmuxCompatStore{}, err
 	}
+	defer file.Close()
 	// Heal stores created by older versions even when this is a read-only
 	// command, so buffer contents are never left world-readable.
-	if err := os.Chmod(path, 0600); err != nil {
+	if err := file.Chmod(0600); err != nil {
+		return tmuxCompatStore{}, err
+	}
+	data, err := io.ReadAll(file)
+	if err != nil {
 		return tmuxCompatStore{}, err
 	}
 	var store tmuxCompatStore

--- a/daemon/remote/cmd/cmuxd-remote/tmux_compat.go
+++ b/daemon/remote/cmd/cmuxd-remote/tmux_compat.go
@@ -1233,11 +1233,17 @@ func emptyTmuxCompatStore() tmuxCompatStore {
 }
 
 func loadTmuxCompatStore() (tmuxCompatStore, error) {
-	data, err := os.ReadFile(tmuxCompatStoreURL())
+	path := tmuxCompatStoreURL()
+	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return emptyTmuxCompatStore(), nil
 		}
+		return tmuxCompatStore{}, err
+	}
+	// Heal stores created by older versions even when this is a read-only
+	// command, so buffer contents are never left world-readable.
+	if err := os.Chmod(path, 0600); err != nil {
 		return tmuxCompatStore{}, err
 	}
 	var store tmuxCompatStore

--- a/daemon/remote/cmd/cmuxd-remote/tmux_compat.go
+++ b/daemon/remote/cmd/cmuxd-remote/tmux_compat.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -1135,7 +1136,8 @@ type tmuxSplitAnchor struct {
 func tmuxAnchoredSplitTarget(rc *rpcContext, workspaceId string) *tmuxSplitAnchor {
 	store := loadTmuxCompatStore()
 	if mvState, ok := store.MainVerticalLayouts[workspaceId]; ok && mvState.LastColumnSurfaceId != "" {
-		lastColumnId, err := tmuxCanonicalSurfaceId(rc, mvState.LastColumnSurfaceId, workspaceId)
+		staleLastColumn := mvState.LastColumnSurfaceId
+		lastColumnId, err := tmuxCanonicalSurfaceId(rc, staleLastColumn, workspaceId)
 		if err == nil {
 			return &tmuxSplitAnchor{
 				targetSurfaceId: lastColumnId,
@@ -1146,10 +1148,15 @@ func tmuxAnchoredSplitTarget(rc *rpcContext, workspaceId string) *tmuxSplitAncho
 
 		// Right-column anchors can outlive the pane they pointed at.
 		// Drop stale state and rebuild from the caller surface instead.
-		mvState.LastColumnSurfaceId = ""
-		store.MainVerticalLayouts[workspaceId] = mvState
-		delete(store.LastSplitSurface, workspaceId)
-		_ = saveTmuxCompatStore(store)
+		_ = withLockedTmuxCompatStore(func(store *tmuxCompatStore) error {
+			if current, ok := store.MainVerticalLayouts[workspaceId]; ok &&
+				current.LastColumnSurfaceId == staleLastColumn {
+				current.LastColumnSurfaceId = ""
+				store.MainVerticalLayouts[workspaceId] = current
+				delete(store.LastSplitSurface, workspaceId)
+			}
+			return nil
+		})
 	}
 
 	candidateAnchors := []string{tmuxCallerSurfaceHandle()}
@@ -1170,10 +1177,17 @@ func tmuxAnchoredSplitTarget(rc *rpcContext, workspaceId string) *tmuxSplitAncho
 		}
 	}
 
-	if _, ok := store.MainVerticalLayouts[workspaceId]; ok {
-		delete(store.MainVerticalLayouts, workspaceId)
-		delete(store.LastSplitSurface, workspaceId)
-		_ = saveTmuxCompatStore(store)
+	observedLayout, hasObservedLayout := store.MainVerticalLayouts[workspaceId]
+	if hasObservedLayout {
+		_ = withLockedTmuxCompatStore(func(store *tmuxCompatStore) error {
+			if current, ok := store.MainVerticalLayouts[workspaceId]; ok &&
+				current.MainSurfaceId == observedLayout.MainSurfaceId &&
+				current.LastColumnSurfaceId == observedLayout.LastColumnSurfaceId {
+				delete(store.MainVerticalLayouts, workspaceId)
+				delete(store.LastSplitSurface, workspaceId)
+			}
+			return nil
+		})
 	}
 	return nil
 }
@@ -1232,6 +1246,38 @@ func loadTmuxCompatStore() tmuxCompatStore {
 }
 
 func saveTmuxCompatStore(store tmuxCompatStore) error {
+	return withLockedTmuxCompatStore(func(current *tmuxCompatStore) error {
+		*current = store
+		return nil
+	})
+}
+
+// withLockedTmuxCompatStore serializes a complete store read-modify-write
+// across independent cmuxd processes. The lock file is separate from the JSON
+// path because writers replace the JSON atomically.
+func withLockedTmuxCompatStore(mutate func(*tmuxCompatStore) error) error {
+	path := tmuxCompatStoreURL()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	lockFile, err := os.OpenFile(path+".lock", os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return err
+	}
+	defer lockFile.Close()
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX); err != nil {
+		return err
+	}
+	defer syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
+
+	store := loadTmuxCompatStore()
+	if err := mutate(&store); err != nil {
+		return err
+	}
+	return saveTmuxCompatStoreUnlocked(store)
+}
+
+func saveTmuxCompatStoreUnlocked(store tmuxCompatStore) error {
 	path := tmuxCompatStoreURL()
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err
@@ -1240,48 +1286,63 @@ func saveTmuxCompatStore(store tmuxCompatStore) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, data, 0644)
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".tmux-compat-store-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	removeTemp := true
+	defer func() {
+		if removeTemp {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if err := tmp.Chmod(0644); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+	removeTemp = false
+	return nil
 }
 
 func tmuxPruneCompatWorkspaceState(workspaceId string) error {
-	store := loadTmuxCompatStore()
-	changed := false
-	if _, ok := store.MainVerticalLayouts[workspaceId]; ok {
+	return withLockedTmuxCompatStore(func(store *tmuxCompatStore) error {
 		delete(store.MainVerticalLayouts, workspaceId)
-		changed = true
-	}
-	if _, ok := store.LastSplitSurface[workspaceId]; ok {
 		delete(store.LastSplitSurface, workspaceId)
-		changed = true
-	}
-	if changed {
-		return saveTmuxCompatStore(store)
-	}
-	return nil
+		return nil
+	})
 }
 
 func tmuxPruneCompatSurfaceState(workspaceId string, surfaceId string) error {
-	store := loadTmuxCompatStore()
-	changed := false
-	if lastSplit := store.LastSplitSurface[workspaceId]; lastSplit == surfaceId {
-		delete(store.LastSplitSurface, workspaceId)
-		changed = true
-	}
-	if layout, ok := store.MainVerticalLayouts[workspaceId]; ok {
-		if layout.MainSurfaceId == surfaceId {
-			delete(store.MainVerticalLayouts, workspaceId)
+	return withLockedTmuxCompatStore(func(store *tmuxCompatStore) error {
+		if lastSplit := store.LastSplitSurface[workspaceId]; lastSplit == surfaceId {
 			delete(store.LastSplitSurface, workspaceId)
-			changed = true
-		} else if layout.LastColumnSurfaceId == surfaceId {
-			layout.LastColumnSurfaceId = ""
-			store.MainVerticalLayouts[workspaceId] = layout
-			changed = true
 		}
-	}
-	if changed {
-		return saveTmuxCompatStore(store)
-	}
-	return nil
+		if layout, ok := store.MainVerticalLayouts[workspaceId]; ok {
+			if layout.MainSurfaceId == surfaceId {
+				delete(store.MainVerticalLayouts, workspaceId)
+				delete(store.LastSplitSurface, workspaceId)
+			} else if layout.LastColumnSurfaceId == surfaceId {
+				layout.LastColumnSurfaceId = ""
+				store.MainVerticalLayouts[workspaceId] = layout
+			}
+		}
+		return nil
+	})
 }
 
 // --- Special key translation ---
@@ -1552,19 +1613,22 @@ func tmuxSplitWindow(rc *rpcContext, args []string) error {
 	newPaneId, _ := created["pane_id"].(string)
 
 	// Track for main-vertical layout
-	store := loadTmuxCompatStore()
-	store.LastSplitSurface[targetWs] = surfaceId
-	if _, ok := store.MainVerticalLayouts[targetWs]; ok {
-		mvs := store.MainVerticalLayouts[targetWs]
-		mvs.LastColumnSurfaceId = surfaceId
-		store.MainVerticalLayouts[targetWs] = mvs
-	} else if direction == "right" && anchoredCallerSurface != "" {
-		store.MainVerticalLayouts[targetWs] = mainVerticalState{
-			MainSurfaceId:       anchoredCallerSurface,
-			LastColumnSurfaceId: surfaceId,
+	if err := withLockedTmuxCompatStore(func(store *tmuxCompatStore) error {
+		store.LastSplitSurface[targetWs] = surfaceId
+		if _, ok := store.MainVerticalLayouts[targetWs]; ok {
+			mvs := store.MainVerticalLayouts[targetWs]
+			mvs.LastColumnSurfaceId = surfaceId
+			store.MainVerticalLayouts[targetWs] = mvs
+		} else if direction == "right" && anchoredCallerSurface != "" {
+			store.MainVerticalLayouts[targetWs] = mainVerticalState{
+				MainSurfaceId:       anchoredCallerSurface,
+				LastColumnSurfaceId: surfaceId,
+			}
 		}
+		return nil
+	}); err != nil {
+		return err
 	}
-	saveTmuxCompatStore(store)
 
 	// Equalize vertical splits
 	rc.call("workspace.equalize_splits", map[string]any{
@@ -1808,9 +1872,12 @@ func tmuxCapturePane(rc *rpcContext, args []string) error {
 	if p.hasFlag("-p") {
 		fmt.Print(text)
 	} else {
-		store := loadTmuxCompatStore()
-		store.Buffers["default"] = text
-		saveTmuxCompatStore(store)
+		if err := withLockedTmuxCompatStore(func(store *tmuxCompatStore) error {
+			store.Buffers["default"] = text
+			return nil
+		}); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -2192,20 +2259,23 @@ func tmuxSelectLayout(rc *rpcContext, args []string) error {
 
 	if layoutName == "main-vertical" {
 		if callerSurface := tmuxCallerSurfaceHandle(); callerSurface != "" {
-			store := loadTmuxCompatStore()
-			existingColumn := ""
-			if existing, ok := store.MainVerticalLayouts[wsId]; ok {
-				existingColumn = existing.LastColumnSurfaceId
+			if err := withLockedTmuxCompatStore(func(store *tmuxCompatStore) error {
+				existingColumn := ""
+				if existing, ok := store.MainVerticalLayouts[wsId]; ok {
+					existingColumn = existing.LastColumnSurfaceId
+				}
+				seedColumn := existingColumn
+				if seedColumn == "" {
+					seedColumn = store.LastSplitSurface[wsId]
+				}
+				store.MainVerticalLayouts[wsId] = mainVerticalState{
+					MainSurfaceId:       callerSurface,
+					LastColumnSurfaceId: seedColumn,
+				}
+				return nil
+			}); err != nil {
+				return err
 			}
-			seedColumn := existingColumn
-			if seedColumn == "" {
-				seedColumn = store.LastSplitSurface[wsId]
-			}
-			store.MainVerticalLayouts[wsId] = mainVerticalState{
-				MainSurfaceId:       callerSurface,
-				LastColumnSurfaceId: seedColumn,
-			}
-			saveTmuxCompatStore(store)
 		}
 	} else if layoutName != "" {
 		_ = tmuxPruneCompatWorkspaceState(wsId)

--- a/daemon/remote/cmd/cmuxd-remote/tmux_compat.go
+++ b/daemon/remote/cmd/cmuxd-remote/tmux_compat.go
@@ -1214,6 +1214,15 @@ func tmuxCompatStoreURL() string {
 	return filepath.Join(home, ".cmuxterm", "tmux-compat-store.json")
 }
 
+func ensureTmuxCompatStoreDirectory() error {
+	directory := filepath.Dir(tmuxCompatStoreURL())
+	if err := os.MkdirAll(directory, 0700); err != nil {
+		return err
+	}
+	// Tighten directories created by older versions (or a permissive umask).
+	return os.Chmod(directory, 0700)
+}
+
 func emptyTmuxCompatStore() tmuxCompatStore {
 	return tmuxCompatStore{
 		Buffers:             make(map[string]string),
@@ -1271,7 +1280,7 @@ func withLockedTmuxCompatStore(mutate func(*tmuxCompatStore) error) error {
 
 func withLockedTmuxCompatStoreIfChanged(mutate func(*tmuxCompatStore) (bool, error)) error {
 	path := tmuxCompatStoreURL()
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+	if err := ensureTmuxCompatStoreDirectory(); err != nil {
 		return err
 	}
 	lockFile, err := os.OpenFile(path+".lock", os.O_CREATE|os.O_RDWR, 0600)
@@ -1300,7 +1309,7 @@ func withLockedTmuxCompatStoreIfChanged(mutate func(*tmuxCompatStore) (bool, err
 
 func saveTmuxCompatStoreUnlocked(store tmuxCompatStore) error {
 	path := tmuxCompatStoreURL()
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+	if err := ensureTmuxCompatStoreDirectory(); err != nil {
 		return err
 	}
 	data, err := json.Marshal(store)
@@ -1318,7 +1327,7 @@ func saveTmuxCompatStoreUnlocked(store tmuxCompatStore) error {
 			_ = os.Remove(tmpPath)
 		}
 	}()
-	if err := tmp.Chmod(0644); err != nil {
+	if err := tmp.Chmod(0600); err != nil {
 		_ = tmp.Close()
 		return err
 	}
@@ -1631,6 +1640,15 @@ func tmuxSplitWindow(rc *rpcContext, args []string) error {
 		}
 	}
 
+	// Validate the store before creating a pane. A malformed or unreadable
+	// store must not turn a successful surface.split into a reported failure
+	// after the pane has already been created.
+	if err := withLockedTmuxCompatStoreIfChanged(func(*tmuxCompatStore) (bool, error) {
+		return false, nil
+	}); err != nil {
+		return fmt.Errorf("validate tmux compatibility store: %w", err)
+	}
+
 	focusNewPane := !p.hasFlag("-d")
 	created, err := rc.call("surface.split", map[string]any{
 		"workspace_id": targetWs,
@@ -1662,7 +1680,13 @@ func tmuxSplitWindow(rc *rpcContext, args []string) error {
 		}
 		return nil
 	}); err != nil {
-		return err
+		if _, rollbackErr := rc.call("surface.close", map[string]any{
+			"workspace_id": targetWs,
+			"surface_id":   surfaceId,
+		}); rollbackErr != nil {
+			return fmt.Errorf("persist tmux compatibility layout: %w (rollback failed: %v)", err, rollbackErr)
+		}
+		return fmt.Errorf("persist tmux compatibility layout: %w", err)
 	}
 
 	// Equalize vertical splits

--- a/daemon/remote/cmd/cmuxd-remote/tmux_compat.go
+++ b/daemon/remote/cmd/cmuxd-remote/tmux_compat.go
@@ -1133,8 +1133,11 @@ type tmuxSplitAnchor struct {
 	direction       string
 }
 
-func tmuxAnchoredSplitTarget(rc *rpcContext, workspaceId string) *tmuxSplitAnchor {
-	store := loadTmuxCompatStore()
+func tmuxAnchoredSplitTarget(rc *rpcContext, workspaceId string) (*tmuxSplitAnchor, error) {
+	store, err := loadTmuxCompatStore()
+	if err != nil {
+		return nil, err
+	}
 	if mvState, ok := store.MainVerticalLayouts[workspaceId]; ok && mvState.LastColumnSurfaceId != "" {
 		staleLastColumn := mvState.LastColumnSurfaceId
 		lastColumnId, err := tmuxCanonicalSurfaceId(rc, staleLastColumn, workspaceId)
@@ -1143,7 +1146,7 @@ func tmuxAnchoredSplitTarget(rc *rpcContext, workspaceId string) *tmuxSplitAncho
 				targetSurfaceId: lastColumnId,
 				callerSurfaceId: "",
 				direction:       "down",
-			}
+			}, nil
 		}
 
 		// Right-column anchors can outlive the pane they pointed at.
@@ -1173,7 +1176,7 @@ func tmuxAnchoredSplitTarget(rc *rpcContext, workspaceId string) *tmuxSplitAncho
 				targetSurfaceId: anchorSurfaceId,
 				callerSurfaceId: anchorSurfaceId,
 				direction:       "right",
-			}
+			}, nil
 		}
 	}
 
@@ -1189,7 +1192,7 @@ func tmuxAnchoredSplitTarget(rc *rpcContext, workspaceId string) *tmuxSplitAncho
 			return nil
 		})
 	}
-	return nil
+	return nil, nil
 }
 
 // --- TmuxCompatStore (local JSON state) ---
@@ -1211,24 +1214,26 @@ func tmuxCompatStoreURL() string {
 	return filepath.Join(home, ".cmuxterm", "tmux-compat-store.json")
 }
 
-func loadTmuxCompatStore() tmuxCompatStore {
+func emptyTmuxCompatStore() tmuxCompatStore {
+	return tmuxCompatStore{
+		Buffers:             make(map[string]string),
+		Hooks:               make(map[string]string),
+		MainVerticalLayouts: make(map[string]mainVerticalState),
+		LastSplitSurface:    make(map[string]string),
+	}
+}
+
+func loadTmuxCompatStore() (tmuxCompatStore, error) {
 	data, err := os.ReadFile(tmuxCompatStoreURL())
 	if err != nil {
-		return tmuxCompatStore{
-			Buffers:             make(map[string]string),
-			Hooks:               make(map[string]string),
-			MainVerticalLayouts: make(map[string]mainVerticalState),
-			LastSplitSurface:    make(map[string]string),
+		if os.IsNotExist(err) {
+			return emptyTmuxCompatStore(), nil
 		}
+		return tmuxCompatStore{}, err
 	}
 	var store tmuxCompatStore
 	if err := json.Unmarshal(data, &store); err != nil {
-		return tmuxCompatStore{
-			Buffers:             make(map[string]string),
-			Hooks:               make(map[string]string),
-			MainVerticalLayouts: make(map[string]mainVerticalState),
-			LastSplitSurface:    make(map[string]string),
-		}
+		return tmuxCompatStore{}, err
 	}
 	if store.Buffers == nil {
 		store.Buffers = make(map[string]string)
@@ -1242,7 +1247,7 @@ func loadTmuxCompatStore() tmuxCompatStore {
 	if store.LastSplitSurface == nil {
 		store.LastSplitSurface = make(map[string]string)
 	}
-	return store
+	return store, nil
 }
 
 func saveTmuxCompatStore(store tmuxCompatStore) error {
@@ -1279,7 +1284,10 @@ func withLockedTmuxCompatStoreIfChanged(mutate func(*tmuxCompatStore) (bool, err
 	}
 	defer syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
 
-	store := loadTmuxCompatStore()
+	store, err := loadTmuxCompatStore()
+	if err != nil {
+		return err
+	}
 	changed, err := mutate(&store)
 	if err != nil {
 		return err
@@ -1610,7 +1618,11 @@ func tmuxSplitWindow(rc *rpcContext, args []string) error {
 	anchoredCallerSurface := ""
 	if callerWorkspace != "" {
 		if wsId, err := tmuxResolveWorkspaceId(rc, callerWorkspace); err == nil {
-			if anchored := tmuxAnchoredSplitTarget(rc, wsId); anchored != nil {
+			anchored, err := tmuxAnchoredSplitTarget(rc, wsId)
+			if err != nil {
+				return err
+			}
+			if anchored != nil {
 				targetWs = wsId
 				targetSurface = anchored.targetSurfaceId
 				direction = anchored.direction
@@ -2313,7 +2325,10 @@ func tmuxShowBuffer(args []string) error {
 	if name == "" {
 		name = "default"
 	}
-	store := loadTmuxCompatStore()
+	store, err := loadTmuxCompatStore()
+	if err != nil {
+		return err
+	}
 	if buf, ok := store.Buffers[name]; ok {
 		fmt.Print(buf)
 	}
@@ -2326,7 +2341,10 @@ func tmuxSaveBuffer(args []string) error {
 	if name == "" {
 		name = "default"
 	}
-	store := loadTmuxCompatStore()
+	store, err := loadTmuxCompatStore()
+	if err != nil {
+		return err
+	}
 	buf, ok := store.Buffers[name]
 	if !ok {
 		return fmt.Errorf("buffer not found: %s", name)

--- a/daemon/remote/cmd/cmuxd-remote/tmux_compat_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/tmux_compat_test.go
@@ -3,11 +3,13 @@ package main
 import (
 	"bufio"
 	"encoding/json"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -172,6 +174,44 @@ func TestTmuxCompatStoreRoundTrip(t *testing.T) {
 		t.Error("missing main vertical layout for ws1")
 	} else if mvs.LastColumnSurfaceId != "surface-col" {
 		t.Errorf("lastColumnSurfaceId = %q, want %q", mvs.LastColumnSurfaceId, "surface-col")
+	}
+}
+
+func TestTmuxCompatStoreConcurrentMutations(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	const writers = 20
+	errors := make(chan error, writers)
+	var group sync.WaitGroup
+	group.Add(writers)
+	for i := 0; i < writers; i++ {
+		i := i
+		go func() {
+			defer group.Done()
+			errors <- withLockedTmuxCompatStore(func(store *tmuxCompatStore) error {
+				store.Buffers["buf-"+fmt.Sprint(i)] = "payload-" + fmt.Sprint(i)
+				return nil
+			})
+		}()
+	}
+	group.Wait()
+	close(errors)
+	for err := range errors {
+		if err != nil {
+			t.Fatalf("concurrent mutation: %v", err)
+		}
+	}
+
+	store := loadTmuxCompatStore()
+	if len(store.Buffers) != writers {
+		t.Fatalf("buffer count = %d, want %d", len(store.Buffers), writers)
+	}
+	for i := 0; i < writers; i++ {
+		name := "buf-" + fmt.Sprint(i)
+		if store.Buffers[name] != "payload-"+fmt.Sprint(i) {
+			t.Errorf("buffer %s = %q, want payload-%d", name, store.Buffers[name], i)
+		}
 	}
 }
 

--- a/daemon/remote/cmd/cmuxd-remote/tmux_compat_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/tmux_compat_test.go
@@ -881,7 +881,9 @@ func TestTmuxShowBuffer(t *testing.T) {
 		t.Fatalf("load: %v", err)
 	}
 	store.Buffers["default"] = "hello world"
-	saveTmuxCompatStore(store)
+	if err := saveTmuxCompatStore(store); err != nil {
+		t.Fatalf("save: %v", err)
+	}
 
 	output := captureStdout(t, func() {
 		tmuxShowBuffer(nil)

--- a/daemon/remote/cmd/cmuxd-remote/tmux_compat_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/tmux_compat_test.go
@@ -254,15 +254,17 @@ func TestTmuxCompatStoreConcurrentProcessMutations(t *testing.T) {
 	type childProcess struct {
 		command *exec.Cmd
 		stderr  *bytes.Buffer
+		reaped  bool
 	}
-	children := make([]childProcess, 0, writers)
+	children := make([]*childProcess, 0, writers)
 	t.Cleanup(func() {
 		for _, child := range children {
+			if child.reaped {
+				continue
+			}
 			if child.command.Process != nil {
 				_ = child.command.Process.Kill()
 			}
-		}
-		for _, child := range children {
 			if child.command.Process != nil {
 				_ = child.command.Wait()
 			}
@@ -280,10 +282,12 @@ func TestTmuxCompatStoreConcurrentProcessMutations(t *testing.T) {
 		if err := command.Start(); err != nil {
 			t.Fatalf("start child %d: %v", i, err)
 		}
-		children = append(children, childProcess{command: command, stderr: stderr})
+		children = append(children, &childProcess{command: command, stderr: stderr})
 	}
 	for i, child := range children {
-		if err := child.command.Wait(); err != nil {
+		err := child.command.Wait()
+		child.reaped = true
+		if err != nil {
 			t.Fatalf("child %d: %v\n%s", i, err, child.stderr.String())
 		}
 	}

--- a/daemon/remote/cmd/cmuxd-remote/tmux_compat_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/tmux_compat_test.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -213,6 +215,86 @@ func TestTmuxCompatStoreConcurrentMutations(t *testing.T) {
 			t.Errorf("buffer %s = %q, want payload-%d", name, store.Buffers[name], i)
 		}
 	}
+}
+
+func TestTmuxCompatStoreConcurrentProcessMutations(t *testing.T) {
+	if os.Getenv("CMUX_TMUX_STORE_CHILD") == "1" {
+		index, err := strconv.Atoi(os.Getenv("CMUX_TMUX_STORE_INDEX"))
+		if err != nil {
+			t.Fatalf("child index: %v", err)
+		}
+		if err := withLockedTmuxCompatStore(func(store *tmuxCompatStore) error {
+			name := "process-buf-" + strconv.Itoa(index)
+			store.Buffers[name] = "process-payload-" + strconv.Itoa(index)
+			return nil
+		}); err != nil {
+			t.Fatalf("child mutation: %v", err)
+		}
+		return
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	const writers = 20
+	if err := withLockedTmuxCompatStore(func(store *tmuxCompatStore) error {
+		store.Buffers["seed"] = strings.Repeat("seed", 32_768)
+		return nil
+	}); err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatalf("test executable: %v", err)
+	}
+	commands := make([]*exec.Cmd, 0, writers)
+	for i := 0; i < writers; i++ {
+		command := exec.Command(
+			executable,
+			"-test.run", "^TestTmuxCompatStoreConcurrentProcessMutations$",
+		)
+		command.Env = childEnvironment(home, i)
+		if err := command.Start(); err != nil {
+			t.Fatalf("start child %d: %v", i, err)
+		}
+		commands = append(commands, command)
+	}
+	for i, command := range commands {
+		if err := command.Wait(); err != nil {
+			t.Fatalf("child %d: %v", i, err)
+		}
+	}
+
+	store := loadTmuxCompatStore()
+	if len(store.Buffers) != writers+1 {
+		t.Fatalf("buffer count = %d, want %d", len(store.Buffers), writers+1)
+	}
+	for i := 0; i < writers; i++ {
+		name := "process-buf-" + strconv.Itoa(i)
+		want := "process-payload-" + strconv.Itoa(i)
+		if store.Buffers[name] != want {
+			t.Errorf("buffer %s = %q, want %q", name, store.Buffers[name], want)
+		}
+	}
+}
+
+func childEnvironment(home string, index int) []string {
+	environment := make([]string, 0, len(os.Environ())+3)
+	for _, value := range os.Environ() {
+		if strings.HasPrefix(value, "HOME=") ||
+			strings.HasPrefix(value, "CMUX_TMUX_STORE_CHILD=") ||
+			strings.HasPrefix(value, "CMUX_TMUX_STORE_INDEX=") {
+			continue
+		}
+		environment = append(environment, value)
+	}
+	environment = append(
+		environment,
+		"HOME="+home,
+		"CMUX_TMUX_STORE_CHILD=1",
+		"CMUX_TMUX_STORE_INDEX="+strconv.Itoa(index),
+	)
+	return environment
 }
 
 func TestTmuxVersion(t *testing.T) {

--- a/daemon/remote/cmd/cmuxd-remote/tmux_compat_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/tmux_compat_test.go
@@ -161,7 +161,10 @@ func TestTmuxCompatStoreRoundTrip(t *testing.T) {
 	os.Setenv("HOME", tmpDir)
 	defer os.Setenv("HOME", origHome)
 
-	store := loadTmuxCompatStore()
+	store, err := loadTmuxCompatStore()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
 	store.Buffers["test"] = "captured text"
 	store.MainVerticalLayouts["ws1"] = mainVerticalState{
 		MainSurfaceId:       "surface-main",
@@ -171,7 +174,10 @@ func TestTmuxCompatStoreRoundTrip(t *testing.T) {
 		t.Fatalf("save: %v", err)
 	}
 
-	loaded := loadTmuxCompatStore()
+	loaded, err := loadTmuxCompatStore()
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
 	if loaded.Buffers["test"] != "captured text" {
 		t.Errorf("buffer = %q, want %q", loaded.Buffers["test"], "captured text")
 	}
@@ -179,6 +185,44 @@ func TestTmuxCompatStoreRoundTrip(t *testing.T) {
 		t.Error("missing main vertical layout for ws1")
 	} else if mvs.LastColumnSurfaceId != "surface-col" {
 		t.Errorf("lastColumnSurfaceId = %q, want %q", mvs.LastColumnSurfaceId, "surface-col")
+	}
+}
+
+func TestTmuxCompatStoreLoadErrorsDoNotOverwriteState(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if _, err := loadTmuxCompatStore(); err != nil {
+		t.Fatalf("missing store should load as empty: %v", err)
+	}
+	storePath := tmuxCompatStoreURL()
+	if err := os.MkdirAll(filepath.Dir(storePath), 0755); err != nil {
+		t.Fatalf("create store directory: %v", err)
+	}
+	malformed := []byte("{not-json")
+	if err := os.WriteFile(storePath, malformed, 0644); err != nil {
+		t.Fatalf("write malformed store: %v", err)
+	}
+	if _, err := loadTmuxCompatStore(); err == nil {
+		t.Fatal("malformed store should return an error")
+	}
+	called := false
+	if err := withLockedTmuxCompatStore(func(store *tmuxCompatStore) error {
+		called = true
+		store.Buffers["unexpected"] = "mutation"
+		return nil
+	}); err == nil {
+		t.Fatal("locked mutation should fail when loading malformed store")
+	}
+	if called {
+		t.Fatal("mutation callback ran after a store load failure")
+	}
+	persisted, err := os.ReadFile(storePath)
+	if err != nil {
+		t.Fatalf("read malformed store: %v", err)
+	}
+	if string(persisted) != string(malformed) {
+		t.Fatalf("malformed store was overwritten: %q", persisted)
 	}
 }
 
@@ -207,7 +251,10 @@ func TestTmuxCompatStoreConcurrentMutations(t *testing.T) {
 		}
 	}
 
-	store := loadTmuxCompatStore()
+	store, loadErr := loadTmuxCompatStore()
+	if loadErr != nil {
+		t.Fatalf("load: %v", loadErr)
+	}
 	if len(store.Buffers) != writers {
 		t.Fatalf("buffer count = %d, want %d", len(store.Buffers), writers)
 	}
@@ -292,7 +339,10 @@ func TestTmuxCompatStoreConcurrentProcessMutations(t *testing.T) {
 		}
 	}
 
-	store := loadTmuxCompatStore()
+	store, loadErr := loadTmuxCompatStore()
+	if loadErr != nil {
+		t.Fatalf("load: %v", loadErr)
+	}
 	if len(store.Buffers) != writers+1 {
 		t.Fatalf("buffer count = %d, want %d", len(store.Buffers), writers+1)
 	}
@@ -826,7 +876,10 @@ func TestTmuxShowBuffer(t *testing.T) {
 	os.Setenv("HOME", tmpDir)
 	defer os.Setenv("HOME", origHome)
 
-	store := loadTmuxCompatStore()
+	store, err := loadTmuxCompatStore()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
 	store.Buffers["default"] = "hello world"
 	saveTmuxCompatStore(store)
 

--- a/daemon/remote/cmd/cmuxd-remote/tmux_compat_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/tmux_compat_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bufio"
+	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -13,6 +15,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 func TestSplitTmuxCmd(t *testing.T) {
@@ -188,7 +191,6 @@ func TestTmuxCompatStoreConcurrentMutations(t *testing.T) {
 	var group sync.WaitGroup
 	group.Add(writers)
 	for i := 0; i < writers; i++ {
-		i := i
 		go func() {
 			defer group.Done()
 			errors <- withLockedTmuxCompatStore(func(store *tmuxCompatStore) error {
@@ -247,21 +249,42 @@ func TestTmuxCompatStoreConcurrentProcessMutations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("test executable: %v", err)
 	}
-	commands := make([]*exec.Cmd, 0, writers)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	type childProcess struct {
+		command *exec.Cmd
+		stderr  *bytes.Buffer
+	}
+	children := make([]childProcess, 0, writers)
+	t.Cleanup(func() {
+		for _, child := range children {
+			if child.command.Process != nil {
+				_ = child.command.Process.Kill()
+			}
+		}
+		for _, child := range children {
+			if child.command.Process != nil {
+				_ = child.command.Wait()
+			}
+		}
+	})
 	for i := 0; i < writers; i++ {
-		command := exec.Command(
+		command := exec.CommandContext(
+			ctx,
 			executable,
 			"-test.run", "^TestTmuxCompatStoreConcurrentProcessMutations$",
 		)
 		command.Env = childEnvironment(home, i)
+		stderr := &bytes.Buffer{}
+		command.Stderr = stderr
 		if err := command.Start(); err != nil {
 			t.Fatalf("start child %d: %v", i, err)
 		}
-		commands = append(commands, command)
+		children = append(children, childProcess{command: command, stderr: stderr})
 	}
-	for i, command := range commands {
-		if err := command.Wait(); err != nil {
-			t.Fatalf("child %d: %v", i, err)
+	for i, child := range children {
+		if err := child.command.Wait(); err != nil {
+			t.Fatalf("child %d: %v\n%s", i, err, child.stderr.String())
 		}
 	}
 

--- a/daemon/remote/go.mod
+++ b/daemon/remote/go.mod
@@ -6,3 +6,5 @@ require (
 	github.com/creack/pty v1.1.24
 	nhooyr.io/websocket v1.8.17
 )
+
+require golang.org/x/sys v0.30.0

--- a/daemon/remote/go.mod
+++ b/daemon/remote/go.mod
@@ -4,7 +4,6 @@ go 1.22
 
 require (
 	github.com/creack/pty v1.1.24
+	golang.org/x/sys v0.30.0
 	nhooyr.io/websocket v1.8.17
 )
-
-require golang.org/x/sys v0.30.0

--- a/daemon/remote/go.sum
+++ b/daemon/remote/go.sum
@@ -1,4 +1,6 @@
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
+golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
+golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 nhooyr.io/websocket v1.8.17 h1:KEVeLJkUywCKVsnLIDlD/5gtayKp8VoCkksHCGGfT9Y=
 nhooyr.io/websocket v1.8.17/go.mod h1:rN9OFWIUwuxg4fR5tELlYC04bXYowCP9GX47ivo2l+c=


### PR DESCRIPTION
Closes https://github.com/manaflow-ai/cmux/issues/11262

The tmux-compatible JSON store currently performs unlocked read-modify-write operations, so concurrent set-buffer processes can overwrite each other. This PR adds a regression test that launches 20 concurrent CLI writers; the follow-up commit serializes all store mutations with an inter-process lock.

The first commit intentionally contains only the regression test so CI can prove it catches the bug.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790815398&installation_model_id=21920&pr_number=11291&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11291&signature=1b28ea925226a371340179f62157a9113dc13fcf9942cae9cb0b64d47df755cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes #11262. Fixes data loss from concurrent `set-buffer` writes by serializing all tmux-compat store mutations with an inter-process `flock`-based lock in both the Swift CLI and the Go daemon. Previously, concurrent writers overwrote each other during unlocked read-modify-write operations.

- Adds regression tests that launch 20 concurrent writers against the CLI and daemon store paths; the CLI test seeds the store and uses a short Unix socket path to stay within macOS `sockaddr_un` limits.
- Store mutations run under the lock and atomically replace the JSON file.
- Stale-layout cleanup only removes state when the stored layout still matches the observed snapshot; the CLI resolves replacement-pane surfaces before locking and retries from a fresh snapshot, surfacing an error if the layout keeps changing.
- Malformed store files are preserved and a missing store on first use loads empty so initial mutations aren't lost; load errors surface instead of resetting the store to empty, and the daemon validates the store before `split-window` so a failed layout write rolls back the created pane.
- Store paths are validated via descriptor-relative operations that reject symlinks and non-regular files; store files and directories are tightened to owner-only permissions, including pre-existing stores and on read-only loads.

<sup>Written for commit 7bcfcd1973bc4b734c95e3f7053cb21a2c3788aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tmux compatibility state handling when multiple commands run concurrently.
  * Prevented updates from being lost during simultaneous buffer, hook, layout, and pane operations.
  * Added safer handling for stale layout information and changing pane arrangements.
  * Improved persistence reliability through atomic saves and compatibility with existing stored state.
  * Preserved malformed saved state when updates cannot be safely applied.

* **Tests**
  * Added coverage for concurrent updates from multiple threads, processes, and CLI commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->