### PR TITLE
fix(cmux-tui): install codex SessionEnd hook at the 3s cap

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/agent_hook_install.rs
+++ b/cmux-tui/crates/cmux-tui/src/agent_hook_install.rs
@@ -44,6 +44,10 @@ const ACTIVATION_NOTE: &str = "Providers load hooks at process start; launch or 
 const MAX_CONFIG_BYTES: u64 = 16 * 1024 * 1024;
 const MAX_HELPER_BYTES: u64 = 128 * 1024 * 1024;
 const COMMAND_HOOK_TIMEOUT_SECONDS: u64 = 5;
+/// codex caps SessionEnd hook timeouts at 3s and warns on every session exit
+/// when hooks.json asks for more (`clamping SessionEnd hook timeout to 3s`),
+/// so the installer writes the cap instead of the generic 5s.
+const CODEX_SESSION_END_TIMEOUT_SECONDS: u64 = 3;
 const GEMINI_HOOK_TIMEOUT_MILLISECONDS: u64 = 5_000;
 const HERMES_COMMAND_TIMEOUT: Duration = Duration::from_secs(5);
 const HERMES_COMMAND_OUTPUT_BYTES: u64 = 4 * 1024 * 1024;
@@ -1230,6 +1234,7 @@ fn rewrite_json_hooks(
     }
     for event in provider.events {
         let command = hook_command(provider.id, event);
+        let timeout = installed_hook_timeout(provider, event, timeout);
         let entry = if nested {
             let command = if matches!(provider.format, Format::Nested { asynchronous: true, .. }) {
                 json!({"type":"command","command":command,"timeout":timeout,"async":true})
@@ -1410,6 +1415,20 @@ fn visit_strings(value: &Value, predicate: &mut impl FnMut(&str) -> bool) -> boo
         Value::Array(values) => values.iter().any(|value| visit_strings(value, predicate)),
         Value::Object(values) => values.values().any(|value| visit_strings(value, predicate)),
         _ => false,
+    }
+}
+
+/// Per-event override of the provider-wide timeout. Only codex SessionEnd
+/// differs: codex clamps it to 3s, so writing more only produces a warning.
+fn installed_hook_timeout(provider: Provider, event: &str, timeout: u64) -> u64 {
+    if provider.id == "codex" { codex_hook_timeout(event) } else { timeout }
+}
+
+fn codex_hook_timeout(event: &str) -> u64 {
+    if event == "SessionEnd" {
+        CODEX_SESSION_END_TIMEOUT_SECONDS
+    } else {
+        COMMAND_HOOK_TIMEOUT_SECONDS
     }
 }
 
@@ -1609,7 +1628,7 @@ fn codex_owned_trust_hashes() -> anyhow::Result<BTreeSet<String>> {
         .iter()
         .map(|event| {
             let label = codex_event_state_label(event)?;
-            Ok(codex_trust_hash(label, &hook_command("codex", event), COMMAND_HOOK_TIMEOUT_SECONDS))
+            Ok(codex_trust_hash(label, &hook_command("codex", event), codex_hook_timeout(event)))
         })
         .collect()
 }
@@ -2232,7 +2251,8 @@ mod tests {
             "subagent_stop",
             "sha256:37436a4778c90ed5ab0e207b2922d3e1151dedfa26c33489c9faef7c990e8866",
         ),
-        // SessionEnd hashes the clamped 3s timeout, not the configured 5s.
+        // SessionEnd is installed at codex's 3s cap; the hash is identical to
+        // the one codex computed for a clamped 5s, so older installs stay trusted.
         ("session_end", "sha256:8366ef19df8ee745ecc7acbd8f72f7109478a583dfd5d06b61537b8e8d19e088"),
     ];
 
@@ -2288,7 +2308,18 @@ mod tests {
                 codex_normalized_timeout(label, Some(timeout)),
                 "{event}: codex must not clamp or floor the installed timeout"
             );
+            if *event == "SessionEnd" {
+                assert_eq!(timeout, CODEX_SESSION_END_TIMEOUT_SECONDS);
+            } else {
+                assert_eq!(timeout, COMMAND_HOOK_TIMEOUT_SECONDS, "{event}");
+            }
         }
+        // A pre-existing install written with the generic 5s stays owned: codex
+        // hashed the clamped value, which is what the installer now writes.
+        assert_eq!(
+            codex_trust_hash("session_end", &hook_command("codex", "SessionEnd"), 5),
+            codex_trust_hash("session_end", &hook_command("codex", "SessionEnd"), 3),
+        );
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/agent_hook_install.rs
+++ b/cmux-tui/crates/cmux-tui/src/agent_hook_install.rs
@@ -2271,6 +2271,27 @@ mod tests {
     }
 
     #[test]
