### PR TITLE
Cloud tree agent parity: follow-ups

### DIFF
--- a/Sources/Cloud/CloudTreeNode.swift
+++ b/Sources/Cloud/CloudTreeNode.swift
@@ -30,8 +30,11 @@ final class CloudTreeNode: NSObject {
         /// A local workspace, grouping the local terminals it projects.
         case localWorkspace(CloudTreeLocalWorkspaceRow)
         case terminal(CloudTreeTerminalRow)
-        /// One VNC display of a machine.
-        case display(SurfaceResource)
+        /// One VNC display of a machine. Under a remote workspace the row carries the
+        /// local workspace already showing that remote workspace (the parent's openIn),
+        /// so its open verb stays inside that workspace instead of jumping to a VNC
+        /// pane elsewhere; pool rows carry nil and keep the global open-or-focus.
+        case display(SurfaceResource, openIn: UUID?)
         /// "Browsers" group (this Mac).
         case browsersGroup(machine: SurfaceMachineID)
         case browser(CloudTreeBrowserRow)
@@ -103,7 +106,7 @@ final class CloudTreeNode: NSObject {
             return machine
         case .localWorkspace: return .local
         case .terminal(let row): return row.resource.machine
-        case .display(let resource), .port(let resource): return resource.machine
+        case .display(let resource, _), .port(let resource): return resource.machine
         case .browser(let row): return row.resource.machine
         }
     }
