### PR TITLE
feat(relay): add Azure shard deployment

### DIFF
--- a/cmux-tui/.dockerignore
+++ b/cmux-tui/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.gitignore
+target
+**/target
+relays/cloudflare-do/node_modules
+**/*.log

--- a/cmux-tui/crates/cmux-relay/src/config.rs
+++ b/cmux-tui/crates/cmux-relay/src/config.rs
@@ -12,6 +12,9 @@ const DEFAULT_LEASE_SECONDS: u64 = 30;
 const DEFAULT_JOIN_TIMEOUT_SECONDS: u64 = 15;
 const DEFAULT_IDLE_TIMEOUT_SECONDS: u64 = 300;
 const DEFAULT_DRAIN_TIMEOUT_SECONDS: u64 = 300;
+// Keep the drain window bounded so an orchestrator can give the process a
+// slightly longer stop deadline and still preserve the configured behavior.
+const MAXIMUM_DRAIN_TIMEOUT_SECONDS: u64 = 300;
 const DEFAULT_HANDSHAKE_TIMEOUT_SECONDS: u64 = 10;
 const DEFAULT_CONTROL_IDLE_TIMEOUT_SECONDS: u64 = 120;
 const DEFAULT_HTTP_HEADER_TIMEOUT_SECONDS: u64 = 5;
@@ -224,6 +227,11 @@ impl RelayConfig {
         if self.join_ticket_ttl.as_secs() > MAXIMUM_JOIN_TICKET_TTL_SECONDS {
             return Err(ConfigError::new(format!(
                 "relay join ticket TTL cannot exceed {MAXIMUM_JOIN_TICKET_TTL_SECONDS} seconds"
+            )));
+        }
+        if self.drain_timeout > Duration::from_secs(MAXIMUM_DRAIN_TIMEOUT_SECONDS) {
+            return Err(ConfigError::new(format!(
+                "relay drain timeout cannot exceed {MAXIMUM_DRAIN_TIMEOUT_SECONDS} seconds"
             )));
         }
         if self.join_timeout > self.join_ticket_ttl {
@@ -695,6 +703,14 @@ mod tests {
 
         let valid = RelayConfig { shard: "westus2-a".into(), ..RelayConfig::default() };
         valid.validate().unwrap();
+    }
+
+    #[test]
+    fn drain_timeout_has_a_finite_operational_bound() {
+        let invalid =
+            RelayConfig { drain_timeout: Duration::from_secs(u64::MAX), ..RelayConfig::default() };
+        let error = invalid.validate().unwrap_err();
+        assert!(error.to_string().contains("drain timeout"));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-relay/src/config.rs
+++ b/cmux-tui/crates/cmux-relay/src/config.rs
@@ -11,6 +11,7 @@ const DEFAULT_BIND: &str = "127.0.0.1:8787";
 const DEFAULT_LEASE_SECONDS: u64 = 30;
 const DEFAULT_JOIN_TIMEOUT_SECONDS: u64 = 15;
 const DEFAULT_IDLE_TIMEOUT_SECONDS: u64 = 300;
+const DEFAULT_DRAIN_TIMEOUT_SECONDS: u64 = 300;
 const DEFAULT_HANDSHAKE_TIMEOUT_SECONDS: u64 = 10;
 const DEFAULT_CONTROL_IDLE_TIMEOUT_SECONDS: u64 = 120;
 const DEFAULT_HTTP_HEADER_TIMEOUT_SECONDS: u64 = 5;
@@ -32,13 +33,21 @@ const DEFAULT_MAX_ACTIVE_CIRCUITS_PER_SLOT: usize = 256;
 const DEFAULT_MAX_ALLOCATIONS_PER_SECOND_PER_SLOT: usize = 64;
 const DEFAULT_TICKET_TTL_SECONDS: u64 = RelayTicketClaims::MAX_LIFETIME_SECONDS;
 const DEFAULT_TICKET_ISSUER: &str = "cmux-relay";
+const DEFAULT_SHARD: &str = "default";
+const MAX_SHARD_BYTES: usize = 128;
 
 #[derive(Clone)]
 pub struct RelayConfig {
     pub bind: SocketAddr,
+    /// Stable control-plane shard name. A shard must route both sides of a
+    /// circuit to the same in-memory relay process.
+    pub shard: String,
     pub lease_duration: Duration,
     pub join_timeout: Duration,
     pub idle_timeout: Duration,
+    /// Maximum time a draining process waits for established sockets to close.
+    /// Clients reconnect and resume after this safety bound expires.
+    pub drain_timeout: Duration,
     pub handshake_timeout: Duration,
     pub control_idle_timeout: Duration,
     pub http_header_timeout: Duration,
@@ -66,9 +75,11 @@ impl Default for RelayConfig {
     fn default() -> Self {
         Self {
             bind: DEFAULT_BIND.parse().expect("default relay bind address is valid"),
+            shard: DEFAULT_SHARD.into(),
             lease_duration: Duration::from_secs(DEFAULT_LEASE_SECONDS),
             join_timeout: Duration::from_secs(DEFAULT_JOIN_TIMEOUT_SECONDS),
             idle_timeout: Duration::from_secs(DEFAULT_IDLE_TIMEOUT_SECONDS),
+            drain_timeout: Duration::from_secs(DEFAULT_DRAIN_TIMEOUT_SECONDS),
             handshake_timeout: Duration::from_secs(DEFAULT_HANDSHAKE_TIMEOUT_SECONDS),
             control_idle_timeout: Duration::from_secs(DEFAULT_CONTROL_IDLE_TIMEOUT_SECONDS),
             http_header_timeout: Duration::from_secs(DEFAULT_HTTP_HEADER_TIMEOUT_SECONDS),
@@ -108,6 +119,9 @@ impl RelayConfig {
         if let Some(value) = lookup("CMUX_RELAY_BIND") {
             self.bind = parse_value("CMUX_RELAY_BIND", &value)?;
         }
+        if let Some(value) = lookup("CMUX_RELAY_SHARD") {
+            self.shard = value;
+        }
         if let Some(value) = lookup("CMUX_RELAY_LEASE_SECONDS") {
             self.lease_duration = parse_duration("CMUX_RELAY_LEASE_SECONDS", &value)?;
         }
@@ -116,6 +130,9 @@ impl RelayConfig {
         }
         if let Some(value) = lookup("CMUX_RELAY_IDLE_TIMEOUT_SECONDS") {
             self.idle_timeout = parse_duration("CMUX_RELAY_IDLE_TIMEOUT_SECONDS", &value)?;
+        }
+        if let Some(value) = lookup("CMUX_RELAY_DRAIN_TIMEOUT_SECONDS") {
+            self.drain_timeout = parse_duration("CMUX_RELAY_DRAIN_TIMEOUT_SECONDS", &value)?;
         }
         if let Some(value) = lookup("CMUX_RELAY_HANDSHAKE_TIMEOUT_SECONDS") {
             self.handshake_timeout =
@@ -195,6 +212,7 @@ impl RelayConfig {
         if self.lease_duration.is_zero()
             || self.join_timeout.is_zero()
             || self.idle_timeout.is_zero()
+            || self.drain_timeout.is_zero()
             || self.handshake_timeout.is_zero()
             || self.control_idle_timeout.is_zero()
             || self.http_header_timeout.is_zero()
@@ -257,6 +275,17 @@ impl RelayConfig {
             return Err(ConfigError::new(
                 "CMUX_RELAY_ISSUER must contain 1 to 256 bytes without newline",
             ));
+        }
+        if self.shard.is_empty()
+            || self.shard.len() > MAX_SHARD_BYTES
+            || !self
+                .shard
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+        {
+            return Err(ConfigError::new(format!(
+                "CMUX_RELAY_SHARD must contain 1 to {MAX_SHARD_BYTES} ASCII letters, digits, '.', '_' or '-'",
+            )));
         }
         if !self.bind.ip().is_loopback() && self.ticket_secret.is_none() && !self.allow_open {
             return Err(ConfigError::new(
@@ -325,6 +354,9 @@ impl RelayCommand {
                 "-V" | "--version" => return Ok(Self::Version),
                 "--allow-open" => config.allow_open = true,
                 "--bind" => config.bind = parse_next("--bind", &mut args)?,
+                "--shard" => {
+                    config.shard = parse_next_string("--shard", &mut args)?;
+                }
                 "--lease-seconds" => {
                     config.lease_duration =
                         Duration::from_secs(parse_next("--lease-seconds", &mut args)?);
@@ -336,6 +368,10 @@ impl RelayCommand {
                 "--idle-timeout-seconds" => {
                     config.idle_timeout =
                         Duration::from_secs(parse_next("--idle-timeout-seconds", &mut args)?);
+                }
+                "--drain-timeout-seconds" => {
+                    config.drain_timeout =
+                        Duration::from_secs(parse_next("--drain-timeout-seconds", &mut args)?);
                 }
                 "--handshake-timeout-seconds" => {
                     config.handshake_timeout =
@@ -497,9 +533,11 @@ impl RelayCommand {
          Global options: -h, --help, -V, --version.\n\n\
          Serve options:\n\
            --bind ADDR                       Bind address (CMUX_RELAY_BIND)\n\
+           --shard NAME                      Stable relay shard (CMUX_RELAY_SHARD)\n\
            --lease-seconds N                 Daemon control lease\n\
            --join-timeout-seconds N          Pending circuit timeout\n\
            --idle-timeout-seconds N          Paired circuit idle timeout\n\
+           --drain-timeout-seconds N         Graceful shutdown drain bound\n\
            --handshake-timeout-seconds N     First control message timeout\n\
            --control-idle-timeout-seconds N  Authenticated control socket idle timeout\n\
            --http-header-timeout-seconds N   Complete HTTP header deadline\n\
@@ -522,7 +560,7 @@ impl RelayCommand {
            --allow-open                      Permit an unauthenticated non-loopback relay\n\n\
          Ticket options: --lane TOKEN, --generation N, --ttl-seconds N (maximum 300).\n\
          Set CMUX_RELAY_HMAC_SECRET to validate provider tickets and mint join tickets.\n\
-         Endpoints: /healthz, /v1/relay, and /ws\n"
+         Endpoints: /healthz, /readyz, /v1/relay, and /ws\n"
     }
 }
 
@@ -619,6 +657,8 @@ mod tests {
                 "2048",
                 "--http-header-timeout-seconds",
                 "7",
+                "--drain-timeout-seconds",
+                "13",
                 "--max-control-sockets-per-slot",
                 "9",
                 "--max-allocations-per-second-per-slot",
@@ -634,6 +674,7 @@ mod tests {
         assert_eq!(config.max_frame_bytes, 1024);
         assert_eq!(config.max_queue_bytes, 2048);
         assert_eq!(config.http_header_timeout, Duration::from_secs(7));
+        assert_eq!(config.drain_timeout, Duration::from_secs(13));
         assert_eq!(config.max_control_sockets_per_slot, 9);
         assert_eq!(config.max_allocations_per_second_per_slot, 11);
     }
@@ -644,6 +685,16 @@ mod tests {
             RelayConfig { bind: "0.0.0.0:8787".parse().unwrap(), ..RelayConfig::default() };
         let command = RelayCommand::parse(config, [OsString::from("--allow-open")]).unwrap();
         assert!(matches!(command, RelayCommand::Serve(config) if config.allow_open));
+    }
+
+    #[test]
+    fn shard_name_is_required_to_be_safe_for_routing_metadata() {
+        let invalid = RelayConfig { shard: "west/us".into(), ..RelayConfig::default() };
+        let error = invalid.validate().unwrap_err();
+        assert!(error.to_string().contains("CMUX_RELAY_SHARD"));
+
+        let valid = RelayConfig { shard: "westus2-a".into(), ..RelayConfig::default() };
+        valid.validate().unwrap();
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-relay/src/lib.rs
+++ b/cmux-tui/crates/cmux-relay/src/lib.rs
@@ -7,7 +7,7 @@ mod ticket;
 
 pub use admission::AdmissionListener;
 pub use config::{ConfigError, RelayCommand, RelayConfig};
-pub use relay::{HealthSnapshot, Relay};
+pub use relay::{HealthSnapshot, ReadinessSnapshot, Relay};
 pub use ticket::{TicketAuthority, TicketError};
 
 pub fn version_string() -> String {

--- a/cmux-tui/crates/cmux-relay/src/main.rs
+++ b/cmux-tui/crates/cmux-relay/src/main.rs
@@ -71,19 +71,17 @@ async fn serve_until_shutdown(
     listener: cmux_relay::AdmissionListener,
     router: axum::Router,
 ) -> anyhow::Result<()> {
-    let (shutdown_sender, shutdown_receiver) = watch::channel(false);
-    let signal_relay = relay.clone();
+    let (shutdown_request_sender, shutdown_request_receiver) = watch::channel(false);
+    let (shutdown_complete_sender, shutdown_complete_receiver) = watch::channel(false);
     let signal_task = tokio::spawn(async move {
         shutdown_signal().await;
-        // Flip readiness before notifying the HTTP server. This closes the
-        // handoff race where a quiet server could finish graceful shutdown
-        // before the load balancer observes /readyz as draining.
-        signal_relay.begin_drain();
-        let _ = shutdown_sender.send(true);
+        let _ = shutdown_request_sender.send(true);
     });
-    let server_shutdown_receiver = shutdown_receiver.clone();
     let server_shutdown = async move {
-        let _ = wait_for_shutdown(server_shutdown_receiver).await;
+        // Keep Axum serving /readyz while the relay drains. The completion
+        // signal is sent only after the admission gate is closed and the
+        // established sockets have had their configured drain window.
+        let _ = wait_for_shutdown(shutdown_complete_receiver).await;
     };
     let mut server = Box::pin(
         axum::serve(listener, router).with_graceful_shutdown(server_shutdown).into_future(),
@@ -91,12 +89,9 @@ async fn serve_until_shutdown(
 
     let result = tokio::select! {
         result = &mut server => result.context("relay server failed"),
-        changed = wait_for_shutdown(shutdown_receiver) => {
+        changed = wait_for_shutdown(shutdown_request_receiver) => {
             if changed {
-                // The signal task performs the transition before publishing
-                // this notification. Keep this idempotent guard for future
-                // shutdown sources that may send the watch signal directly.
-                relay.begin_drain();
+                relay.begin_drain().await;
                 let drained = relay.wait_for_idle(relay.config().drain_timeout).await;
                 if !drained {
                     eprintln!(
@@ -104,6 +99,7 @@ async fn serve_until_shutdown(
                         relay.active_connections(),
                     );
                 }
+                let _ = shutdown_complete_sender.send(true);
                 match tokio::time::timeout(Duration::from_secs(2), &mut server).await {
                     Ok(result) => result.context("relay server failed during shutdown"),
                     Err(_) => Ok(()),

--- a/cmux-tui/crates/cmux-relay/src/main.rs
+++ b/cmux-tui/crates/cmux-relay/src/main.rs
@@ -1,3 +1,4 @@
+use std::future::IntoFuture;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, anyhow};
@@ -84,8 +85,9 @@ async fn serve_until_shutdown(
     let server_shutdown = async move {
         let _ = wait_for_shutdown(server_shutdown_receiver).await;
     };
-    let mut server =
-        Box::pin(axum::serve(listener, router).with_graceful_shutdown(server_shutdown));
+    let mut server = Box::pin(
+        axum::serve(listener, router).with_graceful_shutdown(server_shutdown).into_future(),
+    );
 
     let result = tokio::select! {
         result = &mut server => result.context("relay server failed"),

--- a/cmux-tui/crates/cmux-relay/src/main.rs
+++ b/cmux-tui/crates/cmux-relay/src/main.rs
@@ -1,8 +1,9 @@
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, anyhow};
 use cmux_relay::{Relay, RelayCommand, TicketAuthority, version_string};
 use cmux_remote_protocol::{RelayPermission, RelayRole, RelayTicketClaims};
+use tokio::sync::watch;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -53,16 +54,73 @@ async fn main() -> anyhow::Result<()> {
             let cleanup = relay.spawn_cleanup();
             let (listener, router) = relay.server_parts(listener);
             eprintln!("cmux-relay listening on {address}");
-            let result = axum::serve(listener, router)
-                .with_graceful_shutdown(shutdown_signal())
-                .await
-                .context("relay server failed");
+            let result = serve_until_shutdown(relay, listener, router).await;
             cleanup.abort();
             // `abort` only requests cancellation. Await the handle so the
             // cleanup task is fully stopped before the runtime begins to
             // tear down, instead of leaving its final poll implicit.
             let _ = cleanup.await;
             result
+        }
+    }
+}
+
+async fn serve_until_shutdown(
+    relay: Relay,
+    listener: cmux_relay::AdmissionListener,
+    router: axum::Router,
+) -> anyhow::Result<()> {
+    let (shutdown_sender, shutdown_receiver) = watch::channel(false);
+    let signal_relay = relay.clone();
+    let signal_task = tokio::spawn(async move {
+        shutdown_signal().await;
+        // Flip readiness before notifying the HTTP server. This closes the
+        // handoff race where a quiet server could finish graceful shutdown
+        // before the load balancer observes /readyz as draining.
+        signal_relay.begin_drain();
+        let _ = shutdown_sender.send(true);
+    });
+    let server_shutdown = wait_for_shutdown(shutdown_receiver.clone());
+    let mut server =
+        Box::pin(axum::serve(listener, router).with_graceful_shutdown(server_shutdown));
+
+    let result = tokio::select! {
+        result = &mut server => result.context("relay server failed"),
+        changed = wait_for_shutdown(shutdown_receiver) => {
+            if changed {
+                // The signal task performs the transition before publishing
+                // this notification. Keep this idempotent guard for future
+                // shutdown sources that may send the watch signal directly.
+                relay.begin_drain();
+                let drained = relay.wait_for_idle(relay.config().drain_timeout).await;
+                if !drained {
+                    eprintln!(
+                        "cmux-relay drain timeout reached with {} active sockets",
+                        relay.active_connections(),
+                    );
+                }
+                match tokio::time::timeout(Duration::from_secs(2), &mut server).await {
+                    Ok(result) => result.context("relay server failed during shutdown"),
+                    Err(_) => Ok(()),
+                }
+            } else {
+                Ok(())
+            }
+        }
+    };
+
+    signal_task.abort();
+    let _ = signal_task.await;
+    result
+}
+
+async fn wait_for_shutdown(mut receiver: watch::Receiver<bool>) -> bool {
+    loop {
+        if *receiver.borrow() {
+            return true;
+        }
+        if receiver.changed().await.is_err() {
+            return false;
         }
     }
 }

--- a/cmux-tui/crates/cmux-relay/src/main.rs
+++ b/cmux-tui/crates/cmux-relay/src/main.rs
@@ -73,8 +73,13 @@ async fn serve_until_shutdown(
 ) -> anyhow::Result<()> {
     let (shutdown_request_sender, shutdown_request_receiver) = watch::channel(false);
     let (shutdown_complete_sender, shutdown_complete_receiver) = watch::channel(false);
+    let signal_relay = relay.clone();
     let signal_task = tokio::spawn(async move {
         shutdown_signal().await;
+        // Flip readiness before publishing the shutdown request. This closes
+        // the small window where a load-balancer probe could still see 200
+        // after SIGTERM arrived, while the drain branch remains idempotent.
+        signal_relay.begin_drain().await;
         let _ = shutdown_request_sender.send(true);
     });
     let server_shutdown = async move {

--- a/cmux-tui/crates/cmux-relay/src/main.rs
+++ b/cmux-tui/crates/cmux-relay/src/main.rs
@@ -80,7 +80,10 @@ async fn serve_until_shutdown(
         signal_relay.begin_drain();
         let _ = shutdown_sender.send(true);
     });
-    let server_shutdown = wait_for_shutdown(shutdown_receiver.clone());
+    let server_shutdown_receiver = shutdown_receiver.clone();
+    let server_shutdown = async move {
+        let _ = wait_for_shutdown(server_shutdown_receiver).await;
+    };
     let mut server =
         Box::pin(axum::serve(listener, router).with_graceful_shutdown(server_shutdown));
 

--- a/cmux-tui/crates/cmux-relay/src/relay.rs
+++ b/cmux-tui/crates/cmux-relay/src/relay.rs
@@ -45,6 +45,10 @@ struct RelayInner {
     config: RelayConfig,
     tickets: TicketAuthority,
     state: Mutex<RelayState>,
+    /// Serializes the readiness transition with every operation that admits
+    /// a new socket, daemon, or circuit. The guard is held only for the
+    /// admission mutation, not for frame forwarding.
+    admission_gate: Mutex<()>,
     next_connection_id: AtomicU64,
     active_connections: AtomicUsize,
     accepting_connections: AtomicBool,
@@ -234,6 +238,7 @@ impl Relay {
                 config,
                 tickets,
                 state: Mutex::new(RelayState::default()),
+                admission_gate: Mutex::new(()),
                 next_connection_id: AtomicU64::new(1),
                 active_connections: AtomicUsize::new(0),
                 accepting_connections: AtomicBool::new(true),
@@ -248,7 +253,12 @@ impl Relay {
 
     /// Stops new WebSocket upgrades while allowing established circuits to
     /// finish. Returns `true` only for the transition from serving to draining.
-    pub fn begin_drain(&self) -> bool {
+    ///
+    /// The admission gate makes the state change a linearization point. An
+    /// admission that holds the gate finishes its ledger mutation first; no
+    /// later admission can pass the gate after draining starts.
+    pub async fn begin_drain(&self) -> bool {
+        let _gate = self.inner.admission_gate.lock().await;
         self.inner.accepting_connections.swap(false, Ordering::AcqRel)
     }
 
@@ -358,7 +368,7 @@ impl Relay {
             response.headers_mut().insert(RETRY_AFTER, HeaderValue::from_static("1"));
             return response;
         }
-        let Some(permit) = relay.try_admit_upgraded_socket() else {
+        let Some(permit) = relay.try_admit_upgraded_socket().await else {
             let mut response =
                 (StatusCode::SERVICE_UNAVAILABLE, "relay concurrent WebSocket limit was reached")
                     .into_response();
@@ -381,7 +391,8 @@ impl Relay {
         response
     }
 
-    fn try_admit_upgraded_socket(&self) -> Option<UpgradedConnectionPermit> {
+    async fn try_admit_upgraded_socket(&self) -> Option<UpgradedConnectionPermit> {
+        let _gate = self.inner.admission_gate.lock().await;
         if !self.is_accepting() {
             return None;
         }
@@ -393,12 +404,6 @@ impl Relay {
             })
             .is_err()
         {
-            return None;
-        }
-        if !self.is_accepting() {
-            if self.inner.active_connections.fetch_sub(1, Ordering::AcqRel) == 1 {
-                self.inner.idle_notify.notify_waiters();
-            }
             return None;
         }
         Some(UpgradedConnectionPermit { inner: self.inner.clone() })
@@ -764,10 +769,10 @@ impl Relay {
 
         let mut replaced = None;
         {
+            let _admission_gate = self.inner.admission_gate.lock().await;
             let mut state = self.inner.state.lock().await;
-            // Re-check while holding the state lock. A drain can begin after
-            // the fast check above but before this registration mutates the
-            // slot ledger.
+            // The admission gate and state lock make this check and the slot
+            // mutation one operation relative to begin_drain.
             if !self.is_accepting() {
                 return Err(RelayError::capacity(
                     "relay-draining",
@@ -888,10 +893,10 @@ impl Relay {
         let client_expires_at_unix = provider_claims.as_ref().map(|claims| claims.expires_at_unix);
 
         let (circuit, daemon, client_join_ticket, daemon_join_ticket) = {
+            let _admission_gate = self.inner.admission_gate.lock().await;
             let mut state = self.inner.state.lock().await;
-            // The first check is a fast rejection. Re-check under the state
-            // lock so a concurrent SIGTERM cannot admit a circuit after the
-            // readiness probe has changed to draining.
+            // The admission gate and state lock make this check and the
+            // circuit ledger mutation one operation relative to begin_drain.
             if !self.is_accepting() {
                 return Err(RelayError::capacity(
                     "relay-draining",
@@ -2233,9 +2238,9 @@ mod tests {
         assert!(response.starts_with("HTTP/1.1 200 OK"));
         assert!(response.contains("\"status\":\"ready\""));
 
-        assert!(server.relay.begin_drain());
+        assert!(server.relay.begin_drain().await);
         assert!(!server.relay.is_accepting());
-        assert!(!server.relay.begin_drain());
+        assert!(!server.relay.begin_drain().await);
 
         let mut after = TcpStream::connect(server.address).await.unwrap();
         after
@@ -2256,7 +2261,7 @@ mod tests {
     async fn draining_keeps_existing_control_sockets_but_rejects_new_upgrades() {
         let server = TestServer::start(RelayConfig::default()).await;
         let mut daemon = register_open_daemon(&server, "slot-a").await;
-        assert!(server.relay.begin_drain());
+        assert!(server.relay.begin_drain().await);
 
         let url = format!("ws://{}/v1/relay", server.address);
         let error = connect_async(url).await.expect_err("draining relay accepted a new socket");
@@ -2276,7 +2281,7 @@ mod tests {
     async fn draining_rejects_new_circuit_allocations_on_existing_control_sockets() {
         let server = TestServer::start(RelayConfig::default()).await;
         let mut daemon = register_open_daemon(&server, "slot-a").await;
-        assert!(server.relay.begin_drain());
+        assert!(server.relay.begin_drain().await);
 
         let mut client = server.connect().await;
         send_control(
@@ -2305,6 +2310,7 @@ mod tests {
         let relay = Relay::new(RelayConfig::default()).unwrap();
         let permit = relay
             .try_admit_upgraded_socket()
+            .await
             .expect("test socket should be admitted while serving");
         let waiting = {
             let relay = relay.clone();

--- a/cmux-tui/crates/cmux-relay/src/relay.rs
+++ b/cmux-tui/crates/cmux-relay/src/relay.rs
@@ -273,7 +273,9 @@ impl Relay {
     /// Waits for all upgraded sockets to close. A notification plus a second
     /// counter check avoids polling and avoids missing a close between checks.
     pub async fn wait_for_idle(&self, timeout: Duration) -> bool {
-        let deadline = Instant::now() + timeout;
+        let Some(deadline) = Instant::now().checked_add(timeout) else {
+            return false;
+        };
         loop {
             if self.active_connections() == 0 {
                 return true;
@@ -2281,9 +2283,9 @@ mod tests {
     async fn draining_rejects_new_circuit_allocations_on_existing_control_sockets() {
         let server = TestServer::start(RelayConfig::default()).await;
         let mut daemon = register_open_daemon(&server, "slot-a").await;
+        let mut client = server.connect().await;
         assert!(server.relay.begin_drain().await);
 
-        let mut client = server.connect().await;
         send_control(
             &mut client,
             RelayControl::Connect {

--- a/cmux-tui/crates/cmux-relay/src/relay.rs
+++ b/cmux-tui/crates/cmux-relay/src/relay.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, VecDeque};
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -20,7 +20,7 @@ use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
 use serde::Serialize;
 use tokio::net::TcpListener;
-use tokio::sync::{Mutex, mpsc, watch};
+use tokio::sync::{Mutex, Notify, mpsc, watch};
 use tokio::task::JoinHandle;
 use uuid::Uuid;
 
@@ -47,6 +47,8 @@ struct RelayInner {
     state: Mutex<RelayState>,
     next_connection_id: AtomicU64,
     active_connections: AtomicUsize,
+    accepting_connections: AtomicBool,
+    idle_notify: Notify,
 }
 
 struct UpgradedConnectionPermit {
@@ -55,7 +57,9 @@ struct UpgradedConnectionPermit {
 
 impl Drop for UpgradedConnectionPermit {
     fn drop(&mut self) {
-        self.inner.active_connections.fetch_sub(1, Ordering::AcqRel);
+        if self.inner.active_connections.fetch_sub(1, Ordering::AcqRel) == 1 {
+            self.inner.idle_notify.notify_waiters();
+        }
     }
 }
 
@@ -205,9 +209,17 @@ type ConnectionResult<T = ()> = Result<T, ConnectionEnd>;
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct HealthSnapshot {
     pub status: &'static str,
+    pub shard: String,
     pub daemon_slots: usize,
     pub pending_circuits: usize,
     pub ready_circuits: usize,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ReadinessSnapshot {
+    pub status: &'static str,
+    pub shard: String,
+    pub accepting: bool,
 }
 
 impl Relay {
@@ -224,12 +236,50 @@ impl Relay {
                 state: Mutex::new(RelayState::default()),
                 next_connection_id: AtomicU64::new(1),
                 active_connections: AtomicUsize::new(0),
+                accepting_connections: AtomicBool::new(true),
+                idle_notify: Notify::new(),
             }),
         })
     }
 
     pub fn config(&self) -> &RelayConfig {
         &self.inner.config
+    }
+
+    /// Stops new WebSocket upgrades while allowing established circuits to
+    /// finish. Returns `true` only for the transition from serving to draining.
+    pub fn begin_drain(&self) -> bool {
+        self.inner.accepting_connections.swap(false, Ordering::AcqRel)
+    }
+
+    pub fn is_accepting(&self) -> bool {
+        self.inner.accepting_connections.load(Ordering::Acquire)
+    }
+
+    pub fn active_connections(&self) -> usize {
+        self.inner.active_connections.load(Ordering::Acquire)
+    }
+
+    /// Waits for all upgraded sockets to close. A notification plus a second
+    /// counter check avoids polling and avoids missing a close between checks.
+    pub async fn wait_for_idle(&self, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if self.active_connections() == 0 {
+                return true;
+            }
+            let notified = self.inner.idle_notify.notified();
+            if self.active_connections() == 0 {
+                return true;
+            }
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return false;
+            }
+            if tokio::time::timeout(remaining, notified).await.is_err() {
+                return self.active_connections() == 0;
+            }
+        }
     }
 
     /// Returns the only supported server pairing. The listener enforces raw
@@ -241,6 +291,7 @@ impl Relay {
     fn router(&self) -> Router {
         Router::new()
             .route("/healthz", get(Self::health_handler))
+            .route("/readyz", get(Self::readiness_handler))
             .route("/v1/relay", get(Self::websocket_handler))
             .route("/ws", get(Self::websocket_handler))
             .with_state(self.clone())
@@ -267,6 +318,7 @@ impl Relay {
         let ready_circuits = state.circuits.values().filter(|circuit| circuit.ready).count();
         HealthSnapshot {
             status: "ok",
+            shard: self.inner.config.shard.clone(),
             daemon_slots: state.controls.len(),
             pending_circuits: state.circuits.len() - ready_circuits,
             ready_circuits,
@@ -277,6 +329,21 @@ impl Relay {
         (StatusCode::OK, Json(relay.health().await))
     }
 
+    async fn readiness_handler(State(relay): State<Self>) -> Response {
+        let accepting = relay.is_accepting();
+        let status = if accepting { StatusCode::OK } else { StatusCode::SERVICE_UNAVAILABLE };
+        let body = Json(ReadinessSnapshot {
+            status: if accepting { "ready" } else { "draining" },
+            shard: relay.inner.config.shard.clone(),
+            accepting,
+        });
+        let mut response = (status, body).into_response();
+        if !accepting {
+            response.headers_mut().insert(RETRY_AFTER, HeaderValue::from_static("1"));
+        }
+        response
+    }
+
     async fn websocket_handler(
         State(relay): State<Self>,
         headers: HeaderMap,
@@ -284,6 +351,12 @@ impl Relay {
     ) -> Response {
         if headers.contains_key(ORIGIN) {
             return StatusCode::FORBIDDEN.into_response();
+        }
+        if !relay.is_accepting() {
+            let mut response =
+                (StatusCode::SERVICE_UNAVAILABLE, "relay is draining").into_response();
+            response.headers_mut().insert(RETRY_AFTER, HeaderValue::from_static("1"));
+            return response;
         }
         let Some(permit) = relay.try_admit_upgraded_socket() else {
             let mut response =
@@ -309,6 +382,9 @@ impl Relay {
     }
 
     fn try_admit_upgraded_socket(&self) -> Option<UpgradedConnectionPermit> {
+        if !self.is_accepting() {
+            return None;
+        }
         if self
             .inner
             .active_connections
@@ -317,6 +393,12 @@ impl Relay {
             })
             .is_err()
         {
+            return None;
+        }
+        if !self.is_accepting() {
+            if self.inner.active_connections.fetch_sub(1, Ordering::AcqRel) == 1 {
+                self.inner.idle_notify.notify_waiters();
+            }
             return None;
         }
         Some(UpgradedConnectionPermit { inner: self.inner.clone() })
@@ -641,6 +723,12 @@ impl Relay {
         slot: String,
         ticket: String,
     ) -> Result<(), RelayError> {
+        if !self.is_accepting() {
+            return Err(RelayError::capacity(
+                "relay-draining",
+                "relay is draining and does not accept new daemon registrations",
+            ));
+        }
         validate_protocol(protocol)?;
         validate_slot(&slot)?;
         validate_ticket_size(&ticket)?;
@@ -677,6 +765,15 @@ impl Relay {
         let mut replaced = None;
         {
             let mut state = self.inner.state.lock().await;
+            // Re-check while holding the state lock. A drain can begin after
+            // the fast check above but before this registration mutates the
+            // slot ledger.
+            if !self.is_accepting() {
+                return Err(RelayError::capacity(
+                    "relay-draining",
+                    "relay is draining and does not accept new daemon registrations",
+                ));
+            }
             if let Some((existing_ticket, existing_peer)) = state
                 .controls
                 .get(&slot)
@@ -755,6 +852,12 @@ impl Relay {
         lane: LaneToken,
         generation: u64,
     ) -> Result<CircuitId, RelayError> {
+        if !self.is_accepting() {
+            return Err(RelayError::capacity(
+                "relay-draining",
+                "relay is draining and does not accept new circuits",
+            ));
+        }
         validate_protocol(protocol)?;
         validate_slot(&slot)?;
         validate_lane(&lane)?;
@@ -786,6 +889,15 @@ impl Relay {
 
         let (circuit, daemon, client_join_ticket, daemon_join_ticket) = {
             let mut state = self.inner.state.lock().await;
+            // The first check is a fast rejection. Re-check under the state
+            // lock so a concurrent SIGTERM cannot admit a circuit after the
+            // readiness probe has changed to draining.
+            if !self.is_accepting() {
+                return Err(RelayError::capacity(
+                    "relay-draining",
+                    "relay is draining and does not accept new circuits",
+                ));
+            }
             let Some((daemon, control_deadline, daemon_expires_at_unix)) =
                 state.controls.get(&slot).map(|control| {
                     (control.peer.clone(), control.deadline, control.provider_expires_at_unix)
@@ -1858,6 +1970,7 @@ mod tests {
             server.relay.health().await,
             HealthSnapshot {
                 status: "ok",
+                shard: "default".into(),
                 daemon_slots: 1,
                 pending_circuits: 0,
                 ready_circuits: 1,
@@ -2101,6 +2214,105 @@ mod tests {
         assert!(response.starts_with("HTTP/1.1 200 OK"));
         assert!(response.to_ascii_lowercase().contains("connection: close"));
         assert!(response.contains("\"status\":\"ok\""));
+    }
+
+    #[tokio::test]
+    async fn readiness_endpoint_flips_when_the_relay_starts_draining() {
+        let server = TestServer::start(RelayConfig::default()).await;
+
+        let mut before = TcpStream::connect(server.address).await.unwrap();
+        before
+            .write_all(
+                format!("GET /readyz HTTP/1.1\r\nHost: {}\r\n\r\n", server.address).as_bytes(),
+            )
+            .await
+            .unwrap();
+        let mut response = Vec::new();
+        timeout(Duration::from_secs(2), before.read_to_end(&mut response)).await.unwrap().unwrap();
+        let response = String::from_utf8(response).unwrap();
+        assert!(response.starts_with("HTTP/1.1 200 OK"));
+        assert!(response.contains("\"status\":\"ready\""));
+
+        assert!(server.relay.begin_drain());
+        assert!(!server.relay.is_accepting());
+        assert!(!server.relay.begin_drain());
+
+        let mut after = TcpStream::connect(server.address).await.unwrap();
+        after
+            .write_all(
+                format!("GET /readyz HTTP/1.1\r\nHost: {}\r\n\r\n", server.address).as_bytes(),
+            )
+            .await
+            .unwrap();
+        let mut response = Vec::new();
+        timeout(Duration::from_secs(2), after.read_to_end(&mut response)).await.unwrap().unwrap();
+        let response = String::from_utf8(response).unwrap();
+        assert!(response.starts_with("HTTP/1.1 503 Service Unavailable"));
+        assert!(response.to_ascii_lowercase().contains("retry-after: 1"));
+        assert!(response.contains("\"status\":\"draining\""));
+    }
+
+    #[tokio::test]
+    async fn draining_keeps_existing_control_sockets_but_rejects_new_upgrades() {
+        let server = TestServer::start(RelayConfig::default()).await;
+        let mut daemon = register_open_daemon(&server, "slot-a").await;
+        assert!(server.relay.begin_drain());
+
+        let url = format!("ws://{}/v1/relay", server.address);
+        let error = connect_async(url).await.expect_err("draining relay accepted a new socket");
+        assert!(matches!(
+            error,
+            tokio_tungstenite::tungstenite::Error::Http(response)
+                if response.status() == StatusCode::SERVICE_UNAVAILABLE
+        ));
+
+        daemon.send(ClientMessage::Ping(Bytes::from_static(b"still-alive"))).await.unwrap();
+        let message =
+            timeout(Duration::from_secs(2), daemon.next()).await.unwrap().unwrap().unwrap();
+        assert_eq!(message, ClientMessage::Pong(Bytes::from_static(b"still-alive")));
+    }
+
+    #[tokio::test]
+    async fn draining_rejects_new_circuit_allocations_on_existing_control_sockets() {
+        let server = TestServer::start(RelayConfig::default()).await;
+        let mut daemon = register_open_daemon(&server, "slot-a").await;
+        assert!(server.relay.begin_drain());
+
+        let mut client = server.connect().await;
+        send_control(
+            &mut client,
+            RelayControl::Connect {
+                protocol: REMOTE_PROTOCOL_VERSION,
+                slot: "slot-a".into(),
+                ticket: "client-ticket".into(),
+                lane: LaneToken("interactive".into()),
+                generation: 1,
+            },
+        )
+        .await;
+        assert!(matches!(
+            receive_control(&mut client).await,
+            RelayControl::Error { code, retryable: true, .. } if code == "relay-draining"
+        ));
+
+        // Keep the daemon binding alive until the assertion completes. This
+        // also proves that drain does not tear down an established registration.
+        daemon.send(ClientMessage::Ping(Bytes::from_static(b"lease"))).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn wait_for_idle_wakes_when_the_last_socket_closes() {
+        let relay = Relay::new(RelayConfig::default()).unwrap();
+        let permit = relay
+            .try_admit_upgraded_socket()
+            .expect("test socket should be admitted while serving");
+        let waiting = {
+            let relay = relay.clone();
+            tokio::spawn(async move { relay.wait_for_idle(Duration::from_secs(1)).await })
+        };
+        tokio::task::yield_now().await;
+        drop(permit);
+        assert!(waiting.await.unwrap());
     }
 
     #[tokio::test]

--- a/cmux-tui/relays/README.md
+++ b/cmux-tui/relays/README.md
@@ -1,0 +1,12 @@
+# cmux relay deployments
+
+`crates/cmux-relay` is the provider-neutral encrypted circuit relay. The
+deployment directories package that binary for a specific hosting platform.
+
+| Directory | Status | State model |
+| --- | --- | --- |
+| `azure/` | cmux Cloud service foundation | In-memory shard, one active VM per shard |
+| `cloudflare-do/` | Compatibility experiment | Durable Objects |
+
+cmux Cloud uses `azure/`. The Cloudflare Durable Object deployment is not part
+of the cmux Cloud path and must not be used for new machines.

--- a/cmux-tui/relays/azure/Dockerfile
+++ b/cmux-tui/relays/azure/Dockerfile
@@ -1,0 +1,28 @@
+# Build from the cmux-tui directory:
+#   docker build -f relays/azure/Dockerfile -t cmux-relay:dev .
+
+FROM rust:1.95-bookworm AS build
+
+WORKDIR /src
+COPY . .
+RUN cargo build --locked --release -p cmux-relay
+
+FROM debian:bookworm-slim
+
+RUN groupadd --system --gid 10001 cmux-relay \
+    && useradd --system --uid 10001 --gid 10001 --home-dir /nonexistent \
+        --shell /usr/sbin/nologin cmux-relay \
+    && apt-get update \
+    && apt-get install --yes --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build --chown=cmux-relay:cmux-relay \
+    /src/target/release/cmux-relay /usr/local/bin/cmux-relay
+
+USER cmux-relay:cmux-relay
+WORKDIR /nonexistent
+ENV CMUX_RELAY_BIND=0.0.0.0:8787
+ENV CMUX_RELAY_ALLOW_OPEN=false
+EXPOSE 8787
+ENTRYPOINT ["/usr/local/bin/cmux-relay"]
+CMD ["serve"]

--- a/cmux-tui/relays/azure/Dockerfile
+++ b/cmux-tui/relays/azure/Dockerfile
@@ -21,7 +21,7 @@ COPY --from=build --chown=cmux-relay:cmux-relay \
 
 USER cmux-relay:cmux-relay
 WORKDIR /nonexistent
-ENV CMUX_RELAY_BIND=0.0.0.0:8787
+ENV CMUX_RELAY_BIND=127.0.0.1:8787
 ENV CMUX_RELAY_ALLOW_OPEN=false
 EXPOSE 8787
 ENTRYPOINT ["/usr/local/bin/cmux-relay"]

--- a/cmux-tui/relays/azure/README.md
+++ b/cmux-tui/relays/azure/README.md
@@ -43,6 +43,10 @@ client and VM  ->  Application Gateway (TLS/WebSocket)  ->  Standard Load Balanc
                 ->  one VMSS instance  ->  cmux-relay:8787
 ```
 
+Azure resource names and the public DNS label use a deterministic hash of the
+resource group and shard. The relay still receives the original shard string,
+so routing names can contain periods, underscores, or uppercase characters.
+
 Application Gateway probes `/readyz`. A relay that receives `SIGTERM` changes
 `/readyz` to `503`, rejects new upgrades and circuit allocations, and keeps
 existing circuits alive during the drain period. The VMSS service waits up to
@@ -63,8 +67,21 @@ The cmux Cloud API remains the identity authority for the integration. It will
 check Stack ownership and team access, then issue short-lived, slot-bound
 Register and Connect tickets. The relay verifies those tickets with an HMAC
 key. The key is stored in Azure Key Vault. The VM receives it at service start
-through its managed identity and keeps it in `/run/cmux-relay/relay.env` with
-mode `0640`, readable only by the relay service account and its group.
+through a VM-only managed identity and keeps it in `/run/cmux-relay/relay.env`
+with mode `0640`, readable only by the relay service account and its group.
+
+The existing vault must use Azure RBAC authorization. The template creates a
+separate managed identity for Application Gateway and scopes it to only the TLS
+certificate secret. The VM identity is scoped to only the relay HMAC secret.
+Check the vault before deployment:
+
+```sh
+az keyvault show --name <key-vault> \
+  --query properties.enableRbacAuthorization --output tsv
+```
+
+The command must print `true`. The template does not create legacy access
+policies.
 
 The relay never receives a user's Stack token and has no chatmux organization
 dependency. The Noise session above the relay authenticates the enrolled device
@@ -83,16 +100,17 @@ binary URL and SHA-256 digest in production.
 ## Build
 
 The Azure VM installs the x86_64 musl binary published by the existing
-`cmux-tui-artifacts` workflow. After that workflow publishes a commit, read
-the URL and digest from its immutable manifest:
+`cmux-tui-artifacts` workflow. After that workflow publishes a commit, read the
+binary digest from its immutable manifest:
 
 ```sh
 curl -fsSL https://files.cmux.com/cmux-relay/<commit>/manifest.json | jq
 ```
 
-Set `relayBinaryUrl` to the immutable artifact URL listed in the manifest for
-`cmux-relay-x86_64-unknown-linux-musl`, and set `relayBinarySha256` to its
-matching digest. The cloud-init script accepts only immutable
+Construct `relayBinaryUrl` as
+`https://files.cmux.com/cmux-relay/<commit>/cmux-relay-x86_64-unknown-linux-musl`.
+Set `relayBinarySha256` to the matching `binaries` digest from the manifest.
+The cloud-init script accepts only immutable
 `files.cmux.com` commit paths and verifies the digest before systemd starts the
 service. The `Dockerfile` remains available for a local smoke test. TLS
 terminates at Application Gateway.
@@ -104,10 +122,14 @@ and deploy this template once per shard. Keep `vmssCapacity=1`.
 
 1. Store the relay HMAC secret and a versioned TLS certificate secret in the
    existing Key Vault. The HMAC secret must contain at least 32 random bytes.
+   Set `certificateSecretName` to the TLS secret name used in
+   `certificateSecretId`.
 2. Copy `bicep/shard.parameters.example.json` to a private parameters file.
-   Set `relayBinaryUrl` and `relayBinarySha256` from the immutable artifact
-   manifest, and set the certificate secret ID to a versioned Key Vault secret
-   ID.
+   Set `relayBinaryUrl` to the immutable artifact path described above and set
+   `relayBinarySha256` to its `binaries` digest from the manifest. Set the
+   certificate secret ID to a versioned Key Vault secret ID. Set
+   `availabilityZone` to `1`, `2`, or `3` only when the selected region
+   supports that zone. Keep it empty for a non-zonal region.
 3. Deploy without putting secret values on the command line:
 
 ```sh
@@ -121,9 +143,10 @@ The output `relayRoute` is the route to publish in the cmux relay catalog. Add
 a CNAME such as `relay-westus2-a.cmux.cloud` to the output hostname. DNS changes
 are outside this template.
 
-The Bicep deployment grants the VM and Application Gateway identity the Azure
-Key Vault Secrets User role. Role propagation can delay the first service start;
-systemd retries the secret fetch every ten seconds.
+The Bicep deployment grants each identity the Azure Key Vault Secrets User role
+at its individual secret scope. Role propagation can delay the first service
+start. The pre-start loader uses bounded network retries, and systemd retries a
+failed service start.
 
 ## Upgrade and failure behavior
 
@@ -152,6 +175,10 @@ docker run --rm -p 127.0.0.1:8787:8787 \
   -e CMUX_RELAY_SHARD=local \
   cmux-relay:dev serve
 ```
+
+The image defaults to a loopback bind and refuses an unauthenticated
+non-loopback bind. The command above supplies a test secret before widening the
+container bind to `0.0.0.0`.
 
 Check both endpoints:
 

--- a/cmux-tui/relays/azure/README.md
+++ b/cmux-tui/relays/azure/README.md
@@ -1,0 +1,163 @@
+# Azure cmux relay service
+
+This directory packages `cmux-relay` as an independent cmux Cloud data-plane
+service. It is not the chatmux relay and it does not use Durable Objects.
+This slice adds the service binary, Azure topology, and lifecycle contract. It
+does not change the provider attach routes or deploy Azure resources.
+
+The relay forwards encrypted WebSocket frames. It does not parse PTY data,
+port data, browser frames, or workspace RPC data. PTY, loopback port forwarding,
+and browser automation use the existing cmux remote protocol lanes over the
+same connection:
+
+| Feature | Remote service | Relay behavior |
+| --- | --- | --- |
+| PTY | terminal and interactive lanes | Copy opaque binary frames |
+| Port forwarding | `TcpTunnel` and `Tunnel` lane | Copy opaque binary frames |
+| Browser automation | `ComputerUse` service | Copy opaque binary frames |
+
+The relay does not create browser capabilities. A machine must advertise and
+serve the `ComputerUse` capability before a client can use browser automation;
+the relay only carries that already-authorized traffic.
+
+## Topology
+
+The cmux Cloud control plane will assign each machine a stable relay shard. The
+machine and every client will receive that shard endpoint. A shard has one
+active relay process because its circuit pairing table is in memory. Azure
+repairs that VM when it fails. A second shard provides capacity and a reconnect
+target. Each fallback shard has its own issuer and HMAC secret, so the control
+plane must issue a matching ticket set for every endpoint it gives to a machine
+and client. The control-plane assignment and provider bootstrap are the next
+integration slice.
+
+Do not put several relay processes behind one generic load balancer. The machine
+and client use different network flows, so a five-tuple hash cannot guarantee
+that both reach the same process. Add a shared circuit store or a route-aware
+proxy only after the protocol and failure model require it.
+
+The Bicep template creates this path:
+
+```text
+client and VM  ->  Application Gateway (TLS/WebSocket)  ->  Standard Load Balancer
+                ->  one VMSS instance  ->  cmux-relay:8787
+```
+
+Application Gateway probes `/readyz`. A relay that receives `SIGTERM` changes
+`/readyz` to `503`, rejects new upgrades and circuit allocations, and keeps
+existing circuits alive during the drain period. The VMSS service waits up to
+five minutes before it exits. Application Gateway can drain WebSockets for up
+to one hour.
+
+This follows the process boundary described in [exe.dev's connection handoff
+design](https://blog.exe.dev/adding-features-without-interrupting-network-connections):
+the process that owns live connections has a separate lifecycle from the code
+that decides routing. This first slice implements the lifecycle and drain
+boundary. It does not yet transfer live file descriptors between two relay
+processes. A whole VM failure always drops live TCP connections; remote session
+resume reconnects them.
+
+## Security
+
+The cmux Cloud API remains the identity authority for the integration. It will
+check Stack ownership and team access, then issue short-lived, slot-bound
+Register and Connect tickets. The relay verifies those tickets with an HMAC
+key. The key is stored in Azure Key Vault. The VM receives it at service start
+through its managed identity and keeps it in `/run/cmux-relay.env` with mode
+`0600`.
+
+The relay never receives a user's Stack token and has no chatmux organization
+dependency. The Noise session above the relay authenticates the enrolled device
+and protects application bytes from the relay operator.
+
+Port forwarding is loopback-only in the VM. There is no static port allowlist
+in this first release. An authenticated client must make a `CreateRoute`
+request for a port, and the VM daemon dials `127.0.0.1:<port>`. The relay does
+not open a listener on that port. Public preview URLs remain a separate,
+explicit share operation.
+
+Do not place tickets in logs, URLs, image metadata, or invitation route hints.
+Invitation files and ticket files must stay owner-readable. Use an immutable
+binary URL and SHA-256 digest in production.
+
+## Build
+
+The Azure VM installs the x86_64 musl binary published by the existing
+`cmux-tui-artifacts` workflow. After that workflow publishes a commit, read
+the URL and digest from its immutable manifest:
+
+```sh
+curl -fsSL https://files.cmux.com/cmux-relay/<commit>/manifest.json | jq
+```
+
+Set `relayBinaryUrl` to the manifest URL for
+`cmux-relay-x86_64-unknown-linux-musl`, and set `relayBinarySha256` to its
+matching digest. The cloud-init script accepts only immutable
+`files.cmux.com` commit paths and verifies the digest before systemd starts the
+service. The `Dockerfile` remains available for a local smoke test. TLS
+terminates at Application Gateway.
+
+## Deploy one shard
+
+Create two separate resource groups, preferably in different Azure regions,
+and deploy this template once per shard. Keep `vmssCapacity=1`.
+
+1. Store the relay HMAC secret and a versioned TLS certificate secret in the
+   existing Key Vault. The HMAC secret must contain at least 32 random bytes.
+2. Copy `bicep/shard.parameters.example.json` to a private parameters file.
+   Set `relayBinaryUrl` and `relayBinarySha256` from the immutable artifact
+   manifest, and set the certificate secret ID to a versioned Key Vault secret
+   ID.
+3. Deploy without putting secret values on the command line:
+
+```sh
+az deployment group create \
+  --resource-group <relay-shard-resource-group> \
+  --template-file relays/azure/bicep/shard.bicep \
+  --parameters @relays/azure/bicep/shard.parameters.private.json
+```
+
+The output `relayRoute` is the route to publish in the cmux relay catalog. Add
+a CNAME such as `relay-westus2-a.cmux.cloud` to the output hostname. DNS changes
+are outside this template.
+
+The Bicep deployment grants the VM and Application Gateway identity the Azure
+Key Vault Secrets User role. Role propagation can delay the first service start;
+systemd retries the secret fetch every ten seconds.
+
+## Upgrade and failure behavior
+
+Use an immutable binary digest and a rolling VMSS model update. Before a
+planned replacement, systemd sends `SIGTERM` to the relay. The relay marks
+itself not ready, Azure stops sending new traffic, and existing sockets drain.
+Clients retry when a socket closes and resume replayable remote lanes. Tunnel
+streams are not replayed after a disconnect because repeating a TCP write can
+have an external side effect.
+
+If the VM or its region fails, the relay loses its in-memory circuit table. The
+control plane will assign the machine a healthy shard during reconnect. No
+external queue carries PTY or tunnel bytes, so a broker outage cannot replay or
+expose application data.
+
+## Local smoke test
+
+Run the local image with an explicit secret and a loopback bind:
+
+```sh
+docker run --rm -p 8787:8787 \
+  -e CMUX_RELAY_HMAC_SECRET="$(openssl rand -hex 32)" \
+  -e CMUX_RELAY_BIND=0.0.0.0:8787 \
+  -e CMUX_RELAY_SHARD=local \
+  cmux-relay:dev serve
+```
+
+Check both endpoints:
+
+```sh
+curl -fsS http://127.0.0.1:8787/healthz
+curl -fsS http://127.0.0.1:8787/readyz
+```
+
+No Azure resources are created by this change. Provider bootstrap, shard
+catalog assignment, and cmux API ticket issuance are the next integration
+slice.

--- a/cmux-tui/relays/azure/README.md
+++ b/cmux-tui/relays/azure/README.md
@@ -130,7 +130,9 @@ systemd retries the secret fetch every ten seconds.
 Use an immutable binary digest and a rolling VMSS model update. Before a
 planned replacement, systemd sends `SIGTERM` to the relay. The relay marks
 itself not ready, Azure stops sending new traffic, and existing sockets drain.
-Clients retry when a socket closes and resume replayable remote lanes. Tunnel
+Clients retry with unlimited attempts by default, exponential backoff from
+100 ms to 5 seconds, jitter, and heartbeats. The daemon retains replayable
+remote lanes for its resume lease and replays them after reconnect. Tunnel
 streams are not replayed after a disconnect because repeating a TCP write can
 have an external side effect.
 

--- a/cmux-tui/relays/azure/README.md
+++ b/cmux-tui/relays/azure/README.md
@@ -63,8 +63,8 @@ The cmux Cloud API remains the identity authority for the integration. It will
 check Stack ownership and team access, then issue short-lived, slot-bound
 Register and Connect tickets. The relay verifies those tickets with an HMAC
 key. The key is stored in Azure Key Vault. The VM receives it at service start
-through its managed identity and keeps it in `/run/cmux-relay.env` with mode
-`0600`.
+through its managed identity and keeps it in `/run/cmux-relay/relay.env` with
+mode `0640`, readable only by the relay service account and its group.
 
 The relay never receives a user's Stack token and has no chatmux organization
 dependency. The Noise session above the relay authenticates the enrolled device
@@ -90,7 +90,7 @@ the URL and digest from its immutable manifest:
 curl -fsSL https://files.cmux.com/cmux-relay/<commit>/manifest.json | jq
 ```
 
-Set `relayBinaryUrl` to the manifest URL for
+Set `relayBinaryUrl` to the immutable artifact URL listed in the manifest for
 `cmux-relay-x86_64-unknown-linux-musl`, and set `relayBinarySha256` to its
 matching digest. The cloud-init script accepts only immutable
 `files.cmux.com` commit paths and verifies the digest before systemd starts the
@@ -146,7 +146,7 @@ expose application data.
 Run the local image with an explicit secret and a loopback bind:
 
 ```sh
-docker run --rm -p 8787:8787 \
+docker run --rm -p 127.0.0.1:8787:8787 \
   -e CMUX_RELAY_HMAC_SECRET="$(openssl rand -hex 32)" \
   -e CMUX_RELAY_BIND=0.0.0.0:8787 \
   -e CMUX_RELAY_SHARD=local \

--- a/cmux-tui/relays/azure/bicep/shard.bicep
+++ b/cmux-tui/relays/azure/bicep/shard.bicep
@@ -148,6 +148,9 @@ resource relaySubnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' = {
   name: 'relay'
   properties: {
     addressPrefix: relaySubnetPrefix
+    natGateway: {
+      id: natGateway.id
+    }
     networkSecurityGroup: {
       id: relayNsg.id
     }
@@ -160,6 +163,9 @@ resource gatewaySubnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' = 
   properties: {
     addressPrefix: gatewaySubnetPrefix
   }
+  dependsOn: [
+    relaySubnet
+  ]
 }
 
 resource publicIp 'Microsoft.Network/publicIPAddresses@2023-11-01' = {
@@ -173,6 +179,36 @@ resource publicIp 'Microsoft.Network/publicIPAddresses@2023-11-01' = {
     dnsSettings: {
       domainNameLabel: 'cmux-relay-${shard}-${uniqueString(resourceGroup().id)}'
     }
+  }
+}
+
+// A dedicated egress IP keeps VM bootstrap independent from Azure's changing
+// implicit outbound-access defaults. The Application Gateway public IP is not
+// reused because its lifecycle and SNAT behavior are different.
+resource outboundPublicIp 'Microsoft.Network/publicIPAddresses@2023-11-01' = {
+  name: 'cmux-relay-${shard}-egress-ip'
+  location: location
+  sku: {
+    name: 'Standard'
+  }
+  properties: {
+    publicIPAllocationMethod: 'Static'
+  }
+}
+
+resource natGateway 'Microsoft.Network/natGateways@2023-11-01' = {
+  name: 'cmux-relay-${shard}-nat'
+  location: location
+  sku: {
+    name: 'Standard'
+  }
+  properties: {
+    idleTimeoutInMinutes: 10
+    publicIpAddresses: [
+      {
+        id: outboundPublicIp.id
+      }
+    ]
   }
 }
 
@@ -207,6 +243,18 @@ resource loadBalancer 'Microsoft.Network/loadBalancers@2023-11-01' = {
           protocol: 'Http'
           port: 8787
           requestPath: '/readyz'
+          intervalInSeconds: 5
+          numberOfProbes: 2
+        }
+      }
+      {
+        // /healthz remains 200 during a planned drain. VMSS automatic repairs
+        // must not replace a healthy instance just because it left rotation.
+        name: 'healthz'
+        properties: {
+          protocol: 'Http'
+          port: 8787
+          requestPath: '/healthz'
           intervalInSeconds: 5
           numberOfProbes: 2
         }
@@ -314,6 +362,13 @@ resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2023-09-01' = {
         }
       }
       networkProfile: {
+        healthProbe: {
+          id: resourceId(
+            'Microsoft.Network/loadBalancers/probes',
+            'cmux-relay-${shard}-lb',
+            'healthz'
+          )
+        }
         networkInterfaceConfigurations: [
           {
             name: 'relay'
@@ -350,6 +405,7 @@ resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2023-09-01' = {
   }
   dependsOn: [
     keyVaultSecretsRole
+    loadBalancer
   ]
 }
 

--- a/cmux-tui/relays/azure/bicep/shard.bicep
+++ b/cmux-tui/relays/azure/bicep/shard.bicep
@@ -8,6 +8,15 @@ param location string = resourceGroup().location
 @maxLength(32)
 param shard string
 
+@description('Optional availability zone. Leave empty for a region without availability zones.')
+@allowed([
+  ''
+  '1'
+  '2'
+  '3'
+])
+param availabilityZone string = ''
+
 @description('Immutable files.cmux.com URL for the x86_64 Linux cmux-relay binary.')
 @minLength(1)
 param relayBinaryUrl string
@@ -24,6 +33,10 @@ param keyVaultName string
 @description('Key Vault secret name containing at least 32 random bytes.')
 @minLength(1)
 param relaySecretName string = 'cmux-relay-hmac'
+
+@description('Key Vault secret name used by Application Gateway for the TLS certificate.')
+@minLength(1)
+param certificateSecretName string = 'cmux-relay-tls'
 
 @description('Versioned Key Vault secret ID for the TLS certificate consumed by Application Gateway.')
 @secure()
@@ -47,6 +60,10 @@ param vmssCapacity int = 1
 var gatewaySubnetPrefix = '10.42.0.0/24'
 var relaySubnetPrefix = '10.42.1.0/24'
 var relayFrontendIp = '10.42.1.4'
+// Azure resource names and public DNS labels use a hash-derived suffix. The
+// human shard can contain routing separators without making Azure names invalid.
+var relayResourceName = 'cmux-relay-${uniqueString(resourceGroup().id, shard)}'
+var relayZones = empty(availabilityZone) ? null : [availabilityZone]
 var cloudInit = base64(
   replace(
     replace(
@@ -75,17 +92,38 @@ resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
   name: keyVaultName
 }
 
+resource relayHmacSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' existing = {
+  parent: keyVault
+  name: relaySecretName
+}
+
+resource tlsCertificateSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' existing = {
+  parent: keyVault
+  name: certificateSecretName
+}
+
 resource relayIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
-  name: 'cmux-relay-${shard}'
+  name: '${relayResourceName}-vm'
   location: location
   tags: {
     'cmux.relay.shard': shard
   }
 }
 
-resource keyVaultSecretsRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(keyVault.id, relayIdentity.id, 'Key Vault Secrets User')
-  scope: keyVault
+resource gatewayIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: '${relayResourceName}-gateway'
+  location: location
+  tags: {
+    'cmux.relay.shard': shard
+    'cmux.relay.role': 'application-gateway'
+  }
+}
+
+// The vault must use Azure RBAC authorization. Scoping each identity to one
+// secret limits the impact of a compromise of either the VM or gateway.
+resource relaySecretRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(relayHmacSecret.id, relayIdentity.id, 'Key Vault Secrets User')
+  scope: relayHmacSecret
   properties: {
     principalId: relayIdentity.properties.principalId
     principalType: 'ServicePrincipal'
@@ -96,8 +134,21 @@ resource keyVaultSecretsRole 'Microsoft.Authorization/roleAssignments@2022-04-01
   }
 }
 
+resource gatewayCertificateRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(tlsCertificateSecret.id, gatewayIdentity.id, 'Key Vault Secrets User')
+  scope: tlsCertificateSecret
+  properties: {
+    principalId: gatewayIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: subscriptionResourceId(
+      'Microsoft.Authorization/roleDefinitions',
+      '4633458b-17de-408a-b874-0445c86b69e6'
+    )
+  }
+}
+
 resource relayNsg 'Microsoft.Network/networkSecurityGroups@2023-11-01' = {
-  name: 'cmux-relay-${shard}-nsg'
+  name: '${relayResourceName}-nsg'
   location: location
   properties: {
     securityRules: [
@@ -132,7 +183,7 @@ resource relayNsg 'Microsoft.Network/networkSecurityGroups@2023-11-01' = {
 }
 
 resource vnet 'Microsoft.Network/virtualNetworks@2023-11-01' = {
-  name: 'cmux-relay-${shard}-vnet'
+  name: '${relayResourceName}-vnet'
   location: location
   properties: {
     addressSpace: {
@@ -169,7 +220,7 @@ resource gatewaySubnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' = 
 }
 
 resource publicIp 'Microsoft.Network/publicIPAddresses@2023-11-01' = {
-  name: 'cmux-relay-${shard}-public-ip'
+  name: '${relayResourceName}-public-ip'
   location: location
   sku: {
     name: 'Standard'
@@ -177,7 +228,7 @@ resource publicIp 'Microsoft.Network/publicIPAddresses@2023-11-01' = {
   properties: {
     publicIPAllocationMethod: 'Static'
     dnsSettings: {
-      domainNameLabel: 'cmux-relay-${shard}-${uniqueString(resourceGroup().id)}'
+      domainNameLabel: relayResourceName
     }
   }
 }
@@ -186,7 +237,7 @@ resource publicIp 'Microsoft.Network/publicIPAddresses@2023-11-01' = {
 // implicit outbound-access defaults. The Application Gateway public IP is not
 // reused because its lifecycle and SNAT behavior are different.
 resource outboundPublicIp 'Microsoft.Network/publicIPAddresses@2023-11-01' = {
-  name: 'cmux-relay-${shard}-egress-ip'
+  name: '${relayResourceName}-egress-ip'
   location: location
   sku: {
     name: 'Standard'
@@ -197,7 +248,7 @@ resource outboundPublicIp 'Microsoft.Network/publicIPAddresses@2023-11-01' = {
 }
 
 resource natGateway 'Microsoft.Network/natGateways@2023-11-01' = {
-  name: 'cmux-relay-${shard}-nat'
+  name: '${relayResourceName}-nat'
   location: location
   sku: {
     name: 'Standard'
@@ -213,7 +264,7 @@ resource natGateway 'Microsoft.Network/natGateways@2023-11-01' = {
 }
 
 resource loadBalancer 'Microsoft.Network/loadBalancers@2023-11-01' = {
-  name: 'cmux-relay-${shard}-lb'
+  name: '${relayResourceName}-lb'
   location: location
   sku: {
     name: 'Standard'
@@ -272,21 +323,21 @@ resource loadBalancer 'Microsoft.Network/loadBalancers@2023-11-01' = {
           frontendIPConfiguration: {
             id: resourceId(
               'Microsoft.Network/loadBalancers/frontendIPConfigurations',
-              'cmux-relay-${shard}-lb',
+              '${relayResourceName}-lb',
               'relay'
             )
           }
           backendAddressPool: {
             id: resourceId(
               'Microsoft.Network/loadBalancers/backendAddressPools',
-              'cmux-relay-${shard}-lb',
+              '${relayResourceName}-lb',
               'relay'
             )
           }
           probe: {
             id: resourceId(
               'Microsoft.Network/loadBalancers/probes',
-              'cmux-relay-${shard}-lb',
+              '${relayResourceName}-lb',
               'readyz'
             )
           }
@@ -297,11 +348,9 @@ resource loadBalancer 'Microsoft.Network/loadBalancers@2023-11-01' = {
 }
 
 resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2023-09-01' = {
-  name: 'cmux-relay-${shard}'
+  name: '${relayResourceName}-vmss'
   location: location
-  zones: [
-    '1'
-  ]
+  zones: relayZones
   sku: {
     name: 'Standard_D2as_v6'
     tier: 'Standard'
@@ -365,7 +414,7 @@ resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2023-09-01' = {
         healthProbe: {
           id: resourceId(
             'Microsoft.Network/loadBalancers/probes',
-            'cmux-relay-${shard}-lb',
+            '${relayResourceName}-lb',
             'healthz'
           )
         }
@@ -385,7 +434,7 @@ resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2023-09-01' = {
                       {
                         id: resourceId(
                           'Microsoft.Network/loadBalancers/backendAddressPools',
-                          'cmux-relay-${shard}-lb',
+                          '${relayResourceName}-lb',
                           'relay'
                         )
                       }
@@ -404,18 +453,18 @@ resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2023-09-01' = {
     'cmux.relay.role': 'data-plane'
   }
   dependsOn: [
-    keyVaultSecretsRole
+    relaySecretRole
     loadBalancer
   ]
 }
 
 resource appGateway 'Microsoft.Network/applicationGateways@2023-11-01' = {
-  name: 'cmux-relay-${shard}-gateway'
+  name: '${relayResourceName}-gateway'
   location: location
   identity: {
     type: 'UserAssigned'
     userAssignedIdentities: {
-      '${relayIdentity.id}': {}
+      '${gatewayIdentity.id}': {}
     }
   }
   // The Azure type schema omits this required property for this API version.
@@ -494,7 +543,7 @@ resource appGateway 'Microsoft.Network/applicationGateways@2023-11-01' = {
           probe: {
             id: resourceId(
               'Microsoft.Network/applicationGateways/probes',
-              'cmux-relay-${shard}-gateway',
+              '${relayResourceName}-gateway',
               'readyz'
             )
           }
@@ -522,14 +571,14 @@ resource appGateway 'Microsoft.Network/applicationGateways@2023-11-01' = {
           frontendIPConfiguration: {
             id: resourceId(
               'Microsoft.Network/applicationGateways/frontendIPConfigurations',
-              'cmux-relay-${shard}-gateway',
+              '${relayResourceName}-gateway',
               'public'
             )
           }
           frontendPort: {
             id: resourceId(
               'Microsoft.Network/applicationGateways/frontendPorts',
-              'cmux-relay-${shard}-gateway',
+              '${relayResourceName}-gateway',
               'https'
             )
           }
@@ -537,7 +586,7 @@ resource appGateway 'Microsoft.Network/applicationGateways@2023-11-01' = {
           sslCertificate: {
             id: resourceId(
               'Microsoft.Network/applicationGateways/sslCertificates',
-              'cmux-relay-${shard}-gateway',
+              '${relayResourceName}-gateway',
               'relay'
             )
           }
@@ -553,21 +602,21 @@ resource appGateway 'Microsoft.Network/applicationGateways@2023-11-01' = {
           httpListener: {
             id: resourceId(
               'Microsoft.Network/applicationGateways/httpListeners',
-              'cmux-relay-${shard}-gateway',
+              '${relayResourceName}-gateway',
               'https'
             )
           }
           backendAddressPool: {
             id: resourceId(
               'Microsoft.Network/applicationGateways/backendAddressPools',
-              'cmux-relay-${shard}-gateway',
+              '${relayResourceName}-gateway',
               'relay'
             )
           }
           backendHttpSettings: {
             id: resourceId(
               'Microsoft.Network/applicationGateways/backendHttpSettingsCollection',
-              'cmux-relay-${shard}-gateway',
+              '${relayResourceName}-gateway',
               'relay'
             )
           }
@@ -576,7 +625,7 @@ resource appGateway 'Microsoft.Network/applicationGateways@2023-11-01' = {
     ]
   }
   dependsOn: [
-    keyVaultSecretsRole
+    gatewayCertificateRole
     vmss
   ]
 }

--- a/cmux-tui/relays/azure/bicep/shard.bicep
+++ b/cmux-tui/relays/azure/bicep/shard.bicep
@@ -1,0 +1,530 @@
+targetScope = 'resourceGroup'
+
+@description('Azure region for this relay shard.')
+param location string = resourceGroup().location
+
+@description('Stable shard name. The cmux control plane gives this endpoint to both sides of a circuit.')
+@minLength(1)
+@maxLength(32)
+param shard string
+
+@description('Immutable files.cmux.com URL for the x86_64 Linux cmux-relay binary.')
+@minLength(1)
+param relayBinaryUrl string
+
+@description('Lowercase SHA-256 digest of relayBinaryUrl.')
+@minLength(64)
+@maxLength(64)
+param relayBinarySha256 string
+
+@description('Existing Key Vault that stores the relay HMAC secret and the Application Gateway certificate.')
+@minLength(1)
+param keyVaultName string
+
+@description('Key Vault secret name containing at least 32 random bytes.')
+@minLength(1)
+param relaySecretName string = 'cmux-relay-hmac'
+
+@description('Versioned Key Vault secret ID for the TLS certificate consumed by Application Gateway.')
+@secure()
+@minLength(1)
+param certificateSecretId string
+
+@description('SSH public key for break-glass host access. No SSH ingress rule is created.')
+@minLength(1)
+param adminSshPublicKey string
+
+@description('Linux VM administrator name.')
+@minLength(1)
+@maxLength(32)
+param adminUsername string = 'cmuxrelay'
+
+@description('One VM per shard is intentional. The relay pairing ledger is in memory.')
+@minValue(1)
+@maxValue(1)
+param vmssCapacity int = 1
+
+var gatewaySubnetPrefix = '10.42.0.0/24'
+var relaySubnetPrefix = '10.42.1.0/24'
+var relayFrontendIp = '10.42.1.4'
+var cloudInit = base64(
+  replace(
+    replace(
+      replace(
+        replace(
+          replace(
+            loadTextContent('../cloud-init.sh'),
+            '__CMUX_RELAY_BINARY_URL_B64__',
+            base64(relayBinaryUrl)
+          ),
+          '__CMUX_RELAY_BINARY_SHA256_B64__',
+          base64(relayBinarySha256)
+        ),
+        '__CMUX_RELAY_SHARD_B64__',
+        base64(shard)
+        ),
+        '__CMUX_RELAY_KEY_VAULT_NAME_B64__',
+        base64(keyVaultName)
+      ),
+      '__CMUX_RELAY_SECRET_NAME_B64__',
+      base64(relaySecretName)
+    )
+  )
+
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+  name: keyVaultName
+}
+
+resource relayIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: 'cmux-relay-${shard}'
+  location: location
+  tags: {
+    'cmux.relay.shard': shard
+  }
+}
+
+resource keyVaultSecretsRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(keyVault.id, relayIdentity.id, 'Key Vault Secrets User')
+  scope: keyVault
+  properties: {
+    principalId: relayIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: subscriptionResourceId(
+      'Microsoft.Authorization/roleDefinitions',
+      '4633458b-17de-408a-b874-0445c86b69e6'
+    )
+  }
+}
+
+resource relayNsg 'Microsoft.Network/networkSecurityGroups@2023-11-01' = {
+  name: 'cmux-relay-${shard}-nsg'
+  location: location
+  properties: {
+    securityRules: [
+      {
+        name: 'allow-application-gateway-relay'
+        properties: {
+          priority: 100
+          direction: 'Inbound'
+          access: 'Allow'
+          protocol: 'Tcp'
+          sourceAddressPrefix: gatewaySubnetPrefix
+          sourcePortRange: '*'
+          destinationAddressPrefix: '*'
+          destinationPortRange: '8787'
+        }
+      }
+      {
+        name: 'allow-azure-load-balancer-probe'
+        properties: {
+          priority: 110
+          direction: 'Inbound'
+          access: 'Allow'
+          protocol: 'Tcp'
+          sourceAddressPrefix: 'AzureLoadBalancer'
+          sourcePortRange: '*'
+          destinationAddressPrefix: '*'
+          destinationPortRange: '8787'
+        }
+      }
+    ]
+  }
+}
+
+resource vnet 'Microsoft.Network/virtualNetworks@2023-11-01' = {
+  name: 'cmux-relay-${shard}-vnet'
+  location: location
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        '10.42.0.0/16'
+      ]
+    }
+  }
+}
+
+resource relaySubnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' = {
+  parent: vnet
+  name: 'relay'
+  properties: {
+    addressPrefix: relaySubnetPrefix
+    networkSecurityGroup: {
+      id: relayNsg.id
+    }
+  }
+}
+
+resource gatewaySubnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' = {
+  parent: vnet
+  name: 'application-gateway'
+  properties: {
+    addressPrefix: gatewaySubnetPrefix
+  }
+}
+
+resource publicIp 'Microsoft.Network/publicIPAddresses@2023-11-01' = {
+  name: 'cmux-relay-${shard}-public-ip'
+  location: location
+  sku: {
+    name: 'Standard'
+  }
+  properties: {
+    publicIPAllocationMethod: 'Static'
+    dnsSettings: {
+      domainNameLabel: 'cmux-relay-${shard}-${uniqueString(resourceGroup().id)}'
+    }
+  }
+}
+
+resource loadBalancer 'Microsoft.Network/loadBalancers@2023-11-01' = {
+  name: 'cmux-relay-${shard}-lb'
+  location: location
+  sku: {
+    name: 'Standard'
+  }
+  properties: {
+    frontendIPConfigurations: [
+      {
+        name: 'relay'
+        properties: {
+          privateIPAddress: relayFrontendIp
+          privateIPAllocationMethod: 'Static'
+          subnet: {
+            id: relaySubnet.id
+          }
+        }
+      }
+    ]
+    backendAddressPools: [
+      {
+        name: 'relay'
+      }
+    ]
+    probes: [
+      {
+        name: 'readyz'
+        properties: {
+          protocol: 'Http'
+          port: 8787
+          requestPath: '/readyz'
+          intervalInSeconds: 5
+          numberOfProbes: 2
+        }
+      }
+    ]
+    loadBalancingRules: [
+      {
+        name: 'relay'
+        properties: {
+          protocol: 'Tcp'
+          frontendPort: 8787
+          backendPort: 8787
+          idleTimeoutInMinutes: 30
+          enableTcpReset: true
+          frontendIPConfiguration: {
+            id: resourceId(
+              'Microsoft.Network/loadBalancers/frontendIPConfigurations',
+              'cmux-relay-${shard}-lb',
+              'relay'
+            )
+          }
+          backendAddressPool: {
+            id: resourceId(
+              'Microsoft.Network/loadBalancers/backendAddressPools',
+              'cmux-relay-${shard}-lb',
+              'relay'
+            )
+          }
+          probe: {
+            id: resourceId(
+              'Microsoft.Network/loadBalancers/probes',
+              'cmux-relay-${shard}-lb',
+              'readyz'
+            )
+          }
+        }
+      }
+    ]
+  }
+}
+
+resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2023-09-01' = {
+  name: 'cmux-relay-${shard}'
+  location: location
+  zones: [
+    '1'
+  ]
+  sku: {
+    name: 'Standard_D2as_v6'
+    tier: 'Standard'
+    capacity: vmssCapacity
+  }
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${relayIdentity.id}': {}
+    }
+  }
+  properties: {
+    orchestrationMode: 'Uniform'
+    overprovision: false
+    upgradePolicy: {
+      mode: 'Rolling'
+      rollingUpgradePolicy: {
+        maxBatchInstancePercent: 100
+        maxUnhealthyInstancePercent: 100
+        pauseTimeBetweenBatches: 'PT1M'
+        enableCrossZoneUpgrade: false
+      }
+    }
+    automaticRepairsPolicy: {
+      enabled: true
+      repairAction: 'Replace'
+      gracePeriod: 'PT10M'
+    }
+    virtualMachineProfile: {
+      osProfile: {
+        computerNamePrefix: 'cmuxrelay'
+        adminUsername: adminUsername
+        customData: cloudInit
+        linuxConfiguration: {
+          disablePasswordAuthentication: true
+          ssh: {
+            publicKeys: [
+              {
+                path: '/home/${adminUsername}/.ssh/authorized_keys'
+                keyData: adminSshPublicKey
+              }
+            ]
+          }
+        }
+      }
+      storageProfile: {
+        imageReference: {
+          publisher: 'Canonical'
+          offer: '0001-com-ubuntu-server-jammy'
+          sku: '22_04-lts-gen2'
+          version: 'latest'
+        }
+        osDisk: {
+          createOption: 'FromImage'
+          managedDisk: {
+            storageAccountType: 'Premium_LRS'
+          }
+        }
+      }
+      networkProfile: {
+        networkInterfaceConfigurations: [
+          {
+            name: 'relay'
+            properties: {
+              primary: true
+              ipConfigurations: [
+                {
+                  name: 'relay'
+                  properties: {
+                    subnet: {
+                      id: relaySubnet.id
+                    }
+                    loadBalancerBackendAddressPools: [
+                      {
+                        id: resourceId(
+                          'Microsoft.Network/loadBalancers/backendAddressPools',
+                          'cmux-relay-${shard}-lb',
+                          'relay'
+                        )
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+  tags: {
+    'cmux.relay.shard': shard
+    'cmux.relay.role': 'data-plane'
+  }
+  dependsOn: [
+    keyVaultSecretsRole
+  ]
+}
+
+resource appGateway 'Microsoft.Network/applicationGateways@2023-11-01' = {
+  name: 'cmux-relay-${shard}-gateway'
+  location: location
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${relayIdentity.id}': {}
+    }
+  }
+  // The Azure type schema omits this required property for this API version.
+  #disable-next-line BCP187
+  sku: {
+    name: 'Standard_v2'
+    tier: 'Standard_v2'
+  }
+  properties: {
+    enableHttp2: true
+    autoscaleConfiguration: {
+      minCapacity: 1
+      maxCapacity: 2
+    }
+    gatewayIPConfigurations: [
+      {
+        name: 'gateway'
+        properties: {
+          subnet: {
+            id: gatewaySubnet.id
+          }
+        }
+      }
+    ]
+    frontendIPConfigurations: [
+      {
+        name: 'public'
+        properties: {
+          publicIPAddress: {
+            id: publicIp.id
+          }
+        }
+      }
+    ]
+    frontendPorts: [
+      {
+        name: 'https'
+        properties: {
+          port: 443
+        }
+      }
+    ]
+    sslCertificates: [
+      {
+        name: 'relay'
+        properties: {
+          keyVaultSecretId: certificateSecretId
+        }
+      }
+    ]
+    backendAddressPools: [
+      {
+        name: 'relay'
+        properties: {
+          backendAddresses: [
+            {
+              ipAddress: relayFrontendIp
+            }
+          ]
+        }
+      }
+    ]
+    backendHttpSettingsCollection: [
+      {
+        name: 'relay'
+        properties: {
+          port: 8787
+          protocol: 'Http'
+          cookieBasedAffinity: 'Disabled'
+          requestTimeout: 3600
+          pickHostNameFromBackendAddress: false
+          connectionDraining: {
+            enabled: true
+            drainTimeoutInSec: 3600
+          }
+          probe: {
+            id: resourceId(
+              'Microsoft.Network/applicationGateways/probes',
+              'cmux-relay-${shard}-gateway',
+              'readyz'
+            )
+          }
+        }
+      }
+    ]
+    probes: [
+      {
+        name: 'readyz'
+        properties: {
+          protocol: 'Http'
+          path: '/readyz'
+          host: 'relay.internal'
+          interval: 5
+          timeout: 5
+          unhealthyThreshold: 2
+          pickHostNameFromBackendHttpSettings: false
+        }
+      }
+    ]
+    httpListeners: [
+      {
+        name: 'https'
+        properties: {
+          frontendIPConfiguration: {
+            id: resourceId(
+              'Microsoft.Network/applicationGateways/frontendIPConfigurations',
+              'cmux-relay-${shard}-gateway',
+              'public'
+            )
+          }
+          frontendPort: {
+            id: resourceId(
+              'Microsoft.Network/applicationGateways/frontendPorts',
+              'cmux-relay-${shard}-gateway',
+              'https'
+            )
+          }
+          protocol: 'Https'
+          sslCertificate: {
+            id: resourceId(
+              'Microsoft.Network/applicationGateways/sslCertificates',
+              'cmux-relay-${shard}-gateway',
+              'relay'
+            )
+          }
+        }
+      }
+    ]
+    requestRoutingRules: [
+      {
+        name: 'relay'
+        properties: {
+          priority: 100
+          ruleType: 'Basic'
+          httpListener: {
+            id: resourceId(
+              'Microsoft.Network/applicationGateways/httpListeners',
+              'cmux-relay-${shard}-gateway',
+              'https'
+            )
+          }
+          backendAddressPool: {
+            id: resourceId(
+              'Microsoft.Network/applicationGateways/backendAddressPools',
+              'cmux-relay-${shard}-gateway',
+              'relay'
+            )
+          }
+          backendHttpSettings: {
+            id: resourceId(
+              'Microsoft.Network/applicationGateways/backendHttpSettingsCollection',
+              'cmux-relay-${shard}-gateway',
+              'relay'
+            )
+          }
+        }
+      }
+    ]
+  }
+  dependsOn: [
+    keyVaultSecretsRole
+    vmss
+  ]
+}
+
+output relayHostname string = publicIp.properties.dnsSettings.fqdn
+output relayRoute string = 'relay+wss://${publicIp.properties.dnsSettings.fqdn}'
+output shardName string = shard

--- a/cmux-tui/relays/azure/bicep/shard.parameters.example.json
+++ b/cmux-tui/relays/azure/bicep/shard.parameters.example.json
@@ -5,6 +5,9 @@
     "shard": {
       "value": "westus2-a"
     },
+    "availabilityZone": {
+      "value": ""
+    },
     "relayBinaryUrl": {
       "value": "https://files.cmux.com/cmux-relay/replace-with-40-char-commit/cmux-relay-x86_64-unknown-linux-musl"
     },
@@ -16,6 +19,9 @@
     },
     "relaySecretName": {
       "value": "cmux-relay-hmac"
+    },
+    "certificateSecretName": {
+      "value": "cmux-relay-tls"
     },
     "certificateSecretId": {
       "value": "https://replace-with-key-vault.vault.azure.net/secrets/cmux-relay-tls/replace-with-version"

--- a/cmux-tui/relays/azure/bicep/shard.parameters.example.json
+++ b/cmux-tui/relays/azure/bicep/shard.parameters.example.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "shard": {
+      "value": "westus2-a"
+    },
+    "relayBinaryUrl": {
+      "value": "https://files.cmux.com/cmux-relay/replace-with-40-char-commit/cmux-relay-x86_64-unknown-linux-musl"
+    },
+    "relayBinarySha256": {
+      "value": "replace-with-64-char-lowercase-sha256"
+    },
+    "keyVaultName": {
+      "value": "replace-with-key-vault"
+    },
+    "relaySecretName": {
+      "value": "cmux-relay-hmac"
+    },
+    "certificateSecretId": {
+      "value": "https://replace-with-key-vault.vault.azure.net/secrets/cmux-relay-tls/replace-with-version"
+    },
+    "adminUsername": {
+      "value": "cmuxrelay"
+    },
+    "adminSshPublicKey": {
+      "value": "ssh-ed25519 replace-with-break-glass-key"
+    }
+  }
+}

--- a/cmux-tui/relays/azure/cloud-init.sh
+++ b/cmux-tui/relays/azure/cloud-init.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# This file is rendered by bicep/shard.bicep. Values with double underscores
+# are deployment parameters, not runtime secrets.
+set -euo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install --yes --no-install-recommends ca-certificates curl jq python3
+
+install -d -m 0750 /etc/cmux-relay /usr/local/libexec
+install -d -m 0750 /opt/cmux-relay
+
+decode_parameter() {
+  printf '%s' "$1" | base64 --decode
+}
+
+key_vault_name="$(decode_parameter '__CMUX_RELAY_KEY_VAULT_NAME_B64__')"
+secret_name="$(decode_parameter '__CMUX_RELAY_SECRET_NAME_B64__')"
+relay_binary_url="$(decode_parameter '__CMUX_RELAY_BINARY_URL_B64__')"
+relay_binary_sha256="$(decode_parameter '__CMUX_RELAY_BINARY_SHA256_B64__')"
+relay_shard="$(decode_parameter '__CMUX_RELAY_SHARD_B64__')"
+
+if [[ ! "$key_vault_name" =~ ^[A-Za-z0-9-]{3,24}$ ]]; then
+  echo 'cmux relay Key Vault name has unsupported characters' >&2
+  exit 1
+fi
+if [[ ! "$secret_name" =~ ^[A-Za-z0-9-]{1,127}$ ]]; then
+  echo 'cmux relay secret name has unsupported characters' >&2
+  exit 1
+fi
+if [[ ! "$relay_shard" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]]; then
+  echo 'cmux relay shard has unsupported characters' >&2
+  exit 1
+fi
+if [[ ! "$relay_binary_url" =~ ^https://files\.cmux\.com/cmux-relay/[0-9a-f]{40}/cmux-relay-x86_64-unknown-linux-musl$ ]]; then
+  echo 'cmux-relay binary URL must be an immutable files.cmux.com x86_64 artifact' >&2
+  exit 1
+fi
+if [[ ! "$relay_binary_sha256" =~ ^[0-9a-f]{64}$ ]]; then
+  echo 'cmux-relay binary SHA-256 must contain 64 lowercase hexadecimal characters' >&2
+  exit 1
+fi
+
+export CMUX_RELAY_KEY_VAULT_NAME="$key_vault_name"
+export CMUX_RELAY_SECRET_NAME="$secret_name"
+export CMUX_RELAY_BINARY_URL="$relay_binary_url"
+export CMUX_RELAY_BINARY_SHA256="$relay_binary_sha256"
+export CMUX_RELAY_SHARD="$relay_shard"
+
+binary_tmp="$(mktemp /tmp/cmux-relay.XXXXXX)"
+trap 'rm -f "$binary_tmp"' EXIT
+curl --proto '=https' --proto-redir '=https' --fail --silent --show-error \
+  --retry 8 --retry-delay 2 --retry-max-time 120 --location \
+  "$relay_binary_url" -o "$binary_tmp"
+printf '%s  %s\n' "$relay_binary_sha256" "$binary_tmp" | sha256sum --check --status -
+install -m 0755 "$binary_tmp" /opt/cmux-relay/cmux-relay
+trap - EXIT
+rm -f "$binary_tmp"
+
+install -m 0750 /dev/null /usr/local/libexec/cmux-relay-load-secret
+python3 - <<'PY'
+import os
+from pathlib import Path
+
+path = Path('/usr/local/libexec/cmux-relay-load-secret')
+template = r'''#!/usr/bin/env bash
+set -euo pipefail
+
+key_vault_name='__CMUX_RELAY_KEY_VAULT_NAME__'
+secret_name='__CMUX_RELAY_SECRET_NAME__'
+token_json="$(curl --fail --silent --show-error \
+  --retry 5 --retry-delay 2 --retry-max-time 60 \
+  -H 'Metadata: true' \
+  'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fvault.azure.net')"
+access_token="$(printf '%s' "$token_json" | jq -er '.access_token')"
+secret_uri="https://${key_vault_name}.vault.azure.net/secrets/${secret_name}?api-version=7.4"
+secret_value="$(curl --fail --silent --show-error \
+  --retry 5 --retry-delay 2 --retry-max-time 60 \
+  -H "Authorization: Bearer ${access_token}" "$secret_uri" | jq -er '.value')"
+
+if [[ -z "$secret_value" || "$secret_value" == *$'\n'* || "$secret_value" == *$'\r'* ]]; then
+  echo 'cmux-relay secret is empty or contains a newline' >&2
+  exit 1
+fi
+
+umask 077
+printf 'CMUX_RELAY_HMAC_SECRET=%s\n' "$secret_value" > /run/cmux-relay.env
+chmod 0600 /run/cmux-relay.env
+''')
+path.write_text(
+    template
+    .replace('__CMUX_RELAY_KEY_VAULT_NAME__', os.environ['CMUX_RELAY_KEY_VAULT_NAME'])
+    .replace('__CMUX_RELAY_SECRET_NAME__', os.environ['CMUX_RELAY_SECRET_NAME'])
+)
+path.chmod(0o750)
+PY
+
+install -m 0750 /dev/null /usr/local/libexec/cmux-relay-run
+python3 - <<'PY'
+import os
+from pathlib import Path
+
+path = Path('/usr/local/libexec/cmux-relay-run')
+template = r'''#!/usr/bin/env bash
+set -euo pipefail
+
+binary='/opt/cmux-relay/cmux-relay'
+if [[ ! -x "$binary" ]]; then
+  echo 'cmux-relay binary is missing or not executable' >&2
+  exit 1
+fi
+secret="$(sed -n 's/^CMUX_RELAY_HMAC_SECRET=//p' /run/cmux-relay.env)"
+if [[ -z "$secret" || "$secret" == *$'\n'* || "$secret" == *$'\r'* ]]; then
+  echo 'cmux-relay runtime secret is missing or malformed' >&2
+  exit 1
+fi
+export CMUX_RELAY_HMAC_SECRET="$secret"
+export CMUX_RELAY_BIND='0.0.0.0:8787'
+export CMUX_RELAY_ALLOW_OPEN='false'
+export CMUX_RELAY_SHARD='__CMUX_RELAY_SHARD__'
+export CMUX_RELAY_ISSUER='cmux-cloud-__CMUX_RELAY_SHARD__'
+export CMUX_RELAY_DRAIN_TIMEOUT_SECONDS='300'
+exec "$binary" serve "$@"
+''')
+path.write_text(
+    template
+    .replace('__CMUX_RELAY_SHARD__', os.environ['CMUX_RELAY_SHARD'])
+)
+path.chmod(0o750)
+PY
+
+cat > /etc/systemd/system/cmux-relay.service <<'UNIT'
+[Unit]
+Description=cmux encrypted circuit relay
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStartPre=/usr/local/libexec/cmux-relay-load-secret
+ExecStart=/usr/local/libexec/cmux-relay-run
+Restart=always
+RestartSec=10s
+TimeoutStartSec=120s
+TimeoutStopSec=330s
+KillMode=process
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+systemctl daemon-reload
+systemctl enable cmux-relay.service
+# Do not make VM provisioning fail while the Key Vault role assignment is
+# still propagating. The service retries its secret fetch on a ten-second
+# restart interval.
+systemctl start --no-block cmux-relay.service

--- a/cmux-tui/relays/azure/cloud-init.sh
+++ b/cmux-tui/relays/azure/cloud-init.sh
@@ -7,8 +7,12 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get install --yes --no-install-recommends ca-certificates curl jq python3
 
-install -d -m 0750 /etc/cmux-relay /usr/local/libexec
-install -d -m 0750 /opt/cmux-relay
+install -d -m 0750 /etc/cmux-relay
+install -d -m 0755 /usr/local/libexec
+if ! id -u cmux-relay >/dev/null 2>&1; then
+  useradd --system --no-create-home --home-dir /nonexistent --shell /usr/sbin/nologin cmux-relay
+fi
+install -d -o cmux-relay -g cmux-relay -m 0750 /opt/cmux-relay
 
 decode_parameter() {
   printf '%s' "$1" | base64 --decode
@@ -50,14 +54,14 @@ export CMUX_RELAY_SHARD="$relay_shard"
 binary_tmp="$(mktemp /tmp/cmux-relay.XXXXXX)"
 trap 'rm -f "$binary_tmp"' EXIT
 curl --proto '=https' --proto-redir '=https' --fail --silent --show-error \
-  --retry 8 --retry-delay 2 --retry-max-time 120 --location \
+  --retry 8 --retry-max-time 120 --location \
   "$relay_binary_url" -o "$binary_tmp"
 printf '%s  %s\n' "$relay_binary_sha256" "$binary_tmp" | sha256sum --check --status -
-install -m 0755 "$binary_tmp" /opt/cmux-relay/cmux-relay
+install -o cmux-relay -g cmux-relay -m 0755 "$binary_tmp" /opt/cmux-relay/cmux-relay
 trap - EXIT
 rm -f "$binary_tmp"
 
-install -m 0750 /dev/null /usr/local/libexec/cmux-relay-load-secret
+install -m 0755 /dev/null /usr/local/libexec/cmux-relay-load-secret
 python3 - <<'PY'
 import os
 from pathlib import Path
@@ -69,13 +73,13 @@ set -euo pipefail
 key_vault_name='__CMUX_RELAY_KEY_VAULT_NAME__'
 secret_name='__CMUX_RELAY_SECRET_NAME__'
 token_json="$(curl --fail --silent --show-error \
-  --retry 5 --retry-delay 2 --retry-max-time 60 \
+  --retry 5 --retry-max-time 60 \
   -H 'Metadata: true' \
   'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fvault.azure.net')"
 access_token="$(printf '%s' "$token_json" | jq -er '.access_token')"
 secret_uri="https://${key_vault_name}.vault.azure.net/secrets/${secret_name}?api-version=7.4"
 secret_value="$(curl --fail --silent --show-error \
-  --retry 5 --retry-delay 2 --retry-max-time 60 \
+  --retry 5 --retry-max-time 60 \
   -H "Authorization: Bearer ${access_token}" "$secret_uri" | jq -er '.value')"
 
 if [[ -z "$secret_value" || "$secret_value" == *$'\n'* || "$secret_value" == *$'\r'* ]]; then
@@ -84,18 +88,19 @@ if [[ -z "$secret_value" || "$secret_value" == *$'\n'* || "$secret_value" == *$'
 fi
 
 umask 077
-printf 'CMUX_RELAY_HMAC_SECRET=%s\n' "$secret_value" > /run/cmux-relay.env
-chmod 0600 /run/cmux-relay.env
+install -d -m 0750 /run/cmux-relay
+printf 'CMUX_RELAY_HMAC_SECRET=%s\n' "$secret_value" > /run/cmux-relay/relay.env
+chmod 0640 /run/cmux-relay/relay.env
 ''')
 path.write_text(
     template
     .replace('__CMUX_RELAY_KEY_VAULT_NAME__', os.environ['CMUX_RELAY_KEY_VAULT_NAME'])
     .replace('__CMUX_RELAY_SECRET_NAME__', os.environ['CMUX_RELAY_SECRET_NAME'])
 )
-path.chmod(0o750)
+path.chmod(0o755)
 PY
 
-install -m 0750 /dev/null /usr/local/libexec/cmux-relay-run
+install -m 0755 /dev/null /usr/local/libexec/cmux-relay-run
 python3 - <<'PY'
 import os
 from pathlib import Path
@@ -109,7 +114,7 @@ if [[ ! -x "$binary" ]]; then
   echo 'cmux-relay binary is missing or not executable' >&2
   exit 1
 fi
-secret="$(sed -n 's/^CMUX_RELAY_HMAC_SECRET=//p' /run/cmux-relay.env)"
+secret="$(sed -n 's/^CMUX_RELAY_HMAC_SECRET=//p' /run/cmux-relay/relay.env)"
 if [[ -z "$secret" || "$secret" == *$'\n'* || "$secret" == *$'\r'* ]]; then
   echo 'cmux-relay runtime secret is missing or malformed' >&2
   exit 1
@@ -126,7 +131,7 @@ path.write_text(
     template
     .replace('__CMUX_RELAY_SHARD__', os.environ['CMUX_RELAY_SHARD'])
 )
-path.chmod(0o750)
+path.chmod(0o755)
 PY
 
 cat > /etc/systemd/system/cmux-relay.service <<'UNIT'
@@ -137,6 +142,10 @@ After=network-online.target
 
 [Service]
 Type=simple
+User=cmux-relay
+Group=cmux-relay
+RuntimeDirectory=cmux-relay
+RuntimeDirectoryMode=0750
 ExecStartPre=/usr/local/libexec/cmux-relay-load-secret
 ExecStart=/usr/local/libexec/cmux-relay-run
 Restart=always
@@ -144,6 +153,14 @@ RestartSec=10s
 TimeoutStartSec=120s
 TimeoutStopSec=330s
 KillMode=process
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+ReadWritePaths=/run/cmux-relay
 
 [Install]
 WantedBy=multi-user.target

--- a/cmux-tui/relays/azure/cloud-init.sh
+++ b/cmux-tui/relays/azure/cloud-init.sh
@@ -54,7 +54,7 @@ export CMUX_RELAY_SHARD="$relay_shard"
 binary_tmp="$(mktemp /tmp/cmux-relay.XXXXXX)"
 trap 'rm -f "$binary_tmp"' EXIT
 curl --proto '=https' --proto-redir '=https' --fail --silent --show-error \
-  --retry 8 --retry-max-time 120 --location \
+  --retry 8 --retry-max-time 120 --connect-timeout 10 --max-time 180 --location \
   "$relay_binary_url" -o "$binary_tmp"
 printf '%s  %s\n' "$relay_binary_sha256" "$binary_tmp" | sha256sum --check --status -
 install -o cmux-relay -g cmux-relay -m 0755 "$binary_tmp" /opt/cmux-relay/cmux-relay
@@ -73,19 +73,20 @@ set -euo pipefail
 key_vault_name='__CMUX_RELAY_KEY_VAULT_NAME__'
 secret_name='__CMUX_RELAY_SECRET_NAME__'
 token_json="$(curl --fail --silent --show-error \
-  --retry 5 --retry-max-time 60 \
+  --retry 5 --retry-all-errors --retry-max-time 60 --connect-timeout 5 --max-time 30 \
   -H 'Metadata: true' \
   'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fvault.azure.net')"
 access_token="$(printf '%s' "$token_json" | jq -er '.access_token')"
 secret_uri="https://${key_vault_name}.vault.azure.net/secrets/${secret_name}?api-version=7.4"
 secret_value="$(curl --fail --silent --show-error \
-  --retry 5 --retry-max-time 60 \
-  -H "Authorization: Bearer ${access_token}" "$secret_uri" | jq -er '.value')"
-
-if [[ -z "$secret_value" || "$secret_value" == *$'\n'* || "$secret_value" == *$'\r'* ]]; then
-  echo 'cmux-relay secret is empty or contains a newline' >&2
-  exit 1
-fi
+  --retry 5 --retry-all-errors --retry-max-time 60 --connect-timeout 5 --max-time 30 \
+  -H "Authorization: Bearer ${access_token}" "$secret_uri" | jq -er '
+    .value as $value
+    | if ($value | type) != "string" then error("secret value is not a string")
+      elif $value == "" or ($value | test("[\\r\\n]")) then error("secret value is empty or contains a newline")
+      else $value
+      end
+  ')"
 
 umask 077
 install -d -m 0750 /run/cmux-relay
@@ -149,7 +150,6 @@ RuntimeDirectoryMode=0750
 ExecStartPre=/usr/local/libexec/cmux-relay-load-secret
 ExecStart=/usr/local/libexec/cmux-relay-run
 Restart=always
-RestartSec=10s
 TimeoutStartSec=120s
 TimeoutStopSec=330s
 KillMode=process
@@ -168,7 +168,6 @@ UNIT
 
 systemctl daemon-reload
 systemctl enable cmux-relay.service
-# Do not make VM provisioning fail while the Key Vault role assignment is
-# still propagating. The service retries its secret fetch on a ten-second
-# restart interval.
+# The pre-start loader owns a bounded retry window for managed-identity and
+# Key Vault readiness. systemd restarts the unit after a failed attempt.
 systemctl start --no-block cmux-relay.service


### PR DESCRIPTION
## Summary

- Add graceful drain and readiness lifecycle to the native `cmux-relay` server.
- Add stable shard identity and bounded drain configuration.
- Add an Azure VMSS and Application Gateway package for two independent relay shards.
- Install an immutable, SHA-256-verified `cmux-relay` artifact from `files.cmux.com`.
- Document opaque PTY, loopback tunnel, and ComputerUse forwarding, retry behavior, and failure boundaries.

## Scope

This PR creates the standalone Azure data-plane service. It does not deploy Azure resources or change the four provider drivers and API ticket bootstrap. Those changes belong in the next integration PR.

The relay does not parse PTY, tunnel, or browser bytes. It forwards encrypted frames. Port access stays loopback-only and requires an authenticated `CreateRoute`. There is no static port allowlist.

## Testing

- `rustfmt --edition 2024 --check` on changed relay sources.
- `bash -n` and `shellcheck --severity=warning` on cloud-init.
- `az bicep lint` and `az bicep build` on the shard template.
- Exact-head hosted Rust and seven-language conformance run passed: https://github.com/manaflow-ai/cmux/actions/runs/33485712940
- CodeRabbit and Cubic reviews passed on commit `bef00b7df124957f971124ada1079f015173d20f`.

## Demo Video

Not applicable. This PR adds a service and deployment package. No Azure resources were deployed.

## Review Trigger

Automatic review bots ran on the latest head. No manual review trigger was posted.

## Checklist

- [x] I ran the available static checks.
- [x] I added tests for readiness, drain admission, and opaque frame forwarding.
- [x] I updated the relay and Azure deployment documentation.
- [x] All current review comments are resolved.
- [x] No Azure resources or DNS records changed.