### PR TITLE
perf(cmux-tui): avoid cloning sidebar layout per frame

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/ui/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/mod.rs
@@ -125,8 +125,13 @@ pub fn draw(app: &mut App, frame: &mut Frame) {
             sidebar::draw_tabs(app, frame);
         }
     } else {
-        for placement in app.sidebar_layout.ordered.clone() {
-            match placement.kind {
+        // RailPlacement is Copy. Read one kind at a time so the renderer does
+        // not clone the full ordered layout on every frame. The copied value
+        // also ends the immutable borrow before the selected renderer mutates
+        // app state.
+        for index in 0..app.sidebar_layout.ordered.len() {
+            let kind = app.sidebar_layout.ordered[index].kind;
+            match kind {
                 RailKind::Machine => sidebar::draw_machines(app, frame),
                 RailKind::Workspace => sidebar_input_cursor = sidebar::draw(app, frame),
                 RailKind::Tabs => sidebar::draw_tabs(app, frame),


### PR DESCRIPTION
## Summary
- avoid cloning the ordered sidebar layout on every render frame
- copy only the rail kind needed before each mutable renderer call

## Validation
- rustfmt --edition 2024 --check crates/cmux-tui/src/ui/mod.rs
- git diff --check
- Rust build/tests are delegated to hosted cmux-tui workflow per repository policy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves render performance in `cmux-tui` by no longer cloning the full sidebar layout on every frame. Instead, copies only the `RailKind` needed per iteration, which also ends the immutable borrow before mutable renderer calls.

<sup>Written for commit 25f47fffcfc8a42656ba4aaea74050b4b0336b7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

