### PR TITLE
fix(cmux-tui): harden socket start lock files

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -4867,7 +4867,7 @@ impl SocketStartLock {
         name.push(".spawn-lock");
         let path = socket.with_file_name(name);
         let mut options = std::fs::OpenOptions::new();
-        options.create(true).append(true).read(true);
+        options.create(true).append(true);
         #[cfg(unix)]
         {
             use std::os::unix::fs::OpenOptionsExt as _;

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -4871,7 +4871,7 @@ impl SocketStartLock {
         #[cfg(unix)]
         {
             use std::os::unix::fs::OpenOptionsExt as _;
-            options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC).mode(0o600);
+            options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK).mode(0o600);
         }
         let file = options.open(&path)?;
         #[cfg(unix)]
@@ -4882,6 +4882,12 @@ impl SocketStartLock {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::PermissionDenied,
                     "session-server start lock is not a regular file",
+                ));
+            }
+            if metadata.nlink() != 1 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "session-server start lock has unexpected hard links",
                 ));
             }
             if metadata.uid() != unsafe { libc::geteuid() } {

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -13258,6 +13258,48 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn socket_start_lock_rejects_a_fifo_without_blocking() {
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStrExt;
+        use std::os::unix::fs::OpenOptionsExt;
+
+        let dir = TestSocketDir::create("start-lock-fifo");
+        let socket = dir.path().join("mux.sock");
+        let lock = dir.path().join("mux.sock.spawn-lock");
+        let lock_path = CString::new(lock.as_os_str().as_bytes()).unwrap();
+        let result = unsafe { libc::mkfifo(lock_path.as_ptr(), 0o600) };
+        assert_eq!(result, 0, "mkfifo failed: {}", std::io::Error::last_os_error());
+
+        let (sender, receiver) = std::sync::mpsc::channel();
+        let acquire_socket = socket.clone();
+        let acquire = std::thread::spawn(move || {
+            sender.send(SocketStartLock::acquire(&acquire_socket, Instant::now())).unwrap();
+        });
+
+        let outcome = receiver.recv_timeout(Duration::from_secs(1));
+        if outcome.is_err() {
+            // Release a writer that used blocking open in an unfixed build so
+            // this regression test fails promptly instead of leaking a thread.
+            let reader = std::fs::OpenOptions::new()
+                .read(true)
+                .custom_flags(libc::O_NONBLOCK)
+                .open(&lock)
+                .unwrap();
+            let _ = receiver.recv_timeout(Duration::from_secs(1));
+            drop(reader);
+            acquire.join().unwrap();
+            panic!("opening a start-lock FIFO blocked before type validation");
+        }
+        acquire.join().unwrap();
+        let error = match outcome.unwrap() {
+            Ok(_) => panic!("FIFO start lock must be rejected"),
+            Err(error) => error,
+        };
+        assert_eq!(error.raw_os_error(), Some(libc::ENXIO));
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn socket_start_lock_migrates_existing_lock_to_owner_only_mode() {
         use std::os::unix::fs::{MetadataExt, PermissionsExt};
 
@@ -13271,6 +13313,29 @@ mod tests {
         let metadata = std::fs::metadata(&lock).unwrap();
         assert_eq!(metadata.uid(), unsafe { libc::geteuid() });
         assert_eq!(metadata.permissions().mode() & 0o777, 0o600);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn socket_start_lock_rejects_a_hard_linked_lock_without_chmod() {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+        let dir = TestSocketDir::create("start-lock-hard-link");
+        let socket = dir.path().join("mux.sock");
+        let lock = dir.path().join("mux.sock.spawn-lock");
+        let alias = dir.path().join("lock-alias");
+        std::fs::write(&lock, b"").unwrap();
+        std::fs::set_permissions(&lock, std::fs::Permissions::from_mode(0o644)).unwrap();
+        std::fs::hard_link(&lock, &alias).unwrap();
+
+        let error = match SocketStartLock::acquire(&socket, Instant::now()) {
+            Ok(_) => panic!("hard-linked start lock must be rejected"),
+            Err(error) => error,
+        };
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        let metadata = std::fs::metadata(&lock).unwrap();
+        assert_eq!(metadata.nlink(), 2);
+        assert_eq!(metadata.permissions().mode() & 0o777, 0o644);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -4866,7 +4866,41 @@ impl SocketStartLock {
         let mut name = socket.file_name().unwrap_or_default().to_os_string();
         name.push(".spawn-lock");
         let path = socket.with_file_name(name);
-        let file = std::fs::OpenOptions::new().create(true).append(true).open(&path)?;
+        let mut options = std::fs::OpenOptions::new();
+        options.create(true).append(true).read(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt as _;
+            options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC).mode(0o600);
+        }
+        let file = options.open(&path)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+            let metadata = file.metadata()?;
+            if !metadata.is_file() {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    "session-server start lock is not a regular file",
+                ));
+            }
+            if metadata.uid() != unsafe { libc::geteuid() } {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    "session-server start lock owner changed",
+                ));
+            }
+            let mut permissions = metadata.permissions();
+            permissions.set_mode(0o600);
+            file.set_permissions(permissions)?;
+            let mode = file.metadata()?.permissions().mode();
+            if mode & 0o077 != 0 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    "session-server start lock is not private",
+                ));
+            }
+        }
         loop {
             match fs4::FileExt::try_lock(&file) {
                 Ok(()) => return Ok(Self { _file: file }),

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -13203,6 +13203,42 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn socket_start_lock_rejects_a_symlinked_lock_path() {
+        use std::os::unix::fs::symlink;
+
+        let dir = TestSocketDir::create("start-lock-symlink");
+        let socket = dir.path().join("mux.sock");
+        let lock = dir.path().join("mux.sock.spawn-lock");
+        let target = dir.path().join("target");
+        std::fs::write(&target, b"not the lock").unwrap();
+        symlink(&target, &lock).unwrap();
+
+        let error = match SocketStartLock::acquire(&socket, Instant::now()) {
+            Ok(_) => panic!("symlinked start lock must be rejected"),
+            Err(error) => error,
+        };
+        assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn socket_start_lock_migrates_existing_lock_to_owner_only_mode() {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+        let dir = TestSocketDir::create("start-lock-mode");
+        let socket = dir.path().join("mux.sock");
+        let lock = dir.path().join("mux.sock.spawn-lock");
+        std::fs::write(&lock, b"").unwrap();
+        std::fs::set_permissions(&lock, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let _guard = SocketStartLock::acquire(&socket, Instant::now()).unwrap();
+        let metadata = std::fs::metadata(&lock).unwrap();
+        assert_eq!(metadata.uid(), unsafe { libc::geteuid() });
+        assert_eq!(metadata.permissions().mode() & 0o777, 0o600);
+    }
+
     #[test]
     fn session_name_validation_rejects_path_escape_input() {
         for session in ["", ".", "..", "../escape", "nested/session", "nested\\session"] {

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -13253,7 +13253,7 @@ mod tests {
             Ok(_) => panic!("symlinked start lock must be rejected"),
             Err(error) => error,
         };
-        assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+        assert_eq!(error.raw_os_error(), Some(libc::ELOOP));
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary
- reject symlinked or non-regular `.spawn-lock` files before locking
- require the current user to own the lock and keep permissions owner-only
- add Unix behavior tests for symlink rejection and mode migration

This isolates the SocketStartLock security portion that exists in PR #11155 but is absent from the current-main #11386 replay. The two commits preserve the red then green test history.

## Verification
- `git diff --check`
- `rustfmt --edition 2024 --check cmux-tui/crates/cmux-tui-core/src/server.rs`
- hosted cmux-tui focused workflow pending

Related: https://github.com/manaflow-ai/cmux/pull/11155 https://github.com/manaflow-ai/cmux/pull/11386

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790844623&installation_model_id=21920&pr_number=11396&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11396&signature=0c3cc17a62142afc4f5a280f59d4ade736a470964696327809ac17302f350ea9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the socket start lock so symlinked, non-regular, or hard-linked lock paths are rejected before locking, and acquisition fails unless the lock is owned by the current user and private (owner-only, no group or other access).

- Rejects symlinks with `O_NOFOLLOW` (ELOOP), FIFOs with `O_NONBLOCK` (ENXIO), and hard-linked locks via link count validation.
- Enforces owner-only `0600` permissions on the lock, migrating existing locks while keeping them append-only.
- Adds Unix tests covering each rejection path, the blocking FIFO case, and mode migration.

<sup>Written for commit 339006370e7f49c91736d6571c489c3e47db3b6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security and reliability for the socket startup lock.
  * Rejects unsafe lock paths, including symbolic links and non-file entries.
  * Verifies that the lock is owned by the current user and restricts access to the owner.
  * Automatically updates existing lock files to owner-only permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->