### PR TITLE
fix(relay): avoid reentrant transport auth lock

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -843,20 +843,33 @@ impl PtyManager {
                 .is_some_and(|current| !auth_snapshot_matches(current, &snapshot));
             changed
         };
-        if changed {
-            self.detach_matching(|candidate| candidate == &owner).retire();
-        }
-        let _state = self.inner.tunnel_state.lock().expect("tunnel state lock");
-        if context.cancellation.is_cancelled()
-            || !self.inner.tunnel_authority_generation_current(context)
+        // `detach_matching` acquires `transport_auth_updates` itself. We
+        // already hold that lock here, so call the locked variant to avoid a
+        // non-reentrant mutex deadlock when a transport refresh changes its
+        // authority. Retire controls after publishing the replacement and
+        // releasing the update lock, so platform cleanup cannot block a
+        // concurrent authority refresh.
+        let retired = if changed {
+            Some(self.detach_matching_locked(|candidate| candidate == &owner))
+        } else {
+            None
+        };
         {
-            return;
+            let _state = self.inner.tunnel_state.lock().expect("tunnel state lock");
+            if !context.cancellation.is_cancelled()
+                && self.inner.tunnel_authority_generation_current(context)
+            {
+                self.inner
+                    .transport_auth
+                    .lock()
+                    .expect("transport auth lock")
+                    .insert(owner.clone(), snapshot);
+            }
         }
-        self.inner
-            .transport_auth
-            .lock()
-            .expect("transport auth lock")
-            .insert(owner.clone(), snapshot);
+        drop(_update);
+        if let Some(retired) = retired {
+            retired.retire();
+        }
     }
 
     /// Advance the managed tunnel authority floor before publishing the


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/cmux/pull/11119.

`PtyManager::update_transport_auth` held `transport_auth_updates` and called `detach_matching`, which reacquired the same non-reentrant mutex whenever a transport auth snapshot changed. This deadlocked trust refresh and the existing `changed_transport_auth_cancels_an_in_flight_relay_open` regression.

Call the locked detach helper while the update lock is held, publish the replacement snapshot under the same ordering boundary, then retire controls after releasing the update lock. No Rust/Cargo build was run locally per task constraints.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11366"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790839821&installation_model_id=21920&pr_number=11366&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11366&signature=c595eef45fa5c12020f742af3d149fd2b6c5cb9ff44f74aec7fe422842f1b902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a deadlock in `PtyManager::update_transport_auth` where holding the `transport_auth_updates` lock then calling `detach_matching` reacquired the same non-reentrant mutex on auth snapshot changes, blocking trust refresh and the existing `changed_transport_auth_cancels_an_in_flight_relay_open` regression. Now the locked detach helper is called while the update lock is held, the replacement snapshot is published under the same ordering boundary, and controls are retired after releasing the update lock. No Rust build was run locally.

<sup>Written for commit 9963744cb81f00426153d909b9190f59cf07a46f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

