### PR TITLE
security: pin Claude action to reviewed release

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,10 +34,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          # These events can carry pull-request content. Keep the workspace on
-          # the trusted default branch; never place an untrusted PR checkout at
-          # the workspace root before the secret-bearing action.
-          ref: ${{ github.event.repository.default_branch }}
+          # Leave the ref unset. GitHub checks out the trusted base/default
+          # ref for these events, and the action then fetches the PR branch
+          # itself after validating the actor and restoring protected config.
           fetch-depth: 1
           persist-credentials: false
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,6 +26,9 @@ jobs:
       contents: read
       pull-requests: read
       issues: read
+      # The action exchanges a short-lived OIDC token for its scoped GitHub
+      # App token, even when Claude authentication uses OAuth.
+      id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -15,9 +15,10 @@ on:
 permissions: {}
 
 concurrency:
-  # Cancel webhook retries by event ID while keeping separate user requests
-  # independent. Issue events use the unique run ID as a fallback.
-  group: claude-${{ github.repository }}-${{ github.event.comment.id || github.event.review.id || github.run_id }}
+  # Cancel webhook retries by their payload identity while keeping separate
+  # user requests independent. Issue events have no delivery ID, so combine
+  # the issue ID, action, and update timestamp for a stable event key.
+  group: claude-${{ github.repository }}-${{ github.event.comment.id || github.event.review.id || format('{0}-{1}-{2}', github.event.issue.id, github.event.action, github.event.issue.updated_at) }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,21 +18,32 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    timeout-minutes: 15
     permissions:
       contents: read
       pull-requests: read
       issues: read
-      id-token: write
       actions: read # Required for Claude to read CI results on PRs
+    # Limit duplicate requests for one issue or pull request. The action also
+    # rejects actors without repository write access before it invokes Claude,
+    # so public comments cannot spend the OAuth credential.
+    concurrency:
+      group: claude-${{ github.repository }}-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
+      cancel-in-progress: false
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          # These events can carry pull-request content. Keep the workspace on
+          # the trusted default branch; never place an untrusted PR checkout at
+          # the workspace root before the secret-bearing action.
+          ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@833fb0f8c9f6686b33d963a8bae0a94f4936ab2a # v1.0.211
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
@@ -47,4 +58,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,9 +31,20 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          # Leave the ref unset. GitHub checks out the trusted base/default
-          # ref for these events, and the action then fetches the PR branch
-          # itself after validating the actor and restoring protected config.
+          # Review events otherwise default to the PR merge ref. Pin the root
+          # workspace to the trusted base before the secret-bearing action.
+          # The action fetches the PR only after its actor check and restores
+          # protected configuration paths from this base.
+          ref: ${{ github.event.pull_request.base.sha || github.event.repository.default_branch }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Checkout pull request files for review
+        if: github.event_name == 'pull_request_review' || github.event_name == 'pull_request_review_comment'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: pr-head
           fetch-depth: 1
           persist-credentials: false
 
@@ -42,6 +53,8 @@ jobs:
         uses: anthropics/claude-code-action@833fb0f8c9f6686b33d963a8bae0a94f4936ab2a # v1.0.211
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: >-
+            ${{ (github.event_name == 'pull_request_review' || github.event_name == 'pull_request_review_comment') && '--add-dir pr-head' || '' }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,14 +34,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          # The pinned action validates the actor before restoring protected
-          # Claude configuration paths from the PR base.
+          # Review events otherwise default to the PR merge ref. Pin the
+          # workspace to the immutable base commit before the secret-bearing
+          # action runs. The action fetches the PR only after its actor check
+          # and restores protected configuration paths from the base.
+          # Keep the checkout credential for that authenticated fetch; the
+          # action removes it before Claude starts.
+          ref: ${{ github.event.pull_request.base.sha || github.event.repository.default_branch }}
           fetch-depth: 1
-          persist-credentials: false
+          persist-credentials: true
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@833fb0f8c9f6686b33d963a8bae0a94f4936ab2a # v1.0.211
+        uses: anthropics/claude-code-action@781d62e9d5fbd78b24dcdfd42858332d485fe462 # v1.0.212
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,8 +10,19 @@ on:
   pull_request_review:
     types: [submitted]
 
+# Do not inherit repository-level token scopes. The job grants only the
+# read permissions and OIDC exchange it needs.
+permissions: {}
+
+concurrency:
+  # Deduplicate webhook retries by event ID while keeping separate user
+  # requests independent. Issue events use the unique run ID as a fallback.
+  group: claude-${{ github.repository }}-${{ github.event.comment.id || github.event.review.id || github.run_id }}
+  cancel-in-progress: false
+
 jobs:
   claude:
+    name: Claude request
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
@@ -19,17 +30,14 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 15
-    # Do not coalesce requests here. GitHub keeps only one pending run in a
-    # concurrency group and would silently discard a distinct user request.
+    # The workflow-level group only deduplicates webhook retries by event ID.
     # The pinned action checks repository write access before it invokes Claude.
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
-      # The action exchanges a short-lived OIDC token for its scoped GitHub
-      # App token, even when Claude authentication uses OAuth.
-      id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      contents: read # Read the checked-out base and PR files.
+      pull-requests: read # Read PR metadata and review requests.
+      issues: read # Read issue comments and issue-trigger payloads.
+      id-token: write # Exchange a short-lived token for the scoped GitHub App token.
+      actions: read # Read CI results on pull requests.
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,20 +34,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          # Review events otherwise default to the PR merge ref. Pin the root
-          # workspace to the trusted base before the secret-bearing action.
-          # The action fetches the PR only after its actor check and restores
-          # protected configuration paths from this base.
-          ref: ${{ github.event.pull_request.base.sha || github.event.repository.default_branch }}
-          fetch-depth: 1
-          persist-credentials: false
-
-      - name: Checkout pull request files for review
-        if: github.event_name == 'pull_request_review' || github.event_name == 'pull_request_review_comment'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          path: pr-head
+          # The pinned action validates the actor before restoring protected
+          # Claude configuration paths from the PR base.
           fetch-depth: 1
           persist-credentials: false
 
@@ -56,8 +44,6 @@ jobs:
         uses: anthropics/claude-code-action@833fb0f8c9f6686b33d963a8bae0a94f4936ab2a # v1.0.211
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: >-
-            ${{ (github.event_name == 'pull_request_review' || github.event_name == 'pull_request_review_comment') && '--add-dir pr-head' || '' }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -15,10 +15,10 @@ on:
 permissions: {}
 
 concurrency:
-  # Deduplicate webhook retries by event ID while keeping separate user
-  # requests independent. Issue events use the unique run ID as a fallback.
+  # Cancel webhook retries by event ID while keeping separate user requests
+  # independent. Issue events use the unique run ID as a fallback.
   group: claude-${{ github.repository }}-${{ github.event.comment.id || github.event.review.id || github.run_id }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   claude:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,17 +19,14 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 15
+    # Do not coalesce requests here. GitHub keeps only one pending run in a
+    # concurrency group and would silently discard a distinct user request.
+    # The pinned action checks repository write access before it invokes Claude.
     permissions:
       contents: read
       pull-requests: read
       issues: read
       actions: read # Required for Claude to read CI results on PRs
-    # Limit duplicate requests for one issue or pull request. The action also
-    # rejects actors without repository write access before it invokes Claude,
-    # so public comments cannot spend the OAuth credential.
-    concurrency:
-      group: claude-${{ github.repository }}-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
-      cancel-in-progress: false
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -15,10 +15,10 @@ on:
 permissions: {}
 
 concurrency:
-  # Cancel webhook retries by their payload identity while keeping separate
-  # user requests independent. Issue events have no delivery ID, so combine
-  # the issue ID, action, and update timestamp for a stable event key.
-  group: claude-${{ github.repository }}-${{ github.event.comment.id || github.event.review.id || format('{0}-{1}-{2}', github.event.issue.id, github.event.action, github.event.issue.updated_at) }}
+  # Cancel webhook retries by immutable comment or review ID. GitHub issue
+  # events do not expose a delivery ID, so keep each issue event independent
+  # rather than risking cancellation of a legitimate request.
+  group: claude-${{ github.repository }}-${{ github.event.comment.id || github.event.review.id || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Security hardening for the Claude workflow.

Changes:
- Pin anthropics/claude-code-action v1.0.212 to 781d62e9d5fbd78b24dcdfd42858332d485fe462.
- Pin checkout to v6.0.2.
- Use the immutable pull request base SHA for review-event checkout.
- Keep checkout credentials only for the authenticated branch fetch, then remove them before Claude runs.
- Restore id-token: write for the action OIDC exchange.
- Set empty top-level permissions and explicit least-privilege job permissions.
- Add a 15-minute timeout.
- Deduplicate webhook retries with stable comment, review, and issue event keys.

Verification:
- Exact local autoreview is clean at the current head.
- cmux policy review, actionlint, offline zizmor pedantic audit, diff check, and self-hosted-runner guard pass.
- Hosted CLA, Testbox, Socket, and CodeRabbit checks pass.

Known residuals:
- The third-party action intentionally processes selected pull request files after its actor check. Sensitive paths are restored, and pull request hooks do not run before the action starts.
- The Blacksmith runner variable remains trusted infrastructure and must stay restricted to ephemeral runners.
- OIDC remains required by the action authentication flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automation workflow safety by restricting default permissions and pinning the checkout and Claude action versions.
  * Added safeguards to cancel duplicate runs and limit workflow execution time.
  * Clarified workflow permission and credential-handling behavior with comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->