### PR TITLE
fix(cmux-tui): hide remote errors from pipe relay

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -528,4 +528,29 @@ mod tests {
         let unexpected = anyhow::anyhow!("attach capability negotiation failed");
         assert_eq!(attach_failure_exit_reason(&unexpected, 7), PipeIoExitReason::DaemonLost);
     }
+
+    #[test]
+    fn public_remote_diagnostics_use_a_stable_code_and_hide_server_text() {
+        let error = crate::session::test_remote_rejected_error_with_message(
+            "sensitive remote path /Users/example/private",
+        );
+        let payload = public_error_payload("resize", 80, 24, &error);
+        assert_eq!(payload["diag"]["resize"]["cols"], 80);
+        assert_eq!(payload["diag"]["resize"]["rows"], 24);
+        assert_eq!(
+            payload["diag"]["resize"]["error_code"],
+            REMOTE_OPERATION_FAILED_CODE
+        );
+        assert_eq!(payload["diag"]["resize"]["error"], "remote operation failed");
+        assert!(!payload.to_string().contains("sensitive remote path"));
+    }
+
+    #[test]
+    fn public_local_diagnostics_remain_generic() {
+        let error = anyhow::anyhow!("local detail /private/fixture");
+        let payload = public_error_payload("claim", 0, 0, &error);
+        assert_eq!(payload["diag"]["claim"]["error_code"], LOCAL_OPERATION_FAILED_CODE);
+        assert_eq!(payload["diag"]["claim"]["error"], "operation failed");
+        assert!(!payload.to_string().contains("local detail"));
+    }
 }

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -61,6 +61,8 @@ const MAX_PIPE_IO_INPUT_BASE64_BYTES: usize = MAX_PIPE_IO_INPUT_BYTES.div_ceil(3
 /// top of the embedder's previous terminal state.
 const REPLAY_RESET: &[u8] = b"\x1bc\x1b[3J";
 const DAEMON_LOSS_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
+const REMOTE_OPERATION_FAILED_CODE: &str = "pipe_io.remote_operation_failed";
+const LOCAL_OPERATION_FAILED_CODE: &str = "pipe_io.operation_failed";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PipeIoExitReason {
@@ -187,7 +189,7 @@ pub fn run(
     if let Err(error) = session.claim_terminal_geometry(surface) {
         eprintln!(
             "{}",
-            serde_json::json!({"diag": {"claim-terminal-geometry": {"error": error.to_string()}}})
+            emit_public_error_diagnostic("claim-terminal-geometry", 0, 0, &error)
         );
     }
     spawn_stdin_pump(handle, sender, session.clone(), surface);
@@ -297,10 +299,7 @@ fn spawn_stdin_pump(
                                 })
                             ),
                             Err(error) => eprintln!(
-                                "{}",
-                                serde_json::json!({
-                                    "diag": {"resize": {"cols": cols, "rows": rows, "error": error.to_string()}}
-                                })
+                                "{}", emit_public_error_diagnostic("resize", cols, rows, &error)
                             ),
                         }
                     }
@@ -313,10 +312,7 @@ fn spawn_stdin_pump(
                                 serde_json::json!({"diag": {"claim": {"accepted": true}}})
                             ),
                             Err(error) => eprintln!(
-                                "{}",
-                                serde_json::json!({
-                                    "diag": {"claim": {"error": error.to_string()}}
-                                })
+                                "{}", emit_public_error_diagnostic("claim", 0, 0, &error)
                             ),
                         }
                     }
@@ -331,6 +327,55 @@ fn spawn_stdin_pump(
             let _ = sender.send(PipeIoEvent::StdinClosed);
         })
         .expect("spawn pipe-io stdin pump");
+}
+
+/// Build the machine-readable diagnostic sent to the embedder. Remote
+/// servers control rejection and transport text, so only a stable code and a
+/// generic message cross this boundary. The full error remains in the local
+/// client log for diagnosis.
+fn emit_public_error_diagnostic(
+    operation: &str,
+    cols: u16,
+    rows: u16,
+    error: &anyhow::Error,
+) -> serde_json::Value {
+    crate::client_log::error("pipe-io", &format!("{operation} request failed: {error:#}"));
+    public_error_payload(operation, cols, rows, error)
+}
+
+fn public_error_payload(
+    operation: &str,
+    cols: u16,
+    rows: u16,
+    error: &anyhow::Error,
+) -> serde_json::Value {
+    let is_remote = crate::session::is_remote_request_error(error);
+    let mut details = serde_json::Map::new();
+    if operation == "resize" {
+        details.insert("cols".into(), serde_json::json!(cols));
+        details.insert("rows".into(), serde_json::json!(rows));
+    }
+    details.insert(
+        "error_code".into(),
+        serde_json::Value::String(if is_remote {
+            REMOTE_OPERATION_FAILED_CODE.to_string()
+        } else {
+            LOCAL_OPERATION_FAILED_CODE.to_string()
+        }),
+    );
+    details.insert(
+        "error".into(),
+        serde_json::Value::String(if is_remote {
+            "remote operation failed".to_string()
+        } else {
+            "operation failed".to_string()
+        }),
+    );
+    let mut diag = serde_json::Map::new();
+    diag.insert(operation.to_string(), serde_json::Value::Object(details));
+    let mut root = serde_json::Map::new();
+    root.insert("diag".into(), serde_json::Value::Object(diag));
+    serde_json::Value::Object(root)
 }
 
 fn pump_events_to_stdout(

--- a/cmux-tui/crates/cmux-tui/src/session/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/mod.rs
@@ -150,6 +150,13 @@ pub(crate) fn is_remote_transport_failure(error: &anyhow::Error) -> bool {
         .is_some_and(remote::RemoteRequestError::is_transport_failure)
 }
 
+/// Whether an error came from a request sent to the remote session. Callers
+/// that cross a public boundary must not serialize its `Display` text because
+/// the remote endpoint controls that text.
+pub(crate) fn is_remote_request_error(error: &anyhow::Error) -> bool {
+    error.downcast_ref::<remote::RemoteRequestError>().is_some()
+}
+
 pub(crate) fn is_remote_timeout(error: &anyhow::Error) -> bool {
     error
         .downcast_ref::<remote::RemoteRequestError>()


### PR DESCRIPTION
Follow-up to PR 11221, based on exact head 696daa870e1ae11922962c09b258acbe7e4c867b.

Pipe relay stderr diagnostics no longer expose remote-controlled error text. Full details stay in the internal client log; the embedder receives generic text and stable pipe_io.remote_operation_failed (or local operation code). Behavior assertions cover the public payload and ensure sensitive text is absent.

Validation: git diff --check only. Local cargo/rustc tests were not run per task constraint.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11368"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790839924&installation_model_id=21920&pr_number=11368&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11368&signature=f50922860794785b6935b112ad26a3943f6ff95ee2fa947a2c2b5ba15b97e1e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hides remote-controlled error text from pipe relay diagnostics so embedders no longer receive potentially sensitive server-side messages.

**Bug Fixes**
- Replaces raw error strings with stable error codes (`pipe_io.remote_operation_failed` or `pipe_io.operation_failed`) and generic messages.
- Keeps full error details in the internal client log for diagnosis.
- Adds a helper to classify remote vs. local errors.
- Includes `cols`/`rows` in resize diagnostics only.
- Adds tests ensuring sensitive text never appears in the public payload.

<sup>Written for commit a3409801a524b83ae876058794da2ceec048a923. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

