### PR TITLE
billing: Cloud VM usage metering foundation

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -45,6 +45,9 @@ STRIPE_PRO_YEARLY_PRICE_ID=
 STRIPE_PRO_YEARLY_288_PRICE_ID=
 STRIPE_TEAM_MONTHLY_PRICE_ID=
 STRIPE_TEAM_YEARLY_PRICE_ID=
+# Set to 1 only after the `cmux_vm_active_compute_hours` Stripe meter and its
+# Last-aggregation price are provisioned and the usage reporter is verified.
+STRIPE_USAGE_REPORTING=0
 # Optional local app checkout relay. Only loopback requests can preserve tagged
 # callback schemes. Source and destination must share the 32+ character secret.
 CMUX_APP_PRICING_CHECKOUT_URL=

--- a/web/app/api/billing/plan/route.ts
+++ b/web/app/api/billing/plan/route.ts
@@ -11,10 +11,13 @@ import {
 } from "../../../../services/billing/pro";
 import {
   resolveBillingTeam,
-  type BillingTeamUserLike,
+  type BillingTeamLike,
 } from "../../../../services/billing/teamResolution";
+import {
+  emptyVmUsageStatus,
+  getVmUsageStatus,
+} from "../../../../services/billing/vmUsage";
 import { authProviderErrorResponse } from "../../../../services/vms/authErrors";
-
 
 const ANONYMOUS_IF_EXISTS = "anonymous-if-exists[deprecated]" as const;
 
@@ -28,6 +31,7 @@ export async function GET(request: NextRequest) {
       billingManagement: "none",
       teamPlanId: FREE_PLAN_ID,
       teamBillingManagement: "none",
+      vmUsage: emptyVmUsageStatus(),
       user: null,
     });
   }
@@ -62,12 +66,21 @@ export async function GET(request: NextRequest) {
       billingManagement: "none",
       teamPlanId: FREE_PLAN_ID,
       teamBillingManagement: "none",
+      vmUsage: emptyVmUsageStatus(),
       user: null,
     });
   }
 
   const status = await resolveProPlanStatus(user);
