### PR TITLE
fix(cmux-tui): normalize derived Windows state paths

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -175,7 +175,7 @@ impl std::fmt::Debug for TerminalHostRecord {
 
 impl TerminalHostRecord {
     pub fn record_path(&self, root: &Path) -> PathBuf {
-        root.join(format!("{}.json", self.terminal_id))
+        crate::platform::normalize_filesystem_path(root.join(format!("{}.json", self.terminal_id)))
     }
 }
 
@@ -204,7 +204,7 @@ impl TerminalHostExitRecord {
     }
 
     pub fn record_path(&self, root: &Path) -> PathBuf {
-        root.join(format!("{}.exit", self.terminal_id))
+        crate::platform::normalize_filesystem_path(root.join(format!("{}.exit", self.terminal_id)))
     }
 }
 
@@ -1780,7 +1780,9 @@ mod unix {
         let endpoint_root = PathBuf::from("/tmp").join(format!("cmux-th-{uid}"));
         prepare_private_dir(&endpoint_root)?;
         let endpoint = endpoint_root.join(format!("{terminal_hex}.sock"));
-        let record_path = root.join(format!("{terminal_hex}.json"));
+        let record_path = crate::platform::normalize_filesystem_path(
+            root.join(format!("{terminal_hex}.json")),
+        );
         if record_path.exists() || endpoint.exists() {
             anyhow::bail!("terminal host identity already exists");
         }
@@ -4570,7 +4572,7 @@ mod unix {
     }
 
     fn terminal_host_publication_lock_path(root: &Path) -> PathBuf {
-        root.join(TERMINAL_HOST_PUBLICATION_LOCK_FILE)
+        crate::platform::normalize_filesystem_path(root.join(TERMINAL_HOST_PUBLICATION_LOCK_FILE))
     }
 
     fn validate_terminal_host_publication_lock(

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -1780,9 +1780,8 @@ mod unix {
         let endpoint_root = PathBuf::from("/tmp").join(format!("cmux-th-{uid}"));
         prepare_private_dir(&endpoint_root)?;
         let endpoint = endpoint_root.join(format!("{terminal_hex}.sock"));
-        let record_path = crate::platform::normalize_filesystem_path(
-            root.join(format!("{terminal_hex}.json")),
-        );
+        let record_path =
+            crate::platform::normalize_filesystem_path(root.join(format!("{terminal_hex}.json")));
         if record_path.exists() || endpoint.exists() {
             anyhow::bail!("terminal host identity already exists");
         }

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -536,7 +536,10 @@ impl PersistentSessionStateResetter {
             return Ok(reset);
         }
         let lease = if lock_session_dir_exists {
-            Some(SessionLease::acquire(&session_dir.join(SESSION_WRITER_LOCK_FILE))?)
+            let lock_path = platform::normalize_filesystem_path(
+                session_dir.join(SESSION_WRITER_LOCK_FILE),
+            );
+            Some(SessionLease::acquire(&lock_path)?)
         } else {
             None
         };
@@ -2305,9 +2308,9 @@ impl WorkspaceRegistry {
     }
 
     pub fn open(root: &Path, session_name: &str) -> anyhow::Result<Self> {
-        // Keep the caller's root spelling for the root-level guard and identity
-        // files. Rust's Windows filesystem APIs add the verbatim prefix when
-        // needed; passing a manually prefixed root breaks long-path startup.
+        let root = platform::normalize_filesystem_path(root.to_path_buf());
+        // Keep short roots in their existing spelling while giving all
+        // root-level files the same long-path handling as their descendants.
         let session_dir =
             platform::normalize_filesystem_path(root.join(session_storage_component(session_name)));
         // Normalize the complete database path. The state root can be below
@@ -2320,9 +2323,9 @@ impl WorkspaceRegistry {
         {
             return Err(error.into());
         }
-        let session_guard = acquire_session_guard(root, session_name)?;
-        let machine_id = load_or_create_machine_id(root)?;
-        let resource_effect_pepper = load_or_create_resource_effect_pepper(root)?;
+        let session_guard = acquire_session_guard(&root, session_name)?;
+        let machine_id = load_or_create_machine_id(&root)?;
+        let resource_effect_pepper = load_or_create_resource_effect_pepper(&root)?;
         fs::create_dir_all(&session_dir).with_context(|| {
             format!("create workspace state directory {}", session_dir.display())
         })?;
@@ -5083,7 +5086,7 @@ fn acquire_session_guard_from_private_dir(
 }
 
 fn prepare_session_guard_dir(root: &Path) -> anyhow::Result<PathBuf> {
-    let lock_dir = root.join(SESSION_GUARD_DIR);
+    let lock_dir = platform::normalize_filesystem_path(root.join(SESSION_GUARD_DIR));
     match fs::symlink_metadata(&lock_dir) {
         Ok(metadata) if metadata.file_type().is_dir() => {}
         Ok(_) => anyhow::bail!("session lock directory is not a directory: {}", lock_dir.display()),
@@ -5109,11 +5112,13 @@ fn prepare_session_guard_dir(root: &Path) -> anyhow::Result<PathBuf> {
 }
 
 fn session_guard_lock_path(lock_dir: &Path, session_name: &str) -> PathBuf {
-    lock_dir.join(format!("{}.lock", session_storage_component(session_name)))
+    platform::normalize_filesystem_path(
+        lock_dir.join(format!("{}.lock", session_storage_component(session_name))),
+    )
 }
 
 fn session_guard_coordinator_path(lock_dir: &Path) -> PathBuf {
-    lock_dir.join(SESSION_GUARD_COORDINATOR_FILE)
+    platform::normalize_filesystem_path(lock_dir.join(SESSION_GUARD_COORDINATOR_FILE))
 }
 
 #[cfg(unix)]
@@ -5271,9 +5276,10 @@ fn prepare_terminal_host_root_for_reset(
 }
 
 fn load_or_create_resource_effect_pepper(root: &Path) -> anyhow::Result<ResourceEffectPepper> {
-    fs::create_dir_all(root).with_context(|| format!("create state root {}", root.display()))?;
-    platform::restrict_directory(root)?;
-    let lock_path = root.join(RESOURCE_EFFECT_PEPPER_LOCK_FILE);
+    let root = platform::normalize_filesystem_path(root.to_path_buf());
+    fs::create_dir_all(&root).with_context(|| format!("create state root {}", root.display()))?;
+    platform::restrict_directory(&root)?;
+    let lock_path = platform::normalize_filesystem_path(root.join(RESOURCE_EFFECT_PEPPER_LOCK_FILE));
     let lock = OpenOptions::new()
         .create(true)
         .truncate(false)
@@ -5285,7 +5291,7 @@ fn load_or_create_resource_effect_pepper(root: &Path) -> anyhow::Result<Resource
     FileExt::lock(&lock)
         .with_context(|| format!("lock resource receipt pepper {}", lock_path.display()))?;
 
-    let path = root.join(RESOURCE_EFFECT_PEPPER_FILE);
+    let path = platform::normalize_filesystem_path(root.join(RESOURCE_EFFECT_PEPPER_FILE));
     let result = match fs::symlink_metadata(&path) {
         Ok(metadata) => {
             anyhow::ensure!(
@@ -5316,7 +5322,7 @@ fn load_or_create_resource_effect_pepper(root: &Path) -> anyhow::Result<Resource
                 .with_context(|| format!("write resource receipt pepper {}", path.display()))?;
             file.sync_all()
                 .with_context(|| format!("sync resource receipt pepper {}", path.display()))?;
-            platform::sync_directory(root)
+            platform::sync_directory(&root)
                 .with_context(|| format!("sync state root {}", root.display()))?;
             Ok(pepper)
         }
@@ -5359,9 +5365,10 @@ fn ensure_missing_pepper_can_migrate(root: &Path, pepper_path: &Path) -> anyhow:
 }
 
 fn load_or_create_machine_id(root: &Path) -> anyhow::Result<MachinePublicId> {
-    fs::create_dir_all(root).with_context(|| format!("create state root {}", root.display()))?;
-    platform::restrict_directory(root)?;
-    let lock_path = root.join(MACHINE_ID_LOCK_FILE);
+    let root = platform::normalize_filesystem_path(root.to_path_buf());
+    fs::create_dir_all(&root).with_context(|| format!("create state root {}", root.display()))?;
+    platform::restrict_directory(&root)?;
+    let lock_path = platform::normalize_filesystem_path(root.join(MACHINE_ID_LOCK_FILE));
     let lock = OpenOptions::new()
         .create(true)
         .truncate(false)
@@ -5373,7 +5380,7 @@ fn load_or_create_machine_id(root: &Path) -> anyhow::Result<MachinePublicId> {
     FileExt::lock(&lock)
         .with_context(|| format!("lock machine identity {}", lock_path.display()))?;
 
-    let path = root.join(MACHINE_ID_FILE);
+    let path = platform::normalize_filesystem_path(root.join(MACHINE_ID_FILE));
     let result = match fs::read(&path) {
         Ok(bytes) => {
             platform::restrict_file(&path)?;
@@ -5396,7 +5403,7 @@ fn load_or_create_machine_id(root: &Path) -> anyhow::Result<MachinePublicId> {
                 .and_then(|()| file.write_all(b"\n"))
                 .with_context(|| format!("write machine identity {}", path.display()))?;
             file.sync_all().with_context(|| format!("sync machine identity {}", path.display()))?;
-            platform::sync_directory(root)
+            platform::sync_directory(&root)
                 .with_context(|| format!("sync state root {}", root.display()))?;
             Ok(id)
         }
@@ -5619,8 +5626,12 @@ impl SessionCoordinatorWaiter {
                 let sequence =
                     SESSION_GUARD_COORDINATOR_WAITER_SEQUENCE.fetch_add(1, Ordering::Relaxed);
                 let token = format!("{:x}-{sequence:x}", std::process::id());
-                let registration_path = waiter_dir.join(format!("{token}.waiter"));
-                let temporary_path = waiter_dir.join(format!(".{token}.tmp"));
+                let registration_path = platform::normalize_filesystem_path(
+                    waiter_dir.join(format!("{token}.waiter")),
+                );
+                let temporary_path = platform::normalize_filesystem_path(
+                    waiter_dir.join(format!(".{token}.tmp")),
+                );
                 let fifo_path = std::ffi::CString::new(temporary_path.as_os_str().as_bytes())?;
                 // SAFETY: fifo_path is a valid NUL-terminated path and mode
                 // only grants access to the current user.
@@ -5679,8 +5690,12 @@ impl SessionCoordinatorWaiter {
                 let sequence =
                     SESSION_GUARD_COORDINATOR_WAITER_SEQUENCE.fetch_add(1, Ordering::Relaxed);
                 let token = format!("{:x}-{:x}-{:x}", std::process::id(), address.port(), sequence);
-                let registration_path = waiter_dir.join(format!("{token}.waiter"));
-                let temporary_path = waiter_dir.join(format!(".{token}.tmp"));
+                let registration_path = platform::normalize_filesystem_path(
+                    waiter_dir.join(format!("{token}.waiter")),
+                );
+                let temporary_path = platform::normalize_filesystem_path(
+                    waiter_dir.join(format!(".{token}.tmp")),
+                );
                 let mut options = OpenOptions::new();
                 options.create_new(true).write(true);
                 #[cfg(unix)]
@@ -5799,7 +5814,9 @@ impl Drop for SessionCoordinatorWaiter {
 }
 
 fn session_guard_coordinator_waiter_dir(coordinator_path: &Path) -> PathBuf {
-    coordinator_path.with_file_name(SESSION_GUARD_COORDINATOR_WAITER_DIR)
+    platform::normalize_filesystem_path(
+        coordinator_path.with_file_name(SESSION_GUARD_COORDINATOR_WAITER_DIR),
+    )
 }
 
 fn prepare_session_coordinator_waiter_dir(waiter_dir: &Path) -> anyhow::Result<()> {

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -536,9 +536,8 @@ impl PersistentSessionStateResetter {
             return Ok(reset);
         }
         let lease = if lock_session_dir_exists {
-            let lock_path = platform::normalize_filesystem_path(
-                session_dir.join(SESSION_WRITER_LOCK_FILE),
-            );
+            let lock_path =
+                platform::normalize_filesystem_path(session_dir.join(SESSION_WRITER_LOCK_FILE));
             Some(SessionLease::acquire(&lock_path)?)
         } else {
             None
@@ -5279,7 +5278,8 @@ fn load_or_create_resource_effect_pepper(root: &Path) -> anyhow::Result<Resource
     let root = platform::normalize_filesystem_path(root.to_path_buf());
     fs::create_dir_all(&root).with_context(|| format!("create state root {}", root.display()))?;
     platform::restrict_directory(&root)?;
-    let lock_path = platform::normalize_filesystem_path(root.join(RESOURCE_EFFECT_PEPPER_LOCK_FILE));
+    let lock_path =
+        platform::normalize_filesystem_path(root.join(RESOURCE_EFFECT_PEPPER_LOCK_FILE));
     let lock = OpenOptions::new()
         .create(true)
         .truncate(false)
@@ -5305,7 +5305,7 @@ fn load_or_create_resource_effect_pepper(root: &Path) -> anyhow::Result<Resource
             ResourceEffectPepper::from_bytes(bytes, &path)
         }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            ensure_missing_pepper_can_migrate(root, &path)?;
+            ensure_missing_pepper_can_migrate(&root, &path)?;
             let pepper = ResourceEffectPepper::random()?;
             let mut options = OpenOptions::new();
             options.create_new(true).write(true);
@@ -5626,12 +5626,10 @@ impl SessionCoordinatorWaiter {
                 let sequence =
                     SESSION_GUARD_COORDINATOR_WAITER_SEQUENCE.fetch_add(1, Ordering::Relaxed);
                 let token = format!("{:x}-{sequence:x}", std::process::id());
-                let registration_path = platform::normalize_filesystem_path(
-                    waiter_dir.join(format!("{token}.waiter")),
-                );
-                let temporary_path = platform::normalize_filesystem_path(
-                    waiter_dir.join(format!(".{token}.tmp")),
-                );
+                let registration_path =
+                    platform::normalize_filesystem_path(waiter_dir.join(format!("{token}.waiter")));
+                let temporary_path =
+                    platform::normalize_filesystem_path(waiter_dir.join(format!(".{token}.tmp")));
                 let fifo_path = std::ffi::CString::new(temporary_path.as_os_str().as_bytes())?;
                 // SAFETY: fifo_path is a valid NUL-terminated path and mode
                 // only grants access to the current user.
@@ -5690,12 +5688,10 @@ impl SessionCoordinatorWaiter {
                 let sequence =
                     SESSION_GUARD_COORDINATOR_WAITER_SEQUENCE.fetch_add(1, Ordering::Relaxed);
                 let token = format!("{:x}-{:x}-{:x}", std::process::id(), address.port(), sequence);
-                let registration_path = platform::normalize_filesystem_path(
-                    waiter_dir.join(format!("{token}.waiter")),
-                );
-                let temporary_path = platform::normalize_filesystem_path(
-                    waiter_dir.join(format!(".{token}.tmp")),
-                );
+                let registration_path =
+                    platform::normalize_filesystem_path(waiter_dir.join(format!("{token}.waiter")));
+                let temporary_path =
+                    platform::normalize_filesystem_path(waiter_dir.join(format!(".{token}.tmp")));
                 let mut options = OpenOptions::new();
                 options.create_new(true).write(true);
                 #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/tests.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/tests.rs
@@ -5706,4 +5706,21 @@ fn long_database_descendant_is_normalized_even_when_root_is_short() {
     let database = root.join(session_storage_component("session")).join(WORKSPACE_REGISTRY_FILE);
     let normalized = crate::platform::normalize_filesystem_path(database);
     assert!(normalized.to_string_lossy().starts_with(r"\\?\C:\"));
+
+    let guard_dir = crate::platform::normalize_filesystem_path(root.join(SESSION_GUARD_DIR));
+    let guard_lock = session_guard_lock_path(&guard_dir, "session");
+    let coordinator = session_guard_coordinator_path(&guard_dir);
+    let waiter_dir = session_guard_coordinator_waiter_dir(&coordinator);
+    for path in [
+        guard_dir,
+        guard_lock,
+        coordinator,
+        waiter_dir,
+        crate::platform::normalize_filesystem_path(root.join(MACHINE_ID_LOCK_FILE)),
+        crate::platform::normalize_filesystem_path(root.join(MACHINE_ID_FILE)),
+        crate::platform::normalize_filesystem_path(root.join(RESOURCE_EFFECT_PEPPER_LOCK_FILE)),
+        crate::platform::normalize_filesystem_path(root.join(RESOURCE_EFFECT_PEPPER_FILE)),
+    ] {
+        assert!(path.to_string_lossy().starts_with(r"\\?\C:\"), "{}", path.display());
+    }
 }


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/cmux/pull/11153.

Normalizes every final Windows state path before filesystem use, including session guards, coordinator waiters, machine identity, resource pepper, reset leases, and terminal-host records. Adds a Windows path-shape test for roots below the threshold whose descendants exceed it.

Validation: `git diff --check`; hosted cmux-tui verification pending.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11365"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790839819&installation_model_id=21920&pr_number=11365&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11365&signature=d62398e4cee833edd04e0034f9a6b852b3cac9b47269948df3c362bf55e51737"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes every final Windows state path so sessions with short roots but long descendants no longer fail on Windows. Previously only the database and selected paths were normalized; now all derived paths, including session guards, coordinator waiters, machine identity, resource pepper, reset leases, and terminal-host records, go through `normalize_filesystem_path`.

- Normalizes the state root once in `open()` and reuses it, so root-level files get the same long-path handling as their descendants.
- Extends the long-path Windows test to assert normalized shapes for guard, waiter, machine identity, and resource pepper paths.

<sup>Written for commit 6dfb47c9959a799fb9281f85e218bc25160fb3c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

