### PR TITLE
fix(relay): fence fallback child reap after wait error

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -3806,6 +3806,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cancelled_shell_waiter_does_not_claim_starting_session() {
+        let h = harness(None, None);
+        let cancellation = h.manager.new_open_cancellation().expect("open attempt token");
+        let context = h.context("supervised", h.owner.clone());
+        let env = env_map(&h.home);
+        let open_permit = OpenPermit::new(
+            h.manager.inner.open_slots.clone().try_acquire_owned().expect("open permit"),
+        );
+        let notify = Arc::new(Notify::new());
+        h.manager
+            .inner
+            .shell_starting
+            .lock()
+            .unwrap()
+            .insert("waiting".to_owned(), Arc::clone(&notify));
+
+        // Model a second opener that is waiting for the first owner. The
+        // cancellation branch must win without spawning or removing the
+        // owner's in-progress marker.
+        cancellation.cancel();
+        let result = Arc::clone(&h.manager.inner)
+            .open_shell(
+                "waiting",
+                80,
+                24,
+                &h.home,
+                &env,
+                "p1",
+                None,
+                &context,
+                &cancellation,
+                &open_permit,
+            )
+            .await;
+
+        assert_eq!(result.err().as_deref(), Some("terminal open cancelled"));
+        assert!(h.spawned().is_empty());
+        assert!(h.manager.inner.shell_starting.lock().unwrap().contains_key("waiting"));
+    }
+
+    #[tokio::test]
     async fn cancellation_during_shell_subscribe_is_not_cached_and_killed() {
         let h = harness(None, None);
         h.cancel_on_subscribe.store(true, Ordering::SeqCst);

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -814,8 +814,8 @@ fn spawn_real_pty(spec: &SpawnSpec, handoff: &SpawnHandoff) -> anyhow::Result<Pt
     let (completion, cancel_reader) =
         ProcessOutputCompletion::with_pty_cancellation(1, Arc::clone(&output))?;
     let spawned = pair.spawn(command)?;
-    let cmux_pty::SpawnedPty { mut master, child } = spawned;
-    let mut child_cleanup = SpawnedChildCleanup::new(child);
+    let cmux_pty::SpawnedPty { master, child } = spawned;
+    let child_cleanup = SpawnedChildCleanup::new(child);
     if handoff.is_cancelled() {
         return Err(anyhow::anyhow!("PTY spawn cancelled"));
     }

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -815,7 +815,7 @@ fn spawn_real_pty(spec: &SpawnSpec, handoff: &SpawnHandoff) -> anyhow::Result<Pt
         ProcessOutputCompletion::with_pty_cancellation(1, Arc::clone(&output))?;
     let spawned = pair.spawn(command)?;
     let cmux_pty::SpawnedPty { master, child } = spawned;
-    let child_cleanup = SpawnedChildCleanup::new(child);
+    let mut child_cleanup = SpawnedChildCleanup::new(child);
     if handoff.is_cancelled() {
         return Err(anyhow::anyhow!("PTY spawn cancelled"));
     }
@@ -850,7 +850,6 @@ fn spawn_real_pty(spec: &SpawnSpec, handoff: &SpawnHandoff) -> anyhow::Result<Pt
         return Err(anyhow::anyhow!("PTY reader thread spawn failed"));
     }
     // Blocking wait thread -> exit.
-    let mut child_cleanup = child_cleanup;
     let exit_completion = Arc::clone(&completion);
     let wait_lifecycle = Arc::clone(&lifecycle);
     if std::thread::Builder::new()

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -1485,6 +1485,22 @@ mod tests {
     }
 
     #[derive(Debug)]
