### PR TITLE
test: pin the plan gates for team-less accounts

### DIFF
--- a/web/tests/vm-route-auth.test.ts
+++ b/web/tests/vm-route-auth.test.ts
@@ -647,6 +647,71 @@ describe("VM REST auth", () => {
     expect(createVm).not.toHaveBeenCalled();
   });
 
+  test("blocks a team-less free account from provisioning when CMUX_VM_REQUIRE_PRO is enforced", async () => {
+    // The user-scoped billing fallback (#11225) must never widen access: an
+    // account with zero Stack teams and no subscription resolves to the free
+    // plan and hits the same Pro gate as team-based free users.
+    process.env.CMUX_VM_REQUIRE_PRO = "1";
+    getUser.mockResolvedValue({
+      id: "user-1",
+      displayName: null,
+      primaryEmail: "user@example.com",
+      selectedTeam: null,
+      listTeams: async () => [],
+    });
+
+    const response = await POST(
+      new Request("https://cmux.test/api/vm", {
+        method: "POST",
+        headers: { origin: "https://cmux.test" },
+        body: JSON.stringify({ provider: "freestyle", image: "snapshot-test" }),
+      }),
+    );
+
+    expect(response.status).toBe(402);
+    expect((await response.json() as { error: string }).error).toBe("vm_requires_pro");
+    expect(createVm).not.toHaveBeenCalled();
+    expect(runVmWorkflow).not.toHaveBeenCalled();
+  });
+
+  test("a team-less free account gets exactly the free-plan allowance", async () => {
+    // With the Pro gate off, the freemium policy still applies unchanged:
+    // user-scoped billing carries the free plan's machine ceiling into the
+    // create workflow, where the active-VM limit is enforced.
+    process.env.CMUX_VM_FREE_MAX_ACTIVE_VMS = "1";
+    getUser.mockResolvedValue({
+      id: "user-1",
+      displayName: null,
+      primaryEmail: "user@example.com",
+      selectedTeam: null,
+      listTeams: async () => [],
+    });
+    runVmWorkflow.mockResolvedValue({
+      providerVmId: "provider-vm-free-user-billing",
+      provider: "freestyle",
+      image: "snapshot-test",
+      imageVersion: null,
+      createdAt: 1_777_000_000_000,
+    });
+
+    const response = await POST(
+      new Request("https://cmux.test/api/vm", {
+        method: "POST",
+        headers: { origin: "https://cmux.test" },
+        body: JSON.stringify({ provider: "freestyle", image: "snapshot-test" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(createVm).toHaveBeenCalledWith(expect.objectContaining({
+      userId: "user-1",
+      billingCustomerType: "user",
+      billingTeamId: "user-1",
+      billingPlanId: "free",
+      maxActiveVms: 1,
+    }));
+  });
+
   test("lets a pro plan provision even when CMUX_VM_REQUIRE_PRO is enforced", async () => {
     process.env.CMUX_VM_REQUIRE_PRO = "1";
     getUser.mockResolvedValue(authedStackUser());


### PR DESCRIPTION
Follow-on to #11225, answering "are we accidentally giving VMs to people who aren't on the subscription?" — **no**, and now it's pinned:

- A team-less account with no subscription resolves to the **free** plan and hits the same `CMUX_VM_REQUIRE_PRO` gate as team-based free users → 402 `vm_requires_pro`, nothing provisioned.
- With the Pro gate off, the free plan's machine ceiling (`CMUX_VM_FREE_MAX_ACTIVE_VMS`) rides into the create workflow unchanged under user-scoped billing.

Prod has `CMUX_VM_REQUIRE_PRO`, `CMUX_VM_FREE_MAX_ACTIVE_VMS`, `CMUX_VM_DEFAULT_PLAN`, and the free-plan create-credit vars all set, so these gates are the active policy surface.

`bun test tests/vm-route-auth.test.ts` → 67 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q8M6wNCw6uLEvQaHGUo4SY

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790823272&installation_model_id=21920&pr_number=11311&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11311&signature=3c9695e3ed866a67565aea84ffb174d80be3b02392dcd43db3167ee885a0d2da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the plan gates for team-less accounts so user-scoped billing never accidentally widens VM access.

- Adds a test proving a team-less account with no subscription hits the same `CMUX_VM_REQUIRE_PRO` gate as team-based free users, returning 402 without provisioning.
- Adds a test proving that with the gate off, the free plan's machine ceiling flows through unchanged under user-scoped billing.
- Confirms the create workflow receives user-scoped billing fields and the free-plan `maxActiveVms`.

<sup>Written for commit 7522fe29d0b4d8c12fa0ff6dfa595e88a7d3e479. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for VM creation by free accounts without teams.
  * Verified that Pro-only VM requirements return the appropriate payment error before provisioning begins.
  * Verified successful provisioning with user-scoped billing and free-plan limits when team information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->