-  const teamStatus = await resolveTeamPlanStatus(user);
+  const billingTeam = await resolveBillingTeam(user);
+  const teamStatus = await resolveTeamPlanStatus(billingTeam);
+  const vmUsage = user.isAnonymous
+    ? emptyVmUsageStatus()
+    : await getVmUsageStatus({
+      userId: user.id,
+      billingTeamId: billingTeam?.id,
+      isPro: status.isPro,
+    });
   return jsonResponse({
     authenticated: !user.isAnonymous,
     billingAvailable,
@@ -78,6 +91,7 @@ export async function GET(request: NextRequest) {
     teamBillingManagement: teamStatus.billingManagement,
     metadataChanged: status.metadataChanged,
     hasManualVmPlanOverride: status.hasManualVmPlanOverride,
+    vmUsage,
     user: {
       id: user.id,
       displayName: user.displayName,
@@ -91,8 +105,7 @@ type TeamPlanStatus = {
   readonly billingManagement: BillingManagementKind;
 };
 
-async function resolveTeamPlanStatus(user: BillingTeamUserLike): Promise<TeamPlanStatus> {
-  const team = await resolveBillingTeam(user);
+async function resolveTeamPlanStatus(team: BillingTeamLike | null): Promise<TeamPlanStatus> {
   if (!team?.id) {
     return { planId: FREE_PLAN_ID, billingManagement: "none" };
   }

--- a/web/app/api/cron/vm-usage/route.ts
+++ b/web/app/api/cron/vm-usage/route.ts
@@ -1,0 +1,34 @@
+import { reportVmUsageForActiveSubscriptions } from "../../../../services/billing/vmUsageReporting";
+import { captureCoderouterError } from "../../../../services/errors";
+
+export const maxDuration = 60;
+
+export async function GET(request: Request): Promise<Response> {
+  const secret = process.env.CRON_SECRET?.trim();
+  if (!secret || request.headers.get("authorization") !== `Bearer ${secret}`) {
+    return Response.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const result = await reportVmUsageForActiveSubscriptions();
+    return Response.json({ ok: result.failed === 0, ...result }, {
+      status: result.failed === 0 ? 200 : 503,
+    });
+  } catch (error) {
+    captureCoderouterError(error, {
+      operation: "vm_usage_reporting_cron",
+      recoverable: true,
+    });
+    return Response.json(
+      {
+        error: "vm_usage_reporting_failed",
+        message: "VM usage reporting failed; retry the cron run.",
+        retryable: true,
+      },
+      {
+        status: 503,
+        headers: { "Retry-After": "60" },
+      },
+    );
+  }
+}

--- a/web/app/env.ts
+++ b/web/app/env.ts
@@ -209,6 +209,9 @@ export const env = createEnv({
     STRIPE_PRO_YEARLY_288_PRICE_ID: z.string().min(1).optional(),
     STRIPE_TEAM_MONTHLY_PRICE_ID: z.string().min(1).optional(),
     STRIPE_TEAM_YEARLY_PRICE_ID: z.string().min(1).optional(),
+    // VM overage usage records are opt-in until the metered Stripe price is
+    // provisioned and verified in production.
+    STRIPE_USAGE_REPORTING: z.enum(["0", "1"]).optional(),
     CMUX_APP_PRICING_CHECKOUT_URL: z.string().url().optional(),
     CMUX_APP_PRICING_RELAY_SECRET: z.string().min(32).optional(),
     // App Store Connect API for server-side TestFlight enrollment. Optional:
@@ -378,6 +381,7 @@ export const env = createEnv({
     ),
     STRIPE_TEAM_MONTHLY_PRICE_ID: trimEnv(process.env.STRIPE_TEAM_MONTHLY_PRICE_ID),
     STRIPE_TEAM_YEARLY_PRICE_ID: trimEnv(process.env.STRIPE_TEAM_YEARLY_PRICE_ID),
+    STRIPE_USAGE_REPORTING: trimEnv(process.env.STRIPE_USAGE_REPORTING),
     CMUX_APP_PRICING_CHECKOUT_URL: trimEnv(
       process.env.CMUX_APP_PRICING_CHECKOUT_URL,
     ),

--- a/web/db/migrations/20260831000000_cloud_vm_usage_metering/migration.sql
+++ b/web/db/migrations/20260831000000_cloud_vm_usage_metering/migration.sql
@@ -1,0 +1,47 @@
+CREATE TABLE IF NOT EXISTS "cloud_vm_state_transitions" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "vm_id" uuid NOT NULL,
+  "billing_team_id" text NOT NULL,
+  "from_state" text NOT NULL,
+  "to_state" text NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+DO $$
+BEGIN
+  ALTER TABLE "cloud_vm_state_transitions"
+    ADD CONSTRAINT "cloud_vm_state_transitions_vm_id_cloud_vms_id_fk"
+    FOREIGN KEY ("vm_id") REFERENCES "cloud_vms"("id")
+    ON DELETE CASCADE ON UPDATE NO ACTION;
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Existing rows have no transition history. Establish a non-retroactive
+-- baseline so a running VM starts accruing usage when this ledger is applied,
+-- while unknown time before the migration is never billed.
+INSERT INTO "cloud_vm_state_transitions" (
+  "vm_id",
+  "billing_team_id",
+  "from_state",
+  "to_state",
+  "created_at"
+)
+SELECT
+  "cloud_vms"."id",
+  COALESCE("cloud_vms"."billing_team_id", "cloud_vms"."user_id"),
+  'migration',
+  "cloud_vms"."status"::text,
+  CURRENT_TIMESTAMP
+FROM "cloud_vms"
+WHERE "cloud_vms"."status" <> 'destroyed'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM "cloud_vm_state_transitions" AS existing
+    WHERE existing."vm_id" = "cloud_vms"."id"
+  );
+
+CREATE INDEX IF NOT EXISTS "cloud_vm_state_transitions_team_created_idx"
+  ON "cloud_vm_state_transitions" USING btree ("billing_team_id", "created_at");
+CREATE INDEX IF NOT EXISTS "cloud_vm_state_transitions_vm_created_idx"
+  ON "cloud_vm_state_transitions" USING btree ("vm_id", "created_at");

--- a/web/db/schema.ts
+++ b/web/db/schema.ts
@@ -289,6 +289,30 @@ export const cloudVmUsageEvents = pgTable(
   ],
 );
 
+/**
+ * Immutable VM lifecycle transitions.  These rows are the billing ledger;
+ * cloud_vm_usage_events remains the broader audit/telemetry stream.
+ */
+export const cloudVmStateTransitions = pgTable(
+  "cloud_vm_state_transitions",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    vmId: uuid("vm_id")
+      .notNull()
+      .references(() => cloudVms.id, { onDelete: "cascade" }),
+    // VMs created before team billing was added can have a null billing team.
+    // Repository writes normalize those rows to the owning user id.
+    billingTeamId: text("billing_team_id").notNull(),
+    fromState: text("from_state").notNull(),
+    toState: text("to_state").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("cloud_vm_state_transitions_team_created_idx").on(table.billingTeamId, table.createdAt),
+    index("cloud_vm_state_transitions_vm_created_idx").on(table.vmId, table.createdAt),
+  ],
+);
+
 export const cloudVmBases = pgTable(
   "cloud_vm_bases",
   {

--- a/web/services/billing/vmUsage.ts
+++ b/web/services/billing/vmUsage.ts
@@ -1,0 +1,215 @@
+import { and, eq, inArray } from "drizzle-orm";
+
+import { cloudDb } from "../../db/client";
+import { stripeSubscriptions } from "../../db/schema";
+import {
+  ACTIVE_STRIPE_PRO_STATUSES,
+  PRO_PLAN_ID,
+  TEAM_PLAN_ID,
+} from "./pro";
+import {
+  getTeamActiveComputeHours,
+  type BillingPeriod,
+} from "../vms/usage";
+import { billingPeriodThrough } from "../vms/usageMath";
+export { billingPeriodThrough } from "../vms/usageMath";
+
+/** The allowance currently sold for the Pro plan. */
+export const PRO_INCLUDED_COMPUTE_HOURS = 20;
+
+export type VmUsageStatus = {
+  readonly billingTeamId: string | null;
+  readonly periodStart: string;
+  readonly periodEnd: string;
+  readonly activeComputeHours: number;
+  readonly includedComputeHours: number;
+  readonly overageComputeHours: number;
+};
+
+type UsageSubscription = {
+  readonly currentPeriodEnd: Date | null;
+  readonly raw: unknown;
+};
+
+/**
+ * Returns the current Stripe period when the webhook stored complete period
+ * data. Older rows fall back to the UTC calendar month until they renew.
+ */
+export function resolveVmBillingPeriod(input: {
+  readonly now?: Date;
+  readonly currentPeriodEnd?: Date | null;
+  readonly raw?: unknown;
+}): BillingPeriod {
+  const now = validDate(input.now) ? input.now! : new Date();
+  const raw = record(input.raw);
+  const items = record(raw?.items);
+  const itemData = items?.data;
+  const firstItem = Array.isArray(itemData) ? record(itemData[0]) : null;
+  const start = periodDate(raw?.current_period_start) ?? periodDate(firstItem?.current_period_start);
+  const end = periodDate(raw?.current_period_end) ??
+    periodDate(firstItem?.current_period_end) ??
+    (validDate(input.currentPeriodEnd) ? input.currentPeriodEnd : null);
+  if (start && end && end.getTime() > start.getTime()) {
+    return { start, end };
+  }
+
+  return utcCalendarMonth(now);
+}
+
+export function emptyVmUsageStatus(input: {
+  readonly now?: Date;
+  readonly billingTeamId?: string | null;
+  readonly includedComputeHours?: number;
+  readonly period?: BillingPeriod;
+} = {}): VmUsageStatus {
+  const period = input.period ?? utcCalendarMonth(validDate(input.now) ? input.now! : new Date());
+  const includedComputeHours = finiteNonNegative(input.includedComputeHours ?? 0);
+  return {
+    billingTeamId: input.billingTeamId?.trim() || null,
+    periodStart: period.start.toISOString(),
+    periodEnd: period.end.toISOString(),
+    activeComputeHours: 0,
+    includedComputeHours,
+    overageComputeHours: 0,
+  };
+}
+
+/** Loads the usage scope used by the existing billing plan endpoint. */
+export async function getVmUsageStatus(input: {
+  readonly userId: string;
+  readonly billingTeamId?: string | null;
+  readonly isPro: boolean;
+  readonly now?: Date;
+}): Promise<VmUsageStatus> {
+  const billingTeamId = input.billingTeamId?.trim() || input.userId;
+  const includedComputeHours = input.isPro ? PRO_INCLUDED_COMPUTE_HOURS : 0;
+  const now = validDate(input.now) ? input.now! : new Date();
+  let period = utcCalendarMonth(now);
+
+  try {
+    const subscription = await loadUsageSubscription({
+      userId: input.userId,
+      billingTeamId: input.billingTeamId,
+    });
+    period = resolveVmBillingPeriod({
+      now,
+      currentPeriodEnd: subscription?.currentPeriodEnd,
+      raw: subscription?.raw,
+    });
+    const usagePeriod = billingPeriodThrough(period, now);
+    const activeComputeHours = usagePeriod
+      ? await getTeamActiveComputeHours({ billingTeamId, period: usagePeriod })
+      : 0;
+    const overageComputeHours = Math.max(0, activeComputeHours - includedComputeHours);
+    return {
+      billingTeamId,
+      periodStart: period.start.toISOString(),
+      periodEnd: period.end.toISOString(),
+      activeComputeHours,
+      includedComputeHours,
+      overageComputeHours: roundHours(overageComputeHours),
+    };
+  } catch (error) {
+    // A rolling deployment can briefly run before the new table exists. Keep
+    // the existing entitlement response available and show zero usage until
+    // the migration is applied. Other database failures remain visible.
+    if (isUsageDatabaseUnavailable(error)) {
+      return emptyVmUsageStatus({
+        now,
+        billingTeamId,
+        includedComputeHours,
+        period,
+      });
+    }
+    throw error;
+  }
+}
+
+async function loadUsageSubscription(input: {
+  readonly userId: string;
+  readonly billingTeamId?: string | null;
+}): Promise<UsageSubscription | null> {
+  const teamId = input.billingTeamId?.trim();
+  if (teamId && teamId !== input.userId) {
+    const teamSubscription = await loadUsageSubscriptionForScope(and(
+      eq(stripeSubscriptions.stackTeamId, teamId),
+      eq(stripeSubscriptions.scope, "team"),
+      eq(stripeSubscriptions.plan, TEAM_PLAN_ID),
+    ));
+    if (teamSubscription) return teamSubscription;
+  }
+
+  // Stack personal teams own VM rows even when Stripe owns the Pro
+  // subscription at user scope. Use that user subscription's billing period
+  // when the selected team has no Team subscription of its own.
+  return loadUsageSubscriptionForScope(and(
+    eq(stripeSubscriptions.stackUserId, input.userId),
+    eq(stripeSubscriptions.scope, "user"),
+    eq(stripeSubscriptions.plan, PRO_PLAN_ID),
+  ));
+}
+
+async function loadUsageSubscriptionForScope(
+  scope: ReturnType<typeof and>,
+): Promise<UsageSubscription | null> {
+  const [row] = await cloudDb()
+    .select({
+      currentPeriodEnd: stripeSubscriptions.currentPeriodEnd,
+      raw: stripeSubscriptions.raw,
+    })
+    .from(stripeSubscriptions)
+    .where(and(scope, inArray(stripeSubscriptions.status, ACTIVE_STRIPE_PRO_STATUSES)))
+    .limit(1);
+  return row ?? null;
+}
+
+function utcCalendarMonth(now: Date): BillingPeriod {
+  const year = now.getUTCFullYear();
+  const month = now.getUTCMonth();
+  return {
+    start: new Date(Date.UTC(year, month, 1)),
+    end: new Date(Date.UTC(year, month + 1, 1)),
+  };
+}
+
+function periodDate(value: unknown): Date | null {
+  if (value instanceof Date) return validDate(value) ? value : null;
+  if (typeof value === "number" || typeof value === "string") {
+    const text = String(value).trim();
+    if (!text) return null;
+    const numeric = Number(text);
+    if (Number.isFinite(numeric) && numeric > 0) {
+      const epoch = new Date(numeric * 1_000);
+      return validDate(epoch) ? epoch : null;
+    }
+    const parsed = new Date(text);
+    return validDate(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function validDate(value: Date | null | undefined): value is Date {
+  return value instanceof Date && Number.isFinite(value.getTime());
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function finiteNonNegative(value: number): number {
+  return Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+function roundHours(value: number): number {
+  return Math.round(value * 1_000_000) / 1_000_000;
+}
+
+function isUsageDatabaseUnavailable(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const candidate = error as { readonly code?: unknown; readonly message?: unknown; readonly cause?: unknown };
+  if (candidate.code === "42P01") return true;
+  if (candidate.cause && isUsageDatabaseUnavailable(candidate.cause)) return true;
+  return typeof candidate.message === "string" && /DATABASE_URL|database config|cloud_vm_state_transitions/i.test(candidate.message);
+}

--- a/web/services/billing/vmUsageReporting.ts
+++ b/web/services/billing/vmUsageReporting.ts
@@ -1,0 +1,269 @@
+import { and, eq, inArray } from "drizzle-orm";
+
+import { cloudDb } from "../../db/client";
+import { stripeSubscriptions } from "../../db/schema";
+import {
+  ACTIVE_STRIPE_PRO_STATUSES,
+  PRO_PLAN_ID,
+} from "./pro";
+import { stripe, isStripeBillingConfigured } from "./stripe";
+import {
+  billingPeriodThrough,
+  PRO_INCLUDED_COMPUTE_HOURS,
+  resolveVmBillingPeriod,
+} from "./vmUsage";
+import { getUserPlanActiveComputeHours } from "../vms/usage";
+
+const DEFAULT_REPORT_LIMIT = 1_000;
+const DEFAULT_REPORT_CONCURRENCY = 8;
+
+export type StripeUsageClient = {
+  readonly billing: {
+    readonly meterEvents: {
+      readonly create: (params: {
+        readonly event_name: string;
+        readonly payload: {
+          readonly stripe_customer_id: string;
+          readonly value: string;
+        };
+        readonly identifier: string;
+        readonly timestamp: number;
+      }) => Promise<unknown>;
+    };
+  };
+};
+
+export type VmUsageSubscription = {
+  readonly id: string;
+  readonly customerId: string;
+  readonly stackUserId: string;
+  readonly stackTeamId: string | null;
+  readonly scope: string;
+  readonly plan: string;
+  readonly currentPeriodEnd: Date | null;
+  readonly raw: unknown;
+};
+
+export type VmUsageReportResult = {
+  readonly status:
+    | "disabled"
+    | "unsupported_subscription"
+    | "no_overage"
+    | "not_configured"
+    | "reported";
+  readonly subscriptionId?: string;
+  readonly billingTeamId?: string;
+  readonly activeComputeHours?: number;
+  readonly overageComputeHours?: number;
+  readonly quantity?: number;
+};
+
+export type VmUsageBatchReportResult = {
+  readonly enabled: boolean;
+  readonly checked: number;
+  readonly reported: number;
+  readonly skipped: number;
+  readonly failed: number;
+};
+
+/** Stripe must provision a meter with this event name and Last aggregation. */
+export const VM_USAGE_METER_EVENT_NAME = "cmux_vm_active_compute_hours";
+
+/** The rollout switch is deliberately strict and defaults to disabled. */
+export function isStripeUsageReportingEnabled(
+  environment: Record<string, string | undefined> = process.env,
+): boolean {
+  return environment.STRIPE_USAGE_REPORTING?.trim() === "1";
+}
+
+export function overageComputeHours(
+  activeComputeHours: number,
+  includedComputeHours = PRO_INCLUDED_COMPUTE_HOURS,
+): number {
+  if (!Number.isFinite(activeComputeHours) || !Number.isFinite(includedComputeHours)) return 0;
+  return roundHours(Math.max(0, activeComputeHours - Math.max(0, includedComputeHours)));
+}
+
+/**
+ * Reports cumulative overage to a Stripe meter that uses Last aggregation.
+ * The deterministic identifier makes an hourly retry idempotent.
+ */
+export async function reportVmUsageForSubscription(
+  subscription: VmUsageSubscription,
+  options: {
+    readonly now?: Date;
+    readonly enabled?: boolean;
+    readonly stripeClient?: StripeUsageClient;
+    readonly activeHours?: number;
+  } = {},
+): Promise<VmUsageReportResult> {
+  if (!(options.enabled ?? isStripeUsageReportingEnabled())) {
+    return { status: "disabled", subscriptionId: subscription.id };
+  }
+  if (subscription.scope !== "user" || subscription.plan !== PRO_PLAN_ID) {
+    return {
+      status: "unsupported_subscription",
+      subscriptionId: subscription.id,
+    };
+  }
+
+  const now = validDate(options.now) ? options.now! : new Date();
+  const billingTeamId = subscription.stackTeamId?.trim() || subscription.stackUserId;
+  const period = resolveVmBillingPeriod({
+    now,
+    currentPeriodEnd: subscription.currentPeriodEnd,
+    raw: subscription.raw,
+  });
+  const usagePeriod = billingPeriodThrough(period, now);
+  const activeComputeHours = options.activeHours ?? (usagePeriod
+    ? await getUserPlanActiveComputeHours({
+      userId: subscription.stackUserId,
+      billingPlanId: PRO_PLAN_ID,
+      period: usagePeriod,
+    })
+    : 0);
+  const overageComputeHoursValue = overageComputeHours(activeComputeHours);
+  if (overageComputeHoursValue <= 0) {
+    return {
+      status: "no_overage",
+      subscriptionId: subscription.id,
+      billingTeamId,
+      activeComputeHours,
+      overageComputeHours: 0,
+    };
+  }
+
+  if (!isStripeBillingConfigured() && !options.stripeClient) {
+    return {
+      status: "not_configured",
+      subscriptionId: subscription.id,
+      billingTeamId,
+      activeComputeHours,
+      overageComputeHours: overageComputeHoursValue,
+    };
+  }
+
+  const client = options.stripeClient ?? (stripe() as unknown as StripeUsageClient);
+  const quantity = Math.ceil(overageComputeHoursValue);
+  const timestamp = Math.floor(now.getTime() / 1_000);
+  await client.billing.meterEvents.create({
+    event_name: VM_USAGE_METER_EVENT_NAME,
+    payload: {
+      stripe_customer_id: subscription.customerId,
+      value: String(quantity),
+    },
+    identifier: usageEventIdentifier(subscription.id, period.start, timestamp, quantity),
+    timestamp,
+  });
+  return {
+    status: "reported",
+    subscriptionId: subscription.id,
+    billingTeamId,
+    activeComputeHours,
+    overageComputeHours: overageComputeHoursValue,
+    quantity,
+  };
+}
+
+/** Runs the usage reporter for active personal Pro subscription rows. */
+export async function reportVmUsageForActiveSubscriptions(options: {
+  readonly limit?: number;
+  readonly concurrency?: number;
+  readonly now?: Date;
+  readonly enabled?: boolean;
+  readonly stripeClient?: StripeUsageClient;
+} = {}): Promise<VmUsageBatchReportResult> {
+  const enabled = options.enabled ?? isStripeUsageReportingEnabled();
+  if (!enabled) return { enabled: false, checked: 0, reported: 0, skipped: 0, failed: 0 };
+
+  const limit = boundedInteger(options.limit ?? DEFAULT_REPORT_LIMIT, 1, DEFAULT_REPORT_LIMIT);
+  const rows = await cloudDb()
+    .select({
+      id: stripeSubscriptions.id,
+      customerId: stripeSubscriptions.customerId,
+      stackUserId: stripeSubscriptions.stackUserId,
+      stackTeamId: stripeSubscriptions.stackTeamId,
+      scope: stripeSubscriptions.scope,
+      plan: stripeSubscriptions.plan,
+      currentPeriodEnd: stripeSubscriptions.currentPeriodEnd,
+      raw: stripeSubscriptions.raw,
+    })
+    .from(stripeSubscriptions)
+    .where(and(
+      inArray(stripeSubscriptions.status, ACTIVE_STRIPE_PRO_STATUSES),
+      eq(stripeSubscriptions.scope, "user"),
+      eq(stripeSubscriptions.plan, PRO_PLAN_ID),
+    ))
+    .limit(limit);
+
+  let reported = 0;
+  let skipped = 0;
+  let failed = 0;
+  await mapConcurrent(
+    rows,
+    boundedInteger(
+      options.concurrency ?? DEFAULT_REPORT_CONCURRENCY,
+      1,
+      32,
+    ),
+    async (row) => {
+      try {
+        const result = await reportVmUsageForSubscription(row, {
+          now: options.now,
+          enabled,
+          stripeClient: options.stripeClient,
+        });
+        if (result.status === "reported") reported += 1;
+        else skipped += 1;
+      } catch (error) {
+        failed += 1;
+        console.error("[billing] VM usage report failed", {
+          subscriptionId: row.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    },
+  );
+  return { enabled, checked: rows.length, reported, skipped, failed };
+}
+
+function usageEventIdentifier(
+  subscriptionId: string,
+  periodStart: Date,
+  timestamp: number,
+  quantity: number,
+): string {
+  const periodStartSeconds = Math.floor(periodStart.getTime() / 1_000);
+  const hourBucket = Math.floor(timestamp / 3_600);
+  return `cmux-vm-usage:${subscriptionId}:${periodStartSeconds}:${hourBucket}:${quantity}`;
+}
+
+function roundHours(value: number): number {
+  return Math.round(value * 1_000_000) / 1_000_000;
+}
+
+function validDate(value: Date | null | undefined): value is Date {
+  return value instanceof Date && Number.isFinite(value.getTime());
+}
+
+async function mapConcurrent<T>(
+  values: readonly T[],
+  concurrency: number,
+  visit: (value: T) => Promise<void>,
+): Promise<void> {
+  let next = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, values.length) }, async () => {
+      while (next < values.length) {
+        const index = next;
+        next += 1;
+        await visit(values[index]!);
+      }
+    }),
+  );
+}
+
+function boundedInteger(value: number, minimum: number, maximum: number): number {
+  if (!Number.isFinite(value)) return minimum;
+  return Math.max(minimum, Math.min(maximum, Math.floor(value)));
+}

--- a/web/services/vms/repository.ts
+++ b/web/services/vms/repository.ts
@@ -11,6 +11,7 @@ import {
   cloudVmBillingGrants,
   cloudVmLeases,
   cloudVmSessions,
+  cloudVmStateTransitions,
   cloudVms,
   cloudVmUsageEvents,
 } from "../../db/schema";
@@ -267,6 +268,30 @@ function dbEffect<A>(
 }
 
 type CloudDbTransaction = Parameters<Parameters<ReturnType<typeof cloudDb>["transaction"]>[0]>[0];
+
+async function insertVmStateTransition(
+  tx: CloudDbTransaction,
+  vm: Pick<CloudVmRow, "id" | "userId" | "billingTeamId">,
+  fromState: string,
+  toState: string,
+  createdAt: Date,
+): Promise<void> {
+  if (fromState === toState) return;
+  await tx.insert(cloudVmStateTransitions).values({
+    vmId: vm.id,
+    billingTeamId: vm.billingTeamId ?? vm.userId,
+    fromState,
+    toState,
+    createdAt,
+  });
+}
+
+async function insertVmCreationTransition(
+  tx: CloudDbTransaction,
+  vm: CloudVmRow,
+): Promise<void> {
+  await insertVmStateTransition(tx, vm, "created", vm.status, vm.createdAt);
+}
 
 async function assertAccountVmCreateAllowed(
   tx: CloudDbTransaction,
@@ -538,6 +563,7 @@ export const VmRepositoryLive = Layer.succeed(VmRepository, {
               })
               .returning();
             if (!vm) throw new Error("insert returned no VM row");
+            await insertVmCreationTransition(tx, vm);
             return { inserted: true as const, vm };
           });
         } catch (err) {
@@ -643,6 +669,7 @@ export const VmRepositoryLive = Layer.succeed(VmRepository, {
               })
               .returning();
             if (!vm) throw new Error("insert returned no VM row");
+            await insertVmCreationTransition(tx, vm);
 
             const [base] = existing?.base
               ? await tx
@@ -841,6 +868,7 @@ export const VmRepositoryLive = Layer.succeed(VmRepository, {
             })
             .returning();
           if (!vm) throw new Error("insert returned no VM row");
+          await insertVmCreationTransition(tx, vm);
 
           const [base] = existing?.base
             ? await tx
@@ -928,6 +956,12 @@ export const VmRepositoryLive = Layer.succeed(VmRepository, {
       const db = cloudDb();
       return await db.transaction(async (tx) => {
         const now = new Date();
+        const [previousVm] = await tx
+          .select()
+          .from(cloudVms)
+          .where(eq(cloudVms.id, input.vmId))
+          .for("update")
+          .limit(1);
         const [vm] = await tx
           .update(cloudVms)
           .set({
@@ -943,6 +977,9 @@ export const VmRepositoryLive = Layer.succeed(VmRepository, {
           .where(eq(cloudVms.id, input.vmId))
           .returning();
         if (!vm) throw new Error(`vm row missing during base finalization: ${input.vmId}`);
+        if (previousVm) {
+          await insertVmStateTransition(tx, previousVm, previousVm.status, vm.status, now);
+        }
 
         await tx
           .update(cloudVmBaseGenerations)
@@ -993,6 +1030,12 @@ export const VmRepositoryLive = Layer.succeed(VmRepository, {
       const db = cloudDb();
       await db.transaction(async (tx) => {
         const now = new Date();
+        const [previousVm] = await tx
+          .select()
+          .from(cloudVms)
+          .where(eq(cloudVms.id, input.vmId))
+          .for("update")
+          .limit(1);
         await tx
           .update(cloudVms)
           .set({
@@ -1002,6 +1045,9 @@ export const VmRepositoryLive = Layer.succeed(VmRepository, {
             updatedAt: now,
           })
           .where(eq(cloudVms.id, input.vmId));
+        if (previousVm) {
+          await insertVmStateTransition(tx, previousVm, previousVm.status, "failed", now);
+        }
         await tx
           .update(cloudVmBaseGenerations)
           .set({ state: "failed", updatedAt: now })
@@ -1134,6 +1180,15 @@ export const VmRepositoryLive = Layer.succeed(VmRepository, {
               ),
             )
             .returning();
+          if (reserved) {
+            await insertVmStateTransition(
+              tx,
+              reserved,
+              current.status,
+              reserved.status,
+              reserved.updatedAt,
+            );
+          }
           return reserved ?? current;
         });
       },
@@ -1157,22 +1212,39 @@ export const VmRepositoryLive = Layer.succeed(VmRepository, {
   markProviderObservedStatus: (input) =>
     dbEffect("markProviderObservedStatus", async () => {
       const db = cloudDb();
-      const updated = await db
-        .update(cloudVms)
-        .set({
-          status: input.status,
-          destroyedAt: input.status === "destroyed" ? new Date() : null,
-          updatedAt: new Date(),
-        })
-        .where(
-          and(
+      return await db.transaction(async (tx) => {
+        const [current] = await tx
+          .select()
+          .from(cloudVms)
+          .where(and(
             eq(cloudVms.id, input.id),
             eq(cloudVms.providerVmId, input.providerVmId),
-            ne(cloudVms.status, "destroyed"),
-          ),
-        )
-        .returning({ id: cloudVms.id });
-      return updated.length > 0;
+          ))
+          .for("update")
+          .limit(1);
+        if (!current || current.status === "destroyed") return false;
+
+        const now = new Date();
+        const updated = await tx
+          .update(cloudVms)
+          .set({
+            status: input.status,
+            destroyedAt: input.status === "destroyed" ? now : null,
+            updatedAt: now,
+          })
+          .where(
+            and(
+              eq(cloudVms.id, input.id),
+              eq(cloudVms.providerVmId, input.providerVmId),
+              ne(cloudVms.status, "destroyed"),
+            ),
+          )
+          .returning();
+        const vm = updated[0];
+        if (!vm) return false;
+        await insertVmStateTransition(tx, current, current.status, vm.status, now);
+        return true;
+      });
     }),
 
   setDisplayName: (input) =>
@@ -1189,36 +1261,60 @@ export const VmRepositoryLive = Layer.succeed(VmRepository, {
   markCreateRunning: (input) =>
     dbEffect("markCreateRunning", async () => {
       const db = cloudDb();
-      const [vm] = await db
-        .update(cloudVms)
-        .set({
-          providerVmId: input.providerVmId,
-          imageId: input.image,
-          imageVersion: input.imageVersion ?? null,
-          providerMetadata: input.providerMetadata ?? {},
-          status: "running",
-          failureCode: null,
-          failureMessage: null,
-          updatedAt: new Date(),
-        })
-        .where(eq(cloudVms.id, input.id))
-        .returning();
-      if (!vm) throw new Error(`vm row missing during create finalization: ${input.id}`);
-      return vm;
+      return await db.transaction(async (tx) => {
+        const [previousVm] = await tx
+          .select()
+          .from(cloudVms)
+          .where(eq(cloudVms.id, input.id))
+          .for("update")
+          .limit(1);
+        const now = new Date();
+        const [vm] = await tx
+          .update(cloudVms)
+          .set({
+            providerVmId: input.providerVmId,
+            imageId: input.image,
+            imageVersion: input.imageVersion ?? null,
+            providerMetadata: input.providerMetadata ?? {},
+            status: "running",
+            failureCode: null,
+            failureMessage: null,
+            updatedAt: now,
+          })
+          .where(eq(cloudVms.id, input.id))
+          .returning();
+        if (!vm) throw new Error(`vm row missing during create finalization: ${input.id}`);
+        if (previousVm) {
+          await insertVmStateTransition(tx, previousVm, previousVm.status, vm.status, now);
+        }
+        return vm;
+      });
     }),
 
   markCreateFailed: (input) =>
     dbEffect("markCreateFailed", async () => {
       const db = cloudDb();
-      await db
-        .update(cloudVms)
-        .set({
-          status: "failed",
-          failureCode: input.code,
-          failureMessage: input.message,
-          updatedAt: new Date(),
-        })
-        .where(eq(cloudVms.id, input.id));
+      await db.transaction(async (tx) => {
+        const [previousVm] = await tx
+          .select()
+          .from(cloudVms)
+          .where(eq(cloudVms.id, input.id))
+          .for("update")
+          .limit(1);
+        const now = new Date();
+        await tx
+          .update(cloudVms)
+          .set({
+            status: "failed",
+            failureCode: input.code,
+            failureMessage: input.message,
+            updatedAt: now,
+          })
+          .where(eq(cloudVms.id, input.id));
+        if (previousVm) {
+          await insertVmStateTransition(tx, previousVm, previousVm.status, "failed", now);
+        }
+      });
     }),
 
   hasOwnedSnapshot: (input) =>
@@ -1259,14 +1355,26 @@ export const VmRepositoryLive = Layer.succeed(VmRepository, {
   markDestroyed: (id) =>
     dbEffect("markDestroyed", async () => {
       const db = cloudDb();
-      await db
-        .update(cloudVms)
-        .set({
-          status: "destroyed",
-          destroyedAt: new Date(),
-          updatedAt: new Date(),
-        })
-        .where(eq(cloudVms.id, id));
+      await db.transaction(async (tx) => {
+        const [previousVm] = await tx
+          .select()
+          .from(cloudVms)
+          .where(eq(cloudVms.id, id))
+          .for("update")
+          .limit(1);
+        const now = new Date();
+        await tx
+          .update(cloudVms)
+          .set({
+            status: "destroyed",
+            destroyedAt: now,
+            updatedAt: now,
+          })
+          .where(eq(cloudVms.id, id));
+        if (previousVm) {
+          await insertVmStateTransition(tx, previousVm, previousVm.status, "destroyed", now);
+        }
+      });
     }),
 
   recordLease: (input) =>

--- a/web/services/vms/usage.ts
+++ b/web/services/vms/usage.ts
@@ -1,0 +1,84 @@
+import { and, eq, lte } from "drizzle-orm";
+
+import { cloudDb } from "../../db/client";
+import { cloudVms, cloudVmStateTransitions } from "../../db/schema";
+export {
+  aggregateActiveComputeHours,
+  billingPeriodThrough,
+  calculateActiveComputeHours,
+  isActiveComputeState,
+  ACTIVE_COMPUTE_STATES,
+  type BillingPeriod,
+  type VmStateTransitionEvent,
+} from "./usageMath";
+import {
+  billingPeriodThrough,
+  calculateActiveComputeHours,
+  type BillingPeriod,
+  type VmStateTransitionEvent,
+} from "./usageMath";
+
+export async function loadTeamVmStateTransitions(input: {
+  readonly billingTeamId: string;
+  readonly periodEnd: Date;
+}): Promise<VmStateTransitionEvent[]> {
+  const rows = await cloudDb()
+    .select({
+      id: cloudVmStateTransitions.id,
+      vmId: cloudVmStateTransitions.vmId,
+      billingTeamId: cloudVmStateTransitions.billingTeamId,
+      fromState: cloudVmStateTransitions.fromState,
+      toState: cloudVmStateTransitions.toState,
+      createdAt: cloudVmStateTransitions.createdAt,
+    })
+    .from(cloudVmStateTransitions)
+    .where(and(
+      eq(cloudVmStateTransitions.billingTeamId, input.billingTeamId),
+      lte(cloudVmStateTransitions.createdAt, input.periodEnd),
+    ));
+  return rows;
+}
+
+export async function getTeamActiveComputeHours(input: {
+  readonly billingTeamId: string;
+  readonly period: BillingPeriod;
+}): Promise<number> {
+  const events = await loadTeamVmStateTransitions({
+    billingTeamId: input.billingTeamId,
+    periodEnd: input.period.end,
+  });
+  return calculateActiveComputeHours(events, input.period);
+}
+
+/** Explicit name for API and job callers. */
+export const getActiveComputeHoursForTeam = getTeamActiveComputeHours;
+
+/**
+ * Loads the VM events charged to one user-scoped plan. Personal Pro Stripe
+ * rows use a Stack user id, while VM rows use the selected Stack team id, so
+ * the subscription reporter must join through the owning VM instead of
+ * assuming those identifiers are equal.
+ */
+export async function getUserPlanActiveComputeHours(input: {
+  readonly userId: string;
+  readonly billingPlanId: string;
+  readonly period: BillingPeriod;
+}): Promise<number> {
+  const events = await cloudDb()
+    .select({
+      id: cloudVmStateTransitions.id,
+      vmId: cloudVmStateTransitions.vmId,
+      billingTeamId: cloudVmStateTransitions.billingTeamId,
+      fromState: cloudVmStateTransitions.fromState,
+      toState: cloudVmStateTransitions.toState,
+      createdAt: cloudVmStateTransitions.createdAt,
+    })
+    .from(cloudVmStateTransitions)
+    .innerJoin(cloudVms, eq(cloudVms.id, cloudVmStateTransitions.vmId))
+    .where(and(
+      eq(cloudVms.userId, input.userId),
+      eq(cloudVms.billingPlanId, input.billingPlanId),
+      lte(cloudVmStateTransitions.createdAt, input.period.end),
+    ));
+  return calculateActiveComputeHours(events, input.period);
+}

--- a/web/services/vms/usageMath.ts
+++ b/web/services/vms/usageMath.ts
@@ -72,6 +72,7 @@ export function calculateActiveComputeHours(
   }
 
   const byVm = new Map<string, Array<VmStateTransitionEvent & { readonly timestampMs: number }>>();
+  const seenTransitions = new Map<string, Set<string>>();
   for (const event of events) {
     const vmId = typeof event.vmId === "string" ? event.vmId.trim() : "";
     if (!vmId) continue;
@@ -79,6 +80,11 @@ export function calculateActiveComputeHours(
     if (timestampMs === null) continue;
     const fromState = normalizeState(event.fromState);
     const toState = normalizeState(event.toState);
+    const vmSeenTransitions = seenTransitions.get(vmId) ?? new Set<string>();
+    const transitionKey = `${timestampMs}\u0000${fromState}\u0000${toState}`;
+    if (vmSeenTransitions.has(transitionKey)) continue;
+    vmSeenTransitions.add(transitionKey);
+    seenTransitions.set(vmId, vmSeenTransitions);
     const vmEvents = byVm.get(vmId) ?? [];
     vmEvents.push({ ...event, fromState, toState, timestampMs });
     byVm.set(vmId, vmEvents);

--- a/web/services/vms/usageMath.ts
+++ b/web/services/vms/usageMath.ts
@@ -1,0 +1,206 @@
+/** A billing period is half-open: [start, end). */
+export type BillingPeriod = {
+  readonly start: Date;
+  readonly end: Date;
+};
+
+export type VmStateTransitionEvent = {
+  readonly id?: string | null;
+  readonly vmId: string;
+  readonly billingTeamId?: string | null;
+  readonly fromState: string;
+  readonly toState: string;
+  /** Database rows use createdAt; callers may provide timestamp explicitly. */
+  readonly createdAt?: Date | string | number;
+  readonly timestamp?: Date | string | number;
+};
+
+/** Clips an open billing period to usage that has accrued at the given time. */
+export function billingPeriodThrough(
+  period: BillingPeriod,
+  now: Date,
+): BillingPeriod | null {
+  const startMs = period.start.getTime();
+  const endMs = period.end.getTime();
+  const nowMs = now.getTime();
+  if (
+    !Number.isFinite(startMs) ||
+    !Number.isFinite(endMs) ||
+    !Number.isFinite(nowMs) ||
+    endMs <= startMs ||
+    nowMs <= startMs
+  ) {
+    return null;
+  }
+  return {
+    start: period.start,
+    end: new Date(Math.min(nowMs, endMs)),
+  };
+}
+
+// "running" is the persisted VM state today. The additional names keep the
+// ledger calculator compatible with provider terminology and future states.
+export const ACTIVE_COMPUTE_STATES = [
+  "active",
+  "created",
+  "running",
+  "started",
+] as const;
+
+const activeComputeStates = new Set<string>(ACTIVE_COMPUTE_STATES);
+
+export function isActiveComputeState(state: string): boolean {
+  return activeComputeStates.has(state.trim().toLowerCase());
+}
+
+/**
+ * Calculates VM-hours from immutable state transitions.
+ *
+ * Events before the period establish the state at period start. A VM that is
+ * active at period end is charged through the end of the half-open period.
+ * Invalid timestamps and events for an empty VM id are ignored so one bad
+ * telemetry row cannot corrupt the whole billing read.
+ */
+export function calculateActiveComputeHours(
+  events: readonly VmStateTransitionEvent[],
+  period: BillingPeriod,
+): number {
+  const startMs = period.start.getTime();
+  const endMs = period.end.getTime();
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs <= startMs) {
+    throw new RangeError("Billing period end must be after its start");
+  }
+
+  const byVm = new Map<string, Array<VmStateTransitionEvent & { readonly timestampMs: number }>>();
+  for (const event of events) {
+    const vmId = typeof event.vmId === "string" ? event.vmId.trim() : "";
+    if (!vmId) continue;
+    const timestampMs = toTimestampMs(event.createdAt ?? event.timestamp);
+    if (timestampMs === null) continue;
+    const fromState = normalizeState(event.fromState);
+    const toState = normalizeState(event.toState);
+    const vmEvents = byVm.get(vmId) ?? [];
+    vmEvents.push({ ...event, fromState, toState, timestampMs });
+    byVm.set(vmId, vmEvents);
+  }
+
+  let activeMilliseconds = 0;
+  for (const vmEvents of byVm.values()) {
+    const orderedEvents = orderVmEvents(vmEvents);
+
+    const firstEvent = orderedEvents[0];
+    let state = firstEvent?.fromState ?? "";
+    // A synthetic `created -> started` row marks the creation instant. Do not
+    // charge the part of the period before that first row. For a first
+    // `running -> paused` row, the missing prior history means the VM may have
+    // been running at period start, so the conservative boundary is start.
+    let activeSince: number | null = isActiveComputeState(state)
+      ? state.trim().toLowerCase() === "created"
+        ? Math.max(startMs, firstEvent?.timestampMs ?? startMs)
+        : startMs
+      : null;
+
+    for (const event of orderedEvents) {
+      const timestampMs = event.timestampMs;
+      if (timestampMs < startMs) {
+        state = event.toState;
+        activeSince = isActiveComputeState(state) ? startMs : null;
+        continue;
+      }
+      // A transition at period end closes the prior interval at exactly end;
+      // a transition after end cannot affect this period.
+      if (timestampMs >= endMs) break;
+
+      // Prefer the event's recorded source state if a legacy row left a gap in
+      // the stream. This keeps an incomplete ledger conservative and bounded.
+      if (state !== event.fromState) {
+        if (isActiveComputeState(event.fromState)) {
+          activeSince ??= startMs;
+        } else if (activeSince !== null) {
+          activeMilliseconds += Math.max(0, timestampMs - activeSince);
+          activeSince = null;
+        }
+        state = event.fromState;
+      }
+
+      if (isActiveComputeState(event.toState)) {
+        activeSince ??= timestampMs;
+      } else if (activeSince !== null) {
+        activeMilliseconds += Math.max(0, timestampMs - activeSince);
+        activeSince = null;
+      }
+      state = event.toState;
+    }
+
+    if (activeSince !== null) {
+      activeMilliseconds += Math.max(0, endMs - activeSince);
+    }
+  }
+
+  const hours = activeMilliseconds / 3_600_000;
+  // Keep API and Stripe quantities stable across JavaScript floating point
+  // noise while retaining sub-minute precision.
+  return Math.round(hours * 1_000_000) / 1_000_000;
+}
+
+/**
+ * UUIDs are not causal ordering keys. When two writes share a timestamp,
+ * follow the state chain inside that timestamp before falling back to the
+ * stable id order. This keeps a same-tick create/start sequence from ending
+ * in the wrong state.
+ */
+function orderVmEvents(
+  events: ReadonlyArray<VmStateTransitionEvent & { readonly timestampMs: number }>,
+): Array<VmStateTransitionEvent & { readonly timestampMs: number }> {
+  const sorted = [...events].sort((left, right) =>
+    left.timestampMs - right.timestampMs || (left.id ?? "").localeCompare(right.id ?? ""));
+  const ordered: Array<VmStateTransitionEvent & { readonly timestampMs: number }> = [];
+  let previousState: string | undefined;
+
+  for (let offset = 0; offset < sorted.length;) {
+    const timestampMs = sorted[offset]!.timestampMs;
+    const group: Array<VmStateTransitionEvent & { readonly timestampMs: number }> = [];
+    while (offset < sorted.length && sorted[offset]!.timestampMs === timestampMs) {
+      group.push(sorted[offset]!);
+      offset += 1;
+    }
+
+    while (group.length > 0) {
+      const linkedIndex = previousState === undefined
+        ? group.findIndex((event) => !group.some((candidate) => candidate.toState === event.fromState))
+        : group.findIndex((event) => event.fromState === previousState);
+      const selectedIndex = linkedIndex >= 0 ? linkedIndex : 0;
+      const [selected] = group.splice(selectedIndex, 1);
+      if (!selected) continue;
+      ordered.push(selected);
+      previousState = selected.toState;
+    }
+  }
+
+  return ordered;
+}
+
+/** Compatibility alias for callers that use the aggregation terminology. */
+export const aggregateActiveComputeHours = calculateActiveComputeHours;
+
+function toTimestampMs(value: Date | string | number | undefined): number | null {
+  if (value === undefined) return null;
+  let timestamp: number;
+  if (value instanceof Date) {
+    timestamp = value.getTime();
+  } else if (typeof value === "number") {
+    timestamp = new Date(Math.abs(value) < 100_000_000_000 ? value * 1_000 : value).getTime();
+  } else {
+    const text = value.trim();
+    if (!text) return null;
+    const numeric = Number(text);
+    timestamp = Number.isFinite(numeric)
+      ? new Date(Math.abs(numeric) < 100_000_000_000 ? numeric * 1_000 : numeric).getTime()
+      : new Date(text).getTime();
+  }
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+function normalizeState(state: string): string {
+  return state.trim().toLowerCase();
+}

--- a/web/tests/billing-plan-route.test.ts
+++ b/web/tests/billing-plan-route.test.ts
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { NextRequest } from "next/server";
 
-import { billingEmailClaims, stripeSubscriptions } from "../db/schema";
+import {
+  billingEmailClaims,
+  cloudVmStateTransitions,
+  stripeSubscriptions,
+} from "../db/schema";
 import { withAccountMutationLeaseSupport } from
   "./helpers/account-mutation-db-mock";
 
@@ -13,6 +17,7 @@ let stackConfigured = true;
 let currentUser: ReturnType<typeof planUser> | null = null;
 let stripeSubscriptionRows: Array<Record<string, unknown>> = [];
 let stripeSubscriptionResults: Array<Array<Record<string, unknown>>> = [];
+let stateTransitionRows: Array<Record<string, unknown>> = [];
 let claimLookupCount = 0;
 let dbMissing = false;
 let stackAuthUnavailable = false;
@@ -37,15 +42,23 @@ mock.module("../db/client", () => ({
     return withAccountMutationLeaseSupport({
       select: () => ({
         from: (table: unknown) => ({
-          where: () => ({
-            limit: async () => {
-              if (table === billingEmailClaims) claimLookupCount += 1;
-              if (table !== stripeSubscriptions) return [];
-              return stripeSubscriptionResults.length > 0
-                ? stripeSubscriptionResults.shift()!
-                : stripeSubscriptionRows;
-            },
-          }),
+          where: () => {
+            const rows = table === cloudVmStateTransitions
+              ? stateTransitionRows
+              : table === billingEmailClaims
+              ? []
+              : table !== stripeSubscriptions
+              ? []
+              : stripeSubscriptionResults.length > 0
+              ? stripeSubscriptionResults.shift()!
+              : stripeSubscriptionRows;
+            return Object.assign(Promise.resolve(rows), {
+              limit: async () => {
+                if (table === billingEmailClaims) claimLookupCount += 1;
+                return rows;
+              },
+            });
+          },
         }),
       }),
     });
@@ -60,6 +73,7 @@ describe("billing plan route", () => {
     currentUser = planUser();
     stripeSubscriptionRows = [];
     stripeSubscriptionResults = [];
+    stateTransitionRows = [];
     claimLookupCount = 0;
     dbMissing = false;
     stackAuthUnavailable = false;
@@ -74,6 +88,92 @@ describe("billing plan route", () => {
     expect(response.planId).toBe("pro");
     expect(response.isPro).toBe(true);
     expect(response.billingManagement).toBe("stripe");
+  });
+
+  test("includes current VM usage and the Pro allowance", async () => {
+    stripeSubscriptionRows = [{
+      id: "sub_123",
+      currentPeriodEnd: new Date("2026-09-01T00:00:00Z"),
+      raw: {
+        current_period_start: Math.floor(new Date("2026-08-01T00:00:00Z").getTime() / 1_000),
+        current_period_end: Math.floor(new Date("2026-09-01T00:00:00Z").getTime() / 1_000),
+      },
+    }];
+    stateTransitionRows = [
+      {
+        id: "event-1",
+        vmId: "vm-1",
+        billingTeamId: "user-plan",
+        fromState: "provisioning",
+        toState: "running",
+        createdAt: new Date("2026-08-10T00:00:00Z"),
+      },
+      {
+        id: "event-2",
+        vmId: "vm-1",
+        billingTeamId: "user-plan",
+        fromState: "running",
+        toState: "paused",
+        createdAt: new Date("2026-08-10T02:00:00Z"),
+      },
+    ];
+
+    const response = await planResponse();
+    const usage = response.vmUsage as Record<string, unknown>;
+    expect(usage.activeComputeHours).toBe(2);
+    expect(usage.includedComputeHours).toBe(20);
+    expect(usage.overageComputeHours).toBe(0);
+    expect(usage.billingTeamId).toBe("user-plan");
+  });
+
+  test("uses the personal Pro period for VMs stored under a personal team", async () => {
+    const proSubscription = {
+      id: "sub_personal_team",
+      currentPeriodEnd: new Date("2026-09-15T00:00:00Z"),
+      raw: {
+        current_period_start: Math.floor(new Date("2026-08-15T00:00:00Z").getTime() / 1_000),
+        current_period_end: Math.floor(new Date("2026-09-15T00:00:00Z").getTime() / 1_000),
+      },
+    };
+    currentUser = planUser({
+      selectedTeam: { id: "personal-team", clientReadOnlyMetadata: {} },
+    });
+    // Pro status, Team status, Team-period lookup, then the user-scoped Pro
+    // fallback used for a personal team.
+    stripeSubscriptionResults = [[proSubscription], [], [], [proSubscription]];
+    stateTransitionRows = [
+      {
+        id: "personal-event-1",
+        vmId: "vm-personal",
+        billingTeamId: "personal-team",
+        fromState: "provisioning",
+        toState: "running",
+        createdAt: new Date("2026-08-20T00:00:00Z"),
+      },
+      {
+        id: "personal-event-2",
+        vmId: "vm-personal",
+        billingTeamId: "personal-team",
+        fromState: "running",
+        toState: "paused",
+        createdAt: new Date("2026-08-20T02:00:00Z"),
+      },
+    ];
+
+    const response = await planResponse();
+    const usage = response.vmUsage as Record<string, unknown>;
+    expect(usage.periodStart).toBe("2026-08-15T00:00:00.000Z");
+    expect(usage.periodEnd).toBe("2026-09-15T00:00:00.000Z");
+    expect(usage.activeComputeHours).toBe(2);
+    expect(usage.billingTeamId).toBe("personal-team");
+  });
+
+  test("does not transfer pending ownership during a plan read", async () => {
+    currentUser = planUser({ primaryEmailVerified: true });
+    const response = await planResponse();
+
+    expect(response.planId).toBe("free");
+    expect(claimLookupCount).toBe(0);
   });
 
   test("reports Free for Stack Pro products without Stripe subscription rows", async () => {
@@ -132,14 +232,6 @@ describe("billing plan route", () => {
 
     expect(response.teamPlanId).toBe("free");
     expect(response.teamBillingManagement).toBe("none");
-  });
-
-  test("does not transfer pending ownership during a plan read", async () => {
-    currentUser = planUser({ primaryEmailVerified: true });
-    const response = await planResponse();
-
-    expect(response.planId).toBe("free");
-    expect(claimLookupCount).toBe(0);
   });
 
   test("reports no Team billing management without a billing team", async () => {

--- a/web/tests/db-schema.test.ts
+++ b/web/tests/db-schema.test.ts
@@ -23,7 +23,7 @@ describe("Cloud VM database schema", () => {
   dbTest("applies migrations and enforces create idempotency by account owner", async () => {
     if (!sql) throw new Error("test database not initialized");
 
-    await sql`truncate cloud_vm_billing_grants, cloud_vm_usage_events, cloud_vm_leases, cloud_vms restart identity cascade`;
+    await sql`truncate cloud_vm_state_transitions, cloud_vm_billing_grants, cloud_vm_usage_events, cloud_vm_leases, cloud_vms restart identity cascade`;
 
     const [vm] = await sql<{ id: string }[]>`
       insert into cloud_vms (
@@ -80,6 +80,10 @@ describe("Cloud VM database schema", () => {
       insert into cloud_vm_usage_events (user_id, vm_id, event_type, provider, image_id, metadata)
       values ('user-1', ${vm.id}, 'vm.created', 'e2b', 'cmuxd-ws:test', '{"source":"test"}'::jsonb)
     `;
+    await sql`
+      insert into cloud_vm_state_transitions (vm_id, billing_team_id, from_state, to_state)
+      values (${vm.id}, 'team-1', 'provisioning', 'running')
+    `;
 
     await sql`delete from cloud_vms where id = ${vm.id}`;
 
@@ -92,5 +96,12 @@ describe("Cloud VM database schema", () => {
       select vm_id::text as "usageVmId" from cloud_vm_usage_events where event_type = 'vm.created'
     `;
     expect(usageVmId).toBeNull();
+
+    const [{ transitionCount }] = await sql<{ transitionCount: string }[]>`
+      select count(*)::text as "transitionCount"
+      from cloud_vm_state_transitions
+      where vm_id = ${vm.id}
+    `;
+    expect(transitionCount).toBe("0");
   });
 });

--- a/web/tests/vm-usage-reporting.test.ts
+++ b/web/tests/vm-usage-reporting.test.ts
@@ -36,15 +36,18 @@ describe("VM usage reporting", () => {
     expect(result.overageComputeHours).toBe(2.25);
     // Stripe meter values are whole units. The meter is configured with Last
     // aggregation so each report replaces the cumulative period value.
-    expect(create).toHaveBeenCalledWith({
-      event_name: VM_USAGE_METER_EVENT_NAME,
-      payload: {
-        stripe_customer_id: "cus_usage",
-        value: "3",
-      },
-      identifier: expect.stringContaining("cmux-vm-usage:sub_usage:"),
-      timestamp: Math.floor(now.getTime() / 1_000),
-    });
+    const calls = (create as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    expect(calls.length).toBe(1);
+    const event = calls[0]?.[0] as {
+      event_name: string;
+      payload: { stripe_customer_id: string; value: string };
+      identifier: string;
+      timestamp: number;
+    };
+    expect(event.event_name).toBe(VM_USAGE_METER_EVENT_NAME);
+    expect(event.payload).toEqual({ stripe_customer_id: "cus_usage", value: "3" });
+    expect(event.identifier.startsWith("cmux-vm-usage:sub_usage:")).toBe(true);
+    expect(event.timestamp).toBe(Math.floor(now.getTime() / 1_000));
 
     await reportVmUsageForSubscription(subscription(), {
       enabled: true,
@@ -52,8 +55,9 @@ describe("VM usage reporting", () => {
       now,
       stripeClient: { billing: { meterEvents: { create } } },
     });
-    const firstCall = create.mock.calls[0]?.[0] as { identifier?: string } | undefined;
-    const secondCall = create.mock.calls[1]?.[0] as { identifier?: string } | undefined;
+    const repeatCalls = (create as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    const firstCall = repeatCalls[0]?.[0] as { identifier?: string } | undefined;
+    const secondCall = repeatCalls[1]?.[0] as { identifier?: string } | undefined;
     expect(secondCall?.identifier).toBe(firstCall?.identifier);
   });
 

--- a/web/tests/vm-usage-reporting.test.ts
+++ b/web/tests/vm-usage-reporting.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import {
+  isStripeUsageReportingEnabled,
+  overageComputeHours,
+  reportVmUsageForSubscription,
+  VM_USAGE_METER_EVENT_NAME,
+} from "../services/billing/vmUsageReporting";
+
+describe("VM usage reporting", () => {
+  test("requires the explicit rollout flag", () => {
+    expect(isStripeUsageReportingEnabled({})).toBe(false);
+    expect(isStripeUsageReportingEnabled({ STRIPE_USAGE_REPORTING: "0" })).toBe(false);
+    expect(isStripeUsageReportingEnabled({ STRIPE_USAGE_REPORTING: "1" })).toBe(true);
+    expect(isStripeUsageReportingEnabled({ STRIPE_USAGE_REPORTING: "true" })).toBe(false);
+  });
+
+  test("calculates only hours above the allowance", () => {
+    expect(overageComputeHours(19.9)).toBe(0);
+    expect(overageComputeHours(22.25)).toBe(2.25);
+  });
+
+  test("sends cumulative overage as a meter event", async () => {
+    const create = mock(async () => ({}));
+    const now = new Date("2026-08-15T12:34:56Z");
+    const result = await reportVmUsageForSubscription(subscription(), {
+      enabled: true,
+      activeHours: 22.25,
+      now,
+      stripeClient: {
+        billing: { meterEvents: { create } },
+      },
+    });
+
+    expect(result.status).toBe("reported");
+    expect(result.overageComputeHours).toBe(2.25);
+    // Stripe meter values are whole units. The meter is configured with Last
+    // aggregation so each report replaces the cumulative period value.
+    expect(create).toHaveBeenCalledWith({
+      event_name: VM_USAGE_METER_EVENT_NAME,
+      payload: {
+        stripe_customer_id: "cus_usage",
+        value: "3",
+      },
+      identifier: expect.stringContaining("cmux-vm-usage:sub_usage:"),
+      timestamp: Math.floor(now.getTime() / 1_000),
+    });
+
+    await reportVmUsageForSubscription(subscription(), {
+      enabled: true,
+      activeHours: 22.25,
+      now,
+      stripeClient: { billing: { meterEvents: { create } } },
+    });
+    const firstCall = create.mock.calls[0]?.[0] as { identifier?: string } | undefined;
+    const secondCall = create.mock.calls[1]?.[0] as { identifier?: string } | undefined;
+    expect(secondCall?.identifier).toBe(firstCall?.identifier);
+  });
+
+  test("does not call Stripe when reporting is disabled or below allowance", async () => {
+    const create = mock(async () => ({}));
+    const disabled = await reportVmUsageForSubscription(subscription(), {
+      activeHours: 25,
+      enabled: false,
+      stripeClient: { billing: { meterEvents: { create } } },
+    });
+    expect(disabled.status).toBe("disabled");
+
+    const noOverage = await reportVmUsageForSubscription(subscription(), {
+      activeHours: 20,
+      enabled: true,
+      stripeClient: { billing: { meterEvents: { create } } },
+    });
+    expect(noOverage.status).toBe("no_overage");
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  test("does not apply the Pro allowance to Team subscriptions", async () => {
+    const create = mock(async () => ({}));
+    const result = await reportVmUsageForSubscription({
+      ...subscription(),
+      stackTeamId: "team-usage",
+      scope: "team",
+      plan: "team",
+    }, {
+      activeHours: 25,
+      enabled: true,
+      stripeClient: { billing: { meterEvents: { create } } },
+    });
+
+    expect(result.status).toBe("unsupported_subscription");
+    expect(create).not.toHaveBeenCalled();
+  });
+});
+
+function subscription() {
+  return {
+    id: "sub_usage",
+    customerId: "cus_usage",
+    stackUserId: "user-usage",
+    stackTeamId: null,
+    scope: "user",
+    plan: "pro",
+    currentPeriodEnd: new Date("2026-09-01T00:00:00Z"),
+    raw: {
+      current_period_start: Math.floor(new Date("2026-08-01T00:00:00Z").getTime() / 1_000),
+      current_period_end: Math.floor(new Date("2026-09-01T00:00:00Z").getTime() / 1_000),
+    },
+  };
+}

--- a/web/tests/vm-usage.test.ts
+++ b/web/tests/vm-usage.test.ts
@@ -96,6 +96,13 @@ describe("VM active compute-hour aggregation", () => {
       event("vm-1", "running", "paused", "2026-08-01T03:00:00Z"),
     ], period)).toBe(2);
   });
+
+  test("does not double-count an identical retried transition", () => {
+    expect(calculateActiveComputeHours([
+      event("vm-1", "running", "paused", "2026-08-02T00:00:00Z"),
+      event("vm-1", "running", "paused", "2026-08-02T00:00:00Z"),
+    ], period)).toBe(24);
+  });
 });
 
 function event(

--- a/web/tests/vm-usage.test.ts
+++ b/web/tests/vm-usage.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  billingPeriodThrough,
+  calculateActiveComputeHours,
+} from "../services/vms/usageMath";
+
+const period = {
+  start: new Date("2026-08-01T00:00:00.000Z"),
+  end: new Date("2026-09-01T00:00:00.000Z"),
+};
+
+describe("VM active compute-hour aggregation", () => {
+  test("clips current-period reads at now instead of future period end", () => {
+    const clipped = billingPeriodThrough(period, new Date("2026-08-15T12:00:00Z"));
+    expect(clipped?.start.toISOString()).toBe("2026-08-01T00:00:00.000Z");
+    expect(clipped?.end.toISOString()).toBe("2026-08-15T12:00:00.000Z");
+    expect(calculateActiveComputeHours([
+      event("vm-1", "provisioning", "running", "2026-08-01T00:00:00Z"),
+    ], clipped!)).toBe(348);
+  });
+
+  test("counts pause and resume cycles independently", () => {
+    expect(calculateActiveComputeHours([
+      event("vm-1", "provisioning", "running", "2026-08-01T01:00:00Z"),
+      event("vm-1", "running", "paused", "2026-08-01T05:00:00Z"),
+      event("vm-1", "paused", "running", "2026-08-01T07:30:00Z"),
+      event("vm-1", "running", "destroyed", "2026-08-01T09:00:00Z"),
+    ], period)).toBe(5.5);
+  });
+
+  test("clips a machine that starts before and ends after the period", () => {
+    expect(calculateActiveComputeHours([
+      event("vm-1", "provisioning", "running", "2026-07-20T12:00:00Z"),
+      event("vm-1", "running", "paused", "2026-08-10T00:00:00Z"),
+      event("vm-1", "paused", "running", "2026-08-20T00:00:00Z"),
+      event("vm-1", "running", "destroyed", "2026-09-10T12:00:00Z"),
+    ], period)).toBe(504);
+  });
+
+  test("charges a machine still running at period end", () => {
+    expect(calculateActiveComputeHours([
+      event("vm-1", "provisioning", "running", "2026-08-31T12:00:00Z"),
+    ], period)).toBe(12);
+  });
+
+  test("sums independent machines and accepts provider state aliases", () => {
+    expect(calculateActiveComputeHours([
+      event("vm-1", "created", "started", "2026-08-02T00:00:00Z"),
+      event("vm-1", "started", "stopped", "2026-08-02T02:00:00Z"),
+      event("vm-2", "provisioning", "active", "2026-08-02T01:00:00Z"),
+      event("vm-2", "active", "destroyed", "2026-08-02T04:30:00Z"),
+    ], period)).toBe(5.5);
+  });
+
+  test("uses the recorded source state when a legacy stream starts active", () => {
+    expect(calculateActiveComputeHours([
+      event("vm-1", "running", "paused", "2026-08-01T02:00:00Z"),
+    ], period)).toBe(2);
+  });
+
+  test("normalizes state names and Unix-second timestamps", () => {
+    expect(calculateActiveComputeHours([
+      event("vm-1", "PROVISIONING", "RUNNING", "2026-08-01T01:00:00Z"),
+      {
+        vmId: "vm-1",
+        fromState: "RUNNING",
+        toState: "PAUSED",
+        createdAt: Math.floor(new Date("2026-08-01T03:00:00Z").getTime() / 1_000),
+      },
+    ], period)).toBe(2);
+  });
+
+  test("accepts Unix-second timestamps encoded in JSON strings", () => {
+    expect(calculateActiveComputeHours([
+      event("vm-1", "provisioning", "running", "2026-08-01T01:00:00Z"),
+      {
+        vmId: "vm-1",
+        fromState: "running",
+        toState: "paused",
+        createdAt: String(Math.floor(new Date("2026-08-01T03:00:00Z").getTime() / 1_000)),
+      },
+    ], period)).toBe(2);
+  });
+
+  test("follows a same-timestamp state chain instead of UUID order", () => {
+    expect(calculateActiveComputeHours([
+      {
+        ...event("vm-1", "created", "provisioning", "2026-08-01T01:00:00Z"),
+        id: "z-create",
+      },
+      {
+        ...event("vm-1", "provisioning", "running", "2026-08-01T01:00:00Z"),
+        id: "a-start",
+      },
+      event("vm-1", "running", "paused", "2026-08-01T03:00:00Z"),
+    ], period)).toBe(2);
+  });
+});
+
+function event(
+  vmId: string,
+  fromState: string,
+  toState: string,
+  createdAt: string,
+) {
+  return { vmId, fromState, toState, createdAt };
+}

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -23,6 +23,10 @@
       "schedule": "23 * * * *"
     },
     {
+      "path": "/api/cron/vm-usage",
+      "schedule": "47 * * * *"
+    },
+    {
       "path": "/api/internal/vm/leases/revoke-expired",
       "schedule": "*/10 * * * *"
     },


### PR DESCRIPTION
The pricing page sells Pro as 20 active compute-hours per month then usage-based, but nothing recorded usage. This adds the foundation, no enforcement.

Mechanism: VM lifecycle transitions (create, resume, pause, stop, destroy) now persist usage events; an aggregation function computes active compute-hours per team for a billing period (pause/resume cycles, period-boundary spans, still-running machines); /api/billing/plan exposes vmUsage (consumed, included, overage); hourly /api/cron/vm-usage reports cumulative overage to a Stripe meter (Last aggregation, deterministic identifiers) behind STRIPE_USAGE_REPORTING=1, default OFF.

Out of scope on purpose: pricing copy, hard caps, VM shutdown on overage, subscription logic.

Verification: focused tests pass locally (26 pass across billing-plan-route, db-schema, vm-usage-reporting, vm-usage), tsgo typecheck clean. Local full suite has a pre-existing failing baseline unrelated to this branch; hosted CI is authoritative.

Implementation by Codex (gpt-5), test typing fixup and verification by Claude.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790816447&installation_model_id=21920&pr_number=11297&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11297&signature=2d7428383f3f18575bd04f96bbd8dd2ee03fe25aad395c95509e41efe8b0ea45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the metering foundation for Cloud VM usage — previously nothing recorded usage, and now VM lifecycle transitions persist as a billing ledger. The plan endpoint reports consumed/included/overage hours and an hourly cron reports overage to Stripe behind `STRIPE_USAGE_REPORTING=1` (default off); enforcement, caps, and pricing changes are intentionally left out.

**New Features**
- VM lifecycle transitions (create, resume, pause, stop, destroy) now persist usage events.
- `/api/billing/plan` returns `vmUsage` with active, included, and overage compute-hours.
- An hourly `/api/cron/vm-usage` job reports cumulative overage to a Stripe meter when enabled.

**Migration**
- Apply the `cloud_vm_state_transitions` migration; existing running VMs get a non-retroactive baseline entry.
- Provision the `cmux_vm_active_compute_hours` Stripe meter with Last aggregation before setting `STRIPE_USAGE_REPORTING=1`.

<sup>Written for commit 32d44ce881f059c44ac99cdf5f175d38f53bbfaf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added VM active compute-hour tracking across lifecycle changes.
  * Billing plans now display VM usage, included hours, and overage details.
  * Added scheduled hourly reporting of eligible VM usage to Stripe.
  * Added support for billing-period usage calculations, including pause and resume cycles.

* **Bug Fixes**
  * Prevented status updates to destroyed virtual machines.
  * Improved handling of incomplete, duplicate, and legacy VM state records.

* **Configuration**
  * Added a rollout setting to enable VM usage reporting when billing setup is complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->