@@ -126,7 +129,7 @@ final class CloudTreeNode: NSObject {
         case .workspace(_, let workspace, _, _): return workspace.name
         case .localWorkspace(let row): return row.title
         case .terminal(let row): return row.resource.title
-        case .display(let resource): return resource.title.isEmpty ? String(localized: "cloudTree.node.desktop", defaultValue: "Desktop") : resource.title
+        case .display(let resource, _): return resource.title.isEmpty ? String(localized: "cloudTree.node.desktop", defaultValue: "Desktop") : resource.title
         case .browsersGroup: return String(localized: "cloudTree.group.browsers", defaultValue: "Browsers")
         case .browser(let row): return row.resource.title
         case .portsGroup: return String(localized: "cloudTree.group.ports", defaultValue: "Ports")
@@ -158,7 +161,7 @@ final class CloudTreeNode: NSObject {
         switch kind {
         case .terminal(let row): return row.resource
         case .browser(let row): return row.resource
-        case .display(let resource), .port(let resource): return resource
+        case .display(let resource, _), .port(let resource): return resource
         case .machine, .localMachine, .terminalsPool, .displaysPool, .workspacesGroup, .workspace, .localWorkspace, .browsersGroup, .portsGroup, .placeholder:
             return nil
         }
@@ -408,7 +411,7 @@ enum CloudTreeNodeBuilder {
         let displaysNode: CloudTreeNode? = displays.isEmpty ? nil : CloudTreeNode(
             id: nodeID(displaysPool: machine),
             kind: .displaysPool(machine: machine, count: displays.count),
-            children: displays.map { CloudTreeNode(id: nodeID(resource: $0.id), kind: .display($0)) }
+            children: displays.map { CloudTreeNode(id: nodeID(resource: $0.id), kind: .display($0, openIn: nil)) }
         )
 
         switch info.linkState {
@@ -477,9 +480,10 @@ enum CloudTreeNodeBuilder {
                     // place. Implicit rows stay out of `members`/dragGroup — only
                     // real pointers travel with the workspace's open/drag group.
                     let shownDisplays = workspaceDisplays.isEmpty ? displays : workspaceDisplays
+                    let openInLocal = localWorkspaceShowing(members, snapshot: snapshot)
                     return CloudTreeNode(
                         id: nodeID(workspace: workspace.id, machine: machine),
-                        kind: .workspace(machine: machine, workspace, terminalCount: pointed.count, openIn: localWorkspaceShowing(members, snapshot: snapshot)),
+                        kind: .workspace(machine: machine, workspace, terminalCount: pointed.count, openIn: openInLocal),
                         children: pointed.map {
                             terminalNode($0, snapshot: snapshot, id: nodeID(resource: $0.id, inRemoteWorkspace: workspace.id))
                         } + workspaceBrowsers.map {
@@ -488,7 +492,7 @@ enum CloudTreeNodeBuilder {
                                 kind: .browser(CloudTreeBrowserRow(resource: $0, isOpen: snapshot.isOpen($0.id), workspaceTitle: nil))
                             )
                         } + shownDisplays.map {
-                            CloudTreeNode(id: nodeID(resource: $0.id, inRemoteWorkspace: workspace.id), kind: .display($0))
+                            CloudTreeNode(id: nodeID(resource: $0.id, inRemoteWorkspace: workspace.id), kind: .display($0, openIn: openInLocal))
                         },
                         dragGroup: SurfaceResourceGroup(
                             title: workspace.name,

--- a/Sources/Cloud/CloudTreeNodeActions.swift
+++ b/Sources/Cloud/CloudTreeNodeActions.swift
@@ -8,6 +8,10 @@ import Foundation
 struct CloudTreeNodeActions {
     /// Project a resource into the selected local workspace.
     let project: @MainActor (_ resource: SurfaceResourceID, _ placement: SurfacePlacement, _ reuseExisting: Bool) -> Void
+    /// Project a resource into ONE local workspace, reusing only a pane already in it
+    /// (a workspace's own Desktop row: a VNC pane in another workspace neither
+    /// satisfies the open nor steals focus).
+    let projectInLocalWorkspace: @MainActor (_ resource: SurfaceResourceID, _ workspaceID: UUID) -> Void
     /// Start a plain terminal on a machine (in a cmux-tui workspace when given) and show it.
     let newTerminal: @MainActor (_ machine: SurfaceMachineID, _ remoteWorkspaceID: String?) -> Void
     /// Open a whole group (a workspace's terminals and browsers): the first at the
@@ -81,6 +85,17 @@ struct CloudTreeNodeActions {
             project: { resource, placement, reuseExisting in
                 run(openingLabel(resource.machine)) { catalog in
                     _ = try await catalog.project(resource, into: try destination(placement), focus: true, reuseExisting: reuseExisting)
+                }
+            },
+            projectInLocalWorkspace: { resource, workspaceID in
+                run(openingLabel(resource.machine)) { catalog in
+                    _ = try await catalog.project(
+                        resource,
+                        into: .workspace(id: workspaceID, placement: .split),
+                        focus: true,
+                        reuseExisting: true,
+                        reuseInWorkspace: workspaceID
+                    )
                 }
             },
             newTerminal: { machine, remoteWorkspaceID in

--- a/Sources/Cloud/CloudTreeNodeActions.swift
+++ b/Sources/Cloud/CloudTreeNodeActions.swift
@@ -11,7 +11,7 @@ struct CloudTreeNodeActions {
     /// Project a resource into ONE local workspace, reusing only a pane already in it
     /// (a workspace's own Desktop row: a VNC pane in another workspace neither
     /// satisfies the open nor steals focus).
-    let projectInLocalWorkspace: @MainActor (_ resource: SurfaceResourceID, _ workspaceID: UUID) -> Void
+    let projectInLocalWorkspace: @MainActor (_ resource: SurfaceResourceID, _ workspaceID: UUID, _ placement: SurfacePlacement) -> Void
     /// Start a plain terminal on a machine (in a cmux-tui workspace when given) and show it.
     let newTerminal: @MainActor (_ machine: SurfaceMachineID, _ remoteWorkspaceID: String?) -> Void
     /// Open a whole group (a workspace's terminals and browsers): the first at the
@@ -87,11 +87,11 @@ struct CloudTreeNodeActions {
                     _ = try await catalog.project(resource, into: try destination(placement), focus: true, reuseExisting: reuseExisting)
                 }
             },
-            projectInLocalWorkspace: { resource, workspaceID in
+            projectInLocalWorkspace: { resource, workspaceID, placement in
                 run(openingLabel(resource.machine)) { catalog in
                     _ = try await catalog.project(
                         resource,
-                        into: .workspace(id: workspaceID, placement: .split),
+                        into: .workspace(id: workspaceID, placement: placement),
                         focus: true,
                         reuseExisting: true,
                         reuseInWorkspace: workspaceID

--- a/Sources/Cloud/CloudTreeOutlineView.swift
+++ b/Sources/Cloud/CloudTreeOutlineView.swift
@@ -439,7 +439,7 @@ struct CloudTreeOutlineView: NSViewRepresentable {
                 // that remote workspace — never a jump to a VNC pane in a different
                 // workspace. Pool rows (openIn == nil) keep the global open-or-focus.
                 if let openIn {
-                    nodeActions.projectInLocalWorkspace(resource.id, openIn)
+                    nodeActions.projectInLocalWorkspace(resource.id, openIn, .split)
                 } else {
                     nodeActions.project(resource.id, .split, true)
                 }
@@ -623,16 +623,18 @@ struct CloudTreeOutlineView: NSViewRepresentable {
         /// tab, a second pane (cloud resources only — a local terminal has one pane),
         /// and copying the resource id agents use with `cmux vm open`.
         private func resourceMenuItems(_ resource: SurfaceResource, isLocal: Bool, openInLocalWorkspace: UUID? = nil) -> [NSMenuItem] {
+            // Same scope rule as the row's click, for every verb that may reuse a pane
+            // (one shared path): a workspace's Desktop row never teleports elsewhere.
+            let open: (SurfacePlacement) -> Void = { [nodeActions] placement in
+                if let openInLocalWorkspace {
+                    nodeActions.projectInLocalWorkspace(resource.id, openInLocalWorkspace, placement)
+                } else {
+                    nodeActions.project(resource.id, placement, true)
+                }
+            }
             var items: [NSMenuItem] = [
-                item(String(localized: "cloudTree.menu.open", defaultValue: "Open")) { [nodeActions] in
-                    // Same scope rule as the row's open verb (one shared path).
-                    if let openInLocalWorkspace {
-                        nodeActions.projectInLocalWorkspace(resource.id, openInLocalWorkspace)
-                    } else {
-                        nodeActions.project(resource.id, .split, true)
-                    }
-                },
-                item(String(localized: "cloudTree.menu.openInNewTab", defaultValue: "Open in New Tab")) { [nodeActions] in nodeActions.project(resource.id, .tab, true) },
+                item(String(localized: "cloudTree.menu.open", defaultValue: "Open")) { open(.split) },
+                item(String(localized: "cloudTree.menu.openInNewTab", defaultValue: "Open in New Tab")) { open(.tab) },
             ]
             if !isLocal {
                 items.append(item(String(localized: "cloudTree.menu.openInNewPane", defaultValue: "Open in New Pane")) { [nodeActions] in nodeActions.project(resource.id, .split, false) })

--- a/Sources/Cloud/CloudTreeOutlineView.swift
+++ b/Sources/Cloud/CloudTreeOutlineView.swift
@@ -434,7 +434,16 @@ struct CloudTreeOutlineView: NSViewRepresentable {
                 nodeActions.selectLocalWorkspace(row.workspaceID)
             case .terminal(let row):
                 nodeActions.project(row.resource.id, .split, true)
-            case .display(let resource), .port(let resource):
+            case .display(let resource, let openIn):
+                // A workspace's Desktop row opens INSIDE the local workspace showing
+                // that remote workspace — never a jump to a VNC pane in a different
+                // workspace. Pool rows (openIn == nil) keep the global open-or-focus.
+                if let openIn {
+                    nodeActions.projectInLocalWorkspace(resource.id, openIn)
+                } else {
+                    nodeActions.project(resource.id, .split, true)
+                }
+            case .port(let resource):
                 nodeActions.project(resource.id, .split, true)
             case .browser(let row):
                 nodeActions.project(row.resource.id, .split, true)
@@ -596,7 +605,9 @@ struct CloudTreeOutlineView: NSViewRepresentable {
                 return items
             case .browser(let row):
                 return resourceMenuItems(row.resource, isLocal: row.resource.machine.isLocal)
-            case .display(let resource), .port(let resource):
+            case .display(let resource, let openIn):
+                return resourceMenuItems(resource, isLocal: false, openInLocalWorkspace: openIn)
+            case .port(let resource):
                 return resourceMenuItems(resource, isLocal: false)
             case .browsersGroup, .portsGroup:
                 return [
@@ -611,9 +622,16 @@ struct CloudTreeOutlineView: NSViewRepresentable {
         /// The verbs every surface row shares: open (reusing an open pane), open as a
         /// tab, a second pane (cloud resources only — a local terminal has one pane),
         /// and copying the resource id agents use with `cmux vm open`.
-        private func resourceMenuItems(_ resource: SurfaceResource, isLocal: Bool) -> [NSMenuItem] {
+        private func resourceMenuItems(_ resource: SurfaceResource, isLocal: Bool, openInLocalWorkspace: UUID? = nil) -> [NSMenuItem] {
             var items: [NSMenuItem] = [
-                item(String(localized: "cloudTree.menu.open", defaultValue: "Open")) { [nodeActions] in nodeActions.project(resource.id, .split, true) },
+                item(String(localized: "cloudTree.menu.open", defaultValue: "Open")) { [nodeActions] in
+                    // Same scope rule as the row's open verb (one shared path).
+                    if let openInLocalWorkspace {
+                        nodeActions.projectInLocalWorkspace(resource.id, openInLocalWorkspace)
+                    } else {
+                        nodeActions.project(resource.id, .split, true)
+                    }
+                },
                 item(String(localized: "cloudTree.menu.openInNewTab", defaultValue: "Open in New Tab")) { [nodeActions] in nodeActions.project(resource.id, .tab, true) },
             ]
             if !isLocal {

--- a/Sources/Cloud/CloudTreeRowContentView.swift
+++ b/Sources/Cloud/CloudTreeRowContentView.swift
@@ -97,7 +97,7 @@ struct CloudTreeRowContentView: View {
             )
         case .terminal(let row):
             CloudTreeTerminalRowContent(row: row, style: style)
-        case .display(let resource):
+        case .display(let resource, _):
             CloudTreeLeafRow(
                 style: style,
                 icon: "display",

--- a/Sources/Panels/BrowserPopupWindowController.swift
+++ b/Sources/Panels/BrowserPopupWindowController.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Bonsplit
+import CmuxBrowser
 import CmuxFoundation
 import CmuxSettings
 import ObjectiveC

--- a/Sources/Panels/MarkdownWebRenderer.swift
+++ b/Sources/Panels/MarkdownWebRenderer.swift
@@ -26,7 +26,7 @@ struct MarkdownWebRenderer: NSViewRepresentable {
     /// Called after the renderer view is attached to a window. A panel can
     /// request focus before SwiftUI mounts its WebKit view, so the panel uses
     /// this lifecycle signal to complete that request without polling.
-    let onViewAttachedToWindow: () -> Void = {}
+    var onViewAttachedToWindow: () -> Void = {}
 
     func makeCoordinator() -> Coordinator {
         session.coordinator(panelId: panelId, workspaceId: workspaceId, filePath: filePath)

--- a/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
+++ b/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
@@ -272,22 +272,36 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
     }
 
     /// Runs one close-family command, reconnecting and retrying ONCE when the attempt
-    /// died with the link ("cmux-tui link exited with status …": a dropped tunnel kills
-    /// the whole client run). Safe here because every close verb is idempotent — a
-    /// second attempt against an already-closed target is `selector.not_found`, which
-    /// the callers already tolerate. Non-idempotent verbs (create, run) must not use it.
+    /// died in transport (a dropped tunnel kills the whole client run mid-command).
+    /// Server answers — exit 1 with a structured error such as `selector.not_found` —
+    /// are real results and pass through untouched. Safe here because every close verb
+    /// is idempotent; non-idempotent verbs (create, run) must not use it.
     private func runCloseCommand(_ arguments: (_ socketPath: String) -> [String]) async throws -> Data {
         let connected = try await links.connected(machineID: machineID)
         guard let link = await links.link(machineID: machineID) else { throw ProviderError.machineAsleep(machineID) }
         do {
             return try await link.run(arguments: arguments(connected.socketPath))
         } catch {
-            // selector.not_found is a real answer, not a transport failure.
-            if Self.isSelectorNotFound(error) { throw error }
-            let reconnected = try await links.connected(machineID: machineID)
-            guard let fresh = await links.link(machineID: machineID) else { throw error }
+            guard Self.isTransportDeath(error) else { throw error }
+            // The link learns of its own death asynchronously; one that still claims
+            // to be connected after a transport failure is torn down first so the retry
+            // gets a fresh tunnel instead of the same dead socket.
+            if await links.link(machineID: machineID) === link, await link.isConnected {
+                await links.disconnect(machineID: machineID)
+            }
+            // A failed reconnect reports the close the user acted on, not its own error.
+            guard let reconnected = try? await links.connected(machineID: machineID),
+                  let fresh = await links.link(machineID: machineID) else { throw error }
             return try await fresh.run(arguments: arguments(reconnected.socketPath))
         }
+    }
+
+    /// The cmux-tui client exits 3 for transport and protocol failures (cannot connect
+    /// to the socket, write failed, transport closed before a response); structured
+    /// server errors exit 1 and are answers, not failures to retry.
+    private static func isTransportDeath(_ error: Error) -> Bool {
+        if case CloudMachineLink.LinkError.exited(let status, _) = error { return status == 3 }
+        return false
     }
 
     /// `terminal <id> close`; a terminal whose process already exited is gone from
@@ -298,7 +312,13 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
             _ = try await runCloseCommand { CloudTuiCommandLine.closeTerminalArguments(socketPath: $0, terminalID: id.key) }
         } catch {
             guard let tabID = tabByTerminal[id.key], Self.isSelectorNotFound(error) else { throw error }
-            _ = try await runCloseCommand { CloudTuiCommandLine.closeTabArguments(socketPath: $0, tabID: tabID) }
+            do {
+                _ = try await runCloseCommand { CloudTuiCommandLine.closeTabArguments(socketPath: $0, tabID: tabID) }
+            } catch {
+                // A close whose first attempt reached cmux-tui before the link died is
+                // already applied: not-found on the second look means gone, not failed.
+                guard Self.isSelectorNotFound(error) else { throw error }
+            }
         }
         closeLocalPanes(showing: [id])
         catalog.remove(id)
@@ -321,7 +341,13 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
     /// Terminals…") go through `CloudTreeNodeActions.deleteWorkspaceAndTerminals`,
     /// which closes each terminal first.
     func closeRemoteWorkspace(id: String) async throws {
-        _ = try await runCloseCommand { CloudTuiCommandLine.closeWorkspaceArguments(socketPath: $0, workspaceID: id) }
+        do {
+            _ = try await runCloseCommand { CloudTuiCommandLine.closeWorkspaceArguments(socketPath: $0, workspaceID: id) }
+        } catch {
+            // Already gone (a retry after the first attempt landed, or closed elsewhere):
+            // the local state update below is still the right outcome.
+            guard Self.isSelectorNotFound(error) else { throw error }
+        }
         info.remoteWorkspaces = info.remoteWorkspaces?.filter { $0.id != id }
         catalog.updateMachine(info)
         scheduleRefresh()

--- a/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
+++ b/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
@@ -271,17 +271,34 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
         reprojectRestoredPanes()
     }
 
+    /// Runs one close-family command, reconnecting and retrying ONCE when the attempt
+    /// died with the link ("cmux-tui link exited with status …": a dropped tunnel kills
+    /// the whole client run). Safe here because every close verb is idempotent — a
+    /// second attempt against an already-closed target is `selector.not_found`, which
+    /// the callers already tolerate. Non-idempotent verbs (create, run) must not use it.
+    private func runCloseCommand(_ arguments: (_ socketPath: String) -> [String]) async throws -> Data {
+        let connected = try await links.connected(machineID: machineID)
+        guard let link = await links.link(machineID: machineID) else { throw ProviderError.machineAsleep(machineID) }
+        do {
+            return try await link.run(arguments: arguments(connected.socketPath))
+        } catch {
+            // selector.not_found is a real answer, not a transport failure.
+            if Self.isSelectorNotFound(error) { throw error }
+            let reconnected = try await links.connected(machineID: machineID)
+            guard let fresh = await links.link(machineID: machineID) else { throw error }
+            return try await fresh.run(arguments: arguments(reconnected.socketPath))
+        }
+    }
+
     /// `terminal <id> close`; a terminal whose process already exited is gone from
     /// cmux-tui's selectors, so its tab is closed instead. Either way the resource
     /// leaves the catalog now and the next snapshot confirms.
     func closeTerminal(_ id: SurfaceResourceID) async throws {
-        let connected = try await links.connected(machineID: machineID)
-        guard let link = await links.link(machineID: machineID) else { throw ProviderError.machineAsleep(machineID) }
         do {
-            _ = try await link.run(arguments: CloudTuiCommandLine.closeTerminalArguments(socketPath: connected.socketPath, terminalID: id.key))
+            _ = try await runCloseCommand { CloudTuiCommandLine.closeTerminalArguments(socketPath: $0, terminalID: id.key) }
         } catch {
             guard let tabID = tabByTerminal[id.key], Self.isSelectorNotFound(error) else { throw error }
-            _ = try await link.run(arguments: CloudTuiCommandLine.closeTabArguments(socketPath: connected.socketPath, tabID: tabID))
+            _ = try await runCloseCommand { CloudTuiCommandLine.closeTabArguments(socketPath: $0, tabID: tabID) }
         }
         closeLocalPanes(showing: [id])
         catalog.remove(id)
@@ -304,9 +321,7 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
     /// Terminals…") go through `CloudTreeNodeActions.deleteWorkspaceAndTerminals`,
     /// which closes each terminal first.
     func closeRemoteWorkspace(id: String) async throws {
-        let connected = try await links.connected(machineID: machineID)
-        guard let link = await links.link(machineID: machineID) else { throw ProviderError.machineAsleep(machineID) }
-        _ = try await link.run(arguments: CloudTuiCommandLine.closeWorkspaceArguments(socketPath: connected.socketPath, workspaceID: id))
+        _ = try await runCloseCommand { CloudTuiCommandLine.closeWorkspaceArguments(socketPath: $0, workspaceID: id) }
         info.remoteWorkspaces = info.remoteWorkspaces?.filter { $0.id != id }
         catalog.updateMachine(info)
         scheduleRefresh()

--- a/Sources/Surfaces/SurfaceCatalog.swift
+++ b/Sources/Surfaces/SurfaceCatalog.swift
@@ -219,17 +219,26 @@ final class SurfaceCatalog {
 
     /// The only open path. Reuses an existing projection when `reuseExisting` is set and one
     /// exists (focusing it), otherwise asks the provider to materialize a pane.
+    ///
+    /// `reuseInWorkspace` narrows reuse to projections in that local workspace: a pane
+    /// showing the resource in ANOTHER workspace neither satisfies the open nor steals
+    /// focus — the resource materializes at `destination` instead. A workspace's own
+    /// Desktop row uses this so "open this workspace's screen" never teleports to a
+    /// different workspace's VNC pane. Nil keeps the global open-or-focus jump.
     @discardableResult
-    func project(_ id: SurfaceResourceID, into destination: SurfaceDestination, focus: Bool = true, reuseExisting: Bool = true) async throws -> (projection: SurfaceProjection, reused: Bool) {
+    func project(_ id: SurfaceResourceID, into destination: SurfaceDestination, focus: Bool = true, reuseExisting: Bool = true, reuseInWorkspace: UUID? = nil) async throws -> (projection: SurfaceProjection, reused: Bool) {
         guard let resource = resources[id] else { throw SurfaceCatalogError.unknownResource(id) }
-        if reuseExisting, let existing = projections.first(where: { $0.resource == id }) {
+        if reuseExisting, let existing = projections.first(where: { $0.resource == id && (reuseInWorkspace == nil || $0.workspaceID == reuseInWorkspace) }) {
             try claimCompletedMaterializationIfNeeded(id, projection: existing)
             if focus { focusProjection?(existing) }
             return (existing, true)
         }
         guard let provider = providers[id.machine] else { throw SurfaceCatalogError.noProvider(id.machine) }
 
-        if reuseExisting {
+        // Workspace-scoped reuse missed: an in-flight materialization bound elsewhere
+        // must not be adopted either (it would land — and focus — in that other
+        // workspace), so scoped calls go straight to a fresh materialization.
+        if reuseExisting, reuseInWorkspace == nil {
             let waiterID = UUID()
             let result = try await withTaskCancellationHandler {
                 try await awaitMaterialization(

--- a/Sources/Surfaces/SurfaceCatalog.swift
+++ b/Sources/Surfaces/SurfaceCatalog.swift
@@ -95,7 +95,7 @@ final class SurfaceCatalog {
     private var inFlightProjects: [SurfaceResourceID: SurfaceProjectionMaterialization] = [:]
     /// Workspace-scoped opens (`project(reuseInWorkspace:)`) single-flight per
     /// (resource, local workspace); see `projectScoped`.
-    private var scopedInFlightProjects: [ScopedMaterializationKey: Task<SurfaceProjection, any Error>] = [:]
+    private var scopedInFlightProjects: [ScopedMaterializationKey: ScopedMaterialization] = [:]
     /// Tokens for operations that can still report after the catalog moved on. The provider is
     /// held by the provider task itself and passed to the late-result callback, so these sets do
     /// not keep disconnected providers alive. Every token has one bounded eviction task.
@@ -142,6 +142,7 @@ final class SurfaceCatalog {
             for id in inFlightIDs {
                 cancelInFlightProject(id, error: SurfaceCatalogError.unknownResource(id))
             }
+            retireScopedMaterializations(on: provider.machine)
         }
         providers[provider.machine] = provider
         machines[provider.machine] = provider.info
@@ -153,6 +154,7 @@ final class SurfaceCatalog {
         for id in inFlightIDs {
             cancelInFlightProject(id, error: SurfaceCatalogError.unknownResource(id))
         }
+        retireScopedMaterializations(on: machine)
         // A machine that is gone (deleted, or access ended) takes its URL-backed
         // panes with it: a display or browser pane holds a tokened gateway URL
         // that decays into the hosting provider's raw error page once the
@@ -279,14 +281,25 @@ final class SurfaceCatalog {
         let workspaceID: UUID
     }
 
+    private struct ScopedMaterialization {
+        let provider: any SurfaceProvider
+        let token: UUID
+        let task: Task<SurfaceProjection, any Error>
+    }
+
     /// One provider call per (resource, local workspace) for workspace-scoped opens: a
     /// second scoped open of the same resource into the same workspace joins the pending
     /// call instead of making a duplicate pane, while scoped opens into different
-    /// workspaces stay independent (each workspace shows its own pane by design). The
-    /// call counts against the machine's materialization capacity like any other, and a
-    /// pane that lands after its resource or provider is gone is discarded, not recorded.
-    /// A caller that stops waiting leaves the pane where it asked for it — the pane is
-    /// owned by the catalog either way, unlike the global path's shared single-flight.
+    /// workspaces stay independent (each workspace shows its own pane by design).
+    ///
+    /// Lifecycle mirrors the global single-flight: the call counts against the machine's
+    /// materialization capacity; a pane that lands after its resource or provider is gone
+    /// is discarded, not recorded; replacing or unregistering the provider retires its
+    /// pending scoped calls (a joiner never attaches to a stale provider's call); and a
+    /// caller that stops waiting retires the capacity slot on the bounded retention
+    /// window, so a provider that never answers cannot pin the machine's capacity. The
+    /// one deliberate difference: a caller that stops waiting leaves the pane where it
+    /// asked for it — a per-workspace pane is the requested outcome, owned by the catalog.
     private func projectScoped(
         _ id: SurfaceResourceID,
         resource: SurfaceResource,
@@ -297,9 +310,15 @@ final class SurfaceCatalog {
     ) async throws -> (projection: SurfaceProjection, reused: Bool) {
         let key = ScopedMaterializationKey(resource: id, workspaceID: workspaceID)
         if let pending = scopedInFlightProjects[key] {
-            let projection = try await pending.value
-            if focus { focusProjection?(projection) }
-            return (projection, true)
+            if pending.provider === provider {
+                let projection = try await awaitScopedMaterialization(pending, key: key)
+                if focus { focusProjection?(projection) }
+                return (projection, true)
+            }
+            // The machine's provider changed under the pending call (register/unregister
+            // retire scoped work, so this only closes the same-turn race): its pane, if
+            // any, is discarded by the provider check below; this caller starts fresh.
+            retireScopedMaterialization(key)
         }
         guard trackedMaterializationCounts[provider.machine, default: 0] < maximumTrackedMaterializations else {
             throw SurfaceCatalogError.unavailable(id, reason: "materialization capacity exhausted")
@@ -307,10 +326,7 @@ final class SurfaceCatalog {
         let token = UUID()
         trackMaterialization(token, for: provider)
         let task = Task { @MainActor [weak self] () throws -> SurfaceProjection in
-            defer {
-                self?.releaseTrackedMaterialization(token)
-                self?.scopedInFlightProjects[key] = nil
-            }
+            defer { self?.settleScopedMaterialization(key, token: token) }
             let projection = try await provider.materialize(resource, at: destination, focus: focus)
             guard let self, self.resources[id] != nil, self.providers[id.machine] === provider else {
                 _ = provider.discardMaterialization(projection)
@@ -319,8 +335,58 @@ final class SurfaceCatalog {
             self.record(projection)
             return projection
         }
-        scopedInFlightProjects[key] = task
-        return (try await task.value, false)
+        let entry = ScopedMaterialization(provider: provider, token: token, task: task)
+        scopedInFlightProjects[key] = entry
+        return (try await awaitScopedMaterialization(entry, key: key), false)
+    }
+
+    /// Waits on a scoped call. A caller that stops waiting retires the call's capacity
+    /// slot (bounded, like an abandoned global materialization); the provider operation
+    /// itself stays in flight because provider cancellation is cooperative.
+    private func awaitScopedMaterialization(_ entry: ScopedMaterialization, key: ScopedMaterializationKey) async throws -> SurfaceProjection {
+        try await withTaskCancellationHandler {
+            try await entry.task.value
+        } onCancel: { [weak self] in
+            Task { @MainActor in
+                self?.retireScopedMaterializationCapacity(key, token: entry.token)
+            }
+        }
+    }
+
+    private func retireScopedMaterializationCapacity(_ key: ScopedMaterializationKey, token: UUID) {
+        guard scopedInFlightProjects[key]?.token == token,
+              trackedMaterializationTokens.contains(token),
+              !retiredMaterializationTokens.contains(token) else { return }
+        retireMaterialization(token)
+    }
+
+    /// Drops a pending scoped call from the table and retires its capacity slot. The
+    /// task keeps running to completion (cooperative cancellation) and its late result
+    /// is discarded by the provider/resource check in the task body.
+    private func retireScopedMaterialization(_ key: ScopedMaterializationKey) {
+        guard let pending = scopedInFlightProjects.removeValue(forKey: key) else { return }
+        if trackedMaterializationTokens.contains(pending.token), !retiredMaterializationTokens.contains(pending.token) {
+            retireMaterialization(pending.token)
+        }
+        pending.task.cancel()
+    }
+
+    private func retireScopedMaterializations(on machine: SurfaceMachineID) {
+        for key in scopedInFlightProjects.keys where key.resource.machine == machine {
+            retireScopedMaterialization(key)
+        }
+    }
+
+    /// The scoped call finished (either way): its token stops counting — idempotent with
+    /// an earlier retirement — and its table entry clears unless a newer call replaced it.
+    private func settleScopedMaterialization(_ key: ScopedMaterializationKey, token: UUID) {
+        if retiredMaterializationTokens.remove(token) != nil {
+            retiredMaterializationEvictionTasks.removeValue(forKey: token)?.cancel()
+        }
+        releaseTrackedMaterialization(token)
+        if scopedInFlightProjects[key]?.token == token {
+            scopedInFlightProjects[key] = nil
+        }
     }
 
     private func awaitMaterialization(

--- a/Sources/Surfaces/SurfaceCatalog.swift
+++ b/Sources/Surfaces/SurfaceCatalog.swift
@@ -96,6 +96,9 @@ final class SurfaceCatalog {
     /// Workspace-scoped opens (`project(reuseInWorkspace:)`) single-flight per
     /// (resource, local workspace); see `projectScoped`.
     private var scopedInFlightProjects: [ScopedMaterializationKey: ScopedMaterialization] = [:]
+    /// Callers waiting on a scoped call, by its token: resumed when the call settles, when
+    /// it is retired, or — individually, at once — when the caller itself is cancelled.
+    private var scopedWaiters: [UUID: [UUID: CheckedContinuation<SurfaceProjection, any Error>]] = [:]
     /// Tokens for operations that can still report after the catalog moved on. The provider is
     /// held by the provider task itself and passed to the late-result callback, so these sets do
     /// not keep disconnected providers alive. Every token has one bounded eviction task.
@@ -284,7 +287,7 @@ final class SurfaceCatalog {
     private struct ScopedMaterialization {
         let provider: any SurfaceProvider
         let token: UUID
-        let task: Task<SurfaceProjection, any Error>
+        let task: Task<Void, Never>
     }
 
     /// One provider call per (resource, local workspace) for workspace-scoped opens: a
@@ -325,39 +328,65 @@ final class SurfaceCatalog {
         }
         let token = UUID()
         trackMaterialization(token, for: provider)
-        let task = Task { @MainActor [weak self] () throws -> SurfaceProjection in
-            defer { self?.settleScopedMaterialization(key, token: token) }
-            let projection = try await provider.materialize(resource, at: destination, focus: focus)
-            guard let self, self.resources[id] != nil, self.providers[id.machine] === provider else {
-                _ = provider.discardMaterialization(projection)
-                throw SurfaceCatalogError.unknownResource(id)
+        let task = Task { @MainActor [weak self] in
+            let result: Result<SurfaceProjection, any Error>
+            do {
+                let projection = try await provider.materialize(resource, at: destination, focus: focus)
+                if let self, self.resources[id] != nil, self.providers[id.machine] === provider {
+                    self.record(projection)
+                    result = .success(projection)
+                } else {
+                    _ = provider.discardMaterialization(projection)
+                    result = .failure(SurfaceCatalogError.unknownResource(id))
+                }
+            } catch {
+                result = .failure(error)
             }
-            self.record(projection)
-            return projection
+            self?.settleScopedMaterialization(key, token: token, result: result)
         }
         let entry = ScopedMaterialization(provider: provider, token: token, task: task)
         scopedInFlightProjects[key] = entry
         return (try await awaitScopedMaterialization(entry, key: key), false)
     }
 
-    /// Waits on a scoped call. A caller that stops waiting retires the call's capacity
-    /// slot (bounded, like an abandoned global materialization); the provider operation
-    /// itself stays in flight because provider cancellation is cooperative.
+    /// Waits on a scoped call. A cancelled caller resumes at once with `CancellationError`
+    /// (see `cancelScopedWaiter`); everyone else resumes when the call settles or is retired.
     private func awaitScopedMaterialization(_ entry: ScopedMaterialization, key: ScopedMaterializationKey) async throws -> SurfaceProjection {
-        try await withTaskCancellationHandler {
-            try await entry.task.value
+        let waiterID = UUID()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                guard !Task.isCancelled else {
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
+                scopedWaiters[entry.token, default: [:]][waiterID] = continuation
+            }
         } onCancel: { [weak self] in
             Task { @MainActor in
-                self?.retireScopedMaterializationCapacity(key, token: entry.token)
+                self?.cancelScopedWaiter(key: key, token: entry.token, waiterID: waiterID)
             }
         }
     }
 
-    private func retireScopedMaterializationCapacity(_ key: ScopedMaterializationKey, token: UUID) {
+    /// A caller stopped waiting: it throws `CancellationError` now, and the call's capacity
+    /// slot retires on the bounded window (like an abandoned global materialization). The
+    /// provider operation itself stays in flight because provider cancellation is
+    /// cooperative; its pane still lands in the workspace that asked for it.
+    private func cancelScopedWaiter(key: ScopedMaterializationKey, token: UUID, waiterID: UUID) {
+        guard let continuation = scopedWaiters[token]?.removeValue(forKey: waiterID) else { return }
+        if scopedWaiters[token]?.isEmpty == true { scopedWaiters[token] = nil }
+        continuation.resume(throwing: CancellationError())
         guard scopedInFlightProjects[key]?.token == token,
               trackedMaterializationTokens.contains(token),
               !retiredMaterializationTokens.contains(token) else { return }
         retireMaterialization(token)
+    }
+
+    private func resumeScopedWaiters(_ token: UUID, with result: Result<SurfaceProjection, any Error>) {
+        guard let waiters = scopedWaiters.removeValue(forKey: token) else { return }
+        for continuation in waiters.values {
+            continuation.resume(with: result)
+        }
     }
 
     /// Drops a pending scoped call from the table and retires its capacity slot. The
@@ -369,6 +398,7 @@ final class SurfaceCatalog {
             retireMaterialization(pending.token)
         }
         pending.task.cancel()
+        resumeScopedWaiters(pending.token, with: .failure(SurfaceCatalogError.unknownResource(key.resource)))
     }
 
     private func retireScopedMaterializations(on machine: SurfaceMachineID) {
@@ -378,8 +408,9 @@ final class SurfaceCatalog {
     }
 
     /// The scoped call finished (either way): its token stops counting — idempotent with
-    /// an earlier retirement — and its table entry clears unless a newer call replaced it.
-    private func settleScopedMaterialization(_ key: ScopedMaterializationKey, token: UUID) {
+    /// an earlier retirement — its table entry clears unless a newer call replaced it, and
+    /// every caller still waiting gets the result.
+    private func settleScopedMaterialization(_ key: ScopedMaterializationKey, token: UUID, result: Result<SurfaceProjection, any Error>) {
         if retiredMaterializationTokens.remove(token) != nil {
             retiredMaterializationEvictionTasks.removeValue(forKey: token)?.cancel()
         }
@@ -387,6 +418,7 @@ final class SurfaceCatalog {
         if scopedInFlightProjects[key]?.token == token {
             scopedInFlightProjects[key] = nil
         }
+        resumeScopedWaiters(token, with: result)
     }
 
     private func awaitMaterialization(

--- a/Sources/Surfaces/SurfaceCatalog.swift
+++ b/Sources/Surfaces/SurfaceCatalog.swift
@@ -93,6 +93,9 @@ final class SurfaceCatalog {
     /// Materializations are asynchronous, so actor reentrancy can otherwise let two callers
     /// pass the reuse check before either provider has returned a projection.
     private var inFlightProjects: [SurfaceResourceID: SurfaceProjectionMaterialization] = [:]
+    /// Workspace-scoped opens (`project(reuseInWorkspace:)`) single-flight per
+    /// (resource, local workspace); see `projectScoped`.
+    private var scopedInFlightProjects: [ScopedMaterializationKey: Task<SurfaceProjection, any Error>] = [:]
     /// Tokens for operations that can still report after the catalog moved on. The provider is
     /// held by the provider task itself and passed to the late-result callback, so these sets do
     /// not keep disconnected providers alive. Every token has one bounded eviction task.
@@ -237,8 +240,11 @@ final class SurfaceCatalog {
 
         // Workspace-scoped reuse missed: an in-flight materialization bound elsewhere
         // must not be adopted either (it would land — and focus — in that other
-        // workspace), so scoped calls go straight to a fresh materialization.
-        if reuseExisting, reuseInWorkspace == nil {
+        // workspace), so scoped calls single-flight per workspace instead.
+        if reuseExisting, let reuseInWorkspace {
+            return try await projectScoped(id, resource: resource, provider: provider, into: destination, focus: focus, workspaceID: reuseInWorkspace)
+        }
+        if reuseExisting {
             let waiterID = UUID()
             let result = try await withTaskCancellationHandler {
                 try await awaitMaterialization(
@@ -266,6 +272,55 @@ final class SurfaceCatalog {
         let projection = try await provider.materialize(resource, at: destination, focus: focus)
         record(projection)
         return (projection, false)
+    }
+
+    private struct ScopedMaterializationKey: Hashable {
+        let resource: SurfaceResourceID
+        let workspaceID: UUID
+    }
+
+    /// One provider call per (resource, local workspace) for workspace-scoped opens: a
+    /// second scoped open of the same resource into the same workspace joins the pending
+    /// call instead of making a duplicate pane, while scoped opens into different
+    /// workspaces stay independent (each workspace shows its own pane by design). The
+    /// call counts against the machine's materialization capacity like any other, and a
+    /// pane that lands after its resource or provider is gone is discarded, not recorded.
+    /// A caller that stops waiting leaves the pane where it asked for it — the pane is
+    /// owned by the catalog either way, unlike the global path's shared single-flight.
+    private func projectScoped(
+        _ id: SurfaceResourceID,
+        resource: SurfaceResource,
+        provider: any SurfaceProvider,
+        into destination: SurfaceDestination,
+        focus: Bool,
+        workspaceID: UUID
+    ) async throws -> (projection: SurfaceProjection, reused: Bool) {
+        let key = ScopedMaterializationKey(resource: id, workspaceID: workspaceID)
+        if let pending = scopedInFlightProjects[key] {
+            let projection = try await pending.value
+            if focus { focusProjection?(projection) }
+            return (projection, true)
+        }
+        guard trackedMaterializationCounts[provider.machine, default: 0] < maximumTrackedMaterializations else {
+            throw SurfaceCatalogError.unavailable(id, reason: "materialization capacity exhausted")
+        }
+        let token = UUID()
+        trackMaterialization(token, for: provider)
+        let task = Task { @MainActor [weak self] () throws -> SurfaceProjection in
+            defer {
+                self?.releaseTrackedMaterialization(token)
+                self?.scopedInFlightProjects[key] = nil
+            }
+            let projection = try await provider.materialize(resource, at: destination, focus: focus)
+            guard let self, self.resources[id] != nil, self.providers[id.machine] === provider else {
+                _ = provider.discardMaterialization(projection)
+                throw SurfaceCatalogError.unknownResource(id)
+            }
+            self.record(projection)
+            return projection
+        }
+        scopedInFlightProjects[key] = task
+        return (try await task.value, false)
     }
 
     private func awaitMaterialization(

--- a/Sources/Surfaces/SurfacePaneFactory.swift
+++ b/Sources/Surfaces/SurfacePaneFactory.swift
@@ -269,6 +269,15 @@ enum SurfaceBrowserPlaceholder {
                 .joined()
         } ?? ""
         let spinnerHTML = spinner ? "<div class=\"spinner\" role=\"progressbar\"></div>" : ""
+        // The spinner's stylesheet ships only with a spinner: the failed page
+        // must carry no trace of one (the tests assert on the whole document).
+        let spinnerCSS = spinner ? """
+
+          .spinner { width: 22px; height: 22px; margin: 0 auto 14px; border-radius: 50%;
+                     border: 2px solid rgba(216,222,233,0.25); border-top-color: #d8dee9;
+                     animation: spin 0.9s linear infinite; }
+          @keyframes spin { to { transform: rotate(360deg); } }
+        """ : ""
         return """
         <!doctype html>
         <html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
@@ -279,11 +288,7 @@ enum SurfaceBrowserPlaceholder {
                  font: 14px -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif; }
           main { text-align: center; max-width: 36em; padding: 0 1.5em; }
           h1 { font-size: 15px; font-weight: 500; margin: 0 0 0.6em; }
-          p { margin: 0.3em 0; opacity: 0.8; word-break: break-word; }
-          .spinner { width: 22px; height: 22px; margin: 0 auto 14px; border-radius: 50%;
-                     border: 2px solid rgba(216,222,233,0.25); border-top-color: #d8dee9;
-                     animation: spin 0.9s linear infinite; }
-          @keyframes spin { to { transform: rotate(360deg); } }
+          p { margin: 0.3em 0; opacity: 0.8; word-break: break-word; }\(spinnerCSS)
         </style></head>
         <body><main>\(spinnerHTML)<h1>\(escape(title))</h1>\(detailHTML)</main></body></html>
         """

--- a/cmuxTests/MachinesPanelModelTests.swift
+++ b/cmuxTests/MachinesPanelModelTests.swift
@@ -442,6 +442,17 @@ final class MachinesPanelModelTests: XCTestCase {
         if case .workspace(_, _, _, let openIn) = openByID["machine:vivid-newt/ws/ws_empty"]!.kind {
             XCTAssertNil(openIn, "nothing of it is open anywhere")
         } else { XCTFail("expected ws_empty row") }
+        // Desktop rows: a workspace's own display pointer opens inside the local
+        // workspace showing that remote workspace; the pool row keeps the global jump.
+        if case .display(_, let openIn) = openByID["machine:vivid-newt/ws/ws_main/resource:vivid-newt/display/display:1"]!.kind {
+            XCTAssertEqual(openIn, local, "ws_main shows locally, so its Desktop opens there")
+        } else { XCTFail("expected ws_main display row") }
+        if case .display(_, let openIn) = openByID["resource:vivid-newt/display/display:1"]!.kind {
+            XCTAssertNil(openIn, "the pool Desktop keeps the global open-or-focus")
+        } else { XCTFail("expected pool display row") }
+        if case .display(_, let openIn) = openByID["machine:vivid-newt/ws/ws_empty/resource:vivid-newt/display/display:1"]!.kind {
+            XCTAssertNil(openIn, "ws_empty shows nowhere locally")
+        } else { XCTFail("expected ws_empty display row") }
         XCTAssertNil(CloudTreeNodeBuilder.localWorkspaceShowing([], snapshot: openSnapshot))
         // The workspace's open/drag group carries its display pointer with its terminals.
         XCTAssertEqual(

--- a/cmuxTests/SurfaceCatalogTests.swift
+++ b/cmuxTests/SurfaceCatalogTests.swift
@@ -195,6 +195,40 @@ struct SurfaceCatalogTests {
         #expect(catalog.projections(of: term.id).count == 2)
     }
 
+    @Test func `Workspace-scoped reuse ignores panes in other workspaces`() async throws {
+        let catalog = SurfaceCatalog()
+        let provider = FakeProvider(machine: .cloud("vivid-newt"))
+        catalog.register(provider)
+        let term = terminal(.cloud("vivid-newt"), "display_like")
+        catalog.replaceResources([term], on: .cloud("vivid-newt"))
+        var focused: [SurfaceProjection] = []
+        catalog.focusProjection = { focused.append($0) }
+
+        let wsA = UUID()
+        let wsB = UUID()
+        let a = try await catalog.project(term.id, into: .workspace(id: wsA, placement: .split), reuseInWorkspace: wsA)
+        #expect(!a.reused)
+
+        // A pane in wsA neither satisfies wsB's scoped open nor steals focus:
+        // the resource materializes in wsB (the workspace-Desktop-row bug).
+        let b = try await catalog.project(term.id, into: .workspace(id: wsB, placement: .split), reuseInWorkspace: wsB)
+        #expect(!b.reused)
+        #expect(b.projection.workspaceID == wsB)
+        #expect(provider.materialized.count == 2)
+        #expect(focused.isEmpty, "no jump to the other workspace's pane")
+
+        // Scoped reuse still reuses within its own workspace…
+        let again = try await catalog.project(term.id, into: .workspace(id: wsB, placement: .split), reuseInWorkspace: wsB)
+        #expect(again.reused)
+        #expect(again.projection == b.projection)
+        #expect(focused == [b.projection])
+
+        // …and an unscoped call keeps the global open-or-focus jump.
+        let global = try await catalog.project(term.id, into: .workspace(id: UUID(), placement: .tab))
+        #expect(global.reused)
+        #expect(provider.materialized.count == 2)
+    }
+
     @Test func `Concurrent reuse waits for the in-flight materialization`() async throws {
         let catalog = SurfaceCatalog()
         let provider = FakeProvider(machine: .cloud("vivid-newt"))

--- a/cmuxTests/SurfaceCatalogTests.swift
+++ b/cmuxTests/SurfaceCatalogTests.swift
@@ -283,6 +283,70 @@ struct SurfaceCatalogTests {
         #expect(catalog.projections(of: term.id).isEmpty)
     }
 
+    @Test func `Registering a replacement provider retires its old scoped materialization`() async throws {
+        let catalog = SurfaceCatalog()
+        let oldProvider = FakeProvider(machine: .cloud("vivid-newt"))
+        let gate = MaterializeGate()
+        oldProvider.materializeGate = gate
+        catalog.register(oldProvider)
+        let term = terminal(.cloud("vivid-newt"), "display_like")
+        catalog.replaceResources([term], on: .cloud("vivid-newt"))
+        let ws = UUID()
+        let destination = SurfaceDestination.workspace(id: ws, placement: .split)
+
+        let old = Task { try await catalog.project(term.id, into: destination, reuseInWorkspace: ws) }
+        await gate.waitUntilEntered()
+
+        let replacement = FakeProvider(machine: .cloud("vivid-newt"))
+        catalog.register(replacement)
+        // A scoped open after the swap must not join the stale call: the new provider materializes.
+        let new = try await catalog.project(term.id, into: destination, reuseInWorkspace: ws)
+        #expect(!new.reused)
+        #expect(replacement.materialized.count == 1)
+
+        gate.release()
+        await #expect(throws: SurfaceCatalogError.unknownResource(term.id)) { try await old.value }
+        #expect(oldProvider.discarded.count == 1, "the stale provider's late pane is handed back, not recorded")
+        #expect(catalog.projections(of: term.id) == [new.projection])
+    }
+
+    @Test func `A cancelled scoped open retires its capacity slot`() async throws {
+        let (retired, retiredContinuation) = AsyncStream<Void>.makeStream(bufferingPolicy: .bufferingNewest(1))
+        let clock = ImmediateClock { _ in
+            retiredContinuation.yield(())
+            retiredContinuation.finish()
+        }
+        let catalog = SurfaceCatalog(maximumTrackedMaterializations: 1, materializationClock: clock)
+        let provider = FakeProvider(machine: .cloud("vivid-newt"))
+        let gate = MaterializeGate()
+        provider.materializeGate = gate
+        catalog.register(provider)
+        let term = terminal(.cloud("vivid-newt"), "display_like")
+        let other = terminal(.cloud("vivid-newt"), "term_2")
+        catalog.replaceResources([term, other], on: .cloud("vivid-newt"))
+        let ws = UUID()
+
+        let stuck = Task { try await catalog.project(term.id, into: .workspace(id: ws, placement: .split), reuseInWorkspace: ws) }
+        await gate.waitUntilEntered()
+        // While the scoped call is pending, the machine's single slot is taken.
+        await #expect(throws: SurfaceCatalogError.unavailable(other.id, reason: "materialization capacity exhausted")) {
+            try await catalog.project(other.id, into: .workspace(id: ws, placement: .split), reuseInWorkspace: ws)
+        }
+
+        stuck.cancel()
+        _ = try await awaitFirst(retired)
+        await Task.yield()
+        // The caller gave up: the slot retires on the bounded window, so a provider that
+        // never answers cannot refuse every later open on that machine.
+        provider.materializeGate = nil
+        let later = try await catalog.project(other.id, into: .workspace(id: ws, placement: .split), reuseInWorkspace: ws)
+        #expect(!later.reused)
+        #expect(provider.materialized.count == 2)
+
+        gate.release()
+        _ = try? await stuck.value
+    }
+
     @Test func `Concurrent reuse waits for the in-flight materialization`() async throws {
         let catalog = SurfaceCatalog()
         let provider = FakeProvider(machine: .cloud("vivid-newt"))

--- a/cmuxTests/SurfaceCatalogTests.swift
+++ b/cmuxTests/SurfaceCatalogTests.swift
@@ -229,6 +229,60 @@ struct SurfaceCatalogTests {
         #expect(provider.materialized.count == 2)
     }
 
+    @Test func `Concurrent scoped opens into one workspace share the materialization`() async throws {
+        let catalog = SurfaceCatalog()
+        let provider = FakeProvider(machine: .cloud("vivid-newt"))
+        let gate = MaterializeGate()
+        provider.materializeGate = gate
+        catalog.register(provider)
+        let term = terminal(.cloud("vivid-newt"), "display_like")
+        catalog.replaceResources([term], on: .cloud("vivid-newt"))
+        let ws = UUID()
+        let destination = SurfaceDestination.workspace(id: ws, placement: .split)
+
+        let first = Task { try await catalog.project(term.id, into: destination, reuseInWorkspace: ws) }
+        await gate.waitUntilEntered()
+
+        let (secondStarted, secondStartedContinuation) = AsyncStream<Void>.makeStream(
+            bufferingPolicy: .bufferingNewest(1)
+        )
+        let second = Task { @MainActor in
+            secondStartedContinuation.yield(())
+            secondStartedContinuation.finish()
+            return try await catalog.project(term.id, into: destination, reuseInWorkspace: ws)
+        }
+        _ = try await awaitFirst(secondStarted)
+        #expect(provider.materialized.count == 1, "a double-click on one workspace's Desktop row must not make two panes")
+
+        gate.release()
+        let firstResult = try await first.value
+        let secondResult = try await second.value
+        #expect(!firstResult.reused)
+        #expect(secondResult.reused)
+        #expect(firstResult.projection == secondResult.projection)
+        #expect(catalog.projections(of: term.id).count == 1)
+    }
+
+    @Test func `A scoped open whose resource vanished mid-materialization discards the pane`() async throws {
+        let catalog = SurfaceCatalog()
+        let provider = FakeProvider(machine: .cloud("vivid-newt"))
+        let gate = MaterializeGate()
+        provider.materializeGate = gate
+        catalog.register(provider)
+        let term = terminal(.cloud("vivid-newt"), "display_like")
+        catalog.replaceResources([term], on: .cloud("vivid-newt"))
+        let ws = UUID()
+
+        let open = Task { try await catalog.project(term.id, into: .workspace(id: ws, placement: .split), reuseInWorkspace: ws) }
+        await gate.waitUntilEntered()
+        catalog.replaceResources([], on: .cloud("vivid-newt"))
+        gate.release()
+
+        await #expect(throws: SurfaceCatalogError.self) { try await open.value }
+        #expect(provider.discardInvocations.count == 1, "the late pane is handed back to the provider, not recorded")
+        #expect(catalog.projections(of: term.id).isEmpty)
+    }
+
     @Test func `Concurrent reuse waits for the in-flight materialization`() async throws {
         let catalog = SurfaceCatalog()
         let provider = FakeProvider(machine: .cloud("vivid-newt"))

--- a/cmuxTests/SurfaceCatalogTests.swift
+++ b/cmuxTests/SurfaceCatalogTests.swift
@@ -297,15 +297,22 @@ struct SurfaceCatalogTests {
         let old = Task { try await catalog.project(term.id, into: destination, reuseInWorkspace: ws) }
         await gate.waitUntilEntered()
 
+        let (discarded, discardedContinuation) = AsyncStream<SurfaceProjection>.makeStream(bufferingPolicy: .bufferingNewest(1))
+        oldProvider.onDiscard = { projection in
+            discardedContinuation.yield(projection)
+            discardedContinuation.finish()
+        }
         let replacement = FakeProvider(machine: .cloud("vivid-newt"))
         catalog.register(replacement)
+        // The stale caller is told right away, not when the old provider finally answers.
+        await #expect(throws: SurfaceCatalogError.unknownResource(term.id)) { try await old.value }
         // A scoped open after the swap must not join the stale call: the new provider materializes.
         let new = try await catalog.project(term.id, into: destination, reuseInWorkspace: ws)
         #expect(!new.reused)
         #expect(replacement.materialized.count == 1)
 
         gate.release()
-        await #expect(throws: SurfaceCatalogError.unknownResource(term.id)) { try await old.value }
+        _ = try await awaitFirst(discarded)
         #expect(oldProvider.discarded.count == 1, "the stale provider's late pane is handed back, not recorded")
         #expect(catalog.projections(of: term.id) == [new.projection])
     }
@@ -334,6 +341,8 @@ struct SurfaceCatalogTests {
         }
 
         stuck.cancel()
+        // The cancelled caller stops waiting at once; the provider call keeps going.
+        await #expect(throws: CancellationError.self) { try await stuck.value }
         _ = try await awaitFirst(retired)
         await Task.yield()
         // The caller gave up: the slot retires on the bounded window, so a provider that
@@ -344,7 +353,6 @@ struct SurfaceCatalogTests {
         #expect(provider.materialized.count == 2)
 
         gate.release()
-        _ = try? await stuck.value
     }
 
     @Test func `Concurrent reuse waits for the in-flight materialization`() async throws {


### PR DESCRIPTION
## Summary
Follow-on to #11061 (merged) — rebased onto `main`; three focused fixes to the cloud tree / surface catalog.

**1. Failed placeholder page carries no spinner CSS** — `SurfaceBrowserPlaceholder.failed()` shared its stylesheet with the connecting page, so the failure document still contained the `.spinner` rule and `CmuxTuiSurfaceProviderTests.optimisticPanePlaceholdersLabelAndEscape` (`#expect(!failed.contains("spinner"))`) was red. The spinner's CSS now ships only when the spinner div does.

**2. A workspace's Desktop opens inside that workspace — never a jump elsewhere** — every workspace row carries the machine's display, but the rows shared one resource id and `SurfaceCatalog.project`'s reuse was global: clicking workspace B's Desktop focused the VNC pane already open in workspace A and teleported you there. `project()` gains `reuseInWorkspace:` (scoped calls reuse only a pane in that local workspace, never adopt an in-flight materialization bound elsewhere, otherwise materialize at the destination); display nodes under a remote workspace carry the parent's `openIn`, and both their click and context-menu Open route through the scoped verb. Pool Desktop rows, terminal rows, and the CLI keep the global open-or-focus jump.

**3. Close verbs survive one link death** — closing a workspace or terminal sometimes surfaced `cmux-tui link exited with status 1: {...}` (a transient tunnel drop kills the client run mid-command) and had to be clicked again. `terminal close`/`tab close`/`workspace close` now reconnect and retry exactly once on a link death — safe because closes are idempotent (`selector.not_found` passes through untouched); non-idempotent verbs stay off the helper.

**4. Main compile fixes carried here** (same as #11346 / #11337, so this branch builds until they land): `MarkdownWebRenderer.onViewAttachedToWindow` is a `var` so the memberwise init accepts it; `BrowserPopupWindowController` imports `CmuxBrowser`.

**Review follow-ups (8293f917):** scoped opens single-flight per (resource, local workspace) with capacity tracking and late-result discard (two new `SurfaceCatalogTests`); the close retry fires only on a transport death (client exit 3), tears down a link that still claims connected before reconnecting, keeps the original error if reconnect fails, and `selector.not_found` after an already-applied close counts as closed; "Open in New Tab" on a workspace Desktop row honors the workspace scope like click/Open.

Remaining follow-up candidates:
- [ ] `vm tree <machine>` right after link attach shows `workspaces/ (none yet)` until `--refresh` — warm the snapshot on attach
- [ ] per-workspace independent screens (one virtual display per workspace pointing at the machine): machine-side "create display" verb + app-side placement; snapshot/ports/endpoints are already display-plural
- [ ] UX: the workspace row's ✕ is "Close Workspace (Keep Terminals)" per the protocol contract, and the surviving pool rows read as mystery "detached" leftovers — consider a bulk "Kill Detached Terminals" verb on the Terminals pool and/or making the two close flavors explicit at the ✕
- [ ] devbox image: bake `pcmanfm --desktop` in (desktop rubber-band selection / icons); currently installed at runtime on silver-petrel only, lost on VM restart

## Test plan
- [x] fleet xctest: `cmuxTests/CmuxTuiSurfaceProviderTests` 18/18 (was 17/18)
- [x] fleet xctest: `SurfaceCatalogTests` (incl. new workspace-scoped reuse test) and `MachinesPanelModelTests` 27/27 green
- [x] fleet xctest after the close-retry change: suites still green (compile + behavior)
- [ ] hosted `test-e2e.yml` on the final HEAD: `cmuxTests/SurfaceCatalogTests`, `cmuxTests/MachinesPanelModelTests`, `cmuxTests/CmuxTuiSurfaceProviderTests` (results below in comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cloud workspace displays now open directly in the corresponding local workspace when available.
  * Opening the same resource concurrently in one workspace now reuses a single instance, reducing duplicate panes.
* **Bug Fixes**
  * Closing terminals and remote workspaces now retries once after temporary connection failures.
  * Open operations handle removed resources and provider changes more reliably.
  * Loading pages no longer include unused spinner styling when no spinner is shown.
* **Tests**
  * Added coverage for workspace-specific opening, concurrent launches, cancellations, and connection-related edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->