### PR TITLE
Use native Liquid Glass tabs on iPad

### DIFF
--- a/.github/workflows/reload-build.yml
+++ b/.github/workflows/reload-build.yml
@@ -578,6 +578,8 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGN_IDENTITY="" \
+            ARCHS=arm64 \
+            ONLY_ACTIVE_ARCH=YES \
             SWIFT_OPTIMIZATION_LEVEL=-O \
             SWIFT_COMPILATION_MODE=wholemodule \
             GCC_OPTIMIZATION_LEVEL=s \

--- a/.github/workflows/reload-build.yml
+++ b/.github/workflows/reload-build.yml
@@ -578,8 +578,6 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGN_IDENTITY="" \
-            ARCHS=arm64 \
-            ONLY_ACTIVE_ARCH=YES \
             SWIFT_OPTIMIZATION_LEVEL=-O \
             SWIFT_COMPILATION_MODE=wholemodule \
             GCC_OPTIMIZATION_LEVEL=s \
@@ -608,6 +606,8 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGN_IDENTITY="" \
+            ARCHS=arm64 \
+            ONLY_ACTIVE_ARCH=YES \
             SWIFT_OPTIMIZATION_LEVEL=-O \
             SWIFT_COMPILATION_MODE=wholemodule \
             GCC_OPTIMIZATION_LEVEL=s \

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePinnedNavigationBar.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePinnedNavigationBar.swift
@@ -19,21 +19,13 @@ extension View {
     /// decouples the bar from the content, so it stays expanded exactly like
     /// the terminal surface, where no system scroll view exists to discover.
     ///
-    /// On iOS 27 the native opt-out is applied as well once an Xcode 27
-    /// toolchain builds this target.
+    /// The native opt-out is not declared by the Xcode 27 beta 4 SDK used by
+    /// the supported build lane, so the UIKit scroll-link workaround remains
+    /// the portable implementation until that declaration is available.
     @ViewBuilder
     func mobilePinnedNavigationBar() -> some View {
         #if canImport(UIKit)
-        #if compiler(>=6.4)
-        if #available(iOS 27.0, *) {
-            background(PinnedNavigationBarApplier())
-                .toolbarMinimizeBehavior(.never, for: .navigationBar)
-        } else {
-            background(PinnedNavigationBarApplier())
-        }
-        #else
         background(PinnedNavigationBarApplier())
-        #endif
         #else
         self
         #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimarySearchCoordinator.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimarySearchCoordinator.swift
@@ -34,6 +34,14 @@ final class MobilePrimarySearchCoordinator {
         syncNativeSearchText(fromCommittedQueryFor: selectedScope)
     }
 
+    /// Starts search for the visible primary destination. iPad uses a custom
+    /// bottom control instead of selecting the transient search tab, so the
+    /// scope must be chosen before the searchable navigation stack presents.
+    func beginSearch(for scope: MobilePrimarySearchScope) {
+        self.scope = scope
+        setPresentation(true)
+    }
+
     func setPresentation(_ presented: Bool) {
         if isPresented, !presented {
             resetSearchQuery(for: scope)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimaryTabScaffold.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimaryTabScaffold.swift
@@ -348,8 +348,19 @@ private struct MobileIPadPrimaryBar: View {
 
     var body: some View {
         GeometryReader { geometry in
+            // NavigationSplitView can report its sidebar preference one
+            // layout pass after the rail mounts. Keep the first frame wide
+            // enough for the two tab buttons and align it with the split's
+            // balanced 320...440pt sidebar until the live measurement arrives.
+            let fallbackSidebarWidth = min(
+                440,
+                max(360, geometry.size.width * 0.43)
+            )
+            let measuredSidebarWidth = sidebarWidth > 0
+                ? sidebarWidth
+                : fallbackSidebarWidth
             let controlsWidth = sidebarVisible
-                ? min(geometry.size.width, max(sidebarWidth, 280))
+                ? min(geometry.size.width, max(measuredSidebarWidth, 360))
                 : min(geometry.size.width, 420)
 
             HStack(spacing: 8) {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimaryTabScaffold.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimaryTabScaffold.swift
@@ -106,8 +106,12 @@ struct MobilePrimaryTabScaffold<
                 primaryTabs
                 searchTab
             }
-            // The default iPadOS 26 presentation is the native Liquid Glass
-            // tab strip. Let TabView own its safe area and toolbar placement.
+            // Use Apple's adaptive iPad tab presentation so the system owns
+            // the Liquid Glass tab bar, its sidebar affordance, and its
+            // compact-width adaptation. Keeping this on the root TabView
+            // avoids a second app-owned navigation rail competing with the
+            // terminal toolbar.
+            .tabViewStyle(.sidebarAdaptable)
             .tabViewSearchActivation(.searchTabSelection)
             .accessibilityIdentifier("MobilePrimaryTabs")
             .onChange(of: selection, initial: true) { _, selection in

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimaryTabScaffold.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimaryTabScaffold.swift
@@ -58,19 +58,14 @@ struct MobilePrimaryTabScaffold<
             // bottom rail is the only primary navigation chrome and cannot
             // overlap a navigation toolbar.
             iPadPrimaryContent
-            .safeAreaInset(edge: .bottom, spacing: 0) {
+            .overlay(alignment: .bottomLeading) {
                 MobileIPadPrimaryBar(
                     selection: selection,
                     notificationUnreadCount: notificationUnreadCount,
                     taskComposerAction: taskComposerAction,
                     sidebarWidth: iPadSidebarWidth,
                     sidebarVisible: iPadSidebarVisible,
-                    select: selectTab,
-                    beginSearch: {
-                        let scope = selection.searchScope ?? searchCoordinator.scope
-                        searchCoordinator.beginSearch(for: scope)
-                        selectTab(.search)
-                    }
+                    select: selectTab
                 )
             }
             .accessibilityIdentifier("MobilePrimaryTabs")
@@ -135,19 +130,74 @@ struct MobilePrimaryTabScaffold<
     private var iPadPrimaryContent: some View {
         switch selection {
         case .workspaces:
-            workspaces
+            iPadSearchableContent(scope: .workspaces) {
+                workspaces
+            }
         case .notifications:
-            notifications
+            iPadSearchableContent(scope: .notifications) {
+                notifications
+            }
         case .search:
-            searchDestination
-                .searchable(
-                    text: activeSearchText,
-                    isPresented: searchPresentation,
-                    prompt: activeSearchPrompt
+            // The iPad rail never selects this transient destination. Keep it
+            // renderable for programmatic state, but scope it explicitly so it
+            // cannot inherit whichever root was selected before the transition.
+            iPadSearchableContent(scope: searchCoordinator.scope) {
+                searchDestination
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func iPadSearchableContent<Content: View>(
+        scope: MobilePrimarySearchScope,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        content()
+            .searchable(
+                text: nativeSearchText(for: scope),
+                isPresented: searchPresentation,
+                placement: .toolbar,
+                prompt: searchPrompt(for: scope)
+            )
+            .modifier(MobilePrimarySearchLifecycleModifier(
+                scope: scope,
+                update: updateSearchLifecycle
+            ))
+            .onSubmit(of: .search) {
+                searchCoordinator.commitSubmit()
+            }
+    }
+
+    private func nativeSearchText(for scope: MobilePrimarySearchScope) -> Binding<String> {
+        let activationGeneration = searchCoordinator.activationGeneration
+        return Binding(
+            get: { searchCoordinator.nativeSearchText(for: scope) },
+            set: { value in
+                searchCoordinator.updateNativeSearchText(
+                    value,
+                    for: scope,
+                    activationGeneration: activationGeneration
                 )
-                .onSubmit(of: .search) {
-                    selection = searchCoordinator.commitSubmit()
-                }
+            }
+        )
+    }
+
+    private func searchPrompt(for scope: MobilePrimarySearchScope) -> Text {
+        switch scope {
+        case .workspaces:
+            Text(
+                L10n.string(
+                    "mobile.workspaces.search.placeholder",
+                    defaultValue: "Search workspaces"
+                )
+            )
+        case .notifications:
+            Text(
+                L10n.string(
+                    "mobile.notificationFeed.search.placeholder",
+                    defaultValue: "Search notifications"
+                )
+            )
         }
     }
 
@@ -295,55 +345,29 @@ private struct MobileIPadPrimaryBar: View {
     let sidebarWidth: CGFloat
     let sidebarVisible: Bool
     let select: (MobilePrimaryTab) -> Void
-    let beginSearch: () -> Void
 
     var body: some View {
         GeometryReader { geometry in
-            let columnWidth = sidebarVisible
-                ? min(max(sidebarWidth, 0), geometry.size.width)
-                : 0
+            let controlsWidth = sidebarVisible
+                ? min(geometry.size.width, max(sidebarWidth, 280))
+                : min(geometry.size.width, 420)
 
-            HStack(spacing: 0) {
-                HStack(spacing: 8) {
-                    primaryButton(.workspaces)
-                    primaryButton(.notifications)
-                    if sidebarVisible, selection == .workspaces, let taskComposerAction {
-                        taskComposerButton(taskComposerAction)
-                    }
+            HStack(spacing: 8) {
+                primaryButton(.workspaces)
+                primaryButton(.notifications)
+                if selection == .workspaces, let taskComposerAction {
+                    taskComposerButton(taskComposerAction)
                 }
-                .padding(.leading, 20)
-                .padding(.trailing, sidebarVisible ? 12 : 20)
-                .frame(
-                    width: sidebarVisible
-                        ? min(geometry.size.width, max(columnWidth, 280))
-                        : nil,
-                    alignment: .leading
-                )
-
-                if sidebarVisible {
-                    Divider()
-                        .frame(height: 32)
-                }
-
-                Spacer(minLength: 12)
-
-                HStack(spacing: 8) {
-                    searchButton
-                    if !sidebarVisible, selection == .workspaces, let taskComposerAction {
-                        taskComposerButton(taskComposerAction)
-                    }
-                }
-                .padding(.leading, sidebarVisible ? 12 : 0)
-                .padding(.trailing, 20)
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+            .padding(.horizontal, 20)
+            .frame(width: controlsWidth, height: 72, alignment: .leading)
+            .background(.bar)
         }
-        // `safeAreaInset` uses the child's ideal height. A bare
-        // `GeometryReader` has no useful ideal height and can expand to the
-        // entire screen, starving the destination and centering the rail.
-        // Keep the rail a compact, explicit bottom band.
+        // This is an overlay rather than a root safe-area inset. The terminal
+        // surface owns its own bottom dock and must keep that coordinate system
+        // independent of the sidebar's primary navigation controls.
         .frame(height: 72)
-        .background(.bar)
+        .ignoresSafeArea(.container, edges: .bottom)
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("MobilePrimaryTabBar")
     }
@@ -357,19 +381,6 @@ private struct MobileIPadPrimaryBar: View {
             systemImage: tab == .workspaces ? "rectangle.stack" : "bell",
             badge: tab == .notifications ? notificationUnreadCount : 0
         )
-    }
-
-    private var searchButton: some View {
-        Button(action: beginSearch) {
-            Label(
-                L10n.string("mobile.tabs.search", defaultValue: "Search"),
-                systemImage: "magnifyingglass"
-            )
-            .labelStyle(.titleAndIcon)
-            .frame(minWidth: 88)
-        }
-        .accessibilityIdentifier("MobilePrimaryTabSearch")
-        .buttonStyle(.bordered)
     }
 
     private func taskComposerButton(_ action: @escaping () -> Void) -> some View {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimaryTabScaffold.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimaryTabScaffold.swift
@@ -338,8 +338,11 @@ private struct MobileIPadPrimaryBar: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
         }
-        .frame(minHeight: 64)
-        .padding(.vertical, 4)
+        // `safeAreaInset` uses the child's ideal height. A bare
+        // `GeometryReader` has no useful ideal height and can expand to the
+        // entire screen, starving the destination and centering the rail.
+        // Keep the rail a compact, explicit bottom band.
+        .frame(height: 72)
         .background(.bar)
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("MobilePrimaryTabBar")

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimaryTabScaffold.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimaryTabScaffold.swift
@@ -341,6 +341,7 @@ private struct MobileIPadPrimaryBar: View {
         .frame(minHeight: 64)
         .padding(.vertical, 4)
         .background(.bar)
+        .accessibilityElement(children: .contain)
         .accessibilityIdentifier("MobilePrimaryTabBar")
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimaryTabScaffold.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimaryTabScaffold.swift
@@ -44,26 +44,11 @@ struct MobilePrimaryTabScaffold<
 
     var body: some View {
         if isIPadLayout {
-            TabView(selection: tabSelection) {
-                primaryTabs
-
-                Tab(value: MobilePrimaryTab.search, role: .search) {
-                    searchDestination
-                        .searchable(
-                            text: activeSearchText,
-                            isPresented: searchPresentation,
-                            prompt: activeSearchPrompt
-                        )
-                        .onSubmit(of: .search) {
-                            selection = searchCoordinator.commitSubmit()
-                        }
-                }
-                .accessibilityIdentifier("MobilePrimaryTabSearch")
-            }
-            // iPad has enough room for the primary controls to live in a
-            // bottom rail. The iOS 26 adaptable tab bar otherwise floats over
-            // the split view's navigation toolbar.
-            .toolbarVisibility(.hidden, for: .tabBar)
+            // iPadOS adapts a regular TabView into a top tab strip even when
+            // its tab bar is hidden. Render the destination directly so the
+            // bottom rail is the only primary navigation chrome and cannot
+            // overlap a navigation toolbar.
+            iPadPrimaryContent
             .safeAreaInset(edge: .bottom, spacing: 0) {
                 MobileIPadPrimaryBar(
                     selection: selection,
@@ -132,6 +117,26 @@ struct MobilePrimaryTabScaffold<
                 primaryTabs
             }
             .accessibilityIdentifier("MobilePrimaryTabs")
+        }
+    }
+
+    @ViewBuilder
+    private var iPadPrimaryContent: some View {
+        switch selection {
+        case .workspaces:
+            workspaces
+        case .notifications:
+            notifications
+        case .search:
+            searchDestination
+                .searchable(
+                    text: activeSearchText,
+                    isPresented: searchPresentation,
+                    prompt: activeSearchPrompt
+                )
+                .onSubmit(of: .search) {
+                    selection = searchCoordinator.commitSubmit()
+                }
         }
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimaryTabScaffold.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimaryTabScaffold.swift
@@ -19,6 +19,11 @@ struct MobilePrimaryTabScaffold<
     let notifications: Notifications
     let workspaceSearch: WorkspaceSearch
     let notificationSearch: NotificationSearch
+    /// The measured split-view sidebar width. iPad uses this to keep the
+    /// primary controls in the same bottom column as the sidebar instead of
+    /// centering them in the empty terminal canvas.
+    let iPadSidebarWidth: CGFloat
+    let iPadSidebarVisible: Bool
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.verticalSizeClass) private var verticalSizeClass
 
@@ -27,6 +32,8 @@ struct MobilePrimaryTabScaffold<
         searchCoordinator: MobilePrimarySearchCoordinator,
         notificationUnreadCount: Int,
         taskComposerAction: (() -> Void)? = nil,
+        iPadSidebarWidth: CGFloat = 0,
+        iPadSidebarVisible: Bool = false,
         @ViewBuilder workspaces: () -> Workspaces,
         @ViewBuilder notifications: () -> Notifications,
         @ViewBuilder workspaceSearch: () -> WorkspaceSearch,
@@ -36,6 +43,8 @@ struct MobilePrimaryTabScaffold<
         self.searchCoordinator = searchCoordinator
         self.notificationUnreadCount = notificationUnreadCount
         self.taskComposerAction = taskComposerAction
+        self.iPadSidebarWidth = iPadSidebarWidth
+        self.iPadSidebarVisible = iPadSidebarVisible
         self.workspaces = workspaces()
         self.notifications = notifications()
         self.workspaceSearch = workspaceSearch()
@@ -54,6 +63,8 @@ struct MobilePrimaryTabScaffold<
                     selection: selection,
                     notificationUnreadCount: notificationUnreadCount,
                     taskComposerAction: taskComposerAction,
+                    sidebarWidth: iPadSidebarWidth,
+                    sidebarVisible: iPadSidebarVisible,
                     select: selectTab,
                     beginSearch: {
                         let scope = selection.searchScope ?? searchCoordinator.scope
@@ -281,52 +292,87 @@ private struct MobileIPadPrimaryBar: View {
     let selection: MobilePrimaryTab
     let notificationUnreadCount: Int
     let taskComposerAction: (() -> Void)?
+    let sidebarWidth: CGFloat
+    let sidebarVisible: Bool
     let select: (MobilePrimaryTab) -> Void
     let beginSearch: () -> Void
 
     var body: some View {
-        HStack(spacing: 8) {
-            tabButton(
-                .workspaces,
-                title: L10n.string("mobile.tabs.workspaces", defaultValue: "Workspaces"),
-                systemImage: "rectangle.stack"
-            )
-            tabButton(
-                .notifications,
-                title: L10n.string("mobile.tabs.notifications", defaultValue: "Notifications"),
-                systemImage: "bell",
-                badge: notificationUnreadCount
-            )
+        GeometryReader { geometry in
+            let columnWidth = sidebarVisible
+                ? min(max(sidebarWidth, 0), geometry.size.width)
+                : 0
 
-            Spacer(minLength: 12)
-
-            Button(action: beginSearch) {
-                Label(
-                    L10n.string("mobile.tabs.search", defaultValue: "Search"),
-                    systemImage: "magnifyingglass"
+            HStack(spacing: 0) {
+                HStack(spacing: 8) {
+                    primaryButton(.workspaces)
+                    primaryButton(.notifications)
+                    if sidebarVisible, selection == .workspaces, let taskComposerAction {
+                        taskComposerButton(taskComposerAction)
+                    }
+                }
+                .padding(.leading, 20)
+                .padding(.trailing, sidebarVisible ? 12 : 20)
+                .frame(
+                    width: sidebarVisible
+                        ? min(geometry.size.width, max(columnWidth, 280))
+                        : nil,
+                    alignment: .leading
                 )
-                .labelStyle(.titleAndIcon)
-                .frame(minWidth: 88)
+
+                if sidebarVisible {
+                    Divider()
+                        .frame(height: 32)
+                }
+
+                Spacer(minLength: 12)
+
+                HStack(spacing: 8) {
+                    searchButton
+                    if !sidebarVisible, selection == .workspaces, let taskComposerAction {
+                        taskComposerButton(taskComposerAction)
+                    }
+                }
+                .padding(.leading, sidebarVisible ? 12 : 0)
+                .padding(.trailing, 20)
             }
-            .accessibilityIdentifier("MobilePrimaryTabSearch")
-            .buttonStyle(.bordered)
-
-            if selection == .workspaces, let taskComposerAction {
-                TaskComposerButton(
-                    action: taskComposerAction,
-                    diameter: 56
-                )
-                .accessibilityLabel(
-                    L10n.string("mobile.taskComposer.newTask", defaultValue: "New Task")
-                )
-            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
         }
-        .padding(.horizontal, 20)
-        .padding(.vertical, 10)
-        .frame(maxWidth: 760)
-        .frame(maxWidth: .infinity)
+        .frame(minHeight: 64)
+        .padding(.vertical, 4)
         .background(.bar)
         .accessibilityIdentifier("MobilePrimaryTabBar")
+    }
+
+    private func primaryButton(_ tab: MobilePrimaryTab) -> some View {
+        tabButton(
+            tab,
+            title: tab == .workspaces
+                ? L10n.string("mobile.tabs.workspaces", defaultValue: "Workspaces")
+                : L10n.string("mobile.tabs.notifications", defaultValue: "Notifications"),
+            systemImage: tab == .workspaces ? "rectangle.stack" : "bell",
+            badge: tab == .notifications ? notificationUnreadCount : 0
+        )
+    }
+
+    private var searchButton: some View {
+        Button(action: beginSearch) {
+            Label(
+                L10n.string("mobile.tabs.search", defaultValue: "Search"),
+                systemImage: "magnifyingglass"
+            )
+            .labelStyle(.titleAndIcon)
+            .frame(minWidth: 88)
+        }
+        .accessibilityIdentifier("MobilePrimaryTabSearch")
+        .buttonStyle(.bordered)
+    }
+
+    private func taskComposerButton(_ action: @escaping () -> Void) -> some View {
+        TaskComposerButton(action: action, diameter: 56)
+            .accessibilityLabel(
+                L10n.string("mobile.taskComposer.newTask", defaultValue: "New Task")
+            )
     }
 
     @ViewBuilder

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimaryTabScaffold.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimaryTabScaffold.swift
@@ -19,6 +19,8 @@ struct MobilePrimaryTabScaffold<
     let notifications: Notifications
     let workspaceSearch: WorkspaceSearch
     let notificationSearch: NotificationSearch
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @Environment(\.verticalSizeClass) private var verticalSizeClass
 
     init(
         selection: Binding<MobilePrimaryTab>,
@@ -41,7 +43,45 @@ struct MobilePrimaryTabScaffold<
     }
 
     var body: some View {
-        if #available(iOS 26.0, *) {
+        if isIPadLayout {
+            TabView(selection: tabSelection) {
+                primaryTabs
+
+                Tab(value: MobilePrimaryTab.search, role: .search) {
+                    searchDestination
+                        .searchable(
+                            text: activeSearchText,
+                            isPresented: searchPresentation,
+                            prompt: activeSearchPrompt
+                        )
+                        .onSubmit(of: .search) {
+                            selection = searchCoordinator.commitSubmit()
+                        }
+                }
+                .accessibilityIdentifier("MobilePrimaryTabSearch")
+            }
+            // iPad has enough room for the primary controls to live in a
+            // bottom rail. The iOS 26 adaptable tab bar otherwise floats over
+            // the split view's navigation toolbar.
+            .toolbarVisibility(.hidden, for: .tabBar)
+            .safeAreaInset(edge: .bottom, spacing: 0) {
+                MobileIPadPrimaryBar(
+                    selection: selection,
+                    notificationUnreadCount: notificationUnreadCount,
+                    taskComposerAction: taskComposerAction,
+                    select: selectTab,
+                    beginSearch: {
+                        let scope = selection.searchScope ?? searchCoordinator.scope
+                        searchCoordinator.beginSearch(for: scope)
+                        selectTab(.search)
+                    }
+                )
+            }
+            .accessibilityIdentifier("MobilePrimaryTabs")
+            .onChange(of: selection, initial: true) { _, selection in
+                searchCoordinator.synchronizeSelection(selection)
+            }
+        } else if #available(iOS 26.0, *) {
             ZStack(alignment: .bottomTrailing) {
                 TabView(selection: tabSelection) {
                     primaryTabs
@@ -95,6 +135,10 @@ struct MobilePrimaryTabScaffold<
         }
     }
 
+    private var isIPadLayout: Bool {
+        horizontalSizeClass == .regular && verticalSizeClass == .regular
+    }
+
     /// A tab-view bottom accessory always adds a full-width plate, which is
     /// intended for mini-player content. Compose remains a standalone action
     /// aligned with the detached Search control instead.
@@ -122,6 +166,14 @@ struct MobilePrimaryTabScaffold<
                 selection = newValue
             }
         )
+    }
+
+    private func selectTab(_ tab: MobilePrimaryTab) {
+        if (selection == .search || searchCoordinator.isPresented),
+           tab.searchScope != nil {
+            searchCoordinator.deactivateCurrentSearch()
+        }
+        selection = tab
     }
 
     private var searchPresentation: Binding<Bool> {
@@ -213,6 +265,98 @@ struct MobilePrimaryTabScaffold<
             .accessibilityIdentifier("MobilePrimaryTabNotifications")
         }
         .badge(notificationUnreadCount)
+    }
+}
+
+/// Bottom primary navigation for regular iPad layouts. Keeping this outside
+/// the system tab bar leaves each navigation stack's top toolbar responsible
+/// for its title and actions, while the large iPad canvas gets a useful bottom
+/// control rail.
+private struct MobileIPadPrimaryBar: View {
+    let selection: MobilePrimaryTab
+    let notificationUnreadCount: Int
+    let taskComposerAction: (() -> Void)?
+    let select: (MobilePrimaryTab) -> Void
+    let beginSearch: () -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            tabButton(
+                .workspaces,
+                title: L10n.string("mobile.tabs.workspaces", defaultValue: "Workspaces"),
+                systemImage: "rectangle.stack"
+            )
+            tabButton(
+                .notifications,
+                title: L10n.string("mobile.tabs.notifications", defaultValue: "Notifications"),
+                systemImage: "bell",
+                badge: notificationUnreadCount
+            )
+
+            Spacer(minLength: 12)
+
+            Button(action: beginSearch) {
+                Label(
+                    L10n.string("mobile.tabs.search", defaultValue: "Search"),
+                    systemImage: "magnifyingglass"
+                )
+                .labelStyle(.titleAndIcon)
+                .frame(minWidth: 88)
+            }
+            .accessibilityIdentifier("MobilePrimaryTabSearch")
+            .buttonStyle(.bordered)
+
+            if selection == .workspaces, let taskComposerAction {
+                TaskComposerButton(
+                    action: taskComposerAction,
+                    diameter: 56
+                )
+                .accessibilityLabel(
+                    L10n.string("mobile.taskComposer.newTask", defaultValue: "New Task")
+                )
+            }
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 10)
+        .frame(maxWidth: 760)
+        .frame(maxWidth: .infinity)
+        .background(.bar)
+        .accessibilityIdentifier("MobilePrimaryTabBar")
+    }
+
+    @ViewBuilder
+    private func tabButton(
+        _ tab: MobilePrimaryTab,
+        title: String,
+        systemImage: String,
+        badge: Int = 0
+    ) -> some View {
+        Button {
+            select(tab)
+        } label: {
+            ZStack(alignment: .topTrailing) {
+                Label(title, systemImage: systemImage)
+                    .labelStyle(.titleAndIcon)
+                    .frame(minWidth: 132)
+                if badge > 0 {
+                    Text("\(badge)")
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 2)
+                        .background(.red, in: Capsule())
+                        .offset(x: 7, y: -8)
+                        .accessibilityLabel("\(badge)")
+                }
+            }
+        }
+        .buttonStyle(.borderedProminent)
+        .tint(selection == tab ? .accentColor : .secondary)
+        .accessibilityIdentifier(
+            tab == .workspaces
+                ? "MobilePrimaryTabWorkspaces"
+                : "MobilePrimaryTabNotifications"
+        )
     }
 }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimaryTabScaffold.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimaryTabScaffold.swift
@@ -19,11 +19,6 @@ struct MobilePrimaryTabScaffold<
     let notifications: Notifications
     let workspaceSearch: WorkspaceSearch
     let notificationSearch: NotificationSearch
-    /// The measured split-view sidebar width. iPad uses this to keep the
-    /// primary controls in the same bottom column as the sidebar instead of
-    /// centering them in the empty terminal canvas.
-    let iPadSidebarWidth: CGFloat
-    let iPadSidebarVisible: Bool
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.verticalSizeClass) private var verticalSizeClass
 
@@ -32,8 +27,6 @@ struct MobilePrimaryTabScaffold<
         searchCoordinator: MobilePrimarySearchCoordinator,
         notificationUnreadCount: Int,
         taskComposerAction: (() -> Void)? = nil,
-        iPadSidebarWidth: CGFloat = 0,
-        iPadSidebarVisible: Bool = false,
         @ViewBuilder workspaces: () -> Workspaces,
         @ViewBuilder notifications: () -> Notifications,
         @ViewBuilder workspaceSearch: () -> WorkspaceSearch,
@@ -43,8 +36,6 @@ struct MobilePrimaryTabScaffold<
         self.searchCoordinator = searchCoordinator
         self.notificationUnreadCount = notificationUnreadCount
         self.taskComposerAction = taskComposerAction
-        self.iPadSidebarWidth = iPadSidebarWidth
-        self.iPadSidebarVisible = iPadSidebarVisible
         self.workspaces = workspaces()
         self.notifications = notifications()
         self.workspaceSearch = workspaceSearch()
@@ -53,25 +44,7 @@ struct MobilePrimaryTabScaffold<
 
     var body: some View {
         if isIPadLayout {
-            // iPadOS adapts a regular TabView into a top tab strip even when
-            // its tab bar is hidden. Render the destination directly so the
-            // bottom rail is the only primary navigation chrome and cannot
-            // overlap a navigation toolbar.
-            iPadPrimaryContent
-            .overlay(alignment: .bottomLeading) {
-                MobileIPadPrimaryBar(
-                    selection: selection,
-                    notificationUnreadCount: notificationUnreadCount,
-                    taskComposerAction: taskComposerAction,
-                    sidebarWidth: iPadSidebarWidth,
-                    sidebarVisible: iPadSidebarVisible,
-                    select: selectTab
-                )
-            }
-            .accessibilityIdentifier("MobilePrimaryTabs")
-            .onChange(of: selection, initial: true) { _, selection in
-                searchCoordinator.synchronizeSelection(selection)
-            }
+            iPadTabView
         } else if #available(iOS 26.0, *) {
             ZStack(alignment: .bottomTrailing) {
                 TabView(selection: tabSelection) {
@@ -127,87 +100,55 @@ struct MobilePrimaryTabScaffold<
     }
 
     @ViewBuilder
-    private var iPadPrimaryContent: some View {
-        switch selection {
-        case .workspaces:
-            iPadSearchableContent(scope: .workspaces) {
-                workspaces
+    private var iPadTabView: some View {
+        if #available(iOS 26.0, *) {
+            TabView(selection: tabSelection) {
+                primaryTabs
+                searchTab
             }
-        case .notifications:
-            iPadSearchableContent(scope: .notifications) {
-                notifications
+            // This is Apple's adaptive Liquid Glass tab presentation. On an
+            // iPad it owns the native top tab bar and can move the tabs into
+            // the sidebar when the available width calls for it.
+            .tabViewStyle(.sidebarAdaptable)
+            .tabViewSearchActivation(.searchTabSelection)
+            .accessibilityIdentifier("MobilePrimaryTabs")
+            .onChange(of: selection, initial: true) { _, selection in
+                searchCoordinator.synchronizeSelection(selection)
             }
-        case .search:
-            // The iPad rail never selects this transient destination. Keep it
-            // renderable for programmatic state, but scope it explicitly so it
-            // cannot inherit whichever root was selected before the transition.
-            iPadSearchableContent(scope: searchCoordinator.scope) {
-                searchDestination
+        } else {
+            TabView(selection: $selection) {
+                primaryTabs
             }
+            .tabViewStyle(.sidebarAdaptable)
+            .accessibilityIdentifier("MobilePrimaryTabs")
         }
     }
 
-    @ViewBuilder
-    private func iPadSearchableContent<Content: View>(
-        scope: MobilePrimarySearchScope,
-        @ViewBuilder content: () -> Content
-    ) -> some View {
-        content()
-            .searchable(
-                text: nativeSearchText(for: scope),
-                isPresented: searchPresentation,
-                placement: .toolbar,
-                prompt: searchPrompt(for: scope)
-            )
-            .modifier(MobilePrimarySearchLifecycleModifier(
-                scope: scope,
-                update: updateSearchLifecycle
-            ))
-            .onSubmit(of: .search) {
-                searchCoordinator.commitSubmit()
-            }
-    }
-
-    private func nativeSearchText(for scope: MobilePrimarySearchScope) -> Binding<String> {
-        let activationGeneration = searchCoordinator.activationGeneration
-        return Binding(
-            get: { searchCoordinator.nativeSearchText(for: scope) },
-            set: { value in
-                searchCoordinator.updateNativeSearchText(
-                    value,
-                    for: scope,
-                    activationGeneration: activationGeneration
+    @available(iOS 26.0, *)
+    private var searchTab: some TabContent<MobilePrimaryTab> {
+        Tab(value: MobilePrimaryTab.search, role: .search) {
+            // Keep the searchable modifier on the search destination itself,
+            // so the native tab does not leak a second search field into the
+            // workspaces or notifications toolbars.
+            searchDestination
+                .searchable(
+                    text: activeSearchText,
+                    isPresented: searchPresentation,
+                    prompt: activeSearchPrompt
                 )
-            }
-        )
-    }
-
-    private func searchPrompt(for scope: MobilePrimarySearchScope) -> Text {
-        switch scope {
-        case .workspaces:
-            Text(
-                L10n.string(
-                    "mobile.workspaces.search.placeholder",
-                    defaultValue: "Search workspaces"
-                )
-            )
-        case .notifications:
-            Text(
-                L10n.string(
-                    "mobile.notificationFeed.search.placeholder",
-                    defaultValue: "Search notifications"
-                )
-            )
+                .onSubmit(of: .search) {
+                    selection = searchCoordinator.commitSubmit()
+                }
         }
+        .accessibilityIdentifier("MobilePrimaryTabSearch")
     }
 
     private var isIPadLayout: Bool {
         horizontalSizeClass == .regular && verticalSizeClass == .regular
     }
 
-    /// A tab-view bottom accessory always adds a full-width plate, which is
-    /// intended for mini-player content. Compose remains a standalone action
-    /// aligned with the detached Search control instead.
+    /// Compose remains a standalone action on compact layouts. The native
+    /// iPad tab presentation owns its own Liquid Glass navigation chrome.
     private var iOS26BottomControlDiameter: CGFloat { 62 }
     private var iOS26BottomControlInset: CGFloat { 21 }
     private var iOS26BottomControlSpacing: CGFloat { 12 }
@@ -232,14 +173,6 @@ struct MobilePrimaryTabScaffold<
                 selection = newValue
             }
         )
-    }
-
-    private func selectTab(_ tab: MobilePrimaryTab) {
-        if (selection == .search || searchCoordinator.isPresented),
-           tab.searchScope != nil {
-            searchCoordinator.deactivateCurrentSearch()
-        }
-        selection = tab
     }
 
     private var searchPresentation: Binding<Bool> {
@@ -331,109 +264,6 @@ struct MobilePrimaryTabScaffold<
             .accessibilityIdentifier("MobilePrimaryTabNotifications")
         }
         .badge(notificationUnreadCount)
-    }
-}
-
-/// Bottom primary navigation for regular iPad layouts. Keeping this outside
-/// the system tab bar leaves each navigation stack's top toolbar responsible
-/// for its title and actions, while the large iPad canvas gets a useful bottom
-/// control rail.
-private struct MobileIPadPrimaryBar: View {
-    let selection: MobilePrimaryTab
-    let notificationUnreadCount: Int
-    let taskComposerAction: (() -> Void)?
-    let sidebarWidth: CGFloat
-    let sidebarVisible: Bool
-    let select: (MobilePrimaryTab) -> Void
-
-    var body: some View {
-        GeometryReader { geometry in
-            // NavigationSplitView can report its sidebar preference one
-            // layout pass after the rail mounts. Keep the first frame wide
-            // enough for the two tab buttons and align it with the split's
-            // balanced 320...440pt sidebar until the live measurement arrives.
-            let fallbackSidebarWidth = min(
-                440,
-                max(360, geometry.size.width * 0.43)
-            )
-            let measuredSidebarWidth = sidebarWidth > 0
-                ? sidebarWidth
-                : fallbackSidebarWidth
-            let controlsWidth = sidebarVisible
-                ? min(geometry.size.width, max(measuredSidebarWidth, 360))
-                : min(geometry.size.width, 420)
-
-            HStack(spacing: 8) {
-                primaryButton(.workspaces)
-                primaryButton(.notifications)
-                if selection == .workspaces, let taskComposerAction {
-                    taskComposerButton(taskComposerAction)
-                }
-            }
-            .padding(.horizontal, 20)
-            .frame(width: controlsWidth, height: 72, alignment: .leading)
-            .background(.bar)
-        }
-        // This is an overlay rather than a root safe-area inset. The terminal
-        // surface owns its own bottom dock and must keep that coordinate system
-        // independent of the sidebar's primary navigation controls.
-        .frame(height: 72)
-        .ignoresSafeArea(.container, edges: .bottom)
-        .accessibilityElement(children: .contain)
-        .accessibilityIdentifier("MobilePrimaryTabBar")
-    }
-
-    private func primaryButton(_ tab: MobilePrimaryTab) -> some View {
-        tabButton(
-            tab,
-            title: tab == .workspaces
-                ? L10n.string("mobile.tabs.workspaces", defaultValue: "Workspaces")
-                : L10n.string("mobile.tabs.notifications", defaultValue: "Notifications"),
-            systemImage: tab == .workspaces ? "rectangle.stack" : "bell",
-            badge: tab == .notifications ? notificationUnreadCount : 0
-        )
-    }
-
-    private func taskComposerButton(_ action: @escaping () -> Void) -> some View {
-        TaskComposerButton(action: action, diameter: 56)
-            .accessibilityLabel(
-                L10n.string("mobile.taskComposer.newTask", defaultValue: "New Task")
-            )
-    }
-
-    @ViewBuilder
-    private func tabButton(
-        _ tab: MobilePrimaryTab,
-        title: String,
-        systemImage: String,
-        badge: Int = 0
-    ) -> some View {
-        Button {
-            select(tab)
-        } label: {
-            ZStack(alignment: .topTrailing) {
-                Label(title, systemImage: systemImage)
-                    .labelStyle(.titleAndIcon)
-                    .frame(minWidth: 132)
-                if badge > 0 {
-                    Text("\(badge)")
-                        .font(.caption2.weight(.bold))
-                        .foregroundStyle(.white)
-                        .padding(.horizontal, 5)
-                        .padding(.vertical, 2)
-                        .background(.red, in: Capsule())
-                        .offset(x: 7, y: -8)
-                        .accessibilityLabel("\(badge)")
-                }
-            }
-        }
-        .buttonStyle(.borderedProminent)
-        .tint(selection == tab ? .accentColor : .secondary)
-        .accessibilityIdentifier(
-            tab == .workspaces
-                ? "MobilePrimaryTabWorkspaces"
-                : "MobilePrimaryTabNotifications"
-        )
     }
 }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimaryTabScaffold.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimaryTabScaffold.swift
@@ -106,10 +106,8 @@ struct MobilePrimaryTabScaffold<
                 primaryTabs
                 searchTab
             }
-            // This is Apple's adaptive Liquid Glass tab presentation. On an
-            // iPad it owns the native top tab bar and can move the tabs into
-            // the sidebar when the available width calls for it.
-            .tabViewStyle(.sidebarAdaptable)
+            // The default iPadOS 26 presentation is the native Liquid Glass
+            // tab strip. Let TabView own its safe area and toolbar placement.
             .tabViewSearchActivation(.searchTabSelection)
             .accessibilityIdentifier("MobilePrimaryTabs")
             .onChange(of: selection, initial: true) { _, selection in
@@ -119,7 +117,6 @@ struct MobilePrimaryTabScaffold<
             TabView(selection: $selection) {
                 primaryTabs
             }
-            .tabViewStyle(.sidebarAdaptable)
             .accessibilityIdentifier("MobilePrimaryTabs")
         }
     }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -17,18 +17,17 @@ import SwiftUI
 import AppKit
 #endif
 
-struct WorkspaceDetailView: View {
-    /// Whether the title menu offers manual Reconnect: only once the
-    /// connection is unavailable (an active reconnect needs no manual entry),
-    /// and never during reauthentication, whose blocking banner owns
-    /// recovery.
-    static func canReconnectFromTitleMenu(
-        effectiveConnectionStatus: MobileMacConnectionStatus,
-        connectionRequiresReauth: Bool
-    ) -> Bool {
-        effectiveConnectionStatus == .unavailable && !connectionRequiresReauth
+enum WorkspaceDetailConnectionChrome {
+    static func reconnectAction(
+        connectionRequiresReauth: Bool,
+        reconnect: @escaping () -> Void
+    ) -> (() -> Void)? {
+        connectionRequiresReauth ? nil : reconnect
     }
+}
 
+struct WorkspaceDetailView: View {
+    let host: String
     let connectionStatus: MobileMacConnectionStatus
     let workspace: MobileWorkspacePreview
     @Bindable var store: CMUXMobileShellStore
@@ -48,11 +47,8 @@ struct WorkspaceDetailView: View {
     let signOut: (@MainActor @Sendable () -> Void)?
     @Environment(BrowserSurfaceStore.self) var browserStore
     @Environment(BrowserStreamStore.self) var browserStreamStore
-    @Environment(MobileSimulatorStreamStore.self) var simulatorStreamStore
     @Environment(MobileDisplaySettings.self) private var displaySettings
     @Environment(ToastCenter.self) private var toasts
-    @Environment(\.mobileChildPresentationProvider) private var childPresentationProvider
-    @Environment(\.terminalFilesChipEnabled) var isTerminalFilesChipEnabled
     /// Drives the destructive close-workspace confirmation dialog.
     @State var isConfirmingClose = false
     #if canImport(UIKit)
@@ -61,14 +57,7 @@ struct WorkspaceDetailView: View {
     @State private var feedbackEmail = ""
     @State private var isSubmittingFeedback = false
     @State private var feedbackErrorMessage: String?
-    @State private var isTextSheetPresented = {
-        #if DEBUG
-        AutoConnectMigrationUITestConfiguration.currentProcess?.initialModalHost
-            == .workspaceDetailTerminalText
-        #else
-        false
-        #endif
-    }()
+    @State private var isTextSheetPresented = false
     /// Drives the rename-workspace dialog launched from the picker menu, and its
     /// editable text (seeded with the current name when presented).
     @State var isRenamePresented = false
@@ -77,33 +66,25 @@ struct WorkspaceDetailView: View {
     @State var isCustomizationPresented = false
     /// Live pane width for capping the leading glass title pill.
     @State private var contentWidth: CGFloat = 0
-    // Rendered content width per trailing toolbar item, keyed by item. The
-    // title's width cap subtracts the structurally visible items' widths so
-    // they always fit and iOS never folds them into the overflow More menu
-    // (no per-item priority exists below iOS 27). Only structural removal
-    // deletes an entry (see the onChange handlers); a layout-driven
-    // disappearance (overflow into More) cannot release a reservation and
-    // make the collapse sticky.
-    @State private var trailingToolbarItemWidths: [String: CGFloat] = [:]
-    /// Ratchets on when the trailing cluster's content leaves the bar while
-    /// the screen's own content is still on a window: the system folded it
-    /// into the More menu, so the estimate reserves undershot this device's
-    /// chrome. Never cleared for this view's lifetime; the extra recovery
-    /// reserve un-collapses the bar.
-    @State private var trailingToolbarCollapseDetected = false
-    /// Live window-attachment flags shared with the UIKit probes; reference
-    /// identity keeps event-time reads current where SwiftUI captures of
-    /// value state would be stale.
-    @State private var barPresence = WorkspaceBarPresence()
     /// Terminal captured for the current "View as Text" sheet presentation.
     @State private var textSheetSurfaceID: String?
-    /// Identity of the in-flight New Browser creation. A late RPC result must
-    /// not activate its panel over a selection the user made in the meantime,
-    /// so completion applies only while its request is still current.
-    @State private var browserCreateRequest: UUID?
     @State var terminalPickerRows: [TerminalPickerMenuRow] = []
-    /// Local presenter identity remains separate from the artifact popover payload.
-    @State var isTerminalArtifactFilesPresented = false
+    /// Chat-mode toggle for inline agent chat in place of the terminal.
+    @State var isChatMode = false
+    /// The session chat mode was entered on, pinned so sorting cannot swap the conversation
+    /// out from under the user mid-read. Cleared when chat mode turns off.
+    @State var pinnedChatSessionID: String?
+    @State var chatSessions: [ChatSessionDescriptor] = []
+    @State var chatSessionsWorkspaceID: String?
+    /// Last terminal id whose cached snapshot said it had a chat session.
+    @State var cachedChatToggleTerminalID: String?
+    @State var ignoredChatSessionRefreshKey: String?
+    @State var ignoredChatSessionRefreshID: UUID?
+    @State var ignoredChatSessionRefreshTask: Task<[ChatSessionDescriptor]?, Never>?
+    /// Per-session chat stores kept warm while the workspace detail is visible.
+    @State var chatConversationStores: [String: ChatConversationStore] = [:]
+    /// Per-session composer drafts, surviving toggles back to the terminal.
+    @State var chatDrafts: [String: String] = [:]
     @State var terminalArtifactFilesContext: TerminalArtifactContext?
     @State var selectedTerminalArtifact: TerminalArtifactSelection?
     @State var terminalArtifactThumbnailCache = ChatArtifactThumbnailCache()
@@ -112,6 +93,7 @@ struct WorkspaceDetailView: View {
     @State var isWorkspaceChangesSheetPresented = false
     @State var workspaceChangesHint: MobileWorkspaceChangesHint?
     @State var artifactGalleryRefreshSignal = TerminalArtifactGalleryRefreshSignal.initial
+    /// App lifecycle phase used to re-pull chat sessions on foreground.
     @Environment(\.scenePhase) var scenePhase
     #endif
     /// The active browser surface for this workspace, when a browser pane is open.
@@ -121,47 +103,10 @@ struct WorkspaceDetailView: View {
     var activeBrowserStream: BrowserStreamSurfaceState? {
         browserStreamStore.activeState(in: workspace.rpcWorkspaceID.rawValue)
     }
-    var activeSimulatorStream: MobileSimulatorStreamSurfaceState? {
-        simulatorStreamStore.activeState(in: workspace.rpcWorkspaceID.rawValue)
-    }
     #if os(iOS)
-    /// Uses the root modal owner in the live app and local state in previews.
-    func resolvedPresentation(
-        for child: MobileRootPresentationState.ChildPresentation,
-        fallback: Binding<Bool>
-    ) -> MobileChildSheetPresentation {
-        childPresentationProvider?.presentation(for: child, fallback: fallback)
-            ?? MobileChildSheetPresentation(isPresented: fallback)
+    var terminalFilesChipEnabled: Bool {
+        displaySettings.terminalFilesChipEnabled
     }
-
-    private var feedbackPresentation: MobileChildSheetPresentation {
-        resolvedPresentation(
-            for: .workspaceDetail(.feedbackComposer),
-            fallback: $isFeedbackComposerPresented
-        )
-    }
-
-    private var textSheetPresentation: MobileChildSheetPresentation {
-        resolvedPresentation(
-            for: .workspaceDetail(.terminalText),
-            fallback: $isTextSheetPresented
-        )
-    }
-
-    var workspaceChangesPresentation: MobileChildSheetPresentation {
-        resolvedPresentation(
-            for: .workspaceDetail(.workspaceChanges),
-            fallback: $isWorkspaceChangesSheetPresented
-        )
-    }
-
-    private var customizationPresentation: MobileChildSheetPresentation {
-        resolvedPresentation(
-            for: .workspaceDetail(.customization),
-            fallback: $isCustomizationPresented
-        )
-    }
-
     var showMissingFiles: Bool {
         displaySettings.showMissingFiles
     }
@@ -170,69 +115,40 @@ struct WorkspaceDetailView: View {
     }
     var activeSurface: WorkspaceActiveSurface {
         WorkspaceActiveSurface.derive(
+            isChatMode: isChatMode,
+            hasChosenChatSession: chosenChatSession != nil,
             hasActiveBrowser: activeBrowser != nil,
-            hasActiveBrowserStream: activeBrowserStream != nil,
-            hasActiveSimulatorStream: activeSimulatorStream != nil,
-            selectedMacSurface: workspace.selectedMacSurface(id: store.selectedMacSurfaceID)
+            hasActiveBrowserStream: activeBrowserStream != nil
         )
     }
     #endif
     var body: some View {
-        let content = Group {
-            VStack(spacing: 0) {
-                if let message = store.terminalCreationError,
-                   store.selectedWorkspaceID == workspace.id,
-                   store.terminalCreationErrorWorkspaceID == workspace.rpcWorkspaceID {
-                    terminalCreationRecovery(message: message)
-                }
-                detailSurfaceContent
-            }
-        }
+        let content = Group { detailSurfaceContent }
 
         #if os(iOS)
         content
             .onGeometryChange(for: CGFloat.self) { $0.size.width } action: { contentWidth = $0 }
             .navigationTitle(systemNavigationTitle)
             .mobileTerminalNavigationChrome(theme: store.activeTerminalTheme)
-            // The browser and chat surfaces scroll; without this the system
-            // minimizes the whole bar into a floating "…" pill, unlike the
-            // terminal surface, which has no system scroll view.
-            .mobilePinnedNavigationBar()
-            .trackBarPresence(barPresence)
+            // Paint the navigation container, including the status-bar safe
+            // area, with the same theme as the terminal surface below it.
+            .containerBackground(
+                store.activeTerminalTheme.terminalBackgroundColor,
+                for: .navigation
+            )
             .toolbar { workspaceDetailToolbar }
+            .task(id: chatRefreshKey) { await refreshChatSessions() }
             .task(id: workspace.rpcWorkspaceID.rawValue) {
                 await store.refreshMobileBrowserPanels(workspaceID: workspace.rpcWorkspaceID.rawValue)
-                syncSimulatorStreamPanels()
-                store.refreshWorkspaceSelection()
-                restoreLocalBrowserTabIfRequested()
             }
-            .onChange(of: store.pendingLocalBrowserTabRestoreWorkspaceID) { _, _ in
-                restoreLocalBrowserTabIfRequested()
-            }
-            .onChange(of: browserStreamStore.panelDiscoveryRevision(in: workspace.rpcWorkspaceID.rawValue)) { _, _ in
-                store.refreshWorkspaceSelection()
-            }
-            .onChange(of: workspace.simulators) { _, _ in
-                syncSimulatorStreamPanels()
-                store.refreshWorkspaceSelection()
-            }
-            // Structural removal drops the item's retained measurement so a
-            // returning item takes the fail-safe unmeasured reserve instead of
-            // a stale width for its first layout pass. Layout-driven
-            // disappearance (overflow into More) never flips these conditions,
-            // so it cannot release a reservation and make the collapse sticky.
-            .onChange(of: workspaceChangesAreAvailable) { _, isAvailable in
-                if !isAvailable { trailingToolbarItemWidths["changes"] = nil }
-            }
-            .onChange(of: altScreenNoticeIsVisible) { _, isVisible in
-                if !isVisible { trailingToolbarItemWidths["altscreen-notice"] = nil }
-            }
+            .task(id: chatConversationWarmKey) { await runWarmChatConversation() }
             .onAppear { refreshWorkspaceChangesHint() }
             .onChange(of: workspaceChangesHintEligibilityKey) { _, _ in
                 refreshWorkspaceChangesHint()
             }
             .onChange(of: selectedTerminalID) { _, _ in
                 visibleArtifactCount = 0
+                refreshCachedChatToggleAnchor()
                 syncTerminalPickerRows(includeTitleChanges: true)
             }
             .onChange(of: store.supportsTerminalArtifacts) { _, supportsArtifacts in
@@ -245,25 +161,13 @@ struct WorkspaceDetailView: View {
                 isPresented: $isConfirmingClose,
                 confirm: confirmCloseWorkspaceFromMenu
             )
-            .sheet(
-                isPresented: feedbackPresentation.isPresented,
-                onDismiss: feedbackPresentation.didDismiss
-            ) {
+            .sheet(isPresented: $isFeedbackComposerPresented) {
                 feedbackComposer
             }
-            .sheet(
-                isPresented: textSheetPresentation.isPresented,
-                onDismiss: {
-                    textSheetSurfaceID = nil
-                    textSheetPresentation.didDismiss()
-                }
-            ) {
+            .sheet(isPresented: $isTextSheetPresented) {
                 TerminalTextSheetView(surfaceID: textSheetSurfaceID)
             }
-            .sheet(
-                isPresented: workspaceChangesPresentation.isPresented,
-                onDismiss: workspaceChangesPresentation.didDismiss
-            ) {
+            .sheet(isPresented: $isWorkspaceChangesSheetPresented) {
                 WorkspaceChangesSheet(
                     store: store,
                     workspaceID: workspace.rpcWorkspaceID.rawValue,
@@ -277,10 +181,7 @@ struct WorkspaceDetailView: View {
                 text: $renameText,
                 onSave: commitRenameFromDialog
             )
-            .sheet(
-                isPresented: customizationPresentation.isPresented,
-                onDismiss: customizationPresentation.didDismiss
-            ) {
+            .sheet(isPresented: $isCustomizationPresented) {
                 WorkspaceCustomizationSheet(workspace: workspace) { initialDraft, submittedDraft in
                     await customizeWorkspace?(workspace.id, initialDraft, submittedDraft)
                         ?? .failure()
@@ -297,38 +198,7 @@ struct WorkspaceDetailView: View {
         #endif
     }
 
-    private func terminalCreationRecovery(message: String) -> some View {
-        HStack(alignment: .top, spacing: 10) {
-            Image(systemName: "exclamationmark.triangle.fill")
-                .foregroundStyle(.orange)
-            VStack(alignment: .leading, spacing: 6) {
-                Text(message)
-                    .font(.subheadline)
-                    .fixedSize(horizontal: false, vertical: true)
-                Button {
-                    createTerminal()
-                } label: {
-                    Text(L10n.string("mobile.terminal.creationRetry", defaultValue: "Retry"))
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
-                .accessibilityIdentifier("MobileTerminalCreationRetry")
-            }
-            Spacer(minLength: 0)
-        }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 10)
-        .background(.orange.opacity(0.14))
-        .accessibilityIdentifier("MobileTerminalCreationRecovery")
-    }
-
     #if os(iOS)
-    private var altScreenNoticeIsVisible: Bool {
-        guard let selectedTerminalID else { return false }
-        return store.isAlternateScreen(surfaceID: selectedTerminalID)
-            && displaySettings.showAltScreenNotice
-    }
-
     @ToolbarContentBuilder
     private var workspaceDetailToolbar: some ToolbarContent {
         if backButtonConfiguration != nil {
@@ -342,136 +212,45 @@ struct WorkspaceDetailView: View {
         ToolbarItem(id: "workspace-title", placement: .topBarLeading) {
             workspaceTitleToolbarMenu
         }
-        // iOS 27's visibilityPriority(.high) natively keeps the trailing items
-        // out of the overflow More menu. The symbols are absent from SDK 26.x,
-        // so the branch is compiler-gated until an Xcode 27 toolchain builds
-        // this target; the measured title cap below stays the sizing mechanism
-        // on every OS (the native priority only decides who overflows, it does
-        // not grant the title the remaining space).
-        #if compiler(>=6.4)
-        if #available(iOS 27.0, *) {
-            highPriorityTrailingToolbarItems
-        } else {
-            trailingToolbarItems
-        }
-        #else
-        trailingToolbarItems
-        #endif
-    }
-
-    @ToolbarContentBuilder
-    private var trailingToolbarItems: some ToolbarContent {
-        if altScreenNoticeIsVisible {
+        if let selectedTerminalID,
+           store.isAlternateScreen(surfaceID: selectedTerminalID),
+           displaySettings.showAltScreenNotice {
             ToolbarItem(id: "workspace-altscreen-notice", placement: .topBarTrailing) {
-                altScreenNoticeToolbarContent
-            }
-        }
-        if workspaceChangesAreAvailable {
-            ToolbarItem(id: "workspace-changes", placement: .topBarTrailing) {
-                workspaceChangesToolbarContent
-            }
-        }
-        ToolbarItem(id: "workspace-trailing", placement: .topBarTrailing) {
-            trailingClusterToolbarContent
-        }
-    }
-
-    #if compiler(>=6.4)
-    @available(iOS 27.0, *)
-    @ToolbarContentBuilder
-    private var highPriorityTrailingToolbarItems: some ToolbarContent {
-        if altScreenNoticeIsVisible {
-            ToolbarItem(id: "workspace-altscreen-notice", placement: .topBarTrailing) {
-                altScreenNoticeToolbarContent
-            }
-            .visibilityPriority(.high)
-        }
-        if workspaceChangesAreAvailable {
-            ToolbarItem(id: "workspace-changes", placement: .topBarTrailing) {
-                workspaceChangesToolbarContent
-            }
-            .visibilityPriority(.high)
-        }
-        ToolbarItem(id: "workspace-trailing", placement: .topBarTrailing) {
-            trailingClusterToolbarContent
-        }
-        .visibilityPriority(.high)
-    }
-    #endif
-
-    private var altScreenNoticeToolbarContent: some View {
-        AltScreenNoticeButton {
-            displaySettings.showAltScreenNotice = false
-        }
-        .measureTrailingToolbarItem("altscreen-notice", into: $trailingToolbarItemWidths)
-    }
-
-    private var workspaceChangesToolbarContent: some View {
-        WorkspaceChangesToolbarButton(
-            chip: workspaceChangesChip,
-            workspaceID: workspace.rpcWorkspaceID.rawValue,
-            action: openWorkspaceChanges
-        )
-        // The chrome sits on the terminal theme's background, not the
-        // system scheme; resolve the counts' green/red for that.
-        .environment(\.colorScheme, store.activeTerminalTheme.terminalColorScheme)
-        .measureTrailingToolbarItem("changes", into: $trailingToolbarItemWidths)
-    }
-
-    private var trailingClusterToolbarContent: some View {
-        terminalPickerToolbarButton
-            .frame(width: 44, height: 44)
-            // Only the always-structural cluster wires collapse detection: a
-            // conditional item's structural removal also detaches its probe
-            // and would be indistinguishable from a More-menu collapse.
-            .measureTrailingToolbarItem(
-                "trailing-cluster",
-                into: $trailingToolbarItemWidths,
-                onLeaveBar: {
-                    // A deeper push or a pop detaches the whole screen, this
-                    // content view included, before the bar items animate
-                    // out; only a cluster detach while the content is still
-                    // on a window is the More-menu collapse.
-                    if barPresence.detailContentAttached {
-                        trailingToolbarCollapseDetected = true
-                    }
+                AltScreenNoticeButton {
+                    displaySettings.showAltScreenNotice = false
                 }
-            )
-    }
-
-    // Which trailing toolbar items are structurally in the bar right now.
-    // Must mirror the conditions in trailingToolbarItems.
-    private var structuralTrailingItemKeys: [String] {
-        var keys = ["trailing-cluster"]
-        if altScreenNoticeIsVisible { keys.append("altscreen-notice") }
-        if workspaceChangesAreAvailable { keys.append("changes") }
-        return keys
+            }
+        }
+        if workspaceChangesAreAvailable {
+            ToolbarItem(id: "workspace-changes", placement: .topBarTrailing) {
+                WorkspaceChangesToolbarButton(
+                    chip: workspaceChangesChip,
+                    workspaceID: workspace.rpcWorkspaceID.rawValue,
+                    action: openWorkspaceChanges
+                )
+                // The chrome sits on the terminal theme's background, not the
+                // system scheme; resolve the counts' green/red for that.
+                .environment(\.colorScheme, store.activeTerminalTheme.terminalColorScheme)
+            }
+        }
+        ToolbarItem(id: "workspace-trailing", placement: .topBarTrailing) {
+            toolbarTrailingCluster
+        }
     }
 
     private var workspaceTitleToolbarMenu: some View {
-        let measuredWidths = structuralTrailingItemKeys.compactMap { trailingToolbarItemWidths[$0] }
-        // Reconnect lives in the title menu now that no pill covers the
-        // terminal; reauthentication keeps its own blocking banner.
-        let canReconnect = Self.canReconnectFromTitleMenu(
-            effectiveConnectionStatus: effectiveConnectionStatus,
-            connectionRequiresReauth: store.connectionRequiresReauth
-        )
         let value = WorkspaceTitleMenuValue(
             contentWidth: contentWidth,
             hasBackButton: backButtonConfiguration != nil,
             hasTrailingCluster: true,
-            measuredTrailingItemsWidth: measuredWidths.reduce(0, +),
-            measuredTrailingItemCount: measuredWidths.count,
-            trailingItemCount: structuralTrailingItemKeys.count,
-            hadTrailingCollapse: trailingToolbarCollapseDetected,
-            isEnabled: hasTitleMenuActions || canReconnect,
+            hasChatToggle: shouldShowChatToggle,
+            isEnabled: hasTitleMenuActions,
             workspaceName: workspace.name,
             hasUnread: workspace.hasUnread,
             canCustomizeWorkspace: customizeWorkspace != nil,
             canRenameWorkspace: renameWorkspace != nil,
             canToggleReadState: setWorkspaceUnread != nil,
             canCloseWorkspace: closeWorkspace != nil,
-            canReconnect: canReconnect,
             labelToken: toolbarTitleLabelToken,
             terminalTheme: store.activeTerminalTheme
         )
@@ -485,22 +264,37 @@ struct WorkspaceDetailView: View {
                     canRenameWorkspace: value.canRenameWorkspace,
                     canToggleReadState: value.canToggleReadState,
                     canCloseWorkspace: value.canCloseWorkspace,
-                    canReconnect: value.canReconnect,
                     presentCustomization: presentCustomizationFromMenu,
                     presentRename: presentRenameFromMenu,
                     toggleReadState: toggleWorkspaceReadStateFromMenu,
-                    requestClose: requestCloseWorkspaceFromMenu,
-                    reconnect: reconnectToWorkspaceMac
+                    requestClose: requestCloseWorkspaceFromMenu
                 )
             },
             label: {
                 switch value.labelToken {
-                case .standard(let title, let subtitle, let connectionStatus):
-                    WorkspaceToolbarTitleView(
-                        title: title,
+                case .chat(
+                    let descriptor,
+                    let agentState,
+                    let isConnected,
+                    let titleOverride,
+                    let subtitle
+                ):
+                    ChatSessionHeaderView(
+                        descriptor: descriptor,
+                        agentState: agentState,
+                        isConnected: isConnected,
+                        titleOverride: titleOverride,
                         subtitle: subtitle,
-                        connectionStatus: connectionStatus
+                        style: .toolbarCompact
                     )
+                case .browser(let title):
+                    Text(title)
+                        .font(.headline)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .foregroundStyle(value.terminalTheme.terminalChromeForegroundColor)
+                case .standard(let title, let subtitle):
+                    WorkspaceToolbarTitleView(title: title, subtitle: subtitle)
                 }
             }
         )
@@ -508,34 +302,22 @@ struct WorkspaceDetailView: View {
     }
 
     private var toolbarTitleLabelToken: WorkspaceTitleMenuLabelToken {
-        let connectionStatus = effectiveConnectionStatus
-        if let browser = activeBrowser {
-            // Browser-style surfaces keep the workspace as the pill's title,
-            // like the terminal; the surface's own title (the page or tab)
-            // rides the subtitle line.
-            return .standard(
-                title: workspace.name,
-                subtitle: browser.title,
-                connectionStatus: connectionStatus
+        if isChatMode,
+           let session = chosenChatSession,
+           let conversation = chatConversationStores[session.id] {
+            return .chat(
+                descriptor: conversation.descriptor,
+                agentState: conversation.agentState,
+                isConnected: conversation.isConnected,
+                titleOverride: workspace.name,
+                subtitle: tabName(for: session)
             )
+        } else if let browser = activeBrowser {
+            return .browser(title: browser.title ?? workspace.name)
         } else if let browser = activeBrowserStream {
-            return .standard(
-                title: workspace.name,
-                subtitle: browser.title,
-                connectionStatus: connectionStatus
-            )
-        } else if let simulator = activeSimulatorStream {
-            return .standard(
-                title: workspace.name,
-                subtitle: simulator.selectedDeviceName ?? simulator.title,
-                connectionStatus: connectionStatus
-            )
+            return .browser(title: browser.title ?? workspace.name)
         } else {
-            return .standard(
-                title: workspace.name,
-                subtitle: selectedToolbarSubtitle,
-                connectionStatus: connectionStatus
-            )
+            return .standard(title: workspace.name, subtitle: selectedToolbarSubtitle)
         }
     }
     #endif
@@ -556,11 +338,9 @@ struct WorkspaceDetailView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             #endif
         }
-        // The unavailable terminal stays visible; block interaction so
-        // keystrokes aren't silently dropped once reconnect attempts stop.
-        // A terminal that is merely reconnecting stays interactive (see
-        // `terminalInputIsBlocked`). The status pill attaches after this
-        // modifier and stays tappable.
+        // The disconnected terminal stays visible; block interaction so
+        // keystrokes aren't silently dropped by the disconnected drain path.
+        // The status pill attaches after this modifier and stays tappable.
         .allowsHitTesting(!terminalInputIsBlocked)
         #if os(iOS)
         // Hit-testing only blocks new touches: a terminal focused before the
@@ -578,23 +358,21 @@ struct WorkspaceDetailView: View {
         }
         #endif
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        // No terminal-covering connection chrome: reconnecting is the title
-        // bar's spinner, disconnected is the title's red dot + subtitle with
-        // Reconnect in the title menu, and last-known content stays visible
-        // throughout.
-        #if os(iOS)
-        .overlay(alignment: .topTrailing) {
-            if let terminalID = selectedTerminal?.id.rawValue,
-               !store.isComposerPresented {
-                TerminalSendStatusPill(
-                    status: store.terminalSendStatus(forTerminalID: terminalID)
+        .overlay(alignment: .topLeading) {
+            // The terminal's only connection chrome: last-known content stays
+            // visible and scrollable underneath while the pill shows the
+            // reconnect progress (or offers Reconnect once attempts stop).
+            MobileMacConnectionStatusPill(
+                host: host,
+                status: effectiveConnectionStatus,
+                reconnect: WorkspaceDetailConnectionChrome.reconnectAction(
+                    connectionRequiresReauth: store.connectionRequiresReauth,
+                    reconnect: { reconnectToWorkspaceMac() }
                 )
-                .allowsHitTesting(false)
+            )
                 .padding(.top, 10)
-                .padding(.trailing, 10)
-            }
+                .padding(.leading, 10)
         }
-        #endif
         #if os(iOS) && DEBUG
         // DEBUG/UI-test-only store-side composer probe.
         .overlay {
@@ -608,12 +386,10 @@ struct WorkspaceDetailView: View {
         #if os(iOS)
         // The whole bottom dock is owned by `GhosttySurfaceView` in one
         // coordinate system, so composer growth pushes only the terminal up.
-        .terminalKeyboardGeometryProbe("detail-inside")
         .mobileTerminalSafeAreaExpansion(
             context: safeAreaContext,
             includesBottom: true
         )
-        .terminalKeyboardGeometryProbe("detail-outside")
         .background {
             // Fill under translucent chrome with the terminal's own color.
             store.activeTerminalTheme.terminalBackgroundColor
@@ -623,16 +399,13 @@ struct WorkspaceDetailView: View {
             if let selectedTerminalArtifact {
                 ChatArtifactViewerDestination(
                     path: selectedTerminalArtifact.path,
-                    scope: .terminal
+                    scope: selectedTerminalArtifact.usesSessionAuthorization ? .chat : .terminal
                 ) {
                     self.selectedTerminalArtifact = nil
                 }
                     .environment(
                         \.chatArtifactLoader,
-                        terminalArtifactLoader(
-                            workspaceID: selectedTerminalArtifact.workspaceID,
-                            surfaceID: selectedTerminalArtifact.surfaceID
-                        )
+                        artifactLoader(for: selectedTerminalArtifact)
                     )
             }
         }
@@ -650,7 +423,7 @@ struct WorkspaceDetailView: View {
         #endif
     }
 
-    func reconnectToWorkspaceMac() {
+    private func reconnectToWorkspaceMac() {
         Task {
             await store.reconnectToMac(
                 macDeviceID: workspace.macDeviceID,
@@ -660,13 +433,13 @@ struct WorkspaceDetailView: View {
     }
 
     /// Same-client foreground recovery flips the store's recovery flags while
-    /// `workspace.macConnectionStatus` stays `.connected`; the title bar's
-    /// spinner reflects the recovery. Input gating deliberately does NOT use
-    /// this (see `terminalInputIsBlocked`): a probe's reconnecting display
-    /// coexists with a working keyboard. Hidden retained details keep their
-    /// raw status: the guard only applies to the selected workspace on the
+    /// `workspace.macConnectionStatus` stays `.connected`; the pill reflects
+    /// the recovery. Input gating deliberately does NOT use this (see
+    /// `terminalInputIsBlocked`): a probe's "Reconnecting" display coexists
+    /// with a working keyboard. Hidden retained details keep their raw
+    /// status: the guard only applies to the selected workspace on the
     /// foreground connection.
-    var effectiveConnectionStatus: MobileMacConnectionStatus {
+    private var effectiveConnectionStatus: MobileMacConnectionStatus {
         if store.selectedWorkspaceID == workspace.id,
            store.selectedWorkspaceUsesForegroundConnection {
             if store.connectionRecoveryFailed {
@@ -679,20 +452,23 @@ struct WorkspaceDetailView: View {
         return connectionStatus
     }
 
-    /// Input follows the effective (recovery-aware) status, not the raw row
-    /// status: the redial path downgrades the retained row to unavailable in
-    /// the same turn it marks the recovery as reconnecting, and gating on the
-    /// raw value would resign a working keyboard right as the spinner starts.
-    /// The terminal stays fully interactive while a reconnect is in flight so
-    /// the user can finish typing a thought — keystrokes ride the send
-    /// buffer, and a send that races the dead window fails visibly through
-    /// the send-status pill instead of the keyboard dropping mid-word. Block
-    /// only once the connection is unavailable (attempts stopped or
-    /// foreground recovery failed, which `effectiveConnectionStatus` folds
-    /// in). Internal so the +Surfaces chrome-return refocus can share the
-    /// same policy.
+    /// Input viability is narrower than the displayed status: a same-client
+    /// probe reads "Reconnecting" while the transport is still connected and
+    /// the RPC client still carries keystrokes, so blocking or resigning
+    /// there would dismiss a working keyboard mid-typing. Block only when
+    /// the workspace status itself is disconnected or foreground recovery
+    /// actually failed. Internal so the +Surfaces chrome-return refocus can
+    /// share the same policy.
     var terminalInputIsBlocked: Bool {
-        effectiveConnectionStatus == .unavailable
+        if connectionStatus != .connected {
+            return true
+        }
+        if store.selectedWorkspaceID == workspace.id,
+           store.selectedWorkspaceUsesForegroundConnection,
+           store.connectionRecoveryFailed {
+            return true
+        }
+        return false
     }
 
     #if os(iOS)
@@ -720,10 +496,7 @@ struct WorkspaceDetailView: View {
 
     func terminalArtifactLoader(workspaceID: String, surfaceID: String) -> ChatArtifactLoader {
         guard let source = store.makeChatEventSource() else {
-            return .unsupported(
-                cache: terminalArtifactThumbnailCache,
-                diagnosticLog: store.diagnosticLog
-            )
+            return .unsupported(cache: terminalArtifactThumbnailCache)
         }
         return ChatArtifactLoader(
             terminalWorkspaceID: workspaceID,
@@ -731,7 +504,6 @@ struct WorkspaceDetailView: View {
             supportsArtifacts: store.supportsTerminalArtifacts,
             supportsDirectoryBrowsing: store.supportsTerminalArtifactList,
             cache: terminalArtifactThumbnailCache,
-            diagnosticLog: store.diagnosticLog,
             stat: { path in
                 try await source.terminalArtifactStat(
                     workspaceID: workspaceID,
@@ -773,6 +545,23 @@ struct WorkspaceDetailView: View {
         )
     }
 
+    private func artifactLoader(for selection: TerminalArtifactSelection) -> ChatArtifactLoader {
+        guard let sessionID = selection.sessionID else {
+            return terminalArtifactLoader(
+                workspaceID: selection.workspaceID,
+                surfaceID: selection.surfaceID
+            )
+        }
+        guard store.supportsChatArtifacts,
+              let source = store.makeChatEventSource() else {
+            return .unsupported(cache: terminalArtifactThumbnailCache)
+        }
+        return ChatArtifactLoader(
+            source: source,
+            sessionID: sessionID,
+            cache: terminalArtifactThumbnailCache
+        )
+    }
     #endif
 
     @ViewBuilder
@@ -812,30 +601,21 @@ struct WorkspaceDetailView: View {
         TerminalPickerMenu(
             value: TerminalPickerMenuValue(
                 liveTerminals: workspace.terminals,
-                liveSurfaces: workspace.surfaces,
                 snapshotRows: terminalPickerRows,
                 selectedID: store.selectedTerminalID,
-                // Resolved through the workspace so the auto-presented
-                // fallback surface (no terminals, no explicit selection)
-                // carries the picker checkmark like any picked surface.
-                selectedMacSurfaceID: workspace.selectedMacSurface(id: store.selectedMacSurfaceID)?.id,
                 canCreateWorkspace: canCreateWorkspace,
                 hasActiveBrowser: activeBrowser != nil,
+                isChatMode: isChatMode,
                 browserStreamRows: browserStreamStore.panels(in: workspace.rpcWorkspaceID.rawValue).map(BrowserStreamPickerRow.init),
                 supportsBrowserStream: store.supportsBrowserStream,
-                activeBrowserStreamPanelID: activeBrowserStream?.id,
-                simulatorStreamRows: simulatorStreamStore.panels(in: workspace.rpcWorkspaceID.rawValue).map(SimulatorStreamPickerRow.init),
-                supportsSimulatorStream: store.supportsSimulatorStream,
-                activeSimulatorStreamPanelID: activeSimulatorStream?.id
+                activeBrowserStreamPanelID: activeBrowserStream?.id
             ),
             actions: TerminalPickerMenuActions(
                 selectTerminal: selectTerminalFromPicker,
-                selectMacSurface: selectMacSurfaceFromPicker,
                 createWorkspace: createWorkspaceFromToolbar,
                 createTerminal: createTerminalFromToolbar,
                 openBrowser: openBrowserFromToolbar,
-                selectBrowserStream: { selectBrowserStreamFromToolbar($0) },
-                selectSimulatorStream: selectSimulatorStreamFromToolbar,
+                selectBrowserStream: selectBrowserStreamFromToolbar,
                 openTextSheet: openTextSheetFromMenu,
                 copyDebugLogs: {
                     #if DEBUG
@@ -869,27 +649,21 @@ struct WorkspaceDetailView: View {
     /// Opens the "View as Text" sheet: the terminal's content as selectable
     /// plain text, because the render surface itself has no copy affordance.
     private func openTextSheetFromMenu() {
-        store.recordAppEvent(
-            .terminalTextViewOpened,
-            correlationID: selectedTerminal?.id.rawValue
-        )
-        textSheetPresentation.present {
-            textSheetSurfaceID = selectedTerminal?.id.rawValue
-        }
+        textSheetSurfaceID = selectedTerminal?.id.rawValue
+        isTextSheetPresented = true
     }
 
     private func openFeedbackComposerFromMenu() {
-        feedbackPresentation.present {
-            feedbackText = ""
-            feedbackErrorMessage = nil
-            // A prior submission may still be in flight if the user dismissed the
-            // sheet mid-send (Cancel stays enabled); reset so the reopened composer
-            // does not render Send permanently disabled until that task times out.
-            isSubmittingFeedback = false
-            // Prefill the reply-to address with the signed-in email on the email
-            // path; the privileged agent path never reads it.
-            feedbackEmail = store.signedInUserEmail ?? ""
-        }
+        feedbackText = ""
+        feedbackErrorMessage = nil
+        // A prior submission may still be in flight if the user dismissed the
+        // sheet mid-send (Cancel stays enabled); reset so the reopened composer
+        // does not render Send permanently disabled until that task times out.
+        isSubmittingFeedback = false
+        // Prefill the reply-to address with the signed-in email on the email
+        // path; the privileged agent path never reads it.
+        feedbackEmail = store.signedInUserEmail ?? ""
+        isFeedbackComposerPresented = true
     }
 
     /// Whether the current submission will go straight to the agent (privileged
@@ -941,7 +715,7 @@ struct WorkspaceDetailView: View {
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button(L10n.string("mobile.feedback.cancel", defaultValue: "Cancel")) {
-                        feedbackPresentation.dismiss()
+                        isFeedbackComposerPresented = false
                     }
                 }
                 ToolbarItem(placement: .confirmationAction) {
@@ -1004,7 +778,7 @@ struct WorkspaceDetailView: View {
             isSubmittingFeedback = false
             switch outcome {
             case .sentToAgent, .emailed:
-                feedbackPresentation.dismiss()
+                isFeedbackComposerPresented = false
                 if toasts.isEnabled {
                     // The toast supplies the success haptic; presenting after
                     // the composer dismisses keeps it the single confirmation.
@@ -1059,9 +833,8 @@ struct WorkspaceDetailView: View {
     }
 
     private func presentCustomizationFromMenu() {
-        customizationPresentation.present {
-            dismissTerminalKeyboardForChrome()
-        }
+        dismissTerminalKeyboardForChrome()
+        isCustomizationPresented = true
     }
 
     /// Commit the rename dialog: forward the trimmed name to the Mac, which echoes
@@ -1076,113 +849,31 @@ struct WorkspaceDetailView: View {
 
     private func createTerminalFromToolbar() {
         dismissTerminalKeyboardForChrome()
-        browserCreateRequest = nil
         // Creating a terminal from the (shared) chrome must surface it. If a
         // browser pane is up, close it so `body` leaves the browser branch and
         // shows the new terminal instead of staying on the browser.
         browserStore.closeBrowser(for: workspace.id.rawValue)
         stopActiveBrowserStream()
-        stopActiveSimulatorStream()
-        store.selectedMacSurfaceID = nil
         createTerminal()
     }
 
     private func openBrowserFromToolbar() {
         dismissTerminalKeyboardForChrome()
-        // New Browser creates a real Mac browser pane and streams it, so it
-        // shows the same surface as the Mac Browsers rows. The phone-local
-        // WKWebView pane remains only as a fallback for Macs that cannot
-        // create panels (older builds, disconnected, or creation rejected).
-        guard store.supportsBrowserStreamCreate else {
-            openLocalBrowserFallback()
-            return
-        }
-        let workspaceID = workspace.rpcWorkspaceID.rawValue
-        let request = UUID()
-        browserCreateRequest = request
-        Task {
-            let descriptor = await store.createMobileBrowserPanel(workspaceID: workspaceID)
-            guard browserCreateRequest == request else { return }
-            browserCreateRequest = nil
-            guard let descriptor else {
-                openLocalBrowserFallback()
-                return
-            }
-            selectBrowserStreamFromToolbar(descriptor.panelID, dismissKeyboard: false)
-        }
-    }
-
-    /// Opens (or reveals) the phone-local browser pane for this workspace. The
-    /// detail view flips to the browser because `activeBrowser` becomes
-    /// non-nil; the picker shows a check next to "New Browser" while it is up.
-    private func openLocalBrowserFallback() {
-        let workspaceID = workspace.id.rawValue
-        store.recordAppEvent(.browserCreateStarted, correlationID: workspaceID)
-        _ = browserStore.openBrowser(for: workspaceID)
-        store.recordAppEvent(.browserCreateSucceeded, correlationID: workspaceID)
-        store.recordLastOpenedLocalBrowserTab(in: workspace.id)
+        // Opens (or reveals the existing) browser pane for this workspace. The
+        // detail view flips to the browser because `activeBrowser` becomes
+        // non-nil; the picker shows a check next to "New Browser" while it is up.
+        browserStore.openBrowser(for: workspace.id.rawValue)
         stopActiveBrowserStream()
-        stopActiveSimulatorStream()
-        store.selectedMacSurfaceID = nil
     }
 
-    private func selectBrowserStreamFromToolbar(_ panelID: String, dismissKeyboard: Bool = true) {
-        if dismissKeyboard {
-            dismissTerminalKeyboardForChrome()
-        }
-        browserCreateRequest = nil
+    private func selectBrowserStreamFromToolbar(_ panelID: String) {
+        dismissTerminalKeyboardForChrome()
         browserStore.closeBrowser(for: workspace.id.rawValue)
-        stopActiveSimulatorStream()
-        store.selectedMacSurfaceID = nil
         if let previous = activeBrowserStream, previous.id != panelID {
             Task { await store.stopMobileBrowserStream(panelID: previous.id) }
         }
         _ = browserStreamStore.activate(panelID: panelID, in: workspace.rpcWorkspaceID.rawValue)
-        store.recordLastOpenedBrowserStreamTab(panelID: panelID, in: workspace.id)
         Task { await store.startMobileBrowserStream(panelID: panelID) }
-    }
-
-    private func selectSimulatorStreamFromToolbar(_ panelID: String) {
-        dismissTerminalKeyboardForChrome()
-        browserStore.closeBrowser(for: workspace.id.rawValue)
-        stopActiveBrowserStream()
-        store.selectedMacSurfaceID = nil
-        let workspaceID = workspace.rpcWorkspaceID.rawValue
-        let previousPanelID: String? = activeSimulatorStream.flatMap {
-            $0.id == panelID ? nil : $0.id
-        }
-        // Settle the previous panel's local state before activating the new
-        // one, so switching A -> B leaves A idle instead of frozen on a stale
-        // `.streaming`/`.starting` status.
-        if let previousPanelID {
-            simulatorStreamStore.deactivate(panelID: previousPanelID, in: workspaceID)
-        }
-        _ = simulatorStreamStore.activate(panelID: panelID, in: workspaceID)
-        store.recordLastOpenedSimulatorStreamTab(panelID: panelID, in: workspace.id)
-        // One task, stop awaited before start: two independent tasks have no
-        // ordering guarantee, and the reversed order would tear down the new
-        // stream (or churn host sessions) right after it started.
-        Task {
-            if let previousPanelID {
-                await store.stopMobileSimulatorStream(
-                    panelID: previousPanelID,
-                    workspaceID: workspaceID
-                )
-            }
-            await store.startMobileSimulatorStream(
-                panelID: panelID,
-                workspaceID: workspaceID
-            )
-        }
-    }
-
-    /// Reopens the phone-local browser pane when the store's last-opened-tab
-    /// restore asked for it. The local browser lives in this view layer's
-    /// `BrowserSurfaceStore`, so the composite hands the reopen here as a
-    /// one-shot intent; opening is idempotent for an already-open pane.
-    private func restoreLocalBrowserTabIfRequested() {
-        guard store.consumeLocalBrowserTabRestore(for: workspace.id) else { return }
-        _ = browserStore.openBrowser(for: workspace.id.rawValue)
     }
 
     private func stopActiveBrowserStream() {
@@ -1191,19 +882,12 @@ struct WorkspaceDetailView: View {
         Task { await store.stopMobileBrowserStream(panelID: stream.id) }
     }
 
-    private func stopActiveSimulatorStream() {
-        store.stopActiveMobileSimulatorStream(in: workspace.rpcWorkspaceID.rawValue)
-    }
-
     private func selectTerminalFromPicker(_ terminalID: MobileTerminalPreview.ID) {
         dismissTerminalKeyboardForChrome()
-        browserCreateRequest = nil
         // Choosing a terminal returns from the browser pane (if up) to the
         // terminal. Closing the browser is enough to flip the detail view back.
         browserStore.closeBrowser(for: workspace.id.rawValue)
         stopActiveBrowserStream()
-        stopActiveSimulatorStream()
-        store.selectedMacSurfaceID = nil
         // Switching from the picker is chrome, not a typing intent, so the
         // newly-selected surface must not grab the keyboard on attach. The
         // store suppresses the target's autofocus (and is a no-op when it is
@@ -1212,30 +896,11 @@ struct WorkspaceDetailView: View {
         store.selectTerminalFromChrome(terminalID)
     }
 
-    private func selectMacSurfaceFromPicker(_ surfaceID: MobileSurfacePreview.ID) {
-        dismissTerminalKeyboardForChrome()
-        browserCreateRequest = nil
-        browserStore.closeBrowser(for: workspace.id.rawValue)
-        stopActiveBrowserStream()
-        // Streams outrank Mac surfaces in `WorkspaceActiveSurface.derive`, so
-        // a selected Simulator stream must be cleared before the Mac surface
-        // can become visible.
-        stopActiveSimulatorStream()
-        store.selectMacSurface(surfaceID)
-    }
-
     func dismissTerminalKeyboardForChrome() {
         // Resign the terminal's hidden text input first so the surface clears
         // its keyboard geometry and recomputes full-height before chrome covers
         // it; then sweep any other responder across the scene.
         GhosttySurfaceView.resignActiveInput()
         UIApplication.shared.dismissMobileKeyboard()
-    }
-
-    private func syncSimulatorStreamPanels() {
-        simulatorStreamStore.replaceSimulatorPanels(
-            in: workspace.rpcWorkspaceID.rawValue,
-            with: workspace.simulators
-        )
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -17,17 +17,18 @@ import SwiftUI
 import AppKit
 #endif
 
-enum WorkspaceDetailConnectionChrome {
-    static func reconnectAction(
-        connectionRequiresReauth: Bool,
-        reconnect: @escaping () -> Void
-    ) -> (() -> Void)? {
-        connectionRequiresReauth ? nil : reconnect
-    }
-}
-
 struct WorkspaceDetailView: View {
-    let host: String
+    /// Whether the title menu offers manual Reconnect: only once the
+    /// connection is unavailable (an active reconnect needs no manual entry),
+    /// and never during reauthentication, whose blocking banner owns
+    /// recovery.
+    static func canReconnectFromTitleMenu(
+        effectiveConnectionStatus: MobileMacConnectionStatus,
+        connectionRequiresReauth: Bool
+    ) -> Bool {
+        effectiveConnectionStatus == .unavailable && !connectionRequiresReauth
+    }
+
     let connectionStatus: MobileMacConnectionStatus
     let workspace: MobileWorkspacePreview
     @Bindable var store: CMUXMobileShellStore
@@ -47,8 +48,11 @@ struct WorkspaceDetailView: View {
     let signOut: (@MainActor @Sendable () -> Void)?
     @Environment(BrowserSurfaceStore.self) var browserStore
     @Environment(BrowserStreamStore.self) var browserStreamStore
+    @Environment(MobileSimulatorStreamStore.self) var simulatorStreamStore
     @Environment(MobileDisplaySettings.self) private var displaySettings
     @Environment(ToastCenter.self) private var toasts
+    @Environment(\.mobileChildPresentationProvider) private var childPresentationProvider
+    @Environment(\.terminalFilesChipEnabled) var isTerminalFilesChipEnabled
     /// Drives the destructive close-workspace confirmation dialog.
     @State var isConfirmingClose = false
     #if canImport(UIKit)
@@ -57,7 +61,14 @@ struct WorkspaceDetailView: View {
     @State private var feedbackEmail = ""
     @State private var isSubmittingFeedback = false
     @State private var feedbackErrorMessage: String?
-    @State private var isTextSheetPresented = false
+    @State private var isTextSheetPresented = {
+        #if DEBUG
+        AutoConnectMigrationUITestConfiguration.currentProcess?.initialModalHost
+            == .workspaceDetailTerminalText
+        #else
+        false
+        #endif
+    }()
     /// Drives the rename-workspace dialog launched from the picker menu, and its
     /// editable text (seeded with the current name when presented).
     @State var isRenamePresented = false
@@ -66,25 +77,33 @@ struct WorkspaceDetailView: View {
     @State var isCustomizationPresented = false
     /// Live pane width for capping the leading glass title pill.
     @State private var contentWidth: CGFloat = 0
+    // Rendered content width per trailing toolbar item, keyed by item. The
+    // title's width cap subtracts the structurally visible items' widths so
+    // they always fit and iOS never folds them into the overflow More menu
+    // (no per-item priority exists below iOS 27). Only structural removal
+    // deletes an entry (see the onChange handlers); a layout-driven
+    // disappearance (overflow into More) cannot release a reservation and
+    // make the collapse sticky.
+    @State private var trailingToolbarItemWidths: [String: CGFloat] = [:]
+    /// Ratchets on when the trailing cluster's content leaves the bar while
+    /// the screen's own content is still on a window: the system folded it
+    /// into the More menu, so the estimate reserves undershot this device's
+    /// chrome. Never cleared for this view's lifetime; the extra recovery
+    /// reserve un-collapses the bar.
+    @State private var trailingToolbarCollapseDetected = false
+    /// Live window-attachment flags shared with the UIKit probes; reference
+    /// identity keeps event-time reads current where SwiftUI captures of
+    /// value state would be stale.
+    @State private var barPresence = WorkspaceBarPresence()
     /// Terminal captured for the current "View as Text" sheet presentation.
     @State private var textSheetSurfaceID: String?
+    /// Identity of the in-flight New Browser creation. A late RPC result must
+    /// not activate its panel over a selection the user made in the meantime,
+    /// so completion applies only while its request is still current.
+    @State private var browserCreateRequest: UUID?
     @State var terminalPickerRows: [TerminalPickerMenuRow] = []
-    /// Chat-mode toggle for inline agent chat in place of the terminal.
-    @State var isChatMode = false
-    /// The session chat mode was entered on, pinned so sorting cannot swap the conversation
-    /// out from under the user mid-read. Cleared when chat mode turns off.
-    @State var pinnedChatSessionID: String?
-    @State var chatSessions: [ChatSessionDescriptor] = []
-    @State var chatSessionsWorkspaceID: String?
-    /// Last terminal id whose cached snapshot said it had a chat session.
-    @State var cachedChatToggleTerminalID: String?
-    @State var ignoredChatSessionRefreshKey: String?
-    @State var ignoredChatSessionRefreshID: UUID?
-    @State var ignoredChatSessionRefreshTask: Task<[ChatSessionDescriptor]?, Never>?
-    /// Per-session chat stores kept warm while the workspace detail is visible.
-    @State var chatConversationStores: [String: ChatConversationStore] = [:]
-    /// Per-session composer drafts, surviving toggles back to the terminal.
-    @State var chatDrafts: [String: String] = [:]
+    /// Local presenter identity remains separate from the artifact popover payload.
+    @State var isTerminalArtifactFilesPresented = false
     @State var terminalArtifactFilesContext: TerminalArtifactContext?
     @State var selectedTerminalArtifact: TerminalArtifactSelection?
     @State var terminalArtifactThumbnailCache = ChatArtifactThumbnailCache()
@@ -93,7 +112,6 @@ struct WorkspaceDetailView: View {
     @State var isWorkspaceChangesSheetPresented = false
     @State var workspaceChangesHint: MobileWorkspaceChangesHint?
     @State var artifactGalleryRefreshSignal = TerminalArtifactGalleryRefreshSignal.initial
-    /// App lifecycle phase used to re-pull chat sessions on foreground.
     @Environment(\.scenePhase) var scenePhase
     #endif
     /// The active browser surface for this workspace, when a browser pane is open.
@@ -103,10 +121,47 @@ struct WorkspaceDetailView: View {
     var activeBrowserStream: BrowserStreamSurfaceState? {
         browserStreamStore.activeState(in: workspace.rpcWorkspaceID.rawValue)
     }
-    #if os(iOS)
-    var terminalFilesChipEnabled: Bool {
-        displaySettings.terminalFilesChipEnabled
+    var activeSimulatorStream: MobileSimulatorStreamSurfaceState? {
+        simulatorStreamStore.activeState(in: workspace.rpcWorkspaceID.rawValue)
     }
+    #if os(iOS)
+    /// Uses the root modal owner in the live app and local state in previews.
+    func resolvedPresentation(
+        for child: MobileRootPresentationState.ChildPresentation,
+        fallback: Binding<Bool>
+    ) -> MobileChildSheetPresentation {
+        childPresentationProvider?.presentation(for: child, fallback: fallback)
+            ?? MobileChildSheetPresentation(isPresented: fallback)
+    }
+
+    private var feedbackPresentation: MobileChildSheetPresentation {
+        resolvedPresentation(
+            for: .workspaceDetail(.feedbackComposer),
+            fallback: $isFeedbackComposerPresented
+        )
+    }
+
+    private var textSheetPresentation: MobileChildSheetPresentation {
+        resolvedPresentation(
+            for: .workspaceDetail(.terminalText),
+            fallback: $isTextSheetPresented
+        )
+    }
+
+    var workspaceChangesPresentation: MobileChildSheetPresentation {
+        resolvedPresentation(
+            for: .workspaceDetail(.workspaceChanges),
+            fallback: $isWorkspaceChangesSheetPresented
+        )
+    }
+
+    private var customizationPresentation: MobileChildSheetPresentation {
+        resolvedPresentation(
+            for: .workspaceDetail(.customization),
+            fallback: $isCustomizationPresented
+        )
+    }
+
     var showMissingFiles: Bool {
         displaySettings.showMissingFiles
     }
@@ -115,15 +170,24 @@ struct WorkspaceDetailView: View {
     }
     var activeSurface: WorkspaceActiveSurface {
         WorkspaceActiveSurface.derive(
-            isChatMode: isChatMode,
-            hasChosenChatSession: chosenChatSession != nil,
             hasActiveBrowser: activeBrowser != nil,
-            hasActiveBrowserStream: activeBrowserStream != nil
+            hasActiveBrowserStream: activeBrowserStream != nil,
+            hasActiveSimulatorStream: activeSimulatorStream != nil,
+            selectedMacSurface: workspace.selectedMacSurface(id: store.selectedMacSurfaceID)
         )
     }
     #endif
     var body: some View {
-        let content = Group { detailSurfaceContent }
+        let content = Group {
+            VStack(spacing: 0) {
+                if let message = store.terminalCreationError,
+                   store.selectedWorkspaceID == workspace.id,
+                   store.terminalCreationErrorWorkspaceID == workspace.rpcWorkspaceID {
+                    terminalCreationRecovery(message: message)
+                }
+                detailSurfaceContent
+            }
+        }
 
         #if os(iOS)
         content
@@ -136,19 +200,45 @@ struct WorkspaceDetailView: View {
                 store.activeTerminalTheme.terminalBackgroundColor,
                 for: .navigation
             )
+            // The browser and chat surfaces scroll; without this the system
+            // minimizes the whole bar into a floating "…" pill, unlike the
+            // terminal surface, which has no system scroll view.
+            .mobilePinnedNavigationBar()
+            .trackBarPresence(barPresence)
             .toolbar { workspaceDetailToolbar }
-            .task(id: chatRefreshKey) { await refreshChatSessions() }
             .task(id: workspace.rpcWorkspaceID.rawValue) {
                 await store.refreshMobileBrowserPanels(workspaceID: workspace.rpcWorkspaceID.rawValue)
+                syncSimulatorStreamPanels()
+                store.refreshWorkspaceSelection()
+                restoreLocalBrowserTabIfRequested()
             }
-            .task(id: chatConversationWarmKey) { await runWarmChatConversation() }
+            .onChange(of: store.pendingLocalBrowserTabRestoreWorkspaceID) { _, _ in
+                restoreLocalBrowserTabIfRequested()
+            }
+            .onChange(of: browserStreamStore.panelDiscoveryRevision(in: workspace.rpcWorkspaceID.rawValue)) { _, _ in
+                store.refreshWorkspaceSelection()
+            }
+            .onChange(of: workspace.simulators) { _, _ in
+                syncSimulatorStreamPanels()
+                store.refreshWorkspaceSelection()
+            }
+            // Structural removal drops the item's retained measurement so a
+            // returning item takes the fail-safe unmeasured reserve instead of
+            // a stale width for its first layout pass. Layout-driven
+            // disappearance (overflow into More) never flips these conditions,
+            // so it cannot release a reservation and make the collapse sticky.
+            .onChange(of: workspaceChangesAreAvailable) { _, isAvailable in
+                if !isAvailable { trailingToolbarItemWidths["changes"] = nil }
+            }
+            .onChange(of: altScreenNoticeIsVisible) { _, isVisible in
+                if !isVisible { trailingToolbarItemWidths["altscreen-notice"] = nil }
+            }
             .onAppear { refreshWorkspaceChangesHint() }
             .onChange(of: workspaceChangesHintEligibilityKey) { _, _ in
                 refreshWorkspaceChangesHint()
             }
             .onChange(of: selectedTerminalID) { _, _ in
                 visibleArtifactCount = 0
-                refreshCachedChatToggleAnchor()
                 syncTerminalPickerRows(includeTitleChanges: true)
             }
             .onChange(of: store.supportsTerminalArtifacts) { _, supportsArtifacts in
@@ -161,13 +251,25 @@ struct WorkspaceDetailView: View {
                 isPresented: $isConfirmingClose,
                 confirm: confirmCloseWorkspaceFromMenu
             )
-            .sheet(isPresented: $isFeedbackComposerPresented) {
+            .sheet(
+                isPresented: feedbackPresentation.isPresented,
+                onDismiss: feedbackPresentation.didDismiss
+            ) {
                 feedbackComposer
             }
-            .sheet(isPresented: $isTextSheetPresented) {
+            .sheet(
+                isPresented: textSheetPresentation.isPresented,
+                onDismiss: {
+                    textSheetSurfaceID = nil
+                    textSheetPresentation.didDismiss()
+                }
+            ) {
                 TerminalTextSheetView(surfaceID: textSheetSurfaceID)
             }
-            .sheet(isPresented: $isWorkspaceChangesSheetPresented) {
+            .sheet(
+                isPresented: workspaceChangesPresentation.isPresented,
+                onDismiss: workspaceChangesPresentation.didDismiss
+            ) {
                 WorkspaceChangesSheet(
                     store: store,
                     workspaceID: workspace.rpcWorkspaceID.rawValue,
@@ -181,7 +283,10 @@ struct WorkspaceDetailView: View {
                 text: $renameText,
                 onSave: commitRenameFromDialog
             )
-            .sheet(isPresented: $isCustomizationPresented) {
+            .sheet(
+                isPresented: customizationPresentation.isPresented,
+                onDismiss: customizationPresentation.didDismiss
+            ) {
                 WorkspaceCustomizationSheet(workspace: workspace) { initialDraft, submittedDraft in
                     await customizeWorkspace?(workspace.id, initialDraft, submittedDraft)
                         ?? .failure()
@@ -198,7 +303,38 @@ struct WorkspaceDetailView: View {
         #endif
     }
 
+    private func terminalCreationRecovery(message: String) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+            VStack(alignment: .leading, spacing: 6) {
+                Text(message)
+                    .font(.subheadline)
+                    .fixedSize(horizontal: false, vertical: true)
+                Button {
+                    createTerminal()
+                } label: {
+                    Text(L10n.string("mobile.terminal.creationRetry", defaultValue: "Retry"))
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+                .accessibilityIdentifier("MobileTerminalCreationRetry")
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(.orange.opacity(0.14))
+        .accessibilityIdentifier("MobileTerminalCreationRecovery")
+    }
+
     #if os(iOS)
+    private var altScreenNoticeIsVisible: Bool {
+        guard let selectedTerminalID else { return false }
+        return store.isAlternateScreen(surfaceID: selectedTerminalID)
+            && displaySettings.showAltScreenNotice
+    }
+
     @ToolbarContentBuilder
     private var workspaceDetailToolbar: some ToolbarContent {
         if backButtonConfiguration != nil {
@@ -212,45 +348,136 @@ struct WorkspaceDetailView: View {
         ToolbarItem(id: "workspace-title", placement: .topBarLeading) {
             workspaceTitleToolbarMenu
         }
-        if let selectedTerminalID,
-           store.isAlternateScreen(surfaceID: selectedTerminalID),
-           displaySettings.showAltScreenNotice {
+        // iOS 27's visibilityPriority(.high) natively keeps the trailing items
+        // out of the overflow More menu. The symbols are absent from SDK 26.x,
+        // so the branch is compiler-gated until an Xcode 27 toolchain builds
+        // this target; the measured title cap below stays the sizing mechanism
+        // on every OS (the native priority only decides who overflows, it does
+        // not grant the title the remaining space).
+        #if compiler(>=6.4)
+        if #available(iOS 27.0, *) {
+            highPriorityTrailingToolbarItems
+        } else {
+            trailingToolbarItems
+        }
+        #else
+        trailingToolbarItems
+        #endif
+    }
+
+    @ToolbarContentBuilder
+    private var trailingToolbarItems: some ToolbarContent {
+        if altScreenNoticeIsVisible {
             ToolbarItem(id: "workspace-altscreen-notice", placement: .topBarTrailing) {
-                AltScreenNoticeButton {
-                    displaySettings.showAltScreenNotice = false
-                }
+                altScreenNoticeToolbarContent
             }
         }
         if workspaceChangesAreAvailable {
             ToolbarItem(id: "workspace-changes", placement: .topBarTrailing) {
-                WorkspaceChangesToolbarButton(
-                    chip: workspaceChangesChip,
-                    workspaceID: workspace.rpcWorkspaceID.rawValue,
-                    action: openWorkspaceChanges
-                )
-                // The chrome sits on the terminal theme's background, not the
-                // system scheme; resolve the counts' green/red for that.
-                .environment(\.colorScheme, store.activeTerminalTheme.terminalColorScheme)
+                workspaceChangesToolbarContent
             }
         }
         ToolbarItem(id: "workspace-trailing", placement: .topBarTrailing) {
-            toolbarTrailingCluster
+            trailingClusterToolbarContent
         }
     }
 
+    #if compiler(>=6.4)
+    @available(iOS 27.0, *)
+    @ToolbarContentBuilder
+    private var highPriorityTrailingToolbarItems: some ToolbarContent {
+        if altScreenNoticeIsVisible {
+            ToolbarItem(id: "workspace-altscreen-notice", placement: .topBarTrailing) {
+                altScreenNoticeToolbarContent
+            }
+            .visibilityPriority(.high)
+        }
+        if workspaceChangesAreAvailable {
+            ToolbarItem(id: "workspace-changes", placement: .topBarTrailing) {
+                workspaceChangesToolbarContent
+            }
+            .visibilityPriority(.high)
+        }
+        ToolbarItem(id: "workspace-trailing", placement: .topBarTrailing) {
+            trailingClusterToolbarContent
+        }
+        .visibilityPriority(.high)
+    }
+    #endif
+
+    private var altScreenNoticeToolbarContent: some View {
+        AltScreenNoticeButton {
+            displaySettings.showAltScreenNotice = false
+        }
+        .measureTrailingToolbarItem("altscreen-notice", into: $trailingToolbarItemWidths)
+    }
+
+    private var workspaceChangesToolbarContent: some View {
+        WorkspaceChangesToolbarButton(
+            chip: workspaceChangesChip,
+            workspaceID: workspace.rpcWorkspaceID.rawValue,
+            action: openWorkspaceChanges
+        )
+        // The chrome sits on the terminal theme's background, not the
+        // system scheme; resolve the counts' green/red for that.
+        .environment(\.colorScheme, store.activeTerminalTheme.terminalColorScheme)
+        .measureTrailingToolbarItem("changes", into: $trailingToolbarItemWidths)
+    }
+
+    private var trailingClusterToolbarContent: some View {
+        terminalPickerToolbarButton
+            .frame(width: 44, height: 44)
+            // Only the always-structural cluster wires collapse detection: a
+            // conditional item's structural removal also detaches its probe
+            // and would be indistinguishable from a More-menu collapse.
+            .measureTrailingToolbarItem(
+                "trailing-cluster",
+                into: $trailingToolbarItemWidths,
+                onLeaveBar: {
+                    // A deeper push or a pop detaches the whole screen, this
+                    // content view included, before the bar items animate
+                    // out; only a cluster detach while the content is still
+                    // on a window is the More-menu collapse.
+                    if barPresence.detailContentAttached {
+                        trailingToolbarCollapseDetected = true
+                    }
+                }
+            )
+    }
+
+    // Which trailing toolbar items are structurally in the bar right now.
+    // Must mirror the conditions in trailingToolbarItems.
+    private var structuralTrailingItemKeys: [String] {
+        var keys = ["trailing-cluster"]
+        if altScreenNoticeIsVisible { keys.append("altscreen-notice") }
+        if workspaceChangesAreAvailable { keys.append("changes") }
+        return keys
+    }
+
     private var workspaceTitleToolbarMenu: some View {
+        let measuredWidths = structuralTrailingItemKeys.compactMap { trailingToolbarItemWidths[$0] }
+        // Reconnect lives in the title menu now that no pill covers the
+        // terminal; reauthentication keeps its own blocking banner.
+        let canReconnect = Self.canReconnectFromTitleMenu(
+            effectiveConnectionStatus: effectiveConnectionStatus,
+            connectionRequiresReauth: store.connectionRequiresReauth
+        )
         let value = WorkspaceTitleMenuValue(
             contentWidth: contentWidth,
             hasBackButton: backButtonConfiguration != nil,
             hasTrailingCluster: true,
-            hasChatToggle: shouldShowChatToggle,
-            isEnabled: hasTitleMenuActions,
+            measuredTrailingItemsWidth: measuredWidths.reduce(0, +),
+            measuredTrailingItemCount: measuredWidths.count,
+            trailingItemCount: structuralTrailingItemKeys.count,
+            hadTrailingCollapse: trailingToolbarCollapseDetected,
+            isEnabled: hasTitleMenuActions || canReconnect,
             workspaceName: workspace.name,
             hasUnread: workspace.hasUnread,
             canCustomizeWorkspace: customizeWorkspace != nil,
             canRenameWorkspace: renameWorkspace != nil,
             canToggleReadState: setWorkspaceUnread != nil,
             canCloseWorkspace: closeWorkspace != nil,
+            canReconnect: canReconnect,
             labelToken: toolbarTitleLabelToken,
             terminalTheme: store.activeTerminalTheme
         )
@@ -264,37 +491,22 @@ struct WorkspaceDetailView: View {
                     canRenameWorkspace: value.canRenameWorkspace,
                     canToggleReadState: value.canToggleReadState,
                     canCloseWorkspace: value.canCloseWorkspace,
+                    canReconnect: value.canReconnect,
                     presentCustomization: presentCustomizationFromMenu,
                     presentRename: presentRenameFromMenu,
                     toggleReadState: toggleWorkspaceReadStateFromMenu,
-                    requestClose: requestCloseWorkspaceFromMenu
+                    requestClose: requestCloseWorkspaceFromMenu,
+                    reconnect: reconnectToWorkspaceMac
                 )
             },
             label: {
                 switch value.labelToken {
-                case .chat(
-                    let descriptor,
-                    let agentState,
-                    let isConnected,
-                    let titleOverride,
-                    let subtitle
-                ):
-                    ChatSessionHeaderView(
-                        descriptor: descriptor,
-                        agentState: agentState,
-                        isConnected: isConnected,
-                        titleOverride: titleOverride,
+                case .standard(let title, let subtitle, let connectionStatus):
+                    WorkspaceToolbarTitleView(
+                        title: title,
                         subtitle: subtitle,
-                        style: .toolbarCompact
+                        connectionStatus: connectionStatus
                     )
-                case .browser(let title):
-                    Text(title)
-                        .font(.headline)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                        .foregroundStyle(value.terminalTheme.terminalChromeForegroundColor)
-                case .standard(let title, let subtitle):
-                    WorkspaceToolbarTitleView(title: title, subtitle: subtitle)
                 }
             }
         )
@@ -302,22 +514,34 @@ struct WorkspaceDetailView: View {
     }
 
     private var toolbarTitleLabelToken: WorkspaceTitleMenuLabelToken {
-        if isChatMode,
-           let session = chosenChatSession,
-           let conversation = chatConversationStores[session.id] {
-            return .chat(
-                descriptor: conversation.descriptor,
-                agentState: conversation.agentState,
-                isConnected: conversation.isConnected,
-                titleOverride: workspace.name,
-                subtitle: tabName(for: session)
+        let connectionStatus = effectiveConnectionStatus
+        if let browser = activeBrowser {
+            // Browser-style surfaces keep the workspace as the pill's title,
+            // like the terminal; the surface's own title (the page or tab)
+            // rides the subtitle line.
+            return .standard(
+                title: workspace.name,
+                subtitle: browser.title,
+                connectionStatus: connectionStatus
             )
-        } else if let browser = activeBrowser {
-            return .browser(title: browser.title ?? workspace.name)
         } else if let browser = activeBrowserStream {
-            return .browser(title: browser.title ?? workspace.name)
+            return .standard(
+                title: workspace.name,
+                subtitle: browser.title,
+                connectionStatus: connectionStatus
+            )
+        } else if let simulator = activeSimulatorStream {
+            return .standard(
+                title: workspace.name,
+                subtitle: simulator.selectedDeviceName ?? simulator.title,
+                connectionStatus: connectionStatus
+            )
         } else {
-            return .standard(title: workspace.name, subtitle: selectedToolbarSubtitle)
+            return .standard(
+                title: workspace.name,
+                subtitle: selectedToolbarSubtitle,
+                connectionStatus: connectionStatus
+            )
         }
     }
     #endif
@@ -338,9 +562,11 @@ struct WorkspaceDetailView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             #endif
         }
-        // The disconnected terminal stays visible; block interaction so
-        // keystrokes aren't silently dropped by the disconnected drain path.
-        // The status pill attaches after this modifier and stays tappable.
+        // The unavailable terminal stays visible; block interaction so
+        // keystrokes aren't silently dropped once reconnect attempts stop.
+        // A terminal that is merely reconnecting stays interactive (see
+        // `terminalInputIsBlocked`). The status pill attaches after this
+        // modifier and stays tappable.
         .allowsHitTesting(!terminalInputIsBlocked)
         #if os(iOS)
         // Hit-testing only blocks new touches: a terminal focused before the
@@ -358,21 +584,23 @@ struct WorkspaceDetailView: View {
         }
         #endif
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .overlay(alignment: .topLeading) {
-            // The terminal's only connection chrome: last-known content stays
-            // visible and scrollable underneath while the pill shows the
-            // reconnect progress (or offers Reconnect once attempts stop).
-            MobileMacConnectionStatusPill(
-                host: host,
-                status: effectiveConnectionStatus,
-                reconnect: WorkspaceDetailConnectionChrome.reconnectAction(
-                    connectionRequiresReauth: store.connectionRequiresReauth,
-                    reconnect: { reconnectToWorkspaceMac() }
+        // No terminal-covering connection chrome: reconnecting is the title
+        // bar's spinner, disconnected is the title's red dot + subtitle with
+        // Reconnect in the title menu, and last-known content stays visible
+        // throughout.
+        #if os(iOS)
+        .overlay(alignment: .topTrailing) {
+            if let terminalID = selectedTerminal?.id.rawValue,
+               !store.isComposerPresented {
+                TerminalSendStatusPill(
+                    status: store.terminalSendStatus(forTerminalID: terminalID)
                 )
-            )
+                .allowsHitTesting(false)
                 .padding(.top, 10)
-                .padding(.leading, 10)
+                .padding(.trailing, 10)
+            }
         }
+        #endif
         #if os(iOS) && DEBUG
         // DEBUG/UI-test-only store-side composer probe.
         .overlay {
@@ -386,10 +614,12 @@ struct WorkspaceDetailView: View {
         #if os(iOS)
         // The whole bottom dock is owned by `GhosttySurfaceView` in one
         // coordinate system, so composer growth pushes only the terminal up.
+        .terminalKeyboardGeometryProbe("detail-inside")
         .mobileTerminalSafeAreaExpansion(
             context: safeAreaContext,
             includesBottom: true
         )
+        .terminalKeyboardGeometryProbe("detail-outside")
         .background {
             // Fill under translucent chrome with the terminal's own color.
             store.activeTerminalTheme.terminalBackgroundColor
@@ -399,13 +629,16 @@ struct WorkspaceDetailView: View {
             if let selectedTerminalArtifact {
                 ChatArtifactViewerDestination(
                     path: selectedTerminalArtifact.path,
-                    scope: selectedTerminalArtifact.usesSessionAuthorization ? .chat : .terminal
+                    scope: .terminal
                 ) {
                     self.selectedTerminalArtifact = nil
                 }
                     .environment(
                         \.chatArtifactLoader,
-                        artifactLoader(for: selectedTerminalArtifact)
+                        terminalArtifactLoader(
+                            workspaceID: selectedTerminalArtifact.workspaceID,
+                            surfaceID: selectedTerminalArtifact.surfaceID
+                        )
                     )
             }
         }
@@ -423,7 +656,7 @@ struct WorkspaceDetailView: View {
         #endif
     }
 
-    private func reconnectToWorkspaceMac() {
+    func reconnectToWorkspaceMac() {
         Task {
             await store.reconnectToMac(
                 macDeviceID: workspace.macDeviceID,
@@ -433,13 +666,13 @@ struct WorkspaceDetailView: View {
     }
 
     /// Same-client foreground recovery flips the store's recovery flags while
-    /// `workspace.macConnectionStatus` stays `.connected`; the pill reflects
-    /// the recovery. Input gating deliberately does NOT use this (see
-    /// `terminalInputIsBlocked`): a probe's "Reconnecting" display coexists
-    /// with a working keyboard. Hidden retained details keep their raw
-    /// status: the guard only applies to the selected workspace on the
+    /// `workspace.macConnectionStatus` stays `.connected`; the title bar's
+    /// spinner reflects the recovery. Input gating deliberately does NOT use
+    /// this (see `terminalInputIsBlocked`): a probe's reconnecting display
+    /// coexists with a working keyboard. Hidden retained details keep their
+    /// raw status: the guard only applies to the selected workspace on the
     /// foreground connection.
-    private var effectiveConnectionStatus: MobileMacConnectionStatus {
+    var effectiveConnectionStatus: MobileMacConnectionStatus {
         if store.selectedWorkspaceID == workspace.id,
            store.selectedWorkspaceUsesForegroundConnection {
             if store.connectionRecoveryFailed {
@@ -452,23 +685,20 @@ struct WorkspaceDetailView: View {
         return connectionStatus
     }
 
-    /// Input viability is narrower than the displayed status: a same-client
-    /// probe reads "Reconnecting" while the transport is still connected and
-    /// the RPC client still carries keystrokes, so blocking or resigning
-    /// there would dismiss a working keyboard mid-typing. Block only when
-    /// the workspace status itself is disconnected or foreground recovery
-    /// actually failed. Internal so the +Surfaces chrome-return refocus can
-    /// share the same policy.
+    /// Input follows the effective (recovery-aware) status, not the raw row
+    /// status: the redial path downgrades the retained row to unavailable in
+    /// the same turn it marks the recovery as reconnecting, and gating on the
+    /// raw value would resign a working keyboard right as the spinner starts.
+    /// The terminal stays fully interactive while a reconnect is in flight so
+    /// the user can finish typing a thought — keystrokes ride the send
+    /// buffer, and a send that races the dead window fails visibly through
+    /// the send-status pill instead of the keyboard dropping mid-word. Block
+    /// only once the connection is unavailable (attempts stopped or
+    /// foreground recovery failed, which `effectiveConnectionStatus` folds
+    /// in). Internal so the +Surfaces chrome-return refocus can share the
+    /// same policy.
     var terminalInputIsBlocked: Bool {
-        if connectionStatus != .connected {
-            return true
-        }
-        if store.selectedWorkspaceID == workspace.id,
-           store.selectedWorkspaceUsesForegroundConnection,
-           store.connectionRecoveryFailed {
-            return true
-        }
-        return false
+        effectiveConnectionStatus == .unavailable
     }
 
     #if os(iOS)
@@ -496,7 +726,10 @@ struct WorkspaceDetailView: View {
 
     func terminalArtifactLoader(workspaceID: String, surfaceID: String) -> ChatArtifactLoader {
         guard let source = store.makeChatEventSource() else {
-            return .unsupported(cache: terminalArtifactThumbnailCache)
+            return .unsupported(
+                cache: terminalArtifactThumbnailCache,
+                diagnosticLog: store.diagnosticLog
+            )
         }
         return ChatArtifactLoader(
             terminalWorkspaceID: workspaceID,
@@ -504,6 +737,7 @@ struct WorkspaceDetailView: View {
             supportsArtifacts: store.supportsTerminalArtifacts,
             supportsDirectoryBrowsing: store.supportsTerminalArtifactList,
             cache: terminalArtifactThumbnailCache,
+            diagnosticLog: store.diagnosticLog,
             stat: { path in
                 try await source.terminalArtifactStat(
                     workspaceID: workspaceID,
@@ -545,23 +779,6 @@ struct WorkspaceDetailView: View {
         )
     }
 
-    private func artifactLoader(for selection: TerminalArtifactSelection) -> ChatArtifactLoader {
-        guard let sessionID = selection.sessionID else {
-            return terminalArtifactLoader(
-                workspaceID: selection.workspaceID,
-                surfaceID: selection.surfaceID
-            )
-        }
-        guard store.supportsChatArtifacts,
-              let source = store.makeChatEventSource() else {
-            return .unsupported(cache: terminalArtifactThumbnailCache)
-        }
-        return ChatArtifactLoader(
-            source: source,
-            sessionID: sessionID,
-            cache: terminalArtifactThumbnailCache
-        )
-    }
     #endif
 
     @ViewBuilder
@@ -601,21 +818,30 @@ struct WorkspaceDetailView: View {
         TerminalPickerMenu(
             value: TerminalPickerMenuValue(
                 liveTerminals: workspace.terminals,
+                liveSurfaces: workspace.surfaces,
                 snapshotRows: terminalPickerRows,
                 selectedID: store.selectedTerminalID,
+                // Resolved through the workspace so the auto-presented
+                // fallback surface (no terminals, no explicit selection)
+                // carries the picker checkmark like any picked surface.
+                selectedMacSurfaceID: workspace.selectedMacSurface(id: store.selectedMacSurfaceID)?.id,
                 canCreateWorkspace: canCreateWorkspace,
                 hasActiveBrowser: activeBrowser != nil,
-                isChatMode: isChatMode,
                 browserStreamRows: browserStreamStore.panels(in: workspace.rpcWorkspaceID.rawValue).map(BrowserStreamPickerRow.init),
                 supportsBrowserStream: store.supportsBrowserStream,
-                activeBrowserStreamPanelID: activeBrowserStream?.id
+                activeBrowserStreamPanelID: activeBrowserStream?.id,
+                simulatorStreamRows: simulatorStreamStore.panels(in: workspace.rpcWorkspaceID.rawValue).map(SimulatorStreamPickerRow.init),
+                supportsSimulatorStream: store.supportsSimulatorStream,
+                activeSimulatorStreamPanelID: activeSimulatorStream?.id
             ),
             actions: TerminalPickerMenuActions(
                 selectTerminal: selectTerminalFromPicker,
+                selectMacSurface: selectMacSurfaceFromPicker,
                 createWorkspace: createWorkspaceFromToolbar,
                 createTerminal: createTerminalFromToolbar,
                 openBrowser: openBrowserFromToolbar,
-                selectBrowserStream: selectBrowserStreamFromToolbar,
+                selectBrowserStream: { selectBrowserStreamFromToolbar($0) },
+                selectSimulatorStream: selectSimulatorStreamFromToolbar,
                 openTextSheet: openTextSheetFromMenu,
                 copyDebugLogs: {
                     #if DEBUG
@@ -649,21 +875,27 @@ struct WorkspaceDetailView: View {
     /// Opens the "View as Text" sheet: the terminal's content as selectable
     /// plain text, because the render surface itself has no copy affordance.
     private func openTextSheetFromMenu() {
-        textSheetSurfaceID = selectedTerminal?.id.rawValue
-        isTextSheetPresented = true
+        store.recordAppEvent(
+            .terminalTextViewOpened,
+            correlationID: selectedTerminal?.id.rawValue
+        )
+        textSheetPresentation.present {
+            textSheetSurfaceID = selectedTerminal?.id.rawValue
+        }
     }
 
     private func openFeedbackComposerFromMenu() {
-        feedbackText = ""
-        feedbackErrorMessage = nil
-        // A prior submission may still be in flight if the user dismissed the
-        // sheet mid-send (Cancel stays enabled); reset so the reopened composer
-        // does not render Send permanently disabled until that task times out.
-        isSubmittingFeedback = false
-        // Prefill the reply-to address with the signed-in email on the email
-        // path; the privileged agent path never reads it.
-        feedbackEmail = store.signedInUserEmail ?? ""
-        isFeedbackComposerPresented = true
+        feedbackPresentation.present {
+            feedbackText = ""
+            feedbackErrorMessage = nil
+            // A prior submission may still be in flight if the user dismissed the
+            // sheet mid-send (Cancel stays enabled); reset so the reopened composer
+            // does not render Send permanently disabled until that task times out.
+            isSubmittingFeedback = false
+            // Prefill the reply-to address with the signed-in email on the email
+            // path; the privileged agent path never reads it.
+            feedbackEmail = store.signedInUserEmail ?? ""
+        }
     }
 
     /// Whether the current submission will go straight to the agent (privileged
@@ -715,7 +947,7 @@ struct WorkspaceDetailView: View {
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button(L10n.string("mobile.feedback.cancel", defaultValue: "Cancel")) {
-                        isFeedbackComposerPresented = false
+                        feedbackPresentation.dismiss()
                     }
                 }
                 ToolbarItem(placement: .confirmationAction) {
@@ -778,7 +1010,7 @@ struct WorkspaceDetailView: View {
             isSubmittingFeedback = false
             switch outcome {
             case .sentToAgent, .emailed:
-                isFeedbackComposerPresented = false
+                feedbackPresentation.dismiss()
                 if toasts.isEnabled {
                     // The toast supplies the success haptic; presenting after
                     // the composer dismisses keeps it the single confirmation.
@@ -833,8 +1065,9 @@ struct WorkspaceDetailView: View {
     }
 
     private func presentCustomizationFromMenu() {
-        dismissTerminalKeyboardForChrome()
-        isCustomizationPresented = true
+        customizationPresentation.present {
+            dismissTerminalKeyboardForChrome()
+        }
     }
 
     /// Commit the rename dialog: forward the trimmed name to the Mac, which echoes
@@ -849,31 +1082,113 @@ struct WorkspaceDetailView: View {
 
     private func createTerminalFromToolbar() {
         dismissTerminalKeyboardForChrome()
+        browserCreateRequest = nil
         // Creating a terminal from the (shared) chrome must surface it. If a
         // browser pane is up, close it so `body` leaves the browser branch and
         // shows the new terminal instead of staying on the browser.
         browserStore.closeBrowser(for: workspace.id.rawValue)
         stopActiveBrowserStream()
+        stopActiveSimulatorStream()
+        store.selectedMacSurfaceID = nil
         createTerminal()
     }
 
     private func openBrowserFromToolbar() {
         dismissTerminalKeyboardForChrome()
-        // Opens (or reveals the existing) browser pane for this workspace. The
-        // detail view flips to the browser because `activeBrowser` becomes
-        // non-nil; the picker shows a check next to "New Browser" while it is up.
-        browserStore.openBrowser(for: workspace.id.rawValue)
-        stopActiveBrowserStream()
+        // New Browser creates a real Mac browser pane and streams it, so it
+        // shows the same surface as the Mac Browsers rows. The phone-local
+        // WKWebView pane remains only as a fallback for Macs that cannot
+        // create panels (older builds, disconnected, or creation rejected).
+        guard store.supportsBrowserStreamCreate else {
+            openLocalBrowserFallback()
+            return
+        }
+        let workspaceID = workspace.rpcWorkspaceID.rawValue
+        let request = UUID()
+        browserCreateRequest = request
+        Task {
+            let descriptor = await store.createMobileBrowserPanel(workspaceID: workspaceID)
+            guard browserCreateRequest == request else { return }
+            browserCreateRequest = nil
+            guard let descriptor else {
+                openLocalBrowserFallback()
+                return
+            }
+            selectBrowserStreamFromToolbar(descriptor.panelID, dismissKeyboard: false)
+        }
     }
 
-    private func selectBrowserStreamFromToolbar(_ panelID: String) {
-        dismissTerminalKeyboardForChrome()
+    /// Opens (or reveals) the phone-local browser pane for this workspace. The
+    /// detail view flips to the browser because `activeBrowser` becomes
+    /// non-nil; the picker shows a check next to "New Browser" while it is up.
+    private func openLocalBrowserFallback() {
+        let workspaceID = workspace.id.rawValue
+        store.recordAppEvent(.browserCreateStarted, correlationID: workspaceID)
+        _ = browserStore.openBrowser(for: workspaceID)
+        store.recordAppEvent(.browserCreateSucceeded, correlationID: workspaceID)
+        store.recordLastOpenedLocalBrowserTab(in: workspace.id)
+        stopActiveBrowserStream()
+        stopActiveSimulatorStream()
+        store.selectedMacSurfaceID = nil
+    }
+
+    private func selectBrowserStreamFromToolbar(_ panelID: String, dismissKeyboard: Bool = true) {
+        if dismissKeyboard {
+            dismissTerminalKeyboardForChrome()
+        }
+        browserCreateRequest = nil
         browserStore.closeBrowser(for: workspace.id.rawValue)
+        stopActiveSimulatorStream()
+        store.selectedMacSurfaceID = nil
         if let previous = activeBrowserStream, previous.id != panelID {
             Task { await store.stopMobileBrowserStream(panelID: previous.id) }
         }
         _ = browserStreamStore.activate(panelID: panelID, in: workspace.rpcWorkspaceID.rawValue)
+        store.recordLastOpenedBrowserStreamTab(panelID: panelID, in: workspace.id)
         Task { await store.startMobileBrowserStream(panelID: panelID) }
+    }
+
+    private func selectSimulatorStreamFromToolbar(_ panelID: String) {
+        dismissTerminalKeyboardForChrome()
+        browserStore.closeBrowser(for: workspace.id.rawValue)
+        stopActiveBrowserStream()
+        store.selectedMacSurfaceID = nil
+        let workspaceID = workspace.rpcWorkspaceID.rawValue
+        let previousPanelID: String? = activeSimulatorStream.flatMap {
+            $0.id == panelID ? nil : $0.id
+        }
+        // Settle the previous panel's local state before activating the new
+        // one, so switching A -> B leaves A idle instead of frozen on a stale
+        // `.streaming`/`.starting` status.
+        if let previousPanelID {
+            simulatorStreamStore.deactivate(panelID: previousPanelID, in: workspaceID)
+        }
+        _ = simulatorStreamStore.activate(panelID: panelID, in: workspaceID)
+        store.recordLastOpenedSimulatorStreamTab(panelID: panelID, in: workspace.id)
+        // One task, stop awaited before start: two independent tasks have no
+        // ordering guarantee, and the reversed order would tear down the new
+        // stream (or churn host sessions) right after it started.
+        Task {
+            if let previousPanelID {
+                await store.stopMobileSimulatorStream(
+                    panelID: previousPanelID,
+                    workspaceID: workspaceID
+                )
+            }
+            await store.startMobileSimulatorStream(
+                panelID: panelID,
+                workspaceID: workspaceID
+            )
+        }
+    }
+
+    /// Reopens the phone-local browser pane when the store's last-opened-tab
+    /// restore asked for it. The local browser lives in this view layer's
+    /// `BrowserSurfaceStore`, so the composite hands the reopen here as a
+    /// one-shot intent; opening is idempotent for an already-open pane.
+    private func restoreLocalBrowserTabIfRequested() {
+        guard store.consumeLocalBrowserTabRestore(for: workspace.id) else { return }
+        _ = browserStore.openBrowser(for: workspace.id.rawValue)
     }
 
     private func stopActiveBrowserStream() {
@@ -882,12 +1197,19 @@ struct WorkspaceDetailView: View {
         Task { await store.stopMobileBrowserStream(panelID: stream.id) }
     }
 
+    private func stopActiveSimulatorStream() {
+        store.stopActiveMobileSimulatorStream(in: workspace.rpcWorkspaceID.rawValue)
+    }
+
     private func selectTerminalFromPicker(_ terminalID: MobileTerminalPreview.ID) {
         dismissTerminalKeyboardForChrome()
+        browserCreateRequest = nil
         // Choosing a terminal returns from the browser pane (if up) to the
         // terminal. Closing the browser is enough to flip the detail view back.
         browserStore.closeBrowser(for: workspace.id.rawValue)
         stopActiveBrowserStream()
+        stopActiveSimulatorStream()
+        store.selectedMacSurfaceID = nil
         // Switching from the picker is chrome, not a typing intent, so the
         // newly-selected surface must not grab the keyboard on attach. The
         // store suppresses the target's autofocus (and is a no-op when it is
@@ -896,11 +1218,30 @@ struct WorkspaceDetailView: View {
         store.selectTerminalFromChrome(terminalID)
     }
 
+    private func selectMacSurfaceFromPicker(_ surfaceID: MobileSurfacePreview.ID) {
+        dismissTerminalKeyboardForChrome()
+        browserCreateRequest = nil
+        browserStore.closeBrowser(for: workspace.id.rawValue)
+        stopActiveBrowserStream()
+        // Streams outrank Mac surfaces in `WorkspaceActiveSurface.derive`, so
+        // a selected Simulator stream must be cleared before the Mac surface
+        // can become visible.
+        stopActiveSimulatorStream()
+        store.selectMacSurface(surfaceID)
+    }
+
     func dismissTerminalKeyboardForChrome() {
         // Resign the terminal's hidden text input first so the surface clears
         // its keyboard geometry and recomputes full-height before chrome covers
         // it; then sweep any other responder across the scene.
         GhosttySurfaceView.resignActiveInput()
         UIApplication.shared.dismissMobileKeyboard()
+    }
+
+    private func syncSimulatorStreamPanels() {
+        simulatorStreamStore.replaceSimulatorPanels(
+            in: workspace.rpcWorkspaceID.rawValue,
+            with: workspace.simulators
+        )
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+MacSelection.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+MacSelection.swift
@@ -244,6 +244,7 @@ struct WorkspaceMacTitlePicker: View, Equatable {
                 title: value.title,
                 isLoading: value.isLoading,
                 width: value.labelWidth,
+                truncationMode: value.selection == .machine ? .middle : .tail,
                 statusLine: value.statusLine
             )
             // Put the identity and status on the final combined label element.
@@ -285,6 +286,7 @@ private struct WorkspaceMacTitlePickerLabel: View {
     let title: String
     let isLoading: Bool
     let width: CGFloat
+    let truncationMode: Text.TruncationMode
     var statusLine: WorkspaceConnectionStatusLine?
 
     var body: some View {
@@ -294,9 +296,8 @@ private struct WorkspaceMacTitlePickerLabel: View {
                 Text(title)
                     .font(.headline.weight(.bold))
                     .lineLimit(1)
-                    .truncationMode(.tail)
-                    .allowsTightening(true)
-                    .minimumScaleFactor(0.75)
+                    .truncationMode(truncationMode)
+                    .allowsTightening(false)
                     .layoutPriority(1)
                 ZStack {
                     Image(systemName: "chevron.down")

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+MacSelection.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+MacSelection.swift
@@ -244,7 +244,14 @@ struct WorkspaceMacTitlePicker: View, Equatable {
                 title: value.title,
                 isLoading: value.isLoading,
                 width: value.labelWidth,
-                truncationMode: value.selection == .machine ? .middle : .tail,
+                truncationMode: {
+                    switch value.selection {
+                    case .machine:
+                        return .middle
+                    case .automatic, .all:
+                        return .tail
+                    }
+                }(),
                 statusLine: value.statusLine
             )
             // Put the identity and status on the final combined label element.

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+MacSelection.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+MacSelection.swift
@@ -299,13 +299,16 @@ private struct WorkspaceMacTitlePickerLabel: View {
     var body: some View {
         VStack(spacing: 1) {
             HStack(spacing: 6) {
-                Spacer(minLength: 0)
                 Text(title)
                     .font(.headline.weight(.bold))
                     .lineLimit(1)
                     .truncationMode(truncationMode)
                     .allowsTightening(false)
-                    .layoutPriority(1)
+                    // Leave the text as the flexible item. A high layout
+                    // priority makes a narrow toolbar item ask UIKit to hide
+                    // the entire principal item before SwiftUI can insert an
+                    // ellipsis.
+                    .frame(maxWidth: .infinity, alignment: .center)
                 ZStack {
                     Image(systemName: "chevron.down")
                         .font(.caption.weight(.bold))
@@ -317,7 +320,6 @@ private struct WorkspaceMacTitlePickerLabel: View {
                 }
                 .frame(width: 12, height: 12)
                 .accessibilityHidden(true)
-                Spacer(minLength: 0)
             }
             if let statusLine {
                 WorkspaceConnectionStatusLineView(line: statusLine)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -623,6 +623,12 @@ struct WorkspaceListView: View {
             machineSnapshots: displayedMachineSnapshots,
             filterMachines: displayedFilterMachines
         )
+        #if os(iOS)
+        // Keep the sidebar's navigation container opaque through the status
+        // bar. A plain view background only paints the list's content bounds,
+        // leaving the top safe area to the split view's default system color.
+        .containerBackground(Color(uiColor: .systemGroupedBackground), for: .navigation)
+        #endif
         .accessibilityIdentifier("MobileWorkspaceList")
         .onDisappear {
             invalidateDeferredWorkspaceSelection()

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -312,8 +312,6 @@ struct WorkspaceShellView: View {
                 taskComposerAction: usesCompactStack && !compactNavigationPath.isEmpty
                     ? nil
                     : taskComposerAction,
-                iPadSidebarWidth: splitSidebarWidth,
-                iPadSidebarVisible: !usesCompactStack && splitColumnVisibility != .detailOnly
             ) {
                 workspaceTabContent(
                     canCreateWorkspaceForSelection: presentation.canCreateWorkspaceForSelection

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -400,6 +400,13 @@ struct WorkspaceShellView: View {
                     .primaryTabSelected,
                     detail: .primaryTab(diagnosticPrimaryTab(newValue))
                 )
+                if newValue == .workspaces, !usesCompactStack {
+                    // Returning to Workspaces is a root-navigation action on
+                    // iPad. Restore the split columns if the user arrived
+                    // from a detail-only presentation, so the workspace list
+                    // and its bottom controls are immediately visible.
+                    splitColumnVisibility = .all
+                }
                 if oldValue == .search, newValue != .search {
                     notificationSearchNavigationPath = []
                     workspaceSearchNavigationPath = []

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -145,6 +145,39 @@ private struct WorkspaceShellRenderPresentation {
     let toolbarMachineSnapshots: WorkspaceMachineSnapshots
     let canCreateWorkspaceForSelection: Bool
 }
+
+private struct WorkspaceSplitSidebarWidthKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        let next = nextValue()
+        guard next > 0 else { return }
+        value = next
+    }
+}
+
+/// Paints the split view's background behind the status-bar safe area. The
+/// navigation columns own their content backgrounds, but NavigationSplitView
+/// leaves the root safe area to the hosting view, which otherwise shows the
+/// window's default background across both columns.
+private struct WorkspaceSplitChromeBackground: View {
+    let sidebarColor: Color
+    let detailColor: Color
+    let sidebarWidth: CGFloat
+
+    var body: some View {
+        GeometryReader { geometry in
+            HStack(spacing: 0) {
+                sidebarColor
+                    .frame(width: min(max(sidebarWidth, 0), geometry.size.width))
+                detailColor
+                    .frame(maxWidth: .infinity)
+            }
+            .allowsHitTesting(false)
+        }
+        .ignoresSafeArea(.container, edges: [.horizontal, .top, .bottom])
+    }
+}
 #endif
 
 struct WorkspaceShellView: View {
@@ -195,6 +228,7 @@ struct WorkspaceShellView: View {
     @State private var rootToolbarPendingSelection: WorkspaceMacSelection?
     @State private var rootToolbarSelectionTask: Task<Void, Never>?
     @State private var rootToolbarSelectionGeneration: UInt64 = 0
+    @State private var splitSidebarWidth: CGFloat = 0
     #endif
     @State private var primarySearchCoordinator = MobilePrimarySearchCoordinator()
     @State private var workspaceListFilterState = WorkspaceListFilterState()
@@ -303,6 +337,18 @@ struct WorkspaceShellView: View {
                 notificationSearchTabContent(presentation: presentation)
             }
             .background {
+                if !usesCompactStack {
+                    WorkspaceSplitChromeBackground(
+                        sidebarColor: Color(uiColor: .systemGroupedBackground),
+                        detailColor: store.activeTerminalTheme.terminalBackgroundColor,
+                        sidebarWidth: splitSidebarWidth > 0
+                            ? splitSidebarWidth
+                            : geometry.size.width * 0.35
+                    )
+                }
+            }
+            .ignoresSafeArea(.container, edges: .top)
+            .background {
                 NotificationFeedSearchProjectionSync(
                     searchCoordinator: primarySearchCoordinator,
                     projection: notificationFeedProjection
@@ -310,6 +356,10 @@ struct WorkspaceShellView: View {
             }
             .environment(\.workspaceRootToolbarContentWidth, geometry.size.width)
             .environment(\.workspaceRootToolbarRenderContext, toolbarRenderContext)
+            .onPreferenceChange(WorkspaceSplitSidebarWidthKey.self) { width in
+                guard width > 0 else { return }
+                splitSidebarWidth = width
+            }
             .onChange(of: primarySearchCoordinator.isPresented) { _, isPresented in
                 store.recordAppEvent(
                     isPresented ? .searchPresented : .searchDismissed,
@@ -361,6 +411,16 @@ struct WorkspaceShellView: View {
                 notificationFeedProjection.update(items: items)
             }
         }
+        .background {
+            if !usesCompactStack {
+                WorkspaceSplitChromeBackground(
+                    sidebarColor: Color(uiColor: .systemGroupedBackground),
+                    detailColor: store.activeTerminalTheme.terminalBackgroundColor,
+                    sidebarWidth: splitSidebarWidth
+                )
+            }
+        }
+        .ignoresSafeArea(.container, edges: .top)
         #else
         workspaceTabContent(canCreateWorkspaceForSelection: canCreateWorkspaceForMacSelection)
         .onAppear {
@@ -667,6 +727,15 @@ struct WorkspaceShellView: View {
                     canCreateWorkspaceForSelection: canCreateWorkspaceForSelection
                 )
             }
+            .background {
+                GeometryReader { geometry in
+                    Color.clear
+                        .preference(
+                            key: WorkspaceSplitSidebarWidthKey.self,
+                            value: geometry.size.width
+                        )
+                }
+            }
             .toolbar {
                 rootToolbarContent
             }
@@ -683,6 +752,15 @@ struct WorkspaceShellView: View {
             #endif
         }
         .navigationSplitViewStyle(.balanced)
+        #if os(iOS)
+        .containerBackground(for: .navigationSplitView) {
+            WorkspaceSplitChromeBackground(
+                sidebarColor: Color(uiColor: .systemGroupedBackground),
+                detailColor: store.activeTerminalTheme.terminalBackgroundColor,
+                sidebarWidth: splitSidebarWidth
+            )
+        }
+        #endif
         .onAppear {
             hasPresentedSplitDetail = true
         }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -52,6 +52,14 @@ private enum WorkspaceRootToolbarSizing {
     static let maximumPickerWidth: CGFloat = 124
     private static let nonPickerWidth: CGFloat = 277
 
+    /// Principal toolbar items can be dropped by UIKit when the leading
+    /// controls consume nearly all of a narrow iPad sidebar. Moving the
+    /// picker into the leading group keeps it present, where its label can
+    /// apply the requested ellipsis instead of disappearing as a whole.
+    static func usesLeadingPlacement(for contentWidth: CGFloat) -> Bool {
+        contentWidth > 0 && contentWidth < nonPickerWidth + minimumPickerWidth
+    }
+
     static func pickerWidth(for contentWidth: CGFloat) -> CGFloat {
         min(
             maximumPickerWidth,
@@ -65,6 +73,7 @@ private enum WorkspaceRootToolbarSizing {
 /// feed from drifting away from the workspace-list toolbar contract.
 struct WorkspaceRootToolbarContent: ToolbarContent {
     @Environment(\.workspaceRootToolbarContentWidth) private var contentWidth
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     let openSettings: () -> Void
     let openDevices: () -> Void
@@ -84,7 +93,10 @@ struct WorkspaceRootToolbarContent: ToolbarContent {
             .accessibilityLabel(L10n.string("mobile.workspaces.settings", defaultValue: "Settings"))
             .accessibilityIdentifier("MobileWorkspaceSettingsMenu")
         }
-        ToolbarItem(id: "workspace-list-title", placement: .principal) {
+        ToolbarItem(
+            id: "workspace-list-title",
+            placement: titlePlacement
+        ) {
             WorkspaceMacTitlePicker(
                 value: WorkspaceMacTitlePickerValue(
                     title: title,
@@ -109,6 +121,16 @@ struct WorkspaceRootToolbarContent: ToolbarContent {
             .accessibilityLabel(L10n.string("mobile.connections.title", defaultValue: "Computers"))
             .accessibilityIdentifier("MobileWorkspaceDevicesButton")
         }
+    }
+
+    private var titlePlacement: ToolbarItemPlacement {
+        #if os(iOS)
+        if horizontalSizeClass == .regular,
+           WorkspaceRootToolbarSizing.usesLeadingPlacement(for: contentWidth) {
+            return .topBarLeading
+        }
+        #endif
+        return .principal
     }
 }
 
@@ -291,7 +313,9 @@ struct WorkspaceShellView: View {
                 notificationUnreadCount: presentation.notificationUnreadCount,
                 taskComposerAction: usesCompactStack && !compactNavigationPath.isEmpty
                     ? nil
-                    : taskComposerAction
+                    : taskComposerAction,
+                iPadSidebarWidth: splitSidebarWidth,
+                iPadSidebarVisible: !usesCompactStack && splitColumnVisibility != .detailOnly
             ) {
                 workspaceTabContent(
                     canCreateWorkspaceForSelection: presentation.canCreateWorkspaceForSelection
@@ -354,11 +378,15 @@ struct WorkspaceShellView: View {
                     projection: notificationFeedProjection
                 )
             }
-            .environment(\.workspaceRootToolbarContentWidth, geometry.size.width)
+            .environment(
+                \.workspaceRootToolbarContentWidth,
+                !usesCompactStack && selectedPrimaryTab == .workspaces && splitSidebarWidth > 0
+                    ? splitSidebarWidth
+                    : geometry.size.width
+            )
             .environment(\.workspaceRootToolbarRenderContext, toolbarRenderContext)
             .onPreferenceChange(WorkspaceSplitSidebarWidthKey.self) { width in
-                guard width > 0 else { return }
-                splitSidebarWidth = width
+                splitSidebarWidth = max(0, width)
             }
             .onChange(of: primarySearchCoordinator.isPresented) { _, isPresented in
                 store.recordAppEvent(

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -779,7 +779,10 @@ struct WorkspaceShellView: View {
                 safeAreaContext: splitColumnVisibility == .detailOnly ? .fullWidth : .splitSidebarVisible
             )
             #if os(iOS)
-            .toolbarVisibility(splitColumnVisibility == .detailOnly ? .hidden : .visible, for: .tabBar)
+            // Keep the root tab strip visible when the split collapses to the
+            // terminal. The native iPad Liquid Glass tabs are the primary
+            // destination switcher, not detail-only toolbar chrome.
+            .toolbarVisibility(.visible, for: .tabBar)
             #endif
         }
         .navigationSplitViewStyle(.balanced)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -172,9 +172,7 @@ private struct WorkspaceSplitSidebarWidthKey: PreferenceKey {
     static let defaultValue: CGFloat = 0
 
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        let next = nextValue()
-        guard next > 0 else { return }
-        value = next
+        value = max(0, nextValue())
     }
 }
 

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobilePrimarySearchCoordinatorTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobilePrimarySearchCoordinatorTests.swift
@@ -3,6 +3,18 @@ import Testing
 
 @MainActor
 @Suite struct MobilePrimarySearchCoordinatorTests {
+    @Test func beginSearchSelectsRequestedScopeBeforePresenting() {
+        let coordinator = MobilePrimarySearchCoordinator(initialScope: .workspaces)
+        coordinator.notifications = "alerts"
+
+        coordinator.beginSearch(for: .notifications)
+
+        #expect(coordinator.scope == .notifications)
+        #expect(coordinator.isPresented)
+        #expect(coordinator.activeNativeSearchText() == "alerts")
+        #expect(coordinator.activationGeneration == 1)
+    }
+
     @Test func activePresentedSearchAcceptsExplicitClear() {
         let coordinator = MobilePrimarySearchCoordinator()
         coordinator.synchronizeSelection(.workspaces)

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
@@ -564,6 +564,11 @@ final class TerminalInputTextView: UIView, UIKeyInput, UITextInput {
         let insets = accessoryLayoutInsetsProvider?() ?? .zero
         let leftInset = max(0, insets.left)
         let rightInset = max(0, insets.right)
+        let scrollView = accessoryStackView?.superview as? UIScrollView
+        let previousOffset = scrollView?.contentOffset.x ?? 0
+        let wasAtLeadingEdge = scrollView.map { scroll in
+            previousOffset <= -scroll.adjustedContentInset.left + 1
+        } ?? true
 
         accessoryBackgroundLeadingConstraint?.constant = leftInset
         accessoryBackgroundTrailingConstraint?.constant = -rightInset
@@ -576,6 +581,23 @@ final class TerminalInputTextView: UIView, UIKeyInput, UITextInput {
         if accessoryStackView != nil {
             terminalAccessoryToolbar.setNeedsLayout()
             terminalAccessoryToolbar.layoutIfNeeded()
+
+            guard let scrollView else { return }
+            let minimumOffset = -scrollView.adjustedContentInset.left
+            let maximumOffset = max(
+                minimumOffset,
+                scrollView.contentSize.width
+                    - scrollView.bounds.width
+                    + scrollView.adjustedContentInset.right
+            )
+            let targetOffset = wasAtLeadingEdge
+                ? minimumOffset
+                : min(max(previousOffset, minimumOffset), maximumOffset)
+            guard abs(scrollView.contentOffset.x - targetOffset) > 0.5 else { return }
+            scrollView.setContentOffset(
+                CGPoint(x: targetOffset, y: scrollView.contentOffset.y),
+                animated: false
+            )
         }
     }
 

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
@@ -372,6 +372,11 @@ final class TerminalInputTextView: UIView, UIKeyInput, UITextInput {
         scrollView.showsHorizontalScrollIndicator = false
         scrollView.showsVerticalScrollIndicator = false
         scrollView.alwaysBounceHorizontal = true
+        // The accessory bar is already constrained to the container's safe-area
+        // guides. Letting UIKit apply another automatic inset can shift the
+        // initial horizontal content offset on iPad by the device's leading
+        // safe-area width, hiding the shortcuts at launch.
+        scrollView.contentInsetAdjustmentBehavior = .never
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         // The scroll view's FRAME starts flush at the composer button's
         // trailing edge; the 4pt visual gap the frame constant used to carry

--- a/Sources/Panels/BrowserPopupWindowController.swift
+++ b/Sources/Panels/BrowserPopupWindowController.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Bonsplit
+import CmuxBrowser
 import CmuxFoundation
 import CmuxSettings
 import ObjectiveC


### PR DESCRIPTION
## Summary
- replace the app-owned iPad navigation rail with SwiftUI's native adaptive Liquid Glass tab presentation
- keep the root tab bar visible when the split view collapses to terminal detail
- keep search scoped to its destination, preserve the composer scroll offset, safe-area colors, and picker ellipsis behavior
- keep the pinned navigation-bar workaround compatible with the Xcode 27 beta 4 SDK used by the build lane

## Verification
- clean tagged iOS simulator build: https://github.com/manaflow-ai/cmux/actions/runs/33473955270
- authenticated isolated iPad simulator: `cmux-dev-ipado`, `12B9C900-5FCF-47E9-AA03-BF55C5A2F6A2`
- visual evidence: `artifacts/verify-ui/ipado-native-liquid-glass-clean.png`
- focused hosted E2E: https://github.com/manaflow-ai/cmux/actions/runs/33475688620, build reached the test job but stopped on an unrelated existing macOS `BrowserAppLinkOpenRequest` compile error before test execution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved iPad navigation with an adaptable sidebar tab layout and better search presentation.
  * Search now opens directly in the selected scope.
  * Workspace navigation restores columns and keeps the tab bar visible in detail views.

* **Bug Fixes**
  * Improved workspace backgrounds, toolbar placement, title truncation, and terminal accessory scrolling on iPad.
  * Updated simulator build settings for arm64 devices.
  * Improved navigation and split-view appearance across safe areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->