### PR TITLE
iOS: restore device-only tagged Mac switching

### DIFF
--- a/Packages/iOS/CmuxMobilePairedMac/Sources/CmuxMobilePairedMac/MobilePairedMacStore+Queries.swift
+++ b/Packages/iOS/CmuxMobilePairedMac/Sources/CmuxMobilePairedMac/MobilePairedMacStore+Queries.swift
@@ -1,0 +1,49 @@
+import CMUXMobileCore
+import Foundation
+
+extension Collection where Element == MobilePairedMac {
+    /// Resolves the newest stored row for a physical Mac and optional app instance.
+    ///
+    /// A missing instance tag is a device-level request and therefore matches
+    /// every saved app instance on that physical Mac. A supplied tag remains an
+    /// exact app-instance match. Results are ordered by ``MobilePairedMac/lastSeenAt``
+    /// with a stable pairing-id tie-breaker so device-only callers make the same
+    /// choice regardless of the store implementation's row ordering.
+    /// Device-level mutation APIs keep their separate fail-closed contracts.
+    /// - Parameters:
+    ///   - macDeviceID: Stable identifier of the physical Mac to resolve.
+    ///   - instanceTag: Exact app-instance tag, or `nil` for device-level lookup.
+    /// - Returns: The newest matching row, or `nil` when no row matches.
+    public func mostRecentPairedMac(
+        macDeviceID: String,
+        instanceTag: String?
+    ) -> MobilePairedMac? {
+        let requestedIdentity = CmxMacAppInstanceIdentity(
+            macDeviceID: macDeviceID,
+            instanceTag: instanceTag
+        )
+        return filter { candidate in
+            let candidateIdentity = CmxMacAppInstanceIdentity(
+                macDeviceID: candidate.macDeviceID,
+                instanceTag: candidate.instanceTag
+            )
+            guard candidateIdentity.macDeviceID == requestedIdentity.macDeviceID else {
+                return false
+            }
+            guard let requestedTag = requestedIdentity.instanceTag else {
+                return true
+            }
+            return candidateIdentity.instanceTag == requestedTag
+        }
+        .sorted {
+            if $0.lastSeenAt != $1.lastSeenAt {
+                return $0.lastSeenAt > $1.lastSeenAt
+            }
+            if $0.id != $1.id {
+                return $0.id < $1.id
+            }
+            return ($0.teamID ?? "") < ($1.teamID ?? "")
+        }
+        .first
+    }
+}

--- a/Packages/iOS/CmuxMobilePairedMac/Sources/CmuxMobilePairedMac/MobilePairedMacStore+Queries.swift
+++ b/Packages/iOS/CmuxMobilePairedMac/Sources/CmuxMobilePairedMac/MobilePairedMacStore+Queries.swift
@@ -22,28 +22,35 @@ extension Collection where Element == MobilePairedMac {
             macDeviceID: macDeviceID,
             instanceTag: instanceTag
         )
-        return filter { candidate in
+        var newestMatch: MobilePairedMac?
+        for candidate in self {
             let candidateIdentity = CmxMacAppInstanceIdentity(
                 macDeviceID: candidate.macDeviceID,
                 instanceTag: candidate.instanceTag
             )
             guard candidateIdentity.macDeviceID == requestedIdentity.macDeviceID else {
-                return false
+                continue
             }
-            guard let requestedTag = requestedIdentity.instanceTag else {
-                return true
+            if let requestedTag = requestedIdentity.instanceTag,
+               candidateIdentity.instanceTag != requestedTag {
+                continue
             }
-            return candidateIdentity.instanceTag == requestedTag
+            guard let current = newestMatch else {
+                newestMatch = candidate
+                continue
+            }
+            let candidateIsNewer: Bool
+            if candidate.lastSeenAt != current.lastSeenAt {
+                candidateIsNewer = candidate.lastSeenAt > current.lastSeenAt
+            } else if candidate.id != current.id {
+                candidateIsNewer = candidate.id < current.id
+            } else {
+                candidateIsNewer = (candidate.teamID ?? "") < (current.teamID ?? "")
+            }
+            if candidateIsNewer {
+                newestMatch = candidate
+            }
         }
-        .sorted {
-            if $0.lastSeenAt != $1.lastSeenAt {
-                return $0.lastSeenAt > $1.lastSeenAt
-            }
-            if $0.id != $1.id {
-                return $0.id < $1.id
-            }
-            return ($0.teamID ?? "") < ($1.teamID ?? "")
-        }
-        .first
+        return newestMatch
     }
 }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -3988,8 +3988,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// active row) is reconnected. A no-op when already connected to that Mac.
     /// - Parameters:
     ///   - macDeviceID: The stored physical Mac to switch to.
