### PR TITLE
iOS: keep onboarding behind auth restore

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
@@ -812,9 +812,11 @@ struct CMUXMobileRootView: View {
         )
     }
 
-    /// Whether first-run onboarding should present: only for a signed-in
-    /// account session, and only while a durable milestone remains unfinished.
-    /// Signed out, `rootContent` falls through to the sign-in screen instead.
+    /// Whether first-run onboarding should present: only for a settled,
+    /// signed-in account session, and only while a durable milestone remains
+    /// unfinished. During launch restore, `rootContent` falls through to the
+    /// sign-in screen instead of briefly presenting onboarding for a cached
+    /// identity that may still be rejected.
     /// Deliberately narrower than the composite `isAuthenticated`: a temporary
     /// attach-ticket authentication must reach the shell so the attach
     /// completes, not detour into the tour (whose discovery keep-alive
@@ -822,7 +824,8 @@ struct CMUXMobileRootView: View {
     private var shouldShowOnboarding: Bool {
         #if os(iOS)
         return onboardingStore.progress.shouldShowOnboarding(
-            isAuthenticated: authManager.isAuthenticated
+            isAuthenticated: authManager.isAuthenticated,
+            isRestoringSession: authManager.isRestoringSession
         )
         #else
         return false

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
@@ -482,7 +482,11 @@ struct CMUXMobileRootView: View {
                     insertion: .move(edge: .trailing).combined(with: .opacity),
                     removal: .opacity
                 ))
-        } else if !isAuthenticated {
+        } else if MobileRootAuthGate.shouldShowSignIn(
+            stackAuthenticated: authManager.isAuthenticated,
+            attachTicketAuthenticated: hasActiveAttachTicketAuthentication,
+            isRestoringSession: authManager.isRestoringSession
+        ) {
             SignInView()
                 .transition(reduceMotion ? .opacity : .asymmetric(
                     insertion: .opacity,

--- a/Packages/iOS/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/MobileOnboardingGate.swift
+++ b/Packages/iOS/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/MobileOnboardingGate.swift
@@ -2,20 +2,26 @@ public import CmuxMobileShellModel
 
 /// Pure gating policy for the first-run onboarding screen in the mobile root scene.
 ///
-/// Onboarding presents only to a signed-in account: a signed-out launch goes
-/// straight to sign-in, and the flow presents (or resumes) once authentication
-/// succeeds, handing into same-account computer discovery at the connection
-/// milestone. Beyond authentication the decision uses only durable onboarding
-/// progress. Live connection state never suppresses an unfinished flow, so
-/// cancelling QR fallback returns to the connection step.
+/// Onboarding presents only after the account session is settled: a signed-out
+/// or restoring launch goes straight to sign-in, and the flow presents (or
+/// resumes) once authentication succeeds. Beyond authentication the decision
+/// uses only durable onboarding progress. Live connection state never
+/// suppresses an unfinished flow, so cancelling QR fallback returns to the
+/// connection step.
 public extension MobileOnboardingProgress {
     /// Whether the first-run onboarding should be presented.
     ///
-    /// - Parameter isAuthenticated: Whether an account is signed in. Without
-    ///   one there is nothing to onboard into, so sign-in owns the screen.
+    /// - Parameters:
+    ///   - isAuthenticated: Whether an account is currently authenticated.
+    ///   - isRestoringSession: Whether that session is still being validated at
+    ///     launch. A primed cached identity is not a settled session, so
+    ///     sign-in owns the screen until restore completes.
     /// - Returns: `true` for a signed-in account until onboarding is
     ///   explicitly completed.
-    func shouldShowOnboarding(isAuthenticated: Bool) -> Bool {
-        isAuthenticated && self != .complete
+    func shouldShowOnboarding(
+        isAuthenticated: Bool,
+        isRestoringSession: Bool
+    ) -> Bool {
+        isAuthenticated && !isRestoringSession && self != .complete
     }
 }

--- a/Packages/iOS/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/MobileRootAuthGate.swift
+++ b/Packages/iOS/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/MobileRootAuthGate.swift
@@ -23,6 +23,18 @@ public struct MobileRootAuthGate {
         stackAuthenticated || attachTicketAuthenticated
     }
 
+    /// Whether the root should remain on the sign-in surface while Stack auth
+    /// is absent or its cached session is still being validated. A live attach
+    /// ticket is an explicit exception because it must proceed directly to the
+    /// shell to complete the attach flow.
+    public static func shouldShowSignIn(
+        stackAuthenticated: Bool,
+        attachTicketAuthenticated: Bool = false,
+        isRestoringSession: Bool
+    ) -> Bool {
+        (!stackAuthenticated || isRestoringSession) && !attachTicketAuthenticated
+    }
+
     /// Whether the restoring-session UI should be shown.
     /// - Parameters:
     ///   - stackAuthenticated: Whether Stack auth is established.

--- a/Packages/iOS/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/MobileOnboardingGateTests.swift
+++ b/Packages/iOS/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/MobileOnboardingGateTests.swift
@@ -9,11 +9,17 @@ import Testing
         MobileOnboardingProgress.connect,
     ])
     func showsEveryIncompleteMilestoneWhenSignedIn(_ progress: MobileOnboardingProgress) {
-        #expect(progress.shouldShowOnboarding(isAuthenticated: true))
+        #expect(progress.shouldShowOnboarding(
+            isAuthenticated: true,
+            isRestoringSession: false
+        ))
     }
 
     @Test func skipsCompletedOnboarding() {
-        #expect(!MobileOnboardingProgress.complete.shouldShowOnboarding(isAuthenticated: true))
+        #expect(!MobileOnboardingProgress.complete.shouldShowOnboarding(
+            isAuthenticated: true,
+            isRestoringSession: false
+        ))
     }
 
     @Test(arguments: [
@@ -22,6 +28,20 @@ import Testing
         MobileOnboardingProgress.complete,
     ])
     func neverShowsSignedOut(_ progress: MobileOnboardingProgress) {
-        #expect(!progress.shouldShowOnboarding(isAuthenticated: false))
+        #expect(!progress.shouldShowOnboarding(
+            isAuthenticated: false,
+            isRestoringSession: false
+        ))
+    }
+
+    @Test(arguments: [
+        MobileOnboardingProgress.welcome,
+        MobileOnboardingProgress.connect,
+    ])
+    func neverShowsWhileSessionIsRestoring(_ progress: MobileOnboardingProgress) {
+        #expect(!progress.shouldShowOnboarding(
+            isAuthenticated: true,
+            isRestoringSession: true
+        ))
     }
 }

