### PR TITLE
fix(chatmux-relay): rebase bounded tunnel writer on current main

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2642,6 +2642,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn shared_session_output_uses_each_viewers_own_transport_sink() {
+        let h = harness(None, None);
+        let sent_one = Arc::new(StdMutex::new(Vec::new()));
+        let sent_two = Arc::new(StdMutex::new(Vec::new()));
+        let owner = h.owner.clone();
+        let context = |sent: Arc<StdMutex<Vec<Value>>>| FrameContext {
+            send: Arc::new(move |frame| sent.lock().unwrap().push(frame)),
+            buffered_amount: Arc::new(|| 0),
+            trust: "supervised".to_owned(),
+            local_roots: None,
+            owner_user_id: owner.clone(),
+            transport_id: None,
+        };
+        let open = |pty_id: &str| {
+            serde_json::json!({
+                "version": 4, "type": "pty_open", "ptyId": pty_id, "session": "shared",
+                "cols": 80, "rows": 24, "actorId": "user_owner", "trust": "supervised",
+                "allowedRoots": Value::Null,
+            })
+        };
+        h.manager.handle_frame(&open("viewer-one"), &context(Arc::clone(&sent_one))).await;
+        h.manager.handle_frame(&open("viewer-two"), &context(Arc::clone(&sent_two))).await;
+        h.spawned()[0].emit("shared output");
+
+        let one = sent_one.lock().unwrap();
+        let two = sent_two.lock().unwrap();
+        assert!(
+            one.iter().any(|frame| frame["type"] == "pty_output" && frame["ptyId"] == "viewer-one")
+        );
+        assert!(!one.iter().any(|frame| frame["ptyId"] == "viewer-two"));
+        assert!(
+            two.iter().any(|frame| frame["type"] == "pty_output" && frame["ptyId"] == "viewer-two")
+        );
+        assert!(!two.iter().any(|frame| frame["ptyId"] == "viewer-one"));
+    }
+
+    #[tokio::test]
     async fn detaching_one_viewer_leaves_the_other_live_exit_reaches_every_viewer() {
         let h = harness(None, None);
         h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -337,6 +337,10 @@ struct Attachment {
     actor_id: String,
     /// Transport that opened this attachment (see FrameContext::transport_id).
     transport_id: Option<String>,
+    /// Authentication and transport sink captured when this viewer opens.
+    /// Shared-session output must use this snapshot, never the latest frame's
+    /// connection-wide context.
+    auth: AuthSnapshot,
 }
 
 struct Inner {
@@ -352,7 +356,6 @@ struct Inner {
     cancelled_openings: Mutex<std::collections::HashSet<String>>,
     shell_sessions: Mutex<HashMap<String, Arc<ShellSession>>>,
     shell_starting: Mutex<HashMap<String, Arc<Notify>>>,
-    auth: Mutex<Option<AuthSnapshot>>,
 }
 
 struct ShellStartReservation {
@@ -403,7 +406,6 @@ impl PtyManager {
                 cancelled_openings: Mutex::new(std::collections::HashSet::new()),
                 shell_sessions: Mutex::new(HashMap::new()),
                 shell_starting: Mutex::new(HashMap::new()),
-                auth: Mutex::new(None),
             }),
         }
     }
