### PR TITLE
blaxel image: bump agent and cua-driver pins to latest

### DIFF
--- a/web/services/vms/images/blaxel/Dockerfile
+++ b/web/services/vms/images/blaxel/Dockerfile
@@ -22,7 +22,7 @@
 FROM debian:trixie-slim
 
 # Cache-buster: bump to force a full rebuild on Blaxel's builder.
-ENV CMUX_IMAGE_EPOCH=2026-08-31-r11
+ENV CMUX_IMAGE_EPOCH=2026-08-31-r12
 
 # Blaxel's sandbox API binary is mandatory in every custom image: it is the control
 # plane (port 8080) the driver uses for filesystem and process operations.
@@ -155,17 +155,17 @@ RUN mkdir -p /etc/cmux/icons \
 # cua computer-use driver, pinned.
 ENV CUA_DRIVER_RS_HOME=/opt/cua-driver
 RUN curl -fsSL https://cua.ai/driver/install.sh -o /tmp/cua-install.sh \
-  && CUA_DRIVER_RS_VERSION=0.19.3 CUA_DRIVER_BIN_DIR=/usr/local/bin CUA_DRIVER_NO_MODIFY_PATH=1 bash /tmp/cua-install.sh \
+  && CUA_DRIVER_RS_VERSION=0.23.2 CUA_DRIVER_BIN_DIR=/usr/local/bin CUA_DRIVER_NO_MODIFY_PATH=1 bash /tmp/cua-install.sh \
   && rm -f /tmp/cua-install.sh \
   && ls /usr/local/bin | grep -qi cua
 
 # Coding agents, pinned at bake time (bump with the image epoch). Installed on the
 # mise node so they ride the same toolchain users get.
-ARG CMUX_IMAGE_CLAUDE_CODE_VERSION=2.1.246
-ARG CMUX_IMAGE_CODEX_VERSION=0.150.0
-ARG CMUX_IMAGE_OPENCODE_VERSION=1.18.23
-ARG CMUX_IMAGE_PI_VERSION=0.84.3
-ARG CMUX_IMAGE_AGENT_BROWSER_VERSION=0.35.1
+ARG CMUX_IMAGE_CLAUDE_CODE_VERSION=2.1.252
+ARG CMUX_IMAGE_CODEX_VERSION=0.151.0
+ARG CMUX_IMAGE_OPENCODE_VERSION=1.18.25
+ARG CMUX_IMAGE_PI_VERSION=0.84.4
+ARG CMUX_IMAGE_AGENT_BROWSER_VERSION=0.35.2
 RUN npm install -g --foreground-scripts \
     "@anthropic-ai/claude-code@${CMUX_IMAGE_CLAUDE_CODE_VERSION}" \
     "@openai/codex@${CMUX_IMAGE_CODEX_VERSION}" \


### PR DESCRIPTION
Pins to current latest, verified against npm and GitHub releases today: claude-code 2.1.252, codex 0.151.0, opencode-ai 1.18.25, pi 0.84.4, agent-browser 0.35.2, cua-driver-rs 0.23.2 (was 0.19.3; install contract unchanged upstream). Ghostty 1.3.1-0.ppa2 is still the newest trixie deb. ble.sh nightly, mise toolchains, Chrome, and sandbox-api resolve to latest at bake. Epoch 2026-08-31-r12, already baked to sandbox/cmux-devbox:latest and live-verified in a sandbox (all versions confirmed). Devbox Dockerfile parity bump is a flagged follow-up. vm-blaxel-image tests green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790816034&installation_model_id=21920&pr_number=11293&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11293&signature=ff177870693d79d4ca2b5028b35441951c6dd8cb8c735274ff391e84674750b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the pinned `claude-code`, `codex`, `opencode`, `pi`, `agent-browser`, and `cua-driver` versions in the Blaxel image to their latest releases and bumps the image epoch to force a rebuild. The new versions were verified against upstream releases; the `cua-driver` install contract is unchanged despite the jump from 0.19.3 to 0.23.2.

- Pins `claude-code` 2.1.252, `codex` 0.151.0, `opencode` 1.18.25, `pi` 0.84.4, `agent-browser` 0.35.2, and `cua-driver` 0.23.2.
- `Ghostty` stays at the newest trixie deb; `ble.sh`, mise toolchains, Chrome, and sandbox-api resolve to latest at bake.
- The image is baked and live-verified in a sandbox; devbox Dockerfile parity is a flagged follow-up.

<sup>Written for commit 5ca8111428709e4a44c22b3dc5869dc44c658976. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the computer-use driver and coding-agent tools to newer versions.
  * Refreshed the application image cache to ensure the latest packaged tools are used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->