### PR TITLE
vm: report-only orphan-volume and stuck-provisioning reporter

### DIFF
--- a/web/app/api/cron/vm-reaper/route.ts
+++ b/web/app/api/cron/vm-reaper/route.ts
@@ -1,0 +1,24 @@
+import { captureVmReaperSummary } from "../../../../services/vms/observability";
+import { reapVmResources } from "../../../../services/vms/reaper";
+import { runVmWorkflow } from "../../../../services/vms/workflows";
+
+// Bounded batches keep a run well under this budget; the cap only guards a
+// hung provider call.
+export const maxDuration = 300;
+
+export async function GET(request: Request): Promise<Response> {
+  const secret = process.env.CRON_SECRET;
+  if (!secret || request.headers.get("authorization") !== `Bearer ${secret}`) {
+    return Response.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const summary = await runVmWorkflow(reapVmResources());
+    // Best effort and bounded; never turns a successful run into a 500.
+    await captureVmReaperSummary(summary);
+    return Response.json({ ok: true, ...summary });
+  } catch (err) {
+    console.error("[VM] cron reaper failed", err);
+    return Response.json({ error: "vm_reaper_failed" }, { status: 500 });
+  }
+}

--- a/web/services/vms/drivers/blaxel.ts
+++ b/web/services/vms/drivers/blaxel.ts
@@ -13,6 +13,7 @@ import {
   type VMProvider,
   type VMStats,
   type VMStatus,
+  type VMVolume,
   type CmuxRemoteApprovalResult,
   type CmuxRemoteAttachOptions,
   type CmuxRemoteEndpoint,
@@ -296,6 +297,14 @@ type BlaxelPreview = {
     prefixUrl?: string;
     customDomain?: string;
   };
+};
+
+type BlaxelVolume = {
+  metadata?: { name?: string; createdAt?: string | number };
+  state?: { attachedTo?: string | null };
+  // Keep the parser tolerant of older control-plane responses that surfaced
+  // attachment state at the resource root.
+  attachedTo?: string | null;
 };
 
 // The preview URL is the only ingress to the cmux-tui daemon, and it must stay token-gated:
@@ -655,6 +664,40 @@ function parseJsonArray(text: string): Array<Record<string, unknown>> {
   } catch {
     return [];
   }
+}
+
+function volumeListItems(payload: unknown): unknown[] {
+  if (Array.isArray(payload)) return payload;
+  if (!payload || typeof payload !== "object") return [];
+  const candidate = payload as { items?: unknown; data?: unknown };
+  if (Array.isArray(candidate.items)) return candidate.items;
+  if (Array.isArray(candidate.data)) return candidate.data;
+  return [];
+}
+
+/** Normalize the Blaxel `/volumes` response for provider-agnostic cleanup code. */
+export function parseBlaxelVolumes(payload: unknown): VMVolume[] {
+  return volumeListItems(payload).flatMap((item): VMVolume[] => {
+    if (!item || typeof item !== "object") return [];
+    const volume = item as BlaxelVolume;
+    const name = volume.metadata?.name?.trim();
+    if (!name) return [];
+    const rawCreatedAt = volume.metadata?.createdAt;
+    const createdAt = typeof rawCreatedAt === "number" && Number.isFinite(rawCreatedAt)
+      ? rawCreatedAt
+      : typeof rawCreatedAt === "string"
+        ? Date.parse(rawCreatedAt)
+        : Number.NaN;
+    const attachedValue = volume.state?.attachedTo ?? volume.attachedTo;
+    const attachedTo = typeof attachedValue === "string" && attachedValue.trim().length > 0
+      ? attachedValue.trim()
+      : null;
+    return [{
+      name,
+      createdAt: Number.isFinite(createdAt) ? createdAt : null,
+      attachedTo,
+    }];
+  });
 }
 
 export class BlaxelProvider implements VMProvider {
@@ -1054,6 +1097,12 @@ export class BlaxelProvider implements VMProvider {
         }
       },
     );
+  }
+
+  /** List all persistent volumes in the Blaxel workspace for the reaper. */
+  async listVolumes(): Promise<readonly VMVolume[]> {
+    const payload = await blaxelFetch<unknown>("GET", `${CONTROL_PLANE_BASE}/volumes`);
+    return parseBlaxelVolumes(payload);
   }
 
   async getStatus(vmId: string): Promise<VMStatus> {

--- a/web/services/vms/drivers/blaxel.ts
+++ b/web/services/vms/drivers/blaxel.ts
@@ -684,13 +684,33 @@ function volumeListItems(payload: unknown): unknown[] {
   return [];
 }
 
-function hasVolumePaginationMetadata(payload: unknown): boolean {
+/**
+ * Completion must be an explicit provider signal: a continuation-cursor key
+ * present with an empty value, or hasMore === false. A meta object that only
+ * carries counts (e.g. { total: 1000 }) proves nothing about exhaustion and
+ * must leave coverage marked partial.
+ */
+function volumePaginationComplete(payload: unknown): boolean {
   if (!payload || typeof payload !== "object" || Array.isArray(payload)) return false;
+  const explicitEnd = (source: unknown): boolean => {
+    if (!source || typeof source !== "object" || Array.isArray(source)) return false;
+    const value = source as {
+      nextCursor?: unknown;
+      next_cursor?: unknown;
+      hasMore?: unknown;
+      has_more?: unknown;
+    };
+    if (value.hasMore === false || value.has_more === false) return true;
+    const cursorKeyPresent = "nextCursor" in value || "next_cursor" in value;
+    if (!cursorKeyPresent) return false;
+    const cursor = value.nextCursor ?? value.next_cursor;
+    return cursor === null || cursor === undefined || cursor === "";
+  };
   const candidate = payload as { meta?: unknown; data?: unknown };
-  if (candidate.meta && typeof candidate.meta === "object" && !Array.isArray(candidate.meta)) return true;
+  if (explicitEnd(payload)) return true;
+  if (explicitEnd(candidate.meta)) return true;
   if (candidate.data && typeof candidate.data === "object" && !Array.isArray(candidate.data)) {
-    const data = candidate.data as { meta?: unknown };
-    return !!data.meta && typeof data.meta === "object" && !Array.isArray(data.meta);
+    return explicitEnd((candidate.data as { meta?: unknown }).meta);
   }
   return false;
 }
@@ -779,7 +799,7 @@ export function parseBlaxelVolumePage(payload: unknown, limit = 100): VMVolumePa
     // retain or sort an unbounded provider inventory.
     volumes: parseBlaxelVolumeItems(items.slice(0, boundedLimit)),
     nextCursor: volumeNextCursor(payload),
-    complete: hasVolumePaginationMetadata(payload) && !truncated,
+    complete: volumeNextCursor(payload) === null && volumePaginationComplete(payload) && !truncated,
   };
 }
 

