### PR TITLE
Fix main compile break from #11059: expose onViewAttachedToWindow in the memberwise init

### DIFF
--- a/Sources/Panels/MarkdownWebRenderer.swift
+++ b/Sources/Panels/MarkdownWebRenderer.swift
@@ -26,7 +26,7 @@ struct MarkdownWebRenderer: NSViewRepresentable {
     /// Called after the renderer view is attached to a window. A panel can
     /// request focus before SwiftUI mounts its WebKit view, so the panel uses
     /// this lifecycle signal to complete that request without polling.
-    let onViewAttachedToWindow: () -> Void = {}
+    var onViewAttachedToWindow: () -> Void = {}
 
     func makeCoordinator() -> Coordinator {
         session.coordinator(panelId: panelId, workspaceId: workspaceId, filePath: filePath)


### PR DESCRIPTION
https://github.com/manaflow-ai/cmux/pull/11059 (merged 2026-09-01 06:04Z) passes `onViewAttachedToWindow:` to `MarkdownWebRenderer`'s synthesized memberwise initializer, but the property is a `let` with a default value, which Swift excludes from that initializer — so `MarkdownPanelView.swift:89` fails with "extra argument 'onViewAttachedToWindow' in call" on every branch containing the merge. reload-build is red for fresh branches (cldrn twice, deterministic); parity2 built only because its base predates the merge.

One word: `let` → `var`. The default stays for constructions that omit the argument; the panel's handler now reaches the renderer as #11059 intended.

Blocks every agent's tagged build until merged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11351"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790838125&installation_model_id=21920&pr_number=11351&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11351&signature=79c994686bf580e877eedb8e19dee2d508e71c3587b0cb7d9de9c4dfec7cd257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the main-branch compile break from #11059. `onViewAttachedToWindow` was declared as `let` with a default value, which Swift excludes from `MarkdownWebRenderer`'s synthesized memberwise initializer, so the call in `MarkdownPanelView.swift` failed to compile. Changing it to `var` keeps the default for callers that omit the argument and lets the panel pass its handler as intended, unblocking tagged agent builds on fresh branches.

<sup>Written for commit b93ae3f6f90610be668c87dff723dd6378e7d7b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved renderer lifecycle handling so view-attached callbacks work reliably after the renderer is created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->