### PR TITLE
ios: preload What's New web pages before presenting the sheet

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileWhatsNewSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileWhatsNewSheet.swift
@@ -10,6 +10,10 @@ import SwiftUI
 struct MobileWhatsNewSheet: View {
     let pages: [MobileWhatsNewPage]
     let allowedWebHosts: Set<String>
+    /// Web pages are preloaded before this sheet presents (keyed by
+    /// `listID`), so a web page renders the instant the sheet appears
+    /// instead of loading behind an already-visible sheet.
+    var webLoads: [String: MobileWhatsNewWebPageLoad] = [:]
     let dismiss: () -> Void
     @State private var pageIndex = 0
 
@@ -53,7 +57,11 @@ struct MobileWhatsNewSheet: View {
                 MobileWhatsNewContent(page: page)
             }
         case .web(let url):
-            MobileWhatsNewWebView(url: url, allowedHosts: allowedWebHosts)
+            MobileWhatsNewWebView(
+                url: url,
+                allowedHosts: allowedWebHosts,
+                preloadedLoad: webLoads[page.listID]
+            )
         }
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileWhatsNewWebPageLoad.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileWhatsNewWebPageLoad.swift
@@ -1,0 +1,181 @@
+#if os(iOS)
+import CmuxMobileSupport
+import SwiftUI
+import WebKit
+
+/// One What's New web page load lifecycle, owned outside the presented view
+/// hierarchy so a page can finish loading BEFORE any surface that shows it
+/// appears (HIG Loading: the best content-loading experience finishes before
+/// people become aware of it). Owns the webview, the web-session exchange,
+/// the cookie seeding, the navigation allowlist, and a bounded deadline.
+///
+/// The load settles into a terminal phase exactly once: `loaded` when the
+/// initial page finished, `failed` on the first load error or when the
+/// deadline passes. Later navigation failures (an off-allowlist tap the
+/// policy cancelled, a dead link) never tear down the already-rendered page,
+/// and the allowlist keeps applying to every navigation for the webview's
+/// whole lifetime.
+@MainActor
+@Observable
+final class MobileWhatsNewWebPageLoad {
+    enum Phase {
+        case loading
+        case loaded
+        case failed
+    }
+
+    let url: URL
+    let webView: WKWebView
+    private(set) var phase: Phase = .loading
+
+    private let navigator: Navigator
+    private var loadTask: Task<Void, Never>?
+    private var deadlineTask: Task<Void, Never>?
+    private var outcomeContinuations: [CheckedContinuation<Phase, Never>] = []
+
+    /// Creates the webview and immediately starts the load: exchange the
+    /// native session for web session cookies (`nil` session renders the
+    /// page as an anonymous visitor rather than blocking release-note
+    /// content behind auth), seed them into the webview's own non-persistent
+    /// data store, then load the page. `deadline` bounds the whole sequence;
+    /// `initialInterfaceStyle` pins the off-window load to the app's
+    /// resolved appearance so the page does not flash the other scheme when
+    /// it is installed into the hierarchy.
+    init(
+        url: URL,
+        allowedHosts: Set<String>,
+        webAppSession: (any MobileWebAppSessionProviding)?,
+        deadline: Duration,
+        initialInterfaceStyle: UIUserInterfaceStyle = .unspecified,
+        clock: any Clock<Duration> = ContinuousClock()
+    ) {
+        self.url = url
+        let configuration = WKWebViewConfiguration()
+        configuration.websiteDataStore = .nonPersistent()
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.isOpaque = false
+        webView.backgroundColor = .systemBackground
+        webView.scrollView.backgroundColor = .systemBackground
+        webView.allowsBackForwardNavigationGestures = false
+        webView.overrideUserInterfaceStyle = initialInterfaceStyle
+        self.webView = webView
+        navigator = Navigator(allowedHosts: allowedHosts)
+        navigator.owner = self
+        webView.navigationDelegate = navigator
+
+        loadTask = Task { [weak self, url] in
+            let cookies = await Self.exchangeSessionCookies(webAppSession, for: url)
+            guard let self, !Task.isCancelled else { return }
+            let store = self.webView.configuration.websiteDataStore.httpCookieStore
+            for cookie in cookies {
+                guard !Task.isCancelled else { return }
+                await store.setCookie(cookie)
+            }
+            guard !Task.isCancelled else { return }
+            self.webView.load(URLRequest(url: url))
+        }
+        // Intentional bounded timeout through an injected Clock, cancelled by
+        // `settle(_:)` the moment the load reaches a terminal phase.
+        deadlineTask = Task { [weak self] in
+            guard (try? await clock.sleep(for: deadline)) != nil else { return }
+            self?.settle(.failed)
+        }
+    }
+
+    /// Runs the network-bound session exchange off the main actor so page
+    /// preloads never occupy it; the webview and cookie-store mutations stay
+    /// main-actor in the calling task.
+    @concurrent
+    private nonisolated static func exchangeSessionCookies(
+        _ session: (any MobileWebAppSessionProviding)?,
+        for url: URL
+    ) async -> [HTTPCookie] {
+        await session?.sessionCookies(for: url) ?? []
+    }
+
+    // No deinit cancellation: both tasks hold `self` weakly and settle or
+    // exit within the bounded deadline on their own, and `settle(_:)`
+    // cancels them on every terminal path. A nonisolated deinit cannot
+    // touch these main-actor properties anyway.
+
+    /// Suspends until the load settles. Always resumes: the deadline task
+    /// guarantees a terminal phase even when the network stalls, so a caller
+    /// gating presentation on this can never hang.
+    func outcome() async -> Phase {
+        if phase != .loading { return phase }
+        return await withCheckedContinuation { outcomeContinuations.append($0) }
+    }
+
+    private func settle(_ terminal: Phase) {
+        guard phase == .loading else { return }
+        phase = terminal
+        deadlineTask?.cancel()
+        deadlineTask = nil
+        if terminal == .failed {
+            loadTask?.cancel()
+            loadTask = nil
+            webView.stopLoading()
+        }
+        let continuations = outcomeContinuations
+        outcomeContinuations = []
+        for continuation in continuations {
+            continuation.resume(returning: terminal)
+        }
+    }
+
+    @MainActor
+    private final class Navigator: NSObject, WKNavigationDelegate {
+        private let allowedHosts: Set<String>
+        weak var owner: MobileWhatsNewWebPageLoad?
+
+        init(allowedHosts: Set<String>) {
+            self.allowedHosts = allowedHosts
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            decidePolicyFor navigationAction: WKNavigationAction
+        ) async -> WKNavigationActionPolicy {
+            guard let url = navigationAction.request.url,
+                  mobileWebPageURLAllowed(url, allowedHosts: allowedHosts) else {
+                // WebKit-internal blank navigations carry no host; cancelling
+                // one would fail a load that never touched the network.
+                if navigationAction.request.url?.absoluteString == "about:blank" {
+                    return .allow
+                }
+                // A rejected MAIN-FRAME navigation ends the page load (a
+                // redirect to an off-allowlist host mid-load, for example),
+                // so settle immediately instead of depending on WebKit to
+                // report the policy cancellation before the deadline. After
+                // settling this is a no-op, preserving the rendered page on
+                // off-allowlist link taps.
+                if navigationAction.targetFrame?.isMainFrame != false {
+                    owner?.settle(.failed)
+                }
+                return .cancel
+            }
+            return .allow
+        }
+
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            owner?.settle(.loaded)
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            didFailProvisionalNavigation navigation: WKNavigation!,
+            withError error: Error
+        ) {
+            owner?.settle(.failed)
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            didFail navigation: WKNavigation!,
+            withError error: Error
+        ) {
+            owner?.settle(.failed)
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileWhatsNewWebView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileWhatsNewWebView.swift
@@ -3,49 +3,46 @@ import CmuxMobileSupport
 import SwiftUI
 import WebKit
 
-/// Minimal in-app webview for What's New web pages: cmux-owned hosts only,
-/// system-background appearance so remote pages match the app, a quiet
-/// offline placeholder with a retry control instead of an error shell, and a
-/// bounded load deadline so a stalled page cannot stay blank forever.
-/// Navigation away from the allowlisted hosts is cancelled.
+/// Minimal in-app webview for What's New web pages, rendering a
+/// ``MobileWhatsNewWebPageLoad``: cmux-owned hosts only, system-background
+/// appearance so remote pages match the app, a quiet offline placeholder
+/// with a retry control instead of an error shell, and a bounded load
+/// deadline so a stalled page cannot stay blank forever.
 ///
-/// Pages render as the signed-in app user: before the first request, the
-/// environment's `mobileWebAppSession` exchanges the native Stack session
-/// for web session cookies, which are seeded into the webview's own
-/// non-persistent data store (so the web session dies with this view). When
-/// no session is available the page loads as an anonymous visitor, and Try
-/// Again repeats the exchange with fresh tokens, which also recovers an
-/// expired session. The webview follows the app's resolved light/dark
+/// The one-time launch sheet passes a load it already finished BEFORE
+/// presenting (`preloadedLoad`), so the page renders the instant the sheet
+/// appears. Without one (the Settings archive push, a retry), the view
+/// creates its own load in place: the page renders as the signed-in app
+/// user via the environment's `mobileWebAppSession` session exchange, or as
+/// an anonymous visitor when no session is available. Try Again always
+/// starts a fresh load with a fresh session exchange, which also recovers
+/// an expired session. The webview follows the app's resolved light/dark
 /// appearance and flips live when it changes.
 struct MobileWhatsNewWebView: View {
-    /// One webview load lifecycle: loading until the page finishes, then
-    /// loaded; failed on error or when the load deadline passes first.
-    private enum LoadPhase: Equatable {
-        case loading
-        case loaded
-        case failed
-    }
-
     let url: URL
     let allowedHosts: Set<String>
-    /// Deadline for the initial page load, including the session exchange;
-    /// after it the quiet failure state with the retry control replaces the
+    /// A load finished before this view was surfaced. The sheet path never
+    /// shows loading UI because presentation already gated on this load's
+    /// outcome.
+    var preloadedLoad: MobileWhatsNewWebPageLoad?
+    /// Deadline for an in-place load, including the session exchange; after
+    /// it the quiet failure state with the retry control replaces the
     /// (possibly blank) webview.
     var loadDeadline: Duration = .seconds(20)
     @Environment(\.mobileWebAppSession) private var webAppSession
-    @State private var phase: LoadPhase = .loading
+    @Environment(\.colorScheme) private var colorScheme
     @State private var attempt = 0
-    /// The attempt whose session cookies are resolved; the webview mounts
-    /// only once its own attempt resolved, so a retry always exchanges
-    /// fresh tokens instead of reusing a stale session.
-    @State private var resolvedAttempt: Int?
-    @State private var sessionCookies: [HTTPCookie] = []
+    @State private var localLoad: (attempt: Int, load: MobileWhatsNewWebPageLoad)?
+
+    private var load: MobileWhatsNewWebPageLoad? {
+        localLoad?.load ?? preloadedLoad
+    }
 
     var body: some View {
         ZStack {
             PlatformPalette.systemBackground
                 .ignoresSafeArea()
-            if phase == .failed {
+            if load?.phase == .failed {
                 VStack(spacing: 12) {
                     Image(systemName: "wifi.slash")
                         .font(.title2)
@@ -59,7 +56,6 @@ struct MobileWhatsNewWebView: View {
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
                     Button {
-                        phase = .loading
                         attempt += 1
                     } label: {
                         Text(L10n.string(
@@ -72,72 +68,49 @@ struct MobileWhatsNewWebView: View {
                 }
                 .padding(32)
                 .accessibilityIdentifier("MobileWhatsNewWebUnavailable")
-            } else if resolvedAttempt == attempt {
-                WhatsNewWebViewRepresentable(
-                    url: url,
-                    allowedHosts: allowedHosts,
-                    sessionCookies: sessionCookies,
-                    onFinish: { phase = .loaded },
-                    // Only the initial load can fail into the placeholder.
-                    // A later navigation failure (an off-allowlist tap the
-                    // policy cancelled, a dead link) must not tear down the
-                    // already-rendered page.
-                    onFailure: { if phase == .loading { phase = .failed } }
-                )
-                .id(attempt)
+            } else if let load {
+                WhatsNewWebViewInstaller(webView: load.webView)
+                    .id(ObjectIdentifier(load))
             }
         }
         .task(id: attempt) {
-            await resolveSession()
-        }
-        .task(id: attempt) {
-            // Bounded deadline for the initial load (session exchange plus
-            // page load); cancelled with the view (and superseded by a
-            // retry) via task identity.
-            guard (try? await ContinuousClock().sleep(for: loadDeadline)) != nil else { return }
-            if phase == .loading { phase = .failed }
+            startLoadIfNeeded()
         }
         .accessibilityIdentifier("MobileWhatsNewWebView")
     }
 
-    /// Exchanges the native session for this attempt's web session cookies.
-    /// `nil` (signed out, exchange unavailable) renders the page without a
-    /// session rather than blocking release-note content behind auth.
-    private func resolveSession() async {
-        guard resolvedAttempt != attempt else { return }
-        let cookies = await webAppSession?.sessionCookies(for: url)
-        guard !Task.isCancelled else { return }
-        sessionCookies = cookies ?? []
-        resolvedAttempt = attempt
+    /// Creates this attempt's in-place load. Attempt 0 defers to a preloaded
+    /// page when one exists; re-appearances (sheet page swipes, navigation
+    /// returns) keep the existing load and its webview instead of reloading
+    /// the page.
+    private func startLoadIfNeeded() {
+        if attempt == 0, preloadedLoad != nil { return }
+        guard localLoad?.attempt != attempt else { return }
+        localLoad = (
+            attempt: attempt,
+            load: MobileWhatsNewWebPageLoad(
+                url: url,
+                allowedHosts: allowedHosts,
+                webAppSession: webAppSession,
+                deadline: loadDeadline,
+                initialInterfaceStyle: colorScheme == .dark ? .dark : .light
+            )
+        )
     }
 }
 
-private struct WhatsNewWebViewRepresentable: UIViewRepresentable {
-    let url: URL
-    let allowedHosts: Set<String>
-    let sessionCookies: [HTTPCookie]
-    let onFinish: @MainActor () -> Void
-    let onFailure: @MainActor () -> Void
-
-    func makeCoordinator() -> Coordinator {
-        Coordinator(allowedHosts: allowedHosts, onFinish: onFinish, onFailure: onFailure)
-    }
+/// Installs an externally owned webview and keeps it pinned to the APP's
+/// resolved appearance (the SwiftUI environment's color scheme, which
+/// reflects the system setting plus any in-app override up the hierarchy)
+/// instead of the raw device trait, so the page's `prefers-color-scheme`
+/// and its dynamic system colors always match the surrounding chrome.
+/// `updateUIView` reads the environment again on every SwiftUI update, so
+/// an appearance change flips the live page immediately.
+private struct WhatsNewWebViewInstaller: UIViewRepresentable {
+    let webView: WKWebView
 
     func makeUIView(context: Context) -> WKWebView {
-        let configuration = WKWebViewConfiguration()
-        configuration.websiteDataStore = .nonPersistent()
-        let webView = WKWebView(frame: .zero, configuration: configuration)
-        webView.navigationDelegate = context.coordinator
-        webView.isOpaque = false
-        webView.backgroundColor = .systemBackground
-        webView.scrollView.backgroundColor = .systemBackground
-        webView.allowsBackForwardNavigationGestures = false
         applyResolvedAppearance(to: webView, context: context)
-        context.coordinator.seedSessionAndLoad(
-            webView,
-            cookies: sessionCookies,
-            url: url
-        )
         return webView
     }
 
@@ -145,96 +118,9 @@ private struct WhatsNewWebViewRepresentable: UIViewRepresentable {
         applyResolvedAppearance(to: webView, context: context)
     }
 
-    static func dismantleUIView(_ webView: WKWebView, coordinator: Coordinator) {
-        coordinator.cancelPendingLoad()
-    }
-
-    /// Pins the webview to the APP's resolved appearance (the SwiftUI
-    /// environment's color scheme, which reflects the system setting plus
-    /// any in-app override up the hierarchy) instead of the raw device
-    /// trait, so the page's `prefers-color-scheme` and its dynamic system
-    /// colors always match the surrounding chrome. `updateUIView` reads the
-    /// environment again on every SwiftUI update, so an appearance change
-    /// flips the live page immediately.
     private func applyResolvedAppearance(to webView: WKWebView, context: Context) {
         webView.overrideUserInterfaceStyle =
             context.environment.colorScheme == .dark ? .dark : .light
-    }
-
-    @MainActor
-    final class Coordinator: NSObject, WKNavigationDelegate {
-        private let allowedHosts: Set<String>
-        private let onFinish: @MainActor () -> Void
-        private let onFailure: @MainActor () -> Void
-        private var pendingLoad: Task<Void, Never>?
-
-        init(
-            allowedHosts: Set<String>,
-            onFinish: @escaping @MainActor () -> Void,
-            onFailure: @escaping @MainActor () -> Void
-        ) {
-            self.allowedHosts = allowedHosts
-            self.onFinish = onFinish
-            self.onFailure = onFailure
-        }
-
-        /// Seeds the session cookies into the webview's own data store
-        /// before the first request (or the page would render signed out),
-        /// then starts the load. Event-ordered on the cookie-store
-        /// callbacks, and cancelled when the webview is dismantled.
-        func seedSessionAndLoad(
-            _ webView: WKWebView,
-            cookies: [HTTPCookie],
-            url: URL
-        ) {
-            pendingLoad = Task { @MainActor [weak webView] in
-                for cookie in cookies {
-                    guard !Task.isCancelled,
-                          let store = webView?.configuration.websiteDataStore.httpCookieStore else {
-                        return
-                    }
-                    await store.setCookie(cookie)
-                }
-                guard !Task.isCancelled, let webView else { return }
-                webView.load(URLRequest(url: url))
-            }
-        }
-
-        func cancelPendingLoad() {
-            pendingLoad?.cancel()
-            pendingLoad = nil
-        }
-
-        func webView(
-            _ webView: WKWebView,
-            decidePolicyFor navigationAction: WKNavigationAction
-        ) async -> WKNavigationActionPolicy {
-            guard let url = navigationAction.request.url,
-                  mobileWebPageURLAllowed(url, allowedHosts: allowedHosts) else {
-                return .cancel
-            }
-            return .allow
-        }
-
-        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-            onFinish()
-        }
-
-        func webView(
-            _ webView: WKWebView,
-            didFailProvisionalNavigation navigation: WKNavigation!,
-            withError error: Error
-        ) {
-            onFailure()
-        }
-
-        func webView(
-            _ webView: WKWebView,
-            didFail navigation: WKNavigation!,
-            withError error: Error
-        ) {
-            onFailure()
-        }
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -172,7 +172,17 @@ struct WorkspaceShellView: View {
     /// sheet presents, so remote list changes mid-presentation cannot mutate
     /// an open sheet.
     @Environment(MobileWhatsNewCenter.self) private var whatsNewCenter: MobileWhatsNewCenter?
+    @Environment(\.mobileWebAppSession) private var whatsNewWebAppSession
+    @Environment(\.colorScheme) private var whatsNewColorScheme
     @State private var whatsNewSheetPages: [MobileWhatsNewPage] = []
+    /// Unseen pages staged for presentation, awaiting the web-page preload
+    /// gate; the preload task keys off this so it is view-owned (cancelled on
+    /// disappear) yet triggerable from every presentation call site.
+    @State private var whatsNewCandidatePages: [MobileWhatsNewPage]?
+    /// Finished preloads for the presented sheet's web pages, keyed by
+    /// `listID`. Kept here so the webviews outlive sheet content rebuilds and
+    /// are released when the sheet is dismissed.
+    @State private var whatsNewWebLoads: [String: MobileWhatsNewWebPageLoad] = [:]
     @State private var showsWhatsNewSheet = false
     @State private var notificationNavigationPath: [MobileWorkspacePreview.ID] = []
     @State private var notificationSearchNavigationPath: [MobileWorkspacePreview.ID] = []
@@ -517,10 +527,25 @@ struct WorkspaceShellView: View {
         .onChange(of: store.pairedMacs.isEmpty) { _, _ in
             presentWhatsNewIfNeeded()
         }
-        .sheet(isPresented: $showsWhatsNewSheet) {
+        // The staged candidate's preload gate: web pages load into live
+        // webviews BEFORE the sheet presents, so the sheet never surfaces
+        // with a page still loading behind it. `.task(id:)` (not a Task in
+        // presentWhatsNewIfNeeded) so the preload is view-owned and a
+        // candidate upgraded by a late refresh restarts the gate.
+        .task(id: whatsNewCandidateID) {
+            await preloadAndPresentWhatsNew()
+        }
+        .sheet(isPresented: $showsWhatsNewSheet, onDismiss: {
+            // Release the preloaded webviews only after the dismissal
+            // animation finished; clearing at gate time would blank the
+            // still-visible sheet content mid-animation.
+            whatsNewSheetPages = []
+            whatsNewWebLoads = [:]
+        }) {
             MobileWhatsNewSheet(
                 pages: whatsNewSheetPages,
                 allowedWebHosts: whatsNewCenter?.allowedWebHosts ?? [],
+                webLoads: whatsNewWebLoads,
                 dismiss: { showsWhatsNewSheet = false }
             )
             .presentationDetents([.large])
@@ -539,8 +564,16 @@ struct WorkspaceShellView: View {
     }
 
     #if os(iOS)
-    /// Presents the one-time What's New sheet when there are unseen pages
-    /// and the device already has Computers. Acknowledgement happens in the
+    /// Bound on the whole pre-presentation preload (all pages load
+    /// concurrently). Generous enough for a slow cellular page, short enough
+    /// that a stalled page cannot postpone the notice indefinitely: pages
+    /// that miss it are dropped unacknowledged and try again next launch.
+    private static let whatsNewPreloadDeadline: Duration = .seconds(10)
+
+    /// Stages the one-time What's New sheet when there are unseen pages and
+    /// the device already has Computers. Staging is not presenting: the
+    /// preload gate (`preloadAndPresentWhatsNew`) presents only once every
+    /// page in the sheet renders immediately. Acknowledgement happens in the
     /// sheet content's `onAppear` (first actual presentation, not on
     /// dismiss): early enough that a kill mid-presentation cannot re-show
     /// the sheet forever, late enough that a swallowed presentation (a
@@ -552,7 +585,63 @@ struct WorkspaceShellView: View {
               !showsWhatsNewSheet else { return }
         let pages = whatsNewCenter.unseenPages
         guard !pages.isEmpty else { return }
-        whatsNewSheetPages = pages
+        whatsNewCandidatePages = pages
+    }
+
+    /// The staged candidate's task identity: page identity (not count), so a
+    /// candidate re-staged with the same pages does not restart an in-flight
+    /// preload, while a late refresh that changes the page set does.
+    private var whatsNewCandidateID: String? {
+        whatsNewCandidatePages.map { pages in
+            pages.map(\.listID).joined(separator: "|")
+        }
+    }
+
+    /// Presents the staged candidate once its content is ready. Native
+    /// feature pages are compiled in and always ready; web pages preload
+    /// into live webviews first, and a page that fails or misses the
+    /// deadline is dropped from THIS presentation without acknowledgement
+    /// (same policy as the offline skip in `unseenPages`), so it returns on
+    /// a later launch instead of presenting a sheet that shows loading UI.
+    private func preloadAndPresentWhatsNew() async {
+        guard let pages = whatsNewCandidatePages, !showsWhatsNewSheet else { return }
+        let allowedHosts = whatsNewCenter?.allowedWebHosts ?? []
+        var loads: [String: MobileWhatsNewWebPageLoad] = [:]
+        for page in pages {
+            if case .web(let url) = page.body {
+                loads[page.listID] = MobileWhatsNewWebPageLoad(
+                    url: url,
+                    allowedHosts: allowedHosts,
+                    webAppSession: whatsNewWebAppSession,
+                    deadline: Self.whatsNewPreloadDeadline,
+                    initialInterfaceStyle: whatsNewColorScheme == .dark ? .dark : .light
+                )
+            }
+        }
+        // Loads run concurrently from init; each settles by its own deadline,
+        // so awaiting them in sequence is bounded and cannot hang this task.
+        for load in loads.values {
+            _ = await load.outcome()
+        }
+        guard !Task.isCancelled else { return }
+        whatsNewCandidatePages = nil
+        // The gate conditions can drift during the bounded preload window (a
+        // refresh can withdraw a page, the last Computer can disappear), so
+        // re-check them now instead of trusting the staging-time snapshot.
+        guard let whatsNewCenter, !store.pairedMacs.isEmpty else { return }
+        let stillUnseen = Set(whatsNewCenter.unseenPages.map(\.listID))
+        let readyPages = pages.filter { page in
+            guard stillUnseen.contains(page.listID) else { return false }
+            switch page.body {
+            case .features:
+                return true
+            case .web:
+                return loads[page.listID]?.phase == .loaded
+            }
+        }
+        guard !readyPages.isEmpty, !showsWhatsNewSheet else { return }
+        whatsNewSheetPages = readyPages
+        whatsNewWebLoads = loads.filter { $0.value.phase == .loaded }
         showsWhatsNewSheet = true
     }
     #endif

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileWhatsNewWebPageLoadTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileWhatsNewWebPageLoadTests.swift
@@ -1,0 +1,60 @@
+#if os(iOS)
+import Foundation
+import Testing
+@testable import CmuxMobileShellUI
+
+/// The one-time What's New sheet gates its presentation on every web page's
+/// load outcome, so `outcome()` must always settle: a load that could stay
+/// `.loading` forever would silently suppress the notice for the whole
+/// launch. Both failure paths here are deterministic (no live network): the
+/// navigation allowlist cancels before any request, and the deadline fires
+/// while the session exchange hangs.
+@MainActor
+@Suite struct MobileWhatsNewWebPageLoadTests {
+    /// A session exchange that never resolves, standing in for a wedged
+    /// network: only the load's own deadline can settle it.
+    private struct HangingWebAppSession: MobileWebAppSessionProviding {
+        func sessionCookies(for destination: URL) async -> [HTTPCookie]? {
+            try? await Task.sleep(for: .seconds(3600))
+            return nil
+        }
+    }
+
+    @Test func offAllowlistURLSettlesFailed() async {
+        let load = MobileWhatsNewWebPageLoad(
+            url: URL(string: "https://not-allowlisted.example/whats-new")!,
+            allowedHosts: ["cmux.com"],
+            webAppSession: nil,
+            // The main-frame policy rejection settles the load directly, so
+            // this normally never waits; the deadline only bounds the test
+            // if WebKit ever stops consulting the policy for the first load.
+            deadline: .seconds(5)
+        )
+        #expect(await load.outcome() == .failed)
+        #expect(load.phase == .failed)
+    }
+
+    @Test func deadlineSettlesFailedWhileSessionExchangeHangs() async {
+        let load = MobileWhatsNewWebPageLoad(
+            url: URL(string: "https://cmux.com/whats-new")!,
+            allowedHosts: ["cmux.com"],
+            webAppSession: HangingWebAppSession(),
+            deadline: .milliseconds(50)
+        )
+        #expect(await load.outcome() == .failed)
+    }
+
+    @Test func settledOutcomeAnswersLateAwaitersImmediately() async {
+        let load = MobileWhatsNewWebPageLoad(
+            url: URL(string: "https://cmux.com/whats-new")!,
+            allowedHosts: ["cmux.com"],
+            webAppSession: HangingWebAppSession(),
+            deadline: .milliseconds(50)
+        )
+        _ = await load.outcome()
+        // A second await after settling must answer from the terminal phase
+        // instead of parking a continuation that nothing will ever resume.
+        #expect(await load.outcome() == .failed)
+    }
+}
+#endif


### PR DESCRIPTION
The one-time What's New sheet presented immediately and any web page then did its web-session exchange and WKWebView load behind the already-visible sheet, so the launch notice opened as a blank sheet that filled in seconds later. A sheet should not surface until its content renders immediately (HIG [Loading](https://developer.apple.com/design/human-interface-guidelines/loading): "The best content-loading experience finishes before people become aware of it"; loading in the background before surfacing UI is the sanctioned pattern).

Mechanism: a new `MobileWhatsNewWebPageLoad` owns one page's whole load lifecycle outside the view hierarchy (webview, session exchange, cookie seeding, navigation allowlist, bounded deadline) and settles into a terminal phase exactly once, with an `outcome()` that can never hang because the deadline task guarantees settlement. `WorkspaceShellView` now stages unseen pages as a candidate and a view-owned `.task(id:)` preloads every web page concurrently, presenting only pages that actually rendered; a page that fails or misses the 10s preload deadline is dropped unacknowledged (same policy as the existing offline skip) and returns next launch. Native feature pages are compiled in and present with no added wait. `MobileWhatsNewWebView` is now a thin renderer over a load (preloaded for the sheet, created in place for the Settings archive push), keeping the quiet failure placeholder and the fresh-session Try Again. Swiping between sheet pages no longer reloads a web page either, since the webview is owned outside the page view.

Tests: `MobileWhatsNewWebPageLoadTests` covers both deterministic failure paths (allowlist cancel, deadline while the session exchange hangs) and that a settled load answers late awaiters instead of parking a continuation forever.

Verified on tag `wnpre`: fleet macOS and iOS builds green, isolated-simulator launch shows the sheet appearing with content already rendered, dev-server `/api/whats-new` round confirmed. Localization audit: no new user-facing strings; the existing `mobile.whatsNew.*` keys are reused unchanged.

Includes a cherry-pick of https://github.com/manaflow-ai/cmux/pull/11316 (main is currently red for macOS Debug without it); it dedupes when that merges first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790829776&installation_model_id=21920&pr_number=11333&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11333&signature=28b96c96a34c506dc64b813d3f7f969353cc62fff3beed025121bf50d79ca255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preloads What's New web pages before the sheet presents, so the one-time launch notice no longer appears as a blank sheet that fills in seconds later. The sheet now surfaces only after every web page has rendered; a page that fails or misses the 10s preload deadline is dropped unacknowledged and returns next launch.

- Adds `MobileWhatsNewWebPageLoad`, which owns a page's whole load lifecycle (webview, session exchange, cookie seeding, navigation allowlist, bounded deadline) and always settles to a terminal phase, so presentation can never hang.
- Native feature pages are compiled in and present with no added wait.
- `MobileWhatsNewWebView` is now a thin renderer over a load, so swiping between sheet pages no longer reloads a web page.
- Cherry-picks the macOS Debug compile fix from #11316; it dedupes when that PR merges first.

<sup>Written for commit 4c4013f88ae73adafae388edc2915fb28b6574f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * What's New web pages now preload before the sheet appears, enabling faster and smoother viewing.
  * Previously loaded pages are reused when the sheet reappears.
  * Web content now enforces navigation safeguards and handles loading timeouts.

* **Bug Fixes**
  * Failed or timed-out pages are omitted without being marked as acknowledged.
  * Retry and loading behavior is more reliable when network requests stall.

* **Tests**
  * Added coverage for blocked navigation, stalled sessions, timeouts, and repeated load-result requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->