### PR TITLE
Fix macOS compile break from #11224 (GhosttySurfaceScrollView has no terminalSurface)

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -14229,7 +14229,7 @@ struct GhosttyTerminalView: NSViewRepresentable {
         let wasBoundToDismantledHost: Bool = {
             guard let host, let hostedView else { return false }
             guard TerminalWindowPortalRegistry.hasEntry(for: hostedView, boundTo: host),
-                  let terminalSurface = hostedView.terminalSurface else {
+                  let terminalSurface = hostedView.surfaceView.terminalSurface else {
                 return false
             }
             return terminalSurface.ownsPortalHost(


### PR DESCRIPTION
Current `main` fails the macOS Debug compile: https://github.com/manaflow-ai/cmux/pull/11224 added a portal-ownership guard in `dismantleNSView` that reads `hostedView.terminalSurface`, but `hostedView` is the `GhosttySurfaceScrollView` pane container, which has no such member (the surface hangs off its `GhosttyNSView`). The PR lane has no macOS compile gate, so it merged red; every tagged fleet build from `main` now fails with `value of type 'GhosttySurfaceScrollView' has no member 'terminalSurface'`.

One-line fix: read `hostedView.surfaceView.terminalSurface`, matching every other `terminalSurface` access in the class.

Dictionary:
- **PR lane**: the checks that run on cmux pull requests; they do not include a macOS compile, so a Mac-only compile error can merge.
- **tagged fleet build**: a `cmux DEV <tag>` Debug build produced on the shared Mac fleet by `reload-cloud.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11316"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790824386&installation_model_id=21920&pr_number=11316&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11316&signature=ee9d3d11e9093d95a3f8e550c82e143695c5e8b83ba500d6e9a7faeecf24a18f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the macOS Debug compile break on `main` so tagged fleet builds succeed again. The portal-ownership guard in `dismantleNSView` now reads `hostedView.surfaceView.terminalSurface` instead of `hostedView.terminalSurface`, since the hosted view is the `GhosttySurfaceScrollView` container without that member.

<sup>Written for commit cf0cf9089ccc0f6e86563df35d94c584eb7925da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal view cleanup to reliably access the attached terminal surface.
  * Removed reliance on a direct terminal-surface reference from the scroll view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->