### PR TITLE
billing: report-only team seat drift detection

### DIFF
--- a/web/services/analytics/stripeBilling.ts
+++ b/web/services/analytics/stripeBilling.ts
@@ -83,7 +83,10 @@ export async function captureBillingTeamSeatSync(
 ): Promise<void> {
   await captureBillingPayload({
     name: "cmux_billing_team_seats_synced",
-    insertId: `team-seat-sync:${input.subscriptionId}:${input.oldQuantity}:${input.newQuantity}`,
+    // A repeated legitimate transition (1->2->1->2) must not deduplicate the
+    // later event, so each sync gets a unique id; transport retries inside
+    // this call still share it because the payload is built once.
+    insertId: `team-seat-sync:${input.subscriptionId}:${globalThis.crypto.randomUUID()}`,
     subject: { scope: "team", stackTeamId: input.teamId },
     properties: {
       source: "billing_reconcile",

--- a/web/services/analytics/stripeBilling.ts
+++ b/web/services/analytics/stripeBilling.ts
@@ -22,11 +22,12 @@ export type StripeBillingAnalyticsSubject =
       readonly status?: string;
     };
 
-export type TeamSeatSyncAnalyticsInput = {
+export type TeamSeatDriftAnalyticsInput = {
   readonly subscriptionId: string;
   readonly teamId: string;
-  readonly oldQuantity: number;
-  readonly newQuantity: number;
+  readonly memberCount: number;
+  readonly stripeQuantity: number | null;
+  readonly storedSeats: number | null;
 };
 
 /**
@@ -73,28 +74,28 @@ export async function captureBillingCheckoutStarted(
 }
 
 /**
- * Records a best-effort billing-reconcile team seat change. The event is
- * intentionally separate from Stripe webhook lifecycle events because the
- * membership change is observed by Stack rather than delivered by Stripe.
+ * Records a best-effort billing-reconcile team seat drift observation. The
+ * event is intentionally separate from Stripe webhook lifecycle events because
+ * membership is observed by Stack rather than delivered by Stripe.
  */
-export async function captureBillingTeamSeatSync(
-  input: TeamSeatSyncAnalyticsInput,
+export async function captureBillingTeamSeatDrift(
+  input: TeamSeatDriftAnalyticsInput,
   postHogFetch?: typeof fetch,
 ): Promise<void> {
   await captureBillingPayload({
-    name: "cmux_billing_team_seats_synced",
-    // A repeated legitimate transition (1->2->1->2) must not deduplicate the
-    // later event, so each sync gets a unique id; transport retries inside
-    // this call still share it because the payload is built once.
-    insertId: `team-seat-sync:${input.subscriptionId}:${globalThis.crypto.randomUUID()}`,
+    name: "cmux_billing_team_seat_drift_detected",
+    // Each observation gets a unique id so repeated detections are retained;
+    // transport retries inside this call reuse the payload and insert id.
+    insertId: `team-seat-drift:${input.subscriptionId}:${globalThis.crypto.randomUUID()}`,
     subject: { scope: "team", stackTeamId: input.teamId },
     properties: {
       source: "billing_reconcile",
       billing_scope: "team",
       stack_team_id: input.teamId,
-      old_quantity: input.oldQuantity,
-      new_quantity: input.newQuantity,
       stripe_subscription_id: input.subscriptionId,
+      member_count: input.memberCount,
+      stripe_quantity: input.stripeQuantity,
+      stored_seats: input.storedSeats,
     },
   }, postHogFetch);
 }

--- a/web/services/analytics/stripeBilling.ts
+++ b/web/services/analytics/stripeBilling.ts
@@ -22,6 +22,13 @@ export type StripeBillingAnalyticsSubject =
       readonly status?: string;
     };
 
+export type TeamSeatSyncAnalyticsInput = {
+  readonly subscriptionId: string;
+  readonly teamId: string;
+  readonly oldQuantity: number;
+  readonly newQuantity: number;
+};
+
 /**
  * Best-effort analytics after the billing mutation succeeds. Billing remains
  * authoritative in Stripe, Postgres, and Stack; an analytics outage must never
@@ -61,6 +68,30 @@ export async function captureBillingCheckoutStarted(
       billing_scope: input.subject.scope,
       plan: input.plan,
       billing_interval: input.billingInterval,
+    },
+  }, postHogFetch);
+}
+
+/**
+ * Records a best-effort billing-reconcile team seat change. The event is
+ * intentionally separate from Stripe webhook lifecycle events because the
+ * membership change is observed by Stack rather than delivered by Stripe.
+ */
+export async function captureBillingTeamSeatSync(
+  input: TeamSeatSyncAnalyticsInput,
+  postHogFetch?: typeof fetch,
+): Promise<void> {
+  await captureBillingPayload({
+    name: "cmux_billing_team_seats_synced",
+    insertId: `team-seat-sync:${input.subscriptionId}:${input.oldQuantity}:${input.newQuantity}`,
+    subject: { scope: "team", stackTeamId: input.teamId },
+    properties: {
+      source: "billing_reconcile",
+      billing_scope: "team",
+      stack_team_id: input.teamId,
+      old_quantity: input.oldQuantity,
+      new_quantity: input.newQuantity,
+      stripe_subscription_id: input.subscriptionId,
     },
   }, postHogFetch);
 }

--- a/web/services/billing/reconcile.ts
+++ b/web/services/billing/reconcile.ts
@@ -261,6 +261,22 @@ async function reconcileTeamSeatQuantity(
   const teamId = snapshot.stackTeamId;
   if (!teamId) return { drifted: false, repaired: false };
 
+  // The database snapshot can be stale. When the remote subscription carries
+  // its own identity metadata, it must agree with the snapshot; otherwise we
+  // could bill one team for another team's membership. Fail closed.
+  const remoteTeamId = typeof remote.metadata?.stackTeamId === "string"
+    ? remote.metadata.stackTeamId
+    : null;
+  if (remoteTeamId && remoteTeamId !== teamId) {
+    throw new Error(
+      `Stripe subscription team metadata disagrees with the local row: remote=${remoteTeamId} local=${teamId}`,
+    );
+  }
+  const remotePlan = typeof remote.metadata?.plan === "string" ? remote.metadata.plan : null;
+  if (remotePlan && remotePlan !== "team") {
+    throw new Error(`Stripe subscription plan metadata is not a team plan: ${remotePlan}`);
+  }
+
   const team = await getTeam(teamId);
   if (!team) throw new Error(`Stack team not found for seat reconciliation: ${teamId}`);
   if (typeof team.listUsers !== "function") {
@@ -281,7 +297,6 @@ async function reconcileTeamSeatQuantity(
   }
   if (dryRun) return { drifted: true, repaired: false };
 
-  const oldQuantity = stripeQuantity ?? storedQuantity ?? 1;
   if (stripeNeedsUpdate) {
     const item = remote.items?.data?.[0];
     if (!item?.id) {
@@ -295,12 +310,17 @@ async function reconcileTeamSeatQuantity(
   if (localNeedsUpdate) {
     await updateSeats(snapshot.id, desiredQuantity);
   }
-  await captureTeamSeatSync({
-    subscriptionId: snapshot.id,
-    teamId,
-    oldQuantity,
-    newQuantity: desiredQuantity,
-  });
+  // Only a real Stripe quantity change is a seat change. A local-only repair
+  // (Stripe already at the desired count) is bookkeeping and emits nothing,
+  // so a partially-failed earlier run cannot report desired-to-desired.
+  if (stripeNeedsUpdate) {
+    await captureTeamSeatSync({
+      subscriptionId: snapshot.id,
+      teamId,
+      oldQuantity: stripeQuantity ?? storedQuantity ?? 1,
+      newQuantity: desiredQuantity,
+    });
+  }
   return { drifted: true, repaired: true };
 }
 

--- a/web/services/billing/reconcile.ts
+++ b/web/services/billing/reconcile.ts
@@ -108,6 +108,7 @@ async function reconcileStripeSubscriptionsLocked(
   let drifted = 0;
   let repaired = 0;
   let failed = 0;
+  let stackDeadlineTrips = 0;
   await mapConcurrent(
     snapshots,
     dependencies.concurrency ?? DEFAULT_CONCURRENCY,
@@ -127,7 +128,14 @@ async function reconcileStripeSubscriptionsLocked(
           }
         }
 
-        if (isTeamSnapshot(snapshot) && isActiveStripeSubscriptionStatus(remote.status)) {
+        // After repeated Stack deadline trips, stop starting new drift checks
+        // for this run: an outage must not strand one un-cancellable request
+        // per remaining team row.
+        if (
+          isTeamSnapshot(snapshot) &&
+          isActiveStripeSubscriptionStatus(remote.status) &&
+          stackDeadlineTrips < STACK_DEADLINE_TRIP_LIMIT
+        ) {
           const seatDrift = await detectTeamSeatDrift(
             snapshot,
             remote,
@@ -137,6 +145,7 @@ async function reconcileStripeSubscriptionsLocked(
           rowDrifted ||= seatDrift.drifted;
         }
       } catch (error) {
+        if (error instanceof StackDeadlineError) stackDeadlineTrips += 1;
         failed += 1;
         captureError(error, {
           operation: "stripe_subscription_reconcile",
@@ -230,6 +239,17 @@ function isTeamSnapshot(snapshot: SubscriptionSnapshot): boolean {
  * Reads the current Stack roster and reports disagreement with both remote
  * Stripe quantity and stored seats. This path is intentionally report-only.
  */
+/** The Stack interaction (team lookup + roster read) exceeded its budget. */
+class StackDeadlineError extends Error {
+  constructor(teamId: string) {
+    super(`Stack team interaction exceeded the per-team deadline: ${teamId}`);
+    this.name = "StackDeadlineError";
+  }
+}
+
+const STACK_TEAM_DEADLINE_MS = 15_000;
+const STACK_DEADLINE_TRIP_LIMIT = 3;
+
 async function detectTeamSeatDrift(
   snapshot: SubscriptionSnapshot,
   remote: Stripe.Subscription,
@@ -255,27 +275,33 @@ async function detectTeamSeatDrift(
     throw new Error(`Stripe subscription plan metadata is not a team plan: ${remotePlan}`);
   }
 
-  const team = await getTeam(teamId);
-  if (!team) throw new Error(`Stack team not found for seat drift detection: ${teamId}`);
-  if (typeof team.listUsers !== "function") {
-    throw new Error("Stack Auth server SDK cannot list team members");
-  }
-  // Stack's listUsers() takes no AbortSignal, so the request cannot be
-  // cancelled. On Vercel, the resulting leak is bounded by the invocation
-  // lifetime because the instance freezes when the cron returns.
-  const ROSTER_DEADLINE_MS = 15_000;
-  let rosterTimer: ReturnType<typeof setTimeout> | undefined;
-  const rosterDeadline = new Promise<never>((_, reject) => {
-    rosterTimer = setTimeout(
-      () => reject(new Error("Stack roster listing exceeded the per-team deadline")),
-      ROSTER_DEADLINE_MS,
+  // One deadline covers the ENTIRE Stack interaction: the team lookup can
+  // hang exactly like the roster read. Stack's SDK takes no AbortSignal, so
+  // a timed-out request cannot be cancelled; the run-level breaker in the
+  // caller caps how many such requests one invocation can strand, and the
+  // frozen Vercel instance discards them when the cron returns.
+  let stackTimer: ReturnType<typeof setTimeout> | undefined;
+  const stackDeadline = new Promise<never>((_, reject) => {
+    stackTimer = setTimeout(
+      () => reject(new StackDeadlineError(teamId)),
+      STACK_TEAM_DEADLINE_MS,
     );
   });
   let members: readonly unknown[];
   try {
-    members = await Promise.race([team.listUsers(), rosterDeadline]);
+    members = await Promise.race([
+      (async () => {
+        const team = await getTeam(teamId);
+        if (!team) throw new Error(`Stack team not found for seat drift detection: ${teamId}`);
+        if (typeof team.listUsers !== "function") {
+          throw new Error("Stack Auth server SDK cannot list team members");
+        }
+        return await team.listUsers();
+      })(),
+      stackDeadline,
+    ]);
   } finally {
-    clearTimeout(rosterTimer);
+    clearTimeout(stackTimer);
   }
   if (!Array.isArray(members)) {
     throw new Error("Stack team member listing returned an invalid result");

--- a/web/services/billing/reconcile.ts
+++ b/web/services/billing/reconcile.ts
@@ -1,25 +1,45 @@
 import * as Sentry from "@sentry/nextjs";
-import { asc, inArray, sql } from "drizzle-orm";
+import { asc, eq, inArray, sql } from "drizzle-orm";
 import type Stripe from "stripe";
 
+import { getStackServerApp } from "../../app/lib/stack";
 import { cloudDb } from "../../db/client";
 import { stripeSubscriptions } from "../../db/schema";
+import { captureBillingTeamSeatSync } from "../analytics/stripeBilling";
 import { captureCoderouterError } from "../errors";
 import {
   revokeRouteTokensForTeam,
   revokeRouteTokensForUser,
 } from "../coderouter/repository";
-import { applySubscriptionUpdate } from "./purchase";
+import {
+  applySubscriptionUpdate,
+  isActiveStripeSubscriptionStatus,
+} from "./purchase";
 import { stripe } from "./stripe";
 
 const DEFAULT_LIMIT = 1_000;
 const DEFAULT_CONCURRENCY = 8;
+const TEAM_SEAT_SYNC_LIMIT = 50;
 
 type SubscriptionSnapshot = {
   readonly id: string;
   readonly status: string;
   readonly cancelAtPeriodEnd: boolean;
   readonly currentPeriodEnd: Date | null;
+  readonly scope?: string;
+  readonly stackTeamId?: string | null;
+  readonly seats?: number | null;
+};
+
+type ReconcileStackTeam = {
+  readonly listUsers?: () => Promise<readonly unknown[]>;
+};
+
+type TeamSeatSyncInput = {
+  readonly subscriptionId: string;
+  readonly teamId: string;
+  readonly oldQuantity: number;
+  readonly newQuantity: number;
 };
 
 export type BillingReconcileResult = {
@@ -35,6 +55,13 @@ type BillingReconcileDependencies = {
   readonly retrieve?: (id: string) => Promise<Stripe.Subscription>;
   readonly apply?: (subscription: Stripe.Subscription) => Promise<unknown>;
   readonly markChecked?: (ids: readonly string[]) => Promise<void>;
+  readonly getTeam?: (teamId: string) => Promise<ReconcileStackTeam | null>;
+  readonly updateSubscriptionQuantity?: (
+    id: string,
+    params: Stripe.SubscriptionUpdateParams,
+  ) => Promise<unknown>;
+  readonly updateSeats?: (subscriptionId: string, seats: number) => Promise<void>;
+  readonly captureTeamSeatSync?: (input: TeamSeatSyncInput) => Promise<void>;
   readonly captureError?: (
     error: unknown,
     context: Record<string, string | number | boolean>,
@@ -44,12 +71,15 @@ type BillingReconcileDependencies = {
 };
 
 /**
- * Repairs Stripe/RDS entitlement drift outside request traffic.
+ * Repairs Stripe/RDS entitlement drift outside request traffic and keeps
+ * active Team quantities aligned with Stack membership.
  *
  * Stripe remains authoritative. Re-applying a subscription is idempotent and
  * goes through the same per-principal advisory lock, Stack metadata update,
  * and route-token revocation path as a signed webhook. Retrievals fan out with
- * bounded concurrency; mutations retain their existing principal locks.
+ * bounded concurrency; mutations retain their existing principal locks. Team
+ * membership reads are capped per run so a large roster cannot exhaust the
+ * cron duration budget.
  */
 export async function reconcileStripeSubscriptions(
   options: {
@@ -76,26 +106,61 @@ async function reconcileStripeSubscriptionsLocked(
   const apply = dependencies.apply ?? applySubscriptionUpdateAndRevokeRoutes;
   const markChecked = dependencies.markChecked ?? markSubscriptionsChecked;
   const captureError = dependencies.captureError ?? captureCoderouterError;
+  const getTeam = dependencies.getTeam ?? getStackTeamForReconcile;
+  const updateSubscriptionQuantity = dependencies.updateSubscriptionQuantity ??
+    updateStripeSubscriptionQuantity;
+  const updateSeats = dependencies.updateSeats ?? updateLocalSubscriptionSeats;
+  const captureTeamSeatSync = dependencies.captureTeamSeatSync ?? captureBillingTeamSeatSync;
   const rows = await list(limit + 1);
   const snapshots = rows.slice(0, limit);
 
   let drifted = 0;
   let repaired = 0;
   let failed = 0;
+  let reservedTeamSeatSyncs = 0;
   await mapConcurrent(
     snapshots,
     dependencies.concurrency ?? DEFAULT_CONCURRENCY,
     async (snapshot) => {
+      // Reserve team slots before the first await. The list is ordered by the
+      // shared reconciliation cursor, so this keeps the bounded Stack work
+      // focused on the oldest eligible team rows even when retrievals finish
+      // out of order.
+      const teamSeatSyncReserved = isActiveTeamSnapshot(snapshot) &&
+        reservedTeamSeatSyncs < TEAM_SEAT_SYNC_LIMIT;
+      if (teamSeatSyncReserved) reservedTeamSeatSyncs += 1;
+
+      let rowDrifted = false;
+      let rowRepaired = false;
       try {
         const remote = await retrieve(snapshot.id);
-        if (!hasDrift(snapshot, remote)) return;
-        drifted += 1;
-        if (options.dryRun) return;
-        const result = await apply(remote);
-        if (isSkipped(result)) {
-          throw new Error("Stripe subscription could not be mapped to a billing principal");
+        if (hasDrift(snapshot, remote)) {
+          rowDrifted = true;
+          if (!options.dryRun) {
+            const result = await apply(remote);
+            if (isSkipped(result)) {
+              throw new Error("Stripe subscription could not be mapped to a billing principal");
+            }
+            rowRepaired = true;
+          }
         }
-        repaired += 1;
+
+        if (
+          teamSeatSyncReserved &&
+          isActiveStripeSubscriptionStatus(remote.status)
+        ) {
+          const seatSync = await reconcileTeamSeatQuantity(
+            snapshot,
+            remote,
+            options.dryRun ?? false,
+            getTeam,
+            updateSubscriptionQuantity,
+            updateSeats,
+            captureTeamSeatSync,
+          );
+          rowDrifted ||= seatSync.drifted;
+          rowRepaired ||= seatSync.repaired;
+        }
       } catch (error) {
         failed += 1;
         captureError(error, {
@@ -104,6 +169,8 @@ async function reconcileStripeSubscriptionsLocked(
           recoverable: true,
         });
       }
+      if (rowDrifted) drifted += 1;
+      if (rowRepaired) repaired += 1;
     },
   );
   if (!options.dryRun && snapshots.length > 0) {
@@ -160,6 +227,9 @@ async function listSubscriptionSnapshots(
       status: stripeSubscriptions.status,
       cancelAtPeriodEnd: stripeSubscriptions.cancelAtPeriodEnd,
       currentPeriodEnd: stripeSubscriptions.currentPeriodEnd,
+      scope: stripeSubscriptions.scope,
+      stackTeamId: stripeSubscriptions.stackTeamId,
+      seats: stripeSubscriptions.seats,
     })
     .from(stripeSubscriptions)
     .orderBy(
@@ -167,6 +237,98 @@ async function listSubscriptionSnapshots(
       asc(stripeSubscriptions.id),
     )
     .limit(limit);
+}
+
+function isActiveTeamSnapshot(snapshot: SubscriptionSnapshot): boolean {
+  return snapshot.scope === "team" &&
+    typeof snapshot.stackTeamId === "string" &&
+    snapshot.stackTeamId.length > 0 &&
+    isActiveStripeSubscriptionStatus(snapshot.status);
+}
+
+async function reconcileTeamSeatQuantity(
+  snapshot: SubscriptionSnapshot,
+  remote: Stripe.Subscription,
+  dryRun: boolean,
+  getTeam: (teamId: string) => Promise<ReconcileStackTeam | null>,
+  updateSubscriptionQuantity: (
+    id: string,
+    params: Stripe.SubscriptionUpdateParams,
+  ) => Promise<unknown>,
+  updateSeats: (subscriptionId: string, seats: number) => Promise<void>,
+  captureTeamSeatSync: (input: TeamSeatSyncInput) => Promise<void>,
+): Promise<{ readonly drifted: boolean; readonly repaired: boolean }> {
+  const teamId = snapshot.stackTeamId;
+  if (!teamId) return { drifted: false, repaired: false };
+
+  const team = await getTeam(teamId);
+  if (!team) throw new Error(`Stack team not found for seat reconciliation: ${teamId}`);
+  if (typeof team.listUsers !== "function") {
+    throw new Error("Stack Auth server SDK cannot list team members");
+  }
+  const members = await team.listUsers();
+  if (!Array.isArray(members)) {
+    throw new Error("Stack team member listing returned an invalid result");
+  }
+
+  const desiredQuantity = Math.max(1, members.length);
+  const stripeQuantity = finiteQuantity(remote.items?.data?.[0]?.quantity);
+  const storedQuantity = finiteQuantity(snapshot.seats);
+  const stripeNeedsUpdate = stripeQuantity !== desiredQuantity;
+  const localNeedsUpdate = storedQuantity !== desiredQuantity;
+  if (!stripeNeedsUpdate && !localNeedsUpdate) {
+    return { drifted: false, repaired: false };
+  }
+  if (dryRun) return { drifted: true, repaired: false };
+
+  const oldQuantity = stripeQuantity ?? storedQuantity ?? 1;
+  if (stripeNeedsUpdate) {
+    const item = remote.items?.data?.[0];
+    if (!item?.id) {
+      throw new Error("Stripe team subscription is missing a subscription item");
+    }
+    await updateSubscriptionQuantity(remote.id, {
+      items: [{ id: item.id, quantity: desiredQuantity }],
+      proration_behavior: "create_prorations",
+    });
+  }
+  if (localNeedsUpdate) {
+    await updateSeats(snapshot.id, desiredQuantity);
+  }
+  await captureTeamSeatSync({
+    subscriptionId: snapshot.id,
+    teamId,
+    oldQuantity,
+    newQuantity: desiredQuantity,
+  });
+  return { drifted: true, repaired: true };
+}
+
+async function getStackTeamForReconcile(
+  teamId: string,
+): Promise<ReconcileStackTeam | null> {
+  return getStackServerApp().getTeam(teamId);
+}
+
+async function updateStripeSubscriptionQuantity(
+  id: string,
+  params: Stripe.SubscriptionUpdateParams,
+): Promise<unknown> {
+  return stripe().subscriptions.update(id, params);
+}
+
+async function updateLocalSubscriptionSeats(
+  subscriptionId: string,
+  seats: number,
+): Promise<void> {
+  await cloudDb()
+    .update(stripeSubscriptions)
+    .set({ seats, updatedAt: sql`now()` })
+    .where(eq(stripeSubscriptions.id, subscriptionId));
+}
+
+function finiteQuantity(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
 async function markSubscriptionsChecked(ids: readonly string[]): Promise<void> {

--- a/web/services/billing/reconcile.ts
+++ b/web/services/billing/reconcile.ts
@@ -126,7 +126,7 @@ async function reconcileStripeSubscriptionsLocked(
       // shared reconciliation cursor, so this keeps the bounded Stack work
       // focused on the oldest eligible team rows even when retrievals finish
       // out of order.
-      const teamSeatSyncReserved = isActiveTeamSnapshot(snapshot) &&
+      const teamSeatSyncReserved = isTeamSnapshot(snapshot) &&
         reservedTeamSeatSyncs < TEAM_SEAT_SYNC_LIMIT;
       if (teamSeatSyncReserved) reservedTeamSeatSyncs += 1;
 
@@ -239,11 +239,17 @@ async function listSubscriptionSnapshots(
     .limit(limit);
 }
 
-function isActiveTeamSnapshot(snapshot: SubscriptionSnapshot): boolean {
+/**
+ * Team identity alone reserves a seat-sync slot. The LOCAL status is not
+ * consulted: a drifted row (local canceled, Stripe active) must still true
+ * its seats in the same cycle that repairs the status. The remote status
+ * check at the call site decides whether the sync actually runs; a slot
+ * spent on a remotely-inactive team is a bounded, acceptable waste.
+ */
+function isTeamSnapshot(snapshot: SubscriptionSnapshot): boolean {
   return snapshot.scope === "team" &&
     typeof snapshot.stackTeamId === "string" &&
-    snapshot.stackTeamId.length > 0 &&
-    isActiveStripeSubscriptionStatus(snapshot.status);
+    snapshot.stackTeamId.length > 0;
 }
 
 async function reconcileTeamSeatQuantity(
@@ -282,7 +288,24 @@ async function reconcileTeamSeatQuantity(
   if (typeof team.listUsers !== "function") {
     throw new Error("Stack Auth server SDK cannot list team members");
   }
-  const members = await team.listUsers();
+  // Stack's SDK exposes neither a member count nor pagination, so the
+  // roster read cannot be memory-bounded here; it is time-bounded instead. A
+  // team whose roster cannot load inside the deadline fails fast and is
+  // skipped this run rather than stalling the whole cron.
+  const ROSTER_DEADLINE_MS = 15_000;
+  let rosterTimer: ReturnType<typeof setTimeout> | undefined;
+  const rosterDeadline = new Promise<never>((_, reject) => {
+    rosterTimer = setTimeout(
+      () => reject(new Error("Stack roster listing exceeded the per-team deadline")),
+      ROSTER_DEADLINE_MS,
+    );
+  });
+  let members: readonly unknown[];
+  try {
+    members = await Promise.race([team.listUsers(), rosterDeadline]);
+  } finally {
+    clearTimeout(rosterTimer);
+  }
   if (!Array.isArray(members)) {
     throw new Error("Stack team member listing returned an invalid result");
   }

--- a/web/services/billing/reconcile.ts
+++ b/web/services/billing/reconcile.ts
@@ -117,20 +117,16 @@ async function reconcileStripeSubscriptionsLocked(
       let rowRepaired = false;
       try {
         const remote = await retrieve(snapshot.id);
-        if (hasDrift(snapshot, remote)) {
-          rowDrifted = true;
-          if (!options.dryRun) {
-            const result = await apply(remote);
-            if (isSkipped(result)) {
-              throw new Error("Stripe subscription could not be mapped to a billing principal");
-            }
-            rowRepaired = true;
-          }
-        }
 
-        // After repeated Stack deadline trips, stop starting new drift checks
-        // for this run: an outage must not strand one un-cancellable request
-        // per remaining team row.
+        // Observe team seat drift BEFORE any mutation. This orders the
+        // fail-closed identity checks inside detectTeamSeatDrift ahead of
+        // apply(remote), so a subscription whose Stripe metadata points at a
+        // different team (or a non-team plan) never mutates entitlements; and
+        // the observation compares the roster against a snapshot that apply
+        // has not yet rewritten. Trade-off: a Stack deadline trip also defers
+        // that row's status repair to the next cycle, which is the safe side.
+        // The trip breaker keeps a Stack outage from stranding more than a
+        // few un-cancellable requests per run.
         if (
           isTeamSnapshot(snapshot) &&
           isActiveStripeSubscriptionStatus(remote.status) &&
@@ -143,6 +139,17 @@ async function reconcileStripeSubscriptionsLocked(
             captureTeamSeatDrift,
           );
           rowDrifted ||= seatDrift.drifted;
+        }
+
+        if (hasDrift(snapshot, remote)) {
+          rowDrifted = true;
+          if (!options.dryRun) {
+            const result = await apply(remote);
+            if (isSkipped(result)) {
+              throw new Error("Stripe subscription could not be mapped to a billing principal");
+            }
+            rowRepaired = true;
+          }
         }
       } catch (error) {
         if (error instanceof StackDeadlineError) stackDeadlineTrips += 1;

--- a/web/services/billing/reconcile.ts
+++ b/web/services/billing/reconcile.ts
@@ -1,11 +1,11 @@
 import * as Sentry from "@sentry/nextjs";
-import { asc, eq, inArray, sql } from "drizzle-orm";
+import { asc, inArray, sql } from "drizzle-orm";
 import type Stripe from "stripe";
 
 import { getStackServerApp } from "../../app/lib/stack";
 import { cloudDb } from "../../db/client";
 import { stripeSubscriptions } from "../../db/schema";
-import { captureBillingTeamSeatSync } from "../analytics/stripeBilling";
+import { captureBillingTeamSeatDrift } from "../analytics/stripeBilling";
 import { captureCoderouterError } from "../errors";
 import {
   revokeRouteTokensForTeam,
@@ -19,7 +19,6 @@ import { stripe } from "./stripe";
 
 const DEFAULT_LIMIT = 1_000;
 const DEFAULT_CONCURRENCY = 8;
-const TEAM_SEAT_SYNC_LIMIT = 50;
 
 type SubscriptionSnapshot = {
   readonly id: string;
@@ -35,11 +34,12 @@ type ReconcileStackTeam = {
   readonly listUsers?: () => Promise<readonly unknown[]>;
 };
 
-type TeamSeatSyncInput = {
+type TeamSeatDriftInput = {
   readonly subscriptionId: string;
   readonly teamId: string;
-  readonly oldQuantity: number;
-  readonly newQuantity: number;
+  readonly memberCount: number;
+  readonly stripeQuantity: number | null;
+  readonly storedSeats: number | null;
 };
 
 export type BillingReconcileResult = {
@@ -56,12 +56,7 @@ type BillingReconcileDependencies = {
   readonly apply?: (subscription: Stripe.Subscription) => Promise<unknown>;
   readonly markChecked?: (ids: readonly string[]) => Promise<void>;
   readonly getTeam?: (teamId: string) => Promise<ReconcileStackTeam | null>;
-  readonly updateSubscriptionQuantity?: (
-    id: string,
-    params: Stripe.SubscriptionUpdateParams,
-  ) => Promise<unknown>;
-  readonly updateSeats?: (subscriptionId: string, seats: number) => Promise<void>;
-  readonly captureTeamSeatSync?: (input: TeamSeatSyncInput) => Promise<void>;
+  readonly captureTeamSeatDrift?: (input: TeamSeatDriftInput) => Promise<void>;
   readonly captureError?: (
     error: unknown,
     context: Record<string, string | number | boolean>,
@@ -71,15 +66,14 @@ type BillingReconcileDependencies = {
 };
 
 /**
- * Repairs Stripe/RDS entitlement drift outside request traffic and keeps
- * active Team quantities aligned with Stack membership.
+ * Reconciles Stripe/RDS entitlement drift outside request traffic and reports
+ * active Team seat drift without changing Stripe or stored seat quantities.
  *
  * Stripe remains authoritative. Re-applying a subscription is idempotent and
  * goes through the same per-principal advisory lock, Stack metadata update,
  * and route-token revocation path as a signed webhook. Retrievals fan out with
- * bounded concurrency; mutations retain their existing principal locks. Team
- * membership reads are capped per run so a large roster cannot exhaust the
- * cron duration budget.
+ * bounded concurrency. Team membership reads are bounded by the reconciliation
+ * batch and a per-team deadline; seat drift itself is report-only.
  */
 export async function reconcileStripeSubscriptions(
   options: {
@@ -107,29 +101,17 @@ async function reconcileStripeSubscriptionsLocked(
   const markChecked = dependencies.markChecked ?? markSubscriptionsChecked;
   const captureError = dependencies.captureError ?? captureCoderouterError;
   const getTeam = dependencies.getTeam ?? getStackTeamForReconcile;
-  const updateSubscriptionQuantity = dependencies.updateSubscriptionQuantity ??
-    updateStripeSubscriptionQuantity;
-  const updateSeats = dependencies.updateSeats ?? updateLocalSubscriptionSeats;
-  const captureTeamSeatSync = dependencies.captureTeamSeatSync ?? captureBillingTeamSeatSync;
+  const captureTeamSeatDrift = dependencies.captureTeamSeatDrift ?? captureBillingTeamSeatDrift;
   const rows = await list(limit + 1);
   const snapshots = rows.slice(0, limit);
 
   let drifted = 0;
   let repaired = 0;
   let failed = 0;
-  let reservedTeamSeatSyncs = 0;
   await mapConcurrent(
     snapshots,
     dependencies.concurrency ?? DEFAULT_CONCURRENCY,
     async (snapshot) => {
-      // Reserve team slots before the first await. The list is ordered by the
-      // shared reconciliation cursor, so this keeps the bounded Stack work
-      // focused on the oldest eligible team rows even when retrievals finish
-      // out of order.
-      const teamSeatSyncReserved = isTeamSnapshot(snapshot) &&
-        reservedTeamSeatSyncs < TEAM_SEAT_SYNC_LIMIT;
-      if (teamSeatSyncReserved) reservedTeamSeatSyncs += 1;
-
       let rowDrifted = false;
       let rowRepaired = false;
       try {
@@ -145,21 +127,14 @@ async function reconcileStripeSubscriptionsLocked(
           }
         }
 
-        if (
-          teamSeatSyncReserved &&
-          isActiveStripeSubscriptionStatus(remote.status)
-        ) {
-          const seatSync = await reconcileTeamSeatQuantity(
+        if (isTeamSnapshot(snapshot) && isActiveStripeSubscriptionStatus(remote.status)) {
+          const seatDrift = await detectTeamSeatDrift(
             snapshot,
             remote,
-            options.dryRun ?? false,
             getTeam,
-            updateSubscriptionQuantity,
-            updateSeats,
-            captureTeamSeatSync,
+            captureTeamSeatDrift,
           );
-          rowDrifted ||= seatSync.drifted;
-          rowRepaired ||= seatSync.repaired;
+          rowDrifted ||= seatDrift.drifted;
         }
       } catch (error) {
         failed += 1;
@@ -240,11 +215,10 @@ async function listSubscriptionSnapshots(
 }
 
 /**
- * Team identity alone reserves a seat-sync slot. The LOCAL status is not
- * consulted: a drifted row (local canceled, Stripe active) must still true
- * its seats in the same cycle that repairs the status. The remote status
- * check at the call site decides whether the sync actually runs; a slot
- * spent on a remotely-inactive team is a bounded, acceptable waste.
+ * A team snapshot is eligible for seat-drift detection when it carries a
+ * usable Stack team identity. The remote status check at the call site gates
+ * the roster read, so local status drift does not suppress an active remote
+ * team's report.
  */
 function isTeamSnapshot(snapshot: SubscriptionSnapshot): boolean {
   return snapshot.scope === "team" &&
@@ -252,20 +226,18 @@ function isTeamSnapshot(snapshot: SubscriptionSnapshot): boolean {
     snapshot.stackTeamId.length > 0;
 }
 
-async function reconcileTeamSeatQuantity(
+/**
+ * Reads the current Stack roster and reports disagreement with both remote
+ * Stripe quantity and stored seats. This path is intentionally report-only.
+ */
+async function detectTeamSeatDrift(
   snapshot: SubscriptionSnapshot,
   remote: Stripe.Subscription,
-  dryRun: boolean,
   getTeam: (teamId: string) => Promise<ReconcileStackTeam | null>,
-  updateSubscriptionQuantity: (
-    id: string,
-    params: Stripe.SubscriptionUpdateParams,
-  ) => Promise<unknown>,
-  updateSeats: (subscriptionId: string, seats: number) => Promise<void>,
-  captureTeamSeatSync: (input: TeamSeatSyncInput) => Promise<void>,
-): Promise<{ readonly drifted: boolean; readonly repaired: boolean }> {
+  captureTeamSeatDrift: (input: TeamSeatDriftInput) => Promise<void>,
+): Promise<{ readonly drifted: boolean }> {
   const teamId = snapshot.stackTeamId;
-  if (!teamId) return { drifted: false, repaired: false };
+  if (!teamId) return { drifted: false };
 
   // The database snapshot can be stale. When the remote subscription carries
   // its own identity metadata, it must agree with the snapshot; otherwise we
@@ -284,14 +256,13 @@ async function reconcileTeamSeatQuantity(
   }
 
   const team = await getTeam(teamId);
-  if (!team) throw new Error(`Stack team not found for seat reconciliation: ${teamId}`);
+  if (!team) throw new Error(`Stack team not found for seat drift detection: ${teamId}`);
   if (typeof team.listUsers !== "function") {
     throw new Error("Stack Auth server SDK cannot list team members");
   }
-  // Stack's SDK exposes neither a member count nor pagination, so the
-  // roster read cannot be memory-bounded here; it is time-bounded instead. A
-  // team whose roster cannot load inside the deadline fails fast and is
-  // skipped this run rather than stalling the whole cron.
+  // Stack's listUsers() takes no AbortSignal, so the request cannot be
+  // cancelled. On Vercel, the resulting leak is bounded by the invocation
+  // lifetime because the instance freezes when the cron returns.
   const ROSTER_DEADLINE_MS = 15_000;
   let rosterTimer: ReturnType<typeof setTimeout> | undefined;
   const rosterDeadline = new Promise<never>((_, reject) => {
@@ -312,62 +283,25 @@ async function reconcileTeamSeatQuantity(
 
   const desiredQuantity = Math.max(1, members.length);
   const stripeQuantity = finiteQuantity(remote.items?.data?.[0]?.quantity);
-  const storedQuantity = finiteQuantity(snapshot.seats);
-  const stripeNeedsUpdate = stripeQuantity !== desiredQuantity;
-  const localNeedsUpdate = storedQuantity !== desiredQuantity;
-  if (!stripeNeedsUpdate && !localNeedsUpdate) {
-    return { drifted: false, repaired: false };
+  const storedSeats = finiteQuantity(snapshot.seats);
+  if (stripeQuantity === desiredQuantity && storedSeats === desiredQuantity) {
+    return { drifted: false };
   }
-  if (dryRun) return { drifted: true, repaired: false };
 
-  if (stripeNeedsUpdate) {
-    const item = remote.items?.data?.[0];
-    if (!item?.id) {
-      throw new Error("Stripe team subscription is missing a subscription item");
-    }
-    await updateSubscriptionQuantity(remote.id, {
-      items: [{ id: item.id, quantity: desiredQuantity }],
-      proration_behavior: "create_prorations",
-    });
-  }
-  if (localNeedsUpdate) {
-    await updateSeats(snapshot.id, desiredQuantity);
-  }
-  // Only a real Stripe quantity change is a seat change. A local-only repair
-  // (Stripe already at the desired count) is bookkeeping and emits nothing,
-  // so a partially-failed earlier run cannot report desired-to-desired.
-  if (stripeNeedsUpdate) {
-    await captureTeamSeatSync({
-      subscriptionId: snapshot.id,
-      teamId,
-      oldQuantity: stripeQuantity ?? storedQuantity ?? 1,
-      newQuantity: desiredQuantity,
-    });
-  }
-  return { drifted: true, repaired: true };
+  await captureTeamSeatDrift({
+    subscriptionId: snapshot.id,
+    teamId,
+    memberCount: members.length,
+    stripeQuantity,
+    storedSeats,
+  });
+  return { drifted: true };
 }
 
 async function getStackTeamForReconcile(
   teamId: string,
 ): Promise<ReconcileStackTeam | null> {
   return getStackServerApp().getTeam(teamId);
-}
-
-async function updateStripeSubscriptionQuantity(
-  id: string,
-  params: Stripe.SubscriptionUpdateParams,
-): Promise<unknown> {
-  return stripe().subscriptions.update(id, params);
-}
-
-async function updateLocalSubscriptionSeats(
-  subscriptionId: string,
-  seats: number,
-): Promise<void> {
-  await cloudDb()
-    .update(stripeSubscriptions)
-    .set({ seats, updatedAt: sql`now()` })
-    .where(eq(stripeSubscriptions.id, subscriptionId));
 }
 
 function finiteQuantity(value: unknown): number | null {

--- a/web/tests/billing-reconcile.test.ts
+++ b/web/tests/billing-reconcile.test.ts
@@ -32,6 +32,227 @@ function subscription(
 }
 
 describe("Stripe subscription reconciliation", () => {
+  test("syncs a team seat quantity when membership grows", async () => {
+    const stripeUpdates: Array<{ id: string; params: Record<string, unknown> }> = [];
+    const seatWrites: Array<{ id: string; seats: number }> = [];
+    const analytics: Array<Record<string, unknown>> = [];
+    const result = await reconcileStripeSubscriptions({}, {
+      withLease: withoutLease,
+      list: async () => [{
+        id: "sub_team_growth",
+        status: "active",
+        cancelAtPeriodEnd: false,
+        currentPeriodEnd: new Date(1_800_000_000_000),
+        scope: "team",
+        stackTeamId: "team_growth",
+        seats: 1,
+      }],
+      retrieve: async () => subscription("sub_team_growth", "active", {
+        metadata: { app: "cmux", plan: "team", stackTeamId: "team_growth" },
+        items: {
+          object: "list",
+          data: [{
+            id: "si_team_growth",
+            object: "subscription_item",
+            current_period_end: 1_800_000_000,
+            quantity: 1,
+            price: { id: "price_team" },
+          }],
+          has_more: false,
+          url: "/v1/subscription_items",
+        },
+      }),
+      getTeam: async () => ({
+        listUsers: async () => [{ id: "member-1" }, { id: "member-2" }, { id: "member-3" }],
+      }),
+      updateSubscriptionQuantity: async (id: string, params: Record<string, unknown>) => {
+        stripeUpdates.push({ id, params });
+      },
+      updateSeats: async (id: string, seats: number) => {
+        seatWrites.push({ id, seats });
+      },
+      captureTeamSeatSync: async (input: Record<string, unknown>) => {
+        analytics.push(input);
+      },
+      markChecked: async () => {},
+    });
+
+    expect(stripeUpdates).toEqual([{
+      id: "sub_team_growth",
+      params: {
+        items: [{ id: "si_team_growth", quantity: 3 }],
+        proration_behavior: "create_prorations",
+      },
+    }]);
+    expect(seatWrites).toEqual([{ id: "sub_team_growth", seats: 3 }]);
+    expect(analytics).toEqual([{
+      subscriptionId: "sub_team_growth",
+      teamId: "team_growth",
+      oldQuantity: 1,
+      newQuantity: 3,
+    }]);
+    expect(result).toMatchObject({ checked: 1, drifted: 1, repaired: 1, failed: 0 });
+  });
+
+  test("shrinks team seats to the membership count with a floor of one", async () => {
+    const quantities: number[] = [];
+    const result = await reconcileStripeSubscriptions({}, {
+      withLease: withoutLease,
+      list: async () => [{
+        id: "sub_team_shrink",
+        status: "active",
+        cancelAtPeriodEnd: false,
+        currentPeriodEnd: new Date(1_800_000_000_000),
+        scope: "team",
+        stackTeamId: "team_shrink",
+        seats: 5,
+      }],
+      retrieve: async () => subscription("sub_team_shrink", "active", {
+        metadata: { app: "cmux", plan: "team", stackTeamId: "team_shrink" },
+        items: {
+          object: "list",
+          data: [{
+            id: "si_team_shrink",
+            object: "subscription_item",
+            current_period_end: 1_800_000_000,
+            quantity: 5,
+            price: { id: "price_team" },
+          }],
+          has_more: false,
+          url: "/v1/subscription_items",
+        },
+      }),
+      getTeam: async () => ({ listUsers: async () => [] }),
+      updateSubscriptionQuantity: async (_id: string, params: Record<string, unknown>) => {
+        const items = params.items as Array<{ quantity?: number }>;
+        quantities.push(items[0]?.quantity ?? 0);
+      },
+      updateSeats: async () => {},
+      captureTeamSeatSync: async () => {},
+      markChecked: async () => {},
+    });
+
+    expect(quantities).toEqual([1]);
+    expect(result).toMatchObject({ checked: 1, drifted: 1, repaired: 1, failed: 0 });
+  });
+
+  test("does not call Stripe when team membership already matches the quantity", async () => {
+    let stripeCalls = 0;
+    let seatWrites = 0;
+    let analyticsCalls = 0;
+    await reconcileStripeSubscriptions({}, {
+      withLease: withoutLease,
+      list: async () => [{
+        id: "sub_team_equal",
+        status: "active",
+        cancelAtPeriodEnd: false,
+        currentPeriodEnd: new Date(1_800_000_000_000),
+        scope: "team",
+        stackTeamId: "team_equal",
+        seats: 2,
+      }],
+      retrieve: async () => subscription("sub_team_equal", "active", {
+        metadata: { app: "cmux", plan: "team", stackTeamId: "team_equal" },
+        items: {
+          object: "list",
+          data: [{
+            id: "si_team_equal",
+            object: "subscription_item",
+            current_period_end: 1_800_000_000,
+            quantity: 2,
+            price: { id: "price_team" },
+          }],
+          has_more: false,
+          url: "/v1/subscription_items",
+        },
+      }),
+      getTeam: async () => ({ listUsers: async () => [{ id: "member-1" }, { id: "member-2" }] }),
+      updateSubscriptionQuantity: async () => {
+        stripeCalls += 1;
+      },
+      updateSeats: async () => {
+        seatWrites += 1;
+      },
+      captureTeamSeatSync: async () => {
+        analyticsCalls += 1;
+      },
+      markChecked: async () => {},
+    });
+
+    expect(stripeCalls).toBe(0);
+    expect(seatWrites).toBe(0);
+    expect(analyticsCalls).toBe(0);
+  });
+
+  test("isolates a team seat sync failure and continues with other teams", async () => {
+    const updatedTeams: string[] = [];
+    const contexts: Record<string, unknown>[] = [];
+    const result = await reconcileStripeSubscriptions({}, {
+      withLease: withoutLease,
+      concurrency: 1,
+      list: async () => [
+        {
+          id: "sub_team_failed",
+          status: "active",
+          cancelAtPeriodEnd: false,
+          currentPeriodEnd: new Date(1_800_000_000_000),
+          scope: "team",
+          stackTeamId: "team_failed",
+          seats: 1,
+        },
+        {
+          id: "sub_team_ok",
+          status: "active",
+          cancelAtPeriodEnd: false,
+          currentPeriodEnd: new Date(1_800_000_000_000),
+          scope: "team",
+          stackTeamId: "team_ok",
+          seats: 1,
+        },
+      ],
+      retrieve: async (id) => subscription(id, "active", {
+        metadata: {
+          app: "cmux",
+          plan: "team",
+          stackTeamId: id === "sub_team_failed" ? "team_failed" : "team_ok",
+        },
+        items: {
+          object: "list",
+          data: [{
+            id: `si_${id}`,
+            object: "subscription_item",
+            current_period_end: 1_800_000_000,
+            quantity: 1,
+            price: { id: "price_team" },
+          }],
+          has_more: false,
+          url: "/v1/subscription_items",
+        },
+      }),
+      getTeam: async (teamId: string) => {
+        if (teamId === "team_failed") throw new Error("Stack unavailable");
+        return { listUsers: async () => [{ id: "member-1" }, { id: "member-2" }] };
+      },
+      updateSubscriptionQuantity: async (_id: string, params: Record<string, unknown>) => {
+        const items = params.items as Array<{ quantity?: number }>;
+        updatedTeams.push(String(items[0]?.quantity));
+      },
+      updateSeats: async () => {},
+      captureTeamSeatSync: async () => {},
+      captureError: (_error, context) => {
+        contexts.push(context);
+      },
+      markChecked: async () => {},
+    });
+
+    expect(updatedTeams).toEqual(["2"]);
+    expect(result).toMatchObject({ checked: 2, drifted: 1, repaired: 1, failed: 1 });
+    expect(contexts).toEqual([{
+      operation: "stripe_subscription_reconcile",
+      recoverable: true,
+    }]);
+  });
+
   test("checks remote subscriptions concurrently and repairs only drift", async () => {
     let inFlight = 0;
     let peak = 0;

--- a/web/tests/billing-reconcile.test.ts
+++ b/web/tests/billing-reconcile.test.ts
@@ -366,7 +366,7 @@ describe("Stripe subscription reconciliation", () => {
 
     expect(result).toMatchObject({ checked: 1, drifted: 0, repaired: 0, failed: 1 });
     expect(errors).toHaveLength(1);
-    expect(String(errors[0])).toContain("Stack roster listing exceeded the per-team deadline");
+    expect(String(errors[0])).toContain("Stack team interaction exceeded the per-team deadline");
   }, 20_000);
 
   test("checks remote subscriptions concurrently and repairs only drift", async () => {

--- a/web/tests/billing-reconcile.test.ts
+++ b/web/tests/billing-reconcile.test.ts
@@ -50,11 +50,17 @@ function teamItems(
 }
 
 describe("Stripe subscription reconciliation", () => {
-  test("syncs a team seat quantity when membership grows", async () => {
-    const stripeUpdates: Array<{ id: string; params: Stripe.SubscriptionUpdateParams }> = [];
-    const seatWrites: Array<{ id: string; seats: number }> = [];
+  test("reports team seat drift with current member, Stripe, and stored counts", async () => {
+    let stripeUpdateCalls = 0;
+    let seatWriteCalls = 0;
     const analytics: Array<Record<string, unknown>> = [];
-    const result = await reconcileStripeSubscriptions({}, {
+    const updateSubscriptionQuantity = async () => {
+      stripeUpdateCalls += 1;
+    };
+    const updateSeats = async () => {
+      seatWriteCalls += 1;
+    };
+    const dependencies = {
       withLease: withoutLease,
       list: async () => [{
         id: "sub_team_growth",
@@ -72,43 +78,38 @@ describe("Stripe subscription reconciliation", () => {
       getTeam: async () => ({
         listUsers: async () => [{ id: "member-1" }, { id: "member-2" }, { id: "member-3" }],
       }),
-      updateSubscriptionQuantity: async (id: string, params: Stripe.SubscriptionUpdateParams) => {
-        stripeUpdates.push({ id, params });
-      },
-      updateSeats: async (id: string, seats: number) => {
-        seatWrites.push({ id, seats });
-      },
-      captureTeamSeatSync: async (input: {
-        subscriptionId: string;
-        teamId: string;
-        oldQuantity: number;
-        newQuantity: number;
-      }) => {
+      updateSubscriptionQuantity,
+      updateSeats,
+      captureTeamSeatDrift: async (input: Record<string, unknown>) => {
         analytics.push(input);
       },
       markChecked: async () => {},
-    });
+    };
+    const result = await reconcileStripeSubscriptions({}, dependencies);
 
-    expect(stripeUpdates).toEqual([{
-      id: "sub_team_growth",
-      params: {
-        items: [{ id: "si_team_growth", quantity: 3 }],
-        proration_behavior: "create_prorations",
-      },
-    }]);
-    expect(seatWrites).toEqual([{ id: "sub_team_growth", seats: 3 }]);
+    expect(stripeUpdateCalls).toBe(0);
+    expect(seatWriteCalls).toBe(0);
     expect(analytics).toEqual([{
       subscriptionId: "sub_team_growth",
       teamId: "team_growth",
-      oldQuantity: 1,
-      newQuantity: 3,
+      memberCount: 3,
+      stripeQuantity: 1,
+      storedSeats: 1,
     }]);
-    expect(result).toMatchObject({ checked: 1, drifted: 1, repaired: 1, failed: 0 });
+    expect(result).toMatchObject({ checked: 1, drifted: 1, repaired: 0, failed: 0 });
   });
 
-  test("shrinks team seats to the membership count with a floor of one", async () => {
-    const quantities: number[] = [];
-    const result = await reconcileStripeSubscriptions({}, {
+  test("reports an empty roster as one desired seat without mutating billing", async () => {
+    let stripeUpdateCalls = 0;
+    let seatWriteCalls = 0;
+    const analytics: Array<Record<string, unknown>> = [];
+    const updateSubscriptionQuantity = async () => {
+      stripeUpdateCalls += 1;
+    };
+    const updateSeats = async () => {
+      seatWriteCalls += 1;
+    };
+    const dependencies = {
       withLease: withoutLease,
       list: async () => [{
         id: "sub_team_shrink",
@@ -124,24 +125,38 @@ describe("Stripe subscription reconciliation", () => {
         items: teamItems("si_team_shrink", 5),
       }),
       getTeam: async () => ({ listUsers: async () => [] }),
-      updateSubscriptionQuantity: async (_id: string, params: Stripe.SubscriptionUpdateParams) => {
-        const items = params.items ?? [];
-        quantities.push(items[0]?.quantity ?? 0);
+      updateSubscriptionQuantity,
+      updateSeats,
+      captureTeamSeatDrift: async (input: Record<string, unknown>) => {
+        analytics.push(input);
       },
-      updateSeats: async () => {},
-      captureTeamSeatSync: async () => {},
       markChecked: async () => {},
-    });
+    };
+    const result = await reconcileStripeSubscriptions({}, dependencies);
 
-    expect(quantities).toEqual([1]);
-    expect(result).toMatchObject({ checked: 1, drifted: 1, repaired: 1, failed: 0 });
+    expect(stripeUpdateCalls).toBe(0);
+    expect(seatWriteCalls).toBe(0);
+    expect(analytics).toEqual([{
+      subscriptionId: "sub_team_shrink",
+      teamId: "team_shrink",
+      memberCount: 0,
+      stripeQuantity: 5,
+      storedSeats: 5,
+    }]);
+    expect(result).toMatchObject({ checked: 1, drifted: 1, repaired: 0, failed: 0 });
   });
 
-  test("does not call Stripe when team membership already matches the quantity", async () => {
-    let stripeCalls = 0;
-    let seatWrites = 0;
+  test("emits nothing when team quantities already match", async () => {
+    let stripeUpdateCalls = 0;
+    let seatWriteCalls = 0;
     let analyticsCalls = 0;
-    await reconcileStripeSubscriptions({}, {
+    const updateSubscriptionQuantity = async () => {
+      stripeUpdateCalls += 1;
+    };
+    const updateSeats = async () => {
+      seatWriteCalls += 1;
+    };
+    const dependencies = {
       withLease: withoutLease,
       list: async () => [{
         id: "sub_team_equal",
@@ -157,24 +172,22 @@ describe("Stripe subscription reconciliation", () => {
         items: teamItems("si_team_equal", 2),
       }),
       getTeam: async () => ({ listUsers: async () => [{ id: "member-1" }, { id: "member-2" }] }),
-      updateSubscriptionQuantity: async () => {
-        stripeCalls += 1;
-      },
-      updateSeats: async () => {
-        seatWrites += 1;
-      },
-      captureTeamSeatSync: async () => {
+      updateSubscriptionQuantity,
+      updateSeats,
+      captureTeamSeatDrift: async () => {
         analyticsCalls += 1;
       },
       markChecked: async () => {},
-    });
+    };
+    const result = await reconcileStripeSubscriptions({}, dependencies);
 
-    expect(stripeCalls).toBe(0);
-    expect(seatWrites).toBe(0);
+    expect(stripeUpdateCalls).toBe(0);
+    expect(seatWriteCalls).toBe(0);
     expect(analyticsCalls).toBe(0);
+    expect(result).toMatchObject({ checked: 1, drifted: 0, repaired: 0, failed: 0 });
   });
 
-  test("bounds Stack team seat work to the oldest fifty rows", async () => {
+  test("checks every team in the bounded batch without a reservation quota", async () => {
     const rows = Array.from({ length: 51 }, (_, index) => ({
       id: `sub_team_${index}`,
       status: "active",
@@ -185,10 +198,11 @@ describe("Stripe subscription reconciliation", () => {
       seats: 1,
     }));
     const visitedTeams: string[] = [];
-    await reconcileStripeSubscriptions({}, {
+    const analytics: Array<Record<string, unknown>> = [];
+    const dependencies = {
       withLease: withoutLease,
       list: async () => rows,
-      retrieve: async (id) => subscription(id, "active", {
+      retrieve: async (id: string) => subscription(id, "active", {
         metadata: { app: "cmux", plan: "team", stackTeamId: id.replace("sub_", "") },
         items: teamItems(`si_${id}`, 1),
       }),
@@ -196,23 +210,32 @@ describe("Stripe subscription reconciliation", () => {
         visitedTeams.push(teamId);
         return { listUsers: async () => [{ id: "member-1" }, { id: "member-2" }] };
       },
-      updateSubscriptionQuantity: async () => {},
-      updateSeats: async () => {},
-      captureTeamSeatSync: async () => {},
+      captureTeamSeatDrift: async (input: Record<string, unknown>) => {
+        analytics.push(input);
+      },
       markChecked: async () => {},
-    });
+    };
+    await reconcileStripeSubscriptions({}, dependencies);
 
-    expect(visitedTeams).toHaveLength(50);
+    expect(visitedTeams).toHaveLength(51);
     expect(new Set(visitedTeams)).toEqual(
-      new Set(rows.slice(0, 50).map((row) => row.stackTeamId)),
+      new Set(rows.map((row) => row.stackTeamId)),
     );
-    expect(visitedTeams).not.toContain("team_50");
+    expect(analytics).toHaveLength(51);
   });
 
-  test("isolates a team seat sync failure and continues with other teams", async () => {
-    const updatedTeams: string[] = [];
+  test("isolates a team seat drift failure and continues with other teams", async () => {
+    let stripeUpdateCalls = 0;
+    let seatWriteCalls = 0;
+    const analytics: Array<Record<string, unknown>> = [];
     const contexts: Record<string, unknown>[] = [];
-    const result = await reconcileStripeSubscriptions({}, {
+    const updateSubscriptionQuantity = async () => {
+      stripeUpdateCalls += 1;
+    };
+    const updateSeats = async () => {
+      seatWriteCalls += 1;
+    };
+    const dependencies = {
       withLease: withoutLease,
       concurrency: 1,
       list: async () => [
@@ -235,7 +258,7 @@ describe("Stripe subscription reconciliation", () => {
           seats: 1,
         },
       ],
-      retrieve: async (id) => subscription(id, "active", {
+      retrieve: async (id: string) => subscription(id, "active", {
         metadata: {
           app: "cmux",
           plan: "team",
@@ -247,25 +270,104 @@ describe("Stripe subscription reconciliation", () => {
         if (teamId === "team_failed") throw new Error("Stack unavailable");
         return { listUsers: async () => [{ id: "member-1" }, { id: "member-2" }] };
       },
-      updateSubscriptionQuantity: async (_id: string, params: Stripe.SubscriptionUpdateParams) => {
-        const items = params.items ?? [];
-        updatedTeams.push(String(items[0]?.quantity));
+      updateSubscriptionQuantity,
+      updateSeats,
+      captureTeamSeatDrift: async (input: Record<string, unknown>) => {
+        analytics.push(input);
       },
-      updateSeats: async () => {},
-      captureTeamSeatSync: async () => {},
-      captureError: (_error, context) => {
+      captureError: (_error: unknown, context: Record<string, string | number | boolean>) => {
         contexts.push(context);
       },
       markChecked: async () => {},
-    });
+    };
+    const result = await reconcileStripeSubscriptions({}, dependencies);
 
-    expect(updatedTeams).toEqual(["2"]);
-    expect(result).toMatchObject({ checked: 2, drifted: 1, repaired: 1, failed: 1 });
+    expect(stripeUpdateCalls).toBe(0);
+    expect(seatWriteCalls).toBe(0);
+    expect(analytics).toEqual([{
+      subscriptionId: "sub_team_ok",
+      teamId: "team_ok",
+      memberCount: 2,
+      stripeQuantity: 1,
+      storedSeats: 1,
+    }]);
+    expect(result).toMatchObject({ checked: 2, drifted: 1, repaired: 0, failed: 1 });
     expect(contexts).toEqual([{
       operation: "stripe_subscription_reconcile",
       recoverable: true,
     }]);
   });
+
+  test("fails closed when remote team identity disagrees with the local row", async () => {
+    let rosterReads = 0;
+    let analyticsCalls = 0;
+    const errors: unknown[] = [];
+    const dependencies = {
+      withLease: withoutLease,
+      list: async () => [{
+        id: "sub_team_identity",
+        status: "active",
+        cancelAtPeriodEnd: false,
+        currentPeriodEnd: new Date(1_800_000_000_000),
+        scope: "team",
+        stackTeamId: "team_local",
+        seats: 1,
+      }],
+      retrieve: async () => subscription("sub_team_identity", "active", {
+        metadata: { app: "cmux", plan: "team", stackTeamId: "team_remote" },
+        items: teamItems("si_team_identity", 1),
+      }),
+      getTeam: async () => {
+        rosterReads += 1;
+        return { listUsers: async () => [{ id: "member-1" }, { id: "member-2" }] };
+      },
+      captureTeamSeatDrift: async () => {
+        analyticsCalls += 1;
+      },
+      captureError: (error: unknown) => {
+        errors.push(error);
+      },
+      markChecked: async () => {},
+    };
+    const result = await reconcileStripeSubscriptions({}, dependencies);
+
+    expect(result).toMatchObject({ checked: 1, drifted: 0, repaired: 0, failed: 1 });
+    expect(errors).toHaveLength(1);
+    expect(String(errors[0])).toContain("remote=team_remote local=team_local");
+    expect(rosterReads).toBe(0);
+    expect(analyticsCalls).toBe(0);
+  });
+
+  test("records a recoverable failure when the roster misses the 15-second deadline", async () => {
+    const errors: unknown[] = [];
+    const result = await reconcileStripeSubscriptions({}, {
+      withLease: withoutLease,
+      list: async () => [{
+        id: "sub_team_timeout",
+        status: "active",
+        cancelAtPeriodEnd: false,
+        currentPeriodEnd: new Date(1_800_000_000_000),
+        scope: "team",
+        stackTeamId: "team_timeout",
+        seats: 1,
+      }],
+      retrieve: async () => subscription("sub_team_timeout", "active", {
+        metadata: { app: "cmux", plan: "team", stackTeamId: "team_timeout" },
+        items: teamItems("si_team_timeout", 1),
+      }),
+      getTeam: async () => ({
+        listUsers: () => new Promise<readonly unknown[]>(() => {}),
+      }),
+      captureError: (error: unknown) => {
+        errors.push(error);
+      },
+      markChecked: async () => {},
+    });
+
+    expect(result).toMatchObject({ checked: 1, drifted: 0, repaired: 0, failed: 1 });
+    expect(errors).toHaveLength(1);
+    expect(String(errors[0])).toContain("Stack roster listing exceeded the per-team deadline");
+  }, 20_000);
 
   test("checks remote subscriptions concurrently and repairs only drift", async () => {
     let inFlight = 0;

--- a/web/tests/billing-reconcile.test.ts
+++ b/web/tests/billing-reconcile.test.ts
@@ -31,9 +31,27 @@ function subscription(
   } as Stripe.Subscription;
 }
 
+function teamItems(
+  id: string,
+  quantity: number,
+): Stripe.Subscription["items"] {
+  return {
+    object: "list",
+    data: [{
+      id,
+      object: "subscription_item",
+      current_period_end: 1_800_000_000,
+      quantity,
+      price: { id: "price_team" },
+    }],
+    has_more: false,
+    url: "/v1/subscription_items",
+  } as Stripe.Subscription["items"];
+}
+
 describe("Stripe subscription reconciliation", () => {
   test("syncs a team seat quantity when membership grows", async () => {
-    const stripeUpdates: Array<{ id: string; params: Record<string, unknown> }> = [];
+    const stripeUpdates: Array<{ id: string; params: Stripe.SubscriptionUpdateParams }> = [];
     const seatWrites: Array<{ id: string; seats: number }> = [];
     const analytics: Array<Record<string, unknown>> = [];
     const result = await reconcileStripeSubscriptions({}, {
@@ -49,29 +67,23 @@ describe("Stripe subscription reconciliation", () => {
       }],
       retrieve: async () => subscription("sub_team_growth", "active", {
         metadata: { app: "cmux", plan: "team", stackTeamId: "team_growth" },
-        items: {
-          object: "list",
-          data: [{
-            id: "si_team_growth",
-            object: "subscription_item",
-            current_period_end: 1_800_000_000,
-            quantity: 1,
-            price: { id: "price_team" },
-          }],
-          has_more: false,
-          url: "/v1/subscription_items",
-        },
+        items: teamItems("si_team_growth", 1),
       }),
       getTeam: async () => ({
         listUsers: async () => [{ id: "member-1" }, { id: "member-2" }, { id: "member-3" }],
       }),
-      updateSubscriptionQuantity: async (id: string, params: Record<string, unknown>) => {
+      updateSubscriptionQuantity: async (id: string, params: Stripe.SubscriptionUpdateParams) => {
         stripeUpdates.push({ id, params });
       },
       updateSeats: async (id: string, seats: number) => {
         seatWrites.push({ id, seats });
       },
-      captureTeamSeatSync: async (input: Record<string, unknown>) => {
+      captureTeamSeatSync: async (input: {
+        subscriptionId: string;
+        teamId: string;
+        oldQuantity: number;
+        newQuantity: number;
+      }) => {
         analytics.push(input);
       },
       markChecked: async () => {},
@@ -109,22 +121,11 @@ describe("Stripe subscription reconciliation", () => {
       }],
       retrieve: async () => subscription("sub_team_shrink", "active", {
         metadata: { app: "cmux", plan: "team", stackTeamId: "team_shrink" },
-        items: {
-          object: "list",
-          data: [{
-            id: "si_team_shrink",
-            object: "subscription_item",
-            current_period_end: 1_800_000_000,
-            quantity: 5,
-            price: { id: "price_team" },
-          }],
-          has_more: false,
-          url: "/v1/subscription_items",
-        },
+        items: teamItems("si_team_shrink", 5),
       }),
       getTeam: async () => ({ listUsers: async () => [] }),
-      updateSubscriptionQuantity: async (_id: string, params: Record<string, unknown>) => {
-        const items = params.items as Array<{ quantity?: number }>;
+      updateSubscriptionQuantity: async (_id: string, params: Stripe.SubscriptionUpdateParams) => {
+        const items = params.items ?? [];
         quantities.push(items[0]?.quantity ?? 0);
       },
       updateSeats: async () => {},
@@ -153,18 +154,7 @@ describe("Stripe subscription reconciliation", () => {
       }],
       retrieve: async () => subscription("sub_team_equal", "active", {
         metadata: { app: "cmux", plan: "team", stackTeamId: "team_equal" },
-        items: {
-          object: "list",
-          data: [{
-            id: "si_team_equal",
-            object: "subscription_item",
-            current_period_end: 1_800_000_000,
-            quantity: 2,
-            price: { id: "price_team" },
-          }],
-          has_more: false,
-          url: "/v1/subscription_items",
-        },
+        items: teamItems("si_team_equal", 2),
       }),
       getTeam: async () => ({ listUsers: async () => [{ id: "member-1" }, { id: "member-2" }] }),
       updateSubscriptionQuantity: async () => {
@@ -182,6 +172,41 @@ describe("Stripe subscription reconciliation", () => {
     expect(stripeCalls).toBe(0);
     expect(seatWrites).toBe(0);
     expect(analyticsCalls).toBe(0);
+  });
+
+  test("bounds Stack team seat work to the oldest fifty rows", async () => {
+    const rows = Array.from({ length: 51 }, (_, index) => ({
+      id: `sub_team_${index}`,
+      status: "active",
+      cancelAtPeriodEnd: false,
+      currentPeriodEnd: new Date(1_800_000_000_000),
+      scope: "team",
+      stackTeamId: `team_${index}`,
+      seats: 1,
+    }));
+    const visitedTeams: string[] = [];
+    await reconcileStripeSubscriptions({}, {
+      withLease: withoutLease,
+      list: async () => rows,
+      retrieve: async (id) => subscription(id, "active", {
+        metadata: { app: "cmux", plan: "team", stackTeamId: id.replace("sub_", "") },
+        items: teamItems(`si_${id}`, 1),
+      }),
+      getTeam: async (teamId: string) => {
+        visitedTeams.push(teamId);
+        return { listUsers: async () => [{ id: "member-1" }, { id: "member-2" }] };
+      },
+      updateSubscriptionQuantity: async () => {},
+      updateSeats: async () => {},
+      captureTeamSeatSync: async () => {},
+      markChecked: async () => {},
+    });
+
+    expect(visitedTeams).toHaveLength(50);
+    expect(new Set(visitedTeams)).toEqual(
+      new Set(rows.slice(0, 50).map((row) => row.stackTeamId)),
+    );
+    expect(visitedTeams).not.toContain("team_50");
   });
 
   test("isolates a team seat sync failure and continues with other teams", async () => {
@@ -216,25 +241,14 @@ describe("Stripe subscription reconciliation", () => {
           plan: "team",
           stackTeamId: id === "sub_team_failed" ? "team_failed" : "team_ok",
         },
-        items: {
-          object: "list",
-          data: [{
-            id: `si_${id}`,
-            object: "subscription_item",
-            current_period_end: 1_800_000_000,
-            quantity: 1,
-            price: { id: "price_team" },
-          }],
-          has_more: false,
-          url: "/v1/subscription_items",
-        },
+        items: teamItems(`si_${id}`, 1),
       }),
       getTeam: async (teamId: string) => {
         if (teamId === "team_failed") throw new Error("Stack unavailable");
         return { listUsers: async () => [{ id: "member-1" }, { id: "member-2" }] };
       },
-      updateSubscriptionQuantity: async (_id: string, params: Record<string, unknown>) => {
-        const items = params.items as Array<{ quantity?: number }>;
+      updateSubscriptionQuantity: async (_id: string, params: Stripe.SubscriptionUpdateParams) => {
+        const items = params.items ?? [];
         updatedTeams.push(String(items[0]?.quantity));
       },
       updateSeats: async () => {},

--- a/web/tests/stripe-billing-analytics.test.ts
+++ b/web/tests/stripe-billing-analytics.test.ts
@@ -3,10 +3,36 @@ import type Stripe from "stripe";
 
 import {
   captureBillingCheckoutStarted,
+  captureBillingTeamSeatSync,
   captureStripeBillingEvent,
 } from "../services/analytics/stripeBilling";
 
 describe("Stripe billing analytics", () => {
+  test("captures team seat sync quantities with the Stack team identity", async () => {
+    let payload: Record<string, unknown> = {};
+    await captureBillingTeamSeatSync({
+      subscriptionId: "sub_team_sync",
+      teamId: "team_sync",
+      oldQuantity: 1,
+      newQuantity: 4,
+    }, (async (_input, init) => {
+      payload = JSON.parse(String(init?.body));
+      return new Response(null, { status: 200 });
+    }) as typeof fetch);
+
+    expect(payload).toMatchObject({
+      event: "cmux_billing_team_seats_synced",
+      properties: {
+        distinct_id: "stack-team:team_sync",
+        $insert_id: "team-seat-sync:sub_team_sync:1:4",
+        stack_team_id: "team_sync",
+        old_quantity: 1,
+        new_quantity: 4,
+        stripe_subscription_id: "sub_team_sync",
+      },
+    });
+  });
+
   test("does not use the real transport in a test process", async () => {
     const originalFetch = globalThis.fetch;
     let calls = 0;

--- a/web/tests/stripe-billing-analytics.test.ts
+++ b/web/tests/stripe-billing-analytics.test.ts
@@ -24,13 +24,18 @@ describe("Stripe billing analytics", () => {
       event: "cmux_billing_team_seats_synced",
       properties: {
         distinct_id: "stack-team:team_sync",
-        $insert_id: "team-seat-sync:sub_team_sync:1:4",
         stack_team_id: "team_sync",
         old_quantity: 1,
         new_quantity: 4,
         stripe_subscription_id: "sub_team_sync",
       },
     });
+    // The insert id is unique per sync so PostHog never deduplicates a
+    // repeated legitimate transition; only the prefix and shape are stable.
+    const properties = payload.properties as Record<string, unknown>;
+    expect(String(properties.$insert_id)).toMatch(
+      /^team-seat-sync:sub_team_sync:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
   });
 
   test("does not use the real transport in a test process", async () => {

--- a/web/tests/stripe-billing-analytics.test.ts
+++ b/web/tests/stripe-billing-analytics.test.ts
@@ -3,39 +3,63 @@ import type Stripe from "stripe";
 
 import {
   captureBillingCheckoutStarted,
-  captureBillingTeamSeatSync,
+  captureBillingTeamSeatDrift,
   captureStripeBillingEvent,
 } from "../services/analytics/stripeBilling";
 
 describe("Stripe billing analytics", () => {
-  test("captures team seat sync quantities with the Stack team identity", async () => {
+  test("captures team seat drift counts with the Stack team identity", async () => {
     let payload: Record<string, unknown> = {};
-    await captureBillingTeamSeatSync({
-      subscriptionId: "sub_team_sync",
-      teamId: "team_sync",
-      oldQuantity: 1,
-      newQuantity: 4,
+    await captureBillingTeamSeatDrift({
+      subscriptionId: "sub_team_drift",
+      teamId: "team_drift",
+      memberCount: 4,
+      stripeQuantity: 1,
+      storedSeats: 2,
     }, (async (_input, init) => {
       payload = JSON.parse(String(init?.body));
       return new Response(null, { status: 200 });
     }) as typeof fetch);
 
     expect(payload).toMatchObject({
-      event: "cmux_billing_team_seats_synced",
+      event: "cmux_billing_team_seat_drift_detected",
       properties: {
-        distinct_id: "stack-team:team_sync",
-        stack_team_id: "team_sync",
-        old_quantity: 1,
-        new_quantity: 4,
-        stripe_subscription_id: "sub_team_sync",
+        distinct_id: "stack-team:team_drift",
+        stack_team_id: "team_drift",
+        stripe_subscription_id: "sub_team_drift",
+        member_count: 4,
+        stripe_quantity: 1,
+        stored_seats: 2,
       },
     });
-    // The insert id is unique per sync so PostHog never deduplicates a
-    // repeated legitimate transition; only the prefix and shape are stable.
+    // The insert id is unique per detection so PostHog never deduplicates a
+    // repeated observation; only the prefix and shape are stable.
     const properties = payload.properties as Record<string, unknown>;
     expect(String(properties.$insert_id)).toMatch(
-      /^team-seat-sync:sub_team_sync:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      /^team-seat-drift:sub_team_drift:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
     );
+  });
+
+  test("reuses one insert id across transport retries", async () => {
+    const insertIds: unknown[] = [];
+    let attempts = 0;
+    await captureBillingTeamSeatDrift({
+      subscriptionId: "sub_retry",
+      teamId: "team_retry",
+      memberCount: 3,
+      stripeQuantity: 1,
+      storedSeats: 1,
+    }, (async (_input, init) => {
+      attempts += 1;
+      const body = JSON.parse(String(init?.body)) as { properties: Record<string, unknown> };
+      insertIds.push(body.properties.$insert_id);
+      if (attempts === 1) throw new Error("temporary PostHog failure");
+      return new Response(null, { status: 200 });
+    }) as typeof fetch);
+
+    expect(attempts).toBe(2);
+    expect(insertIds).toHaveLength(2);
+    expect(insertIds[0]).toBe(insertIds[1]);
   });
 
   test("does not use the real transport in a test process", async () => {


### PR DESCRIPTION
Detects and reports team seat drift without mutating anything. For every team-scope subscription row in the reconcile batch whose REMOTE status is active, the job reads the Stack roster (15s deadline-raced; the SDK's listUsers takes no AbortSignal, so the request cannot be cancelled — on Vercel the leak is bounded by the invocation lifetime) and, when member count disagrees with the Stripe quantity or the stored seats, emits one cmux_billing_team_seat_drift_detected event carrying member_count, stripe_quantity, and stored_seats with a unique per-detection insert id. Remote subscription metadata must agree with the local row's team identity, failing closed on drift.

This is a deliberate descope. Three review rounds found design defects in the mutating version (shared-cursor starvation of unreserved teams, pre-apply seat snapshot staleness, uncancellable roster reads compounding). Reporting first measures the underbilling population; enforcement (truing the Stripe quantity) follows as its own designed PR with a dedicated cursor once the drift data exists. Until then teams below their member count remain underbilled, stated plainly.

Verification: bun run typecheck clean; 24 tests pass across the reconcile and analytics suites, including assertions that no Stripe update and no seats write ever occur.

Work was produced across interrupted codex runs and completed and verified by the session agent.