### PR TITLE
Fix sidebar pump replay geometry tests

### DIFF
--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
@@ -67,6 +67,8 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
     private var renameSession: SidebarRowInlineRenameSession?
     var isEditing: Bool { renameSession != nil }
     private var pumpCancellables: [AnyCancellable] = []
+    private weak var pumpWorkspace: Workspace?
+    private var pumpRebuild: (@MainActor () -> Void)?
     private var isPresentationActive = true
 
 #if DEBUG
@@ -81,17 +83,20 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
         workspace: Workspace,
         rebuild: @escaping @MainActor () -> Void
     ) {
+        pumpRebuild = rebuild
+        guard pumpWorkspace !== workspace else { return }
         pumpCancellables.removeAll()
+        pumpWorkspace = workspace
         workspace.sidebarImmediateObservationPublisher
             .receive(on: DispatchQueue.main)
-            .sink { _ in
-                MainActor.assumeIsolated { rebuild() }
+            .sink { [weak self] _ in
+                MainActor.assumeIsolated { self?.pumpRebuild?() }
             }
             .store(in: &pumpCancellables)
         workspace.sidebarObservationPublisher
             .debounce(for: .milliseconds(40), scheduler: DispatchQueue.main)
-            .sink { _ in
-                MainActor.assumeIsolated { rebuild() }
+            .sink { [weak self] _ in
+                MainActor.assumeIsolated { self?.pumpRebuild?() }
             }
             .store(in: &pumpCancellables)
         rebuild()
@@ -287,6 +292,8 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
         contextMenuDidClose = nil
         contextMenuVisible = false
         pumpCancellables.removeAll()
+        pumpWorkspace = nil
+        pumpRebuild = nil
         setPresentationActive(false)
         return postUpdateActions
     }

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
@@ -74,10 +74,9 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
     /// optimistic press/deselect, hover enforcement).
     var applyModelProbeForTesting: ((SidebarWorkspaceRowModel) -> Void)?
 #endif
-
     /// Per-row churn pump: mirrors TabItemView's onReceive subscriptions so
     /// metadata/branch/PR updates repaint just this cell without any
-    /// container re-render. Installed per configure; replaced on reuse.
+    /// container re-render; installation also replays the current model.
     func installPump(
         workspace: Workspace,
         rebuild: @escaping @MainActor () -> Void
@@ -95,6 +94,7 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
                 MainActor.assumeIsolated { rebuild() }
             }
             .store(in: &pumpCancellables)
+        rebuild()
     }
 
     /// Measurement/apply entry used by the pump path.

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
@@ -88,12 +88,14 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
         pumpCancellables.removeAll()
         pumpWorkspace = workspace
         workspace.sidebarImmediateObservationPublisher
+            .dropFirst()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 MainActor.assumeIsolated { self?.pumpRebuild?() }
             }
             .store(in: &pumpCancellables)
         workspace.sidebarObservationPublisher
