### PR TITLE
Fix signed-in pricing page showing signed out

### DIFF
--- a/Sources/Panels/BrowserPanel+PrewarmedWebViewAdoption.swift
+++ b/Sources/Panels/BrowserPanel+PrewarmedWebViewAdoption.swift
@@ -1,5 +1,6 @@
 import Foundation
 import WebKit
+import CmuxBrowser
 
 /// Hover-prewarm adoption support for ``BrowserPanel``: profile resolution
 /// shared with prewarm callers, and the eligibility gate the initializer uses
@@ -30,6 +31,17 @@ extension BrowserPanel {
               initialRequest == nil,
               renderInitialNavigation,
               let initialURL else {
+            return nil
+        }
+        guard !BrowserAppTheme.supportsAppSurface(
+            url: initialURL,
+            trustedOrigin: AuthEnvironment.appSessionHandoffOrigin
+        ) else {
+            // An older prewarm may still contain a page loaded without the
+            // native session. Never retain that page for a later panel.
+            BrowserPrewarmedWebViewPool.shared.discard(
+                reason: "native-app-session-required"
+            )
             return nil
         }
         return BrowserPrewarmedWebViewPool.shared.claim(

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1960,7 +1960,12 @@ final class BrowserPanel: Panel, ObservableObject {
     var browserViewportHostRestorationTask: Task<Void, Never>?
     var browserViewportHostRestorationPending = false
     var websiteDataStore: WKWebsiteDataStore
-    private let preservesExplicitEphemeralWebsiteDataStore: Bool
+    private var preservesExplicitEphemeralWebsiteDataStore: Bool
+    private var appSessionStoreRequiresNativeBootstrap = false
+    private let appSessionNavigationRequest: (@MainActor (URL) async -> BrowserAppSessionRequestOutcome)?
+    private var pendingAppSessionNavigationTask: Task<Void, Never>?
+    private var pendingAppSessionNavigationCompletion: ((WKNavigation?) -> Void)?
+    private var appSessionNavigationGeneration: UInt64 = 0
     var browserAutomationUserScripts: [WKUserScript] = []
     var browserAutomationInitScriptCount = 0
     var browserAutomationStyleScriptCount = 0
@@ -3392,7 +3397,8 @@ final class BrowserPanel: Panel, ObservableObject {
         bypassRemoteProxy: Bool = false,
         isRemoteWorkspace: Bool = false,
         remoteWebsiteDataStoreIdentifier: UUID? = nil,
-        websiteDataStore explicitWebsiteDataStore: WKWebsiteDataStore? = nil
+        websiteDataStore explicitWebsiteDataStore: WKWebsiteDataStore? = nil,
+        appSessionNavigationRequest: (@MainActor (URL) async -> BrowserAppSessionRequestOutcome)? = nil
     ) {
         // Register fallback defaults and normalize legacy/out-of-range settings once
         // per process, before any setting is read below or by the SwiftUI view.
@@ -3401,6 +3407,7 @@ final class BrowserPanel: Panel, ObservableObject {
         self.mobileBrowserDialogBroker = MobileBrowserDialogBroker(panelID: self.id.uuidString)
         self.workspaceId = workspaceId
         self.externalNavigationHandler = BrowserExternalNavigationHandler()
+        self.appSessionNavigationRequest = appSessionNavigationRequest
         let resolvedProfileID = Self.resolvedProfileID(requested: profileID)
         self.profileID = resolvedProfileID
         self.insecureHTTPBypassHostOnce = BrowserInsecureHTTPSettings.normalizeHost(bypassInsecureHTTPHostOnce ?? "")
@@ -4107,7 +4114,14 @@ final class BrowserPanel: Panel, ObservableObject {
     }
 
     var explicitEphemeralWebsiteDataStoreForSibling: WKWebsiteDataStore? {
-        preservesExplicitEphemeralWebsiteDataStore ? websiteDataStore : nil
+        // A failed or signed-out app handoff owns an empty isolated store. Do
+        // not copy it to a sibling, because the sibling would otherwise skip
+        // the native exchange and render the signed-out app shell.
+        guard preservesExplicitEphemeralWebsiteDataStore,
+              !appSessionStoreRequiresNativeBootstrap else {
+            return nil
+        }
+        return websiteDataStore
     }
 
     func reattachToWorkspace(
@@ -4142,6 +4156,7 @@ final class BrowserPanel: Panel, ObservableObject {
 
     @discardableResult
     func switchToProfile(_ requestedProfileID: UUID) -> Bool {
+        cancelPendingNativeAppSessionNavigation()
         guard !preservesExplicitEphemeralWebsiteDataStore else {
             return false
         }
@@ -4186,6 +4201,7 @@ final class BrowserPanel: Panel, ObservableObject {
         if let previousCmuxWebView = previousWebView as? CmuxWebView { previousCmuxWebView.clearBrowserDownloadCallbacks() }
 
         profileID = resolvedProfileID
+        appSessionStoreRequiresNativeBootstrap = false
         historyStore = BrowserProfileStore.shared.historyStore(for: resolvedProfileID)
         BrowserProfileStore.shared.noteUsed(resolvedProfileID)
 
@@ -4304,6 +4320,7 @@ final class BrowserPanel: Panel, ObservableObject {
     }
 
     func restoreSessionSnapshot(_ snapshot: SessionBrowserPanelSnapshot) {
+        cancelPendingNativeAppSessionNavigation()
         // Diff viewer surfaces navigate via the app-owned custom scheme, so they
         // restore even though the original local HTTP server is gone. Manifest
         // preparation is detached from the main actor; the scheme request also
@@ -4940,8 +4957,9 @@ final class BrowserPanel: Panel, ObservableObject {
     }
 
     func close() {
-        cancelHiddenWebViewDiscard()
         isClosingWebViewLifecycle = true
+        cancelPendingNativeAppSessionNavigation()
+        cancelHiddenWebViewDiscard()
         trustedLocalFileURL = nil
         pendingTrustedLocalFileURL = nil
         automationNavigationCoordinator.invalidate()
@@ -5362,6 +5380,221 @@ final class BrowserPanel: Panel, ObservableObject {
 
     // MARK: - Navigation
 
+    /// Returns true for the signed-in app pages that must receive the native
+    /// Stack session before WebKit starts the document load.
+    static func supportsNativeAppSession(
+        for url: URL,
+        trustedOrigin: URL = AuthEnvironment.appSessionHandoffOrigin
+    ) -> Bool {
+        BrowserAppTheme.supportsAppSurface(
+            url: url,
+            trustedOrigin: trustedOrigin
+        )
+    }
+
+    private func shouldBootstrapNativeAppSession(
+        destinationURL: URL,
+        request: URLRequest
+    ) -> Bool {
+        guard !isClosingWebViewLifecycle,
+              !usesRemoteWorkspaceProxy,
+              Self.supportsNativeAppSession(for: destinationURL),
+              (request.httpMethod ?? "GET").uppercased() == "GET",
+              (!preservesExplicitEphemeralWebsiteDataStore
+                  || appSessionStoreRequiresNativeBootstrap) else {
+            return false
+        }
+        return appSessionNavigationRequest != nil || AppDelegate.shared?.auth != nil
+    }
+
+    private func requestNativeAppSession(
+        for destinationURL: URL
+    ) async -> BrowserAppSessionRequestOutcome {
+        if let appSessionNavigationRequest {
+            return await appSessionNavigationRequest(destinationURL)
+        }
+        guard let auth = AppDelegate.shared?.auth else {
+            return .notAuthenticated
+        }
+        return await auth.browserAppSession.request(destinationURL: destinationURL)
+    }
+
+    private func nativeAppSessionNavigationIsCurrent(
+        _ navigation: BrowserAppSessionNavigation
+    ) -> Bool {
+        // An injected request provider is a deterministic test seam. The
+        // production provider is checked against the controller's auth
+        // generation before its cookies are exposed to this panel.
+        if appSessionNavigationRequest != nil {
+            return true
+        }
+        guard let auth = AppDelegate.shared?.auth else { return false }
+        return auth.browserAppSession.isCurrent(
+            generation: navigation.generation,
+            authSessionGeneration: navigation.authSessionGeneration
+        )
+    }
+
+    private func cancelPendingNativeAppSessionNavigation() {
+        appSessionNavigationGeneration &+= 1
+        let completion = pendingAppSessionNavigationCompletion
+        pendingAppSessionNavigationCompletion = nil
+        pendingAppSessionNavigationTask?.cancel()
+        pendingAppSessionNavigationTask = nil
+        completion?(nil)
+    }
+
+    /// Starts the native-to-web exchange for a trusted app surface. The
+    /// destination is not loaded until the exchange returns, so a persistent
+    /// browser profile can never render the signed-out shell first.
+    private func beginNativeAppSessionNavigationIfNeeded(
+        request: URLRequest,
+        destinationURL: URL,
+        recordTypedNavigation: Bool,
+        preserveRestoredSessionHistory: Bool,
+        onNavigationStarted: ((WKNavigation?) -> Void)?
+    ) -> Bool {
+        guard shouldBootstrapNativeAppSession(
+            destinationURL: destinationURL,
+            request: request
+        ) else {
+            return false
+        }
+
+        cancelPendingNativeAppSessionNavigation()
+        let requestGeneration = appSessionNavigationGeneration
+        currentURL = destinationURL
+        hiddenWebViewDiscardManager.updateRestoredSessionRenderIntent(nil)
+        navigationDelegate?.recordAttemptedRequest(request, displayURL: destinationURL)
+        refreshBackgroundAppearance()
+        shouldRenderWebView = true
+        shouldPreloadInitialNavigationInBackground = false
+        if recordTypedNavigation {
+            historyStore.recordTypedNavigation(url: destinationURL)
+        }
+        pendingAppSessionNavigationCompletion = onNavigationStarted
+
+        pendingAppSessionNavigationTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            var outcome = await self.requestNativeAppSession(for: destinationURL)
+            if !Task.isCancelled, outcome.shouldRetry {
+                outcome = await self.requestNativeAppSession(for: destinationURL)
+            }
+            guard !Task.isCancelled,
+                  self.appSessionNavigationGeneration == requestGeneration else {
+                return
+            }
+            self.pendingAppSessionNavigationTask = nil
+            self.pendingAppSessionNavigationCompletion = nil
+
+            switch outcome {
+            case let .navigation(navigation):
+                guard self.nativeAppSessionNavigationIsCurrent(navigation),
+                      self.adoptAppSessionNavigation(
+                          navigation,
+                          onNavigationStarted: onNavigationStarted
+                      ) else {
+                    self.loadAppSurfaceWithoutNativeSession(
+                        request: request,
+                        destinationURL: destinationURL,
+                        preserveRestoredSessionHistory: preserveRestoredSessionHistory,
+                        requestGeneration: requestGeneration,
+                        onNavigationStarted: onNavigationStarted
+                    )
+                    return
+                }
+            case .cancelled:
+                // A cancelled exchange has no usable credentials. Continue in
+                // a fresh isolated store so the panel cannot retain or render
+                // the previous profile while auth state settles.
+                self.loadAppSurfaceWithoutNativeSession(
+                    request: request,
+                    destinationURL: destinationURL,
+                    preserveRestoredSessionHistory: preserveRestoredSessionHistory,
+                    requestGeneration: requestGeneration,
+                    onNavigationStarted: onNavigationStarted
+                )
+            case .notAuthenticated, .transientFailure, .failed:
+                self.loadAppSurfaceWithoutNativeSession(
+                    request: request,
+                    destinationURL: destinationURL,
+                    preserveRestoredSessionHistory: preserveRestoredSessionHistory,
+                    requestGeneration: requestGeneration,
+                    onNavigationStarted: onNavigationStarted
+                )
+            }
+        }
+        return true
+    }
+
+    private func loadAppSurfaceWithoutNativeSession(
+        request: URLRequest,
+        destinationURL: URL,
+        preserveRestoredSessionHistory: Bool,
+        requestGeneration: UInt64,
+        onNavigationStarted: ((WKNavigation?) -> Void)?
+    ) {
+        guard appSessionNavigationGeneration == requestGeneration else { return }
+        adoptIsolatedAppSessionStore()
+        performNavigation(
+            request: request,
+            originalURL: destinationURL,
+            recordTypedNavigation: false,
+            preserveRestoredSessionHistory: preserveRestoredSessionHistory,
+            onNavigationStarted: onNavigationStarted,
+            skipNativeAppSession: true
+        )
+    }
+
+    /// Installs the isolated store returned by the native session exchange and
+    /// then performs the requested navigation in the replacement web view.
+    @discardableResult
+    func adoptAppSessionNavigation(
+        _ navigation: BrowserAppSessionNavigation,
+        onNavigationStarted: ((WKNavigation?) -> Void)? = nil
+    ) -> Bool {
+        guard let destinationURL = navigation.request.url,
+              Self.supportsNativeAppSession(for: destinationURL),
+              (navigation.request.httpMethod ?? "GET").uppercased() == "GET",
+              navigation.websiteDataStore !== WKWebsiteDataStore.default(),
+              navigation.websiteDataStore.identifier == nil else {
+            return false
+        }
+
+        cancelPendingNativeAppSessionNavigation()
+        closeAllPopupControllers()
+        websiteDataStore = navigation.websiteDataStore
+        preservesExplicitEphemeralWebsiteDataStore = true
+        appSessionStoreRequiresNativeBootstrap = false
+        historyStore = BrowserHistoryStore(fileURL: nil)
+        resetForWorkspaceContextChange(
+            reason: "appSessionNavigation",
+            forceWebViewReplacement: true
+        )
+        AppDelegate.shared?.auth?.browserAppSession.register(self)
+        let startedNavigation = navigateWithoutInsecureHTTPPrompt(
+            request: navigation.request,
+            recordTypedNavigation: false,
+            trustedInternalNavigation: true,
+            skipNativeAppSession: true
+        )
+        onNavigationStarted?(startedNavigation)
+        return true
+    }
+
+    private func adoptIsolatedAppSessionStore() {
+        closeAllPopupControllers()
+        websiteDataStore = WKWebsiteDataStore.nonPersistent()
+        preservesExplicitEphemeralWebsiteDataStore = true
+        appSessionStoreRequiresNativeBootstrap = true
+        historyStore = BrowserHistoryStore(fileURL: nil)
+        resetForWorkspaceContextChange(
+            reason: "appSessionFallback",
+            forceWebViewReplacement: true
+        )
+        AppDelegate.shared?.auth?.browserAppSession.register(self)
+    }
+
     /// Navigate to a URL
     @discardableResult
     func navigate(
@@ -5419,6 +5652,7 @@ final class BrowserPanel: Panel, ObservableObject {
         recordTypedNavigation: Bool,
         preserveRestoredSessionHistory: Bool = false,
         trustedInternalNavigation: Bool = false,
+        skipNativeAppSession: Bool = false,
         onNavigationStarted: ((WKNavigation?) -> Void)? = nil
     ) -> WKNavigation? {
         guard let url = request.url else {
@@ -5462,7 +5696,8 @@ final class BrowserPanel: Panel, ObservableObject {
             originalURL: url,
             recordTypedNavigation: recordTypedNavigation,
             preserveRestoredSessionHistory: preserveRestoredSessionHistory,
-            onNavigationStarted: onNavigationStarted
+            onNavigationStarted: onNavigationStarted,
+            skipNativeAppSession: skipNativeAppSession
         )
     }
 
@@ -5495,12 +5730,27 @@ final class BrowserPanel: Panel, ObservableObject {
         originalURL: URL,
         recordTypedNavigation: Bool,
         preserveRestoredSessionHistory: Bool,
-        onNavigationStarted: ((WKNavigation?) -> Void)? = nil
+        onNavigationStarted: ((WKNavigation?) -> Void)? = nil,
+        skipNativeAppSession: Bool = false
     ) -> WKNavigation? {
+        // Any new navigation supersedes an in-flight native session exchange.
+        // The exchange may finish after the caller has moved to another URL,
+        // so invalidate it before WebKit or the fallback path starts loading.
+        cancelPendingNativeAppSessionNavigation()
         cancelHiddenWebViewDiscard()
         clearWebContentTerminationRecovery()
         if !preserveRestoredSessionHistory {
             abandonRestoredSessionHistoryIfNeeded()
+        }
+        if !skipNativeAppSession,
+           beginNativeAppSessionNavigationIfNeeded(
+               request: request,
+               destinationURL: originalURL,
+               recordTypedNavigation: recordTypedNavigation,
+               preserveRestoredSessionHistory: preserveRestoredSessionHistory,
+               onNavigationStarted: onNavigationStarted
+           ) {
+            return nil
         }
         let effectiveRequest = remoteProxyPreparedRequest(from: request, logScope: "rewrite")
         hiddenWebViewDiscardManager.updateRestoredSessionRenderIntent(nil)
@@ -6017,8 +6267,10 @@ extension BrowserPanel {
         // Stop exposing the authenticated store before its asynchronous WebKit
         // deletion callback completes. If WebKit drops that callback, the live
         // panel is still isolated from the previous account immediately.
+        cancelPendingNativeAppSessionNavigation()
         closeAllPopupControllers()
         websiteDataStore = WKWebsiteDataStore.nonPersistent()
+        appSessionStoreRequiresNativeBootstrap = true
         resetForWorkspaceContextChange(
             reason: "appSessionSignOut",
             forceWebViewReplacement: true
@@ -6113,6 +6365,7 @@ extension BrowserPanel {
 
     /// Go back in history
     func goBack() {
+        cancelPendingNativeAppSessionNavigation()
         guard canGoBack else { return }
         reactivateDiscardedWebViewWithoutNavigation(reason: "goBack")
         cancelInFlightNavigationBeforeHistoryTraversal()
@@ -6151,6 +6404,7 @@ extension BrowserPanel {
 
     /// Go forward in history
     func goForward() {
+        cancelPendingNativeAppSessionNavigation()
         guard canGoForward else { return }
         reactivateDiscardedWebViewWithoutNavigation(reason: "goForward")
         cancelInFlightNavigationBeforeHistoryTraversal()
@@ -6327,6 +6581,7 @@ extension BrowserPanel {
     /// Reload the current page
     @discardableResult
     func reload() -> WKNavigation? {
+        cancelPendingNativeAppSessionNavigation()
         if prepareForReload(reason: "reload", mode: .soft) {
             return nil
         }
@@ -6336,6 +6591,7 @@ extension BrowserPanel {
 
     /// Reload the current page, bypassing WebKit's cache.
     func hardReload() {
+        cancelPendingNativeAppSessionNavigation()
         if prepareForReload(reason: "hardReload", mode: .hard) {
             return
         }
@@ -6345,6 +6601,7 @@ extension BrowserPanel {
 
     /// Stop loading
     func stopLoading() {
+        cancelPendingNativeAppSessionNavigation()
         // Fail closed: a reveal must never blank-shell-heal over an explicit Stop.
         userStoppedLoadSinceWebViewReplacement = true
         webView.stopLoading()

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1963,6 +1963,7 @@ final class BrowserPanel: Panel, ObservableObject {
     private var preservesExplicitEphemeralWebsiteDataStore: Bool
     private var appSessionStoreRequiresNativeBootstrap = false
     private let appSessionNavigationRequest: (@MainActor (URL) async -> BrowserAppSessionRequestOutcome)?
+    private let appSessionNavigationDidAdopt: (@MainActor (WKWebsiteDataStore) -> Void)?
     private var pendingAppSessionNavigationTask: Task<Void, Never>?
     private var pendingAppSessionNavigationCompletion: ((WKNavigation?) -> Void)?
     private var appSessionNavigationGeneration: UInt64 = 0
@@ -3398,7 +3399,8 @@ final class BrowserPanel: Panel, ObservableObject {
         isRemoteWorkspace: Bool = false,
         remoteWebsiteDataStoreIdentifier: UUID? = nil,
         websiteDataStore explicitWebsiteDataStore: WKWebsiteDataStore? = nil,
-        appSessionNavigationRequest: (@MainActor (URL) async -> BrowserAppSessionRequestOutcome)? = nil
+        appSessionNavigationRequest: (@MainActor (URL) async -> BrowserAppSessionRequestOutcome)? = nil,
+        appSessionNavigationDidAdopt: (@MainActor (WKWebsiteDataStore) -> Void)? = nil
     ) {
         // Register fallback defaults and normalize legacy/out-of-range settings once
         // per process, before any setting is read below or by the SwiftUI view.
@@ -3408,6 +3410,7 @@ final class BrowserPanel: Panel, ObservableObject {
         self.workspaceId = workspaceId
         self.externalNavigationHandler = BrowserExternalNavigationHandler()
         self.appSessionNavigationRequest = appSessionNavigationRequest
+        self.appSessionNavigationDidAdopt = appSessionNavigationDidAdopt
         let resolvedProfileID = Self.resolvedProfileID(requested: profileID)
         self.profileID = resolvedProfileID
         self.insecureHTTPBypassHostOnce = BrowserInsecureHTTPSettings.normalizeHost(bypassInsecureHTTPHostOnce ?? "")
@@ -3702,6 +3705,14 @@ final class BrowserPanel: Panel, ObservableObject {
                 return window
             }
             return browserFallbackInteractiveModalHostWindow()
+        }
+
+        // A panel duplicated from an authenticated app surface can be created
+        // before its workspace host runs `configureBrowserPanel`. Register it
+        // while its controller-owned store is still identifiable so sign-out
+        // cleanup reaches every panel sharing that store.
+        if preservesExplicitEphemeralWebsiteDataStore {
+            AppDelegate.shared?.auth?.browserAppSession.register(self)
         }
 
         if let initialRequest {
@@ -5578,6 +5589,7 @@ final class BrowserPanel: Panel, ObservableObject {
             trustedInternalNavigation: true,
             skipNativeAppSession: true
         )
+        appSessionNavigationDidAdopt?(websiteDataStore)
         onNavigationStarted?(startedNavigation)
         return true
     }

--- a/Sources/PricingPlansScreen.swift
+++ b/Sources/PricingPlansScreen.swift
@@ -30,8 +30,15 @@ enum ProUpgradePresenter {
            appDelegate.proUpgradeWorkspaceExists(workspaceId: workspaceId) {
             return
         }
+        let url = appPricingURLForCurrentAppearance()
+        guard !BrowserPanel.supportsNativeAppSession(for: url) else {
+            // Pricing must receive the native Stack session before its first
+            // document load. A persistent prewarm would render the signed-out
+            // shell and could later be adopted by an older panel.
+            return
+        }
         BrowserPrewarmedWebViewPool.shared.prewarm(
-            url: appPricingURLForCurrentAppearance(),
+            url: url,
             profileID: BrowserPanel.resolvedProfileID(requested: nil)
         )
     }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -260,6 +260,7 @@
 		A5001A02A1B2C3D4E5F60718 /* AppWindowBackdropControllerDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001A03A1B2C3D4E5F60718 /* AppWindowBackdropControllerDependencies.swift */; };
 		A5001A00A1B2C3D4E5F60718 /* AppWindowChromeComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001A01A1B2C3D4E5F60718 /* AppWindowChromeComposition.swift */; };
 		A5001100 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A5001101 /* Assets.xcassets */; };
+		C0DE7A010000000000000001 /* AsyncTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7A010000000000000002 /* AsyncTestSupport.swift */; };
 		961300000000000000000003 /* AttributedString+SidebarRowLinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961300000000000000000004 /* AttributedString+SidebarRowLinks.swift */; };
 		D9FEC58D5BACCF76459F1BBE /* AuthEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43430FA5929121E2EAAB3091 /* AuthEnvironment.swift */; };
 		A47E00010000000000000001 /* AuthEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A47E00010000000000000002 /* AuthEnvironmentTests.swift */; };
@@ -3325,6 +3326,7 @@
 		A5001A03A1B2C3D4E5F60718 /* AppWindowBackdropControllerDependencies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Windowing/AppWindowBackdropControllerDependencies.swift; sourceTree = "<group>"; };
 		A5001A01A1B2C3D4E5F60718 /* AppWindowChromeComposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Windowing/AppWindowChromeComposition.swift; sourceTree = "<group>"; };
 		A5001101 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		C0DE7A010000000000000002 /* AsyncTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncTestSupport.swift; sourceTree = "<group>"; };
 		961300000000000000000004 /* AttributedString+SidebarRowLinks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Sidebar/AttributedString+SidebarRowLinks.swift"; sourceTree = "<group>"; };
 		43430FA5929121E2EAAB3091 /* AuthEnvironment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AuthEnvironment.swift; sourceTree = "<group>"; };
 		A47E00010000000000000002 /* AuthEnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthEnvironmentTests.swift; sourceTree = "<group>"; };
@@ -8571,6 +8573,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C0DE58990000000000000002 /* CmuxWebViewKeyDownReentryTests.swift */,
 				C0DE58990000000000000012 /* CmuxWebViewWebContentUndoTests.swift */,
 				C0DE49870000000000000002 /* BrowserWebContentProcessTests.swift */,
+				C0DE7A010000000000000002 /* AsyncTestSupport.swift */,
 				43F90FAF3FD44F11BF547BE9 /* CmuxWebViewMouseNavigationButtonTests.swift */,
 				D3622001A1B2C3D4E5F60718 /* BrowserArrowKeyForwardingTests.swift */,
 				D3622101A1B2C3D4E5F60718 /* EditableTextViewArrowKeyForwardingTests.swift */,
@@ -11815,6 +11818,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				A11EAA000000000000000000 /* AppearanceSettingsTests.swift in Sources */,
 				C8046FF15781CC7E4F8EAEA6 /* AppHostWindowReleaseGuardTests.swift in Sources */,
 				A7206E010000000000000001 /* AppIconAppearanceObserverTests.swift in Sources */,
+				C0DE7A010000000000000001 /* AsyncTestSupport.swift in Sources */,
 				A47E00010000000000000001 /* AuthEnvironmentTests.swift in Sources */,
 				AA9457BF0000000000000001 /* AutoNamingClaudeArgumentsTests.swift in Sources */,
 				FF068325E8A04E51A30AE9BA /* AutoNamingCodexAdapterTests.swift in Sources */,

--- a/cmuxTests/AsyncTestSupport.swift
+++ b/cmuxTests/AsyncTestSupport.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+enum AsyncTestSupport {
+    struct Timeout: Error, Sendable {}
+
+    /// Waits for the first value from a test signal, with a bounded failure.
+    static func awaitFirst<T: Sendable>(
+        _ stream: AsyncStream<T>,
+        timeout: Duration = .seconds(1)
+    ) async throws -> T {
+        try await withThrowingTaskGroup(of: T.self) { group in
+            group.addTask {
+                var iterator = stream.makeAsyncIterator()
+                guard let value = await iterator.next() else {
+                    throw Timeout()
+                }
+                return value
+            }
+            group.addTask {
+                try await ContinuousClock().sleep(for: timeout)
+                throw Timeout()
+            }
+            defer { group.cancelAll() }
+            guard let value = try await group.next() else {
+                throw Timeout()
+            }
+            return value
+        }
+    }
+}

--- a/cmuxTests/BrowserWebContentProcessTests.swift
+++ b/cmuxTests/BrowserWebContentProcessTests.swift
@@ -15,6 +15,33 @@ import WebKit
 @Suite(.serialized)
 struct BrowserWebContentProcessTests {
     private let recoveryURL = URL(string: "data:text/html,cmux-recovery")!
+    private struct TestTimeout: Error {}
+
+    /// Waits for a test-owned signal and fails if the implementation never
+    /// reaches the state under test.
+    private nonisolated func awaitFirst<T: Sendable>(
+        _ stream: AsyncStream<T>,
+        timeout: Duration = .seconds(2)
+    ) async throws -> T {
+        try await withThrowingTaskGroup(of: T.self) { group in
+            group.addTask {
+                var iterator = stream.makeAsyncIterator()
+                guard let value = await iterator.next() else {
+                    throw TestTimeout()
+                }
+                return value
+            }
+            group.addTask {
+                try await ContinuousClock().sleep(for: timeout)
+                throw TestTimeout()
+            }
+            defer { group.cancelAll() }
+            guard let value = try await group.next() else {
+                throw TestTimeout()
+            }
+            return value
+        }
+    }
 
     @Test
     func authCallbackNavigationPolicyIsPureAndFailClosed() {
@@ -203,7 +230,9 @@ struct BrowserWebContentProcessTests {
         let destinationURL = AuthEnvironment.appSessionHandoffOrigin
             .appendingPathComponent("app-pricing")
         let websiteDataStore = WKWebsiteDataStore.nonPersistent()
+        let (adopted, adoptedContinuation) = AsyncStream<Void>.makeStream()
         var requestCount = 0
+        var adoptedStore: WKWebsiteDataStore?
         let panel = BrowserPanel(
             workspaceId: UUID(),
             initialURL: destinationURL,
@@ -216,19 +245,21 @@ struct BrowserWebContentProcessTests {
                     generation: 1,
                     authSessionGeneration: 1
                 ))
+            },
+            appSessionNavigationDidAdopt: { store in
+                adoptedStore = store
+                adoptedContinuation.yield(())
             }
         )
-        defer { panel.close() }
+        defer {
+            adoptedContinuation.finish()
+            panel.close()
+        }
 
-        for _ in 0..<200 where requestCount == 0 {
-            await Task.yield()
-        }
-        for _ in 0..<200 where panel.websiteDataStore !== websiteDataStore
-            || panel.webView.configuration.websiteDataStore !== websiteDataStore {
-            await Task.yield()
-        }
+        _ = try await awaitFirst(adopted)
 
         #expect(requestCount == 1)
+        #expect(adoptedStore === websiteDataStore)
         #expect(panel.websiteDataStore === websiteDataStore)
         #expect(panel.webView.configuration.websiteDataStore === websiteDataStore)
         #expect(panel.shouldRenderWebView)

--- a/cmuxTests/BrowserWebContentProcessTests.swift
+++ b/cmuxTests/BrowserWebContentProcessTests.swift
@@ -15,33 +15,6 @@ import WebKit
 @Suite(.serialized)
 struct BrowserWebContentProcessTests {
     private let recoveryURL = URL(string: "data:text/html,cmux-recovery")!
-    private struct TestTimeout: Error {}
-
-    /// Waits for a test-owned signal and fails if the implementation never
-    /// reaches the state under test.
-    private nonisolated func awaitFirst<T: Sendable>(
-        _ stream: AsyncStream<T>,
-        timeout: Duration = .seconds(2)
-    ) async throws -> T {
-        try await withThrowingTaskGroup(of: T.self) { group in
-            group.addTask {
-                var iterator = stream.makeAsyncIterator()
-                guard let value = await iterator.next() else {
-                    throw TestTimeout()
-                }
-                return value
-            }
-            group.addTask {
-                try await ContinuousClock().sleep(for: timeout)
-                throw TestTimeout()
-            }
-            defer { group.cancelAll() }
-            guard let value = try await group.next() else {
-                throw TestTimeout()
-            }
-            return value
-        }
-    }
 
     @Test
     func authCallbackNavigationPolicyIsPureAndFailClosed() {
@@ -256,7 +229,7 @@ struct BrowserWebContentProcessTests {
             panel.close()
         }
 
-        _ = try await awaitFirst(adopted)
+        _ = try await AsyncTestSupport.awaitFirst(adopted, timeout: .seconds(2))
 
         #expect(requestCount == 1)
         #expect(adoptedStore === websiteDataStore)

--- a/cmuxTests/BrowserWebContentProcessTests.swift
+++ b/cmuxTests/BrowserWebContentProcessTests.swift
@@ -199,6 +199,42 @@ struct BrowserWebContentProcessTests {
     }
 
     @Test
+    func appSurfaceNavigationUsesTheNativeSessionStoreBeforeRendering() async throws {
+        let destinationURL = AuthEnvironment.appSessionHandoffOrigin
+            .appendingPathComponent("app-pricing")
+        let websiteDataStore = WKWebsiteDataStore.nonPersistent()
+        var requestCount = 0
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            initialURL: destinationURL,
+            appSessionNavigationRequest: { destination in
+                requestCount += 1
+                #expect(destination == destinationURL)
+                return .navigation(BrowserAppSessionNavigation(
+                    request: URLRequest(url: destination),
+                    websiteDataStore: websiteDataStore,
+                    generation: 1,
+                    authSessionGeneration: 1
+                ))
+            }
+        )
+        defer { panel.close() }
+
+        for _ in 0..<200 where requestCount == 0 {
+            await Task.yield()
+        }
+        for _ in 0..<200 where panel.websiteDataStore !== websiteDataStore
+            || panel.webView.configuration.websiteDataStore !== websiteDataStore {
+            await Task.yield()
+        }
+
+        #expect(requestCount == 1)
+        #expect(panel.websiteDataStore === websiteDataStore)
+        #expect(panel.webView.configuration.websiteDataStore === websiteDataStore)
+        #expect(panel.shouldRenderWebView)
+    }
+
+    @Test
     func authenticatedHandoffNavigationPinsTheNativeAuthGeneration() {
         let navigation = BrowserAppSessionNavigation(
             request: URLRequest(url: URL(string: "https://cmux.test/dashboard")!),

--- a/cmuxTests/SurfaceCatalogTests.swift
+++ b/cmuxTests/SurfaceCatalogTests.swift
@@ -10,8 +10,6 @@ import Testing
 @MainActor
 @Suite
 struct SurfaceCatalogTests {
-    private struct TestTimeout: Error {}
-
     /// Lets timeout behavior be tested without waiting on wall-clock time.
     private final class ImmediateClock: Clock, @unchecked Sendable {
         typealias Instant = ContinuousClock.Instant
@@ -34,27 +32,6 @@ struct SurfaceCatalogTests {
                 return sleepCount
             }
             onSleep(count)
-        }
-    }
-
-    /// Await a test signal without allowing a broken setup to hang the test process.
-    private nonisolated func awaitFirst<T: Sendable>(
-        _ stream: AsyncStream<T>,
-        timeout: Duration = .seconds(1)
-    ) async throws -> T {
-        try await withThrowingTaskGroup(of: T.self) { group in
-            group.addTask {
-                var iterator = stream.makeAsyncIterator()
-                guard let value = await iterator.next() else { throw TestTimeout() }
-                return value
-            }
-            group.addTask {
-                try await ContinuousClock().sleep(for: timeout)
-                throw TestTimeout()
-            }
-            defer { group.cancelAll() }
-            guard let value = try await group.next() else { throw TestTimeout() }
-            return value
         }
     }
 
@@ -250,7 +227,7 @@ struct SurfaceCatalogTests {
             secondStartedContinuation.finish()
             return try await catalog.project(term.id, into: destination)
         }
-        _ = try await awaitFirst(secondStarted)
+        _ = try await AsyncTestSupport.awaitFirst(secondStarted)
         #expect(provider.materialized.count == 1, "a concurrent reuse must share the pending provider call")
 
         gate.release()
@@ -320,12 +297,12 @@ struct SurfaceCatalogTests {
             cancellationResultContinuation.finish()
         }
         project.cancel()
-        let cancelledBeforeRelease = try await awaitFirst(cancellationResult)
+        let cancelledBeforeRelease = try await AsyncTestSupport.awaitFirst(cancellationResult)
         #expect(cancelledBeforeRelease, "cancelling the caller must not wait for the provider")
 
         gate.release()
         await observer.value
-        _ = try await awaitFirst(discarded)
+        _ = try await AsyncTestSupport.awaitFirst(discarded)
         #expect(catalog.projections.isEmpty)
         #expect(provider.discarded.count == 1, "a late provider result must close the pane after the last caller cancels")
     }
@@ -457,19 +434,19 @@ struct SurfaceCatalogTests {
             group.addTask { try await replacement.value }
             group.addTask {
                 try await ContinuousClock().sleep(for: .seconds(1))
-                throw TestTimeout()
+                throw AsyncTestSupport.Timeout()
             }
             defer { group.cancelAll() }
-            guard let result = try await group.next() else { throw TestTimeout() }
+            guard let result = try await group.next() else { throw AsyncTestSupport.Timeout() }
             return result
         }
         #expect(result.reused == false)
         #expect(replacementProvider.materialized.count == 1)
 
-        _ = try await awaitFirst(retirementDeadline)
+        _ = try await AsyncTestSupport.awaitFirst(retirementDeadline)
         await Task.yield()
         gate.release()
-        _ = try await awaitFirst(discarded)
+        _ = try await AsyncTestSupport.awaitFirst(discarded)
         #expect(oldProvider.discarded.count == 1, "a result after retirement eviction must still close its pane")
     }
 
@@ -638,7 +615,7 @@ struct SurfaceCatalogTests {
             try await oldProject.value
         }
 
-        _ = try await awaitFirst(evictionStarted)
+        _ = try await AsyncTestSupport.awaitFirst(evictionStarted)
         await Task.yield()
 
         let replacementProvider = FakeProvider(machine: .cloud("vivid-newt"))


### PR DESCRIPTION
## Root cause
The native app keeps Stack auth in `AuthCoordinator`, but the pricing `WKWebView` loaded with the normal browser profile. The existing native-to-web session exchange only ran for app links opened into a split, so direct pricing and Pro welcome entrypoints had no Stack cookies.

## Fix
- Route trusted `/app-pricing` and `/app-pro-welcome` navigations through `BrowserAppSessionController` before the first document load.
- Adopt the controller's isolated cookie store, reject stale prewarmed pricing pages, and invalidate exchanges when navigation or sign-out supersedes them.
- Keep unauthenticated recovery isolated and prevent empty fallback stores from being copied to sibling tabs.
- Add a behavior regression test for the native session store handoff.

## Verification
- Cloud tagged build `fpa` passed: https://github.com/manaflow-ai/cmux/actions/runs/33488001376
- Tagged socket preflight opened `http://localhost:4200/app-pricing?cmux_app=1`; page showed `Current plan` and no signed-out banner.
- Screenshot: `artifacts/verify-auth/pricing-authenticated.png`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790845357&installation_model_id=21920&pr_number=11400&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11400&signature=b690d270f656e49b565614b400ebcee5dbf02a592685296242ae959100ebf84a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes signed-in pricing and Pro welcome pages showing the signed-out shell when opened directly, by passing them through the native Stack session exchange before the first load.

**Bug Fixes**
- Routes trusted `/app-pricing` and `/app-pro-welcome` navigations through `BrowserAppSessionController` before the first document load.
- Adopts the controller's isolated cookie store, discards stale prewarmed pricing pages, and skips prewarming app surfaces entirely.
- Invalidates in-flight session exchanges when user navigation, history traversal, reload, profile switch, or sign-out supersedes them.
- Keeps unauthenticated recovery isolated and prevents empty fallback stores from being copied to sibling tabs.
- Adds a regression test for the native session store handoff, backed by a shared `AsyncTestSupport` timeout helper.

<sup>Written for commit 2ccc0e8d69b65c034cf905628198f00ccb0fdbb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