@@ -429,19 +431,12 @@ impl PtyManager {
                 cancelled_openings: Mutex::new(std::collections::HashSet::new()),
                 shell_sessions: Mutex::new(HashMap::new()),
                 shell_starting: Mutex::new(HashMap::new()),
-                auth: Mutex::new(None),
             }),
         }
     }
 
     /// Handle one Worker -> relay PTY frame.
     pub async fn handle_frame(&self, frame: &Value, context: &FrameContext) {
-        *self.inner.auth.lock().expect("auth lock") = Some(AuthSnapshot {
-            trust: context.trust.clone(),
-            owner_user_id: context.owner_user_id.clone(),
-            send: Arc::clone(&context.send),
-            buffered_amount: Arc::clone(&context.buffered_amount),
-        });
         let frame_type = frame.get("type").and_then(Value::as_str).unwrap_or_default();
         match frame_type {
             "pty_open" => self.inner.clone().open(frame, context).await,
@@ -773,6 +768,12 @@ impl Inner {
                 control: opened.control,
                 actor_id: actor.to_owned(),
                 transport_id: context.transport_id.clone(),
+                auth: AuthSnapshot {
+                    trust: context.trust.clone(),
+                    owner_user_id: context.owner_user_id.clone(),
+                    send: Arc::clone(&context.send),
+                    buffered_amount: Arc::clone(&context.buffered_amount),
+                },
             },
         );
         if let Some(previous) = previous {
@@ -820,8 +821,11 @@ impl Inner {
     }
 
     fn emit_output(&self, pty_id: &str, chunk: &Bytes, context: &FrameContext) {
-        let Some(auth) = self.auth.lock().expect("auth lock").clone() else { return };
-        if self.authorize_snapshot(pty_id, &auth, context, "output").is_none() {
+        let Some(attachment) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()
+        else {
+            return;
+        };
+        if !self.authorize_attachment(pty_id, &attachment, context, "output") {
             return;
         }
         // Zero-byte chunks carry nothing and historically crashed the web
@@ -829,7 +833,7 @@ impl Inner {
         if chunk.is_empty() {
             return;
         }
-        let buffered = (auth.buffered_amount)();
+        let buffered = (attachment.auth.buffered_amount)();
         // Admit the complete frame before sending it. The socket may accept a
         // frame exactly at the cap, but must reject one that would push the
         // buffered amount over the cap.
@@ -846,7 +850,7 @@ impl Inner {
             );
             return;
         }
-        (auth.send)(json!({
+        (attachment.auth.send)(json!({
             "version": PTY_PROTOCOL_VERSION,
             "type": "pty_output",
             "ptyId": pty_id,
@@ -855,8 +859,11 @@ impl Inner {
     }
 
     fn emit_exit(&self, pty_id: &str, code: i64, context: &FrameContext) {
-        let Some(auth) = self.auth.lock().expect("auth lock").clone() else { return };
-        if self.authorize_snapshot(pty_id, &auth, context, "exit").is_none() {
+        let Some(attachment) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()
+        else {
+            return;
+        };
+        if !self.authorize_attachment(pty_id, &attachment, context, "exit") {
             return;
         }
         let mut attachments = self.attachments.lock().expect("attach lock");
@@ -866,7 +873,7 @@ impl Inner {
         }
         attachments.remove(pty_id);
         drop(attachments);
-        (auth.send)(json!({
+        (attachment.auth.send)(json!({
             "version": PTY_PROTOCOL_VERSION,
             "type": "pty_exit",
             "ptyId": pty_id,
@@ -909,24 +916,59 @@ impl Inner {
     }
 
     fn authorize(&self, pty_id: &str, context: &FrameContext, action: &str) -> Option<Attachment> {
-        let auth = self.auth.lock().expect("auth lock").clone()?;
-        self.authorize_snapshot(pty_id, &auth, context, action)
+        let attachment = self.attachments.lock().expect("attach lock").get(pty_id)?.clone();
+        self.authorize_attachment_with_context(pty_id, &attachment, context, action)
+            .then_some(attachment)
     }
 
-    fn authorize_snapshot(
+    fn authorize_attachment(
         &self,
         pty_id: &str,
-        auth: &AuthSnapshot,
+        attachment: &Attachment,
         context: &FrameContext,
         action: &str,
-    ) -> Option<Attachment> {
-        let attachment = self.attachments.lock().expect("attach lock").get(pty_id)?.clone();
-        let owner = auth.owner_user_id.as_deref();
-        let allowed = !auth.trust.is_empty()
-            && (auth.trust != "observe"
+    ) -> bool {
+        self.authorize_values(
+            pty_id,
+            attachment,
+            &attachment.auth.trust,
+            attachment.auth.owner_user_id.as_deref(),
+            context,
+            action,
+        )
+    }
+
+    fn authorize_attachment_with_context(
+        &self,
+        pty_id: &str,
+        attachment: &Attachment,
+        context: &FrameContext,
+        action: &str,
+    ) -> bool {
+        self.authorize_values(
+            pty_id,
+            attachment,
+            &context.trust,
+            context.owner_user_id.as_deref(),
+            context,
+            action,
+        )
+    }
+
+    fn authorize_values(
+        &self,
+        pty_id: &str,
+        attachment: &Attachment,
+        trust: &str,
+        owner: Option<&str>,
+        context: &FrameContext,
+        action: &str,
+    ) -> bool {
+        let allowed = !trust.is_empty()
+            && (trust != "observe"
                 || (owner.is_some() && owner == Some(attachment.actor_id.as_str())));
         if allowed {
-            Some(attachment)
+            true
         } else {
             self.close(pty_id);
             send_pty_error(
@@ -935,7 +977,7 @@ impl Inner {
                 "trust_revoked",
                 &format!("PTY {action} refused after trust change"),
             );
-            None
+            false
         }
     }
 

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2323,7 +2323,7 @@ mod tests {
                 buffered_amount: Arc::new(move || buffered.load(Ordering::SeqCst)),
                 trust: trust.to_owned(),
                 local_roots: None,
-                owner_user_id: owner,
+                owner_user_id: owner.clone(),
                 transport_id: None,
                 cancellation: CancellationToken::new(),
                 current_auth: {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -281,6 +281,9 @@ pub struct FrameContext {
     pub transport_id: Option<String>,
     /// Raised when the transport that requested this work disconnects.
     pub cancellation: CancellationToken,
+    /// Reads the current authentication for this transport. Long-lived PTY
+    /// sinks must not rely on the credentials captured when they opened.
+    pub current_auth: Arc<dyn Fn() -> (String, Option<String>) + Send + Sync>,
 }
 
 #[derive(Clone)]
@@ -2331,6 +2334,11 @@ mod tests {
                 owner_user_id: owner,
                 transport_id: None,
                 cancellation: CancellationToken::new(),
+                current_auth: {
+                    let trust = trust.to_owned();
+                    let owner = owner.clone();
+                    Arc::new(move || (trust.clone(), owner.clone()))
+                },
             }
         }
 
@@ -2556,6 +2564,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn revoke_before_passive_output_does_not_leak_to_viewer() {
+        let h = harness(None, None);
+        let auth = Arc::new(StdMutex::new(("supervised".to_owned(), h.owner.clone())));
+        let sent = Arc::clone(&h.sent);
+        let auth_for_context = Arc::clone(&auth);
+        let context = FrameContext {
+            send: Arc::new(move |frame| sent.lock().unwrap().push(frame)),
+            buffered_amount: Arc::new(|| 0),
+            trust: "supervised".to_owned(),
+            local_roots: None,
+            owner_user_id: h.owner.clone(),
+            transport_id: Some("viewer-transport".to_owned()),
+            cancellation: CancellationToken::new(),
+            current_auth: Arc::new(move || auth_for_context.lock().unwrap().clone()),
+        };
+        let open = serde_json::json!({
+            "version": 4, "type": "pty_open", "ptyId": "p1", "session": "main",
+            "cols": 80, "rows": 24, "actorId": "user_owner", "trust": "supervised",
+            "allowedRoots": Value::Null,
+        });
+        h.manager.handle_frame(&open, &context).await;
+        *auth.lock().unwrap() = ("observe".to_owned(), Some("different-owner".to_owned()));
+        h.spawned()[0].emit("secret");
+        assert!(!h.sent().iter().any(|f| f["type"] == "pty_output"));
+    }
+
+    #[tokio::test]
     async fn close_requires_current_trust() {
         let h = harness(None, None);
         h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;
@@ -2696,6 +2731,8 @@ mod tests {
             local_roots: None,
             owner_user_id: owner.clone(),
             transport_id: None,
+            cancellation: CancellationToken::new(),
+            current_auth: Arc::new(|| ("supervised".to_owned(), Some("user_owner".to_owned()))),
         };
         let open = |pty_id: &str| {
             serde_json::json!({

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -19,7 +19,7 @@
 //! every non-empty allowed root list; env scrubbed; per-pty buffered output capped; no
 //! empty frames; unknown ptyIds tolerated; refusals answer pty_error.
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -313,6 +313,8 @@ struct ViewerSink {
 /// fans output out to every attachment (multi-viewer, tmux-style).
 struct ShellSession {
     control: Arc<dyn PtyControl>,
+    /// Serializes pause ownership transitions before touching the shared PTY.
+    flow_lock: Mutex<()>,
     inner: Mutex<ShellInner>,
     banner: Option<Vec<u8>>,
 }
@@ -322,6 +324,8 @@ struct ShellInner {
     ring_size: usize,
     alive: bool,
     viewers: Vec<ViewerSink>,
+    /// Viewer ids that currently own a pause on the shared PTY.
+    paused_viewers: HashSet<u64>,
 }
 
 #[derive(Clone)]
@@ -1170,12 +1174,14 @@ impl Inner {
                 let PtyHandle { control, output, banner } = handle;
                 let shell_session = Arc::new(ShellSession {
                     control,
+                    flow_lock: Mutex::new(()),
                     banner,
                     inner: Mutex::new(ShellInner {
                         ring: VecDeque::new(),
                         ring_size: 0,
                         alive: true,
                         viewers: Vec::new(),
+                        paused_viewers: HashSet::new(),
                     }),
                 });
                 // Session-level plumbing runs for the session's whole life:
@@ -1207,6 +1213,7 @@ impl Inner {
                     let viewers = {
                         let mut inner = exit_session.inner.lock().expect("shell inner lock");
                         inner.alive = false;
+                        inner.paused_viewers.clear();
                         std::mem::take(&mut inner.viewers)
                     };
                     manager.shell_sessions.lock().expect("shell lock").remove(&session_name);
@@ -1282,9 +1289,18 @@ struct ShellViewerControl {
 
 impl ShellViewerControl {
     fn release(&self) {
-        self.released.store(true, Ordering::SeqCst);
-        let mut inner = self.session.inner.lock().expect("shell inner lock");
-        inner.viewers.retain(|viewer| viewer.id != self.viewer_id);
+        if self.released.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        let _flow = self.session.flow_lock.lock().expect("shell flow lock");
+        let should_resume = {
+            let mut inner = self.session.inner.lock().expect("shell inner lock");
+            inner.viewers.retain(|viewer| viewer.id != self.viewer_id);
+            inner.paused_viewers.remove(&self.viewer_id) && inner.paused_viewers.is_empty()
+        };
+        if should_resume {
+            self.session.control.resume();
+        }
     }
 }
 
@@ -1296,10 +1312,27 @@ impl PtyControl for ShellViewerControl {
         self.session.control.resize(cols, rows);
     }
     fn pause(&self) {
-        self.session.control.pause();
+        let _flow = self.session.flow_lock.lock().expect("shell flow lock");
+        if self.released.load(Ordering::SeqCst) {
+            return;
+        }
+        let should_pause = {
+            let mut inner = self.session.inner.lock().expect("shell inner lock");
+            inner.paused_viewers.insert(self.viewer_id) && inner.paused_viewers.len() == 1
+        };
+        if should_pause {
+            self.session.control.pause();
+        }
     }
     fn resume(&self) {
-        self.session.control.resume();
+        let _flow = self.session.flow_lock.lock().expect("shell flow lock");
+        let should_resume = {
+            let mut inner = self.session.inner.lock().expect("shell inner lock");
+            inner.paused_viewers.remove(&self.viewer_id) && inner.paused_viewers.is_empty()
+        };
+        if should_resume {
+            self.session.control.resume();
+        }
     }
     fn kill(&self) {
         self.release();

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1240,7 +1240,12 @@ impl Inner {
                             let Some(dropped) = inner.ring.pop_front() else { break };
                             inner.ring_size -= dropped.len();
                         }
-                        inner.viewers.iter().map(|viewer| Arc::clone(&viewer.on_data)).collect()
+                        inner
+                            .viewers
+                            .iter()
+                            .filter(|viewer| !inner.paused_viewers.contains(&viewer.id))
+                            .map(|viewer| Arc::clone(&viewer.on_data))
+                            .collect()
                     };
                     for on_data in viewers_to_notify {
                         on_data(chunk.clone());

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1210,6 +1210,7 @@ impl Inner {
                     }
                 });
                 let on_session_exit: ExitSink = Arc::new(move |code: i64| {
+                    let _flow = exit_session.flow_lock.lock().expect("shell flow lock");
                     let viewers = {
                         let mut inner = exit_session.inner.lock().expect("shell inner lock");
                         inner.alive = false;

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1241,8 +1241,8 @@ impl Inner {
         let closing = Arc::new(AtomicBool::new(false));
         let (on_data, on_exit) = self.sinks(pty_id, context);
 
-        // The per-attachment control proxies onto the session pty but its
-        // kill() only unhooks this viewer (release), never the session.
+        // The per-attachment control proxies onto the session pty. Its
+        // kill() releases this viewer and any pause it owns, never the session.
         let proxy = Arc::new(ShellViewerControl {
             session: Arc::clone(&shell_session),
             viewer_id,

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -828,7 +828,12 @@ impl Inner {
         else {
             return;
         };
-        if !self.authorize_attachment(pty_id, &attachment, context, "output") {
+        if attachment.transport_id != context.transport_id {
+            return;
+        }
+        let (trust, owner) = (context.current_auth)();
+        if !self.authorize_values(pty_id, &attachment, &trust, owner.as_deref(), context, "output")
+        {
             return;
         }
         // Zero-byte chunks carry nothing and historically crashed the web
@@ -866,7 +871,11 @@ impl Inner {
         else {
             return;
         };
-        if !self.authorize_attachment(pty_id, &attachment, context, "exit") {
+        if attachment.transport_id != context.transport_id {
+            return;
+        }
+        let (trust, owner) = (context.current_auth)();
+        if !self.authorize_values(pty_id, &attachment, &trust, owner.as_deref(), context, "exit") {
             return;
         }
         let mut attachments = self.attachments.lock().expect("attach lock");
@@ -922,23 +931,6 @@ impl Inner {
         let attachment = self.attachments.lock().expect("attach lock").get(pty_id)?.clone();
         self.authorize_attachment_with_context(pty_id, &attachment, context, action)
             .then_some(attachment)
-    }
-
-    fn authorize_attachment(
-        &self,
-        pty_id: &str,
-        attachment: &Attachment,
-        context: &FrameContext,
-        action: &str,
-    ) -> bool {
-        self.authorize_values(
-            pty_id,
-            attachment,
-            &attachment.auth.trust,
-            attachment.auth.owner_user_id.as_deref(),
-            context,
-            action,
-        )
     }
 
     fn authorize_attachment_with_context(

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1247,7 +1247,7 @@ impl Inner {
                     }
                 });
                 let on_session_exit: ExitSink = Arc::new(move |code: i64| {
-                    let _flow = exit_session.flow_lock.lock().expect("shell flow lock");
+                    let flow = exit_session.flow_lock.lock().expect("shell flow lock");
                     let viewers = {
                         let mut inner = exit_session.inner.lock().expect("shell inner lock");
                         inner.alive = false;
@@ -1255,6 +1255,7 @@ impl Inner {
                         std::mem::take(&mut inner.viewers)
                     };
                     manager.shell_sessions.lock().expect("shell lock").remove(&session_name);
+                    drop(flow);
                     for viewer in viewers {
                         (viewer.on_exit)(code);
                     }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2052,7 +2052,13 @@ mod tests {
 
     impl FakePty {
         fn emit(&self, text: &str) {
-            let sink = self.state.lock().unwrap().on_data.clone();
+            let (sink, paused) = {
+                let state = self.state.lock().unwrap();
+                (state.on_data.clone(), state.paused)
+            };
+            if paused {
+                return;
+            }
             if let Some(sink) = sink {
                 sink(Bytes::copy_from_slice(text.as_bytes()));
             }
@@ -2619,6 +2625,27 @@ mod tests {
         let last = last.last().unwrap();
         assert_eq!(last["type"], "pty_exit");
         assert_eq!(last["ptyId"], "p2");
+    }
+
+    #[tokio::test]
+    async fn closing_a_paused_shell_viewer_resumes_the_shared_session() {
+        let h = harness(None, None);
+        h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;
+        h.open("p2", "main", Value::Null, "supervised", h.owner.clone()).await;
+        let pty = h.spawned()[0].clone();
+
+        h.frame(serde_json::json!({ "type": "pty_flow", "ptyId": "p1", "pause": true })).await;
+        assert!(pty.state.lock().unwrap().paused);
+
+        h.frame(serde_json::json!({ "type": "pty_close", "ptyId": "p1" })).await;
+        assert!(!pty.state.lock().unwrap().paused);
+
+        let before = h.sent().len();
+        pty.emit("after detach");
+        let outputs: Vec<&Value> =
+            h.sent()[before..].iter().filter(|frame| ty(frame) == "pty_output").collect();
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(outputs[0]["ptyId"], "p2");
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2675,8 +2675,9 @@ mod tests {
 
         let before = h.sent().len();
         pty.emit("after detach");
+        let sent = h.sent();
         let outputs: Vec<&Value> =
-            h.sent()[before..].iter().filter(|frame| ty(frame) == "pty_output").collect();
+            sent[before..].iter().filter(|frame| ty(frame) == "pty_output").collect();
         assert_eq!(outputs.len(), 1);
         assert_eq!(outputs[0]["ptyId"], "p2");
     }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -318,6 +318,8 @@ struct ShellSession {
     control: Arc<dyn PtyControl>,
     /// Serializes pause ownership transitions before touching the shared PTY.
     flow_lock: Mutex<()>,
+    /// Serializes output delivery with paused-viewer replay.
+    dispatch_lock: Mutex<()>,
     inner: Mutex<ShellInner>,
     banner: Option<Vec<u8>>,
 }
@@ -329,6 +331,10 @@ struct ShellInner {
     viewers: Vec<ViewerSink>,
     /// Viewer ids that currently own a pause on the shared PTY.
     paused_viewers: HashSet<u64>,
+    /// Bounded output accumulated for paused or resuming viewers.
+    paused_backlog: HashMap<u64, PausedBacklog>,
+    /// Viewers whose paused output is being replayed in order.
+    draining_viewers: HashSet<u64>,
 }
 
 #[derive(Clone)]
@@ -1212,6 +1218,7 @@ impl Inner {
                 let shell_session = Arc::new(ShellSession {
                     control,
                     flow_lock: Mutex::new(()),
+                    dispatch_lock: Mutex::new(()),
                     banner,
                     inner: Mutex::new(ShellInner {
                         ring: VecDeque::new(),
@@ -1219,6 +1226,8 @@ impl Inner {
                         alive: true,
                         viewers: Vec::new(),
                         paused_viewers: HashSet::new(),
+                        paused_backlog: HashMap::new(),
+                        draining_viewers: HashSet::new(),
                     }),
                 });
                 // Session-level plumbing runs for the session's whole life:
@@ -1232,6 +1241,7 @@ impl Inner {
                 let exit_session = Arc::clone(&shell_session);
                 let manager = Arc::clone(&self);
                 let on_session_data: DataSink = Arc::new(move |chunk: Bytes| {
+                    let _dispatch = data_session.dispatch_lock.lock().expect("shell dispatch lock");
                     let viewers_to_notify: Vec<Arc<dyn Fn(Bytes) + Send + Sync>> = {
                         let mut inner = data_session.inner.lock().expect("shell inner lock");
                         inner.ring_size += chunk.len();
@@ -1240,12 +1250,24 @@ impl Inner {
                             let Some(dropped) = inner.ring.pop_front() else { break };
                             inner.ring_size -= dropped.len();
                         }
-                        inner
-                            .viewers
-                            .iter()
-                            .filter(|viewer| !inner.paused_viewers.contains(&viewer.id))
-                            .map(|viewer| Arc::clone(&viewer.on_data))
-                            .collect()
+                        let mut viewers_to_notify = Vec::new();
+                        for viewer in &inner.viewers {
+                            if inner.paused_viewers.contains(&viewer.id)
+                                || inner.draining_viewers.contains(&viewer.id)
+                            {
+                                let backlog = inner.paused_backlog.entry(viewer.id).or_default();
+                                backlog.chunks.push_back(chunk.clone());
+                                backlog.bytes += chunk.len();
+                                while backlog.bytes > scrollback_limit && backlog.chunks.len() > 1 {
+                                    if let Some(dropped) = backlog.chunks.pop_front() {
+                                        backlog.bytes -= dropped.len();
+                                    }
+                                }
+                            } else {
+                                viewers_to_notify.push(Arc::clone(&viewer.on_data));
+                            }
+                        }
+                        viewers_to_notify
                     };
                     for on_data in viewers_to_notify {
                         on_data(chunk.clone());
@@ -1257,6 +1279,8 @@ impl Inner {
                         let mut inner = exit_session.inner.lock().expect("shell inner lock");
                         inner.alive = false;
                         inner.paused_viewers.clear();
+                        inner.paused_backlog.clear();
+                        inner.draining_viewers.clear();
                         std::mem::take(&mut inner.viewers)
                     };
                     manager.shell_sessions.lock().expect("shell lock").remove(&session_name);
@@ -1325,6 +1349,12 @@ impl Inner {
     }
 }
 
+#[derive(Default)]
+struct PausedBacklog {
+    chunks: VecDeque<Bytes>,
+    bytes: usize,
+}
+
 struct ShellViewerControl {
     session: Arc<ShellSession>,
     viewer_id: u64,
@@ -1340,6 +1370,8 @@ impl ShellViewerControl {
         let should_resume = {
             let mut inner = self.session.inner.lock().expect("shell inner lock");
             inner.viewers.retain(|viewer| viewer.id != self.viewer_id);
+            inner.paused_backlog.remove(&self.viewer_id);
+            inner.draining_viewers.remove(&self.viewer_id);
             inner.paused_viewers.remove(&self.viewer_id) && inner.paused_viewers.is_empty()
         };
         if should_resume {
@@ -1369,13 +1401,59 @@ impl PtyControl for ShellViewerControl {
         }
     }
     fn resume(&self) {
-        let _flow = self.session.flow_lock.lock().expect("shell flow lock");
         let should_resume = {
+            let _flow = self.session.flow_lock.lock().expect("shell flow lock");
             let mut inner = self.session.inner.lock().expect("shell inner lock");
-            inner.paused_viewers.remove(&self.viewer_id) && inner.paused_viewers.is_empty()
+            let removed = inner.paused_viewers.remove(&self.viewer_id);
+            if removed {
+                inner.draining_viewers.insert(self.viewer_id);
+                inner.paused_backlog.entry(self.viewer_id).or_default();
+            }
+            removed && inner.paused_viewers.is_empty()
         };
         if should_resume {
             self.session.control.resume();
+        }
+        self.drain_backlog();
+    }
+
+    fn drain_backlog(&self) {
+        let _dispatch = self.session.dispatch_lock.lock().expect("shell dispatch lock");
+        loop {
+            let next = {
+                let _flow = self.session.flow_lock.lock().expect("shell flow lock");
+                let mut inner = self.session.inner.lock().expect("shell inner lock");
+                if self.released.load(Ordering::SeqCst) {
+                    inner.paused_backlog.remove(&self.viewer_id);
+                    inner.draining_viewers.remove(&self.viewer_id);
+                    None
+                } else {
+                    let Some(on_data) = inner
+                        .viewers
+                        .iter()
+                        .find(|viewer| viewer.id == self.viewer_id)
+                        .map(|viewer| Arc::clone(&viewer.on_data))
+                    else {
+                        inner.paused_backlog.remove(&self.viewer_id);
+                        inner.draining_viewers.remove(&self.viewer_id);
+                        None
+                    };
+                    let chunk = inner.paused_backlog.get_mut(&self.viewer_id).and_then(|backlog| {
+                        let chunk = backlog.chunks.pop_front()?;
+                        backlog.bytes -= chunk.len();
+                        Some(chunk)
+                    });
+                    if let Some(chunk) = chunk {
+                        Some((on_data, chunk))
+                    } else {
+                        inner.paused_backlog.remove(&self.viewer_id);
+                        inner.draining_viewers.remove(&self.viewer_id);
+                        None
+                    }
+                }
+            };
+            let Some((on_data, chunk)) = next else { break };
+            on_data(chunk);
         }
     }
     fn kill(&self) {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2135,6 +2135,14 @@ mod tests {
                 sink(Bytes::copy_from_slice(text.as_bytes()));
             }
         }
+
+        fn emit_while_paused(&self, text: &str) {
+            let sink = self.state.lock().unwrap().on_data.clone();
+            if let Some(sink) = sink {
+                sink(Bytes::copy_from_slice(text.as_bytes()));
+            }
+        }
+
         fn exit(&self, code: i64) {
             let sink = self.state.lock().unwrap().on_exit.clone();
             if let Some(sink) = sink {
@@ -2748,6 +2756,29 @@ mod tests {
             two.iter().any(|frame| frame["type"] == "pty_output" && frame["ptyId"] == "viewer-two")
         );
         assert!(!two.iter().any(|frame| frame["ptyId"] == "viewer-one"));
+    }
+
+    #[tokio::test]
+    async fn paused_shell_viewer_does_not_receive_continued_output() {
+        let h = harness(None, None);
+        h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;
+        h.open("p2", "main", Value::Null, "supervised", h.owner.clone()).await;
+        let pty = h.spawned()[0].clone();
+
+        h.frame(serde_json::json!({ "type": "pty_flow", "ptyId": "p1", "pause": true })).await;
+        let before = h.sent().len();
+        pty.emit_while_paused("continued output");
+        let outputs: Vec<(String, String)> = h.sent()[before..]
+            .iter()
+            .filter(|frame| ty(frame) == "pty_output")
+            .map(|frame| {
+                (
+                    frame["ptyId"].as_str().unwrap().to_owned(),
+                    from_b64(frame["dataB64"].as_str().unwrap()),
+                )
+            })
+            .collect();
+        assert_eq!(outputs, vec![("p2".to_owned(), "continued output".to_owned())]);
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -680,14 +680,8 @@ async fn relay_session(
                     }
                 };
                 let snapshot = auth.lock().expect("auth lock").clone();
-                let context = make_context(
-                    &out,
-                    &pending,
-                    &snapshot,
-                    &auth,
-                    &transport,
-                    &connection_token,
-                );
+                let context =
+                    make_context(&out, &pending, &snapshot, &auth, &transport, &connection_token);
                 tokio::select! {
                     biased;
                     _ = connection_token.cancelled() => break,

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -546,6 +546,7 @@ fn make_context(
     out: &OutboundSink,
     pending: &Arc<AtomicU64>,
     auth: &AuthSnapshot,
+    auth_state: &Arc<std::sync::Mutex<AuthSnapshot>>,
     transport_id: &str,
     cancellation: &CancellationToken,
 ) -> FrameContext {
@@ -581,6 +582,13 @@ fn make_context(
         owner_user_id: auth.owner.clone(),
         transport_id: Some(transport_id.to_owned()),
         cancellation: cancellation.clone(),
+        current_auth: {
+            let auth = Arc::clone(auth_state);
+            Arc::new(move || {
+                let snapshot = auth.lock().expect("auth lock").clone();
+                (snapshot.trust, snapshot.owner)
+            })
+        },
     }
 }
 
@@ -672,8 +680,14 @@ async fn relay_session(
                     }
                 };
                 let snapshot = auth.lock().expect("auth lock").clone();
-                let context =
-                    make_context(&out, &pending, &snapshot, &transport, &connection_token);
+                let context = make_context(
+                    &out,
+                    &pending,
+                    &snapshot,
+                    &auth,
+                    &transport,
+                    &connection_token,
+                );
                 tokio::select! {
                     biased;
                     _ = connection_token.cancelled() => break,
@@ -1138,6 +1152,7 @@ async fn relay_session(
                                     &out_tx,
                                     &pending,
                                     &snapshot,
+                                    &auth,
                                     &transport_id,
                                     &connection_cancellation,
                                 );

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -38,20 +38,20 @@
 //! already attach terminals through the cmux CLI. Paired human machines
 //! never run this listener: it starts from the managed branch only.
 
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64;
-use serde_json::{Value, json};
+use base64::Engine as _;
+use serde_json::{json, Value};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 use crate::pty::{
-    FrameContext, PTY_PROTOCOL_VERSION, PtyManager, random_hex, session_name_ok, surface_ref_ok,
+    random_hex, session_name_ok, surface_ref_ok, FrameContext, PtyManager, PTY_PROTOCOL_VERSION,
 };
 
 /// Loopback port the gateway's spliced streams dial. The chatmux Worker
@@ -73,6 +73,11 @@ const OPEN_TIMEOUT: Duration = Duration::from_secs(10);
 /// manager's own 1 MiB output cap stays the hard boundary above this.
 const FLOW_PAUSE_BYTES: u64 = 262_144;
 const FLOW_RESUME_BYTES: u64 = 32_768;
+/// Admission is synchronous from the manager callback, so the writer queue
+/// uses non-blocking sends with both message and byte budgets. The byte cap
+/// leaves room for a maximum PTY frame and a follow-up control/error frame.
+const WRITER_QUEUE_CAPACITY: usize = 128;
+const WRITER_QUEUE_BYTE_CAP: u64 = (MAX_TUNNEL_FRAME_BYTES as u64 + HEADER_BYTES as u64) * 2;
 
 /// Relay pty_error codes -> browser wire codes. Mirrors the Worker's
 /// browserErrorCode map (apps/backend/src/terminal/relay-pty.ts). KEEP IN
@@ -253,9 +258,12 @@ enum WriterMessage {
 struct Connection {
     pty_id: String,
     manager: Arc<PtyManager>,
-    writer_tx: mpsc::UnboundedSender<WriterMessage>,
+    writer_tx: mpsc::Sender<WriterMessage>,
+    /// Serializes queue admission with the End marker so no frame can be
+    /// inserted after shutdown and silently be dropped by the writer.
+    queue_gate: Mutex<()>,
     /// pty_flow requests from the writer's water marks (true = pause).
-    flow_tx: mpsc::UnboundedSender<bool>,
+    flow_tx: mpsc::Sender<bool>,
     /// Bytes queued toward the socket and not yet written.
     pending_out: AtomicU64,
     paused: AtomicBool,
@@ -269,17 +277,69 @@ struct Connection {
 
 impl Connection {
     fn send_control(&self, frame: &Value) {
-        self.enqueue(WriterMessage::Frame(encode_control_frame(frame)));
+        let _ = self.enqueue(WriterMessage::Frame(encode_control_frame(frame)));
     }
 
-    fn enqueue(&self, message: WriterMessage) {
-        if self.finished.load(Ordering::SeqCst) {
-            return;
+    fn reserve_bytes(&self, amount: u64) -> bool {
+        let mut current = self.pending_out.load(Ordering::SeqCst);
+        loop {
+            let Some(next) = current.checked_add(amount) else {
+                return false;
+            };
+            if next > WRITER_QUEUE_BYTE_CAP {
+                return false;
+            }
+            match self.pending_out.compare_exchange(
+                current,
+                next,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            ) {
+                Ok(_) => return true,
+                Err(actual) => current = actual,
+            }
         }
-        if let WriterMessage::Frame(frame) = &message {
-            self.pending_out.fetch_add(frame.len() as u64, Ordering::SeqCst);
+    }
+
+    fn release_bytes(&self, amount: u64) {
+        self.pending_out.fetch_sub(amount, Ordering::SeqCst);
+    }
+
+    /// Pause the source before closing when a stalled peer exhausts admission.
+    fn reject_due_to_backpressure(&self) {
+        if !self.paused.swap(true, Ordering::SeqCst) {
+            let _ = self.flow_tx.try_send(true);
         }
-        let _ = self.writer_tx.send(message);
+        self.finish();
+    }
+
+    fn enqueue(&self, message: WriterMessage) -> bool {
+        let frame_bytes = match &message {
+            WriterMessage::Frame(frame) => frame.len() as u64,
+            WriterMessage::End => 0,
+        };
+        let mut reserved = false;
+        let admitted = {
+            let _gate = self.queue_gate.lock().expect("writer queue lock");
+            if self.finished.load(Ordering::SeqCst) {
+                false
+            } else if frame_bytes != 0 && !self.reserve_bytes(frame_bytes) {
+                false
+            } else {
+                reserved = frame_bytes != 0;
+                self.writer_tx.try_send(message).is_ok()
+            }
+        };
+        if admitted {
+            return true;
+        }
+        if reserved {
+            self.release_bytes(frame_bytes);
+        }
+        if !self.finished.load(Ordering::SeqCst) {
+            self.reject_due_to_backpressure();
+        }
+        false
     }
 
     /// Idempotent shutdown: flush queued frames, close the socket, and let
@@ -287,10 +347,11 @@ impl Connection {
     /// session lives on for a later re-attach, the same rule a dropped
     /// relay-socket viewer follows).
     fn finish(&self) {
+        let _gate = self.queue_gate.lock().expect("writer queue lock");
         if self.finished.swap(true, Ordering::SeqCst) {
             return;
         }
-        let _ = self.writer_tx.send(WriterMessage::End);
+        let _ = self.writer_tx.try_send(WriterMessage::End);
         self.done.cancel();
     }
 
@@ -335,14 +396,16 @@ impl Connection {
                 else {
                     return;
                 };
-                self.enqueue(WriterMessage::Frame(encode_pty_frame(&bytes)));
+                if !self.enqueue(WriterMessage::Frame(encode_pty_frame(&bytes))) {
+                    return;
+                }
                 // Socket-side congestion: pause the source through the
                 // manager's own flow verb; the writer resumes it below the
                 // low-water mark.
                 if self.pending_out.load(Ordering::SeqCst) > FLOW_PAUSE_BYTES
                     && !self.paused.swap(true, Ordering::SeqCst)
                 {
-                    let _ = self.flow_tx.send(true);
+                    let _ = self.flow_tx.try_send(true);
                 }
             }
             Some("pty_exit") => {
@@ -449,12 +512,13 @@ async fn handle_client_frame(
 async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: CancellationToken) {
     let _ = stream.set_nodelay(true);
     let (mut read_half, mut write_half) = stream.into_split();
-    let (writer_tx, mut writer_rx) = mpsc::unbounded_channel::<WriterMessage>();
-    let (flow_tx, mut flow_rx) = mpsc::unbounded_channel::<bool>();
+    let (writer_tx, mut writer_rx) = mpsc::channel::<WriterMessage>(WRITER_QUEUE_CAPACITY);
+    let (flow_tx, mut flow_rx) = mpsc::channel::<bool>(4);
     let connection = Arc::new(Connection {
         pty_id: format!("tunnel-{}", random_hex(8)),
         manager: Arc::clone(&manager),
         writer_tx,
+        queue_gate: Mutex::new(()),
         flow_tx,
         pending_out: AtomicU64::new(0),
         paused: AtomicBool::new(false),
@@ -485,7 +549,13 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
                         if previous.saturating_sub(length) < FLOW_RESUME_BYTES
                             && connection.paused.swap(false, Ordering::SeqCst)
                         {
-                            let _ = connection.flow_tx.send(false);
+                            let _ = connection.flow_tx.try_send(false);
+                        }
+                        // `finish` may race with a full queue, so End is only
+                        // best effort. Once all admitted frames drain, stop
+                        // without waiting for another sender-side message.
+                        if connection.finished.load(Ordering::SeqCst) && writer_rx.is_empty() {
+                            break;
                         }
                     }
                     WriterMessage::End => break,
@@ -502,7 +572,9 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
         let context = context.clone();
         tokio::spawn(async move {
             while let Some(pause) = flow_rx.recv().await {
-                if connection.finished.load(Ordering::SeqCst) {
+                // Deliver a final pause even when shutdown has started. This
+                // keeps PTY flow semantics intact for a queue-overflow close.
+                if connection.finished.load(Ordering::SeqCst) && !pause {
                     break;
                 }
                 let frame = json!({

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -495,6 +495,7 @@ impl Connection {
             owner_user_id: None,
             transport_id: Some(self.pty_id.clone()),
             cancellation: self.done.clone(),
+            current_auth: Arc::new(|| ("supervised".to_owned(), None)),
         }
     }
 }

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -916,6 +916,69 @@ mod tests {
         }
     }
 
+    fn test_connection(
+        rig: &Rig,
+    ) -> (Arc<Connection>, mpsc::Receiver<WriterMessage>, mpsc::Receiver<bool>) {
+        let (writer_tx, writer_rx) = mpsc::channel(WRITER_QUEUE_CAPACITY);
+        let (flow_tx, flow_rx) = mpsc::channel(4);
+        let connection = Arc::new(Connection {
+            pty_id: "test-pty".to_owned(),
+            manager: Arc::clone(&rig.manager),
+            writer_tx,
+            queue_gate: Mutex::new(()),
+            flow_tx,
+            pending_out: AtomicU64::new(0),
+            paused: AtomicBool::new(false),
+            open_sent: AtomicBool::new(false),
+            opened_seen: AtomicBool::new(false),
+            finished: AtomicBool::new(false),
+            done: CancellationToken::new(),
+        });
+        (connection, writer_rx, flow_rx)
+    }
+
+    #[tokio::test]
+    async fn stalled_peer_hits_the_byte_budget_and_pauses_before_close() {
+        let rig = rig().await;
+        let (connection, mut writer_rx, mut flow_rx) = test_connection(&rig);
+        let frame_len = WRITER_QUEUE_BYTE_CAP as usize / 2;
+        assert!(connection.enqueue(WriterMessage::Frame(vec![1; frame_len])));
+        assert!(connection.enqueue(WriterMessage::Frame(vec![2; frame_len])));
+        assert!(!connection.enqueue(WriterMessage::Frame(vec![3])));
+        assert!(connection.finished.load(Ordering::SeqCst));
+        assert!(connection.pending_out.load(Ordering::SeqCst) <= WRITER_QUEUE_BYTE_CAP);
+        assert_eq!(flow_rx.try_recv(), Ok(true));
+        match writer_rx.recv().await.expect("first admitted frame") {
+            WriterMessage::Frame(frame) => assert_eq!(frame[0], 1),
+            WriterMessage::End => panic!("queue order changed"),
+        }
+        match writer_rx.recv().await.expect("second admitted frame") {
+            WriterMessage::Frame(frame) => assert_eq!(frame[0], 2),
+            WriterMessage::End => panic!("queue order changed"),
+        }
+        rig.cancel.cancel();
+    }
+
+    #[tokio::test]
+    async fn full_writer_queue_closes_without_growing_beyond_message_budget() {
+        let rig = rig().await;
+        let (connection, mut writer_rx, mut flow_rx) = test_connection(&rig);
+        for index in 0..WRITER_QUEUE_CAPACITY {
+            assert!(connection.enqueue(WriterMessage::Frame(vec![index as u8])));
+        }
+        assert!(!connection.enqueue(WriterMessage::Frame(vec![0])));
+        assert!(connection.finished.load(Ordering::SeqCst));
+        assert_eq!(flow_rx.try_recv(), Ok(true));
+        for index in 0..WRITER_QUEUE_CAPACITY {
+            match writer_rx.recv().await.expect("admitted frame") {
+                WriterMessage::Frame(frame) => assert_eq!(frame, vec![index as u8]),
+                WriterMessage::End => panic!("queue order changed"),
+            }
+        }
+        assert!(writer_rx.try_recv().is_err());
+        rig.cancel.cancel();
+    }
+
     // -- live listener ------------------------------------------------------
 
     #[tokio::test]

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -729,10 +729,13 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
     // A queue-overflow close must deliver pty_flow(true) before the
     // attachment is released. The timeout prevents a broken manager from
     // holding the connection task forever.
+    // `timeout` consumes the join result when it completes. Await the handle
+    // only after a timeout-triggered abort, otherwise polling a completed
+    // JoinHandle panics and skips the owed attachment detach below.
     if tokio::time::timeout(FLOW_DRAIN_TIMEOUT, &mut flow).await.is_err() {
         flow.abort();
+        let _ = flow.await;
     }
-    let _ = flow.await;
     // Detach, never kill: the owed close releases only this connection's
     // attachment (transport-fenced), and the session lives on.
     if connection.open_sent.load(Ordering::SeqCst) {

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -813,6 +813,7 @@ mod tests {
         resized: Vec<(u16, u16)>,
         pause_calls: usize,
         resume_calls: usize,
+        paused: bool,
         killed: bool,
     }
 
@@ -823,7 +824,13 @@ mod tests {
 
     impl FakePty {
         fn emit(&self, text: &str) {
-            let sink = self.state.lock().unwrap().on_data.clone();
+            let (sink, paused) = {
+                let state = self.state.lock().unwrap();
+                (state.on_data.clone(), state.paused)
+            };
+            if paused {
+                return;
+            }
             if let Some(sink) = sink {
                 sink(Bytes::copy_from_slice(text.as_bytes()));
             }
@@ -844,10 +851,14 @@ mod tests {
             self.state.lock().unwrap().resized.push((cols, rows));
         }
         fn pause(&self) {
-            self.state.lock().unwrap().pause_calls += 1;
+            let mut state = self.state.lock().unwrap();
+            state.pause_calls += 1;
+            state.paused = true;
         }
         fn resume(&self) {
-            self.state.lock().unwrap().resume_calls += 1;
+            let mut state = self.state.lock().unwrap();
+            state.resume_calls += 1;
+            state.paused = false;
         }
         fn kill(&self) {
             self.state.lock().unwrap().killed = true;
@@ -1093,15 +1104,16 @@ mod tests {
         }
     }
 
-    fn test_connection(
+    fn test_connection_with_id(
         rig: &Rig,
+        pty_id: &str,
     ) -> (Arc<Connection>, mpsc::Receiver<WriterMessage>, watch::Receiver<bool>) {
         let (writer_tx, writer_rx) = mpsc::channel(WRITER_QUEUE_CAPACITY);
         let overflow_permit = writer_tx.clone().try_reserve_owned().expect("reserve overflow slot");
         let end_permit = writer_tx.clone().try_reserve_owned().expect("reserve End slot");
         let (flow_tx, flow_rx) = watch::channel(false);
         let connection = Arc::new(Connection {
-            pty_id: "test-pty".to_owned(),
+            pty_id: pty_id.to_owned(),
             manager: Arc::clone(&rig.manager),
             writer_tx,
             overflow_permit: Mutex::new(Some(overflow_permit)),
@@ -1118,19 +1130,33 @@ mod tests {
         (connection, writer_rx, flow_rx)
     }
 
-    async fn attach_test_pty(rig: &Rig, connection: &Arc<Connection>) -> FakePty {
+    fn test_connection(
+        rig: &Rig,
+    ) -> (Arc<Connection>, mpsc::Receiver<WriterMessage>, watch::Receiver<bool>) {
+        test_connection_with_id(rig, "test-pty")
+    }
+
+    async fn attach_test_pty_with_session(
+        rig: &Rig,
+        connection: &Arc<Connection>,
+        session: &str,
+    ) -> FakePty {
         connection.open_sent.store(true, Ordering::SeqCst);
         let context = connection.frame_context();
         let open = json!({
             "version": PTY_PROTOCOL_VERSION,
             "type": "pty_open",
             "ptyId": connection.pty_id,
-            "session": "flow-test",
+            "session": session,
             "cols": 80,
             "rows": 24,
         });
         rig.manager.handle_frame(&open, &context).await;
         spawned_pty(rig).await
+    }
+
+    async fn attach_test_pty(rig: &Rig, connection: &Arc<Connection>) -> FakePty {
+        attach_test_pty_with_session(rig, connection, "flow-test").await
     }
 
     #[tokio::test]
@@ -1214,6 +1240,43 @@ mod tests {
             .expect("flow worker deadline")
             .expect("flow worker join");
         assert_eq!(pty.state.lock().unwrap().pause_calls, 1);
+        rig.cancel.cancel();
+    }
+
+    #[tokio::test]
+    async fn overflow_close_resumes_shared_shell_for_other_viewer() {
+        let rig = rig().await;
+        let (slow, _slow_writer_rx, slow_flow_rx) = test_connection_with_id(&rig, "slow-pty");
+        let (other, mut other_writer_rx, _other_flow_rx) =
+            test_connection_with_id(&rig, "other-pty");
+        let pty = attach_test_pty_with_session(&rig, &slow, "shared-flow-test").await;
+        let _ = attach_test_pty_with_session(&rig, &other, "shared-flow-test").await;
+
+        let flow = spawn_flow_worker(Arc::clone(&slow), slow.frame_context(), slow_flow_rx);
+        slow.reject_due_to_backpressure();
+        tokio::time::timeout(FLOW_DRAIN_TIMEOUT, flow)
+            .await
+            .expect("flow worker deadline")
+            .expect("flow worker join");
+        assert!(pty.state.lock().unwrap().paused);
+
+        let close = json!({
+            "version": PTY_PROTOCOL_VERSION,
+            "type": "pty_close",
+            "ptyId": slow.pty_id,
+        });
+        rig.manager.handle_frame(&close, &slow.frame_context()).await;
+        let state = pty.state.lock().unwrap();
+        assert!(!state.paused, "detaching the overflowed viewer must resume the shell");
+        assert_eq!(state.resume_calls, 1);
+        drop(state);
+
+        while other_writer_rx.try_recv().is_ok() {}
+        pty.emit("after detach");
+        match other_writer_rx.try_recv().expect("other viewer output") {
+            WriterMessage::Frame(frame) => assert_eq!(&frame[HEADER_BYTES..], b"after detach"),
+            WriterMessage::End => panic!("other viewer detached unexpectedly"),
+        }
         rig.cancel.cancel();
     }
 

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -130,7 +130,6 @@ fn encode_overflow_frame() -> Vec<u8> {
     encode_control_frame(&json!({
         "t": "error",
         "code": "overflow",
-        "message": "terminal output queue is full; reconnect to resume",
     }))
 }
 

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -42,16 +42,16 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine as _;
-use serde_json::{json, Value};
+use base64::engine::general_purpose::STANDARD as BASE64;
+use serde_json::{Value, json};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
 
 use crate::pty::{
-    random_hex, session_name_ok, surface_ref_ok, FrameContext, PtyManager, PTY_PROTOCOL_VERSION,
+    FrameContext, PTY_PROTOCOL_VERSION, PtyManager, random_hex, session_name_ok, surface_ref_ok,
 };
 
 /// Loopback port the gateway's spliced streams dial. The chatmux Worker
@@ -73,11 +73,14 @@ const OPEN_TIMEOUT: Duration = Duration::from_secs(10);
 /// manager's own 1 MiB output cap stays the hard boundary above this.
 const FLOW_PAUSE_BYTES: u64 = 262_144;
 const FLOW_RESUME_BYTES: u64 = 32_768;
+const FLOW_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 /// Admission is synchronous from the manager callback, so the writer queue
-/// uses non-blocking sends with both message and byte budgets. The byte cap
-/// leaves room for a maximum PTY frame and a follow-up control/error frame.
+/// uses non-blocking sends with both message and byte budgets. Every ordinary
+/// frame leaves a byte reserve for the explicit overflow frame. Two channel
+/// permits reserve one message slot for overflow and one for shutdown.
 const WRITER_QUEUE_CAPACITY: usize = 128;
 const WRITER_QUEUE_BYTE_CAP: u64 = (MAX_TUNNEL_FRAME_BYTES as u64 + HEADER_BYTES as u64) * 2;
+const WRITER_OVERFLOW_BYTE_RESERVE: u64 = 4 * 1024;
 
 /// Relay pty_error codes -> browser wire codes. Mirrors the Worker's
 /// browserErrorCode map (apps/backend/src/terminal/relay-pty.ts). KEEP IN
@@ -121,6 +124,14 @@ pub fn encode_control_frame(frame: &Value) -> Vec<u8> {
 
 pub fn encode_pty_frame(bytes: &[u8]) -> Vec<u8> {
     encode_tunnel_frame(FRAME_KIND_PTY, bytes)
+}
+
+fn encode_overflow_frame() -> Vec<u8> {
+    encode_control_frame(&json!({
+        "t": "error",
+        "code": "overflow",
+        "message": "terminal output queue is full; reconnect to resume",
+    }))
 }
 
 /// Incremental frame decoder. After one failure the decoder is poisoned: a
@@ -259,11 +270,18 @@ struct Connection {
     pty_id: String,
     manager: Arc<PtyManager>,
     writer_tx: mpsc::Sender<WriterMessage>,
+    /// A permanently reserved channel slot for the explicit overflow frame.
+    overflow_permit: Mutex<Option<mpsc::OwnedPermit<WriterMessage>>>,
+    /// A permanently reserved channel slot for shutdown. `finish` is
+    /// synchronous, so it cannot wait for queue capacity.
+    end_permit: Mutex<Option<mpsc::OwnedPermit<WriterMessage>>>,
     /// Serializes queue admission with the End marker so no frame can be
     /// inserted after shutdown and silently be dropped by the writer.
     queue_gate: Mutex<()>,
-    /// pty_flow requests from the writer's water marks (true = pause).
-    flow_tx: mpsc::Sender<bool>,
+    /// Latest pty_flow state from the writer's water marks (true = pause).
+    /// A watch channel retains only the latest state, so flow notifications
+    /// cannot grow while the manager handles a previous request.
+    flow_tx: watch::Sender<bool>,
     /// Bytes queued toward the socket and not yet written.
     pending_out: AtomicU64,
     paused: AtomicBool,
@@ -280,13 +298,13 @@ impl Connection {
         let _ = self.enqueue(WriterMessage::Frame(encode_control_frame(frame)));
     }
 
-    fn reserve_bytes(&self, amount: u64) -> bool {
+    fn reserve_bytes(&self, amount: u64, limit: u64) -> bool {
         let mut current = self.pending_out.load(Ordering::SeqCst);
         loop {
             let Some(next) = current.checked_add(amount) else {
                 return false;
             };
-            if next > WRITER_QUEUE_BYTE_CAP {
+            if next > limit {
                 return false;
             }
             match self.pending_out.compare_exchange(
@@ -307,26 +325,58 @@ impl Connection {
 
     /// Pause the source before closing when a stalled peer exhausts admission.
     fn reject_due_to_backpressure(&self) {
-        if !self.paused.swap(true, Ordering::SeqCst) {
-            let _ = self.flow_tx.try_send(true);
+        let _gate = self.queue_gate.lock().expect("writer queue lock");
+        if self.finished.load(Ordering::SeqCst) {
+            return;
         }
-        self.finish();
+        // The ordinary admission limit always leaves this byte range unused.
+        // The owned permit leaves one message slot unused. Together they make
+        // this error observable even when the peer is stalled and the data
+        // queue is full.
+        let overflow = encode_overflow_frame();
+        let overflow_bytes = overflow.len() as u64;
+        if self.reserve_bytes(overflow_bytes, WRITER_QUEUE_BYTE_CAP) {
+            if let Some(permit) = self.overflow_permit.lock().expect("overflow permit lock").take()
+            {
+                permit.send(WriterMessage::Frame(overflow));
+            } else {
+                self.release_bytes(overflow_bytes);
+            }
+        }
+        let should_publish_pause = !self.paused.swap(true, Ordering::SeqCst);
+        self.finished.store(true, Ordering::SeqCst);
+        if let Some(permit) = self.end_permit.lock().expect("end permit lock").take() {
+            permit.send(WriterMessage::End);
+        }
+        if should_publish_pause {
+            // Publish before cancellation. The flow worker may wake on `done`
+            // immediately, so sending afterward could lose the required
+            // pause notification.
+            self.flow_tx.send_replace(true);
+        }
+        self.done.cancel();
     }
 
     fn enqueue(&self, message: WriterMessage) -> bool {
         let frame_bytes = match &message {
             WriterMessage::Frame(frame) => frame.len() as u64,
-            WriterMessage::End => 0,
+            WriterMessage::End => {
+                self.finish();
+                return true;
+            }
         };
         let mut reserved = false;
         let admitted = {
             let _gate = self.queue_gate.lock().expect("writer queue lock");
             if self.finished.load(Ordering::SeqCst) {
                 false
-            } else if frame_bytes != 0 && !self.reserve_bytes(frame_bytes) {
+            } else if !self.reserve_bytes(
+                frame_bytes,
+                WRITER_QUEUE_BYTE_CAP.saturating_sub(WRITER_OVERFLOW_BYTE_RESERVE),
+            ) {
                 false
             } else {
-                reserved = frame_bytes != 0;
+                reserved = true;
                 self.writer_tx.try_send(message).is_ok()
             }
         };
@@ -351,7 +401,9 @@ impl Connection {
         if self.finished.swap(true, Ordering::SeqCst) {
             return;
         }
-        let _ = self.writer_tx.try_send(WriterMessage::End);
+        if let Some(permit) = self.end_permit.lock().expect("end permit lock").take() {
+            permit.send(WriterMessage::End);
+        }
         self.done.cancel();
     }
 
@@ -405,7 +457,7 @@ impl Connection {
                 if self.pending_out.load(Ordering::SeqCst) > FLOW_PAUSE_BYTES
                     && !self.paused.swap(true, Ordering::SeqCst)
                 {
-                    let _ = self.flow_tx.try_send(true);
+                    self.flow_tx.send_replace(true);
                 }
             }
             Some("pty_exit") => {
@@ -509,15 +561,80 @@ async fn handle_client_frame(
     }
 }
 
+fn spawn_flow_worker(
+    connection: Arc<Connection>,
+    context: FrameContext,
+    mut flow_rx: watch::Receiver<bool>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut applied_pause = false;
+        loop {
+            tokio::select! {
+                biased;
+                changed = flow_rx.changed() => {
+                    if changed.is_err() {
+                        break;
+                    }
+                    let pause = *flow_rx.borrow_and_update();
+                    if pause == applied_pause {
+                        continue;
+                    }
+                    let frame = json!({
+                        "version": PTY_PROTOCOL_VERSION,
+                        "type": "pty_flow",
+                        "ptyId": connection.pty_id,
+                        "pause": pause,
+                    });
+                    connection.manager.handle_frame(&frame, &context).await;
+                    applied_pause = pause;
+                }
+                _ = connection.done.cancelled() => {
+                    // `finish` may race with the watch notification. Read the
+                    // current value once more so a final pause is not lost.
+                    let pause = *flow_rx.borrow();
+                    if pause != applied_pause {
+                        let frame = json!({
+                            "version": PTY_PROTOCOL_VERSION,
+                            "type": "pty_flow",
+                            "ptyId": connection.pty_id,
+                            "pause": pause,
+                        });
+                        connection.manager.handle_frame(&frame, &context).await;
+                    }
+                    break;
+                }
+            }
+        }
+    })
+}
+
 async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: CancellationToken) {
     let _ = stream.set_nodelay(true);
     let (mut read_half, mut write_half) = stream.into_split();
     let (writer_tx, mut writer_rx) = mpsc::channel::<WriterMessage>(WRITER_QUEUE_CAPACITY);
-    let (flow_tx, mut flow_rx) = mpsc::channel::<bool>(4);
+    // Keep one channel slot for an overflow error and one for End. These
+    // owned permits make both markers enqueueable even when the peer stalls.
+    let overflow_permit = match writer_tx.clone().try_reserve_owned() {
+        Ok(permit) => permit,
+        Err(_) => {
+            let _ = write_half.shutdown().await;
+            return;
+        }
+    };
+    let end_permit = match writer_tx.clone().try_reserve_owned() {
+        Ok(permit) => permit,
+        Err(_) => {
+            let _ = write_half.shutdown().await;
+            return;
+        }
+    };
+    let (flow_tx, flow_rx) = watch::channel(false);
     let connection = Arc::new(Connection {
         pty_id: format!("tunnel-{}", random_hex(8)),
         manager: Arc::clone(&manager),
         writer_tx,
+        overflow_permit: Mutex::new(Some(overflow_permit)),
+        end_permit: Mutex::new(Some(end_permit)),
         queue_gate: Mutex::new(()),
         flow_tx,
         pending_out: AtomicU64::new(0),
@@ -546,16 +663,11 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
                             connection.finish();
                             break;
                         }
-                        if previous.saturating_sub(length) < FLOW_RESUME_BYTES
+                        if !connection.finished.load(Ordering::SeqCst)
+                            && previous.saturating_sub(length) < FLOW_RESUME_BYTES
                             && connection.paused.swap(false, Ordering::SeqCst)
                         {
-                            let _ = connection.flow_tx.try_send(false);
-                        }
-                        // `finish` may race with a full queue, so End is only
-                        // best effort. Once all admitted frames drain, stop
-                        // without waiting for another sender-side message.
-                        if connection.finished.load(Ordering::SeqCst) && writer_rx.is_empty() {
-                            break;
+                            connection.flow_tx.send_replace(false);
                         }
                     }
                     WriterMessage::End => break,
@@ -566,27 +678,9 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
     };
 
     // Flow verbs need the async manager; drain them on their own task so a
-    // slow open never delays a pause.
-    let flow = {
-        let connection = Arc::clone(&connection);
-        let context = context.clone();
-        tokio::spawn(async move {
-            while let Some(pause) = flow_rx.recv().await {
-                // Deliver a final pause even when shutdown has started. This
-                // keeps PTY flow semantics intact for a queue-overflow close.
-                if connection.finished.load(Ordering::SeqCst) && !pause {
-                    break;
-                }
-                let frame = json!({
-                    "version": PTY_PROTOCOL_VERSION,
-                    "type": "pty_flow",
-                    "ptyId": connection.pty_id,
-                    "pause": pause,
-                });
-                connection.manager.handle_frame(&frame, &context).await;
-            }
-        })
-    };
+    // slow open never delays a pause. The watch receiver retains the latest
+    // state instead of accumulating bool messages.
+    let mut flow = spawn_flow_worker(Arc::clone(&connection), context.clone(), flow_rx);
 
     // Reader: strictly in arrival order, so input received while an open
     // settles lands after the attachment exists. Awaiting each frame is the
@@ -632,6 +726,13 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
         }
     }
     connection.finish();
+    // A queue-overflow close must deliver pty_flow(true) before the
+    // attachment is released. The timeout prevents a broken manager from
+    // holding the connection task forever.
+    if tokio::time::timeout(FLOW_DRAIN_TIMEOUT, &mut flow).await.is_err() {
+        flow.abort();
+    }
+    let _ = flow.await;
     // Detach, never kill: the owed close releases only this connection's
     // attachment (transport-fenced), and the session lives on.
     if connection.open_sent.load(Ordering::SeqCst) {
@@ -642,13 +743,11 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
         });
         manager.handle_frame(&close, &context).await;
     }
-    flow.abort();
     // A peer that stopped reading can wedge the final flush forever; the
     // attachment is already released above, so cap the flush and reap.
     if tokio::time::timeout(Duration::from_secs(30), &mut writer).await.is_err() {
         writer.abort();
     }
-    let _ = flow.await;
 }
 
 /// Start the loopback listener. Managed mode only — the caller's managed
@@ -712,6 +811,8 @@ mod tests {
         on_exit: Option<ExitSink>,
         written: Vec<Vec<u8>>,
         resized: Vec<(u16, u16)>,
+        pause_calls: usize,
+        resume_calls: usize,
         killed: bool,
     }
 
@@ -742,8 +843,12 @@ mod tests {
         fn resize(&self, cols: u16, rows: u16) {
             self.state.lock().unwrap().resized.push((cols, rows));
         }
-        fn pause(&self) {}
-        fn resume(&self) {}
+        fn pause(&self) {
+            self.state.lock().unwrap().pause_calls += 1;
+        }
+        fn resume(&self) {
+            self.state.lock().unwrap().resume_calls += 1;
+        }
         fn kill(&self) {
             self.state.lock().unwrap().killed = true;
         }
@@ -990,13 +1095,17 @@ mod tests {
 
     fn test_connection(
         rig: &Rig,
-    ) -> (Arc<Connection>, mpsc::Receiver<WriterMessage>, mpsc::Receiver<bool>) {
+    ) -> (Arc<Connection>, mpsc::Receiver<WriterMessage>, watch::Receiver<bool>) {
         let (writer_tx, writer_rx) = mpsc::channel(WRITER_QUEUE_CAPACITY);
-        let (flow_tx, flow_rx) = mpsc::channel(4);
+        let overflow_permit = writer_tx.clone().try_reserve_owned().expect("reserve overflow slot");
+        let end_permit = writer_tx.clone().try_reserve_owned().expect("reserve End slot");
+        let (flow_tx, flow_rx) = watch::channel(false);
         let connection = Arc::new(Connection {
             pty_id: "test-pty".to_owned(),
             manager: Arc::clone(&rig.manager),
             writer_tx,
+            overflow_permit: Mutex::new(Some(overflow_permit)),
+            end_permit: Mutex::new(Some(end_permit)),
             queue_gate: Mutex::new(()),
             flow_tx,
             pending_out: AtomicU64::new(0),
@@ -1009,17 +1118,32 @@ mod tests {
         (connection, writer_rx, flow_rx)
     }
 
+    async fn attach_test_pty(rig: &Rig, connection: &Arc<Connection>) -> FakePty {
+        connection.open_sent.store(true, Ordering::SeqCst);
+        let context = connection.frame_context();
+        let open = json!({
+            "version": PTY_PROTOCOL_VERSION,
+            "type": "pty_open",
+            "ptyId": connection.pty_id,
+            "session": "flow-test",
+            "cols": 80,
+            "rows": 24,
+        });
+        rig.manager.handle_frame(&open, &context).await;
+        spawned_pty(rig).await
+    }
+
     #[tokio::test]
     async fn stalled_peer_hits_the_byte_budget_and_pauses_before_close() {
         let rig = rig().await;
-        let (connection, mut writer_rx, mut flow_rx) = test_connection(&rig);
-        let frame_len = WRITER_QUEUE_BYTE_CAP as usize / 2;
+        let (connection, mut writer_rx, flow_rx) = test_connection(&rig);
+        let frame_len = (WRITER_QUEUE_BYTE_CAP - WRITER_OVERFLOW_BYTE_RESERVE) as usize / 2;
         assert!(connection.enqueue(WriterMessage::Frame(vec![1; frame_len])));
         assert!(connection.enqueue(WriterMessage::Frame(vec![2; frame_len])));
         assert!(!connection.enqueue(WriterMessage::Frame(vec![3])));
         assert!(connection.finished.load(Ordering::SeqCst));
         assert!(connection.pending_out.load(Ordering::SeqCst) <= WRITER_QUEUE_BYTE_CAP);
-        assert_eq!(flow_rx.try_recv(), Ok(true));
+        assert!(*flow_rx.borrow());
         match writer_rx.recv().await.expect("first admitted frame") {
             WriterMessage::Frame(frame) => assert_eq!(frame[0], 1),
             WriterMessage::End => panic!("queue order changed"),
@@ -1028,26 +1152,68 @@ mod tests {
             WriterMessage::Frame(frame) => assert_eq!(frame[0], 2),
             WriterMessage::End => panic!("queue order changed"),
         }
+        match writer_rx.recv().await.expect("overflow control frame") {
+            WriterMessage::Frame(frame) => {
+                let error: Value = serde_json::from_slice(&frame[HEADER_BYTES..]).unwrap();
+                assert_eq!(error["code"], "overflow");
+            }
+            WriterMessage::End => panic!("End overtook overflow error"),
+        }
+        assert!(matches!(writer_rx.recv().await, Some(WriterMessage::End)));
         rig.cancel.cancel();
     }
 
     #[tokio::test]
     async fn full_writer_queue_closes_without_growing_beyond_message_budget() {
         let rig = rig().await;
-        let (connection, mut writer_rx, mut flow_rx) = test_connection(&rig);
-        for index in 0..WRITER_QUEUE_CAPACITY {
+        let (connection, mut writer_rx, flow_rx) = test_connection(&rig);
+        let data_capacity = WRITER_QUEUE_CAPACITY - 2;
+        for index in 0..data_capacity {
             assert!(connection.enqueue(WriterMessage::Frame(vec![index as u8])));
         }
         assert!(!connection.enqueue(WriterMessage::Frame(vec![0])));
         assert!(connection.finished.load(Ordering::SeqCst));
-        assert_eq!(flow_rx.try_recv(), Ok(true));
-        for index in 0..WRITER_QUEUE_CAPACITY {
+        assert!(*flow_rx.borrow());
+        for index in 0..data_capacity {
             match writer_rx.recv().await.expect("admitted frame") {
                 WriterMessage::Frame(frame) => assert_eq!(frame, vec![index as u8]),
                 WriterMessage::End => panic!("queue order changed"),
             }
         }
-        assert!(writer_rx.try_recv().is_err());
+        match writer_rx.recv().await.expect("overflow control frame") {
+            WriterMessage::Frame(frame) => {
+                let error: Value = serde_json::from_slice(&frame[HEADER_BYTES..]).unwrap();
+                assert_eq!(error["code"], "overflow");
+            }
+            WriterMessage::End => panic!("End overtook overflow error"),
+        }
+        assert!(matches!(writer_rx.recv().await, Some(WriterMessage::End)));
+        rig.cancel.cancel();
+    }
+
+    #[tokio::test]
+    async fn flow_notifications_retain_only_the_latest_state() {
+        let rig = rig().await;
+        let (connection, _writer_rx, mut flow_rx) = test_connection(&rig);
+        connection.flow_tx.send_replace(true);
+        connection.flow_tx.send_replace(false);
+        assert!(flow_rx.changed().await.is_ok());
+        assert!(!*flow_rx.borrow_and_update());
+        rig.cancel.cancel();
+    }
+
+    #[tokio::test]
+    async fn overflow_delivers_pause_before_flow_worker_stops() {
+        let rig = rig().await;
+        let (connection, _writer_rx, flow_rx) = test_connection(&rig);
+        let pty = attach_test_pty(&rig, &connection).await;
+        let flow = spawn_flow_worker(Arc::clone(&connection), connection.frame_context(), flow_rx);
+        connection.reject_due_to_backpressure();
+        tokio::time::timeout(FLOW_DRAIN_TIMEOUT, flow)
+            .await
+            .expect("flow worker deadline")
+            .expect("flow worker join");
+        assert_eq!(pty.state.lock().unwrap().pause_calls, 1);
         rig.cancel.cancel();
     }
 


### PR DESCRIPTION
## Summary

Rebase the cmux TUI tunnel-writer work from [PR #11206](https://github.com/manaflow-ai/cmux/pull/11206) onto current `main`, preserving its test-first commit sequence and resolving only concrete `chatmux-relay` conflicts.

This stack includes the tested E0382 fix from [PR #11357](https://github.com/manaflow-ai/cmux/pull/11357). The relay test helper clones `owner` for `FrameContext::owner_user_id` before the `current_auth` closure captures its snapshot. Runtime behavior is unchanged.

The current-main pass also fixes two concrete shared-shell issues: exit callbacks now run after releasing `flow_lock`, and paused viewers retain bounded output backlog for ordered replay when resumed. The regression test covers continued output while a viewer is paused.

## Verification

Base: `main` at `717f35768bbfc7a60c0a81ce9fe4b0c74fafd674`.
Head: `296e07c8c778ed4b21631d05f8ec00309a7906dc`.

Local checks passed:

- `rustfmt --check --edition 2024 cmux-tui/crates/chatmux-relay/src/pty.rs cmux-tui/crates/chatmux-relay/src/session.rs cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs`
- `git diff --check`

No local Cargo or Rust compilation was run. Run focused hosted verification on this exact head:

```bash
./scripts/verify-cmux-tui-hosted.sh --filter chatmux_relay
```

This PR supersedes the old-main stack in [#11206](https://github.com/manaflow-ai/cmux/pull/11206). [#11357](https://github.com/manaflow-ai/cmux/pull/11357) is redundant once this current-main stack is accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved terminal flow control with bounded output buffering to prevent excessive queue growth.
  * Added clear overflow handling when terminal output exceeds capacity.
  * Added per-viewer pause and resume behavior, including ordered replay of output received while paused.
  * Terminal access now reflects current authorization status during output and session changes.

* **Bug Fixes**
  * Prevented paused viewers from receiving unintended live output.
  * Improved output routing and cleanup when viewers disconnect or authorization changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->