### PR TITLE
fix(cmux-tui): install codex SessionEnd hook at the 3s cap

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
+++ b/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
@@ -14,9 +14,9 @@ const MAX_NATIVE_PAYLOAD_BYTES: u64 = 1024 * 1024;
 const MAX_MESSAGE_BYTES: usize = 4 * 1024 * 1024;
 const MAX_RESPONSE_BYTES: usize = 16 * 1024 * 1024;
 const SOCKET_TIMEOUT: Duration = Duration::from_secs(4);
-/// Codex kills SessionEnd hooks at 3s (its hard cap). Leave a small margin for
-/// the helper to report its own error instead of dying mid-append.
-const CODEX_SESSION_END_SOCKET_TIMEOUT: Duration = Duration::from_millis(2_900);
+/// Codex kills SessionEnd hooks at 3s (its hard cap). Reserve 500ms for
+/// process startup and for the helper to report its own error.
+const CODEX_SESSION_END_SOCKET_TIMEOUT: Duration = Duration::from_millis(2_500);
 
 #[derive(Debug, PartialEq, Eq)]
 struct Args {
@@ -355,7 +355,7 @@ mod tests {
     fn codex_session_end_gives_up_before_the_codex_hook_cap() {
         let timeout = socket_timeout("codex", "SessionEnd");
         assert!(timeout > Duration::from_secs(2));
-        assert!(timeout < Duration::from_secs(3));
+        assert!(timeout + Duration::from_millis(500) <= Duration::from_secs(3));
         assert_eq!(socket_timeout("codex", "Stop"), SOCKET_TIMEOUT);
         assert_eq!(socket_timeout("claude", "SessionEnd"), SOCKET_TIMEOUT);
     }

--- a/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
+++ b/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
@@ -25,12 +25,13 @@ struct Args {
 }
 
 fn main() -> ExitCode {
+    let started = Instant::now();
     let arguments = env::args().skip(1).collect::<Vec<_>>();
     if arguments.iter().any(|argument| matches!(argument.as_str(), "-h" | "--help")) {
         println!("Usage: cmux-tui-hook <agent> <native-event>");
         return ExitCode::SUCCESS;
     }
-    match parse_args(arguments).and_then(run) {
+    match parse_args(arguments).and_then(|args| run(args, started)) {
         Ok(()) => ExitCode::SUCCESS,
         Err(error) => {
             eprintln!("cmux-tui-hook: {error:#}");
@@ -39,8 +40,7 @@ fn main() -> ExitCode {
     }
 }
 
-fn run(args: Args) -> anyhow::Result<()> {
-    let started = Instant::now();
+fn run(args: Args, started: Instant) -> anyhow::Result<()> {
     let timeout = socket_timeout(&args.source, &args.native_event);
     if shadowed_by_grok(&args.source, env::var_os("GROK_HOOK_EVENT").as_deref()) {
         drain_native_payload()?;

--- a/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
+++ b/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
@@ -14,9 +14,9 @@ const MAX_NATIVE_PAYLOAD_BYTES: u64 = 1024 * 1024;
 const MAX_MESSAGE_BYTES: usize = 4 * 1024 * 1024;
 const MAX_RESPONSE_BYTES: usize = 16 * 1024 * 1024;
 const SOCKET_TIMEOUT: Duration = Duration::from_secs(4);
-/// codex kills SessionEnd hooks at 3s (its hard cap), so the helper must give
-/// up first and report its own error instead of dying mid-append.
-const CODEX_SESSION_END_SOCKET_TIMEOUT: Duration = Duration::from_secs(2);
+/// Codex kills SessionEnd hooks at 3s (its hard cap). Leave a small margin for
+/// the helper to report its own error instead of dying mid-append.
+const CODEX_SESSION_END_SOCKET_TIMEOUT: Duration = Duration::from_millis(2_900);
 
 #[derive(Debug, PartialEq, Eq)]
 struct Args {
@@ -353,9 +353,22 @@ mod tests {
 
     #[test]
     fn codex_session_end_gives_up_before_the_codex_hook_cap() {
-        assert!(socket_timeout("codex", "SessionEnd") < Duration::from_secs(3));
+        let timeout = socket_timeout("codex", "SessionEnd");
+        assert!(timeout > Duration::from_secs(2));
+        assert!(timeout < Duration::from_secs(3));
         assert_eq!(socket_timeout("codex", "Stop"), SOCKET_TIMEOUT);
         assert_eq!(socket_timeout("claude", "SessionEnd"), SOCKET_TIMEOUT);
+    }
+
+    #[test]
+    fn codex_session_end_allows_append_before_the_hook_cap() {
+        let started = Instant::now();
+        let result = retry_until(socket_timeout("codex", "SessionEnd"), |_deadline| {
+            std::thread::sleep(Duration::from_millis(2_100));
+            Ok::<_, AppendAttemptError>(())
+        });
+        assert!(result.is_ok());
+        assert!(started.elapsed() >= Duration::from_secs(2));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
+++ b/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
@@ -40,6 +40,8 @@ fn main() -> ExitCode {
 }
 
 fn run(args: Args) -> anyhow::Result<()> {
+    let started = Instant::now();
+    let timeout = socket_timeout(&args.source, &args.native_event);
     if shadowed_by_grok(&args.source, env::var_os("GROK_HOOK_EVENT").as_deref()) {
         drain_native_payload()?;
         return Ok(());
@@ -60,7 +62,7 @@ fn run(args: Args) -> anyhow::Result<()> {
         native,
     )?;
     let event = serde_json::to_value(ingress)?;
-    append(&socket, event, socket_timeout(&args.source, &args.native_event))
+    append(&socket, event, started, timeout)
 }
 
 fn shadowed_by_grok(source: &str, grok_hook_event: Option<&std::ffi::OsStr>) -> bool {
@@ -109,7 +111,7 @@ fn socket_timeout(source: &str, native_event: &str) -> Duration {
     }
 }
 
-fn append(socket: &Path, event: Value, timeout: Duration) -> anyhow::Result<()> {
+fn append(socket: &Path, event: Value, started: Instant, timeout: Duration) -> anyhow::Result<()> {
     let (request_id, idempotency_key) = random_identifiers()?;
     let request = json!({
         "protocol":"cmux.protocol/2",
@@ -125,7 +127,9 @@ fn append(socket: &Path, event: Value, timeout: Duration) -> anyhow::Result<()> 
         bail!("agent hook request exceeds the 4 MiB protocol limit");
     }
 
-    retry_until(timeout, |deadline| append_once(socket, &encoded, &request_id, deadline))
+    retry_until_deadline(started + timeout, timeout, |deadline| {
+        append_once(socket, &encoded, &request_id, deadline)
+    })
 }
 
 #[derive(Debug)]
@@ -138,7 +142,14 @@ fn retry_until<T>(
     timeout: Duration,
     mut attempt: impl FnMut(Instant) -> Result<T, AppendAttemptError>,
 ) -> anyhow::Result<T> {
-    let deadline = Instant::now() + timeout;
+    retry_until_deadline(Instant::now() + timeout, timeout, attempt)
+}
+
+fn retry_until_deadline<T>(
+    deadline: Instant,
+    timeout: Duration,
+    mut attempt: impl FnMut(Instant) -> Result<T, AppendAttemptError>,
+) -> anyhow::Result<T> {
     let mut last_error = None;
     loop {
         let remaining = deadline.saturating_duration_since(Instant::now());
@@ -363,12 +374,14 @@ mod tests {
     #[test]
     fn codex_session_end_allows_append_before_the_hook_cap() {
         let started = Instant::now();
-        let result = retry_until(socket_timeout("codex", "SessionEnd"), |_deadline| {
+        let timeout = socket_timeout("codex", "SessionEnd");
+        std::thread::sleep(Duration::from_millis(100));
+        let result = retry_until_deadline(started + timeout, timeout, |_deadline| {
             std::thread::sleep(Duration::from_millis(2_100));
             Ok::<_, AppendAttemptError>(())
         });
         assert!(result.is_ok());
-        assert!(started.elapsed() >= Duration::from_secs(2));
+        assert!(started.elapsed() >= Duration::from_millis(2_200));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
+++ b/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
@@ -62,6 +62,7 @@ fn run(args: Args, started: Instant) -> anyhow::Result<()> {
         native,
     )?;
     let event = serde_json::to_value(ingress)?;
+    let started = (args.source == "codex" && args.native_event == "SessionEnd").then_some(started);
     append(&socket, event, started, timeout)
 }
 
@@ -111,7 +112,12 @@ fn socket_timeout(source: &str, native_event: &str) -> Duration {
     }
 }
 
-fn append(socket: &Path, event: Value, started: Instant, timeout: Duration) -> anyhow::Result<()> {
+fn append(
+    socket: &Path,
+    event: Value,
+    started: Option<Instant>,
+    timeout: Duration,
+) -> anyhow::Result<()> {
     let (request_id, idempotency_key) = random_identifiers()?;
     let request = json!({
         "protocol":"cmux.protocol/2",
@@ -127,9 +133,12 @@ fn append(socket: &Path, event: Value, started: Instant, timeout: Duration) -> a
         bail!("agent hook request exceeds the 4 MiB protocol limit");
     }
 
-    retry_until_deadline(started + timeout, timeout, |deadline| {
-        append_once(socket, &encoded, &request_id, deadline)
-    })
+    match started {
+        Some(started) => retry_until_deadline(started + timeout, timeout, |deadline| {
+            append_once(socket, &encoded, &request_id, deadline)
+        }),
+        None => retry_until(timeout, |deadline| append_once(socket, &encoded, &request_id, deadline)),
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Current-main rebase candidate for #11373. Keeps the two-commit regression sequence. Codex SessionEnd installs at 3s, helper socket append is bounded at 2s, and trust hash compatibility remains covered. Standalone rustfmt and git diff --check pass. No local Cargo/Rust tests run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Installs codex `SessionEnd` hooks at codex's 3s cap instead of the generic 5s, so codex no longer prints its clamping warning. The helper socket now gives up 2.5s after process start, not after append begins, so codex's cap is respected while still allowing an append that runs ~2.1s.

- Existing installs stay owned because codex already hashed the clamped 3s value.
- Tests verify the installed timeouts survive codex normalization and that a 2.1s append completes before the 2.5s cap.

<sup>Written for commit 4220863a8c61b897656fe2020d76671c33821d22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session-end hook reliability with a dedicated 2.5-second completion window while preserving the overall three-second execution limit.
  * Ensured journal updates use a consistent time budget measured from hook startup.
  * Improved retry behavior so operations can complete successfully before the deadline.
  * Added validation for operations that complete slightly after two seconds, provided they finish within the allowed limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->