### PR TITLE
fix(tui): prevent reducer snapshot cursor regression

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
@@ -2034,7 +2034,8 @@ mod tests {
             .put_journal_reducer_state("agent_roster", 3, 9, r#"{"entries":{"old":{}}}"#)
             .unwrap();
 
-        let (_, cursor, snapshot) = registry.journal_reducer_state("agent_roster").unwrap().unwrap();
+        let (_, cursor, snapshot) =
+            registry.journal_reducer_state("agent_roster").unwrap().unwrap();
         assert_eq!(cursor, 10);
         assert!(snapshot.contains("new"));
     }

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
@@ -2023,6 +2023,21 @@ mod tests {
     }
 
     #[test]
+    fn reducer_state_cursor_does_not_regress_on_late_write() {
+        let registry = WorkspaceRegistry::in_memory("reducer-cursor-monotonic").unwrap();
+        registry
+            .put_journal_reducer_state("agent_roster", 3, 10, r#"{"entries":{"new":{}}}"#)
+            .unwrap();
+        registry
+            .put_journal_reducer_state("agent_roster", 3, 9, r#"{"entries":{"old":{}}}"#)
+            .unwrap();
+
+        let (_, cursor, snapshot) = registry.journal_reducer_state("agent_roster").unwrap().unwrap();
+        assert_eq!(cursor, 10);
+        assert!(snapshot.contains("new"));
+    }
+
+    #[test]
     fn persistent_reader_observes_commits_on_an_independent_connection() {
         let root = std::env::temp_dir().join(format!("cmux-journal-reader-{}", new_uuid_v4()));
         let mut registry = WorkspaceRegistry::open(&root, "reader").unwrap();

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
@@ -931,7 +931,9 @@ impl WorkspaceRegistry {
         });
         self.connection.execute(
             "INSERT INTO meta(key, value) VALUES(?1, ?2)
-             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value
+             WHERE COALESCE(CAST(json_extract(meta.value, '$.cursor') AS INTEGER), 0)
+                   <= CAST(json_extract(excluded.value, '$.cursor') AS INTEGER)",
             params![format!("journal_reducer.{reducer_id}"), value.to_string()],
         )?;
         Ok(())


### PR DESCRIPTION
Stacked on https://github.com/manaflow-ai/cmux/pull/11364.

Adds a regression test and a SQLite monotonic cursor guard so late reducer writes cannot overwrite newer snapshots. Hosted focused tests are required; no local cargo tests were run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11374"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790840557&installation_model_id=21920&pr_number=11374&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11374&signature=7b3b6d366676f9124fb320a27bd638dcf778c31c281196ff73236a2b5af14174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes reducer snapshot persistence in the TUI journal so a late write with an older cursor can no longer overwrite a newer snapshot.

- Adds a SQLite `ON CONFLICT` guard that only updates when the incoming cursor is equal to or newer than the stored cursor.
- Adds a regression test covering the late-write scenario.

<sup>Written for commit 251a795d7cbf7ce07b685f2e5024662d26828ed7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

