### PR TITLE
fix(chatmux-relay): resolve E0382 in auth test harness

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2317,7 +2317,7 @@ mod tests {
                 buffered_amount: Arc::new(move || buffered.load(Ordering::SeqCst)),
                 trust: trust.to_owned(),
                 local_roots: None,
-                owner_user_id: owner,
+                owner_user_id: owner.clone(),
                 transport_id: None,
                 current_auth: {
                     let trust = trust.to_owned();


### PR DESCRIPTION
## Summary

Fix the exact-head hosted cmux-tui compile failure in the chatmux-relay test helper.

`Harness::context` moved `owner` into `FrameContext::owner_user_id` and then attempted to clone it for the `current_auth` closure, producing `error[E0382]: borrow of moved value: owner`. The helper now clones the owner for the field so the closure keeps its independent snapshot semantics.

## Verification

Local checks passed:

- `rustfmt --check --edition 2024 cmux-tui/crates/chatmux-relay/src/pty.rs`
- `git diff --check`

No local Cargo or Rust compilation was run. Hosted rerun plan:

```bash
./scripts/verify-cmux-tui-hosted.sh --filter chatmux_relay
```

This follow-up targets the live head branch `feat-tui-tunnel-bounded-writer` of [PR #11206](https://github.com/manaflow-ai/cmux/pull/11206).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11357"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790839189&installation_model_id=21920&pr_number=11357&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11357&signature=f1fb2f3a229d90fcf6d6a53c786b6a2872b2896f19517482505451622fd5f278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `chatmux-relay` test harness compile error caused by `owner` being moved into `FrameContext::owner_user_id` before the `current_auth` closure. The harness now clones `owner` for the field, preserving the closure's snapshot semantics.

<sup>Written for commit ad3769ed54606b5c919729b3a72d59d05467309f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

