### PR TITLE
billing: enforce Team subscription seats

### DIFF
--- a/web/app/api/billing/plan/route.ts
+++ b/web/app/api/billing/plan/route.ts
@@ -5,7 +5,6 @@ import { parseBearer, jsonResponse } from "../../../../services/vms/routeHelpers
 import {
   FREE_PLAN_ID,
   TEAM_PLAN_ID,
-  hasActiveTeamSubscriptionForTeam,
   isStripePortalRecoverable,
   resolveProPlanStatus,
   stripeBillingStatusForTeam,
@@ -15,6 +14,11 @@ import {
   resolveBillingTeam,
   type BillingTeamUserLike,
 } from "../../../../services/billing/teamResolution";
+import {
+  resolveTeamSeatEntitlement,
+  teamSeatMemberListingAvailable,
+  type TeamSeatResolverOptions,
+} from "../../../../services/billing/teamSeats";
 import { authProviderErrorResponse } from "../../../../services/vms/authErrors";
 
 
@@ -69,7 +73,7 @@ export async function GET(request: NextRequest) {
   }
 
   const status = await resolveProPlanStatus(user);
-  const teamStatus = await resolveTeamPlanStatus(user);
+  const teamStatus = await resolveTeamPlanStatus(user, stackServerApp);
   return jsonResponse({
     authenticated: !user.isAnonymous,
     billingAvailable,
@@ -93,19 +97,35 @@ type TeamPlanStatus = {
   readonly billingManagement: BillingManagementKind;
 };
 
-async function resolveTeamPlanStatus(user: BillingTeamUserLike): Promise<TeamPlanStatus> {
+async function resolveTeamPlanStatus(
+  user: BillingTeamUserLike,
+  stackApp: TeamSeatResolverOptions["stackApp"],
+): Promise<TeamPlanStatus> {
   const team = await resolveBillingTeam(user);
   if (!team?.id) {
     return { planId: FREE_PLAN_ID, billingManagement: "none" };
   }
-  const stripeActive = await hasActiveTeamSubscriptionForTeam(team.id);
-  if (stripeActive) {
+  const teamBilling = await stripeBillingStatusForTeam(team.id);
+  if (teamBilling.hasActiveSubscription) {
+    const seatOptions: TeamSeatResolverOptions = {
+      stackApp,
+      stackTeam: team,
+      subscription: {
+        active: true,
+        seats: teamBilling.seats,
+      },
+    };
+    if (user.id && teamSeatMemberListingAvailable(seatOptions)) {
+      const seat = await resolveTeamSeatEntitlement(team.id, user.id, seatOptions);
+      if (!seat.entitled) {
+        return { planId: FREE_PLAN_ID, billingManagement: "stripe" };
+      }
+    }
     return { planId: TEAM_PLAN_ID, billingManagement: "stripe" };
   }
   // Mirror the personal-plan rule: the portal is only useful when it has a
   // recoverable subscription to manage. Terminally canceled teams and
   // customer-only rows must keep the checkout path.
-  const teamBilling = await stripeBillingStatusForTeam(team.id);
   return {
     planId: FREE_PLAN_ID,
     billingManagement: isStripePortalRecoverable(teamBilling) ? "stripe" : "none",

--- a/web/services/billing/pro.ts
+++ b/web/services/billing/pro.ts
@@ -109,6 +109,8 @@ export type StripeBillingStatus = {
   readonly hasCustomer: boolean;
   /** Whether the newest subscription grants current Pro access. */
   readonly hasActiveSubscription: boolean;
+  /** Team subscription quantity. Personal subscriptions always return null. */
+  readonly seats: number | null;
 };
 export type StripeBillingStatusQuery = (
   stackUserId: string,
@@ -471,6 +473,7 @@ export async function stripeBillingStatusForTeam(
         cancelAtPeriodEnd: stripeSubscriptions.cancelAtPeriodEnd,
         currentPeriodEnd: stripeSubscriptions.currentPeriodEnd,
         updatedAt: stripeSubscriptions.updatedAt,
+        seats: stripeSubscriptions.seats,
       })
       .from(stripeSubscriptions)
       .where(
@@ -493,10 +496,14 @@ export async function stripeBillingStatusForTeam(
       hasActiveTeamSubscriptionForTeam(stackTeamId),
     ]);
     const subscription = pickPortalMetadataRow(subscriptionRows);
+    const activeSubscription = subscriptionRows.find((row) =>
+      (ACTIVE_STRIPE_PRO_STATUSES as readonly string[]).includes(row.status)) ??
+      (hasActiveSubscription ? subscriptionRows[0] : undefined);
     return stripeBillingStatusFromRows(
       customerRows[0]?.id ?? null,
       subscription,
       hasActiveSubscription,
+      activeSubscription?.seats ?? null,
     );
   } catch (error) {
     if (isMissingDatabaseConfig(error)) return emptyStripeBillingStatus();
@@ -654,6 +661,7 @@ function stripeBillingStatusFromRows(
     readonly cancelAtPeriodEnd?: boolean | null;
   } | undefined,
   activeSubscriptionOverride?: boolean,
+  seats: number | null = null,
 ): StripeBillingStatus {
   const subscriptionStatus = subscription?.status ??
     (activeSubscriptionOverride ? "active" : null);
@@ -666,6 +674,7 @@ function stripeBillingStatusFromRows(
       subscriptionStatus !== null &&
       (ACTIVE_STRIPE_PRO_STATUSES as readonly string[]).includes(subscriptionStatus)
     ),
+    seats,
   };
 }
 
@@ -676,5 +685,6 @@ function emptyStripeBillingStatus(): StripeBillingStatus {
     cancelAtPeriodEnd: false,
     hasCustomer: false,
     hasActiveSubscription: false,
+    seats: null,
   };
 }

--- a/web/services/billing/teamResolution.ts
+++ b/web/services/billing/teamResolution.ts
@@ -2,9 +2,22 @@ export type BillingTeamLike = {
   readonly id: string;
   readonly displayName: string | null;
   readonly clientReadOnlyMetadata?: unknown;
+  readonly listUsers?: (
+    options?: BillingTeamMemberListOptions,
+  ) => Promise<BillingTeamMemberList>;
+};
+
+export type BillingTeamMemberListOptions = {
+  readonly cursor?: string;
+  readonly limit?: number;
+};
+
+export type BillingTeamMemberList = readonly unknown[] & {
+  readonly nextCursor?: string | null;
 };
 
 export type BillingTeamUserLike = {
+  readonly id?: string;
   readonly selectedTeam?: unknown;
   readonly listTeams?: () => Promise<readonly unknown[]>;
 };
@@ -54,12 +67,21 @@ export function billingTeamFromUnknown(value: unknown): BillingTeamLike | null {
   if (typeof id !== "string" || !id) return null;
   const displayName = (value as { displayName?: unknown; name?: unknown }).displayName ??
     (value as { name?: unknown }).name;
+  const listUsers = (value as { listUsers?: unknown }).listUsers;
   return {
     id,
     displayName: typeof displayName === "string" && displayName.trim()
       ? displayName.trim()
       : null,
     clientReadOnlyMetadata: (value as { clientReadOnlyMetadata?: unknown }).clientReadOnlyMetadata,
+    ...(typeof listUsers === "function"
+      ? {
+          listUsers: async (options?: BillingTeamMemberListOptions) =>
+            await (listUsers as (
+              options?: BillingTeamMemberListOptions,
+            ) => Promise<unknown> | unknown).call(value, options) as BillingTeamMemberList,
+        }
+      : {}),
   };
 }
 

--- a/web/services/billing/teamSeats.ts
+++ b/web/services/billing/teamSeats.ts
@@ -1,0 +1,565 @@
+import { and, desc, eq, inArray } from "drizzle-orm";
+
+import { getStackServerApp } from "../../app/lib/stack";
+import { cloudDb } from "../../db/client";
+import { stripeSubscriptions } from "../../db/schema";
+import { ACTIVE_STRIPE_PRO_STATUSES, TEAM_PLAN_ID } from "./pro";
+
+/**
+ * Stack Auth owns the Team settings page, including invitations and member
+ * changes. There is no local mutation route to guard, so this module applies
+ * the seat license when a Team entitlement is consumed.
+ */
+
+const DEFAULT_TEAM_SEAT_CACHE_TTL_MS = 30_000;
+const MAX_TEAM_SEAT_CACHE_ENTRIES = 256;
+const MAX_TEAM_MEMBER_PAGES = 100;
+const TEAM_MEMBER_PAGE_SIZE = 100;
+const MAX_TEAM_MEMBERS = 10_000;
+const TEAM_MEMBER_READ_TIMEOUT_MS = 15_000;
+
+type TeamMemberListOptions = {
+  readonly cursor?: string;
+  readonly limit?: number;
+};
+
+type StackTeamMemberList = readonly unknown[] & {
+  readonly nextCursor?: string | null;
+};
+
+type StackSeatTeam = {
+  readonly listUsers?: (
+    options?: TeamMemberListOptions,
+  ) => Promise<unknown> | unknown;
+};
+
+type StackSeatApp = {
+  readonly getTeam?: (id: string) => Promise<unknown> | unknown;
+};
+
+/** A small structural seam. It also keeps tests independent of Stack classes. */
+export type TeamSeatResolverOptions = {
+  readonly stackApp?: StackSeatApp | null;
+  /** A Team object returned by Stack Auth. `team` is retained as an alias. */
+  readonly stackTeam?: unknown;
+  readonly team?: unknown;
+  /** Optional state snapshot supplied by a caller that already read billing. */
+  readonly subscription?: TeamSubscriptionSeatSnapshot;
+  /** Test and service seam for loading the durable subscription quantity. */
+  readonly loadSubscription?: (
+    stackTeamId: string,
+  ) => Promise<TeamSubscriptionSeatSnapshot>;
+  /** Set false when a caller explicitly needs an uncached read. */
+  readonly cache?: boolean;
+};
+
+export type TeamSubscriptionSeatSnapshot = {
+  /** True when an active Team subscription row exists. */
+  readonly active: boolean;
+  /** The licensed quantity from that row, if it is present and valid. */
+  readonly seats: number | null;
+  /** True when the billing read was unavailable, rather than inactive. */
+  readonly unavailable?: boolean;
+};
+
+/** The result used by both billing-plan and VM entitlement resolution. */
+export type TeamSeatDecision = {
+  readonly status: "active" | "inactive" | "unavailable";
+  readonly entitled: boolean;
+  readonly seatCount: number | null;
+  readonly memberCount: number | null;
+  readonly memberListingAvailable: boolean;
+};
+
+type TeamMember = {
+  readonly id: string;
+  readonly createdAtMs: number | null;
+};
+
+type TeamMemberRoster = {
+  readonly available: boolean;
+  readonly members: readonly TeamMember[];
+};
+
+type CachedValue<T> = {
+  readonly expiresAt: number;
+  readonly value: Promise<T>;
+};
+
+const subscriptionCache = new Map<string, CachedValue<TeamSubscriptionSeatSnapshot>>();
+const rosterCache = new Map<string, CachedValue<TeamMemberRoster>>();
+
+/**
+ * Read the active Team subscription and its quantity from the durable billing
+ * row. Stack metadata is not used for the seat count.
+ */
+export async function teamSubscriptionSeatSnapshot(
+  stackTeamId: string,
+): Promise<TeamSubscriptionSeatSnapshot> {
+  try {
+    const db = cloudDb();
+    const query = db
+      .select({
+        id: stripeSubscriptions.id,
+        seats: stripeSubscriptions.seats,
+        updatedAt: stripeSubscriptions.updatedAt,
+        currentPeriodEnd: stripeSubscriptions.currentPeriodEnd,
+      })
+      .from(stripeSubscriptions)
+      .where(
+        and(
+          eq(stripeSubscriptions.stackTeamId, stackTeamId),
+          eq(stripeSubscriptions.scope, "team"),
+          eq(stripeSubscriptions.plan, TEAM_PLAN_ID),
+          inArray(stripeSubscriptions.status, [...ACTIVE_STRIPE_PRO_STATUSES]),
+        ),
+      );
+    // Lightweight test doubles can omit orderBy. The production query uses it
+    // so a renewed row is preferred when more than one active row exists.
+    const orderedQuery = typeof query.orderBy === "function"
+      ? query.orderBy(
+          desc(stripeSubscriptions.updatedAt),
+          desc(stripeSubscriptions.currentPeriodEnd),
+        )
+      : query;
+    const limited = typeof orderedQuery.limit === "function"
+      ? orderedQuery.limit(10)
+      : orderedQuery;
+    const rows = await limited as readonly { seats?: unknown }[];
+    const row = rows[0];
+    return {
+      active: row !== undefined,
+      seats: row ? normalizedSeatCount(row.seats) : null,
+      unavailable: false,
+    };
+  } catch {
+    // Entitlement checks must not turn a temporary billing database outage into
+    // a mass sign-out. The existing Team metadata remains authoritative until
+    // the next bounded read succeeds.
+    return { active: false, seats: null, unavailable: true };
+  }
+}
+
+/**
+ * Decide whether one Stack user is covered by a Team subscription's seats.
+ * When membership creation dates are absent (the current Stack response), the
+ * resolver keeps the lexicographically oldest member ids. This is deterministic
+ * across requests and is documented instead of depending on API result order.
+ */
+export async function resolveTeamSeatEntitlement(
+  stackTeamId: string,
+  stackUserId: string,
+  options: TeamSeatResolverOptions = {},
+): Promise<TeamSeatDecision> {
+  const subscription = await loadSubscriptionSnapshot(stackTeamId, options);
+
+  if (!subscription.active) {
+    return {
+      status: subscription.unavailable ? "unavailable" : "inactive",
+      entitled: Boolean(subscription.unavailable),
+      seatCount: null,
+      memberCount: null,
+      memberListingAvailable: false,
+    };
+  }
+
+  const seatCount = normalizedSeatCount(subscription.seats);
+  // Rows written before the seats column was introduced have no quantity. Do
+  // not revoke those existing subscriptions until billing reconciliation fills
+  // the value; current Team checkout rows always store a positive quantity.
+  if (seatCount === null) {
+    return {
+      status: "active",
+      entitled: true,
+      seatCount: null,
+      memberCount: null,
+      memberListingAvailable: false,
+    };
+  }
+
+  const roster = await loadCachedRoster(stackTeamId, options);
+  if (!roster.available) {
+    // A known paid quantity with no readable roster fails closed. Otherwise a
+    // hosted Stack outage could grant every member an unbounded Team seat.
+    return {
+      status: "active",
+      entitled: false,
+      seatCount,
+      memberCount: null,
+      memberListingAvailable: false,
+    };
+  }
+
+  const memberIds = new Set(roster.members.map((member) => member.id));
+  if (!memberIds.has(stackUserId)) {
+    return {
+      status: "active",
+      entitled: false,
+      seatCount,
+      memberCount: roster.members.length,
+      memberListingAvailable: true,
+    };
+  }
+
+  if (roster.members.length <= seatCount) {
+    return {
+      status: "active",
+      entitled: true,
+      seatCount,
+      memberCount: roster.members.length,
+      memberListingAvailable: true,
+    };
+  }
+
+  const assigned = assignedSeatMemberIds(roster.members, seatCount);
+  return {
+    status: "active",
+    entitled: assigned.has(stackUserId),
+    seatCount,
+    memberCount: roster.members.length,
+    memberListingAvailable: true,
+  };
+}
+
+/**
+ * Return true when a caller has a possible Stack roster reader. A numeric
+ * subscription quantity also makes the gate applicable, so an unavailable
+ * reader is handled by the fail-closed decision above.
+ */
+export function teamSeatMemberListingAvailable(
+  options: TeamSeatResolverOptions,
+): boolean {
+  const team = options.stackTeam ?? options.team;
+  if (hasListUsers(team)) return true;
+  if (hasGetTeam(options.stackApp)) return true;
+  return options.subscription?.active === true &&
+    normalizedSeatCount(options.subscription.seats) !== null;
+}
+
+/** Apply the seat gate only to the Team plan. */
+export async function effectiveTeamPlanForMember(
+  planId: string | null,
+  stackTeamId: string,
+  stackUserId: string,
+  options: TeamSeatResolverOptions = {},
+): Promise<string | null> {
+  if (planId?.trim().toLowerCase() !== TEAM_PLAN_ID) return planId;
+  const decision = await resolveTeamSeatEntitlement(
+    stackTeamId,
+    stackUserId,
+    options,
+  );
+  return decision.entitled ? planId : "free";
+}
+
+/** Test hook for clearing process-local subscription and roster state. */
+export function clearTeamSeatCacheForTests(): void {
+  subscriptionCache.clear();
+  rosterCache.clear();
+}
+
+async function loadSubscriptionSnapshot(
+  stackTeamId: string,
+  options: TeamSeatResolverOptions,
+): Promise<TeamSubscriptionSeatSnapshot> {
+  if (options.subscription) return normalizeSubscription(options.subscription);
+
+  const loader = options.loadSubscription ?? teamSubscriptionSeatSnapshot;
+  const useCache = options.cache !== false;
+  if (!useCache) return safeSubscriptionRead(loader, stackTeamId);
+
+  const now = Date.now();
+  const cached = subscriptionCache.get(stackTeamId);
+  if (cached && cached.expiresAt > now) return cached.value;
+  if (cached) subscriptionCache.delete(stackTeamId);
+
+  const value = safeSubscriptionRead(loader, stackTeamId);
+  setBoundedCache(subscriptionCache, stackTeamId, value, now);
+  return value;
+}
+
+async function safeSubscriptionRead(
+  loader: (stackTeamId: string) => Promise<TeamSubscriptionSeatSnapshot>,
+  stackTeamId: string,
+): Promise<TeamSubscriptionSeatSnapshot> {
+  try {
+    return normalizeSubscription(await loader(stackTeamId));
+  } catch {
+    return { active: false, seats: null, unavailable: true };
+  }
+}
+
+function normalizeSubscription(
+  value: TeamSubscriptionSeatSnapshot | null | undefined,
+): TeamSubscriptionSeatSnapshot {
+  if (!value || typeof value !== "object") {
+    return { active: false, seats: null, unavailable: true };
+  }
+  return {
+    active: value.active === true,
+    seats: normalizedSeatCount(value.seats),
+    unavailable: value.unavailable === true,
+  };
+}
+
+async function loadCachedRoster(
+  stackTeamId: string,
+  options: TeamSeatResolverOptions,
+): Promise<TeamMemberRoster> {
+  const useCache = options.cache !== false;
+  if (!useCache) return loadTeamRoster(stackTeamId, options);
+
+  const now = Date.now();
+  const cached = rosterCache.get(stackTeamId);
+  if (cached && cached.expiresAt > now) return cached.value;
+  if (cached) rosterCache.delete(stackTeamId);
+
+  const value = loadTeamRoster(stackTeamId, options);
+  setBoundedCache(rosterCache, stackTeamId, value, now);
+  return value;
+}
+
+function setBoundedCache<T>(
+  cache: Map<string, CachedValue<T>>,
+  key: string,
+  value: Promise<T>,
+  now: number,
+): void {
+  if (cache.size >= MAX_TEAM_SEAT_CACHE_ENTRIES) {
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) cache.delete(oldest);
+  }
+  const entry: CachedValue<T> = {
+    expiresAt: now + teamSeatCacheTtlMs(),
+    value,
+  };
+  cache.set(key, entry);
+  // A rejected Stack request must not poison the cache until its TTL expires.
+  void value.catch(() => {
+    if (cache.get(key) === entry) cache.delete(key);
+  });
+}
+
+async function loadTeamRoster(
+  stackTeamId: string,
+  options: TeamSeatResolverOptions,
+): Promise<TeamMemberRoster> {
+  let team = stackTeamFromUnknown(options.stackTeam ?? options.team);
+  if (!team) {
+    try {
+      const app = options.stackApp ?? (getStackServerApp() as unknown as StackSeatApp);
+      if (!hasGetTeam(app)) return { available: false, members: [] };
+      team = stackTeamFromUnknown(await app.getTeam!(stackTeamId));
+    } catch {
+      return { available: false, members: [] };
+    }
+  }
+  if (!team || !hasListUsers(team)) {
+    return { available: false, members: [] };
+  }
+
+  try {
+    const rawMembers = await listAllTeamMembers(team);
+    return { available: true, members: normalizeMembers(rawMembers) };
+  } catch {
+    return { available: false, members: [] };
+  }
+}
+
+async function listAllTeamMembers(team: StackSeatTeam): Promise<readonly unknown[]> {
+  const members: unknown[] = [];
+  const seenCursors = new Set<string>();
+  let cursor: string | undefined;
+
+  for (let pageIndex = 0; pageIndex < MAX_TEAM_MEMBER_PAGES; pageIndex += 1) {
+    const response = await withDeadline(
+      () => cursor
+        ? team.listUsers!({ cursor, limit: TEAM_MEMBER_PAGE_SIZE })
+        : team.listUsers!({ limit: TEAM_MEMBER_PAGE_SIZE }),
+      TEAM_MEMBER_READ_TIMEOUT_MS,
+    );
+    const page = teamMemberPage(response);
+    if (!page) throw new Error("Stack team member listing returned an invalid result");
+    members.push(...page.members);
+    if (members.length > MAX_TEAM_MEMBERS) {
+      throw new Error("Stack team member listing exceeded its bound");
+    }
+    const nextCursor = normalizedCursor(page.nextCursor);
+    if (!nextCursor) return members;
+    if (seenCursors.has(nextCursor)) {
+      throw new Error("Stack team member pagination repeated a cursor");
+    }
+    seenCursors.add(nextCursor);
+    cursor = nextCursor;
+  }
+  throw new Error("Stack team member pagination exceeded its page bound");
+}
+
+function stackTeamFromUnknown(value: unknown): StackSeatTeam | null {
+  if (!value || typeof value !== "object") return null;
+  const listUsers = (value as { readonly listUsers?: unknown }).listUsers;
+  if (typeof listUsers !== "function") return null;
+  return {
+    listUsers: (options) =>
+      (listUsers as (options?: TeamMemberListOptions) => Promise<unknown> | unknown)
+        .call(value, options),
+  };
+}
+
+function hasListUsers(value: unknown): value is StackSeatTeam {
+  return !!stackTeamFromUnknown(value);
+}
+
+function hasGetTeam(value: unknown): value is StackSeatApp & {
+  readonly getTeam: (id: string) => Promise<unknown> | unknown;
+} {
+  return !!value && typeof value === "object" &&
+    typeof (value as { readonly getTeam?: unknown }).getTeam === "function";
+}
+
+function teamMemberPage(
+  value: unknown,
+): { readonly members: readonly unknown[]; readonly nextCursor: unknown } | null {
+  if (Array.isArray(value)) {
+    return {
+      members: value,
+      nextCursor: (value as StackTeamMemberList).nextCursor,
+    };
+  }
+  if (!value || typeof value !== "object") return null;
+  const record = value as Record<string, unknown>;
+  const members = [record.members, record.users, record.items, record.data]
+    .find((candidate): candidate is readonly unknown[] => Array.isArray(candidate));
+  return members
+    ? { members, nextCursor: record.nextCursor ?? record.next_cursor }
+    : null;
+}
+
+function normalizeMembers(values: readonly unknown[]): readonly TeamMember[] {
+  const byId = new Map<string, TeamMember>();
+  for (const value of values) {
+    if (!value || typeof value !== "object") continue;
+    const rawId = (value as { readonly id?: unknown }).id;
+    if (typeof rawId !== "string" || !rawId.trim()) continue;
+    const id = rawId.trim();
+    const member = {
+      id,
+      createdAtMs: membershipCreatedAtMs(value),
+    };
+    const existing = byId.get(id);
+    if (!existing || (existing.createdAtMs === null && member.createdAtMs !== null)) {
+      byId.set(id, member);
+    }
+  }
+  return [...byId.values()];
+}
+
+/**
+ * Use an explicit membership/join timestamp only when Stack exposes one. Do
+ * not use a user's sign-up date: that is not the date they joined this team.
+ */
+function membershipCreatedAtMs(value: object): number | null {
+  const record = value as Record<string, unknown>;
+  const membership = record.membership;
+  const candidates = [
+    record.membershipCreatedAt,
+    record.membership_created_at,
+    record.joinedAt,
+    record.joined_at,
+    record.createdAt,
+    record.created_at,
+    membership && typeof membership === "object"
+      ? (membership as Record<string, unknown>).createdAt
+      : undefined,
+    membership && typeof membership === "object"
+      ? (membership as Record<string, unknown>).created_at
+      : undefined,
+  ];
+  for (const candidate of candidates) {
+    const parsed = timestampMs(candidate);
+    if (parsed !== null) return parsed;
+  }
+  return null;
+}
+
+function timestampMs(value: unknown): number | null {
+  if (value instanceof Date) {
+    const timestamp = value.getTime();
+    return Number.isFinite(timestamp) ? timestamp : null;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.abs(value) < 1_000_000_000_000 ? value * 1_000 : value;
+  }
+  if (typeof value !== "string" || !value.trim()) return null;
+  const numeric = Number(value);
+  if (Number.isFinite(numeric)) {
+    return Math.abs(numeric) < 1_000_000_000_000 ? numeric * 1_000 : numeric;
+  }
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function assignedSeatMemberIds(
+  members: readonly TeamMember[],
+  seats: number,
+): ReadonlySet<string> {
+  const hasCompleteDates = members.every((member) => member.createdAtMs !== null);
+  const ordered = [...members].sort((left, right) => {
+    if (hasCompleteDates) {
+      const dateOrder = left.createdAtMs! - right.createdAtMs!;
+      if (dateOrder !== 0) return dateOrder;
+    }
+    return compareMemberIds(left.id, right.id);
+  });
+  return new Set(ordered.slice(0, seats).map((member) => member.id));
+}
+
+function compareMemberIds(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+function normalizedCursor(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function normalizedSeatCount(value: unknown): number | null {
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) && value >= 1 ? value : null;
+  }
+  if (typeof value === "string" && /^\d+$/.test(value.trim())) {
+    const parsed = Number(value.trim());
+    return Number.isSafeInteger(parsed) && parsed >= 1 ? parsed : null;
+  }
+  return null;
+}
+
+function teamSeatCacheTtlMs(raw = process.env.CMUX_TEAM_SEAT_CACHE_TTL_MS): number {
+  if (raw === undefined || raw.trim() === "") return DEFAULT_TEAM_SEAT_CACHE_TTL_MS;
+  const parsed = Number(raw.trim());
+  return Number.isSafeInteger(parsed) && parsed >= 0
+    ? parsed
+    : DEFAULT_TEAM_SEAT_CACHE_TTL_MS;
+}
+
+async function withDeadline<T>(
+  operation: () => Promise<T> | T,
+  timeoutMs: number,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(
+      () => reject(new Error("Stack team member listing exceeded its deadline")),
+      timeoutMs,
+    );
+  });
+  try {
+    return await Promise.race([
+      Promise.resolve().then(operation),
+      timeout,
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}

--- a/web/services/vms/auth.ts
+++ b/web/services/vms/auth.ts
@@ -13,7 +13,15 @@ import {
   billingTeamFromUnknown,
   resolveBillingTeam,
   type BillingTeamLike,
+  type BillingTeamMemberListOptions,
+  type BillingTeamMemberList,
 } from "../billing/teamResolution";
+import { FREE_PLAN_ID, TEAM_PLAN_ID } from "../billing/pro";
+import {
+  resolveTeamSeatEntitlement,
+  teamSeatMemberListingAvailable,
+  type TeamSeatResolverOptions,
+} from "../billing/teamSeats";
 
 export type AuthedUser = {
   id: string;
@@ -469,7 +477,11 @@ export async function verifyRequest(
       options.subrouterAuthorizationSignal,
     );
     if (user) {
-      const authed = await authedUserFromStackUser(user, options);
+      const authed = await authedUserFromStackUser(
+        user,
+        options,
+        stackServerApp,
+      );
       if (authed && cacheKey) {
         writeNativeAuthCache(cacheKey, authed, tokens, authCacheTtlMs());
       }
@@ -495,7 +507,7 @@ export async function verifyRequest(
     options.subrouterAuthorizationSignal,
   );
   if (user) {
-    return await authedUserFromStackUser(user, options);
+    return await authedUserFromStackUser(user, options, stackServerApp);
   }
   return null;
 }
@@ -503,6 +515,7 @@ export async function verifyRequest(
 async function authedUserFromStackUser(
   user: StackUserLike,
   options: VerifyRequestOptions,
+  stackApp: TeamSeatResolverOptions["stackApp"],
 ): Promise<AuthedUser | null> {
   if (!options.allowDeletingAccount && await isAccountDeletionAuthBlocked(user)) {
     return null;
@@ -537,23 +550,39 @@ async function authedUserFromStackUser(
     ...listedTeams.map((team) => team.id),
   ]);
   const teams = uniqueTeams([selectedTeam, ...listedTeams]);
-  const billingTeam = await resolveBillingTeam({
-    selectedTeam,
-    listTeams: async () => listedTeams,
-  });
-  const userBillingPlanId = billingPlanIdFromMetadata(user.clientReadOnlyMetadata) ?? null;
-  const billingPlanId = billingPlanIdFromMetadata(billingTeam?.clientReadOnlyMetadata) ?? userBillingPlanId;
   const rawTeams = new Map<string, unknown>();
   if (selectedTeam) rawTeams.set(selectedTeam.id, selectedTeamRaw);
   for (const raw of listedTeamRaw) {
     const team = billingTeamFromUnknown(raw);
     if (team) rawTeams.set(team.id, raw);
   }
+  const seatCheckedTeams = await Promise.all(
+    teams.map((team) => teamWithSeatCheckedPlan(
+      team,
+      user.id,
+      stackApp,
+      rawTeams.get(team.id),
+    )),
+  );
+  const seatCheckedTeamsById = new Map(
+    seatCheckedTeams.map((team) => [team.id, team]),
+  );
+  const seatCheckedSelectedTeam = selectedTeam
+    ? seatCheckedTeamsById.get(selectedTeam.id) ?? selectedTeam
+    : null;
+  const seatCheckedListedTeams = listedTeams.map((team) =>
+    seatCheckedTeamsById.get(team.id) ?? team);
+  const billingTeam = await resolveBillingTeam({
+    selectedTeam: seatCheckedSelectedTeam,
+    listTeams: async () => seatCheckedListedTeams,
+  });
+  const userBillingPlanId = billingPlanIdFromMetadata(user.clientReadOnlyMetadata) ?? null;
+  const billingPlanId = billingPlanIdFromMetadata(billingTeam?.clientReadOnlyMetadata) ?? userBillingPlanId;
   const enforceSubrouterPermissions =
     options.subrouterAuthorizationSignal
       ? subrouterPermissionEnforcementEnabled()
       : false;
-  const authedTeams = teams.map((team) => ({
+  const authedTeams = seatCheckedTeams.map((team) => ({
     id: team.id,
     displayName: team.displayName,
     billingPlanId: billingPlanIdFromMetadata(team.clientReadOnlyMetadata),
@@ -599,6 +628,47 @@ async function authedUserFromStackUser(
       return pending;
     },
   };
+}
+
+async function teamWithSeatCheckedPlan(
+  team: BillingTeamLike,
+  userId: string,
+  stackApp: TeamSeatResolverOptions["stackApp"],
+  rawTeam: unknown,
+): Promise<BillingTeamLike> {
+  if (billingPlanIdFromMetadata(team.clientReadOnlyMetadata)?.toLowerCase() !== TEAM_PLAN_ID) {
+    return team;
+  }
+  const stackTeam = stackTeamWithMemberListing(rawTeam) ?? team;
+  const seatOptions: TeamSeatResolverOptions = { stackApp, stackTeam };
+  if (!teamSeatMemberListingAvailable(seatOptions)) return team;
+
+  const seat = await resolveTeamSeatEntitlement(team.id, userId, seatOptions);
+  if (seat.status === "inactive" || seat.entitled) return team;
+  return {
+    ...team,
+    clientReadOnlyMetadata: freeTeamPlanMetadata(team.clientReadOnlyMetadata),
+  };
+}
+
+function stackTeamWithMemberListing(value: unknown): TeamSeatResolverOptions["stackTeam"] {
+  if (!value || typeof value !== "object") return null;
+  const listUsers = (value as { readonly listUsers?: unknown }).listUsers;
+  if (typeof listUsers !== "function") return null;
+  return {
+    listUsers: async (options?: BillingTeamMemberListOptions) =>
+      await (listUsers as (
+        options?: BillingTeamMemberListOptions,
+      ) => Promise<unknown> | unknown).call(value, options) as BillingTeamMemberList,
+  };
+}
+
+function freeTeamPlanMetadata(metadata: unknown): Record<string, unknown> {
+  const record = metadata && typeof metadata === "object" && !Array.isArray(metadata)
+    ? { ...(metadata as Record<string, unknown>) }
+    : {};
+  record.cmuxPlan = FREE_PLAN_ID;
+  return record;
 }
 
 async function subrouterPermissions(

--- a/web/tests/billing-plan-route.test.ts
+++ b/web/tests/billing-plan-route.test.ts
@@ -111,7 +111,21 @@ describe("billing plan route", () => {
     currentUser = planUser({
       selectedTeam: { id: "team-plan", clientReadOnlyMetadata: {} },
     });
-    stripeSubscriptionResults = [[], [{ id: "sub_team" }]];
+    // Queue order under the seats-aware route: two personal-plan queries,
+    // then stripeBillingStatusForTeam's subscription-row query (needs status
+    // and seats), then hasActiveTeamSubscriptionForTeam.
+    stripeSubscriptionResults = [
+      [],
+      [],
+      [{
+        status: "active",
+        cancelAtPeriodEnd: false,
+        currentPeriodEnd: null,
+        updatedAt: null,
+        seats: null,
+      }],
+      [{ id: "sub_team" }],
+    ];
 
     const response = await planResponse();
 

--- a/web/tests/billing-team-seats.test.ts
+++ b/web/tests/billing-team-seats.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import {
+  clearTeamSeatCacheForTests,
+  resolveTeamSeatEntitlement,
+} from "../services/billing/teamSeats";
+
+describe("Team subscription seat enforcement", () => {
+  beforeEach(() => {
+    clearTeamSeatCacheForTests();
+  });
+
+  test("keeps every member entitled below the subscription seat count", async () => {
+    const listUsers = mock(async () => [
+      { id: "member-a" },
+      { id: "member-b" },
+    ]);
+    const getTeam = mock(async () => ({ listUsers }));
+    const loadSubscription = mock(async () => ({ active: true, seats: 3 }));
+
+    const decision = await resolveTeamSeatEntitlement(
+      "team-under-limit",
+      "member-b",
+      { stackApp: { getTeam }, loadSubscription, cache: false },
+    );
+
+    expect(decision).toEqual({
+      status: "active",
+      entitled: true,
+      seatCount: 3,
+      memberCount: 2,
+      memberListingAvailable: true,
+    });
+    expect(loadSubscription).toHaveBeenCalledWith("team-under-limit");
+    expect(getTeam).toHaveBeenCalledWith("team-under-limit");
+    expect(listUsers).toHaveBeenCalledTimes(1);
+  });
+
+  test("demotes members beyond the limit with a deterministic member-id tiebreak", async () => {
+    const getTeam = async () => ({
+      // Stack's team-user response does not promise membership creation time.
+      // The resolver therefore keeps the lexicographically oldest id.
+      listUsers: async () => [
+        { id: "member-b", signedUpAt: new Date("2020-01-01") },
+        { id: "member-a", signedUpAt: new Date("2025-01-01") },
+      ],
+    });
+    const options = {
+      stackApp: { getTeam },
+      loadSubscription: async () => ({ active: true, seats: 1 }),
+      cache: false,
+    };
+
+    const included = await resolveTeamSeatEntitlement(
+      "team-at-limit",
+      "member-a",
+      options,
+    );
+    const overLimit = await resolveTeamSeatEntitlement(
+      "team-at-limit",
+      "member-b",
+      options,
+    );
+
+    expect(included.entitled).toBe(true);
+    expect(overLimit).toMatchObject({
+      status: "active",
+      entitled: false,
+      seatCount: 1,
+      memberCount: 2,
+    });
+  });
+
+  test("uses the seat quantity from the subscription loader", async () => {
+    const loadSubscription = mock(async () => ({ active: true, seats: 2 }));
+    const stackApp = {
+      getTeam: async () => ({
+        listUsers: async () => [
+          { id: "member-a" },
+          { id: "member-b" },
+          { id: "member-c" },
+        ],
+      }),
+    };
+
+    const decision = await resolveTeamSeatEntitlement(
+      "team-subscription-seats",
+      "member-c",
+      { stackApp, loadSubscription, cache: false },
+    );
+
+    expect(loadSubscription).toHaveBeenCalledWith("team-subscription-seats");
+    expect(decision.seatCount).toBe(2);
+    expect(decision.entitled).toBe(false);
+  });
+
+  test("shares one bounded subscription and roster lookup for concurrent checks", async () => {
+    const loadSubscription = mock(async () => ({ active: true, seats: 2 }));
+    const listUsers = mock(async () => [
+      { id: "member-a" },
+      { id: "member-b" },
+    ]);
+    const getTeam = mock(async () => ({ listUsers }));
+
+    const [first, second] = await Promise.all([
+      resolveTeamSeatEntitlement("team-cached", "member-a", {
+        stackApp: { getTeam },
+        loadSubscription,
+      }),
+      resolveTeamSeatEntitlement("team-cached", "member-b", {
+        stackApp: { getTeam },
+        loadSubscription,
+      }),
+    ]);
+
+    expect(first.entitled).toBe(true);
+    expect(second.entitled).toBe(true);
+    expect(loadSubscription).toHaveBeenCalledTimes(1);
+    expect(getTeam).toHaveBeenCalledTimes(1);
+    expect(listUsers).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
A team paying for N seats could add unlimited members and every member received Team entitlements. Stack Auth's hosted surfaces own membership (no in-repo add/invite route exists to guard), so enforcement happens at entitlement-consumption time instead: /api/billing/plan and VM auth resolution demote members beyond the paid seat count to the free plan.

Mechanism: new web/services/billing/teamSeats.ts resolves a member's seat coverage from the durable Stripe subscription row's quantity plus a bounded Stack roster read (paged, capped, 15s timeout, 30s in-process cache). Members beyond the seat count are demoted keeping the lexicographically oldest member ids, a deterministic documented tiebreak since Stack does not expose membership creation time. With a known paid quantity and no readable roster the check fails closed; a billing-database outage fails open so an infra blip cannot mass-revoke teams. Legacy subscription rows with no seats quantity stay ungated until reconciliation fills the value.

Verification: billing-team-seats (4 tests) and billing-plan-route pass locally, tsgo typecheck clean. Local full suite has a pre-existing failing baseline unrelated to this branch; hosted CI is authoritative.

Implementation by Codex (gpt-5), verification by Claude. Note for reviewers: the demotion threshold means an over-limit team's newest members lose Team features silently; if product prefers a grace banner over hard demotion, that is a one-line policy change in resolveTeamSeatEntitlement.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11352"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790838136&installation_model_id=21920&pr_number=11352&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11352&signature=7bd448502e1004cf9af2f91dfb0bd48a5a8ed9683eb3ae3dc88110f5f9779712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces Team subscription seats so a team paying for N seats can no longer add unlimited members and give everyone Team entitlements. Members beyond the paid seat count are demoted to the free plan in `/api/billing/plan` and VM auth resolution; over-limit members silently lose Team features.

**Behavioral notes**
- Seat quantity comes from the durable Stripe subscription row; roster reads are paged, bounded, cached for 30s, and run under a 15s timeout.
- Without membership join timestamps, seats go to the lexicographically oldest member ids so the assignment is deterministic across requests.
- A known seat quantity with an unreadable roster fails closed; a billing-database outage fails open to avoid mass sign-outs.
- Legacy subscription rows without a seats quantity stay ungated until reconciliation fills the value.

<sup>Written for commit 3aa0f3688a90df63be25b95c06ee7621524809c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added team billing seat enforcement based on active subscription seat limits.
  * Team members without an entitled seat now receive free-plan access.
  * Added support for subscription seat counts and paginated team member listings.

* **Bug Fixes**
  * Improved handling of inactive, unavailable, and legacy team subscription data.
  * Ensured seat assignments remain deterministic when teams exceed capacity.

* **Tests**
  * Added coverage for seat eligibility, over-capacity demotion, subscription seat counts, and caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->