### PR TITLE
Add cmux caffeinate CLI verb and optional Sleepy Mode lock screen while caffeinated

### DIFF
--- a/CLI/CMUXCLI+Caffeinate.swift
+++ b/CLI/CMUXCLI+Caffeinate.swift
@@ -12,6 +12,7 @@ extension CMUXCLI {
         jsonOutput: Bool
     ) throws {
         var lockScreen: Bool?
+        var lockMac: Bool?
         var jsonFlag = false
         var positional: [String] = []
         for arg in commandArgs {
@@ -20,13 +21,15 @@ extension CMUXCLI {
                 lockScreen = true
             case "--no-lock-screen":
                 lockScreen = false
+            case "--lock-mac":
+                lockMac = true
             case "--json":
                 jsonFlag = true
             default:
                 if arg.hasPrefix("-") {
                     throw CLIError(message: String(
                         localized: "cli.caffeinate.error.unknownFlag",
-                        defaultValue: "caffeinate: unknown flag '\(arg)'. Flags: --lock-screen, --no-lock-screen, --json"
+                        defaultValue: "caffeinate: unknown flag '\(arg)'. Flags: --lock-screen, --no-lock-screen, --lock-mac, --json"
                     ))
                 }
                 positional.append(arg)
@@ -43,19 +46,19 @@ extension CMUXCLI {
         let payload: [String: Any]
         switch subcommand {
         case "status":
-            guard lockScreen == nil else {
+            guard lockScreen == nil, lockMac == nil else {
                 throw CLIError(message: String(
                     localized: "cli.caffeinate.error.statusLockScreen",
-                    defaultValue: "caffeinate status doesn't take --lock-screen/--no-lock-screen"
+                    defaultValue: "caffeinate status doesn't take lock-screen/lock-mac flags"
                 ))
             }
             payload = try client.sendV2(method: "caffeine.status", params: [:])
         case "on", "off":
-            payload = try setCaffeine(enabled: subcommand == "on", lockScreen: lockScreen, client: client)
+            payload = try setCaffeine(enabled: subcommand == "on", lockScreen: lockScreen, lockMac: lockMac, client: client)
         case "toggle":
             let status = try client.sendV2(method: "caffeine.status", params: [:])
             let enabled = (status["enabled"] as? Bool) ?? false
-            payload = try setCaffeine(enabled: !enabled, lockScreen: lockScreen, client: client)
+            payload = try setCaffeine(enabled: !enabled, lockScreen: lockScreen, lockMac: lockMac, client: client)
         default:
             throw CLIError(message: String(
                 localized: "cli.caffeinate.error.unknownSubcommand",
@@ -70,10 +73,13 @@ extension CMUXCLI {
         }
     }
 
-    private func setCaffeine(enabled: Bool, lockScreen: Bool?, client: SocketClient) throws -> [String: Any] {
+    private func setCaffeine(enabled: Bool, lockScreen: Bool?, lockMac: Bool?, client: SocketClient) throws -> [String: Any] {
         var params: [String: Any] = ["enabled": enabled]
         if let lockScreen {
             params["lock_screen"] = lockScreen
+        }
+        if let lockMac {
+            params["lock_mac"] = lockMac
         }
         return try client.sendV2(method: "caffeine.set", params: params)
     }

--- a/CLI/CMUXCLI+Caffeinate.swift
+++ b/CLI/CMUXCLI+Caffeinate.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+extension CMUXCLI {
+    /// `cmux caffeinate [status|on|off|toggle] [--lock-screen|--no-lock-screen]`
+    ///
+    /// Thin client over the app's `caffeine.status`/`caffeine.set` socket
+    /// commands, which are the single caffeinate action path shared with the
+    /// iOS Keep Awake RPC, the menu-bar toggle, and Settings.
+    func runCaffeinateCommand(
+        commandArgs: [String],
+        client: SocketClient,
+        jsonOutput: Bool
+    ) throws {
+        var lockScreen: Bool?
+        var jsonFlag = false
+        var positional: [String] = []
+        for arg in commandArgs {
+            switch arg {
+            case "--lock-screen":
+                lockScreen = true
+            case "--no-lock-screen":
+                lockScreen = false
+            case "--json":
+                jsonFlag = true
+            default:
+                if arg.hasPrefix("-") {
+                    throw CLIError(message: String(
+                        localized: "cli.caffeinate.error.unknownFlag",
+                        defaultValue: "caffeinate: unknown flag '\(arg)'. Flags: --lock-screen, --no-lock-screen, --json"
+                    ))
+                }
+                positional.append(arg)
+            }
+        }
+        guard positional.count <= 1 else {
+            throw CLIError(message: String(
+                localized: "cli.caffeinate.error.tooManyArguments",
+                defaultValue: "caffeinate takes one subcommand: status, on, off, or toggle"
+            ))
+        }
+        let subcommand = positional.first ?? "status"
+
+        let payload: [String: Any]
+        switch subcommand {
+        case "status":
+            guard lockScreen == nil else {
+                throw CLIError(message: String(
+                    localized: "cli.caffeinate.error.statusLockScreen",
+                    defaultValue: "caffeinate status doesn't take --lock-screen/--no-lock-screen"
+                ))
+            }
+            payload = try client.sendV2(method: "caffeine.status", params: [:])
+        case "on", "off":
+            payload = try setCaffeine(enabled: subcommand == "on", lockScreen: lockScreen, client: client)
+        case "toggle":
+            let status = try client.sendV2(method: "caffeine.status", params: [:])
+            let enabled = (status["enabled"] as? Bool) ?? false
+            payload = try setCaffeine(enabled: !enabled, lockScreen: lockScreen, client: client)
+        default:
+            throw CLIError(message: String(
+                localized: "cli.caffeinate.error.unknownSubcommand",
+                defaultValue: "Unknown caffeinate subcommand '\(subcommand)'. Use status, on, off, or toggle."
+            ))
+        }
+
+        if jsonOutput || jsonFlag {
+            print(jsonString(payload))
+        } else {
+            print(renderCaffeineStatusText(payload))
+        }
+    }
+
+    private func setCaffeine(enabled: Bool, lockScreen: Bool?, client: SocketClient) throws -> [String: Any] {
+        var params: [String: Any] = ["enabled": enabled]
+        if let lockScreen {
+            params["lock_screen"] = lockScreen
+        }
+        return try client.sendV2(method: "caffeine.set", params: params)
+    }
+
+    private func renderCaffeineStatusText(_ payload: [String: Any]) -> String {
+        let enabled = (payload["enabled"] as? Bool) ?? false
+        let lockScreenActive = (payload["lock_screen_active"] as? Bool) ?? false
+        let awakeLine = enabled
+            ? String(localized: "cli.caffeinate.status.on", defaultValue: "Keep Mac Awake: on")
+            : String(localized: "cli.caffeinate.status.off", defaultValue: "Keep Mac Awake: off")
+        let lockLine = lockScreenActive
+            ? String(localized: "cli.caffeinate.lockScreen.shown", defaultValue: "Lock screen (Sleepy Mode): shown")
+            : String(localized: "cli.caffeinate.lockScreen.hidden", defaultValue: "Lock screen (Sleepy Mode): hidden")
+        return awakeLine + "\n" + lockLine
+    }
+}

--- a/CLI/CMUXCLI+CommandSuggestions.swift
+++ b/CLI/CMUXCLI+CommandSuggestions.swift
@@ -65,6 +65,7 @@ extension CMUXCLI {
         "browser-forward",
         "browser-reload",
         "browser-status",
+        "caffeinate",
         "capabilities",
         "capture-pane",
         "claude-hook",

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -6934,6 +6934,9 @@ struct CMUXCLI {
         case "memory":
             try runMemoryCommand(commandArgs: commandArgs, client: client, jsonOutput: jsonOutput, idFormat: idFormat)
 
+        case "caffeinate", "caffeine":
+            try runCaffeinateCommand(commandArgs: commandArgs, client: client, jsonOutput: jsonOutput)
+
         case "focus-pane":
             let workspaceArg = workspaceFromArgsOrEnv(commandArgs, windowOverride: windowId)
             guard let paneRaw = optionValue(commandArgs, name: "--pane") ?? commandArgs.first else {
@@ -19212,6 +19215,36 @@ struct CMUXCLI {
               cmux memory
               cmux memory --groups 20
               cmux --json memory --all
+            """)
+        case "caffeinate", "caffeine":
+            return String(localized: "cli.help.caffeinate", defaultValue: """
+            Usage: cmux caffeinate [status|on|off|toggle] [flags]
+
+            Keep the Mac awake (Keep Mac Awake), optionally covering the screen with the
+            Sleepy Mode lock screen while it is on. This is the same action the menu-bar
+            toggle, Settings, and the iOS Keep Awake switch use.
+
+            Subcommands:
+              status                       Print the current state (default)
+              on                           Keep the Mac awake
+              off                          Let the Mac sleep again
+              toggle                       Flip the current state
+
+            Flags:
+              --lock-screen                Also show the Sleepy Mode lock screen
+              --no-lock-screen             Keep the screen uncovered (and hide a lock
+                                           screen caffeinate itself put up)
+              --json                       Structured JSON output
+
+            Without a lock-screen flag, turning it on follows the Settings preference
+            "Show while Keep Mac Awake is on" (Settings > Sleepy Mode). The keep-awake
+            assertion is not persisted: quitting cmux always releases it.
+
+            Example:
+              cmux caffeinate on
+              cmux caffeinate on --lock-screen
+              cmux caffeinate off
+              cmux --json caffeinate status
             """)
         case "focus-pane":
             return """
@@ -40547,6 +40580,7 @@ export default CMUXSessionRestore;
           tree [--all] [--workspace <id|ref|index>] [--window <id|ref|index>]
           top [--all] [--workspace <id|ref|index>] [--window <id|ref|index>] [--processes] [--sort <cpu|mem|proc>] [--flat] [--format <tree|tsv>]
           memory [--all] [--workspace <id|ref|index>] [--groups <count>]
+          caffeinate [status|on|off|toggle] [--lock-screen|--no-lock-screen]
           focus-pane --pane <id|ref|index> [--workspace <id|ref|index>] [--window <id|ref|index>]
           new-pane [--type <terminal|browser|simulator>] [--direction <left|right|up|down>] [--workspace <id|ref|index>] [--window <id|ref|index>] [--url <url>] \(String(localized: "cli.browser.profile.option", defaultValue: "[--profile <name|uuid>]")) [--focus <true|false>]
           new-surface [--type <terminal|browser|simulator|agent-session>] [--pane <id|ref|index>] [--workspace <id|ref|index>] [--window <id|ref|index>] [--url <url>] [--provider <codex|claude|opencode>] [--renderer <react|solid>] [--focus <true|false>]

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -19234,15 +19234,20 @@ struct CMUXCLI {
               --lock-screen                Also show the Sleepy Mode lock screen
               --no-lock-screen             Keep the screen uncovered (and hide a lock
                                            screen caffeinate itself put up)
+              --lock-mac                   Also engage the real macOS login lock (Touch
+                                           ID or password to get back in); implies
+                                           --lock-screen unless --no-lock-screen
               --json                       Structured JSON output
 
-            Without a lock-screen flag, turning it on follows the Settings preference
-            "Show while Keep Mac Awake is on" (Settings > Sleepy Mode). The keep-awake
-            assertion is not persisted: quitting cmux always releases it.
+            Without flags, turning it on follows the Settings preferences "Show while
+            Keep Mac Awake is on" and "Lock Mac while Keep Mac Awake is on"
+            (Settings > Sleepy Mode). Turning caffeinate off never unlocks the Mac.
+            The keep-awake assertion is not persisted: quitting cmux always releases it.
 
             Example:
               cmux caffeinate on
               cmux caffeinate on --lock-screen
+              cmux caffeinate on --lock-mac
               cmux caffeinate off
               cmux --json caffeinate status
             """)
@@ -40580,7 +40585,7 @@ export default CMUXSessionRestore;
           tree [--all] [--workspace <id|ref|index>] [--window <id|ref|index>]
           top [--all] [--workspace <id|ref|index>] [--window <id|ref|index>] [--processes] [--sort <cpu|mem|proc>] [--flat] [--format <tree|tsv>]
           memory [--all] [--workspace <id|ref|index>] [--groups <count>]
-          caffeinate [status|on|off|toggle] [--lock-screen|--no-lock-screen]
+          caffeinate [status|on|off|toggle] [--lock-screen|--no-lock-screen] [--lock-mac]
           focus-pane --pane <id|ref|index> [--workspace <id|ref|index>] [--window <id|ref|index>]
           new-pane [--type <terminal|browser|simulator>] [--direction <left|right|up|down>] [--workspace <id|ref|index>] [--window <id|ref|index>] [--url <url>] \(String(localized: "cli.browser.profile.option", defaultValue: "[--profile <name|uuid>]")) [--focus <true|false>]
           new-surface [--type <terminal|browser|simulator|agent-session>] [--pane <id|ref|index>] [--workspace <id|ref|index>] [--window <id|ref|index>] [--url <url>] [--provider <codex|claude|opencode>] [--renderer <react|solid>] [--focus <true|false>]

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/SleepyModeSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/SleepyModeSection.swift
@@ -108,6 +108,16 @@ public struct SleepyModeSection: View {
             SettingsCard {
                 SettingsCardRow(
                     configurationReview: .settingsOnly,
+                    String(localized: "sleepyMode.settings.showWhenKeepingAwake", defaultValue: "Show while Keep Mac Awake is on"),
+                    subtitle: String(localized: "sleepyMode.settings.showWhenKeepingAwake.subtitle", defaultValue: "Covers the screen with Sleepy Mode whenever cmux keeps this Mac awake, including from the menu bar, the cmux CLI, or your iPhone.")
+                ) {
+                    Toggle("", isOn: $store.showWhenKeepingAwake).labelsHidden().controlSize(.small)
+                }
+            }
+
+            SettingsCard {
+                SettingsCardRow(
+                    configurationReview: .settingsOnly,
                     String(localized: "sleepyMode.settings.securityNote", defaultValue: "About security"),
                     subtitle: String(localized: "sleepyMode.settings.securityNote.subtitle", defaultValue: "Sleepy Mode is a screensaver, not a lock — any key or click wakes it. For real security, use the \u{201C}Lock Mac\u{201D} button in the scene, which engages the actual macOS login lock.")
                 ) {

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/SleepyModeSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/SleepyModeSection.swift
@@ -113,6 +113,14 @@ public struct SleepyModeSection: View {
                 ) {
                     Toggle("", isOn: $store.showWhenKeepingAwake).labelsHidden().controlSize(.small)
                 }
+                SettingsCardDivider()
+                SettingsCardRow(
+                    configurationReview: .settingsOnly,
+                    String(localized: "sleepyMode.settings.lockMacWhenKeepingAwake", defaultValue: "Lock Mac while Keep Mac Awake is on"),
+                    subtitle: String(localized: "sleepyMode.settings.lockMacWhenKeepingAwake.subtitle", defaultValue: "Also engages the real macOS login lock, so Touch ID or your password is required to get back in. The Mac keeps running behind the lock.")
+                ) {
+                    Toggle("", isOn: $store.lockMacWhenKeepingAwake).labelsHidden().controlSize(.small)
+                }
             }
 
             SettingsCard {

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/SleepyMode/SleepyModeConfig.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/SleepyMode/SleepyModeConfig.swift
@@ -21,6 +21,10 @@ public struct SleepyModeConfig: Equatable, Sendable {
     public var showStatus = true
     /// Whether one walking pet per running agent is drawn.
     public var showPets = true
+    /// Whether the scene is shown as a lock screen whenever cmux keeps the
+    /// Mac awake (menu bar, CLI, or iOS Keep Awake). Off by default so
+    /// enabling Keep Mac Awake never covers the screen unless opted in.
+    public var showWhenKeepingAwake = false
 
     // Default custom colors below are matched to the cmux theme so "Custom"
     // starts familiar; "RRGGBB" hex.

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/SleepyMode/SleepyModeConfig.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/SleepyMode/SleepyModeConfig.swift
@@ -25,6 +25,9 @@ public struct SleepyModeConfig: Equatable, Sendable {
     /// Mac awake (menu bar, CLI, or iOS Keep Awake). Off by default so
     /// enabling Keep Mac Awake never covers the screen unless opted in.
     public var showWhenKeepingAwake = false
+    /// Whether keeping the Mac awake also engages the real macOS login lock,
+    /// so only Touch ID or the account password gets back in. Off by default.
+    public var lockMacWhenKeepingAwake = false
 
     // Default custom colors below are matched to the cmux theme so "Custom"
     // starts familiar; "RRGGBB" hex.

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/SleepyMode/SleepyModeDefaultsKeys.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/SleepyMode/SleepyModeDefaultsKeys.swift
@@ -13,6 +13,7 @@ struct SleepyModeDefaultsKeys {
     static let showStatus = "sleepyMode.showStatus"
     static let showPets = "sleepyMode.showPets"
     static let showWhenKeepingAwake = "sleepyMode.showWhenKeepingAwake"
+    static let lockMacWhenKeepingAwake = "sleepyMode.lockMacWhenKeepingAwake"
     static let customFace = "sleepyMode.customFace"
     static let customCap = "sleepyMode.customCap"
     static let customBlush = "sleepyMode.customBlush"

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/SleepyMode/SleepyModeDefaultsKeys.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/SleepyMode/SleepyModeDefaultsKeys.swift
@@ -12,6 +12,7 @@ struct SleepyModeDefaultsKeys {
     static let showClock = "sleepyMode.showClock"
     static let showStatus = "sleepyMode.showStatus"
     static let showPets = "sleepyMode.showPets"
+    static let showWhenKeepingAwake = "sleepyMode.showWhenKeepingAwake"
     static let customFace = "sleepyMode.customFace"
     static let customCap = "sleepyMode.customCap"
     static let customBlush = "sleepyMode.customBlush"

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/SleepyMode/SleepyModeSettingsStore.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/SleepyMode/SleepyModeSettingsStore.swift
@@ -35,6 +35,9 @@ public final class SleepyModeSettingsStore {
     public var showStatus: Bool { didSet { persist(showStatus, SleepyModeDefaultsKeys.showStatus) } }
     /// Whether one walking pet per running agent is drawn.
     public var showPets: Bool { didSet { persist(showPets, SleepyModeDefaultsKeys.showPets) } }
+    /// Whether the scene is shown as a lock screen whenever cmux keeps the
+    /// Mac awake.
+    public var showWhenKeepingAwake: Bool { didSet { persist(showWhenKeepingAwake, SleepyModeDefaultsKeys.showWhenKeepingAwake) } }
 
     /// Custom face color ("RRGGBB"), used when `theme == .custom`.
     public var customFace: String { didSet { persist(customFace, SleepyModeDefaultsKeys.customFace) } }
@@ -65,6 +68,7 @@ public final class SleepyModeSettingsStore {
         showClock = defaults.object(forKey: SleepyModeDefaultsKeys.showClock) as? Bool ?? fallback.showClock
         showStatus = defaults.object(forKey: SleepyModeDefaultsKeys.showStatus) as? Bool ?? fallback.showStatus
         showPets = defaults.object(forKey: SleepyModeDefaultsKeys.showPets) as? Bool ?? fallback.showPets
+        showWhenKeepingAwake = defaults.object(forKey: SleepyModeDefaultsKeys.showWhenKeepingAwake) as? Bool ?? fallback.showWhenKeepingAwake
         customFace = defaults.string(forKey: SleepyModeDefaultsKeys.customFace) ?? fallback.customFace
         customCap = defaults.string(forKey: SleepyModeDefaultsKeys.customCap) ?? fallback.customCap
         customBlush = defaults.string(forKey: SleepyModeDefaultsKeys.customBlush) ?? fallback.customBlush

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/SleepyMode/SleepyModeSettingsStore.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/SleepyMode/SleepyModeSettingsStore.swift
@@ -38,6 +38,8 @@ public final class SleepyModeSettingsStore {
     /// Whether the scene is shown as a lock screen whenever cmux keeps the
     /// Mac awake.
     public var showWhenKeepingAwake: Bool { didSet { persist(showWhenKeepingAwake, SleepyModeDefaultsKeys.showWhenKeepingAwake) } }
+    /// Whether keeping the Mac awake also engages the real macOS login lock.
+    public var lockMacWhenKeepingAwake: Bool { didSet { persist(lockMacWhenKeepingAwake, SleepyModeDefaultsKeys.lockMacWhenKeepingAwake) } }
 
     /// Custom face color ("RRGGBB"), used when `theme == .custom`.
     public var customFace: String { didSet { persist(customFace, SleepyModeDefaultsKeys.customFace) } }
@@ -69,6 +71,7 @@ public final class SleepyModeSettingsStore {
         showStatus = defaults.object(forKey: SleepyModeDefaultsKeys.showStatus) as? Bool ?? fallback.showStatus
         showPets = defaults.object(forKey: SleepyModeDefaultsKeys.showPets) as? Bool ?? fallback.showPets
         showWhenKeepingAwake = defaults.object(forKey: SleepyModeDefaultsKeys.showWhenKeepingAwake) as? Bool ?? fallback.showWhenKeepingAwake
+        lockMacWhenKeepingAwake = defaults.object(forKey: SleepyModeDefaultsKeys.lockMacWhenKeepingAwake) as? Bool ?? fallback.lockMacWhenKeepingAwake
         customFace = defaults.string(forKey: SleepyModeDefaultsKeys.customFace) ?? fallback.customFace
         customCap = defaults.string(forKey: SleepyModeDefaultsKeys.customCap) ?? fallback.customCap
         customBlush = defaults.string(forKey: SleepyModeDefaultsKeys.customBlush) ?? fallback.customBlush

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -108,6 +108,90 @@
         "ja": { "stringUnit": { "state": "translated", "value": "「Macをスリープさせない」はまだ利用できません。" } }
       }
     },
+    "caffeine.error.invalidLockScreen": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "lock_screen must be true or false." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "lock_screen には true か false を指定してください。" } }
+      }
+    },
+    "cli.caffeinate.error.tooManyArguments": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "caffeinate takes one subcommand: status, on, off, or toggle" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "caffeinate のサブコマンドは status、on、off、toggle のいずれか1つです" } }
+      }
+    },
+    "cli.caffeinate.error.statusLockScreen": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "caffeinate status doesn't take --lock-screen/--no-lock-screen" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "caffeinate status に --lock-screen/--no-lock-screen は指定できません" } }
+      }
+    },
+    "cli.caffeinate.error.unknownFlag": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "caffeinate: unknown flag '%@'. Flags: --lock-screen, --no-lock-screen, --json" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "caffeinate: 不明なフラグ「%@」。使用できるフラグ: --lock-screen、--no-lock-screen、--json" } }
+      }
+    },
+    "cli.caffeinate.error.unknownSubcommand": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Unknown caffeinate subcommand '%@'. Use status, on, off, or toggle." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "不明な caffeinate サブコマンド「%@」。status、on、off、toggle を使用してください。" } }
+      }
+    },
+    "cli.caffeinate.status.on": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Keep Mac Awake: on" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "Macをスリープさせない: オン" } }
+      }
+    },
+    "cli.caffeinate.status.off": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Keep Mac Awake: off" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "Macをスリープさせない: オフ" } }
+      }
+    },
+    "cli.caffeinate.lockScreen.shown": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Lock screen (Sleepy Mode): shown" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "ロック画面（おやすみモード）: 表示中" } }
+      }
+    },
+    "cli.caffeinate.lockScreen.hidden": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Lock screen (Sleepy Mode): hidden" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "ロック画面（おやすみモード）: 非表示" } }
+      }
+    },
+    "cli.help.caffeinate": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Usage: cmux caffeinate [status|on|off|toggle] [flags]\n\nKeep the Mac awake (Keep Mac Awake), optionally covering the screen with the\nSleepy Mode lock screen while it is on. This is the same action the menu-bar\ntoggle, Settings, and the iOS Keep Awake switch use.\n\nSubcommands:\n  status                       Print the current state (default)\n  on                           Keep the Mac awake\n  off                          Let the Mac sleep again\n  toggle                       Flip the current state\n\nFlags:\n  --lock-screen                Also show the Sleepy Mode lock screen\n  --no-lock-screen             Keep the screen uncovered (and hide a lock\n                               screen caffeinate itself put up)\n  --json                       Structured JSON output\n\nWithout a lock-screen flag, turning it on follows the Settings preference\n\"Show while Keep Mac Awake is on\" (Settings > Sleepy Mode). The keep-awake\nassertion is not persisted: quitting cmux always releases it.\n\nExample:\n  cmux caffeinate on\n  cmux caffeinate on --lock-screen\n  cmux caffeinate off\n  cmux --json caffeinate status" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "Usage: cmux caffeinate [status|on|off|toggle] [flags]\n\nMacをスリープさせず、オンの間はおやすみモードのロック画面で画面を覆うこともできます。メニューバーのトグル、設定、iOS の Keep Awake スイッチと同じアクションを使います。\n\nSubcommands:\n  status                       現在の状態を表示（既定）\n  on                           Macをスリープさせない\n  off                          Macのスリープを再び許可\n  toggle                       現在の状態を反転\n\nFlags:\n  --lock-screen                おやすみモードのロック画面も表示\n  --no-lock-screen             画面を覆わない（caffeinate 自身が表示したロック画面は閉じる）\n  --json                       構造化 JSON 出力\n\nロック画面フラグを付けない場合、オンにすると設定の「『Macをスリープさせない』中に表示」（設定 > おやすみモード）に従います。キープアウェイクのアサーションは永続化されず、cmux を終了すると常に解除されます。\n\nExample:\n  cmux caffeinate on\n  cmux caffeinate on --lock-screen\n  cmux caffeinate off\n  cmux --json caffeinate status" } }
+      }
+    },
+    "sleepyMode.settings.showWhenKeepingAwake": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Show while Keep Mac Awake is on" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "「Macをスリープさせない」中に表示" } }
+      }
+    },
+    "sleepyMode.settings.showWhenKeepingAwake.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Covers the screen with Sleepy Mode whenever cmux keeps this Mac awake, including from the menu bar, the cmux CLI, or your iPhone." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "メニューバー、cmux CLI、iPhone のいずれから有効にした場合でも、cmux がこの Mac をスリープさせない間はおやすみモードで画面を覆います。" } }
+      }
+    },
     "cli.help.notify.reply": {
       "extractionState": "manual",
       "localizations": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -125,15 +125,36 @@
     "cli.caffeinate.error.statusLockScreen": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "caffeinate status doesn't take --lock-screen/--no-lock-screen" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "caffeinate status に --lock-screen/--no-lock-screen は指定できません" } }
+        "en": { "stringUnit": { "state": "translated", "value": "caffeinate status doesn't take lock-screen/lock-mac flags" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "caffeinate status に lock-screen/lock-mac 系フラグは指定できません" } }
+      }
+    },
+    "caffeine.error.invalidLockMac": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "lock_mac must be true or false." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "lock_mac には true か false を指定してください。" } }
+      }
+    },
+    "sleepyMode.settings.lockMacWhenKeepingAwake": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Lock Mac while Keep Mac Awake is on" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "「Macをスリープさせない」中にMacをロック" } }
+      }
+    },
+    "sleepyMode.settings.lockMacWhenKeepingAwake.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Also engages the real macOS login lock, so Touch ID or your password is required to get back in. The Mac keeps running behind the lock." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "本物の macOS ログインロックも同時にかけるため、復帰には Touch ID かパスワードが必要になります。ロック中も Mac は動作し続けます。" } }
       }
     },
     "cli.caffeinate.error.unknownFlag": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "caffeinate: unknown flag '%@'. Flags: --lock-screen, --no-lock-screen, --json" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "caffeinate: 不明なフラグ「%@」。使用できるフラグ: --lock-screen、--no-lock-screen、--json" } }
+        "en": { "stringUnit": { "state": "translated", "value": "caffeinate: unknown flag '%@'. Flags: --lock-screen, --no-lock-screen, --lock-mac, --json" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "caffeinate: 不明なフラグ「%@」。使用できるフラグ: --lock-screen、--no-lock-screen、--lock-mac、--json" } }
       }
     },
     "cli.caffeinate.error.unknownSubcommand": {
@@ -174,8 +195,8 @@
     "cli.help.caffeinate": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "Usage: cmux caffeinate [status|on|off|toggle] [flags]\n\nKeep the Mac awake (Keep Mac Awake), optionally covering the screen with the\nSleepy Mode lock screen while it is on. This is the same action the menu-bar\ntoggle, Settings, and the iOS Keep Awake switch use.\n\nSubcommands:\n  status                       Print the current state (default)\n  on                           Keep the Mac awake\n  off                          Let the Mac sleep again\n  toggle                       Flip the current state\n\nFlags:\n  --lock-screen                Also show the Sleepy Mode lock screen\n  --no-lock-screen             Keep the screen uncovered (and hide a lock\n                               screen caffeinate itself put up)\n  --json                       Structured JSON output\n\nWithout a lock-screen flag, turning it on follows the Settings preference\n\"Show while Keep Mac Awake is on\" (Settings > Sleepy Mode). The keep-awake\nassertion is not persisted: quitting cmux always releases it.\n\nExample:\n  cmux caffeinate on\n  cmux caffeinate on --lock-screen\n  cmux caffeinate off\n  cmux --json caffeinate status" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "Usage: cmux caffeinate [status|on|off|toggle] [flags]\n\nMacをスリープさせず、オンの間はおやすみモードのロック画面で画面を覆うこともできます。メニューバーのトグル、設定、iOS の Keep Awake スイッチと同じアクションを使います。\n\nSubcommands:\n  status                       現在の状態を表示（既定）\n  on                           Macをスリープさせない\n  off                          Macのスリープを再び許可\n  toggle                       現在の状態を反転\n\nFlags:\n  --lock-screen                おやすみモードのロック画面も表示\n  --no-lock-screen             画面を覆わない（caffeinate 自身が表示したロック画面は閉じる）\n  --json                       構造化 JSON 出力\n\nロック画面フラグを付けない場合、オンにすると設定の「『Macをスリープさせない』中に表示」（設定 > おやすみモード）に従います。キープアウェイクのアサーションは永続化されず、cmux を終了すると常に解除されます。\n\nExample:\n  cmux caffeinate on\n  cmux caffeinate on --lock-screen\n  cmux caffeinate off\n  cmux --json caffeinate status" } }
+        "en": { "stringUnit": { "state": "translated", "value": "Usage: cmux caffeinate [status|on|off|toggle] [flags]\n\nKeep the Mac awake (Keep Mac Awake), optionally covering the screen with the\nSleepy Mode lock screen while it is on. This is the same action the menu-bar\ntoggle, Settings, and the iOS Keep Awake switch use.\n\nSubcommands:\n  status                       Print the current state (default)\n  on                           Keep the Mac awake\n  off                          Let the Mac sleep again\n  toggle                       Flip the current state\n\nFlags:\n  --lock-screen                Also show the Sleepy Mode lock screen\n  --no-lock-screen             Keep the screen uncovered (and hide a lock\n                               screen caffeinate itself put up)\n  --lock-mac                   Also engage the real macOS login lock (Touch\n                               ID or password to get back in); implies\n                               --lock-screen unless --no-lock-screen\n  --json                       Structured JSON output\n\nWithout flags, turning it on follows the Settings preferences \"Show while\nKeep Mac Awake is on\" and \"Lock Mac while Keep Mac Awake is on\"\n(Settings > Sleepy Mode). Turning caffeinate off never unlocks the Mac.\nThe keep-awake assertion is not persisted: quitting cmux always releases it.\n\nExample:\n  cmux caffeinate on\n  cmux caffeinate on --lock-screen\n  cmux caffeinate on --lock-mac\n  cmux caffeinate off\n  cmux --json caffeinate status" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "Usage: cmux caffeinate [status|on|off|toggle] [flags]\n\nMacをスリープさせず、オンの間はおやすみモードのロック画面で画面を覆うこともできます。メニューバーのトグル、設定、iOS の Keep Awake スイッチと同じアクションを使います。\n\nSubcommands:\n  status                       現在の状態を表示（既定）\n  on                           Macをスリープさせない\n  off                          Macのスリープを再び許可\n  toggle                       現在の状態を反転\n\nFlags:\n  --lock-screen                おやすみモードのロック画面も表示\n  --no-lock-screen             画面を覆わない（caffeinate 自身が表示したロック画面は閉じる）\n  --lock-mac                   本物の macOS ログインロックもかける（復帰には Touch ID かパスワードが必要）。--no-lock-screen がない限り --lock-screen を含む\n  --json                       構造化 JSON 出力\n\nフラグを付けない場合、オンにすると設定の「『Macをスリープさせない』中に表示」と「『Macをスリープさせない』中にMacをロック」（設定 > おやすみモード）に従います。caffeinate をオフにしても Mac のロックは解除されません。キープアウェイクのアサーションは永続化されず、cmux を終了すると常に解除されます。\n\nExample:\n  cmux caffeinate on\n  cmux caffeinate on --lock-screen\n  cmux caffeinate on --lock-mac\n  cmux caffeinate off\n  cmux --json caffeinate status" } }
       }
     },
     "sleepyMode.settings.showWhenKeepingAwake": {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2425,6 +2425,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         caffeineController.lockScreenPreference = {
             SleepyModeController.shared.store.showWhenKeepingAwake
         }
+        caffeineController.lockMacPreference = {
+            SleepyModeController.shared.store.lockMacWhenKeepingAwake
+        }
+        caffeineController.lockMacAction = {
+            let controls = SleepyModeController.shared.powerControls
+            Task { await controls.lockMacNow() }
+        }
         caffeineController.onStateChange = { [weak self] enabled in
             self?.menuBarExtraController?.refreshForDebugControls()
             MobileHostService.emitEvent(

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2421,11 +2421,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         AIAccountsClient.bootstrap(auth: auth.coordinator)
         PhonePushClient.shared.configure(auth: auth.coordinator)
         MobileHostService.shared.configure(auth: auth.coordinator)
+        caffeineController.lockScreenPresenter = SleepyModeController.shared
+        caffeineController.lockScreenPreference = {
+            SleepyModeController.shared.store.showWhenKeepingAwake
+        }
         caffeineController.onStateChange = { [weak self] enabled in
             self?.menuBarExtraController?.refreshForDebugControls()
             MobileHostService.emitEvent(
                 topic: "caffeine.status.changed",
-                payload: ["enabled": enabled]
+                payload: [
+                    "enabled": enabled,
+                    "lock_screen_active": self?.caffeineController.isLockScreenPresented ?? false
+                ]
             )
         }
         DeviceRegistryClient.shared.configure(auth: auth.coordinator)
@@ -10289,6 +10296,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         menuBarExtraController = makeMenuBarExtraController()
         SleepyModeController.shared.onStateChange = { [weak self] in
             self?.menuBarExtraController?.refreshForDebugControls()
+            if !SleepyModeController.shared.isActive {
+                // Covers every exit path (any key/click, palette), including
+                // the caffeinate action's own dismiss, which is idempotent.
+                self?.caffeineController.noteLockScreenDismissed()
+            }
         }
     }
 

--- a/Sources/CaffeineController.swift
+++ b/Sources/CaffeineController.swift
@@ -1,10 +1,25 @@
 import Foundation
 import Observation
 
+/// Presents/dismisses the full-screen scene shown while the Mac is kept awake.
+/// Implemented by `SleepyModeController`; injected so tests can observe the
+/// transitions without AppKit windows.
+@MainActor
+protocol CaffeineLockScreenPresenting: AnyObject {
+    var isPresented: Bool { get }
+    func present()
+    func dismiss()
+}
+
 /// Owns cmux's process-scoped idle-sleep activity.
 ///
 /// The assertion keeps the Mac reachable while its display remains free to
 /// sleep. It is intentionally not persisted: quitting cmux always releases it.
+///
+/// This is the single caffeinate action path: the CLI/socket `caffeine.*`
+/// commands, the iOS Keep Awake RPC, the menu-bar toggle, and the Settings
+/// toggle all mutate through `setEnabled`, which also drives the optional
+/// lock screen (Sleepy Mode) while the Mac is kept awake.
 @MainActor
 @Observable
 final class CaffeineController {
@@ -17,6 +32,19 @@ final class CaffeineController {
     @ObservationIgnored private let endActivity: EndActivity
     @ObservationIgnored private var activity: (any NSObjectProtocol)?
     @ObservationIgnored var onStateChange: ((Bool) -> Void)?
+
+    /// The lock screen shown while caffeinated; nil when the composition root
+    /// hasn't wired one (tests, early startup).
+    @ObservationIgnored var lockScreenPresenter: (any CaffeineLockScreenPresenting)?
+    /// Persisted "show the lock screen while keeping the Mac awake" preference,
+    /// consulted when a caller doesn't pass an explicit per-call choice.
+    @ObservationIgnored var lockScreenPreference: () -> Bool = { false }
+    /// True while the currently visible lock screen was presented by this
+    /// controller (as opposed to the user starting Sleepy Mode themselves).
+    /// Only a caffeine-owned lock screen is dismissed when caffeine ends.
+    @ObservationIgnored private var ownsLockScreen = false
+
+    var isLockScreenPresented: Bool { lockScreenPresenter?.isPresented ?? false }
 
     init(
         beginActivity: @escaping BeginActivity = {
@@ -33,21 +61,68 @@ final class CaffeineController {
         self.endActivity = endActivity
     }
 
-    func setEnabled(_ enabled: Bool) {
-        guard enabled != isEnabled else { return }
+    /// `lockScreen` is the per-call override (CLI `--lock-screen` /
+    /// `--no-lock-screen`, RPC `lock_screen`); nil falls back to the persisted
+    /// preference on the disabled→enabled transition and leaves the lock
+    /// screen untouched on redundant enables.
+    func setEnabled(_ enabled: Bool, lockScreen: Bool? = nil) {
+        let wasEnabled = isEnabled
 
-        if enabled {
-            activity = beginActivity()
-        } else if let activity {
-            endActivity(activity)
-            self.activity = nil
+        if enabled != wasEnabled {
+            if enabled {
+                activity = beginActivity()
+            } else if let activity {
+                endActivity(activity)
+                self.activity = nil
+            }
+            isEnabled = enabled
         }
 
-        isEnabled = enabled
-        onStateChange?(enabled)
+        applyLockScreen(enabled: enabled, wasEnabled: wasEnabled, override: lockScreen)
+
+        if enabled != wasEnabled {
+            onStateChange?(enabled)
+        }
     }
 
     func toggle() {
         setEnabled(!isEnabled)
+    }
+
+    /// Called when the lock screen goes away through its own exit path (any
+    /// key/click, the palette toggle). Dropping ownership here keeps a Sleepy
+    /// Mode session the user starts LATER from being torn down when caffeine
+    /// ends.
+    func noteLockScreenDismissed() {
+        ownsLockScreen = false
+    }
+
+    private func applyLockScreen(enabled: Bool, wasEnabled: Bool, override: Bool?) {
+        guard let presenter = lockScreenPresenter else { return }
+
+        guard enabled else {
+            // Ending caffeine tears down only a lock screen caffeine put up;
+            // a user-started Sleepy Mode session stays.
+            if ownsLockScreen, presenter.isPresented {
+                presenter.dismiss()
+            }
+            ownsLockScreen = false
+            return
+        }
+
+        // Redundant enables without an explicit choice leave the lock screen
+        // alone, so a user who dismissed it isn't surprised by it returning.
+        let want: Bool? = override ?? (wasEnabled ? nil : lockScreenPreference())
+        guard let want else { return }
+
+        if want {
+            if !presenter.isPresented {
+                presenter.present()
+                ownsLockScreen = true
+            }
+        } else if ownsLockScreen, presenter.isPresented {
+            presenter.dismiss()
+            ownsLockScreen = false
+        }
     }
 }

--- a/Sources/CaffeineController.swift
+++ b/Sources/CaffeineController.swift
@@ -44,6 +44,13 @@ final class CaffeineController {
     /// Only a caffeine-owned lock screen is dismissed when caffeine ends.
     @ObservationIgnored private var ownsLockScreen = false
 
+    /// Persisted "engage the real macOS login lock while keeping the Mac
+    /// awake" preference; the lock can only be lifted with Touch ID or the
+    /// account password, which is why it is an action, never state we undo.
+    @ObservationIgnored var lockMacPreference: () -> Bool = { false }
+    /// Fires the real macOS login lock (Sleepy Mode's "Lock Mac" action).
+    @ObservationIgnored var lockMacAction: () -> Void = {}
+
     var isLockScreenPresented: Bool { lockScreenPresenter?.isPresented ?? false }
 
     init(
@@ -61,11 +68,13 @@ final class CaffeineController {
         self.endActivity = endActivity
     }
 
-    /// `lockScreen` is the per-call override (CLI `--lock-screen` /
-    /// `--no-lock-screen`, RPC `lock_screen`); nil falls back to the persisted
-    /// preference on the disabled→enabled transition and leaves the lock
-    /// screen untouched on redundant enables.
-    func setEnabled(_ enabled: Bool, lockScreen: Bool? = nil) {
+    /// `lockScreen` and `lockMac` are the per-call overrides (CLI
+    /// `--lock-screen`/`--no-lock-screen`/`--lock-mac`, RPC `lock_screen`/
+    /// `lock_mac`); nil falls back to the persisted preferences on the
+    /// disabled→enabled transition and leaves both untouched on redundant
+    /// enables. `lockMac` implies the cover unless the cover was explicitly
+    /// declined.
+    func setEnabled(_ enabled: Bool, lockScreen: Bool? = nil, lockMac: Bool? = nil) {
         let wasEnabled = isEnabled
 
         if enabled != wasEnabled {
@@ -78,7 +87,7 @@ final class CaffeineController {
             isEnabled = enabled
         }
 
-        applyLockScreen(enabled: enabled, wasEnabled: wasEnabled, override: lockScreen)
+        applyLockScreen(enabled: enabled, wasEnabled: wasEnabled, override: lockScreen, lockMacOverride: lockMac)
 
         if enabled != wasEnabled {
             onStateChange?(enabled)
@@ -97,13 +106,12 @@ final class CaffeineController {
         ownsLockScreen = false
     }
 
-    private func applyLockScreen(enabled: Bool, wasEnabled: Bool, override: Bool?) {
-        guard let presenter = lockScreenPresenter else { return }
-
+    private func applyLockScreen(enabled: Bool, wasEnabled: Bool, override: Bool?, lockMacOverride: Bool?) {
         guard enabled else {
-            // Ending caffeine tears down only a lock screen caffeine put up;
-            // a user-started Sleepy Mode session stays.
-            if ownsLockScreen, presenter.isPresented {
+            // Ending caffeine tears down only a lock screen caffeine put up; a
+            // user-started Sleepy Mode session stays, and an engaged macOS
+            // lock stays until the user unlocks it themselves.
+            if let presenter = lockScreenPresenter, ownsLockScreen, presenter.isPresented {
                 presenter.dismiss()
             }
             ownsLockScreen = false
@@ -112,17 +120,26 @@ final class CaffeineController {
 
         // Redundant enables without an explicit choice leave the lock screen
         // alone, so a user who dismissed it isn't surprised by it returning.
-        let want: Bool? = override ?? (wasEnabled ? nil : lockScreenPreference())
-        guard let want else { return }
+        let wantLockMac: Bool? = lockMacOverride ?? (wasEnabled ? nil : lockMacPreference())
+        var wantCover: Bool? = override ?? (wasEnabled ? nil : lockScreenPreference())
+        if wantLockMac == true, wantCover == nil {
+            wantCover = true
+        }
 
-        if want {
-            if !presenter.isPresented {
-                presenter.present()
-                ownsLockScreen = true
+        if let presenter = lockScreenPresenter, let wantCover {
+            if wantCover {
+                if !presenter.isPresented {
+                    presenter.present()
+                    ownsLockScreen = true
+                }
+            } else if ownsLockScreen, presenter.isPresented {
+                presenter.dismiss()
+                ownsLockScreen = false
             }
-        } else if ownsLockScreen, presenter.isPresented {
-            presenter.dismiss()
-            ownsLockScreen = false
+        }
+
+        if wantLockMac == true {
+            lockMacAction()
         }
     }
 }

--- a/Sources/SleepyModeController.swift
+++ b/Sources/SleepyModeController.swift
@@ -1,7 +1,10 @@
 import AppKit
 import CmuxSettingsUI
 import IOKit.pwr_mgt
+import os
 import SwiftUI
+
+private let sleepyLogger = Logger(subsystem: "com.cmuxterm.app", category: "SleepyMode")
 
 /// Owns "Sleepy Mode": a cute full-screen keep-awake screensaver. It holds
 /// IOKit power assertions so the Mac (and its display) stay awake — useful for
@@ -101,10 +104,12 @@ final class SleepyModeController {
     private func rebuildOverlayWindows() {
         tearDownOverlayWindows()
         let screens = NSScreen.screens.isEmpty ? [NSScreen.main].compactMap { $0 } : NSScreen.screens
+        sleepyLogger.info("rebuildOverlayWindows: \(screens.count) screen(s): \(screens.map { "\($0.localizedName) \(NSStringFromRect($0.frame))" }.joined(separator: " | "), privacy: .public)")
         for screen in screens {
             let window = makeOverlayWindow(for: screen)
             overlayWindows.append(window)
             window.orderFrontRegardless()
+            sleepyLogger.info("overlay ordered front: screen=\(screen.localizedName, privacy: .public) windowNumber=\(window.windowNumber) visible=\(window.isVisible) onScreen=\(window.screen?.localizedName ?? "nil", privacy: .public) frame=\(NSStringFromRect(window.frame), privacy: .public)")
         }
         overlayWindows.first?.makeKeyAndOrderFront(nil)
     }
@@ -112,7 +117,7 @@ final class SleepyModeController {
     private func makeOverlayWindow(for screen: NSScreen) -> SleepyOverlayWindow {
         let window = SleepyOverlayWindow(
             contentRect: screen.frame,
-            styleMask: [.borderless],
+            styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
         )

--- a/Sources/SleepyModeController.swift
+++ b/Sources/SleepyModeController.swift
@@ -197,3 +197,11 @@ final class SleepyModeController {
         }
     }
 }
+
+/// Sleepy Mode doubles as the lock screen the caffeinate action can show
+/// while it keeps the Mac awake.
+extension SleepyModeController: CaffeineLockScreenPresenting {
+    var isPresented: Bool { isActive }
+    func present() { activate() }
+    func dismiss() { deactivate() }
+}

--- a/Sources/SleepyOverlayWindow.swift
+++ b/Sources/SleepyOverlayWindow.swift
@@ -2,7 +2,14 @@ import AppKit
 
 /// Borderless screensaver window for Sleepy Mode. Any key or click wakes it
 /// (it is deliberately not a lock); the controller wires `onExit` to deactivate.
-final class SleepyOverlayWindow: NSWindow {
+///
+/// NSPanel, not NSWindow: the window server only admits panels with
+/// `.nonactivatingPanel` onto ANOTHER app's fullscreen Space. A plain
+/// borderless NSWindow with `.canJoinAllSpaces + .fullScreenAuxiliary`
+/// reports `isVisible` but is never composited on a display whose active
+/// Space is some other app's fullscreen window, leaving that screen
+/// uncovered (found on a two-display setup with cmux fullscreen on one).
+final class SleepyOverlayWindow: NSPanel {
     /// Invoked on any key/click to dismiss the screensaver.
     var onExit: (() -> Void)?
 

--- a/Sources/TerminalController+Caffeine.swift
+++ b/Sources/TerminalController+Caffeine.swift
@@ -43,10 +43,24 @@ extension TerminalController {
             }
             lockScreen = value
         }
+        var lockMac: Bool?
+        if v2HasNonNullParam(params, "lock_mac") {
+            guard let value = v2Bool(params, "lock_mac") else {
+                return .err(
+                    code: "invalid_params",
+                    message: String(
+                        localized: "caffeine.error.invalidLockMac",
+                        defaultValue: "lock_mac must be true or false."
+                    ),
+                    data: nil
+                )
+            }
+            lockMac = value
+        }
         guard let caffeineController else {
             return v2CaffeineStatus()
         }
-        caffeineController.setEnabled(enabled, lockScreen: lockScreen)
+        caffeineController.setEnabled(enabled, lockScreen: lockScreen, lockMac: lockMac)
         return .ok(Self.caffeineStatusPayload(caffeineController))
     }
 

--- a/Sources/TerminalController+Caffeine.swift
+++ b/Sources/TerminalController+Caffeine.swift
@@ -13,7 +13,7 @@ extension TerminalController {
                 data: nil
             )
         }
-        return .ok(["enabled": caffeineController.isEnabled])
+        return .ok(Self.caffeineStatusPayload(caffeineController))
     }
 
     @MainActor
@@ -29,10 +29,32 @@ extension TerminalController {
                 data: nil
             )
         }
+        var lockScreen: Bool?
+        if v2HasNonNullParam(params, "lock_screen") {
+            guard let value = v2Bool(params, "lock_screen") else {
+                return .err(
+                    code: "invalid_params",
+                    message: String(
+                        localized: "caffeine.error.invalidLockScreen",
+                        defaultValue: "lock_screen must be true or false."
+                    ),
+                    data: nil
+                )
+            }
+            lockScreen = value
+        }
         guard let caffeineController else {
             return v2CaffeineStatus()
         }
-        caffeineController.setEnabled(enabled)
-        return .ok(["enabled": caffeineController.isEnabled])
+        caffeineController.setEnabled(enabled, lockScreen: lockScreen)
+        return .ok(Self.caffeineStatusPayload(caffeineController))
+    }
+
+    @MainActor
+    private static func caffeineStatusPayload(_ controller: CaffeineController) -> [String: Any] {
+        [
+            "enabled": controller.isEnabled,
+            "lock_screen_active": controller.isLockScreenPresented
+        ]
     }
 }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -13419,6 +13419,7 @@ class TerminalController {
                 case "clock": store.showClock.toggle()
                 case "status": store.showStatus.toggle()
                 case "pets": store.showPets.toggle()
+                case "keepawake": store.showWhenKeepingAwake.toggle()
                 default: unknown = true
                 }
             case "customcolor":

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -13420,6 +13420,7 @@ class TerminalController {
                 case "status": store.showStatus.toggle()
                 case "pets": store.showPets.toggle()
                 case "keepawake": store.showWhenKeepingAwake.toggle()
+                case "lockmac": store.lockMacWhenKeepingAwake.toggle()
                 default: unknown = true
                 }
             case "customcolor":

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -695,6 +695,7 @@
 		6D9C51AB30A64B1ABC819144 /* CMUXCLI+AutoNamingHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5257257034CA4729B1211168 /* CMUXCLI+AutoNamingHooks.swift */; };
 		6D9C51AB30A64B1ABC819145 /* CMUXCLI+AutoNamingSummarizers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5257257034CA4729B1211169 /* CMUXCLI+AutoNamingSummarizers.swift */; };
 		8056A0000000000000000002 /* CMUXCLI+BrowserViewport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8056A0000000000000000001 /* CMUXCLI+BrowserViewport.swift */; };
+		CAFE0002A1B2C3D4E5F60001 /* CMUXCLI+Caffeinate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFE0001A1B2C3D4E5F60001 /* CMUXCLI+Caffeinate.swift */; };
 		B9000074A1B2C3D4E5F60719 /* CMUXCLI+CampfireExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000075A1B2C3D4E5F60719 /* CMUXCLI+CampfireExtension.swift */; };
 		B9000078A1B2C3D4E5F60719 /* CMUXCLI+CampfireExtensionInstall.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000079A1B2C3D4E5F60719 /* CMUXCLI+CampfireExtensionInstall.swift */; };
 		B9000076A1B2C3D4E5F60719 /* CMUXCLI+CampfireNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000077A1B2C3D4E5F60719 /* CMUXCLI+CampfireNotifications.swift */; };
@@ -3738,6 +3739,7 @@
 		5257257034CA4729B1211168 /* CMUXCLI+AutoNamingHooks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+AutoNamingHooks.swift"; sourceTree = "<group>"; };
 		5257257034CA4729B1211169 /* CMUXCLI+AutoNamingSummarizers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+AutoNamingSummarizers.swift"; sourceTree = "<group>"; };
 		8056A0000000000000000001 /* CMUXCLI+BrowserViewport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+BrowserViewport.swift"; sourceTree = "<group>"; };
+		CAFE0001A1B2C3D4E5F60001 /* CMUXCLI+Caffeinate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+Caffeinate.swift"; sourceTree = "<group>"; };
 		B9000075A1B2C3D4E5F60719 /* CMUXCLI+CampfireExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+CampfireExtension.swift"; sourceTree = "<group>"; };
 		B9000079A1B2C3D4E5F60719 /* CMUXCLI+CampfireExtensionInstall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+CampfireExtensionInstall.swift"; sourceTree = "<group>"; };
 		B9000077A1B2C3D4E5F60719 /* CMUXCLI+CampfireNotifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+CampfireNotifications.swift"; sourceTree = "<group>"; };
@@ -8227,6 +8229,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				B9000051A1B2C3D4E5F60719 /* CMUXCLI+Config.swift */,
 				7E5D35CC62B0F252F9EC2AD1 /* CMUXCLI+WorkspaceTodo.swift */,
 				CC0033E15A1B2C3D4E5F0002 /* CMUXCLI+Comments.swift */,
+				CAFE0001A1B2C3D4E5F60001 /* CMUXCLI+Caffeinate.swift */,
 				CC0033E15A1B2C3D4E5F0021 /* CMUXCLI+VMTui.swift */,
 				CC0033E15A1B2C3D4E5F0102 /* CMUXCLI+VMTransfer.swift */,
 				B9000053A1B2C3D4E5F60719 /* CMUXCLI+InstallPreview.swift */,
@@ -11539,6 +11542,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				6D9C51AB30A64B1ABC819144 /* CMUXCLI+AutoNamingHooks.swift in Sources */,
 				6D9C51AB30A64B1ABC819145 /* CMUXCLI+AutoNamingSummarizers.swift in Sources */,
 				8056A0000000000000000002 /* CMUXCLI+BrowserViewport.swift in Sources */,
+				CAFE0002A1B2C3D4E5F60001 /* CMUXCLI+Caffeinate.swift in Sources */,
 				B9000074A1B2C3D4E5F60719 /* CMUXCLI+CampfireExtension.swift in Sources */,
 				B9000078A1B2C3D4E5F60719 /* CMUXCLI+CampfireExtensionInstall.swift in Sources */,
 				B9000076A1B2C3D4E5F60719 /* CMUXCLI+CampfireNotifications.swift in Sources */,

--- a/cmuxTests/CaffeineControllerTests.swift
+++ b/cmuxTests/CaffeineControllerTests.swift
@@ -59,4 +59,127 @@ struct CaffeineControllerTests {
         #expect(!controller.isEnabled)
         #expect(releaseCount == 1)
     }
+
+    @MainActor
+    private final class FakeLockScreen: CaffeineLockScreenPresenting {
+        var isPresented = false
+        var presentCount = 0
+        var dismissCount = 0
+
+        func present() {
+            isPresented = true
+            presentCount += 1
+        }
+
+        func dismiss() {
+            isPresented = false
+            dismissCount += 1
+        }
+    }
+
+    private func makeController(preference: @escaping () -> Bool, lockScreen: FakeLockScreen) -> CaffeineController {
+        let controller = CaffeineController(
+            beginActivity: { NSObject() },
+            endActivity: { _ in }
+        )
+        controller.lockScreenPresenter = lockScreen
+        controller.lockScreenPreference = preference
+        return controller
+    }
+
+    @Test
+    func preferenceShowsLockScreenForTheFullCaffeineWindow() {
+        let lockScreen = FakeLockScreen()
+        let controller = makeController(preference: { true }, lockScreen: lockScreen)
+
+        controller.setEnabled(true)
+        #expect(lockScreen.isPresented)
+        #expect(lockScreen.presentCount == 1)
+
+        controller.setEnabled(false)
+        #expect(!lockScreen.isPresented)
+        #expect(lockScreen.dismissCount == 1)
+    }
+
+    @Test
+    func preferenceOffKeepsTheScreenUncoveredUnlessOverridden() {
+        let lockScreen = FakeLockScreen()
+        let controller = makeController(preference: { false }, lockScreen: lockScreen)
+
+        controller.setEnabled(true)
+        #expect(!lockScreen.isPresented)
+
+        controller.setEnabled(false)
+        controller.setEnabled(true, lockScreen: true)
+        #expect(lockScreen.isPresented)
+    }
+
+    @Test
+    func explicitNoLockScreenBeatsThePreference() {
+        let lockScreen = FakeLockScreen()
+        let controller = makeController(preference: { true }, lockScreen: lockScreen)
+
+        controller.setEnabled(true, lockScreen: false)
+        #expect(!lockScreen.isPresented)
+    }
+
+    @Test
+    func lockScreenOverrideAppliesWhileAlreadyCaffeinated() {
+        let lockScreen = FakeLockScreen()
+        let controller = makeController(preference: { false }, lockScreen: lockScreen)
+
+        controller.setEnabled(true)
+        controller.setEnabled(true, lockScreen: true)
+        #expect(lockScreen.isPresented)
+
+        controller.setEnabled(true, lockScreen: false)
+        #expect(!lockScreen.isPresented)
+    }
+
+    @Test
+    func redundantEnableDoesNotResurrectAManuallyDismissedLockScreen() {
+        let lockScreen = FakeLockScreen()
+        let controller = makeController(preference: { true }, lockScreen: lockScreen)
+
+        controller.setEnabled(true)
+        lockScreen.isPresented = false // user pressed a key; overlay exited
+        controller.noteLockScreenDismissed()
+
+        controller.setEnabled(true)
+        #expect(!lockScreen.isPresented)
+        #expect(lockScreen.presentCount == 1)
+
+        controller.setEnabled(false)
+        #expect(lockScreen.dismissCount == 0)
+    }
+
+    @Test
+    func userOwnedLockScreenSurvivesCaffeineEnd() {
+        let lockScreen = FakeLockScreen()
+        let controller = makeController(preference: { true }, lockScreen: lockScreen)
+
+        lockScreen.isPresented = true // user started Sleepy Mode themselves
+
+        controller.setEnabled(true)
+        #expect(lockScreen.presentCount == 0)
+
+        controller.setEnabled(false)
+        #expect(lockScreen.isPresented)
+        #expect(lockScreen.dismissCount == 0)
+    }
+
+    @Test
+    func lockScreenStartedAfterManualDismissBelongsToTheUser() {
+        let lockScreen = FakeLockScreen()
+        let controller = makeController(preference: { true }, lockScreen: lockScreen)
+
+        controller.setEnabled(true)
+        lockScreen.isPresented = false // user dismissed the caffeine lock screen
+        controller.noteLockScreenDismissed()
+        lockScreen.isPresented = true // then started Sleepy Mode manually
+
+        controller.setEnabled(false)
+        #expect(lockScreen.isPresented)
+        #expect(lockScreen.dismissCount == 0)
+    }
 }

--- a/cmuxTests/CaffeineControllerTests.swift
+++ b/cmuxTests/CaffeineControllerTests.swift
@@ -169,6 +169,52 @@ struct CaffeineControllerTests {
     }
 
     @Test
+    func lockMacFiresOnEnableAndImpliesTheCover() {
+        let lockScreen = FakeLockScreen()
+        let controller = makeController(preference: { false }, lockScreen: lockScreen)
+        var lockMacCount = 0
+        controller.lockMacAction = { lockMacCount += 1 }
+
+        controller.setEnabled(true, lockMac: true)
+        #expect(lockMacCount == 1)
+        #expect(lockScreen.isPresented)
+
+        controller.setEnabled(false)
+        #expect(lockMacCount == 1)
+    }
+
+    @Test
+    func lockMacPreferenceAppliesOnTheEnableTransitionOnly() {
+        let lockScreen = FakeLockScreen()
+        let controller = makeController(preference: { false }, lockScreen: lockScreen)
+        var lockMacCount = 0
+        controller.lockMacPreference = { true }
+        controller.lockMacAction = { lockMacCount += 1 }
+
+        controller.setEnabled(true)
+        #expect(lockMacCount == 1)
+
+        controller.setEnabled(true)
+        #expect(lockMacCount == 1)
+
+        controller.setEnabled(false)
+        controller.setEnabled(true, lockMac: false)
+        #expect(lockMacCount == 1)
+    }
+
+    @Test
+    func explicitNoCoverKeepsLockMacUncovered() {
+        let lockScreen = FakeLockScreen()
+        let controller = makeController(preference: { false }, lockScreen: lockScreen)
+        var lockMacCount = 0
+        controller.lockMacAction = { lockMacCount += 1 }
+
+        controller.setEnabled(true, lockScreen: false, lockMac: true)
+        #expect(lockMacCount == 1)
+        #expect(!lockScreen.isPresented)
+    }
+
+    @Test
     func lockScreenStartedAfterManualDismissBelongsToTheUser() {
         let lockScreen = FakeLockScreen()
         let controller = makeController(preference: { true }, lockScreen: lockScreen)

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -117,6 +117,7 @@ Environment:
 | `list-pane-surfaces` | List surfaces in a pane. |
 | `tree` | Print a window, workspace, pane, and surface tree. |
 | `top` | Print process/resource usage for cmux windows, workspaces, panes, and surfaces. |
+| `caffeinate` | Alias `caffeine`. Keep the Mac awake: `status` (default), `on`, `off`, `toggle`, with `--lock-screen`/`--no-lock-screen` to control the Sleepy Mode lock screen. Routes through the same `caffeine.set` action as the menu-bar toggle, Settings, and the iOS Keep Awake switch; without a flag, `on` follows the "Show while Keep Mac Awake is on" Sleepy Mode setting. |
 | `focus-pane` | Focus a pane. |
 | `new-pane` | Create a pane with terminal or browser content. |
 | `new-surface` | Create a surface inside a pane. |

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -117,7 +117,7 @@ Environment:
 | `list-pane-surfaces` | List surfaces in a pane. |
 | `tree` | Print a window, workspace, pane, and surface tree. |
 | `top` | Print process/resource usage for cmux windows, workspaces, panes, and surfaces. |
-| `caffeinate` | Alias `caffeine`. Keep the Mac awake: `status` (default), `on`, `off`, `toggle`, with `--lock-screen`/`--no-lock-screen` to control the Sleepy Mode lock screen. Routes through the same `caffeine.set` action as the menu-bar toggle, Settings, and the iOS Keep Awake switch; without a flag, `on` follows the "Show while Keep Mac Awake is on" Sleepy Mode setting. |
+| `caffeinate` | Alias `caffeine`. Keep the Mac awake: `status` (default), `on`, `off`, `toggle`, with `--lock-screen`/`--no-lock-screen` to control the Sleepy Mode lock screen and `--lock-mac` to also engage the real macOS login lock (Touch ID or password to get back in; implies the cover unless `--no-lock-screen`; `off` never unlocks). Routes through the same `caffeine.set` action as the menu-bar toggle, Settings, and the iOS Keep Awake switch; without flags, `on` follows the "Show while Keep Mac Awake is on" and "Lock Mac while Keep Mac Awake is on" Sleepy Mode settings. |
 | `focus-pane` | Focus a pane. |
 | `new-pane` | Create a pane with terminal or browser content. |
 | `new-surface` | Create a surface inside a pane. |


### PR DESCRIPTION
Two changes to the Keep Mac Awake (caffeinate) feature.

**One command path.** `caffeine.set` / `caffeine.status` on the control socket are now the single caffeinate action: the new CLI verb, the iOS Keep Awake RPC, the menu-bar toggle, and the Settings toggle all end in `CaffeineController.setEnabled`, so every surface gets identical behavior. The new verb:

```
cmux caffeinate            # status (default): Keep Mac Awake + lock screen state
cmux caffeinate on [--lock-screen|--no-lock-screen]
cmux caffeinate off
cmux caffeinate toggle
cmux --json caffeinate status
```

`caffeine.set` gains an optional `lock_screen` bool and `caffeine.status` now also reports `lock_screen_active`; the `caffeine.status.changed` event payload carries `lock_screen_active` too (additive, older iOS clients ignore it).

**Lock screen while caffeinated (like Codex).** While cmux keeps the Mac awake it can cover every screen with the existing Sleepy Mode scene. Per call via `--lock-screen`/`--no-lock-screen` (RPC `lock_screen`); with no explicit choice, turning caffeine on follows a new persisted Sleepy Mode setting, "Show while Keep Mac Awake is on" (default off, so existing Keep Mac Awake behavior is unchanged). Ownership is explicit: caffeine dismisses only a lock screen it presented itself. A Sleepy Mode session the user started stays up when caffeine ends, and a lock screen the user dismissed by pressing a key does not come back on redundant enables; keep-awake itself persists after a manual dismiss, matching Sleepy Mode's documented any-key-wakes design.

`CaffeineController` gets an injected `CaffeineLockScreenPresenting` (implemented by `SleepyModeController`) plus a preference closure, both wired in `AppDelegate`, keeping the controller unit-testable. New `CaffeineControllerTests` cover the ownership matrix (preference on/off, per-call overrides, redundant enables, user-owned sessions, manual dismiss then manual restart). Strings are localized (en + ja), the verb is documented in `docs/cli-contract.md`, and Settings search finds the new toggle through the existing Sleepy Mode aliases ("caffeinate", "keep awake").

Note: current main is red for the macOS app target (missing `import CmuxBrowser`, fix in https://github.com/manaflow-ai/cmux/pull/11337); the tagged fleet build for this PR used that one-liner as an uncommitted overlay. This PR does not include it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11338"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790831960&installation_model_id=21920&pr_number=11338&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11338&signature=70fcaff45bb65b6dcadd4e86ef6b2c939ec03b6fb0186f495f742c8575806708"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `cmux caffeinate` CLI verb and lets Keep Mac Awake optionally show the Sleepy Mode lock screen and engage the real macOS login lock while the Mac stays awake. The menu-bar toggle, Settings, the iOS Keep Awake RPC, and the new CLI verb all route through `CaffeineController.setEnabled`, so every surface behaves identically.

- New verb: `cmux caffeinate [status|on|off|toggle]`, with `--lock-screen` / `--no-lock-screen` / `--lock-mac` flags and `--json` output.
- `caffeine.set` accepts optional `lock_screen` and `lock_mac` bools; `caffeine.status` and the `caffeine.status.changed` event now report `lock_screen_active` (additive, older iOS clients ignore it).
- Without explicit flags, turning caffeine on follows the new persisted Sleepy Mode settings "Show while Keep Mac Awake is on" and "Lock Mac while Keep Mac Awake is on" (both default off, so existing behavior is unchanged).
- `--lock-mac` engages the real macOS login lock through the existing Sleepy Mode Lock Mac action, so only Touch ID or the account password gets back in; turning caffeine off never unlocks.
- Caffeine dismisses only a lock screen it presented; a user-started Sleepy Mode session stays up when caffeine ends, and a manually dismissed lock screen does not return on redundant enables.
- The Sleepy overlay is now a nonactivating `NSPanel`, which the window server admits onto another app's fullscreen Space, so all displays get covered.
- Adds `sleepy_mode toggle keepawake` and `sleepy_mode toggle lockmac` so the socket can drive both new settings.
- The macOS app target on main is currently red (missing `import CmuxBrowser`); that fix is not included here.

<sup>Written for commit 9317e7589be825d30ec510125ced02d7c651b132. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `caffeinate` CLI support with `status`, `on`, `off`, and `toggle` commands, plus JSON output and a `caffeine` alias.
  * Added optional Sleepy Mode lock-screen and real Mac-lock controls.
  * Added settings to show Sleepy Mode and lock the Mac while Keep Mac Awake is enabled.
  * Improved lock-screen behavior across CLI, menu bar, Settings, and iPhone controls.
  * Added support for fullscreen and multi-display lock-screen overlays.

* **Documentation**
  * Documented the new CLI command, options, aliases, and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

**Update (round 3):** the overlay is now a `.nonactivatingPanel` NSPanel so it covers displays whose active Space is another app's fullscreen window (window-server-verified; a plain NSWindow reports `isVisible` but never composites there). And `caffeinate on --lock-mac` (RPC `lock_mac`, or the "Lock Mac while Keep Mac Awake is on" setting) additionally engages the real macOS login lock via the existing `SleepyPowerControls.lockMacNow()`, so only Touch ID or the account password gets back in; `off` never unlocks. Re-adding an app-level Touch ID gate was deliberately avoided per the rationale in 7e0d922c2d (an app cannot make an unbypassable lock).
