### PR TITLE
Fix main compile: import CmuxBrowser in BrowserPopupWindowController

### DIFF
--- a/Sources/Panels/BrowserPopupWindowController.swift
+++ b/Sources/Panels/BrowserPopupWindowController.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Bonsplit
+import CmuxBrowser
 import CmuxFoundation
 import CmuxSettings
 import ObjectiveC


### PR DESCRIPTION
Current main does not compile for the macOS app target: https://github.com/manaflow-ai/cmux/pull/10634 added two `BrowserAppLinkOpenRequest` uses to `Sources/Panels/BrowserPopupWindowController.swift` (lines 491 and 785) without importing `CmuxBrowser`, where that public type lives. The sibling files touched by the same PR (`BrowserNavigationDelegate.swift`, `BrowserPanel.swift`) already import it. The PR lane has no macOS compile gate, so the break landed silently; every tagged fleet build off main now fails with `cannot find 'BrowserAppLinkOpenRequest' in scope`.

One-line fix: add `import CmuxBrowser` to the file's import list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11337"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790831876&installation_model_id=21920&pr_number=11337&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11337&signature=35e3e66e228f0d6e0910c6e0fcbe50101f1fb9bf636288e871e841d2583a0b0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the missing `CmuxBrowser` import to `BrowserPopupWindowController.swift` so the macOS app target compiles again. A recent PR added uses of `BrowserAppLinkOpenRequest` without this import, breaking every tagged fleet build with `cannot find 'BrowserAppLinkOpenRequest' in scope`.

<sup>Written for commit dafaf02bcf1bf2746f076437b400632f7b0eb0ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