+            .dropFirst()
             .debounce(for: .milliseconds(40), scheduler: DispatchQueue.main)
             .sink { [weak self] _ in
                 MainActor.assumeIsolated { self?.pumpRebuild?() }

--- a/cmuxTests/SidebarWorkspaceTableTests.swift
+++ b/cmuxTests/SidebarWorkspaceTableTests.swift
@@ -523,8 +523,7 @@ struct SidebarWorkspaceTableTests {
     func unreadRefreshKeepsTableHeightInLockstepWithTheReconfiguredCell() async throws {
         let workspace = Workspace()
         let baseModel = SidebarWorkspaceRowSuspensionTests.makeModel(workspaceId: workspace.id)
-        var pumpModel = baseModel
-        pumpModel.latestNotificationText = "metadata refresh"
+        let pumpModel = SidebarWorkspaceRowSuspensionTests.makeModel(customDescription: "metadata refresh", workspaceId: workspace.id)
         let environment = SidebarWorkspaceTableEnvironmentSnapshot(
             colorScheme: .dark,
             globalFontMagnificationPercent: 100,
@@ -595,10 +594,9 @@ struct SidebarWorkspaceTableTests {
         // The initial pump replay installs a height override for the shorter
         // live model. The unread update below must retire that override before
         // the cell is painted with its taller notification preview.
+        await flushUntil { cell.currentModelForMeasurement?.snapshot.customDescription == "metadata refresh" }
         let pumpHeight = controller.tableView(container.tableView, heightOfRow: 0)
-        let baseHeight = ceil(
-            cell.layoutContent(model: baseModel, width: cell.bounds.width, apply: false)
-        )
+        let baseHeight = row.estimatedHeight
         #expect(pumpHeight > baseHeight)
 
         let latestText = String(repeating: "latest agent message ", count: 30)
@@ -688,15 +686,14 @@ struct SidebarWorkspaceTableTests {
             table.view(atColumn: 0, row: 0, makeIfNecessary: true)
                 as? SidebarWorkspaceRowTableCellView
         )
+        await flushUntil { cell.currentModelForMeasurement?.snapshot.customDescription == pumpDescription }
         #expect(
             cell.currentModelForMeasurement?.snapshot.customDescription
                 == pumpDescription
         )
 
         let pumpHeight = controller.tableView(table, heightOfRow: 0)
-        let authoritativeHeight = ceil(
-            cell.layoutContent(model: baseModel, width: cell.bounds.width, apply: false)
-        )
+        let authoritativeHeight = row.estimatedHeight
         #expect(pumpHeight > authoritativeHeight)
 
         // The row configuration is intentionally identical. An unrelated
@@ -785,8 +782,10 @@ struct SidebarWorkspaceTableTests {
     func widthMismatchedPumpOverrideIsRenotedWhenApplyReleasesIt() async throws {
         let workspace = Workspace()
         let baseModel = SidebarWorkspaceRowSuspensionTests.makeModel(workspaceId: workspace.id)
-        var pumpModel = baseModel
-        pumpModel.latestNotificationText = String(repeating: "live metadata ", count: 30)
+        let pumpModel = SidebarWorkspaceRowSuspensionTests.makeModel(
+            customDescription: String(repeating: "live metadata ", count: 30),
+            workspaceId: workspace.id
+        )
         let environment = SidebarWorkspaceTableEnvironmentSnapshot(
             colorScheme: .dark,
             globalFontMagnificationPercent: 100,
@@ -839,11 +838,9 @@ struct SidebarWorkspaceTableTests {
             container.tableView.view(atColumn: 0, row: 0, makeIfNecessary: true)
                 as? SidebarWorkspaceRowTableCellView
         )
-        #expect(cell.currentModelForMeasurement?.latestNotificationText == pumpModel.latestNotificationText)
+        await flushUntil { cell.currentModelForMeasurement?.snapshot.customDescription == pumpModel.snapshot.customDescription }
         let initialPumpHeight = controller.tableView(container.tableView, heightOfRow: 0)
-        let baseHeight = ceil(
-            cell.layoutContent(model: baseModel, width: cell.bounds.width, apply: false)
-        )
+        let baseHeight = row.estimatedHeight
         #expect(initialPumpHeight > baseHeight)
 
         // Change the measured width without delivering the bounds notification

--- a/cmuxTests/SidebarWorkspaceTableTests.swift
+++ b/cmuxTests/SidebarWorkspaceTableTests.swift
@@ -518,7 +518,6 @@ struct SidebarWorkspaceTableTests {
         let offsetAfter = table.rect(ofRow: nextAnchorIndex).minY - table.visibleRect.minY
         #expect(abs(offsetAfter - offsetBefore) < 0.5)
     }
-
     @Test
     @MainActor
     func unreadRefreshKeepsTableHeightInLockstepWithTheReconfiguredCell() async throws {
@@ -840,6 +839,7 @@ struct SidebarWorkspaceTableTests {
             container.tableView.view(atColumn: 0, row: 0, makeIfNecessary: true)
                 as? SidebarWorkspaceRowTableCellView
         )
+        #expect(cell.currentModelForMeasurement?.latestNotificationText == pumpModel.latestNotificationText)
         let initialPumpHeight = controller.tableView(container.tableView, heightOfRow: 0)
         let baseHeight = ceil(
             cell.layoutContent(model: baseModel, width: cell.bounds.width, apply: false)

--- a/cmuxTests/SidebarWorkspaceTableTests.swift
+++ b/cmuxTests/SidebarWorkspaceTableTests.swift
@@ -666,6 +666,7 @@ struct SidebarWorkspaceTableTests {
             defer: false
         )
         window.contentView = container
+        window.orderFront(nil)
         defer {
             window.contentView = nil
             window.close()


### PR DESCRIPTION
Fixes the sidebar row pump lifecycle by replaying the current rebuilt model during pump installation, before queued publisher delivery can run. This keeps the painted model and AppKit height override in lockstep during initial layout and retirement.

Closes https://github.com/manaflow-ai/cmux/issues/11243

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790818353&installation_model_id=21920&pr_number=11302&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11302&signature=2ba4120eb30feece4b7a36b5b72cd429cc30a15bf4ca3801e893217898acea39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sidebar pump replay so the cell's painted model and AppKit height override stay in sync during initial layout and retirement. Previously, the pump only delivered queued publisher events, so the first rebuilt model wasn't applied until later. `installPump` now replays the current model immediately and exactly once, stores the rebuild closure on the cell so the subscription survives repaints, and skips re-subscribing for the same workspace. Geometry tests use pump-owned content and await the replay before measuring. Closes #11243.

<sup>Written for commit 4992d25e9aaeb16632c491ff2ab56738d76f64d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sidebar workspace rows now display the latest state immediately when installed, keeping visual content and row sizing synchronized during updates.
  * Improved refresh behavior when workspace notifications or measurement settings change.

* **Tests**
  * Expanded coverage for notification updates, row-height consistency, and refreshed display content during workspace changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->