### PR TITLE
iOS: make composer cancellation test fixture cancellation-aware

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DelayedTeamPairedMacStore.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DelayedTeamPairedMacStore.swift
@@ -16,7 +16,9 @@ actor DelayedTeamPairedMacStore: MobilePairedMacStoring, PairedMacBackupRefreshi
     private let blockedTeams: Set<String>
     private var startedTeams: Set<String> = []
     private var startWaiters: [String: [CheckedContinuation<Void, Never>]] = [:]
-    private var blockers: [String: [CheckedContinuation<Void, Never>]] = [:]
+    // Keep an id with each parked read so release and cancellation can race
+    // without resuming another load's continuation.
+    private var blockers: [String: [(id: UUID, continuation: CheckedContinuation<Void, Never>)]] = [:]
     private var upsertCount = 0
     private var loadAllCount = 0
     private var recordReplacement: (
@@ -170,9 +172,26 @@ actor DelayedTeamPairedMacStore: MobilePairedMacStoring, PairedMacBackupRefreshi
         let key = teamID ?? ""
         markStarted(key)
         if blockedTeams.contains(key) {
-            await withCheckedContinuation { continuation in
-                blockers[key, default: []].append(continuation)
+            let blockerID = UUID()
+            // Canceled aggregation tasks must release their fake read just as
+            // the real store releases a canceled I/O operation.
+            await withTaskCancellationHandler {
+                await withCheckedContinuation { continuation in
+                    guard !Task.isCancelled else {
+                        continuation.resume()
+                        return
+                    }
+                    blockers[key, default: []].append((
+                        id: blockerID,
+                        continuation: continuation
+                    ))
+                }
+            } onCancel: {
+                Task {
+                    await self.cancelLoadAllBlocker(key: key, id: blockerID)
+                }
             }
+            try Task.checkCancellation()
         }
         let result: [MobilePairedMac]
         if key.isEmpty {
@@ -289,7 +308,21 @@ actor DelayedTeamPairedMacStore: MobilePairedMacStoring, PairedMacBackupRefreshi
         } else {
             blockers[key] = queued
         }
-        blocker.resume()
+        blocker.continuation.resume()
+    }
+
+    private func cancelLoadAllBlocker(key: String, id: UUID) {
+        guard var queued = blockers[key],
+              let index = queued.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+        let blocker = queued.remove(at: index)
+        if queued.isEmpty {
+            blockers.removeValue(forKey: key)
+        } else {
+            blockers[key] = queued
+        }
+        blocker.continuation.resume()
     }
 
     func waitUntilUpsertCount(_ count: Int) async {

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileTaskComposerCancellationTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileTaskComposerCancellationTests.swift
@@ -55,10 +55,12 @@ import Testing
     }
 
     @Test func cancellingSupersededSubmissionDoesNotCancelNewerMacSwitch() async throws {
+        // Name the paired instances explicitly so both submissions exercise
+        // the warm control-pool promotion path before the display cache loads.
         let pairedStore = DelayedTeamPairedMacStore(
             recordsByTeam: ["": [
-                Self.pairedMac(macDeviceID: "secondary-b"),
-                Self.pairedMac(macDeviceID: "secondary-c"),
+                Self.pairedMac(macDeviceID: "secondary-b", instanceTag: "b"),
+                Self.pairedMac(macDeviceID: "secondary-c", instanceTag: "c"),
             ]],
             blockedTeams: [""]
         )
@@ -68,15 +70,23 @@ import Testing
             router: RoutingHostRouter(),
             pairedMacStore: pairedStore
         )
+        defer {
+            // The successful switch starts a trailing aggregation pass. Stop
+            // the lifecycle owner so its delayed store read receives the same
+            // cancellation signal as a real background transition.
+            store.suspendForegroundRefresh()
+        }
         try installSecondaryClient(
             on: store,
             macDeviceID: "secondary-b",
+            instanceTag: "b",
             router: routerB,
             supportedHostCapabilities: ["workspace.task_create.v1"]
         )
         try installSecondaryClient(
             on: store,
             macDeviceID: "secondary-c",
+            instanceTag: "c",
             router: routerC,
             supportedHostCapabilities: ["workspace.task_create.v1"]
         )
@@ -86,6 +96,7 @@ import Testing
         let submissionB = Task { @MainActor in
             await store.submitTaskComposer(
                 macDeviceID: "secondary-b",
+                instanceTag: "b",
                 spec: MobileWorkspaceCreateSpec(title: "B", operationID: UUID()),
                 willStartCreate: { boundaryBCount += 1 }
             )
@@ -97,6 +108,7 @@ import Testing
         let submissionC = Task { @MainActor in
             await store.submitTaskComposer(
                 macDeviceID: "secondary-c",
+                instanceTag: "c",
                 spec: MobileWorkspaceCreateSpec(title: "C", operationID: UUID()),
                 willStartCreate: { boundaryCCount += 1 }
             )
@@ -105,7 +117,6 @@ import Testing
 
         submissionB.cancel()
         #expect(store.isMacSwitchInFlight)
-        await pairedStore.release(teamID: nil)
         _ = await submissionB.value
         #expect(store.isMacSwitchInFlight)
 
@@ -124,7 +135,10 @@ import Testing
         #expect(await routerC.recordedWorkspaceCreateCount() == 1)
     }
 
-    private static func pairedMac(macDeviceID: String) -> MobilePairedMac {
+    private static func pairedMac(
+        macDeviceID: String,
+        instanceTag: String? = nil
+    ) -> MobilePairedMac {
         MobilePairedMac(
             macDeviceID: macDeviceID,
             displayName: macDeviceID,
@@ -132,7 +146,8 @@ import Testing
             createdAt: Date(),
             lastSeenAt: Date(),
             isActive: false,
-            stackUserID: "routing-user"
+            stackUserID: "routing-user",
+            instanceTag: instanceTag
         )
     }
 }


### PR DESCRIPTION
Closes https://github.com/manaflow-ai/cmux/issues/11256

## Summary

The hang is a test-harness defect, not a production Mac-switch cancellation defect. The fixture used untagged paired rows, which missed the intended warm control-pool path and parked extra fake `loadAll` calls in continuations that ignored cancellation.

The regression now uses exact instance tags for the B/C warm clients. `DelayedTeamPairedMacStore` gives every parked read an identity, removes and resumes that exact continuation on task cancellation, then propagates `CancellationError`. The successful test also stops the foreground-refresh lifecycle so its trailing aggregation read is cancelled deterministically.

The two commits preserve the required red/green history: the first makes the intended regression path deterministic and still hangs; the second fixes the cancellation-aware fake.

## Verification

- `/usr/bin/time -p /usr/bin/perl -e 'alarm 600; exec @ARGV' -- swift test --package-path Packages/iOS/CmuxMobileShell --filter MobileTaskComposerCancellationTests` on the original `origin/main` fixture (hard timeout reproduced the hang).
- `swift test --package-path Packages/iOS/CmuxMobileShell --filter MobileTaskComposerCancellationTests` on macOS 26.5 (2 tests passed; suite 0.068s).
- `MACLEASE_SESSION_USERS=multi /Users/austinwang/manaflow/cmuxterm-hq/scripts/maclease.sh run --host cmux-aws-m4pro --ttl 30m --desc 'issue-11256 focused composer cancellation test' --ref issue-11256-composer-cancellation-hang -- swift test --package-path Packages/iOS/CmuxMobileShell --filter MobileTaskComposerCancellationTests` on macOS 15.7.4 (2 tests passed; build 61.08s, suite 0.386s).
- `/usr/bin/time -p /usr/bin/perl -e 'alarm 900; exec @ARGV' -- swift test --parallel --num-workers 1 --package-path Packages/iOS/CmuxMobileShell` on macOS 15.7.4 (full package runner completed in 268.01s; exit 1 from pre-existing unrelated connection/authority failures, while `MobileTaskComposerCancellationTests` completed).
- `MACLEASE_SESSION_USERS=multi /Users/austinwang/manaflow/cmuxterm-hq/scripts/maclease.sh run --host cmux-aws-m4pro --slot cmux-aws-m4pro.3 --ttl 35m --desc 'issue-11256 full CmuxMobileShell suite' --ref issue-11256-composer-cancellation-hang -- bash -lc '/usr/bin/time -p python3 scripts/ci/run_with_timeout.py --timeout-seconds 600 -- swift test --package-path Packages/iOS/CmuxMobileShell'` after the final rebase (the target suite passed in 114.404s inside the aggregate run; the aggregate hit 600s amid the same unrelated baseline failures).
- `python3 scripts/swift_warning_budget.py --log /tmp/issue11256-focused-final.log` (passed; 0 warnings in the focused final log).
- `git diff --check origin/main...HEAD` (passed).
- `wc -l Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DelayedTeamPairedMacStore.swift Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileTaskComposerCancellationTests.swift` (420 and 153 lines; both under 500).
- `python3 scripts/swift_file_length_budget.py` (not available in this checkout; neither that script nor `.github/swift-file-length-budget.tsv` exists, so both touched files were checked directly and remain under 500 lines).