--- a/Packages/iOS/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/MobileRootAuthGateTests.swift
+++ b/Packages/iOS/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/MobileRootAuthGateTests.swift
@@ -50,6 +50,29 @@ import Testing
         ))
     }
 
+    @Test func keepsSignInVisibleWhileCachedSessionRestores() {
+        #expect(MobileRootAuthGate.shouldShowSignIn(
+            stackAuthenticated: true,
+            attachTicketAuthenticated: false,
+            isRestoringSession: true
+        ))
+        #expect(MobileRootAuthGate.shouldShowSignIn(
+            stackAuthenticated: false,
+            attachTicketAuthenticated: false,
+            isRestoringSession: false
+        ))
+        #expect(!MobileRootAuthGate.shouldShowSignIn(
+            stackAuthenticated: true,
+            attachTicketAuthenticated: false,
+            isRestoringSession: false
+        ))
+        #expect(!MobileRootAuthGate.shouldShowSignIn(
+            stackAuthenticated: false,
+            attachTicketAuthenticated: true,
+            isRestoringSession: true
+        ))
+    }
+
     @Test func clearsOnlyStaleTemporaryAttachAuthentication() {
         #expect(MobileRootAuthGate.shouldClearAttachTicketAuthentication(
             pairingResult: .failed,

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -14229,7 +14229,7 @@ struct GhosttyTerminalView: NSViewRepresentable {
         let wasBoundToDismantledHost: Bool = {
             guard let host, let hostedView else { return false }
             guard TerminalWindowPortalRegistry.hasEntry(for: hostedView, boundTo: host),
-                  let terminalSurface = hostedView.terminalSurface else {
+                  let terminalSurface = hostedView.surfaceView.terminalSurface else {
                 return false
             }
             return terminalSurface.ownsPortalHost(


### PR DESCRIPTION
## Summary

- keep first-run onboarding hidden while cached authentication is still restoring
- add behavior coverage for the authenticated-but-restoring launch state

## Verification

- `swift test --package-path Packages/iOS/CmuxMobileWorkspace --filter MobileOnboardingGateTests`
- Fleet tagged macOS reload reached compilation but failed in unrelated `GhosttyTerminalView.swift` baseline compilation before producing an app artifact.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11310"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790822970&installation_model_id=21920&pr_number=11310&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11310&signature=9ada5ca8affd25c4cc4cd23e7fe77e1690d6e19360a28c745d8e4a174ad15801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the iOS auth surface visible during launch session restore so cached identities don't briefly show onboarding or shell content before validation, and corrects a macOS portal teardown to reference the hosted surface view. Previously the tour could appear for a signed-in identity that wasn't yet validated; now sign-in stays until restore settles.

- `MobileRootAuthGate.shouldShowSignIn` keeps sign-in visible while a cached Stack session restores, unless a live attach ticket is present.
- `MobileOnboardingProgress.shouldShowOnboarding` now requires an `isRestoringSession` flag.
- Adds coverage for the authenticated-but-restoring state in `MobileOnboardingGateTests` and `MobileRootAuthGateTests`.
- `GhosttyTerminalView` portal teardown now reads `hostedView.surfaceView.terminalSurface` instead of `hostedView.terminalSurface`.

<sup>Written for commit 91d176e73f69064798f7622198f1682d413dd0c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented onboarding from appearing while a saved account session is being restored during app launch.
  * Kept the sign-in screen visible until session restoration completes.
  * Allowed active attach flows to proceed directly to the shell.
  * Improved terminal view cleanup when navigating away from a terminal session.

* **Tests**
  * Added coverage for onboarding and sign-in behavior during session restoration, including attach flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->