--- a/web/services/vms/drivers/blaxel.ts
+++ b/web/services/vms/drivers/blaxel.ts
@@ -690,6 +690,23 @@ function volumeListItems(payload: unknown): unknown[] {
  * carries counts (e.g. { total: 1000 }) proves nothing about exhaustion and
  * must leave coverage marked partial.
  */
+/**
+ * A payload only counts as a volume page when it carries a recognized items
+ * container. Completion claims from shapes we cannot parse must fail closed,
+ * otherwise a malformed response reads as an empty-but-complete inventory.
+ */
+function hasRecognizedVolumeContainer(payload: unknown): boolean {
+  if (Array.isArray(payload)) return true;
+  if (!payload || typeof payload !== "object") return false;
+  const candidate = payload as { items?: unknown; data?: unknown };
+  if (Array.isArray(candidate.items) || Array.isArray(candidate.data)) return true;
+  if (candidate.data && typeof candidate.data === "object") {
+    const data = candidate.data as { items?: unknown; data?: unknown };
+    return Array.isArray(data.items) || Array.isArray(data.data);
+  }
+  return false;
+}
+
 function volumePaginationComplete(payload: unknown): boolean {
   if (!payload || typeof payload !== "object" || Array.isArray(payload)) return false;
   const explicitEnd = (source: unknown): boolean => {
@@ -799,7 +816,10 @@ export function parseBlaxelVolumePage(payload: unknown, limit = 100): VMVolumePa
     // retain or sort an unbounded provider inventory.
     volumes: parseBlaxelVolumeItems(items.slice(0, boundedLimit)),
     nextCursor: volumeNextCursor(payload),
-    complete: volumeNextCursor(payload) === null && volumePaginationComplete(payload) && !truncated,
+    complete: hasRecognizedVolumeContainer(payload) &&
+      volumeNextCursor(payload) === null &&
+      volumePaginationComplete(payload) &&
+      !truncated,
   };
 }
 

--- a/web/services/vms/drivers/blaxel.ts
+++ b/web/services/vms/drivers/blaxel.ts
@@ -14,6 +14,9 @@ import {
   type VMStats,
   type VMStatus,
   type VMVolume,
+  type VMVolumePage,
+  type VMVolumeListOptions,
+  type VMVolumeInventory,
   type CmuxRemoteApprovalResult,
   type CmuxRemoteAttachOptions,
   type CmuxRemoteEndpoint,
@@ -301,10 +304,10 @@ type BlaxelPreview = {
 
 type BlaxelVolume = {
   metadata?: { name?: string; createdAt?: string | number };
-  state?: { attachedTo?: string | null };
+  state?: { attachedTo?: unknown };
   // Keep the parser tolerant of older control-plane responses that surfaced
   // attachment state at the resource root.
-  attachedTo?: string | null;
+  attachedTo?: unknown;
 };
 
 // The preview URL is the only ingress to the cmux-tui daemon, and it must stay token-gated:
@@ -672,32 +675,112 @@ function volumeListItems(payload: unknown): unknown[] {
   const candidate = payload as { items?: unknown; data?: unknown };
   if (Array.isArray(candidate.items)) return candidate.items;
   if (Array.isArray(candidate.data)) return candidate.data;
+  // Current Blaxel responses wrap the page as `{ data: { items }, meta }`.
+  if (candidate.data && typeof candidate.data === "object") {
+    const data = candidate.data as { items?: unknown; data?: unknown };
+    if (Array.isArray(data.items)) return data.items;
+    if (Array.isArray(data.data)) return data.data;
+  }
   return [];
 }
 
-/** Normalize the Blaxel `/volumes` response for provider-agnostic cleanup code. */
-export function parseBlaxelVolumes(payload: unknown): VMVolume[] {
-  return volumeListItems(payload).flatMap((item): VMVolume[] => {
+function hasVolumePaginationMetadata(payload: unknown): boolean {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return false;
+  const candidate = payload as { meta?: unknown; data?: unknown };
+  if (candidate.meta && typeof candidate.meta === "object" && !Array.isArray(candidate.meta)) return true;
+  if (candidate.data && typeof candidate.data === "object" && !Array.isArray(candidate.data)) {
+    const data = candidate.data as { meta?: unknown };
+    return !!data.meta && typeof data.meta === "object" && !Array.isArray(data.meta);
+  }
+  return false;
+}
+
+function volumeNextCursor(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object") return null;
+  const candidate = payload as {
+    nextCursor?: unknown;
+    next_cursor?: unknown;
+    meta?: unknown;
+    data?: unknown;
+  };
+  const readMeta = (meta: unknown): string | null => {
+    if (!meta || typeof meta !== "object") return null;
+    const value = meta as { nextCursor?: unknown; next_cursor?: unknown };
+    const cursor = value.nextCursor ?? value.next_cursor;
+    return typeof cursor === "string" && cursor.trim().length > 0 ? cursor.trim() : null;
+  };
+  return readMeta(candidate.meta) ??
+    (typeof candidate.nextCursor === "string" && candidate.nextCursor.trim().length > 0
+      ? candidate.nextCursor.trim()
+      : typeof candidate.next_cursor === "string" && candidate.next_cursor.trim().length > 0
+        ? candidate.next_cursor.trim()
+        : candidate.data && typeof candidate.data === "object"
+          ? readMeta((candidate.data as { meta?: unknown }).meta)
+          : null);
+}
+
+function attachmentFields(volume: BlaxelVolume): Pick<VMVolume, "attachedTo" | "attachmentState"> {
+  const hasOwn = (value: object, key: string): boolean => Object.prototype.hasOwnProperty.call(value, key);
+  const state = volume.state && typeof volume.state === "object" ? volume.state : undefined;
+  const stateHasAttachment = !!state && hasOwn(state, "attachedTo");
+  const rootHasAttachment = hasOwn(volume, "attachedTo");
+  const raw = stateHasAttachment
+    ? state?.attachedTo
+      : rootHasAttachment
+      ? volume.attachedTo
+      : undefined;
+
+  if (typeof raw === "string" && raw.trim().length > 0) {
+    return { attachedTo: raw.trim(), attachmentState: "attached" };
+  }
+  if (raw === null) return { attachedTo: null, attachmentState: "unattached" };
+  // An absent, empty, or malformed attachment field is not proof of freedom.
+  return { attachmentState: "unknown" };
+}
+
+function parseBlaxelVolumeItems(items: readonly unknown[]): VMVolume[] {
+  return items.flatMap((item): VMVolume[] => {
     if (!item || typeof item !== "object") return [];
     const volume = item as BlaxelVolume;
-    const name = volume.metadata?.name?.trim();
+    const rawName = volume.metadata && typeof volume.metadata === "object"
+      ? (volume.metadata as { name?: unknown }).name
+      : undefined;
+    const name = typeof rawName === "string" ? rawName.trim() : "";
     if (!name) return [];
-    const rawCreatedAt = volume.metadata?.createdAt;
+    const rawCreatedAt = volume.metadata && typeof volume.metadata === "object"
+      ? (volume.metadata as { createdAt?: unknown }).createdAt
+      : undefined;
     const createdAt = typeof rawCreatedAt === "number" && Number.isFinite(rawCreatedAt)
       ? rawCreatedAt
       : typeof rawCreatedAt === "string"
         ? Date.parse(rawCreatedAt)
         : Number.NaN;
-    const attachedValue = volume.state?.attachedTo ?? volume.attachedTo;
-    const attachedTo = typeof attachedValue === "string" && attachedValue.trim().length > 0
-      ? attachedValue.trim()
-      : null;
+    const attachment = attachmentFields(volume);
     return [{
       name,
       createdAt: Number.isFinite(createdAt) ? createdAt : null,
-      attachedTo,
+      ...attachment,
     }];
   });
+}
+
+/** Normalize the Blaxel `/volumes` response for provider-agnostic cleanup code. */
+export function parseBlaxelVolumes(payload: unknown): VMVolume[] {
+  return parseBlaxelVolumeItems(volumeListItems(payload));
+}
+
+/** Parse one bounded Blaxel volume page, including its opaque continuation cursor. */
+export function parseBlaxelVolumePage(payload: unknown, limit = 100): VMVolumePage {
+  const boundedLimit = Number.isSafeInteger(limit) && limit > 0 ? Math.min(limit, 100) : 100;
+  const items = volumeListItems(payload);
+  const truncated = items.length > boundedLimit;
+  return {
+    // Slice before normalization so legacy responses do not make the reaper
+    // retain or sort an unbounded provider inventory.
+    volumes: parseBlaxelVolumeItems(items.slice(0, boundedLimit)),
+    nextCursor: volumeNextCursor(payload),
+    complete: hasVolumePaginationMetadata(payload) && !truncated,
+  };
 }
 
 export class BlaxelProvider implements VMProvider {
@@ -1099,10 +1182,26 @@ export class BlaxelProvider implements VMProvider {
     );
   }
 
-  /** List all persistent volumes in the Blaxel workspace for the reaper. */
-  async listVolumes(): Promise<readonly VMVolume[]> {
-    const payload = await blaxelFetch<unknown>("GET", `${CONTROL_PLANE_BASE}/volumes`);
-    return parseBlaxelVolumes(payload);
+  /** List one bounded page of volumes; the no-argument form keeps legacy callers working. */
+  async listVolumes(): Promise<readonly VMVolume[]>;
+  async listVolumes(options: VMVolumeListOptions): Promise<VMVolumePage>;
+  async listVolumes(options?: VMVolumeListOptions): Promise<VMVolumeInventory> {
+    const query = new URLSearchParams();
+    if (options) {
+      const limit = Number.isSafeInteger(options.limit) && options.limit > 0
+        ? Math.min(options.limit, 100)
+        : 100;
+      query.set("limit", String(limit));
+      if (options.cursor) query.set("cursor", options.cursor);
+      // The provider supports ordered cursor pages. This keeps a run fair for
+      // old volumes without requiring the reaper to sort an unbounded result.
+      query.set("sort", "createdAt:asc");
+    }
+    const suffix = query.size > 0 ? `?${query.toString()}` : "";
+    const payload = await blaxelFetch<unknown>("GET", `${CONTROL_PLANE_BASE}/volumes${suffix}`);
+    return options
+      ? parseBlaxelVolumePage(payload, options.limit)
+      : parseBlaxelVolumes(payload);
   }
 
   async getStatus(vmId: string): Promise<VMStatus> {

--- a/web/services/vms/drivers/types.ts
+++ b/web/services/vms/drivers/types.ts
@@ -26,6 +26,15 @@ export type VMStats = {
   readonly diskUsedMb?: number;
 };
 
+/** A provider persistent volume normalized for control-plane cleanup. */
+export type VMVolume = {
+  readonly name: string;
+  /** Epoch milliseconds from provider metadata, when present. */
+  readonly createdAt?: number | null;
+  /** Provider attachment id, or null when the volume is free. */
+  readonly attachedTo?: string | null;
+};
+
 export type VMHandle = {
   provider: ProviderId;
   providerVmId: string;
@@ -228,6 +237,9 @@ export interface VMProvider {
    * destroyed machine may be passed here.
    */
   deleteHomeVolume?(volumeName: string): Promise<void>;
+
+  /** Optional provider volume inventory used by the VM resource reaper. */
+  listVolumes?(): Promise<readonly VMVolume[]>;
 
   getStatus?(vmId: string): Promise<VMStatus>;
   /// Live CPU/memory/disk for the Cloud panel's activity view. Must not wake a

--- a/web/services/vms/drivers/types.ts
+++ b/web/services/vms/drivers/types.ts
@@ -26,14 +26,36 @@ export type VMStats = {
   readonly diskUsedMb?: number;
 };
 
-/** A provider persistent volume normalized for control-plane cleanup. */
+/** A provider persistent volume normalized for report-only inventory scans. */
 export type VMVolume = {
   readonly name: string;
   /** Epoch milliseconds from provider metadata, when present. */
   readonly createdAt?: number | null;
-  /** Provider attachment id, or null when the volume is free. */
+  /**
+   * Provider attachment id. `null` means the provider explicitly reported that
+   * the volume is not attached; `undefined` means attachment is unknown.
+   */
   readonly attachedTo?: string | null;
+  /** Optional explicit state for providers that distinguish unknown from free. */
+  readonly attachmentState?: "attached" | "unattached" | "unknown";
 };
+
+/** One bounded provider page returned to the report-only reaper. */
+export type VMVolumePage = {
+  readonly volumes: readonly VMVolume[];
+  readonly nextCursor?: string | null;
+  /** Whether the provider explicitly supports pagination for this response. */
+  readonly complete?: boolean;
+};
+
+export type VMVolumeListOptions = {
+  /** Provider page size. Callers must keep this at or below their run budget. */
+  readonly limit: number;
+  readonly cursor?: string;
+};
+
+/** Legacy providers may still return one array; the reaper treats it as partial coverage. */
+export type VMVolumeInventory = readonly VMVolume[] | VMVolumePage;
 
 export type VMHandle = {
   provider: ProviderId;
@@ -238,8 +260,8 @@ export interface VMProvider {
    */
   deleteHomeVolume?(volumeName: string): Promise<void>;
 
-  /** Optional provider volume inventory used by the VM resource reaper. */
-  listVolumes?(): Promise<readonly VMVolume[]>;
+  /** Optional provider volume inventory used by the report-only VM reaper. */
+  listVolumes?(options?: VMVolumeListOptions): Promise<VMVolumeInventory>;
 
   getStatus?(vmId: string): Promise<VMStatus>;
   /// Live CPU/memory/disk for the Cloud panel's activity view. Must not wake a

--- a/web/services/vms/observability.ts
+++ b/web/services/vms/observability.ts
@@ -201,7 +201,7 @@ export async function captureVmReaperSummary(
   try {
     // Keep the capture alive after a Vercel response. In tests and scripts there
     // is no Next request scope, so the task is still awaited below.
-    after(task);
+    after(() => task);
   } catch {
     // No request scope. The caller still awaits the bounded task.
   }

--- a/web/services/vms/observability.ts
+++ b/web/services/vms/observability.ts
@@ -107,6 +107,7 @@ export const VM_REAPER_POSTHOG_DISTINCT_ID = "cmux-vm-reaper";
 export type VmReaperSummaryTelemetry = {
   readonly reportOnly: boolean;
   readonly candidates: number;
+  readonly reported: number;
   readonly deleted: number;
   readonly skipped: number;
   readonly errors: number;
@@ -114,11 +115,17 @@ export type VmReaperSummaryTelemetry = {
     readonly candidates: number;
     readonly deleted: number;
     readonly reported: number;
+    readonly unknownAttachment: number;
+    readonly unknownReference: number;
+    readonly scanned: number;
+    readonly providerPages: number;
+    readonly coveragePartial: boolean;
     readonly skipped: number;
     readonly errors: number;
   };
   readonly stuckProvisioning: {
     readonly candidates: number;
+    readonly reported: number;
     readonly recovered: number;
     readonly failed: number;
     readonly destroyed: number;
@@ -139,9 +146,8 @@ const VM_REAPER_CAPTURE_TIMEOUT_MS = 2_000;
  * Deliver one aggregate reaper outcome to PostHog.
  *
  * The event is production-only by default. A force flag is useful for a
- * staging smoke test, but the report-only/delete decision remains controlled
- * by the reaper itself. Delivery is best effort and bounded so telemetry can
- * never turn a successful cleanup run into a failed cron request.
+ * staging smoke test. Delivery is best effort and bounded so telemetry can
+ * never turn a successful report run into a failed cron request.
  */
 export async function captureVmReaperSummary(
   summary: VmReaperSummaryTelemetry,
@@ -154,24 +160,30 @@ export async function captureVmReaperSummary(
   if (!enabled) return;
 
   const properties: Record<string, string | number | boolean> = {
-    report_only: summary.reportOnly,
-    delete_enabled: !summary.reportOnly,
+    report_only: true,
     candidates: boundedTelemetryCount(summary.candidates),
+    reported: boundedTelemetryCount(summary.reported),
     deleted: boundedTelemetryCount(summary.deleted),
     skipped: boundedTelemetryCount(summary.skipped),
     errors: boundedTelemetryCount(summary.errors),
     orphan_volume_candidates: boundedTelemetryCount(summary.orphanVolumes.candidates),
     orphan_volume_deleted: boundedTelemetryCount(summary.orphanVolumes.deleted),
     orphan_volume_reported: boundedTelemetryCount(summary.orphanVolumes.reported),
+    orphan_volume_unknown_attachment: boundedTelemetryCount(summary.orphanVolumes.unknownAttachment),
+    orphan_volume_unknown_reference: boundedTelemetryCount(summary.orphanVolumes.unknownReference),
+    orphan_volume_scanned: boundedTelemetryCount(summary.orphanVolumes.scanned),
+    orphan_volume_provider_pages: boundedTelemetryCount(summary.orphanVolumes.providerPages),
+    orphan_volume_coverage_partial: summary.orphanVolumes.coveragePartial,
     orphan_volume_skipped: boundedTelemetryCount(summary.orphanVolumes.skipped),
     orphan_volume_errors: boundedTelemetryCount(summary.orphanVolumes.errors),
     stuck_provisioning_candidates: boundedTelemetryCount(summary.stuckProvisioning.candidates),
+    stuck_provisioning_reported: boundedTelemetryCount(summary.stuckProvisioning.reported),
     stuck_provisioning_recovered: boundedTelemetryCount(summary.stuckProvisioning.recovered),
     stuck_provisioning_failed: boundedTelemetryCount(summary.stuckProvisioning.failed),
     stuck_provisioning_destroyed: boundedTelemetryCount(summary.stuckProvisioning.destroyed),
     stuck_provisioning_skipped: boundedTelemetryCount(summary.stuckProvisioning.skipped),
     stuck_provisioning_errors: boundedTelemetryCount(summary.stuckProvisioning.errors),
-    schema_version: 1,
+    schema_version: 2,
     $insert_id: randomUUID(),
     $geoip_disable: true,
     $process_person_profile: false,

--- a/web/services/vms/observability.ts
+++ b/web/services/vms/observability.ts
@@ -100,6 +100,128 @@ export function reportVmErrorResponse(input: VmErrorResponseInput): void {
 
 export type VmProvisionOperation = "create" | "fork" | "restore" | "base_open" | "base_reset";
 
+/** Stable PostHog event name for one bounded VM reaper invocation. */
+export const VM_REAPER_POSTHOG_EVENT = "cloud_vm_reaper_run";
+export const VM_REAPER_POSTHOG_DISTINCT_ID = "cmux-vm-reaper";
+
+export type VmReaperSummaryTelemetry = {
+  readonly reportOnly: boolean;
+  readonly candidates: number;
+  readonly deleted: number;
+  readonly skipped: number;
+  readonly errors: number;
+  readonly orphanVolumes: {
+    readonly candidates: number;
+    readonly deleted: number;
+    readonly reported: number;
+    readonly skipped: number;
+    readonly errors: number;
+  };
+  readonly stuckProvisioning: {
+    readonly candidates: number;
+    readonly recovered: number;
+    readonly failed: number;
+    readonly destroyed: number;
+    readonly skipped: number;
+    readonly errors: number;
+  };
+};
+
+type VmReaperTelemetryOptions = {
+  readonly env?: Record<string, string | undefined>;
+  readonly fetch?: typeof fetch;
+  readonly now?: Date;
+};
+
+const VM_REAPER_CAPTURE_TIMEOUT_MS = 2_000;
+
+/**
+ * Deliver one aggregate reaper outcome to PostHog.
+ *
+ * The event is production-only by default. A force flag is useful for a
+ * staging smoke test, but the report-only/delete decision remains controlled
+ * by the reaper itself. Delivery is best effort and bounded so telemetry can
+ * never turn a successful cleanup run into a failed cron request.
+ */
+export async function captureVmReaperSummary(
+  summary: VmReaperSummaryTelemetry,
+  options: VmReaperTelemetryOptions = {},
+): Promise<void> {
+  const env = options.env ?? process.env;
+  const enabled = env.VERCEL_ENV === "production" ||
+    env.CMUX_VM_REAPER_ANALYTICS_FORCE === "1" ||
+    env.CMUX_VM_ANALYTICS_FORCE === "1";
+  if (!enabled) return;
+
+  const properties: Record<string, string | number | boolean> = {
+    report_only: summary.reportOnly,
+    delete_enabled: !summary.reportOnly,
+    candidates: boundedTelemetryCount(summary.candidates),
+    deleted: boundedTelemetryCount(summary.deleted),
+    skipped: boundedTelemetryCount(summary.skipped),
+    errors: boundedTelemetryCount(summary.errors),
+    orphan_volume_candidates: boundedTelemetryCount(summary.orphanVolumes.candidates),
+    orphan_volume_deleted: boundedTelemetryCount(summary.orphanVolumes.deleted),
+    orphan_volume_reported: boundedTelemetryCount(summary.orphanVolumes.reported),
+    orphan_volume_skipped: boundedTelemetryCount(summary.orphanVolumes.skipped),
+    orphan_volume_errors: boundedTelemetryCount(summary.orphanVolumes.errors),
+    stuck_provisioning_candidates: boundedTelemetryCount(summary.stuckProvisioning.candidates),
+    stuck_provisioning_recovered: boundedTelemetryCount(summary.stuckProvisioning.recovered),
+    stuck_provisioning_failed: boundedTelemetryCount(summary.stuckProvisioning.failed),
+    stuck_provisioning_destroyed: boundedTelemetryCount(summary.stuckProvisioning.destroyed),
+    stuck_provisioning_skipped: boundedTelemetryCount(summary.stuckProvisioning.skipped),
+    stuck_provisioning_errors: boundedTelemetryCount(summary.stuckProvisioning.errors),
+    schema_version: 1,
+    $insert_id: randomUUID(),
+    $geoip_disable: true,
+    $process_person_profile: false,
+  };
+  const now = options.now ?? new Date();
+  const body = JSON.stringify({
+    api_key: POSTHOG_PROJECT_KEY,
+    event: VM_REAPER_POSTHOG_EVENT,
+    distinct_id: VM_REAPER_POSTHOG_DISTINCT_ID,
+    properties,
+    timestamp: now.toISOString(),
+  });
+  const fetchImpl = options.fetch ?? fetch;
+  const task = postVmReaperTelemetry(body, fetchImpl);
+  try {
+    // Keep the capture alive after a Vercel response. In tests and scripts there
+    // is no Next request scope, so the task is still awaited below.
+    after(task);
+  } catch {
+    // No request scope. The caller still awaits the bounded task.
+  }
+  await task;
+}
+
+async function postVmReaperTelemetry(body: string, fetchImpl: typeof fetch): Promise<void> {
+  try {
+    const response = await fetchImpl(`${POSTHOG_HOST}/capture/`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body,
+      signal: AbortSignal.timeout(VM_REAPER_CAPTURE_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      console.error("[VM] reaper summary telemetry rejected", { status: response.status });
+    }
+  } catch (error) {
+    console.error("[VM] reaper summary telemetry failed", safeTelemetryError(error));
+  }
+}
+
+function boundedTelemetryCount(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(1_000_000_000, Math.trunc(value)));
+}
+
+function safeTelemetryError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.replace(/Bearer\s+\S+/gi, "Bearer [redacted]").slice(0, 300);
+}
+
 /**
  * Provisioning outcome choke point, run as a response finalizer. Two legs:
  *

--- a/web/services/vms/providerGateway.ts
+++ b/web/services/vms/providerGateway.ts
@@ -14,6 +14,7 @@ import {
   type VMHandle,
   type VMStatus,
   type VMStats,
+  type VMVolume,
   type CmuxRemoteApprovalResult,
   type CmuxRemoteAttachOptions,
   type CmuxRemoteEndpoint,
@@ -28,6 +29,10 @@ export type VmProviderGatewayShape = {
     provider: ProviderId,
     volumeName: string,
   ) => Effect.Effect<void, VmProviderOperationError>;
+  /** Optional provider volume inventory used by the VM resource reaper. */
+  readonly listVolumes?: (
+    provider: ProviderId,
+  ) => Effect.Effect<readonly VMVolume[], VmProviderOperationError>;
   readonly getStatus?: (provider: ProviderId, vmId: string) => Effect.Effect<VMStatus, VmProviderOperationError>;
   readonly resume?: (provider: ProviderId, vmId: string) => Effect.Effect<VMHandle, VmProviderOperationError>;
   readonly pause?: (provider: ProviderId, vmId: string) => Effect.Effect<void, VmProviderOperationError>;
@@ -108,6 +113,13 @@ export const VmProviderGatewayLive = Layer.succeed(VmProviderGateway, {
       // Providers without persistent volumes have nothing to delete.
       if (!impl.deleteHomeVolume) return;
       await impl.deleteHomeVolume(volumeName);
+    }),
+  listVolumes: (provider) =>
+    providerEffect(provider, "listVolumes", async () => {
+      const impl = getProvider(provider);
+      // Providers without persistent volume support have no inventory to reap.
+      if (!impl.listVolumes) return [];
+      return await impl.listVolumes();
     }),
   getStatus: (provider, vmId) =>
     providerEffect(provider, "getStatus", async () => {

--- a/web/services/vms/providerGateway.ts
+++ b/web/services/vms/providerGateway.ts
@@ -12,9 +12,10 @@ import {
   type SnapshotRef,
   type SSHEndpoint,
   type VMHandle,
+  type VMVolumeInventory,
+  type VMVolumeListOptions,
   type VMStatus,
   type VMStats,
-  type VMVolume,
   type CmuxRemoteApprovalResult,
   type CmuxRemoteAttachOptions,
   type CmuxRemoteEndpoint,
@@ -29,10 +30,11 @@ export type VmProviderGatewayShape = {
     provider: ProviderId,
     volumeName: string,
   ) => Effect.Effect<void, VmProviderOperationError>;
-  /** Optional provider volume inventory used by the VM resource reaper. */
+  /** Optional provider volume inventory used by the report-only VM reaper. */
   readonly listVolumes?: (
     provider: ProviderId,
-  ) => Effect.Effect<readonly VMVolume[], VmProviderOperationError>;
+    options?: VMVolumeListOptions,
+  ) => Effect.Effect<VMVolumeInventory, VmProviderOperationError>;
   readonly getStatus?: (provider: ProviderId, vmId: string) => Effect.Effect<VMStatus, VmProviderOperationError>;
   readonly resume?: (provider: ProviderId, vmId: string) => Effect.Effect<VMHandle, VmProviderOperationError>;
   readonly pause?: (provider: ProviderId, vmId: string) => Effect.Effect<void, VmProviderOperationError>;
@@ -114,12 +116,12 @@ export const VmProviderGatewayLive = Layer.succeed(VmProviderGateway, {
       if (!impl.deleteHomeVolume) return;
       await impl.deleteHomeVolume(volumeName);
     }),
-  listVolumes: (provider) =>
+  listVolumes: (provider, options) =>
     providerEffect(provider, "listVolumes", async () => {
       const impl = getProvider(provider);
       // Providers without persistent volume support have no inventory to reap.
       if (!impl.listVolumes) return [];
-      return await impl.listVolumes();
+      return await impl.listVolumes(options);
     }),
   getStatus: (provider, vmId) =>
     providerEffect(provider, "getStatus", async () => {

--- a/web/services/vms/reaper.ts
+++ b/web/services/vms/reaper.ts
@@ -1,0 +1,543 @@
+import * as Effect from "effect/Effect";
+import type { VMStatus, VMVolume, ProviderId } from "./drivers";
+import { isProviderNotFoundError } from "./providerErrors";
+import { VmProviderGateway, type VmProviderGatewayShape } from "./providerGateway";
+import {
+  VmRepository,
+  type CloudVmRow,
+  type VmRepositoryShape,
+} from "./repository";
+import { isMachineOwnedHomeVolumeName } from "./volumeNaming";
+
+/** The reaper is intentionally small enough to finish inside one Vercel invocation. */
+export const VM_REAPER_DEFAULT_VOLUME_LIMIT = 100;
+export const VM_REAPER_DEFAULT_PROVISIONING_LIMIT = 100;
+export const VM_REAPER_DEFAULT_STUCK_PROVISIONING_MINUTES = 60;
+export const VM_REAPER_MAX_BATCH_LIMIT = 100;
+export const VM_REAPER_SYSTEM_USER_ID = "cmux-vm-reaper";
+
+const ORPHAN_VOLUME_EVENT = "vm.reaper.orphan_volume";
+const STUCK_VOLUME_ERROR_EVENT = "vm.reaper.orphan_volume_error";
+const STUCK_PROVISIONING_FAILURE_CODE = "provisioning_timeout";
+
+export type VmReaperCounts = {
+  readonly candidates: number;
+  readonly deleted: number;
+  readonly reported: number;
+  readonly skipped: number;
+  readonly errors: number;
+};
+
+export type VmStuckProvisioningCounts = {
+  readonly candidates: number;
+  readonly recovered: number;
+  readonly failed: number;
+  readonly destroyed: number;
+  readonly skipped: number;
+  readonly errors: number;
+};
+
+export type VmReaperSummary = {
+  /** True when no provider deletion was enabled for this run. */
+  readonly reportOnly: boolean;
+  readonly orphanVolumes: VmReaperCounts;
+  readonly stuckProvisioning: VmStuckProvisioningCounts;
+  /** Aggregate fields are convenient for dashboards and the PostHog event. */
+  readonly candidates: number;
+  readonly deleted: number;
+  readonly skipped: number;
+  readonly errors: number;
+};
+
+export type VmReaperOptions = {
+  readonly now?: Date;
+  /** Explicit option wins over CMUX_VM_REAPER_DELETE. */
+  readonly deleteVolumes?: boolean;
+  readonly volumeLimit?: number;
+  readonly provisioningLimit?: number;
+  /** Threshold in milliseconds. Explicit option wins over the env setting. */
+  readonly stuckProvisioningAgeMs?: number;
+  readonly env?: Record<string, string | undefined>;
+};
+
+type MutableSummary = {
+  reportOnly: boolean;
+  orphanVolumes: {
+    candidates: number;
+    deleted: number;
+    reported: number;
+    skipped: number;
+    errors: number;
+  };
+  stuckProvisioning: {
+    candidates: number;
+    recovered: number;
+    failed: number;
+    destroyed: number;
+    skipped: number;
+    errors: number;
+  };
+};
+
+type ReaperOutcome = "deleted" | "reported" | "skipped" | "error";
+type StuckOutcome = "recovered" | "failed" | "destroyed" | "skipped" | "error";
+
+/**
+ * Reconcile old provisioning rows and clean up unreferenced Blaxel volumes.
+ * Every item is isolated in its own Effect boundary. A provider or database
+ * failure for one item becomes an error count and never aborts the batch.
+ */
+export function reapVmResources(
+  input: VmReaperOptions = {},
+): Effect.Effect<
+  VmReaperSummary,
+  never,
+  VmRepository | VmProviderGateway
+> {
+  return Effect.gen(function* () {
+    const repo = yield* VmRepository;
+    const providers = yield* VmProviderGateway;
+    const env = input.env ?? process.env;
+    const now = input.now ?? new Date();
+    const deleteVolumes = input.deleteVolumes ?? env.CMUX_VM_REAPER_DELETE === "1";
+    const summary: MutableSummary = {
+      reportOnly: !deleteVolumes,
+      orphanVolumes: { candidates: 0, deleted: 0, reported: 0, skipped: 0, errors: 0 },
+      stuckProvisioning: { candidates: 0, recovered: 0, failed: 0, destroyed: 0, skipped: 0, errors: 0 },
+    };
+
+    // Process stuck rows first. A row that is conclusively dead should no
+    // longer protect its old machine-owned volume during this same run.
+    yield* reapStuckProvisioningRows(repo, providers, summary, {
+      now,
+      limit: resolveLimit(input.provisioningLimit, env.CMUX_VM_REAPER_PROVISIONING_LIMIT),
+      ageMs: input.stuckProvisioningAgeMs ?? resolveStuckAgeMs(env),
+    });
+
+    yield* reapOrphanVolumes(repo, providers, summary, {
+      deleteVolumes,
+      limit: resolveLimit(input.volumeLimit, env.CMUX_VM_REAPER_VOLUME_LIMIT),
+    });
+
+    const orphan = summary.orphanVolumes;
+    const stuck = summary.stuckProvisioning;
+    return {
+      reportOnly: summary.reportOnly,
+      orphanVolumes: orphan,
+      stuckProvisioning: stuck,
+      candidates: orphan.candidates + stuck.candidates,
+      deleted: orphan.deleted + stuck.destroyed,
+      skipped: orphan.skipped + stuck.skipped,
+      errors: orphan.errors + stuck.errors,
+    } satisfies VmReaperSummary;
+  });
+}
+
+/** Alias kept for callers that name the job after its Cloud VM scope. */
+export const reapCloudVmResources = reapVmResources;
+
+function reapStuckProvisioningRows(
+  repo: VmRepositoryShape,
+  providers: VmProviderGatewayShape,
+  summary: MutableSummary,
+  input: { readonly now: Date; readonly limit: number; readonly ageMs: number },
+): Effect.Effect<void, never> {
+  const candidatesEffect = repo.stuckProvisioningCandidates
+    ? repo.stuckProvisioningCandidates({
+      before: new Date(input.now.getTime() - input.ageMs),
+      limit: input.limit,
+    })
+    : Effect.succeed([] as CloudVmRow[]);
+
+  return Effect.gen(function* () {
+    const candidates = yield* candidatesEffect.pipe(
+      Effect.catchAll((error) => Effect.sync(() => {
+        summary.stuckProvisioning.errors += 1;
+        console.error("[VM] reaper could not list stuck provisioning rows", safeErrorMessage(error));
+        return [] as CloudVmRow[];
+      })),
+    );
+    summary.stuckProvisioning.candidates = candidates.length;
+    yield* Effect.forEach(
+      candidates,
+      (vm) => reapOneStuckProvisioningRow(repo, providers, summary, vm, input.now),
+      { concurrency: 1, discard: true },
+    );
+  });
+}
+
+function reapOneStuckProvisioningRow(
+  repo: VmRepositoryShape,
+  providers: VmProviderGatewayShape,
+  summary: MutableSummary,
+  vm: CloudVmRow,
+  now: Date,
+): Effect.Effect<void, never> {
+  return Effect.gen(function* () {
+    const providerVmId = vm.providerVmId?.trim() || null;
+    if (!providerVmId) {
+      const marked = yield* markProvisioningFailed(repo, vm).pipe(Effect.either);
+      if (marked._tag === "Left") {
+        recordStuckError(summary, vm, marked.left, "mark_failed");
+        return;
+      }
+      if (!marked.right) {
+        summary.stuckProvisioning.skipped += 1;
+        console.info("[VM] reaper skipped stale provisioning row changed concurrently", { vmId: vm.id });
+        return;
+      }
+      summary.stuckProvisioning.failed += 1;
+      console.warn("[VM] reaper marked provisioning row failed without provider id", {
+        vmId: vm.id,
+        ageMinutes: ageMinutes(vm.createdAt, now),
+      });
+      yield* recordVmUsageEvent(repo, vm, "vm.create.failed", {
+        source: "vm_reaper",
+        code: STUCK_PROVISIONING_FAILURE_CODE,
+        reason: "provider_vm_id_missing",
+      });
+      return;
+    }
+
+    const getStatus = providers.getStatus;
+    if (!getStatus) {
+      recordStuckError(summary, vm, new Error("provider status is not supported"), "get_status");
+      return;
+    }
+
+    const statusResult = yield* getStatus(vm.provider, providerVmId).pipe(Effect.either);
+    let providerStatus: VMStatus;
+    if (statusResult._tag === "Left") {
+      if (!isProviderNotFoundError(statusResult.left)) {
+        recordStuckError(summary, vm, statusResult.left, "get_status");
+        return;
+      }
+      providerStatus = "destroyed";
+    } else {
+      providerStatus = statusResult.right;
+    }
+
+    if (providerStatus === "creating") {
+      summary.stuckProvisioning.skipped += 1;
+      console.info("[VM] reaper left provider still creating", { vmId: vm.id, providerVmId });
+      return;
+    }
+
+    const desiredStatus = stuckDbStatus(
+      vm,
+      providerStatus as Exclude<VMStatus, "creating">,
+    );
+    const updated = yield* repo.markProviderObservedStatus({
+      id: vm.id,
+      providerVmId,
+      status: desiredStatus,
+    }).pipe(Effect.either);
+    if (updated._tag === "Left") {
+      recordStuckError(summary, vm, updated.left, "mark_status");
+      return;
+    }
+    if (!updated.right) {
+      summary.stuckProvisioning.skipped += 1;
+      console.info("[VM] reaper skipped stale provisioning row changed concurrently", { vmId: vm.id });
+      return;
+    }
+
+    if (desiredStatus === "destroyed") {
+      summary.stuckProvisioning.destroyed += 1;
+      console.warn("[VM] reaper marked missing provider sandbox destroyed", { vmId: vm.id, providerVmId });
+      yield* recordVmUsageEvent(repo, vm, "vm.destroyed", {
+        source: "vm_reaper",
+        reason: "provider_sandbox_missing",
+      });
+      return;
+    }
+
+    summary.stuckProvisioning.recovered += 1;
+    console.info("[VM] reaper reconciled stale provisioning row", {
+      vmId: vm.id,
+      providerVmId,
+      status: desiredStatus,
+    });
+  });
+}
+
+function reapOrphanVolumes(
+  repo: VmRepositoryShape,
+  providers: VmProviderGatewayShape,
+  summary: MutableSummary,
+  input: { readonly deleteVolumes: boolean; readonly limit: number },
+): Effect.Effect<void, never> {
+  const listVolumes = providers.listVolumes;
+  if (!listVolumes) return Effect.void;
+
+  return Effect.gen(function* () {
+    const liveReferences = yield* loadLiveVolumeReferences(repo).pipe(
+      Effect.catchAll((error) => Effect.sync(() => {
+        console.error("[VM] reaper could not load live volume references", safeErrorMessage(error));
+        return null as Set<string> | null;
+      })),
+    );
+    const listed = yield* listVolumes("blaxel").pipe(
+      Effect.catchAll((error) => Effect.sync(() => {
+        summary.orphanVolumes.errors += 1;
+        console.error("[VM] reaper could not list provider volumes", safeErrorMessage(error));
+        return [] as readonly VMVolume[];
+      })),
+    );
+    const candidates = listed
+      .filter((volume) => isMachineOwnedHomeVolumeName(volume.name))
+      .sort(compareVolumes)
+      .slice(0, input.limit);
+    summary.orphanVolumes.candidates = candidates.length;
+
+    yield* Effect.forEach(
+      candidates,
+      (volume) => reapOneOrphanVolume(repo, providers, summary, volume, {
+        deleteVolumes: input.deleteVolumes,
+        liveReferences,
+      }),
+      { concurrency: 1, discard: true },
+    );
+  });
+}
+
+function reapOneOrphanVolume(
+  repo: VmRepositoryShape,
+  providers: VmProviderGatewayShape,
+  summary: MutableSummary,
+  volume: VMVolume,
+  input: {
+    readonly deleteVolumes: boolean;
+    readonly liveReferences: Set<string> | null;
+  },
+): Effect.Effect<void, never> {
+  return Effect.gen(function* () {
+    const name = volume.name.trim();
+    const attachedTo = normalizedAttachment(volume);
+    if (attachedTo) {
+      summary.orphanVolumes.skipped += 1;
+      console.info("[VM] reaper skipped attached volume", { volumeName: name, attachedTo });
+      return;
+    }
+
+    if (input.liveReferences?.has(name)) {
+      summary.orphanVolumes.skipped += 1;
+      console.info("[VM] reaper skipped volume referenced by a live VM", { volumeName: name });
+      return;
+    }
+
+    // Recheck ownership immediately before deletion. The initial inventory is
+    // only a snapshot and a create can claim a volume while this run proceeds.
+    if (repo.isLiveHomeVolumeReferenced) {
+      const referenceResult = yield* repo.isLiveHomeVolumeReferenced({
+        provider: "blaxel",
+        volumeName: name,
+      }).pipe(Effect.either);
+      if (referenceResult._tag === "Left") {
+        recordVolumeError(summary, name, referenceResult.left, "reference_check");
+        return;
+      }
+      if (referenceResult.right) {
+        summary.orphanVolumes.skipped += 1;
+        console.info("[VM] reaper skipped volume claimed during the run", { volumeName: name });
+        return;
+      }
+    }
+
+    if (!input.deleteVolumes) {
+      summary.orphanVolumes.reported += 1;
+      console.info("[VM] reaper orphan volume report-only candidate", { volumeName: name });
+      yield* recordSystemUsageEvent(repo, ORPHAN_VOLUME_EVENT, {
+        volumeName: name,
+        mode: "report",
+        action: "report",
+      });
+      return;
+    }
+
+    if (!providers.deleteHomeVolume) {
+      recordVolumeError(summary, name, new Error("provider volume deletion is not supported"), "delete");
+      return;
+    }
+    const deleted = yield* providers.deleteHomeVolume("blaxel", name).pipe(Effect.either);
+    if (deleted._tag === "Left") {
+      recordVolumeError(summary, name, deleted.left, "delete");
+      return;
+    }
+    summary.orphanVolumes.deleted += 1;
+    console.info("[VM] reaper deleted orphan volume", { volumeName: name });
+    yield* recordSystemUsageEvent(repo, ORPHAN_VOLUME_EVENT, {
+      volumeName: name,
+      mode: "delete",
+      action: "deleted",
+    });
+  });
+}
+
+function loadLiveVolumeReferences(
+  repo: VmRepositoryShape,
+): Effect.Effect<Set<string>, never> {
+  if (!repo.listLiveHomeVolumeNames) return Effect.succeed(new Set<string>());
+  return repo.listLiveHomeVolumeNames({ provider: "blaxel" }).pipe(
+    Effect.map((names) => new Set(names.map((name) => name.trim()).filter(Boolean))),
+  ) as Effect.Effect<Set<string>, never>;
+}
+
+function markProvisioningFailed(
+  repo: VmRepositoryShape,
+  vm: CloudVmRow,
+): Effect.Effect<boolean, unknown> {
+  if (repo.markProvisioningFailed) {
+    return repo.markProvisioningFailed({
+      id: vm.id,
+      code: STUCK_PROVISIONING_FAILURE_CODE,
+      message: "Cloud VM provisioning exceeded the reconciliation threshold.",
+    });
+  }
+  // Compatibility fallback for focused repository doubles and older deploys.
+  return repo.markCreateFailed({
+    id: vm.id,
+    code: STUCK_PROVISIONING_FAILURE_CODE,
+    message: "Cloud VM provisioning exceeded the reconciliation threshold.",
+  }).pipe(Effect.as(true));
+}
+
+function stuckDbStatus(
+  vm: CloudVmRow,
+  providerStatus: Exclude<VMStatus, "creating">,
+): "running" | "paused" | "destroyed" {
+  if (providerStatus !== "destroyed") return providerStatus;
+  const homeVolume = vm.providerMetadata?.homeVolume;
+  // A volume-backed machine can be resurrected after its compute disappears.
+  // Preserve the existing workflow semantics and leave it paused.
+  return typeof homeVolume === "string" && homeVolume.trim().length > 0 ? "paused" : "destroyed";
+}
+
+function recordVmUsageEvent(
+  repo: VmRepositoryShape,
+  vm: CloudVmRow,
+  eventType: string,
+  metadata: Record<string, unknown>,
+): Effect.Effect<void, never> {
+  return repo.recordUsageEvent({
+    userId: vm.userId,
+    billingTeamId: vm.billingTeamId,
+    billingPlanId: vm.billingPlanId,
+    vmId: vm.id,
+    eventType,
+    provider: vm.provider,
+    imageId: vm.imageId,
+    metadata,
+  }).pipe(
+    Effect.catchAll((error) => Effect.sync(() => {
+      console.error("[VM] reaper could not record VM usage event", {
+        vmId: vm.id,
+        eventType,
+        error: safeErrorMessage(error),
+      });
+    })),
+  );
+}
+
+function recordSystemUsageEvent(
+  repo: VmRepositoryShape,
+  eventType: string,
+  metadata: Record<string, unknown>,
+): Effect.Effect<void, never> {
+  return repo.recordUsageEvent({
+    userId: VM_REAPER_SYSTEM_USER_ID,
+    billingTeamId: null,
+    billingPlanId: null,
+    eventType,
+    provider: "blaxel",
+    metadata,
+  }).pipe(
+    Effect.catchAll((error) => Effect.sync(() => {
+      console.error("[VM] reaper could not record volume usage event", {
+        eventType,
+        volumeName: metadata.volumeName,
+        error: safeErrorMessage(error),
+      });
+    })),
+  );
+}
+
+function recordVolumeError(
+  summary: MutableSummary,
+  volumeName: string,
+  error: unknown,
+  operation: string,
+): void {
+  summary.orphanVolumes.errors += 1;
+  summary.orphanVolumes.skipped += 1;
+  console.error("[VM] reaper skipped volume after item error", {
+    volumeName,
+    operation,
+    error: safeErrorMessage(error),
+  });
+  // The item-level error is also visible in the provider usage ledger when the
+  // caller's repository supports it. The main action path records this event
+  // asynchronously below only for the provider action itself.
+}
+
+function recordStuckError(
+  summary: MutableSummary,
+  vm: CloudVmRow,
+  error: unknown,
+  operation: string,
+): void {
+  summary.stuckProvisioning.errors += 1;
+  summary.stuckProvisioning.skipped += 1;
+  console.error("[VM] reaper skipped provisioning row after item error", {
+    vmId: vm.id,
+    operation,
+    error: safeErrorMessage(error),
+  });
+}
+
+function compareVolumes(a: VMVolume, b: VMVolume): number {
+  const aCreated = typeof a.createdAt === "number" && Number.isFinite(a.createdAt) ? a.createdAt : 0;
+  const bCreated = typeof b.createdAt === "number" && Number.isFinite(b.createdAt) ? b.createdAt : 0;
+  if (aCreated !== bCreated) return aCreated - bCreated;
+  return a.name.localeCompare(b.name);
+}
+
+function normalizedAttachment(volume: VMVolume): string | null {
+  const value = volume.attachedTo;
+  if (typeof value === "string" && value.trim().length > 0) return value.trim();
+  return value == null ? null : String(value);
+}
+
+function resolveLimit(value: number | undefined, envValue: string | undefined): number {
+  const candidate = value ?? parsePositiveInteger(envValue);
+  if (candidate === null || candidate === undefined) return VM_REAPER_DEFAULT_VOLUME_LIMIT;
+  return Math.max(1, Math.min(VM_REAPER_MAX_BATCH_LIMIT, Math.trunc(candidate)));
+}
+
+function resolveStuckAgeMs(env: Record<string, string | undefined>): number {
+  const raw = env.CMUX_VM_REAPER_STUCK_PROVISIONING_MINUTES ??
+    env.CMUX_VM_REAPER_STUCK_THRESHOLD_MINUTES ??
+    env.CMUX_VM_REAPER_STUCK_AGE_MINUTES;
+  const minutes = parsePositiveInteger(raw) ?? VM_REAPER_DEFAULT_STUCK_PROVISIONING_MINUTES;
+  return minutes * 60 * 1_000;
+}
+
+function parsePositiveInteger(value: string | undefined): number | null {
+  const trimmed = value?.trim();
+  if (!trimmed || !/^\d+$/.test(trimmed)) return null;
+  const parsed = Number(trimmed);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function ageMinutes(createdAt: Date, now: Date): number {
+  return Math.max(0, Math.round((now.getTime() - createdAt.getTime()) / 60_000));
+}
+
+function safeErrorMessage(error: unknown): string {
+  const raw = error instanceof Error ? error.message : String(error);
+  return raw.replace(/Bearer\s+\S+/gi, "Bearer [redacted]").slice(0, 500);
+}
+
+// Keep these names exported for focused tests and future cron dashboards.
+export const VM_REAPER_ORPHAN_VOLUME_EVENT = ORPHAN_VOLUME_EVENT;
+export const VM_REAPER_VOLUME_ERROR_EVENT = STUCK_VOLUME_ERROR_EVENT;

--- a/web/services/vms/reaper.ts
+++ b/web/services/vms/reaper.ts
@@ -1,6 +1,9 @@
 import * as Effect from "effect/Effect";
-import type { VMStatus, VMVolume } from "./drivers";
-import { isProviderNotFoundError } from "./providerErrors";
+import type {
+  VMVolume,
+  VMVolumeInventory,
+  VMVolumePage,
+} from "./drivers";
 import { VmProviderGateway, type VmProviderGatewayShape } from "./providerGateway";
 import {
   VmRepository,
@@ -9,31 +12,46 @@ import {
 } from "./repository";
 import { isMachineOwnedHomeVolumeName } from "./volumeNaming";
 
-/** The reaper is intentionally small enough to finish inside one Vercel invocation. */
+/** Maximum number of candidate reports emitted by one run. */
 export const VM_REAPER_DEFAULT_VOLUME_LIMIT = 100;
 export const VM_REAPER_DEFAULT_PROVISIONING_LIMIT = 100;
-export const VM_REAPER_DEFAULT_STUCK_PROVISIONING_MINUTES = 60;
-export const VM_REAPER_DEFAULT_ORPHAN_VOLUME_MIN_AGE_MINUTES = 2 * 60;
-export const VM_REAPER_DEFAULT_CREATING_TERMINAL_AGE_MINUTES = 24 * 60;
+export const VM_REAPER_DEFAULT_VOLUME_SCAN_LIMIT = 1_000;
 export const VM_REAPER_MAX_BATCH_LIMIT = 100;
+export const VM_REAPER_MAX_VOLUME_SCAN_LIMIT = 1_000;
+export const VM_REAPER_DEFAULT_STUCK_PROVISIONING_MINUTES = 60;
 export const VM_REAPER_SYSTEM_USER_ID = "cmux-vm-reaper";
 
 const ORPHAN_VOLUME_EVENT = "vm.reaper.orphan_volume";
-const ORPHAN_VOLUME_OBSERVATION_EVENT = "vm.reaper.orphan_volume_observed";
-const STUCK_PROVISIONING_TERMINAL_EVENT = "vm.reaper.stuck_provisioning_terminal";
-const STUCK_VOLUME_ERROR_EVENT = "vm.reaper.orphan_volume_error";
-const STUCK_PROVISIONING_FAILURE_CODE = "provisioning_timeout";
+const ORPHAN_VOLUME_UNKNOWN_ATTACHMENT_EVENT = "vm.reaper.orphan_volume_unknown_attachment";
+const ORPHAN_VOLUME_UNKNOWN_REFERENCE_EVENT = "vm.reaper.orphan_volume_unknown_reference";
+const STUCK_PROVISIONING_EVENT = "vm.reaper.stuck_provisioning";
 
 export type VmReaperCounts = {
+  /** Known machine-owned, explicitly unattached volumes with no live row. */
   readonly candidates: number;
-  readonly deleted: number;
+  /** Usage events successfully emitted for this category. */
   readonly reported: number;
+  /** Always zero. The report-only cron has no lifecycle mutation path. */
+  readonly deleted: number;
+  /** Provider attachment was absent or malformed, so the state was unknown. */
+  readonly unknownAttachment: number;
+  /** A known-free volume could not be checked against live VM rows. */
+  readonly unknownReference: number;
+  /** Provider records inspected during this run. */
+  readonly scanned: number;
+  /** Provider pages fetched during this run. */
+  readonly providerPages: number;
+  /** True when the provider did not prove that the inventory was exhausted. */
+  readonly coveragePartial: boolean;
   readonly skipped: number;
   readonly errors: number;
 };
 
 export type VmStuckProvisioningCounts = {
+  /** Rows older than the configured threshold returned by the repository. */
   readonly candidates: number;
+  readonly reported: number;
+  /** Retained as zero-valued compatibility fields for existing dashboards. */
   readonly recovered: number;
   readonly failed: number;
   readonly destroyed: number;
@@ -42,12 +60,13 @@ export type VmStuckProvisioningCounts = {
 };
 
 export type VmReaperSummary = {
-  /** True when no provider deletion was enabled for this run. */
+  /** Always true. This cron only observes and records findings. */
   readonly reportOnly: boolean;
   readonly orphanVolumes: VmReaperCounts;
   readonly stuckProvisioning: VmStuckProvisioningCounts;
-  /** Aggregate fields are convenient for dashboards and the PostHog event. */
   readonly candidates: number;
+  readonly reported: number;
+  /** Always zero. Kept for stable API/telemetry consumers. */
   readonly deleted: number;
   readonly skipped: number;
   readonly errors: number;
@@ -55,16 +74,13 @@ export type VmReaperSummary = {
 
 export type VmReaperOptions = {
   readonly now?: Date;
-  /** Explicit option wins over CMUX_VM_REAPER_DELETE. */
-  readonly deleteVolumes?: boolean;
+  /** Maximum number of orphan candidates to report in one run. */
   readonly volumeLimit?: number;
+  /** Maximum number of provider volume records to inspect in one run. */
+  readonly volumeScanLimit?: number;
   readonly provisioningLimit?: number;
-  /** Threshold in milliseconds. Explicit option wins over the env setting. */
+  /** Age threshold in milliseconds. */
   readonly stuckProvisioningAgeMs?: number;
-  /** Minimum provider-volume age before a prior observation can be deleted. */
-  readonly orphanVolumeMinAgeMs?: number;
-  /** Maximum age for a provider that remains in `creating`. */
-  readonly stuckProvisioningTerminalAgeMs?: number;
   readonly env?: Record<string, string | undefined>;
 };
 
@@ -72,13 +88,19 @@ type MutableSummary = {
   reportOnly: boolean;
   orphanVolumes: {
     candidates: number;
-    deleted: number;
     reported: number;
+    deleted: number;
+    unknownAttachment: number;
+    unknownReference: number;
+    scanned: number;
+    providerPages: number;
+    coveragePartial: boolean;
     skipped: number;
     errors: number;
   };
   stuckProvisioning: {
     candidates: number;
+    reported: number;
     recovered: number;
     failed: number;
     destroyed: number;
@@ -88,9 +110,12 @@ type MutableSummary = {
 };
 
 /**
- * Reconcile old provisioning rows and clean up unreferenced Blaxel volumes.
- * Every item is isolated in its own Effect boundary. A provider or database
- * failure for one item becomes an error count and never aborts the batch.
+ * Run the bounded Cloud VM observability report.
+ *
+ * This function intentionally has no provider or repository lifecycle mutation
+ * calls. It lists provider volumes, checks live row references, and records
+ * usage events for findings. A provider page without a trustworthy continuation
+ * signal is treated as partial coverage.
  */
 export function reapVmResources(
   input: VmReaperOptions = {},
@@ -104,45 +129,64 @@ export function reapVmResources(
     const providers = yield* VmProviderGateway;
     const env = input.env ?? process.env;
     const now = input.now ?? new Date();
-    const deleteVolumes = input.deleteVolumes ?? env.CMUX_VM_REAPER_DELETE === "1";
-    const orphanVolumeMinAgeMs = resolveDurationOption(
-      input.orphanVolumeMinAgeMs,
-      resolveOrphanVolumeMinAgeMs(env),
+    const volumeLimit = resolveLimit(
+      input.volumeLimit,
+      env.CMUX_VM_REAPER_VOLUME_LIMIT,
+      VM_REAPER_DEFAULT_VOLUME_LIMIT,
     );
-    const stuckProvisioningTerminalAgeMs = resolveDurationOption(
-      input.stuckProvisioningTerminalAgeMs,
-      resolveCreatingTerminalAgeMs(env),
+    const volumeScanLimit = resolveScanLimit(
+      input.volumeScanLimit,
+      env.CMUX_VM_REAPER_VOLUME_SCAN_LIMIT ?? env.CMUX_VM_REAPER_SCAN_LIMIT,
+      volumeLimit,
     );
     const summary: MutableSummary = {
-      reportOnly: !deleteVolumes,
-      orphanVolumes: { candidates: 0, deleted: 0, reported: 0, skipped: 0, errors: 0 },
-      stuckProvisioning: { candidates: 0, recovered: 0, failed: 0, destroyed: 0, skipped: 0, errors: 0 },
+      reportOnly: true,
+      orphanVolumes: {
+        candidates: 0,
+        reported: 0,
+        deleted: 0,
+        unknownAttachment: 0,
+        unknownReference: 0,
+        scanned: 0,
+        providerPages: 0,
+        coveragePartial: false,
+        skipped: 0,
+        errors: 0,
+      },
+      stuckProvisioning: {
+        candidates: 0,
+        reported: 0,
+        recovered: 0,
+        failed: 0,
+        destroyed: 0,
+        skipped: 0,
+        errors: 0,
+      },
     };
 
-    // Process stuck rows first. A row that is conclusively dead should no
-    // longer protect its old machine-owned volume during this same run.
-    yield* reapStuckProvisioningRows(repo, providers, summary, {
+    yield* reportStuckProvisioningRows(repo, summary, {
       now,
-      limit: resolveLimit(input.provisioningLimit, env.CMUX_VM_REAPER_PROVISIONING_LIMIT),
-      ageMs: input.stuckProvisioningAgeMs ?? resolveStuckAgeMs(env),
-      terminalAgeMs: stuckProvisioningTerminalAgeMs,
+      limit: resolveLimit(
+        input.provisioningLimit,
+        env.CMUX_VM_REAPER_PROVISIONING_LIMIT,
+        VM_REAPER_DEFAULT_PROVISIONING_LIMIT,
+      ),
+      ageMs: resolveDurationOption(input.stuckProvisioningAgeMs, resolveStuckAgeMs(env)),
     });
-
-    yield* reapOrphanVolumes(repo, providers, summary, {
-      deleteVolumes,
-      limit: resolveLimit(input.volumeLimit, env.CMUX_VM_REAPER_VOLUME_LIMIT),
-      minAgeMs: orphanVolumeMinAgeMs,
-      now,
+    yield* reportOrphanVolumes(repo, providers, summary, {
+      limit: volumeLimit,
+      scanLimit: volumeScanLimit,
     });
 
     const orphan = summary.orphanVolumes;
     const stuck = summary.stuckProvisioning;
     return {
-      reportOnly: summary.reportOnly,
+      reportOnly: true,
       orphanVolumes: orphan,
       stuckProvisioning: stuck,
       candidates: orphan.candidates + stuck.candidates,
-      deleted: orphan.deleted + stuck.destroyed,
+      reported: orphan.reported + stuck.reported,
+      deleted: 0,
       skipped: orphan.skipped + stuck.skipped,
       errors: orphan.errors + stuck.errors,
     } satisfies VmReaperSummary;
@@ -152,474 +196,259 @@ export function reapVmResources(
 /** Alias kept for callers that name the job after its Cloud VM scope. */
 export const reapCloudVmResources = reapVmResources;
 
-function reapStuckProvisioningRows(
+function reportStuckProvisioningRows(
   repo: VmRepositoryShape,
-  providers: VmProviderGatewayShape,
   summary: MutableSummary,
-  input: {
-    readonly now: Date;
-    readonly limit: number;
-    readonly ageMs: number;
-    readonly terminalAgeMs: number;
-  },
+  input: { readonly now: Date; readonly limit: number; readonly ageMs: number },
 ): Effect.Effect<void, never> {
-  const candidatesEffect = repo.stuckProvisioningCandidates
-    ? repo.stuckProvisioningCandidates({
+  const listCandidates = repo.stuckProvisioningCandidates;
+  if (!listCandidates) return Effect.void;
+  return Effect.gen(function* () {
+    const result = yield* listCandidates({
       before: new Date(input.now.getTime() - input.ageMs),
       limit: input.limit,
-    })
-    : Effect.succeed([] as CloudVmRow[]);
-
-  return Effect.gen(function* () {
-    const candidates = yield* candidatesEffect.pipe(
-      Effect.catchAll((error) => Effect.sync(() => {
-        summary.stuckProvisioning.errors += 1;
-        console.error("[VM] reaper could not list stuck provisioning rows", safeErrorMessage(error));
-        return [] as CloudVmRow[];
-      })),
-    );
-    summary.stuckProvisioning.candidates = candidates.length;
-    yield* Effect.forEach(
-      candidates,
-      (vm) => reapOneStuckProvisioningRow(repo, providers, summary, vm, {
-        now: input.now,
-        terminalAgeMs: input.terminalAgeMs,
-      }),
-      { concurrency: 1, discard: true },
-    );
-  });
-}
-
-function reapOneStuckProvisioningRow(
-  repo: VmRepositoryShape,
-  providers: VmProviderGatewayShape,
-  summary: MutableSummary,
-  vm: CloudVmRow,
-  input: { readonly now: Date; readonly terminalAgeMs: number },
-): Effect.Effect<void, never> {
-  return Effect.gen(function* () {
-    const providerVmId = vm.providerVmId?.trim() || null;
-    if (!providerVmId) {
-      const marked = yield* markProvisioningFailed(repo, vm).pipe(Effect.either);
-      if (marked._tag === "Left") {
-        recordStuckError(summary, vm, marked.left, "mark_failed");
-        return;
-      }
-      if (!marked.right) {
-        summary.stuckProvisioning.skipped += 1;
-        console.info("[VM] reaper skipped stale provisioning row changed concurrently", { vmId: vm.id });
-        return;
-      }
-      summary.stuckProvisioning.failed += 1;
-      console.warn("[VM] reaper marked provisioning row failed without provider id", {
-        vmId: vm.id,
-        ageMinutes: ageMinutes(vm.createdAt, input.now),
-      });
-      yield* recordVmUsageEvent(repo, vm, "vm.create.failed", {
-        source: "vm_reaper",
-        code: STUCK_PROVISIONING_FAILURE_CODE,
-        reason: "provider_vm_id_missing",
-      });
-      return;
-    }
-
-    const getStatus = providers.getStatus;
-    if (!getStatus) {
-      recordStuckError(summary, vm, new Error("provider status is not supported"), "get_status");
-      return;
-    }
-
-    const statusResult = yield* getStatus(vm.provider, providerVmId).pipe(Effect.either);
-    let providerStatus: VMStatus;
-    if (statusResult._tag === "Left") {
-      if (!isProviderNotFoundError(statusResult.left)) {
-        recordStuckError(summary, vm, statusResult.left, "get_status");
-        return;
-      }
-      providerStatus = "destroyed";
-    } else {
-      providerStatus = statusResult.right;
-    }
-
-    if (providerStatus === "creating") {
-      if (!isOlderThan(vm.createdAt, input.now, input.terminalAgeMs)) {
-        summary.stuckProvisioning.skipped += 1;
-        console.info("[VM] reaper left provider still creating", { vmId: vm.id, providerVmId });
-        return;
-      }
-
-      const marked = yield* markProvisioningFailed(repo, vm).pipe(Effect.either);
-      if (marked._tag === "Left") {
-        recordStuckError(summary, vm, marked.left, "mark_terminal_failed");
-        return;
-      }
-      if (!marked.right) {
-        summary.stuckProvisioning.skipped += 1;
-        console.info("[VM] reaper skipped terminal creating row changed concurrently", { vmId: vm.id });
-        return;
-      }
-
-      summary.stuckProvisioning.failed += 1;
-      console.warn("[VM] reaper finalized provider-creating row after terminal deadline", {
-        vmId: vm.id,
-        providerVmId,
-        ageMinutes: ageMinutes(vm.createdAt, input.now),
-      });
-      yield* recordVmUsageEvent(repo, vm, "vm.create.failed", {
-        source: "vm_reaper",
-        code: STUCK_PROVISIONING_FAILURE_CODE,
-        reason: "provider_still_creating_terminal_deadline",
-        providerStatus,
-      });
-      yield* recordVmUsageEvent(repo, vm, STUCK_PROVISIONING_TERMINAL_EVENT, {
-        source: "vm_reaper",
-        reason: "provider_still_creating_terminal_deadline",
-        providerStatus,
-        terminalAgeMinutes: Math.round(input.terminalAgeMs / 60_000),
-      });
-      return;
-    }
-
-    const desiredStatus = stuckDbStatus(
-      vm,
-      providerStatus as Exclude<VMStatus, "creating">,
-    );
-    const updated = yield* repo.markProviderObservedStatus({
-      id: vm.id,
-      providerVmId,
-      status: desiredStatus,
-      expectedStatus: "provisioning",
     }).pipe(Effect.either);
-    if (updated._tag === "Left") {
-      recordStuckError(summary, vm, updated.left, "mark_status");
-      return;
-    }
-    if (!updated.right) {
-      summary.stuckProvisioning.skipped += 1;
-      console.info("[VM] reaper skipped stale provisioning row changed concurrently", { vmId: vm.id });
+    if (result._tag === "Left") {
+      summary.stuckProvisioning.errors += 1;
+      console.error("[VM] reaper could not list stuck provisioning rows", safeErrorMessage(result.left));
       return;
     }
 
-    if (desiredStatus === "destroyed") {
-      summary.stuckProvisioning.destroyed += 1;
-      console.warn("[VM] reaper marked missing provider sandbox destroyed", { vmId: vm.id, providerVmId });
-      yield* recordVmUsageEvent(repo, vm, "vm.destroyed", {
+    // The repository orders this query oldest first. Keep only a bounded
+    // oldest subset as a defensive measure for alternate implementations that
+    // return more rows than requested.
+    const eligible = result.right.filter((vm) => isOlderThan(vm.createdAt, input.now, input.ageMs));
+    const candidates = selectOldestVmRows(eligible, input.limit);
+    summary.stuckProvisioning.candidates = candidates.length;
+    if (eligible.length > candidates.length) summary.stuckProvisioning.skipped += eligible.length - candidates.length;
+
+    for (const vm of candidates) {
+      const recorded = yield* recordVmUsageEvent(repo, vm, STUCK_PROVISIONING_EVENT, {
         source: "vm_reaper",
-        reason: "provider_sandbox_missing",
+        reason: "age_over_threshold",
+        ageMinutes: ageMinutes(vm.createdAt, input.now),
+        thresholdMinutes: Math.ceil(input.ageMs / 60_000),
+        providerVmIdPresent: !!vm.providerVmId?.trim(),
       });
-      return;
+      if (recorded) summary.stuckProvisioning.reported += 1;
+      else summary.stuckProvisioning.errors += 1;
     }
-
-    summary.stuckProvisioning.recovered += 1;
-    console.info("[VM] reaper reconciled stale provisioning row", {
-      vmId: vm.id,
-      providerVmId,
-      status: desiredStatus,
-    });
   });
 }
 
-function reapOrphanVolumes(
+function reportOrphanVolumes(
   repo: VmRepositoryShape,
   providers: VmProviderGatewayShape,
   summary: MutableSummary,
-  input: {
-    readonly deleteVolumes: boolean;
-    readonly limit: number;
-    readonly minAgeMs: number;
-    readonly now: Date;
-  },
+  input: { readonly limit: number; readonly scanLimit: number },
 ): Effect.Effect<void, never> {
   const listVolumes = providers.listVolumes;
-  if (!listVolumes) return Effect.void;
-
-  return Effect.gen(function* () {
-    const listed = yield* listVolumes("blaxel").pipe(
-      Effect.catchAll((error) => Effect.sync(() => {
-        summary.orphanVolumes.errors += 1;
-        console.error("[VM] reaper could not list provider volumes", safeErrorMessage(error));
-        return [] as readonly VMVolume[];
-      })),
-    );
-    const candidates = yield* selectOrphanVolumeCandidates(repo, summary, listed, input.limit);
-    const observations = yield* loadOrphanVolumeObservations(
-      repo,
-      candidates.map((volume) => volume.name),
-      summary,
-    );
-    summary.orphanVolumes.candidates = candidates.length;
-
-    yield* Effect.forEach(
-      candidates,
-      (volume) => reapOneOrphanVolume(repo, providers, summary, volume, {
-        deleteVolumes: input.deleteVolumes,
-        minAgeMs: input.minAgeMs,
-        now: input.now,
-        observations,
-      }),
-      { concurrency: 1, discard: true },
-    );
-  });
-}
-
-/**
- * Select a bounded batch after removing provider-attached and database-live
- * volumes. Reference queries are chunked so a large provider inventory never
- * becomes an unbounded SQL `IN` list.
- */
-function selectOrphanVolumeCandidates(
-  repo: VmRepositoryShape,
-  summary: MutableSummary,
-  listed: readonly VMVolume[],
-  limit: number,
-): Effect.Effect<VMVolume[], never> {
-  return Effect.gen(function* () {
-    const owned = listed
-      .filter((volume) => isMachineOwnedHomeVolumeName(volume.name))
-      .sort(compareVolumes);
-    const unattached = owned.filter((volume) => {
-      const attachedTo = normalizedAttachment(volume);
-      if (!attachedTo) return true;
-      summary.orphanVolumes.skipped += 1;
-      console.info("[VM] reaper skipped attached volume", {
-        volumeName: volume.name.trim(),
-        attachedTo,
-      });
-      return false;
-    });
-    const candidates: VMVolume[] = [];
-    let offset = 0;
-
-    while (offset < unattached.length && candidates.length < limit) {
-      const chunk = unattached.slice(offset, offset + limit);
-      offset += chunk.length;
-      let liveNames: readonly string[] = [];
-
-      if (repo.listLiveHomeVolumeNames) {
-        const result = yield* repo.listLiveHomeVolumeNames({
-          provider: "blaxel",
-          volumeNames: chunk.map((volume) => volume.name.trim()),
-        }).pipe(Effect.either);
-        if (result._tag === "Left") {
-          summary.orphanVolumes.errors += 1;
-          summary.orphanVolumes.skipped += chunk.length;
-          console.error("[VM] reaper could not load live volume references", safeErrorMessage(result.left));
-          continue;
-        }
-        liveNames = result.right;
-      }
-
-      const liveReferences = new Set(liveNames.map((name) => name.trim()).filter(Boolean));
-      for (const volume of chunk) {
-        const name = volume.name.trim();
-        if (liveReferences.has(name)) {
-          summary.orphanVolumes.skipped += 1;
-          console.info("[VM] reaper skipped volume referenced by a live VM", { volumeName: name });
-          continue;
-        }
-        candidates.push(volume);
-        if (candidates.length >= limit) break;
-      }
-    }
-    return candidates;
-  });
-}
-
-type OrphanVolumeObservationState = {
-  readonly available: boolean;
-  readonly byName: ReadonlyMap<string, Date>;
-};
-
-function loadOrphanVolumeObservations(
-  repo: VmRepositoryShape,
-  volumeNames: readonly string[],
-  summary: MutableSummary,
-): Effect.Effect<OrphanVolumeObservationState, never> {
-  if (!repo.listOrphanVolumeObservations || volumeNames.length === 0) {
-    return Effect.succeed({ available: !!repo.listOrphanVolumeObservations, byName: new Map() });
+  if (!listVolumes) {
+    summary.orphanVolumes.coveragePartial = true;
+    return Effect.void;
   }
-  return repo.listOrphanVolumeObservations({ provider: "blaxel", volumeNames }).pipe(
-    Effect.map((observations) => {
-      const byName = new Map<string, Date>();
-      for (const observation of observations) {
-        const name = observation.volumeName.trim();
-        if (!name || byName.has(name)) continue;
-        if (!(observation.firstObservedAt instanceof Date) || !Number.isFinite(observation.firstObservedAt.getTime())) {
-          continue;
-        }
-        byName.set(name, observation.firstObservedAt);
+
+  return Effect.gen(function* () {
+    let cursor: string | undefined;
+    let exhausted = false;
+    const seenCursors = new Set<string>();
+    const seenNames = new Set<string>();
+    let candidateLimitReached = false;
+
+    while (!exhausted &&
+      summary.orphanVolumes.scanned < input.scanLimit &&
+      summary.orphanVolumes.providerPages < VM_REAPER_MAX_VOLUME_SCAN_LIMIT) {
+      const remaining = input.scanLimit - summary.orphanVolumes.scanned;
+      const requestLimit = Math.max(1, Math.min(VM_REAPER_MAX_BATCH_LIMIT, remaining));
+      const listed = yield* listVolumes("blaxel", {
+        limit: requestLimit,
+        ...(cursor ? { cursor } : {}),
+      }).pipe(Effect.either);
+      if (listed._tag === "Left") {
+        summary.orphanVolumes.errors += 1;
+        summary.orphanVolumes.coveragePartial = true;
+        console.error("[VM] reaper could not list provider volumes", safeErrorMessage(listed.left));
+        break;
       }
-      return { available: true, byName } satisfies OrphanVolumeObservationState;
-    }),
-    Effect.catchAll((error) => Effect.sync(() => {
-      summary.orphanVolumes.errors += 1;
-      console.error("[VM] reaper could not load orphan volume observations", safeErrorMessage(error));
-      return { available: false, byName: new Map() } satisfies OrphanVolumeObservationState;
-    })),
-  );
+
+      summary.orphanVolumes.providerPages += 1;
+      const page = normalizeVolumeInventory(listed.right, remaining);
+      if (page.truncated) summary.orphanVolumes.coveragePartial = true;
+      // The inventory is sliced before this point. Sorting is therefore at
+      // most the remaining run budget, even for a legacy array response.
+      const selected = selectOldestVolumes(page.volumes, remaining);
+      summary.orphanVolumes.scanned += selected.length;
+
+      const pageReport = yield* reportVolumePage(
+        repo,
+        summary,
+        selected,
+        input.limit,
+        seenNames,
+      );
+      candidateLimitReached ||= pageReport.candidateLimitReached;
+
+      const nextCursor = page.nextCursor;
+      if (!page.paginated) {
+        // An array is the legacy provider contract. It cannot prove that the
+        // inventory is complete, so report partial coverage even when short.
+        summary.orphanVolumes.coveragePartial = true;
+        exhausted = true;
+      } else if (!nextCursor) {
+        // A provider page with explicit pagination metadata and no cursor is
+        // complete. A legacy object without that metadata is not proof of
+        // completion, even if it returned fewer than the requested records.
+        if (!page.complete) summary.orphanVolumes.coveragePartial = true;
+        exhausted = true;
+        // Do not retain the previous page's cursor when the inventory is
+        // exhausted. A stale cursor would incorrectly turn a complete run
+        // into a partial one below.
+        cursor = undefined;
+      } else if (seenCursors.has(nextCursor)) {
+        summary.orphanVolumes.errors += 1;
+        summary.orphanVolumes.coveragePartial = true;
+        console.error("[VM] reaper stopped repeated provider volume cursor", { cursor: nextCursor });
+        exhausted = true;
+      } else {
+        seenCursors.add(nextCursor);
+        cursor = nextCursor;
+      }
+
+      // An empty page can still carry a valid continuation cursor. Follow it
+      // rather than silently declaring the inventory complete.
+      if (selected.length === 0 && !nextCursor) exhausted = true;
+    }
+
+    if (!exhausted && (
+      cursor ||
+      summary.orphanVolumes.scanned >= input.scanLimit ||
+      summary.orphanVolumes.providerPages >= VM_REAPER_MAX_VOLUME_SCAN_LIMIT
+    )) {
+      summary.orphanVolumes.coveragePartial = true;
+    }
+    // The candidate limit is a reporting cap. If an additional eligible
+    // candidate was found, the run did not cover all reportable findings.
+    if (candidateLimitReached) summary.orphanVolumes.coveragePartial = true;
+  });
 }
 
-function reapOneOrphanVolume(
+function reportVolumePage(
   repo: VmRepositoryShape,
-  providers: VmProviderGatewayShape,
   summary: MutableSummary,
-  volume: VMVolume,
-  input: {
-    readonly deleteVolumes: boolean;
-    readonly minAgeMs: number;
-    readonly now: Date;
-    readonly observations: OrphanVolumeObservationState;
-  },
-): Effect.Effect<void, never> {
+  volumes: readonly VMVolume[],
+  candidateLimit: number,
+  seenNames: Set<string>,
+): Effect.Effect<{ readonly candidateLimitReached: boolean }, never> {
   return Effect.gen(function* () {
-    const name = volume.name.trim();
-    const attachedTo = normalizedAttachment(volume);
-    if (attachedTo) {
-      summary.orphanVolumes.skipped += 1;
-      console.info("[VM] reaper skipped attached volume", { volumeName: name, attachedTo });
-      return;
-    }
-
-    // Recheck ownership immediately before deletion. The initial inventory is
-    // only a snapshot and a create can claim a volume while this run proceeds.
-    if (repo.isLiveHomeVolumeReferenced) {
-      const referenceResult = yield* repo.isLiveHomeVolumeReferenced({
-        provider: "blaxel",
-        volumeName: name,
-      }).pipe(Effect.either);
-      if (referenceResult._tag === "Left") {
-        recordVolumeError(summary, name, referenceResult.left, "reference_check");
-        return;
-      }
-      if (referenceResult.right) {
+    const free: Array<{ readonly volume: VMVolume; readonly name: string }> = [];
+    for (const volume of volumes) {
+      const name = normalizedVolumeName(volume);
+      if (!name || !isMachineOwnedHomeVolumeName(name)) continue;
+      if (seenNames.has(name)) {
         summary.orphanVolumes.skipped += 1;
-        console.info("[VM] reaper skipped volume claimed during the run", { volumeName: name });
-        return;
+        continue;
       }
-    }
-
-    const firstObservedAt = input.observations.byName.get(name);
-    const hasPriorObservation = input.observations.available &&
-      !!firstObservedAt &&
-      firstObservedAt.getTime() < input.now.getTime();
-    if (!hasPriorObservation) {
-      // A delete-enabled deployment must fail closed when the durable marker
-      // path is unavailable. Report-only deployments can still surface the
-      // candidate without pretending it is safe to delete.
-      if (!input.observations.available || !repo.recordOrphanVolumeObservation) {
-        if (input.deleteVolumes) {
-          summary.orphanVolumes.skipped += 1;
-          console.warn("[VM] reaper cannot delete volume without an observation marker", { volumeName: name });
-          return;
-        }
-        summary.orphanVolumes.reported += 1;
-        yield* recordSystemUsageEvent(repo, ORPHAN_VOLUME_EVENT, {
-          volumeName: name,
+      seenNames.add(name);
+      const state = attachmentState(volume);
+      if (state === "attached") {
+        summary.orphanVolumes.skipped += 1;
+        console.info("[VM] reaper skipped attached volume", { volumeName: name });
+      } else if (state === "unknown") {
+        summary.orphanVolumes.unknownAttachment += 1;
+        const recorded = yield* recordSystemUsageEvent(repo, ORPHAN_VOLUME_UNKNOWN_ATTACHMENT_EVENT, {
+          source: "vm_reaper",
           mode: "report",
           action: "report",
-          reason: "observation_marker_unavailable",
+          reason: "attachment_state_unknown",
+          volumeName: name,
+          attachmentState: "unknown",
+          attachment: "unknown",
+          createdAt: volume.createdAt ?? null,
         });
-        return;
+        if (recorded) summary.orphanVolumes.reported += 1;
+        else summary.orphanVolumes.errors += 1;
+      } else {
+        free.push({ volume, name });
+      }
+    }
+
+    if (free.length === 0) return { candidateLimitReached: false };
+
+    const liveReferences = yield* loadLiveReferences(
+      repo,
+      free.map(({ name }) => name),
+      summary,
+    );
+    if (!liveReferences) {
+      for (const { volume, name } of free) {
+        summary.orphanVolumes.unknownReference += 1;
+        const recorded = yield* recordSystemUsageEvent(repo, ORPHAN_VOLUME_UNKNOWN_REFERENCE_EVENT, {
+          source: "vm_reaper",
+          mode: "report",
+          action: "report",
+          reason: "live_reference_unknown",
+          volumeName: name,
+          attachmentState: "unattached",
+          attachment: "unattached",
+          liveReference: "unknown",
+          createdAt: volume.createdAt ?? null,
+        });
+        if (recorded) summary.orphanVolumes.reported += 1;
+        else summary.orphanVolumes.errors += 1;
+      }
+      return { candidateLimitReached: false };
+    }
+
+    let candidateLimitReached = false;
+    for (const { volume, name } of free) {
+      if (liveReferences.has(name)) {
+        summary.orphanVolumes.skipped += 1;
+        console.info("[VM] reaper skipped volume referenced by a live VM", { volumeName: name });
+        continue;
       }
 
-      const recorded = yield* repo.recordOrphanVolumeObservation({
-        provider: "blaxel",
-        volumeName: name,
-        observedAt: input.now,
-      }).pipe(Effect.either);
-      if (recorded._tag === "Left") {
-        recordVolumeError(summary, name, recorded.left, "record_observation");
-        return;
+      if (summary.orphanVolumes.candidates >= candidateLimit) {
+        candidateLimitReached = true;
+        summary.orphanVolumes.skipped += 1;
+        continue;
       }
-      summary.orphanVolumes.reported += 1;
-      console.info("[VM] reaper recorded first orphan volume observation", { volumeName: name });
-      yield* recordSystemUsageEvent(repo, ORPHAN_VOLUME_EVENT, {
-        volumeName: name,
-        mode: "report",
-        action: "observe",
-        reason: "first_observation",
-      });
-      return;
-    }
-
-    const ageMs = volumeAgeMs(volume, input.now);
-    if (ageMs === null || ageMs < input.minAgeMs) {
-      summary.orphanVolumes.reported += 1;
-      console.info("[VM] reaper deferred young orphan volume", {
-        volumeName: name,
-        ageMinutes: ageMs === null ? null : Math.round(ageMs / 60_000),
-        minimumAgeMinutes: Math.round(input.minAgeMs / 60_000),
-      });
-      yield* recordSystemUsageEvent(repo, ORPHAN_VOLUME_EVENT, {
-        volumeName: name,
+      summary.orphanVolumes.candidates += 1;
+      const recorded = yield* recordSystemUsageEvent(repo, ORPHAN_VOLUME_EVENT, {
+        source: "vm_reaper",
         mode: "report",
         action: "report",
-        reason: "minimum_age",
-        minimumAgeMinutes: Math.round(input.minAgeMs / 60_000),
-      });
-      return;
-    }
-
-    if (!input.deleteVolumes) {
-      summary.orphanVolumes.reported += 1;
-      console.info("[VM] reaper orphan volume report-only candidate", { volumeName: name });
-      yield* recordSystemUsageEvent(repo, ORPHAN_VOLUME_EVENT, {
+        reason: "unattached_without_live_reference",
         volumeName: name,
-        mode: "report",
-        action: "report",
+        attachmentState: "unattached",
+        attachment: "unattached",
+        liveReference: false,
+        createdAt: volume.createdAt ?? null,
       });
-      return;
+      if (recorded) summary.orphanVolumes.reported += 1;
+      else summary.orphanVolumes.errors += 1;
     }
-
-    if (!providers.deleteHomeVolume) {
-      recordVolumeError(summary, name, new Error("provider volume deletion is not supported"), "delete");
-      return;
-    }
-    const deleted = yield* providers.deleteHomeVolume("blaxel", name).pipe(Effect.either);
-    if (deleted._tag === "Left") {
-      recordVolumeError(summary, name, deleted.left, "delete");
-      return;
-    }
-    summary.orphanVolumes.deleted += 1;
-    console.info("[VM] reaper deleted orphan volume", { volumeName: name });
-    yield* recordSystemUsageEvent(repo, ORPHAN_VOLUME_EVENT, {
-      volumeName: name,
-      mode: "delete",
-      action: "deleted",
-    });
+    return { candidateLimitReached };
   });
 }
 
-function markProvisioningFailed(
+function loadLiveReferences(
   repo: VmRepositoryShape,
-  vm: CloudVmRow,
-): Effect.Effect<boolean, unknown> {
-  if (repo.markProvisioningFailed) {
-    return repo.markProvisioningFailed({
-      id: vm.id,
-      code: STUCK_PROVISIONING_FAILURE_CODE,
-      message: "Cloud VM provisioning exceeded the reconciliation threshold.",
-      expectedStatus: "provisioning",
-    });
+  names: readonly string[],
+  summary: MutableSummary,
+): Effect.Effect<Set<string> | null, never> {
+  if (!repo.listLiveHomeVolumeNames || names.length === 0) {
+    summary.orphanVolumes.errors += 1;
+    console.error("[VM] reaper cannot verify live volume references");
+    return Effect.succeed(null);
   }
-  // Compatibility fallback for focused repository doubles and older deploys.
-  return repo.markCreateFailed({
-    id: vm.id,
-    code: STUCK_PROVISIONING_FAILURE_CODE,
-    message: "Cloud VM provisioning exceeded the reconciliation threshold.",
-    expectedStatus: "provisioning",
-  }).pipe(Effect.as(true));
-}
-
-function stuckDbStatus(
-  vm: CloudVmRow,
-  providerStatus: Exclude<VMStatus, "creating">,
-): "running" | "paused" | "destroyed" {
-  if (providerStatus !== "destroyed") return providerStatus;
-  const homeVolume = vm.providerMetadata?.homeVolume;
-  // A volume-backed machine can be resurrected after its compute disappears.
-  // Preserve the existing workflow semantics and leave it paused.
-  return typeof homeVolume === "string" && homeVolume.trim().length > 0 ? "paused" : "destroyed";
+  return repo.listLiveHomeVolumeNames({ provider: "blaxel", volumeNames: names }).pipe(
+    Effect.map((liveNames) => new Set(liveNames.map((name) => name.trim()).filter(Boolean))),
+    Effect.catchAll((error) => Effect.sync(() => {
+      summary.orphanVolumes.errors += 1;
+      console.error("[VM] reaper could not load live volume references", safeErrorMessage(error));
+      return null;
+    })),
+  );
 }
 
 function recordVmUsageEvent(
@@ -627,7 +456,7 @@ function recordVmUsageEvent(
   vm: CloudVmRow,
   eventType: string,
   metadata: Record<string, unknown>,
-): Effect.Effect<void, never> {
+): Effect.Effect<boolean, never> {
   return repo.recordUsageEvent({
     userId: vm.userId,
     billingTeamId: vm.billingTeamId,
@@ -638,12 +467,14 @@ function recordVmUsageEvent(
     imageId: vm.imageId,
     metadata,
   }).pipe(
+    Effect.as(true),
     Effect.catchAll((error) => Effect.sync(() => {
       console.error("[VM] reaper could not record VM usage event", {
         vmId: vm.id,
         eventType,
         error: safeErrorMessage(error),
       });
+      return false;
     })),
   );
 }
@@ -652,7 +483,7 @@ function recordSystemUsageEvent(
   repo: VmRepositoryShape,
   eventType: string,
   metadata: Record<string, unknown>,
-): Effect.Effect<void, never> {
+): Effect.Effect<boolean, never> {
   return repo.recordUsageEvent({
     userId: VM_REAPER_SYSTEM_USER_ID,
     billingTeamId: null,
@@ -661,92 +492,137 @@ function recordSystemUsageEvent(
     provider: "blaxel",
     metadata,
   }).pipe(
+    Effect.as(true),
     Effect.catchAll((error) => Effect.sync(() => {
       console.error("[VM] reaper could not record volume usage event", {
         eventType,
         volumeName: metadata.volumeName,
         error: safeErrorMessage(error),
       });
+      return false;
     })),
   );
 }
 
-function recordVolumeError(
-  summary: MutableSummary,
-  volumeName: string,
-  error: unknown,
-  operation: string,
-): void {
-  summary.orphanVolumes.errors += 1;
-  summary.orphanVolumes.skipped += 1;
-  console.error("[VM] reaper skipped volume after item error", {
-    volumeName,
-    operation,
-    error: safeErrorMessage(error),
-  });
-  // The item-level error is also visible in the provider usage ledger when the
-  // caller's repository supports it. The main action path records this event
-  // asynchronously below only for the provider action itself.
+function normalizeVolumeInventory(value: VMVolumeInventory, limit: number): {
+  readonly volumes: readonly VMVolume[];
+  readonly nextCursor: string | null;
+  readonly paginated: boolean;
+  readonly complete: boolean;
+  readonly truncated: boolean;
+} {
+  const boundedLimit = Math.max(1, Math.trunc(limit));
+  if (Array.isArray(value)) {
+    return {
+      volumes: value.slice(0, boundedLimit),
+      nextCursor: null,
+      paginated: false,
+      complete: false,
+      truncated: value.length > boundedLimit,
+    };
+  }
+  const page = value as VMVolumePage;
+  const rawVolumes = Array.isArray(page.volumes) ? page.volumes : [];
+  const truncated = rawVolumes.length > boundedLimit;
+  const hasExplicitEnd = Object.prototype.hasOwnProperty.call(page, "nextCursor") &&
+    page.nextCursor === null;
+  return {
+    volumes: rawVolumes.slice(0, boundedLimit),
+    nextCursor: typeof page.nextCursor === "string" && page.nextCursor.trim().length > 0
+      ? page.nextCursor.trim()
+      : null,
+    paginated: true,
+    // A page is complete only when the provider explicitly says so, or when
+    // it explicitly returns a null continuation cursor. A plain object with
+    // no pagination metadata must remain partial for safety.
+    complete: !truncated && (page.complete === true || (page.complete === undefined && hasExplicitEnd)),
+    truncated,
+  };
 }
 
-function recordStuckError(
-  summary: MutableSummary,
-  vm: CloudVmRow,
-  error: unknown,
-  operation: string,
-): void {
-  summary.stuckProvisioning.errors += 1;
-  summary.stuckProvisioning.skipped += 1;
-  console.error("[VM] reaper skipped provisioning row after item error", {
-    vmId: vm.id,
-    operation,
-    error: safeErrorMessage(error),
-  });
+/** Sort the already-bounded page so the oldest records are reported first. */
+function selectOldestVolumes(
+  volumes: readonly VMVolume[],
+  limit: number,
+): readonly VMVolume[] {
+  const boundedLimit = Math.max(1, Math.trunc(limit));
+  return [...volumes].slice(0, boundedLimit).sort(compareVolumes);
+}
+
+function attachmentState(volume: VMVolume): "attached" | "unattached" | "unknown" {
+  if (typeof volume.attachedTo === "string" && volume.attachedTo.trim().length > 0) return "attached";
+  if (volume.attachedTo === null) return "unattached";
+  if (volume.attachmentState === "attached" ||
+    volume.attachmentState === "unattached" ||
+    volume.attachmentState === "unknown") {
+    return volume.attachmentState;
+  }
+  return "unknown";
+}
+
+function normalizedVolumeName(volume: VMVolume): string | null {
+  const name = typeof volume.name === "string" ? volume.name.trim() : "";
+  return name || null;
 }
 
 function compareVolumes(a: VMVolume, b: VMVolume): number {
-  const aCreated = typeof a.createdAt === "number" && Number.isFinite(a.createdAt) ? a.createdAt : 0;
-  const bCreated = typeof b.createdAt === "number" && Number.isFinite(b.createdAt) ? b.createdAt : 0;
+  const aCreated = typeof a.createdAt === "number" && Number.isFinite(a.createdAt) ? a.createdAt : Number.POSITIVE_INFINITY;
+  const bCreated = typeof b.createdAt === "number" && Number.isFinite(b.createdAt) ? b.createdAt : Number.POSITIVE_INFINITY;
   if (aCreated !== bCreated) return aCreated - bCreated;
-  return a.name.localeCompare(b.name);
+  return (normalizedVolumeName(a) ?? "").localeCompare(normalizedVolumeName(b) ?? "");
 }
 
-function normalizedAttachment(volume: VMVolume): string | null {
-  const value = volume.attachedTo;
-  if (typeof value === "string" && value.trim().length > 0) return value.trim();
-  return value == null ? null : String(value);
+function compareVmRows(a: CloudVmRow, b: CloudVmRow): number {
+  const created = a.createdAt.getTime() - b.createdAt.getTime();
+  return created || a.id.localeCompare(b.id);
 }
 
-function resolveLimit(value: number | undefined, envValue: string | undefined): number {
-  const candidate = value ?? parsePositiveInteger(envValue);
-  if (candidate === null || candidate === undefined) return VM_REAPER_DEFAULT_VOLUME_LIMIT;
+/** Keep the oldest bounded subset of provisioning rows. */
+function selectOldestVmRows(rows: readonly CloudVmRow[], limit: number): CloudVmRow[] {
+  const boundedLimit = Math.max(1, Math.trunc(limit));
+  if (rows.length <= boundedLimit) return [...rows].sort(compareVmRows);
+  const selected: CloudVmRow[] = [];
+  for (const row of rows) {
+    let low = 0;
+    let high = selected.length;
+    while (low < high) {
+      const middle = low + Math.floor((high - low) / 2);
+      if (compareVmRows(selected[middle]!, row) <= 0) low = middle + 1;
+      else high = middle;
+    }
+    if (low >= boundedLimit && selected.length >= boundedLimit) continue;
+    selected.splice(low, 0, row);
+    if (selected.length > boundedLimit) selected.pop();
+  }
+  return selected;
+}
+
+function resolveLimit(value: number | undefined, envValue: string | undefined, fallback: number): number {
+  const candidate = typeof value === "number" && Number.isFinite(value)
+    ? value
+    : parsePositiveInteger(envValue) ?? fallback;
   return Math.max(1, Math.min(VM_REAPER_MAX_BATCH_LIMIT, Math.trunc(candidate)));
+}
+
+function resolveScanLimit(value: number | undefined, envValue: string | undefined, candidateLimit: number): number {
+  const candidate = typeof value === "number" && Number.isFinite(value)
+    ? value
+    : parsePositiveInteger(envValue) ?? VM_REAPER_DEFAULT_VOLUME_SCAN_LIMIT;
+  return Math.max(
+    candidateLimit,
+    Math.min(VM_REAPER_MAX_VOLUME_SCAN_LIMIT, Math.max(1, Math.trunc(candidate))),
+  );
 }
 
 function resolveStuckAgeMs(env: Record<string, string | undefined>): number {
   const raw = env.CMUX_VM_REAPER_STUCK_PROVISIONING_MINUTES ??
     env.CMUX_VM_REAPER_STUCK_THRESHOLD_MINUTES ??
     env.CMUX_VM_REAPER_STUCK_AGE_MINUTES;
-  const minutes = parsePositiveInteger(raw) ?? VM_REAPER_DEFAULT_STUCK_PROVISIONING_MINUTES;
-  return minutes * 60 * 1_000;
-}
-
-function resolveOrphanVolumeMinAgeMs(env: Record<string, string | undefined>): number {
-  const minutes = parsePositiveInteger(env.CMUX_VM_REAPER_ORPHAN_VOLUME_MIN_AGE_MINUTES) ??
-    VM_REAPER_DEFAULT_ORPHAN_VOLUME_MIN_AGE_MINUTES;
-  return minutes * 60 * 1_000;
-}
-
-function resolveCreatingTerminalAgeMs(env: Record<string, string | undefined>): number {
-  const minutes = parsePositiveInteger(env.CMUX_VM_REAPER_STUCK_PROVISIONING_TERMINAL_MINUTES) ??
-    VM_REAPER_DEFAULT_CREATING_TERMINAL_AGE_MINUTES;
-  return minutes * 60 * 1_000;
+  return (parsePositiveInteger(raw) ?? VM_REAPER_DEFAULT_STUCK_PROVISIONING_MINUTES) * 60 * 1_000;
 }
 
 function resolveDurationOption(value: number | undefined, fallback: number): number {
-  return typeof value === "number" && Number.isFinite(value) && value >= 0
-    ? Math.trunc(value)
-    : fallback;
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? Math.trunc(value) : fallback;
 }
 
 function parsePositiveInteger(value: string | undefined): number | null {
@@ -761,13 +637,7 @@ function ageMinutes(createdAt: Date, now: Date): number {
 }
 
 function isOlderThan(createdAt: Date, now: Date, thresholdMs: number): boolean {
-  return now.getTime() - createdAt.getTime() >= thresholdMs;
-}
-
-function volumeAgeMs(volume: VMVolume, now: Date): number | null {
-  const createdAt = volume.createdAt;
-  if (typeof createdAt !== "number" || !Number.isFinite(createdAt)) return null;
-  return Math.max(0, now.getTime() - createdAt);
+  return now.getTime() - createdAt.getTime() > thresholdMs;
 }
 
 function safeErrorMessage(error: unknown): string {
@@ -775,8 +645,7 @@ function safeErrorMessage(error: unknown): string {
   return raw.replace(/Bearer\s+\S+/gi, "Bearer [redacted]").slice(0, 500);
 }
 
-// Keep these names exported for focused tests and future cron dashboards.
 export const VM_REAPER_ORPHAN_VOLUME_EVENT = ORPHAN_VOLUME_EVENT;
-export const VM_REAPER_ORPHAN_VOLUME_OBSERVATION_EVENT = ORPHAN_VOLUME_OBSERVATION_EVENT;
-export const VM_REAPER_STUCK_PROVISIONING_TERMINAL_EVENT = STUCK_PROVISIONING_TERMINAL_EVENT;
-export const VM_REAPER_VOLUME_ERROR_EVENT = STUCK_VOLUME_ERROR_EVENT;
+export const VM_REAPER_ORPHAN_VOLUME_UNKNOWN_ATTACHMENT_EVENT = ORPHAN_VOLUME_UNKNOWN_ATTACHMENT_EVENT;
+export const VM_REAPER_ORPHAN_VOLUME_UNKNOWN_REFERENCE_EVENT = ORPHAN_VOLUME_UNKNOWN_REFERENCE_EVENT;
+export const VM_REAPER_STUCK_PROVISIONING_EVENT = STUCK_PROVISIONING_EVENT;

--- a/web/services/vms/reaper.ts
+++ b/web/services/vms/reaper.ts
@@ -1,5 +1,5 @@
 import * as Effect from "effect/Effect";
-import type { VMStatus, VMVolume, ProviderId } from "./drivers";
+import type { VMStatus, VMVolume } from "./drivers";
 import { isProviderNotFoundError } from "./providerErrors";
 import { VmProviderGateway, type VmProviderGatewayShape } from "./providerGateway";
 import {
@@ -13,10 +13,14 @@ import { isMachineOwnedHomeVolumeName } from "./volumeNaming";
 export const VM_REAPER_DEFAULT_VOLUME_LIMIT = 100;
 export const VM_REAPER_DEFAULT_PROVISIONING_LIMIT = 100;
 export const VM_REAPER_DEFAULT_STUCK_PROVISIONING_MINUTES = 60;
+export const VM_REAPER_DEFAULT_ORPHAN_VOLUME_MIN_AGE_MINUTES = 2 * 60;
+export const VM_REAPER_DEFAULT_CREATING_TERMINAL_AGE_MINUTES = 24 * 60;
 export const VM_REAPER_MAX_BATCH_LIMIT = 100;
 export const VM_REAPER_SYSTEM_USER_ID = "cmux-vm-reaper";
 
 const ORPHAN_VOLUME_EVENT = "vm.reaper.orphan_volume";
+const ORPHAN_VOLUME_OBSERVATION_EVENT = "vm.reaper.orphan_volume_observed";
+const STUCK_PROVISIONING_TERMINAL_EVENT = "vm.reaper.stuck_provisioning_terminal";
 const STUCK_VOLUME_ERROR_EVENT = "vm.reaper.orphan_volume_error";
 const STUCK_PROVISIONING_FAILURE_CODE = "provisioning_timeout";
 
@@ -57,6 +61,10 @@ export type VmReaperOptions = {
   readonly provisioningLimit?: number;
   /** Threshold in milliseconds. Explicit option wins over the env setting. */
   readonly stuckProvisioningAgeMs?: number;
+  /** Minimum provider-volume age before a prior observation can be deleted. */
+  readonly orphanVolumeMinAgeMs?: number;
+  /** Maximum age for a provider that remains in `creating`. */
+  readonly stuckProvisioningTerminalAgeMs?: number;
   readonly env?: Record<string, string | undefined>;
 };
 
@@ -79,9 +87,6 @@ type MutableSummary = {
   };
 };
 
-type ReaperOutcome = "deleted" | "reported" | "skipped" | "error";
-type StuckOutcome = "recovered" | "failed" | "destroyed" | "skipped" | "error";
-
 /**
  * Reconcile old provisioning rows and clean up unreferenced Blaxel volumes.
  * Every item is isolated in its own Effect boundary. A provider or database
@@ -100,6 +105,14 @@ export function reapVmResources(
     const env = input.env ?? process.env;
     const now = input.now ?? new Date();
     const deleteVolumes = input.deleteVolumes ?? env.CMUX_VM_REAPER_DELETE === "1";
+    const orphanVolumeMinAgeMs = resolveDurationOption(
+      input.orphanVolumeMinAgeMs,
+      resolveOrphanVolumeMinAgeMs(env),
+    );
+    const stuckProvisioningTerminalAgeMs = resolveDurationOption(
+      input.stuckProvisioningTerminalAgeMs,
+      resolveCreatingTerminalAgeMs(env),
+    );
     const summary: MutableSummary = {
       reportOnly: !deleteVolumes,
       orphanVolumes: { candidates: 0, deleted: 0, reported: 0, skipped: 0, errors: 0 },
@@ -112,11 +125,14 @@ export function reapVmResources(
       now,
       limit: resolveLimit(input.provisioningLimit, env.CMUX_VM_REAPER_PROVISIONING_LIMIT),
       ageMs: input.stuckProvisioningAgeMs ?? resolveStuckAgeMs(env),
+      terminalAgeMs: stuckProvisioningTerminalAgeMs,
     });
 
     yield* reapOrphanVolumes(repo, providers, summary, {
       deleteVolumes,
       limit: resolveLimit(input.volumeLimit, env.CMUX_VM_REAPER_VOLUME_LIMIT),
+      minAgeMs: orphanVolumeMinAgeMs,
+      now,
     });
 
     const orphan = summary.orphanVolumes;
@@ -140,7 +156,12 @@ function reapStuckProvisioningRows(
   repo: VmRepositoryShape,
   providers: VmProviderGatewayShape,
   summary: MutableSummary,
-  input: { readonly now: Date; readonly limit: number; readonly ageMs: number },
+  input: {
+    readonly now: Date;
+    readonly limit: number;
+    readonly ageMs: number;
+    readonly terminalAgeMs: number;
+  },
 ): Effect.Effect<void, never> {
   const candidatesEffect = repo.stuckProvisioningCandidates
     ? repo.stuckProvisioningCandidates({
@@ -160,7 +181,10 @@ function reapStuckProvisioningRows(
     summary.stuckProvisioning.candidates = candidates.length;
     yield* Effect.forEach(
       candidates,
-      (vm) => reapOneStuckProvisioningRow(repo, providers, summary, vm, input.now),
+      (vm) => reapOneStuckProvisioningRow(repo, providers, summary, vm, {
+        now: input.now,
+        terminalAgeMs: input.terminalAgeMs,
+      }),
       { concurrency: 1, discard: true },
     );
   });
@@ -171,7 +195,7 @@ function reapOneStuckProvisioningRow(
   providers: VmProviderGatewayShape,
   summary: MutableSummary,
   vm: CloudVmRow,
-  now: Date,
+  input: { readonly now: Date; readonly terminalAgeMs: number },
 ): Effect.Effect<void, never> {
   return Effect.gen(function* () {
     const providerVmId = vm.providerVmId?.trim() || null;
@@ -189,7 +213,7 @@ function reapOneStuckProvisioningRow(
       summary.stuckProvisioning.failed += 1;
       console.warn("[VM] reaper marked provisioning row failed without provider id", {
         vmId: vm.id,
-        ageMinutes: ageMinutes(vm.createdAt, now),
+        ageMinutes: ageMinutes(vm.createdAt, input.now),
       });
       yield* recordVmUsageEvent(repo, vm, "vm.create.failed", {
         source: "vm_reaper",
@@ -218,8 +242,41 @@ function reapOneStuckProvisioningRow(
     }
 
     if (providerStatus === "creating") {
-      summary.stuckProvisioning.skipped += 1;
-      console.info("[VM] reaper left provider still creating", { vmId: vm.id, providerVmId });
+      if (!isOlderThan(vm.createdAt, input.now, input.terminalAgeMs)) {
+        summary.stuckProvisioning.skipped += 1;
+        console.info("[VM] reaper left provider still creating", { vmId: vm.id, providerVmId });
+        return;
+      }
+
+      const marked = yield* markProvisioningFailed(repo, vm).pipe(Effect.either);
+      if (marked._tag === "Left") {
+        recordStuckError(summary, vm, marked.left, "mark_terminal_failed");
+        return;
+      }
+      if (!marked.right) {
+        summary.stuckProvisioning.skipped += 1;
+        console.info("[VM] reaper skipped terminal creating row changed concurrently", { vmId: vm.id });
+        return;
+      }
+
+      summary.stuckProvisioning.failed += 1;
+      console.warn("[VM] reaper finalized provider-creating row after terminal deadline", {
+        vmId: vm.id,
+        providerVmId,
+        ageMinutes: ageMinutes(vm.createdAt, input.now),
+      });
+      yield* recordVmUsageEvent(repo, vm, "vm.create.failed", {
+        source: "vm_reaper",
+        code: STUCK_PROVISIONING_FAILURE_CODE,
+        reason: "provider_still_creating_terminal_deadline",
+        providerStatus,
+      });
+      yield* recordVmUsageEvent(repo, vm, STUCK_PROVISIONING_TERMINAL_EVENT, {
+        source: "vm_reaper",
+        reason: "provider_still_creating_terminal_deadline",
+        providerStatus,
+        terminalAgeMinutes: Math.round(input.terminalAgeMs / 60_000),
+      });
       return;
     }
 
@@ -231,6 +288,7 @@ function reapOneStuckProvisioningRow(
       id: vm.id,
       providerVmId,
       status: desiredStatus,
+      expectedStatus: "provisioning",
     }).pipe(Effect.either);
     if (updated._tag === "Left") {
       recordStuckError(summary, vm, updated.left, "mark_status");
@@ -265,18 +323,17 @@ function reapOrphanVolumes(
   repo: VmRepositoryShape,
   providers: VmProviderGatewayShape,
   summary: MutableSummary,
-  input: { readonly deleteVolumes: boolean; readonly limit: number },
+  input: {
+    readonly deleteVolumes: boolean;
+    readonly limit: number;
+    readonly minAgeMs: number;
+    readonly now: Date;
+  },
 ): Effect.Effect<void, never> {
   const listVolumes = providers.listVolumes;
   if (!listVolumes) return Effect.void;
 
   return Effect.gen(function* () {
-    const liveReferences = yield* loadLiveVolumeReferences(repo).pipe(
-      Effect.catchAll((error) => Effect.sync(() => {
-        console.error("[VM] reaper could not load live volume references", safeErrorMessage(error));
-        return null as Set<string> | null;
-      })),
-    );
     const listed = yield* listVolumes("blaxel").pipe(
       Effect.catchAll((error) => Effect.sync(() => {
         summary.orphanVolumes.errors += 1;
@@ -284,21 +341,122 @@ function reapOrphanVolumes(
         return [] as readonly VMVolume[];
       })),
     );
-    const candidates = listed
-      .filter((volume) => isMachineOwnedHomeVolumeName(volume.name))
-      .sort(compareVolumes)
-      .slice(0, input.limit);
+    const candidates = yield* selectOrphanVolumeCandidates(repo, summary, listed, input.limit);
+    const observations = yield* loadOrphanVolumeObservations(
+      repo,
+      candidates.map((volume) => volume.name),
+      summary,
+    );
     summary.orphanVolumes.candidates = candidates.length;
 
     yield* Effect.forEach(
       candidates,
       (volume) => reapOneOrphanVolume(repo, providers, summary, volume, {
         deleteVolumes: input.deleteVolumes,
-        liveReferences,
+        minAgeMs: input.minAgeMs,
+        now: input.now,
+        observations,
       }),
       { concurrency: 1, discard: true },
     );
   });
+}
+
+/**
+ * Select a bounded batch after removing provider-attached and database-live
+ * volumes. Reference queries are chunked so a large provider inventory never
+ * becomes an unbounded SQL `IN` list.
+ */
+function selectOrphanVolumeCandidates(
+  repo: VmRepositoryShape,
+  summary: MutableSummary,
+  listed: readonly VMVolume[],
+  limit: number,
+): Effect.Effect<VMVolume[], never> {
+  return Effect.gen(function* () {
+    const owned = listed
+      .filter((volume) => isMachineOwnedHomeVolumeName(volume.name))
+      .sort(compareVolumes);
+    const unattached = owned.filter((volume) => {
+      const attachedTo = normalizedAttachment(volume);
+      if (!attachedTo) return true;
+      summary.orphanVolumes.skipped += 1;
+      console.info("[VM] reaper skipped attached volume", {
+        volumeName: volume.name.trim(),
+        attachedTo,
+      });
+      return false;
+    });
+    const candidates: VMVolume[] = [];
+    let offset = 0;
+
+    while (offset < unattached.length && candidates.length < limit) {
+      const chunk = unattached.slice(offset, offset + limit);
+      offset += chunk.length;
+      let liveNames: readonly string[] = [];
+
+      if (repo.listLiveHomeVolumeNames) {
+        const result = yield* repo.listLiveHomeVolumeNames({
+          provider: "blaxel",
+          volumeNames: chunk.map((volume) => volume.name.trim()),
+        }).pipe(Effect.either);
+        if (result._tag === "Left") {
+          summary.orphanVolumes.errors += 1;
+          summary.orphanVolumes.skipped += chunk.length;
+          console.error("[VM] reaper could not load live volume references", safeErrorMessage(result.left));
+          continue;
+        }
+        liveNames = result.right;
+      }
+
+      const liveReferences = new Set(liveNames.map((name) => name.trim()).filter(Boolean));
+      for (const volume of chunk) {
+        const name = volume.name.trim();
+        if (liveReferences.has(name)) {
+          summary.orphanVolumes.skipped += 1;
+          console.info("[VM] reaper skipped volume referenced by a live VM", { volumeName: name });
+          continue;
+        }
+        candidates.push(volume);
+        if (candidates.length >= limit) break;
+      }
+    }
+    return candidates;
+  });
+}
+
+type OrphanVolumeObservationState = {
+  readonly available: boolean;
+  readonly byName: ReadonlyMap<string, Date>;
+};
+
+function loadOrphanVolumeObservations(
+  repo: VmRepositoryShape,
+  volumeNames: readonly string[],
+  summary: MutableSummary,
+): Effect.Effect<OrphanVolumeObservationState, never> {
+  if (!repo.listOrphanVolumeObservations || volumeNames.length === 0) {
+    return Effect.succeed({ available: !!repo.listOrphanVolumeObservations, byName: new Map() });
+  }
+  return repo.listOrphanVolumeObservations({ provider: "blaxel", volumeNames }).pipe(
+    Effect.map((observations) => {
+      const byName = new Map<string, Date>();
+      for (const observation of observations) {
+        const name = observation.volumeName.trim();
+        if (!name || byName.has(name)) continue;
+        if (!(observation.firstObservedAt instanceof Date) || !Number.isFinite(observation.firstObservedAt.getTime())) {
+          continue;
+        }
+        byName.set(name, observation.firstObservedAt);
+      }
+      return { available: true, byName } satisfies OrphanVolumeObservationState;
+    }),
+    Effect.catchAll((error) => Effect.sync(() => {
+      summary.orphanVolumes.errors += 1;
+      console.error("[VM] reaper could not load orphan volume observations", safeErrorMessage(error));
+      return { available: false, byName: new Map() } satisfies OrphanVolumeObservationState;
+    })),
+  );
 }
 
 function reapOneOrphanVolume(
@@ -308,7 +466,9 @@ function reapOneOrphanVolume(
   volume: VMVolume,
   input: {
     readonly deleteVolumes: boolean;
-    readonly liveReferences: Set<string> | null;
+    readonly minAgeMs: number;
+    readonly now: Date;
+    readonly observations: OrphanVolumeObservationState;
   },
 ): Effect.Effect<void, never> {
   return Effect.gen(function* () {
@@ -317,12 +477,6 @@ function reapOneOrphanVolume(
     if (attachedTo) {
       summary.orphanVolumes.skipped += 1;
       console.info("[VM] reaper skipped attached volume", { volumeName: name, attachedTo });
-      return;
-    }
-
-    if (input.liveReferences?.has(name)) {
-      summary.orphanVolumes.skipped += 1;
-      console.info("[VM] reaper skipped volume referenced by a live VM", { volumeName: name });
       return;
     }
 
@@ -342,6 +496,68 @@ function reapOneOrphanVolume(
         console.info("[VM] reaper skipped volume claimed during the run", { volumeName: name });
         return;
       }
+    }
+
+    const firstObservedAt = input.observations.byName.get(name);
+    const hasPriorObservation = input.observations.available &&
+      !!firstObservedAt &&
+      firstObservedAt.getTime() < input.now.getTime();
+    if (!hasPriorObservation) {
+      // A delete-enabled deployment must fail closed when the durable marker
+      // path is unavailable. Report-only deployments can still surface the
+      // candidate without pretending it is safe to delete.
+      if (!input.observations.available || !repo.recordOrphanVolumeObservation) {
+        if (input.deleteVolumes) {
+          summary.orphanVolumes.skipped += 1;
+          console.warn("[VM] reaper cannot delete volume without an observation marker", { volumeName: name });
+          return;
+        }
+        summary.orphanVolumes.reported += 1;
+        yield* recordSystemUsageEvent(repo, ORPHAN_VOLUME_EVENT, {
+          volumeName: name,
+          mode: "report",
+          action: "report",
+          reason: "observation_marker_unavailable",
+        });
+        return;
+      }
+
+      const recorded = yield* repo.recordOrphanVolumeObservation({
+        provider: "blaxel",
+        volumeName: name,
+        observedAt: input.now,
+      }).pipe(Effect.either);
+      if (recorded._tag === "Left") {
+        recordVolumeError(summary, name, recorded.left, "record_observation");
+        return;
+      }
+      summary.orphanVolumes.reported += 1;
+      console.info("[VM] reaper recorded first orphan volume observation", { volumeName: name });
+      yield* recordSystemUsageEvent(repo, ORPHAN_VOLUME_EVENT, {
+        volumeName: name,
+        mode: "report",
+        action: "observe",
+        reason: "first_observation",
+      });
+      return;
+    }
+
+    const ageMs = volumeAgeMs(volume, input.now);
+    if (ageMs === null || ageMs < input.minAgeMs) {
+      summary.orphanVolumes.reported += 1;
+      console.info("[VM] reaper deferred young orphan volume", {
+        volumeName: name,
+        ageMinutes: ageMs === null ? null : Math.round(ageMs / 60_000),
+        minimumAgeMinutes: Math.round(input.minAgeMs / 60_000),
+      });
+      yield* recordSystemUsageEvent(repo, ORPHAN_VOLUME_EVENT, {
+        volumeName: name,
+        mode: "report",
+        action: "report",
+        reason: "minimum_age",
+        minimumAgeMinutes: Math.round(input.minAgeMs / 60_000),
+      });
+      return;
     }
 
     if (!input.deleteVolumes) {
@@ -374,15 +590,6 @@ function reapOneOrphanVolume(
   });
 }
 
-function loadLiveVolumeReferences(
-  repo: VmRepositoryShape,
-): Effect.Effect<Set<string>, never> {
-  if (!repo.listLiveHomeVolumeNames) return Effect.succeed(new Set<string>());
-  return repo.listLiveHomeVolumeNames({ provider: "blaxel" }).pipe(
-    Effect.map((names) => new Set(names.map((name) => name.trim()).filter(Boolean))),
-  ) as Effect.Effect<Set<string>, never>;
-}
-
 function markProvisioningFailed(
   repo: VmRepositoryShape,
   vm: CloudVmRow,
@@ -392,6 +599,7 @@ function markProvisioningFailed(
       id: vm.id,
       code: STUCK_PROVISIONING_FAILURE_CODE,
       message: "Cloud VM provisioning exceeded the reconciliation threshold.",
+      expectedStatus: "provisioning",
     });
   }
   // Compatibility fallback for focused repository doubles and older deploys.
@@ -399,6 +607,7 @@ function markProvisioningFailed(
     id: vm.id,
     code: STUCK_PROVISIONING_FAILURE_CODE,
     message: "Cloud VM provisioning exceeded the reconciliation threshold.",
+    expectedStatus: "provisioning",
   }).pipe(Effect.as(true));
 }
 
@@ -522,6 +731,24 @@ function resolveStuckAgeMs(env: Record<string, string | undefined>): number {
   return minutes * 60 * 1_000;
 }
 
+function resolveOrphanVolumeMinAgeMs(env: Record<string, string | undefined>): number {
+  const minutes = parsePositiveInteger(env.CMUX_VM_REAPER_ORPHAN_VOLUME_MIN_AGE_MINUTES) ??
+    VM_REAPER_DEFAULT_ORPHAN_VOLUME_MIN_AGE_MINUTES;
+  return minutes * 60 * 1_000;
+}
+
+function resolveCreatingTerminalAgeMs(env: Record<string, string | undefined>): number {
+  const minutes = parsePositiveInteger(env.CMUX_VM_REAPER_STUCK_PROVISIONING_TERMINAL_MINUTES) ??
+    VM_REAPER_DEFAULT_CREATING_TERMINAL_AGE_MINUTES;
+  return minutes * 60 * 1_000;
+}
+
+function resolveDurationOption(value: number | undefined, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? Math.trunc(value)
+    : fallback;
+}
+
 function parsePositiveInteger(value: string | undefined): number | null {
   const trimmed = value?.trim();
   if (!trimmed || !/^\d+$/.test(trimmed)) return null;
@@ -533,6 +760,16 @@ function ageMinutes(createdAt: Date, now: Date): number {
   return Math.max(0, Math.round((now.getTime() - createdAt.getTime()) / 60_000));
 }
 
+function isOlderThan(createdAt: Date, now: Date, thresholdMs: number): boolean {
+  return now.getTime() - createdAt.getTime() >= thresholdMs;
+}
+
+function volumeAgeMs(volume: VMVolume, now: Date): number | null {
+  const createdAt = volume.createdAt;
+  if (typeof createdAt !== "number" || !Number.isFinite(createdAt)) return null;
+  return Math.max(0, now.getTime() - createdAt);
+}
+
 function safeErrorMessage(error: unknown): string {
   const raw = error instanceof Error ? error.message : String(error);
   return raw.replace(/Bearer\s+\S+/gi, "Bearer [redacted]").slice(0, 500);
@@ -540,4 +777,6 @@ function safeErrorMessage(error: unknown): string {
 
 // Keep these names exported for focused tests and future cron dashboards.
 export const VM_REAPER_ORPHAN_VOLUME_EVENT = ORPHAN_VOLUME_EVENT;
+export const VM_REAPER_ORPHAN_VOLUME_OBSERVATION_EVENT = ORPHAN_VOLUME_OBSERVATION_EVENT;
+export const VM_REAPER_STUCK_PROVISIONING_TERMINAL_EVENT = STUCK_PROVISIONING_TERMINAL_EVENT;
 export const VM_REAPER_VOLUME_ERROR_EVENT = STUCK_VOLUME_ERROR_EVENT;

--- a/web/services/vms/reaper.ts
+++ b/web/services/vms/reaper.ts
@@ -379,6 +379,7 @@ function reportVolumePage(
 ): Effect.Effect<{ readonly candidateLimitReached: boolean }, never> {
   return Effect.gen(function* () {
     const free: Array<{ readonly volume: VMVolume; readonly name: string }> = [];
+    const unknownAttachment: Array<{ readonly volume: VMVolume; readonly name: string }> = [];
     for (const volume of volumes) {
       const name = normalizedVolumeName(volume);
       if (!name || !isMachineOwnedHomeVolumeName(name)) continue;
@@ -393,6 +394,33 @@ function reportVolumePage(
         console.info("[VM] reaper skipped attached volume", { volumeName: name });
       } else if (state === "unknown") {
         summary.orphanVolumes.unknownAttachment += 1;
+        unknownAttachment.push({ volume, name });
+      } else {
+        free.push({ volume, name });
+      }
+    }
+
+    // A persistent unknown state must not append one event per cron run
+    // forever: the same 24h dedup window applies, keyed per event type.
+    if (unknownAttachment.length > 0) {
+      const recentUnknownKeys = yield* loadRecentReaperReportKeys(
+        repo,
+        ORPHAN_VOLUME_UNKNOWN_ATTACHMENT_EVENT,
+        unknownAttachment.map(({ name }) => name),
+        now,
+        () => {
+          summary.orphanVolumes.errors += 1;
+        },
+      );
+      for (const { volume, name } of unknownAttachment) {
+        if (recentUnknownKeys.has(name)) {
+          summary.orphanVolumes.skipped += 1;
+          console.info("[VM] reaper skipped unknown-attachment volume", {
+            volumeName: name,
+            reason: "already_reported",
+          });
+          continue;
+        }
         const recorded = yield* recordSystemUsageEvent(repo, ORPHAN_VOLUME_UNKNOWN_ATTACHMENT_EVENT, {
           source: "vm_reaper",
           mode: "report",
@@ -405,8 +433,6 @@ function reportVolumePage(
         });
         if (recorded) summary.orphanVolumes.reported += 1;
         else summary.orphanVolumes.errors += 1;
-      } else {
-        free.push({ volume, name });
       }
     }
 
@@ -418,8 +444,25 @@ function reportVolumePage(
       summary,
     );
     if (!liveReferences) {
+      const recentUnknownRefKeys = yield* loadRecentReaperReportKeys(
+        repo,
+        ORPHAN_VOLUME_UNKNOWN_REFERENCE_EVENT,
+        free.map(({ name }) => name),
+        now,
+        () => {
+          summary.orphanVolumes.errors += 1;
+        },
+      );
       for (const { volume, name } of free) {
         summary.orphanVolumes.unknownReference += 1;
+        if (recentUnknownRefKeys.has(name)) {
+          summary.orphanVolumes.skipped += 1;
+          console.info("[VM] reaper skipped unknown-reference volume", {
+            volumeName: name,
+            reason: "already_reported",
+          });
+          continue;
+        }
         const recorded = yield* recordSystemUsageEvent(repo, ORPHAN_VOLUME_UNKNOWN_REFERENCE_EVENT, {
           source: "vm_reaper",
           mode: "report",

--- a/web/services/vms/reaper.ts
+++ b/web/services/vms/reaper.ts
@@ -313,10 +313,25 @@ function reportOrphanVolumes(
       }
       const remaining = input.scanLimit - summary.orphanVolumes.scanned;
       const requestLimit = Math.max(1, Math.min(VM_REAPER_MAX_BATCH_LIMIT, remaining));
+      // The wall-clock budget must bound the in-flight call too, not only
+      // loop entry: a hung provider request otherwise runs to the platform
+      // limit. Timeout lands in the error branch below as partial coverage.
+      const remainingBudgetMs = Math.max(
+        1_000,
+        VM_REAPER_SCAN_DEADLINE_MS - (Date.now() - scanStartedAtMs),
+      );
       const listed = yield* listVolumes("blaxel", {
         limit: requestLimit,
         ...(cursor ? { cursor } : {}),
-      }).pipe(Effect.either);
+      }).pipe(
+        Effect.timeoutFail({
+          duration: remainingBudgetMs,
+          onTimeout: () => new Error(
+            `provider volume list exceeded the scan deadline (${remainingBudgetMs}ms remaining)`,
+          ),
+        }),
+        Effect.either,
+      );
       if (listed._tag === "Left") {
         summary.orphanVolumes.errors += 1;
         summary.orphanVolumes.coveragePartial = true;

--- a/web/services/vms/reaper.ts
+++ b/web/services/vms/reaper.ts
@@ -19,12 +19,14 @@ export const VM_REAPER_DEFAULT_VOLUME_SCAN_LIMIT = 1_000;
 export const VM_REAPER_MAX_BATCH_LIMIT = 100;
 export const VM_REAPER_MAX_VOLUME_SCAN_LIMIT = 1_000;
 export const VM_REAPER_DEFAULT_STUCK_PROVISIONING_MINUTES = 60;
+export const VM_REAPER_DEFAULT_VOLUME_MIN_AGE_MINUTES = 120;
 export const VM_REAPER_SYSTEM_USER_ID = "cmux-vm-reaper";
 
 const ORPHAN_VOLUME_EVENT = "vm.reaper.orphan_volume";
 const ORPHAN_VOLUME_UNKNOWN_ATTACHMENT_EVENT = "vm.reaper.orphan_volume_unknown_attachment";
 const ORPHAN_VOLUME_UNKNOWN_REFERENCE_EVENT = "vm.reaper.orphan_volume_unknown_reference";
 const STUCK_PROVISIONING_EVENT = "vm.reaper.stuck_provisioning";
+const VM_REAPER_REPORT_DEDUP_WINDOW_MS = 24 * 60 * 60 * 1_000;
 
 export type VmReaperCounts = {
   /** Known machine-owned, explicitly unattached volumes with no live row. */
@@ -48,7 +50,7 @@ export type VmReaperCounts = {
 };
 
 export type VmStuckProvisioningCounts = {
-  /** Rows older than the configured threshold returned by the repository. */
+  /** Rows whose updatedAt is older than the configured threshold. */
   readonly candidates: number;
   readonly reported: number;
   /** Retained as zero-valued compatibility fields for existing dashboards. */
@@ -139,6 +141,8 @@ export function reapVmResources(
       env.CMUX_VM_REAPER_VOLUME_SCAN_LIMIT ?? env.CMUX_VM_REAPER_SCAN_LIMIT,
       volumeLimit,
     );
+    const volumeMinAgeMs = (parsePositiveInteger(env.CMUX_VM_REAPER_VOLUME_MIN_AGE_MINUTES) ??
+      VM_REAPER_DEFAULT_VOLUME_MIN_AGE_MINUTES) * 60 * 1_000;
     const summary: MutableSummary = {
       reportOnly: true,
       orphanVolumes: {
@@ -176,6 +180,8 @@ export function reapVmResources(
     yield* reportOrphanVolumes(repo, providers, summary, {
       limit: volumeLimit,
       scanLimit: volumeScanLimit,
+      now,
+      minAgeMs: volumeMinAgeMs,
     });
 
     const orphan = summary.orphanVolumes;
@@ -206,7 +212,9 @@ function reportStuckProvisioningRows(
   return Effect.gen(function* () {
     const result = yield* listCandidates({
       before: new Date(input.now.getTime() - input.ageMs),
-      limit: input.limit,
+      // Fetch the full bounded scan window before applying the report limit.
+      // This lets a recently reported row make room for the next row.
+      limit: VM_REAPER_MAX_BATCH_LIMIT,
     }).pipe(Effect.either);
     if (result._tag === "Left") {
       summary.stuckProvisioning.errors += 1;
@@ -214,19 +222,40 @@ function reportStuckProvisioningRows(
       return;
     }
 
-    // The repository orders this query oldest first. Keep only a bounded
-    // oldest subset as a defensive measure for alternate implementations that
-    // return more rows than requested.
-    const eligible = result.right.filter((vm) => isOlderThan(vm.createdAt, input.now, input.ageMs));
-    const candidates = selectOldestVmRows(eligible, input.limit);
+    // The repository orders this query by updatedAt oldest first. Keep only a
+    // bounded oldest subset as a defensive measure for alternate
+    // implementations that return more rows than requested.
+    const eligible = result.right.filter((vm) => isOlderThan(vm.updatedAt, input.now, input.ageMs));
+    const scanWindow = selectOldestVmRows(eligible, VM_REAPER_MAX_BATCH_LIMIT);
+    if (eligible.length > scanWindow.length) summary.stuckProvisioning.skipped += eligible.length - scanWindow.length;
+
+    const recentKeys = yield* loadRecentReaperReportKeys(
+      repo,
+      STUCK_PROVISIONING_EVENT,
+      scanWindow.map((vm) => vm.id),
+      input.now,
+      () => {
+        summary.stuckProvisioning.errors += 1;
+      },
+    );
+    const unreported = scanWindow.filter((vm) => {
+      if (!recentKeys.has(vm.id)) return true;
+      summary.stuckProvisioning.skipped += 1;
+      console.info("[VM] reaper skipped stuck provisioning row", {
+        vmId: vm.id,
+        reason: "already_reported",
+      });
+      return false;
+    });
+    const candidates = selectOldestVmRows(unreported, input.limit);
     summary.stuckProvisioning.candidates = candidates.length;
-    if (eligible.length > candidates.length) summary.stuckProvisioning.skipped += eligible.length - candidates.length;
+    if (unreported.length > candidates.length) summary.stuckProvisioning.skipped += unreported.length - candidates.length;
 
     for (const vm of candidates) {
       const recorded = yield* recordVmUsageEvent(repo, vm, STUCK_PROVISIONING_EVENT, {
         source: "vm_reaper",
         reason: "age_over_threshold",
-        ageMinutes: ageMinutes(vm.createdAt, input.now),
+        ageMinutes: ageMinutes(vm.updatedAt, input.now),
         thresholdMinutes: Math.ceil(input.ageMs / 60_000),
         providerVmIdPresent: !!vm.providerVmId?.trim(),
       });
@@ -240,7 +269,12 @@ function reportOrphanVolumes(
   repo: VmRepositoryShape,
   providers: VmProviderGatewayShape,
   summary: MutableSummary,
-  input: { readonly limit: number; readonly scanLimit: number },
+  input: {
+    readonly limit: number;
+    readonly scanLimit: number;
+    readonly now: Date;
+    readonly minAgeMs: number;
+  },
 ): Effect.Effect<void, never> {
   const listVolumes = providers.listVolumes;
   if (!listVolumes) {
@@ -285,6 +319,8 @@ function reportOrphanVolumes(
         selected,
         input.limit,
         seenNames,
+        input.now,
+        input.minAgeMs,
       );
       candidateLimitReached ||= pageReport.candidateLimitReached;
 
@@ -338,6 +374,8 @@ function reportVolumePage(
   volumes: readonly VMVolume[],
   candidateLimit: number,
   seenNames: Set<string>,
+  now: Date,
+  minAgeMs: number,
 ): Effect.Effect<{ readonly candidateLimitReached: boolean }, never> {
   return Effect.gen(function* () {
     const free: Array<{ readonly volume: VMVolume; readonly name: string }> = [];
@@ -399,11 +437,45 @@ function reportVolumePage(
       return { candidateLimitReached: false };
     }
 
-    let candidateLimitReached = false;
-    for (const { volume, name } of free) {
+    const ageEligible: Array<{ readonly volume: VMVolume; readonly name: string }> = [];
+    for (const item of free) {
+      const { volume, name } = item;
       if (liveReferences.has(name)) {
         summary.orphanVolumes.skipped += 1;
         console.info("[VM] reaper skipped volume referenced by a live VM", { volumeName: name });
+        continue;
+      }
+
+      const createdAt = parseVolumeCreatedAt(volume.createdAt);
+      if (!createdAt || now.getTime() - createdAt.getTime() < minAgeMs) {
+        summary.orphanVolumes.skipped += 1;
+        console.info("[VM] reaper skipped orphan volume", {
+          volumeName: name,
+          reason: "age_unknown_or_below_grace",
+        });
+        continue;
+      }
+      ageEligible.push(item);
+    }
+
+    const recentKeys = yield* loadRecentReaperReportKeys(
+      repo,
+      ORPHAN_VOLUME_EVENT,
+      ageEligible.map(({ name }) => name),
+      now,
+      () => {
+        summary.orphanVolumes.errors += 1;
+      },
+    );
+
+    let candidateLimitReached = false;
+    for (const { volume, name } of ageEligible) {
+      if (recentKeys.has(name)) {
+        summary.orphanVolumes.skipped += 1;
+        console.info("[VM] reaper skipped orphan volume", {
+          volumeName: name,
+          reason: "already_reported",
+        });
         continue;
       }
 
@@ -429,6 +501,33 @@ function reportVolumePage(
     }
     return { candidateLimitReached };
   });
+}
+
+function loadRecentReaperReportKeys(
+  repo: VmRepositoryShape,
+  eventType: string,
+  keys: readonly string[],
+  now: Date,
+  onError: (error: unknown) => void,
+): Effect.Effect<Set<string>, never> {
+  if (keys.length === 0) return Effect.succeed(new Set<string>());
+  return repo.recentReaperReportKeys({
+    eventType,
+    keys,
+    since: new Date(now.getTime() - VM_REAPER_REPORT_DEDUP_WINDOW_MS),
+  }).pipe(
+    Effect.map((reportedKeys) => new Set(
+      reportedKeys.map((key) => key.trim()).filter(Boolean),
+    )),
+    Effect.catchAll((error) => Effect.sync(() => {
+      onError(error);
+      console.error("[VM] reaper could not query recent report keys", {
+        eventType,
+        error: safeErrorMessage(error),
+      });
+      return new Set<string>();
+    })),
+  );
 }
 
 function loadLiveReferences(
@@ -566,15 +665,15 @@ function normalizedVolumeName(volume: VMVolume): string | null {
 }
 
 function compareVolumes(a: VMVolume, b: VMVolume): number {
-  const aCreated = typeof a.createdAt === "number" && Number.isFinite(a.createdAt) ? a.createdAt : Number.POSITIVE_INFINITY;
-  const bCreated = typeof b.createdAt === "number" && Number.isFinite(b.createdAt) ? b.createdAt : Number.POSITIVE_INFINITY;
+  const aCreated = parseVolumeCreatedAt(a.createdAt)?.getTime() ?? Number.POSITIVE_INFINITY;
+  const bCreated = parseVolumeCreatedAt(b.createdAt)?.getTime() ?? Number.POSITIVE_INFINITY;
   if (aCreated !== bCreated) return aCreated - bCreated;
   return (normalizedVolumeName(a) ?? "").localeCompare(normalizedVolumeName(b) ?? "");
 }
 
 function compareVmRows(a: CloudVmRow, b: CloudVmRow): number {
-  const created = a.createdAt.getTime() - b.createdAt.getTime();
-  return created || a.id.localeCompare(b.id);
+  const updated = a.updatedAt.getTime() - b.updatedAt.getTime();
+  return updated || a.id.localeCompare(b.id);
 }
 
 /** Keep the oldest bounded subset of provisioning rows. */
@@ -630,6 +729,17 @@ function parsePositiveInteger(value: string | undefined): number | null {
   if (!trimmed || !/^\d+$/.test(trimmed)) return null;
   const parsed = Number(trimmed);
   return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function parseVolumeCreatedAt(value: unknown): Date | null {
+  const parsed = value instanceof Date
+    ? new Date(value.getTime())
+    : typeof value === "number"
+      ? new Date(value)
+      : typeof value === "string" && value.trim().length > 0
+        ? new Date(value)
+        : null;
+  return parsed && Number.isFinite(parsed.getTime()) ? parsed : null;
 }
 
 function ageMinutes(createdAt: Date, now: Date): number {

--- a/web/services/vms/reaper.ts
+++ b/web/services/vms/reaper.ts
@@ -18,6 +18,10 @@ export const VM_REAPER_DEFAULT_PROVISIONING_LIMIT = 100;
 export const VM_REAPER_DEFAULT_VOLUME_SCAN_LIMIT = 1_000;
 export const VM_REAPER_MAX_BATCH_LIMIT = 100;
 export const VM_REAPER_MAX_VOLUME_SCAN_LIMIT = 1_000;
+/** Sequential provider page requests allowed per run; far below the item cap. */
+export const VM_REAPER_MAX_VOLUME_SCAN_PAGES = 20;
+/** Wall-clock budget for the volume scan, well inside the route's 300s cap. */
+export const VM_REAPER_SCAN_DEADLINE_MS = 120_000;
 export const VM_REAPER_DEFAULT_STUCK_PROVISIONING_MINUTES = 60;
 export const VM_REAPER_DEFAULT_VOLUME_MIN_AGE_MINUTES = 120;
 export const VM_REAPER_SYSTEM_USER_ID = "cmux-vm-reaper";
@@ -289,9 +293,24 @@ function reportOrphanVolumes(
     const seenNames = new Set<string>();
     let candidateLimitReached = false;
 
+    const scanStartedAtMs = Date.now();
     while (!exhausted &&
       summary.orphanVolumes.scanned < input.scanLimit &&
       summary.orphanVolumes.providerPages < VM_REAPER_MAX_VOLUME_SCAN_LIMIT) {
+      // A provider returning many small or empty pages must not monopolize
+      // the cron budget: cap sequential pages and bound the scan wall clock.
+      if (summary.orphanVolumes.providerPages >= VM_REAPER_MAX_VOLUME_SCAN_PAGES) {
+        summary.orphanVolumes.coveragePartial = true;
+        console.info("[VM] reaper stopped at the provider page cap", {
+          pages: summary.orphanVolumes.providerPages,
+        });
+        break;
+      }
+      if (Date.now() - scanStartedAtMs >= VM_REAPER_SCAN_DEADLINE_MS) {
+        summary.orphanVolumes.coveragePartial = true;
+        console.info("[VM] reaper stopped at the scan deadline");
+        break;
+      }
       const remaining = input.scanLimit - summary.orphanVolumes.scanned;
       const requestLimit = Math.max(1, Math.min(VM_REAPER_MAX_BATCH_LIMIT, remaining));
       const listed = yield* listVolumes("blaxel", {
@@ -358,7 +377,7 @@ function reportOrphanVolumes(
     if (!exhausted && (
       cursor ||
       summary.orphanVolumes.scanned >= input.scanLimit ||
-      summary.orphanVolumes.providerPages >= VM_REAPER_MAX_VOLUME_SCAN_LIMIT
+      summary.orphanVolumes.providerPages >= VM_REAPER_MAX_VOLUME_SCAN_PAGES
     )) {
       summary.orphanVolumes.coveragePartial = true;
     }

--- a/web/services/vms/repository.ts
+++ b/web/services/vms/repository.ts
@@ -151,10 +151,32 @@ export type VmRepositoryShape = {
   readonly reconciliationCandidates: (input: {
     readonly limit: number;
   }) => Effect.Effect<CloudVmRow[], VmDatabaseError>;
+  /** Live VM rows that currently claim a persistent home volume. */
+  readonly listLiveHomeVolumeNames?: (input: {
+    readonly provider: ProviderId;
+  }) => Effect.Effect<readonly string[], VmDatabaseError>;
+  /** Point-in-time ownership recheck immediately before a provider delete. */
+  readonly isLiveHomeVolumeReferenced?: (input: {
+    readonly provider: ProviderId;
+    readonly volumeName: string;
+  }) => Effect.Effect<boolean, VmDatabaseError>;
+  /** Oldest provisioning rows for the bounded resource reaper. */
+  readonly stuckProvisioningCandidates?: (input: {
+    readonly before: Date;
+    readonly limit: number;
+  }) => Effect.Effect<CloudVmRow[], VmDatabaseError>;
+  /** Atomic transition used when a stale provisioning row has no provider id. */
+  readonly markProvisioningFailed?: (input: {
+    readonly id: string;
+    readonly code: string;
+    readonly message: string;
+  }) => Effect.Effect<boolean, VmDatabaseError>;
   readonly markProviderObservedStatus: (input: {
     readonly id: string;
     readonly providerVmId: string;
     readonly status: CloudVmStatus;
+    /** When set, do not overwrite a row that another worker already advanced. */
+    readonly expectedStatus?: CloudVmStatus;
   }) => Effect.Effect<boolean, VmDatabaseError>;
   readonly setDisplayName: (input: {
     readonly id: string;
@@ -1158,6 +1180,52 @@ export const VmRepositoryLive = Layer.succeed(VmRepository, {
         .limit(input.limit);
     }),
 
+  listLiveHomeVolumeNames: (input) =>
+    dbEffect("listLiveHomeVolumeNames", async () => {
+      const db = cloudDb();
+      const homeVolume = sql<string | null>`${cloudVms.providerMetadata}->>'homeVolume'`;
+      const rows = await db
+        .select({ homeVolume })
+        .from(cloudVms)
+        .where(and(
+          eq(cloudVms.provider, input.provider),
+          inArray(cloudVms.status, ["provisioning", "running", "paused"]),
+          sql`${homeVolume} is not null and ${homeVolume} <> ''`,
+        ));
+      return rows
+        .map((row) => row.homeVolume?.trim())
+        .filter((name): name is string => !!name);
+    }),
+
+  isLiveHomeVolumeReferenced: (input) =>
+    dbEffect("isLiveHomeVolumeReferenced", async () => {
+      const db = cloudDb();
+      const [row] = await db
+        .select({ id: cloudVms.id })
+        .from(cloudVms)
+        .where(and(
+          eq(cloudVms.provider, input.provider),
+          inArray(cloudVms.status, ["provisioning", "running", "paused"]),
+          sql`${cloudVms.providerMetadata}->>'homeVolume' = ${input.volumeName}`,
+        ))
+        .limit(1);
+      return !!row;
+    }),
+
+  stuckProvisioningCandidates: (input) =>
+    dbEffect("stuckProvisioningCandidates", async () => {
+      const db = cloudDb();
+      return await db
+        .select()
+        .from(cloudVms)
+        .where(and(
+          eq(cloudVms.status, "provisioning"),
+          lt(cloudVms.createdAt, input.before),
+        ))
+        .orderBy(asc(cloudVms.createdAt), asc(cloudVms.id))
+        .limit(input.limit);
+    }),
+
   markProviderObservedStatus: (input) =>
     dbEffect("markProviderObservedStatus", async () => {
       const db = cloudDb();
@@ -1172,6 +1240,7 @@ export const VmRepositoryLive = Layer.succeed(VmRepository, {
           and(
             eq(cloudVms.id, input.id),
             eq(cloudVms.providerVmId, input.providerVmId),
+            ...(input.expectedStatus ? [eq(cloudVms.status, input.expectedStatus)] : []),
             ne(cloudVms.status, "destroyed"),
           ),
         )
@@ -1223,6 +1292,22 @@ export const VmRepositoryLive = Layer.succeed(VmRepository, {
           updatedAt: new Date(),
         })
         .where(eq(cloudVms.id, input.id));
+    }),
+
+  markProvisioningFailed: (input) =>
+    dbEffect("markProvisioningFailed", async () => {
+      const db = cloudDb();
+      const updated = await db
+        .update(cloudVms)
+        .set({
+          status: "failed",
+          failureCode: input.code,
+          failureMessage: input.message,
+          updatedAt: new Date(),
+        })
+        .where(and(eq(cloudVms.id, input.id), eq(cloudVms.status, "provisioning")))
+        .returning({ id: cloudVms.id });
+      return updated.length > 0;
     }),
 
   hasOwnedSnapshot: (input) =>

--- a/web/services/vms/repository.ts
+++ b/web/services/vms/repository.ts
@@ -165,6 +165,11 @@ export type VmRepositoryShape = {
     readonly before: Date;
     readonly limit: number;
   }) => Effect.Effect<CloudVmRow[], VmDatabaseError>;
+  readonly recentReaperReportKeys: (input: {
+    readonly eventType: string;
+    readonly keys: readonly string[];
+    readonly since: Date;
+  }) => Effect.Effect<string[], VmDatabaseError>;
   readonly markProviderObservedStatus: (input: {
     readonly id: string;
     readonly providerVmId: string;
@@ -411,6 +416,16 @@ function boundedReaperVolumeNames(names: readonly string[]): string[] {
   if (normalized.length > VM_REAPER_REFERENCE_NAME_LIMIT) {
     throw new Error(
       `VM reaper reference query has ${normalized.length} names; maximum is ${VM_REAPER_REFERENCE_NAME_LIMIT}`,
+    );
+  }
+  return normalized;
+}
+
+function boundedReaperKeys(keys: readonly string[]): string[] {
+  const normalized = [...new Set(keys.map((key) => key.trim()).filter(Boolean))];
+  if (normalized.length > VM_REAPER_REFERENCE_NAME_LIMIT) {
+    throw new Error(
+      `VM reaper report key query has ${normalized.length} keys; maximum is ${VM_REAPER_REFERENCE_NAME_LIMIT}`,
     );
   }
   return normalized;
@@ -1204,6 +1219,30 @@ export const VmRepositoryLive = Layer.succeed(VmRepository, {
         .filter((name): name is string => !!name);
     }),
 
+  recentReaperReportKeys: (input) =>
+    dbEffect("recentReaperReportKeys", async () => {
+      const keys = boundedReaperKeys(input.keys);
+      // An empty key list must never become an unbounded usage-event scan.
+      if (keys.length === 0) return [];
+      const db = cloudDb();
+      const reportKey = input.eventType === "vm.reaper.orphan_volume"
+        ? sql<string | null>`${cloudVmUsageEvents.metadata}->>'volumeName'`
+        : sql<string | null>`${cloudVmUsageEvents.vmId}::text`;
+      const rows = await db
+        .select({ key: reportKey })
+        .from(cloudVmUsageEvents)
+        .where(and(
+          eq(cloudVmUsageEvents.eventType, input.eventType),
+          gt(cloudVmUsageEvents.createdAt, input.since),
+          inArray(reportKey, keys),
+        ));
+      return [...new Set(
+        rows
+          .map((row) => row.key?.trim())
+          .filter((key): key is string => !!key),
+      )];
+    }),
+
   stuckProvisioningCandidates: (input) =>
     dbEffect("stuckProvisioningCandidates", async () => {
       const db = cloudDb();
@@ -1212,9 +1251,9 @@ export const VmRepositoryLive = Layer.succeed(VmRepository, {
         .from(cloudVms)
         .where(and(
           eq(cloudVms.status, "provisioning"),
-          lt(cloudVms.createdAt, input.before),
+          lt(cloudVms.updatedAt, input.before),
         ))
-        .orderBy(asc(cloudVms.createdAt), asc(cloudVms.id))
+        .orderBy(asc(cloudVms.updatedAt), asc(cloudVms.id))
         .limit(input.limit);
     }),
 

--- a/web/services/vms/repository.ts
+++ b/web/services/vms/repository.ts
@@ -47,12 +47,6 @@ export type CloudVmSessionRow = typeof cloudVmSessions.$inferSelect;
 export type CloudVmLeaseKind = typeof cloudVmLeases.$inferInsert.kind;
 export type CloudVmStatus = CloudVmRow["status"];
 export type CloudVmSessionStatus = CloudVmSessionRow["status"];
-export type VmOrphanVolumeObservation = {
-  readonly volumeName: string;
-  readonly firstObservedAt: Date;
-};
-
-const VM_REAPER_ORPHAN_VOLUME_OBSERVATION_EVENT = "vm.reaper.orphan_volume_observed";
 // Reaper batches are capped at 100. Keep repository calls bounded even if a
 // future caller passes a malformed or oversized name list.
 const VM_REAPER_REFERENCE_NAME_LIMIT = 100;
@@ -166,41 +160,15 @@ export type VmRepositoryShape = {
     /** Candidate names only; an empty list must not trigger an unbounded scan. */
     readonly volumeNames: readonly string[];
   }) => Effect.Effect<readonly string[], VmDatabaseError>;
-  /** First-observed markers for the bounded orphan-volume candidate set. */
-  readonly listOrphanVolumeObservations?: (input: {
-    readonly provider: ProviderId;
-    readonly volumeNames: readonly string[];
-  }) => Effect.Effect<readonly VmOrphanVolumeObservation[], VmDatabaseError>;
-  /** Persist the first observation of an orphan candidate. */
-  readonly recordOrphanVolumeObservation?: (input: {
-    readonly provider: ProviderId;
-    readonly volumeName: string;
-    readonly observedAt: Date;
-  }) => Effect.Effect<void, VmDatabaseError>;
-  /** Point-in-time ownership recheck immediately before a provider delete. */
-  readonly isLiveHomeVolumeReferenced?: (input: {
-    readonly provider: ProviderId;
-    readonly volumeName: string;
-  }) => Effect.Effect<boolean, VmDatabaseError>;
   /** Oldest provisioning rows for the bounded resource reaper. */
   readonly stuckProvisioningCandidates?: (input: {
     readonly before: Date;
     readonly limit: number;
   }) => Effect.Effect<CloudVmRow[], VmDatabaseError>;
-  /** Atomic transition used when a stale provisioning row has no provider id. */
-  readonly markProvisioningFailed?: (input: {
-    readonly id: string;
-    readonly code: string;
-    readonly message: string;
-    /** When set, do not overwrite a row another worker already advanced. */
-    readonly expectedStatus?: CloudVmStatus;
-  }) => Effect.Effect<boolean, VmDatabaseError>;
   readonly markProviderObservedStatus: (input: {
     readonly id: string;
     readonly providerVmId: string;
     readonly status: CloudVmStatus;
-    /** When set, do not overwrite a row that another worker already advanced. */
-    readonly expectedStatus?: CloudVmStatus;
   }) => Effect.Effect<boolean, VmDatabaseError>;
   readonly setDisplayName: (input: {
     readonly id: string;
@@ -217,8 +185,6 @@ export type VmRepositoryShape = {
     readonly id: string;
     readonly code: string;
     readonly message: string;
-    /** Optional compare-and-set guard for cleanup/reconciliation callers. */
-    readonly expectedStatus?: CloudVmStatus;
   }) => Effect.Effect<void, VmDatabaseError>;
   readonly hasOwnedSnapshot: (input: {
     readonly userId: string;
@@ -1238,86 +1204,6 @@ export const VmRepositoryLive = Layer.succeed(VmRepository, {
         .filter((name): name is string => !!name);
     }),
 
-  listOrphanVolumeObservations: (input) =>
-    dbEffect("listOrphanVolumeObservations", async () => {
-      const volumeNames = boundedReaperVolumeNames(input.volumeNames);
-      if (volumeNames.length === 0) return [];
-      const db = cloudDb();
-      const volumeName = sql<string | null>`${cloudVmUsageEvents.metadata}->>'volumeName'`;
-      const rows = await db
-        .select({
-          volumeName,
-          firstObservedAt: cloudVmUsageEvents.createdAt,
-        })
-        .from(cloudVmUsageEvents)
-        .where(and(
-          eq(cloudVmUsageEvents.provider, input.provider),
-          eq(cloudVmUsageEvents.eventType, VM_REAPER_ORPHAN_VOLUME_OBSERVATION_EVENT),
-          inArray(volumeName, volumeNames),
-        ))
-        .orderBy(asc(cloudVmUsageEvents.createdAt), asc(cloudVmUsageEvents.id));
-
-      const firstByName = new Map<string, Date>();
-      for (const row of rows) {
-        const name = row.volumeName?.trim();
-        if (!name || firstByName.has(name)) continue;
-        firstByName.set(name, row.firstObservedAt);
-      }
-      return [...firstByName].map(([name, firstObservedAt]) => ({
-        volumeName: name,
-        firstObservedAt,
-      }));
-    }),
-
-  recordOrphanVolumeObservation: (input) =>
-    dbEffect("recordOrphanVolumeObservation", async () => {
-      const volumeName = input.volumeName.trim();
-      if (!volumeName) return;
-      const db = cloudDb();
-      // The reaper loads markers before it writes the current run's markers,
-      // so a duplicate under a concurrent invocation is harmless. Avoid the
-      // common duplicate case to keep the usage ledger compact.
-      const markerName = sql<string | null>`${cloudVmUsageEvents.metadata}->>'volumeName'`;
-      const [existing] = await db
-        .select({ id: cloudVmUsageEvents.id })
-        .from(cloudVmUsageEvents)
-        .where(and(
-          eq(cloudVmUsageEvents.provider, input.provider),
-          eq(cloudVmUsageEvents.eventType, VM_REAPER_ORPHAN_VOLUME_OBSERVATION_EVENT),
-          eq(markerName, volumeName),
-        ))
-        .limit(1);
-      if (existing) return;
-      await db.insert(cloudVmUsageEvents).values({
-        userId: "cmux-vm-reaper",
-        billingTeamId: null,
-        billingPlanId: null,
-        vmId: null,
-        eventType: VM_REAPER_ORPHAN_VOLUME_OBSERVATION_EVENT,
-        provider: input.provider,
-        metadata: {
-          volumeName,
-          firstObservedAt: input.observedAt.toISOString(),
-        },
-        createdAt: input.observedAt,
-      });
-    }),
-
-  isLiveHomeVolumeReferenced: (input) =>
-    dbEffect("isLiveHomeVolumeReferenced", async () => {
-      const db = cloudDb();
-      const [row] = await db
-        .select({ id: cloudVms.id })
-        .from(cloudVms)
-        .where(and(
-          eq(cloudVms.provider, input.provider),
-          inArray(cloudVms.status, ["provisioning", "running", "paused"]),
-          sql`${cloudVms.providerMetadata}->>'homeVolume' = ${input.volumeName}`,
-        ))
-        .limit(1);
-      return !!row;
-    }),
-
   stuckProvisioningCandidates: (input) =>
     dbEffect("stuckProvisioningCandidates", async () => {
       const db = cloudDb();
@@ -1346,7 +1232,6 @@ export const VmRepositoryLive = Layer.succeed(VmRepository, {
           and(
             eq(cloudVms.id, input.id),
             eq(cloudVms.providerVmId, input.providerVmId),
-            ...(input.expectedStatus ? [eq(cloudVms.status, input.expectedStatus)] : []),
             ne(cloudVms.status, "destroyed"),
           ),
         )
@@ -1397,29 +1282,7 @@ export const VmRepositoryLive = Layer.succeed(VmRepository, {
           failureMessage: input.message,
           updatedAt: new Date(),
         })
-        .where(and(
-          eq(cloudVms.id, input.id),
-          ...(input.expectedStatus ? [eq(cloudVms.status, input.expectedStatus)] : []),
-        ));
-    }),
-
-  markProvisioningFailed: (input) =>
-    dbEffect("markProvisioningFailed", async () => {
-      const db = cloudDb();
-      const updated = await db
-        .update(cloudVms)
-        .set({
-          status: "failed",
-          failureCode: input.code,
-          failureMessage: input.message,
-          updatedAt: new Date(),
-        })
-        .where(and(
-          eq(cloudVms.id, input.id),
-          eq(cloudVms.status, input.expectedStatus ?? "provisioning"),
-        ))
-        .returning({ id: cloudVms.id });
-      return updated.length > 0;
+        .where(eq(cloudVms.id, input.id));
     }),
 
   hasOwnedSnapshot: (input) =>

--- a/web/services/vms/repository.ts
+++ b/web/services/vms/repository.ts
@@ -1225,7 +1225,10 @@ export const VmRepositoryLive = Layer.succeed(VmRepository, {
       // An empty key list must never become an unbounded usage-event scan.
       if (keys.length === 0) return [];
       const db = cloudDb();
-      const reportKey = input.eventType === "vm.reaper.orphan_volume"
+      // Every orphan-volume event type (base, unknown-attachment,
+      // unknown-reference) is a system event keyed by volume name; only
+      // VM-row events (stuck provisioning) key by vmId.
+      const reportKey = input.eventType.startsWith("vm.reaper.orphan_volume")
         ? sql<string | null>`${cloudVmUsageEvents.metadata}->>'volumeName'`
         : sql<string | null>`${cloudVmUsageEvents.vmId}::text`;
       const rows = await db

--- a/web/services/vms/repository.ts
+++ b/web/services/vms/repository.ts
@@ -47,6 +47,15 @@ export type CloudVmSessionRow = typeof cloudVmSessions.$inferSelect;
 export type CloudVmLeaseKind = typeof cloudVmLeases.$inferInsert.kind;
 export type CloudVmStatus = CloudVmRow["status"];
 export type CloudVmSessionStatus = CloudVmSessionRow["status"];
+export type VmOrphanVolumeObservation = {
+  readonly volumeName: string;
+  readonly firstObservedAt: Date;
+};
+
+const VM_REAPER_ORPHAN_VOLUME_OBSERVATION_EVENT = "vm.reaper.orphan_volume_observed";
+// Reaper batches are capped at 100. Keep repository calls bounded even if a
+// future caller passes a malformed or oversized name list.
+const VM_REAPER_REFERENCE_NAME_LIMIT = 100;
 
 export type BeginCreateResult =
   | { readonly inserted: true; readonly vm: CloudVmRow }
@@ -154,7 +163,20 @@ export type VmRepositoryShape = {
   /** Live VM rows that currently claim a persistent home volume. */
   readonly listLiveHomeVolumeNames?: (input: {
     readonly provider: ProviderId;
+    /** Candidate names only; an empty list must not trigger an unbounded scan. */
+    readonly volumeNames: readonly string[];
   }) => Effect.Effect<readonly string[], VmDatabaseError>;
+  /** First-observed markers for the bounded orphan-volume candidate set. */
+  readonly listOrphanVolumeObservations?: (input: {
+    readonly provider: ProviderId;
+    readonly volumeNames: readonly string[];
+  }) => Effect.Effect<readonly VmOrphanVolumeObservation[], VmDatabaseError>;
+  /** Persist the first observation of an orphan candidate. */
+  readonly recordOrphanVolumeObservation?: (input: {
+    readonly provider: ProviderId;
+    readonly volumeName: string;
+    readonly observedAt: Date;
+  }) => Effect.Effect<void, VmDatabaseError>;
   /** Point-in-time ownership recheck immediately before a provider delete. */
   readonly isLiveHomeVolumeReferenced?: (input: {
     readonly provider: ProviderId;
@@ -170,6 +192,8 @@ export type VmRepositoryShape = {
     readonly id: string;
     readonly code: string;
     readonly message: string;
+    /** When set, do not overwrite a row another worker already advanced. */
+    readonly expectedStatus?: CloudVmStatus;
   }) => Effect.Effect<boolean, VmDatabaseError>;
   readonly markProviderObservedStatus: (input: {
     readonly id: string;
@@ -193,6 +217,8 @@ export type VmRepositoryShape = {
     readonly id: string;
     readonly code: string;
     readonly message: string;
+    /** Optional compare-and-set guard for cleanup/reconciliation callers. */
+    readonly expectedStatus?: CloudVmStatus;
   }) => Effect.Effect<void, VmDatabaseError>;
   readonly hasOwnedSnapshot: (input: {
     readonly userId: string;
@@ -412,6 +438,16 @@ function baseScope(input: {
 function baseName(value: string | null | undefined) {
   const trimmed = value?.trim();
   return trimmed || "base";
+}
+
+function boundedReaperVolumeNames(names: readonly string[]): string[] {
+  const normalized = [...new Set(names.map((name) => name.trim()).filter(Boolean))];
+  if (normalized.length > VM_REAPER_REFERENCE_NAME_LIMIT) {
+    throw new Error(
+      `VM reaper reference query has ${normalized.length} names; maximum is ${VM_REAPER_REFERENCE_NAME_LIMIT}`,
+    );
+  }
+  return normalized;
 }
 
 export const VmRepositoryLive = Layer.succeed(VmRepository, {
@@ -1182,6 +1218,10 @@ export const VmRepositoryLive = Layer.succeed(VmRepository, {
 
   listLiveHomeVolumeNames: (input) =>
     dbEffect("listLiveHomeVolumeNames", async () => {
+      const volumeNames = boundedReaperVolumeNames(input.volumeNames);
+      // Never fall back to the old unbounded inventory query. The reaper
+      // supplies a bounded chunk, and an empty chunk is fail-closed.
+      if (volumeNames.length === 0) return [];
       const db = cloudDb();
       const homeVolume = sql<string | null>`${cloudVms.providerMetadata}->>'homeVolume'`;
       const rows = await db
@@ -1189,12 +1229,78 @@ export const VmRepositoryLive = Layer.succeed(VmRepository, {
         .from(cloudVms)
         .where(and(
           eq(cloudVms.provider, input.provider),
+          inArray(homeVolume, volumeNames),
           inArray(cloudVms.status, ["provisioning", "running", "paused"]),
           sql`${homeVolume} is not null and ${homeVolume} <> ''`,
         ));
       return rows
         .map((row) => row.homeVolume?.trim())
         .filter((name): name is string => !!name);
+    }),
+
+  listOrphanVolumeObservations: (input) =>
+    dbEffect("listOrphanVolumeObservations", async () => {
+      const volumeNames = boundedReaperVolumeNames(input.volumeNames);
+      if (volumeNames.length === 0) return [];
+      const db = cloudDb();
+      const volumeName = sql<string | null>`${cloudVmUsageEvents.metadata}->>'volumeName'`;
+      const rows = await db
+        .select({
+          volumeName,
+          firstObservedAt: cloudVmUsageEvents.createdAt,
+        })
+        .from(cloudVmUsageEvents)
+        .where(and(
+          eq(cloudVmUsageEvents.provider, input.provider),
+          eq(cloudVmUsageEvents.eventType, VM_REAPER_ORPHAN_VOLUME_OBSERVATION_EVENT),
+          inArray(volumeName, volumeNames),
+        ))
+        .orderBy(asc(cloudVmUsageEvents.createdAt), asc(cloudVmUsageEvents.id));
+
+      const firstByName = new Map<string, Date>();
+      for (const row of rows) {
+        const name = row.volumeName?.trim();
+        if (!name || firstByName.has(name)) continue;
+        firstByName.set(name, row.firstObservedAt);
+      }
+      return [...firstByName].map(([name, firstObservedAt]) => ({
+        volumeName: name,
+        firstObservedAt,
+      }));
+    }),
+
+  recordOrphanVolumeObservation: (input) =>
+    dbEffect("recordOrphanVolumeObservation", async () => {
+      const volumeName = input.volumeName.trim();
+      if (!volumeName) return;
+      const db = cloudDb();
+      // The reaper loads markers before it writes the current run's markers,
+      // so a duplicate under a concurrent invocation is harmless. Avoid the
+      // common duplicate case to keep the usage ledger compact.
+      const markerName = sql<string | null>`${cloudVmUsageEvents.metadata}->>'volumeName'`;
+      const [existing] = await db
+        .select({ id: cloudVmUsageEvents.id })
+        .from(cloudVmUsageEvents)
+        .where(and(
+          eq(cloudVmUsageEvents.provider, input.provider),
+          eq(cloudVmUsageEvents.eventType, VM_REAPER_ORPHAN_VOLUME_OBSERVATION_EVENT),
+          eq(markerName, volumeName),
+        ))
+        .limit(1);
+      if (existing) return;
+      await db.insert(cloudVmUsageEvents).values({
+        userId: "cmux-vm-reaper",
+        billingTeamId: null,
+        billingPlanId: null,
+        vmId: null,
+        eventType: VM_REAPER_ORPHAN_VOLUME_OBSERVATION_EVENT,
+        provider: input.provider,
+        metadata: {
+          volumeName,
+          firstObservedAt: input.observedAt.toISOString(),
+        },
+        createdAt: input.observedAt,
+      });
     }),
 
   isLiveHomeVolumeReferenced: (input) =>
@@ -1291,7 +1397,10 @@ export const VmRepositoryLive = Layer.succeed(VmRepository, {
           failureMessage: input.message,
           updatedAt: new Date(),
         })
-        .where(eq(cloudVms.id, input.id));
+        .where(and(
+          eq(cloudVms.id, input.id),
+          ...(input.expectedStatus ? [eq(cloudVms.status, input.expectedStatus)] : []),
+        ));
     }),
 
   markProvisioningFailed: (input) =>
@@ -1305,7 +1414,10 @@ export const VmRepositoryLive = Layer.succeed(VmRepository, {
           failureMessage: input.message,
           updatedAt: new Date(),
         })
-        .where(and(eq(cloudVms.id, input.id), eq(cloudVms.status, "provisioning")))
+        .where(and(
+          eq(cloudVms.id, input.id),
+          eq(cloudVms.status, input.expectedStatus ?? "provisioning"),
+        ))
         .returning({ id: cloudVms.id });
       return updated.length > 0;
     }),

--- a/web/services/vms/volumeNaming.ts
+++ b/web/services/vms/volumeNaming.ts
@@ -1,0 +1,29 @@
+import { createHash } from "node:crypto";
+
+/** Stable per-user home volume name. The user id is never embedded in the name. */
+export function homeVolumeNameForUser(userId: string): string {
+  const digest = createHash("sha256").update(userId).digest("hex").slice(0, 12);
+  return `cmux-home-${digest}`;
+}
+
+/**
+ * Per-machine home volume template. The provider replaces `{machine}` with
+ * the final machine name after it resolves a name collision.
+ */
+export function homeVolumeTemplateForUser(userId: string): string {
+  return `${homeVolumeNameForUser(userId)}-{machine}`;
+}
+
+/**
+ * Names created by `homeVolumeTemplateForUser`.
+ *
+ * The suffix is deliberately limited to the provider machine-name grammar.
+ * The shared per-user volume has no suffix and therefore never matches.
+ */
+const MACHINE_OWNED_HOME_VOLUME_PATTERN =
+  /^cmux-home-[0-9a-f]{12}-[a-z0-9](?:[a-z0-9-]{0,39}[a-z0-9])?$/;
+
+export function isMachineOwnedHomeVolumeName(value: unknown): value is string {
+  return typeof value === "string" && MACHINE_OWNED_HOME_VOLUME_PATTERN.test(value.trim());
+}
+

--- a/web/services/vms/workflows.ts
+++ b/web/services/vms/workflows.ts
@@ -57,6 +57,21 @@ import {
 } from "./repository";
 import { measureVmEffect, type VmTimingSink } from "./timings";
 
+export {
+  homeVolumeNameForUser,
+  homeVolumeTemplateForUser,
+  isMachineOwnedHomeVolumeName,
+} from "./volumeNaming";
+export { reapVmResources } from "./reaper";
+export type {
+  VmReaperOptions,
+  VmReaperSummary,
+} from "./reaper";
+import {
+  homeVolumeNameForUser,
+  homeVolumeTemplateForUser,
+} from "./volumeNaming";
+
 export type VmEntry = {
   readonly providerVmId: string;
   readonly provider: ProviderId;
@@ -216,21 +231,6 @@ export function reconcileVmProviderStatuses(input: {
       skippedNoGetStatus: false,
     };
   });
-}
-
-/** Stable per-user home volume name; the volume, not the sandbox, is the durable machine. */
-export function homeVolumeNameForUser(userId: string): string {
-  const digest = createHash("sha256").update(userId).digest("hex").slice(0, 12);
-  return `cmux-home-${digest}`;
-}
-
-/**
- * Per-machine home volume template. The driver substitutes the generated
- * machine name for `{machine}` once the name is final, so every fresh machine
- * gets its own durable home instead of contending for the single user volume.
- */
-export function homeVolumeTemplateForUser(userId: string): string {
-  return `${homeVolumeNameForUser(userId)}-{machine}`;
 }
 
 /**

--- a/web/tests/vm-reaper.test.ts
+++ b/web/tests/vm-reaper.test.ts
@@ -1,16 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import type { ProviderId, VMVolume } from "../services/vms/drivers";
+import type { VMVolume, VMVolumeInventory } from "../services/vms/drivers";
 import { VmProviderGateway, type VmProviderGatewayShape } from "../services/vms/providerGateway";
 import {
   VmRepository,
   type CloudVmRow,
   type VmRepositoryShape,
 } from "../services/vms/repository";
-import { VmProviderOperationError } from "../services/vms/errors";
-import { reapVmResources } from "../services/vms/workflows";
-import type { VmReaperOptions } from "../services/vms/reaper";
+import { reapVmResources, type VmReaperOptions } from "../services/vms/reaper";
 
 const NOW = new Date("2026-08-31T20:00:00.000Z");
 
@@ -42,23 +40,23 @@ function baseRepository(): VmRepositoryShape {
     beginBaseOpen: () => Effect.die("unused"),
     beginBaseReset: () => Effect.die("unused"),
     markBaseCreateRunning: () => Effect.die("unused"),
-    markBaseCreateFailed: () => Effect.void,
+    markBaseCreateFailed: () => Effect.die("unexpected lifecycle write"),
     activeLimitCandidates: () => Effect.succeed([]),
     reservePausedResume: () => Effect.die("unused"),
     reconciliationCandidates: () => Effect.succeed([]),
-    markProviderObservedStatus: () => Effect.succeed(true),
-    setDisplayName: () => Effect.succeed(true),
+    markProviderObservedStatus: () => Effect.die("unexpected lifecycle write"),
+    setDisplayName: () => Effect.die("unexpected lifecycle write"),
     markCreateRunning: () => Effect.die("unused"),
-    markCreateFailed: () => Effect.void,
+    markCreateFailed: () => Effect.die("unexpected lifecycle write"),
     hasOwnedSnapshot: () => Effect.succeed(false),
     findUserVm: () => Effect.succeed(null),
-    markDestroyed: () => Effect.void,
-    recordLease: () => Effect.void,
+    markDestroyed: () => Effect.die("unexpected lifecycle write"),
+    recordLease: () => Effect.die("unexpected lifecycle write"),
     accountDeletionIdentityLeases: () => Effect.succeed([]),
     listVmSessions: () => Effect.succeed([]),
     upsertVmSession: () => Effect.die("unused"),
     activeIdentityLeases: () => Effect.succeed([]),
-    markLeasesRevoked: () => Effect.void,
+    markLeasesRevoked: () => Effect.die("unexpected lifecycle write"),
     recordUsageEvent: () => Effect.void,
     recordUsageEvents: () => Effect.void,
   } as unknown as VmRepositoryShape;
@@ -68,29 +66,16 @@ function repository(overrides: Partial<VmRepositoryShape> = {}): VmRepositorySha
   return { ...baseRepository(), ...overrides };
 }
 
-function withObservations(
-  repo: VmRepositoryShape,
-  observations: Map<string, Date> = new Map(),
-): VmRepositoryShape {
-  return {
-    ...repo,
-    listOrphanVolumeObservations: ({ volumeNames }) => Effect.succeed(
-      volumeNames.flatMap((volumeName) => {
-        const firstObservedAt = observations.get(volumeName);
-        return firstObservedAt ? [{ volumeName, firstObservedAt }] : [];
-      }),
-    ),
-    recordOrphanVolumeObservation: ({ volumeName, observedAt }) => Effect.sync(() => {
-      if (!observations.has(volumeName)) observations.set(volumeName, observedAt);
-    }),
-  };
-}
-
-function oldVolume(name: string, ageMs = 3 * 60 * 60 * 1000): VMVolume {
+function oldVolume(
+  name: string,
+  overrides: Partial<VMVolume> = {},
+): VMVolume {
   return {
     name,
-    createdAt: NOW.getTime() - ageMs,
+    createdAt: NOW.getTime() - 3 * 60 * 60 * 1000,
     attachedTo: null,
+    attachmentState: "unattached",
+    ...overrides,
   };
 }
 
@@ -101,7 +86,7 @@ function vmRow(overrides: Partial<CloudVmRow> = {}): CloudVmRow {
     billingTeamId: "team-reaper",
     billingPlanId: "pro",
     provider: "blaxel",
-    providerVmId: "noble-wren",
+    providerVmId: "stale-sandbox",
     displayName: null,
     imageId: "blaxel/base-image:latest",
     imageVersion: null,
@@ -117,416 +102,233 @@ function vmRow(overrides: Partial<CloudVmRow> = {}): CloudVmRow {
   };
 }
 
-function missingProviderError(vmId: string): VmProviderOperationError {
-  return new VmProviderOperationError({
-    provider: "blaxel",
-    operation: "getStatus",
-    cause: new Error(`sandbox ${vmId} -> 404 not found`),
-  });
+function runReaper(
+  repo: VmRepositoryShape,
+  provider: VmProviderGatewayShape,
+  options: VmReaperOptions = {},
+) {
+  return Effect.runPromise(
+    reapVmResources({ now: NOW, ...options }).pipe(
+      Effect.provide(workflowLayer(repo, provider)),
+    ),
+  );
 }
 
-describe("Cloud VM reaper", () => {
-  test("filters shared/user volumes and reports an unattached machine volume without deleting", async () => {
-    const deleted: string[] = [];
+describe("Cloud VM reaper report", () => {
+  test("reports only known orphan candidates and never deletes or writes VM rows", async () => {
     const usage: Array<Record<string, unknown>> = [];
-    const observations = new Map<string, Date>();
-    const volumes: VMVolume[] = [
-      { name: "cmux-home-abcdef123456", createdAt: 1, attachedTo: null },
-      { name: "cmux-home-abcdef123456-noble-wren", createdAt: 2, attachedTo: null },
-      { name: "cmux-home-abcdef123456-bold-fox", createdAt: 3, attachedTo: "sandbox:bold-fox" },
-      { name: "user-home-noble-wren", createdAt: 4, attachedTo: null },
-    ];
-    const repo = withObservations(repository({
-      listLiveHomeVolumeNames: () => Effect.succeed([]),
+    const deleted: string[] = [];
+    const liveLookups: string[][] = [];
+    const repo = repository({
+      listLiveHomeVolumeNames: ({ volumeNames }) => Effect.sync(() => {
+        liveLookups.push([...volumeNames]);
+        return [];
+      }),
       stuckProvisioningCandidates: () => Effect.succeed([]),
       recordUsageEvent: (event) => Effect.sync(() => usage.push(event as Record<string, unknown>)),
-    }), observations);
+    });
     const provider = {
       ...baseProvider(),
-      listVolumes: () => Effect.succeed(volumes),
-      deleteHomeVolume: (_provider: ProviderId, name: string) => Effect.sync(() => deleted.push(name)),
-    };
+      listVolumes: () => Effect.succeed([
+        oldVolume("cmux-home-abcdef123456-noble-wren"),
+        oldVolume("cmux-home-abcdef123456-bold-fox", { attachedTo: "sandbox:bold-fox", attachmentState: "attached" }),
+        oldVolume("cmux-home-abcdef123456"),
+        oldVolume("shared-volume"),
+      ]),
+      deleteHomeVolume: (_provider: "blaxel", name: string) => Effect.sync(() => deleted.push(name)),
+    } as unknown as VmProviderGatewayShape;
 
-    const result = await Effect.runPromise(
-      reapVmResources({ now: NOW, deleteVolumes: false }).pipe(
-        Effect.provide(workflowLayer(repo, provider)),
-      ),
-    );
+    const result = await runReaper(repo, provider, {
+      // A legacy array is still accepted, but it must be marked partial.
+      volumeLimit: 10,
+      volumeScanLimit: 10,
+    });
 
     expect(result.reportOnly).toBe(true);
+    expect(result.deleted).toBe(0);
     expect(result.orphanVolumes.candidates).toBe(1);
     expect(result.orphanVolumes.reported).toBe(1);
-    expect(result.orphanVolumes.skipped).toBe(1);
+    expect(result.orphanVolumes.deleted).toBe(0);
+    expect(result.orphanVolumes.coveragePartial).toBe(true);
+    expect(liveLookups).toEqual([["cmux-home-abcdef123456-noble-wren"]]);
     expect(deleted).toEqual([]);
     expect(usage).toHaveLength(1);
     expect(usage[0]).toMatchObject({
       eventType: "vm.reaper.orphan_volume",
       metadata: {
         volumeName: "cmux-home-abcdef123456-noble-wren",
-        mode: "report",
+        attachmentState: "unattached",
+        liveReference: false,
       },
     });
   });
 
-  test("deletes only a free machine-owned volume when delete mode is enabled", async () => {
-    const deleted: string[] = [];
-    const name = "cmux-home-abcdef123456-noble-wren";
-    const observations = new Map([[name, new Date(NOW.getTime() - 60 * 60 * 1000)]]);
-    const repo = withObservations(repository({
-      listLiveHomeVolumeNames: () => Effect.succeed([]),
+  test("reports unknown attachment separately and never treats it as free", async () => {
+    const usage: Array<Record<string, unknown>> = [];
+    const liveLookups: string[][] = [];
+    const repo = repository({
+      listLiveHomeVolumeNames: ({ volumeNames }) => Effect.sync(() => {
+        liveLookups.push([...volumeNames]);
+        return [];
+      }),
       stuckProvisioningCandidates: () => Effect.succeed([]),
-    }), observations);
-    const provider = {
-      ...baseProvider(),
-      listVolumes: () => Effect.succeed([oldVolume(name)]),
-      deleteHomeVolume: (_provider: ProviderId, name: string) => Effect.sync(() => deleted.push(name)),
-    };
-
-    const result = await Effect.runPromise(
-      reapVmResources({ now: NOW, deleteVolumes: true }).pipe(
-        Effect.provide(workflowLayer(repo, provider)),
-      ),
-    );
-
-    expect(result.reportOnly).toBe(false);
-    expect(result.orphanVolumes.deleted).toBe(1);
-    expect(deleted).toEqual(["cmux-home-abcdef123456-noble-wren"]);
-  });
-
-  test("skips a machine volume referenced by a live VM row", async () => {
-    const deleted: string[] = [];
-    const repo = withObservations(repository({
-      listLiveHomeVolumeNames: () => Effect.succeed(["cmux-home-abcdef123456-noble-wren"]),
-      stuckProvisioningCandidates: () => Effect.succeed([]),
-    }));
+      recordUsageEvent: (event) => Effect.sync(() => usage.push(event as Record<string, unknown>)),
+    });
     const provider = {
       ...baseProvider(),
       listVolumes: () => Effect.succeed([
-        { name: "cmux-home-abcdef123456-noble-wren", createdAt: 2, attachedTo: null },
+        { name: "cmux-home-abcdef123456-unknown-state", createdAt: 1 },
+        oldVolume("cmux-home-abcdef123456-explicit-free"),
       ]),
-      deleteHomeVolume: (_provider: ProviderId, name: string) => Effect.sync(() => deleted.push(name)),
-    };
+    } as unknown as VmProviderGatewayShape;
 
-    const result = await Effect.runPromise(
-      reapVmResources({ now: NOW, deleteVolumes: true }).pipe(
-        Effect.provide(workflowLayer(repo, provider)),
-      ),
-    );
+    const result = await runReaper(repo, provider, { volumeScanLimit: 10 });
 
-    expect(result.orphanVolumes.deleted).toBe(0);
-    expect(result.orphanVolumes.skipped).toBe(1);
-    expect(deleted).toEqual([]);
-  });
-
-  test("marks a stale provisioning row destroyed when the provider sandbox is gone", async () => {
-    const updates: Array<Record<string, unknown>> = [];
-    const usage: Array<Record<string, unknown>> = [];
-    const row = vmRow({ providerVmId: "stale-sandbox" });
-    const repo = withObservations(repository({
-      listLiveHomeVolumeNames: () => Effect.succeed([]),
-      stuckProvisioningCandidates: () => Effect.succeed([row]),
-      markProviderObservedStatus: (update) => Effect.sync(() => {
-        updates.push(update as Record<string, unknown>);
-        return true;
-      }),
-      recordUsageEvent: (event) => Effect.sync(() => usage.push(event as Record<string, unknown>)),
-    }));
-    const provider = {
-      ...baseProvider(),
-      listVolumes: () => Effect.succeed([]),
-      getStatus: (_provider: ProviderId, vmId: string) => Effect.fail(missingProviderError(vmId)),
-    };
-
-    const result = await Effect.runPromise(
-      reapVmResources({ now: NOW, deleteVolumes: false }).pipe(
-        Effect.provide(workflowLayer(repo, provider)),
-      ),
-    );
-
-    expect(result.stuckProvisioning.destroyed).toBe(1);
-    expect(result.stuckProvisioning.failed).toBe(0);
-    expect(updates).toEqual([
-      { id: row.id, providerVmId: "stale-sandbox", status: "destroyed", expectedStatus: "provisioning" },
-    ]);
+    expect(result.orphanVolumes.unknownAttachment).toBe(1);
+    expect(result.orphanVolumes.candidates).toBe(1);
+    expect(result.orphanVolumes.reported).toBe(2);
+    expect(liveLookups).toEqual([["cmux-home-abcdef123456-explicit-free"]]);
     expect(usage).toContainEqual(expect.objectContaining({
-      eventType: "vm.destroyed",
-      vmId: row.id,
-      metadata: expect.objectContaining({ source: "vm_reaper" }),
+      eventType: "vm.reaper.orphan_volume_unknown_attachment",
+      metadata: expect.objectContaining({
+        volumeName: "cmux-home-abcdef123456-unknown-state",
+        attachmentState: "unknown",
+        attachment: "unknown",
+      }),
+    }));
+    expect(usage).not.toContainEqual(expect.objectContaining({
+      eventType: "vm.reaper.orphan_volume",
+      metadata: expect.objectContaining({ volumeName: "cmux-home-abcdef123456-unknown-state" }),
     }));
   });
 
-  test("marks a stale provisioning row failed when it never received a provider id", async () => {
-    const failures: Array<Record<string, unknown>> = [];
+  test("reports stale provisioning rows without provider reads or repository status writes", async () => {
     const usage: Array<Record<string, unknown>> = [];
     const row = vmRow({ providerVmId: null });
-    const repo = withObservations(repository({
-      listLiveHomeVolumeNames: () => Effect.succeed([]),
+    let statusReads = 0;
+    const repo = repository({
       stuckProvisioningCandidates: () => Effect.succeed([row]),
-      markProvisioningFailed: (input) => Effect.sync(() => {
-        failures.push(input as Record<string, unknown>);
-        return true;
-      }),
       recordUsageEvent: (event) => Effect.sync(() => usage.push(event as Record<string, unknown>)),
-    }));
-    const provider = {
-      ...baseProvider(),
-      listVolumes: () => Effect.succeed([]),
-    };
-
-    const result = await Effect.runPromise(
-      reapVmResources({ now: NOW, deleteVolumes: false }).pipe(
-        Effect.provide(workflowLayer(repo, provider)),
-      ),
-    );
-
-    expect(result.stuckProvisioning.failed).toBe(1);
-    expect(failures[0]).toMatchObject({
-      id: row.id,
-      code: "provisioning_timeout",
     });
-    expect(usage).toContainEqual(expect.objectContaining({
-      eventType: "vm.create.failed",
-      vmId: row.id,
-    }));
-  });
-
-  test("does not delete a newly observed volume until it is old and observed by a prior run", async () => {
-    const deleted: string[] = [];
-    const name = "cmux-home-abcdef123456-new-volume";
-    const observations = new Map<string, Date>();
-    const volume: VMVolume = {
-      name,
-      createdAt: NOW.getTime() - 30 * 60 * 1000,
-      attachedTo: null,
-    };
-    const repo = withObservations(repository({
-      listLiveHomeVolumeNames: () => Effect.succeed([]),
-      isLiveHomeVolumeReferenced: () => Effect.succeed(false),
-      stuckProvisioningCandidates: () => Effect.succeed([]),
-    }), observations);
     const provider = {
       ...baseProvider(),
-      listVolumes: () => Effect.succeed([volume]),
-      deleteHomeVolume: (_provider: ProviderId, volumeName: string) =>
-        Effect.sync(() => deleted.push(volumeName)),
-    };
-    const run = (now: Date) => Effect.runPromise(
-      reapVmResources({ now, deleteVolumes: true } as VmReaperOptions).pipe(
-        Effect.provide(workflowLayer(repo, provider)),
-      ),
-    );
-
-    const first = await run(NOW);
-    expect(first.orphanVolumes.deleted).toBe(0);
-    expect(first.orphanVolumes.reported).toBe(1);
-    expect(observations.has(name)).toBe(true);
-
-    const tooYoung = await run(new Date(NOW.getTime() + 60 * 60 * 1000));
-    expect(tooYoung.orphanVolumes.deleted).toBe(0);
-
-    const oldEnough = await run(new Date(NOW.getTime() + 2 * 60 * 60 * 1000));
-    expect(oldEnough.orphanVolumes.deleted).toBe(1);
-    expect(deleted).toEqual([name]);
-  });
-
-  test("does not delete an old volume on its first orphan observation", async () => {
-    const deleted: string[] = [];
-    const name = "cmux-home-abcdef123456-old-first-observation";
-    const observations = new Map<string, Date>();
-    const repo = withObservations(repository({
-      listLiveHomeVolumeNames: () => Effect.succeed([]),
-      isLiveHomeVolumeReferenced: () => Effect.succeed(false),
-      stuckProvisioningCandidates: () => Effect.succeed([]),
-    }), observations);
-    const provider = {
-      ...baseProvider(),
-      listVolumes: () => Effect.succeed([oldVolume(name)]),
-      deleteHomeVolume: (_provider: ProviderId, volumeName: string) =>
-        Effect.sync(() => deleted.push(volumeName)),
-    };
-
-    const result = await Effect.runPromise(
-      reapVmResources({ now: NOW, deleteVolumes: true }).pipe(
-        Effect.provide(workflowLayer(repo, provider)),
-      ),
-    );
-
-    expect(result.orphanVolumes.deleted).toBe(0);
-    expect(result.orphanVolumes.reported).toBe(1);
-    expect(observations.get(name)).toEqual(NOW);
-    expect(deleted).toEqual([]);
-  });
-
-  test("does not overwrite a provisioning row that changed while provider status was read", async () => {
-    const updates: Array<Record<string, unknown>> = [];
-    const row = vmRow({ providerVmId: "racing-sandbox" });
-    const repo = withObservations(repository({
-      listLiveHomeVolumeNames: () => Effect.succeed([]),
-      stuckProvisioningCandidates: () => Effect.succeed([row]),
-      markProviderObservedStatus: (update) => Effect.sync(() => {
-        updates.push(update as Record<string, unknown>);
-        return false;
+      getStatus: () => Effect.sync(() => {
+        statusReads += 1;
+        return "running" as const;
       }),
-    }));
-    const provider = {
-      ...baseProvider(),
       listVolumes: () => Effect.succeed([]),
-      getStatus: () => Effect.succeed("running" as const),
-    };
+    } as unknown as VmProviderGatewayShape;
 
-    const result = await Effect.runPromise(
-      reapVmResources({ now: NOW, deleteVolumes: false }).pipe(
-        Effect.provide(workflowLayer(repo, provider)),
-      ),
-    );
+    const result = await runReaper(repo, provider);
 
-    expect(result.stuckProvisioning.recovered).toBe(0);
-    expect(result.stuckProvisioning.skipped).toBe(1);
-    expect(updates).toEqual([
-      {
-        id: row.id,
-        providerVmId: "racing-sandbox",
-        status: "running",
-        expectedStatus: "provisioning",
-      },
-    ]);
+    expect(result.stuckProvisioning.candidates).toBe(1);
+    expect(result.stuckProvisioning.reported).toBe(1);
+    expect(result.stuckProvisioning.failed).toBe(0);
+    expect(result.stuckProvisioning.destroyed).toBe(0);
+    expect(statusReads).toBe(0);
+    expect(usage).toContainEqual(expect.objectContaining({
+      eventType: "vm.reaper.stuck_provisioning",
+      vmId: row.id,
+      metadata: expect.objectContaining({ reason: "age_over_threshold" }),
+    }));
   });
 
-  test("finalizes a provider-creating row after the terminal deadline", async () => {
-    const failures: Array<Record<string, unknown>> = [];
+  test("checks live references in bounded batches and excludes referenced volumes", async () => {
     const usage: Array<Record<string, unknown>> = [];
-    const row = vmRow({
-      providerVmId: "creating-too-long",
-      createdAt: new Date(NOW.getTime() - 5 * 60 * 60 * 1000),
-      updatedAt: new Date(NOW.getTime() - 5 * 60 * 60 * 1000),
-    });
-    const repo = withObservations(repository({
-      listLiveHomeVolumeNames: () => Effect.succeed([]),
-      stuckProvisioningCandidates: () => Effect.succeed([row]),
-      markProvisioningFailed: (input) => Effect.sync(() => {
-        failures.push(input as Record<string, unknown>);
-        return true;
+    const lookupBatches: string[][] = [];
+    const liveName = "cmux-home-aaaaaaaaaaaa-noble-wren";
+    const orphanName = "cmux-home-bbbbbbbbbbbb-noble-wren";
+    const repo = repository({
+      listLiveHomeVolumeNames: ({ volumeNames }) => Effect.sync(() => {
+        lookupBatches.push([...volumeNames]);
+        return volumeNames.filter((name) => name === liveName);
       }),
-      recordUsageEvent: (event) => Effect.sync(() => usage.push(event as Record<string, unknown>)),
-    }));
-    const provider = {
-      ...baseProvider(),
-      listVolumes: () => Effect.succeed([]),
-      getStatus: () => Effect.succeed("creating" as const),
-    };
-
-    const result = await Effect.runPromise(
-      reapVmResources({
-        now: NOW,
-        deleteVolumes: false,
-        stuckProvisioningTerminalAgeMs: 4 * 60 * 60 * 1000,
-      } as VmReaperOptions).pipe(
-        Effect.provide(workflowLayer(repo, provider)),
-      ),
-    );
-
-    expect(result.stuckProvisioning.failed).toBe(1);
-    expect(result.stuckProvisioning.skipped).toBe(0);
-    expect(failures).toContainEqual(expect.objectContaining({
-      id: row.id,
-      code: "provisioning_timeout",
-    }));
-    expect(usage).toContainEqual(expect.objectContaining({
-      eventType: "vm.reaper.stuck_provisioning_terminal",
-      vmId: row.id,
-    }));
-  });
-
-  test("filters live volumes before the limit and keeps reference lookups bounded", async () => {
-    const deleted: string[] = [];
-    const seenReferenceBatches: string[][] = [];
-    const liveNames = new Set(
-      ["aaaaaaaaaaaa", "bbbbbbbbbbbb", "cccccccccccc"].map((digest) =>
-        `cmux-home-${digest}-noble-wren`),
-    );
-    const orphanNames = [
-      "cmux-home-dddddddddddd-noble-wren",
-      "cmux-home-eeeeeeeeeeee-noble-wren",
-    ];
-    const volumes = [
-      ...Array.from(liveNames, (name) => oldVolume(name)),
-      ...orphanNames.map((name) => oldVolume(name)),
-    ];
-    const observations = new Map(orphanNames.map((name) => [
-      name,
-      new Date(NOW.getTime() - 60 * 60 * 1000),
-    ]));
-    const repo = withObservations(repository({
-      listLiveHomeVolumeNames: ((input?: { readonly volumeNames?: readonly string[] }) => {
-        const names = [...(input?.volumeNames ?? [])];
-        seenReferenceBatches.push(names);
-        return Effect.succeed(names.filter((name) => liveNames.has(name)));
-      }) as VmRepositoryShape["listLiveHomeVolumeNames"],
-      isLiveHomeVolumeReferenced: () => Effect.succeed(false),
       stuckProvisioningCandidates: () => Effect.succeed([]),
-    }), observations);
+      recordUsageEvent: (event) => Effect.sync(() => usage.push(event as Record<string, unknown>)),
+    });
     const provider = {
       ...baseProvider(),
-      listVolumes: () => Effect.succeed(volumes),
-      deleteHomeVolume: (_provider: ProviderId, name: string) => Effect.sync(() => deleted.push(name)),
-    };
+      listVolumes: () => Effect.succeed([
+        oldVolume(liveName),
+        oldVolume(orphanName),
+      ]),
+    } as unknown as VmProviderGatewayShape;
 
-    const result = await Effect.runPromise(
-      reapVmResources({ now: NOW, deleteVolumes: true, volumeLimit: 2 }).pipe(
-        Effect.provide(workflowLayer(repo, provider)),
-      ),
-    );
+    const result = await runReaper(repo, provider, { volumeLimit: 1, volumeScanLimit: 2 });
 
-    expect(result.orphanVolumes.deleted).toBe(2);
-    expect(deleted).toEqual(orphanNames);
-    expect(seenReferenceBatches.length).toBeGreaterThan(1);
-    expect(seenReferenceBatches.every((batch) => batch.length <= 2)).toBe(true);
+    expect(lookupBatches).toEqual([[liveName, orphanName]]);
+    expect(result.orphanVolumes.candidates).toBe(1);
+    expect(result.orphanVolumes.reported).toBe(1);
+    expect(usage[0]).toMatchObject({ metadata: { volumeName: orphanName } });
   });
 
-  test("bounds volume and provisioning batches and processes oldest first", async () => {
-    const deleted: string[] = [];
-    const statusCalls: string[] = [];
-    const volumes: VMVolume[] = Array.from({ length: 105 }, (_, index) => ({
-      name: `cmux-home-${index.toString(16).padStart(12, "0")}-noble-wren`,
-      createdAt: index + 1,
-      attachedTo: null,
-    }));
-    const rows = Array.from({ length: 105 }, (_, index) => vmRow({
-      id: `00000000-0000-4000-8000-${(index + 100).toString(16).padStart(12, "0")}`,
-      providerVmId: `stale-${index}`,
-      createdAt: new Date(NOW.getTime() - (index + 2) * 60 * 60 * 1000),
-      updatedAt: new Date(NOW.getTime() - (index + 2) * 60 * 60 * 1000),
-    }));
-    const observations = new Map(volumes.map((volume) => [
-      volume.name,
-      new Date(NOW.getTime() - 60 * 60 * 1000),
-    ]));
-    const repo = withObservations(repository({
+  test("follows provider cursors to avoid starving a batch and records scan coverage", async () => {
+    const usage: Array<Record<string, unknown>> = [];
+    const calls: Array<{ limit: number; cursor?: string }> = [];
+    const firstPage: VMVolume[] = [
+      oldVolume("cmux-home-aaaaaaaaaaaa-attached", { attachedTo: "sandbox:a", attachmentState: "attached" }),
+      oldVolume("not-a-machine-volume"),
+    ];
+    const secondPage: VMVolume[] = [oldVolume("cmux-home-bbbbbbbbbbbb-orphan")];
+    const repo = repository({
       listLiveHomeVolumeNames: () => Effect.succeed([]),
-      stuckProvisioningCandidates: ({ limit }) => Effect.succeed(rows.slice(0, limit)),
-      markProviderObservedStatus: ({ providerVmId }) => Effect.sync(() => {
-        statusCalls.push(providerVmId);
-        return true;
+      stuckProvisioningCandidates: () => Effect.succeed([]),
+      recordUsageEvent: (event) => Effect.sync(() => usage.push(event as Record<string, unknown>)),
+    });
+    const provider = {
+      ...baseProvider(),
+      listVolumes: (_provider: "blaxel", options: { limit: number; cursor?: string }): Effect.Effect<VMVolumeInventory> => Effect.sync(() => {
+        calls.push({ limit: options.limit, ...(options.cursor ? { cursor: options.cursor } : {}) });
+        return options.cursor
+          ? { volumes: secondPage, nextCursor: null }
+          : { volumes: firstPage, nextCursor: "page-2" };
       }),
-    }), observations);
+    } as unknown as VmProviderGatewayShape;
+
+    const result = await runReaper(repo, provider, { volumeLimit: 1, volumeScanLimit: 3 });
+
+    expect(calls).toEqual([
+      { limit: 3 },
+      { limit: 1, cursor: "page-2" },
+    ]);
+    expect(result.orphanVolumes.scanned).toBe(3);
+    expect(result.orphanVolumes.candidates).toBe(1);
+    expect(result.orphanVolumes.coveragePartial).toBe(false);
+    expect(usage).toContainEqual(expect.objectContaining({
+      eventType: "vm.reaper.orphan_volume",
+      metadata: expect.objectContaining({ volumeName: "cmux-home-bbbbbbbbbbbb-orphan" }),
+    }));
+  });
+
+  test("caps a legacy non-paginated inventory and marks coverage partial", async () => {
+    const usage: Array<Record<string, unknown>> = [];
+    const scannedNames: string[][] = [];
+    const volumes = Array.from({ length: 20 }, (_, index) => oldVolume(
+      `cmux-home-${index.toString(16).padStart(12, "0")}-noble-wren`,
+    ));
+    const repo = repository({
+      listLiveHomeVolumeNames: ({ volumeNames }) => Effect.sync(() => {
+        scannedNames.push([...volumeNames]);
+        return [];
+      }),
+      stuckProvisioningCandidates: () => Effect.succeed([]),
+      recordUsageEvent: (event) => Effect.sync(() => usage.push(event as Record<string, unknown>)),
+    });
     const provider = {
       ...baseProvider(),
       listVolumes: () => Effect.succeed(volumes),
-      deleteHomeVolume: (_provider: ProviderId, name: string) => Effect.sync(() => deleted.push(name)),
-      getStatus: () => Effect.succeed("running" as const),
-    };
+    } as unknown as VmProviderGatewayShape;
 
-    const result = await Effect.runPromise(
-      reapVmResources({ now: NOW, deleteVolumes: true }).pipe(
-        Effect.provide(workflowLayer(repo, provider)),
-      ),
-    );
+    const result = await runReaper(repo, provider, {
+      volumeLimit: 2,
+      volumeScanLimit: 3,
+    });
 
-    expect(result.orphanVolumes.deleted).toBe(100);
-    expect(deleted).toHaveLength(100);
-    expect(deleted[0]).toBe(volumes[0]?.name);
-    expect(result.stuckProvisioning.recovered).toBe(100);
-    expect(statusCalls).toHaveLength(100);
-    expect(statusCalls[0]).toBe("stale-0");
+    expect(result.orphanVolumes.scanned).toBe(3);
+    expect(result.orphanVolumes.candidates).toBe(2);
+    expect(result.orphanVolumes.reported).toBe(2);
+    expect(result.orphanVolumes.coveragePartial).toBe(true);
+    expect(scannedNames.flat().length).toBe(3);
+    expect(usage).toHaveLength(2);
   });
 });

--- a/web/tests/vm-reaper.test.ts
+++ b/web/tests/vm-reaper.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import type { VMVolume } from "../services/vms/drivers";
+import type { ProviderId, VMVolume } from "../services/vms/drivers";
 import { VmProviderGateway, type VmProviderGatewayShape } from "../services/vms/providerGateway";
 import {
   VmRepository,
@@ -12,10 +12,6 @@ import { VmProviderOperationError } from "../services/vms/errors";
 import { reapVmResources } from "../services/vms/workflows";
 
 const NOW = new Date("2026-08-31T20:00:00.000Z");
-
-function providerLayer(provider: VmProviderGatewayShape) {
-  return Layer.succeed(VmProviderGateway, provider);
-}
 
 function workflowLayer(repo: VmRepositoryShape, provider: VmProviderGatewayShape) {
   return Layer.mergeAll(
@@ -67,6 +63,10 @@ function baseRepository(): VmRepositoryShape {
   } as unknown as VmRepositoryShape;
 }
 
+function repository(overrides: Partial<VmRepositoryShape> = {}): VmRepositoryShape {
+  return { ...baseRepository(), ...overrides };
+}
+
 function vmRow(overrides: Partial<CloudVmRow> = {}): CloudVmRow {
   return {
     id: "00000000-0000-4000-8000-000000000001",
@@ -108,14 +108,15 @@ describe("Cloud VM reaper", () => {
       { name: "cmux-home-abcdef123456-bold-fox", createdAt: 3, attachedTo: "sandbox:bold-fox" },
       { name: "user-home-noble-wren", createdAt: 4, attachedTo: null },
     ];
-    const repo = baseRepository();
-    repo.listLiveHomeVolumeNames = () => Effect.succeed([]);
-    repo.stuckProvisioningCandidates = () => Effect.succeed([]);
-    repo.recordUsageEvent = (event) => Effect.sync(() => usage.push(event as Record<string, unknown>));
+    const repo = repository({
+      listLiveHomeVolumeNames: () => Effect.succeed([]),
+      stuckProvisioningCandidates: () => Effect.succeed([]),
+      recordUsageEvent: (event) => Effect.sync(() => usage.push(event as Record<string, unknown>)),
+    });
     const provider = {
       ...baseProvider(),
       listVolumes: () => Effect.succeed(volumes),
-      deleteHomeVolume: (_provider, name) => Effect.sync(() => deleted.push(name)),
+      deleteHomeVolume: (_provider: ProviderId, name: string) => Effect.sync(() => deleted.push(name)),
     };
 
     const result = await Effect.runPromise(
@@ -141,15 +142,16 @@ describe("Cloud VM reaper", () => {
 
   test("deletes only a free machine-owned volume when delete mode is enabled", async () => {
     const deleted: string[] = [];
-    const repo = baseRepository();
-    repo.listLiveHomeVolumeNames = () => Effect.succeed([]);
-    repo.stuckProvisioningCandidates = () => Effect.succeed([]);
+    const repo = repository({
+      listLiveHomeVolumeNames: () => Effect.succeed([]),
+      stuckProvisioningCandidates: () => Effect.succeed([]),
+    });
     const provider = {
       ...baseProvider(),
       listVolumes: () => Effect.succeed([
         { name: "cmux-home-abcdef123456-noble-wren", createdAt: 2, attachedTo: null },
       ]),
-      deleteHomeVolume: (_provider, name) => Effect.sync(() => deleted.push(name)),
+      deleteHomeVolume: (_provider: ProviderId, name: string) => Effect.sync(() => deleted.push(name)),
     };
 
     const result = await Effect.runPromise(
@@ -165,15 +167,16 @@ describe("Cloud VM reaper", () => {
 
   test("skips a machine volume referenced by a live VM row", async () => {
     const deleted: string[] = [];
-    const repo = baseRepository();
-    repo.listLiveHomeVolumeNames = () => Effect.succeed(["cmux-home-abcdef123456-noble-wren"]);
-    repo.stuckProvisioningCandidates = () => Effect.succeed([]);
+    const repo = repository({
+      listLiveHomeVolumeNames: () => Effect.succeed(["cmux-home-abcdef123456-noble-wren"]),
+      stuckProvisioningCandidates: () => Effect.succeed([]),
+    });
     const provider = {
       ...baseProvider(),
       listVolumes: () => Effect.succeed([
         { name: "cmux-home-abcdef123456-noble-wren", createdAt: 2, attachedTo: null },
       ]),
-      deleteHomeVolume: (_provider, name) => Effect.sync(() => deleted.push(name)),
+      deleteHomeVolume: (_provider: ProviderId, name: string) => Effect.sync(() => deleted.push(name)),
     };
 
     const result = await Effect.runPromise(
@@ -191,18 +194,19 @@ describe("Cloud VM reaper", () => {
     const updates: Array<Record<string, unknown>> = [];
     const usage: Array<Record<string, unknown>> = [];
     const row = vmRow({ providerVmId: "stale-sandbox" });
-    const repo = baseRepository();
-    repo.listLiveHomeVolumeNames = () => Effect.succeed([]);
-    repo.stuckProvisioningCandidates = () => Effect.succeed([row]);
-    repo.markProviderObservedStatus = (update) => Effect.sync(() => {
-      updates.push(update as Record<string, unknown>);
-      return true;
+    const repo = repository({
+      listLiveHomeVolumeNames: () => Effect.succeed([]),
+      stuckProvisioningCandidates: () => Effect.succeed([row]),
+      markProviderObservedStatus: (update) => Effect.sync(() => {
+        updates.push(update as Record<string, unknown>);
+        return true;
+      }),
+      recordUsageEvent: (event) => Effect.sync(() => usage.push(event as Record<string, unknown>)),
     });
-    repo.recordUsageEvent = (event) => Effect.sync(() => usage.push(event as Record<string, unknown>));
     const provider = {
       ...baseProvider(),
       listVolumes: () => Effect.succeed([]),
-      getStatus: (_provider, vmId) => Effect.fail(missingProviderError(vmId)),
+      getStatus: (_provider: ProviderId, vmId: string) => Effect.fail(missingProviderError(vmId)),
     };
 
     const result = await Effect.runPromise(
@@ -227,14 +231,15 @@ describe("Cloud VM reaper", () => {
     const failures: Array<Record<string, unknown>> = [];
     const usage: Array<Record<string, unknown>> = [];
     const row = vmRow({ providerVmId: null });
-    const repo = baseRepository();
-    repo.listLiveHomeVolumeNames = () => Effect.succeed([]);
-    repo.stuckProvisioningCandidates = () => Effect.succeed([row]);
-    repo.markProvisioningFailed = (input) => Effect.sync(() => {
-      failures.push(input as Record<string, unknown>);
-      return true;
+    const repo = repository({
+      listLiveHomeVolumeNames: () => Effect.succeed([]),
+      stuckProvisioningCandidates: () => Effect.succeed([row]),
+      markProvisioningFailed: (input) => Effect.sync(() => {
+        failures.push(input as Record<string, unknown>);
+        return true;
+      }),
+      recordUsageEvent: (event) => Effect.sync(() => usage.push(event as Record<string, unknown>)),
     });
-    repo.recordUsageEvent = (event) => Effect.sync(() => usage.push(event as Record<string, unknown>));
     const provider = {
       ...baseProvider(),
       listVolumes: () => Effect.succeed([]),
@@ -271,17 +276,18 @@ describe("Cloud VM reaper", () => {
       createdAt: new Date(NOW.getTime() - (index + 2) * 60 * 60 * 1000),
       updatedAt: new Date(NOW.getTime() - (index + 2) * 60 * 60 * 1000),
     }));
-    const repo = baseRepository();
-    repo.listLiveHomeVolumeNames = () => Effect.succeed([]);
-    repo.stuckProvisioningCandidates = ({ limit }) => Effect.succeed(rows.slice(0, limit));
-    repo.markProviderObservedStatus = ({ providerVmId }) => Effect.sync(() => {
-      statusCalls.push(providerVmId);
-      return true;
+    const repo = repository({
+      listLiveHomeVolumeNames: () => Effect.succeed([]),
+      stuckProvisioningCandidates: ({ limit }) => Effect.succeed(rows.slice(0, limit)),
+      markProviderObservedStatus: ({ providerVmId }) => Effect.sync(() => {
+        statusCalls.push(providerVmId);
+        return true;
+      }),
     });
     const provider = {
       ...baseProvider(),
       listVolumes: () => Effect.succeed(volumes),
-      deleteHomeVolume: (_provider, name) => Effect.sync(() => deleted.push(name)),
+      deleteHomeVolume: (_provider: ProviderId, name: string) => Effect.sync(() => deleted.push(name)),
       getStatus: () => Effect.succeed("running" as const),
     };
 

--- a/web/tests/vm-reaper.test.ts
+++ b/web/tests/vm-reaper.test.ts
@@ -68,38 +68,22 @@ function repository(overrides: Partial<VmRepositoryShape> = {}): VmRepositorySha
   return { ...baseRepository(), ...overrides };
 }
 
-type ReaperObservation = {
-  readonly volumeName: string;
-  readonly firstObservedAt: Date;
-};
-
-type ReaperRepositoryExtensions = {
-  readonly listOrphanVolumeObservations: (input: {
-    readonly provider: ProviderId;
-    readonly volumeNames: readonly string[];
-  }) => Effect.Effect<readonly ReaperObservation[], never>;
-  readonly recordOrphanVolumeObservation: (input: {
-    readonly provider: ProviderId;
-    readonly volumeName: string;
-    readonly observedAt: Date;
-  }) => Effect.Effect<void, never>;
-};
-
 function withObservations(
   repo: VmRepositoryShape,
   observations: Map<string, Date> = new Map(),
 ): VmRepositoryShape {
-  const extended = repo as VmRepositoryShape & ReaperRepositoryExtensions;
-  extended.listOrphanVolumeObservations = ({ volumeNames }) => Effect.succeed(
-    volumeNames.flatMap((volumeName) => {
-      const firstObservedAt = observations.get(volumeName);
-      return firstObservedAt ? [{ volumeName, firstObservedAt }] : [];
+  return {
+    ...repo,
+    listOrphanVolumeObservations: ({ volumeNames }) => Effect.succeed(
+      volumeNames.flatMap((volumeName) => {
+        const firstObservedAt = observations.get(volumeName);
+        return firstObservedAt ? [{ volumeName, firstObservedAt }] : [];
+      }),
+    ),
+    recordOrphanVolumeObservation: ({ volumeName, observedAt }) => Effect.sync(() => {
+      if (!observations.has(volumeName)) observations.set(volumeName, observedAt);
     }),
-  );
-  extended.recordOrphanVolumeObservation = ({ volumeName, observedAt }) => Effect.sync(() => {
-    if (!observations.has(volumeName)) observations.set(volumeName, observedAt);
-  });
-  return extended;
+  };
 }
 
 function oldVolume(name: string, ageMs = 3 * 60 * 60 * 1000): VMVolume {
@@ -343,6 +327,34 @@ describe("Cloud VM reaper", () => {
     const oldEnough = await run(new Date(NOW.getTime() + 2 * 60 * 60 * 1000));
     expect(oldEnough.orphanVolumes.deleted).toBe(1);
     expect(deleted).toEqual([name]);
+  });
+
+  test("does not delete an old volume on its first orphan observation", async () => {
+    const deleted: string[] = [];
+    const name = "cmux-home-abcdef123456-old-first-observation";
+    const observations = new Map<string, Date>();
+    const repo = withObservations(repository({
+      listLiveHomeVolumeNames: () => Effect.succeed([]),
+      isLiveHomeVolumeReferenced: () => Effect.succeed(false),
+      stuckProvisioningCandidates: () => Effect.succeed([]),
+    }), observations);
+    const provider = {
+      ...baseProvider(),
+      listVolumes: () => Effect.succeed([oldVolume(name)]),
+      deleteHomeVolume: (_provider: ProviderId, volumeName: string) =>
+        Effect.sync(() => deleted.push(volumeName)),
+    };
+
+    const result = await Effect.runPromise(
+      reapVmResources({ now: NOW, deleteVolumes: true }).pipe(
+        Effect.provide(workflowLayer(repo, provider)),
+      ),
+    );
+
+    expect(result.orphanVolumes.deleted).toBe(0);
+    expect(result.orphanVolumes.reported).toBe(1);
+    expect(observations.get(name)).toEqual(NOW);
+    expect(deleted).toEqual([]);
   });
 
   test("does not overwrite a provisioning row that changed while provider status was read", async () => {

--- a/web/tests/vm-reaper.test.ts
+++ b/web/tests/vm-reaper.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../services/vms/repository";
 import { VmProviderOperationError } from "../services/vms/errors";
 import { reapVmResources } from "../services/vms/workflows";
+import type { VmReaperOptions } from "../services/vms/reaper";
 
 const NOW = new Date("2026-08-31T20:00:00.000Z");
 
@@ -67,6 +68,48 @@ function repository(overrides: Partial<VmRepositoryShape> = {}): VmRepositorySha
   return { ...baseRepository(), ...overrides };
 }
 
+type ReaperObservation = {
+  readonly volumeName: string;
+  readonly firstObservedAt: Date;
+};
+
+type ReaperRepositoryExtensions = {
+  readonly listOrphanVolumeObservations: (input: {
+    readonly provider: ProviderId;
+    readonly volumeNames: readonly string[];
+  }) => Effect.Effect<readonly ReaperObservation[], never>;
+  readonly recordOrphanVolumeObservation: (input: {
+    readonly provider: ProviderId;
+    readonly volumeName: string;
+    readonly observedAt: Date;
+  }) => Effect.Effect<void, never>;
+};
+
+function withObservations(
+  repo: VmRepositoryShape,
+  observations: Map<string, Date> = new Map(),
+): VmRepositoryShape {
+  const extended = repo as VmRepositoryShape & ReaperRepositoryExtensions;
+  extended.listOrphanVolumeObservations = ({ volumeNames }) => Effect.succeed(
+    volumeNames.flatMap((volumeName) => {
+      const firstObservedAt = observations.get(volumeName);
+      return firstObservedAt ? [{ volumeName, firstObservedAt }] : [];
+    }),
+  );
+  extended.recordOrphanVolumeObservation = ({ volumeName, observedAt }) => Effect.sync(() => {
+    if (!observations.has(volumeName)) observations.set(volumeName, observedAt);
+  });
+  return extended;
+}
+
+function oldVolume(name: string, ageMs = 3 * 60 * 60 * 1000): VMVolume {
+  return {
+    name,
+    createdAt: NOW.getTime() - ageMs,
+    attachedTo: null,
+  };
+}
+
 function vmRow(overrides: Partial<CloudVmRow> = {}): CloudVmRow {
   return {
     id: "00000000-0000-4000-8000-000000000001",
@@ -102,17 +145,18 @@ describe("Cloud VM reaper", () => {
   test("filters shared/user volumes and reports an unattached machine volume without deleting", async () => {
     const deleted: string[] = [];
     const usage: Array<Record<string, unknown>> = [];
+    const observations = new Map<string, Date>();
     const volumes: VMVolume[] = [
       { name: "cmux-home-abcdef123456", createdAt: 1, attachedTo: null },
       { name: "cmux-home-abcdef123456-noble-wren", createdAt: 2, attachedTo: null },
       { name: "cmux-home-abcdef123456-bold-fox", createdAt: 3, attachedTo: "sandbox:bold-fox" },
       { name: "user-home-noble-wren", createdAt: 4, attachedTo: null },
     ];
-    const repo = repository({
+    const repo = withObservations(repository({
       listLiveHomeVolumeNames: () => Effect.succeed([]),
       stuckProvisioningCandidates: () => Effect.succeed([]),
       recordUsageEvent: (event) => Effect.sync(() => usage.push(event as Record<string, unknown>)),
-    });
+    }), observations);
     const provider = {
       ...baseProvider(),
       listVolumes: () => Effect.succeed(volumes),
@@ -126,7 +170,7 @@ describe("Cloud VM reaper", () => {
     );
 
     expect(result.reportOnly).toBe(true);
-    expect(result.orphanVolumes.candidates).toBe(2);
+    expect(result.orphanVolumes.candidates).toBe(1);
     expect(result.orphanVolumes.reported).toBe(1);
     expect(result.orphanVolumes.skipped).toBe(1);
     expect(deleted).toEqual([]);
@@ -142,15 +186,15 @@ describe("Cloud VM reaper", () => {
 
   test("deletes only a free machine-owned volume when delete mode is enabled", async () => {
     const deleted: string[] = [];
-    const repo = repository({
+    const name = "cmux-home-abcdef123456-noble-wren";
+    const observations = new Map([[name, new Date(NOW.getTime() - 60 * 60 * 1000)]]);
+    const repo = withObservations(repository({
       listLiveHomeVolumeNames: () => Effect.succeed([]),
       stuckProvisioningCandidates: () => Effect.succeed([]),
-    });
+    }), observations);
     const provider = {
       ...baseProvider(),
-      listVolumes: () => Effect.succeed([
-        { name: "cmux-home-abcdef123456-noble-wren", createdAt: 2, attachedTo: null },
-      ]),
+      listVolumes: () => Effect.succeed([oldVolume(name)]),
       deleteHomeVolume: (_provider: ProviderId, name: string) => Effect.sync(() => deleted.push(name)),
     };
 
@@ -167,10 +211,10 @@ describe("Cloud VM reaper", () => {
 
   test("skips a machine volume referenced by a live VM row", async () => {
     const deleted: string[] = [];
-    const repo = repository({
+    const repo = withObservations(repository({
       listLiveHomeVolumeNames: () => Effect.succeed(["cmux-home-abcdef123456-noble-wren"]),
       stuckProvisioningCandidates: () => Effect.succeed([]),
-    });
+    }));
     const provider = {
       ...baseProvider(),
       listVolumes: () => Effect.succeed([
@@ -194,7 +238,7 @@ describe("Cloud VM reaper", () => {
     const updates: Array<Record<string, unknown>> = [];
     const usage: Array<Record<string, unknown>> = [];
     const row = vmRow({ providerVmId: "stale-sandbox" });
-    const repo = repository({
+    const repo = withObservations(repository({
       listLiveHomeVolumeNames: () => Effect.succeed([]),
       stuckProvisioningCandidates: () => Effect.succeed([row]),
       markProviderObservedStatus: (update) => Effect.sync(() => {
@@ -202,7 +246,7 @@ describe("Cloud VM reaper", () => {
         return true;
       }),
       recordUsageEvent: (event) => Effect.sync(() => usage.push(event as Record<string, unknown>)),
-    });
+    }));
     const provider = {
       ...baseProvider(),
       listVolumes: () => Effect.succeed([]),
@@ -218,7 +262,7 @@ describe("Cloud VM reaper", () => {
     expect(result.stuckProvisioning.destroyed).toBe(1);
     expect(result.stuckProvisioning.failed).toBe(0);
     expect(updates).toEqual([
-      { id: row.id, providerVmId: "stale-sandbox", status: "destroyed" },
+      { id: row.id, providerVmId: "stale-sandbox", status: "destroyed", expectedStatus: "provisioning" },
     ]);
     expect(usage).toContainEqual(expect.objectContaining({
       eventType: "vm.destroyed",
@@ -231,7 +275,7 @@ describe("Cloud VM reaper", () => {
     const failures: Array<Record<string, unknown>> = [];
     const usage: Array<Record<string, unknown>> = [];
     const row = vmRow({ providerVmId: null });
-    const repo = repository({
+    const repo = withObservations(repository({
       listLiveHomeVolumeNames: () => Effect.succeed([]),
       stuckProvisioningCandidates: () => Effect.succeed([row]),
       markProvisioningFailed: (input) => Effect.sync(() => {
@@ -239,7 +283,7 @@ describe("Cloud VM reaper", () => {
         return true;
       }),
       recordUsageEvent: (event) => Effect.sync(() => usage.push(event as Record<string, unknown>)),
-    });
+    }));
     const provider = {
       ...baseProvider(),
       listVolumes: () => Effect.succeed([]),
@@ -262,6 +306,171 @@ describe("Cloud VM reaper", () => {
     }));
   });
 
+  test("does not delete a newly observed volume until it is old and observed by a prior run", async () => {
+    const deleted: string[] = [];
+    const name = "cmux-home-abcdef123456-new-volume";
+    const observations = new Map<string, Date>();
+    const volume: VMVolume = {
+      name,
+      createdAt: NOW.getTime() - 30 * 60 * 1000,
+      attachedTo: null,
+    };
+    const repo = withObservations(repository({
+      listLiveHomeVolumeNames: () => Effect.succeed([]),
+      isLiveHomeVolumeReferenced: () => Effect.succeed(false),
+      stuckProvisioningCandidates: () => Effect.succeed([]),
+    }), observations);
+    const provider = {
+      ...baseProvider(),
+      listVolumes: () => Effect.succeed([volume]),
+      deleteHomeVolume: (_provider: ProviderId, volumeName: string) =>
+        Effect.sync(() => deleted.push(volumeName)),
+    };
+    const run = (now: Date) => Effect.runPromise(
+      reapVmResources({ now, deleteVolumes: true } as VmReaperOptions).pipe(
+        Effect.provide(workflowLayer(repo, provider)),
+      ),
+    );
+
+    const first = await run(NOW);
+    expect(first.orphanVolumes.deleted).toBe(0);
+    expect(first.orphanVolumes.reported).toBe(1);
+    expect(observations.has(name)).toBe(true);
+
+    const tooYoung = await run(new Date(NOW.getTime() + 60 * 60 * 1000));
+    expect(tooYoung.orphanVolumes.deleted).toBe(0);
+
+    const oldEnough = await run(new Date(NOW.getTime() + 2 * 60 * 60 * 1000));
+    expect(oldEnough.orphanVolumes.deleted).toBe(1);
+    expect(deleted).toEqual([name]);
+  });
+
+  test("does not overwrite a provisioning row that changed while provider status was read", async () => {
+    const updates: Array<Record<string, unknown>> = [];
+    const row = vmRow({ providerVmId: "racing-sandbox" });
+    const repo = withObservations(repository({
+      listLiveHomeVolumeNames: () => Effect.succeed([]),
+      stuckProvisioningCandidates: () => Effect.succeed([row]),
+      markProviderObservedStatus: (update) => Effect.sync(() => {
+        updates.push(update as Record<string, unknown>);
+        return false;
+      }),
+    }));
+    const provider = {
+      ...baseProvider(),
+      listVolumes: () => Effect.succeed([]),
+      getStatus: () => Effect.succeed("running" as const),
+    };
+
+    const result = await Effect.runPromise(
+      reapVmResources({ now: NOW, deleteVolumes: false }).pipe(
+        Effect.provide(workflowLayer(repo, provider)),
+      ),
+    );
+
+    expect(result.stuckProvisioning.recovered).toBe(0);
+    expect(result.stuckProvisioning.skipped).toBe(1);
+    expect(updates).toEqual([
+      {
+        id: row.id,
+        providerVmId: "racing-sandbox",
+        status: "running",
+        expectedStatus: "provisioning",
+      },
+    ]);
+  });
+
+  test("finalizes a provider-creating row after the terminal deadline", async () => {
+    const failures: Array<Record<string, unknown>> = [];
+    const usage: Array<Record<string, unknown>> = [];
+    const row = vmRow({
+      providerVmId: "creating-too-long",
+      createdAt: new Date(NOW.getTime() - 5 * 60 * 60 * 1000),
+      updatedAt: new Date(NOW.getTime() - 5 * 60 * 60 * 1000),
+    });
+    const repo = withObservations(repository({
+      listLiveHomeVolumeNames: () => Effect.succeed([]),
+      stuckProvisioningCandidates: () => Effect.succeed([row]),
+      markProvisioningFailed: (input) => Effect.sync(() => {
+        failures.push(input as Record<string, unknown>);
+        return true;
+      }),
+      recordUsageEvent: (event) => Effect.sync(() => usage.push(event as Record<string, unknown>)),
+    }));
+    const provider = {
+      ...baseProvider(),
+      listVolumes: () => Effect.succeed([]),
+      getStatus: () => Effect.succeed("creating" as const),
+    };
+
+    const result = await Effect.runPromise(
+      reapVmResources({
+        now: NOW,
+        deleteVolumes: false,
+        stuckProvisioningTerminalAgeMs: 4 * 60 * 60 * 1000,
+      } as VmReaperOptions).pipe(
+        Effect.provide(workflowLayer(repo, provider)),
+      ),
+    );
+
+    expect(result.stuckProvisioning.failed).toBe(1);
+    expect(result.stuckProvisioning.skipped).toBe(0);
+    expect(failures).toContainEqual(expect.objectContaining({
+      id: row.id,
+      code: "provisioning_timeout",
+    }));
+    expect(usage).toContainEqual(expect.objectContaining({
+      eventType: "vm.reaper.stuck_provisioning_terminal",
+      vmId: row.id,
+    }));
+  });
+
+  test("filters live volumes before the limit and keeps reference lookups bounded", async () => {
+    const deleted: string[] = [];
+    const seenReferenceBatches: string[][] = [];
+    const liveNames = new Set(
+      ["aaaaaaaaaaaa", "bbbbbbbbbbbb", "cccccccccccc"].map((digest) =>
+        `cmux-home-${digest}-noble-wren`),
+    );
+    const orphanNames = [
+      "cmux-home-dddddddddddd-noble-wren",
+      "cmux-home-eeeeeeeeeeee-noble-wren",
+    ];
+    const volumes = [
+      ...Array.from(liveNames, (name) => oldVolume(name)),
+      ...orphanNames.map((name) => oldVolume(name)),
+    ];
+    const observations = new Map(orphanNames.map((name) => [
+      name,
+      new Date(NOW.getTime() - 60 * 60 * 1000),
+    ]));
+    const repo = withObservations(repository({
+      listLiveHomeVolumeNames: ((input?: { readonly volumeNames?: readonly string[] }) => {
+        const names = [...(input?.volumeNames ?? [])];
+        seenReferenceBatches.push(names);
+        return Effect.succeed(names.filter((name) => liveNames.has(name)));
+      }) as VmRepositoryShape["listLiveHomeVolumeNames"],
+      isLiveHomeVolumeReferenced: () => Effect.succeed(false),
+      stuckProvisioningCandidates: () => Effect.succeed([]),
+    }), observations);
+    const provider = {
+      ...baseProvider(),
+      listVolumes: () => Effect.succeed(volumes),
+      deleteHomeVolume: (_provider: ProviderId, name: string) => Effect.sync(() => deleted.push(name)),
+    };
+
+    const result = await Effect.runPromise(
+      reapVmResources({ now: NOW, deleteVolumes: true, volumeLimit: 2 }).pipe(
+        Effect.provide(workflowLayer(repo, provider)),
+      ),
+    );
+
+    expect(result.orphanVolumes.deleted).toBe(2);
+    expect(deleted).toEqual(orphanNames);
+    expect(seenReferenceBatches.length).toBeGreaterThan(1);
+    expect(seenReferenceBatches.every((batch) => batch.length <= 2)).toBe(true);
+  });
+
   test("bounds volume and provisioning batches and processes oldest first", async () => {
     const deleted: string[] = [];
     const statusCalls: string[] = [];
@@ -276,14 +485,18 @@ describe("Cloud VM reaper", () => {
       createdAt: new Date(NOW.getTime() - (index + 2) * 60 * 60 * 1000),
       updatedAt: new Date(NOW.getTime() - (index + 2) * 60 * 60 * 1000),
     }));
-    const repo = repository({
+    const observations = new Map(volumes.map((volume) => [
+      volume.name,
+      new Date(NOW.getTime() - 60 * 60 * 1000),
+    ]));
+    const repo = withObservations(repository({
       listLiveHomeVolumeNames: () => Effect.succeed([]),
       stuckProvisioningCandidates: ({ limit }) => Effect.succeed(rows.slice(0, limit)),
       markProviderObservedStatus: ({ providerVmId }) => Effect.sync(() => {
         statusCalls.push(providerVmId);
         return true;
       }),
-    });
+    }), observations);
     const provider = {
       ...baseProvider(),
       listVolumes: () => Effect.succeed(volumes),

--- a/web/tests/vm-reaper.test.ts
+++ b/web/tests/vm-reaper.test.ts
@@ -1,0 +1,301 @@
+import { describe, expect, test } from "bun:test";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import type { VMVolume } from "../services/vms/drivers";
+import { VmProviderGateway, type VmProviderGatewayShape } from "../services/vms/providerGateway";
+import {
+  VmRepository,
+  type CloudVmRow,
+  type VmRepositoryShape,
+} from "../services/vms/repository";
+import { VmProviderOperationError } from "../services/vms/errors";
+import { reapVmResources } from "../services/vms/workflows";
+
+const NOW = new Date("2026-08-31T20:00:00.000Z");
+
+function providerLayer(provider: VmProviderGatewayShape) {
+  return Layer.succeed(VmProviderGateway, provider);
+}
+
+function workflowLayer(repo: VmRepositoryShape, provider: VmProviderGatewayShape) {
+  return Layer.mergeAll(
+    Layer.succeed(VmRepository, repo),
+    Layer.succeed(VmProviderGateway, provider),
+  );
+}
+
+function baseProvider(): VmProviderGatewayShape {
+  return {
+    create: () => Effect.die("unused"),
+    destroy: () => Effect.void,
+    exec: () => Effect.die("unused"),
+    openAttach: () => Effect.die("unused"),
+    openSSH: () => Effect.die("unused"),
+    revokeSSHIdentity: () => Effect.void,
+  } as unknown as VmProviderGatewayShape;
+}
+
+function baseRepository(): VmRepositoryShape {
+  return {
+    listUserVms: () => Effect.succeed([]),
+    claimBillingGrant: () => Effect.succeed({ kind: "already_claimed" }),
+    markBillingGrantApplied: () => Effect.void,
+    deleteBillingGrant: () => Effect.void,
+    beginCreate: () => Effect.die("unused"),
+    beginBaseOpen: () => Effect.die("unused"),
+    beginBaseReset: () => Effect.die("unused"),
+    markBaseCreateRunning: () => Effect.die("unused"),
+    markBaseCreateFailed: () => Effect.void,
+    activeLimitCandidates: () => Effect.succeed([]),
+    reservePausedResume: () => Effect.die("unused"),
+    reconciliationCandidates: () => Effect.succeed([]),
+    markProviderObservedStatus: () => Effect.succeed(true),
+    setDisplayName: () => Effect.succeed(true),
+    markCreateRunning: () => Effect.die("unused"),
+    markCreateFailed: () => Effect.void,
+    hasOwnedSnapshot: () => Effect.succeed(false),
+    findUserVm: () => Effect.succeed(null),
+    markDestroyed: () => Effect.void,
+    recordLease: () => Effect.void,
+    accountDeletionIdentityLeases: () => Effect.succeed([]),
+    listVmSessions: () => Effect.succeed([]),
+    upsertVmSession: () => Effect.die("unused"),
+    activeIdentityLeases: () => Effect.succeed([]),
+    markLeasesRevoked: () => Effect.void,
+    recordUsageEvent: () => Effect.void,
+    recordUsageEvents: () => Effect.void,
+  } as unknown as VmRepositoryShape;
+}
+
+function vmRow(overrides: Partial<CloudVmRow> = {}): CloudVmRow {
+  return {
+    id: "00000000-0000-4000-8000-000000000001",
+    userId: "user-reaper",
+    billingTeamId: "team-reaper",
+    billingPlanId: "pro",
+    provider: "blaxel",
+    providerVmId: "noble-wren",
+    displayName: null,
+    imageId: "blaxel/base-image:latest",
+    imageVersion: null,
+    status: "provisioning",
+    idempotencyKey: "reaper-key",
+    createdAt: new Date(NOW.getTime() - 2 * 60 * 60 * 1000),
+    updatedAt: new Date(NOW.getTime() - 2 * 60 * 60 * 1000),
+    destroyedAt: null,
+    failureCode: null,
+    failureMessage: null,
+    providerMetadata: {},
+    ...overrides,
+  };
+}
+
+function missingProviderError(vmId: string): VmProviderOperationError {
+  return new VmProviderOperationError({
+    provider: "blaxel",
+    operation: "getStatus",
+    cause: new Error(`sandbox ${vmId} -> 404 not found`),
+  });
+}
+
+describe("Cloud VM reaper", () => {
+  test("filters shared/user volumes and reports an unattached machine volume without deleting", async () => {
+    const deleted: string[] = [];
+    const usage: Array<Record<string, unknown>> = [];
+    const volumes: VMVolume[] = [
+      { name: "cmux-home-abcdef123456", createdAt: 1, attachedTo: null },
+      { name: "cmux-home-abcdef123456-noble-wren", createdAt: 2, attachedTo: null },
+      { name: "cmux-home-abcdef123456-bold-fox", createdAt: 3, attachedTo: "sandbox:bold-fox" },
+      { name: "user-home-noble-wren", createdAt: 4, attachedTo: null },
+    ];
+    const repo = baseRepository();
+    repo.listLiveHomeVolumeNames = () => Effect.succeed([]);
+    repo.stuckProvisioningCandidates = () => Effect.succeed([]);
+    repo.recordUsageEvent = (event) => Effect.sync(() => usage.push(event as Record<string, unknown>));
+    const provider = {
+      ...baseProvider(),
+      listVolumes: () => Effect.succeed(volumes),
+      deleteHomeVolume: (_provider, name) => Effect.sync(() => deleted.push(name)),
+    };
+
+    const result = await Effect.runPromise(
+      reapVmResources({ now: NOW, deleteVolumes: false }).pipe(
+        Effect.provide(workflowLayer(repo, provider)),
+      ),
+    );
+
+    expect(result.reportOnly).toBe(true);
+    expect(result.orphanVolumes.candidates).toBe(2);
+    expect(result.orphanVolumes.reported).toBe(1);
+    expect(result.orphanVolumes.skipped).toBe(1);
+    expect(deleted).toEqual([]);
+    expect(usage).toHaveLength(1);
+    expect(usage[0]).toMatchObject({
+      eventType: "vm.reaper.orphan_volume",
+      metadata: {
+        volumeName: "cmux-home-abcdef123456-noble-wren",
+        mode: "report",
+      },
+    });
+  });
+
+  test("deletes only a free machine-owned volume when delete mode is enabled", async () => {
+    const deleted: string[] = [];
+    const repo = baseRepository();
+    repo.listLiveHomeVolumeNames = () => Effect.succeed([]);
+    repo.stuckProvisioningCandidates = () => Effect.succeed([]);
+    const provider = {
+      ...baseProvider(),
+      listVolumes: () => Effect.succeed([
+        { name: "cmux-home-abcdef123456-noble-wren", createdAt: 2, attachedTo: null },
+      ]),
+      deleteHomeVolume: (_provider, name) => Effect.sync(() => deleted.push(name)),
+    };
+
+    const result = await Effect.runPromise(
+      reapVmResources({ now: NOW, deleteVolumes: true }).pipe(
+        Effect.provide(workflowLayer(repo, provider)),
+      ),
+    );
+
+    expect(result.reportOnly).toBe(false);
+    expect(result.orphanVolumes.deleted).toBe(1);
+    expect(deleted).toEqual(["cmux-home-abcdef123456-noble-wren"]);
+  });
+
+  test("skips a machine volume referenced by a live VM row", async () => {
+    const deleted: string[] = [];
+    const repo = baseRepository();
+    repo.listLiveHomeVolumeNames = () => Effect.succeed(["cmux-home-abcdef123456-noble-wren"]);
+    repo.stuckProvisioningCandidates = () => Effect.succeed([]);
+    const provider = {
+      ...baseProvider(),
+      listVolumes: () => Effect.succeed([
+        { name: "cmux-home-abcdef123456-noble-wren", createdAt: 2, attachedTo: null },
+      ]),
+      deleteHomeVolume: (_provider, name) => Effect.sync(() => deleted.push(name)),
+    };
+
+    const result = await Effect.runPromise(
+      reapVmResources({ now: NOW, deleteVolumes: true }).pipe(
+        Effect.provide(workflowLayer(repo, provider)),
+      ),
+    );
+
+    expect(result.orphanVolumes.deleted).toBe(0);
+    expect(result.orphanVolumes.skipped).toBe(1);
+    expect(deleted).toEqual([]);
+  });
+
+  test("marks a stale provisioning row destroyed when the provider sandbox is gone", async () => {
+    const updates: Array<Record<string, unknown>> = [];
+    const usage: Array<Record<string, unknown>> = [];
+    const row = vmRow({ providerVmId: "stale-sandbox" });
+    const repo = baseRepository();
+    repo.listLiveHomeVolumeNames = () => Effect.succeed([]);
+    repo.stuckProvisioningCandidates = () => Effect.succeed([row]);
+    repo.markProviderObservedStatus = (update) => Effect.sync(() => {
+      updates.push(update as Record<string, unknown>);
+      return true;
+    });
+    repo.recordUsageEvent = (event) => Effect.sync(() => usage.push(event as Record<string, unknown>));
+    const provider = {
+      ...baseProvider(),
+      listVolumes: () => Effect.succeed([]),
+      getStatus: (_provider, vmId) => Effect.fail(missingProviderError(vmId)),
+    };
+
+    const result = await Effect.runPromise(
+      reapVmResources({ now: NOW, deleteVolumes: false }).pipe(
+        Effect.provide(workflowLayer(repo, provider)),
+      ),
+    );
+
+    expect(result.stuckProvisioning.destroyed).toBe(1);
+    expect(result.stuckProvisioning.failed).toBe(0);
+    expect(updates).toEqual([
+      { id: row.id, providerVmId: "stale-sandbox", status: "destroyed" },
+    ]);
+    expect(usage).toContainEqual(expect.objectContaining({
+      eventType: "vm.destroyed",
+      vmId: row.id,
+      metadata: expect.objectContaining({ source: "vm_reaper" }),
+    }));
+  });
+
+  test("marks a stale provisioning row failed when it never received a provider id", async () => {
+    const failures: Array<Record<string, unknown>> = [];
+    const usage: Array<Record<string, unknown>> = [];
+    const row = vmRow({ providerVmId: null });
+    const repo = baseRepository();
+    repo.listLiveHomeVolumeNames = () => Effect.succeed([]);
+    repo.stuckProvisioningCandidates = () => Effect.succeed([row]);
+    repo.markProvisioningFailed = (input) => Effect.sync(() => {
+      failures.push(input as Record<string, unknown>);
+      return true;
+    });
+    repo.recordUsageEvent = (event) => Effect.sync(() => usage.push(event as Record<string, unknown>));
+    const provider = {
+      ...baseProvider(),
+      listVolumes: () => Effect.succeed([]),
+    };
+
+    const result = await Effect.runPromise(
+      reapVmResources({ now: NOW, deleteVolumes: false }).pipe(
+        Effect.provide(workflowLayer(repo, provider)),
+      ),
+    );
+
+    expect(result.stuckProvisioning.failed).toBe(1);
+    expect(failures[0]).toMatchObject({
+      id: row.id,
+      code: "provisioning_timeout",
+    });
+    expect(usage).toContainEqual(expect.objectContaining({
+      eventType: "vm.create.failed",
+      vmId: row.id,
+    }));
+  });
+
+  test("bounds volume and provisioning batches and processes oldest first", async () => {
+    const deleted: string[] = [];
+    const statusCalls: string[] = [];
+    const volumes: VMVolume[] = Array.from({ length: 105 }, (_, index) => ({
+      name: `cmux-home-${index.toString(16).padStart(12, "0")}-noble-wren`,
+      createdAt: index + 1,
+      attachedTo: null,
+    }));
+    const rows = Array.from({ length: 105 }, (_, index) => vmRow({
+      id: `00000000-0000-4000-8000-${(index + 100).toString(16).padStart(12, "0")}`,
+      providerVmId: `stale-${index}`,
+      createdAt: new Date(NOW.getTime() - (index + 2) * 60 * 60 * 1000),
+      updatedAt: new Date(NOW.getTime() - (index + 2) * 60 * 60 * 1000),
+    }));
+    const repo = baseRepository();
+    repo.listLiveHomeVolumeNames = () => Effect.succeed([]);
+    repo.stuckProvisioningCandidates = ({ limit }) => Effect.succeed(rows.slice(0, limit));
+    repo.markProviderObservedStatus = ({ providerVmId }) => Effect.sync(() => {
+      statusCalls.push(providerVmId);
+      return true;
+    });
+    const provider = {
+      ...baseProvider(),
+      listVolumes: () => Effect.succeed(volumes),
+      deleteHomeVolume: (_provider, name) => Effect.sync(() => deleted.push(name)),
+      getStatus: () => Effect.succeed("running" as const),
+    };
+
+    const result = await Effect.runPromise(
+      reapVmResources({ now: NOW, deleteVolumes: true }).pipe(
+        Effect.provide(workflowLayer(repo, provider)),
+      ),
+    );
+
+    expect(result.orphanVolumes.deleted).toBe(100);
+    expect(deleted).toHaveLength(100);
+    expect(deleted[0]).toBe(volumes[0]?.name);
+    expect(result.stuckProvisioning.recovered).toBe(100);
+    expect(statusCalls).toHaveLength(100);
+    expect(statusCalls[0]).toBe("stale-0");
+  });
+});

--- a/web/tests/vm-reaper.test.ts
+++ b/web/tests/vm-reaper.test.ts
@@ -57,6 +57,7 @@ function baseRepository(): VmRepositoryShape {
     upsertVmSession: () => Effect.die("unused"),
     activeIdentityLeases: () => Effect.succeed([]),
     markLeasesRevoked: () => Effect.die("unexpected lifecycle write"),
+    recentReaperReportKeys: () => Effect.succeed([]),
     recordUsageEvent: () => Effect.void,
     recordUsageEvents: () => Effect.void,
   } as unknown as VmRepositoryShape;
@@ -204,7 +205,11 @@ describe("Cloud VM reaper report", () => {
 
   test("reports stale provisioning rows without provider reads or repository status writes", async () => {
     const usage: Array<Record<string, unknown>> = [];
-    const row = vmRow({ providerVmId: null });
+    const row = vmRow({
+      providerVmId: null,
+      createdAt: new Date(NOW.getTime() - 8 * 60 * 60 * 1000),
+      updatedAt: new Date(NOW.getTime() - 2 * 60 * 60 * 1000),
+    });
     let statusReads = 0;
     const repo = repository({
       stuckProvisioningCandidates: () => Effect.succeed([row]),
@@ -229,7 +234,123 @@ describe("Cloud VM reaper report", () => {
     expect(usage).toContainEqual(expect.objectContaining({
       eventType: "vm.reaper.stuck_provisioning",
       vmId: row.id,
-      metadata: expect.objectContaining({ reason: "age_over_threshold" }),
+      metadata: expect.objectContaining({ reason: "age_over_threshold", ageMinutes: 120 }),
+    }));
+  });
+
+  test("excludes recent reports before applying each report limit", async () => {
+    const usage: Array<Record<string, unknown>> = [];
+    const firstVolumeName = "cmux-home-aaaaaaaaaaaa-first-volume";
+    const laterVolumeName = "cmux-home-bbbbbbbbbbbb-later-volume";
+    const firstRow = vmRow({
+      id: "00000000-0000-4000-8000-000000000011",
+      createdAt: new Date(NOW.getTime() - 6 * 60 * 60 * 1000),
+      updatedAt: new Date(NOW.getTime() - 4 * 60 * 60 * 1000),
+    });
+    const laterRow = vmRow({
+      id: "00000000-0000-4000-8000-000000000012",
+      createdAt: new Date(NOW.getTime() - 5 * 60 * 60 * 1000),
+      updatedAt: new Date(NOW.getTime() - 3 * 60 * 60 * 1000),
+    });
+    const recentLookups: Array<{ eventType: string; keys: string[]; since: Date }> = [];
+    const repo = repository({
+      listLiveHomeVolumeNames: () => Effect.succeed([]),
+      stuckProvisioningCandidates: () => Effect.succeed([firstRow, laterRow]),
+      recentReaperReportKeys: (input) => Effect.sync(() => {
+        recentLookups.push({ ...input, keys: [...input.keys] });
+        return input.eventType === "vm.reaper.orphan_volume"
+          ? [firstVolumeName]
+          : [firstRow.id];
+      }),
+      recordUsageEvent: (event) => Effect.sync(() => usage.push(event as Record<string, unknown>)),
+    });
+    const provider = {
+      ...baseProvider(),
+      listVolumes: () => Effect.succeed([
+        oldVolume(firstVolumeName, { createdAt: NOW.getTime() - 4 * 60 * 60 * 1000 }),
+        oldVolume(laterVolumeName, { createdAt: NOW.getTime() - 3 * 60 * 60 * 1000 }),
+      ]),
+    } as unknown as VmProviderGatewayShape;
+
+    const result = await runReaper(repo, provider, {
+      volumeLimit: 1,
+      volumeScanLimit: 2,
+      provisioningLimit: 1,
+    });
+
+    expect(result.orphanVolumes.candidates).toBe(1);
+    expect(result.orphanVolumes.reported).toBe(1);
+    expect(result.orphanVolumes.skipped).toBe(1);
+    expect(result.stuckProvisioning.candidates).toBe(1);
+    expect(result.stuckProvisioning.reported).toBe(1);
+    expect(result.stuckProvisioning.skipped).toBe(1);
+    expect(recentLookups).toHaveLength(2);
+    expect(usage).toContainEqual(expect.objectContaining({
+      eventType: "vm.reaper.orphan_volume",
+      metadata: expect.objectContaining({ volumeName: laterVolumeName }),
+    }));
+    expect(usage).not.toContainEqual(expect.objectContaining({
+      eventType: "vm.reaper.orphan_volume",
+      metadata: expect.objectContaining({ volumeName: firstVolumeName }),
+    }));
+    expect(usage).toContainEqual(expect.objectContaining({
+      eventType: "vm.reaper.stuck_provisioning",
+      vmId: laterRow.id,
+    }));
+    expect(usage).not.toContainEqual(expect.objectContaining({
+      eventType: "vm.reaper.stuck_provisioning",
+      vmId: firstRow.id,
+    }));
+  });
+
+  test("skips orphan volumes that are younger than the grace period or have unknown age", async () => {
+    const usage: Array<Record<string, unknown>> = [];
+    const repo = repository({
+      listLiveHomeVolumeNames: () => Effect.succeed([]),
+      recordUsageEvent: (event) => Effect.sync(() => usage.push(event as Record<string, unknown>)),
+    });
+    const provider = {
+      ...baseProvider(),
+      listVolumes: () => Effect.succeed([
+        oldVolume("cmux-home-cccccccccccc-young", {
+          createdAt: new Date(NOW.getTime() - 30 * 60 * 1000),
+        } as unknown as Partial<VMVolume>),
+        oldVolume("cmux-home-dddddddddddd-unknown", {
+          createdAt: "not-a-date",
+        } as unknown as Partial<VMVolume>),
+      ]),
+    } as unknown as VmProviderGatewayShape;
+
+    const result = await runReaper(repo, provider, { volumeScanLimit: 10 });
+
+    expect(result.orphanVolumes.candidates).toBe(0);
+    expect(result.orphanVolumes.reported).toBe(0);
+    expect(result.orphanVolumes.skipped).toBe(2);
+    expect(usage).toHaveLength(0);
+  });
+
+  test("does not report a provisioning row with a fresh updatedAt", async () => {
+    const usage: Array<Record<string, unknown>> = [];
+    const row = vmRow({
+      createdAt: new Date(NOW.getTime() - 8 * 60 * 60 * 1000),
+      updatedAt: new Date(NOW.getTime() - 5 * 60 * 1000),
+    });
+    const repo = repository({
+      stuckProvisioningCandidates: () => Effect.succeed([row]),
+      recordUsageEvent: (event) => Effect.sync(() => usage.push(event as Record<string, unknown>)),
+    });
+    const provider = {
+      ...baseProvider(),
+      listVolumes: () => Effect.succeed([]),
+    } as unknown as VmProviderGatewayShape;
+
+    const result = await runReaper(repo, provider);
+
+    expect(result.stuckProvisioning.candidates).toBe(0);
+    expect(result.stuckProvisioning.reported).toBe(0);
+    expect(usage).not.toContainEqual(expect.objectContaining({
+      eventType: "vm.reaper.stuck_provisioning",
+      vmId: row.id,
     }));
   });
 

--- a/web/tests/vm-workflows.test.ts
+++ b/web/tests/vm-workflows.test.ts
@@ -1751,6 +1751,7 @@ describe("VM Effect workflows", () => {
       upsertVmSession: () => Effect.fail(new Error("unused") as never),
       activeIdentityLeases: () => Effect.succeed([]),
       markLeasesRevoked: () => Effect.void,
+      recentReaperReportKeys: () => Effect.succeed([]),
       recordUsageEvent: () => Effect.void,
       recordUsageEvents: () => {
         usageEventAttempts += 1;
@@ -4898,6 +4899,7 @@ function testWorkflowRepo(input: {
         input.revokedLeaseBatches?.push([...leaseIds]);
         input.revokedLeaseIds?.push(...leaseIds);
       }),
+    recentReaperReportKeys: () => Effect.succeed([]),
     recordUsageEvent: (event) =>
       Effect.sync(() => {
         input.usageEvents?.push(event);

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -29,6 +29,10 @@
     {
       "path": "/api/internal/iroh/retention",
       "schedule": "43 * * * *"
+    },
+    {
+      "path": "/api/cron/vm-reaper",
+      "schedule": "49 * * * *"
     }
   ]
 }


### PR DESCRIPTION
Hourly cron (/api/cron/vm-reaper, :49) that reports, and only reports, the two cost-leak populations: orphaned machine-owned Blaxel volumes and VM rows stuck in provisioning. It deletes nothing and mutates no row state.

This is a deliberate descope. Two adversarial review rounds found five P1 defects each in the automated deletion and recovery machinery (deletion races against in-flight creates, unknown attachment states, stale observation reuse, unbounded scans, batch starvation). Safe automated deletion needs stable provider volume ids, observation epochs, and durable pagination cursors, designed as their own change. Until then, the reports give operators exact candidates for supervised cleanup.

Mechanics: bounded paginated provider scan with a partial-coverage flag, unknown attachment reported as unknown and never treated as free, usage events per candidate, and a cloud_vm_reaper_run PostHog summary per run (production-only, bounded 2s). maxDuration 300, CRON_SECRET-guarded.

Verification: bun run typecheck clean; vm-reaper suite 6 pass. Trade-off, stated: pre-existing orphan volumes keep billing until an operator acts on the reports; stuck rows are surfaced, not auto-recovered (the existing reconcile cron and the destroy-path fixes from PR 11251 stop new leaks).

Work was produced across interrupted codex runs and completed and reviewed by the session agent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scheduled VM monitoring for stale provisioning records and orphaned storage volumes.
  * Added paginated volume inventory for improved coverage of large environments.
  * Added secure, privacy-preserving home-volume naming.
  * Added aggregate monitoring telemetry and JSON status reporting.
  * Monitoring now runs hourly on a scheduled basis.

* **Safety**
  * Monitoring is report-only and does not delete resources or modify VM records.
  * Added bounded scans, partial-coverage detection, duplicate-report prevention, and protected scheduled access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->