### PR TITLE
fix(tui): reopen retired terminals on newer session starts

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/journal_reducers.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_reducers.rs
@@ -228,11 +228,19 @@ impl AgentRoster {
         let socket_echo = event.adapter_id() == Some(SOCKET_REPORT_ADAPTER);
         let detected_echo = event.adapter_id() == Some(DETECTED_REPORT_ADAPTER);
         let external_echo = socket_echo || detected_echo;
-        if self.retired_terminals.contains_key(terminal_id) {
-            // The resource registry permanently tombstones a terminal public
-            // id. No delayed journal row can create a new lifecycle for that
-            // id, including a later session-start event.
-            return Vec::new();
+        if let Some(retired_at) = self.retired_terminals.get(terminal_id).copied() {
+            // A terminal retirement fences records through the committed
+            // cursor that caused it. A strictly newer hook session start is a
+            // new lifecycle, so clear only that terminal's fence and let the
+            // normal session-generation checks below run. All older rows,
+            // non-start rows, and external echoes remain suppressed.
+            if external_echo
+                || event.kind != "agent.session.started"
+                || event.sequence <= retired_at
+            {
+                return Vec::new();
+            }
+            self.retired_terminals.remove(terminal_id);
         }
         let (state, source, session, agent, updated_at_ms) = if external_echo {
             // Socket echo: explicit state and timestamp carried in the
@@ -907,7 +915,7 @@ mod tests {
     }
 
     #[test]
-    fn retired_terminal_rejects_late_events_even_with_a_new_session_start() {
+    fn retired_terminal_rejects_late_events_but_allows_a_newer_session_start() {
         let subjects = terminal_subject("term_a");
         let payload = json!({});
         let mut roster = AgentRoster::default();
@@ -920,22 +928,23 @@ mod tests {
         assert!(roster.apply(&hook_event(2, "agent.turn.started", &subjects, &payload)).is_empty());
         assert!(!roster.entries.contains_key("term_a"));
 
-        // A terminal resource id is tombstoned permanently. A later hook
-        // session start must not recreate roster state for that id, even when
-        // it claims a different provider session.
+        // A session start at or before the retirement cursor is still stale.
         assert!(
             roster.apply(&hook_event(1, "agent.session.started", &subjects, &payload)).is_empty()
         );
         let new_session_payload = json!({
+            "adapter": {"id": "claude", "version": 1},
             "normalized": {"agent_session_id": "new-session"}
         });
-        assert!(
-            roster
-                .apply(&hook_event(2, "agent.session.started", &subjects, &new_session_payload))
-                .is_empty()
-        );
-        assert!(!roster.entries.contains_key("term_a"));
-        assert!(roster.is_retired("term_a"));
+        let deltas =
+            roster.apply(&hook_event(2, "agent.session.started", &subjects, &new_session_payload));
+        assert_eq!(deltas.len(), 1);
+        assert_eq!(roster.entries["term_a"].session.as_deref(), Some("new-session"));
+        assert!(!roster.is_retired("term_a"));
+
+        // Session-less rows from the old lifecycle cannot cross into the
+        // reopened native session.
+        assert!(roster.apply(&hook_event(3, "agent.turn.started", &subjects, &payload)).is_empty());
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/journal_reducers.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_reducers.rs
@@ -939,6 +939,42 @@ mod tests {
     }
 
     #[test]
+    fn retired_terminal_reopens_for_a_newer_session_start_but_suppresses_old_session_events() {
+        let subjects = terminal_subject("term_a");
+        let old_payload = json!({
+            "adapter": {"id": "claude", "version": 1},
+            "normalized": {"agent_session_id": "old-session"}
+        });
+        let new_payload = json!({
+            "adapter": {"id": "claude", "version": 1},
+            "normalized": {"agent_session_id": "new-session"}
+        });
+        let mut roster = AgentRoster::default();
+
+        roster.apply(&hook_event(1, "agent.session.started", &subjects, &old_payload));
+        assert!(roster.retire_terminal("term_a", 2));
+
+        // A delayed row from the retired lifecycle remains fenced.
+        assert!(
+            roster.apply(&hook_event(2, "agent.turn.started", &subjects, &old_payload)).is_empty()
+        );
+
+        // A strictly newer session start is a new lifecycle on the same
+        // terminal, so it must clear the retirement fence and reappear.
+        let deltas = roster.apply(&hook_event(3, "agent.session.started", &subjects, &new_payload));
+        assert_eq!(deltas.len(), 1);
+        assert!(!roster.is_retired("term_a"));
+        assert_eq!(roster.entries["term_a"].session.as_deref(), Some("new-session"));
+
+        // Events from the old provider session cannot cross into the reopened
+        // lifecycle even after the terminal is live again.
+        assert!(
+            roster.apply(&hook_event(4, "agent.turn.started", &subjects, &old_payload)).is_empty()
+        );
+        assert_eq!(roster.entries["term_a"].state, "idle");
+    }
+
+    #[test]
     fn retirement_cursor_only_moves_forward() {
         let subjects = terminal_subject("term_a");
         let payload = json!({});

--- a/cmux-tui/crates/cmux-tui-core/src/journal_reducers.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_reducers.rs
@@ -228,7 +228,8 @@ impl AgentRoster {
         let socket_echo = event.adapter_id() == Some(SOCKET_REPORT_ADAPTER);
         let detected_echo = event.adapter_id() == Some(DETECTED_REPORT_ADAPTER);
         let external_echo = socket_echo || detected_echo;
-        if let Some(retired_at) = self.retired_terminals.get(terminal_id).copied() {
+        let retired_at = self.retired_terminals.get(terminal_id).copied();
+        if let Some(retired_at) = retired_at {
             // A terminal retirement fences records through the committed
             // cursor that caused it. A strictly newer hook session start is a
             // new lifecycle, so clear only that terminal's fence and let the
@@ -240,7 +241,6 @@ impl AgentRoster {
             {
                 return Vec::new();
             }
-            self.retired_terminals.remove(terminal_id);
         }
         let (state, source, session, agent, updated_at_ms) = if external_echo {
             // Socket echo: explicit state and timestamp carried in the
@@ -326,6 +326,12 @@ impl AgentRoster {
                 } else if !is_session_start || !fence.ended || event.sequence <= fence.sequence {
                     return Vec::new();
                 }
+            }
+            // Clear the retirement fence only after the event passes all
+            // session-generation checks. An invalid newer start must leave
+            // the tombstone intact for later replay.
+            if retired_at.is_some() {
+                self.retired_terminals.remove(terminal_id);
             }
             self.hook_fences.insert(
                 terminal_id.to_string(),

--- a/cmux-tui/crates/cmux-tui-core/src/journal_reducers.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_reducers.rs
@@ -984,6 +984,38 @@ mod tests {
     }
 
     #[test]
+    fn invalid_newer_session_start_does_not_clear_retirement_tombstone() {
+        let subjects = terminal_subject("term_a");
+        let active_payload = json!({
+            "adapter": {"id": "claude", "version": 1},
+            "normalized": {"agent_session_id": "active-session"}
+        });
+        let new_payload = json!({
+            "adapter": {"id": "claude", "version": 1},
+            "normalized": {"agent_session_id": "new-session"}
+        });
+        let mut roster = AgentRoster::default();
+        roster.apply(&hook_event(1, "agent.session.started", &subjects, &active_payload));
+
+        // A stale snapshot can contain both fences while it is being
+        // reconciled. The live hook generation makes this newer start
+        // invalid because it attempts to replace an active session.
+        roster.retired_terminals.insert("term_a".into(), 2);
+        roster.hook_fences.insert(
+            "term_a".into(),
+            RosterFence { session_id: "active-session".into(), sequence: 3, ended: false },
+        );
+
+        assert!(
+            roster
+                .apply(&hook_event(4, "agent.session.started", &subjects, &new_payload))
+                .is_empty()
+        );
+        assert!(roster.is_retired("term_a"));
+        assert_eq!(roster.entries["term_a"].session.as_deref(), Some("active-session"));
+    }
+
+    #[test]
     fn retirement_cursor_only_moves_forward() {
         let subjects = terminal_subject("term_a");
         let payload = json!({});


### PR DESCRIPTION
## Summary
- Add a behavior regression for reopening a retired terminal on a strictly newer `agent.session.started` event.
- Clear only the matching retirement tombstone for newer hook session starts.
- Continue suppressing stale, non-start, external, and old-session events.

## Regression commits
1. `fefd21995e` adds the failing behavior test.
2. `f613164c0c` implements the sequence-aware tombstone clearing and updates the lifecycle expectation.

## Verification
- `rustfmt --edition 2024 cmux-tui/crates/cmux-tui-core/src/journal_reducers.rs`
- `git diff --check`
- Cargo and Rust tests were not run locally per repository policy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790840845&installation_model_id=21920&pr_number=11376&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11376&signature=8f6699ec1e09411bf8672eeecbb1660e5b7ed34eb7456980379c37e7f5ec3212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reopens retired terminals when a strictly newer `agent.session.started` event arrives, instead of permanently suppressing all later events for that terminal. The retirement fence is cleared only after a newer hook session start passes all session-generation checks; stale, non-start, external, and old-session events are still ignored, and an invalid newer start leaves the tombstone intact.

<sup>Written for commit c064f2d5182c10dbb777e7d9a0659d570d8a182c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

