### PR TITLE
fix(cmux-tui): detach the agent hook helper from the provider

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
+++ b/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
@@ -597,6 +597,7 @@ mod tests {
             b"{}\n",
             "request_missing_socket",
             Instant::now() + Duration::from_millis(100),
+            &|| {},
         );
 
         assert!(matches!(result, Err(AppendAttemptError::Fatal(_))));

--- a/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
+++ b/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
@@ -27,11 +27,15 @@ const MAX_NATIVE_PAYLOAD_BYTES: u64 = 1024 * 1024;
 const MAX_MESSAGE_BYTES: usize = 4 * 1024 * 1024;
 const MAX_RESPONSE_BYTES: usize = 16 * 1024 * 1024;
 const SOCKET_TIMEOUT: Duration = Duration::from_secs(4);
-/// Safety bound on the provider-facing wait for the child's "request written"
+/// Bound on the provider-facing wait for the child's "request written"
 /// signal. The child itself gives up at `SOCKET_TIMEOUT` and closes the pipe,
 /// so this only fires if the child is stuck; the margin keeps the child's own
 /// deadline authoritative.
-const HANDOFF_SAFETY_WAIT: Duration = Duration::from_secs(5);
+const HANDOFF_WAIT: Duration = Duration::from_secs(5);
+/// codex kills SessionEnd hooks at 3s (its hard cap). The provider-facing
+/// process must report an unconfirmed handoff before that instead of being
+/// killed; the detached child keeps trying to deliver the event regardless.
+const CODEX_SESSION_END_HANDOFF_WAIT: Duration = Duration::from_secs(2);
 /// Hidden mode: the detached child on platforms without `fork`. The request id
 /// arrives as the first stdin line and the encoded request follows.
 const DETACHED_MODE_ARG: &str = "__detached-append";
@@ -88,7 +92,42 @@ fn run(args: Args) -> anyhow::Result<()> {
     )?;
     let event = serde_json::to_value(ingress)?;
     let (request_id, encoded) = encode_request(event)?;
-    detach::append_detached(&socket, &request_id, &encoded)
+    let handoff = handoff_wait(&args.source, &args.native_event);
+    match detach::append_detached(&socket, &request_id, &encoded, handoff)? {
+        Handoff::Sent => Ok(()),
+        Handoff::ChildExited => bail!("hook child gave up before writing the journal request"),
+        Handoff::TimedOut => {
+            bail!("journal request handoff was not confirmed within {} ms", handoff.as_millis())
+        }
+    }
+}
+
+/// Outcome of the provider-facing wait for the detached child.
+#[derive(Debug, PartialEq, Eq)]
+enum Handoff {
+    /// The child wrote the full request to the server socket.
+    Sent,
+    /// The child exited without writing the request (no listener, or it gave
+    /// up at `SOCKET_TIMEOUT`).
+    ChildExited,
+    /// The bound elapsed first; the child is still trying on its own.
+    TimedOut,
+}
+
+fn handoff_wait(source: &str, native_event: &str) -> Duration {
+    if source == "codex" && native_event == "SessionEnd" {
+        CODEX_SESSION_END_HANDOFF_WAIT
+    } else {
+        HANDOFF_WAIT
+    }
+}
+
+/// Detached-child confirmation on platforms that respawn instead of forking:
+/// one byte on stdout once the request is written.
+fn confirm_handoff_on_stdout() {
+    let mut stdout = io::stdout().lock();
+    let _ = std::io::Write::write_all(&mut stdout, b"1");
+    let _ = std::io::Write::flush(&mut stdout);
 }
 
 /// Entry point of the detached child spawned by `DETACHED_MODE_ARG`.
