### PR TITLE
fix(cmux): linearize pipe relay stderr parsing

### DIFF
--- a/Sources/TuiManualIOPump.swift
+++ b/Sources/TuiManualIOPump.swift
@@ -880,7 +880,8 @@ func splitTuiManualIOStderrLines(_ data: Data) -> (completeLines: [Data], remain
         completeLines.append(Data(data[lineStart..<index]))
         lineStart = data.index(after: index)
     }
-    return (completeLines, Data(data[lineStart...]))
+    let remainder = lineStart == data.startIndex ? data : Data(data[lineStart...])
+    return (completeLines, remainder)
 }
 
 /// Lock-guarded stderr accumulator: the relay prints its machine-readable

--- a/Sources/TuiManualIOPump.swift
+++ b/Sources/TuiManualIOPump.swift
@@ -844,11 +844,9 @@ final class TuiManualIOStderrStream: @unchecked Sendable {
     private func scanLines(_ data: Data, onResizeDiag: @Sendable () -> Void) {
         lock.lock()
         pendingLine.append(data)
-        var lines: [Data] = []
-        while let newline = pendingLine.firstIndex(of: 0x0A) {
-            lines.append(Data(pendingLine[pendingLine.startIndex..<newline]))
-            pendingLine = Data(pendingLine[pendingLine.index(after: newline)...])
-        }
+        let split = splitTuiManualIOStderrLines(pendingLine)
+        let lines = split.completeLines
+        pendingLine = split.remainder
         // Bound the buffer against a relay that misbehaves and never prints
         // a newline; diag and exit lines are all short.
         if pendingLine.count > 64 * 1024 {
@@ -870,6 +868,19 @@ final class TuiManualIOStderrStream: @unchecked Sendable {
         lock.unlock()
         target?.readabilityHandler = nil
     }
+}
+
+/// Splits one accumulated stderr buffer in a single pass. Repeatedly
+/// searching and replacing a `Data` prefix copies the remaining suffix for
+/// every line, which makes a burst of short diagnostics quadratic.
+func splitTuiManualIOStderrLines(_ data: Data) -> (completeLines: [Data], remainder: Data) {
+    var completeLines: [Data] = []
+    var lineStart = data.startIndex
+    for index in data.indices where data[index] == 0x0A {
+        completeLines.append(Data(data[lineStart..<index]))
+        lineStart = data.index(after: index)
+    }
+    return (completeLines, Data(data[lineStart...]))
 }
 
 /// Lock-guarded stderr accumulator: the relay prints its machine-readable

--- a/cmuxTests/TuiManualIOPumpTests.swift
+++ b/cmuxTests/TuiManualIOPumpTests.swift
@@ -258,6 +258,15 @@ struct TuiManualIOPumpTests {
         #expect(text == "a\nb\n\(claim)c\nd\n")
     }
 
+    @Test
+    func stderrLineSplitterKeepsCompleteLinesAndTrailingPartialData() {
+        let data = Data("first\nsecond\npartial".utf8)
+        let split = splitTuiManualIOStderrLines(data)
+
+        #expect(split.completeLines == [Data("first".utf8), Data("second".utf8)])
+        #expect(split.remainder == Data("partial".utf8))
+    }
+
     // MARK: - Registry
 
     @MainActor


### PR DESCRIPTION
Follow-up to PR 11221, based on exact head 696daa870e1ae11922962c09b258acbe7e4c867b.\n\nThe relay stderr parser now scans each accumulated Data buffer once, then copies only complete lines and one bounded remainder. This removes quadratic suffix copying during diagnostic bursts while preserving line framing and the 64 KiB cap.\n\nValidation: git diff --check only. No local Cargo/Rust/Xcode tests were run per task constraint. Official Apple guidance documents RangeReplaceableCollection.removeFirst as O(n), which motivated the change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11382"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790842070&installation_model_id=21920&pr_number=11382&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11382&signature=00c83bf4a37c13639ce7f83290c852ede509269fcd0c228f42f9cd873c001a97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the relay stderr line splitter's repeated suffix copying with a single-pass scan, so diagnostic bursts no longer cause quadratic time in the relay parser.

- Preserves the trailing partial buffer without copying it.
- Keeps line framing and the 64 KiB buffer cap unchanged.
- Adds a test for complete lines plus a trailing partial line.

<sup>Written for commit ac072d92a50e41c2e6193e15aa5fcf4b2990150f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

