### PR TITLE
iOS: ship App Store builds with crash reporting on, default telemetry consent on

### DIFF
--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/UserDefaultsAnalyticsConsentProvider.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/UserDefaultsAnalyticsConsentProvider.swift
@@ -3,8 +3,10 @@ public import Foundation
 /// A consent provider backed by the shared telemetry opt-out in `UserDefaults`.
 ///
 /// This provider reads the same backing key as the app's anonymous-telemetry
-/// setting. A missing value defaults to disabled, and every access reads the
-/// store again so live setting changes apply without rebuilding consumers.
+/// setting. A missing value defaults to enabled (the Settings toggle is the
+/// opt-out; its `@AppStorage` default in `MobileSettingsView` must stay in
+/// sync with the fallback here), and every access reads the store again so
+/// live setting changes apply without rebuilding consumers.
 ///
 /// ```swift
 /// let consent = UserDefaultsAnalyticsConsentProvider(defaults: .standard)
@@ -29,6 +31,6 @@ public struct UserDefaultsAnalyticsConsentProvider: AnalyticsConsentProviding {
 
     /// Whether anonymous product telemetry is enabled in the defaults store.
     public var isTelemetryEnabled: Bool {
-        defaults.object(forKey: Self.telemetryKey) as? Bool ?? false
+        defaults.object(forKey: Self.telemetryKey) as? Bool ?? true
     }
 }

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/UserDefaultsAnalyticsConsentProviderTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/UserDefaultsAnalyticsConsentProviderTests.swift
@@ -4,18 +4,18 @@ import Testing
 @testable import CMUXMobileCore
 
 @Suite struct UserDefaultsAnalyticsConsentProviderTests {
-    @Test func defaultsOffAndTracksLiveChanges() throws {
+    @Test func defaultsOnAndTracksLiveChanges() throws {
         let suiteName = "cmux.analytics-consent.\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
         let consent = UserDefaultsAnalyticsConsentProvider(defaults: defaults)
-        #expect(!consent.isTelemetryEnabled)
-
-        defaults.set(true, forKey: UserDefaultsAnalyticsConsentProvider.telemetryKey)
         #expect(consent.isTelemetryEnabled)
 
         defaults.set(false, forKey: UserDefaultsAnalyticsConsentProvider.telemetryKey)
         #expect(!consent.isTelemetryEnabled)
+
+        defaults.set(true, forKey: UserDefaultsAnalyticsConsentProvider.telemetryKey)
+        #expect(consent.isTelemetryEnabled)
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
@@ -43,7 +43,9 @@ struct MobileSettingsView: View {
     var initialFocus: MobileSettingsFocus? = nil
     /// Lets the root modal coordinator advance directly to queued content.
     var dismissAction: (() -> Void)? = nil
-    @AppStorage(MobileSettingsView.sendAnonymousTelemetryKey) private var sendAnonymousTelemetry = false
+    // Default mirrors UserDefaultsAnalyticsConsentProvider's fallback: telemetry
+    // is on until the user opts out here.
+    @AppStorage(MobileSettingsView.sendAnonymousTelemetryKey) private var sendAnonymousTelemetry = true
 
     @Environment(\.dismiss) private var dismiss
     @State private var showingShortcuts = false

--- a/ios/scripts/cloud-testflight.sh
+++ b/ios/scripts/cloud-testflight.sh
@@ -148,10 +148,12 @@ case "$LANE" in
     BETA_BUNDLE_ID="com.cmux.app"
     LANE_DISPLAY_NAME="cmux"
     [[ "$TAG" == "beta" ]] && TAG="appstore"
-    # The App Store lane ships with crash reporting off. upload-testflight.sh
-    # enforces this at export time, so the fleet archive must bake it in (the
-    # hq cloud script forwards this env into the remote xcodebuild archive).
-    export CMUX_CRASH_REPORTING_ENABLED="NO"
+    # The App Store lane ships with crash reporting on, matching beta.
+    # upload-testflight.sh enforces the lane value at export time, so the
+    # fleet archive must bake it in (the hq cloud script forwards this env
+    # into the remote xcodebuild archive). The in-app telemetry consent
+    # toggle remains the user-facing opt-out for crash reports and analytics.
+    export CMUX_CRASH_REPORTING_ENABLED="YES"
     ;;
   *)
     die "unsupported lane: $LANE (expected beta or appstore)"

--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -581,7 +581,7 @@ case "$LANE" in
     PRODUCT_BUNDLE_IDENTIFIER="${IOS_APPSTORE_BUNDLE_ID:-com.cmux.app}"
     PROVISIONING_PROFILE_NAME="${IOS_APPSTORE_PROVISIONING_PROFILE_NAME:-cmux App Store Distribution}"
     PRODUCT_DISPLAY_NAME="${IOS_APPSTORE_DISPLAY_NAME:-cmux}"
-    CRASH_REPORTING_ENABLED="NO"
+    CRASH_REPORTING_ENABLED="YES"
     ;;
   *)
     echo "error: unsupported lane '$LANE'" >&2
@@ -938,8 +938,8 @@ if [[ -n "$ARCHIVE_APP" && -d "$ARCHIVE_APP" ]]; then
   fi
   if [[ "$LANE" == "appstore" ]]; then
     ARCHIVE_CRASH_REPORTING_ENABLED="$("$PLISTBUDDY" -c 'Print :CMUXCrashReportingEnabled' "$ARCHIVE_APP/Info.plist" 2>/dev/null || true)"
-    if [[ "$ARCHIVE_CRASH_REPORTING_ENABLED" != "NO" ]]; then
-      echo "error: App Store archive CMUXCrashReportingEnabled is '${ARCHIVE_CRASH_REPORTING_ENABLED:-<absent>}', expected 'NO'; refusing to export" >&2
+    if [[ "$ARCHIVE_CRASH_REPORTING_ENABLED" != "$CRASH_REPORTING_ENABLED" ]]; then
+      echo "error: App Store archive CMUXCrashReportingEnabled is '${ARCHIVE_CRASH_REPORTING_ENABLED:-<absent>}', expected '$CRASH_REPORTING_ENABLED'; refusing to export" >&2
       exit 1
     fi
   fi


### PR DESCRIPTION
Owner directive: official App Store builds must ship with crash reporting and analytics enabled.

Before: the appstore lane baked `CMUXCrashReportingEnabled=NO` into the official binary (Sentry never started), and iOS telemetry consent (`sendAnonymousTelemetry`) defaulted to off, so analytics stayed silent until a user found the Settings toggle. Net effect: App Store installs sent no crash reports and no analytics.

Changes:
- `ios/scripts/upload-testflight.sh`: appstore lane sets `CRASH_REPORTING_ENABLED=YES`; the archive export gate now asserts the archive matches the lane value instead of hardcoding NO (the signed-IPA gate already followed the lane variable).
- `ios/scripts/cloud-testflight.sh`: appstore lane exports `CMUX_CRASH_REPORTING_ENABLED=YES` so fleet archives bake it in.
- `CMUXMobileCore/UserDefaultsAnalyticsConsentProvider`: missing consent value now defaults to enabled, matching the macOS settings catalog default (`app.sendAnonymousTelemetry` defaultValue: true) for the same shared key. One consent source gates both Sentry crash reporting and analytics; the Settings toggle remains the opt-out.
- `MobileSettingsView`: the toggle's `@AppStorage` default mirrors the provider fallback so the switch shows the effective state.
- Consent provider test updated for the new default (defaults on, live toggle both directions).

Tests: `UserDefaultsAnalyticsConsentProviderTests` passes. The 15 `DiagnosticEventPresentationTests` failures in `CMUXMobileCore` reproduce byte-identically on pristine `origin/main` (pre-existing, unrelated).

Note for reviewers: App Privacy labels in App Store Connect must declare Diagnostics/Usage Data collection before the next submission ships with this; being handled with the 1.0.0 resubmission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790832328&installation_model_id=21920&pr_number=11340&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11340&signature=158429330c0c04ee7e494a9375fd9c80886d636393c92c1dd31dc225c5af1ba8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
App Store builds now ship with crash reporting and anonymous telemetry enabled by default; previously the appstore lane baked `CMUXCrashReportingEnabled=NO` and consent defaulted to off, so official installs sent no Sentry data. The Settings toggle remains the user-facing opt-out for both.

- The appstore lanes in `upload-testflight.sh` and `cloud-testflight.sh` now set `CRASH_REPORTING_ENABLED=YES`, and the archive export gate checks the archive against the lane value instead of hardcoding `NO`.
- Missing consent in `UserDefaultsAnalyticsConsentProvider` now defaults to on, matching the macOS default for the shared `sendAnonymousTelemetry` key; `MobileSettingsView`'s `@AppStorage` default mirrors it so the switch shows the effective state.
- App Privacy labels in App Store Connect must declare Diagnostics/Usage Data collection before the next submission ships with this.

<sup>Written for commit 3ad477cee9801e9cbfccfd78433f6dd414fa9746. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