+    struct FailingTestChildKiller {
+        kills: TestArc<AtomicUsize>,
+    }
+
+    impl cmux_pty::ChildKiller for FailingTestChildKiller {
+        fn kill(&mut self) -> std::io::Result<()> {
+            self.kills.fetch_add(1, AtomicOrdering::Relaxed);
+            Err(std::io::Error::other("injected kill failure"))
+        }
+
+        fn clone_killer(&self) -> Box<dyn cmux_pty::ChildKiller + Send + Sync> {
+            Box::new(Self { kills: TestArc::clone(&self.kills) })
+        }
+    }
+
+    #[derive(Debug)]
     struct TestMaster;
 
     impl MasterPty for TestMaster {
@@ -1562,6 +1578,47 @@ mod tests {
         let state = lifecycle.lock().expect("lifecycle lock");
         assert!(state.reaping);
         assert!(state.termination_started);
+    }
+
+    #[test]
+    fn fallback_kill_error_keeps_reaping_fence_during_concurrent_master_drop() {
+        let kills = TestArc::new(AtomicUsize::new(0));
+        let lifecycle = ChildLifecycle::new(Some(42));
+        let (ready_tx, ready_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let wait_lifecycle = TestArc::clone(&lifecycle);
+        let wait_kills = TestArc::clone(&kills);
+        let wait_thread = thread::spawn(move || {
+            let claimed = ChildLifecycle::begin_reaping(&wait_lifecycle);
+            let kill_failed = {
+                let mut killer = FailingTestChildKiller { kills: wait_kills };
+                killer.kill().is_err()
+            };
+            ready_tx.send((claimed, kill_failed)).expect("fallback result");
+            release_rx.recv().expect("fallback wait release");
+            wait_lifecycle.lock().expect("lifecycle lock").exited = true;
+        });
+
+        let (claimed, kill_failed) = ready_rx.recv().expect("fallback result");
+        assert!(claimed, "fallback wait must claim the lifecycle");
+        assert!(kill_failed, "test child kill must exercise the error path");
+
+        let control = MasterControl {
+            master: Mutex::new(Box::new(TestMaster)),
+            writer: Mutex::new(Box::new(std::io::sink())),
+            killer: Mutex::new(Box::new(FailingTestChildKiller { kills: TestArc::clone(&kills) })),
+            lifecycle: TestArc::clone(&lifecycle),
+        };
+        let drop_thread = thread::spawn(move || drop(control));
+        drop_thread.join().expect("master control drop");
+
+        assert_eq!(kills.load(AtomicOrdering::Relaxed), 1);
+        release_tx.send(()).expect("release fallback wait");
+        wait_thread.join().expect("fallback wait thread");
+
+        let state = lifecycle.lock().expect("lifecycle lock");
+        assert!(state.exited);
+        assert!(state.reaping);
     }
 
     #[test]

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -877,11 +877,13 @@ fn spawn_real_pty(spec: &SpawnSpec, handoff: &SpawnHandoff) -> anyhow::Result<Pt
                 }
             };
             let wait_result = wait_result.or_else(|_| {
-                // Keep the old error path: a failed wait requests termination
-                // through the lifecycle gate, then retries the blocking reap.
-                let _ = ChildLifecycle::terminate(&wait_lifecycle, |_| {
-                    child_cleanup.child_mut().kill()
-                });
+                // A failed first wait still falls back to a blocking reap.
+                // Claim the reaping fence before asking the child to die so
+                // a kill error cannot reopen the lifecycle while `wait`
+                // releases the PID for reuse.
+                if ChildLifecycle::begin_reaping(&wait_lifecycle) {
+                    let _ = child_cleanup.child_mut().kill();
+                }
                 child_cleanup.wait()
             });
             let code = wait_result.map(|status| i64::from(status.exit_code() as i32)).unwrap_or(0);

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -21,7 +21,7 @@ use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use cmux_pty::{ChildKiller, MasterPty, PtySize};
+use cmux_pty::{MasterPty, PtySize};
 use sha2::{Digest, Sha256};
 use tokio_util::sync::CancellationToken;
 
@@ -790,6 +790,17 @@ fn wait_for_child_exit_without_reaping(pid: libc::pid_t) -> std::io::Result<()> 
     }
 }
 
+fn fallback_child_reap<T, E, K, W>(lifecycle: &ChildLifecycleHandle, kill: K, wait: W) -> Result<T, E>
+where
+    K: FnOnce() -> Result<(), E>,
+    W: FnOnce() -> Result<T, E>,
+{
+    if ChildLifecycle::begin_reaping(lifecycle) {
+        let _ = kill();
+    }
+    wait()
+}
+
 fn spawn_real_pty(spec: &SpawnSpec, handoff: &SpawnHandoff) -> anyhow::Result<PtyHandle> {
     if handoff.is_cancelled() {
         return Err(anyhow::anyhow!("PTY spawn cancelled"));
@@ -869,10 +880,7 @@ fn spawn_real_pty(spec: &SpawnSpec, handoff: &SpawnHandoff) -> anyhow::Result<Pt
                     // fallback wait can reap it. Claim termination before
                     // reaping so MasterControl::drop cannot signal this PID
                     // after the kernel makes it available for reuse.
-                    if ChildLifecycle::begin_reaping(&wait_lifecycle) {
-                        let _ = child_cleanup.child_mut().kill();
-                    }
-                    child_cleanup.wait()
+                    fallback_child_reap(&wait_lifecycle, || child_cleanup.child_mut().kill(), || child_cleanup.wait())
                 }
             };
             let wait_result = wait_result.or_else(|_| {
@@ -880,10 +888,7 @@ fn spawn_real_pty(spec: &SpawnSpec, handoff: &SpawnHandoff) -> anyhow::Result<Pt
                 // Claim the reaping fence before asking the child to die so
                 // a kill error cannot reopen the lifecycle while `wait`
                 // releases the PID for reuse.
-                if ChildLifecycle::begin_reaping(&wait_lifecycle) {
-                    let _ = child_cleanup.child_mut().kill();
-                }
-                child_cleanup.wait()
+                fallback_child_reap(&wait_lifecycle, || child_cleanup.child_mut().kill(), || child_cleanup.wait())
             });
             let code = wait_result.map(|status| i64::from(status.exit_code() as i32)).unwrap_or(0);
             wait_lifecycle.lock().expect("child lifecycle lock").exited = true;
