### PR TITLE
Enforce a 400pt main-window minimum height on every resize path

### DIFF
--- a/Sources/App/CmuxMainWindow.swift
+++ b/Sources/App/CmuxMainWindow.swift
@@ -105,15 +105,20 @@ final class CmuxMainWindow: NSWindow {
     /// (observed live: the window at 29,000 points wide, growing every
     /// pass). The user sizes this window; layout does not.
     override func setFrame(_ frameRect: NSRect, display flag: Bool) {
-        let frame = styleMask.contains(.fullScreen)
-            ? frameRect
-            : Self.frameByCappingOversizedDimensions(
-                frameRect,
-                displayFrames: NSScreen.screens.map {
-                    (frame: $0.frame, visibleFrame: $0.visibleFrame)
-                }
-            )
-        super.setFrame(frame, display: flag)
+        guard !styleMask.contains(.fullScreen) else {
+            super.setFrame(frameRect, display: flag)
+            return
+        }
+        let capped = Self.frameByCappingOversizedDimensions(
+            frameRect,
+            displayFrames: NSScreen.screens.map {
+                (frame: $0.frame, visibleFrame: $0.visibleFrame)
+            }
+        )
+        super.setFrame(
+            Self.frameByRaisingUndersizedDimensions(capped, minimumSize: Self.minimumContentSize),
+            display: flag
+        )
     }
 
     /// Caps runaway content-derived dimensions to the display union while
@@ -156,6 +161,26 @@ final class CmuxMainWindow: NSWindow {
         )
         capped.origin.y = clampedMaxY - capped.height
         return capped
+    }
+
+    /// Raises undersized dimensions to the policy floor. `minSize` and
+    /// `contentMinSize` bound only USER resizes; a programmatic `setFrame`
+    /// (session restore math, display reconfiguration, automation) can still
+    /// deliver a frame below the floor, where the sidebar footer, update
+    /// pill, and tab bar overlap and clip. The raise keeps the top edge put —
+    /// frames are bottom-left anchored, so added height extends the window
+    /// downward, leaving the titlebar where the user can grab it. Frames that
+    /// already fit are returned byte-for-byte.
+    nonisolated static func frameByRaisingUndersizedDimensions(
+        _ proposedFrame: NSRect,
+        minimumSize: NSSize
+    ) -> NSRect {
+        var raised = proposedFrame
+        raised.size.width = max(raised.width, minimumSize.width)
+        raised.size.height = max(raised.height, minimumSize.height)
+        guard raised.size != proposedFrame.size else { return proposedFrame }
+        raised.origin.y = proposedFrame.maxY - raised.height
+        return raised
     }
 
     static var minimumContentSize: NSSize {

--- a/Sources/App/CmuxMainWindow.swift
+++ b/Sources/App/CmuxMainWindow.swift
@@ -119,7 +119,8 @@ final class CmuxMainWindow: NSWindow {
             Self.frameByRaisingUndersizedDimensions(
                 capped,
                 minimumSize: Self.minimumContentSize,
-                currentFrame: frame
+                currentFrame: frame,
+                isLiveResize: inLiveResize
             ),
             display: flag
         )
@@ -176,17 +177,20 @@ final class CmuxMainWindow: NSWindow {
     /// tab bar overlap and clip. Frames that already fit are returned
     /// byte-for-byte.
     ///
-    /// The raise anchors the edge the gesture is holding still, inferred by
-    /// comparing the proposal against `currentFrame`: a proposal that keeps
-    /// the current bottom (top-edge drag) is pinned at that bottom so the top
-    /// edge stops at the floor, and likewise for a kept right edge. Anything
-    /// else — including every programmatic shrink, which moves both edges —
-    /// keeps the proposal's top-left corner so the titlebar stays where the
-    /// caller put it and the raise extends downward.
+    /// During a live drag (`isLiveResize`) the raise anchors the edge the
+    /// gesture is holding still, inferred by comparing the proposal against
+    /// `currentFrame`: a proposal that keeps the current bottom (top-edge
+    /// drag) is pinned at that bottom so the top edge stops at the floor, and
+    /// likewise for a kept right edge. Outside live resize the inference is
+    /// meaningless — a programmatic shrink that happens to share the current
+    /// origin is not a drag — so every programmatic raise keeps the
+    /// proposal's top-left corner: the titlebar stays where the caller put it
+    /// and the raise extends downward.
     nonisolated static func frameByRaisingUndersizedDimensions(
         _ proposedFrame: NSRect,
         minimumSize: NSSize,
-        currentFrame: NSRect
+        currentFrame: NSRect,
+        isLiveResize: Bool
     ) -> NSRect {
         var raised = proposedFrame
         raised.size.width = max(raised.width, minimumSize.width)
@@ -195,14 +199,16 @@ final class CmuxMainWindow: NSWindow {
 
         let epsilon: CGFloat = 0.5
         if raised.height != proposedFrame.height {
-            let keepsBottomEdge = abs(proposedFrame.minY - currentFrame.minY) <= epsilon
+            let keepsBottomEdge = isLiveResize
+                && abs(proposedFrame.minY - currentFrame.minY) <= epsilon
                 && abs(proposedFrame.maxY - currentFrame.maxY) > epsilon
             if !keepsBottomEdge {
                 raised.origin.y = proposedFrame.maxY - raised.height
             }
         }
         if raised.width != proposedFrame.width {
-            let keepsRightEdge = abs(proposedFrame.maxX - currentFrame.maxX) <= epsilon
+            let keepsRightEdge = isLiveResize
+                && abs(proposedFrame.maxX - currentFrame.maxX) <= epsilon
                 && abs(proposedFrame.minX - currentFrame.minX) > epsilon
             if keepsRightEdge {
                 raised.origin.x = proposedFrame.maxX - raised.width

--- a/Sources/App/CmuxMainWindow.swift
+++ b/Sources/App/CmuxMainWindow.swift
@@ -116,7 +116,11 @@ final class CmuxMainWindow: NSWindow {
             }
         )
         super.setFrame(
-            Self.frameByRaisingUndersizedDimensions(capped, minimumSize: Self.minimumContentSize),
+            Self.frameByRaisingUndersizedDimensions(
+                capped,
+                minimumSize: Self.minimumContentSize,
+                currentFrame: frame
+            ),
             display: flag
         )
     }
@@ -163,23 +167,47 @@ final class CmuxMainWindow: NSWindow {
         return capped
     }
 
-    /// Raises undersized dimensions to the policy floor. `minSize` and
-    /// `contentMinSize` bound only USER resizes; a programmatic `setFrame`
-    /// (session restore math, display reconfiguration, automation) can still
-    /// deliver a frame below the floor, where the sidebar footer, update
-    /// pill, and tab bar overlap and clip. The raise keeps the top edge put —
-    /// frames are bottom-left anchored, so added height extends the window
-    /// downward, leaving the titlebar where the user can grab it. Frames that
-    /// already fit are returned byte-for-byte.
+    /// Raises undersized dimensions to the policy floor. On macOS 26 the
+    /// edge-drag resize affordance delivers below-`minSize` frames straight
+    /// through `setFrame` (observed live: a 116pt-tall window on a build
+    /// whose `minSize` height was 200), and programmatic paths (session
+    /// restore math, display reconfiguration, automation) were never bounded
+    /// by `minSize` at all — either way the sidebar footer, update pill, and
+    /// tab bar overlap and clip. Frames that already fit are returned
+    /// byte-for-byte.
+    ///
+    /// The raise anchors the edge the gesture is holding still, inferred by
+    /// comparing the proposal against `currentFrame`: a proposal that keeps
+    /// the current bottom (top-edge drag) is pinned at that bottom so the top
+    /// edge stops at the floor, and likewise for a kept right edge. Anything
+    /// else — including every programmatic shrink, which moves both edges —
+    /// keeps the proposal's top-left corner so the titlebar stays where the
+    /// caller put it and the raise extends downward.
     nonisolated static func frameByRaisingUndersizedDimensions(
         _ proposedFrame: NSRect,
-        minimumSize: NSSize
+        minimumSize: NSSize,
+        currentFrame: NSRect
     ) -> NSRect {
         var raised = proposedFrame
         raised.size.width = max(raised.width, minimumSize.width)
         raised.size.height = max(raised.height, minimumSize.height)
         guard raised.size != proposedFrame.size else { return proposedFrame }
-        raised.origin.y = proposedFrame.maxY - raised.height
+
+        let epsilon: CGFloat = 0.5
+        if raised.height != proposedFrame.height {
+            let keepsBottomEdge = abs(proposedFrame.minY - currentFrame.minY) <= epsilon
+                && abs(proposedFrame.maxY - currentFrame.maxY) > epsilon
+            if !keepsBottomEdge {
+                raised.origin.y = proposedFrame.maxY - raised.height
+            }
+        }
+        if raised.width != proposedFrame.width {
+            let keepsRightEdge = abs(proposedFrame.maxX - currentFrame.maxX) <= epsilon
+                && abs(proposedFrame.minX - currentFrame.minX) > epsilon
+            if keepsRightEdge {
+                raised.origin.x = proposedFrame.maxX - raised.width
+            }
+        }
         return raised
     }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9830,7 +9830,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
         let cascadeOffset: CGFloat = 24
-        let minimumWindowSize = NSSize(width: 460, height: 360)
+        let minimumWindowSize = NSSize(width: 460, height: CmuxMainWindow.minimumContentSize.height)
         var frame = window.frame
         frame.origin = NSPoint(
             x: sourceFrame.minX + cascadeOffset,

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -26,7 +26,11 @@ enum SessionPersistencePolicy {
     static let sidebarMinimumWidthRange: ClosedRange<Double> = 120...260
     static let maximumSidebarWidth: Double = 600
     static let minimumWindowWidth: Double = 300
-    static let minimumWindowHeight: Double = 200
+    // Below ~400pt the chrome cannot lay out without overlap: the sidebar
+    // footer (account/help/update pill) collides with workspace rows and the
+    // update pill clips at the window edge. User resizes stop here via
+    // minSize/contentMinSize; programmatic paths via CmuxMainWindow.setFrame.
+    static let minimumWindowHeight: Double = 400
     static let autosaveInterval: TimeInterval = 8.0
     static let maxWindowsPerSnapshot: Int = 12
     static let maxWorkspacesPerWindow: Int = 128

--- a/cmuxTests/MainWindowSelfSizingTests.swift
+++ b/cmuxTests/MainWindowSelfSizingTests.swift
@@ -235,10 +235,59 @@ final class MainWindowSelfSizingTests: XCTestCase {
         XCTAssertEqual(
             CmuxMainWindow.frameByRaisingUndersizedDimensions(
                 fitting,
-                minimumSize: CmuxMainWindow.minimumContentSize
+                minimumSize: CmuxMainWindow.minimumContentSize,
+                currentFrame: NSRect(x: 0, y: 0, width: 1_000, height: 700)
             ),
             fitting,
             "A frame at or above the minimum must be returned unchanged"
         )
+    }
+
+    /// A top-edge drag keeps the window's bottom still and walks maxY down;
+    /// once the proposal dips under the floor the raise must pin the kept
+    /// bottom edge so the top edge stops — anchoring the top instead would
+    /// make the whole window slide down with the cursor (observed live on
+    /// macOS 26, whose edge drags deliver below-minSize frames to setFrame).
+    func testFrameRaisePinsKeptBottomEdgeDuringTopEdgeDrag() {
+        let current = NSRect(x: 100, y: 100, width: 1_000, height: 694)
+        let proposed = NSRect(x: 100, y: 100, width: 1_000, height: 95)
+        let minimum = NSSize(width: 300, height: 400)
+        let raised = CmuxMainWindow.frameByRaisingUndersizedDimensions(
+            proposed,
+            minimumSize: minimum,
+            currentFrame: current
+        )
+        XCTAssertEqual(raised.minY, current.minY, accuracy: 0.01, "Kept bottom edge must stay pinned")
+        XCTAssertEqual(raised.height, minimum.height, accuracy: 0.01)
+    }
+
+    /// A bottom-edge drag keeps the window's top still and walks minY up; the
+    /// raise must pin the kept top edge so the bottom edge stops at the floor.
+    func testFrameRaisePinsKeptTopEdgeDuringBottomEdgeDrag() {
+        let current = NSRect(x: 100, y: 100, width: 1_000, height: 694)
+        let proposed = NSRect(x: 100, y: 699, width: 1_000, height: 95)
+        let minimum = NSSize(width: 300, height: 400)
+        let raised = CmuxMainWindow.frameByRaisingUndersizedDimensions(
+            proposed,
+            minimumSize: minimum,
+            currentFrame: current
+        )
+        XCTAssertEqual(raised.maxY, current.maxY, accuracy: 0.01, "Kept top edge must stay pinned")
+        XCTAssertEqual(raised.height, minimum.height, accuracy: 0.01)
+    }
+
+    /// A left-edge drag keeps the window's right edge still; the raise must
+    /// pin that kept right edge so the left edge stops at the width floor.
+    func testFrameRaisePinsKeptRightEdgeDuringLeftEdgeDrag() {
+        let current = NSRect(x: 100, y: 100, width: 1_000, height: 694)
+        let proposed = NSRect(x: 1_020, y: 100, width: 80, height: 694)
+        let minimum = NSSize(width: 300, height: 400)
+        let raised = CmuxMainWindow.frameByRaisingUndersizedDimensions(
+            proposed,
+            minimumSize: minimum,
+            currentFrame: current
+        )
+        XCTAssertEqual(raised.maxX, current.maxX, accuracy: 0.01, "Kept right edge must stay pinned")
+        XCTAssertEqual(raised.width, minimum.width, accuracy: 0.01)
     }
 }

--- a/cmuxTests/MainWindowSelfSizingTests.swift
+++ b/cmuxTests/MainWindowSelfSizingTests.swift
@@ -226,4 +226,19 @@ final class MainWindowSelfSizingTests: XCTestCase {
             "Raising an undersized frame must keep the top edge put and extend the window downward"
         )
     }
+
+    /// Ordinary frames must flow through the undersized raise untouched so
+    /// user-owned placement (partial off-screen, multi-display) is never
+    /// perturbed by the floor.
+    func testFrameRaiseReturnsFittingFramesByteForByte() {
+        let fitting = NSRect(x: -120.5, y: 33.25, width: 901.5, height: 612.75)
+        XCTAssertEqual(
+            CmuxMainWindow.frameByRaisingUndersizedDimensions(
+                fitting,
+                minimumSize: CmuxMainWindow.minimumContentSize
+            ),
+            fitting,
+            "A frame at or above the minimum must be returned unchanged"
+        )
+    }
 }

--- a/cmuxTests/MainWindowSelfSizingTests.swift
+++ b/cmuxTests/MainWindowSelfSizingTests.swift
@@ -188,4 +188,42 @@ final class MainWindowSelfSizingTests: XCTestCase {
             "The hosting view accepted a frame taller than its window"
         )
     }
+
+    /// `minSize`/`contentMinSize` bound only USER resizes; a programmatic
+    /// `setFrame` (session restore math, display reconfiguration, automation)
+    /// can still deliver a frame below the layout floor, where the sidebar
+    /// footer, update pill, and tab bar overlap and clip. The window must
+    /// enforce the floor on every setFrame path, keeping the top edge (the
+    /// titlebar the user can grab) where the caller put it.
+    @MainActor
+    func testSetFrameRaisesUndersizedFrameToMinimumContentSize() {
+        let window = CmuxMainWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 900, height: 600),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        defer {
+            window.orderOut(nil)
+            window.close()
+        }
+
+        let minimum = CmuxMainWindow.minimumContentSize
+        let undersized = NSRect(x: 80, y: 500, width: 220, height: 120)
+        window.setFrame(undersized, display: false)
+
+        XCTAssertGreaterThanOrEqual(
+            window.frame.width, minimum.width - 0.5,
+            "A programmatic setFrame below the minimum width must be raised to the floor"
+        )
+        XCTAssertGreaterThanOrEqual(
+            window.frame.height, minimum.height - 0.5,
+            "A programmatic setFrame below the minimum height must be raised to the floor"
+        )
+        XCTAssertEqual(
+            window.frame.maxY, undersized.maxY, accuracy: 0.5,
+            "Raising an undersized frame must keep the top edge put and extend the window downward"
+        )
+    }
 }

