### PR TITLE
fix(cmux): require structured manual IO resize diagnostics

### DIFF
--- a/Sources/TuiManualIOPump.swift
+++ b/Sources/TuiManualIOPump.swift
@@ -854,8 +854,7 @@ final class TuiManualIOStderrStream: @unchecked Sendable {
         }
         lock.unlock()
         for line in lines {
-            if line.range(of: Data(#""diag""#.utf8)) != nil,
-               line.range(of: Data(#""resize""#.utf8)) != nil {
+            if isTuiManualIOResizeDiagLine(line) {
                 onResizeDiag()
             }
         }
@@ -868,6 +867,15 @@ final class TuiManualIOStderrStream: @unchecked Sendable {
         lock.unlock()
         target?.readabilityHandler = nil
     }
+}
+
+/// Returns true only for the relay's structured resize diagnostic. Matching
+/// JSON fields avoids treating human-readable stderr text as an ack.
+func isTuiManualIOResizeDiagLine(_ line: Data) -> Bool {
+    guard let object = try? JSONSerialization.jsonObject(with: line) as? [String: Any],
+          let diag = object["diag"] as? [String: Any]
+    else { return false }
+    return diag["resize"] != nil
 }
 
 /// Splits one accumulated stderr buffer in a single pass. Repeatedly

--- a/Sources/TuiManualIOPump.swift
+++ b/Sources/TuiManualIOPump.swift
@@ -880,7 +880,8 @@ func splitTuiManualIOStderrLines(_ data: Data) -> (completeLines: [Data], remain
         completeLines.append(Data(data[lineStart..<index]))
         lineStart = data.index(after: index)
     }
-    return (completeLines, Data(data[lineStart...]))
+    let remainder = lineStart == data.startIndex ? data : Data(data[lineStart...])
+    return (completeLines, remainder)
 }
 
 /// Lock-guarded stderr accumulator: the relay prints its machine-readable

--- a/Sources/TuiManualIOPump.swift
+++ b/Sources/TuiManualIOPump.swift
@@ -844,7 +844,7 @@ final class TuiManualIOStderrStream: @unchecked Sendable {
     private func scanLines(_ data: Data, onResizeDiag: @Sendable () -> Void) {
         lock.lock()
         pendingLine.append(data)
-        let split = splitTuiManualIOStderrLines(pendingLine)
+        let split = Self.splitLines(pendingLine)
         let lines = split.completeLines
         pendingLine = split.remainder
         // Bound the buffer against a relay that misbehaves and never prints
@@ -854,7 +854,7 @@ final class TuiManualIOStderrStream: @unchecked Sendable {
         }
         lock.unlock()
         for line in lines {
-            if isTuiManualIOResizeDiagLine(line) {
+            if Self.isResizeDiagLine(line) {
                 onResizeDiag()
             }
         }
@@ -867,29 +867,30 @@ final class TuiManualIOStderrStream: @unchecked Sendable {
         lock.unlock()
         target?.readabilityHandler = nil
     }
-}
 
-/// Returns true only for the relay's structured resize diagnostic. Matching
-/// JSON fields avoids treating human-readable stderr text as an ack.
-func isTuiManualIOResizeDiagLine(_ line: Data) -> Bool {
-    guard let object = try? JSONSerialization.jsonObject(with: line) as? [String: Any],
-          let diag = object["diag"] as? [String: Any]
-    else { return false }
-    return diag["resize"] != nil
-}
-
-/// Splits one accumulated stderr buffer in a single pass. Repeatedly
-/// searching and replacing a `Data` prefix copies the remaining suffix for
-/// every line, which makes a burst of short diagnostics quadratic.
-func splitTuiManualIOStderrLines(_ data: Data) -> (completeLines: [Data], remainder: Data) {
-    var completeLines: [Data] = []
-    var lineStart = data.startIndex
-    for index in data.indices where data[index] == 0x0A {
-        completeLines.append(Data(data[lineStart..<index]))
-        lineStart = data.index(after: index)
+    /// Splits one accumulated stderr buffer in a single pass. Repeatedly
+    /// searching and replacing a `Data` prefix copies the remaining suffix for
+    /// every line, which makes a burst of short diagnostics quadratic.
+    static func splitLines(_ data: Data) -> (completeLines: [Data], remainder: Data) {
+        var completeLines: [Data] = []
+        var lineStart = data.startIndex
+        for index in data.indices where data[index] == 0x0A {
+            completeLines.append(Data(data[lineStart..<index]))
+            lineStart = data.index(after: index)
+        }
+        let remainder = lineStart == data.startIndex ? data : Data(data[lineStart...])
+        return (completeLines, remainder)
     }
-    let remainder = lineStart == data.startIndex ? data : Data(data[lineStart...])
-    return (completeLines, remainder)
+
+    /// Returns true only for the relay's structured resize diagnostic.
+    /// Matching JSON fields avoids treating human-readable stderr text as an
+    /// acknowledgement.
+    static func isResizeDiagLine(_ line: Data) -> Bool {
+        guard let object = try? JSONSerialization.jsonObject(with: line) as? [String: Any],
+              let diag = object["diag"] as? [String: Any]
+        else { return false }
+        return diag["resize"] != nil
+    }
 }
 
 /// Lock-guarded stderr accumulator: the relay prints its machine-readable

--- a/Sources/TuiManualIOPump.swift
+++ b/Sources/TuiManualIOPump.swift
@@ -844,11 +844,9 @@ final class TuiManualIOStderrStream: @unchecked Sendable {
     private func scanLines(_ data: Data, onResizeDiag: @Sendable () -> Void) {
         lock.lock()
         pendingLine.append(data)
-        var lines: [Data] = []
-        while let newline = pendingLine.firstIndex(of: 0x0A) {
-            lines.append(Data(pendingLine[pendingLine.startIndex..<newline]))
-            pendingLine = Data(pendingLine[pendingLine.index(after: newline)...])
-        }
+        let split = splitTuiManualIOStderrLines(pendingLine)
+        let lines = split.completeLines
+        pendingLine = split.remainder
         // Bound the buffer against a relay that misbehaves and never prints
         // a newline; diag and exit lines are all short.
         if pendingLine.count > 64 * 1024 {
@@ -870,6 +868,19 @@ final class TuiManualIOStderrStream: @unchecked Sendable {
         lock.unlock()
         target?.readabilityHandler = nil
     }
+}
+
+/// Splits one accumulated stderr buffer in a single pass. Repeatedly
+/// searching and replacing a `Data` prefix copies the remaining suffix for
+/// every line, which makes a burst of short diagnostics quadratic.
+func splitTuiManualIOStderrLines(_ data: Data) -> (completeLines: [Data], remainder: Data) {
+    var completeLines: [Data] = []
+    var lineStart = data.startIndex
+    for index in data.indices where data[index] == 0x0A {
+        completeLines.append(Data(data[lineStart..<index]))
+        lineStart = data.index(after: index)
+    }
+    return (completeLines, Data(data[lineStart...]))
 }
 
 /// Lock-guarded stderr accumulator: the relay prints its machine-readable

--- a/cmuxTests/TuiManualIOPumpTests.swift
+++ b/cmuxTests/TuiManualIOPumpTests.swift
@@ -268,6 +268,22 @@ struct TuiManualIOPumpTests {
     }
 
     @Test
+    func stderrResizeAckRequiresTheStructuredDiagObject() {
+        #expect(
+            isTuiManualIOResizeDiagLine(
+                Data(#"{"diag":{"resize":{"cols":80,"rows":24,"accepted":true}}}"#.utf8)
+            )
+        )
+        // Human-readable diagnostics can contain both words without being an
+        // acknowledgement. They must not release the resize backpressure.
+        #expect(
+            !isTuiManualIOResizeDiagLine(
+                Data("resize diag failed: retrying".utf8)
+            )
+        )
+    }
+
+    @Test
     func stderrAccumulatorCanAppendAndReadTheTail() {
         let box = TuiManualIOStderrBox()
         box.append(Data("first\n".utf8))

--- a/cmuxTests/TuiManualIOPumpTests.swift
+++ b/cmuxTests/TuiManualIOPumpTests.swift
@@ -261,7 +261,7 @@ struct TuiManualIOPumpTests {
     @Test
     func stderrLineSplitterKeepsCompleteLinesAndTrailingPartialData() {
         let data = Data("first\nsecond\npartial".utf8)
-        let split = splitTuiManualIOStderrLines(data)
+        let split = TuiManualIOStderrStream.splitLines(data)
 
         #expect(split.completeLines == [Data("first".utf8), Data("second".utf8)])
         #expect(split.remainder == Data("partial".utf8))
@@ -270,14 +270,14 @@ struct TuiManualIOPumpTests {
     @Test
     func stderrResizeAckRequiresTheStructuredDiagObject() {
         #expect(
-            isTuiManualIOResizeDiagLine(
+            TuiManualIOStderrStream.isResizeDiagLine(
                 Data(#"{"diag":{"resize":{"cols":80,"rows":24,"accepted":true}}}"#.utf8)
             )
         )
         // Human-readable diagnostics can contain both words without being an
         // acknowledgement. They must not release the resize backpressure.
         #expect(
-            !isTuiManualIOResizeDiagLine(
+            !TuiManualIOStderrStream.isResizeDiagLine(
                 Data("resize diag failed: retrying".utf8)
             )
         )

--- a/cmuxTests/TuiManualIOPumpTests.swift
+++ b/cmuxTests/TuiManualIOPumpTests.swift
@@ -258,6 +258,15 @@ struct TuiManualIOPumpTests {
         #expect(text == "a\nb\n\(claim)c\nd\n")
     }
 
+    @Test
+    func stderrLineSplitterKeepsCompleteLinesAndTrailingPartialData() {
+        let data = Data("first\nsecond\npartial".utf8)
+        let split = splitTuiManualIOStderrLines(data)
+
+        #expect(split.completeLines == [Data("first".utf8), Data("second".utf8)])
+        #expect(split.remainder == Data("partial".utf8))
+    }
+
     // MARK: - Registry
 
     @MainActor

--- a/cmuxTests/TuiManualIOPumpTests.swift
+++ b/cmuxTests/TuiManualIOPumpTests.swift
@@ -267,6 +267,15 @@ struct TuiManualIOPumpTests {
         #expect(split.remainder == Data("partial".utf8))
     }
 
+    @Test
+    func stderrAccumulatorCanAppendAndReadTheTail() {
+        let box = TuiManualIOStderrBox()
+        box.append(Data("first\n".utf8))
+        box.append(Data("exit\n".utf8))
+
+        #expect(box.text() == "first\nexit\n")
+    }
+
     // MARK: - Registry
 
     @MainActor


### PR DESCRIPTION
Stacked on #11382.

The stderr reader previously treated any line containing both “diag” and “resize” as an acknowledgement. Human-readable errors could release the latest-wins resize scheduler before the relay applied the resize. Parse the documented JSON shape (diag.resize) instead, with behavior coverage for valid and misleading lines.

Commits are test-first: the regression test is in the first commit, and the production fix is in the second.

Validation: git diff --check. Hosted cmux-tui/macOS checks are required; no local Xcode tests were run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes manual IO stderr parsing so only the relay's structured JSON resize diagnostic (`{"diag":{"resize":...}}`) releases the resize scheduler. Previously any line containing both "diag" and "resize" counted as an ack, so human-readable errors could release the latest-wins scheduler before the relay applied the resize.

**Refactors**
- Splits accumulated stderr lines in a single pass, avoiding quadratic copying for bursts of short diagnostics.
- Scopes the split and resize-check helpers as static methods so they're directly testable.
- Adds coverage for line splitting, partial buffer tails, and misleading human-readable diagnostics.

<sup>Written for commit f2b3d58ac04b187a870faa933b66450c82dc953a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

