### PR TITLE
cloud-vm smoke: --paid marks the smoke user as a pro plan

### DIFF
--- a/web/scripts/cloud-vm/smoke-vm-api.mjs
+++ b/web/scripts/cloud-vm/smoke-vm-api.mjs
@@ -13,12 +13,16 @@ import {
   requireEnvKeys,
 } from "./projects.mjs";
 
-const usage = "Usage: smoke-vm-api.mjs [web-dir] <staging|production> [--create] [--provider e2b|freestyle|daytona|blaxel|default] [--image <manifest image id or version>] [--url https://preview.example] [--vercel-curl] [--skip-attach]";
+const usage = "Usage: smoke-vm-api.mjs [web-dir] <staging|production> [--create] [--provider e2b|freestyle|daytona|blaxel|default] [--image <manifest image id or version>] [--url https://preview.example] [--vercel-curl] [--skip-attach] [--paid]";
 const args = process.argv.slice(2);
 const { webDir, target, project, rest } = parseWebDirAndTarget(args, usage);
 const shouldCreate = rest.includes("--create");
 const useVercelCurl = rest.includes("--vercel-curl");
 const skipAttach = rest.includes("--skip-attach");
+// --paid marks the throwaway smoke user as a paid plan via the billing
+// metadata key the entitlements layer reads (cmuxVmPlan). Required to
+// exercise provisioning now that free plans are gated (vm_requires_pro).
+const paid = rest.includes("--paid");
 const provider = optionValue(rest, "--provider") ?? "e2b";
 const image = optionValue(rest, "--image");
 const targetUrl = optionValue(rest, "--url") ?? project.url;
@@ -132,6 +136,9 @@ try {
     displayName: `cmux ${project.stackLabel} smoke`,
   });
 
+  if (paid) {
+    await user.update({ clientReadOnlyMetadata: { cmuxVmPlan: "pro" } });
+  }
   const session = await user.createSession({ expiresInMillis: 20 * 60 * 1000, isImpersonation: true });
   const tokens = await session.getTokens();
   if (!tokens.accessToken || !tokens.refreshToken) throw new Error("Stack did not return smoke session tokens");


### PR DESCRIPTION
The Pro gate (https://github.com/manaflow-ai/cmux/pull/11332) returns 402 `vm_requires_pro` for free plans, which killed the sanctioned production create smoke (`scripts/cloud-vm/smoke-vm-api.mjs --create`). `--paid` sets the billing metadata key the entitlements layer reads (`clientReadOnlyMetadata.cmuxVmPlan = "pro"`) on the throwaway smoke user, restoring the verification path without touching the global `CMUX_VM_ALLOW_FREE_PROVISIONING` escape hatch.

Verified against production this morning while investigating the 07:10-07:29 UTC failure burst (Blaxel us-was-1 platform incident): `--paid` create 200 on blaxel (34.8s during their degradation), attach over cmux-remote, destroy clean; without `--paid` the same flow correctly 402s. Operator script only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790840807&installation_model_id=21920&pr_number=11375&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11375&signature=5ed4cde4fd171fa413d0987e5c6133219d15f032ed76d82831b7c4343de2496a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `--paid` flag to `web/scripts/cloud-vm/smoke-vm-api.mjs` that sets the `cmuxVmPlan = "pro"` billing metadata key on the throwaway smoke user, restoring the create smoke path that broke when free plans started returning 402 `vm_requires_pro`.

- Without `--paid`, the create flow still 402s as expected.
- The flag is scoped to the script; it doesn't touch the global `CMUX_VM_ALLOW_FREE_PROVISIONING` escape hatch.

<sup>Written for commit d5066c31de47c6eb1ee505e3fb0c3011f42eb863. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--paid` option to the VM API smoke test, allowing tests to run with a simulated Pro plan.
  * Updated the command usage documentation to include the new option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->