@@ -108,7 +147,7 @@ fn detached_child_from_stdin() -> anyhow::Result<()> {
         .read_to_end(&mut encoded)
         .context("read detached request")?;
     anyhow::ensure!(encoded.len() <= MAX_MESSAGE_BYTES, "detached request exceeds 4 MiB");
-    append_with_receipt(&socket, &request_id, &encoded, &|| {})
+    append_with_receipt(&socket, &request_id, &encoded, &confirm_handoff_on_stdout)
 }
 
 fn shadowed_by_grok(source: &str, grok_hook_event: Option<&std::ffi::OsStr>) -> bool {
@@ -393,12 +432,12 @@ fn read_before(
 #[cfg(unix)]
 mod detach {
     use std::io;
-    use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd};
+    use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
     use std::path::Path;
 
     use anyhow::Context;
 
-    use super::{HANDOFF_SAFETY_WAIT, append_with_receipt};
+    use super::{Handoff, append_with_receipt};
 
     /// Forks a detached child that performs the append, then returns once the
     /// child has written the request (normally milliseconds) or has given up
@@ -410,7 +449,8 @@ mod detach {
         socket: &Path,
         request_id: &str,
         encoded: &[u8],
-    ) -> anyhow::Result<()> {
+        handoff_wait: std::time::Duration,
+    ) -> anyhow::Result<Handoff> {
         let mut fds = [0_i32; 2];
         // SAFETY: `fds` is a valid two-element array for pipe(2) to fill.
         if unsafe { libc::pipe(fds.as_mut_ptr()) } != 0 {
@@ -434,8 +474,7 @@ mod detach {
             unsafe { libc::_exit(code) };
         }
         drop(write_end);
-        wait_for_handoff(&read_end);
-        Ok(())
+        Ok(wait_for_handoff(&read_end, handoff_wait))
     }
 
     fn child_main(socket: &Path, request_id: &str, encoded: &[u8], handoff: OwnedFd) -> i32 {
@@ -445,12 +484,18 @@ mod detach {
         if redirect_stdio_to_null().is_err() {
             return 1;
         }
-        let handoff = handoff.into_raw_fd();
+        // Signal once, then close the pipe: retries after a parent timeout must
+        // not write into a pipe nobody reads (Rust ignores SIGPIPE, so a
+        // second write would only fail, but closing keeps the contract exact).
+        let handoff = std::cell::Cell::new(Some(handoff));
         let signal_sent = move || {
-            let byte = [1_u8];
-            // SAFETY: `handoff` stays open for the child's lifetime and the
-            // buffer is one valid byte. A failed write only delays the parent.
-            let _ = unsafe { libc::write(handoff, byte.as_ptr().cast(), 1) };
+            if let Some(handoff) = handoff.take() {
+                let byte = [1_u8];
+                // SAFETY: `handoff` is open until dropped below and the buffer
+                // is one valid byte. A failed write only delays the parent.
+                let _ = unsafe { libc::write(handoff.as_raw_fd(), byte.as_ptr().cast(), 1) };
+                drop(handoff);
+            }
         };
         match append_with_receipt(socket, request_id, encoded, &signal_sent) {
             Ok(()) => 0,
@@ -472,47 +517,59 @@ mod detach {
     }
 
     /// Returns when the child reports the request was written (one byte) or
-    /// exits (EOF). `HANDOFF_SAFETY_WAIT` is an absolute deadline, so a signal
-    /// storm cannot extend it through repeated `EINTR`.
-    fn wait_for_handoff(read_end: &OwnedFd) {
-        let deadline = std::time::Instant::now() + HANDOFF_SAFETY_WAIT;
+    /// exits (EOF). `handoff_wait` is an absolute deadline, so a signal storm
+    /// cannot extend it through repeated `EINTR`.
+    fn wait_for_handoff(read_end: &OwnedFd, handoff_wait: std::time::Duration) -> Handoff {
+        let deadline = std::time::Instant::now() + handoff_wait;
         let mut descriptor =
             libc::pollfd { fd: read_end.as_raw_fd(), events: libc::POLLIN, revents: 0 };
         loop {
             let remaining = deadline.saturating_duration_since(std::time::Instant::now());
             if remaining.is_zero() {
-                return;
+                return Handoff::TimedOut;
             }
             let timeout_ms = i32::try_from(remaining.as_millis().max(1)).unwrap_or(i32::MAX);
             // SAFETY: `descriptor` is one valid pollfd for the poll duration.
             let ready = unsafe { libc::poll(&mut descriptor, 1, timeout_ms) };
-            if ready >= 0 || io::Error::last_os_error().kind() != io::ErrorKind::Interrupted {
-                return;
+            if ready == 0 {
+                return Handoff::TimedOut;
             }
+            if ready < 0 {
+                if io::Error::last_os_error().kind() == io::ErrorKind::Interrupted {
+                    continue;
+                }
+                return Handoff::TimedOut;
+            }
+            let mut byte = [0_u8; 1];
+            // SAFETY: `read_end` is open and `byte` is a valid one-byte buffer.
+            let read = unsafe { libc::read(read_end.as_raw_fd(), byte.as_mut_ptr().cast(), 1) };
+            return if read == 1 { Handoff::Sent } else { Handoff::ChildExited };
         }
     }
 }
 
 #[cfg(not(unix))]
 mod detach {
-    use std::io::Write;
+    use std::io::{Read, Write};
     use std::path::Path;
     use std::process::{Command, Stdio};
+    use std::sync::mpsc;
+    use std::time::Duration;
 
     use anyhow::Context;
 
-    use super::DETACHED_MODE_ARG;
+    use super::{DETACHED_MODE_ARG, Handoff};
 
     /// Respawns this helper detached from the provider's console and process
-    /// group with the request on its stdin. The request is written to the
-    /// child's pipe before returning; unlike the unix path this does not wait
-    /// for the child's socket write, so ordering and backpressure on Windows
-    /// follow spawn order only.
+    /// group with the request on its stdin, then waits (bounded) for the
+    /// child's one-byte confirmation that the request reached the server
+    /// socket, giving the same ordering and backpressure as the fork path.
     pub(super) fn append_detached(
         socket: &Path,
         request_id: &str,
         encoded: &[u8],
-    ) -> anyhow::Result<()> {
+        handoff_wait: Duration,
+    ) -> anyhow::Result<Handoff> {
         use std::os::windows::process::CommandExt;
         const DETACHED_PROCESS: u32 = 0x0000_0008;
         const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
@@ -521,18 +578,30 @@ mod detach {
             .arg(DETACHED_MODE_ARG)
             .env("CMUX_TUI_SOCKET", socket)
             .stdin(Stdio::piped())
-            .stdout(Stdio::null())
+            .stdout(Stdio::piped())
             .stderr(Stdio::null())
             .creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP)
             .spawn()
             .context("spawn detached hook child")?;
         let mut stdin = child.stdin.take().context("detached hook child has no stdin")?;
+        let mut stdout = child.stdout.take().context("detached hook child has no stdout")?;
         stdin.write_all(request_id.as_bytes())?;
         stdin.write_all(b"\n")?;
         stdin.write_all(encoded)?;
         stdin.flush()?;
         drop(stdin);
-        Ok(())
+        // Pipe reads have no timeout on Windows; a reader thread plus a
+        // bounded channel wait gives the same absolute deadline as poll(2).
+        let (sender, receiver) = mpsc::channel();
+        std::thread::spawn(move || {
+            let mut byte = [0_u8; 1];
+            let outcome = match stdout.read(&mut byte) {
+                Ok(1) => Handoff::Sent,
+                _ => Handoff::ChildExited,
+            };
+            let _ = sender.send(outcome);
+        });
+        Ok(receiver.recv_timeout(handoff_wait).unwrap_or(Handoff::TimedOut))
     }
 }
 
@@ -551,6 +620,13 @@ fn random_identifiers() -> anyhow::Result<(String, String)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn codex_session_end_handoff_stays_below_the_codex_hook_cap() {
+        assert!(handoff_wait("codex", "SessionEnd") < Duration::from_secs(3));
+        assert!(handoff_wait("codex", "Stop") > SOCKET_TIMEOUT);
+        assert!(handoff_wait("claude", "SessionEnd") > SOCKET_TIMEOUT);
+    }
 
     #[test]
     fn parses_short_positional_source_and_event() {

--- a/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
+++ b/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
@@ -1,3 +1,13 @@
+//! Agent hook helper: forwards one provider hook event to the cmux-tui
+//! session journal.
+//!
+//! Providers (codex, cursor, gemini, grok) run hook commands synchronously
+//! and block the agent until the command exits, so this helper never waits
+//! on the journal server in the provider's process: it reads the payload,
+//! hands the request to a detached child, and exits once the child has
+//! written the request (bounded by `HANDOFF_WAIT`) so events reach the
+//! server in provider order. The child waits for the receipt and retries.
+
 use std::env;
 use std::io::{self, BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
@@ -14,9 +24,13 @@ const MAX_NATIVE_PAYLOAD_BYTES: u64 = 1024 * 1024;
 const MAX_MESSAGE_BYTES: usize = 4 * 1024 * 1024;
 const MAX_RESPONSE_BYTES: usize = 16 * 1024 * 1024;
 const SOCKET_TIMEOUT: Duration = Duration::from_secs(4);
-/// codex kills SessionEnd hooks at 3s (its hard cap), so the helper must give
-/// up first and report its own error instead of dying mid-append.
-const CODEX_SESSION_END_SOCKET_TIMEOUT: Duration = Duration::from_secs(2);
+/// Longest the provider-facing process waits for the detached child to write
+/// the request. Normally the write lands in a few milliseconds; this bound only
+/// matters when the server is not accepting connections.
+const HANDOFF_WAIT: Duration = Duration::from_millis(500);
+/// Hidden mode: the detached child on platforms without `fork`. The request id
+/// arrives as the first stdin line and the encoded request follows.
+const DETACHED_MODE_ARG: &str = "__detached-append";
 
 #[derive(Debug, PartialEq, Eq)]
 struct Args {
@@ -26,6 +40,15 @@ struct Args {
 
 fn main() -> ExitCode {
     let arguments = env::args().skip(1).collect::<Vec<_>>();
+    if arguments.len() == 1 && arguments[0] == DETACHED_MODE_ARG {
+        return match detached_child_from_stdin() {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(error) => {
+                eprintln!("cmux-tui-hook: {error:#}");
+                ExitCode::FAILURE
+            }
+        };
+    }
     if arguments.iter().any(|argument| matches!(argument.as_str(), "-h" | "--help")) {
         println!("Usage: cmux-tui-hook <agent> <native-event>");
         return ExitCode::SUCCESS;
@@ -60,7 +83,28 @@ fn run(args: Args) -> anyhow::Result<()> {
         native,
     )?;
     let event = serde_json::to_value(ingress)?;
-    append(&socket, event, socket_timeout(&args.source, &args.native_event))
+    let (request_id, encoded) = encode_request(event)?;
+    detach::append_detached(&socket, &request_id, &encoded)
+}
+
+/// Entry point of the detached child spawned by `DETACHED_MODE_ARG`.
+fn detached_child_from_stdin() -> anyhow::Result<()> {
+    let socket = env::var_os("CMUX_TUI_SOCKET")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .context("CMUX_TUI_SOCKET is required in detached mode")?;
+    let mut reader = BufReader::new(io::stdin().lock());
+    let mut request_id = String::new();
+    reader.read_line(&mut request_id).context("read detached request id")?;
+    let request_id = request_id.trim_end_matches(['\r', '\n']).to_owned();
+    anyhow::ensure!(!request_id.is_empty(), "detached request id is empty");
+    let mut encoded = Vec::new();
+    reader
+        .take(MAX_MESSAGE_BYTES as u64 + 1)
+        .read_to_end(&mut encoded)
+        .context("read detached request")?;
+    anyhow::ensure!(encoded.len() <= MAX_MESSAGE_BYTES, "detached request exceeds 4 MiB");
+    append_with_receipt(&socket, &request_id, &encoded, &|| {})
 }
 
 fn shadowed_by_grok(source: &str, grok_hook_event: Option<&std::ffi::OsStr>) -> bool {
@@ -101,15 +145,7 @@ fn read_native_payload(reader: impl Read) -> anyhow::Result<Value> {
     Ok(json!({"encoding":"base64","data":BASE64.encode(bytes)}))
 }
 
-fn socket_timeout(source: &str, native_event: &str) -> Duration {
-    if source == "codex" && native_event == "SessionEnd" {
-        CODEX_SESSION_END_SOCKET_TIMEOUT
-    } else {
-        SOCKET_TIMEOUT
-    }
-}
-
-fn append(socket: &Path, event: Value, timeout: Duration) -> anyhow::Result<()> {
+fn encode_request(event: Value) -> anyhow::Result<(String, Vec<u8>)> {
     let (request_id, idempotency_key) = random_identifiers()?;
     let request = json!({
         "protocol":"cmux.protocol/2",
@@ -124,8 +160,21 @@ fn append(socket: &Path, event: Value, timeout: Duration) -> anyhow::Result<()> 
     if encoded.len() > MAX_MESSAGE_BYTES {
         bail!("agent hook request exceeds the 4 MiB protocol limit");
     }
+    Ok((request_id, encoded))
+}
 
-    retry_until(timeout, |deadline| append_once(socket, &encoded, &request_id, deadline))
+/// Sends the request and waits for the journal receipt, retrying until
+/// `SOCKET_TIMEOUT`. `on_sent` runs each time the full request has been
+/// written to the server, so the parent can stop waiting for ordering.
+fn append_with_receipt(
+    socket: &Path,
+    request_id: &str,
+    encoded: &[u8],
+    on_sent: &dyn Fn(),
+) -> anyhow::Result<()> {
+    retry_until(SOCKET_TIMEOUT, |deadline| {
+        append_once(socket, encoded, request_id, deadline, on_sent)
+    })
 }
 
 #[derive(Debug)]
@@ -167,9 +216,11 @@ fn append_once(
     encoded: &[u8],
     request_id: &str,
     deadline: Instant,
+    on_sent: &dyn Fn(),
 ) -> Result<(), AppendAttemptError> {
     let mut stream = connect_before(socket, deadline)?;
     write_before(&mut *stream, encoded, deadline)?;
+    on_sent();
     let response = read_before(stream, deadline)?;
     let response: Value = serde_json::from_slice(&response)
         .map_err(|error| AppendAttemptError::Fatal(error.into()))?;
@@ -335,6 +386,141 @@ fn read_before(
     }
 }
 
+#[cfg(unix)]
+mod detach {
+    use std::io;
+    use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd};
+    use std::path::Path;
+
+    use anyhow::Context;
+
+    use super::{HANDOFF_WAIT, append_with_receipt};
+
+    /// Forks a detached child that performs the append, then returns once the
+    /// child has written the request or `HANDOFF_WAIT` elapsed.
+    pub(super) fn append_detached(
+        socket: &Path,
+        request_id: &str,
+        encoded: &[u8],
+    ) -> anyhow::Result<()> {
+        let mut fds = [0_i32; 2];
+        // SAFETY: `fds` is a valid two-element array for pipe(2) to fill.
+        if unsafe { libc::pipe(fds.as_mut_ptr()) } != 0 {
+            return Err(io::Error::last_os_error()).context("create hook handoff pipe");
+        }
+        // SAFETY: pipe(2) returned two fresh descriptors this process owns.
+        let (read_end, write_end) =
+            unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) };
+        // SAFETY: the process is single-threaded here. The payload was read on
+        // the main thread and the connector thread is only spawned by the
+        // child after the fork, so no lock can be held by a vanished thread.
+        let pid = unsafe { libc::fork() };
+        if pid < 0 {
+            return Err(io::Error::last_os_error()).context("fork hook child");
+        }
+        if pid == 0 {
+            drop(read_end);
+            let code = child_main(socket, request_id, encoded, write_end);
+            // SAFETY: _exit only terminates the child without running
+            // destructors that could touch parent-owned state.
+            unsafe { libc::_exit(code) };
+        }
+        drop(write_end);
+        wait_for_handoff(&read_end);
+        Ok(())
+    }
+
+    fn child_main(socket: &Path, request_id: &str, encoded: &[u8], handoff: OwnedFd) -> i32 {
+        // SAFETY: setsid has no memory-safety preconditions; failure only
+        // means this process already leads a session, which is harmless.
+        unsafe { libc::setsid() };
+        if redirect_stdio_to_null().is_err() {
+            return 1;
+        }
+        let handoff = handoff.into_raw_fd();
+        let signal_sent = move || {
+            let byte = [1_u8];
+            // SAFETY: `handoff` stays open for the child's lifetime and the
+            // buffer is one valid byte. A failed write only delays the parent.
+            let _ = unsafe { libc::write(handoff, byte.as_ptr().cast(), 1) };
+        };
+        match append_with_receipt(socket, request_id, encoded, &signal_sent) {
+            Ok(()) => 0,
+            Err(_) => 1,
+        }
+    }
+
+    /// The provider waits for EOF on the hook's stdout, so the child must
+    /// drop the inherited pipes before the parent exits.
+    fn redirect_stdio_to_null() -> io::Result<()> {
+        let null = std::fs::OpenOptions::new().read(true).write(true).open("/dev/null")?;
+        for fd in [libc::STDIN_FILENO, libc::STDOUT_FILENO, libc::STDERR_FILENO] {
+            // SAFETY: both descriptors are open; dup2 replaces `fd` atomically.
+            if unsafe { libc::dup2(null.as_raw_fd(), fd) } < 0 {
+                return Err(io::Error::last_os_error());
+            }
+        }
+        Ok(())
+    }
+
+    /// Returns when the child reports the request was written (one byte), the
+    /// child exits (EOF), or `HANDOFF_WAIT` elapses.
+    fn wait_for_handoff(read_end: &OwnedFd) {
+        let mut descriptor =
+            libc::pollfd { fd: read_end.as_raw_fd(), events: libc::POLLIN, revents: 0 };
+        let timeout_ms = i32::try_from(HANDOFF_WAIT.as_millis()).unwrap_or(i32::MAX);
+        loop {
+            // SAFETY: `descriptor` is one valid pollfd for the poll duration.
+            let ready = unsafe { libc::poll(&mut descriptor, 1, timeout_ms) };
+            if ready >= 0 || io::Error::last_os_error().kind() != io::ErrorKind::Interrupted {
+                return;
+            }
+        }
+    }
+}
+
+#[cfg(not(unix))]
+mod detach {
+    use std::io::Write;
+    use std::path::Path;
+    use std::process::{Command, Stdio};
+
+    use anyhow::Context;
+
+    use super::DETACHED_MODE_ARG;
+
+    /// Respawns this helper detached from the provider's console and process
+    /// group with the request on its stdin. The request is written to the
+    /// child's pipe before returning, so consecutive hooks still start in
+    /// provider order; the receipt wait happens in the child.
+    pub(super) fn append_detached(
+        socket: &Path,
+        request_id: &str,
+        encoded: &[u8],
+    ) -> anyhow::Result<()> {
+        use std::os::windows::process::CommandExt;
+        const DETACHED_PROCESS: u32 = 0x0000_0008;
+        const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+        let exe = std::env::current_exe().context("locate hook helper")?;
+        let mut child = Command::new(exe)
+            .arg(DETACHED_MODE_ARG)
+            .env("CMUX_TUI_SOCKET", socket)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP)
+            .spawn()
+            .context("spawn detached hook child")?;
+        let mut stdin = child.stdin.take().context("detached hook child has no stdin")?;
+        stdin.write_all(request_id.as_bytes())?;
+        stdin.write_all(b"\n")?;
+        stdin.write_all(encoded)?;
+        stdin.flush()?;
+        drop(stdin);
+        Ok(())
+    }
+}
+
 fn random_identifiers() -> anyhow::Result<(String, String)> {
     let mut bytes = [0_u8; 16];
     getrandom::fill(&mut bytes).map_err(|error| anyhow!("allocate hook identity: {error}"))?;
@@ -350,13 +536,6 @@ fn random_identifiers() -> anyhow::Result<(String, String)> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn codex_session_end_gives_up_before_the_codex_hook_cap() {
-        assert!(socket_timeout("codex", "SessionEnd") < Duration::from_secs(3));
-        assert_eq!(socket_timeout("codex", "Stop"), SOCKET_TIMEOUT);
-        assert_eq!(socket_timeout("claude", "SessionEnd"), SOCKET_TIMEOUT);
-    }
 
     #[test]
     fn parses_short_positional_source_and_event() {

--- a/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
+++ b/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
@@ -3,10 +3,13 @@
 //!
 //! Providers (codex, cursor, gemini, grok) run hook commands synchronously
 //! and block the agent until the command exits, so this helper never waits
-//! on the journal server in the provider's process: it reads the payload,
+//! for the journal commit in the provider's process: it reads the payload,
 //! hands the request to a detached child, and exits once the child has
-//! written the request (bounded by `HANDOFF_WAIT`) so events reach the
-//! server in provider order. The child waits for the receipt and retries.
+//! written the request to the server socket. Waiting for that write, and not
+//! for the receipt, keeps two properties: events reach the server in
+//! provider order, and a server that stops accepting requests applies
+//! backpressure to the provider instead of spawning an unbounded number of
+//! retrying children. The child waits for the receipt and retries.
 
 use std::env;
 use std::io::{self, BufRead, BufReader, Read};
@@ -24,10 +27,11 @@ const MAX_NATIVE_PAYLOAD_BYTES: u64 = 1024 * 1024;
 const MAX_MESSAGE_BYTES: usize = 4 * 1024 * 1024;
 const MAX_RESPONSE_BYTES: usize = 16 * 1024 * 1024;
 const SOCKET_TIMEOUT: Duration = Duration::from_secs(4);
-/// Longest the provider-facing process waits for the detached child to write
-/// the request. Normally the write lands in a few milliseconds; this bound only
-/// matters when the server is not accepting connections.
-const HANDOFF_WAIT: Duration = Duration::from_millis(500);
+/// Safety bound on the provider-facing wait for the child's "request written"
+/// signal. The child itself gives up at `SOCKET_TIMEOUT` and closes the pipe,
+/// so this only fires if the child is stuck; the margin keeps the child's own
+/// deadline authoritative.
+const HANDOFF_SAFETY_WAIT: Duration = Duration::from_secs(5);
 /// Hidden mode: the detached child on platforms without `fork`. The request id
 /// arrives as the first stdin line and the encoded request follows.
 const DETACHED_MODE_ARG: &str = "__detached-append";
@@ -394,10 +398,14 @@ mod detach {
 
     use anyhow::Context;
 
-    use super::{HANDOFF_WAIT, append_with_receipt};
+    use super::{HANDOFF_SAFETY_WAIT, append_with_receipt};
 
     /// Forks a detached child that performs the append, then returns once the
-    /// child has written the request or `HANDOFF_WAIT` elapsed.
+    /// child has written the request (normally milliseconds) or has given up
+    /// on delivering it. Ordering and backpressure both follow from that: the
+    /// next provider hook cannot start until this request is in the server's
+    /// socket buffer, and a server that stops accepting stalls the provider
+    /// for at most the child's `SOCKET_TIMEOUT` instead of fanning out.
     pub(super) fn append_detached(
         socket: &Path,
         request_id: &str,
@@ -463,13 +471,19 @@ mod detach {
         Ok(())
     }
 
-    /// Returns when the child reports the request was written (one byte), the
-    /// child exits (EOF), or `HANDOFF_WAIT` elapses.
+    /// Returns when the child reports the request was written (one byte) or
+    /// exits (EOF). `HANDOFF_SAFETY_WAIT` is an absolute deadline, so a signal
+    /// storm cannot extend it through repeated `EINTR`.
     fn wait_for_handoff(read_end: &OwnedFd) {
+        let deadline = std::time::Instant::now() + HANDOFF_SAFETY_WAIT;
         let mut descriptor =
             libc::pollfd { fd: read_end.as_raw_fd(), events: libc::POLLIN, revents: 0 };
-        let timeout_ms = i32::try_from(HANDOFF_WAIT.as_millis()).unwrap_or(i32::MAX);
         loop {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            if remaining.is_zero() {
+                return;
+            }
+            let timeout_ms = i32::try_from(remaining.as_millis().max(1)).unwrap_or(i32::MAX);
             // SAFETY: `descriptor` is one valid pollfd for the poll duration.
             let ready = unsafe { libc::poll(&mut descriptor, 1, timeout_ms) };
             if ready >= 0 || io::Error::last_os_error().kind() != io::ErrorKind::Interrupted {
@@ -491,8 +505,9 @@ mod detach {
 
     /// Respawns this helper detached from the provider's console and process
     /// group with the request on its stdin. The request is written to the
-    /// child's pipe before returning, so consecutive hooks still start in
-    /// provider order; the receipt wait happens in the child.
+    /// child's pipe before returning; unlike the unix path this does not wait
+    /// for the child's socket write, so ordering and backpressure on Windows
+    /// follow spawn order only.
     pub(super) fn append_detached(
         socket: &Path,
         request_id: &str,

--- a/cmux-tui/crates/cmux-tui/tests/journal_hook_detach.rs
+++ b/cmux-tui/crates/cmux-tui/tests/journal_hook_detach.rs
@@ -1,0 +1,112 @@
+//! `cmux-tui-hook` must never hold the provider hostage to the journal
+//! server: it exits once the request is written, and a detached child waits
+//! for the receipt. Providers block their agent on the hook's exit and on EOF
+//! of its stdout, so both must happen before the server answers.
+
+#![cfg(unix)]
+
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+fn socket_path(name: &str) -> PathBuf {
+    let stamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
+    PathBuf::from("/tmp").join(format!("cmux-hd-{name}-{}-{stamp}.sock", std::process::id()))
+}
+
+fn spawn_hook(socket: &PathBuf, event: &str) -> Child {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_cmux-tui-hook"))
+        .args(["codex", event])
+        .env("CMUX_TUI_SOCKET", socket)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child.stdin.take().unwrap().write_all(b"{\"session_id\":\"detach-test\"}\n").unwrap();
+    child
+}
+
+/// Waits for exit AND stdout/stderr EOF, which is what a provider waits for.
+fn wait_with_output(child: Child, budget: Duration) -> Option<std::process::Output> {
+    let (sender, receiver) = std::sync::mpsc::channel();
+    thread::spawn(move || {
+        let _ = sender.send(child.wait_with_output());
+    });
+    receiver.recv_timeout(budget).ok().and_then(Result::ok)
+}
+
+fn read_request(stream: &UnixStream) -> String {
+    let mut line = String::new();
+    BufReader::new(stream).read_line(&mut line).unwrap();
+    line
+}
+
+fn reply(mut stream: &UnixStream, request: &str) {
+    let request: serde_json::Value = serde_json::from_str(request).unwrap();
+    let response = serde_json::json!({
+        "protocol":"cmux.protocol/2","type":"response","id":request["id"],"ok":true,
+        "result":{"value":{"sequence":"1"}}
+    });
+    stream.write_all(format!("{response}\n").as_bytes()).unwrap();
+}
+
+#[test]
+fn detached_hook_exits_before_the_server_answers() {
+    let socket = socket_path("exit");
+    let listener = UnixListener::bind(&socket).unwrap();
+    let started = Instant::now();
+    let child = spawn_hook(&socket, "Stop");
+    let (stream, _) = listener.accept().unwrap();
+    let request = read_request(&stream);
+    assert!(request.contains("\"session.journal.append\""), "{request}");
+
+    // The server has not answered yet; the provider-facing process must be
+    // gone, with its stdout closed, well inside the 4 s receipt deadline.
+    let output = wait_with_output(child, Duration::from_secs(3))
+        .expect("hook must exit before the journal receipt arrives");
+    assert!(output.status.success(), "{output:?}");
+    assert!(started.elapsed() < Duration::from_secs(3));
+
+    reply(&stream, &request);
+    let _ = std::fs::remove_file(&socket);
+}
+
+#[test]
+fn detached_hook_writes_the_request_before_exiting_even_when_the_server_is_not_accepting() {
+    let socket = socket_path("order");
+    let listener = UnixListener::bind(&socket).unwrap();
+    // Nothing accepts yet: the requests sit in the listen backlog. Each hook
+    // still exits only after its own request is written, so provider order
+    // becomes arrival order.
+    for event in ["SessionStart", "UserPromptSubmit", "Stop"] {
+        let output = wait_with_output(spawn_hook(&socket, event), Duration::from_secs(3))
+            .expect("hook must exit while the server is not accepting");
+        assert!(output.status.success(), "{event}: {output:?}");
+    }
+    let mut seen = Vec::new();
+    for _ in 0..3 {
+        let (stream, _) = listener.accept().unwrap();
+        let request = read_request(&stream);
+        let value: serde_json::Value = serde_json::from_str(&request).unwrap();
+        seen.push(
+            value["params"]["event"]["payload"]["native_event"].as_str().unwrap_or("").to_owned(),
+        );
+        reply(&stream, &request);
+    }
+    assert_eq!(seen, ["SessionStart", "UserPromptSubmit", "Stop"]);
+    let _ = std::fs::remove_file(&socket);
+}
+
+#[test]
+fn detached_hook_without_a_listener_exits_immediately() {
+    let socket = socket_path("dead");
+    let started = Instant::now();
+    let output = wait_with_output(spawn_hook(&socket, "Stop"), Duration::from_secs(3))
+        .expect("hook must exit when no server listens");
+    assert!(output.status.success(), "{output:?}");
+    assert!(started.elapsed() < Duration::from_secs(2));
+}

--- a/cmux-tui/crates/cmux-tui/tests/journal_hook_detach.rs
+++ b/cmux-tui/crates/cmux-tui/tests/journal_hook_detach.rs
@@ -65,7 +65,7 @@ fn detached_hook_exits_before_the_server_answers() {
     assert!(request.contains("\"session.journal.append\""), "{request}");
 
     // The server has not answered yet; the provider-facing process must be
-    // gone, with its stdout closed, well inside the 4 s receipt deadline.
+    // gone, with its stdout closed, without waiting for the receipt.
     let output = wait_with_output(child, Duration::from_secs(3))
         .expect("hook must exit before the journal receipt arrives");
     assert!(output.status.success(), "{output:?}");

--- a/cmux-tui/crates/cmux-tui/tests/journal_hook_detach.rs
+++ b/cmux-tui/crates/cmux-tui/tests/journal_hook_detach.rs
@@ -102,11 +102,14 @@ fn detached_hook_writes_the_request_before_exiting_even_when_the_server_is_not_a
 }
 
 #[test]
-fn detached_hook_without_a_listener_exits_immediately() {
+fn detached_hook_without_a_listener_fails_immediately() {
     let socket = socket_path("dead");
     let started = Instant::now();
     let output = wait_with_output(spawn_hook(&socket, "Stop"), Duration::from_secs(3))
         .expect("hook must exit when no server listens");
-    assert!(output.status.success(), "{output:?}");
+    // No listener means this terminal is not attached to a live cmux-tui: the
+    // child gives up at once and the provider-facing process reports it,
+    // without spending the retry deadline.
+    assert!(!output.status.success(), "{output:?}");
     assert!(started.elapsed() < Duration::from_secs(2));
 }


### PR DESCRIPTION
Stacked on https://github.com/manaflow-ai/cmux/pull/11373 (base retargets to `main` when that merges).

Providers without an async hook flag (codex, cursor, gemini, grok) block the agent until the hook exits and its stdout closes. `cmux-tui-hook` waited up to 4 s for the journal receipt, so every hook event paid the server's commit latency (15–390 ms measured on a loaded Mac) on the agent's critical path, and a wedged server cost the full timeout.

The helper now forks before any thread exists. The child redirects stdio to `/dev/null`, calls `setsid`, connects, writes the request, signals the parent over a pipe, then waits for the receipt and retries as before. The parent exits on that signal or after 500 ms, so consecutive hooks still reach the server in provider order and the provider's cost is process spawn only (~20 ms). Windows respawns the helper detached with the request on stdin, without the sequencing wait.

Trade-offs: ordering is now by request arrival instead of provider serialization, the same as Claude's `async: true` hooks today; a hook whose child is killed loses its event, the same case as the provider killing the hook at its timeout today. The codex SessionEnd 2 s budget from #11373 is removed because the provider no longer waits on the helper.

Tests: `crates/cmux-tui/tests/journal_hook_detach.rs` proves the helper exits with stdout closed before the server answers, that requests are written in provider order even while the server is not accepting, and that a dead socket exits immediately.

https://claude.ai/code/session_01NvVHvU3Zijvi6berGDg6Ed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11399"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790845330&installation_model_id=21920&pr_number=11399&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11399&signature=a2ed8344bb50fc2f55c85c3357bfc8f1eb6230e6eac046df05cea41dc3348e88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detaches the hook helper from the provider so agent hooks no longer stall on journal server latency. The helper hands the request to a detached child and exits once the request is written, so providers without an async hook flag (codex, cursor, gemini, grok) only pay process spawn cost instead of waiting up to 4 s for the receipt.

**Changes**
- The child waits for the journal receipt and retries as before; the parent exits once the child signals the request was written, or when the child gives up at its socket timeout.
- Waiting for the write keeps requests in provider order and applies backpressure: a server that stops accepting stalls the provider instead of spawning a retrying child per event.
- On Windows, the helper respawns detached with the request on stdin and the same one-byte confirmation over the child's stdout, so ordering and backpressure match the fork path.
- A dead journal socket fails the hook immediately instead of waiting out the retry deadline.
- A killed child loses its event, same as today when the provider kills the hook.
- codex SessionEnd keeps a 2 s handoff bound so codex's 3 s cap cannot kill the parent while the detached child keeps delivering.

<sup>Written for commit 6e584ba1e93ca49441da65e746fc471dccbee734. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

