### PR TITLE
fix(tui): validate plugin journal quarantine ownership

### DIFF
--- a/cmux-tui/crates/cmux-tui/Cargo.toml
+++ b/cmux-tui/crates/cmux-tui/Cargo.toml
@@ -45,11 +45,11 @@ sha2.workspace = true
 uuid.workspace = true
 wait-timeout.workspace = true
 fs4.workspace = true
+tokio.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 cmux-remote.workspace = true
 cmux-remote-protocol.workspace = true
-tokio.workspace = true
 url.workspace = true
 async-trait.workspace = true
 

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -152,6 +152,7 @@ use serde::{Deserialize, Deserializer};
 use serde_json::{Value, json};
 use unicode_width::UnicodeWidthStr;
 use wait_timeout::ChildExt;
+use fs4::FileExt;
 
 use crate::localization::catalog;
 
@@ -4097,32 +4098,70 @@ pub(crate) fn write_sidebar_plugin_at_path(
     path: &Path,
     plugin: Option<&SidebarPluginConfig>,
 ) -> anyhow::Result<ConfigWriteOutcome> {
-    let mut root = read_config_value(path)?;
-    let Some(root_object) = root.as_object_mut() else {
-        anyhow::bail!("{} must contain a JSON object", path.display());
-    };
-    match plugin {
-        Some(plugin) => {
-            let sidebar = root_object.entry("sidebar").or_insert_with(|| json!({}));
-            if !sidebar.is_object() {
-                *sidebar = json!({});
+    with_config_file_lock(path, || {
+        let mut root = read_config_value(path)?;
+        let Some(root_object) = root.as_object_mut() else {
+            anyhow::bail!("{} must contain a JSON object", path.display());
+        };
+        match plugin {
+            Some(plugin) => {
+                let sidebar = root_object.entry("sidebar").or_insert_with(|| json!({}));
+                if !sidebar.is_object() {
+                    *sidebar = json!({});
+                }
+                let sidebar_object =
+                    sidebar.as_object_mut().expect("sidebar was just made an object");
+                let mut plugin_value = json!({ "command": &plugin.command });
+                if let Some(cwd) = &plugin.cwd {
+                    plugin_value["cwd"] = json!(cwd);
+                }
+                sidebar_object.insert("plugin".to_string(), plugin_value);
             }
-            let sidebar_object = sidebar.as_object_mut().expect("sidebar was just made an object");
-            let mut plugin_value = json!({ "command": &plugin.command });
-            if let Some(cwd) = &plugin.cwd {
-                plugin_value["cwd"] = json!(cwd);
+            None => {
+                if let Some(sidebar) = root_object.get_mut("sidebar")
+                    && let Some(sidebar_object) = sidebar.as_object_mut()
+                {
+                    sidebar_object.remove("plugin");
+                }
             }
-            sidebar_object.insert("plugin".to_string(), plugin_value);
         }
-        None => {
-            if let Some(sidebar) = root_object.get_mut("sidebar")
-                && let Some(sidebar_object) = sidebar.as_object_mut()
-            {
-                sidebar_object.remove("plugin");
-            }
-        }
+        write_config_value_atomic_unlocked(path, &root)
+    })
+}
+
+/// Serialize all config read-modify-write operations for every cmux-tui
+/// process. The lock is a sibling of the config file because an atomic rename
+/// changes the destination inode and therefore cannot safely carry the lock.
+pub(crate) fn with_config_file_lock<T>(
+    path: &Path,
+    operation: impl FnOnce() -> anyhow::Result<T>,
+) -> anyhow::Result<T> {
+    let parent = config_parent_directory(path);
+    ensure_config_parent_directory(parent)?;
+    let file_name = path.file_name().and_then(|name| name.to_str()).unwrap_or("cmux-tui.json");
+    let lock_path = parent.join(format!(".{file_name}.lock"));
+    let mut options = OpenOptions::new();
+    options.create(true).read(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{MetadataExt as _, OpenOptionsExt as _, PermissionsExt as _};
+        options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC).mode(0o600);
     }
-    write_config_value_atomic(path, &root)
+    let file = options.open(&lock_path)?;
+    #[cfg(unix)]
+    {
+        let metadata = file.metadata()?;
+        anyhow::ensure!(
+            metadata.uid() == unsafe { libc::geteuid() },
+            "config lock owner changed"
+        );
+        anyhow::ensure!(
+            metadata.permissions().mode() & 0o022 == 0,
+            "config lock is writable by another user"
+        );
+    }
+    FileExt::lock(&file)?;
+    operation()
 }
 
 fn read_config_value(path: &Path) -> anyhow::Result<Value> {
@@ -4143,10 +4182,29 @@ fn read_config_value(path: &Path) -> anyhow::Result<Value> {
 /// [`ConfigWriteOutcome::CommittedButUnsynced`] value means a supported
 /// directory sync failed.
 fn write_config_value_atomic(path: &Path, value: &Value) -> anyhow::Result<ConfigWriteOutcome> {
-    write_config_value_atomic_with_sync(path, value, &sync_config_parent_directory)
+    with_config_file_lock(path, || {
+        write_config_value_atomic_unlocked(path, value)
+    })
+}
+
+fn write_config_value_atomic_unlocked(
+    path: &Path,
+    value: &Value,
+) -> anyhow::Result<ConfigWriteOutcome> {
+    write_config_value_atomic_with_sync_unlocked(path, value, &sync_config_parent_directory)
 }
 
 fn write_config_value_atomic_with_sync(
+    path: &Path,
+    value: &Value,
+    sync_parent: &dyn Fn(&Path) -> anyhow::Result<ConfigParentSyncOutcome>,
+) -> anyhow::Result<ConfigWriteOutcome> {
+    with_config_file_lock(path, || {
+        write_config_value_atomic_with_sync_unlocked(path, value, sync_parent)
+    })
+}
+
+fn write_config_value_atomic_with_sync_unlocked(
     path: &Path,
     value: &Value,
     sync_parent: &dyn Fn(&Path) -> anyhow::Result<ConfigParentSyncOutcome>,
@@ -9048,8 +9106,11 @@ mod tests {
         assert!(!error.to_string().is_empty());
 
         let entries = std::fs::read_dir(&dir.path).unwrap().collect::<Result<Vec<_>, _>>().unwrap();
-        assert_eq!(entries.len(), 1, "failed writes must remove their staging file");
-        assert_eq!(entries[0].path(), path);
+        assert!(entries.iter().any(|entry| entry.path() == path));
+        assert!(
+            entries.iter().all(|entry| !entry.file_name().to_string_lossy().ends_with(".tmp")),
+            "failed writes must remove their staging file"
+        );
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -4144,7 +4144,7 @@ pub(crate) fn with_config_file_lock<T>(
     options.create(true).read(true).write(true);
     #[cfg(unix)]
     {
-        use std::os::unix::fs::{MetadataExt as _, OpenOptionsExt as _, PermissionsExt as _};
+        use std::os::unix::fs::OpenOptionsExt as _;
         options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC).mode(0o600);
     }
     let file = options.open(&lock_path)?;

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -147,12 +147,12 @@ use cmux_tui_core::TRANSPORT_SAFE_CAPTURE_MEGAPIXELS;
 use cmux_tui_core::platform;
 use cmux_tui_core::{CursorShape, DefaultColors, Rgb};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use fs4::FileExt;
 use ratatui::style::Color;
 use serde::{Deserialize, Deserializer};
 use serde_json::{Value, json};
 use unicode_width::UnicodeWidthStr;
 use wait_timeout::ChildExt;
-use fs4::FileExt;
 
 use crate::localization::catalog;
 
@@ -4150,11 +4150,9 @@ pub(crate) fn with_config_file_lock<T>(
     let file = options.open(&lock_path)?;
     #[cfg(unix)]
     {
+        use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
         let metadata = file.metadata()?;
-        anyhow::ensure!(
-            metadata.uid() == unsafe { libc::geteuid() },
-            "config lock owner changed"
-        );
+        anyhow::ensure!(metadata.uid() == unsafe { libc::geteuid() }, "config lock owner changed");
         anyhow::ensure!(
             metadata.permissions().mode() & 0o022 == 0,
             "config lock is writable by another user"
@@ -4182,9 +4180,7 @@ fn read_config_value(path: &Path) -> anyhow::Result<Value> {
 /// [`ConfigWriteOutcome::CommittedButUnsynced`] value means a supported
 /// directory sync failed.
 fn write_config_value_atomic(path: &Path, value: &Value) -> anyhow::Result<ConfigWriteOutcome> {
-    with_config_file_lock(path, || {
-        write_config_value_atomic_unlocked(path, value)
-    })
+    with_config_file_lock(path, || write_config_value_atomic_unlocked(path, value))
 }
 
 fn write_config_value_atomic_unlocked(

--- a/cmux-tui/crates/cmux-tui/src/localization.rs
+++ b/cmux-tui/crates/cmux-tui/src/localization.rs
@@ -122,6 +122,11 @@ pub(crate) struct SessionMessages {
     mux_subscription_recovery_failed: &'static str,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct PluginMessages {
+    pub operation_failed: &'static str,
+}
+
 impl SessionMessages {
     pub(crate) fn mux_subscription_recovery_failed(&self, error: &str) -> String {
         self.mux_subscription_recovery_failed.replace("{error}", error)
@@ -1096,6 +1101,7 @@ pub(crate) struct Catalog {
     pub graphics: GraphicsMessages,
     pub terminal: TerminalMessages,
     pub session: SessionMessages,
+    pub plugin: PluginMessages,
     pub session_reset: SessionResetMessages,
     pub machine_agent: MachineAgentMessages,
     pub menu: MenuMessages,
@@ -1235,6 +1241,7 @@ static ENGLISH: Catalog = Catalog {
         mux_subscription_recovered: "Mux event backlog overflowed; subscription recovered",
         mux_subscription_recovery_failed: "Mux event backlog recovery failed; queued input was discarded while retrying: {error}",
     },
+    plugin: PluginMessages { operation_failed: "Plugin operation failed; retry the command" },
     session_reset: SessionResetMessages {
         help: "  cmux session <name> reset-state [--force --confirm-reset <token>] [--state <path>]\n    Preview or confirm a scoped saved-state reset",
         exact_name_required: "session reset-state requires an exact session name",
@@ -1880,6 +1887,9 @@ static JAPANESE: Catalog = Catalog {
         operation_canceled: "セッション操作はキャンセルされました",
         mux_subscription_recovered: "Mux イベントの滞留が上限を超えました。購読を復旧しました",
         mux_subscription_recovery_failed: "Mux イベントの滞留から復旧できませんでした。再試行中のキュー入力を破棄しました: {error}",
+    },
+    plugin: PluginMessages {
+        operation_failed: "プラグイン操作に失敗しました。コマンドを再試行してください",
     },
     session_reset: SessionResetMessages {
         help: "  cmux session <name> reset-state [--force --confirm-reset <token>] [--state <path>]\n    スコープ付き保存状態のリセットをプレビューまたは確認実行",

--- a/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
+++ b/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
@@ -1432,7 +1432,7 @@ fn replace_installed_plugin_with_config<C: FnOnce() -> anyhow::Result<()>>(
 fn capture_config_snapshot() -> anyhow::Result<ConfigSnapshot> {
     let path = config::config_path()?;
     let (config_existed, sidebar_plugin, original_non_object) = match fs::read_to_string(&path) {
-        Ok(text) if text.trim().is_empty() => (true, None, None),
+        Ok(text) if text.trim().is_empty() => (Some(true), None, None),
         Ok(text) => {
             let value: Value = serde_json::from_str(&text)?;
             let sidebar_plugin = value
@@ -1441,9 +1441,9 @@ fn capture_config_snapshot() -> anyhow::Result<ConfigSnapshot> {
                 .and_then(|sidebar| sidebar.get("plugin"))
                 .cloned();
             let original_non_object = (!value.is_object()).then_some(value);
-            (true, sidebar_plugin, original_non_object)
+            (Some(true), sidebar_plugin, original_non_object)
         }
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => (false, None, None),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => (Some(false), None, None),
         Err(error) => return Err(error.into()),
     };
     Ok(ConfigSnapshot { path, config_existed, sidebar_plugin, original_non_object })
@@ -1513,6 +1513,10 @@ fn replace_installed_plugin_with_fs<F: InstallFilesystem, C: FnOnce() -> anyhow:
         })?;
         metadata_installed = true;
         sync_directory(&registry)?;
+        // The committed journal is the recovery point. Persist the directory
+        // entry for the installed plugin before recording that point, so a
+        // crash cannot leave a committed journal with a missing target.
+        sync_directory(install_root)?;
         after_install()?;
         write_install_journal(
             &journal_path,

--- a/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
+++ b/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
@@ -907,6 +907,41 @@ fn direct_child_named(parent: &Path, path: &Path, predicate: impl FnOnce(&str) -
         && path.file_name().and_then(|name| name.to_str()).is_some_and(predicate)
 }
 
+fn is_generated_install_temp_name(name: &str) -> bool {
+    let Some(stamp) = name.strip_prefix(".install-") else { return false };
+    let Some((pid, nonce)) = stamp.split_once('-') else { return false };
+    !pid.is_empty()
+        && !nonce.is_empty()
+        && pid.bytes().all(|byte| byte.is_ascii_digit())
+        && nonce.bytes().all(|byte| byte.is_ascii_digit())
+}
+
+fn validate_install_temp_path(install_root: &Path, path: &Path) -> anyhow::Result<()> {
+    anyhow::ensure!(
+        direct_child_named(install_root, path, is_generated_install_temp_name),
+        "install journal temporary directory is outside the install root"
+    );
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => anyhow::ensure!(
+            metadata.is_dir() && !metadata.file_type().is_symlink(),
+            "install journal temporary directory is not a real directory"
+        ),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn remove_install_temp_if_present(install_root: &Path, path: &Path) -> anyhow::Result<()> {
+    // Validate again immediately before recursive removal. This keeps the
+    // recursive operation restricted to a generated, direct-child directory.
+    validate_install_temp_path(install_root, path)?;
+    match fs::symlink_metadata(path) {
+        Ok(_) => fs::remove_dir_all(path).map_err(Into::into),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
 fn validate_install_journal_paths(
     install_root: &Path,
     journal_path: &Path,
@@ -926,12 +961,7 @@ fn validate_install_journal_paths(
         }),
         "install journal target backup is outside the install root"
     );
-    anyhow::ensure!(
-        direct_child_named(install_root, &journal.temp_dir, |name| {
-            name.starts_with(".install-")
-        }),
-        "install journal temporary directory is outside the install root"
-    );
+    validate_install_temp_path(install_root, &journal.temp_dir)?;
     let registry = install_root.join(".registry");
     if fs::symlink_metadata(&registry).is_ok() {
         ensure_real_directory(&registry)?;
@@ -1169,7 +1199,7 @@ fn reconcile_install_transactions(install_root: &Path) -> anyhow::Result<()> {
         if committed {
             remove_path_if_present(&journal.target_backup)?;
             remove_path_if_present(&journal.metadata_backup)?;
-            remove_path_if_present(&journal.temp_dir)?;
+            remove_install_temp_if_present(install_root, &journal.temp_dir)?;
             remove_path_if_present(&journal.metadata_temp)?;
         } else {
             match journal.phase {
@@ -1200,7 +1230,7 @@ fn reconcile_install_transactions(install_root: &Path) -> anyhow::Result<()> {
                             &journal.name,
                         ))?;
                     }
-                    remove_path_if_present(&journal.temp_dir)?;
+                    remove_install_temp_if_present(install_root, &journal.temp_dir)?;
                     remove_path_if_present(&journal.metadata_temp)?;
                 }
                 InstallJournalPhase::Committed => unreachable!(),
@@ -1922,7 +1952,7 @@ mod tests {
         let target = root.join("demo");
         let registry = root.join(".registry");
         let metadata_path = registry.join("demo.json");
-        let temp_dir = root.join(".install");
+        let temp_dir = root.join(".install-123-456");
         let metadata_temp = registry.join(".demo.tmp");
         fs::create_dir_all(target.join("bin")).unwrap();
         fs::write(target.join("marker"), "old").unwrap();
@@ -2185,6 +2215,56 @@ mod tests {
         assert_eq!(fs::read_dir(quarantined).unwrap().count(), 1);
         fs::remove_file(outside).unwrap();
         fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn invalid_journal_temp_paths_are_quarantined_without_recursive_delete() {
+        for (label, temp_name, make_directory) in
+            [("prefix", ".install-important", true), ("file", ".install-123-456", false)]
+        {
+            let root = std::env::temp_dir().join(format!(
+                "cmux-plugin-journal-temp-{label}-{}-{}",
+                std::process::id(),
+                now_nanos()
+            ));
+            let registry = root.join(".registry");
+            fs::create_dir_all(&registry).unwrap();
+            let temp_dir = root.join(temp_name);
+            if make_directory {
+                fs::create_dir_all(temp_dir.join("nested")).unwrap();
+                fs::write(temp_dir.join("nested/sentinel"), b"keep").unwrap();
+            } else {
+                fs::write(&temp_dir, b"keep").unwrap();
+            }
+            let journal_path = install_journal_path(&root, label);
+            write_install_journal(
+                &journal_path,
+                &InstallJournal {
+                    owner_token: None,
+                    name: label.into(),
+                    target_backup: root.join(format!(".{label}.1-2.plugin-backup")),
+                    metadata_backup: registry.join(format!(".{label}.1-2.metadata-backup.json")),
+                    temp_dir: temp_dir.clone(),
+                    metadata_temp: registry.join(format!(".{label}.1-2.tmp")),
+                    target_existed: false,
+                    metadata_existed: false,
+                    config_snapshot: None,
+                    expected_sidebar_plugin: None,
+                    phase: InstallJournalPhase::Committed,
+                },
+            )
+            .unwrap();
+
+            reconcile_install_transactions(&root).unwrap();
+            if make_directory {
+                assert_eq!(fs::read(temp_dir.join("nested/sentinel")).unwrap(), b"keep");
+            } else {
+                assert_eq!(fs::read(&temp_dir).unwrap(), b"keep");
+            }
+            assert!(!journal_path.exists());
+            assert_eq!(fs::read_dir(root.join(INVALID_INSTALL_JOURNAL_DIR)).unwrap().count(), 1);
+            fs::remove_dir_all(root).unwrap();
+        }
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
+++ b/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
@@ -203,7 +203,10 @@ fn acquire_plugin_operation_lock() -> anyhow::Result<PluginOperationLock> {
         use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
         let metadata = file.metadata()?;
         anyhow::ensure!(metadata.uid() == unsafe { libc::geteuid() }, "plugin lock owner changed");
-        anyhow::ensure!(metadata.permissions().mode() & 0o022 == 0, "plugin lock is writable by another user");
+        anyhow::ensure!(
+            metadata.permissions().mode() & 0o022 == 0,
+            "plugin lock is writable by another user"
+        );
     }
     FileExt::lock(&file)?;
     Ok(PluginOperationLock(file))
@@ -1158,7 +1161,8 @@ fn reconcile_install_transactions(install_root: &Path) -> anyhow::Result<()> {
             .map(|owner_token| commit_marker_matches(&marker_path, owner_token))
             .transpose()?
             .unwrap_or(false);
-        let committed = matches!(&journal.phase, InstallJournalPhase::Committed) || marker_committed;
+        let committed =
+            matches!(&journal.phase, InstallJournalPhase::Committed) || marker_committed;
         if committed {
             remove_path_if_present(&journal.target_backup)?;
             remove_path_if_present(&journal.metadata_backup)?;
@@ -1167,36 +1171,39 @@ fn reconcile_install_transactions(install_root: &Path) -> anyhow::Result<()> {
         } else {
             match journal.phase {
                 InstallJournalPhase::Prepared => {
-                if let Some(snapshot) = &journal.config_snapshot {
-                    let legacy_target = journal
-                        .expected_sidebar_plugin
-                        .is_none()
-                        .then(|| install_root.join(&journal.name));
-                    restore_config_snapshot(
-                        snapshot,
-                        journal.expected_sidebar_plugin.as_ref(),
-                        legacy_target.as_deref(),
-                    )?;
-                }
-                if journal.target_existed {
-                    if path_entry_exists(&journal.target_backup)? {
+                    if let Some(snapshot) = &journal.config_snapshot {
+                        let legacy_target = journal
+                            .expected_sidebar_plugin
+                            .is_none()
+                            .then(|| install_root.join(&journal.name));
+                        restore_config_snapshot(
+                            snapshot,
+                            journal.expected_sidebar_plugin.as_ref(),
+                            legacy_target.as_deref(),
+                        )?;
+                    }
+                    if journal.target_existed {
+                        if path_entry_exists(&journal.target_backup)? {
+                            remove_path_if_present(&install_root.join(&journal.name))?;
+                            fs::rename(&journal.target_backup, install_root.join(&journal.name))?;
+                        }
+                    } else {
                         remove_path_if_present(&install_root.join(&journal.name))?;
-                        fs::rename(&journal.target_backup, install_root.join(&journal.name))?;
                     }
-                } else {
-                    remove_path_if_present(&install_root.join(&journal.name))?;
-                }
-                if journal.metadata_existed {
-                    let metadata_path = registry_metadata_path(install_root, &journal.name);
-                    if path_entry_exists(&journal.metadata_backup)? {
-                        remove_path_if_present(&metadata_path)?;
-                        fs::rename(&journal.metadata_backup, metadata_path)?;
+                    if journal.metadata_existed {
+                        let metadata_path = registry_metadata_path(install_root, &journal.name);
+                        if path_entry_exists(&journal.metadata_backup)? {
+                            remove_path_if_present(&metadata_path)?;
+                            fs::rename(&journal.metadata_backup, metadata_path)?;
+                        }
+                    } else {
+                        remove_path_if_present(&registry_metadata_path(
+                            install_root,
+                            &journal.name,
+                        ))?;
                     }
-                } else {
-                    remove_path_if_present(&registry_metadata_path(install_root, &journal.name))?;
-                }
-                remove_path_if_present(&journal.temp_dir)?;
-                remove_path_if_present(&journal.metadata_temp)?;
+                    remove_path_if_present(&journal.temp_dir)?;
+                    remove_path_if_present(&journal.metadata_temp)?;
                 }
                 InstallJournalPhase::Committed => unreachable!(),
             }
@@ -1279,9 +1286,8 @@ fn cleanup_orphan_commit_markers(
     for entry in entries {
         let path = entry?.path();
         let Some(name) = path.file_name().and_then(|value| value.to_str()) else { continue };
-        let Some(plugin_name) = name
-            .strip_prefix('.')
-            .and_then(|value| value.strip_suffix(".install-commit"))
+        let Some(plugin_name) =
+            name.strip_prefix('.').and_then(|value| value.strip_suffix(".install-commit"))
         else {
             continue;
         };
@@ -1310,14 +1316,15 @@ fn restore_config_snapshot(
             Err(error) => return Err(error.into()),
         };
         let current = root.get("sidebar").and_then(|sidebar| sidebar.get("plugin"));
-        let current_is_transaction = expected_sidebar_plugin.is_some_and(|expected| {
-            current == Some(expected)
-        }) || expected_sidebar_plugin.is_none() && legacy_target.is_some_and(|target| {
-            current
-                .and_then(|plugin| plugin.get("cwd"))
-                .and_then(Value::as_str)
-                .is_some_and(|cwd| same_path(Path::new(cwd), target))
-        });
+        let current_is_transaction = expected_sidebar_plugin
+            .is_some_and(|expected| current == Some(expected))
+            || expected_sidebar_plugin.is_none()
+                && legacy_target.is_some_and(|target| {
+                    current
+                        .and_then(|plugin| plugin.get("cwd"))
+                        .and_then(Value::as_str)
+                        .is_some_and(|cwd| same_path(Path::new(cwd), target))
+                });
         if !current_is_transaction {
             // The user or another cmux process selected a different plugin after
             // this transaction started. Leave that newer state untouched. A
@@ -1558,10 +1565,7 @@ fn replace_installed_plugin_with_fs<F: InstallFilesystem, C: FnOnce() -> anyhow:
             }
         }
         if let Some(snapshot) = &journal.config_snapshot {
-            let legacy_target = journal
-                .expected_sidebar_plugin
-                .is_none()
-                .then(|| target.clone());
+            let legacy_target = journal.expected_sidebar_plugin.is_none().then(|| target.clone());
             if let Err(rollback_error) = restore_config_snapshot(
                 snapshot,
                 journal.expected_sidebar_plugin.as_ref(),
@@ -2282,7 +2286,8 @@ mod tests {
         )
         .unwrap_err();
         assert!(error.to_string().contains("injected config failure"));
-        let current: Value = serde_json::from_str(&fs::read_to_string(config_path).unwrap()).unwrap();
+        let current: Value =
+            serde_json::from_str(&fs::read_to_string(config_path).unwrap()).unwrap();
         assert_eq!(current["sidebar"]["plugin"]["command"], json!(["newer"]));
         assert_eq!(current["theme"]["name"], json!("changed"));
         fs::remove_dir_all(root).unwrap();

--- a/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
+++ b/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
@@ -601,11 +601,22 @@ fn resolved_run_command_for_target(
 ) -> anyhow::Result<Vec<String>> {
     let mut command = resolved_run_command(manifest, staged_dir)?;
     let staged_root = canonical_path(staged_dir)?;
-    let target_root = canonical_path(target_dir)?;
+    // Do not canonicalize the final target component. A forced replacement can
+    // receive a symlink at this path, and resolving it would persist the old
+    // destination instead of the new install root.
+    let target_root = canonical_parent_with_name(target_dir)?;
     if let Ok(relative) = Path::new(&command[0]).strip_prefix(&staged_root) {
         command[0] = target_root.join(relative).display().to_string();
     }
     Ok(command)
+}
+
+fn canonical_parent_with_name(path: &Path) -> anyhow::Result<PathBuf> {
+    let name = path
+        .file_name()
+        .ok_or_else(|| anyhow::anyhow!("path has no final component"))?;
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    Ok(canonical_path(parent)?.join(name))
 }
 
 fn verify_executable(path: &str) -> anyhow::Result<()> {
@@ -1232,12 +1243,18 @@ fn reconcile_install_transactions(install_root: &Path) -> anyhow::Result<()> {
                     }
                     remove_install_temp_if_present(install_root, &journal.temp_dir)?;
                     remove_path_if_present(&journal.metadata_temp)?;
+                    // Persist both restored directory entries before deleting
+                    // the journal that records how to recover them.
+                    sync_directory(install_root)?;
+                    sync_directory(&install_root.join(".registry"))?;
                 }
                 InstallJournalPhase::Committed => unreachable!(),
             }
         }
         remove_path_if_present(&path)?;
         remove_path_if_present(&marker_path)?;
+        sync_directory(install_root)?;
+        sync_directory(&install_root.join(".registry"))?;
     }
     cleanup_orphan_metadata_temps(install_root, &protected_metadata_temps)?;
     cleanup_orphan_commit_markers(install_root, &valid_journal_names)?;
@@ -1838,6 +1855,32 @@ mod tests {
             fs::set_permissions(&executable, fs::Permissions::from_mode(0o755)).unwrap();
         }
         let manifest = parse_manifest(&manifest_text("demo")).unwrap();
+        let command = resolved_run_command_for_target(&manifest, &staged, &target).unwrap();
+        assert_eq!(command, vec![target.join("bin/sidebar").display().to_string()]);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn staged_command_mapping_does_not_follow_target_symlink() {
+        use std::os::unix::fs::{PermissionsExt, symlink};
+
+        let root = std::env::temp_dir().join(format!(
+            "cmux-plugin-command-symlink-{}-{}",
+            std::process::id(),
+            now_nanos()
+        ));
+        let staged = root.join(".install");
+        let target = root.join("demo");
+        let old_target = root.join("old-demo");
+        fs::create_dir_all(staged.join("bin")).unwrap();
+        fs::create_dir_all(&old_target).unwrap();
+        symlink(&old_target, &target).unwrap();
+        let executable = staged.join("bin/sidebar");
+        fs::write(&executable, "#!/bin/sh\nexit 0\n").unwrap();
+        fs::set_permissions(&executable, fs::Permissions::from_mode(0o755)).unwrap();
+        let manifest = parse_manifest(&manifest_text("demo")).unwrap();
+
         let command = resolved_run_command_for_target(&manifest, &staged, &target).unwrap();
         assert_eq!(command, vec![target.join("bin/sidebar").display().to_string()]);
         fs::remove_dir_all(root).unwrap();

--- a/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
+++ b/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -49,7 +49,9 @@ impl ManagerError {
                 }
                 details
             }
-            Self::Failure(error) => json!({"reason": error.to_string()}),
+            Self::Failure(_) => {
+                json!({"reason": crate::localization::catalog().plugin.operation_failed})
+            }
         }
     }
 
@@ -63,7 +65,9 @@ impl std::fmt::Display for ManagerError {
         match self {
             Self::Usage(message) => formatter.write_str(message),
             Self::Validation { reason, .. } => formatter.write_str(reason),
-            Self::Failure(error) => std::fmt::Display::fmt(error, formatter),
+            Self::Failure(_) => {
+                formatter.write_str(crate::localization::catalog().plugin.operation_failed)
+            }
         }
     }
 }
@@ -127,6 +131,7 @@ struct PluginRegistryMetadata {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 #[serde(rename_all = "snake_case")]
 enum InstallJournalPhase {
     Prepared,
@@ -134,9 +139,8 @@ enum InstallJournalPhase {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct InstallJournal {
-    #[serde(default = "default_owner_token")]
-    owner_token: String,
     name: String,
     target_backup: PathBuf,
     metadata_backup: PathBuf,
@@ -145,61 +149,59 @@ struct InstallJournal {
     target_existed: bool,
     metadata_existed: bool,
     config_snapshot: Option<ConfigSnapshot>,
-    #[serde(default)]
-    expected_sidebar_plugin: Option<Value>,
     phase: InstallJournalPhase,
 }
 
-fn default_owner_token() -> String {
-    "legacy".to_string()
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct ConfigSnapshot {
     path: PathBuf,
-    #[serde(default)]
-    config_existed: bool,
-    #[serde(default)]
     sidebar_plugin: Option<Value>,
-    #[serde(default)]
-    original_non_object: Option<Value>,
 }
 
-struct PluginOperationLock {
-    _file: fs::File,
-}
+const INVALID_INSTALL_JOURNAL_DIR: &str = ".invalid-install-journals";
+const MAX_INSTALL_JOURNAL_BYTES: usize = 1024 * 1024;
+const JOURNAL_QUARANTINE_ATTEMPTS: usize = 16;
+
+struct PluginOperationLock(fs::File);
 
 fn acquire_plugin_operation_lock() -> anyhow::Result<PluginOperationLock> {
     let root = install_root()?;
     fs::create_dir_all(&root)?;
+    ensure_real_directory(&root)?;
     let path = root.join(".install.lock");
     let file = fs::OpenOptions::new().create(true).read(true).write(true).open(path)?;
-    file.lock()?;
-    Ok(PluginOperationLock { _file: file })
+    FileExt::lock(&file)?;
+    Ok(PluginOperationLock(file))
 }
 
 pub(crate) fn execute(positionals: &[String], options: CliOptions) -> Result<Value, ManagerError> {
-    match positionals.first().map(String::as_str) {
-        Some("install") => {
-            let _lock = acquire_plugin_operation_lock().map_err(ManagerError::Failure)?;
-            install_command(positionals, &options)
-        }
-        Some("list") => list_command(positionals, &options),
-        Some("use") => {
-            let _lock = acquire_plugin_operation_lock().map_err(ManagerError::Failure)?;
-            use_command(positionals, &options)
-        }
-        Some("update") => {
-            let _lock = acquire_plugin_operation_lock().map_err(ManagerError::Failure)?;
-            update_command(positionals, &options)
-        }
-        Some("remove") => {
-            let _lock = acquire_plugin_operation_lock().map_err(ManagerError::Failure)?;
-            remove_command(positionals, &options)
-        }
-        Some(other) => Err(ManagerError::Usage(format!("unknown plugin subcommand {other:?}"))),
-        None => Err(ManagerError::Usage("plugin subcommand is required".to_string())),
-    }
+    with_optional_operation_lock(
+        command_requires_operation_lock(positionals),
+        || acquire_plugin_operation_lock().map_err(ManagerError::Failure),
+        || match positionals.first().map(String::as_str) {
+            Some("install") => install_command(positionals, &options),
+            Some("list") => list_command(positionals, &options),
+            Some("use") => use_command(positionals, &options),
+            Some("update") => update_command(positionals, &options),
+            Some("remove") => remove_command(positionals, &options),
+            Some(other) => Err(ManagerError::Usage(format!("unknown plugin subcommand {other:?}"))),
+            None => Err(ManagerError::Usage("plugin subcommand is required".to_string())),
+        },
+    )
+}
+
+fn command_requires_operation_lock(positionals: &[String]) -> bool {
+    matches!(positionals.first().map(String::as_str), Some("install" | "use" | "update" | "remove"))
+}
+
+fn with_optional_operation_lock<T>(
+    requires_lock: bool,
+    acquire: impl FnOnce() -> Result<PluginOperationLock, ManagerError>,
+    operation: impl FnOnce() -> Result<T, ManagerError>,
+) -> Result<T, ManagerError> {
+    let _lock = requires_lock.then(acquire).transpose()?;
+    operation()
 }
 
 fn install_command(positionals: &[String], options: &CliOptions) -> Result<Value, ManagerError> {
@@ -225,18 +227,16 @@ fn install_command(positionals: &[String], options: &CliOptions) -> Result<Value
 
     let mut metadata_temp_path = None;
     let result = (|| -> Result<Value, ManagerError> {
-        let manifest = read_manifest(&temp_dir)
-            .map_err(|error| ManagerError::validation(None, error.to_string()))?;
+        let manifest = read_manifest(&temp_dir).map_err(|_| {
+            ManagerError::validation(Some("manifest"), "plugin manifest is invalid")
+        })?;
         let name = installed_name(&manifest, options.name.as_deref())
-            .map_err(|error| ManagerError::validation(Some("name"), error.to_string()))?;
+            .map_err(|_| ManagerError::validation(Some("name"), "plugin name is invalid"))?;
         let target = root.join(&name);
-        if target.exists() && !options.force {
+        if path_entry_exists(&target)? && !options.force {
             return Err(ManagerError::validation(
                 Some("name"),
-                format!(
-                    "plugin {name:?} is already installed at {}; use --force to replace it",
-                    target.display()
-                ),
+                "plugin is already installed; use --force to replace it",
             ));
         }
         run_build_if_needed(&manifest, &temp_dir)?;
@@ -248,38 +248,12 @@ fn install_command(positionals: &[String], options: &CliOptions) -> Result<Value
         let id = metadata.id;
         let selected = selected_plugin_cwd()?.is_some_and(|cwd| same_path(&cwd, &target));
         let config_snapshot = selected.then(capture_config_snapshot).transpose()?;
-        let expected_sidebar_plugin = if selected {
-            let staging_command = resolved_run_command(&manifest, &temp_dir)?;
-            let staging_root = canonical_path(&temp_dir)?;
-            let target_root = canonical_path(&target)?;
-            let expected_command = staging_command
-                .into_iter()
-                .enumerate()
-                .map(|(index, argument)| {
-                    if index == 0 {
-                        let command_path = Path::new(&argument);
-                        if let Ok(relative) = command_path.strip_prefix(&staging_root) {
-                            return target_root.join(relative).display().to_string();
-                        }
-                    }
-                    argument
-                })
-                .collect::<Vec<_>>();
-            let expected_cwd = canonical_path(&target)?;
-            Some(json!({
-                "command": expected_command,
-                "cwd": expected_cwd.display().to_string(),
-            }))
-        } else {
-            None
-        };
         replace_installed_plugin_with_config(
             &root,
             &name,
             &temp_dir,
             &metadata_temp,
             config_snapshot,
-            expected_sidebar_plugin,
             || {
                 if selected {
                     let command = resolved_run_command(&manifest, &target)?;
@@ -301,8 +275,8 @@ fn install_command(positionals: &[String], options: &CliOptions) -> Result<Value
         })}))
     })();
     if result.is_err() {
-        if temp_dir.exists() {
-            let _ = fs::remove_dir_all(&temp_dir);
+        if path_entry_exists(&temp_dir).unwrap_or(false) {
+            let _ = remove_path_if_present(&temp_dir);
         }
         if let Some(metadata_temp) = metadata_temp_path {
             let _ = fs::remove_file(metadata_temp);
@@ -316,7 +290,7 @@ fn list_command(positionals: &[String], options: &CliOptions) -> Result<Value, M
     if positionals.len() != 1 {
         return Err(ManagerError::Usage("usage: cmux sidebar plugin list".to_string()));
     }
-    let plugins = installed_plugins()?;
+    let plugins = installed_plugins(false)?;
     Ok(Value::Array(plugins.iter().map(plugin_json).collect()))
 }
 
@@ -336,7 +310,7 @@ fn use_command(positionals: &[String], options: &CliOptions) -> Result<Value, Ma
     let command = resolved_run_command(&plugin.manifest, &plugin.dir)?;
     verify_executable(&command[0])?;
     let cwd = canonical_path(&plugin.dir)?;
-    config::write_sidebar_plugin(Some(&SidebarPluginConfig {
+    persist_sidebar_plugin(Some(&SidebarPluginConfig {
         command,
         cwd: Some(cwd.display().to_string()),
     }))?;
@@ -359,7 +333,7 @@ fn update_command(positionals: &[String], options: &CliOptions) -> Result<Value,
     verify_executable(&command[0])?;
     if plugin.selected {
         let cwd = canonical_path(&plugin.dir)?;
-        config::write_sidebar_plugin(Some(&SidebarPluginConfig {
+        persist_sidebar_plugin(Some(&SidebarPluginConfig {
             command,
             cwd: Some(cwd.display().to_string()),
         }))?;
@@ -377,7 +351,7 @@ fn remove_command(positionals: &[String], options: &CliOptions) -> Result<Value,
     let installed = resolve_installed_plugin(&positionals[1])?;
     let mut plugin = plugin_json(&installed);
     if installed.selected {
-        config::write_sidebar_plugin(None)?;
+        persist_sidebar_plugin(None)?;
     }
     fs::remove_dir_all(&installed.dir)?;
     remove_registry_metadata(&install_root()?, &installed.name)?;
@@ -387,9 +361,25 @@ fn remove_command(positionals: &[String], options: &CliOptions) -> Result<Value,
 }
 
 fn write_builtin_config(_options: &CliOptions) -> Result<Value, ManagerError> {
-    config::write_sidebar_plugin(None)?;
-    let plugins = installed_plugins()?;
+    // Recovery must complete before changing the user's selection. Otherwise a
+    // prepared transaction can restore its snapshot after we select the
+    // builtin plugin, silently undoing the requested operation.
+    let root = install_root()?;
+    reconcile_install_transactions(&root)?;
+    persist_sidebar_plugin(None)?;
+    let plugins = installed_plugins(false)?;
     Ok(json!({"plugins": plugins.iter().map(plugin_json).collect::<Vec<_>>()}))
+}
+
+fn persist_sidebar_plugin(plugin: Option<&SidebarPluginConfig>) -> Result<(), ManagerError> {
+    if let Some(error) = config::write_sidebar_plugin(plugin)?.into_unsynced_error() {
+        crate::client_log::stderr_log!(
+            "config",
+            "{}",
+            crate::localization::catalog().config.write_durability_warning(&error.to_string())
+        );
+    }
+    Ok(())
 }
 
 fn reject_plugin_flags(
@@ -410,9 +400,15 @@ fn reject_plugin_flags(
     Ok(())
 }
 
-fn installed_plugins() -> anyhow::Result<Vec<InstalledPlugin>> {
+fn installed_plugins(reconcile: bool) -> anyhow::Result<Vec<InstalledPlugin>> {
     let root = install_root()?;
-    reconcile_install_transactions(&root)?;
+    // Read-only listing skips recovery so a read-only install root does not
+    // need a lock file. Mutating callers hold the operation lock and reconcile.
+    if reconcile {
+        reconcile_install_transactions(&root)?;
+    } else {
+        reject_listing_with_pending_transaction(&root)?;
+    }
     let selected = selected_plugin_cwd()?;
     let mut plugins = Vec::new();
     let entries = match fs::read_dir(&root) {
@@ -450,6 +446,22 @@ fn installed_plugins() -> anyhow::Result<Vec<InstalledPlugin>> {
     Ok(plugins)
 }
 
+fn reject_listing_with_pending_transaction(install_root: &Path) -> anyhow::Result<()> {
+    let entries = match fs::read_dir(install_root) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.into()),
+    };
+    for entry in entries {
+        let entry = entry?;
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else { continue };
+        if name.starts_with('.') && name.ends_with(".install-journal.json") {
+            anyhow::bail!("plugin installation recovery is pending");
+        }
+    }
+    Ok(())
+}
+
 fn resolve_installed_plugin(selector: &str) -> Result<InstalledPlugin, ManagerError> {
     let forced_name = selector.strip_prefix("name:");
     let selector = forced_name.unwrap_or(selector);
@@ -461,7 +473,7 @@ fn resolve_installed_plugin(selector: &str) -> Result<InstalledPlugin, ManagerEr
         validate_plugin_name(selector)
             .map_err(|error| ManagerError::validation(Some("sidebar_plugin"), error.to_string()))?;
     }
-    installed_plugins()?
+    installed_plugins(true)?
         .into_iter()
         .find(|plugin| if by_id { plugin.id == selector } else { plugin.name == selector })
         .ok_or_else(|| {
@@ -703,21 +715,27 @@ impl InstallFilesystem for StandardInstallFilesystem {
     }
 }
 
-fn unique_backup_path(parent: &Path, name: &str, suffix: &str) -> PathBuf {
+fn remove_entry_with_filesystem<F: InstallFilesystem>(
+    filesystem: &F,
+    path: &Path,
+) -> std::io::Result<()> {
+    let metadata = fs::symlink_metadata(path)?;
+    if metadata.is_dir() { filesystem.remove_dir_all(path) } else { filesystem.remove_file(path) }
+}
+
+fn unique_backup_path(parent: &Path, name: &str, suffix: &str) -> anyhow::Result<PathBuf> {
     loop {
         let path = parent.join(format!(".{name}.{}-{}{suffix}", std::process::id(), now_nanos()));
-        if !path.exists() {
-            return path;
+        match fs::symlink_metadata(&path) {
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(path),
+            Err(error) => return Err(error.into()),
         }
     }
 }
 
 fn install_journal_path(install_root: &Path, name: &str) -> PathBuf {
     install_root.join(format!(".{name}.install-journal.json"))
-}
-
-fn install_commit_marker_path(install_root: &Path, name: &str) -> PathBuf {
-    install_root.join(format!(".{name}.install-commit"))
 }
 
 fn write_install_journal(path: &Path, journal: &InstallJournal) -> anyhow::Result<()> {
@@ -729,7 +747,14 @@ fn write_install_journal(path: &Path, journal: &InstallJournal) -> anyhow::Resul
     ));
     let encoded = serde_json::to_vec(journal)?;
     let result = (|| -> anyhow::Result<()> {
-        let mut file = fs::OpenOptions::new().create_new(true).write(true).open(&temp)?;
+        let mut options = fs::OpenOptions::new();
+        options.create_new(true).write(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt as _;
+            options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC).mode(0o600);
+        }
+        let mut file = options.open(&temp)?;
         file.write_all(&encoded)?;
         file.write_all(b"\n")?;
         file.sync_all()?;
@@ -744,6 +769,38 @@ fn write_install_journal(path: &Path, journal: &InstallJournal) -> anyhow::Resul
     result
 }
 
+/// Read a recovery journal without following a final-component symlink or
+/// accepting an unbounded file. Journals control cleanup after a crash, so a
+/// malformed or attacker-written file must never become an arbitrary file
+/// operation.
+fn read_install_journal(path: &Path) -> anyhow::Result<Vec<u8>> {
+    let mut options = fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+    }
+    let mut file = options.open(path)?;
+    let metadata = file.metadata()?;
+    anyhow::ensure!(metadata.is_file(), "install journal is not a regular file");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        anyhow::ensure!(
+            metadata.permissions().mode() & 0o7777 == 0o600,
+            "install journal permissions are not private"
+        );
+    }
+    let mut bytes = Vec::new();
+    file.take((MAX_INSTALL_JOURNAL_BYTES + 1) as u64).read_to_end(&mut bytes)?;
+    anyhow::ensure!(
+        bytes.len() <= MAX_INSTALL_JOURNAL_BYTES,
+        "install journal exceeds {MAX_INSTALL_JOURNAL_BYTES} bytes"
+    );
+    Ok(bytes)
+}
+
 #[cfg(unix)]
 fn sync_directory(path: &Path) -> anyhow::Result<()> {
     fs::File::open(path)?.sync_all()?;
@@ -755,40 +812,16 @@ fn sync_directory(_path: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn sync_transaction_directories(install_root: &Path) -> anyhow::Result<()> {
-    sync_directory(install_root)?;
-    sync_directory(&install_root.join(".registry"))?;
-    Ok(())
-}
-
-fn write_install_commit_marker(
-    install_root: &Path,
-    name: &str,
-    owner_token: &str,
-) -> anyhow::Result<()> {
-    let path = install_commit_marker_path(install_root, name);
-    let result = (|| -> anyhow::Result<()> {
-        let mut file = fs::OpenOptions::new().create_new(true).write(true).open(&path)?;
-        file.write_all(owner_token.as_bytes())?;
-        file.write_all(b"\n")?;
-        file.sync_all()?;
-        drop(file);
-        sync_directory(install_root)?;
-        Ok(())
-    })();
-    if result.is_err() {
-        let _ = fs::remove_file(&path);
+/// Returns whether a directory entry exists, including a dangling symlink.
+/// `Path::exists` follows symlinks and therefore cannot represent an existing
+/// entry whose target has been removed. Transaction replacement and recovery
+/// must preserve those entries as well as regular files and directories.
+fn path_entry_exists(path: &Path) -> anyhow::Result<bool> {
+    match fs::symlink_metadata(path) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error.into()),
     }
-    result
-}
-
-fn commit_marker_matches(path: &Path, owner_token: &str) -> anyhow::Result<bool> {
-    let contents = match fs::read_to_string(path) {
-        Ok(contents) => contents,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
-        Err(error) => return Err(error.into()),
-    };
-    Ok(contents.trim() == owner_token)
 }
 
 fn remove_path_if_present(path: &Path) -> anyhow::Result<()> {
@@ -805,17 +838,114 @@ fn remove_path_if_present(path: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn path_exists(path: &Path) -> anyhow::Result<bool> {
-    match fs::symlink_metadata(path) {
-        Ok(_) => Ok(true),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
-        Err(error) => Err(error.into()),
+fn ensure_real_directory(path: &Path) -> anyhow::Result<()> {
+    let metadata = fs::symlink_metadata(path)?;
+    anyhow::ensure!(
+        metadata.is_dir() && !metadata.file_type().is_symlink(),
+        "plugin state directory is not a real directory"
+    );
+    Ok(())
+}
+
+fn direct_child_named(parent: &Path, path: &Path, predicate: impl FnOnce(&str) -> bool) -> bool {
+    path.parent() == Some(parent)
+        && path.file_name().and_then(|name| name.to_str()).is_some_and(predicate)
+}
+
+fn validate_install_journal_paths(
+    install_root: &Path,
+    journal_path: &Path,
+    journal: &InstallJournal,
+) -> anyhow::Result<()> {
+    validate_plugin_name(&journal.name)?;
+    anyhow::ensure!(
+        journal_path == install_journal_path(install_root, &journal.name),
+        "install journal name does not match its path"
+    );
+    anyhow::ensure!(
+        direct_child_named(install_root, &journal.target_backup, |name| {
+            name.starts_with(&format!(".{}.", journal.name)) && name.ends_with(".plugin-backup")
+        }),
+        "install journal target backup is outside the install root"
+    );
+    anyhow::ensure!(
+        direct_child_named(install_root, &journal.temp_dir, |name| {
+            name.starts_with(".install-")
+        }),
+        "install journal temporary directory is outside the install root"
+    );
+    let registry = install_root.join(".registry");
+    if fs::symlink_metadata(&registry).is_ok() {
+        ensure_real_directory(&registry)?;
     }
+    anyhow::ensure!(
+        direct_child_named(&registry, &journal.metadata_backup, |name| {
+            name.starts_with(&format!(".{}.", journal.name))
+                && name.ends_with(".metadata-backup.json")
+        }),
+        "install journal metadata backup is outside the registry"
+    );
+    anyhow::ensure!(
+        direct_child_named(&registry, &journal.metadata_temp, |name| {
+            name.starts_with(&format!(".{}.", journal.name)) && name.ends_with(".tmp")
+        }),
+        "install journal metadata staging path is outside the registry"
+    );
+    if let Some(snapshot) = &journal.config_snapshot {
+        anyhow::ensure!(
+            snapshot.path == config::config_path()?,
+            "install journal config snapshot path is not the active config"
+        );
+    }
+    Ok(())
+}
+
+fn quarantine_install_journal(install_root: &Path, path: &Path) -> anyhow::Result<()> {
+    let quarantine = install_root.join(INVALID_INSTALL_JOURNAL_DIR);
+    match fs::symlink_metadata(&quarantine) {
+        Ok(metadata) => {
+            anyhow::ensure!(metadata.is_dir(), "invalid journal quarantine is not a directory")
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            match fs::create_dir(&quarantine) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                    ensure_real_directory(&quarantine)?;
+                }
+                Err(error) => return Err(error.into()),
+            }
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt as _;
+                fs::set_permissions(&quarantine, fs::Permissions::from_mode(0o700))?;
+            }
+        }
+        Err(error) => return Err(error.into()),
+    }
+    let basename =
+        path.file_name().and_then(|name| name.to_str()).unwrap_or("invalid-install-journal");
+    for attempt in 0..JOURNAL_QUARANTINE_ATTEMPTS {
+        let destination =
+            quarantine.join(format!("{basename}.{}-{attempt}.quarantined", std::process::id()));
+        if fs::symlink_metadata(&destination).is_ok() {
+            continue;
+        }
+        match fs::rename(path, &destination) {
+            Ok(()) => return Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => return Err(error.into()),
+        }
+    }
+    anyhow::bail!("could not quarantine invalid install journal")
 }
 
 fn reconcile_install_transactions(install_root: &Path) -> anyhow::Result<()> {
-    cleanup_orphan_metadata_temps(install_root)?;
-    cleanup_orphan_commit_markers(install_root)?;
+    if let Ok(metadata) = fs::symlink_metadata(install_root) {
+        anyhow::ensure!(
+            metadata.is_dir() && !metadata.file_type().is_symlink(),
+            "plugin install root is not a real directory"
+        );
+    }
     let entries = match fs::read_dir(install_root) {
         Ok(entries) => entries,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
@@ -828,36 +958,37 @@ fn reconcile_install_transactions(install_root: &Path) -> anyhow::Result<()> {
         if !name.starts_with('.') || !name.ends_with(".install-journal.json") {
             continue;
         }
-        let journal: InstallJournal = match serde_json::from_slice(&fs::read(&path)?) {
-            Ok(journal) => journal,
-            Err(_) => continue,
+        let journal_bytes = match read_install_journal(&path) {
+            Ok(bytes) => bytes,
+            Err(_) => {
+                quarantine_install_journal(install_root, &path)?;
+                continue;
+            }
         };
-        if validate_install_journal(install_root, &journal).is_err() {
-            continue;
-        }
-        if install_journal_path(install_root, &journal.name) != path {
-            continue;
-        }
-        let marker_path = install_commit_marker_path(install_root, &journal.name);
-        let marker_committed = commit_marker_matches(&marker_path, &journal.owner_token)?;
-        if matches!(&journal.phase, InstallJournalPhase::Committed) || marker_committed {
-            remove_path_if_present(&journal.target_backup)?;
-            remove_path_if_present(&journal.metadata_backup)?;
-            remove_path_if_present(&journal.temp_dir)?;
-            remove_path_if_present(&journal.metadata_temp)?;
-            sync_transaction_directories(install_root)?;
-            remove_path_if_present(&path)?;
-            sync_transaction_directories(install_root)?;
-            remove_path_if_present(&marker_path)?;
+        let journal: InstallJournal = match serde_json::from_slice(&journal_bytes) {
+            Ok(journal) => journal,
+            Err(_) => {
+                quarantine_install_journal(install_root, &path)?;
+                continue;
+            }
+        };
+        if validate_install_journal_paths(install_root, &path, &journal).is_err() {
+            quarantine_install_journal(install_root, &path)?;
             continue;
         }
         match journal.phase {
+            InstallJournalPhase::Committed => {
+                remove_path_if_present(&journal.target_backup)?;
+                remove_path_if_present(&journal.metadata_backup)?;
+                remove_path_if_present(&journal.temp_dir)?;
+                remove_path_if_present(&journal.metadata_temp)?;
+            }
             InstallJournalPhase::Prepared => {
                 if let Some(snapshot) = &journal.config_snapshot {
-                    restore_config_snapshot(snapshot, journal.expected_sidebar_plugin.as_ref())?;
+                    restore_config_snapshot(snapshot)?;
                 }
                 if journal.target_existed {
-                    if path_exists(&journal.target_backup)? {
+                    if path_entry_exists(&journal.target_backup)? {
                         remove_path_if_present(&install_root.join(&journal.name))?;
                         fs::rename(&journal.target_backup, install_root.join(&journal.name))?;
                     }
@@ -866,7 +997,7 @@ fn reconcile_install_transactions(install_root: &Path) -> anyhow::Result<()> {
                 }
                 if journal.metadata_existed {
                     let metadata_path = registry_metadata_path(install_root, &journal.name);
-                    if path_exists(&journal.metadata_backup)? {
+                    if path_entry_exists(&journal.metadata_backup)? {
                         remove_path_if_present(&metadata_path)?;
                         fs::rename(&journal.metadata_backup, metadata_path)?;
                     }
@@ -875,104 +1006,21 @@ fn reconcile_install_transactions(install_root: &Path) -> anyhow::Result<()> {
                 }
                 remove_path_if_present(&journal.temp_dir)?;
                 remove_path_if_present(&journal.metadata_temp)?;
-                sync_transaction_directories(install_root)?;
             }
-            InstallJournalPhase::Committed => unreachable!(),
         }
         remove_path_if_present(&path)?;
-        sync_transaction_directories(install_root)?;
-        remove_path_if_present(&marker_path)?;
     }
     Ok(())
 }
 
-fn cleanup_orphan_metadata_temps(install_root: &Path) -> anyhow::Result<()> {
-    let registry = install_root.join(".registry");
-    let entries = match fs::read_dir(&registry) {
-        Ok(entries) => entries,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-        Err(error) => return Err(error.into()),
-    };
-    for entry in entries {
-        let path = entry?.path();
-        let Some(name) = path.file_name().and_then(|value| value.to_str()) else { continue };
-        if name.starts_with('.') && name.ends_with(".tmp") {
-            remove_path_if_present(&path)?;
-        }
-    }
-    Ok(())
-}
-
-fn cleanup_orphan_commit_markers(install_root: &Path) -> anyhow::Result<()> {
-    let entries = match fs::read_dir(install_root) {
-        Ok(entries) => entries,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-        Err(error) => return Err(error.into()),
-    };
-    for entry in entries {
-        let path = entry?.path();
-        let Some(name) = path.file_name().and_then(|value| value.to_str()) else { continue };
-        if !name.starts_with('.') || !name.ends_with(".install-commit") {
-            continue;
-        }
-        let plugin_name = name.trim_start_matches('.').trim_end_matches(".install-commit");
-        if validate_plugin_name(plugin_name).is_err()
-            || !path_exists(&install_journal_path(install_root, plugin_name))?
-        {
-            remove_path_if_present(&path)?;
-        }
-    }
-    Ok(())
-}
-
-fn validate_install_journal(install_root: &Path, journal: &InstallJournal) -> anyhow::Result<()> {
-    if journal.owner_token.is_empty() {
-        anyhow::bail!("transaction owner token is missing");
-    }
-    validate_plugin_name(&journal.name)?;
-    let registry = install_root.join(".registry");
-    let expected_target = install_root.join(&journal.name);
-    let expected_metadata = registry_metadata_path(install_root, &journal.name);
-    let paths = [
-        ("target backup", &journal.target_backup, install_root),
-        ("metadata backup", &journal.metadata_backup, &registry),
-        ("staging directory", &journal.temp_dir, install_root),
-        ("metadata staging", &journal.metadata_temp, &registry),
-    ];
-    for (label, path, parent) in paths {
-        if path.parent() != Some(parent) {
-            anyhow::bail!("{label} path escapes its transaction directory");
-        }
-    }
-    if journal.target_backup == expected_target || journal.temp_dir == expected_target {
-        anyhow::bail!("transaction path aliases the live plugin");
-    }
-    if journal.metadata_backup == expected_metadata || journal.metadata_temp == expected_metadata {
-        anyhow::bail!("transaction path aliases live metadata");
-    }
-    Ok(())
-}
-
-fn restore_config_snapshot(
-    snapshot: &ConfigSnapshot,
-    expected_sidebar_plugin: Option<&Value>,
-) -> anyhow::Result<()> {
+fn restore_config_snapshot(snapshot: &ConfigSnapshot) -> anyhow::Result<()> {
     let mut root = match fs::read_to_string(&snapshot.path) {
         Ok(text) if text.trim().is_empty() => json!({}),
         Ok(text) => serde_json::from_str(&text)?,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => json!({}),
         Err(error) => return Err(error.into()),
     };
-    if let Some(expected) = expected_sidebar_plugin {
-        let current = root.get("sidebar").and_then(|sidebar| sidebar.get("plugin"));
-        if current != Some(expected) {
-            return Ok(());
-        }
-    }
     let Some(root_object) = root.as_object_mut() else {
-        if let Some(original) = &snapshot.original_non_object {
-            return write_config_value_atomic_local(&snapshot.path, original);
-        }
         anyhow::bail!("{} must contain a JSON object", snapshot.path.display());
     };
     match &snapshot.sidebar_plugin {
@@ -994,13 +1042,6 @@ fn restore_config_snapshot(
             }
         }
     }
-    if !snapshot.config_existed && snapshot.sidebar_plugin.is_none() {
-        return match fs::remove_file(&snapshot.path) {
-            Ok(()) => Ok(()),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-            Err(error) => Err(error.into()),
-        };
-    }
     write_config_value_atomic_local(&snapshot.path, &root)
 }
 
@@ -1011,7 +1052,14 @@ fn write_config_value_atomic_local(path: &Path, value: &Value) -> anyhow::Result
     let temp =
         parent.join(format!(".{file_name}.{}.{}-restore.tmp", std::process::id(), now_nanos()));
     let result = (|| -> anyhow::Result<()> {
-        let mut file = fs::OpenOptions::new().create_new(true).write(true).open(&temp)?;
+        let mut options = fs::OpenOptions::new();
+        options.create_new(true).write(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt as _;
+            options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC).mode(0o600);
+        }
+        let mut file = options.open(&temp)?;
         serde_json::to_writer_pretty(&mut file, value)?;
         file.write_all(b"\n")?;
         file.sync_all()?;
@@ -1026,7 +1074,6 @@ fn write_config_value_atomic_local(path: &Path, value: &Value) -> anyhow::Result
     result
 }
 
-#[cfg(test)]
 fn replace_installed_plugin(
     install_root: &Path,
     name: &str,
@@ -1040,7 +1087,6 @@ fn replace_installed_plugin(
         temp_dir,
         metadata_temp,
         None,
-        None,
         || Ok(()),
     )
 }
@@ -1051,7 +1097,6 @@ fn replace_installed_plugin_with_config<C: FnOnce() -> anyhow::Result<()>>(
     temp_dir: &Path,
     metadata_temp: &Path,
     config_snapshot: Option<ConfigSnapshot>,
-    expected_sidebar_plugin: Option<Value>,
     after_install: C,
 ) -> anyhow::Result<()> {
     replace_installed_plugin_with_fs(
@@ -1061,29 +1106,22 @@ fn replace_installed_plugin_with_config<C: FnOnce() -> anyhow::Result<()>>(
         temp_dir,
         metadata_temp,
         config_snapshot,
-        expected_sidebar_plugin,
         after_install,
     )
 }
 
 fn capture_config_snapshot() -> anyhow::Result<ConfigSnapshot> {
     let path = config::config_path()?;
-    let (config_existed, sidebar_plugin, original_non_object) = match fs::read_to_string(&path) {
-        Ok(text) if text.trim().is_empty() => (true, None, None),
-        Ok(text) => {
-            let value: Value = serde_json::from_str(&text)?;
-            let sidebar_plugin = value
-                .as_object()
-                .and_then(|root| root.get("sidebar"))
-                .and_then(|sidebar| sidebar.get("plugin"))
-                .cloned();
-            let original_non_object = (!value.is_object()).then_some(value);
-            (true, sidebar_plugin, original_non_object)
-        }
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => (false, None, None),
+    let sidebar_plugin = match fs::read_to_string(&path) {
+        Ok(text) if text.trim().is_empty() => None,
+        Ok(text) => serde_json::from_str::<Value>(&text)?
+            .get("sidebar")
+            .and_then(|sidebar| sidebar.get("plugin"))
+            .cloned(),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
         Err(error) => return Err(error.into()),
     };
-    Ok(ConfigSnapshot { path, config_existed, sidebar_plugin, original_non_object })
+    Ok(ConfigSnapshot { path, sidebar_plugin })
 }
 
 fn replace_installed_plugin_with_fs<F: InstallFilesystem, C: FnOnce() -> anyhow::Result<()>>(
@@ -1093,19 +1131,22 @@ fn replace_installed_plugin_with_fs<F: InstallFilesystem, C: FnOnce() -> anyhow:
     temp_dir: &Path,
     metadata_temp: &Path,
     config_snapshot: Option<ConfigSnapshot>,
-    expected_sidebar_plugin: Option<Value>,
     after_install: C,
 ) -> anyhow::Result<()> {
+    ensure_real_directory(install_root)?;
+    let registry = install_root.join(".registry");
+    if fs::symlink_metadata(&registry).is_ok() {
+        ensure_real_directory(&registry)?;
+    }
     let target = install_root.join(name);
-    let target_exists = path_exists(&target)?;
+    let target_exists = path_entry_exists(&target)?;
     let metadata_path = registry_metadata_path(install_root, name);
-    let target_backup = unique_backup_path(install_root, name, ".plugin-backup");
+    let target_backup = unique_backup_path(install_root, name, ".plugin-backup")?;
     let metadata_backup =
-        unique_backup_path(&install_root.join(".registry"), name, ".metadata-backup.json");
-    let metadata_exists = path_exists(&metadata_path)?;
+        unique_backup_path(&install_root.join(".registry"), name, ".metadata-backup.json")?;
+    let metadata_exists = path_entry_exists(&metadata_path)?;
     let journal_path = install_journal_path(install_root, name);
     let journal = InstallJournal {
-        owner_token: format!("{}-{}", std::process::id(), now_nanos()),
         name: name.to_string(),
         target_backup: target_backup.clone(),
         metadata_backup: metadata_backup.clone(),
@@ -1114,7 +1155,6 @@ fn replace_installed_plugin_with_fs<F: InstallFilesystem, C: FnOnce() -> anyhow:
         target_existed: target_exists,
         metadata_existed: metadata_exists,
         config_snapshot,
-        expected_sidebar_plugin,
         phase: InstallJournalPhase::Prepared,
     };
     write_install_journal(&journal_path, &journal)?;
@@ -1144,9 +1184,12 @@ fn replace_installed_plugin_with_fs<F: InstallFilesystem, C: FnOnce() -> anyhow:
             anyhow::anyhow!("failed to persist {}: {error}", metadata_path.display())
         })?;
         metadata_installed = true;
+        sync_directory(&registry)?;
         after_install()?;
-        sync_transaction_directories(install_root)?;
-        write_install_commit_marker(install_root, name, &journal.owner_token)?;
+        write_install_journal(
+            &journal_path,
+            &InstallJournal { phase: InstallJournalPhase::Committed, ..journal.clone() },
+        )?;
         Ok(())
     })();
 
@@ -1170,7 +1213,7 @@ fn replace_installed_plugin_with_fs<F: InstallFilesystem, C: FnOnce() -> anyhow:
         if target_installed {
             if let Err(rollback_error) = filesystem.rename(&target, temp_dir) {
                 rollback_errors.push(format!("plugin staging: {rollback_error}"));
-                match filesystem.remove_dir_all(&target) {
+                match remove_entry_with_filesystem(filesystem, &target) {
                     Ok(()) => {}
                     Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
                     Err(error) => rollback_errors.push(format!("plugin removal: {error}")),
@@ -1183,21 +1226,9 @@ fn replace_installed_plugin_with_fs<F: InstallFilesystem, C: FnOnce() -> anyhow:
             }
         }
         if let Some(snapshot) = &journal.config_snapshot
-            && let Err(rollback_error) =
-                restore_config_snapshot(snapshot, journal.expected_sidebar_plugin.as_ref())
+            && let Err(rollback_error) = restore_config_snapshot(snapshot)
         {
             rollback_errors.push(format!("config restore: {rollback_error}"));
-        }
-        if rollback_errors.is_empty()
-            && let Err(sync_error) = sync_transaction_directories(install_root)
-        {
-            rollback_errors.push(format!("rollback directory sync: {sync_error}"));
-        }
-        if rollback_errors.is_empty() {
-            let marker_path = install_commit_marker_path(install_root, name);
-            if let Err(marker_error) = remove_path_if_present(&marker_path) {
-                rollback_errors.push(format!("commit marker cleanup: {marker_error}"));
-            }
         }
         if rollback_errors.is_empty() {
             if let Err(rollback_error) = filesystem.remove_file(&journal_path)
@@ -1215,7 +1246,7 @@ fn replace_installed_plugin_with_fs<F: InstallFilesystem, C: FnOnce() -> anyhow:
     // The replacement is committed once both new paths are in place. Keep the
     // committed journal until all cleanup succeeds, so a later invocation can
     // retry cleanup if access is temporarily unavailable.
-    let backup_dir_clean = match filesystem.remove_dir_all(&target_backup) {
+    let backup_dir_clean = match remove_entry_with_filesystem(filesystem, &target_backup) {
         Ok(()) => true,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => true,
         Err(_) => false,
@@ -1225,17 +1256,9 @@ fn replace_installed_plugin_with_fs<F: InstallFilesystem, C: FnOnce() -> anyhow:
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => true,
         Err(_) => false,
     };
-    let marker_path = install_commit_marker_path(install_root, name);
-    if backup_dir_clean
-        && metadata_backup_clean
-        && sync_transaction_directories(install_root).is_ok()
-    {
-        let journal_removed = filesystem.remove_file(&journal_path).is_ok();
-        if journal_removed {
-            let _ = sync_transaction_directories(install_root);
-            let _ = remove_path_if_present(&marker_path);
-            let _ = sync_transaction_directories(install_root);
-        }
+    let backups_clean = backup_dir_clean && metadata_backup_clean;
+    if backups_clean {
+        let _ = filesystem.remove_file(&journal_path);
     }
     Ok(())
 }
@@ -1249,6 +1272,7 @@ fn write_registry_metadata_temp(
     validate_plugin_id(&metadata.id)?;
     let registry = install_root.join(".registry");
     fs::create_dir_all(&registry)?;
+    ensure_real_directory(&registry)?;
     let temp = registry.join(format!(".{name}.{}-{}.tmp", std::process::id(), now_nanos()));
     let encoded = serde_json::to_vec(metadata)?;
     let mut file = fs::OpenOptions::new().create_new(true).write(true).open(&temp)?;
@@ -1259,7 +1283,6 @@ fn write_registry_metadata_temp(
     Ok(temp)
 }
 
-#[cfg(test)]
 fn replace_registry_metadata(
     install_root: &Path,
     name: &str,
@@ -1348,6 +1371,93 @@ fn now_nanos() -> u128 {
 mod tests {
     use super::*;
     use std::cell::Cell;
+
+    #[test]
+    fn manager_failure_response_redacts_internal_error_details() {
+        let error = ManagerError::from(anyhow::anyhow!(
+            "failed to read /private/plugin-state/secret.toml: injected detail"
+        ));
+        let rendered = error.to_string();
+        let details = error.details().to_string();
+        assert!(!rendered.contains("/private/plugin-state/secret.toml"));
+        assert!(!rendered.contains("injected detail"));
+        assert!(!details.contains("/private/plugin-state/secret.toml"));
+        assert!(!details.contains("injected detail"));
+    }
+
+    #[test]
+    fn read_only_plugin_command_skips_operation_lock() {
+        let operation_ran = Cell::new(false);
+        let result = with_optional_operation_lock(
+            false,
+            || panic!("read-only plugin command must not acquire the operation lock"),
+            || {
+                operation_ran.set(true);
+                Ok::<_, ManagerError>(())
+            },
+        );
+        assert!(result.is_ok());
+        assert!(operation_ran.get());
+    }
+
+    #[test]
+    fn mutating_plugin_command_acquires_operation_lock_before_running() {
+        let lock_acquired = Cell::new(false);
+        let operation_ran = Cell::new(false);
+        let result = with_optional_operation_lock(
+            true,
+            || {
+                lock_acquired.set(true);
+                Err(ManagerError::Usage("lock probe".to_string()))
+            },
+            || {
+                operation_ran.set(true);
+                Ok::<_, ManagerError>(())
+            },
+        );
+        assert!(result.is_err());
+        assert!(lock_acquired.get());
+        assert!(!operation_ran.get());
+    }
+
+    #[test]
+    fn only_mutating_plugin_commands_require_operation_lock() {
+        assert!(!command_requires_operation_lock(&["list".to_string()]));
+        for command in ["install", "use", "update", "remove"] {
+            assert!(command_requires_operation_lock(&[command.to_string()]));
+        }
+        assert!(!command_requires_operation_lock(&[]));
+    }
+
+    #[test]
+    fn read_only_listing_allows_a_clean_root_without_creating_a_lock() {
+        let root = std::env::temp_dir().join(format!(
+            "cmux-plugin-read-only-list-{}-{}",
+            std::process::id(),
+            now_nanos()
+        ));
+        fs::create_dir_all(&root).unwrap();
+        assert!(reject_listing_with_pending_transaction(&root).is_ok());
+        assert!(!root.join(".install.lock").exists());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn read_only_listing_rejects_pending_journal_without_mutating_root() {
+        let root = std::env::temp_dir().join(format!(
+            "cmux-plugin-read-only-pending-{}-{}",
+            std::process::id(),
+            now_nanos()
+        ));
+        fs::create_dir_all(&root).unwrap();
+        let journal = root.join(".demo.install-journal.json");
+        fs::write(&journal, b"pending").unwrap();
+        let error = reject_listing_with_pending_transaction(&root).unwrap_err();
+        assert_eq!(error.to_string(), "plugin installation recovery is pending");
+        assert!(journal.exists());
+        assert!(!root.join(".install.lock").exists());
+        fs::remove_dir_all(root).unwrap();
+    }
 
     fn manifest_text(name: &str) -> String {
         format!(
@@ -1500,7 +1610,6 @@ mod tests {
             &temp_dir,
             &metadata_temp,
             None,
-            None,
             || Ok(()),
         )
         .unwrap_err();
@@ -1512,6 +1621,40 @@ mod tests {
         );
         assert!(temp_dir.exists());
         assert!(metadata_temp.exists());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn replacement_failure_preserves_dangling_plugin_and_metadata_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let (root, target, temp_dir, metadata_temp) = replacement_fixture("dangling");
+        let metadata_path = registry_metadata_path(&root, "demo");
+        fs::remove_dir_all(&target).unwrap();
+        fs::remove_file(&metadata_path).unwrap();
+        let missing_target = root.join("missing-target");
+        let missing_metadata = root.join("missing-metadata");
+        symlink(&missing_target, &target).unwrap();
+        symlink(&missing_metadata, &metadata_path).unwrap();
+
+        // The fourth rename is the metadata install. It fails after both
+        // dangling entries have been backed up, so rollback must restore the
+        // symlinks rather than treating them as absent.
+        let filesystem = FailingRenameFilesystem { fail_at: 4, calls: Cell::new(0) };
+        let error = replace_installed_plugin_with_fs(
+            &filesystem,
+            &root,
+            "demo",
+            &temp_dir,
+            &metadata_temp,
+            None,
+            || Ok(()),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("failed to persist"));
+        assert_eq!(fs::read_link(&target).unwrap(), missing_target);
+        assert_eq!(fs::read_link(&metadata_path).unwrap(), missing_metadata);
         fs::remove_dir_all(root).unwrap();
     }
 
@@ -1536,6 +1679,28 @@ mod tests {
     }
 
     #[test]
+    fn replacement_cleans_up_a_regular_file_target_backup() {
+        let (root, target, temp_dir, metadata_temp) = replacement_fixture("file-target");
+        fs::remove_dir_all(&target).unwrap();
+        fs::write(&target, b"old file").unwrap();
+
+        replace_installed_plugin(&root, "demo", &temp_dir, &metadata_temp).unwrap();
+        assert_eq!(fs::read_to_string(target.join("marker")).unwrap(), "new");
+        assert_eq!(
+            read_registry_metadata(&root, "demo").unwrap().id,
+            "sidebar_plugin_22222222222222222222222222222222"
+        );
+        assert!(!install_journal_path(&root, "demo").exists());
+        assert!(
+            fs::read_dir(&root)
+                .unwrap()
+                .filter_map(Result::ok)
+                .all(|entry| !entry.file_name().to_string_lossy().contains("plugin-backup"))
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
     fn reconciliation_restores_an_interrupted_replacement() {
         let (root, target, temp_dir, metadata_temp) = replacement_fixture("reconcile");
         let metadata_path = registry_metadata_path(&root, "demo");
@@ -1548,7 +1713,6 @@ mod tests {
         write_install_journal(
             &journal_path,
             &InstallJournal {
-                owner_token: "test-owner".into(),
                 name: "demo".into(),
                 target_backup: target_backup.clone(),
                 metadata_backup: metadata_backup.clone(),
@@ -1557,7 +1721,6 @@ mod tests {
                 target_existed: true,
                 metadata_existed: true,
                 config_snapshot: None,
-                expected_sidebar_plugin: None,
                 phase: InstallJournalPhase::Prepared,
             },
         )
@@ -1577,39 +1740,40 @@ mod tests {
     }
 
     #[test]
-    fn reconciliation_cleans_committed_backups() {
-        let (root, target, temp_dir, metadata_temp) = replacement_fixture("committed-cleanup");
-        let metadata_path = registry_metadata_path(&root, "demo");
-        let target_backup = root.join(".demo.recovery.plugin-backup");
-        let metadata_backup = root.join(".registry/.demo.recovery.metadata-backup.json");
-        fs::rename(&target, &target_backup).unwrap();
-        fs::rename(&metadata_path, &metadata_backup).unwrap();
-        fs::rename(&temp_dir, &target).unwrap();
+    fn invalid_journal_paths_are_quarantined_without_touching_outside_files() {
+        let root = std::env::temp_dir().join(format!(
+            "cmux-plugin-journal-boundary-{}-{}",
+            std::process::id(),
+            now_nanos()
+        ));
+        let registry = root.join(".registry");
+        let outside =
+            root.with_file_name(format!("{}-outside", root.file_name().unwrap().to_string_lossy()));
+        fs::create_dir_all(&registry).unwrap();
+        fs::write(&outside, b"keep").unwrap();
         let journal_path = install_journal_path(&root, "demo");
         write_install_journal(
             &journal_path,
             &InstallJournal {
-                owner_token: "test-owner".into(),
                 name: "demo".into(),
-                target_backup: target_backup.clone(),
-                metadata_backup: metadata_backup.clone(),
-                temp_dir,
-                metadata_temp,
-                target_existed: true,
-                metadata_existed: true,
+                target_backup: outside.clone(),
+                metadata_backup: registry.join(".demo.recovery.metadata-backup.json"),
+                temp_dir: root.join(".install-1-2"),
+                metadata_temp: registry.join(".demo.1-2.tmp"),
+                target_existed: false,
+                metadata_existed: false,
                 config_snapshot: None,
-                expected_sidebar_plugin: None,
                 phase: InstallJournalPhase::Committed,
             },
         )
         .unwrap();
-        write_install_commit_marker(&root, "demo", "test-owner").unwrap();
+
         reconcile_install_transactions(&root).unwrap();
-        assert!(target.exists());
-        assert!(!target_backup.exists());
-        assert!(!metadata_backup.exists());
+        assert_eq!(fs::read(&outside).unwrap(), b"keep");
         assert!(!journal_path.exists());
-        assert!(!install_commit_marker_path(&root, "demo").exists());
+        let quarantined = root.join(INVALID_INSTALL_JOURNAL_DIR);
+        assert_eq!(fs::read_dir(quarantined).unwrap().count(), 1);
+        fs::remove_file(outside).unwrap();
         fs::remove_dir_all(root).unwrap();
     }
 
@@ -1624,9 +1788,7 @@ mod tests {
         .unwrap();
         let snapshot = ConfigSnapshot {
             path: config_path.clone(),
-            config_existed: true,
             sidebar_plugin: Some(json!({"command": ["old"]})),
-            original_non_object: None,
         };
         let error = replace_installed_plugin_with_fs(
             &StandardInstallFilesystem,
@@ -1635,7 +1797,6 @@ mod tests {
             &temp_dir,
             &metadata_temp,
             Some(snapshot),
-            Some(json!({"command": ["new"]})),
             || {
                 fs::write(
                     &config_path,

--- a/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
+++ b/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
@@ -1664,9 +1664,8 @@ fn replace_installed_plugin_with_fs<F: InstallFilesystem, C: FnOnce() -> anyhow:
         // so the next operation can retry cleanup.
         let journal_parent = journal_path.parent().unwrap_or_else(|| Path::new("."));
         let registry = install_root.join(".registry");
-        let cleanup_durable = sync_directory(install_root)
-            .and_then(|()| sync_directory(&registry))
-            .is_ok();
+        let cleanup_durable =
+            sync_directory(install_root).and_then(|()| sync_directory(&registry)).is_ok();
         if cleanup_durable {
             let journal_removed = match filesystem.remove_file(&journal_path) {
                 Ok(()) => true,

--- a/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
+++ b/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
@@ -950,18 +950,74 @@ fn rename_into_quarantine(
 ) -> std::io::Result<()> {
     use std::ffi::CString;
     use std::os::unix::ffi::OsStrExt;
-    use std::os::unix::fs::OpenOptionsExt;
-    use std::os::unix::io::AsRawFd;
-    let root = fs::OpenOptions::new().read(true).custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW).open(install_root)?;
-    let dir = fs::OpenOptions::new().read(true).custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW).open(quarantine)?;
-    let from = CString::new(path.file_name().ok_or_else(|| std::io::Error::other("journal has no basename"))?.as_bytes()).map_err(|_| std::io::Error::other("invalid journal basename"))?;
-    let to = CString::new(destination.file_name().ok_or_else(|| std::io::Error::other("quarantine destination has no basename"))?.as_bytes()).map_err(|_| std::io::Error::other("invalid quarantine basename"))?;
-    let result = unsafe { libc::renameat(root.as_raw_fd(), from.as_ptr(), dir.as_raw_fd(), to.as_ptr()) };
+    use std::os::unix::io::{AsRawFd, FromRawFd};
+
+    let root_name = CString::new(install_root.as_os_str().as_bytes())
+        .map_err(|_| std::io::Error::other("invalid install root path"))?;
+    // SAFETY: `root_name` is a live, NUL-terminated path and `open` does not
+    // retain its pointer. The no-follow flag prevents a symlink root.
+    let root_fd = unsafe {
+        libc::open(
+            root_name.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if root_fd < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // SAFETY: `open` returned a new owned descriptor.
+    let root = unsafe { std::fs::File::from_raw_fd(root_fd) };
+
+    let quarantine_name = CString::new(
+        quarantine
+            .file_name()
+            .ok_or_else(|| std::io::Error::other("quarantine has no basename"))?
+            .as_bytes(),
+    )
+    .map_err(|_| std::io::Error::other("invalid quarantine basename"))?;
+    // Resolve the quarantine directory relative to the already-open root. A
+    // concurrent replacement of the install-root pathname cannot redirect it.
+    let quarantine_fd = unsafe {
+        libc::openat(
+            root.as_raw_fd(),
+            quarantine_name.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if quarantine_fd < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // SAFETY: `openat` returned a new owned descriptor.
+    let quarantine = unsafe { std::fs::File::from_raw_fd(quarantine_fd) };
+
+    let from = CString::new(
+        path.file_name()
+            .ok_or_else(|| std::io::Error::other("journal has no basename"))?
+            .as_bytes(),
+    )
+    .map_err(|_| std::io::Error::other("invalid journal basename"))?;
+    let to = CString::new(
+        destination
+            .file_name()
+            .ok_or_else(|| std::io::Error::other("quarantine destination has no basename"))?
+            .as_bytes(),
+    )
+    .map_err(|_| std::io::Error::other("invalid quarantine destination basename"))?;
+    // SAFETY: all descriptors are open directories, names are live
+    // NUL-terminated strings, and `renameat` does not retain their pointers.
+    let result = unsafe {
+        libc::renameat(root.as_raw_fd(), from.as_ptr(), quarantine.as_raw_fd(), to.as_ptr())
+    };
     if result == 0 { Ok(()) } else { Err(std::io::Error::last_os_error()) }
 }
 
 #[cfg(not(unix))]
-fn rename_into_quarantine(_: &Path, _: &Path, path: &Path, destination: &Path) -> std::io::Result<()> {
+fn rename_into_quarantine(
+    _: &Path,
+    _: &Path,
+    path: &Path,
+    destination: &Path,
+) -> std::io::Result<()> {
     fs::rename(path, destination)
 }
 

--- a/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
+++ b/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
@@ -229,7 +229,10 @@ pub(crate) fn execute(positionals: &[String], options: CliOptions) -> Result<Val
 }
 
 fn command_requires_operation_lock(positionals: &[String]) -> bool {
-    matches!(positionals.first().map(String::as_str), Some("install" | "use" | "update" | "remove"))
+    matches!(
+        positionals.first().map(String::as_str),
+        Some("install" | "list" | "use" | "update" | "remove")
+    )
 }
 
 fn with_optional_operation_lock<T>(
@@ -285,15 +288,20 @@ fn install_command(positionals: &[String], options: &CliOptions) -> Result<Value
         let id = metadata.id;
         let selected = selected_plugin_cwd()?.is_some_and(|cwd| same_path(&cwd, &target));
         let config_snapshot = selected.then(capture_config_snapshot).transpose()?;
-        // Compute the exact JSON value that the config writer will install. Recovery
-        // uses it as a compare-and-swap guard, so a newer selection is never lost.
-        let expected_sidebar_plugin = if selected {
-            let command = resolved_run_command(&manifest, &target)?;
-            let cwd = canonical_path(&target)?;
-            Some(json!({"command": command, "cwd": cwd.display().to_string()}))
+        // Compute the exact JSON value that the config writer will install. Resolve
+        // the command from the staged tree, then map it to the final target so a
+        // forced replacement with a new executable path does not inspect the old
+        // installation.
+        let selected_plugin = if selected {
+            let command = resolved_run_command_for_target(&manifest, &temp_dir, &target)?;
+            let cwd = canonical_path(&target)?.display().to_string();
+            Some((command, cwd))
         } else {
             None
         };
+        let expected_sidebar_plugin = selected_plugin
+            .as_ref()
+            .map(|(command, cwd)| json!({"command": command, "cwd": cwd}));
         replace_installed_plugin_with_config(
             &root,
             &name,
@@ -302,12 +310,10 @@ fn install_command(positionals: &[String], options: &CliOptions) -> Result<Value
             config_snapshot,
             expected_sidebar_plugin,
             || {
-                if selected {
-                    let command = resolved_run_command(&manifest, &target)?;
-                    let cwd = canonical_path(&target)?;
+                if let Some((command, cwd)) = selected_plugin.as_ref() {
                     let outcome = config::write_sidebar_plugin(Some(&SidebarPluginConfig {
-                        command,
-                        cwd: Some(cwd.display().to_string()),
+                        command: command.clone(),
+                        cwd: Some(cwd.clone()),
                     }))?;
                     if let Some(error) = outcome.into_unsynced_error() {
                         return Err(error);
@@ -340,7 +346,7 @@ fn list_command(positionals: &[String], options: &CliOptions) -> Result<Value, M
     if positionals.len() != 1 {
         return Err(ManagerError::Usage("usage: cmux sidebar plugin list".to_string()));
     }
-    let plugins = installed_plugins(false)?;
+    let plugins = installed_plugins()?;
     Ok(Value::Array(plugins.iter().map(plugin_json).collect()))
 }
 
@@ -417,7 +423,7 @@ fn write_builtin_config(_options: &CliOptions) -> Result<Value, ManagerError> {
     let root = install_root()?;
     reconcile_install_transactions(&root)?;
     persist_sidebar_plugin(None)?;
-    let plugins = installed_plugins(false)?;
+    let plugins = installed_plugins()?;
     Ok(json!({"plugins": plugins.iter().map(plugin_json).collect::<Vec<_>>()}))
 }
 
@@ -450,15 +456,9 @@ fn reject_plugin_flags(
     Ok(())
 }
 
-fn installed_plugins(reconcile: bool) -> anyhow::Result<Vec<InstalledPlugin>> {
+fn installed_plugins() -> anyhow::Result<Vec<InstalledPlugin>> {
     let root = install_root()?;
-    // Read-only listing skips recovery so a read-only install root does not
-    // need a lock file. Mutating callers hold the operation lock and reconcile.
-    if reconcile {
-        reconcile_install_transactions(&root)?;
-    } else {
-        reject_listing_with_pending_transaction(&root)?;
-    }
+    reconcile_install_transactions(&root)?;
     let selected = selected_plugin_cwd()?;
     let mut plugins = Vec::new();
     let entries = match fs::read_dir(&root) {
@@ -496,22 +496,6 @@ fn installed_plugins(reconcile: bool) -> anyhow::Result<Vec<InstalledPlugin>> {
     Ok(plugins)
 }
 
-fn reject_listing_with_pending_transaction(install_root: &Path) -> anyhow::Result<()> {
-    let entries = match fs::read_dir(install_root) {
-        Ok(entries) => entries,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-        Err(error) => return Err(error.into()),
-    };
-    for entry in entries {
-        let entry = entry?;
-        let Some(name) = entry.file_name().to_str().map(str::to_owned) else { continue };
-        if name.starts_with('.') && name.ends_with(".install-journal.json") {
-            anyhow::bail!("plugin installation recovery is pending");
-        }
-    }
-    Ok(())
-}
-
 fn resolve_installed_plugin(selector: &str) -> Result<InstalledPlugin, ManagerError> {
     let forced_name = selector.strip_prefix("name:");
     let selector = forced_name.unwrap_or(selector);
@@ -523,7 +507,7 @@ fn resolve_installed_plugin(selector: &str) -> Result<InstalledPlugin, ManagerEr
         validate_plugin_name(selector)
             .map_err(|error| ManagerError::validation(Some("sidebar_plugin"), error.to_string()))?;
     }
-    installed_plugins(true)?
+    installed_plugins()?
         .into_iter()
         .find(|plugin| if by_id { plugin.id == selector } else { plugin.name == selector })
         .ok_or_else(|| {
@@ -607,6 +591,20 @@ fn resolved_run_command(manifest: &PluginManifest, dir: &Path) -> anyhow::Result
     let first = Path::new(&command[0]);
     if first.is_relative() {
         command[0] = canonical_path(&dir.join(first))?.display().to_string();
+    }
+    Ok(command)
+}
+
+fn resolved_run_command_for_target(
+    manifest: &PluginManifest,
+    staged_dir: &Path,
+    target_dir: &Path,
+) -> anyhow::Result<Vec<String>> {
+    let mut command = resolved_run_command(manifest, staged_dir)?;
+    let staged_root = canonical_path(staged_dir)?;
+    let target_root = canonical_path(target_dir)?;
+    if let Ok(relative) = Path::new(&command[0]).strip_prefix(&staged_root) {
+        command[0] = target_root.join(relative).display().to_string();
     }
     Ok(command)
 }
@@ -1599,6 +1597,17 @@ fn replace_installed_plugin_with_fs<F: InstallFilesystem, C: FnOnce() -> anyhow:
                 restore_config_snapshot(snapshot, journal.expected_sidebar_plugin.as_ref())
             {
                 rollback_errors.push(format!("config restore: {rollback_error}"));
+            }
+        }
+        if rollback_errors.is_empty() {
+            if let Err(sync_error) = sync_directory(install_root) {
+                rollback_errors.push(format!("install root sync: {sync_error}"));
+            }
+            if rollback_errors.is_empty() {
+                let registry = install_root.join(".registry");
+                if let Err(sync_error) = sync_directory(&registry) {
+                    rollback_errors.push(format!("registry sync: {sync_error}"));
+                }
             }
         }
         if rollback_errors.is_empty() {

--- a/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
+++ b/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
@@ -299,9 +299,8 @@ fn install_command(positionals: &[String], options: &CliOptions) -> Result<Value
         } else {
             None
         };
-        let expected_sidebar_plugin = selected_plugin
-            .as_ref()
-            .map(|(command, cwd)| json!({"command": command, "cwd": cwd}));
+        let expected_sidebar_plugin =
+            selected_plugin.as_ref().map(|(command, cwd)| json!({"command": command, "cwd": cwd}));
         replace_installed_plugin_with_config(
             &root,
             &name,

--- a/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
+++ b/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
@@ -1280,6 +1280,11 @@ fn cleanup_orphan_metadata_temps(
     protected: &HashSet<PathBuf>,
 ) -> anyhow::Result<()> {
     let registry = install_root.join(".registry");
+    match fs::symlink_metadata(&registry) {
+        Ok(_) => ensure_real_directory(&registry)?,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.into()),
+    }
     let entries = match fs::read_dir(&registry) {
         Ok(entries) => entries,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
@@ -2179,6 +2184,33 @@ mod tests {
         assert!(unrelated.exists());
         assert!(directory.exists());
         fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reconciliation_rejects_registry_symlink_before_orphan_cleanup() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "cmux-plugin-registry-symlink-{}-{}",
+            std::process::id(),
+            now_nanos()
+        ));
+        let outside =
+            root.with_file_name(format!("{}-outside", root.file_name().unwrap().to_string_lossy()));
+        fs::create_dir_all(&root).unwrap();
+        fs::create_dir_all(&outside).unwrap();
+        let outside_temp = outside.join(".demo.123-456.tmp");
+        fs::write(&outside_temp, b"keep").unwrap();
+        symlink(&outside, root.join(".registry")).unwrap();
+
+        let error = reconcile_install_transactions(&root).unwrap_err();
+        assert!(error.to_string().contains("real directory"));
+        assert_eq!(fs::read(&outside_temp).unwrap(), b"keep");
+
+        fs::remove_file(root.join(".registry")).unwrap();
+        fs::remove_dir_all(root).unwrap();
+        fs::remove_dir_all(outside).unwrap();
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
+++ b/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
@@ -612,9 +612,7 @@ fn resolved_run_command_for_target(
 }
 
 fn canonical_parent_with_name(path: &Path) -> anyhow::Result<PathBuf> {
-    let name = path
-        .file_name()
-        .ok_or_else(|| anyhow::anyhow!("path has no final component"))?;
+    let name = path.file_name().ok_or_else(|| anyhow::anyhow!("path has no final component"))?;
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
     Ok(canonical_path(parent)?.join(name))
 }

--- a/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
+++ b/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
@@ -930,13 +930,39 @@ fn quarantine_install_journal(install_root: &Path, path: &Path) -> anyhow::Resul
         if fs::symlink_metadata(&destination).is_ok() {
             continue;
         }
-        match fs::rename(path, &destination) {
+        match rename_into_quarantine(install_root, &quarantine, path, &destination) {
             Ok(()) => return Ok(()),
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
             Err(error) => return Err(error.into()),
         }
     }
     anyhow::bail!("could not quarantine invalid install journal")
+}
+
+/// Rename using directory handles so a concurrent replacement of the
+/// quarantine path cannot redirect the journal outside the install root.
+#[cfg(unix)]
+fn rename_into_quarantine(
+    install_root: &Path,
+    quarantine: &Path,
+    path: &Path,
+    destination: &Path,
+) -> std::io::Result<()> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::OpenOptionsExt;
+    use std::os::unix::io::AsRawFd;
+    let root = fs::OpenOptions::new().read(true).custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW).open(install_root)?;
+    let dir = fs::OpenOptions::new().read(true).custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW).open(quarantine)?;
+    let from = CString::new(path.file_name().ok_or_else(|| std::io::Error::other("journal has no basename"))?.as_bytes()).map_err(|_| std::io::Error::other("invalid journal basename"))?;
+    let to = CString::new(destination.file_name().ok_or_else(|| std::io::Error::other("quarantine destination has no basename"))?.as_bytes()).map_err(|_| std::io::Error::other("invalid quarantine basename"))?;
+    let result = unsafe { libc::renameat(root.as_raw_fd(), from.as_ptr(), dir.as_raw_fd(), to.as_ptr()) };
+    if result == 0 { Ok(()) } else { Err(std::io::Error::last_os_error()) }
+}
+
+#[cfg(not(unix))]
+fn rename_into_quarantine(_: &Path, _: &Path, path: &Path, destination: &Path) -> std::io::Result<()> {
+    fs::rename(path, destination)
 }
 
 fn reconcile_install_transactions(install_root: &Path) -> anyhow::Result<()> {

--- a/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
+++ b/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
@@ -305,10 +305,13 @@ fn install_command(positionals: &[String], options: &CliOptions) -> Result<Value
                 if selected {
                     let command = resolved_run_command(&manifest, &target)?;
                     let cwd = canonical_path(&target)?;
-                    config::write_sidebar_plugin(Some(&SidebarPluginConfig {
+                    let outcome = config::write_sidebar_plugin(Some(&SidebarPluginConfig {
                         command,
                         cwd: Some(cwd.display().to_string()),
                     }))?;
+                    if let Some(error) = outcome.into_unsynced_error() {
+                        return Err(error);
+                    }
                 }
                 Ok(())
             },
@@ -828,7 +831,7 @@ fn read_install_journal(path: &Path) -> anyhow::Result<Vec<u8>> {
         use std::os::unix::fs::OpenOptionsExt as _;
         options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
     }
-    let mut file = options.open(path)?;
+    let file = options.open(path)?;
     let metadata = file.metadata()?;
     anyhow::ensure!(metadata.is_file(), "install journal is not a regular file");
     #[cfg(unix)]
@@ -1088,7 +1091,7 @@ fn commit_marker_matches(path: &Path, owner_token: &str) -> anyhow::Result<bool>
         use std::os::unix::fs::OpenOptionsExt as _;
         options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
     }
-    let mut file = match options.open(path) {
+    let file = match options.open(path) {
         Ok(file) => file,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
         Err(error) => return Err(error.into()),
@@ -1172,14 +1175,9 @@ fn reconcile_install_transactions(install_root: &Path) -> anyhow::Result<()> {
             match journal.phase {
                 InstallJournalPhase::Prepared => {
                     if let Some(snapshot) = &journal.config_snapshot {
-                        let legacy_target = journal
-                            .expected_sidebar_plugin
-                            .is_none()
-                            .then(|| install_root.join(&journal.name));
                         restore_config_snapshot(
                             snapshot,
                             journal.expected_sidebar_plugin.as_ref(),
-                            legacy_target.as_deref(),
                         )?;
                     }
                     if journal.target_existed {
@@ -1306,8 +1304,11 @@ fn cleanup_orphan_commit_markers(
 fn restore_config_snapshot(
     snapshot: &ConfigSnapshot,
     expected_sidebar_plugin: Option<&Value>,
-    legacy_target: Option<&Path>,
 ) -> anyhow::Result<()> {
+    // Journals written before the exact value was recorded cannot prove that
+    // the current selection belongs to this transaction. Fail closed before
+    // reading or locking the config, so recovery never guesses from a cwd.
+    let Some(expected_sidebar_plugin) = expected_sidebar_plugin else { return Ok(()) };
     config::with_config_file_lock(&snapshot.path, || {
         let mut root = match fs::read_to_string(&snapshot.path) {
             Ok(text) if text.trim().is_empty() => json!({}),
@@ -1316,20 +1317,11 @@ fn restore_config_snapshot(
             Err(error) => return Err(error.into()),
         };
         let current = root.get("sidebar").and_then(|sidebar| sidebar.get("plugin"));
-        let current_is_transaction = expected_sidebar_plugin
-            .is_some_and(|expected| current == Some(expected))
-            || expected_sidebar_plugin.is_none()
-                && legacy_target.is_some_and(|target| {
-                    current
-                        .and_then(|plugin| plugin.get("cwd"))
-                        .and_then(Value::as_str)
-                        .is_some_and(|cwd| same_path(Path::new(cwd), target))
-                });
+        let current_is_transaction = current == Some(expected_sidebar_plugin);
         if !current_is_transaction {
             // The user or another cmux process selected a different plugin after
             // this transaction started. Leave that newer state untouched. A
-            // legacy journal has no exact value, so its target cwd is the
-            // narrow compatibility predicate.
+            // journal without an exact value was handled above.
             return Ok(());
         }
         let Some(root_object) = root.as_object_mut() else {
@@ -1529,6 +1521,11 @@ fn replace_installed_plugin_with_fs<F: InstallFilesystem, C: FnOnce() -> anyhow:
             &journal_path,
             &InstallJournal { phase: InstallJournalPhase::Committed, ..journal.clone() },
         )?;
+        // Keep the committed journal and the installed directory entry
+        // durable before cleanup can remove the recovery evidence.
+        let journal_parent = journal_path.parent().unwrap_or_else(|| Path::new("."));
+        sync_directory(journal_parent)?;
+        sync_directory(install_root)?;
         Ok(())
     })();
 
@@ -1565,12 +1562,9 @@ fn replace_installed_plugin_with_fs<F: InstallFilesystem, C: FnOnce() -> anyhow:
             }
         }
         if let Some(snapshot) = &journal.config_snapshot {
-            let legacy_target = journal.expected_sidebar_plugin.is_none().then(|| target.clone());
-            if let Err(rollback_error) = restore_config_snapshot(
-                snapshot,
-                journal.expected_sidebar_plugin.as_ref(),
-                legacy_target.as_deref(),
-            ) {
+            if let Err(rollback_error) =
+                restore_config_snapshot(snapshot, journal.expected_sidebar_plugin.as_ref())
+            {
                 rollback_errors.push(format!("config restore: {rollback_error}"));
             }
         }
@@ -2094,53 +2088,39 @@ mod tests {
         fs::remove_dir_all(root).unwrap();
     }
 
-    #[cfg(unix)]
     #[test]
-    fn reconciliation_migrates_a_legacy_journal_without_overwriting_newer_config() {
-        use std::os::unix::fs::PermissionsExt;
-
-        let (root, target, temp_dir, metadata_temp) = replacement_fixture("legacy-journal");
-        let metadata_path = registry_metadata_path(&root, "demo");
-        let target_backup = root.join(".demo.recovery.plugin-backup");
-        let metadata_backup = root.join(".registry/.demo.recovery.metadata-backup.json");
-        fs::rename(&target, &target_backup).unwrap();
-        fs::rename(&metadata_path, &metadata_backup).unwrap();
-        fs::rename(&temp_dir, &target).unwrap();
-
+    fn legacy_config_snapshot_fails_closed_without_exact_expected_value() {
+        let root = std::env::temp_dir().join(format!(
+            "cmux-plugin-legacy-config-{}-{}",
+            std::process::id(),
+            now_nanos()
+        ));
+        fs::create_dir_all(&root).unwrap();
         let config_path = root.join("config.json");
         let current_config = json!({
             "sidebar": {
                 "plugin": {
                     "command": ["new"],
-                    "cwd": target.canonicalize().unwrap().display().to_string()
+                    "cwd": root.join("demo").display().to_string()
                 }
-            }
+            },
+            "theme": {"name": "keep"}
         });
         fs::write(&config_path, serde_json::to_vec(&current_config).unwrap()).unwrap();
-        let journal_path = install_journal_path(&root, "demo");
-        let legacy = json!({
-            "name": "demo",
-            "target_backup": target_backup,
-            "metadata_backup": metadata_backup,
-            "temp_dir": temp_dir,
-            "metadata_temp": metadata_temp,
-            "target_existed": true,
-            "metadata_existed": true,
-            "config_snapshot": {
-                "path": config_path,
-                "sidebar_plugin": {"command": ["old"]}
-            },
-            "phase": "prepared"
-        });
-        fs::write(&journal_path, serde_json::to_vec(&legacy).unwrap()).unwrap();
-        fs::set_permissions(&journal_path, fs::Permissions::from_mode(0o644)).unwrap();
+        let snapshot = ConfigSnapshot {
+            path: config_path.clone(),
+            config_existed: Some(true),
+            sidebar_plugin: Some(json!({"command": ["old"]})),
+            original_non_object: None,
+        };
 
-        reconcile_install_transactions(&root).unwrap();
-        assert_eq!(fs::read_to_string(target.join("marker")).unwrap(), "old");
-        let restored: Value =
-            serde_json::from_str(&fs::read_to_string(root.join("config.json")).unwrap()).unwrap();
-        assert_eq!(restored["sidebar"]["plugin"]["command"], json!(["old"]));
-        assert!(!journal_path.exists());
+        // A legacy journal has no exact value for the plugin it wrote. Even
+        // when its cwd matches, recovery must leave the current selection.
+        restore_config_snapshot(&snapshot, None).unwrap();
+        let after: Value =
+            serde_json::from_str(&fs::read_to_string(&config_path).unwrap()).unwrap();
+        assert_eq!(after, current_config);
+        assert!(!config_path.with_file_name(".config.json.lock").exists());
         fs::remove_dir_all(root).unwrap();
     }
 

--- a/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
+++ b/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::fs;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
@@ -141,6 +142,11 @@ enum InstallJournalPhase {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct InstallJournal {
+    /// Journals written by the first transaction implementation carried an
+    /// owner token and an optional commit marker. Keep the field during
+    /// migration so those journals remain recoverable. New journals omit it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    owner_token: Option<String>,
     name: String,
     target_backup: PathBuf,
     metadata_backup: PathBuf,
@@ -161,12 +167,21 @@ struct InstallJournal {
 #[serde(deny_unknown_fields)]
 struct ConfigSnapshot {
     path: PathBuf,
+    /// These fields were present in journals written before the stricter
+    /// journal parser. Defaults preserve their on-disk format during a
+    /// compatibility read.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    config_existed: Option<bool>,
+    #[serde(default)]
     sidebar_plugin: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    original_non_object: Option<Value>,
 }
 
 const INVALID_INSTALL_JOURNAL_DIR: &str = ".invalid-install-journals";
 const MAX_INSTALL_JOURNAL_BYTES: usize = 1024 * 1024;
 const JOURNAL_QUARANTINE_ATTEMPTS: usize = 16;
+const MAX_ORPHAN_METADATA_TEMP_CLEANUP: usize = 256;
 
 struct PluginOperationLock(fs::File);
 
@@ -175,7 +190,21 @@ fn acquire_plugin_operation_lock() -> anyhow::Result<PluginOperationLock> {
     fs::create_dir_all(&root)?;
     ensure_real_directory(&root)?;
     let path = root.join(".install.lock");
-    let file = fs::OpenOptions::new().create(true).read(true).write(true).open(path)?;
+    let mut options = fs::OpenOptions::new();
+    options.create(true).read(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC).mode(0o600);
+    }
+    let file = options.open(path)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+        let metadata = file.metadata()?;
+        anyhow::ensure!(metadata.uid() == unsafe { libc::geteuid() }, "plugin lock owner changed");
+        anyhow::ensure!(metadata.permissions().mode() & 0o022 == 0, "plugin lock is writable by another user");
+    }
     FileExt::lock(&file)?;
     Ok(PluginOperationLock(file))
 }
@@ -801,9 +830,14 @@ fn read_install_journal(path: &Path) -> anyhow::Result<Vec<u8>> {
     anyhow::ensure!(metadata.is_file(), "install journal is not a regular file");
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt as _;
+        use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
         anyhow::ensure!(
-            metadata.permissions().mode() & 0o7777 == 0o600,
+            metadata.uid() == unsafe { libc::geteuid() },
+            "install journal owner changed"
+        );
+        let mode = metadata.permissions().mode();
+        anyhow::ensure!(
+            mode & 0o022 == 0 && mode & 0o111 == 0,
             "install journal permissions are not private"
         );
     }
@@ -872,6 +906,9 @@ fn validate_install_journal_paths(
     journal_path: &Path,
     journal: &InstallJournal,
 ) -> anyhow::Result<()> {
+    if let Some(owner_token) = &journal.owner_token {
+        anyhow::ensure!(valid_owner_token(owner_token), "install journal owner token is invalid");
+    }
     validate_plugin_name(&journal.name)?;
     anyhow::ensure!(
         journal_path == install_journal_path(install_root, &journal.name),
@@ -1036,6 +1073,38 @@ fn rename_into_quarantine(
     fs::rename(path, destination)
 }
 
+fn install_commit_marker_path(install_root: &Path, name: &str) -> PathBuf {
+    install_root.join(format!(".{name}.install-commit"))
+}
+
+fn commit_marker_matches(path: &Path, owner_token: &str) -> anyhow::Result<bool> {
+    let mut options = fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+    }
+    let mut file = match options.open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error.into()),
+    };
+    anyhow::ensure!(file.metadata()?.is_file(), "install commit marker is not a regular file");
+    let mut bytes = Vec::new();
+    file.take(257).read_to_end(&mut bytes)?;
+    if bytes.len() > 256 {
+        return Ok(false);
+    }
+    Ok(std::str::from_utf8(&bytes).ok().is_some_and(|value| value.trim() == owner_token))
+}
+
+fn valid_owner_token(token: &str) -> bool {
+    !token.is_empty()
+        && token.len() <= 128
+        && token.bytes().all(|byte| byte.is_ascii_alphanumeric() || byte == b'-' || byte == b'_')
+}
+
 fn reconcile_install_transactions(install_root: &Path) -> anyhow::Result<()> {
     if let Ok(metadata) = fs::symlink_metadata(install_root) {
         anyhow::ensure!(
@@ -1048,13 +1117,20 @@ fn reconcile_install_transactions(install_root: &Path) -> anyhow::Result<()> {
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
         Err(error) => return Err(error.into()),
     };
+    let mut journal_paths = Vec::new();
     for entry in entries {
-        let entry = entry?;
-        let path = entry.path();
-        let Some(name) = path.file_name().and_then(|value| value.to_str()) else { continue };
-        if !name.starts_with('.') || !name.ends_with(".install-journal.json") {
-            continue;
+        let path = entry?.path();
+        let is_journal = path
+            .file_name()
+            .and_then(|value| value.to_str())
+            .is_some_and(|name| name.starts_with('.') && name.ends_with(".install-journal.json"));
+        if is_journal {
+            journal_paths.push(path);
         }
+    }
+    let mut valid_journal_names = HashSet::new();
+    let mut protected_metadata_temps = HashSet::new();
+    for path in journal_paths {
         let journal_bytes = match read_install_journal(&path) {
             Ok(bytes) => bytes,
             Err(_) => {
@@ -1073,18 +1149,34 @@ fn reconcile_install_transactions(install_root: &Path) -> anyhow::Result<()> {
             quarantine_install_journal(install_root, &path)?;
             continue;
         }
-        match journal.phase {
-            InstallJournalPhase::Committed => {
-                remove_path_if_present(&journal.target_backup)?;
-                remove_path_if_present(&journal.metadata_backup)?;
-                remove_path_if_present(&journal.temp_dir)?;
-                remove_path_if_present(&journal.metadata_temp)?;
-            }
-            InstallJournalPhase::Prepared => {
-                if let (Some(snapshot), Some(expected)) =
-                    (&journal.config_snapshot, journal.expected_sidebar_plugin.as_ref())
-                {
-                    restore_config_snapshot(snapshot, expected)?;
+        valid_journal_names.insert(journal.name.clone());
+        protected_metadata_temps.insert(journal.metadata_temp.clone());
+        let marker_path = install_commit_marker_path(install_root, &journal.name);
+        let marker_committed = journal
+            .owner_token
+            .as_deref()
+            .map(|owner_token| commit_marker_matches(&marker_path, owner_token))
+            .transpose()?
+            .unwrap_or(false);
+        let committed = matches!(&journal.phase, InstallJournalPhase::Committed) || marker_committed;
+        if committed {
+            remove_path_if_present(&journal.target_backup)?;
+            remove_path_if_present(&journal.metadata_backup)?;
+            remove_path_if_present(&journal.temp_dir)?;
+            remove_path_if_present(&journal.metadata_temp)?;
+        } else {
+            match journal.phase {
+                InstallJournalPhase::Prepared => {
+                if let Some(snapshot) = &journal.config_snapshot {
+                    let legacy_target = journal
+                        .expected_sidebar_plugin
+                        .is_none()
+                        .then(|| install_root.join(&journal.name));
+                    restore_config_snapshot(
+                        snapshot,
+                        journal.expected_sidebar_plugin.as_ref(),
+                        legacy_target.as_deref(),
+                    )?;
                 }
                 if journal.target_existed {
                     if path_entry_exists(&journal.target_backup)? {
@@ -1105,9 +1197,102 @@ fn reconcile_install_transactions(install_root: &Path) -> anyhow::Result<()> {
                 }
                 remove_path_if_present(&journal.temp_dir)?;
                 remove_path_if_present(&journal.metadata_temp)?;
+                }
+                InstallJournalPhase::Committed => unreachable!(),
             }
         }
         remove_path_if_present(&path)?;
+        remove_path_if_present(&marker_path)?;
+    }
+    cleanup_orphan_metadata_temps(install_root, &protected_metadata_temps)?;
+    cleanup_orphan_commit_markers(install_root, &valid_journal_names)?;
+    Ok(())
+}
+
+fn is_generated_metadata_temp_name(name: &str) -> bool {
+    let Some(rest) = name.strip_prefix('.') else { return false };
+    let Some(rest) = rest.strip_suffix(".tmp") else { return false };
+    let Some((plugin, stamp)) = rest.split_once('.') else { return false };
+    let Some((pid, nonce)) = stamp.split_once('-') else { return false };
+    validate_plugin_name(plugin).is_ok()
+        && !pid.is_empty()
+        && !nonce.is_empty()
+        && pid.bytes().all(|byte| byte.is_ascii_digit())
+        && nonce.bytes().all(|byte| byte.is_ascii_digit())
+}
+
+fn remove_file_entry_if_present(path: &Path) -> anyhow::Result<()> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.into()),
+    };
+    // Never recurse from orphan cleanup. A directory with a generated-looking
+    // name can be supplied by another process, and recovery must not remove an
+    // unbounded tree.
+    if metadata.is_dir() {
+        return Ok(());
+    }
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn cleanup_orphan_metadata_temps(
+    install_root: &Path,
+    protected: &HashSet<PathBuf>,
+) -> anyhow::Result<()> {
+    let registry = install_root.join(".registry");
+    let entries = match fs::read_dir(&registry) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.into()),
+    };
+    let mut removed = 0;
+    for entry in entries {
+        let path = entry?.path();
+        let Some(name) = path.file_name().and_then(|value| value.to_str()) else { continue };
+        if !is_generated_metadata_temp_name(name) || protected.contains(&path) {
+            continue;
+        }
+        if removed == MAX_ORPHAN_METADATA_TEMP_CLEANUP {
+            break;
+        }
+        remove_file_entry_if_present(&path)?;
+        removed += 1;
+    }
+    Ok(())
+}
+
+fn cleanup_orphan_commit_markers(
+    install_root: &Path,
+    valid_journal_names: &HashSet<String>,
+) -> anyhow::Result<()> {
+    let entries = match fs::read_dir(install_root) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.into()),
+    };
+    let mut removed = 0;
+    for entry in entries {
+        let path = entry?.path();
+        let Some(name) = path.file_name().and_then(|value| value.to_str()) else { continue };
+        let Some(plugin_name) = name
+            .strip_prefix('.')
+            .and_then(|value| value.strip_suffix(".install-commit"))
+        else {
+            continue;
+        };
+        if valid_journal_names.contains(plugin_name)
+            || validate_plugin_name(plugin_name).is_err()
+            || removed == MAX_ORPHAN_METADATA_TEMP_CLEANUP
+        {
+            continue;
+        }
+        remove_file_entry_if_present(&path)?;
+        removed += 1;
     }
     Ok(())
 }
@@ -1115,44 +1300,65 @@ fn reconcile_install_transactions(install_root: &Path) -> anyhow::Result<()> {
 fn restore_config_snapshot(
     snapshot: &ConfigSnapshot,
     expected_sidebar_plugin: Option<&Value>,
+    legacy_target: Option<&Path>,
 ) -> anyhow::Result<()> {
-    let mut root = match fs::read_to_string(&snapshot.path) {
-        Ok(text) if text.trim().is_empty() => json!({}),
-        Ok(text) => serde_json::from_str(&text)?,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => json!({}),
-        Err(error) => return Err(error.into()),
-    };
-    if let Some(expected) = expected_sidebar_plugin {
+    config::with_config_file_lock(&snapshot.path, || {
+        let mut root = match fs::read_to_string(&snapshot.path) {
+            Ok(text) if text.trim().is_empty() => json!({}),
+            Ok(text) => serde_json::from_str(&text)?,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => json!({}),
+            Err(error) => return Err(error.into()),
+        };
         let current = root.get("sidebar").and_then(|sidebar| sidebar.get("plugin"));
-        if current != Some(expected) {
+        let current_is_transaction = expected_sidebar_plugin.is_some_and(|expected| {
+            current == Some(expected)
+        }) || expected_sidebar_plugin.is_none() && legacy_target.is_some_and(|target| {
+            current
+                .and_then(|plugin| plugin.get("cwd"))
+                .and_then(Value::as_str)
+                .is_some_and(|cwd| same_path(Path::new(cwd), target))
+        });
+        if !current_is_transaction {
             // The user or another cmux process selected a different plugin after
-            // this transaction started. Leave that newer state untouched.
+            // this transaction started. Leave that newer state untouched. A
+            // legacy journal has no exact value, so its target cwd is the
+            // narrow compatibility predicate.
             return Ok(());
         }
-    }
-    let Some(root_object) = root.as_object_mut() else {
-        anyhow::bail!("{} must contain a JSON object", snapshot.path.display());
-    };
-    match &snapshot.sidebar_plugin {
-        Some(plugin) => {
-            let sidebar = root_object.entry("sidebar").or_insert_with(|| json!({}));
-            if !sidebar.is_object() {
-                *sidebar = json!({});
+        let Some(root_object) = root.as_object_mut() else {
+            if let Some(original) = &snapshot.original_non_object {
+                return write_config_value_atomic_local(&snapshot.path, original);
             }
-            sidebar
-                .as_object_mut()
-                .expect("sidebar was just made an object")
-                .insert("plugin".to_string(), plugin.clone());
-        }
-        None => {
-            if let Some(sidebar) = root_object.get_mut("sidebar")
-                && let Some(sidebar_object) = sidebar.as_object_mut()
-            {
-                sidebar_object.remove("plugin");
+            anyhow::bail!("{} must contain a JSON object", snapshot.path.display());
+        };
+        match &snapshot.sidebar_plugin {
+            Some(plugin) => {
+                let sidebar = root_object.entry("sidebar").or_insert_with(|| json!({}));
+                if !sidebar.is_object() {
+                    *sidebar = json!({});
+                }
+                sidebar
+                    .as_object_mut()
+                    .expect("sidebar was just made an object")
+                    .insert("plugin".to_string(), plugin.clone());
+            }
+            None => {
+                if let Some(sidebar) = root_object.get_mut("sidebar")
+                    && let Some(sidebar_object) = sidebar.as_object_mut()
+                {
+                    sidebar_object.remove("plugin");
+                }
             }
         }
-    }
-    write_config_value_atomic_local(&snapshot.path, &root)
+        if snapshot.config_existed == Some(false) && snapshot.sidebar_plugin.is_none() {
+            return match fs::remove_file(&snapshot.path) {
+                Ok(()) => Ok(()),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                Err(error) => Err(error.into()),
+            };
+        }
+        write_config_value_atomic_local(&snapshot.path, &root)
+    })
 }
 
 fn write_config_value_atomic_local(path: &Path, value: &Value) -> anyhow::Result<()> {
@@ -1225,16 +1431,22 @@ fn replace_installed_plugin_with_config<C: FnOnce() -> anyhow::Result<()>>(
 
 fn capture_config_snapshot() -> anyhow::Result<ConfigSnapshot> {
     let path = config::config_path()?;
-    let sidebar_plugin = match fs::read_to_string(&path) {
-        Ok(text) if text.trim().is_empty() => None,
-        Ok(text) => serde_json::from_str::<Value>(&text)?
-            .get("sidebar")
-            .and_then(|sidebar| sidebar.get("plugin"))
-            .cloned(),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+    let (config_existed, sidebar_plugin, original_non_object) = match fs::read_to_string(&path) {
+        Ok(text) if text.trim().is_empty() => (true, None, None),
+        Ok(text) => {
+            let value: Value = serde_json::from_str(&text)?;
+            let sidebar_plugin = value
+                .as_object()
+                .and_then(|root| root.get("sidebar"))
+                .and_then(|sidebar| sidebar.get("plugin"))
+                .cloned();
+            let original_non_object = (!value.is_object()).then_some(value);
+            (true, sidebar_plugin, original_non_object)
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => (false, None, None),
         Err(error) => return Err(error.into()),
     };
-    Ok(ConfigSnapshot { path, sidebar_plugin })
+    Ok(ConfigSnapshot { path, config_existed, sidebar_plugin, original_non_object })
 }
 
 fn replace_installed_plugin_with_fs<F: InstallFilesystem, C: FnOnce() -> anyhow::Result<()>>(
@@ -1244,6 +1456,7 @@ fn replace_installed_plugin_with_fs<F: InstallFilesystem, C: FnOnce() -> anyhow:
     temp_dir: &Path,
     metadata_temp: &Path,
     config_snapshot: Option<ConfigSnapshot>,
+    expected_sidebar_plugin: Option<Value>,
     after_install: C,
 ) -> anyhow::Result<()> {
     ensure_real_directory(install_root)?;
@@ -1260,6 +1473,7 @@ fn replace_installed_plugin_with_fs<F: InstallFilesystem, C: FnOnce() -> anyhow:
     let metadata_exists = path_entry_exists(&metadata_path)?;
     let journal_path = install_journal_path(install_root, name);
     let journal = InstallJournal {
+        owner_token: None,
         name: name.to_string(),
         target_backup: target_backup.clone(),
         metadata_backup: metadata_backup.clone(),
@@ -1339,11 +1553,18 @@ fn replace_installed_plugin_with_fs<F: InstallFilesystem, C: FnOnce() -> anyhow:
                 rollback_errors.push(format!("plugin restore: {rollback_error}"));
             }
         }
-        if let (Some(snapshot), Some(expected)) =
-            (&journal.config_snapshot, journal.expected_sidebar_plugin.as_ref())
-            && let Err(rollback_error) = restore_config_snapshot(snapshot, expected)
-        {
-            rollback_errors.push(format!("config restore: {rollback_error}"));
+        if let Some(snapshot) = &journal.config_snapshot {
+            let legacy_target = journal
+                .expected_sidebar_plugin
+                .is_none()
+                .then(|| target.clone());
+            if let Err(rollback_error) = restore_config_snapshot(
+                snapshot,
+                journal.expected_sidebar_plugin.as_ref(),
+                legacy_target.as_deref(),
+            ) {
+                rollback_errors.push(format!("config restore: {rollback_error}"));
+            }
         }
         if rollback_errors.is_empty() {
             if let Err(rollback_error) = filesystem.remove_file(&journal_path)
@@ -1390,7 +1611,14 @@ fn write_registry_metadata_temp(
     ensure_real_directory(&registry)?;
     let temp = registry.join(format!(".{name}.{}-{}.tmp", std::process::id(), now_nanos()));
     let encoded = serde_json::to_vec(metadata)?;
-    let mut file = fs::OpenOptions::new().create_new(true).write(true).open(&temp)?;
+    let mut options = fs::OpenOptions::new();
+    options.create_new(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC).mode(0o600);
+    }
+    let mut file = options.open(&temp)?;
     file.write_all(&encoded)?;
     file.write_all(b"\n")?;
     file.sync_all()?;
@@ -1830,6 +2058,7 @@ mod tests {
         write_install_journal(
             &journal_path,
             &InstallJournal {
+                owner_token: None,
                 name: "demo".into(),
                 target_backup: target_backup.clone(),
                 metadata_backup: metadata_backup.clone(),
@@ -1857,6 +2086,79 @@ mod tests {
         fs::remove_dir_all(root).unwrap();
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn reconciliation_migrates_a_legacy_journal_without_overwriting_newer_config() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let (root, target, temp_dir, metadata_temp) = replacement_fixture("legacy-journal");
+        let metadata_path = registry_metadata_path(&root, "demo");
+        let target_backup = root.join(".demo.recovery.plugin-backup");
+        let metadata_backup = root.join(".registry/.demo.recovery.metadata-backup.json");
+        fs::rename(&target, &target_backup).unwrap();
+        fs::rename(&metadata_path, &metadata_backup).unwrap();
+        fs::rename(&temp_dir, &target).unwrap();
+
+        let config_path = root.join("config.json");
+        let current_config = json!({
+            "sidebar": {
+                "plugin": {
+                    "command": ["new"],
+                    "cwd": target.canonicalize().unwrap().display().to_string()
+                }
+            }
+        });
+        fs::write(&config_path, serde_json::to_vec(&current_config).unwrap()).unwrap();
+        let journal_path = install_journal_path(&root, "demo");
+        let legacy = json!({
+            "name": "demo",
+            "target_backup": target_backup,
+            "metadata_backup": metadata_backup,
+            "temp_dir": temp_dir,
+            "metadata_temp": metadata_temp,
+            "target_existed": true,
+            "metadata_existed": true,
+            "config_snapshot": {
+                "path": config_path,
+                "sidebar_plugin": {"command": ["old"]}
+            },
+            "phase": "prepared"
+        });
+        fs::write(&journal_path, serde_json::to_vec(&legacy).unwrap()).unwrap();
+        fs::set_permissions(&journal_path, fs::Permissions::from_mode(0o644)).unwrap();
+
+        reconcile_install_transactions(&root).unwrap();
+        assert_eq!(fs::read_to_string(target.join("marker")).unwrap(), "old");
+        let restored: Value =
+            serde_json::from_str(&fs::read_to_string(root.join("config.json")).unwrap()).unwrap();
+        assert_eq!(restored["sidebar"]["plugin"]["command"], json!(["old"]));
+        assert!(!journal_path.exists());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn reconciliation_removes_only_generated_metadata_temps() {
+        let root = std::env::temp_dir().join(format!(
+            "cmux-plugin-orphan-temp-{}-{}",
+            std::process::id(),
+            now_nanos()
+        ));
+        let registry = root.join(".registry");
+        fs::create_dir_all(&registry).unwrap();
+        let generated = registry.join(".demo.123-456.tmp");
+        let unrelated = registry.join(".notes.tmp");
+        let directory = registry.join(".demo.789-012.tmp");
+        fs::write(&generated, b"generated").unwrap();
+        fs::write(&unrelated, b"keep").unwrap();
+        fs::create_dir(&directory).unwrap();
+
+        reconcile_install_transactions(&root).unwrap();
+        assert!(!generated.exists());
+        assert!(unrelated.exists());
+        assert!(directory.exists());
+        fs::remove_dir_all(root).unwrap();
+    }
+
     #[test]
     fn invalid_journal_paths_are_quarantined_without_touching_outside_files() {
         let root = std::env::temp_dir().join(format!(
@@ -1873,6 +2175,7 @@ mod tests {
         write_install_journal(
             &journal_path,
             &InstallJournal {
+                owner_token: None,
                 name: "demo".into(),
                 target_backup: outside.clone(),
                 metadata_backup: registry.join(".demo.recovery.metadata-backup.json"),
@@ -1907,7 +2210,9 @@ mod tests {
         .unwrap();
         let snapshot = ConfigSnapshot {
             path: config_path.clone(),
+            config_existed: Some(true),
             sidebar_plugin: Some(json!({"command": ["old"]})),
+            original_non_object: None,
         };
         let expected = json!({"command": ["new"]});
         let error = replace_installed_plugin_with_fs(
@@ -1951,7 +2256,9 @@ mod tests {
         .unwrap();
         let snapshot = ConfigSnapshot {
             path: config_path.clone(),
+            config_existed: Some(true),
             sidebar_plugin: Some(json!({"command": ["old"]})),
+            original_non_object: None,
         };
         let error = replace_installed_plugin_with_fs(
             &StandardInstallFilesystem,

--- a/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
+++ b/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
@@ -1657,7 +1657,28 @@ fn replace_installed_plugin_with_fs<F: InstallFilesystem, C: FnOnce() -> anyhow:
     };
     let backups_clean = backup_dir_clean && metadata_backup_clean;
     if backups_clean {
-        let _ = filesystem.remove_file(&journal_path);
+        // The committed journal is the last recovery evidence. Make both
+        // backup removals durable before unlinking it, otherwise a crash can
+        // lose the journal while resurrecting one of the backups as an
+        // unreachable orphan. If the directory sync fails, keep the journal
+        // so the next operation can retry cleanup.
+        let journal_parent = journal_path.parent().unwrap_or_else(|| Path::new("."));
+        let registry = install_root.join(".registry");
+        let cleanup_durable = sync_directory(install_root)
+            .and_then(|()| sync_directory(&registry))
+            .is_ok();
+        if cleanup_durable {
+            let journal_removed = match filesystem.remove_file(&journal_path) {
+                Ok(()) => true,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => true,
+                Err(_) => false,
+            };
+            if journal_removed {
+                // A failed final sync is safe: the committed journal may
+                // remain and recovery will repeat the idempotent cleanup.
+                let _ = sync_directory(journal_parent);
+            }
+        }
     }
     Ok(())
 }

--- a/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
+++ b/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
@@ -149,6 +149,11 @@ struct InstallJournal {
     target_existed: bool,
     metadata_existed: bool,
     config_snapshot: Option<ConfigSnapshot>,
+    /// The value this transaction wrote to the selected-plugin key. Recovery
+    /// restores the old value only while this exact value is still present;
+    /// a later user selection must never be overwritten by stale recovery.
+    #[serde(default)]
+    expected_sidebar_plugin: Option<Value>,
     phase: InstallJournalPhase,
 }
 
@@ -248,12 +253,22 @@ fn install_command(positionals: &[String], options: &CliOptions) -> Result<Value
         let id = metadata.id;
         let selected = selected_plugin_cwd()?.is_some_and(|cwd| same_path(&cwd, &target));
         let config_snapshot = selected.then(capture_config_snapshot).transpose()?;
+        // Compute the exact JSON value that the config writer will install. Recovery
+        // uses it as a compare-and-swap guard, so a newer selection is never lost.
+        let expected_sidebar_plugin = if selected {
+            let command = resolved_run_command(&manifest, &target)?;
+            let cwd = canonical_path(&target)?;
+            Some(json!({"command": command, "cwd": cwd.display().to_string()}))
+        } else {
+            None
+        };
         replace_installed_plugin_with_config(
             &root,
             &name,
             &temp_dir,
             &metadata_temp,
             config_snapshot,
+            expected_sidebar_plugin,
             || {
                 if selected {
                     let command = resolved_run_command(&manifest, &target)?;
@@ -1066,8 +1081,10 @@ fn reconcile_install_transactions(install_root: &Path) -> anyhow::Result<()> {
                 remove_path_if_present(&journal.metadata_temp)?;
             }
             InstallJournalPhase::Prepared => {
-                if let Some(snapshot) = &journal.config_snapshot {
-                    restore_config_snapshot(snapshot)?;
+                if let (Some(snapshot), Some(expected)) =
+                    (&journal.config_snapshot, journal.expected_sidebar_plugin.as_ref())
+                {
+                    restore_config_snapshot(snapshot, expected)?;
                 }
                 if journal.target_existed {
                     if path_entry_exists(&journal.target_backup)? {
@@ -1095,13 +1112,24 @@ fn reconcile_install_transactions(install_root: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn restore_config_snapshot(snapshot: &ConfigSnapshot) -> anyhow::Result<()> {
+fn restore_config_snapshot(
+    snapshot: &ConfigSnapshot,
+    expected_sidebar_plugin: Option<&Value>,
+) -> anyhow::Result<()> {
     let mut root = match fs::read_to_string(&snapshot.path) {
         Ok(text) if text.trim().is_empty() => json!({}),
         Ok(text) => serde_json::from_str(&text)?,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => json!({}),
         Err(error) => return Err(error.into()),
     };
+    if let Some(expected) = expected_sidebar_plugin {
+        let current = root.get("sidebar").and_then(|sidebar| sidebar.get("plugin"));
+        if current != Some(expected) {
+            // The user or another cmux process selected a different plugin after
+            // this transaction started. Leave that newer state untouched.
+            return Ok(());
+        }
+    }
     let Some(root_object) = root.as_object_mut() else {
         anyhow::bail!("{} must contain a JSON object", snapshot.path.display());
     };
@@ -1169,6 +1197,7 @@ fn replace_installed_plugin(
         temp_dir,
         metadata_temp,
         None,
+        None,
         || Ok(()),
     )
 }
@@ -1179,6 +1208,7 @@ fn replace_installed_plugin_with_config<C: FnOnce() -> anyhow::Result<()>>(
     temp_dir: &Path,
     metadata_temp: &Path,
     config_snapshot: Option<ConfigSnapshot>,
+    expected_sidebar_plugin: Option<Value>,
     after_install: C,
 ) -> anyhow::Result<()> {
     replace_installed_plugin_with_fs(
@@ -1188,6 +1218,7 @@ fn replace_installed_plugin_with_config<C: FnOnce() -> anyhow::Result<()>>(
         temp_dir,
         metadata_temp,
         config_snapshot,
+        expected_sidebar_plugin,
         after_install,
     )
 }
@@ -1237,6 +1268,7 @@ fn replace_installed_plugin_with_fs<F: InstallFilesystem, C: FnOnce() -> anyhow:
         target_existed: target_exists,
         metadata_existed: metadata_exists,
         config_snapshot,
+        expected_sidebar_plugin,
         phase: InstallJournalPhase::Prepared,
     };
     write_install_journal(&journal_path, &journal)?;
@@ -1307,8 +1339,9 @@ fn replace_installed_plugin_with_fs<F: InstallFilesystem, C: FnOnce() -> anyhow:
                 rollback_errors.push(format!("plugin restore: {rollback_error}"));
             }
         }
-        if let Some(snapshot) = &journal.config_snapshot
-            && let Err(rollback_error) = restore_config_snapshot(snapshot)
+        if let (Some(snapshot), Some(expected)) =
+            (&journal.config_snapshot, journal.expected_sidebar_plugin.as_ref())
+            && let Err(rollback_error) = restore_config_snapshot(snapshot, expected)
         {
             rollback_errors.push(format!("config restore: {rollback_error}"));
         }
@@ -1692,6 +1725,7 @@ mod tests {
             &temp_dir,
             &metadata_temp,
             None,
+            None,
             || Ok(()),
         )
         .unwrap_err();
@@ -1730,6 +1764,7 @@ mod tests {
             "demo",
             &temp_dir,
             &metadata_temp,
+            None,
             None,
             || Ok(()),
         )
@@ -1803,6 +1838,7 @@ mod tests {
                 target_existed: true,
                 metadata_existed: true,
                 config_snapshot: None,
+                expected_sidebar_plugin: None,
                 phase: InstallJournalPhase::Prepared,
             },
         )
@@ -1845,6 +1881,7 @@ mod tests {
                 target_existed: false,
                 metadata_existed: false,
                 config_snapshot: None,
+                expected_sidebar_plugin: None,
                 phase: InstallJournalPhase::Committed,
             },
         )
@@ -1872,6 +1909,7 @@ mod tests {
             path: config_path.clone(),
             sidebar_plugin: Some(json!({"command": ["old"]})),
         };
+        let expected = json!({"command": ["new"]});
         let error = replace_installed_plugin_with_fs(
             &StandardInstallFilesystem,
             &root,
@@ -1879,6 +1917,7 @@ mod tests {
             &temp_dir,
             &metadata_temp,
             Some(snapshot),
+            Some(expected),
             || {
                 fs::write(
                     &config_path,
@@ -1898,6 +1937,43 @@ mod tests {
             read_registry_metadata(&root, "demo").unwrap().id,
             "sidebar_plugin_11111111111111111111111111111111"
         );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn config_rollback_preserves_a_newer_plugin_selection() {
+        let (root, _target, temp_dir, metadata_temp) = replacement_fixture("config-newer");
+        let config_path = root.join("config.json");
+        fs::write(
+            &config_path,
+            "{\"sidebar\":{\"plugin\":{\"command\":[\"old\"]}},\"theme\":{\"name\":\"keep\"}}\n",
+        )
+        .unwrap();
+        let snapshot = ConfigSnapshot {
+            path: config_path.clone(),
+            sidebar_plugin: Some(json!({"command": ["old"]})),
+        };
+        let error = replace_installed_plugin_with_fs(
+            &StandardInstallFilesystem,
+            &root,
+            "demo",
+            &temp_dir,
+            &metadata_temp,
+            Some(snapshot),
+            Some(json!({"command": ["new"]})),
+            || {
+                fs::write(
+                    &config_path,
+                    "{\"sidebar\":{\"plugin\":{\"command\":[\"newer\"]}},\"theme\":{\"name\":\"changed\"}}\n",
+                )?;
+                anyhow::bail!("injected config failure")
+            },
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("injected config failure"));
+        let current: Value = serde_json::from_str(&fs::read_to_string(config_path).unwrap()).unwrap();
+        assert_eq!(current["sidebar"]["plugin"]["command"], json!(["newer"]));
+        assert_eq!(current["theme"]["name"], json!("changed"));
         fs::remove_dir_all(root).unwrap();
     }
 

--- a/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
+++ b/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
@@ -1799,41 +1799,34 @@ mod tests {
     }
 
     #[test]
-    fn only_mutating_plugin_commands_require_operation_lock() {
-        assert!(!command_requires_operation_lock(&["list".to_string()]));
-        for command in ["install", "use", "update", "remove"] {
+    fn every_plugin_listing_and_mutation_requires_operation_lock() {
+        for command in ["install", "list", "use", "update", "remove"] {
             assert!(command_requires_operation_lock(&[command.to_string()]));
         }
         assert!(!command_requires_operation_lock(&[]));
     }
 
     #[test]
-    fn read_only_listing_allows_a_clean_root_without_creating_a_lock() {
+    fn staged_command_is_mapped_to_the_final_plugin_root() {
         let root = std::env::temp_dir().join(format!(
-            "cmux-plugin-read-only-list-{}-{}",
+            "cmux-plugin-command-map-{}-{}",
             std::process::id(),
             now_nanos()
         ));
-        fs::create_dir_all(&root).unwrap();
-        assert!(reject_listing_with_pending_transaction(&root).is_ok());
-        assert!(!root.join(".install.lock").exists());
-        fs::remove_dir_all(root).unwrap();
-    }
-
-    #[test]
-    fn read_only_listing_rejects_pending_journal_without_mutating_root() {
-        let root = std::env::temp_dir().join(format!(
-            "cmux-plugin-read-only-pending-{}-{}",
-            std::process::id(),
-            now_nanos()
-        ));
-        fs::create_dir_all(&root).unwrap();
-        let journal = root.join(".demo.install-journal.json");
-        fs::write(&journal, b"pending").unwrap();
-        let error = reject_listing_with_pending_transaction(&root).unwrap_err();
-        assert_eq!(error.to_string(), "plugin installation recovery is pending");
-        assert!(journal.exists());
-        assert!(!root.join(".install.lock").exists());
+        let staged = root.join(".install");
+        let target = root.join("demo");
+        fs::create_dir_all(staged.join("bin")).unwrap();
+        fs::create_dir_all(&target).unwrap();
+        let executable = staged.join("bin/sidebar");
+        fs::write(&executable, "#!/bin/sh\nexit 0\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&executable, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        let manifest = parse_manifest(&manifest_text("demo")).unwrap();
+        let command = resolved_run_command_for_target(&manifest, &staged, &target).unwrap();
+        assert_eq!(command, vec![target.join("bin/sidebar").display().to_string()]);
         fs::remove_dir_all(root).unwrap();
     }
 

--- a/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
+++ b/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
@@ -922,10 +922,13 @@ fn validate_install_temp_path(install_root: &Path, path: &Path) -> anyhow::Resul
         "install journal temporary directory is outside the install root"
     );
     match fs::symlink_metadata(path) {
-        Ok(metadata) => anyhow::ensure!(
-            metadata.is_dir() && !metadata.file_type().is_symlink(),
-            "install journal temporary directory is not a real directory"
-        ),
+        Ok(metadata) => {
+            anyhow::ensure!(
+                metadata.is_dir() && !metadata.file_type().is_symlink(),
+                "install journal temporary directory is not a real directory"
+            );
+            Ok(())
+        }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(error) => Err(error.into()),
     }
@@ -1054,7 +1057,7 @@ fn rename_into_quarantine(
         return Err(std::io::Error::last_os_error());
     }
     // SAFETY: `open` returned a new owned descriptor.
-    let root = unsafe { std::fs::File::from_raw_fd(root_fd) };
+    let root = unsafe { fs::File::from_raw_fd(root_fd) };
 
     let quarantine_name = CString::new(
         quarantine
@@ -1076,7 +1079,7 @@ fn rename_into_quarantine(
         return Err(std::io::Error::last_os_error());
     }
     // SAFETY: `openat` returned a new owned descriptor.
-    let quarantine = unsafe { std::fs::File::from_raw_fd(quarantine_fd) };
+    let quarantine = unsafe { fs::File::from_raw_fd(quarantine_fd) };
 
     let from = CString::new(
         path.file_name()

--- a/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
+++ b/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
@@ -2314,6 +2314,48 @@ mod tests {
         fs::remove_dir_all(root).unwrap();
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn insecure_journal_quarantine_directory_rejects_invalid_journal() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = std::env::temp_dir().join(format!(
+            "cmux-plugin-journal-quarantine-mode-{}-{}",
+            std::process::id(),
+            now_nanos()
+        ));
+        let registry = root.join(".registry");
+        fs::create_dir_all(&registry).unwrap();
+        let quarantine = root.join(INVALID_INSTALL_JOURNAL_DIR);
+        fs::create_dir(&quarantine).unwrap();
+        fs::set_permissions(&quarantine, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let journal_path = install_journal_path(&root, "demo");
+        write_install_journal(
+            &journal_path,
+            &InstallJournal {
+                owner_token: None,
+                name: "demo".into(),
+                target_backup: root.join("outside.plugin-backup"),
+                metadata_backup: registry.join(".demo.recovery.metadata-backup.json"),
+                temp_dir: root.join(".install-1-2"),
+                metadata_temp: registry.join(".demo.1-2.tmp"),
+                target_existed: false,
+                metadata_existed: false,
+                config_snapshot: None,
+                expected_sidebar_plugin: None,
+                phase: InstallJournalPhase::Committed,
+            },
+        )
+        .unwrap();
+
+        let error = reconcile_install_transactions(&root).unwrap_err();
+        assert!(error.to_string().contains("accessible by another user"));
+        assert!(journal_path.exists());
+        assert_eq!(fs::read_dir(&quarantine).unwrap().count(), 0);
+        fs::remove_dir_all(root).unwrap();
+    }
+
     #[test]
     fn invalid_journal_temp_paths_are_quarantined_without_recursive_delete() {
         for (label, temp_name, make_directory) in

--- a/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
+++ b/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
@@ -908,6 +908,31 @@ fn ensure_real_directory(path: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
+#[cfg(unix)]
+fn ensure_private_directory(path: &Path) -> anyhow::Result<()> {
+    use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+
+    let metadata = fs::symlink_metadata(path)?;
+    anyhow::ensure!(
+        metadata.is_dir() && !metadata.file_type().is_symlink(),
+        "plugin state directory is not a real directory"
+    );
+    anyhow::ensure!(
+        metadata.uid() == unsafe { libc::geteuid() },
+        "plugin state directory owner changed"
+    );
+    anyhow::ensure!(
+        metadata.permissions().mode() & 0o077 == 0,
+        "plugin state directory is accessible by another user"
+    );
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn ensure_private_directory(path: &Path) -> anyhow::Result<()> {
+    ensure_real_directory(path)
+}
+
 fn direct_child_named(parent: &Path, path: &Path, predicate: impl FnOnce(&str) -> bool) -> bool {
     path.parent() == Some(parent)
         && path.file_name().and_then(|name| name.to_str()).is_some_and(predicate)
@@ -1000,22 +1025,25 @@ fn validate_install_journal_paths(
 fn quarantine_install_journal(install_root: &Path, path: &Path) -> anyhow::Result<()> {
     let quarantine = install_root.join(INVALID_INSTALL_JOURNAL_DIR);
     match fs::symlink_metadata(&quarantine) {
-        Ok(metadata) => {
-            anyhow::ensure!(metadata.is_dir(), "invalid journal quarantine is not a directory")
-        }
+        Ok(_) => ensure_private_directory(&quarantine)?,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            match fs::create_dir(&quarantine) {
+            #[cfg(unix)]
+            let create_result = {
+                use std::os::unix::fs::DirBuilderExt as _;
+                let mut builder = fs::DirBuilder::new();
+                builder.mode(0o700);
+                builder.create(&quarantine)
+            };
+            #[cfg(not(unix))]
+            let create_result = fs::create_dir(&quarantine);
+            match create_result {
                 Ok(()) => {}
                 Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-                    ensure_real_directory(&quarantine)?;
+                    ensure_private_directory(&quarantine)?;
                 }
                 Err(error) => return Err(error.into()),
             }
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::PermissionsExt as _;
-                fs::set_permissions(&quarantine, fs::Permissions::from_mode(0o700))?;
-            }
+            ensure_private_directory(&quarantine)?;
         }
         Err(error) => return Err(error.into()),
     }
@@ -1047,6 +1075,7 @@ fn rename_into_quarantine(
 ) -> std::io::Result<()> {
     use std::ffi::CString;
     use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
     use std::os::unix::io::{AsRawFd, FromRawFd};
 
     let root_name = CString::new(install_root.as_os_str().as_bytes())
@@ -1086,6 +1115,17 @@ fn rename_into_quarantine(
     }
     // SAFETY: `openat` returned a new owned descriptor.
     let quarantine = unsafe { fs::File::from_raw_fd(quarantine_fd) };
+
+    let quarantine_metadata = quarantine.metadata()?;
+    if !quarantine_metadata.is_dir()
+        || quarantine_metadata.uid() != unsafe { libc::geteuid() }
+        || quarantine_metadata.permissions().mode() & 0o077 != 0
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "invalid install journal quarantine directory",
+        ));
+    }
 
     let from = CString::new(
         path.file_name()


### PR DESCRIPTION
Follow-up hardening for https://github.com/manaflow-ai/cmux/pull/11154.

Existing invalid-install-journal quarantine directories are now required to be effective-user owned and inaccessible to group/other users. Creation uses mode 0700 without a path-based chmod race, and rename validates the opened directory descriptor before moving a journal.

Regression test commit 9c9516ceb8 adds coverage for an insecure 0755 quarantine directory; fix commit a962fe5530 enforces the policy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790839924&installation_model_id=21920&pr_number=11369&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11369&signature=500fb48f15e0194ca93d52abca77d97784bfdf4880651b696b7602fbe8facaa9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens plugin install journal handling so recovery cannot move or delete files outside the plugin state directory, and stale recovery cannot overwrite a newer plugin selection.

**Journal quarantine**
- Quarantine directories must be effective-user owned with mode 0700; creation uses mode 0700 without a path-based chmod race.
- Renames into quarantine use `openat`/`renameat` on validated directory descriptors.
- Journal reads reject symlinks, non-owned files, group/other-accessible files, and files over 1MB.

**Recovery and locking**
- Journal paths must be direct children of the install root or registry before any file operation.
- Legacy journals without an exact expected config value fail closed rather than guessing from cwd.
- `list` and builtin-config writes reconcile transactions first so prepared rollbacks cannot undo a newer selection.
- Config writes now take a file lock, and plugin errors no longer expose internal paths or details.

<sup>Written for commit a962fe553027d55d691330ad0f236caa7b32bf29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

