### PR TITLE
fix(tui): fail closed on invalid agent roster snapshots

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/journal_reducers.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_reducers.rs
@@ -540,4 +540,23 @@ mod tests {
         assert!(roster.apply(&foreign).is_empty());
         assert!(!roster.entries.is_empty());
     }
+
+    #[test]
+    fn restore_rejects_semantically_invalid_entries() {
+        let invalid_snapshots = [
+            // Unknown state and source spellings must not be reinterpreted.
+            r#"{"entries":{"term_a":{"state":"running","source":"hook","session":null,"agent":null,"updated_at_ms":1}}}"#,
+            r#"{"entries":{"term_a":{"state":"working","source":"poll","session":null,"agent":null,"updated_at_ms":1}}}"#,
+            // Done rows are removed during folding and cannot be a live snapshot.
+            r#"{"entries":{"term_a":{"state":"done","source":"hook","session":null,"agent":null,"updated_at_ms":1}}}"#,
+            // Detected rows must identify the adapter that produced them.
+            r#"{"entries":{"term_a":{"state":"working","source":"detected","session":null,"agent":null,"updated_at_ms":1}}}"#,
+            // A blank terminal identity cannot be addressed by later events.
+            r#"{"entries":{"":{"state":"working","source":"hook","session":null,"agent":null,"updated_at_ms":1}}}"#,
+        ];
+
+        for snapshot in invalid_snapshots {
+            assert!(AgentRoster::restore(snapshot).is_none(), "snapshot was accepted: {snapshot}");
+        }
+    }
 }

--- a/cmux-tui/crates/cmux-tui-core/src/journal_reducers.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_reducers.rs
@@ -124,6 +124,7 @@ impl<'a> RosterEvent<'a> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct RosterEntry {
     pub(crate) state: String,
     pub(crate) source: String,
@@ -161,6 +162,7 @@ pub(crate) enum RosterDelta {
 /// ignores socket reports so a slow poller cannot overwrite live hook
 /// state.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct AgentRoster {
     pub(crate) entries: HashMap<String, RosterEntry>,
 }
@@ -276,7 +278,22 @@ impl AgentRoster {
     }
 
     pub(crate) fn restore(snapshot: &str) -> Option<Self> {
-        serde_json::from_str(snapshot).ok()
+        let roster: Self = serde_json::from_str(snapshot).ok()?;
+        // A syntactically valid snapshot can still be unusable. In
+        // particular, an entry with an unknown source/state would make the
+        // reducer silently reinterpret persisted data, and a done entry can
+        // never be produced by `apply` because done removes the row.
+        if roster.entries.iter().any(|(terminal_id, entry)| {
+            terminal_id.is_empty()
+                || agent_state_from_str(&entry.state).is_none()
+                || entry.state == AgentState::Done.as_str()
+                || agent_source_from_str(&entry.source).is_none()
+                || (entry.source == AgentSource::Detected.as_str()
+                    && entry.agent.as_deref().is_none_or(str::is_empty))
+        }) {
+            return None;
+        }
+        Some(roster)
     }
 }
 

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -23816,6 +23816,64 @@ mod tests {
     }
 
     #[test]
