### PR TITLE
fix(cmux-tui): reject hostless terminal cwd

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -930,6 +930,16 @@ pub fn spawn_cwd_to_local_path(value: &str) -> Option<PathBuf> {
     terminal_pwd_to_local_path(value)
 }
 
+pub const SNAPSHOT_RELATIVE_CWD_PREFIX: &str = "cmux-tui:relative-cwd:";
+
+pub fn snapshot_cwd_to_local_path(value: &str) -> Option<PathBuf> {
+    if let Some(relative) = value.strip_prefix(SNAPSHOT_RELATIVE_CWD_PREFIX) {
+        return (!relative.is_empty() && !relative.contains('\0'))
+            .then(|| PathBuf::from(relative));
+    }
+    terminal_pwd_to_local_path(value)
+}
+
 fn terminal_pwd_path_is_safe(path: &Path) -> bool {
     if !path.is_absolute() {
         return false;
@@ -1472,6 +1482,10 @@ mod tests {
             Some(PathBuf::from(r"C:\Users\alice\src"))
         );
         assert_eq!(spawn_cwd_to_local_path("file:///tmp/hostless"), None);
+        assert_eq!(
+            snapshot_cwd_to_local_path("cmux-tui:relative-cwd:subdir"),
+            Some(PathBuf::from("subdir"))
+        );
     }
 
     #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -917,9 +917,8 @@ pub fn local_terminal_pwd_to_local_path(value: &str) -> Option<PathBuf> {
 /// may be ordinary absolute paths, while terminal-reported OSC 7 values must
 /// go through the stricter host check above.
 pub fn spawn_cwd_to_local_path(value: &str) -> Option<PathBuf> {
-    let plain = Path::new(value);
-    if terminal_pwd_path_is_safe(plain) {
-        return Some(plain.to_owned());
+    if !value.is_empty() && !value.contains('\0') && url::Url::parse(value).is_err() {
+        return Some(PathBuf::from(value));
     }
     terminal_pwd_to_local_path(value)
 }
@@ -1452,6 +1451,12 @@ mod tests {
             local_terminal_pwd_to_local_path("file:///tmp/hostless"),
             Some(PathBuf::from("/tmp/hostless"))
         );
+    }
+
+    #[test]
+    fn spawn_cwd_preserves_trusted_relative_paths() {
+        assert_eq!(spawn_cwd_to_local_path("subdir"), Some(PathBuf::from("subdir")));
+        assert_eq!(spawn_cwd_to_local_path("file:///tmp/hostless"), None);
     }
 
     #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -881,14 +881,11 @@ pub fn terminal_pwd_to_local_path(value: &str) -> Option<PathBuf> {
     if url.scheme() != "file" {
         return None;
     }
-    if let Some(host) = url.host_str()
-        && !terminal_pwd_host_is_local(host)
-    {
+    let host = url.host_str()?;
+    if !terminal_pwd_host_is_local(host) {
         return None;
     }
-    if url.host_str().is_some() {
-        url.set_host(Some("localhost")).ok()?;
-    }
+    url.set_host(Some("localhost")).ok()?;
     url.to_file_path().ok().filter(|path| terminal_pwd_path_is_safe(path))
 }
 

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -877,6 +877,8 @@ fn default_terminal_cwd_from(launch: Option<&Path>) -> Option<String> {
 /// name a safe local spawn directory, so callers should fall back to the
 /// surface's original working directory when this returns `None`.
 pub fn terminal_pwd_to_local_path(value: &str) -> Option<PathBuf> {
+    // Hosted surfaces never trust hostless OSC 7 values. Their authenticated
+    // spawn CWD is the only safe fallback when no local host is identified.
     let mut url = url::Url::parse(value).ok()?;
     if url.scheme() != "file" {
         return None;

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -889,6 +889,17 @@ pub fn terminal_pwd_to_local_path(value: &str) -> Option<PathBuf> {
     url.to_file_path().ok().filter(|path| terminal_pwd_path_is_safe(path))
 }
 
+/// Convert a trusted spawn working directory into a local path. Spawn CWDs
+/// may be ordinary absolute paths, while terminal-reported OSC 7 values must
+/// go through the stricter host check above.
+pub fn spawn_cwd_to_local_path(value: &str) -> Option<PathBuf> {
+    let plain = Path::new(value);
+    if terminal_pwd_path_is_safe(plain) {
+        return Some(plain.to_owned());
+    }
+    terminal_pwd_to_local_path(value)
+}
+
 fn terminal_pwd_path_is_safe(path: &Path) -> bool {
     if !path.is_absolute() {
         return false;

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -920,11 +920,7 @@ pub fn spawn_cwd_to_local_path(value: &str) -> Option<PathBuf> {
     if value.is_empty() || value.contains('\0') {
         return None;
     }
-    let bytes = value.as_bytes();
-    let is_drive_path = bytes.len() >= 2
-        && bytes[0].is_ascii_alphabetic()
-        && bytes[1] == b':';
-    if is_drive_path || !value.contains("://") {
+    if !value.get(..5).is_some_and(|prefix| prefix.eq_ignore_ascii_case("file:")) {
         return Some(PathBuf::from(value));
     }
     terminal_pwd_to_local_path(value)
@@ -1480,6 +1476,10 @@ mod tests {
         assert_eq!(
             spawn_cwd_to_local_path(r"C:\Users\alice\src"),
             Some(PathBuf::from(r"C:\Users\alice\src"))
+        );
+        assert_eq!(
+            spawn_cwd_to_local_path("/tmp/foo://bar"),
+            Some(PathBuf::from("/tmp/foo://bar"))
         );
         assert_eq!(spawn_cwd_to_local_path("file:///tmp/hostless"), None);
         assert_eq!(

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -917,7 +917,14 @@ pub fn local_terminal_pwd_to_local_path(value: &str) -> Option<PathBuf> {
 /// may be ordinary absolute paths, while terminal-reported OSC 7 values must
 /// go through the stricter host check above.
 pub fn spawn_cwd_to_local_path(value: &str) -> Option<PathBuf> {
-    if !value.is_empty() && !value.contains('\0') && url::Url::parse(value).is_err() {
+    if value.is_empty() || value.contains('\0') {
+        return None;
+    }
+    let bytes = value.as_bytes();
+    let is_drive_path = bytes.len() >= 2
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':';
+    if is_drive_path || !value.contains("://") {
         return Some(PathBuf::from(value));
     }
     terminal_pwd_to_local_path(value)
@@ -1456,6 +1463,14 @@ mod tests {
     #[test]
     fn spawn_cwd_preserves_trusted_relative_paths() {
         assert_eq!(spawn_cwd_to_local_path("subdir"), Some(PathBuf::from("subdir")));
+        assert_eq!(
+            spawn_cwd_to_local_path("build:debug"),
+            Some(PathBuf::from("build:debug"))
+        );
+        assert_eq!(
+            spawn_cwd_to_local_path(r"C:\Users\alice\src"),
+            Some(PathBuf::from(r"C:\Users\alice\src"))
+        );
         assert_eq!(spawn_cwd_to_local_path("file:///tmp/hostless"), None);
     }
 

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -1487,6 +1487,14 @@ mod tests {
         );
     }
 
+    #[test]
+    fn snapshot_cwd_rejects_forged_spawn_marker_from_osc7() {
+        assert_eq!(
+            snapshot_cwd_to_local_path("cmux-tui:spawn-cwd:/tmp/attacker-controlled"),
+            None
+        );
+    }
+
     #[cfg(unix)]
     #[test]
     fn local_hostname_decoder_accepts_non_utf8_os_bytes() {

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -926,12 +926,11 @@ pub fn spawn_cwd_to_local_path(value: &str) -> Option<PathBuf> {
     terminal_pwd_to_local_path(value)
 }
 
-pub const SNAPSHOT_RELATIVE_CWD_PREFIX: &str = "cmux-tui:relative-cwd:";
+pub const SNAPSHOT_SPAWN_CWD_PREFIX: &str = "cmux-tui:spawn-cwd:";
 
 pub fn snapshot_cwd_to_local_path(value: &str) -> Option<PathBuf> {
-    if let Some(relative) = value.strip_prefix(SNAPSHOT_RELATIVE_CWD_PREFIX) {
-        return (!relative.is_empty() && !relative.contains('\0'))
-            .then(|| PathBuf::from(relative));
+    if let Some(path) = value.strip_prefix(SNAPSHOT_SPAWN_CWD_PREFIX) {
+        return (!path.is_empty() && !path.contains('\0')).then(|| PathBuf::from(path));
     }
     terminal_pwd_to_local_path(value)
 }
@@ -1483,7 +1482,7 @@ mod tests {
         );
         assert_eq!(spawn_cwd_to_local_path("file:///tmp/hostless"), None);
         assert_eq!(
-            snapshot_cwd_to_local_path("cmux-tui:relative-cwd:subdir"),
+            snapshot_cwd_to_local_path("cmux-tui:spawn-cwd:subdir"),
             Some(PathBuf::from("subdir"))
         );
     }

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -923,16 +923,41 @@ pub fn spawn_cwd_to_local_path(value: &str) -> Option<PathBuf> {
     if !value.get(..5).is_some_and(|prefix| prefix.eq_ignore_ascii_case("file:")) {
         return Some(PathBuf::from(value));
     }
-    terminal_pwd_to_local_path(value)
+    if value.starts_with("cmux-tui:spawn-cwd:") {
+        return None;
+    }
+    // Legacy daemons serialized the authenticated spawn path directly.
+    // Snapshot data is received over the owner-token authenticated host
+    // channel, so preserve that format for backward compatibility.
+    spawn_cwd_to_local_path(value)
 }
 
-pub const SNAPSHOT_SPAWN_CWD_PREFIX: &str = "cmux-tui:spawn-cwd:";
+/// Versioned, host-authenticated provenance for a spawn CWD fallback. The
+/// capability token prevents a shell's OSC 7 payload from impersonating this
+/// value when a daemon adopts the host later.
+pub const SNAPSHOT_SPAWN_CWD_PREFIX: &str = "cmux-tui:spawn-cwd:v1:";
 
-pub fn snapshot_cwd_to_local_path(value: &str) -> Option<PathBuf> {
-    if let Some(path) = value.strip_prefix(SNAPSHOT_SPAWN_CWD_PREFIX) {
+pub fn snapshot_cwd_to_local_path(value: &str, owner_token: Option<&str>) -> Option<PathBuf> {
+    if let Some(payload) = value.strip_prefix(SNAPSHOT_SPAWN_CWD_PREFIX) {
+        let (token, path) = payload.split_once(':')?;
+        let expected = owner_token?;
+        if !constant_time_equal(token.as_bytes(), expected.as_bytes()) {
+            return None;
+        }
         return (!path.is_empty() && !path.contains('\0')).then(|| PathBuf::from(path));
     }
     terminal_pwd_to_local_path(value)
+}
+
+fn constant_time_equal(left: &[u8], right: &[u8]) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    let mut difference = 0_u8;
+    for (left, right) in left.iter().zip(right) {
+        difference |= left ^ right;
+    }
+    difference == 0
 }
 
 fn terminal_pwd_path_is_safe(path: &Path) -> bool {
@@ -1468,10 +1493,7 @@ mod tests {
     #[test]
     fn spawn_cwd_preserves_trusted_relative_paths() {
         assert_eq!(spawn_cwd_to_local_path("subdir"), Some(PathBuf::from("subdir")));
-        assert_eq!(
-            spawn_cwd_to_local_path("build:debug"),
-            Some(PathBuf::from("build:debug"))
-        );
+        assert_eq!(spawn_cwd_to_local_path("build:debug"), Some(PathBuf::from("build:debug")));
         assert_eq!(
             spawn_cwd_to_local_path(r"C:\Users\alice\src"),
             Some(PathBuf::from(r"C:\Users\alice\src"))
@@ -1482,7 +1504,10 @@ mod tests {
         );
         assert_eq!(spawn_cwd_to_local_path("file:///tmp/hostless"), None);
         assert_eq!(
-            snapshot_cwd_to_local_path("cmux-tui:spawn-cwd:subdir"),
+            snapshot_cwd_to_local_path(
+                "cmux-tui:spawn-cwd:v1:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef:subdir",
+                Some("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+            ),
             Some(PathBuf::from("subdir"))
         );
     }
@@ -1490,7 +1515,14 @@ mod tests {
     #[test]
     fn snapshot_cwd_rejects_forged_spawn_marker_from_osc7() {
         assert_eq!(
-            snapshot_cwd_to_local_path("cmux-tui:spawn-cwd:/tmp/attacker-controlled"),
+            snapshot_cwd_to_local_path("cmux-tui:spawn-cwd:/tmp/attacker-controlled", None),
+            None
+        );
+        assert_eq!(
+            snapshot_cwd_to_local_path(
+                "cmux-tui:spawn-cwd:v1:bad-token:/tmp/attacker-controlled",
+                Some("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+            ),
             None
         );
     }

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -1158,10 +1158,7 @@ mod tests {
             assert_eq!(terminal_pwd_to_local_path(path), None, "{path}");
         }
         assert_eq!(terminal_pwd_to_local_path(r"C:\Users\alice\src"), None);
-        assert_eq!(
-            terminal_pwd_to_local_path("file:///C:/Users/alice/src"),
-            Some(PathBuf::from(r"C:\Users\alice\src"))
-        );
+        assert_eq!(terminal_pwd_to_local_path("file:///C:/Users/alice/src"), None);
     }
 
     #[cfg(windows)]
@@ -1409,6 +1406,7 @@ mod tests {
             terminal_pwd_to_local_path("file://localhost/tmp/local"),
             Some(PathBuf::from("/tmp/local"))
         );
+        assert_eq!(terminal_pwd_to_local_path("file:///tmp/hostless"), None);
         // Hostless absolute paths are ambiguous for hosted terminals. A
         // remote shell can emit one and otherwise redirect a local spawn.
         assert_eq!(terminal_pwd_to_local_path("/tmp/plain"), None);

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -929,7 +929,7 @@ pub fn spawn_cwd_to_local_path(value: &str) -> Option<PathBuf> {
     // Legacy daemons serialized the authenticated spawn path directly.
     // Snapshot data is received over the owner-token authenticated host
     // channel, so preserve that format for backward compatibility.
-    spawn_cwd_to_local_path(value)
+    terminal_pwd_to_local_path(value)
 }
 
 /// Versioned, host-authenticated provenance for a spawn CWD fallback. The
@@ -946,7 +946,7 @@ pub fn snapshot_cwd_to_local_path(value: &str, owner_token: Option<&str>) -> Opt
         }
         return (!path.is_empty() && !path.contains('\0')).then(|| PathBuf::from(path));
     }
-    terminal_pwd_to_local_path(value)
+    spawn_cwd_to_local_path(value)
 }
 
 fn constant_time_equal(left: &[u8], right: &[u8]) -> bool {

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -889,6 +889,30 @@ pub fn terminal_pwd_to_local_path(value: &str) -> Option<PathBuf> {
     url.to_file_path().ok().filter(|path| terminal_pwd_path_is_safe(path))
 }
 
+/// Convert a local terminal's OSC 7 working directory. Local PTYs may emit a
+/// hostless file URL or an ordinary absolute path, both of which are valid
+/// local reports. Hosted PTYs must use [`terminal_pwd_to_local_path`] instead.
+pub fn local_terminal_pwd_to_local_path(value: &str) -> Option<PathBuf> {
+    let plain = Path::new(value);
+    if terminal_pwd_path_is_safe(plain) {
+        return Some(plain.to_owned());
+    }
+
+    let mut url = url::Url::parse(value).ok()?;
+    if url.scheme() != "file" {
+        return None;
+    }
+    if let Some(host) = url.host_str()
+        && !terminal_pwd_host_is_local(host)
+    {
+        return None;
+    }
+    if url.host_str().is_some() {
+        url.set_host(Some("localhost")).ok()?;
+    }
+    url.to_file_path().ok().filter(|path| terminal_pwd_path_is_safe(path))
+}
+
 /// Convert a trusted spawn working directory into a local path. Spawn CWDs
 /// may be ordinary absolute paths, while terminal-reported OSC 7 values must
 /// go through the stricter host check above.

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -1423,6 +1423,15 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn local_terminal_pwd_keeps_hostless_osc7_urls() {
+        assert_eq!(
+            local_terminal_pwd_to_local_path("file:///tmp/hostless"),
+            Some(PathBuf::from("/tmp/hostless"))
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn local_hostname_decoder_accepts_non_utf8_os_bytes() {
         assert_eq!(decode_local_hostname(b"host\xff"), Some("host�".to_string()));
         assert_eq!(decode_local_hostname(b""), None);

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -877,11 +877,6 @@ fn default_terminal_cwd_from(launch: Option<&Path>) -> Option<String> {
 /// name a safe local spawn directory, so callers should fall back to the
 /// surface's original working directory when this returns `None`.
 pub fn terminal_pwd_to_local_path(value: &str) -> Option<PathBuf> {
-    let plain = Path::new(value);
-    if terminal_pwd_path_is_safe(plain) {
-        return Some(plain.to_owned());
-    }
-
     let mut url = url::Url::parse(value).ok()?;
     if url.scheme() != "file" {
         return None;
@@ -1162,10 +1157,7 @@ mod tests {
         ] {
             assert_eq!(terminal_pwd_to_local_path(path), None, "{path}");
         }
-        assert_eq!(
-            terminal_pwd_to_local_path(r"C:\Users\alice\src"),
-            Some(PathBuf::from(r"C:\Users\alice\src"))
-        );
+        assert_eq!(terminal_pwd_to_local_path(r"C:\Users\alice\src"), None);
         assert_eq!(
             terminal_pwd_to_local_path("file:///C:/Users/alice/src"),
             Some(PathBuf::from(r"C:\Users\alice\src"))

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -1417,7 +1417,9 @@ mod tests {
             terminal_pwd_to_local_path("file://localhost/tmp/local"),
             Some(PathBuf::from("/tmp/local"))
         );
-        assert_eq!(terminal_pwd_to_local_path("/tmp/plain"), Some(PathBuf::from("/tmp/plain")));
+        // Hostless absolute paths are ambiguous for hosted terminals. A
+        // remote shell can emit one and otherwise redirect a local spawn.
+        assert_eq!(terminal_pwd_to_local_path("/tmp/plain"), None);
         assert_eq!(terminal_pwd_to_local_path("file://remote.invalid/tmp/nope"), None);
     }
 

--- a/cmux-tui/crates/cmux-tui-core/src/resource_router/content.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/resource_router/content.rs
@@ -335,7 +335,7 @@ fn terminal_process_get(
     if let Some(executable) = executable {
         value["executable"] = json!(executable);
     }
-    if let Some(cwd) = surface.pwd().or_else(|| surface.spawn_cwd()) {
+    if let Some(cwd) = surface.local_cwd() {
         value["cwd"] = json!(cwd);
     }
     Ok(value)
@@ -2404,6 +2404,9 @@ mod tests {
             }
         }
 
+        surface
+            .try_with_terminal(|terminal| terminal.vt_write(b"\x1b]7;file:///tmp/hostless\x1b\\"))
+            .unwrap();
         let process =
             dispatch(&mux, parsed_request("terminal.process.get", &selectors, json!({}), None))
                 .unwrap();
@@ -2411,7 +2414,7 @@ mod tests {
         assert_eq!(process["argv"], json!(["fake-shell", "argument with spaces"]));
         assert!(process["pid"].is_u64());
         assert!(process["children"].is_array());
-        assert!(process.get("cwd").is_none_or(Value::is_string));
+        assert_eq!(process["cwd"], "/tmp/hostless");
         let foreground = process.get("foreground_cwd").expect("foreground_cwd is present");
         assert!(foreground.is_null() || foreground.is_string());
     }

--- a/cmux-tui/crates/cmux-tui-core/src/resource_router/content.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/resource_router/content.rs
@@ -2404,9 +2404,7 @@ mod tests {
             }
         }
 
-        surface
-            .try_with_terminal(|terminal| terminal.vt_write(b"\x1b]7;file:///tmp/hostless\x1b\\"))
-            .unwrap();
+        surface.set_test_pwd(Some("file:///tmp/hostless".into()));
         let process =
             dispatch(&mux, parsed_request("terminal.process.get", &selectors, json!({}), None))
                 .unwrap();

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -2922,13 +2922,12 @@ impl Surface {
         let supports_clear_history_key_fallback = attachment.supports_clear_history();
         let journal_capture_supported = attachment.supports_journal_detach_fence();
         // Snapshot CWD values are terminal-reported metadata, including for
-        // legacy protocol versions. Reject ambiguous plain paths and emit a
-        // diagnostic instead of silently inheriting the daemon default.
-        let snapshot_cwd =
-            snapshot.cwd.as_deref().and_then(platform::snapshot_cwd_to_local_path);
-        if snapshot.cwd.is_some() && snapshot_cwd.is_none() {
-            eprintln!("cmux-tui: discarded untrusted terminal-host snapshot cwd");
-        }
+        // legacy protocol versions. Reject ambiguous plain paths instead of
+        // silently inheriting them as a local spawn directory. A current host
+        // fallback carries its authenticated provenance token.
+        let snapshot_cwd = snapshot.cwd.as_deref().and_then(|cwd| {
+            platform::snapshot_cwd_to_local_path(cwd, Some(attachment.record.owner_token.as_str()))
+        });
         let render_state = RenderState::new()?;
         let (frame_requests, frame_rx) = sync_channel(1);
         #[cfg(test)]
@@ -5473,11 +5472,13 @@ impl Surface {
         } else {
             platform::local_terminal_pwd_to_local_path
         };
-        self.pwd()
-            .as_deref()
-            .and_then(terminal_pwd_to_local_path)
-            .map(|path| path.to_string_lossy().into_owned())
-            .or_else(|| {
+        let terminal_cwd = if hosted { None } else {
+            self.pwd()
+                .as_deref()
+                .and_then(terminal_pwd_to_local_path)
+                .map(|path| path.to_string_lossy().into_owned())
+        };
+        terminal_cwd.or_else(|| {
                 self.spawn_cwd()
                     .as_deref()
                     .and_then(platform::spawn_cwd_to_local_path)

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -2960,7 +2960,11 @@ impl Surface {
                 host_exit_record_path: Some(host_exit_record_path),
                 pid: snapshot.pid,
                 command: snapshot.command,
-                cwd: snapshot.cwd,
+                cwd: snapshot
+                    .cwd
+                    .as_deref()
+                    .and_then(platform::spawn_cwd_to_local_path)
+                    .map(|path| path.to_string_lossy().into_owned()),
                 exit: Mutex::new(None),
                 local_pty_drained: AtomicBool::new(true),
                 exit_notified: AtomicBool::new(false),
@@ -5448,7 +5452,12 @@ impl Surface {
             .as_deref()
             .and_then(platform::terminal_pwd_to_local_path)
             .map(|path| path.to_string_lossy().into_owned())
-            .or_else(|| self.spawn_cwd())
+            .or_else(|| {
+                self.spawn_cwd()
+                    .as_deref()
+                    .and_then(platform::spawn_cwd_to_local_path)
+                    .map(|path| path.to_string_lossy().into_owned())
+            })
     }
 
     pub fn process_id(&self) -> Option<u32> {

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -5241,7 +5241,7 @@ impl Surface {
                 {
                     matches!(
                         &*pty.runtime.lock().unwrap(),
-                        PtyRuntime::Hosted(_) | PtyRuntime::ExitedHosted
+                        PtyRuntime::Hosted(_)
                     )
                 }
                 #[cfg(not(unix))]
@@ -5455,7 +5455,10 @@ impl Surface {
             Surface::Pty(pty) => {
                 #[cfg(unix)]
                 {
-                    matches!(&*pty.runtime.lock().unwrap(), PtyRuntime::Hosted(_))
+                    matches!(
+                        &*pty.runtime.lock().unwrap(),
+                        PtyRuntime::Hosted(_) | PtyRuntime::ExitedHosted
+                    )
                 }
                 #[cfg(not(unix))]
                 {

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -2924,7 +2924,8 @@ impl Surface {
         // Snapshot CWD values are terminal-reported metadata, including for
         // legacy protocol versions. Reject ambiguous plain paths and emit a
         // diagnostic instead of silently inheriting the daemon default.
-        let snapshot_cwd = snapshot.cwd.as_deref().and_then(platform::terminal_pwd_to_local_path);
+        let snapshot_cwd =
+            snapshot.cwd.as_deref().and_then(platform::snapshot_cwd_to_local_path);
         if snapshot.cwd.is_some() && snapshot_cwd.is_none() {
             eprintln!("cmux-tui: discarded untrusted terminal-host snapshot cwd");
         }

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -2963,13 +2963,7 @@ impl Surface {
                 cwd: snapshot
                     .cwd
                     .as_deref()
-                    .and_then(|cwd| {
-                        if protocol_version >= crate::terminal_host_protocol::PROTOCOL_VERSION {
-                            platform::terminal_pwd_to_local_path(cwd)
-                        } else {
-                            platform::spawn_cwd_to_local_path(cwd)
-                        }
-                    })
+                    .and_then(platform::terminal_pwd_to_local_path)
                     .map(|path| path.to_string_lossy().into_owned()),
                 exit: Mutex::new(None),
                 local_pty_drained: AtomicBool::new(true),
@@ -5245,7 +5239,10 @@ impl Surface {
             Surface::Pty(pty) => {
                 #[cfg(unix)]
                 {
-                    matches!(&*pty.runtime.lock().unwrap(), PtyRuntime::Hosted(_))
+                    matches!(
+                        &*pty.runtime.lock().unwrap(),
+                        PtyRuntime::Hosted(_) | PtyRuntime::ExitedHosted
+                    )
                 }
                 #[cfg(not(unix))]
                 {

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -5484,6 +5484,11 @@ impl Surface {
             })
     }
 
+    #[cfg(test)]
+    pub(crate) fn set_test_pwd(&self, pwd: Option<String>) {
+        *self.as_pty().expect("test PTY surface").pwd.lock().unwrap() = pwd;
+    }
+
     pub fn process_id(&self) -> Option<u32> {
         self.as_pty().and_then(|pty| pty.pid)
     }

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -2921,6 +2921,13 @@ impl Surface {
         let host_exit_record_path = attachment.exit_record_path();
         let supports_clear_history_key_fallback = attachment.supports_clear_history();
         let journal_capture_supported = attachment.supports_journal_detach_fence();
+        // Snapshot CWD values are terminal-reported metadata, including for
+        // legacy protocol versions. Reject ambiguous plain paths and emit a
+        // diagnostic instead of silently inheriting the daemon default.
+        let snapshot_cwd = snapshot.cwd.as_deref().and_then(platform::terminal_pwd_to_local_path);
+        if snapshot.cwd.is_some() && snapshot_cwd.is_none() {
+            eprintln!("cmux-tui: discarded untrusted terminal-host snapshot cwd");
+        }
         let render_state = RenderState::new()?;
         let (frame_requests, frame_rx) = sync_channel(1);
         #[cfg(test)]
@@ -2960,11 +2967,7 @@ impl Surface {
                 host_exit_record_path: Some(host_exit_record_path),
                 pid: snapshot.pid,
                 command: snapshot.command,
-                cwd: snapshot
-                    .cwd
-                    .as_deref()
-                    .and_then(platform::terminal_pwd_to_local_path)
-                    .map(|path| path.to_string_lossy().into_owned()),
+                cwd: snapshot_cwd.map(|path| path.to_string_lossy().into_owned()),
                 exit: Mutex::new(None),
                 local_pty_drained: AtomicBool::new(true),
                 exit_notified: AtomicBool::new(false),

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -2963,7 +2963,13 @@ impl Surface {
                 cwd: snapshot
                     .cwd
                     .as_deref()
-                    .and_then(platform::terminal_pwd_to_local_path)
+                    .and_then(|cwd| {
+                        if protocol_version >= crate::terminal_host_protocol::PROTOCOL_VERSION {
+                            platform::terminal_pwd_to_local_path(cwd)
+                        } else {
+                            platform::spawn_cwd_to_local_path(cwd)
+                        }
+                    })
                     .map(|path| path.to_string_lossy().into_owned()),
                 exit: Mutex::new(None),
                 local_pty_drained: AtomicBool::new(true),
@@ -5448,9 +5454,27 @@ impl Surface {
     }
 
     pub fn local_cwd(&self) -> Option<String> {
+        let hosted = match self {
+            Surface::Pty(pty) => {
+                #[cfg(unix)]
+                {
+                    matches!(&*pty.runtime.lock().unwrap(), PtyRuntime::Hosted(_))
+                }
+                #[cfg(not(unix))]
+                {
+                    false
+                }
+            }
+            Surface::Browser(_) => false,
+        };
+        let terminal_pwd_to_local_path = if hosted {
+            platform::terminal_pwd_to_local_path
+        } else {
+            platform::local_terminal_pwd_to_local_path
+        };
         self.pwd()
             .as_deref()
-            .and_then(platform::terminal_pwd_to_local_path)
+            .and_then(terminal_pwd_to_local_path)
             .map(|path| path.to_string_lossy().into_owned())
             .or_else(|| {
                 self.spawn_cwd()

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -5242,10 +5242,7 @@ impl Surface {
             Surface::Pty(pty) => {
                 #[cfg(unix)]
                 {
-                    matches!(
-                        &*pty.runtime.lock().unwrap(),
-                        PtyRuntime::Hosted(_)
-                    )
+                    matches!(&*pty.runtime.lock().unwrap(), PtyRuntime::Hosted(_))
                 }
                 #[cfg(not(unix))]
                 {

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -2963,7 +2963,7 @@ impl Surface {
                 cwd: snapshot
                     .cwd
                     .as_deref()
-                    .and_then(platform::spawn_cwd_to_local_path)
+                    .and_then(platform::terminal_pwd_to_local_path)
                     .map(|path| path.to_string_lossy().into_owned()),
                 exit: Mutex::new(None),
                 local_pty_drained: AtomicBool::new(true),

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -9253,22 +9253,13 @@ mod unix {
         #[test]
         fn late_snapshot_prefers_current_terminal_pwd_then_spawn_fallback() {
             let mut term = Terminal::new(80, 24, 0, Callbacks::default()).unwrap();
-            assert_eq!(
-                snapshot_cwd(&term, Some("/spawn")),
-                Some("file://localhost/spawn".into())
-            );
+            assert_eq!(snapshot_cwd(&term, Some("/spawn")), Some("file://localhost/spawn".into()));
 
             term.vt_write(b"\x1b]7;file:///live\x1b\\");
-            assert_eq!(
-                snapshot_cwd(&term, Some("/spawn")),
-                Some("file://localhost/spawn".into())
-            );
+            assert_eq!(snapshot_cwd(&term, Some("/spawn")), Some("file://localhost/spawn".into()));
 
             term.vt_write(b"\x1b]7;\x1b\\");
-            assert_eq!(
-                snapshot_cwd(&term, Some("/spawn")),
-                Some("file://localhost/spawn".into())
-            );
+            assert_eq!(snapshot_cwd(&term, Some("/spawn")), Some("file://localhost/spawn".into()));
             assert_eq!(snapshot_cwd(&term, Some("file:///spawn")), None);
         }
 

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -3444,8 +3444,19 @@ mod unix {
         frames
     }
 
+    /// Persist only a local path in the adoption snapshot. A host can outlive
+    /// its daemon, so a raw OSC 7 URL here would become the next surface's
+    /// inherited spawn directory after reattachment.
     fn snapshot_cwd(term: &Terminal, spawn_cwd: Option<&str>) -> Option<String> {
-        term.pwd().or_else(|| spawn_cwd.map(str::to_owned))
+        term.pwd()
+            .as_deref()
+            .and_then(crate::platform::terminal_pwd_to_local_path)
+            .map(|path| path.to_string_lossy().into_owned())
+            .or_else(|| {
+                spawn_cwd
+                    .and_then(crate::platform::spawn_cwd_to_local_path)
+                    .map(|path| path.to_string_lossy().into_owned())
+            })
     }
 
     impl HostShared {

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -3457,7 +3457,10 @@ mod unix {
         // belongs to this host. Use only the authenticated spawn fallback.
         let _ = term;
         let path = spawn_cwd.and_then(crate::platform::spawn_cwd_to_local_path)?;
-        if protocol_version < PROTOCOL_VERSION {
+        // Only the negotiated current protocol understands authenticated
+        // provenance markers. Treat legacy and unknown values as legacy wire
+        // format so peers never receive a marker they cannot decode.
+        if protocol_version != PROTOCOL_VERSION {
             return Some(path.to_string_lossy().into_owned());
         }
         Some(format!(
@@ -9278,6 +9281,19 @@ mod unix {
             term.vt_write(b"\x1b]7;\x1b\\");
             assert_eq!(snapshot_cwd(&term, Some("/spawn"), &owner_token, PROTOCOL_VERSION), Some(marker));
             assert_eq!(snapshot_cwd(&term, Some("file:///spawn"), &owner_token, PROTOCOL_VERSION), None);
+        }
+
+        #[test]
+        fn snapshot_cwd_uses_legacy_path_for_old_and_unknown_protocols() {
+            let term = Terminal::new(80, 24, 0, Callbacks::default()).unwrap();
+            let owner_token =
+                CapabilityToken::from_bytes([7; crate::terminal_host::CAPABILITY_TOKEN_LEN]);
+            for protocol_version in [LEGACY_PROTOCOL_VERSION, PROTOCOL_VERSION + 1] {
+                assert_eq!(
+                    snapshot_cwd(&term, Some("/spawn"), &owner_token, protocol_version),
+                    Some("/spawn".into())
+                );
+            }
         }
 
         #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -9289,9 +9289,11 @@ mod unix {
             let owner_token =
                 CapabilityToken::from_bytes([7; crate::terminal_host::CAPABILITY_TOKEN_LEN]);
             for protocol_version in [LEGACY_PROTOCOL_VERSION, PROTOCOL_VERSION + 1] {
+                let snapshot = snapshot_cwd(&term, Some("/spawn"), &owner_token, protocol_version);
+                assert_eq!(snapshot, Some("/spawn".into()));
                 assert_eq!(
-                    snapshot_cwd(&term, Some("/spawn"), &owner_token, protocol_version),
-                    Some("/spawn".into())
+                    crate::platform::snapshot_cwd_to_local_path(snapshot.as_deref().unwrap(), None),
+                    Some(std::path::PathBuf::from("/spawn"))
                 );
             }
         }

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -3444,21 +3444,26 @@ mod unix {
         frames
     }
 
-    /// Persist only a local path in the adoption snapshot. A host can outlive
-    /// its daemon, so a raw OSC 7 URL here would become the next surface's
-    /// inherited spawn directory after reattachment.
-    fn snapshot_cwd(term: &Terminal, spawn_cwd: Option<&str>) -> Option<String> {
-        if let Some(path) =
-            term.pwd().as_deref().and_then(crate::platform::terminal_pwd_to_local_path)
-        {
-            let mut url = url::Url::from_file_path(path).ok()?;
-            url.set_host(Some("localhost")).ok()?;
-            return Some(url.into());
-        }
+    /// Persist a local spawn path with host-authenticated provenance. A host
+    /// can outlive its daemon, so a raw OSC 7 URL here would become the next
+    /// surface's inherited spawn directory after reattachment.
+    fn snapshot_cwd(
+        term: &Terminal,
+        spawn_cwd: Option<&str>,
+        owner_token: &CapabilityToken,
+        protocol_version: u16,
+    ) -> Option<String> {
+        // OSC 7 is terminal-controlled metadata and cannot prove that a path
+        // belongs to this host. Use only the authenticated spawn fallback.
+        let _ = term;
         let path = spawn_cwd.and_then(crate::platform::spawn_cwd_to_local_path)?;
+        if protocol_version < PROTOCOL_VERSION {
+            return Some(path.to_string_lossy().into_owned());
+        }
         Some(format!(
-            "{}{}",
+            "{}{}:{}",
             crate::platform::SNAPSHOT_SPAWN_CWD_PREFIX,
+            encode_hex(owner_token.as_bytes()),
             path.to_string_lossy()
         ))
     }
@@ -5462,7 +5467,7 @@ mod unix {
                     colors: colors.clone(),
                     pid: host.pid,
                     command: host.command.clone(),
-                    cwd: snapshot_cwd(&term, host.cwd.as_deref()),
+                    cwd: snapshot_cwd(&term, host.cwd.as_deref(), &host.owner_token, selected_version),
                 },
                 colors,
                 snapshot_sequence,
@@ -9258,14 +9263,21 @@ mod unix {
         #[test]
         fn late_snapshot_prefers_current_terminal_pwd_then_spawn_fallback() {
             let mut term = Terminal::new(80, 24, 0, Callbacks::default()).unwrap();
-            assert_eq!(snapshot_cwd(&term, Some("/spawn")), Some("cmux-tui:spawn-cwd:/spawn".into()));
+            let owner_token =
+                CapabilityToken::from_bytes([7; crate::terminal_host::CAPABILITY_TOKEN_LEN]);
+            let marker = format!(
+                "{}{}:/spawn",
+                crate::platform::SNAPSHOT_SPAWN_CWD_PREFIX,
+                encode_hex(owner_token.as_bytes())
+            );
+            assert_eq!(snapshot_cwd(&term, Some("/spawn"), &owner_token, PROTOCOL_VERSION), Some(marker.clone()));
 
             term.vt_write(b"\x1b]7;file:///live\x1b\\");
-            assert_eq!(snapshot_cwd(&term, Some("/spawn")), Some("cmux-tui:spawn-cwd:/spawn".into()));
+            assert_eq!(snapshot_cwd(&term, Some("/spawn"), &owner_token, PROTOCOL_VERSION), Some(marker.clone()));
 
             term.vt_write(b"\x1b]7;\x1b\\");
-            assert_eq!(snapshot_cwd(&term, Some("/spawn")), Some("cmux-tui:spawn-cwd:/spawn".into()));
-            assert_eq!(snapshot_cwd(&term, Some("file:///spawn")), None);
+            assert_eq!(snapshot_cwd(&term, Some("/spawn"), &owner_token, PROTOCOL_VERSION), Some(marker));
+            assert_eq!(snapshot_cwd(&term, Some("file:///spawn"), &owner_token, PROTOCOL_VERSION), None);
         }
 
         #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -9246,10 +9246,11 @@ mod unix {
             assert_eq!(snapshot_cwd(&term, Some("/spawn")), Some("/spawn".into()));
 
             term.vt_write(b"\x1b]7;file:///live\x1b\\");
-            assert_eq!(snapshot_cwd(&term, Some("/spawn")), Some("file:///live".into()));
+            assert_eq!(snapshot_cwd(&term, Some("/spawn")), Some("/spawn".into()));
 
             term.vt_write(b"\x1b]7;\x1b\\");
             assert_eq!(snapshot_cwd(&term, Some("/spawn")), Some("/spawn".into()));
+            assert_eq!(snapshot_cwd(&term, Some("file:///spawn")), None);
         }
 
         #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -3448,7 +3448,8 @@ mod unix {
     /// its daemon, so a raw OSC 7 URL here would become the next surface's
     /// inherited spawn directory after reattachment.
     fn snapshot_cwd(term: &Terminal, spawn_cwd: Option<&str>) -> Option<String> {
-        term.pwd()
+        term
+            .pwd()
             .as_deref()
             .and_then(crate::platform::terminal_pwd_to_local_path)
             .map(|path| path.to_string_lossy().into_owned())
@@ -9254,13 +9255,22 @@ mod unix {
         #[test]
         fn late_snapshot_prefers_current_terminal_pwd_then_spawn_fallback() {
             let mut term = Terminal::new(80, 24, 0, Callbacks::default()).unwrap();
-            assert_eq!(snapshot_cwd(&term, Some("/spawn")), Some("/spawn".into()));
+            assert_eq!(
+                snapshot_cwd(&term, Some("/spawn")),
+                Some("file://localhost/spawn".into())
+            );
 
             term.vt_write(b"\x1b]7;file:///live\x1b\\");
-            assert_eq!(snapshot_cwd(&term, Some("/spawn")), Some("/spawn".into()));
+            assert_eq!(
+                snapshot_cwd(&term, Some("/spawn")),
+                Some("file://localhost/spawn".into())
+            );
 
             term.vt_write(b"\x1b]7;\x1b\\");
-            assert_eq!(snapshot_cwd(&term, Some("/spawn")), Some("/spawn".into()));
+            assert_eq!(
+                snapshot_cwd(&term, Some("/spawn")),
+                Some("file://localhost/spawn".into())
+            );
             assert_eq!(snapshot_cwd(&term, Some("file:///spawn")), None);
         }
 

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -3453,6 +3453,13 @@ mod unix {
             .as_deref()
             .and_then(crate::platform::terminal_pwd_to_local_path)
             .or_else(|| spawn_cwd.and_then(crate::platform::spawn_cwd_to_local_path))?;
+        if !path.is_absolute() {
+            return Some(format!(
+                "{}{}",
+                crate::platform::SNAPSHOT_RELATIVE_CWD_PREFIX,
+                path.to_string_lossy()
+            ));
+        }
         let mut url = url::Url::from_file_path(path).ok()?;
         url.set_host(Some("localhost")).ok()?;
         Some(url.into())

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -3448,16 +3448,14 @@ mod unix {
     /// its daemon, so a raw OSC 7 URL here would become the next surface's
     /// inherited spawn directory after reattachment.
     fn snapshot_cwd(term: &Terminal, spawn_cwd: Option<&str>) -> Option<String> {
-        term
+        let path = term
             .pwd()
             .as_deref()
             .and_then(crate::platform::terminal_pwd_to_local_path)
-            .map(|path| path.to_string_lossy().into_owned())
-            .or_else(|| {
-                spawn_cwd
-                    .and_then(crate::platform::spawn_cwd_to_local_path)
-                    .map(|path| path.to_string_lossy().into_owned())
-            })
+            .or_else(|| spawn_cwd.and_then(crate::platform::spawn_cwd_to_local_path))?;
+        let mut url = url::Url::from_file_path(path).ok()?;
+        url.set_host(Some("localhost")).ok()?;
+        Some(url.into())
     }
 
     impl HostShared {

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -3448,21 +3448,19 @@ mod unix {
     /// its daemon, so a raw OSC 7 URL here would become the next surface's
     /// inherited spawn directory after reattachment.
     fn snapshot_cwd(term: &Terminal, spawn_cwd: Option<&str>) -> Option<String> {
-        let path = term
-            .pwd()
-            .as_deref()
-            .and_then(crate::platform::terminal_pwd_to_local_path)
-            .or_else(|| spawn_cwd.and_then(crate::platform::spawn_cwd_to_local_path))?;
-        if !path.is_absolute() {
-            return Some(format!(
-                "{}{}",
-                crate::platform::SNAPSHOT_RELATIVE_CWD_PREFIX,
-                path.to_string_lossy()
-            ));
+        if let Some(path) =
+            term.pwd().as_deref().and_then(crate::platform::terminal_pwd_to_local_path)
+        {
+            let mut url = url::Url::from_file_path(path).ok()?;
+            url.set_host(Some("localhost")).ok()?;
+            return Some(url.into());
         }
-        let mut url = url::Url::from_file_path(path).ok()?;
-        url.set_host(Some("localhost")).ok()?;
-        Some(url.into())
+        let path = spawn_cwd.and_then(crate::platform::spawn_cwd_to_local_path)?;
+        Some(format!(
+            "{}{}",
+            crate::platform::SNAPSHOT_SPAWN_CWD_PREFIX,
+            path.to_string_lossy()
+        ))
     }
 
     impl HostShared {
@@ -9260,13 +9258,13 @@ mod unix {
         #[test]
         fn late_snapshot_prefers_current_terminal_pwd_then_spawn_fallback() {
             let mut term = Terminal::new(80, 24, 0, Callbacks::default()).unwrap();
-            assert_eq!(snapshot_cwd(&term, Some("/spawn")), Some("file://localhost/spawn".into()));
+            assert_eq!(snapshot_cwd(&term, Some("/spawn")), Some("cmux-tui:spawn-cwd:/spawn".into()));
 
             term.vt_write(b"\x1b]7;file:///live\x1b\\");
-            assert_eq!(snapshot_cwd(&term, Some("/spawn")), Some("file://localhost/spawn".into()));
+            assert_eq!(snapshot_cwd(&term, Some("/spawn")), Some("cmux-tui:spawn-cwd:/spawn".into()));
 
             term.vt_write(b"\x1b]7;\x1b\\");
-            assert_eq!(snapshot_cwd(&term, Some("/spawn")), Some("file://localhost/spawn".into()));
+            assert_eq!(snapshot_cwd(&term, Some("/spawn")), Some("cmux-tui:spawn-cwd:/spawn".into()));
             assert_eq!(snapshot_cwd(&term, Some("file:///spawn")), None);
         }
 


### PR DESCRIPTION
## Summary
- Reject hostless absolute OSC 7 paths before local cwd inheritance can use remote PTY metadata.
- Keep local and remote `file://` URLs with validated local hosts.

## Testing
- `git diff --check`
- Canonical exact-head autoreview against `717f35768bbfc7a60c0a81ce9fe4b0c74fafd674`: clean, overall correctness 0.88.
- Rust tests/builds were not run locally per cmux-tui Blacksmith Testbox policy.

## Issues
- Related: https://github.com/manaflow-ai/cmux/pull/9511

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790844310&installation_model_id=21920&pr_number=11395&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11395&signature=e228f0cc9a3851359c494aa0dfd5aea333f8bf52c553a947607646f92918e1a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects hostless OSC 7 terminal cwd paths so a remote PTY can't redirect a local spawn or leak through reattachment.

- `terminal_pwd_to_local_path` only accepts `file://` URLs with a validated local host; exited hosted PTYs stay untrusted.
- Local PTYs keep hostless OSC 7 reports via `local_terminal_pwd_to_local_path`.
- Spawn working directories use `spawn_cwd_to_local_path`, which preserves plain absolute, relative, drive, and colon-containing paths exactly but rejects hostless file URLs.
- Snapshot cwd values ignore terminal OSC 7 entirely and persist only the authenticated spawn cwd, wrapped in an owner-token `cmux-tui:spawn-cwd:v1:` prefix; reattachment verifies the token with constant-time comparison, and legacy file-URL values still pass through the host check.
- The provenance marker is only emitted for the negotiated current protocol; legacy and unknown protocol versions get the raw spawn path so peers never receive a marker they can't decode.
- `terminal.process.get` now reports the sanitized `local_cwd()` instead of the raw terminal pwd.

<sup>Written for commit a7cde50d1d40c286313e4edd02820b2293e2211e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved working-directory handling across hosted and local terminal sessions.
  * Invalid, unresolved, or improperly formatted terminal paths are now rejected instead of being interpreted as local paths.
  * Hosted session directories now use authenticated spawn information when available.
  * Terminal process information consistently reports the resolved local working directory.
  * Improved fallback behavior when the current terminal directory cannot be resolved.
  * Updated handling for legacy and unknown protocol versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->