### PR TITLE
updater: keep "You're up to date" when an install attempt resolves no update

### DIFF
--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/AttemptUpdateCoordinator.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/AttemptUpdateCoordinator.swift
@@ -87,7 +87,14 @@ struct AttemptUpdateCoordinator {
             case .error:
                 phase = .inactive
                 return .none
-            case .idle, .checking, .updateAvailable, .notFound,
+            case .notFound:
+                // A check session that was already in flight when the user asked to install
+                // resolved "no update". Being up to date is a truthful, visible outcome, not an
+                // install failure (issue #9262); end the attempt quietly and let the `.notFound`
+                // state render as the normal up-to-date result.
+                phase = .inactive
+                return .none
+            case .idle, .checking, .updateAvailable,
                     .startingDownload, .downloading, .extracting, .installing:
                 // No model emission can prove that a new Sparkle check started. If the explicit
                 // controller signal never arrived, this accepted attempt ended unexpectedly.

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController+Checking.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController+Checking.swift
@@ -224,8 +224,13 @@ extension UpdateController: UpdateDriverEventDelegate {
             switch model.state {
             case .downloading, .extracting, .installing, .error:
                 return
+            case .notFound:
+                // The check completed and "You're up to date" is already on screen (issue
+                // #9262). The coordinator ends the attempt when it drains this transition;
+                // replacing the visible up-to-date terminal with an install error would be false.
+                return
             case .idle, .permissionRequest, .preparingCheck, .checking, .updateAvailable,
-                    .notFound, .startingDownload:
+                    .startingDownload:
                 setInstallDidNotStartError(
                     diagnostic: "accepted install cycle finished before download (check=\(updateCheck.rawValue), error=\(error.map(driver.formatErrorForLog) ?? "none"))"
                 )

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/AttemptUpdateCoordinatorTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/AttemptUpdateCoordinatorTests.swift
@@ -119,6 +119,17 @@ import Testing
         #expect(!coordinator.isMonitoring)
     }
 
+    /// Regression (issue #9262, queued variant): the user asked to install while another check
+    /// session was still finishing, so the fresh check is queued and `didStartFreshCheck()` has
+    /// not fired yet. If that in-flight session resolves "no update", being up to date must stand
+    /// as the visible result — not become a retryable "Update Didn't Start" error.
+    @Test func staleSessionNoUpdateBeforeFreshCheckEndsAttemptQuietly() {
+        var coordinator = AttemptUpdateCoordinator()
+        _ = coordinator.requestInstallLatest(currentState: .checking(.init(cancel: {})))
+        #expect(coordinator.handleStateChange(.notFound(.init(acknowledgement: {}))) == .none)
+        #expect(!coordinator.isMonitoring)
+    }
+
     /// `.idle` in the same phase is still a genuine failure: the accepted attempt ended with no
     /// result at all, so it must keep reporting `.installFailed`.
     @Test func reportsInstallFailedWhenFreshCheckEndsAtIdle() {

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateControllerPipelineTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateControllerPipelineTests.swift
@@ -423,6 +423,58 @@ import Testing
         }
     }
 
+    /// Regression (issue #9262, queued variant): "Attempt Update" issued while another check
+    /// session is still finishing queues the fresh check behind it. If that in-flight session
+    /// resolves "no update", the up-to-date result must stand instead of becoming a red
+    /// "check your internet connection" error.
+    @Test func upToDateResultWhileFreshCheckIsQueuedShowsNoUpdateInsteadOfError() async {
+        let harness = Harness()
+
+        harness.model.setState(.checking(.init(cancel: {})))
+        harness.controller.attemptUpdate()
+        // The fresh check is queued behind the in-flight session; Sparkle was not called yet.
+        #expect(harness.updater.checkForUpdatesCallCount == 0)
+
+        // The in-flight session resolves: already up to date.
+        harness.model.setState(.notFound(.init(acknowledgement: {})))
+
+        // Give any erroneous reaction a chance to replace the state.
+        for _ in 0..<2_000 { await Task.yield() }
+
+        guard case .notFound = harness.model.state else {
+            Issue.record("queued up-to-date attempt replaced notFound with: \(harness.model.state)")
+            return
+        }
+        #expect(!harness.controller.attemptCoordinator.isMonitoring)
+    }
+
+    /// The up-to-date terminal must also survive Sparkle finishing the accepted-install cycle in
+    /// the same actor turn as the no-update resolution, before the reaction stream drains the
+    /// `.notFound` transition: the cycle-finish observer must treat "no update found" as a visible
+    /// outcome, not as an install that never started.
+    @Test func cycleFinishArrivingBeforeNotFoundIsDrainedKeepsUpToDateResult() async {
+        let harness = Harness()
+        let stalePrompt = ChoiceBox()
+
+        harness.model.setState(updateAvailable("0.64.15", replyingInto: stalePrompt))
+        harness.controller.attemptUpdate()
+        harness.finishSparkleCycle()
+        await waitUntil("fresh check to start") { harness.updater.checkForUpdatesCallCount == 1 }
+
+        harness.model.setState(.checking(.init(cancel: {})))
+        // No suspension between these two calls: the cycle finish observes `.notFound` while the
+        // attempt coordinator is still monitoring.
+        harness.model.setState(.notFound(.init(acknowledgement: {})))
+        harness.finishSparkleCycle()
+
+        for _ in 0..<2_000 { await Task.yield() }
+
+        guard case .notFound = harness.model.state else {
+            Issue.record("cycle finish replaced notFound with: \(harness.model.state)")
+            return
+        }
+    }
+
     /// If the live prompt is still visible but already answered before the queued confirm
     /// hand-off runs, the controller must not log a fake install attempt or leave the watchdog
     /// armed for a prompt Sparkle will never accept again.


### PR DESCRIPTION
A user on the newest build for their channel who triggers an install attempt (Attempt Update palette command, an Install and Relaunch button, or a stale update pill) could still see the red **Update Didn't Start / check your internet connection** error instead of the normal "You're up to date" result.

https://github.com/manaflow-ai/cmux/pull/9435 fixed the direct path for https://github.com/manaflow-ai/cmux/issues/9262 (the fresh check itself resolving "no update"), but two variants of the same class survived:

1. **Queued variant**: `attemptUpdate()` while another check session is still finishing queues the fresh check. The in-flight session's `notFound` reaches `AttemptUpdateCoordinator` in `awaitingFreshCheck`, which mapped it to `installFailed`. A completed check saying "no update" is a truthful, visible outcome regardless of which session produced it, so the coordinator now ends the attempt quietly. The install watchdog still bounds genuinely stalled attempts.
2. **Cycle-finish ordering**: `updateDriverDidFinishCycle` raised the error over a `.notFound` state it observed before the reaction stream drained that transition to the coordinator. `.notFound` now counts as a visible terminal there, like `.error`.

After an install is actually accepted (`startingDownload` phase), `notFound` still fails the attempt; genuinely stalled installs still surface the error via the watchdog.

Regression tests land in the first commit (red), the fix in the second (green). `swift test --package-path Packages/macOS/CmuxUpdater`: 90/90 pass.

Context: this is the same bug class a user hit on stable v0.64.22, which was cut ~14h before #9435 merged, so no shipped stable release contains the original fix yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790824845&installation_model_id=21920&pr_number=11318&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11318&signature=bfa4c90c22845c00ea5c127d2e08325242040593da49f3e1538d6a44602498e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes install attempts on up-to-date builds showing "Update Didn't Start" instead of "You're up to date" by treating a completed "no update" check as a truthful, visible outcome (issue #9262).

- The attempt coordinator now ends quietly when a queued in-flight check session resolves no update.
- The cycle-finish observer now counts `.notFound` as a visible terminal, like `.error`.
- After an install is accepted (`startingDownload`), `notFound` still fails the attempt, and the watchdog still bounds genuinely stalled installs.
- Adds regression tests for the queued variant and the cycle-finish ordering.

<sup>Written for commit d78d4422fb70a015ebc4f73f8de2e4b9f50b417e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed update attempts incorrectly showing installation or connectivity errors when no update is available.
  - “You’re up to date” results now remain visible when an update check finishes during an installation attempt.
  - Improved handling of queued update checks and completed update cycles.

- **Tests**
  - Added regression coverage for stale and overlapping update-check scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->