+    fn invalid_agent_roster_snapshot_clears_its_cursor() {
+        let root = std::env::temp_dir()
+            .join(format!("cmux-roster-invalid-snapshot-{}", crate::workspace_registry::new_uuid_v4()));
+        let session = "roster-invalid-snapshot";
+        let registry = WorkspaceRegistry::open(&root, session).unwrap();
+        registry
+            .put_journal_reducer_state(
+                crate::journal_reducers::AGENT_ROSTER_REDUCER_ID,
+                crate::journal_reducers::AGENT_ROSTER_REDUCER_VERSION,
+                42,
+                r#"{"entries":{"term_a":{"state":"working","source":"detected","session":null,"agent":null,"updated_at_ms":1}}}"#,
+            )
+            .unwrap();
+
+        let host = restore_agent_roster(&registry).unwrap();
+        assert_eq!(host.cursor, 0, "an invalid snapshot must not retain its cursor");
+        assert!(host.roster.entries.is_empty());
+        let persisted = registry
+            .journal_reducer_state(crate::journal_reducers::AGENT_ROSTER_REDUCER_ID)
+            .unwrap()
+            .unwrap();
+        assert_eq!(persisted.1, 0, "reset state must clear the persisted cursor");
+
+        drop(registry);
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn unreplayable_agent_roster_cursor_fails_closed() {
+        let root = std::env::temp_dir()
+            .join(format!("cmux-roster-unreplayable-{}", crate::workspace_registry::new_uuid_v4()));
+        let session = "roster-unreplayable";
+        let registry = WorkspaceRegistry::open(&root, session).unwrap();
+        // The snapshot is valid, but its cursor points past the retained
+        // journal head. This is the same fail-closed path as a retention gap.
+        registry
+            .put_journal_reducer_state(
+                crate::journal_reducers::AGENT_ROSTER_REDUCER_ID,
+                crate::journal_reducers::AGENT_ROSTER_REDUCER_VERSION,
+                42,
+                r#"{"entries":{"term_a":{"state":"working","source":"hook","session":null,"agent":"claude","updated_at_ms":1}}}"#,
+            )
+            .unwrap();
+
+        let host = restore_agent_roster(&registry).unwrap();
+        assert_eq!(host.cursor, 0, "an unreplayable cursor must fail closed");
+        assert!(host.roster.entries.is_empty());
+        let persisted = registry
+            .journal_reducer_state(crate::journal_reducers::AGENT_ROSTER_REDUCER_ID)
+            .unwrap()
+            .unwrap();
+        assert_eq!(persisted.1, 0, "the unreplayable cursor must be cleared");
+
+        drop(registry);
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
     fn failed_raw_agent_report_rolls_back_projection_memory_revision_and_event() {
         let mux = test_mux();
         let surface = mux.new_workspace(None, None).unwrap();

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -1174,7 +1174,9 @@ fn restore_agent_roster(registry: &WorkspaceRegistry) -> anyhow::Result<AgentRos
                     0,
                     &host.roster.snapshot().to_string(),
                 ) {
-                    eprintln!("cmux-tui: clearing the unreplayable agent roster snapshot failed: {reset_error}");
+                    eprintln!(
+                        "cmux-tui: clearing the unreplayable agent roster snapshot failed: {reset_error}"
+                    );
                 }
                 return Ok(AgentRosterHost::default());
             }
@@ -23849,8 +23851,10 @@ mod tests {
 
     #[test]
     fn invalid_agent_roster_snapshot_clears_its_cursor() {
-        let root = std::env::temp_dir()
-            .join(format!("cmux-roster-invalid-snapshot-{}", crate::workspace_registry::new_uuid_v4()));
+        let root = std::env::temp_dir().join(format!(
+            "cmux-roster-invalid-snapshot-{}",
+            crate::workspace_registry::new_uuid_v4()
+        ));
         let session = "roster-invalid-snapshot";
         let registry = WorkspaceRegistry::open(&root, session).unwrap();
         registry

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -1168,11 +1168,12 @@ fn restore_agent_roster(registry: &WorkspaceRegistry) -> anyhow::Result<AgentRos
                 // is derived state, so fail closed with an empty host rather
                 // than exposing a partial state at a nonzero cursor.
                 eprintln!("cmux-tui: agent roster snapshot cannot be replayed: {error}");
+                let empty_snapshot = AgentRoster::default().snapshot().to_string();
                 if let Err(reset_error) = registry.put_journal_reducer_state(
                     AGENT_ROSTER_REDUCER_ID,
                     AGENT_ROSTER_REDUCER_VERSION,
                     0,
-                    &host.roster.snapshot().to_string(),
+                    &empty_snapshot,
                 ) {
                     eprintln!(
                         "cmux-tui: clearing the unreplayable agent roster snapshot failed: {reset_error}"
@@ -23904,6 +23905,7 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(persisted.1, 0, "the unreplayable cursor must be cleared");
+        assert_eq!(persisted.2, r#"{"entries":{}}"#);
 
         drop(registry);
         std::fs::remove_dir_all(root).unwrap();

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -1138,15 +1138,47 @@ fn restore_agent_roster(registry: &WorkspaceRegistry) -> anyhow::Result<AgentRos
     use crate::journal_reducers::{
         AGENT_ROSTER_REDUCER_ID, AGENT_ROSTER_REDUCER_VERSION, AgentRoster, RosterEvent,
     };
+    let mut reset_persisted_state = false;
     let mut host = match registry.journal_reducer_state(AGENT_ROSTER_REDUCER_ID)? {
         Some((version, cursor, snapshot)) if version == AGENT_ROSTER_REDUCER_VERSION => {
-            AgentRosterHost { roster: AgentRoster::restore(&snapshot).unwrap_or_default(), cursor }
+            // Never keep a cursor whose snapshot was rejected. The cursor is
+            // only meaningful together with the state it follows; retaining
+            // it would skip the journal prefix needed to rebuild the roster.
+            match AgentRoster::restore(&snapshot) {
+                Some(roster) => AgentRosterHost { roster, cursor },
+                None => {
+                    reset_persisted_state = true;
+                    AgentRosterHost::default()
+                }
+            }
         }
-        _ => AgentRosterHost::default(),
+        Some(_) => {
+            reset_persisted_state = true;
+            AgentRosterHost::default()
+        }
+        None => AgentRosterHost::default(),
     };
     let started_at = host.cursor;
     loop {
-        let page = registry.session_journal_after(host.cursor, 512)?;
+        let page = match registry.session_journal_after(host.cursor, 512) {
+            Ok(page) => page,
+            Err(error) => {
+                // A pruned journal can no longer fill the gap between the
+                // persisted cursor and the first retained record. The roster
+                // is derived state, so fail closed with an empty host rather
+                // than exposing a partial state at a nonzero cursor.
+                eprintln!("cmux-tui: agent roster snapshot cannot be replayed: {error}");
+                if let Err(reset_error) = registry.put_journal_reducer_state(
+                    AGENT_ROSTER_REDUCER_ID,
+                    AGENT_ROSTER_REDUCER_VERSION,
+                    0,
+                    &host.roster.snapshot().to_string(),
+                ) {
+                    eprintln!("cmux-tui: clearing the unreplayable agent roster snapshot failed: {reset_error}");
+                }
+                return Ok(AgentRosterHost::default());
+            }
+        };
         if page.records.is_empty() {
             break;
         }
@@ -1155,7 +1187,7 @@ fn restore_agent_roster(registry: &WorkspaceRegistry) -> anyhow::Result<AgentRos
             host.cursor = host.cursor.max(record.sequence);
         }
     }
-    if host.cursor != started_at {
+    if host.cursor != started_at || reset_persisted_state {
         registry.put_journal_reducer_state(
             AGENT_ROSTER_REDUCER_ID,
             AGENT_ROSTER_REDUCER_VERSION,


### PR DESCRIPTION
## Summary
- Reject semantically invalid agent roster snapshots before restoring state.
- Reset invalid or unreplayable reducer cursors so retention gaps fail closed.
- Add behavior coverage for invalid snapshots and unreplayable cursors.

## Testing
- `rustfmt --edition 2024 --check cmux-tui/crates/cmux-tui-core/src/journal_reducers.rs cmux-tui/crates/cmux-tui-core/src/mux.rs`
- Hosted focused verification: https://github.com/manaflow-ai/cmux/actions/runs/33482113204

## Issues
- Related: https://github.com/manaflow-ai/cmux/pull/11068

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790839616&installation_model_id=21920&pr_number=11364&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11364&signature=55ebae0ce46105e8493ea4cc6dd6dbd52d6a05efef05d6d49fe978d54215e99b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives the live agent roster from the session journal as a durable reducer fold and fails closed on invalid or unreplayable snapshots by discarding them and re-folding from the journal head, clearing stale roster entries when a journal retention gap blocks the re-fold. Adds herdr-based screen detection so agents without hooks appear in the roster, and carries the reporting adapter id through agent records and events to the views.

**New Features**
- Persists each journal reducer's cursor and snapshot in the registry; restarts restore the snapshot and fold only the journal tail.
- Ports the herdr screen-detection engine with 21 vendored manifests; a session-owned scanner detects agent states from terminal output and journals edge-triggered transitions.
- Sorts agents views by attention (blocked > working > idle) then recency; tab views keep tree order.

**Migration**
- Reducer version bumps to 3 so older persisted snapshots are discarded on startup.
- Direct socket/SDK agent reports now append an echo journal event, so each fresh report publishes twice on the shared change epoch.
- `AgentChanged` events and agent records include an optional adapter id; socket-only reports leave it absent.

<sup>Written for commit 5fba1b62eae69b09f4dcbe4927775f94024034c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

