### PR TITLE
Glue terminal frames to live window resize ticks

### DIFF
--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -2230,7 +2230,14 @@ final class WindowTerminalPortal: NSObject {
             // normal frame-change refresh path won't run. Nudge geometry + redraw so newly
             // revealed terminals don't sit on a stale/blank IOSurface until later focus churn.
             hostedView.reconcileGeometryNow()
-            if syncLayout {
+            // Mid window live-resize the pass runs synchronously inside the
+            // resize tick's still-open transaction (see the didResize
+            // observer), where refreshSurfaceNow's displayIfNeeded reaches
+            // ghostty's Metal drawFrame and wedges on a present only that
+            // transaction can commit. Unlike the frame-change branch above,
+            // a reveal cannot skip its redraw outright — the surface would
+            // sit blank until later churn — so defer it one main-queue turn.
+            if syncLayout, !isWindowLiveResizeActive {
                 hostedView.refreshSurfaceNow(reason: "portal.reveal")
             } else {
                 deferSurfaceRefresh(forHostedId: hostedId, reason: "portal.reveal.deferred")

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -780,8 +780,17 @@ final class WindowTerminalPortal: NSObject {
         geometryObservers.append(center.addObserver(
             forName: NSWindow.didResizeNotification,
             object: window,
-            queue: .main
+            queue: nil
         ) { [weak self] notification in
+            // queue nil on purpose: NSWindow posts didResize synchronously
+            // from inside setFrame on the main thread, so this handler runs
+            // while the resize tick's transaction is still open — the only
+            // point where hosted frames can land in the SAME commit as the
+            // window's new size. A .main operation queue defers the handler
+            // by a runloop turn, and during a live resize that turn is the
+            // visible difference between the terminal tracking the window
+            // edge and trailing it by a frame for the whole drag.
+            guard Thread.isMainThread else { return }
             MainActor.assumeIsolated {
 #if DEBUG
                 // Standing tripwire for PROGRAMMATIC window growth — the
@@ -805,7 +814,21 @@ final class WindowTerminalPortal: NSObject {
                 }
 #endif
                 guard let self, self.selfFrameWriteDepth == 0 else { return }
-                self.scheduleExternalGeometrySynchronize()
+                if self.isWindowLiveResizeActive {
+                    // Live resize: run the pass INSIDE this tick so hosted
+                    // frames commit together with the window's new size. The
+                    // pass forces subtree layout first (fresh anchor frames)
+                    // and every synchronous-redraw path is already gated off
+                    // while live resize is active (see synchronizeHostedView
+                    // and reconcileVisibleHostedViewsAfterGeometrySync), so
+                    // it cannot reach the open-transaction Metal wedge that
+                    // displayIfNeeded would risk here. Re-entrant echoes die
+                    // in currentlySynchronizingPortalId and the geometry
+                    // signature check.
+                    self.synchronizeAllEntriesFromExternalGeometryChange()
+                } else {
+                    self.scheduleExternalGeometrySynchronize()
+                }
             }
         })
         geometryObservers.append(center.addObserver(

--- a/cmuxTests/TerminalWindowPortalLifecycleHiddenRefreshTests.swift
+++ b/cmuxTests/TerminalWindowPortalLifecycleHiddenRefreshTests.swift
@@ -158,6 +158,65 @@ extension TerminalWindowPortalLifecycleTests {
         withExtendedLifetime((leftSurface, rightSurface)) {}
     }
 
+    /// Regression: during a live window resize, each `didResize` tick must
+    /// synchronize hosted terminal frames INSIDE the tick — in the same
+    /// transaction that commits the window's new size. The portal's queued
+    /// sync (one main-queue hop) paints every tick with the PREVIOUS tick's
+    /// hosted frames, so the terminal visibly trails the window edge during
+    /// the whole drag (Ghostty hosts surfaces directly in the hierarchy and
+    /// has no such gap).
+    @MainActor
+    func testLiveResizeTickSynchronizesHostedFrameWithinTheSameTick() throws {
+        let window = makeTestWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 520, height: 340),
+            styleMask: [.titled, .closable, .resizable]
+        )
+        defer {
+            NotificationCenter.default.post(name: NSWindow.willCloseNotification, object: window)
+            window.orderOut(nil)
+        }
+        realizeWindowLayout(window)
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let portal = makeTrackedPortal(window: window)
+        let anchor = NSView(frame: NSRect(x: 8, y: 8, width: 240, height: 160))
+        anchor.autoresizingMask = [.width, .height]
+        contentView.addSubview(anchor)
+
+        let surface = makeTrackedTerminalSurface()
+        portal.bind(hostedView: surface.hostedView, to: anchor, visibleInUI: true)
+        portal.synchronizeHostedViewForAnchor(anchor)
+        drainMainQueue()
+        realizeWindowLayout(window)
+        XCTAssertEqual(
+            surface.hostedView.frame.size,
+            NSSize(width: 240, height: 160),
+            "Precondition: the hosted view tracks the anchor at rest"
+        )
+
+        portal.isWindowLiveResizeActiveOverrideForTesting = true
+
+        // One live-resize tick: setFrame posts didResize synchronously and
+        // the anchor grows with the content view through its autoresizing
+        // mask before the notification fires.
+        var frame = window.frame
+        frame.size.width += 100
+        frame.size.height += 60
+        window.setFrame(frame, display: false)
+
+        // No queue drain on purpose: the assertion runs before any queued
+        // portal pass can fire, exactly like the tick's own CA commit does.
+        XCTAssertEqual(
+            surface.hostedView.frame.size,
+            NSSize(width: 340, height: 220),
+            "A live-resize tick must glue hosted frames within the same tick, not a runloop turn later"
+        )
+        withExtendedLifetime(surface) {}
+    }
+
     /// Regression: switching a pane's tab from a terminal to a browser hides
     /// the terminal only through its registry entry — the SwiftUI update that
     /// carries visible=false is dropped by the portal-host ownership gate


### PR DESCRIPTION
During a live window resize, cmux terminals visibly trail the window edge; Ghostty stays glued. The cause is timing, not rendering: the portal that hosts the real terminal views observed `NSWindow.didResize` on the main OperationQueue and then coalesced its geometry pass through `DispatchQueue.main.async`, so hosted frames were written at least one runloop turn after each resize tick committed. Every tick painted the window's new size with the previous tick's terminal frames. Ghostty hosts surfaces directly in the view hierarchy, so its frames land in the same layout pass; the portal indirection is why cmux felt slower.

Fix: observe `didResize` with `queue: nil`, which AppKit delivers synchronously from inside `setFrame` while the tick's transaction is still open, and run the full portal geometry pass synchronously when a live resize is active. The pass forces subtree layout first, so it reads final anchor frames (bonsplit re-imposes divider fractions inside the same layout pass), writes hosted frames into the same commit as the window's new size, and applies grid-changing surface resizes in-tick. Non-live-resize resizes keep the scheduled, coalesced path.

Safety: every synchronous-redraw path is already gated off while live resize is active (`synchronizeHostedView`'s refresh branch and `reconcileVisibleHostedViewsAfterGeometrySync` both skip mid-resize), so the synchronous pass cannot reach the open-transaction Metal `displayIfNeeded` wedge documented in the portal. Re-entrant echoes terminate in `currentlySynchronizingPortalId` and the external-geometry signature check. Per-tick work is unchanged: the same pass ran before, one turn late.

Commit 1 adds the regression test only (a live-resize tick must glue hosted frames with no queue drain), commit 2 adds the fix, so the test's red-then-green is visible in the commit history.

Dictionary: portal = the AppKit overlay that hosts real terminal views above the SwiftUI hierarchy and copies placeholder geometry onto them; live resize = the window-edge drag AppKit tracks between willStart/didEndLiveResize; tick = one mouse-driven `setFrame` during that drag; anchor = the empty SwiftUI placeholder view whose frame the portal mirrors; transaction = the Core Animation commit that atomically presents one frame's view changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11323"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790826433&installation_model_id=21920&pr_number=11323&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11323&signature=f27954ab23a061cbde63410cb1890c6613d8ca9d7f357a1187a649580d64083e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes terminal frames trailing the window edge during live resize so the terminal stays glued to the resize tick, matching Ghostty's behavior.

- Observes `didResize` with `queue: nil` so the geometry pass runs synchronously inside the tick's transaction; non-live-resize resizes keep the scheduled, coalesced path.
- The in-tick pass forces subtree layout first, so it reads final anchor frames and writes hosted frames into the same commit as the window's new size.
- Reveals that happen inside the tick defer their redraw one main-queue turn, since the synchronous path would hit the open-transaction Metal `displayIfNeeded` wedge; a reveal can't skip the redraw outright or the surface stays blank.
- Adds a regression test asserting a live-resize tick writes hosted frames with no queue drain.

**Migration**
- None.

<sup>Written for commit 98b35d38d5a04db873b7a2ad09b345187806ad27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal window resizing so hosted terminal content stays synchronized during live resizing.
  * Deferred visual refreshes appropriately during active resizing to reduce rendering issues and keep interactions smooth.

* **Tests**
  * Added regression coverage verifying hosted terminal frames update within the same resize operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->