### PR TITLE
Fix cmuxTests compile breaks (actor-isolated controllingTTYName, hasUnreadNotification signature)

### DIFF
--- a/cmuxTests/TerminalControllingTTYWaiter.swift
+++ b/cmuxTests/TerminalControllingTTYWaiter.swift
@@ -26,12 +26,12 @@ struct TerminalControllingTTYWaiter {
     ) async throws -> String {
         let deadline = clock.now + timeout
         while clock.now < deadline {
-            if let ttyName = terminal.surface.controllingTTYName() {
+            if let ttyName = await terminal.surface.controllingTTYName() {
                 return ttyName
             }
             try await clock.sleep(for: pollInterval)
         }
-        if let ttyName = terminal.surface.controllingTTYName() {
+        if let ttyName = await terminal.surface.controllingTTYName() {
             return ttyName
         }
         throw NSError(

--- a/cmuxTests/TerminalNotificationSocketAttributionTests.swift
+++ b/cmuxTests/TerminalNotificationSocketAttributionTests.swift
@@ -33,7 +33,7 @@ extension TerminalNotificationSocketActionTests {
         let result = try XCTUnwrap(response["result"] as? [String: Any])
         XCTAssertEqual(result["workspace_id"] as? String, fixture.workspace.id.uuidString)
         XCTAssertTrue(result["surface_id"] is NSNull)
-        XCTAssertTrue(fixture.store.hasUnreadNotification(forTabId: fixture.workspace.id))
+        XCTAssertTrue(fixture.store.hasUnreadNotification(forTabId: fixture.workspace.id, surfaceId: nil))
         XCTAssertFalse(fixture.store.hasUnreadNotification(forTabId: foreignWorkspace.id, surfaceId: foreignSurfaceId))
     }
 
@@ -198,7 +198,7 @@ extension TerminalNotificationSocketActionTests {
         let result = try XCTUnwrap(response["result"] as? [String: Any])
         XCTAssertEqual(result["workspace_id"] as? String, fixture.workspace.id.uuidString)
         XCTAssertTrue(result["surface_id"] is NSNull)
-        XCTAssertTrue(fixture.store.hasUnreadNotification(forTabId: fixture.workspace.id))
+        XCTAssertTrue(fixture.store.hasUnreadNotification(forTabId: fixture.workspace.id, surfaceId: nil))
         XCTAssertFalse(
             fixture.store.hasUnreadNotification(
                 forTabId: foreignWorkspace.id,


### PR DESCRIPTION
The macOS unit-test target (cmux-unit scheme) does not compile on main, so every fleet xctest run fails before executing a test. Two breaks, both from app changes that did not update the test target (the PR lane runs no macOS unit tests, so they merged silently):

`cmuxTests/TerminalControllingTTYWaiter.swift` calls `controllingTTYName()` on the MainActor-isolated `TerminalSurface` from a nonisolated async poll loop without `await`. Added the two `await`s.

`cmuxTests/TerminalNotificationSocketAttributionTests.swift` has two call sites of `hasUnreadNotification(forTabId:)` that predate the added `surfaceId:` parameter. Passed `surfaceId: nil` to keep them workspace-level assertions, matching sibling sites that check a workspace without naming a surface.

Verified on a fleet slot: with these two files patched, the cmux-unit scheme's test target compiles (the previous run's four compile errors are gone; that run then failed only on the runner's missing GUI session, an infra issue unrelated to compilation).

Related: https://github.com/manaflow-ai/cmux/pull/11316 fixes the app-target compile break from the same merge window.

Dictionary: test target = the cmuxTests bundle that xcodebuild compiles and injects into the app for unit tests; scheme = the Xcode run configuration that selects which targets build and test; PR lane = the checks that run on pull requests, which currently include no macOS compile or unit-test job; fleet xctest = running the unit tests on a leased Mac from the shared builder fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11339"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790832135&installation_model_id=21920&pr_number=11339&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11339&signature=d8b5f7258a1111824c0180717d09ccb15f78f6a3f358bfb8c0195976854e7b60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the macOS unit-test target so fleet xctest runs stop failing before executing any test.

- Adds `await` to the MainActor-isolated `controllingTTYName()` calls in the poll loop.
- Passes `surfaceId: nil` to `hasUnreadNotification(forTabId:)` to keep the workspace-level assertions.

<sup>Written for commit 6077edd86d717ad31109ca2981b1370e01dbfb3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