-    ///   - instanceTag: Exact saved app instance to switch to, or `nil` for
-    ///     legacy device-level routing.
+    ///   - instanceTag: Exact saved app instance to switch to, or `nil` to
+    ///     resolve the most recently seen instance for device-level routing.
     /// - Returns: `true` if the foreground connection now targets that Mac (or
     ///   already did), `false` if the switch could not connect — so callers like
     ///   `openWorkspace` can avoid selecting a workspace whose Mac is not live.
@@ -4120,26 +4120,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             await restoreMacSwitchBaselineIfCancelled(switchAttemptID)
             return false
         }
-        let matchesTarget: (MobilePairedMac) -> Bool = { mac in
-            MacPairingKey(mac) == MacPairingKey(
-                macDeviceID: macDeviceID,
-                instanceTag: instanceTag
-            )
-        }
-        let targetMatches = storeMacs.filter(matchesTarget)
-        // A device-only request against MULTIPLE stored sibling builds is
-        // ambiguous: the store orders by recency, not build authority, so
-        // dialing `first` could disconnect the current focus in favor of an
-        // arbitrary sibling. Fail the switch; pairing-aware callers pass the
-        // tag, and legacy device-only entry points must not guess.
-        if instanceTag == nil,
-           Set(targetMatches.map(MacPairingKey.init)).count > 1 {
-            mobileShellLog.error(
-                "switchToMac: device-only request is ambiguous across stored sibling builds mac=\(macDeviceID, privacy: .public)"
-            )
-            return false
-        }
-        guard let refreshedTarget = targetMatches.first else {
+        guard let refreshedTarget = storeMacs.mostRecentPairedMac(
+            macDeviceID: macDeviceID,
+            instanceTag: instanceTag
+        ) else {
             if !hasActiveMacConnection,
                await restorePreviousMacIfNeeded(macSwitchRestoreBaseline, switchAttemptID: switchAttemptID) {
                 macSwitchRestoreBaseline = nil

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DeviceOnlyMacSwitchTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DeviceOnlyMacSwitchTests.swift
@@ -9,6 +9,7 @@ import Testing
 /// which saved app instance owns the row.
 @MainActor
 @Suite struct DeviceOnlyMacSwitchTests {
+    /// A nil-tag switch resolves a single tagged row and dials its route.
     @Test func deviceOnlySwitchResolvesAndDialsTaggedRow() async throws {
         let now = Date(timeIntervalSince1970: 1_000)
         let router = LivenessHostRouter()
@@ -48,6 +49,7 @@ import Testing
         #expect(store.activeMacInstanceTag == "feature-a")
     }
 
+    /// A nil-tag switch chooses the newest tagged row without crossing devices.
     @Test func deviceOnlySwitchUsesMostRecentTaggedRowForOneMac() async throws {
         let now = Date(timeIntervalSince1970: 2_000)
         let router = LivenessHostRouter()
@@ -112,6 +114,7 @@ import Testing
         #expect(store.activeMacInstanceTag == "new-build")
     }
 
+    /// A supplied tag selects only its exact saved app-instance row.
     @Test func taggedSwitchStillUsesExactInstanceRow() async throws {
         let now = Date(timeIntervalSince1970: 3_000)
         let router = LivenessHostRouter()
@@ -164,6 +167,7 @@ import Testing
         #expect(!factory.attemptedPorts().contains(51_031))
     }
 
+    /// Creates a loopback route for a scripted transport attempt.
     private func loopbackRoute(id: String, port: Int) throws -> CmxAttachRoute {
         try CmxAttachRoute(
             id: id,
@@ -173,6 +177,7 @@ import Testing
         )
     }
 
+    /// Creates an isolated SQLite paired-Mac store for one test.
     private func makePairedMacStore() throws -> (MobilePairedMacStore, URL) {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -186,6 +191,7 @@ import Testing
         return (store, directory)
     }
 
+    /// Builds a shell wired to the test transport and identity provider.
     private func makeShell(
         pairedStore: MobilePairedMacStore,
         factory: RouteRecordingTransportFactory,
@@ -209,6 +215,7 @@ import Testing
         )
     }
 
+    /// Disables background secondary dials so switch attempts stay observable.
     private func aggregationDefaults() -> UserDefaults {
         let defaults = UserDefaults(
             suiteName: "device-only-switch-aggregation-\(UUID().uuidString)"

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DeviceOnlyMacSwitchTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DeviceOnlyMacSwitchTests.swift
@@ -1,0 +1,219 @@
+import CMUXMobileCore
+import CmuxMobilePairedMac
+import CmuxMobileRPC
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+/// Behavior coverage for switches whose caller knows a physical Mac but not
+/// which saved app instance owns the row.
+@MainActor
+@Suite struct DeviceOnlyMacSwitchTests {
+    @Test func deviceOnlySwitchResolvesAndDialsTaggedRow() async throws {
+        let now = Date(timeIntervalSince1970: 1_000)
+        let router = LivenessHostRouter()
+        await router.setHostIdentity(
+            deviceID: "test-mac",
+            instanceTag: "feature-a",
+            displayName: "Test Mac"
+        )
+        let factory = RouteRecordingTransportFactory(
+            router: router,
+            box: TransportBox(),
+            failingPorts: []
+        )
+        let route = try loopbackRoute(id: "feature-a", port: 51_010)
+        let (pairedStore, directory) = try makePairedMacStore()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try await pairedStore.upsert(
+            macDeviceID: "test-mac",
+            displayName: "Test Mac",
+            routes: [route],
+            instanceTag: "feature-a",
+            markActive: true,
+            stackUserID: "user-1",
+            teamID: nil,
+            now: now
+        )
+        let store = makeShell(
+            pairedStore: pairedStore,
+            factory: factory,
+            now: now
+        )
+        await store.loadPairedMacs()
+
+        #expect(await store.switchToMac(macDeviceID: "test-mac"))
+        #expect(factory.attemptedPorts().first == 51_010)
+        #expect(store.foregroundMacDeviceID == "test-mac")
+        #expect(store.activeMacInstanceTag == "feature-a")
+    }
+
+    @Test func deviceOnlySwitchUsesMostRecentTaggedRowForOneMac() async throws {
+        let now = Date(timeIntervalSince1970: 2_000)
+        let router = LivenessHostRouter()
+        await router.setHostIdentity(
+            deviceID: "test-mac",
+            instanceTag: "new-build",
+            displayName: "Test Mac"
+        )
+        let factory = RouteRecordingTransportFactory(
+            router: router,
+            box: TransportBox(),
+            failingPorts: [51_020]
+        )
+        let oldRoute = try loopbackRoute(id: "old-build", port: 51_020)
+        let newRoute = try loopbackRoute(id: "new-build", port: 51_021)
+        let otherRoute = try loopbackRoute(id: "other-mac", port: 51_022)
+        let (pairedStore, directory) = try makePairedMacStore()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try await pairedStore.upsert(
+            macDeviceID: "test-mac",
+            displayName: "Test Mac",
+            routes: [oldRoute],
+            instanceTag: "old-build",
+            markActive: true,
+            stackUserID: "user-1",
+            teamID: nil,
+            now: now
+        )
+        try await pairedStore.upsert(
+            macDeviceID: "test-mac",
+            displayName: "Test Mac",
+            routes: [newRoute],
+            instanceTag: "new-build",
+            markActive: false,
+            stackUserID: "user-1",
+            teamID: nil,
+            now: now.addingTimeInterval(1)
+        )
+        try await pairedStore.upsert(
+            macDeviceID: "other-mac",
+            displayName: "Other Mac",
+            routes: [otherRoute],
+            instanceTag: "other-build",
+            markActive: false,
+            stackUserID: "user-1",
+            teamID: nil,
+            now: now.addingTimeInterval(2)
+        )
+        let store = makeShell(
+            pairedStore: pairedStore,
+            factory: factory,
+            now: now
+        )
+        await store.loadPairedMacs()
+
+        #expect(await store.switchToMac(macDeviceID: "test-mac"))
+        let attempts = factory.attemptedPorts()
+        #expect(attempts.first == 51_021)
+        #expect(!attempts.contains(51_020))
+        #expect(!attempts.contains(51_022))
+        #expect(store.foregroundMacDeviceID == "test-mac")
+        #expect(store.activeMacInstanceTag == "new-build")
+    }
+
+    @Test func taggedSwitchStillUsesExactInstanceRow() async throws {
+        let now = Date(timeIntervalSince1970: 3_000)
+        let router = LivenessHostRouter()
+        await router.setHostIdentity(
+            deviceID: "test-mac",
+            instanceTag: "new-build",
+            displayName: "Test Mac"
+        )
+        let factory = RouteRecordingTransportFactory(
+            router: router,
+            box: TransportBox(),
+            failingPorts: [51_030]
+        )
+        let oldRoute = try loopbackRoute(id: "old-build", port: 51_030)
+        let newRoute = try loopbackRoute(id: "new-build", port: 51_031)
+        let (pairedStore, directory) = try makePairedMacStore()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try await pairedStore.upsert(
+            macDeviceID: "test-mac",
+            displayName: "Test Mac",
+            routes: [oldRoute],
+            instanceTag: "old-build",
+            markActive: false,
+            stackUserID: "user-1",
+            teamID: nil,
+            now: now
+        )
+        try await pairedStore.upsert(
+            macDeviceID: "test-mac",
+            displayName: "Test Mac",
+            routes: [newRoute],
+            instanceTag: "new-build",
+            markActive: true,
+            stackUserID: "user-1",
+            teamID: nil,
+            now: now.addingTimeInterval(1)
+        )
+        let store = makeShell(
+            pairedStore: pairedStore,
+            factory: factory,
+            now: now
+        )
+        await store.loadPairedMacs()
+
+        #expect(!(await store.switchToMac(
+            macDeviceID: "test-mac",
+            instanceTag: "old-build"
+        )))
+        #expect(factory.attemptedPorts().first == 51_030)
+        #expect(!factory.attemptedPorts().contains(51_031))
+    }
+
+    private func loopbackRoute(id: String, port: Int) throws -> CmxAttachRoute {
+        try CmxAttachRoute(
+            id: id,
+            kind: .debugLoopback,
+            endpoint: .hostPort(host: "127.0.0.1", port: port),
+            priority: port
+        )
+    }
+
+    private func makePairedMacStore() throws -> (MobilePairedMacStore, URL) {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        let store = try MobilePairedMacStore(
+            databaseURL: directory.appendingPathComponent("paired-macs.sqlite3")
+        )
+        return (store, directory)
+    }
+
+    private func makeShell(
+        pairedStore: MobilePairedMacStore,
+        factory: RouteRecordingTransportFactory,
+        now: Date
+    ) -> MobileShellComposite {
+        return MobileShellComposite(
+            runtime: LivenessTestRuntime(
+                transportFactory: factory,
+                now: { now },
+                supportedRouteKinds: [.debugLoopback]
+            ),
+            isSignedIn: true,
+            pairedMacStore: pairedStore,
+            identityProvider: StaticIdentityProvider(userID: "user-1"),
+            reachability: AlwaysOnlineReachability(),
+            pairingHintDefaults: UserDefaults(
+                suiteName: "device-only-switch-\(UUID().uuidString)"
+            )!,
+            multiMacAggregationDefaults: aggregationDefaults(),
+            hiddenMacStore: InMemoryPairedMacHiddenStore()
+        )
+    }
+
+    private func aggregationDefaults() -> UserDefaults {
+        let defaults = UserDefaults(
+            suiteName: "device-only-switch-aggregation-\(UUID().uuidString)"
+        )!
+        defaults.set(false, forKey: "multiMacAggregation")
+        return defaults
+    }
+}


### PR DESCRIPTION
## Summary

- Resolve device-only paired-Mac switches against tagged rows, selecting the most recently seen matching instance with a deterministic tie-breaker.
- Keep explicit instance-tag switches exact and restrict every lookup to the requested physical Mac.
- Keep the shared resolver in the paired-Mac query layer so all switch callers use the same policy.

Closes https://github.com/manaflow-ai/cmux/issues/11255

## Verification

~~~text
swift test --package-path Packages/iOS/CmuxMobileShell --filter DeviceOnlyMacSwitchTests
  Expected red on the pre-fix commit: both nil-tag behavior tests returned false with no dial.

arch -arm64 swift test --scratch-path /tmp/cmux11255-shell-test --jobs 4 --package-path Packages/iOS/CmuxMobileShell --filter 'DeviceOnlyMacSwitchTests|ReconnectRouteSelectionTests/sameDeviceTagSwitchFailureRestoresLiveInstanceRoute'
  Passed: 4 tests.

arch -arm64 swift build --package-path Packages/iOS/CmuxMobilePairedMac
  Passed.

python3 scripts/check-package-resolved-policy.py
  Passed.

python3 scripts/check-workspace-package-groups.py --check
  Passed.

./scripts/lint-pbxproj-test-wiring.sh
  Passed.

python3 scripts/swift_warning_budget.py --log /tmp/cmux11255-shell-build.log
  Passed; no actual warnings.

python3 scripts/swift_file_length_budget.py
  Not runnable in this checkout: the script and .github/swift-file-length-budget.tsv are absent on origin/main.

arch -arm64 swift test --scratch-path /tmp/cmux11255-paired-test --jobs 4 --package-path Packages/iOS/CmuxMobilePairedMac
  Existing baseline failure: canonicalizesUUIDsAcrossProductionMutationsWhilePreservingOpaqueIDs.
~~~

No UI changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790828141&installation_model_id=21920&pr_number=11328&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11328&signature=06323c0642a43ad86a341a6359e25fca8ea74cc793f0cce641796c4613fe3c67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes device-only Mac switching so a nil-tag switch resolves the most recently seen tagged instance for a physical Mac instead of failing when multiple saved sibling builds exist.

**Behavior**

- Device-only switches (`instanceTag: nil`) now match the newest tagged row for that Mac, with a stable tie-breaker when recency matches.
- Explicit instance-tag switches stay exact and are still restricted to the requested Mac.
- The shared resolver lives in the paired-Mac query layer as a single linear pass so all switch callers follow the same policy.

Closes https://github.com/manaflow-ai/cmux/issues/11255.

<sup>Written for commit 2be24a72b8969b23782ef318bc2c5e814ef90042. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mac switching now selects the most recently seen paired Mac when multiple app instances are available.
  * Device-specific requests work without requiring an instance tag.
  * Exact instance-tag routing remains supported.

* **Bug Fixes**
  * Improved Mac selection for devices with multiple paired instances.

* **Tests**
  * Added coverage for device-only switching, recent-instance selection, and exact instance routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->