### PR TITLE
tests: main's cmuxTests does not compile since #11345 — CloudTreeNativeDragOwnershipTests fixture lacks projectInLocalWorkspace

### DIFF
--- a/cmuxTests/CloudTreeNativeDragOwnershipTests.swift
+++ b/cmuxTests/CloudTreeNativeDragOwnershipTests.swift
@@ -271,6 +271,7 @@ struct CloudTreeNativeDragOwnershipTests {
 
     private static let nodeActions = CloudTreeNodeActions(
         project: { _, _, _ in },
+        projectInLocalWorkspace: { _, _ in },
         newTerminal: { _, _ in },
         openGroup: { _, _, _, _ in },
         openGroupAsWorkspace: { _, _, _ in },


### PR DESCRIPTION
## Summary

`origin/main` (`d2a1ac9704`) fails to compile the `cmuxTests` target:

```
cmuxTests/CloudTreeNativeDragOwnershipTests.swift:273:32: error: missing argument for parameter 'projectInLocalWorkspace' in call
```

#11345 (`28b71b2d06`) squash-merged `CloudTreeNodeActions.projectInLocalWorkspace` (originally from #11300) but the merge happened before the branch's fixture fix (`01c447cd98`) was pushed, and #11346 did not end up carrying that line onto main. One-line fix: the test fixture passes `projectInLocalWorkspace: { _, _ in }`.

Note: once this compiles, `CloudTreeNativeDragOwnershipTests."An abandoned Cloud writer revokes its provisional capability on deallocation"` (added by #11186, never run on CI before today) fails deterministically — reproduced twice on the #11345 branch — that is a separate, pre-existing issue and is not addressed here.

## Test plan
- [x] `test-e2e.yml` `cmuxTests/CloudTreeNativeDragOwnershipTests` on this branch: run 33485956319 — test target compiles, 3/4 pass; the remaining failure is the #11186 test, filed as https://github.com/manaflow-ai/cmux/issues/11388

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhsDDbUPPMnYKyTy7AXxBd

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11384"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790842345&installation_model_id=21920&pr_number=11384&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11384&signature=f251f56c1d7d14cbb59c193f57fb1c9afae0a720429c1a737de06ca65a0a4a91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `cmuxTests` target so it compiles again by adding the missing `projectInLocalWorkspace` argument to the `CloudTreeNativeDragOwnershipTests` fixture.

- The compile error came from `#11345` adding `CloudTreeNodeActions.projectInLocalWorkspace` without updating this test fixture.
- Once compiling, the "An abandoned Cloud writer revokes its provisional capability on deallocation" test fails deterministically; that's a separate pre-existing issue.

<sup>Written for commit 1cc0657d885d191e122a448200ebdfcba58d3bcc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->