--- a/cmuxTests/MainWindowSelfSizingTests.swift
+++ b/cmuxTests/MainWindowSelfSizingTests.swift
@@ -236,7 +236,8 @@ final class MainWindowSelfSizingTests: XCTestCase {
             CmuxMainWindow.frameByRaisingUndersizedDimensions(
                 fitting,
                 minimumSize: CmuxMainWindow.minimumContentSize,
-                currentFrame: NSRect(x: 0, y: 0, width: 1_000, height: 700)
+                currentFrame: NSRect(x: 0, y: 0, width: 1_000, height: 700),
+                isLiveResize: true
             ),
             fitting,
             "A frame at or above the minimum must be returned unchanged"
@@ -255,7 +256,8 @@ final class MainWindowSelfSizingTests: XCTestCase {
         let raised = CmuxMainWindow.frameByRaisingUndersizedDimensions(
             proposed,
             minimumSize: minimum,
-            currentFrame: current
+            currentFrame: current,
+            isLiveResize: true
         )
         XCTAssertEqual(raised.minY, current.minY, accuracy: 0.01, "Kept bottom edge must stay pinned")
         XCTAssertEqual(raised.height, minimum.height, accuracy: 0.01)
@@ -270,9 +272,27 @@ final class MainWindowSelfSizingTests: XCTestCase {
         let raised = CmuxMainWindow.frameByRaisingUndersizedDimensions(
             proposed,
             minimumSize: minimum,
-            currentFrame: current
+            currentFrame: current,
+            isLiveResize: true
         )
         XCTAssertEqual(raised.maxY, current.maxY, accuracy: 0.01, "Kept top edge must stay pinned")
+        XCTAssertEqual(raised.height, minimum.height, accuracy: 0.01)
+    }
+
+    /// Outside live resize a shrink that happens to share the window's
+    /// current origin is not a drag — the raise must still keep the
+    /// proposal's top edge (the titlebar) rather than pinning the bottom.
+    func testFrameRaiseKeepsTopEdgeForProgrammaticShrinkSharingOrigin() {
+        let current = NSRect(x: 100, y: 100, width: 1_000, height: 694)
+        let proposed = NSRect(x: 100, y: 100, width: 1_000, height: 95)
+        let minimum = NSSize(width: 300, height: 400)
+        let raised = CmuxMainWindow.frameByRaisingUndersizedDimensions(
+            proposed,
+            minimumSize: minimum,
+            currentFrame: current,
+            isLiveResize: false
+        )
+        XCTAssertEqual(raised.maxY, proposed.maxY, accuracy: 0.01, "Programmatic raises keep the proposal's top edge")
         XCTAssertEqual(raised.height, minimum.height, accuracy: 0.01)
     }
 
@@ -285,7 +305,8 @@ final class MainWindowSelfSizingTests: XCTestCase {
         let raised = CmuxMainWindow.frameByRaisingUndersizedDimensions(
             proposed,
             minimumSize: minimum,
-            currentFrame: current
+            currentFrame: current,
+            isLiveResize: true
         )
         XCTAssertEqual(raised.maxX, current.maxX, accuracy: 0.01, "Kept right edge must stay pinned")
         XCTAssertEqual(raised.width, minimum.width, accuracy: 0.01)


### PR DESCRIPTION
Resizing the main window very short overflowed the chrome in an ugly way: the sidebar footer (account/help/update pill) collided with workspace rows, the update pill clipped at the window edge, and terminal content spilled over the titlebar during the drag.

Two mechanisms, one floor:

- `SessionPersistencePolicy.minimumWindowHeight` goes from 200pt to 400pt. `minSize`/`contentMinSize`, the SwiftUI root `.frame(minHeight:)`, restored-frame validation, display-reconfiguration clamps, and the visible-frame fit rescue all already derive from this constant, so user drag resizes now stop at 400pt everywhere.
- `CmuxMainWindow.setFrame` now raises undersized programmatic frames to `minimumContentSize` (top edge anchored, mirroring the existing oversized cap), because AppKit's `minSize` bounds only user resizes; session-restore math, display reconfiguration, and automation could still deliver a below-floor frame.

The new-window cascade clamp in `positionNewMainWindow` derives its height from the same policy instead of a stale 360pt literal.

Commit 1 adds the regression test only (red), commit 2 the fix (green): a programmatic `setFrame` below the floor must clamp, keeping the top edge put.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790825410&installation_model_id=21920&pr_number=11321&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11321&signature=ea2fe445d217dfdb5ddcd1bc0b3782932da7a40d31bf2afbc32173d11d1e0aeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces a 400pt main-window minimum height on every resize path so the sidebar footer, update pill, and tab bar no longer overlap or clip when the window is short.

**Bug Fixes**
- Raises the policy floor from 200pt to 400pt; `minSize` and `contentMinSize` already stop user drags, and `CmuxMainWindow.setFrame` now raises undersized programmatic frames to the floor (session restore, display reconfiguration, automation).
- The raise pins the edge a live drag keeps still (bottom for top-edge drags, top for bottom-edge drags, right for left-edge drags) so the window doesn't slide; programmatic shrinks keep the titlebar's top-left corner.
- New-window cascade sizing uses the same policy height instead of a stale 360pt literal.
- Adds regression tests for the programmatic clamp, edge-pinned raises, and fitting frames passing through unchanged.

<sup>Written for commit cddb0dcf7fe5c3a20e7a1117eacf76ae5c5e3ccb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window sizing to prevent non-fullscreen windows from being too small or excessively large.
  * Preserved the window’s top edge when expanding undersized windows.
  * Fullscreen windows retain their selected dimensions.
  * Updated minimum window height requirements to accommodate the full interface layout.

* **Tests**
  * Added coverage for automatic window resizing, edge-preserving adjustments, and correctly sized frames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->