### PR TITLE
fix(cmux-tui): fence repeated ABA echo keys

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -6526,6 +6526,13 @@ impl Mux {
         source: AgentSource,
         session: Option<&str>,
     ) -> anyhow::Result<Option<String>> {
+        // Resource revisions are durable and strictly monotonic. Include the
+        // current revision in the transition key so an ABA sequence cannot
+        // reuse the key from an earlier cycle after the compatibility cache
+        // returns to the same state. Repeated polls of one semantic state
+        // still return early through `unchanged`, so steady-state reports do
+        // not append another echo.
+        let resource_revision = self.state.lock().unwrap().resource_revision;
         // The durable projection is updated before its echo is folded. Read
         // it first so a blocked roster replay still has a stable semantic
         // receipt for repeated reports.
@@ -6619,7 +6626,7 @@ impl Mux {
         // journal cursor would make an unrelated event defeat coalescing and
         // turn a steady socket poll into one durable row per event elsewhere.
         let material = format!(
-            "agent-report-echo-v4|{terminal_id}|{}|{}|{:?}|{previous}",
+            "agent-report-echo-v5|{terminal_id}|{}|{}|{:?}|revision={resource_revision}|{previous}",
             state.as_str(),
             source.as_str(),
             session,

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -24724,9 +24724,8 @@ mod tests {
             "cmux-roster-aba-repeat-echo-{}",
             crate::workspace_registry::new_uuid_v4()
         ));
-        let mux =
-            Mux::open_persistent("roster-aba-repeat-echo", SurfaceOptions::default(), &root)
-                .unwrap();
+        let mux = Mux::open_persistent("roster-aba-repeat-echo", SurfaceOptions::default(), &root)
+            .unwrap();
         let surface = mux.new_workspace(None, None).unwrap();
         let terminal_id = surface.terminal_public_id().cloned().expect("workspace terminal");
         let states = [
@@ -24748,30 +24747,29 @@ mod tests {
             .unwrap();
         }
 
-        let keys = mux
-            .workspace_registry
-            .lock()
-            .unwrap()
-            .session_journal_after(0, 1024)
-            .unwrap()
-            .records
-            .into_iter()
-            .filter(|record| {
-                record
-                    .subjects
-                    .iter()
-                    .any(|subject| subject.kind == "terminal" && subject.id == terminal_id.as_str())
-            })
-            .filter_map(|record| {
-                (record
-                    .payload
-                    .get("adapter")
-                    .and_then(|adapter| adapter.get("id"))
-                    .and_then(Value::as_str)
-                    == Some(crate::journal_reducers::SOCKET_REPORT_ADAPTER))
-                .then_some(record.event_id)
-            })
-            .collect::<std::collections::HashSet<_>>();
+        let keys =
+            mux.workspace_registry
+                .lock()
+                .unwrap()
+                .session_journal_after(0, 1024)
+                .unwrap()
+                .records
+                .into_iter()
+                .filter(|record| {
+                    record.subjects.iter().any(|subject| {
+                        subject.kind == "terminal" && subject.id == terminal_id.as_str()
+                    })
+                })
+                .filter_map(|record| {
+                    (record
+                        .payload
+                        .get("adapter")
+                        .and_then(|adapter| adapter.get("id"))
+                        .and_then(Value::as_str)
+                        == Some(crate::journal_reducers::SOCKET_REPORT_ADAPTER))
+                    .then_some(record.event_id)
+                })
+                .collect::<std::collections::HashSet<_>>();
         assert_eq!(keys.len(), states.len(), "each ABA transition needs a unique echo");
 
         mux.shutdown();

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -24712,6 +24712,67 @@ mod tests {
     }
 
     #[test]
+    fn socket_echoes_do_not_reuse_keys_after_repeated_aba_cycles() {
+        let root = std::env::temp_dir().join(format!(
+            "cmux-roster-aba-repeat-echo-{}",
+            crate::workspace_registry::new_uuid_v4()
+        ));
+        let mux =
+            Mux::open_persistent("roster-aba-repeat-echo", SurfaceOptions::default(), &root)
+                .unwrap();
+        let surface = mux.new_workspace(None, None).unwrap();
+        let terminal_id = surface.terminal_public_id().cloned().expect("workspace terminal");
+        let states = [
+            AgentState::Working,
+            AgentState::Blocked,
+            AgentState::Working,
+            AgentState::Blocked,
+            AgentState::Working,
+            AgentState::Blocked,
+        ];
+
+        for state in states {
+            mux.report_agent(
+                surface.id,
+                state,
+                AgentSource::Socket,
+                Some("aba-repeat-session".into()),
+            )
+            .unwrap();
+        }
+
+        let keys = mux
+            .workspace_registry
+            .lock()
+            .unwrap()
+            .session_journal_after(0, 1024)
+            .unwrap()
+            .records
+            .into_iter()
+            .filter(|record| {
+                record
+                    .subjects
+                    .iter()
+                    .any(|subject| subject.kind == "terminal" && subject.id == terminal_id.as_str())
+            })
+            .filter_map(|record| {
+                (record
+                    .payload
+                    .get("adapter")
+                    .and_then(|adapter| adapter.get("id"))
+                    .and_then(Value::as_str)
+                    == Some(crate::journal_reducers::SOCKET_REPORT_ADAPTER))
+                .then_some(record.event_id)
+            })
+            .collect::<std::collections::HashSet<_>>();
+        assert_eq!(keys.len(), states.len(), "each ABA transition needs a unique echo");
+
+        mux.shutdown();
+        drop(mux);
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
     fn repeated_socket_done_reports_coalesce_after_roster_removal() {
         let root = std::env::temp_dir()
             .join(format!("cmux-roster-done-echo-{}", crate::workspace_registry::new_uuid_v4()));


### PR DESCRIPTION
Stacked follow-up for PR #11002.

The durable echo key previously hashed only the current semantic state and its predecessor. A repeated Working → Blocked → Working → Blocked cycle reused the earlier Blocked key and could replay or reject the later transition.

This adds a durable monotonic resource revision to the transition key. Immediate identical reports still coalesce before key generation.

Commits:
- 881a3ac8ae adds the failing repeated-ABA behavior test.
- e378a1387c adds the fix.

Validation: `git diff --check`; hosted cmux-tui verification is required because local Cargo/rustc is prohibited.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790840910&installation_model_id=21920&pr_number=11377&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11377&signature=66970f7634884b40e7a2d9f6cf279f8918b87e4c5fd23f560dd8af5d91d5d42b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes repeated ABA echo key reuse in `cmux-tui` by including a durable monotonic resource revision in the transition key, so repeated Working → Blocked → Working cycles no longer reuse an earlier key and can replay or reject the later transition.

<sup>Written for commit 3a62c0e41065676216c92b76b0a617c765763e91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