+    fn codex_session_end_hook_timeout_stays_within_the_codex_cap() {
+        let root = tempfile::tempdir().unwrap();
+        let context = context(root.path());
+        let plan = Plan { action: Action::Install, providers: vec!["codex".into()] };
+        let result = run_with_context(&plan, &context);
+        assert!(!result.failed, "{}", result.value);
+        let hooks: Value =
+            serde_json::from_slice(&fs::read(context.home.join(".codex/hooks.json")).unwrap())
+                .unwrap();
+        for event in CODEX_EVENTS {
+            let timeout = hooks["hooks"][*event][0]["hooks"][0]["timeout"].as_u64().unwrap();
+            let label = codex_event_state_label(event).unwrap();
+            assert_eq!(
+                timeout,
+                codex_normalized_timeout(label, Some(timeout)),
+                "{event}: codex must not clamp or floor the installed timeout"
+            );
+        }
+    }
+
+    #[test]
     fn codex_trust_keys_use_the_installed_group_position() {
         let root = tempfile::tempdir().unwrap();
         let context = context(root.path());

--- a/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
+++ b/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
@@ -14,6 +14,9 @@ const MAX_NATIVE_PAYLOAD_BYTES: u64 = 1024 * 1024;
 const MAX_MESSAGE_BYTES: usize = 4 * 1024 * 1024;
 const MAX_RESPONSE_BYTES: usize = 16 * 1024 * 1024;
 const SOCKET_TIMEOUT: Duration = Duration::from_secs(4);
+/// codex kills SessionEnd hooks at 3s (its hard cap), so the helper must give
+/// up first and report its own error instead of dying mid-append.
+const CODEX_SESSION_END_SOCKET_TIMEOUT: Duration = Duration::from_secs(2);
 
 #[derive(Debug, PartialEq, Eq)]
 struct Args {
@@ -57,7 +60,7 @@ fn run(args: Args) -> anyhow::Result<()> {
         native,
     )?;
     let event = serde_json::to_value(ingress)?;
-    append(&socket, event)
+    append(&socket, event, socket_timeout(&args.source, &args.native_event))
 }
 
 fn shadowed_by_grok(source: &str, grok_hook_event: Option<&std::ffi::OsStr>) -> bool {
@@ -98,7 +101,15 @@ fn read_native_payload(reader: impl Read) -> anyhow::Result<Value> {
     Ok(json!({"encoding":"base64","data":BASE64.encode(bytes)}))
 }
 
-fn append(socket: &Path, event: Value) -> anyhow::Result<()> {
+fn socket_timeout(source: &str, native_event: &str) -> Duration {
+    if source == "codex" && native_event == "SessionEnd" {
+        CODEX_SESSION_END_SOCKET_TIMEOUT
+    } else {
+        SOCKET_TIMEOUT
+    }
+}
+
+fn append(socket: &Path, event: Value, timeout: Duration) -> anyhow::Result<()> {
     let (request_id, idempotency_key) = random_identifiers()?;
     let request = json!({
         "protocol":"cmux.protocol/2",
@@ -114,7 +125,7 @@ fn append(socket: &Path, event: Value) -> anyhow::Result<()> {
         bail!("agent hook request exceeds the 4 MiB protocol limit");
     }
 
-    retry_until(SOCKET_TIMEOUT, |deadline| append_once(socket, &encoded, &request_id, deadline))
+    retry_until(timeout, |deadline| append_once(socket, &encoded, &request_id, deadline))
 }
 
 #[derive(Debug)]
@@ -339,6 +350,13 @@ fn random_identifiers() -> anyhow::Result<(String, String)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn codex_session_end_gives_up_before_the_codex_hook_cap() {
+        assert!(socket_timeout("codex", "SessionEnd") < Duration::from_secs(3));
+        assert_eq!(socket_timeout("codex", "Stop"), SOCKET_TIMEOUT);
+        assert_eq!(socket_timeout("claude", "SessionEnd"), SOCKET_TIMEOUT);
+    }
 
     #[test]
     fn parses_short_positional_source_and_event() {


### PR DESCRIPTION
Every codex exit printed `clamping SessionEnd hook timeout to 3s in ~/.codex/hooks.json` because `cmux-tui agent-hooks install` wrote the generic 5s timeout for every codex event, and codex caps SessionEnd at 3s. The installer now writes 3s for that one event. The codex trust hash does not change: codex hashes the normalized (clamped) timeout, which is what the installer already covered in #11258, so existing installs stay trusted and need no re-run.

The `cmux-tui-hook` helper also budgeted 4s for the journal append, longer than codex allows for SessionEnd, so a slow socket got the helper SIGKILLed mid-append instead of failing on its own. It now gives up at 2s for codex SessionEnd only.

Codex has no async hook flag (Claude's `async: true` is already used), so the hook stays synchronous. The append is a local socket write that normally takes milliseconds; the timeout only bounds a wedged socket.

Commit 1 adds the failing test, commit 2 the fix.

https://claude.ai/code/session_01NvVHvU3Zijvi6berGDg6Ed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11373"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790840518&installation_model_id=21920&pr_number=11373&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11373&signature=356e9c302bce8142194623a7f0d68b61804b305a2f1f2cf25b1f3575ac916061"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes codex `SessionEnd` hook handling so codex stops printing a clamping warning on every session exit, and the hook helper fails cleanly on a wedged socket instead of being killed mid-append.

- The installer writes codex's 3s `SessionEnd` cap instead of the generic 5s timeout.
- The helper now gives up after 2s on codex `SessionEnd` appends instead of waiting 4s; all other events keep the 4s budget.
- Existing installs stay trusted and need no re-run because codex hashes the clamped timeout, which is unchanged.

<sup>Written for commit daefc031e1b48bb54182b595ad5aeec37707bd4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex session-end hook reliability by applying timeouts that respect Codex’s execution limits.
  * Reduced socket wait times for Codex session-end events to help hooks complete before Codex terminates them.
  * Preserved existing timeout behavior for other hook sources and events.
  * Maintained trust for previously installed session-end hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->