@@ -1442,6 +1447,7 @@ pub fn valid_session(name: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use cmux_pty::ChildKiller as _;
     use super::*;
     use std::os::unix::net::UnixStream;
     use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
@@ -1590,19 +1596,24 @@ mod tests {
         let wait_lifecycle = TestArc::clone(&lifecycle);
         let wait_kills = TestArc::clone(&kills);
         let wait_thread = thread::spawn(move || {
-            let claimed = ChildLifecycle::begin_reaping(&wait_lifecycle);
-            let kill_failed = {
-                let mut killer = FailingTestChildKiller { kills: wait_kills };
-                killer.kill().is_err()
-            };
-            ready_tx.send((claimed, kill_failed)).expect("fallback result");
-            release_rx.recv().expect("fallback wait release");
-            wait_lifecycle.lock().expect("lifecycle lock").exited = true;
+            let result = fallback_child_reap(
+                &wait_lifecycle,
+                || {
+                    let mut killer = FailingTestChildKiller { kills: wait_kills };
+                    killer.kill()
+                },
+                || {
+                    ready_tx.send(()).expect("fallback result");
+                    release_rx.recv().expect("fallback wait release");
+                    wait_lifecycle.lock().expect("lifecycle lock").exited = true;
+                    Ok::<(), std::io::Error>(())
+                },
+            );
+            result.expect("fallback reap");
         });
 
-        let (claimed, kill_failed) = ready_rx.recv().expect("fallback result");
-        assert!(claimed, "fallback wait must claim the lifecycle");
-        assert!(kill_failed, "test child kill must exercise the error path");
+        ready_rx.recv().expect("fallback result");
+        assert!(lifecycle.lock().expect("lifecycle lock").reaping);
 
         let control = MasterControl {
             master: Mutex::new(Box::new(TestMaster)),

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -21,7 +21,7 @@ use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use cmux_pty::{MasterPty, PtySize};
+use cmux_pty::{ChildKiller, MasterPty, PtySize};
 use sha2::{Digest, Sha256};
 use tokio_util::sync::CancellationToken;
 

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -790,9 +790,9 @@ fn wait_for_child_exit_without_reaping(pid: libc::pid_t) -> std::io::Result<()> 
     }
 }
 
-fn fallback_child_reap<T, E, K, W>(lifecycle: &ChildLifecycleHandle, kill: K, wait: W) -> Result<T, E>
+fn fallback_child_reap<T, E, K, W, EK>(lifecycle: &ChildLifecycleHandle, kill: K, wait: W) -> Result<T, E>
 where
-    K: FnOnce() -> Result<(), E>,
+    K: FnOnce() -> Result<(), EK>,
     W: FnOnce() -> Result<T, E>,
 {
     if ChildLifecycle::begin_reaping(lifecycle) {


### PR DESCRIPTION
Rebased follow-up for #11215 onto current parent #11366. Claims the child reaping fence before fallback kill, preserves it on kill failure, and adds regression coverage for concurrent MasterControl drop and cancelled shell waiters. Hosted verification required; no local Rust build run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race where a PTY child wait failure could reopen the lifecycle during a concurrent `MasterControl` drop, risking a double reap or lost session. Fallback reaps now claim the reaping fence before killing the child and keep the fence when the kill fails.

**Changes**
- Extracts the fenced fallback into a `fallback_child_reap` helper that accepts distinct kill and wait error types.
- Adds regression tests for the concurrent drop race and for a cancelled shell waiter leaving the starting session untouched.

<sup>Written for commit b955ab9865b7a7cb4b7a2a11ec80e72991351477. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

