### PR TITLE
fix(cmux-tui): combine bounded relay lifecycle fixes

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -962,8 +962,7 @@ impl Inner {
             let mut opening = self.opening_state.lock().expect("opening state lock");
             let cancelled = opening.cancelled.get(&pty_id) == Some(&reservation_owner);
             let authority_changed = !self.tunnel_authority_generation_current(context);
-            let reservation_owned =
-                opening.reservations.get(&pty_id) == Some(&reservation_owner);
+            let reservation_owned = opening.reservations.get(&pty_id) == Some(&reservation_owner);
             if !reservation_owned || cancelled || auth_changed || authority_changed {
                 if reservation_owned {
                     opening.reservations.remove(&pty_id);
@@ -1103,9 +1102,9 @@ impl Inner {
         let removed = {
             let _state = self.tunnel_state.lock().expect("tunnel state lock");
             let mut attachments = self.attachments.lock().expect("attach lock");
-            let same = attachments
-                .get(pty_id)
-                .is_some_and(|current| Arc::ptr_eq(&current.operation_gate, &attachment.operation_gate));
+            let same = attachments.get(pty_id).is_some_and(|current| {
+                Arc::ptr_eq(&current.operation_gate, &attachment.operation_gate)
+            });
             if same { attachments.remove(pty_id).is_some() } else { false }
         };
         if !removed {
@@ -1144,13 +1143,8 @@ impl Inner {
     /// transport may not act on it. A `None` caller owns everything (legacy).
     fn transport_owns(&self, pty_id: &str, context: &FrameContext) -> bool {
         let Some(transport_id) = context.transport_id.as_deref() else { return true };
-        if let Some(owner) = self
-            .opening_state
-            .lock()
-            .expect("opening state lock")
-            .reservations
-            .get(pty_id)
-            .cloned()
+        if let Some(owner) =
+            self.opening_state.lock().expect("opening state lock").reservations.get(pty_id).cloned()
         {
             return owner.owner.id.as_deref() == Some(transport_id)
                 && owner.owner.kind == context.transport_kind;
@@ -1220,9 +1214,9 @@ impl Inner {
         let removed = {
             let _state = self.tunnel_state.lock().expect("tunnel state lock");
             let mut attachments = self.attachments.lock().expect("attach lock");
-            let same = attachments
-                .get(pty_id)
-                .is_some_and(|current| Arc::ptr_eq(&current.operation_gate, &attachment.operation_gate));
+            let same = attachments.get(pty_id).is_some_and(|current| {
+                Arc::ptr_eq(&current.operation_gate, &attachment.operation_gate)
+            });
             if same { attachments.remove(pty_id).is_some() } else { false }
         };
         if removed {
@@ -1232,9 +1226,11 @@ impl Inner {
     }
 
     fn attachment_is_current(&self, pty_id: &str, attachment: &Attachment) -> bool {
-        self.attachments.lock().expect("attach lock").get(pty_id).is_some_and(|current| {
-            Arc::ptr_eq(&current.operation_gate, &attachment.operation_gate)
-        })
+        self.attachments
+            .lock()
+            .expect("attach lock")
+            .get(pty_id)
+            .is_some_and(|current| Arc::ptr_eq(&current.operation_gate, &attachment.operation_gate))
     }
 
     fn transport_auth_is_current(&self, context: &FrameContext, auth: &AuthSnapshot) -> bool {
@@ -1282,9 +1278,9 @@ impl Inner {
         let removed = {
             let _state = self.tunnel_state.lock().expect("tunnel state lock");
             let mut attachments = self.attachments.lock().expect("attach lock");
-            let same = attachments
-                .get(pty_id)
-                .is_some_and(|current| Arc::ptr_eq(&current.operation_gate, &attachment.operation_gate));
+            let same = attachments.get(pty_id).is_some_and(|current| {
+                Arc::ptr_eq(&current.operation_gate, &attachment.operation_gate)
+            });
             if same { attachments.remove(pty_id) } else { None }
         };
         if let Some(removed) = removed {
@@ -3254,14 +3250,10 @@ mod tests {
             spawn_cwd: PathBuf::new(),
             spawn_term: String::new(),
         };
-        let owner_a = TransportOwner {
-            id: Some("tunnel-a".to_owned()),
-            kind: TransportKind::Tunnel,
-        };
-        let owner_b = TransportOwner {
-            id: Some("tunnel-b".to_owned()),
-            kind: TransportKind::Tunnel,
-        };
+        let owner_a =
+            TransportOwner { id: Some("tunnel-a".to_owned()), kind: TransportKind::Tunnel };
+        let owner_b =
+            TransportOwner { id: Some("tunnel-b".to_owned()), kind: TransportKind::Tunnel };
         {
             let mut attachments = inner.attachments.lock().unwrap();
             attachments.insert(
@@ -3285,8 +3277,10 @@ mod tests {
                 },
             );
         }
-        let mut context_a = h.context_with_transport("supervised", h.owner.clone(), Some("tunnel-a"));
-        let mut context_b = h.context_with_transport("supervised", h.owner.clone(), Some("tunnel-b"));
+        let mut context_a =
+            h.context_with_transport("supervised", h.owner.clone(), Some("tunnel-a"));
+        let mut context_b =
+            h.context_with_transport("supervised", h.owner.clone(), Some("tunnel-b"));
         context_a.transport_kind = TransportKind::Tunnel;
         context_b.transport_kind = TransportKind::Tunnel;
         inner.cache_transport_auth(&context_a);
@@ -3322,16 +3316,10 @@ mod tests {
         let inner = Arc::clone(&h.manager.inner);
         let id = "reused".to_owned();
         let owner_a = OpeningOwner {
-            owner: TransportOwner {
-                id: Some("tunnel-a".to_owned()),
-                kind: TransportKind::Tunnel,
-            },
+            owner: TransportOwner { id: Some("tunnel-a".to_owned()), kind: TransportKind::Tunnel },
         };
         let owner_b = OpeningOwner {
-            owner: TransportOwner {
-                id: Some("tunnel-b".to_owned()),
-                kind: TransportKind::Tunnel,
-            },
+            owner: TransportOwner { id: Some("tunnel-b".to_owned()), kind: TransportKind::Tunnel },
         };
         let old = OpeningReservation {
             inner: Arc::clone(&inner),

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1904,44 +1904,48 @@ impl Inner {
             return;
         }
         let _delivery = attachment.delivery_gate.lock().expect("attachment delivery lock");
-        let removed = {
+        let current = {
             let _state = self.tunnel_state.lock().expect("tunnel state lock");
-            let mut attachments = self.attachments.lock().expect("attach lock");
-            let same = attachments.get(pty_id).is_some_and(|current| {
+            let attachments = self.attachments.lock().expect("attach lock");
+            let current = attachments.get(pty_id).is_some_and(|current| {
                 Arc::ptr_eq(&current.operation_gate, &attachment.operation_gate)
             });
-            if !same {
-                false
-            } else {
-                // Queue the exit while this attachment still owns pty_id.
-                // The state and map locks serialize this enqueue with a
-                // replacement open, so the old exit cannot target the new
-                // generation. send_live is a bounded, non-blocking enqueue.
-                (auth.send_live)(
-                    json!({
-                        "version": PTY_PROTOCOL_VERSION,
-                        "type": "pty_exit",
-                        "ptyId": pty_id,
-                        "code": code,
-                    }),
-                    Arc::clone(&attachment.delivery_live),
-                );
+            if current {
                 // A normal PTY exit ends new publication but keeps the live
                 // token for frames already queued. The writer must preserve
                 // opened/output ordering before delivering this exit frame.
                 Self::revoke_for_exit(&attachment);
                 attachment.closing.store(true, Ordering::Release);
-                attachments.remove(pty_id).is_some()
             }
+            current
         };
-        if !removed {
+        if !current {
             return;
         }
-        // Exit publication crosses the transport boundary. Release the
-        // lifecycle state before invoking the callback.
         drop(_delivery);
         drop(_operation);
         drop(_publication);
+        // Keep the closing attachment registered during this non-blocking
+        // enqueue. A replacement open retires it and clears delivery_live,
+        // so the writer drops this old exit instead of targeting the reused
+        // pty id. No lifecycle lock crosses the external callback.
+        (auth.send_live)(
+            json!({
+                "version": PTY_PROTOCOL_VERSION,
+                "type": "pty_exit",
+                "ptyId": pty_id,
+                "code": code,
+            }),
+            Arc::clone(&attachment.delivery_live),
+        );
+        let _state = self.tunnel_state.lock().expect("tunnel state lock");
+        let mut attachments = self.attachments.lock().expect("attach lock");
+        let same = attachments.get(pty_id).is_some_and(|current| {
+            Arc::ptr_eq(&current.operation_gate, &attachment.operation_gate)
+        });
+        if same {
+            attachments.remove(pty_id);
+        }
     }
 
     /// Detach, NOT kill: idempotent, unknown ptyId tolerated.
@@ -2145,13 +2149,7 @@ impl Inner {
             })
         };
         if let Some((owner, _active_cancellation)) = opening {
-            let owner_matches = match context.transport_kind {
-                TransportKind::Legacy => context.transport_id.is_none(),
-                TransportKind::Relay | TransportKind::Tunnel => {
-                    context.transport_id.is_some()
-                        && owner.owner == TransportOwner::from_context(context)
-                }
-            };
+            let owner_matches = owner.owner == TransportOwner::from_context(context);
             let authorized = owner_matches
                 && Self::matching_trust(&auth, context).is_some()
                 && self.tunnel_authority_generation_current(context)

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -984,7 +984,16 @@ fn send_typed_pty_error(
         RelayPtyErrorCode::TerminalGone => "terminal_gone",
         RelayPtyErrorCode::Failed => "failed",
     };
-    send_pty_error(context, pty_id, wire_code, message);
+    // Do not reflect provider or filesystem details to remote callers.
+    let safe_message = match code {
+        RelayPtyErrorCode::BadRequest => "invalid terminal request",
+        RelayPtyErrorCode::TrustRefused => "terminal access denied",
+        RelayPtyErrorCode::SessionLimit => "terminal session limit reached",
+        RelayPtyErrorCode::TerminalGone => "terminal is no longer available",
+        RelayPtyErrorCode::Failed => "terminal open failed",
+    };
+    let _ = message;
+    send_pty_error(context, pty_id, wire_code, safe_message);
 }
 
 impl Inner {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -440,6 +440,9 @@ struct ViewerSink {
 /// fans output out to every attachment (multi-viewer, tmux-style).
 struct ShellSession {
     control: Arc<dyn PtyControl>,
+    /// Created shell sessions own their PTY until the final viewer leaves.
+    /// Keep this at session scope so creator detachment cannot orphan it.
+    cleanup_when_empty: bool,
     /// Existing-session opens that have selected this session but have not
     /// published their viewer yet. Cancellation cleanup must not kill the
     /// session while one of these opens can still attach.
@@ -2782,6 +2785,7 @@ impl Inner {
                 let PtyHandle { control, output, banner } = handle;
                 let shell_session = Arc::new(ShellSession {
                     control,
+                    cleanup_when_empty: true,
                     pending_viewers: AtomicUsize::new(0),
                     flow_lock: Mutex::new(()),
                     dispatch_lock: Mutex::new(()),
@@ -2934,7 +2938,6 @@ impl Inner {
         // A stable viewer id lets release remove exactly this sink.
         let viewer_id = next_viewer_id();
         let released = Arc::new(AtomicBool::new(false));
-        let cleanup_if_empty = Arc::new(AtomicBool::new(created));
         let closing = Arc::new(AtomicBool::new(false));
         let (on_data, on_exit) = self.sinks(pty_id, context, Arc::clone(&closing));
 
@@ -2947,7 +2950,6 @@ impl Inner {
             pending_viewer: Arc::clone(&pending_viewer),
             manager: Arc::clone(&self),
             session_name: session.to_owned(),
-            cleanup_if_empty: Arc::clone(&cleanup_if_empty),
         });
 
         let start_session = Arc::clone(&shell_session);
@@ -2979,11 +2981,6 @@ impl Inner {
                         delivery_lock: Arc::clone(delivery_lock),
                     });
                     inner.draining_viewers.insert(viewer_id);
-                    // Keep cleanup armed until the viewer is published while
-                    // holding the flow lock. A close racing this callback
-                    // then either cleans up before publication, or observes
-                    // the published viewer and performs normal detach.
-                    cleanup_if_empty.store(false, Ordering::Release);
                 }
                 (banner, replay, alive, delivery_lock)
             };
@@ -3048,7 +3045,6 @@ struct ShellViewerControl {
     viewer_id: u64,
     released: Arc<AtomicBool>,
     pending_viewer: Arc<AtomicBool>,
-    cleanup_if_empty: Arc<AtomicBool>,
 }
 
 impl ShellViewerControl {
@@ -3066,7 +3062,7 @@ impl ShellViewerControl {
             inner.paused_viewers.remove(&self.viewer_id);
         }
         let no_viewers = self.session.inner.lock().expect("shell inner lock").viewers.is_empty();
-        let cleanup = self.cleanup_if_empty.load(Ordering::Acquire)
+        let cleanup = self.session.cleanup_when_empty
             && self.session.pending_viewers.load(Ordering::Acquire) == 0
             && no_viewers;
         if cleanup

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -699,6 +699,9 @@ impl PtyManager {
     /// Network frames never get to replace an existing snapshot implicitly.
     pub fn update_transport_auth(&self, context: &FrameContext) {
         debug_assert!(context.transport_id.is_some(), "transport refresh needs an id");
+        if Trust::parse(&context.trust).is_none() {
+            return;
+        }
         let _state = self.inner.tunnel_state.lock().expect("tunnel state lock");
         if !self.inner.tunnel_authority_generation_current(context) {
             return;
@@ -1401,10 +1404,10 @@ impl Inner {
         auth: &AuthSnapshot,
         context: &FrameContext,
     ) -> bool {
+        let Some(trust) = Self::matching_trust(auth, context) else { return false };
         let owner = auth.owner_user_id.as_deref();
-        let trust_allowed = !auth.trust.is_empty()
-            && (auth.trust != "observe"
-                || (owner.is_some() && owner == Some(attachment.actor_id.as_str())));
+        let trust_allowed = trust != Trust::Observe
+            || (owner.is_some() && owner == Some(attachment.actor_id.as_str()));
         trust_allowed
             && !attachment.closing.load(Ordering::SeqCst)
             && self.tunnel_authority_generation_current(context)
@@ -1454,6 +1457,9 @@ impl Inner {
     }
 
     fn transport_auth_is_current(&self, context: &FrameContext, auth: &AuthSnapshot) -> bool {
+        if Self::matching_trust(auth, context).is_none() {
+            return false;
+        }
         self.transport_auth
             .lock()
             .expect("transport auth lock")
@@ -1475,10 +1481,11 @@ impl Inner {
         context: &FrameContext,
         action: &str,
     ) {
-        let trust_allowed = !auth.trust.is_empty()
-            && (auth.trust != "observe"
+        let trust_allowed = Self::matching_trust(auth, context).is_some_and(|trust| {
+            trust != Trust::Observe
                 || (auth.owner_user_id.is_some()
-                    && auth.owner_user_id.as_deref() == Some(attachment.actor_id.as_str())));
+                    && auth.owner_user_id.as_deref() == Some(attachment.actor_id.as_str()))
+        });
         if trust_allowed
             && self.tunnel_authority_generation_current(context)
             && self.transport_auth_is_current(context, auth)
@@ -1564,6 +1571,11 @@ fn drive_handle(
 
 impl Inner {
     fn cache_transport_auth(&self, context: &FrameContext) -> bool {
+        // The frame context is a security boundary. Never let an unknown
+        // trust string reuse a previously cached valid snapshot.
+        if Trust::parse(&context.trust).is_none() {
+            return false;
+        }
         let _state = self.tunnel_state.lock().expect("tunnel state lock");
         if !self.tunnel_authority_generation_current(context) {
             return false;
@@ -1584,6 +1596,12 @@ impl Inner {
             transport_auth.entry(owner).or_insert(snapshot);
         }
         true
+    }
+
+    fn matching_trust(auth: &AuthSnapshot, context: &FrameContext) -> Option<Trust> {
+        let auth_trust = Trust::parse(&auth.trust)?;
+        let context_trust = Trust::parse(&context.trust)?;
+        (auth_trust == context_trust).then_some(auth_trust)
     }
 
     fn tunnel_authority_generation_current(&self, context: &FrameContext) -> bool {
@@ -3066,6 +3084,37 @@ mod tests {
         assert_eq!(sent[0]["type"], "pty_error");
         assert_eq!(sent[0]["code"], "trust_refused");
         assert!(h.spawned().is_empty(), "malformed authority must not allocate a PTY");
+    }
+
+    #[tokio::test]
+    async fn unknown_trust_cannot_reuse_existing_attachment_authority() {
+        let h = harness(None, None);
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "p1",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+            "actorId": "user_owner",
+        });
+        let mut trusted =
+            h.context_with_transport("supervised", h.owner.clone(), Some("tunnel-a"));
+        trusted.transport_kind = TransportKind::Tunnel;
+        h.manager.handle_frame(&frame, &trusted).await;
+        let pty = h.spawned()[0].clone();
+
+        let input = serde_json::json!({
+            "type": "pty_input",
+            "ptyId": "p1",
+            "dataB64": b64("must-not-write"),
+        });
+        let mut forged =
+            h.context_with_transport("forged-trust", h.owner.clone(), Some("tunnel-a"));
+        forged.transport_kind = TransportKind::Tunnel;
+        h.manager.handle_frame(&input, &forged).await;
+
+        assert!(pty.state.lock().unwrap().written.is_empty());
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -904,14 +904,13 @@ fn send_pty_error(context: &FrameContext, pty_id: &str, code: &str, _message: &s
 /// opening reservation. Tunnel state is a public boundary, so an unknown
 /// trust value must fail closed even when the normal producer only emits enum
 /// values.
-fn terminal_open_trust_allowed(context: &FrameContext, frame: &Value) -> bool {
+fn terminal_open_trust_allowed(context: &FrameContext, actor: &str) -> bool {
     let Some(trust) = Trust::parse(&context.trust) else {
         return false;
     };
     if trust != Trust::Observe {
         return true;
     }
-    let actor = frame.get("actorId").and_then(Value::as_str).unwrap_or_default();
     context.owner_user_id.as_deref().is_some_and(|owner| owner == actor)
 }
 
@@ -945,7 +944,10 @@ impl Inner {
         if pty_id.is_empty() {
             return;
         }
-        if !terminal_open_trust_allowed(context, frame) {
+        // Read the actor once at the boundary. The same immutable identity is
+        // used for admission and for the attachment ownership record.
+        let actor = frame.get("actorId").and_then(Value::as_str).unwrap_or_default().to_owned();
+        if !terminal_open_trust_allowed(context, &actor) {
             send_pty_error(context, &pty_id, "trust_refused", "terminal trust is not established");
             return;
         }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1896,15 +1896,33 @@ impl Inner {
             return;
         }
         let _delivery = attachment.delivery_gate.lock().expect("attachment delivery lock");
+        let exit_live = Arc::new(AtomicBool::new(true));
         let removed = {
-            Self::revoke_publication(&attachment);
-            attachment.closing.store(true, Ordering::Release);
             let _state = self.tunnel_state.lock().expect("tunnel state lock");
             let mut attachments = self.attachments.lock().expect("attach lock");
             let same = attachments.get(pty_id).is_some_and(|current| {
                 Arc::ptr_eq(&current.operation_gate, &attachment.operation_gate)
             });
-            if same { attachments.remove(pty_id).is_some() } else { false }
+            if !same {
+                false
+            } else {
+                // Queue the exit while this attachment still owns pty_id.
+                // The state and map locks serialize this enqueue with a
+                // replacement open, so the old exit cannot target the new
+                // generation. send_live is a bounded, non-blocking enqueue.
+                (auth.send_live)(
+                    json!({
+                        "version": PTY_PROTOCOL_VERSION,
+                        "type": "pty_exit",
+                        "ptyId": pty_id,
+                        "code": code,
+                    }),
+                    Arc::clone(&exit_live),
+                );
+                Self::revoke_publication(&attachment);
+                attachment.closing.store(true, Ordering::Release);
+                attachments.remove(pty_id).is_some()
+            }
         };
         if !removed {
             return;
@@ -1914,15 +1932,6 @@ impl Inner {
         drop(_delivery);
         drop(_operation);
         drop(_publication);
-        (auth.send_live)(
-            json!({
-                "version": PTY_PROTOCOL_VERSION,
-                "type": "pty_exit",
-                "ptyId": pty_id,
-                "code": code,
-            }),
-            Arc::new(AtomicBool::new(true)),
-        );
     }
 
     /// Detach, NOT kill: idempotent, unknown ptyId tolerated.

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -737,7 +737,8 @@ impl PtyManager {
         let authority_current = self.inner.cache_transport_auth(context);
         match frame_type {
             "pty_open" => {
-                let Some(cancellation) = cancellation.or_else(|| self.new_open_cancellation())
+                let Some(cancellation) =
+                    cancellation.or_else(|| self.new_open_cancellation_for_context(context))
                 else {
                     let pty_id = frame.get("ptyId").and_then(Value::as_str).unwrap_or_default();
                     if !pty_id.is_empty() {
@@ -921,6 +922,19 @@ impl PtyManager {
     pub fn detach_transport_kind(&self, transport_id: &str, kind: TransportKind) {
         let owner = TransportOwner { id: Some(transport_id.to_owned()), kind };
         let target_owner = owner;
+        // Publish the exact owner fence before scanning cached state. The
+        // owner may disconnect before its first frame, so there may be no
+        // auth snapshot, reservation, or attachment for `detach_matching` to
+        // discover. `cache_transport_auth` takes the same state boundary and
+        // therefore cannot recreate this owner after the fence is visible.
+        {
+            let _state = self.inner.tunnel_state.lock().expect("tunnel state lock");
+            self.inner
+                .detached_transports
+                .lock()
+                .expect("detached transport lock")
+                .insert(owner.clone());
+        }
         // The matcher publishes the disconnect fence before removing state.
         // A queued frame can then never repopulate the vacant cache.
         self.detach_matching(move |candidate| candidate == &target_owner, true).retire();
@@ -1075,6 +1089,29 @@ impl PtyManager {
     /// Allocate the capability that identifies one in-flight terminal open.
     /// IDs are never reused. Exhaustion is a fail-closed terminal limit.
     pub(crate) fn new_open_cancellation(&self) -> Option<OpenCancellation> {
+        self.allocate_open_cancellation(CancellationToken::new())
+    }
+
+    /// Allocate an open capability that is also cancelled when the owning
+    /// transport disconnects. A child token keeps the local timeout/revocation
+    /// cancellation independent while inheriting the transport lifetime.
+    pub(crate) fn new_open_cancellation_for_context(
+        &self,
+        context: &FrameContext,
+    ) -> Option<OpenCancellation> {
+        self.new_open_cancellation_with_parent(&context.cancellation)
+    }
+
+    /// Allocate an open capability whose lifetime is bounded by `parent`.
+    /// The caller can still cancel this capability independently.
+    pub(crate) fn new_open_cancellation_with_parent(
+        &self,
+        parent: &CancellationToken,
+    ) -> Option<OpenCancellation> {
+        self.allocate_open_cancellation(parent.child_token())
+    }
+
+    fn allocate_open_cancellation(&self, token: CancellationToken) -> Option<OpenCancellation> {
         let mut current = self.inner.next_open_attempt.load(Ordering::Relaxed);
         loop {
             if current == 0 {
@@ -1088,10 +1125,7 @@ impl PtyManager {
                 Ordering::Relaxed,
             ) {
                 Ok(_) => {
-                    return Some(OpenCancellation {
-                        token: CancellationToken::new(),
-                        attempt_id: current,
-                    });
+                    return Some(OpenCancellation { token, attempt_id: current });
                 }
                 Err(observed) => current = observed,
             }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -5240,6 +5240,19 @@ mod tests {
         }
     }
 
+    #[test]
+    fn detached_transport_revokes_surface_delivery_token() {
+        let h = harness(None, None);
+        let context = h.context_with_transport("supervised", h.owner.clone(), Some("relay-live"));
+        h.manager.update_transport_auth(&context);
+        let auth = h.manager.inner.auth_for_transport(&context).expect("transport authority");
+        assert!(auth.delivery_live.load(Ordering::Acquire));
+
+        h.manager.detach_transport_kind("relay-live", TransportKind::Relay);
+
+        assert!(!auth.delivery_live.load(Ordering::Acquire));
+    }
+
     #[tokio::test]
     async fn tunnel_authority_without_a_generation_is_rejected_after_revoke() {
         let h = harness(None, None);

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -26,17 +26,15 @@ use std::sync::{Arc, Mutex};
 use tokio::sync::{Notify, OwnedSemaphorePermit, Semaphore};
 use tokio_util::sync::CancellationToken;
 
+use crate::actions::{expand_path, scrubbed_env, validate_request_path};
+use crate::control::ControlHandle;
+use crate::relay_wire::RelayPtyErrorCode;
+use crate::trust::Trust;
 use async_trait::async_trait;
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use bytes::Bytes;
 use serde_json::{Value, json};
-use tokio_util::sync::CancellationToken;
-
-use crate::actions::{expand_path, scrubbed_env, validate_request_path};
-use crate::control::ControlHandle;
-use crate::relay_wire::RelayPtyErrorCode;
-use crate::trust::Trust;
 
 pub const PTY_PROTOCOL_VERSION: u64 = 4;
 

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -931,10 +931,11 @@ impl PtyManager {
         self.detach_matching(|_| true).retire();
     }
 
-    /// One transport dropped: release only its attachments and cancel only
-    /// its in-flight opens. Sessions live on either way (docs/TERMINAL.md).
+    /// One legacy relay transport dropped: release only its attachments and
+    /// cancel only its in-flight opens. Identified tunnel transports must use
+    /// `detach_transport_kind`, because transport IDs are scoped by kind.
     pub fn detach_transport(&self, transport_id: &str) {
-        self.detach_matching(|owner| owner.id.as_deref() == Some(transport_id)).retire();
+        self.detach_transport_kind(transport_id, TransportKind::Relay);
     }
 
     /// One typed transport dropped. This avoids treating an opaque relay ID
@@ -5339,6 +5340,30 @@ mod tests {
         assert!(h.manager.has_attachment("p-tunnel"), "the tunnel viewer must survive");
         h.manager.detach_all();
         assert!(!h.manager.has_attachment("p-tunnel"));
+    }
+
+    #[tokio::test]
+    async fn legacy_detach_transport_does_not_cross_transport_kind() {
+        let h = harness(None, None);
+        h.open_with_transport("p-relay", "relay-side", "shared-id").await;
+
+        let mut tunnel = h.context_with_transport("supervised", h.owner.clone(), Some("shared-id"));
+        tunnel.transport_kind = TransportKind::Tunnel;
+        h.manager.update_transport_auth(&tunnel);
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "p-tunnel",
+            "session": "tunnel-side",
+            "cols": 80,
+            "rows": 24,
+            "actorId": "user_owner",
+        });
+        h.manager.handle_frame(&frame, &tunnel).await;
+
+        h.manager.detach_transport("shared-id");
+        assert!(!h.manager.has_attachment("p-relay"));
+        assert!(h.manager.has_attachment("p-tunnel"));
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1071,9 +1071,10 @@ impl Inner {
         };
         let env = pty_env(&self.env);
 
+        let cancellation_token = cancellation.token();
         let cmux_tui = tokio::select! {
-            _ = cancellation.token().cancelled() => return,
-            resolved = self.deps.resolve_cmux_tui(cancellation.token()) => resolved,
+            _ = cancellation_token.cancelled() => return,
+            resolved = self.deps.resolve_cmux_tui(cancellation_token.clone()) => resolved,
         };
         if cancellation.is_cancelled() {
             return;
@@ -1672,15 +1673,16 @@ impl Inner {
         cancellation: &OpenCancellation,
     ) -> Result<Opened, String> {
         let socket_dir = self.deps.socket_dir();
+        let cancellation_token = cancellation.token();
         let ensured = tokio::select! {
-            _ = cancellation.token().cancelled() => return Err("terminal open cancelled".to_owned()),
+            _ = cancellation_token.cancelled() => return Err("terminal open cancelled".to_owned()),
             result = self.deps.ensure_daemon(
                 cmux_tui,
                 session,
                 &socket_dir,
                 cwd,
                 env,
-                cancellation.token(),
+                cancellation_token.clone(),
             ) => result,
         }?;
         let roots_scoped = context.local_roots.as_deref().is_some_and(|r| !r.is_empty())

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -912,8 +912,17 @@ impl PtyManager {
     /// One transport dropped: release only its attachments and cancel only
     /// its in-flight opens. Sessions live on either way (docs/TERMINAL.md).
     pub fn detach_transport(&self, transport_id: &str) {
-        // This legacy entry point does not carry a transport class. The
-        // matcher fences every typed identity for this opaque id.
+        // This legacy entry point does not carry a transport class. Fence
+        // every possible typed identity before scanning cached state, so an
+        // owner that disconnects before its first frame cannot be recreated.
+        {
+            let _state = self.inner.tunnel_state.lock().expect("tunnel state lock");
+            let mut detached =
+                self.inner.detached_transports.lock().expect("detached transport lock");
+            for kind in [TransportKind::Legacy, TransportKind::Relay, TransportKind::Tunnel] {
+                detached.insert(TransportOwner { id: Some(transport_id.to_owned()), kind });
+            }
+        }
         self.detach_matching(|owner| owner.id.as_deref() == Some(transport_id), true).retire();
     }
 
@@ -1586,16 +1595,15 @@ impl Inner {
         let Some(attachment) = self.attachment(pty_id) else {
             return;
         };
-        // Serialize authorization, revocation, and publication for this
-        // attachment. This prevents a close from racing the final snapshot
-        // check and sending stale output after retirement.
-        let _operation = attachment.operation_gate.lock().expect("attachment operation lock");
+        // Serialize only the authorization snapshot. Never hold the gate
+        // across the transport callback: a stalled consumer must not block a
+        // disconnect or trust revocation from retiring this attachment.
         let authorized = {
+            let _operation = attachment.operation_gate.lock().expect("attachment operation lock");
             let _state = self.tunnel_state.lock().expect("tunnel state lock");
             self.attachment_is_authorized(pty_id, &attachment, &auth, context)
         };
         if !authorized {
-            drop(_operation);
             self.handle_authorization_failure(pty_id, &attachment, &auth, context, "output");
             return;
         }
@@ -1609,7 +1617,6 @@ impl Inner {
         // frame exactly at the cap, but must reject one that would push the
         // buffered amount over the cap.
         if buffered.saturating_add(chunk.len() as u64) > self.output_cap {
-            drop(_operation);
             self.retire_if_current(pty_id, &attachment);
             send_pty_error(
                 context,
@@ -1622,7 +1629,10 @@ impl Inner {
             );
             return;
         }
-        // The operation gate remains held through this check and send.
+        // This final identity check is the publication linearization point.
+        // A concurrent detach may complete after the check, in which case
+        // this already-admitted frame is ordered before that detach. It can
+        // never block retirement while the callback runs.
         if !self.attachment_snapshot_is_current(pty_id, &attachment) {
             return;
         }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -409,6 +409,9 @@ struct ViewerSink {
     id: u64,
     on_data: Arc<dyn Fn(Bytes) + Send + Sync>,
     on_exit: Arc<dyn Fn(i64) + Send + Sync>,
+    /// Serializes this viewer's live and replay callbacks without blocking
+    /// other viewers on a session-wide lock.
+    delivery_lock: Arc<Mutex<()>>,
 }
 
 /// A fallback $SHELL session: one PTY, a bounded ring, and a viewer set that
@@ -2453,7 +2456,7 @@ impl Inner {
                 let manager = Arc::clone(&self);
                 let on_session_data: DataSink = Arc::new(move |chunk: Bytes| {
                     let _dispatch = data_session.dispatch_lock.lock().expect("shell dispatch lock");
-                    let viewers_to_notify: Vec<Arc<dyn Fn(Bytes) + Send + Sync>> = {
+                    let viewers_to_notify: Vec<(Arc<Mutex<()>>, Arc<dyn Fn(Bytes) + Send + Sync>)> = {
                         let mut inner = data_session.inner.lock().expect("shell inner lock");
                         inner.ring_size += chunk.len();
                         inner.ring.push_back(chunk.clone());
@@ -2475,12 +2478,17 @@ impl Inner {
                                     }
                                 }
                             } else {
-                                viewers_to_notify.push(Arc::clone(&viewer.on_data));
+                                viewers_to_notify.push((
+                                    Arc::clone(&viewer.delivery_lock),
+                                    Arc::clone(&viewer.on_data),
+                                ));
                             }
                         }
                         viewers_to_notify
                     };
-                    for on_data in viewers_to_notify {
+                    drop(_dispatch);
+                    for (delivery_lock, on_data) in viewers_to_notify {
+                        let _delivery = delivery_lock.lock().expect("viewer delivery lock");
                         on_data(chunk.clone());
                     }
                 });
@@ -2496,6 +2504,7 @@ impl Inner {
                     };
                     manager.shell_sessions.lock().expect("shell lock").remove(&session_name);
                     for viewer in viewers {
+                        let _delivery = viewer.delivery_lock.lock().expect("viewer delivery lock");
                         (viewer.on_exit)(code);
                     }
                 });
@@ -2541,7 +2550,7 @@ impl Inner {
 
         let start_session = Arc::clone(&shell_session);
         let start: Box<dyn FnOnce() + Send> = Box::new(move || {
-            let (banner, replay, alive) = {
+            let (banner, replay, alive, delivery_lock) = {
                 let _dispatch = start_session.dispatch_lock.lock().expect("shell dispatch lock");
                 let _flow = start_session.flow_lock.lock().expect("shell flow lock");
                 let mut inner = start_session.inner.lock().expect("shell inner lock");
@@ -2553,27 +2562,32 @@ impl Inner {
                     inner.ring.iter().flat_map(|c| c.iter().copied()).collect::<Vec<u8>>()
                 });
                 let alive = inner.alive;
-                if alive {
+                let delivery_lock = alive.then(|| Arc::new(Mutex::new(())));
+                if let Some(delivery_lock) = &delivery_lock {
                     inner.viewers.push(ViewerSink {
                         id: viewer_id,
                         on_data: Arc::clone(&on_data),
                         on_exit: Arc::clone(&on_exit),
+                        delivery_lock: Arc::clone(delivery_lock),
                     });
                     inner.draining_viewers.insert(viewer_id);
                 }
-                (banner, replay, alive)
+                (banner, replay, alive, delivery_lock)
             };
+            if !alive {
+                on_exit(0);
+                return;
+            }
+            let Some(delivery_lock) = delivery_lock else { return };
             if let Some(banner) = banner {
+                let _delivery = delivery_lock.lock().expect("viewer delivery lock");
                 on_data(Bytes::from(banner));
             }
             if let Some(replay) = replay {
+                let _delivery = delivery_lock.lock().expect("viewer delivery lock");
                 on_data(Bytes::from(replay));
             }
             if released.load(Ordering::SeqCst) {
-                return;
-            }
-            if !alive {
-                on_exit(0);
                 return;
             }
             loop {
@@ -2598,6 +2612,7 @@ impl Inner {
                     }
                 };
                 let Some(chunk) = chunk else { break };
+                let _delivery = delivery_lock.lock().expect("viewer delivery lock");
                 on_data(chunk);
             }
         });
@@ -2697,14 +2712,19 @@ impl PtyControl for ShellViewerControl {
                         .find(|viewer| viewer.id == self.viewer_id)
                         .map(|viewer| Arc::clone(&viewer.on_data))
                     {
+                        let delivery_lock = inner
+                            .viewers
+                            .iter()
+                            .find(|viewer| viewer.id == self.viewer_id)
+                            .map(|viewer| Arc::clone(&viewer.delivery_lock));
                         let chunk =
                             inner.paused_backlog.get_mut(&self.viewer_id).and_then(|backlog| {
                                 let chunk = backlog.chunks.pop_front()?;
                                 backlog.bytes -= chunk.len();
                                 Some(chunk)
                             });
-                        if let Some(chunk) = chunk {
-                            Some((on_data, chunk))
+                        if let (Some(delivery_lock), Some(chunk)) = (delivery_lock, chunk) {
+                            Some((delivery_lock, on_data, chunk))
                         } else {
                             inner.paused_backlog.remove(&self.viewer_id);
                             inner.draining_viewers.remove(&self.viewer_id);
@@ -2717,7 +2737,8 @@ impl PtyControl for ShellViewerControl {
                     }
                 }
             };
-            let Some((on_data, chunk)) = next else { break };
+            let Some((delivery_lock, on_data, chunk)) = next else { break };
+            let _delivery = delivery_lock.lock().expect("viewer delivery lock");
             on_data(chunk);
         }
     }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -669,9 +669,9 @@ impl PtyManager {
         self.detach_matching_unlocked(|owner| owner.kind == TransportKind::Tunnel);
     }
 
-    fn detach_matching(&self, owns: impl Fn(Option<&str>) -> bool) {
+    fn detach_matching(&self, owns: impl Fn(&TransportOwner) -> bool) {
         let _lifecycle = self.inner.tunnel_lifecycle.lock().expect("tunnel lifecycle lock");
-        self.detach_matching_unlocked(|owner| owns(owner.id.as_deref()));
+        self.detach_matching_unlocked(owns);
     }
 
     fn detach_matching_unlocked(&self, owns: impl Fn(&TransportOwner) -> bool) {
@@ -784,13 +784,12 @@ impl Inner {
             fail(code, &message);
             return;
         }
-        let mut reservation =
-            OpeningReservation {
-                inner: Arc::clone(&self),
-                id: pty_id.clone(),
-                owner: reservation_owner.clone(),
-                active: true,
-            };
+        let mut reservation = OpeningReservation {
+            inner: Arc::clone(&self),
+            id: pty_id.clone(),
+            owner: reservation_owner.clone(),
+            active: true,
+        };
 
         let session = frame.get("session").and_then(Value::as_str).unwrap_or_default().to_owned();
         let (Some(cols), Some(rows)) = (clamp_dim(frame.get("cols")), clamp_dim(frame.get("rows")))
@@ -947,10 +946,10 @@ impl Inner {
             .get(&TransportOwner::from_context(context))
             .is_none_or(|auth| {
                 auth.trust != context.trust
-                || auth.local_roots != context.local_roots
-                || auth.owner_user_id != context.owner_user_id
-                || auth.auth_generation != context.auth_generation
-                || auth.transport_kind != context.transport_kind
+                    || auth.local_roots != context.local_roots
+                    || auth.owner_user_id != context.owner_user_id
+                    || auth.auth_generation != context.auth_generation
+                    || auth.transport_kind != context.transport_kind
             });
         let authority_changed = !self.tunnel_authority_generation_current(context);
         let reservation_owned = opening.get(&pty_id) == Some(&reservation_owner);

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -455,8 +455,7 @@ impl PtyManager {
     pub async fn handle_frame(&self, frame: &Value, context: &FrameContext) {
         {
             let snapshot = AuthSnapshot::from_context(context);
-            let mut transport_auth =
-                self.inner.transport_auth.lock().expect("transport auth lock");
+            let mut transport_auth = self.inner.transport_auth.lock().expect("transport auth lock");
             if context.transport_id.is_none() {
                 // Legacy whole-manager callers use `None` and provide the
                 // current trust on each frame. Keep that contract for non-

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1594,10 +1594,40 @@ impl Inner {
         // ordering gate before crossing the transport boundary so a blocked
         // client cannot stall detach or authority revocation.
         drop(_publication);
+        // A detach may win after the first admission check while this task
+        // prepares the frame. Re-check immediately before each external
+        // callback and retire the exact attachment when the capability is no
+        // longer current.
+        let Some(current_attachment) = self
+            .attachment(pty_id)
+            .filter(|attachment| Arc::ptr_eq(&attachment.publication_gate, &publication_gate))
+        else {
+            return;
+        };
+        let Some(auth) = self.auth_for_transport(context) else {
+            self.retire_if_current(pty_id, &current_attachment);
+            return;
+        };
+        if !self.transport_auth_is_current(context, &auth)
+            || !self.attachment_snapshot_is_current(pty_id, &current_attachment)
+        {
+            self.retire_if_current(pty_id, &current_attachment);
+            return;
+        }
         (context.send)(Value::Object(opened_frame));
 
         // Output only AFTER pty_opened (ordering): banner, then scrollback
         // replay, then live bytes.
+        if context.cancellation.is_cancelled()
+            || !self
+                .auth_for_transport(context)
+                .is_some_and(|auth| self.transport_auth_is_current(context, &auth))
+            || !self
+                .attachment(pty_id)
+                .is_some_and(|attachment| self.attachment_snapshot_is_current(pty_id, &attachment))
+        {
+            return;
+        }
         start();
     }
 

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -3518,6 +3518,37 @@ mod tests {
         assert!(!inner.opening_state.lock().unwrap().cancelled.contains_key("p1"));
     }
 
+    #[tokio::test(flavor = "current_thread")]
+    async fn cancelled_open_is_fenced_before_its_task_is_first_polled() {
+        let h = harness(None, None);
+        let manager = Arc::new(h.manager);
+        let context = h.context_with_transport("supervised", h.owner.clone(), Some("tunnel-a"));
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "p1",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+        });
+        let cancellation = CancellationToken::new();
+        let task_cancellation = cancellation.clone();
+        let task_manager = Arc::clone(&manager);
+        let task = tokio::spawn(async move {
+            task_manager
+                .handle_frame_with_open_cancellation(&frame, &context, Some(task_cancellation))
+                .await;
+        });
+
+        // A current-thread executor does not poll the spawned task until this
+        // function yields. Cancelling first proves the pre-reservation fence,
+        // rather than relying on the task having installed a reservation.
+        cancellation.cancel();
+        task.await.unwrap();
+        assert!(h.recorded.lock().unwrap().spawned.is_empty());
+        assert_eq!(manager.attachment_count(), 0);
+    }
+
     #[tokio::test]
     async fn detach_transport_releases_only_that_transports_attachments() {
         let h = harness(None, None);

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -797,17 +797,9 @@ impl PtyManager {
         };
         let _state = self.inner.tunnel_state.lock().expect("tunnel state lock");
         let mut opening = self.inner.opening_state.lock().expect("opening state lock");
-        // The attempt identity check is added in the follow-up fix commit.
-        // Keeping only the transport comparison here makes the regression
-        // test fail against the red commit when a pty id is reused.
-        if let Some(current) = opening
-            .reservations
-            .get(pty_id)
-            .filter(|current| current.owner == owner.owner)
-            .cloned()
-        {
+        if opening.reservations.get(pty_id) == Some(&owner) {
             opening.reservations.remove(pty_id);
-            opening.cancelled.insert(pty_id.to_owned(), current);
+            opening.cancelled.insert(pty_id.to_owned(), owner);
         }
     }
 

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2552,6 +2552,9 @@ impl Inner {
                 if cancellation.is_cancelled() {
                     remove_cached_shell_if_same(&self, session, &shell_session);
                     shell_session.control.kill();
+                    self.shell_starting.lock().expect("shell starting lock").remove(session);
+                    reservation.active = false;
+                    reservation.notify.notify_waiters();
                     return Err("terminal open cancelled".to_owned());
                 }
                 self.shell_starting.lock().expect("shell starting lock").remove(session);

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -858,17 +858,17 @@ impl PtyManager {
     }
 
     fn detach_matching(&self, owns: impl Fn(&TransportOwner) -> bool) -> RetiredAttachments {
-        // The state lock couples authority transitions with the final open
-        // install. PTY kill calls happen after it is released, so one slow
-        // attachment cannot block unrelated tunnel operations.
-        let _state = self.inner.tunnel_state.lock().expect("tunnel state lock");
-        self.inner
-            .transport_auth
-            .lock()
-            .expect("transport auth lock")
-            .retain(|owner, _| !owns(owner));
-        let mut retired = Vec::new();
-        {
+        // Revoke the transport snapshot and opening reservations at one
+        // authority boundary. Do not wait for an attachment operation while
+        // holding the state lock: output/control callbacks take the gate
+        // before that lock, so waiting here would deadlock the relay.
+        let candidates = {
+            let _state = self.inner.tunnel_state.lock().expect("tunnel state lock");
+            self.inner
+                .transport_auth
+                .lock()
+                .expect("transport auth lock")
+                .retain(|owner, _| !owns(owner));
             let mut opening = self.inner.opening_state.lock().expect("opening state lock");
             let cancelled: Vec<(String, OpeningOwner)> = opening
                 .reservations
@@ -884,19 +884,37 @@ impl PtyManager {
                 opening.cancelled.insert(id, owner);
             }
 
-            let mut attachments = self.inner.attachments.lock().expect("attach lock");
-            let ids: Vec<String> = attachments
+            self.inner
+                .attachments
+                .lock()
+                .expect("attach lock")
                 .iter()
                 .filter(|(_, attachment)| owns(&attachment.owner))
-                .map(|(id, _)| id.clone())
-                .collect();
-            for id in ids {
-                if let Some(attachment) = attachments.remove(&id) {
-                    retired.push(attachment);
-                }
+                .map(|(id, attachment)| (id.clone(), attachment.clone()))
+                .collect::<Vec<_>>()
+        };
+
+        // Removal is linearized with publication by the same per-attachment
+        // gate. If an output callback already owns the gate, it completes
+        // before removal. If removal wins, the callback observes that its
+        // identity is gone and cannot publish after revocation.
+        let mut retired = Vec::new();
+        for (id, candidate) in candidates {
+            let operation = candidate.operation_gate.lock().expect("attachment operation lock");
+            let removed = {
+                let _state = self.inner.tunnel_state.lock().expect("tunnel state lock");
+                let mut attachments = self.inner.attachments.lock().expect("attach lock");
+                let same = attachments.get(&id).is_some_and(|current| {
+                    Arc::ptr_eq(&current.operation_gate, &candidate.operation_gate)
+                });
+                if same { attachments.remove(&id) } else { None }
+            };
+            if let Some(removed) = removed {
+                removed.closing.store(true, Ordering::SeqCst);
+                retired.push(removed);
             }
+            drop(operation);
         }
-        drop(_state);
         RetiredAttachments { inner: Arc::clone(&self.inner), attachments: retired }
     }
 
@@ -1328,6 +1346,7 @@ impl Inner {
             self.attachment_is_authorized(pty_id, &attachment, &auth, context)
         };
         if !authorized {
+            drop(_operation);
             self.handle_authorization_failure(pty_id, &attachment, &auth, context, "output");
             return;
         }
@@ -1341,6 +1360,7 @@ impl Inner {
         // frame exactly at the cap, but must reject one that would push the
         // buffered amount over the cap.
         if buffered.saturating_add(chunk.len() as u64) > self.output_cap {
+            drop(_operation);
             self.retire_if_current(pty_id, &attachment);
             send_pty_error(
                 context,
@@ -1517,6 +1537,47 @@ impl Inner {
 
     fn close_authorized(&self, pty_id: &str, context: &FrameContext) {
         let Some(auth) = self.auth_for_transport(context) else { return };
+
+        // A close may arrive while the PTY provider is still resolving. In
+        // that window there is no attachment to authorize, but the opening
+        // reservation is already consuming capacity. Cancel only the exact
+        // owner that the caller is allowed to retire, so a late close cannot
+        // cancel a replacement that reused the same pty id.
+        let opening_owner = self
+            .opening_state
+            .lock()
+            .expect("opening state lock")
+            .reservations
+            .get(pty_id)
+            .cloned();
+        if let Some(owner) = opening_owner {
+            let owner_matches = context.transport_id.is_none()
+                || owner.owner == TransportOwner::from_context(context);
+            let authorized = owner_matches
+                && Self::matching_trust(&auth, context).is_some()
+                && self.tunnel_authority_generation_current(context)
+                && self.transport_auth_is_current(context, &auth);
+            if !authorized {
+                return;
+            }
+            let cancellation = {
+                let _state = self.tunnel_state.lock().expect("tunnel state lock");
+                let mut opening = self.opening_state.lock().expect("opening state lock");
+                if opening.reservations.get(pty_id) != Some(&owner) {
+                    None
+                } else {
+                    opening.reservations.remove(pty_id);
+                    let cancellation = opening.cancellations.remove(&owner);
+                    opening.cancelled.insert(pty_id.to_owned(), owner);
+                    cancellation
+                }
+            };
+            if let Some(cancellation) = cancellation {
+                cancellation.cancel();
+            }
+            return;
+        }
+
         let Some(attachment) = self.attachment(pty_id) else { return };
         let _operation = attachment.operation_gate.lock().expect("attachment operation lock");
         let authorized = {
@@ -1604,6 +1665,9 @@ impl Inner {
     }
 
     fn retire_if_current(&self, pty_id: &str, attachment: &Attachment) {
+        // The operation gate is the publication/removal linearization point.
+        // Callers must release any prior guard before entering this helper.
+        let operation = attachment.operation_gate.lock().expect("attachment operation lock");
         let removed = {
             let _state = self.tunnel_state.lock().expect("tunnel state lock");
             let mut attachments = self.attachments.lock().expect("attach lock");
@@ -1612,6 +1676,10 @@ impl Inner {
             });
             if same { attachments.remove(pty_id) } else { None }
         };
+        if let Some(ref removed) = removed {
+            removed.closing.store(true, Ordering::SeqCst);
+        }
+        drop(operation);
         if let Some(removed) = removed {
             self.retire_attachment(removed);
         }
@@ -4242,10 +4310,7 @@ mod tests {
         // continue, independent of scheduler timing.
         entered.notified().await;
         manager
-            .handle_frame(
-                &serde_json::json!({ "type": "pty_close", "ptyId": "p1" }),
-                &context,
-            )
+            .handle_frame(&serde_json::json!({ "type": "pty_close", "ptyId": "p1" }), &context)
             .await;
         assert!(cancellation.is_cancelled());
 

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -382,6 +382,9 @@ struct ShellInner {
 #[derive(Clone)]
 struct Attachment {
     closing: Arc<AtomicBool>,
+    /// Serializes operations for this attachment only. The relay state lock
+    /// must never be held while a PTY control method runs.
+    operation_gate: Arc<Mutex<()>>,
     /// Releases this attachment (detach a viewer, close a control stream,
     /// kill a viewer PTY) — never kills a shared session.
     control: Arc<dyn PtyControl>,
@@ -395,6 +398,15 @@ struct OpeningOwner {
     owner: TransportOwner,
 }
 
+#[derive(Default)]
+struct OpeningState {
+    reservations: HashMap<String, OpeningOwner>,
+    /// The owner is part of the cancellation key. A late drop from an old
+    /// reservation cannot clear a marker for a newer reservation of the same
+    /// pty id.
+    cancelled: HashMap<String, OpeningOwner>,
+}
+
 struct Inner {
     deps: Arc<dyn PtyDeps>,
     home: PathBuf,
@@ -403,9 +415,9 @@ struct Inner {
     scrollback_limit: usize,
     output_cap: u64,
     attachments: Mutex<HashMap<String, Attachment>>,
-    /// ptyId -> typed transport that reserved it.
-    opening_ids: Mutex<HashMap<String, OpeningOwner>>,
-    cancelled_openings: Mutex<std::collections::HashSet<String>>,
+    /// Reservations and cancellation markers share one lock so close and
+    /// open cannot observe a gap between the two states.
+    opening_state: Mutex<OpeningState>,
     shell_sessions: Mutex<HashMap<String, Arc<ShellSession>>>,
     shell_starting: Mutex<HashMap<String, Arc<Notify>>>,
     /// Authentication is scoped to the transport that owns an attachment.
@@ -413,10 +425,9 @@ struct Inner {
     /// one global snapshot would let the last frame on either transport
     /// authorize asynchronous output for every other attachment.
     transport_auth: Mutex<HashMap<TransportOwner, AuthSnapshot>>,
-    /// Serializes tunnel authorization side effects with authority revocation.
-    /// The lock is held only across synchronous PTY operations and final
-    /// attachment installation, never across provider awaits.
-    tunnel_lifecycle: Mutex<()>,
+    /// Serializes short authority and attachment state transitions. It is
+    /// never held while a PTY control method, callback, or provider await runs.
+    tunnel_state: Mutex<()>,
     /// Monotonic floor for managed tunnel authority generations. It remains
     /// effective while a stale open is still unwinding after revocation.
     tunnel_authority_generation: AtomicU64,
@@ -447,12 +458,13 @@ struct OpeningReservation {
 impl Drop for OpeningReservation {
     fn drop(&mut self) {
         if self.active {
-            let mut opening = self.inner.opening_ids.lock().expect("opening lock");
-            if opening.get(&self.id) == Some(&self.owner) {
-                opening.remove(&self.id);
+            let mut state = self.inner.opening_state.lock().expect("opening state lock");
+            if state.reservations.get(&self.id) == Some(&self.owner) {
+                state.reservations.remove(&self.id);
+                if state.cancelled.get(&self.id) == Some(&self.owner) {
+                    state.cancelled.remove(&self.id);
+                }
             }
-            drop(opening);
-            self.inner.cancelled_openings.lock().expect("cancelled openings lock").remove(&self.id);
         }
     }
 }
@@ -472,12 +484,11 @@ impl PtyManager {
                 scrollback_limit: SCROLLBACK_LIMIT,
                 output_cap: OUTPUT_BUFFER_CAP,
                 attachments: Mutex::new(HashMap::new()),
-                opening_ids: Mutex::new(HashMap::new()),
-                cancelled_openings: Mutex::new(std::collections::HashSet::new()),
+                opening_state: Mutex::new(OpeningState::default()),
                 shell_sessions: Mutex::new(HashMap::new()),
                 shell_starting: Mutex::new(HashMap::new()),
                 transport_auth: Mutex::new(HashMap::new()),
-                tunnel_lifecycle: Mutex::new(()),
+                tunnel_state: Mutex::new(()),
                 tunnel_authority_generation: AtomicU64::new(0),
             }),
         }
@@ -500,12 +511,11 @@ impl PtyManager {
                 scrollback_limit,
                 output_cap,
                 attachments: Mutex::new(HashMap::new()),
-                opening_ids: Mutex::new(HashMap::new()),
-                cancelled_openings: Mutex::new(std::collections::HashSet::new()),
+                opening_state: Mutex::new(OpeningState::default()),
                 shell_sessions: Mutex::new(HashMap::new()),
                 shell_starting: Mutex::new(HashMap::new()),
                 transport_auth: Mutex::new(HashMap::new()),
-                tunnel_lifecycle: Mutex::new(()),
+                tunnel_state: Mutex::new(()),
                 tunnel_authority_generation: AtomicU64::new(0),
             }),
         }
@@ -521,7 +531,6 @@ impl PtyManager {
             "pty_open" => self.inner.clone().open(frame, context).await,
             "pty_input" => {
                 let Some(pty_id) = frame.get("ptyId").and_then(Value::as_str) else { return };
-                let _lifecycle = self.inner.tunnel_lifecycle_guard(context);
                 if !self.inner.tunnel_authority_generation_current(context) {
                     return;
                 }
@@ -536,13 +545,12 @@ impl PtyManager {
                 else {
                     return;
                 };
-                if let Some(attachment) = self.inner.authorize(pty_id, context, "input") {
+                self.inner.with_authorized(pty_id, context, "input", |attachment| {
                     attachment.control.write(&data);
-                }
+                });
             }
             "pty_resize" => {
                 let Some(pty_id) = frame.get("ptyId").and_then(Value::as_str) else { return };
-                let _lifecycle = self.inner.tunnel_lifecycle_guard(context);
                 if !self.inner.tunnel_authority_generation_current(context) {
                     return;
                 }
@@ -554,13 +562,12 @@ impl PtyManager {
                 else {
                     return;
                 };
-                if let Some(attachment) = self.inner.authorize(pty_id, context, "resize") {
+                self.inner.with_authorized(pty_id, context, "resize", |attachment| {
                     attachment.control.resize(cols, rows);
-                }
+                });
             }
             "pty_flow" => {
                 let Some(pty_id) = frame.get("ptyId").and_then(Value::as_str) else { return };
-                let _lifecycle = self.inner.tunnel_lifecycle_guard(context);
                 if !self.inner.tunnel_authority_generation_current(context) {
                     return;
                 }
@@ -568,17 +575,16 @@ impl PtyManager {
                     return;
                 }
                 let pause = frame.get("pause").and_then(Value::as_bool).unwrap_or(false);
-                if let Some(attachment) = self.inner.authorize(pty_id, context, "flow") {
+                self.inner.with_authorized(pty_id, context, "flow", |attachment| {
                     if pause {
                         attachment.control.pause();
                     } else {
                         attachment.control.resume();
                     }
-                }
+                });
             }
             "pty_close" => {
                 let Some(pty_id) = frame.get("ptyId").and_then(Value::as_str) else { return };
-                let _lifecycle = self.inner.tunnel_lifecycle_guard(context);
                 if !self.inner.tunnel_authority_generation_current(context) {
                     return;
                 }
@@ -597,7 +603,7 @@ impl PtyManager {
     /// Network frames never get to replace an existing snapshot implicitly.
     pub fn update_transport_auth(&self, context: &FrameContext) {
         debug_assert!(context.transport_id.is_some(), "transport refresh needs an id");
-        let _lifecycle = self.inner.tunnel_lifecycle_guard(context);
+        let _state = self.inner.tunnel_state.lock().expect("tunnel state lock");
         if !self.inner.tunnel_authority_generation_current(context) {
             return;
         }
@@ -612,7 +618,7 @@ impl PtyManager {
     /// matching snapshot. A stale in-flight frame cannot recreate a removed
     /// transport entry after this point.
     pub fn set_tunnel_authority_generation(&self, generation: u64) {
-        let _lifecycle = self.inner.tunnel_lifecycle.lock().expect("tunnel lifecycle lock");
+        let _state = self.inner.tunnel_state.lock().expect("tunnel state lock");
         let mut current = self.inner.tunnel_authority_generation.load(Ordering::Acquire);
         while generation > current {
             match self.inner.tunnel_authority_generation.compare_exchange_weak(
@@ -665,43 +671,48 @@ impl PtyManager {
     /// tunnel authority on disconnect or trust renegotiation; existing tunnel
     /// viewers must lose their attachments at the same boundary.
     pub fn detach_tunnel_transports(&self) {
-        let _lifecycle = self.inner.tunnel_lifecycle.lock().expect("tunnel lifecycle lock");
-        self.detach_matching_unlocked(|owner| owner.kind == TransportKind::Tunnel);
+        self.detach_matching(|owner| owner.kind == TransportKind::Tunnel);
     }
 
     fn detach_matching(&self, owns: impl Fn(&TransportOwner) -> bool) {
-        let _lifecycle = self.inner.tunnel_lifecycle.lock().expect("tunnel lifecycle lock");
-        self.detach_matching_unlocked(owns);
-    }
-
-    fn detach_matching_unlocked(&self, owns: impl Fn(&TransportOwner) -> bool) {
-        // Openings first: close() records cancellation for a reserved id, so
-        // a late open cannot install an attachment after its transport died.
-        let mut ids: Vec<String> = {
-            let opening = self.inner.opening_ids.lock().expect("opening lock");
-            opening
-                .iter()
-                .filter(|(_, owner)| owns(&owner.owner))
-                .map(|(id, _)| id.clone())
-                .collect()
-        };
-        {
-            let attachments = self.inner.attachments.lock().expect("attach lock");
-            ids.extend(
-                attachments
-                    .iter()
-                    .filter(|(_, attachment)| owns(&attachment.owner))
-                    .map(|(id, _)| id.clone()),
-            );
-        }
-        for id in ids {
-            self.inner.close(&id);
-        }
+        // The state lock couples authority transitions with the final open
+        // install. PTY kill calls happen after it is released, so one slow
+        // attachment cannot block unrelated tunnel operations.
+        let _state = self.inner.tunnel_state.lock().expect("tunnel state lock");
         self.inner
             .transport_auth
             .lock()
             .expect("transport auth lock")
             .retain(|owner, _| !owns(owner));
+        let mut retired = Vec::new();
+        {
+            let mut opening = self.inner.opening_state.lock().expect("opening state lock");
+            let cancelled: Vec<(String, OpeningOwner)> = opening
+                .reservations
+                .iter()
+                .filter(|(_, owner)| owns(&owner.owner))
+                .map(|(id, owner)| (id.clone(), owner.clone()))
+                .collect();
+            for (id, owner) in cancelled {
+                opening.cancelled.insert(id, owner);
+            }
+
+            let mut attachments = self.inner.attachments.lock().expect("attach lock");
+            let ids: Vec<String> = attachments
+                .iter()
+                .filter(|(_, attachment)| owns(&attachment.owner))
+                .map(|(id, _)| id.clone())
+                .collect();
+            for id in ids {
+                if let Some(attachment) = attachments.remove(&id) {
+                    retired.push(attachment);
+                }
+            }
+        }
+        drop(_state);
+        for attachment in retired {
+            self.inner.retire_attachment(attachment);
+        }
     }
 }
 
@@ -764,19 +775,18 @@ impl Inner {
         let fail = |code: &str, message: &str| send_pty_error(context, &pty_id, code, message);
         let reservation_owner = OpeningOwner { owner: TransportOwner::from_context(context) };
         let reservation_result = {
-            let mut opening = self.opening_ids.lock().expect("opening lock");
-            let attached = self.attachments.lock().expect("attach lock").contains_key(&pty_id);
-            if attached || opening.contains_key(&pty_id) {
+            let _state = self.tunnel_state.lock().expect("tunnel state lock");
+            let mut opening = self.opening_state.lock().expect("opening state lock");
+            let attachments = self.attachments.lock().expect("attach lock");
+            if attachments.contains_key(&pty_id) || opening.reservations.contains_key(&pty_id) {
                 Err(("bad_request", "ptyId is already attached".to_owned()))
-            } else if self.attachments.lock().expect("attach lock").len() + opening.len()
-                >= self.max_ptys
-            {
+            } else if attachments.len() + opening.reservations.len() >= self.max_ptys {
                 Err((
                     "session_limit",
                     format!("this relay caps concurrent terminals at {}", self.max_ptys),
                 ))
             } else {
-                opening.insert(pty_id.clone(), reservation_owner.clone());
+                opening.reservations.insert(pty_id.clone(), reservation_owner.clone());
                 Ok(())
             }
         };
@@ -933,62 +943,62 @@ impl Inner {
         };
 
         // Keep the opening reservation held until the attachment is installed.
-        // `close` takes this lock first, so it cannot observe a gap between
-        // removing the opening marker and inserting the attachment.
-        let _lifecycle = self.tunnel_lifecycle_guard(context);
-        let mut opening = self.opening_ids.lock().expect("opening lock");
-        let cancelled =
-            self.cancelled_openings.lock().expect("cancelled openings lock").remove(&pty_id);
-        let auth_changed = self
-            .transport_auth
-            .lock()
-            .expect("transport auth lock")
-            .get(&TransportOwner::from_context(context))
-            .is_none_or(|auth| {
-                auth.trust != context.trust
-                    || auth.local_roots != context.local_roots
-                    || auth.owner_user_id != context.owner_user_id
-                    || auth.auth_generation != context.auth_generation
-                    || auth.transport_kind != context.transport_kind
-            });
-        let authority_changed = !self.tunnel_authority_generation_current(context);
-        let reservation_owned = opening.get(&pty_id) == Some(&reservation_owner);
-        if !reservation_owned || cancelled || auth_changed || authority_changed {
-            if reservation_owned {
-                opening.remove(&pty_id);
+        // The short state lock couples this transition with revocation, while
+        // no PTY operation runs under it.
+        let (surface, start, previous) = {
+            let _state = self.tunnel_state.lock().expect("tunnel state lock");
+            let auth_changed = self
+                .transport_auth
+                .lock()
+                .expect("transport auth lock")
+                .get(&TransportOwner::from_context(context))
+                .is_none_or(|auth| {
+                    auth.trust != context.trust
+                        || auth.local_roots != context.local_roots
+                        || auth.owner_user_id != context.owner_user_id
+                        || auth.auth_generation != context.auth_generation
+                        || auth.transport_kind != context.transport_kind
+                });
+            let mut opening = self.opening_state.lock().expect("opening state lock");
+            let cancelled = opening.cancelled.get(&pty_id) == Some(&reservation_owner);
+            let authority_changed = !self.tunnel_authority_generation_current(context);
+            let reservation_owned =
+                opening.reservations.get(&pty_id) == Some(&reservation_owner);
+            if !reservation_owned || cancelled || auth_changed || authority_changed {
+                if reservation_owned {
+                    opening.reservations.remove(&pty_id);
+                }
+                if opening.cancelled.get(&pty_id) == Some(&reservation_owner) {
+                    opening.cancelled.remove(&pty_id);
+                }
+                reservation.active = false;
+                return;
             }
-            drop(opening);
+            // The value is now owned by the attachment map. Its Drop handler
+            // must not release a live viewer when this local is consumed below.
+            opened.cleanup_on_drop = false;
+            let closing = opened.closing.take().expect("opened closing handle");
+            let control = opened.control.take().expect("opened control handle");
+            let start = opened.start.take().expect("opened start callback");
+            let surface = opened.surface.take();
+            let previous = self.attachments.lock().expect("attach lock").insert(
+                pty_id.clone(),
+                Attachment {
+                    closing,
+                    operation_gate: Arc::new(Mutex::new(())),
+                    control,
+                    actor_id: actor.to_owned(),
+                    owner: TransportOwner::from_context(context),
+                },
+            );
+            opening.reservations.remove(&pty_id);
+            opening.cancelled.remove(&pty_id);
             reservation.active = false;
-            return;
-        }
-        // The value is now owned by the attachment map. Its Drop handler
-        // must not release a live viewer when this local is consumed below.
-        opened.cleanup_on_drop = false;
-        let closing = opened.closing.take().expect("opened closing handle");
-        let control = opened.control.take().expect("opened control handle");
-        let start = opened.start.take().expect("opened start callback");
-        let surface = opened.surface.take();
-        let previous = self.attachments.lock().expect("attach lock").insert(
-            pty_id.clone(),
-            Attachment {
-                closing,
-                control,
-                actor_id: actor.to_owned(),
-                owner: TransportOwner::from_context(context),
-            },
-        );
+            (surface, start, previous)
+        };
         if let Some(previous) = previous {
-            previous.closing.store(true, Ordering::SeqCst);
-            previous.control.kill();
+            self.retire_attachment(previous);
         }
-        opening.remove(&pty_id);
-        drop(opening);
-        reservation.active = false;
-
-        // The attachment is installed. Release the lifecycle guard before
-        // callbacks: `start` can synchronously emit output, which takes this
-        // guard again.
-        drop(_lifecycle);
 
         let mut opened_frame = serde_json::Map::new();
         opened_frame.insert("version".to_owned(), Value::from(PTY_PROTOCOL_VERSION));
@@ -1028,14 +1038,19 @@ impl Inner {
     }
 
     fn emit_output(&self, pty_id: &str, chunk: &Bytes, context: &FrameContext) {
-        let _lifecycle = self.tunnel_lifecycle_guard(context);
         if !self.tunnel_authority_generation_current(context) {
             return;
         }
         let Some(auth) = self.auth_for_transport(context) else {
             return;
         };
-        if self.authorize_snapshot(pty_id, &auth, context, "output").is_none() {
+        let Some(attachment) = self.attachment(pty_id) else {
+            return;
+        };
+        let _operation = attachment.operation_gate.lock().expect("attachment operation lock");
+        if !self.attachment_is_authorized(pty_id, &attachment, &auth, context) {
+            drop(_operation);
+            self.handle_authorization_failure(pty_id, &attachment, &auth, context, "output");
             return;
         }
         // Zero-byte chunks carry nothing and historically crashed the web
@@ -1048,7 +1063,8 @@ impl Inner {
         // frame exactly at the cap, but must reject one that would push the
         // buffered amount over the cap.
         if buffered.saturating_add(chunk.len() as u64) > self.output_cap {
-            self.close(pty_id);
+            drop(_operation);
+            self.retire_if_current(pty_id, &attachment);
             send_pty_error(
                 context,
                 pty_id,
@@ -1069,23 +1085,34 @@ impl Inner {
     }
 
     fn emit_exit(&self, pty_id: &str, code: i64, context: &FrameContext) {
-        let _lifecycle = self.tunnel_lifecycle_guard(context);
         if !self.tunnel_authority_generation_current(context) {
             return;
         }
         let Some(auth) = self.auth_for_transport(context) else {
             return;
         };
-        if self.authorize_snapshot(pty_id, &auth, context, "exit").is_none() {
+        let Some(attachment) = self.attachment(pty_id) else {
+            return;
+        };
+        let _operation = attachment.operation_gate.lock().expect("attachment operation lock");
+        if !self.attachment_is_authorized(pty_id, &attachment, &auth, context) {
+            drop(_operation);
+            self.handle_authorization_failure(pty_id, &attachment, &auth, context, "exit");
             return;
         }
-        let mut attachments = self.attachments.lock().expect("attach lock");
-        match attachments.get(pty_id) {
-            Some(attachment) if !attachment.closing.load(Ordering::SeqCst) => {}
-            _ => return,
+        let removed = {
+            let _state = self.tunnel_state.lock().expect("tunnel state lock");
+            let mut attachments = self.attachments.lock().expect("attach lock");
+            let same = attachments
+                .get(pty_id)
+                .is_some_and(|current| Arc::ptr_eq(&current.operation_gate, &attachment.operation_gate));
+            if same { attachments.remove(pty_id).is_some() } else { false }
+        };
+        if !removed {
+            return;
         }
-        attachments.remove(pty_id);
-        drop(attachments);
+        attachment.closing.store(true, Ordering::SeqCst);
+        drop(_operation);
         (auth.send)(json!({
             "version": PTY_PROTOCOL_VERSION,
             "type": "pty_exit",
@@ -1097,20 +1124,18 @@ impl Inner {
     /// Detach, NOT kill: idempotent, unknown ptyId tolerated.
     fn close(&self, pty_id: &str) {
         // Match `open`'s lock order. If opening still owns the reservation,
-        // record cancellation and let it dispose the newly opened PTY.
-        let opening = self.opening_ids.lock().expect("opening lock");
-        if opening.contains_key(pty_id) {
-            self.cancelled_openings
-                .lock()
-                .expect("cancelled openings lock")
-                .insert(pty_id.to_owned());
-            return;
-        }
-        drop(opening);
-        let attachment = self.attachments.lock().expect("attach lock").remove(pty_id);
+        // record an owner-specific cancellation and let it dispose the PTY.
+        let attachment = {
+            let _state = self.tunnel_state.lock().expect("tunnel state lock");
+            let mut opening = self.opening_state.lock().expect("opening state lock");
+            if let Some(owner) = opening.reservations.get(pty_id).cloned() {
+                opening.cancelled.insert(pty_id.to_owned(), owner);
+                return;
+            }
+            self.attachments.lock().expect("attach lock").remove(pty_id)
+        };
         if let Some(attachment) = attachment {
-            attachment.closing.store(true, Ordering::SeqCst);
-            attachment.control.kill();
+            self.retire_attachment(attachment);
         }
     }
 
@@ -1119,20 +1144,38 @@ impl Inner {
     /// transport may not act on it. A `None` caller owns everything (legacy).
     fn transport_owns(&self, pty_id: &str, context: &FrameContext) -> bool {
         let Some(transport_id) = context.transport_id.as_deref() else { return true };
+        if let Some(owner) = self
+            .opening_state
+            .lock()
+            .expect("opening state lock")
+            .reservations
+            .get(pty_id)
+            .cloned()
+        {
+            return owner.owner.id.as_deref() == Some(transport_id)
+                && owner.owner.kind == context.transport_kind;
+        }
         if let Some(attachment) = self.attachments.lock().expect("attach lock").get(pty_id) {
             return attachment.owner.id.as_deref() == Some(transport_id)
                 && attachment.owner.kind == context.transport_kind;
         }
-        if let Some(owner) = self.opening_ids.lock().expect("opening lock").get(pty_id) {
-            return owner.owner.id.as_deref() == Some(transport_id)
-                && owner.owner.kind == context.transport_kind;
-        }
         true
     }
 
-    fn authorize(&self, pty_id: &str, context: &FrameContext, action: &str) -> Option<Attachment> {
-        let auth = self.auth_for_transport(context)?;
-        self.authorize_snapshot(pty_id, &auth, context, action)
+    fn with_authorized<F>(&self, pty_id: &str, context: &FrameContext, action: &str, operation: F)
+    where
+        F: FnOnce(&Attachment),
+    {
+        let Some(auth) = self.auth_for_transport(context) else { return };
+        let Some(attachment) = self.attachment(pty_id) else { return };
+        let operation_gate = Arc::clone(&attachment.operation_gate);
+        let _operation = operation_gate.lock().expect("attachment operation lock");
+        if !self.attachment_is_authorized(pty_id, &attachment, &auth, context) {
+            drop(_operation);
+            self.handle_authorization_failure(pty_id, &attachment, &auth, context, action);
+            return;
+        }
+        operation(&attachment);
     }
 
     fn auth_for_transport(&self, context: &FrameContext) -> Option<AuthSnapshot> {
@@ -1140,35 +1183,119 @@ impl Inner {
         self.transport_auth.lock().expect("transport auth lock").get(&key).cloned()
     }
 
-    fn authorize_snapshot(
+    fn attachment(&self, pty_id: &str) -> Option<Attachment> {
+        self.attachments.lock().expect("attach lock").get(pty_id).cloned()
+    }
+
+    fn attachment_is_authorized(
         &self,
         pty_id: &str,
+        attachment: &Attachment,
         auth: &AuthSnapshot,
         context: &FrameContext,
-        action: &str,
-    ) -> Option<Attachment> {
-        let attachment = self.attachments.lock().expect("attach lock").get(pty_id)?.clone();
+    ) -> bool {
         let owner = auth.owner_user_id.as_deref();
-        let allowed = !auth.trust.is_empty()
+        let trust_allowed = !auth.trust.is_empty()
             && (auth.trust != "observe"
                 || (owner.is_some() && owner == Some(attachment.actor_id.as_str())));
-        if allowed {
-            Some(attachment)
-        } else {
-            self.close(pty_id);
-            send_pty_error(
-                context,
-                pty_id,
-                "trust_revoked",
-                &format!("PTY {action} refused after trust change"),
-            );
-            None
-        }
+        trust_allowed
+            && !attachment.closing.load(Ordering::SeqCst)
+            && self.tunnel_authority_generation_current(context)
+            && self.attachment_is_current(pty_id, attachment)
+            && self.transport_auth_is_current(context, auth)
+            && (context.transport_id.is_none()
+                || (attachment.owner.id == context.transport_id
+                    && attachment.owner.kind == context.transport_kind))
     }
 
     fn close_authorized(&self, pty_id: &str, context: &FrameContext) {
-        let _ = self.authorize(pty_id, context, "close");
-        self.close(pty_id);
+        let Some(auth) = self.auth_for_transport(context) else { return };
+        let Some(attachment) = self.attachment(pty_id) else { return };
+        let _operation = attachment.operation_gate.lock().expect("attachment operation lock");
+        if !self.attachment_is_authorized(pty_id, &attachment, &auth, context) {
+            drop(_operation);
+            self.handle_authorization_failure(pty_id, &attachment, &auth, context, "close");
+            return;
+        }
+        let removed = {
+            let _state = self.tunnel_state.lock().expect("tunnel state lock");
+            let mut attachments = self.attachments.lock().expect("attach lock");
+            let same = attachments
+                .get(pty_id)
+                .is_some_and(|current| Arc::ptr_eq(&current.operation_gate, &attachment.operation_gate));
+            if same { attachments.remove(pty_id).is_some() } else { false }
+        };
+        if removed {
+            attachment.closing.store(true, Ordering::SeqCst);
+            attachment.control.kill();
+        }
+    }
+
+    fn attachment_is_current(&self, pty_id: &str, attachment: &Attachment) -> bool {
+        self.attachments.lock().expect("attach lock").get(pty_id).is_some_and(|current| {
+            Arc::ptr_eq(&current.operation_gate, &attachment.operation_gate)
+        })
+    }
+
+    fn transport_auth_is_current(&self, context: &FrameContext, auth: &AuthSnapshot) -> bool {
+        self.transport_auth
+            .lock()
+            .expect("transport auth lock")
+            .get(&TransportOwner::from_context(context))
+            .is_some_and(|current| {
+                current.trust == auth.trust
+                    && current.local_roots == auth.local_roots
+                    && current.owner_user_id == auth.owner_user_id
+                    && current.auth_generation == auth.auth_generation
+                    && current.transport_kind == auth.transport_kind
+            })
+    }
+
+    fn handle_authorization_failure(
+        &self,
+        pty_id: &str,
+        attachment: &Attachment,
+        auth: &AuthSnapshot,
+        context: &FrameContext,
+        action: &str,
+    ) {
+        let trust_allowed = !auth.trust.is_empty()
+            && (auth.trust != "observe"
+                || (auth.owner_user_id.is_some()
+                    && auth.owner_user_id.as_deref() == Some(attachment.actor_id.as_str())));
+        if trust_allowed
+            && self.tunnel_authority_generation_current(context)
+            && self.transport_auth_is_current(context, auth)
+        {
+            return;
+        }
+        self.retire_if_current(pty_id, attachment);
+        send_pty_error(
+            context,
+            pty_id,
+            "trust_revoked",
+            &format!("PTY {action} refused after trust change"),
+        );
+    }
+
+    fn retire_if_current(&self, pty_id: &str, attachment: &Attachment) {
+        let removed = {
+            let _state = self.tunnel_state.lock().expect("tunnel state lock");
+            let mut attachments = self.attachments.lock().expect("attach lock");
+            let same = attachments
+                .get(pty_id)
+                .is_some_and(|current| Arc::ptr_eq(&current.operation_gate, &attachment.operation_gate));
+            if same { attachments.remove(pty_id) } else { None }
+        };
+        if let Some(removed) = removed {
+            self.retire_attachment(removed);
+        }
+    }
+
+    fn retire_attachment(&self, attachment: Attachment) {
+        let _operation = attachment.operation_gate.lock().expect("attachment operation lock");
+        attachment.closing.store(true, Ordering::SeqCst);
+        attachment.control.kill();
     }
 }
 
@@ -1217,16 +1344,8 @@ fn drive_handle(
 }
 
 impl Inner {
-    fn tunnel_lifecycle_guard(
-        &self,
-        context: &FrameContext,
-    ) -> Option<std::sync::MutexGuard<'_, ()>> {
-        (context.transport_kind == TransportKind::Tunnel)
-            .then(|| self.tunnel_lifecycle.lock().expect("tunnel lifecycle lock"))
-    }
-
     fn cache_transport_auth(&self, context: &FrameContext) -> bool {
-        let _lifecycle = self.tunnel_lifecycle_guard(context);
+        let _state = self.tunnel_state.lock().expect("tunnel state lock");
         if !self.tunnel_authority_generation_current(context) {
             return false;
         }
@@ -2193,7 +2312,6 @@ impl Inner {
                 }));
             }
         }
-        let _lifecycle = self.tunnel_lifecycle_guard(context);
         if !self.tunnel_authority_generation_current(context) {
             return;
         }
@@ -2294,7 +2412,7 @@ mod tests {
     use crate::control::{CloseHandler, EventHandler};
     use std::future::Future;
     use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
-    use std::sync::{Arc as TestArc, Barrier, Mutex as StdMutex};
+    use std::sync::{Arc as TestArc, Barrier, Mutex as StdMutex, mpsc::sync_channel};
     use std::thread;
 
     static NEXT_TEST_DIRECTORY: AtomicU64 = AtomicU64::new(0);
@@ -2390,6 +2508,23 @@ mod tests {
             state.on_data = Some(on_data);
             state.on_exit = Some(on_exit);
         }
+    }
+
+    struct BlockingControl {
+        entered: Arc<Barrier>,
+        release: Arc<Barrier>,
+    }
+
+    impl PtyControl for BlockingControl {
+        fn write(&self, _data: &[u8]) {
+            self.entered.wait();
+            self.release.wait();
+        }
+
+        fn resize(&self, _cols: u16, _rows: u16) {}
+        fn pause(&self) {}
+        fn resume(&self) {}
+        fn kill(&self) {}
     }
 
     #[derive(Default)]
@@ -3101,6 +3236,121 @@ mod tests {
         // A caller with no transport identity owns the whole manager (legacy).
         h.manager.handle_frame(&close, &h.context("supervised", h.owner.clone())).await;
         assert!(!h.manager.has_attachment("p1"));
+    }
+
+    #[test]
+    fn tunnel_operations_on_different_attachments_do_not_share_a_gate() {
+        let h = harness(None, None);
+        let inner = Arc::clone(&h.manager.inner);
+        let entered = Arc::new(Barrier::new(2));
+        let release = Arc::new(Barrier::new(2));
+        let slow: Arc<dyn PtyControl> = Arc::new(BlockingControl {
+            entered: Arc::clone(&entered),
+            release: Arc::clone(&release),
+        });
+        let fast = FakePty {
+            state: Arc::new(StdMutex::new(FakeState::default())),
+            spawn_file: String::new(),
+            spawn_cwd: PathBuf::new(),
+            spawn_term: String::new(),
+        };
+        let owner_a = TransportOwner {
+            id: Some("tunnel-a".to_owned()),
+            kind: TransportKind::Tunnel,
+        };
+        let owner_b = TransportOwner {
+            id: Some("tunnel-b".to_owned()),
+            kind: TransportKind::Tunnel,
+        };
+        {
+            let mut attachments = inner.attachments.lock().unwrap();
+            attachments.insert(
+                "p1".to_owned(),
+                Attachment {
+                    closing: Arc::new(AtomicBool::new(false)),
+                    operation_gate: Arc::new(Mutex::new(())),
+                    control: slow,
+                    actor_id: "user_owner".to_owned(),
+                    owner: owner_a.clone(),
+                },
+            );
+            attachments.insert(
+                "p2".to_owned(),
+                Attachment {
+                    closing: Arc::new(AtomicBool::new(false)),
+                    operation_gate: Arc::new(Mutex::new(())),
+                    control: Arc::new(fast),
+                    actor_id: "user_owner".to_owned(),
+                    owner: owner_b.clone(),
+                },
+            );
+        }
+        let mut context_a = h.context_with_transport("supervised", h.owner.clone(), Some("tunnel-a"));
+        let mut context_b = h.context_with_transport("supervised", h.owner.clone(), Some("tunnel-b"));
+        context_a.transport_kind = TransportKind::Tunnel;
+        context_b.transport_kind = TransportKind::Tunnel;
+        inner.cache_transport_auth(&context_a);
+        inner.cache_transport_auth(&context_b);
+
+        let slow_inner = Arc::clone(&inner);
+        let slow_context = context_a.clone();
+        let slow_thread = thread::spawn(move || {
+            slow_inner.with_authorized("p1", &slow_context, "input", |attachment| {
+                attachment.control.write(b"slow");
+            });
+        });
+        entered.wait();
+
+        let (done_tx, done_rx) = sync_channel(1);
+        let fast_inner = Arc::clone(&inner);
+        let fast_context = context_b.clone();
+        let fast_thread = thread::spawn(move || {
+            fast_inner.with_authorized("p2", &fast_context, "input", |attachment| {
+                attachment.control.write(b"fast");
+            });
+            done_tx.send(()).unwrap();
+        });
+        assert!(done_rx.recv_timeout(Duration::from_secs(1)).is_ok());
+        release.wait();
+        slow_thread.join().unwrap();
+        fast_thread.join().unwrap();
+    }
+
+    #[test]
+    fn an_old_open_drop_cannot_clear_a_new_owner_cancellation_marker() {
+        let h = harness(None, None);
+        let inner = Arc::clone(&h.manager.inner);
+        let id = "reused".to_owned();
+        let owner_a = OpeningOwner {
+            owner: TransportOwner {
+                id: Some("tunnel-a".to_owned()),
+                kind: TransportKind::Tunnel,
+            },
+        };
+        let owner_b = OpeningOwner {
+            owner: TransportOwner {
+                id: Some("tunnel-b".to_owned()),
+                kind: TransportKind::Tunnel,
+            },
+        };
+        let old = OpeningReservation {
+            inner: Arc::clone(&inner),
+            id: id.clone(),
+            owner: owner_a.clone(),
+            active: true,
+        };
+        {
+            let mut state = inner.opening_state.lock().unwrap();
+            state.reservations.insert(id.clone(), owner_a.clone());
+            state.cancelled.insert(id.clone(), owner_a.clone());
+            state.reservations.remove(&id);
+            state.reservations.insert(id.clone(), owner_b.clone());
+            state.cancelled.insert(id.clone(), owner_b.clone());
+        }
+        drop(old);
+        let state = inner.opening_state.lock().unwrap();
+        assert_eq!(state.reservations.get(&id), Some(&owner_b));
+        assert_eq!(state.cancelled.get(&id), Some(&owner_b));
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -290,6 +290,7 @@ pub struct FrameContext {
 #[derive(Clone)]
 struct AuthSnapshot {
     trust: String,
+    local_roots: Option<Vec<String>>,
     owner_user_id: Option<String>,
     send: Arc<dyn Fn(Value) + Send + Sync>,
     buffered_amount: Arc<dyn Fn() -> u64 + Send + Sync>,
@@ -444,6 +445,7 @@ impl PtyManager {
             context.transport_id.clone(),
             AuthSnapshot {
                 trust: context.trust.clone(),
+                local_roots: context.local_roots.clone(),
                 owner_user_id: context.owner_user_id.clone(),
                 send: Arc::clone(&context.send),
                 buffered_amount: Arc::clone(&context.buffered_amount),
@@ -777,14 +779,25 @@ impl Inner {
         let mut opening = self.opening_ids.lock().expect("opening lock");
         let cancelled =
             self.cancelled_openings.lock().expect("cancelled openings lock").remove(&pty_id);
-        if cancelled {
+        let auth_changed = self
+            .transport_auth
+            .lock()
+            .expect("transport auth lock")
+            .get(&context.transport_id)
+            .is_none_or(|auth| {
+                auth.trust != context.trust
+                    || auth.local_roots != context.local_roots
+                    || auth.owner_user_id != context.owner_user_id
+            });
+        if cancelled || auth_changed {
             opening.remove(&pty_id);
             drop(opening);
             reservation.active = false;
-            opened.closing.store(true, Ordering::SeqCst);
-            opened.control.kill();
             return;
         }
+        // The value is now owned by the attachment map. Its Drop handler
+        // must not release a live viewer when this local is consumed below.
+        opened.cleanup_on_drop = false;
         let previous = self.attachments.lock().expect("attach lock").insert(
             pty_id.clone(),
             Attachment {
@@ -980,6 +993,19 @@ struct Opened {
     control: Arc<dyn PtyControl>,
     closing: Arc<AtomicBool>,
     start: Box<dyn FnOnce() + Send>,
+    /// A cancelled open can finish after the caller's deadline. Until the
+    /// attachment is installed, dropping this value must release the spawned
+    /// viewer instead of leaking a PTY and its process group.
+    cleanup_on_drop: bool,
+}
+
+impl Drop for Opened {
+    fn drop(&mut self) {
+        if self.cleanup_on_drop {
+            self.closing.store(true, Ordering::SeqCst);
+            self.control.kill();
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1125,6 +1151,7 @@ impl Inner {
             control,
             closing: Arc::new(AtomicBool::new(false)),
             start: Box::new(move || drive_handle(output, banner, on_data, on_exit)),
+            cleanup_on_drop: true,
         })
     }
 
@@ -1302,7 +1329,7 @@ impl Inner {
             }
         });
 
-        Ok(Opened { created, surface: None, control: proxy, closing, start })
+        Ok(Opened { created, surface: None, control: proxy, closing, start, cleanup_on_drop: true })
     }
 }
 
@@ -1860,6 +1887,7 @@ impl Inner {
             control: proxy,
             closing: Arc::new(AtomicBool::new(false)),
             start: Box::new(move || start_stream.go_live(on_data, on_exit)),
+            cleanup_on_drop: true,
         }))
     }
 

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -23,7 +23,7 @@ use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
-use tokio::sync::{Notify, Semaphore};
+use tokio::sync::{Notify, OwnedSemaphorePermit, Semaphore};
 use tokio_util::sync::CancellationToken;
 
 use async_trait::async_trait;
@@ -249,12 +249,43 @@ pub struct EnsureDaemon {
     pub socket_path: PathBuf,
 }
 
+/// Capacity owned by one in-flight PTY open. Blocking setup workers retain a
+/// clone until their closure returns, including when the async caller is
+/// cancelled.
+#[derive(Clone)]
+pub(crate) struct OpenPermit(Arc<OwnedSemaphorePermit>);
+
+impl OpenPermit {
+    fn new(permit: OwnedSemaphorePermit) -> Self {
+        Self(Arc::new(permit))
+    }
+}
+
+/// Start blocking PTY setup without releasing its open capacity when the
+/// async owner is cancelled.
+pub(crate) fn spawn_blocking_with_open_permit<T, F>(
+    permit: OpenPermit,
+    operation: F,
+) -> tokio::task::JoinHandle<T>
+where
+    T: Send + 'static,
+    F: FnOnce() -> T + Send + 'static,
+{
+    let _ = permit;
+    tokio::task::spawn_blocking(operation)
+}
+
 #[async_trait]
 pub trait PtyDeps: Send + Sync {
     /// Start a PTY while observing the lifetime of its open operation. An
     /// implementation must reclaim any process or descriptor it creates when
     /// the token is cancelled before ownership is returned.
-    async fn spawn_pty(&self, spec: SpawnSpec, cancellation: CancellationToken) -> PtyHandle;
+    async fn spawn_pty(
+        &self,
+        spec: SpawnSpec,
+        cancellation: CancellationToken,
+        permit: OpenPermit,
+    ) -> PtyHandle;
     async fn resolve_cmux_tui(&self, cancellation: CancellationToken) -> Option<CmuxTui>;
     async fn ensure_daemon(
         &self,
@@ -965,8 +996,8 @@ impl Inner {
         // leave that task unwinding in the background, so the permit remains
         // owned until the task returns. This is the supervisor boundary that
         // makes stalled providers consume only the finite terminal budget.
-        let _open_permit = match self.open_slots.clone().try_acquire_owned() {
-            Ok(permit) => permit,
+        let open_permit = match self.open_slots.clone().try_acquire_owned() {
+            Ok(permit) => OpenPermit::new(permit),
             Err(_) => {
                 send_pty_error(context, &pty_id, "session_limit", "terminal limit reached");
                 return;
@@ -1091,6 +1122,7 @@ impl Inner {
                     server_roots.as_deref(),
                     context,
                     &cancellation,
+                    &open_permit,
                 )
                 .await
             {
@@ -1120,6 +1152,7 @@ impl Inner {
                             server_roots.as_deref(),
                             context,
                             &cancellation,
+                            &open_permit,
                         )
                         .await
                 } else {
@@ -1134,6 +1167,7 @@ impl Inner {
                             server_roots.as_deref(),
                             context,
                             &cancellation,
+                            &open_permit,
                         )
                         .await
                 };
@@ -1666,6 +1700,7 @@ impl Inner {
         server_roots: Option<&[String]>,
         context: &FrameContext,
         cancellation: &OpenCancellation,
+        open_permit: &OpenPermit,
     ) -> Result<Opened, String> {
         let socket_dir = self.deps.socket_dir();
         let cancellation_token = cancellation.token();
@@ -1787,6 +1822,7 @@ impl Inner {
                     cancellation: cancellation.token(),
                 },
                 cancellation.token(),
+                open_permit.clone(),
             )
             .await;
         let control = Arc::clone(&handle.control);
@@ -1817,6 +1853,7 @@ impl Inner {
         server_roots: Option<&[String]>,
         context: &FrameContext,
         cancellation: &OpenCancellation,
+        open_permit: &OpenPermit,
     ) -> Result<Opened, String> {
         let mut created = false;
         let shell_session = loop {
@@ -1876,6 +1913,7 @@ impl Inner {
                             cancellation: cancellation.token(),
                         },
                         cancellation.token(),
+                        open_permit.clone(),
                     )
                     .await;
                 if cancellation.is_cancelled() {
@@ -2395,6 +2433,7 @@ impl Inner {
         server_roots: Option<&[String]>,
         context: &FrameContext,
         cancellation: &OpenCancellation,
+        open_permit: &OpenPermit,
     ) -> Result<Option<Opened>, (RelayPtyErrorCode, String)> {
         let socket_dir = self.deps.socket_dir();
         let ensured = self
@@ -2888,7 +2927,12 @@ mod tests {
 
     #[async_trait]
     impl PtyDeps for FakeDeps {
-        async fn spawn_pty(&self, spec: SpawnSpec, _cancellation: CancellationToken) -> PtyHandle {
+        async fn spawn_pty(
+            &self,
+            spec: SpawnSpec,
+            _cancellation: CancellationToken,
+            _permit: OpenPermit,
+        ) -> PtyHandle {
             let pty = FakePty {
                 state: Arc::new(StdMutex::new(FakeState::default())),
                 spawn_file: spec.file.clone(),
@@ -3259,11 +3303,25 @@ mod tests {
         cancellation.cancel();
         let context = h.context("supervised", h.owner.clone());
         let env = env_map(&h.home);
+        let open_permit = OpenPermit::new(
+            h.manager.inner.open_slots.clone().try_acquire_owned().expect("open permit"),
+        );
 
         // The fake returns a handle even for a cancelled token. This models a
         // blocking provider that finishes its spawn while cancellation wins.
         let result = Arc::clone(&h.manager.inner)
-            .open_shell("cancelled", 80, 24, &h.home, &env, "p1", None, &context, &cancellation)
+            .open_shell(
+                "cancelled",
+                80,
+                24,
+                &h.home,
+                &env,
+                "p1",
+                None,
+                &context,
+                &cancellation,
+                &open_permit,
+            )
             .await;
 
         assert_eq!(result.err().as_deref(), Some("terminal open cancelled"));
@@ -3902,6 +3960,28 @@ mod tests {
         task.await.unwrap();
         assert!(h.recorded.lock().unwrap().spawned.is_empty());
         assert_eq!(manager.attachment_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn blocking_open_worker_keeps_its_permit_until_completion() {
+        let slots = Arc::new(Semaphore::new(1));
+        let permit = OpenPermit::new(slots.clone().try_acquire_owned().expect("open permit"));
+        let (started_tx, started_rx) = sync_channel(1);
+        let (release_tx, release_rx) = sync_channel(1);
+        let worker = spawn_blocking_with_open_permit(permit, move || {
+            started_tx.send(()).expect("worker start receiver");
+            release_rx.recv().expect("worker release sender");
+        });
+
+        started_rx.recv_timeout(Duration::from_secs(1)).expect("blocking worker must start");
+        assert!(
+            slots.clone().try_acquire_owned().is_err(),
+            "cancelled open capacity must stay held by the blocking worker"
+        );
+
+        release_tx.send(()).expect("worker release receiver");
+        worker.await.expect("blocking worker join");
+        assert!(slots.try_acquire_owned().is_ok(), "open permit returns after worker completion");
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2577,6 +2577,7 @@ impl Inner {
                 if context.local_roots.as_deref().is_some_and(|r| !r.is_empty())
                     || server_roots.is_some_and(|r| !r.is_empty())
                 {
+                    existing.pending_viewers.fetch_sub(1, Ordering::AcqRel);
                     return Err("cannot reattach existing shell under scoped roots".to_owned());
                 }
                 pending_viewer.store(true, Ordering::Release);

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -320,6 +320,9 @@ pub trait PtyDeps: Send + Sync {
 #[derive(Clone)]
 pub struct FrameContext {
     pub send: Arc<dyn Fn(Value) + Send + Sync>,
+    /// Enqueue a stream frame with a liveness token. The transport writer
+    /// drops the frame when the attachment is revoked before socket delivery.
+    pub send_live: Arc<dyn Fn(Value, Arc<AtomicBool>) + Send + Sync>,
     pub buffered_amount: Arc<dyn Fn() -> u64 + Send + Sync>,
     pub trust: String,
     pub local_roots: Option<Vec<String>>,
@@ -370,6 +373,7 @@ struct AuthSnapshot {
     local_roots: Option<Vec<String>>,
     owner_user_id: Option<String>,
     send: Arc<dyn Fn(Value) + Send + Sync>,
+    send_live: Arc<dyn Fn(Value, Arc<AtomicBool>) + Send + Sync>,
     buffered_amount: Arc<dyn Fn() -> u64 + Send + Sync>,
     auth_generation: Option<u64>,
     transport_kind: TransportKind,
@@ -382,6 +386,7 @@ impl AuthSnapshot {
             local_roots: context.local_roots.clone(),
             owner_user_id: context.owner_user_id.clone(),
             send: Arc::clone(&context.send),
+            send_live: Arc::clone(&context.send_live),
             buffered_amount: Arc::clone(&context.buffered_amount),
             auth_generation: context.auth_generation,
             transport_kind: context.transport_kind,
@@ -467,6 +472,9 @@ struct Attachment {
     control_gate: Arc<Mutex<()>>,
     /// Serializes output and exit delivery for one attachment.
     delivery_gate: Arc<Mutex<()>>,
+    /// Cleared at the attachment retirement boundary. Queued stream frames
+    /// carry this token so the writer can discard them after revocation.
+    delivery_live: Arc<AtomicBool>,
     /// Serializes open success publication with attachment retirement. This
     /// is separate because start callbacks can emit output and re-enter the
     /// operation gate.
@@ -1590,6 +1598,7 @@ impl Inner {
                     operation_gate: Arc::new(Mutex::new(())),
                     control_gate: Arc::new(Mutex::new(())),
                     delivery_gate: Arc::new(Mutex::new(())),
+                    delivery_live: Arc::new(AtomicBool::new(true)),
                     publication_gate: Arc::clone(&publication_gate),
                     publication_state: Arc::new(AtomicU64::new(0)),
                     control,
@@ -1817,12 +1826,13 @@ impl Inner {
         // the transport callback because a stalled sink must not block detach
         // or trust revocation.
         drop(delivery);
-        (auth.send)(json!({
+        let frame = json!({
             "version": PTY_PROTOCOL_VERSION,
             "type": "pty_output",
             "ptyId": pty_id,
             "dataB64": BASE64.encode(chunk),
-        }));
+        });
+        (auth.send_live)(frame, Arc::clone(&attachment.delivery_live));
     }
 
     fn emit_exit(&self, pty_id: &str, code: i64, context: &FrameContext) {
@@ -2213,6 +2223,7 @@ impl Inner {
     }
 
     fn revoke_publication(attachment: &Attachment) {
+        attachment.delivery_live.store(false, Ordering::Release);
         attachment.publication_state.fetch_or(1, Ordering::AcqRel);
     }
 
@@ -4178,9 +4189,11 @@ mod tests {
     impl Harness {
         fn context(&self, trust: &str, owner: Option<String>) -> FrameContext {
             let sent = Arc::clone(&self.sent);
+            let sent_live = Arc::clone(&self.sent);
             let buffered = Arc::clone(&self.buffered);
             FrameContext {
                 send: Arc::new(move |frame| sent.lock().unwrap().push(frame)),
+                send_live: Arc::new(move |frame, _live| sent_live.lock().unwrap().push(frame)),
                 buffered_amount: Arc::new(move || buffered.load(Ordering::SeqCst)),
                 trust: trust.to_owned(),
                 local_roots: None,
@@ -5172,6 +5185,7 @@ mod tests {
                     operation_gate: Arc::new(Mutex::new(())),
                     control_gate: Arc::new(Mutex::new(())),
                     delivery_gate: Arc::new(Mutex::new(())),
+                    delivery_live: Arc::new(AtomicBool::new(true)),
                     publication_gate: Arc::new(Mutex::new(())),
                     publication_state: Arc::new(AtomicU64::new(0)),
                     control: slow,
@@ -5187,6 +5201,7 @@ mod tests {
                     operation_gate: Arc::new(Mutex::new(())),
                     control_gate: Arc::new(Mutex::new(())),
                     delivery_gate: Arc::new(Mutex::new(())),
+                    delivery_live: Arc::new(AtomicBool::new(true)),
                     publication_gate: Arc::new(Mutex::new(())),
                     publication_state: Arc::new(AtomicU64::new(0)),
                     control: Arc::new(fast),
@@ -5245,6 +5260,7 @@ mod tests {
                     operation_gate: Arc::new(Mutex::new(())),
                     control_gate: Arc::new(Mutex::new(())),
                     delivery_gate: Arc::new(Mutex::new(())),
+                    delivery_live: Arc::new(AtomicBool::new(true)),
                     publication_gate: Arc::new(Mutex::new(())),
                     publication_state: Arc::new(AtomicU64::new(0)),
                     control: Arc::new(BlockingControl {
@@ -5302,6 +5318,7 @@ mod tests {
                     operation_gate: Arc::new(Mutex::new(())),
                     control_gate: Arc::new(Mutex::new(())),
                     delivery_gate: Arc::new(Mutex::new(())),
+                    delivery_live: Arc::new(AtomicBool::new(true)),
                     publication_gate: Arc::new(Mutex::new(())),
                     publication_state: Arc::new(AtomicU64::new(0)),
                     control: Arc::new(BlockingControl {
@@ -5350,8 +5367,20 @@ mod tests {
             send: {
                 let entered = Arc::clone(&entered);
                 let release = Arc::clone(&release);
+                let sent = Arc::clone(&sent);
                 Arc::new(move |frame| {
                     sent.lock().unwrap().push(frame);
+                    entered.wait();
+                    release.wait();
+                })
+            },
+            send_live: {
+                let entered = Arc::clone(&entered);
+                let release = Arc::clone(&release);
+                Arc::new(move |frame, live| {
+                    if live.load(Ordering::Acquire) {
+                        sent.lock().unwrap().push(frame);
+                    }
                     entered.wait();
                     release.wait();
                 })
@@ -5380,6 +5409,7 @@ mod tests {
             operation_gate: Arc::new(Mutex::new(())),
             control_gate: Arc::new(Mutex::new(())),
             delivery_gate: Arc::new(Mutex::new(())),
+            delivery_live: Arc::new(AtomicBool::new(true)),
             publication_gate: Arc::new(Mutex::new(())),
             publication_state: Arc::new(AtomicU64::new(0)),
             control: Arc::new(pty),
@@ -5860,7 +5890,11 @@ mod tests {
         let sent_a = Arc::new(StdMutex::new(Vec::<Value>::new()));
         let sent_b = Arc::new(StdMutex::new(Vec::<Value>::new()));
         let context = |sent: Arc<StdMutex<Vec<Value>>>, transport: &str| FrameContext {
-            send: Arc::new(move |frame| sent.lock().unwrap().push(frame)),
+            send: {
+                let sent = Arc::clone(&sent);
+                Arc::new(move |frame| sent.lock().unwrap().push(frame))
+            },
+            send_live: Arc::new(move |frame, _live| sent.lock().unwrap().push(frame)),
             buffered_amount: Arc::new(|| 0),
             trust: "supervised".to_owned(),
             local_roots: None,
@@ -6040,6 +6074,7 @@ mod tests {
         let sink = Arc::clone(&sent);
         let context = FrameContext {
             send: Arc::new(move |frame| sink.lock().unwrap().push(frame)),
+            send_live: Arc::new(|_, _| {}),
             buffered_amount: Arc::new(|| 0),
             trust: "supervised".to_owned(),
             local_roots: None,

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2637,7 +2637,8 @@ impl Inner {
                 // identity is cached, and remove only this exact session so a
                 // replacement cannot be disturbed.
                 if cancellation.is_cancelled() {
-                    let removed = remove_cached_shell_if_same_without_viewers(&self, session, &shell_session);
+                    let removed =
+                        remove_cached_shell_if_same_without_viewers(&self, session, &shell_session);
                     if removed {
                         shell_session.control.kill();
                     }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -844,7 +844,7 @@ impl PtyManager {
             changed
         };
         if changed {
-            self.inner.detach_matching_locked(|candidate| candidate == &owner).retire();
+            self.detach_matching(|candidate| candidate == &owner).retire();
         }
         let _state = self.inner.tunnel_state.lock().expect("tunnel state lock");
         if context.cancellation.is_cancelled()
@@ -2267,9 +2267,10 @@ impl Inner {
                 }
             };
             if !owner {
+                let cancellation_token = cancellation.token();
                 tokio::select! {
                     biased;
-                    _ = cancellation.token().cancelled() => {
+                    _ = cancellation_token.cancelled() => {
                         return Err("terminal open cancelled".to_owned());
                     }
                     _ = waiter.expect("shell waiter") => {}

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1960,6 +1960,7 @@ impl Inner {
         // caller is allowed to retire, so a late close cannot cancel a
         // replacement that reused the same pty id.
         let opening = {
+            let _state = self.tunnel_state.lock().expect("tunnel state lock");
             let state = self.opening_state.lock().expect("opening state lock");
             state.reservations.get(pty_id).cloned().map(|owner| (owner, None)).or_else(|| {
                 state

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2400,6 +2400,17 @@ impl Drop for ControlEndOnDrop {
     }
 }
 
+/// Run potentially blocking PTY teardown away from the async executor. A
+/// drop can happen on a Tokio worker during cancellation, so never invoke the
+/// provider's kill implementation inline on that path.
+fn schedule_control_kill(control: Arc<dyn PtyControl>) {
+    if let Ok(handle) = tokio::runtime::Handle::try_current() {
+        handle.spawn_blocking(move || control.kill());
+    } else {
+        std::thread::spawn(move || control.kill());
+    }
+}
+
 impl Drop for Opened {
     fn drop(&mut self) {
         if self.cleanup_on_drop {
@@ -2407,7 +2418,7 @@ impl Drop for Opened {
                 closing.store(true, Ordering::SeqCst);
             }
             if let Some(control) = &self.control {
-                control.kill();
+                schedule_control_kill(Arc::clone(control));
             }
         }
     }
@@ -4555,16 +4566,12 @@ mod tests {
         };
         let drop_task = tokio::spawn(async move { drop(opened) });
 
-        tokio::task::spawn_blocking(move || entered.wait())
-            .await
-            .expect("kill must start");
+        tokio::task::spawn_blocking(move || entered.wait()).await.expect("kill must start");
         assert!(
             tokio::time::timeout(Duration::from_millis(100), drop_task).await.is_ok(),
             "Opened::drop must not wait for a blocking PTY kill"
         );
-        tokio::task::spawn_blocking(move || release.wait())
-            .await
-            .expect("kill release");
+        tokio::task::spawn_blocking(move || release.wait()).await.expect("kill release");
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -4311,6 +4311,29 @@ mod tests {
         assert_eq!(h.spawned().len(), 1, "published authority admits the transport");
     }
 
+    #[tokio::test]
+    async fn detached_transport_cannot_start_provider_work() {
+        let gate = Arc::new(ResolveGate {
+            entered: Arc::new(Notify::new()),
+            release: Arc::new(Notify::new()),
+        });
+        let h = harness_with_control_and_gate(None, None, None, None, Some(gate));
+        let context = h.context_with_transport("supervised", h.owner.clone(), Some("relay-gone"));
+        h.manager.update_transport_auth(&context);
+        h.manager.detach_transport_kind("relay-gone", TransportKind::Relay);
+
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "late-open",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+        });
+        h.manager.handle_frame(&frame, &context).await;
+        assert!(h.spawned().is_empty(), "a detached transport must not reach provider setup");
+    }
+
     #[test]
     fn transport_authority_registry_releases_every_disconnected_identity() {
         let h = harness(None, None);

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -19,7 +19,7 @@
 //! every non-empty allowed root list; env scrubbed; per-pty buffered output capped; no
 //! empty frames; unknown ptyIds tolerated; refusals answer pty_error.
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -415,6 +415,10 @@ struct ViewerSink {
 /// fans output out to every attachment (multi-viewer, tmux-style).
 struct ShellSession {
     control: Arc<dyn PtyControl>,
+    /// Serializes pause ownership transitions before touching the shared PTY.
+    flow_lock: Mutex<()>,
+    /// Serializes output delivery with paused-viewer replay.
+    dispatch_lock: Mutex<()>,
     inner: Mutex<ShellInner>,
     banner: Option<Vec<u8>>,
 }
@@ -424,6 +428,18 @@ struct ShellInner {
     ring_size: usize,
     alive: bool,
     viewers: Vec<ViewerSink>,
+    /// Viewer ids that currently own a pause on the shared PTY.
+    paused_viewers: HashSet<u64>,
+    /// Bounded output accumulated for paused or resuming viewers.
+    paused_backlog: HashMap<u64, PausedBacklog>,
+    /// Viewers whose paused output is being replayed in order.
+    draining_viewers: HashSet<u64>,
+}
+
+#[derive(Default)]
+struct PausedBacklog {
+    chunks: VecDeque<Bytes>,
+    bytes: usize,
 }
 
 #[derive(Clone)]
@@ -2390,12 +2406,17 @@ impl Inner {
                 let PtyHandle { control, output, banner } = handle;
                 let shell_session = Arc::new(ShellSession {
                     control,
+                    flow_lock: Mutex::new(()),
+                    dispatch_lock: Mutex::new(()),
                     banner,
                     inner: Mutex::new(ShellInner {
                         ring: VecDeque::new(),
                         ring_size: 0,
                         alive: true,
                         viewers: Vec::new(),
+                        paused_viewers: HashSet::new(),
+                        paused_backlog: HashMap::new(),
+                        draining_viewers: HashSet::new(),
                     }),
                 });
                 // Session-level plumbing runs for the session's whole life:
@@ -2409,6 +2430,7 @@ impl Inner {
                 let exit_session = Arc::clone(&shell_session);
                 let manager = Arc::clone(&self);
                 let on_session_data: DataSink = Arc::new(move |chunk: Bytes| {
+                    let _dispatch = data_session.dispatch_lock.lock().expect("shell dispatch lock");
                     let viewers_to_notify: Vec<Arc<dyn Fn(Bytes) + Send + Sync>> = {
                         let mut inner = data_session.inner.lock().expect("shell inner lock");
                         inner.ring_size += chunk.len();
@@ -2417,7 +2439,24 @@ impl Inner {
                             let Some(dropped) = inner.ring.pop_front() else { break };
                             inner.ring_size -= dropped.len();
                         }
-                        inner.viewers.iter().map(|viewer| Arc::clone(&viewer.on_data)).collect()
+                        let mut viewers_to_notify = Vec::new();
+                        for viewer in &inner.viewers {
+                            if inner.paused_viewers.contains(&viewer.id)
+                                || inner.draining_viewers.contains(&viewer.id)
+                            {
+                                let backlog = inner.paused_backlog.entry(viewer.id).or_default();
+                                backlog.chunks.push_back(chunk.clone());
+                                backlog.bytes += chunk.len();
+                                while backlog.bytes > scrollback_limit && backlog.chunks.len() > 1 {
+                                    if let Some(dropped) = backlog.chunks.pop_front() {
+                                        backlog.bytes -= dropped.len();
+                                    }
+                                }
+                            } else {
+                                viewers_to_notify.push(Arc::clone(&viewer.on_data));
+                            }
+                        }
+                        viewers_to_notify
                     };
                     for on_data in viewers_to_notify {
                         on_data(chunk.clone());
@@ -2425,8 +2464,12 @@ impl Inner {
                 });
                 let on_session_exit: ExitSink = Arc::new(move |code: i64| {
                     let viewers = {
+                        let _flow = exit_session.flow_lock.lock().expect("shell flow lock");
                         let mut inner = exit_session.inner.lock().expect("shell inner lock");
                         inner.alive = false;
+                        inner.paused_viewers.clear();
+                        inner.paused_backlog.clear();
+                        inner.draining_viewers.clear();
                         std::mem::take(&mut inner.viewers)
                     };
                     manager.shell_sessions.lock().expect("shell lock").remove(&session_name);
@@ -2476,6 +2519,7 @@ impl Inner {
 
         let start_session = Arc::clone(&shell_session);
         let start: Box<dyn FnOnce() + Send> = Box::new(move || {
+            let _dispatch = start_session.dispatch_lock.lock().expect("shell dispatch lock");
             let (banner, replay, alive) = {
                 let inner = start_session.inner.lock().expect("shell inner lock");
                 let banner = created.then(|| start_session.banner.clone()).flatten();
@@ -2523,8 +2567,17 @@ struct ShellViewerControl {
 impl ShellViewerControl {
     fn release(&self) {
         self.released.store(true, Ordering::SeqCst);
-        let mut inner = self.session.inner.lock().expect("shell inner lock");
-        inner.viewers.retain(|viewer| viewer.id != self.viewer_id);
+        let should_resume = {
+            let _flow = self.session.flow_lock.lock().expect("shell flow lock");
+            let mut inner = self.session.inner.lock().expect("shell inner lock");
+            inner.viewers.retain(|viewer| viewer.id != self.viewer_id);
+            inner.paused_backlog.remove(&self.viewer_id);
+            inner.draining_viewers.remove(&self.viewer_id);
+            inner.paused_viewers.remove(&self.viewer_id) && inner.paused_viewers.is_empty()
+        };
+        if should_resume {
+            self.session.control.resume();
+        }
     }
 }
 
@@ -2536,10 +2589,70 @@ impl PtyControl for ShellViewerControl {
         self.session.control.resize(cols, rows);
     }
     fn pause(&self) {
-        self.session.control.pause();
+        let should_pause = {
+            let _flow = self.session.flow_lock.lock().expect("shell flow lock");
+            let mut inner = self.session.inner.lock().expect("shell inner lock");
+            inner.paused_viewers.insert(self.viewer_id) && inner.paused_viewers.len() == 1
+        };
+        if should_pause {
+            self.session.control.pause();
+        }
     }
     fn resume(&self) {
-        self.session.control.resume();
+        let should_resume = {
+            let _flow = self.session.flow_lock.lock().expect("shell flow lock");
+            let mut inner = self.session.inner.lock().expect("shell inner lock");
+            let removed = inner.paused_viewers.remove(&self.viewer_id);
+            if removed {
+                inner.draining_viewers.insert(self.viewer_id);
+                inner.paused_backlog.entry(self.viewer_id).or_default();
+            }
+            removed && inner.paused_viewers.is_empty()
+        };
+        if should_resume {
+            self.session.control.resume();
+        }
+        self.drain_backlog();
+    }
+
+    fn drain_backlog(&self) {
+        let _dispatch = self.session.dispatch_lock.lock().expect("shell dispatch lock");
+        loop {
+            let next = {
+                let _flow = self.session.flow_lock.lock().expect("shell flow lock");
+                let mut inner = self.session.inner.lock().expect("shell inner lock");
+                if self.released.load(Ordering::SeqCst) {
+                    inner.paused_backlog.remove(&self.viewer_id);
+                    inner.draining_viewers.remove(&self.viewer_id);
+                    None
+                } else {
+                    let Some(on_data) = inner
+                        .viewers
+                        .iter()
+                        .find(|viewer| viewer.id == self.viewer_id)
+                        .map(|viewer| Arc::clone(&viewer.on_data))
+                    else {
+                        inner.paused_backlog.remove(&self.viewer_id);
+                        inner.draining_viewers.remove(&self.viewer_id);
+                        None
+                    };
+                    let chunk = inner.paused_backlog.get_mut(&self.viewer_id).and_then(|backlog| {
+                        let chunk = backlog.chunks.pop_front()?;
+                        backlog.bytes -= chunk.len();
+                        Some(chunk)
+                    });
+                    if let Some(chunk) = chunk {
+                        Some((on_data, chunk))
+                    } else {
+                        inner.paused_backlog.remove(&self.viewer_id);
+                        inner.draining_viewers.remove(&self.viewer_id);
+                        None
+                    }
+                }
+            };
+            let Some((on_data, chunk)) = next else { break };
+            on_data(chunk);
+        }
     }
     fn kill(&self) {
         self.release();

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1875,7 +1875,13 @@ impl Inner {
     }
 
     fn transport_auth_is_current(&self, context: &FrameContext, auth: &AuthSnapshot) -> bool {
-        if context.cancellation.is_cancelled() || Self::matching_trust(auth, context).is_none() {
+        if context.cancellation.is_cancelled()
+            || Self::matching_trust(auth, context).is_none()
+            // `auth_for_transport` is keyed only by transport id and kind.
+            // Require the complete frame snapshot here so a stale context
+            // cannot reuse an older owner's identity or root scope.
+            || !auth_snapshot_matches(auth, &AuthSnapshot::from_context(context))
+        {
             return false;
         }
         let key = TransportOwner::from_context(context);
@@ -5008,6 +5014,32 @@ mod tests {
         });
         h.manager.handle_frame(&frame, &old).await;
         assert!(h.spawned().is_empty(), "a stale relay context must not start a PTY");
+    }
+
+    #[tokio::test]
+    async fn stale_transport_identity_cannot_open_after_owner_change() {
+        let h = harness(None, None);
+        let old =
+            h.context_with_transport("observe", Some("user_owner".to_owned()), Some("relay-a"));
+        h.manager.update_transport_auth(&old);
+
+        // The transport id and trust are unchanged, but the reconciled owner
+        // changed. The old cached authority must not authorize this frame.
+        let mut changed = old.clone();
+        changed.owner_user_id = Some("attacker".to_owned());
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "stale-owner",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+            "actorId": "attacker",
+        });
+
+        h.manager.handle_frame(&frame, &changed).await;
+
+        assert!(h.spawned().is_empty(), "stale owner metadata must not authorize a PTY open");
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1566,6 +1566,9 @@ impl Inner {
                 match result {
                     Ok(opened) => opened,
                     Err(message) => {
+                        if cancellation.is_cancelled() {
+                            return;
+                        }
                         fail("failed", &message);
                         return;
                     }
@@ -2683,6 +2686,11 @@ impl Inner {
                     return Err("cannot reattach existing shell under scoped roots".to_owned());
                 }
                 pending_viewer.store(true, Ordering::Release);
+                let _flow = existing.flow_lock.lock().expect("shell flow lock");
+                if cancellation.is_cancelled() {
+                    existing.pending_viewers.fetch_sub(1, Ordering::AcqRel);
+                    return Err("terminal open cancelled".to_owned());
+                }
                 existing.control.resize(cols, rows);
                 break existing;
             }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2919,6 +2919,9 @@ impl PtyControl for ShellViewerControl {
     fn pause(&self) {
         let should_pause = {
             let _flow = self.session.flow_lock.lock().expect("shell flow lock");
+            if self.released.load(Ordering::Acquire) {
+                return;
+            }
             let mut inner = self.session.inner.lock().expect("shell inner lock");
             inner.paused_viewers.insert(self.viewer_id) && inner.paused_viewers.len() == 1
         };

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1904,7 +1904,6 @@ impl Inner {
             return;
         }
         let _delivery = attachment.delivery_gate.lock().expect("attachment delivery lock");
-        let exit_live = Arc::new(AtomicBool::new(true));
         let removed = {
             let _state = self.tunnel_state.lock().expect("tunnel state lock");
             let mut attachments = self.attachments.lock().expect("attach lock");
@@ -1925,7 +1924,7 @@ impl Inner {
                         "ptyId": pty_id,
                         "code": code,
                     }),
-                    Arc::clone(&exit_live),
+                    Arc::clone(&attachment.delivery_live),
                 );
                 // A normal PTY exit ends new publication but keeps the live
                 // token for frames already queued. The writer must preserve

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1597,11 +1597,14 @@ impl Inner {
             let removed = {
                 let _state = self.tunnel_state.lock().expect("tunnel state lock");
                 let mut attachments = self.attachments.lock().expect("attach lock");
-                if let Some(current) = attachments.get(&pty_id) {
+                let same = attachments.get(&pty_id).is_some_and(|current| {
+                    Arc::ptr_eq(&current.publication_gate, &publication_gate)
+                });
+                if same && let Some(current) = attachments.get(&pty_id) {
                     Self::revoke_publication(current);
                     current.closing.store(true, Ordering::Release);
                 }
-                attachments.remove(&pty_id)
+                same.then(|| attachments.remove(&pty_id)).flatten()
             };
             if let Some(removed) = removed {
                 self.retire_attachment(removed);

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -4046,6 +4046,35 @@ mod tests {
         fn end(&self) {}
     }
 
+    /// A control plane that accepts a request but never answers until the
+    /// test releases it. This models a daemon that wedged after connect.
+    struct HangingControl {
+        started: Arc<Notify>,
+        release: Arc<Notify>,
+    }
+
+    impl ControlHandle for HangingControl {
+        fn request(
+            &self,
+            _cmd: &str,
+            _params: Value,
+        ) -> std::pin::Pin<Box<dyn Future<Output = Option<Value>> + Send + '_>> {
+            let started = Arc::clone(&self.started);
+            let release = Arc::clone(&self.release);
+            Box::pin(async move {
+                started.notify_one();
+                release.notified().await;
+                None
+            })
+        }
+        fn send(&self, _cmd: &str, _params: Value) {}
+        fn on_event(&self, _handler: EventHandler) {}
+        fn on_close(&self, _handler: CloseHandler) {}
+        fn pause(&self) {}
+        fn resume(&self) {}
+        fn end(&self) {}
+    }
+
     #[tokio::test]
     async fn missing_surface_refuses_with_typed_terminal_gone() {
         let cmux = CmuxTui { file: "/opt/cmux-tui".to_owned(), prefix: Vec::new() };
@@ -4070,6 +4099,46 @@ mod tests {
         assert_eq!(error["message"], "terminal is no longer available");
         // A gone terminal must NOT degrade to a whole-session attach.
         assert!(!sent.iter().any(|f| ty(f) == "pty_opened"));
+    }
+
+    #[tokio::test]
+    async fn existing_surface_probe_stops_when_open_is_cancelled() {
+        let started = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        let control = Arc::new(HangingControl {
+            started: Arc::clone(&started),
+            release: Arc::clone(&release),
+        });
+        let cmux = CmuxTui { file: "/opt/cmux-tui".to_owned(), prefix: Vec::new() };
+        let h = harness_with_control(Some(cmux), None, None, Some(control));
+        let context = h.context("supervised", h.owner.clone());
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "p1",
+            "session": "main",
+            "surface": "resource-1",
+            "cols": 80,
+            "rows": 24,
+        });
+        let cancellation = h.manager.new_open_cancellation().expect("open attempt token");
+        let task_manager = Arc::new(h.manager);
+        let task_context = context.clone();
+        let task_cancellation = cancellation.clone();
+        let task = tokio::spawn(async move {
+            task_manager
+                .handle_frame_with_open_cancellation(&frame, &task_context, Some(task_cancellation))
+                .await;
+        });
+
+        started.notified().await;
+        cancellation.cancel();
+        task.await.unwrap();
+        assert!(!task_manager.has_attachment("p1"));
+        let state = task_manager.inner.opening_state.lock().unwrap();
+        assert!(state.reservations.is_empty());
+        assert!(state.active_openings.is_empty());
+        release.notify_waiters();
     }
 
     #[tokio::test]
@@ -4123,6 +4192,39 @@ mod tests {
         // A caller with no transport identity owns the whole manager (legacy).
         h.manager.handle_frame(&close, &h.context("supervised", h.owner.clone())).await;
         assert!(!h.manager.has_attachment("p1"));
+    }
+
+    #[tokio::test]
+    async fn detached_transport_rejects_late_frames_and_allows_a_fresh_owner() {
+        let h = harness(None, None);
+        let old = h.context_with_transport("supervised", h.owner.clone(), Some("relay-old"));
+        h.manager.update_transport_auth(&old);
+        h.manager.detach_transport_kind("relay-old", TransportKind::Relay);
+
+        let old_frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "late",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+        });
+        h.manager.handle_frame(&old_frame, &old).await;
+        assert!(h.spawned().is_empty(), "a detached transport must stay fenced");
+        assert!(!h.manager.inner.cache_transport_auth(&old));
+
+        let fresh = h.context_with_transport("supervised", h.owner.clone(), Some("relay-fresh"));
+        h.manager.update_transport_auth(&fresh);
+        let fresh_frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "fresh",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+        });
+        h.manager.handle_frame(&fresh_frame, &fresh).await;
+        assert_eq!(h.spawned().len(), 1, "a new transport identity remains usable");
     }
 
     #[test]

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2554,7 +2554,8 @@ mod tests {
         ) -> FrameContext {
             let mut context = self.context(trust, owner);
             context.transport_id = transport_id.map(str::to_owned);
-            context.transport_kind = transport_id.map_or(TransportKind::Legacy, |_| TransportKind::Relay);
+            context.transport_kind =
+                transport_id.map_or(TransportKind::Legacy, |_| TransportKind::Relay);
             context
         }
 

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -4683,6 +4683,57 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn paused_backlog_overflow_detaches_instead_of_evicting_bytes() {
+        let h = harness(None, None);
+        h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;
+        h.open("p2", "main", Value::Null, "supervised", h.owner.clone()).await;
+        let pty = h.spawned()[0].clone();
+        h.frame(serde_json::json!({ "type": "pty_flow", "ptyId": "p1", "pause": true })).await;
+
+        let chunk = "x".repeat(SCROLLBACK_LIMIT / 2 + 1);
+        pty.emit_while_paused(&chunk);
+        pty.emit_while_paused(&chunk);
+
+        let sent = h.sent();
+        assert!(sent.iter().any(|frame| {
+            frame["type"] == "pty_exit" && frame["ptyId"] == "p1" && frame["code"] == 1
+        }));
+        assert!(
+            !sent.iter().any(|frame| { frame["type"] == "pty_output" && frame["ptyId"] == "p1" })
+        );
+    }
+
+    #[tokio::test]
+    async fn output_rechecks_publication_after_delivery_gate_wait() {
+        let h = harness(None, None);
+        h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;
+        let pty = h.spawned()[0].clone();
+        let attachment = h.manager.inner.attachment("p1").expect("attachment");
+        let publication_before = attachment.publication_state.load(Ordering::Acquire);
+        let delivery = attachment.delivery_gate.lock().expect("delivery gate");
+        let emit = thread::spawn(move || pty.emit("stale after revoke"));
+
+        for _ in 0..10_000 {
+            if attachment.publication_state.load(Ordering::Acquire) > publication_before {
+                break;
+            }
+            thread::yield_now();
+        }
+        assert!(attachment.publication_state.load(Ordering::Acquire) > publication_before);
+        Inner::revoke_publication(&attachment);
+        attachment.closing.store(true, Ordering::Release);
+        h.manager.inner.attachments.lock().expect("attach lock").remove("p1");
+        drop(delivery);
+        emit.join().expect("output callback thread");
+
+        assert!(
+            !h.sent()
+                .iter()
+                .any(|frame| { frame["type"] == "pty_output" && frame["ptyId"] == "p1" })
+        );
+    }
+
+    #[tokio::test]
     async fn detaching_one_viewer_leaves_the_other_live_exit_reaches_every_viewer() {
         let h = harness(None, None);
         h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1703,7 +1703,10 @@ impl Inner {
             self.retire_if_current(&pty_id, &current_attachment);
             return;
         }
-        (context.send)(Value::Object(opened_frame));
+        (context.send_live)(
+            Value::Object(opened_frame),
+            Arc::clone(&current_attachment.delivery_live),
+        );
 
         // Output only AFTER pty_opened (ordering): banner, then scrollback
         // replay, then live bytes.
@@ -1911,12 +1914,15 @@ impl Inner {
         drop(_delivery);
         drop(_operation);
         drop(_publication);
-        (auth.send)(json!({
-            "version": PTY_PROTOCOL_VERSION,
-            "type": "pty_exit",
-            "ptyId": pty_id,
-            "code": code,
-        }));
+        (auth.send_live)(
+            json!({
+                "version": PTY_PROTOCOL_VERSION,
+                "type": "pty_exit",
+                "ptyId": pty_id,
+                "code": code,
+            }),
+            Arc::new(AtomicBool::new(true)),
+        );
     }
 
     /// Detach, NOT kill: idempotent, unknown ptyId tolerated.

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -374,6 +374,10 @@ struct AuthSnapshot {
     owner_user_id: Option<String>,
     send: Arc<dyn Fn(Value) + Send + Sync>,
     send_live: Arc<dyn Fn(Value, Arc<AtomicBool>) + Send + Sync>,
+    /// Transport-wide delivery fence for replies without a PTY attachment,
+    /// such as surface-list results. Authority replacement and detach revoke
+    /// this token before removing the cached snapshot.
+    delivery_live: Arc<AtomicBool>,
     buffered_amount: Arc<dyn Fn() -> u64 + Send + Sync>,
     auth_generation: Option<u64>,
     transport_kind: TransportKind,
@@ -387,6 +391,7 @@ impl AuthSnapshot {
             owner_user_id: context.owner_user_id.clone(),
             send: Arc::clone(&context.send),
             send_live: Arc::clone(&context.send_live),
+            delivery_live: Arc::new(AtomicBool::new(true)),
             buffered_amount: Arc::clone(&context.buffered_amount),
             auth_generation: context.auth_generation,
             transport_kind: context.transport_kind,
@@ -1097,7 +1102,14 @@ impl PtyManager {
             // Every identified opening and attachment is admitted through an
             // active auth snapshot. Removing that snapshot is the disconnect
             // fence. No historical tombstone is stored.
-            transport_auth.retain(|owner, _| !owns(owner));
+            transport_auth.retain(|owner, snapshot| {
+                if owns(owner) {
+                    snapshot.delivery_live.store(false, Ordering::Release);
+                    false
+                } else {
+                    true
+                }
+            });
             let mut opening = self.inner.opening_state.lock().expect("opening state lock");
             let cancelled: Vec<(String, OpeningOwner)> = opening
                 .reservations
@@ -3832,12 +3844,15 @@ impl Inner {
         {
             return;
         }
-        (context.send)(json!({
-            "version": PTY_PROTOCOL_VERSION,
-            "type": "surface_list_result",
-            "requestId": request_id,
-            "surfaces": surfaces,
-        }));
+        (context.send_live)(
+            json!({
+                "version": PTY_PROTOCOL_VERSION,
+                "type": "surface_list_result",
+                "requestId": request_id,
+                "surfaces": surfaces,
+            }),
+            Arc::clone(&auth.delivery_live),
+        );
     }
 
     /// Enumerate the live terminals inside one cmux-tui session (W86):

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2524,9 +2524,12 @@ impl Inner {
             "--socket".to_owned(),
             ensured.socket_path.to_string_lossy().into_owned(),
         ]);
-        let handle = self
-            .deps
-            .spawn_pty(
+        let handle = tokio::select! {
+            biased;
+            _ = cancellation.token().cancelled() => {
+                return Err((RelayPtyErrorCode::Failed, "terminal open cancelled".to_owned()));
+            }
+            handle = self.deps.spawn_pty(
                 SpawnSpec {
                     file: cmux_tui.file.clone(),
                     args,
@@ -2538,8 +2541,8 @@ impl Inner {
                 },
                 cancellation.token(),
                 open_permit.clone(),
-            )
-            .await;
+            ) => handle,
+        };
         let control = Arc::clone(&handle.control);
         let output = Arc::clone(&handle.output);
         let banner = handle.banner.clone();
@@ -2624,9 +2627,12 @@ impl Inner {
             };
             {
                 let shell = self.deps.shell();
-                let handle = self
-                    .deps
-                    .spawn_pty(
+                let handle = tokio::select! {
+                    biased;
+                    _ = cancellation.token().cancelled() => {
+                        return Err("terminal open cancelled".to_owned());
+                    }
+                    handle = self.deps.spawn_pty(
                         SpawnSpec {
                             file: shell,
                             args: Vec::new(),
@@ -2638,8 +2644,8 @@ impl Inner {
                         },
                         cancellation.token(),
                         open_permit.clone(),
-                    )
-                    .await;
+                    ) => handle,
+                };
                 if cancellation.is_cancelled() {
                     handle.control.kill();
                     return Err("terminal open cancelled".to_owned());

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -443,6 +443,10 @@ struct OpeningOwner {
 #[derive(Default)]
 struct OpeningState {
     reservations: HashMap<String, OpeningOwner>,
+    /// Cancellation capability for each live reservation. The owner key
+    /// keeps a late timeout from cancelling a replacement that reused the
+    /// same pty id.
+    cancellations: HashMap<OpeningOwner, OpenCancellation>,
     /// The owner is part of the cancellation key. A late drop from an old
     /// reservation cannot clear a marker for a newer reservation of the same
     /// pty id.
@@ -513,6 +517,7 @@ impl Drop for OpeningReservation {
             if state.reservations.get(&self.id) == Some(&self.owner) {
                 state.reservations.remove(&self.id);
             }
+            state.cancellations.remove(&self.owner);
             if state.cancelled.get(&self.id) == Some(&self.owner) {
                 state.cancelled.remove(&self.id);
             }
@@ -837,6 +842,7 @@ impl PtyManager {
         let mut opening = self.inner.opening_state.lock().expect("opening state lock");
         if opening.reservations.get(pty_id) == Some(&owner) {
             opening.reservations.remove(pty_id);
+            opening.cancellations.remove(&owner);
             opening.cancelled.insert(pty_id.to_owned(), owner);
         }
     }
@@ -862,6 +868,9 @@ impl PtyManager {
                 .collect();
             for (id, owner) in cancelled {
                 opening.reservations.remove(&id);
+                if let Some(cancellation) = opening.cancellations.remove(&owner) {
+                    cancellation.cancel();
+                }
                 opening.cancelled.insert(id, owner);
             }
 
@@ -1025,6 +1034,7 @@ impl Inner {
                 ))
             } else {
                 opening.reservations.insert(pty_id.clone(), reservation_owner.clone());
+                opening.cancellations.insert(reservation_owner.clone(), cancellation.clone());
                 Ok(())
             }
         };
@@ -1209,6 +1219,7 @@ impl Inner {
                 if reservation_owned {
                     opening.reservations.remove(&pty_id);
                 }
+                opening.cancellations.remove(&reservation_owner);
                 if opening.cancelled.get(&pty_id) == Some(&reservation_owner) {
                     opening.cancelled.remove(&pty_id);
                 }
@@ -1233,6 +1244,7 @@ impl Inner {
                 },
             );
             opening.reservations.remove(&pty_id);
+            opening.cancellations.remove(&reservation_owner);
             opening.cancelled.remove(&pty_id);
             reservation.active = false;
             (surface, start, previous)

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -577,10 +577,6 @@ fn remove_cached_shell_if_same_without_viewers(
     session: &str,
     target: &Arc<ShellSession>,
 ) -> bool {
-    let mut shells = inner.shell_sessions.lock().expect("shell lock");
-    if !shells.get(session).is_some_and(|cached| Arc::ptr_eq(cached, target)) {
-        return false;
-    }
     // Serialize with viewer start. A concurrent opener may have cloned this
     // session but cannot publish its viewer while this dispatch lock is held.
     let _dispatch = target.dispatch_lock.lock().expect("shell dispatch lock");
@@ -589,15 +585,27 @@ fn remove_cached_shell_if_same_without_viewers(
     {
         return false;
     }
+    let mut shells = inner.shell_sessions.lock().expect("shell lock");
+    if !shells.get(session).is_some_and(|cached| Arc::ptr_eq(cached, target)) {
+        return false;
+    }
     shells.remove(session);
     true
 }
 
 fn reserve_cached_shell(inner: &Inner, session: &str) -> Option<Arc<ShellSession>> {
-    let shells = inner.shell_sessions.lock().expect("shell lock");
-    let existing = shells.get(session).cloned()?;
+    let existing = inner.shell_sessions.lock().expect("shell lock").get(session).cloned()?;
     let _dispatch = existing.dispatch_lock.lock().expect("shell dispatch lock");
     if !existing.inner.lock().expect("shell inner lock").alive {
+        return None;
+    }
+    if !inner
+        .shell_sessions
+        .lock()
+        .expect("shell lock")
+        .get(session)
+        .is_some_and(|cached| Arc::ptr_eq(cached, &existing))
+    {
         return None;
     }
     existing.pending_viewers.fetch_add(1, Ordering::AcqRel);
@@ -2843,12 +2851,14 @@ impl Inner {
                         inner.draining_viewers.clear();
                         std::mem::take(&mut inner.viewers)
                     };
-                    let mut shells = manager.shell_sessions.lock().expect("shell lock");
-                    if shells
-                        .get(&session_name)
-                        .is_some_and(|cached| Arc::ptr_eq(cached, &exit_session))
                     {
-                        shells.remove(&session_name);
+                        let mut shells = manager.shell_sessions.lock().expect("shell lock");
+                        if shells
+                            .get(&session_name)
+                            .is_some_and(|cached| Arc::ptr_eq(cached, &exit_session))
+                        {
+                            shells.remove(&session_name);
+                        }
                     }
                     for viewer in viewers {
                         let _delivery = viewer.delivery_lock.lock().expect("viewer delivery lock");

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -599,6 +599,19 @@ impl OpenCancellation {
     }
 }
 
+async fn request_control_with_cancellation(
+    control: &Arc<dyn ControlHandle>,
+    command: &str,
+    params: Value,
+    cancellation: &OpenCancellation,
+) -> Option<Value> {
+    tokio::select! {
+        biased;
+        _ = cancellation.token.cancelled() => None,
+        response = control.request(command, params) => response,
+    }
+}
+
 /// Attachments whose ownership has already been removed from the manager.
 /// The controls are retired after the caller releases any outer trust lock,
 /// so a slow platform kill cannot block authorization readers or a later
@@ -2017,7 +2030,14 @@ impl Inner {
             if cancellation.is_cancelled() {
                 return Err("terminal open cancelled".to_owned());
             }
-            let Some(listed) = control.request("list-workspaces", json!({})).await else {
+            let Some(listed) = request_control_with_cancellation(
+                &control,
+                "list-workspaces",
+                json!({}),
+                cancellation,
+            )
+            .await
+            else {
                 control.end();
                 return Err("cannot inspect existing daemon surfaces".to_owned());
             };
@@ -2052,8 +2072,13 @@ impl Inner {
                 if cancellation.is_cancelled() {
                     return Err("terminal open cancelled".to_owned());
                 }
-                let Some(info) =
-                    control.request("process-info", json!({ "surface": tab.surface_id })).await
+                let Some(info) = request_control_with_cancellation(
+                    &control,
+                    "process-info",
+                    json!({ "surface": tab.surface_id }),
+                    cancellation,
+                )
+                .await
                 else {
                     control.end();
                     return Err("cannot inspect existing surface cwd".to_owned());
@@ -2174,7 +2199,13 @@ impl Inner {
                 }
             };
             if !owner {
-                waiter.expect("shell waiter").await;
+                tokio::select! {
+                    biased;
+                    _ = cancellation.token().cancelled() => {
+                        return Err("terminal open cancelled".to_owned());
+                    }
+                    _ = waiter.expect("shell waiter") => {}
+                }
                 continue;
             }
             if self.shell_sessions.lock().expect("shell lock").len() >= self.max_ptys {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -458,6 +458,9 @@ struct Attachment {
     /// Serializes operations for this attachment only. The relay state lock
     /// must never be held while a PTY control method runs.
     operation_gate: Arc<Mutex<()>>,
+    /// Serializes PTY control calls for one attachment. Retirement never
+    /// waits on this gate, so a blocked provider cannot block detach.
+    control_gate: Arc<Mutex<()>>,
     /// Serializes open success publication with attachment retirement. This
     /// is separate because start callbacks can emit output and re-enter the
     /// operation gate.
@@ -1563,6 +1566,7 @@ impl Inner {
                     closing,
                     active_operations: Arc::new(AtomicUsize::new(0)),
                     operation_gate: Arc::new(Mutex::new(())),
+                    control_gate: Arc::new(Mutex::new(())),
                     publication_gate: Arc::clone(&publication_gate),
                     publication_state: Arc::new(AtomicU64::new(0)),
                     control,
@@ -1954,6 +1958,7 @@ impl Inner {
             Self::release_operation(&attachment);
             return false;
         }
+        let _control = attachment.control_gate.lock().expect("attachment control lock");
         operation(&attachment);
         Self::release_operation(&attachment);
         // The operation was admitted at the snapshot boundary and may finish
@@ -2558,9 +2563,9 @@ impl Inner {
                 {
                     return Err("cannot reattach existing shell under scoped roots".to_owned());
                 }
-                existing.control.resize(cols, rows);
                 existing.pending_viewers.fetch_add(1, Ordering::AcqRel);
                 pending_viewer.store(true, Ordering::Release);
+                existing.control.resize(cols, rows);
                 break existing;
             }
             let (notify, owner, waiter) = {
@@ -5018,6 +5023,7 @@ mod tests {
                     closing: Arc::new(AtomicBool::new(false)),
                     active_operations: Arc::new(AtomicUsize::new(0)),
                     operation_gate: Arc::new(Mutex::new(())),
+                    control_gate: Arc::new(Mutex::new(())),
                     publication_gate: Arc::new(Mutex::new(())),
                     publication_state: Arc::new(AtomicU64::new(0)),
                     control: slow,
@@ -5031,6 +5037,7 @@ mod tests {
                     closing: Arc::new(AtomicBool::new(false)),
                     active_operations: Arc::new(AtomicUsize::new(0)),
                     operation_gate: Arc::new(Mutex::new(())),
+                    control_gate: Arc::new(Mutex::new(())),
                     publication_gate: Arc::new(Mutex::new(())),
                     publication_state: Arc::new(AtomicU64::new(0)),
                     control: Arc::new(fast),
@@ -5087,6 +5094,7 @@ mod tests {
                     closing: Arc::new(AtomicBool::new(false)),
                     active_operations: Arc::new(AtomicUsize::new(0)),
                     operation_gate: Arc::new(Mutex::new(())),
+                    control_gate: Arc::new(Mutex::new(())),
                     publication_gate: Arc::new(Mutex::new(())),
                     publication_state: Arc::new(AtomicU64::new(0)),
                     control: Arc::new(BlockingControl {
@@ -5142,6 +5150,7 @@ mod tests {
                     closing: Arc::new(AtomicBool::new(false)),
                     active_operations: Arc::new(AtomicUsize::new(0)),
                     operation_gate: Arc::new(Mutex::new(())),
+                    control_gate: Arc::new(Mutex::new(())),
                     publication_gate: Arc::new(Mutex::new(())),
                     publication_state: Arc::new(AtomicU64::new(0)),
                     control: Arc::new(BlockingControl {
@@ -5218,6 +5227,7 @@ mod tests {
             closing: Arc::new(AtomicBool::new(false)),
             active_operations: Arc::new(AtomicUsize::new(0)),
             operation_gate: Arc::new(Mutex::new(())),
+            control_gate: Arc::new(Mutex::new(())),
             publication_gate: Arc::new(Mutex::new(())),
             publication_state: Arc::new(AtomicU64::new(0)),
             control: Arc::new(pty),

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -36,6 +36,7 @@ use tokio_util::sync::CancellationToken;
 use crate::actions::{expand_path, scrubbed_env, validate_request_path};
 use crate::control::ControlHandle;
 use crate::relay_wire::RelayPtyErrorCode;
+use crate::trust::Trust;
 
 pub const PTY_PROTOCOL_VERSION: u64 = 4;
 
@@ -899,6 +900,21 @@ fn send_pty_error(context: &FrameContext, pty_id: &str, code: &str, _message: &s
     }));
 }
 
+/// Validate the local authority before acquiring a PTY permit or creating an
+/// opening reservation. Tunnel state is a public boundary, so an unknown
+/// trust value must fail closed even when the normal producer only emits enum
+/// values.
+fn terminal_open_trust_allowed(context: &FrameContext, frame: &Value) -> bool {
+    let Some(trust) = Trust::parse(&context.trust) else {
+        return false;
+    };
+    if trust != Trust::Observe {
+        return true;
+    }
+    let actor = frame.get("actorId").and_then(Value::as_str).unwrap_or_default();
+    context.owner_user_id.as_deref().is_some_and(|owner| owner == actor)
+}
+
 fn send_typed_pty_error(
     context: &FrameContext,
     pty_id: &str,
@@ -927,6 +943,10 @@ impl Inner {
         }
         let pty_id = frame.get("ptyId").and_then(Value::as_str).unwrap_or_default().to_owned();
         if pty_id.is_empty() {
+            return;
+        }
+        if !terminal_open_trust_allowed(context, frame) {
+            send_pty_error(context, &pty_id, "trust_refused", "terminal trust is not established");
             return;
         }
         // Keep one permit for the complete provider/PTY open. A timeout may
@@ -1004,21 +1024,6 @@ impl Inner {
         // OWNER's terminal. Any trust level admits the owner.
         // Only locally established trust is authoritative. Missing local
         // state fails closed; the untrusted frame cannot elevate access.
-        let trust = context.trust.clone();
-        if trust.is_empty() {
-            fail("trust_refused", "terminal trust is not established");
-            return;
-        }
-        let owner = context.owner_user_id.as_deref();
-        let actor = frame.get("actorId").and_then(Value::as_str).unwrap_or_default();
-        if trust == "observe" && (owner.is_none() || Some(actor) != owner) {
-            fail(
-                "trust_refused",
-                "this machine is paired at observe trust; terminals are owner-only",
-            );
-            return;
-        }
-
         // cwd discipline: the local config and server-echoed root lists both
         // apply when present, else $HOME.
         let server_roots = match parse_allowed_roots(frame) {
@@ -3681,6 +3686,15 @@ mod tests {
         assert!(!state.cancelled.contains_key("reused"));
         assert!(old_cancellation.is_cancelled());
         assert!(!new_cancellation.is_cancelled());
+    }
+
+    #[test]
+    fn open_attempt_tokens_fail_closed_before_reuse_on_counter_wrap() {
+        let h = harness(None, None);
+        h.manager.inner.next_open_attempt.store(u64::MAX, Ordering::Relaxed);
+        let last = h.manager.new_open_cancellation().expect("last unique token");
+        assert_eq!(last.attempt_id(), u64::MAX);
+        assert!(h.manager.new_open_cancellation().is_none());
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -19,7 +19,7 @@
 //! every non-empty allowed root list; env scrubbed; per-pty buffered output capped; no
 //! empty frames; unknown ptyIds tolerated; refusals answer pty_error.
 
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -247,14 +247,17 @@ pub struct EnsureDaemon {
     pub socket_path: PathBuf,
 }
 
-/// Capacity owned by one in-flight PTY open. Blocking setup workers retain a
-/// clone until their closure returns, including when the async caller is
-/// cancelled.
+/// Opaque capacity owned by one in-flight PTY open.
+///
+/// `PtyDeps` implementations receive this value and must keep it alive until
+/// all blocking setup for the open has returned. Cloning the value is safe,
+/// and dropping every clone releases one slot. The constructor is private so
+/// callers cannot mint capacity outside `PtyManager` admission.
 #[derive(Clone)]
-pub(crate) struct OpenPermit(Arc<OwnedSemaphorePermit>);
+pub struct OpenPermit(Arc<OwnedSemaphorePermit>);
 
 impl OpenPermit {
-    fn new(permit: OwnedSemaphorePermit) -> Self {
+    pub(crate) fn new(permit: OwnedSemaphorePermit) -> Self {
         Self(Arc::new(permit))
     }
 }
@@ -382,6 +385,14 @@ impl AuthSnapshot {
     }
 }
 
+fn auth_snapshot_matches(left: &AuthSnapshot, right: &AuthSnapshot) -> bool {
+    left.trust == right.trust
+        && left.local_roots == right.local_roots
+        && left.owner_user_id == right.owner_user_id
+        && left.auth_generation == right.auth_generation
+        && left.transport_kind == right.transport_kind
+}
+
 /// Scrubbed env for interactive PTYs (actions.mjs base, real TERM).
 pub fn pty_env(base: &HashMap<String, String>) -> HashMap<String, String> {
     let mut env = scrubbed_env(base);
@@ -473,16 +484,11 @@ struct Inner {
     /// one global snapshot would let the last frame on either transport
     /// authorize asynchronous output for every other attachment.
     transport_auth: Mutex<HashMap<TransportOwner, AuthSnapshot>>,
-    /// A transport being replaced is fenced before its old snapshot is
-    /// removed. This closes the gap in which a stale frame could otherwise
-    /// repopulate the cache while its opening is being cancelled.
-    revoked_transports: Mutex<HashSet<TransportOwner>>,
-    /// A transport that has disconnected is permanently fenced for the life
-    /// of this manager. Relay transport ids are random per connection and
-    /// must never be reused, so a late frame cannot clear this tombstone by
-    /// publishing another snapshot with the same id. A reconnect receives a
-    /// new owner instead.
-    detached_transports: Mutex<HashSet<TransportOwner>>,
+    /// Serializes authority replacement. The lock spans the short map
+    /// transition and the detached-attachment scan, but never platform I/O.
+    /// Without this separate lock, two concurrent refreshes could each
+    /// observe the same old snapshot and publish in reverse order.
+    transport_auth_updates: Mutex<()>,
     /// Serializes short authority and attachment state transitions. It is
     /// never held while a PTY control method, callback, or provider await runs.
     tunnel_state: Mutex<()>,
@@ -667,8 +673,7 @@ impl PtyManager {
                 shell_sessions: Mutex::new(HashMap::new()),
                 shell_starting: Mutex::new(HashMap::new()),
                 transport_auth: Mutex::new(HashMap::new()),
-                revoked_transports: Mutex::new(HashSet::new()),
-                detached_transports: Mutex::new(HashSet::new()),
+                transport_auth_updates: Mutex::new(()),
                 tunnel_state: Mutex::new(()),
                 tunnel_authority_generation: AtomicU64::new(0),
                 next_open_attempt: AtomicU64::new(1),
@@ -698,8 +703,7 @@ impl PtyManager {
                 shell_sessions: Mutex::new(HashMap::new()),
                 shell_starting: Mutex::new(HashMap::new()),
                 transport_auth: Mutex::new(HashMap::new()),
-                revoked_transports: Mutex::new(HashSet::new()),
-                detached_transports: Mutex::new(HashSet::new()),
+                transport_auth_updates: Mutex::new(()),
                 tunnel_state: Mutex::new(()),
                 tunnel_authority_generation: AtomicU64::new(0),
                 next_open_attempt: AtomicU64::new(1),
@@ -809,65 +813,50 @@ impl PtyManager {
 
     /// Publish the authoritative snapshot for one live transport. This is
     /// called only after the relay has reconciled trust, roots, and owner.
-    /// Network frames never get to replace an existing snapshot implicitly.
+    /// Network frames never get to register or replace an existing snapshot
+    /// implicitly. Callers must publish this snapshot before dispatching the
+    /// first frame for an identified transport.
     pub fn update_transport_auth(&self, context: &FrameContext) {
         debug_assert!(context.transport_id.is_some(), "transport refresh needs an id");
-        if Trust::parse(&context.trust).is_none() {
+        if context.transport_id.is_none()
+            || context.cancellation.is_cancelled()
+            || Trust::parse(&context.trust).is_none()
+        {
             return;
         }
         let owner = TransportOwner::from_context(context);
         let snapshot = AuthSnapshot::from_context(context);
-        // Fence a changed snapshot before removing its reservations. The
-        // marker makes stale frames fail closed while the per-attachment gate
-        // drains any operation already in progress.
+        // Serialize replacement. A changed snapshot is removed before the
+        // new one is published, so stale frames cannot re-register it during
+        // attachment cleanup.
+        let _update = self.inner.transport_auth_updates.lock().expect("transport auth update lock");
         let changed = {
             let _state = self.inner.tunnel_state.lock().expect("tunnel state lock");
-            if !self.inner.tunnel_authority_generation_current(context) {
-                return;
-            }
-            if self
-                .inner
-                .detached_transports
-                .lock()
-                .expect("detached transport lock")
-                .contains(&owner)
+            if context.cancellation.is_cancelled()
+                || !self.inner.tunnel_authority_generation_current(context)
             {
-                // A disconnected owner is never re-authorized. A reconnect
-                // must use its freshly generated transport id.
                 return;
             }
-            let mut revoked = self.inner.revoked_transports.lock().expect("revoked transport lock");
             let transport_auth = self.inner.transport_auth.lock().expect("transport auth lock");
-            let changed = transport_auth.get(&owner).is_some_and(|current| {
-                current.trust != snapshot.trust
-                    || current.local_roots != snapshot.local_roots
-                    || current.owner_user_id != snapshot.owner_user_id
-                    || current.auth_generation != snapshot.auth_generation
-                    || current.transport_kind != snapshot.transport_kind
-            });
-            if changed {
-                revoked.insert(owner.clone());
-            }
+            let changed = transport_auth
+                .get(&owner)
+                .is_some_and(|current| !auth_snapshot_matches(current, &snapshot));
             changed
         };
         if changed {
-            self.inner.detach_matching(|candidate| candidate == &owner, false).retire();
+            self.inner.detach_matching_locked(|candidate| candidate == &owner).retire();
         }
         let _state = self.inner.tunnel_state.lock().expect("tunnel state lock");
-        if !self.inner.tunnel_authority_generation_current(context) {
-            return;
-        }
-        if self.inner.detached_transports.lock().expect("detached transport lock").contains(&owner)
+        if context.cancellation.is_cancelled()
+            || !self.inner.tunnel_authority_generation_current(context)
         {
             return;
         }
-        let mut revoked = self.inner.revoked_transports.lock().expect("revoked transport lock");
         self.inner
             .transport_auth
             .lock()
             .expect("transport auth lock")
             .insert(owner.clone(), snapshot);
-        revoked.remove(&owner);
     }
 
     /// Advance the managed tunnel authority floor before publishing the
@@ -906,24 +895,13 @@ impl PtyManager {
     /// must use `detach_transport` so it cannot detach attachments the
     /// managed tunnel listener (or another socket) owns.
     pub fn detach_all(&self) {
-        self.detach_matching(|_| true, true).retire();
+        self.detach_matching(|_| true).retire();
     }
 
     /// One transport dropped: release only its attachments and cancel only
     /// its in-flight opens. Sessions live on either way (docs/TERMINAL.md).
     pub fn detach_transport(&self, transport_id: &str) {
-        // This legacy entry point does not carry a transport class. Fence
-        // every possible typed identity before scanning cached state, so an
-        // owner that disconnects before its first frame cannot be recreated.
-        {
-            let _state = self.inner.tunnel_state.lock().expect("tunnel state lock");
-            let mut detached =
-                self.inner.detached_transports.lock().expect("detached transport lock");
-            for kind in [TransportKind::Legacy, TransportKind::Relay, TransportKind::Tunnel] {
-                detached.insert(TransportOwner { id: Some(transport_id.to_owned()), kind });
-            }
-        }
-        self.detach_matching(|owner| owner.id.as_deref() == Some(transport_id), true).retire();
+        self.detach_matching(|owner| owner.id.as_deref() == Some(transport_id)).retire();
     }
 
     /// One typed transport dropped. This avoids treating an opaque relay ID
@@ -931,22 +909,11 @@ impl PtyManager {
     pub fn detach_transport_kind(&self, transport_id: &str, kind: TransportKind) {
         let owner = TransportOwner { id: Some(transport_id.to_owned()), kind };
         let target_owner = owner;
-        // Publish the exact owner fence before scanning cached state. The
-        // owner may disconnect before its first frame, so there may be no
-        // auth snapshot, reservation, or attachment for `detach_matching` to
-        // discover. `cache_transport_auth` takes the same state boundary and
-        // therefore cannot recreate this owner after the fence is visible.
-        {
-            let _state = self.inner.tunnel_state.lock().expect("tunnel state lock");
-            self.inner
-                .detached_transports
-                .lock()
-                .expect("detached transport lock")
-                .insert(owner.clone());
-        }
-        // The matcher publishes the disconnect fence before removing state.
-        // A queued frame can then never repopulate the vacant cache.
-        self.detach_matching(move |candidate| candidate == &target_owner, true).retire();
+        // Identified transports must be registered explicitly. Removing the
+        // active snapshot is therefore sufficient to reject a queued frame,
+        // including one from a connection that disconnected before its first
+        // frame. A reconnect gets a fresh random identity.
+        self.detach_matching(move |candidate| candidate == &target_owner).retire();
     }
 
     /// Release all managed tunnel attachments. The relay connection clears
@@ -961,7 +928,7 @@ impl PtyManager {
     /// This lets session reconciliation release the global trust lock before
     /// touching platform PTY state.
     pub fn detach_tunnel_transports_deferred(&self) -> RetiredAttachments {
-        self.detach_matching(|owner| owner.kind == TransportKind::Tunnel, true)
+        self.detach_matching(|owner| owner.kind == TransportKind::Tunnel)
     }
 
     /// Cancel one opening reservation at the timeout boundary. The capability
@@ -989,31 +956,24 @@ impl PtyManager {
         }
     }
 
-    fn detach_matching(
-        &self,
-        owns: impl Fn(&TransportOwner) -> bool,
-        fence_detached: bool,
-    ) -> RetiredAttachments {
+    fn detach_matching(&self, owns: impl Fn(&TransportOwner) -> bool) -> RetiredAttachments {
+        let _update = self.inner.transport_auth_updates.lock().expect("transport auth update lock");
+        self.detach_matching_locked(owns)
+    }
+
+    /// Remove one ownership set while the authority-update lock is held.
+    /// Callers must retire the returned controls after the state boundary.
+    fn detach_matching_locked(&self, owns: impl Fn(&TransportOwner) -> bool) -> RetiredAttachments {
         // Revoke the transport snapshot and opening reservations at one
         // authority boundary. Do not wait for an attachment operation while
         // holding the state lock: output/control callbacks take the gate
         // before that lock, so waiting here would deadlock the relay.
         let candidates = {
             let _state = self.inner.tunnel_state.lock().expect("tunnel state lock");
-            let mut detached =
-                self.inner.detached_transports.lock().expect("detached transport lock");
             let mut transport_auth = self.inner.transport_auth.lock().expect("transport auth lock");
-            // Every live opening and attachment is admitted through an auth
-            // snapshot. On a real disconnect, fence matching identities
-            // before removing state. Authority replacement uses the same
-            // cleanup without a terminal disconnect fence.
-            if fence_detached {
-                for owner in transport_auth.keys().filter(|owner| owns(owner)) {
-                    if owner.id.is_some() {
-                        detached.insert(owner.clone());
-                    }
-                }
-            }
+            // Every identified opening and attachment is admitted through an
+            // active auth snapshot. Removing that snapshot is the disconnect
+            // fence. No historical tombstone is stored.
             transport_auth.retain(|owner, _| !owns(owner));
             let mut opening = self.inner.opening_state.lock().expect("opening state lock");
             let cancelled: Vec<(String, OpeningOwner)> = opening
@@ -1022,13 +982,6 @@ impl PtyManager {
                 .filter(|(_, owner)| owns(&owner.owner))
                 .map(|(id, owner)| (id.clone(), owner.clone()))
                 .collect();
-            if fence_detached {
-                for (_, owner) in &cancelled {
-                    if owner.owner.id.is_some() {
-                        detached.insert(owner.owner.clone());
-                    }
-                }
-            }
             for (id, owner) in cancelled {
                 opening.reservations.remove(&id);
                 if let Some(cancellation) = opening.cancellations.remove(&owner) {
@@ -1044,10 +997,7 @@ impl PtyManager {
                     (id.clone(), owner.clone(), cancellation.clone())
                 })
                 .collect();
-            for (id, owner, cancellation) in active {
-                if fence_detached && owner.owner.id.is_some() {
-                    detached.insert(owner.owner.clone());
-                }
+            for (id, _owner, cancellation) in active {
                 opening.active_openings.remove(&id);
                 cancellation.cancel();
             }
@@ -1061,13 +1011,6 @@ impl PtyManager {
                 .filter(|(_, attachment)| owns(&attachment.owner))
                 .map(|(id, attachment)| (id.clone(), attachment.clone()))
                 .collect::<Vec<_>>();
-            if fence_detached {
-                for (_, attachment) in &candidates {
-                    if attachment.owner.id.is_some() {
-                        detached.insert(attachment.owner.clone());
-                    }
-                }
-            }
             candidates
         };
 
@@ -1776,14 +1719,11 @@ impl Inner {
     }
 
     fn auth_for_transport(&self, context: &FrameContext) -> Option<AuthSnapshot> {
+        if context.cancellation.is_cancelled() {
+            return None;
+        }
         let key = TransportOwner::from_context(context);
         let _state = self.tunnel_state.lock().expect("tunnel state lock");
-        if self.detached_transports.lock().expect("detached transport lock").contains(&key) {
-            return None;
-        }
-        if self.revoked_transports.lock().expect("revoked transport lock").contains(&key) {
-            return None;
-        }
         self.transport_auth.lock().expect("transport auth lock").get(&key).cloned()
     }
 
@@ -1908,20 +1848,15 @@ impl Inner {
     }
 
     fn transport_auth_is_current(&self, context: &FrameContext, auth: &AuthSnapshot) -> bool {
-        if Self::matching_trust(auth, context).is_none() {
+        if context.cancellation.is_cancelled() || Self::matching_trust(auth, context).is_none() {
             return false;
         }
         let key = TransportOwner::from_context(context);
-        if self.revoked_transports.lock().expect("revoked transport lock").contains(&key) {
-            return false;
-        }
-        self.transport_auth.lock().expect("transport auth lock").get(&key).is_some_and(|current| {
-            current.trust == auth.trust
-                && current.local_roots == auth.local_roots
-                && current.owner_user_id == auth.owner_user_id
-                && current.auth_generation == auth.auth_generation
-                && current.transport_kind == auth.transport_kind
-        })
+        self.transport_auth
+            .lock()
+            .expect("transport auth lock")
+            .get(&key)
+            .is_some_and(|current| auth_snapshot_matches(current, auth))
     }
 
     fn handle_authorization_failure(
@@ -2056,53 +1991,32 @@ impl Inner {
     fn cache_transport_auth(&self, context: &FrameContext) -> bool {
         // The frame context is a security boundary. Never let an unknown
         // trust string reuse a previously cached valid snapshot.
-        if Trust::parse(&context.trust).is_none() {
+        if context.cancellation.is_cancelled() || Trust::parse(&context.trust).is_none() {
             return false;
         }
         let _state = self.tunnel_state.lock().expect("tunnel state lock");
-        if !self.tunnel_authority_generation_current(context) {
+        if context.cancellation.is_cancelled() || !self.tunnel_authority_generation_current(context)
+        {
             return false;
         }
         let snapshot = AuthSnapshot::from_context(context);
         let owner = TransportOwner::from_context(context);
-        if self.detached_transports.lock().expect("detached transport lock").contains(&owner) {
-            // Disconnect is terminal for this transport identity. Do not let
-            // a queued frame recreate an entry after detach removed it.
-            return false;
-        }
-        let revoked =
-            self.revoked_transports.lock().expect("revoked transport lock").contains(&owner);
-        if revoked {
-            return false;
-        }
-        let mut transport_auth = self.transport_auth.lock().expect("transport auth lock");
         if context.transport_id.is_none() {
             // Legacy whole-manager callers use `None` and provide the
             // current trust on each frame. Keep that contract for non-
             // transport code.
-            transport_auth.insert(owner, snapshot);
-        } else {
-            // A connection can have an open in flight while trust is
-            // renegotiated. Do not let that stale frame overwrite the
-            // authoritative snapshot; session code calls
-            // `update_transport_auth` at each reconciliation boundary.
-            match transport_auth.entry(owner) {
-                std::collections::hash_map::Entry::Vacant(entry) => {
-                    entry.insert(snapshot);
-                }
-                std::collections::hash_map::Entry::Occupied(entry) => {
-                    let cached = entry.get();
-                    if cached.trust != snapshot.trust
-                        || cached.local_roots != snapshot.local_roots
-                        || cached.owner_user_id != snapshot.owner_user_id
-                        || cached.auth_generation != snapshot.auth_generation
-                    {
-                        return false;
-                    }
-                }
-            }
+            self.transport_auth.lock().expect("transport auth lock").insert(owner, snapshot);
+            return true;
         }
-        true
+        // Identified transports must publish authority through
+        // `update_transport_auth` before their first frame. A frame cannot
+        // create a new map entry, so removing the active snapshot is a
+        // complete disconnect fence without an unbounded tombstone set.
+        self.transport_auth
+            .lock()
+            .expect("transport auth lock")
+            .get(&owner)
+            .is_some_and(|cached| auth_snapshot_matches(cached, &snapshot))
     }
 
     fn matching_trust(auth: &AuthSnapshot, context: &FrameContext) -> Option<Trust> {
@@ -3621,6 +3535,7 @@ mod tests {
             });
             let context =
                 self.context_with_transport("supervised", self.owner.clone(), Some(transport_id));
+            self.manager.update_transport_auth(&context);
             self.manager.handle_frame(&frame, &context).await;
         }
 
@@ -3766,6 +3681,7 @@ mod tests {
         });
         let mut trusted = h.context_with_transport("supervised", h.owner.clone(), Some("tunnel-a"));
         trusted.transport_kind = TransportKind::Tunnel;
+        h.manager.update_transport_auth(&trusted);
         h.manager.handle_frame(&frame, &trusted).await;
         let pty = h.spawned()[0].clone();
 

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2636,6 +2636,7 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
     use std::sync::{Arc as TestArc, Barrier, Mutex as StdMutex, mpsc::sync_channel};
     use std::thread;
+    use std::time::Duration;
 
     static NEXT_TEST_DIRECTORY: AtomicU64 = AtomicU64::new(0);
 
@@ -3584,9 +3585,9 @@ mod tests {
         entered.wait();
 
         let (done_tx, done_rx) = sync_channel(1);
-        let revoke_inner = Arc::clone(&inner);
+        let revoke_manager = PtyManager { inner: Arc::clone(&inner) };
         let revoke = thread::spawn(move || {
-            revoke_inner.detach_tunnel_transports();
+            revoke_manager.detach_tunnel_transports();
             done_tx.send(()).unwrap();
         });
         let completed_without_waiting = done_rx.recv_timeout(Duration::from_millis(250)).is_ok();
@@ -3702,8 +3703,8 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn cancelled_open_is_fenced_before_its_task_is_first_polled() {
         let h = harness(None, None);
-        let manager = Arc::new(h.manager);
         let context = h.context_with_transport("supervised", h.owner.clone(), Some("tunnel-a"));
+        let manager = Arc::new(h.manager);
         let frame = serde_json::json!({
             "version": 4,
             "type": "pty_open",

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -31,6 +31,7 @@ use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use bytes::Bytes;
 use serde_json::{Value, json};
+use tokio_util::sync::CancellationToken;
 
 use crate::actions::{expand_path, scrubbed_env, validate_request_path};
 use crate::control::ControlHandle;
@@ -559,12 +560,28 @@ impl PtyManager {
 
     /// Handle one Worker -> relay PTY frame.
     pub async fn handle_frame(&self, frame: &Value, context: &FrameContext) {
+        self.handle_frame_with_open_cancellation(frame, context, None).await;
+    }
+
+    /// Handle a frame whose `pty_open` is owned by a connection-level
+    /// cancellation token. The token is created before the task is spawned,
+    /// so a deadline or disconnect can fence an open even when its task has
+    /// not received its first poll yet.
+    pub(crate) async fn handle_frame_with_open_cancellation(
+        &self,
+        frame: &Value,
+        context: &FrameContext,
+        cancellation: Option<CancellationToken>,
+    ) {
+        if cancellation.as_ref().is_some_and(|token| token.is_cancelled()) {
+            return;
+        }
         let frame_type = frame.get("type").and_then(Value::as_str).unwrap_or_default();
         if !self.inner.cache_transport_auth(context) {
             return;
         }
         match frame_type {
-            "pty_open" => self.inner.clone().open(frame, context).await,
+            "pty_open" => self.inner.clone().open(frame, context, cancellation).await,
             "pty_input" => {
                 let Some(pty_id) = frame.get("ptyId").and_then(Value::as_str) else { return };
                 if !self.inner.tunnel_authority_generation_current(context) {
@@ -821,7 +838,15 @@ fn send_typed_pty_error(
 }
 
 impl Inner {
-    async fn open(self: Arc<Self>, frame: &Value, context: &FrameContext) {
+    async fn open(
+        self: Arc<Self>,
+        frame: &Value,
+        context: &FrameContext,
+        cancellation: Option<CancellationToken>,
+    ) {
+        if cancellation.as_ref().is_some_and(|token| token.is_cancelled()) {
+            return;
+        }
         let pty_id = frame.get("ptyId").and_then(Value::as_str).unwrap_or_default().to_owned();
         if pty_id.is_empty() {
             return;
@@ -837,6 +862,9 @@ impl Inner {
                 return;
             }
         };
+        if cancellation.as_ref().is_some_and(|token| token.is_cancelled()) {
+            return;
+        }
         if !self.tunnel_authority_generation_current(context) {
             send_pty_error(context, &pty_id, "trust_revoked", "tunnel authority changed");
             return;
@@ -941,6 +969,9 @@ impl Inner {
         let env = pty_env(&self.env);
 
         let cmux_tui = self.deps.resolve_cmux_tui().await;
+        if cancellation.as_ref().is_some_and(|token| token.is_cancelled()) {
+            return;
+        }
         let opened = if let (Some(cmux_tui), Some(surface_ref)) =
             (cmux_tui.as_ref(), surface_ref.as_ref())
         {
@@ -1030,9 +1061,16 @@ impl Inner {
                 });
             let mut opening = self.opening_state.lock().expect("opening state lock");
             let cancelled = opening.cancelled.get(&pty_id) == Some(&reservation_owner);
+            let externally_cancelled =
+                cancellation.as_ref().is_some_and(|token| token.is_cancelled());
             let authority_changed = !self.tunnel_authority_generation_current(context);
             let reservation_owned = opening.reservations.get(&pty_id) == Some(&reservation_owner);
-            if !reservation_owned || cancelled || auth_changed || authority_changed {
+            if !reservation_owned
+                || cancelled
+                || externally_cancelled
+                || auth_changed
+                || authority_changed
+            {
                 if reservation_owned {
                     opening.reservations.remove(&pty_id);
                 }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -4115,6 +4115,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn closing_an_in_flight_open_cancels_provider_resolution() {
+        let entered = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        let gate =
+            Arc::new(ResolveGate { entered: Arc::clone(&entered), release: Arc::clone(&release) });
+        let h = harness_with_control_and_gate(None, None, None, None, Some(gate));
+        let context = h.context_with_transport("supervised", h.owner.clone(), Some("tunnel-a"));
+        let manager = Arc::new(h.manager);
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "p1",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+        });
+        let cancellation = manager.new_open_cancellation().expect("open attempt token");
+        let task_manager = Arc::clone(&manager);
+        let task_context = context.clone();
+        let task_cancellation = cancellation.clone();
+        let task = tokio::spawn(async move {
+            task_manager
+                .handle_frame_with_open_cancellation(&frame, &task_context, Some(task_cancellation))
+                .await;
+        });
+
+        // Provider resolution is paused only after the reservation is live.
+        // Close must signal the exact open before allowing the provider to
+        // continue, independent of scheduler timing.
+        entered.notified().await;
+        manager.inner.close("p1");
+        assert!(cancellation.is_cancelled());
+
+        release.notify_one();
+        task.await.unwrap();
+        assert_eq!(manager.attachment_count(), 0);
+    }
+
+    #[tokio::test]
     async fn blocking_open_worker_keeps_its_permit_until_completion() {
         let slots = Arc::new(Semaphore::new(1));
         let permit = OpenPermit::new(slots.clone().try_acquire_owned().expect("open permit"));

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1854,10 +1854,8 @@ impl Inner {
         {
             return;
         }
-        // The gate protects the final lifecycle check. Do not hold it across
-        // the transport callback because a stalled sink must not block detach
-        // or trust revocation.
-        drop(delivery);
+        // send_live is a bounded, non-blocking transport enqueue. Keep the
+        // gate through it so concurrent output and exit frames retain order.
         let frame = json!({
             "version": PTY_PROTOCOL_VERSION,
             "type": "pty_output",
@@ -1865,6 +1863,7 @@ impl Inner {
             "dataB64": BASE64.encode(chunk),
         });
         (auth.send_live)(frame, Arc::clone(&attachment.delivery_live));
+        drop(delivery);
     }
 
     fn emit_exit(&self, pty_id: &str, code: i64, context: &FrameContext) {
@@ -5431,8 +5430,10 @@ mod tests {
                     if live.load(Ordering::Acquire) {
                         sent.lock().unwrap().push(frame);
                     }
-                    entered.wait();
-                    release.wait();
+                    thread::spawn(move || {
+                        entered.wait();
+                        release.wait();
+                    });
                 })
             },
             buffered_amount: Arc::new(|| 0),

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1679,9 +1679,11 @@ impl Inner {
 
     fn emit_output(&self, pty_id: &str, chunk: &Bytes, context: &FrameContext) {
         if !self.tunnel_authority_generation_current(context) {
+            self.retire_stale_transport_attachment(pty_id, context);
             return;
         }
         let Some(auth) = self.auth_for_transport(context) else {
+            self.retire_stale_transport_attachment(pty_id, context);
             return;
         };
         let Some(attachment) = self.attachment(pty_id) else {
@@ -1739,9 +1741,11 @@ impl Inner {
 
     fn emit_exit(&self, pty_id: &str, code: i64, context: &FrameContext) {
         if !self.tunnel_authority_generation_current(context) {
+            self.retire_stale_transport_attachment(pty_id, context);
             return;
         }
         let Some(auth) = self.auth_for_transport(context) else {
+            self.retire_stale_transport_attachment(pty_id, context);
             return;
         };
         let Some(attachment) = self.attachment(pty_id) else {
@@ -2058,6 +2062,13 @@ impl Inner {
     fn attachment_snapshot_is_current(&self, pty_id: &str, attachment: &Attachment) -> bool {
         !attachment.closing.load(Ordering::Acquire)
             && self.attachment_is_current(pty_id, attachment)
+    }
+
+    fn retire_stale_transport_attachment(&self, pty_id: &str, context: &FrameContext) {
+        let Some(attachment) = self.attachment(pty_id) else { return };
+        if attachment.owner == TransportOwner::from_context(context) {
+            self.retire_if_current(pty_id, &attachment);
+        }
     }
 
     fn try_claim_publication(attachment: &Attachment) -> bool {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -3098,8 +3098,7 @@ mod tests {
             "rows": 24,
             "actorId": "user_owner",
         });
-        let mut trusted =
-            h.context_with_transport("supervised", h.owner.clone(), Some("tunnel-a"));
+        let mut trusted = h.context_with_transport("supervised", h.owner.clone(), Some("tunnel-a"));
         trusted.transport_kind = TransportKind::Tunnel;
         h.manager.handle_frame(&frame, &trusted).await;
         let pty = h.spawned()[0].clone();

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -458,6 +458,10 @@ struct Attachment {
     /// is separate because start callbacks can emit output and re-enter the
     /// operation gate.
     publication_gate: Arc<Mutex<()>>,
+    /// Even values admit output publication. Revocation flips the low bit,
+    /// giving emitters an atomic linearization point without waiting on the
+    /// transport callback.
+    publication_state: Arc<AtomicU64>,
     /// Releases this attachment (detach a viewer, close a control stream,
     /// kill a viewer PTY) — never kills a shared session.
     control: Arc<dyn PtyControl>,
@@ -1063,6 +1067,7 @@ impl PtyManager {
             let publication =
                 candidate.publication_gate.lock().expect("attachment publication lock");
             let operation = candidate.operation_gate.lock().expect("attachment operation lock");
+            Self::revoke_publication(&candidate);
             candidate.closing.store(true, Ordering::Release);
             let removed = {
                 let _state = self.inner.tunnel_state.lock().expect("tunnel state lock");
@@ -1536,6 +1541,7 @@ impl Inner {
                     active_operations: Arc::new(AtomicUsize::new(0)),
                     operation_gate: Arc::new(Mutex::new(())),
                     publication_gate: Arc::clone(&publication_gate),
+                    publication_state: Arc::new(AtomicU64::new(0)),
                     control,
                     actor_id: actor.to_owned(),
                     owner: TransportOwner::from_context(context),
@@ -1569,6 +1575,7 @@ impl Inner {
                 let _state = self.tunnel_state.lock().expect("tunnel state lock");
                 let mut attachments = self.attachments.lock().expect("attach lock");
                 if let Some(current) = attachments.get(&pty_id) {
+                    Self::revoke_publication(current);
                     current.closing.store(true, Ordering::Release);
                 }
                 attachments.remove(&pty_id)
@@ -1696,11 +1703,12 @@ impl Inner {
             );
             return;
         }
-        // This final identity check is the publication linearization point.
-        // A concurrent detach may complete after the check, in which case
-        // this already-admitted frame is ordered before that detach. It can
-        // never block retirement while the callback runs.
-        if !self.attachment_snapshot_is_current(pty_id, &attachment) {
+        // Claim publication atomically with revocation. If detach wins the
+        // claim, no callback runs. If this claim wins first, the frame is
+        // ordered before detach even if the callback itself is slow.
+        if !self.attachment_snapshot_is_current(pty_id, &attachment)
+            || !Self::try_claim_publication(&attachment)
+        {
             return;
         }
         (auth.send)(json!({
@@ -1734,6 +1742,7 @@ impl Inner {
             return;
         }
         let removed = {
+            Self::revoke_publication(&attachment);
             attachment.closing.store(true, Ordering::Release);
             let _state = self.tunnel_state.lock().expect("tunnel state lock");
             let mut attachments = self.attachments.lock().expect("attach lock");
@@ -2032,6 +2041,29 @@ impl Inner {
             && self.attachment_is_current(pty_id, attachment)
     }
 
+    fn try_claim_publication(attachment: &Attachment) -> bool {
+        loop {
+            let state = attachment.publication_state.load(Ordering::Acquire);
+            if state & 1 != 0 {
+                return false;
+            }
+            let next = state.wrapping_add(2);
+            match attachment.publication_state.compare_exchange_weak(
+                state,
+                next,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return true,
+                Err(_) => continue,
+            }
+        }
+    }
+
+    fn revoke_publication(attachment: &Attachment) {
+        attachment.publication_state.fetch_or(1, Ordering::AcqRel);
+    }
+
     fn transport_auth_is_current(&self, context: &FrameContext, auth: &AuthSnapshot) -> bool {
         if context.cancellation.is_cancelled()
             || Self::matching_trust(auth, context).is_none()
@@ -2084,6 +2116,7 @@ impl Inner {
         // Callers must release any prior guard before entering this helper.
         let publication = attachment.publication_gate.lock().expect("attachment publication lock");
         let operation = attachment.operation_gate.lock().expect("attachment operation lock");
+        Self::revoke_publication(attachment);
         attachment.closing.store(true, Ordering::Release);
         let removed = {
             let _state = self.tunnel_state.lock().expect("tunnel state lock");
@@ -2105,6 +2138,7 @@ impl Inner {
         // was linearized before removal from the attachment map; killing the
         // control concurrently closes that admitted operation when the
         // platform permits it, while this transition remains bounded.
+        Self::revoke_publication(&attachment);
         attachment.closing.store(true, Ordering::SeqCst);
         attachment.control.kill();
     }
@@ -4816,6 +4850,7 @@ mod tests {
                     active_operations: Arc::new(AtomicUsize::new(0)),
                     operation_gate: Arc::new(Mutex::new(())),
                     publication_gate: Arc::new(Mutex::new(())),
+                    publication_state: Arc::new(AtomicU64::new(0)),
                     control: slow,
                     actor_id: "user_owner".to_owned(),
                     owner: owner_a,
@@ -4828,6 +4863,7 @@ mod tests {
                     active_operations: Arc::new(AtomicUsize::new(0)),
                     operation_gate: Arc::new(Mutex::new(())),
                     publication_gate: Arc::new(Mutex::new(())),
+                    publication_state: Arc::new(AtomicU64::new(0)),
                     control: Arc::new(fast),
                     actor_id: "user_owner".to_owned(),
                     owner: owner_b,
@@ -4883,6 +4919,7 @@ mod tests {
                     active_operations: Arc::new(AtomicUsize::new(0)),
                     operation_gate: Arc::new(Mutex::new(())),
                     publication_gate: Arc::new(Mutex::new(())),
+                    publication_state: Arc::new(AtomicU64::new(0)),
                     control: Arc::new(BlockingControl {
                         entered: Arc::clone(&entered),
                         release: Arc::clone(&release),
@@ -4937,6 +4974,7 @@ mod tests {
                     active_operations: Arc::new(AtomicUsize::new(0)),
                     operation_gate: Arc::new(Mutex::new(())),
                     publication_gate: Arc::new(Mutex::new(())),
+                    publication_state: Arc::new(AtomicU64::new(0)),
                     control: Arc::new(BlockingControl {
                         entered: Arc::clone(&entered),
                         release: Arc::clone(&release),
@@ -5012,6 +5050,7 @@ mod tests {
             active_operations: Arc::new(AtomicUsize::new(0)),
             operation_gate: Arc::new(Mutex::new(())),
             publication_gate: Arc::new(Mutex::new(())),
+            publication_state: Arc::new(AtomicU64::new(0)),
             control: Arc::new(pty),
             actor_id: "user_owner".to_owned(),
             owner: TransportOwner {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1109,6 +1109,7 @@ impl PtyManager {
             let publication =
                 candidate.publication_gate.lock().expect("attachment publication lock");
             let operation = candidate.operation_gate.lock().expect("attachment operation lock");
+            let delivery = candidate.delivery_gate.lock().expect("attachment delivery lock");
             Self::revoke_publication(&candidate);
             candidate.closing.store(true, Ordering::Release);
             let removed = {
@@ -1122,6 +1123,7 @@ impl PtyManager {
             if let Some(removed) = removed {
                 retired.push(removed);
             }
+            drop(delivery);
             drop(operation);
             drop(publication);
         }
@@ -1803,6 +1805,14 @@ impl Inner {
             return;
         }
         let _delivery = attachment.delivery_gate.lock().expect("attachment delivery lock");
+        // Retirement takes the same delivery gate before revocation. Recheck
+        // after a wait so a claim made before detach cannot call the
+        // transport after that attachment has been revoked or removed.
+        if !self.attachment_snapshot_is_current(pty_id, &attachment)
+            || attachment.publication_state.load(Ordering::Acquire) & 1 != 0
+        {
+            return;
+        }
         (auth.send)(json!({
             "version": PTY_PROTOCOL_VERSION,
             "type": "pty_output",
@@ -1851,6 +1861,7 @@ impl Inner {
             self.handle_authorization_failure(pty_id, &attachment, &auth, context, "exit");
             return;
         }
+        let _delivery = attachment.delivery_gate.lock().expect("attachment delivery lock");
         let removed = {
             Self::revoke_publication(&attachment);
             attachment.closing.store(true, Ordering::Release);
@@ -1868,7 +1879,6 @@ impl Inner {
         // lifecycle state before invoking the callback.
         drop(_operation);
         drop(_publication);
-        let _delivery = attachment.delivery_gate.lock().expect("attachment delivery lock");
         (auth.send)(json!({
             "version": PTY_PROTOCOL_VERSION,
             "type": "pty_exit",
@@ -2137,6 +2147,7 @@ impl Inner {
             self.handle_authorization_failure(pty_id, &attachment, &auth, context, "close");
             return;
         }
+        let _delivery = attachment.delivery_gate.lock().expect("attachment delivery lock");
         let removed = {
             Self::revoke_publication(&attachment);
             attachment.closing.store(true, Ordering::Release);
@@ -2150,6 +2161,7 @@ impl Inner {
         if removed {
             // Killing a PTY can acquire a platform mutex. Keep it outside the
             // lifecycle barrier and the per-attachment operation gate.
+            drop(_delivery);
             drop(_operation);
             drop(_publication);
             attachment.control.kill();
@@ -2251,6 +2263,7 @@ impl Inner {
         // Callers must release any prior guard before entering this helper.
         let publication = attachment.publication_gate.lock().expect("attachment publication lock");
         let operation = attachment.operation_gate.lock().expect("attachment operation lock");
+        let delivery = attachment.delivery_gate.lock().expect("attachment delivery lock");
         Self::revoke_publication(attachment);
         attachment.closing.store(true, Ordering::Release);
         let removed = {
@@ -2261,6 +2274,7 @@ impl Inner {
             });
             if same { attachments.remove(pty_id) } else { None }
         };
+        drop(delivery);
         drop(operation);
         drop(publication);
         if let Some(removed) = removed {
@@ -2273,8 +2287,11 @@ impl Inner {
         // was linearized before removal from the attachment map; killing the
         // control concurrently closes that admitted operation when the
         // platform permits it, while this transition remains bounded.
-        Self::revoke_publication(&attachment);
-        attachment.closing.store(true, Ordering::SeqCst);
+        {
+            let _delivery = attachment.delivery_gate.lock().expect("attachment delivery lock");
+            Self::revoke_publication(&attachment);
+            attachment.closing.store(true, Ordering::SeqCst);
+        }
         attachment.control.kill();
     }
 }
@@ -2717,15 +2734,11 @@ impl Inner {
                                 || inner.draining_viewers.contains(&viewer.id)
                             {
                                 let backlog = inner.paused_backlog.entry(viewer.id).or_default();
-                                backlog.chunks.push_back(chunk.clone());
-                                backlog.bytes += chunk.len();
-                                while backlog.bytes > scrollback_limit && backlog.chunks.len() > 1 {
-                                    if let Some(dropped) = backlog.chunks.pop_front() {
-                                        backlog.bytes -= dropped.len();
-                                    }
-                                }
-                                if backlog.bytes > scrollback_limit {
+                                if chunk.len() > scrollback_limit.saturating_sub(backlog.bytes) {
                                     overflowed_viewers.insert(viewer.id);
+                                } else {
+                                    backlog.chunks.push_back(chunk.clone());
+                                    backlog.bytes += chunk.len();
                                 }
                             } else {
                                 viewers_to_notify.push((

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2035,6 +2035,7 @@ impl Inner {
             return;
         }
         let removed = {
+            Self::revoke_publication(&attachment);
             attachment.closing.store(true, Ordering::Release);
             let _state = self.tunnel_state.lock().expect("tunnel state lock");
             let mut attachments = self.attachments.lock().expect("attach lock");

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1667,25 +1667,46 @@ impl Inner {
     }
 
     /// Build the per-attachment emit closures (output + exit framing).
-    fn sinks(self: &Arc<Self>, pty_id: &str, context: &FrameContext) -> (DataSink, ExitSink) {
+    fn sinks(
+        self: &Arc<Self>,
+        pty_id: &str,
+        context: &FrameContext,
+        generation: Arc<AtomicBool>,
+    ) -> (DataSink, ExitSink) {
         let on_data = {
             let inner = Arc::clone(self);
             let context = context.clone();
             let pty_id = pty_id.to_owned();
-            Arc::new(move |chunk: Bytes| inner.emit_output(&pty_id, &chunk, &context))
-                as Arc<dyn Fn(Bytes) + Send + Sync>
+            let generation = Arc::clone(&generation);
+            Arc::new(move |chunk: Bytes| {
+                inner.emit_output_for_generation(&pty_id, &chunk, &context, &generation)
+            }) as Arc<dyn Fn(Bytes) + Send + Sync>
         };
         let on_exit = {
             let inner = Arc::clone(self);
             let context = context.clone();
             let pty_id = pty_id.to_owned();
-            Arc::new(move |code: i64| inner.emit_exit(&pty_id, code, &context))
-                as Arc<dyn Fn(i64) + Send + Sync>
+            Arc::new(move |code: i64| {
+                inner.emit_exit_for_generation(&pty_id, code, &context, &generation)
+            }) as Arc<dyn Fn(i64) + Send + Sync>
         };
         (on_data, on_exit)
     }
 
     fn emit_output(&self, pty_id: &str, chunk: &Bytes, context: &FrameContext) {
+        let generation = self.attachment(pty_id).map(|attachment| attachment.closing);
+        if let Some(generation) = generation {
+            self.emit_output_for_generation(pty_id, chunk, context, &generation);
+        }
+    }
+
+    fn emit_output_for_generation(
+        &self,
+        pty_id: &str,
+        chunk: &Bytes,
+        context: &FrameContext,
+        generation: &Arc<AtomicBool>,
+    ) {
         if !self.tunnel_authority_generation_current(context) {
             self.retire_stale_transport_attachment(pty_id, context);
             return;
@@ -1697,6 +1718,9 @@ impl Inner {
         let Some(attachment) = self.attachment(pty_id) else {
             return;
         };
+        if !Arc::ptr_eq(&attachment.closing, generation) {
+            return;
+        }
         // Serialize only the authorization snapshot. Never hold the gate
         // across the transport callback: a stalled consumer must not block a
         // disconnect or trust revocation from retiring this attachment.
@@ -1748,6 +1772,19 @@ impl Inner {
     }
 
     fn emit_exit(&self, pty_id: &str, code: i64, context: &FrameContext) {
+        let generation = self.attachment(pty_id).map(|attachment| attachment.closing);
+        if let Some(generation) = generation {
+            self.emit_exit_for_generation(pty_id, code, context, &generation);
+        }
+    }
+
+    fn emit_exit_for_generation(
+        &self,
+        pty_id: &str,
+        code: i64,
+        context: &FrameContext,
+        generation: &Arc<AtomicBool>,
+    ) {
         if !self.tunnel_authority_generation_current(context) {
             self.retire_stale_transport_attachment(pty_id, context);
             return;
@@ -1759,6 +1796,9 @@ impl Inner {
         let Some(attachment) = self.attachment(pty_id) else {
             return;
         };
+        if !Arc::ptr_eq(&attachment.closing, generation) {
+            return;
+        }
         let _publication = attachment.publication_gate.lock().expect("attachment publication lock");
         let _operation = attachment.operation_gate.lock().expect("attachment operation lock");
         let authorized = {
@@ -2465,12 +2505,13 @@ impl Inner {
         let control = Arc::clone(&handle.control);
         let output = Arc::clone(&handle.output);
         let banner = handle.banner.clone();
-        let (on_data, on_exit) = self.sinks(pty_id, context);
+        let closing = Arc::new(AtomicBool::new(false));
+        let (on_data, on_exit) = self.sinks(pty_id, context, Arc::clone(&closing));
         Ok(Opened {
             created: ensured.created,
             surface: None,
             control: Some(control),
-            closing: Some(Arc::new(AtomicBool::new(false))),
+            closing: Some(closing),
             start: Some(Box::new(move || drive_handle(output, banner, on_data, on_exit))),
             cleanup_on_drop: true,
         })
@@ -2696,7 +2737,7 @@ impl Inner {
         let released = Arc::new(AtomicBool::new(false));
         let cleanup_if_empty = Arc::new(AtomicBool::new(created));
         let closing = Arc::new(AtomicBool::new(false));
-        let (on_data, on_exit) = self.sinks(pty_id, context);
+        let (on_data, on_exit) = self.sinks(pty_id, context, Arc::clone(&closing));
 
         // The per-attachment control proxies onto the session pty but its
         // kill() only unhooks this viewer (release), never the session.
@@ -2821,9 +2862,11 @@ impl ShellViewerControl {
             inner.draining_viewers.remove(&self.viewer_id);
             inner.paused_viewers.remove(&self.viewer_id);
         }
-        if self.cleanup_if_empty.load(Ordering::Acquire)
+        let no_viewers = self.session.inner.lock().expect("shell inner lock").viewers.is_empty();
+        let cleanup = self.cleanup_if_empty.load(Ordering::Acquire)
             && self.session.pending_viewers.load(Ordering::Acquire) == 0
-            && self.session.inner.lock().expect("shell inner lock").viewers.is_empty()
+            && no_viewers;
+        if cleanup
             && remove_cached_shell_if_same_without_viewers(
                 &self.manager,
                 &self.session_name,
@@ -3477,11 +3520,13 @@ impl Inner {
 
         let proxy = Arc::new(ControlTerminalControl { control, surface_id });
         control_guard.disarm();
-        let (on_data, _) = self.sinks(pty_id, context);
+        let closing = Arc::new(AtomicBool::new(false));
+        let (on_data, _) = self.sinks(pty_id, context, Arc::clone(&closing));
         let relay = Arc::clone(&self);
         let context_for_exit = context.clone();
         let pty_id_for_exit = pty_id.to_owned();
         let stream_for_exit = Arc::clone(&stream);
+        let exit_generation = Arc::clone(&closing);
         let on_exit: ExitSink = Arc::new(move |code| {
             if stream_for_exit.overflowed() {
                 relay.close(&pty_id_for_exit);
@@ -3492,7 +3537,12 @@ impl Inner {
                     "pty output backlog overflowed; reattach to continue receiving output",
                 );
             } else {
-                relay.emit_exit(&pty_id_for_exit, code, &context_for_exit);
+                relay.emit_exit_for_generation(
+                    &pty_id_for_exit,
+                    code,
+                    &context_for_exit,
+                    &exit_generation,
+                );
             }
         });
         let start_stream = Arc::clone(&stream);
@@ -3500,7 +3550,7 @@ impl Inner {
             created: ensured.created,
             surface: Some(surface_ref.to_owned()),
             control: Some(proxy),
-            closing: Some(Arc::new(AtomicBool::new(false))),
+            closing: Some(closing),
             start: Some(Box::new(move || start_stream.go_live(on_data, on_exit))),
             cleanup_on_drop: true,
         }))

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -3782,6 +3782,58 @@ mod tests {
     }
 
     #[test]
+    fn tunnel_output_progresses_while_input_is_blocked() {
+        let h = harness(None, None);
+        let inner = Arc::clone(&h.manager.inner);
+        let entered = Arc::new(Barrier::new(2));
+        let release = Arc::new(Barrier::new(2));
+        let owner = TransportOwner { id: Some("tunnel-a".to_owned()), kind: TransportKind::Tunnel };
+        {
+            let mut attachments = inner.attachments.lock().unwrap();
+            attachments.insert(
+                "p1".to_owned(),
+                Attachment {
+                    closing: Arc::new(AtomicBool::new(false)),
+                    operation_gate: Arc::new(Mutex::new(())),
+                    control: Arc::new(BlockingControl {
+                        entered: Arc::clone(&entered),
+                        release: Arc::clone(&release),
+                    }),
+                    actor_id: "user_owner".to_owned(),
+                    owner,
+                },
+            );
+        }
+        let mut context = h.context_with_transport("supervised", h.owner.clone(), Some("tunnel-a"));
+        context.transport_kind = TransportKind::Tunnel;
+        inner.cache_transport_auth(&context);
+
+        let operation_inner = Arc::clone(&inner);
+        let operation_context = context.clone();
+        let operation = thread::spawn(move || {
+            operation_inner.with_authorized("p1", &operation_context, "input", |attachment| {
+                attachment.control.write(b"blocked");
+            });
+        });
+        entered.wait();
+
+        let (output_tx, output_rx) = sync_channel(1);
+        let output_inner = Arc::clone(&inner);
+        let output_context = context;
+        let output = thread::spawn(move || {
+            output_inner.emit_output("p1", &Bytes::from_static(b"output"), &output_context);
+            output_tx.send(()).unwrap();
+        });
+        let progressed = output_rx.recv_timeout(Duration::from_millis(250)).is_ok();
+
+        release.wait();
+        operation.join().unwrap();
+        output.join().unwrap();
+        assert!(progressed, "output must not wait for a blocking PTY input operation");
+        assert!(h.sent().iter().any(|frame| frame["type"] == "pty_output"));
+    }
+
+    #[test]
     fn tunnel_revocation_does_not_wait_for_a_blocking_operation() {
         let h = harness(None, None);
         let inner = Arc::clone(&h.manager.inner);

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2673,7 +2673,7 @@ impl Inner {
                 let manager = Arc::clone(&self);
                 let on_session_data: DataSink = Arc::new(move |chunk: Bytes| {
                     let _dispatch = data_session.dispatch_lock.lock().expect("shell dispatch lock");
-                    let viewers_to_notify: Vec<(Arc<Mutex<()>>, Arc<dyn Fn(Bytes) + Send + Sync>)> = {
+                    let (viewers_to_notify, viewers_to_exit) = {
                         let mut inner = data_session.inner.lock().expect("shell inner lock");
                         inner.ring_size += chunk.len();
                         inner.ring.push_back(chunk.clone());
@@ -2682,6 +2682,7 @@ impl Inner {
                             inner.ring_size -= dropped.len();
                         }
                         let mut viewers_to_notify = Vec::new();
+                        let mut overflowed_viewers = HashSet::new();
                         for viewer in &inner.viewers {
                             if inner.paused_viewers.contains(&viewer.id)
                                 || inner.draining_viewers.contains(&viewer.id)
@@ -2694,6 +2695,9 @@ impl Inner {
                                         backlog.bytes -= dropped.len();
                                     }
                                 }
+                                if backlog.bytes > scrollback_limit {
+                                    overflowed_viewers.insert(viewer.id);
+                                }
                             } else {
                                 viewers_to_notify.push((
                                     Arc::clone(&viewer.delivery_lock),
@@ -2701,12 +2705,35 @@ impl Inner {
                                 ));
                             }
                         }
-                        viewers_to_notify
+                        let exits = if !overflowed_viewers.is_empty() {
+                            let exits: Vec<_> = inner
+                                .viewers
+                                .iter()
+                                .filter(|viewer| overflowed_viewers.contains(&viewer.id))
+                                .map(|viewer| {
+                                    (Arc::clone(&viewer.delivery_lock), Arc::clone(&viewer.on_exit))
+                                })
+                                .collect();
+                            inner.viewers.retain(|viewer| !overflowed_viewers.contains(&viewer.id));
+                            for viewer_id in overflowed_viewers {
+                                inner.paused_viewers.remove(&viewer_id);
+                                inner.paused_backlog.remove(&viewer_id);
+                                inner.draining_viewers.remove(&viewer_id);
+                            }
+                            exits
+                        } else {
+                            Vec::new()
+                        };
+                        (viewers_to_notify, exits)
                     };
                     drop(_dispatch);
                     for (delivery_lock, on_data) in viewers_to_notify {
                         let _delivery = delivery_lock.lock().expect("viewer delivery lock");
                         on_data(chunk.clone());
+                    }
+                    for (delivery_lock, on_exit) in viewers_to_exit {
+                        let _delivery = delivery_lock.lock().expect("viewer delivery lock");
+                        on_exit(1);
                     }
                 });
                 let on_session_exit: ExitSink = Arc::new(move |code: i64| {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -453,20 +453,23 @@ impl PtyManager {
 
     /// Handle one Worker -> relay PTY frame.
     pub async fn handle_frame(&self, frame: &Value, context: &FrameContext) {
-        let snapshot = AuthSnapshot::from_context(context);
-        let mut transport_auth = self.inner.transport_auth.lock().expect("transport auth lock");
-        if context.transport_id.is_none() {
-            // Legacy whole-manager callers use `None` and provide the current
-            // trust on each frame. Keep that contract for non-transport code.
-            transport_auth.insert(context.transport_id.clone(), snapshot);
-        } else {
-            // A connection can have an open in flight while trust is
-            // renegotiated. Do not let that stale frame overwrite the
-            // authoritative snapshot; session code calls
-            // `update_transport_auth` at each reconciliation boundary.
-            transport_auth.entry(context.transport_id.clone()).or_insert(snapshot);
+        {
+            let snapshot = AuthSnapshot::from_context(context);
+            let mut transport_auth =
+                self.inner.transport_auth.lock().expect("transport auth lock");
+            if context.transport_id.is_none() {
+                // Legacy whole-manager callers use `None` and provide the
+                // current trust on each frame. Keep that contract for non-
+                // transport code.
+                transport_auth.insert(context.transport_id.clone(), snapshot);
+            } else {
+                // A connection can have an open in flight while trust is
+                // renegotiated. Do not let that stale frame overwrite the
+                // authoritative snapshot; session code calls
+                // `update_transport_auth` at each reconciliation boundary.
+                transport_auth.entry(context.transport_id.clone()).or_insert(snapshot);
+            }
         }
-        drop(transport_auth);
         let frame_type = frame.get("type").and_then(Value::as_str).unwrap_or_default();
         match frame_type {
             "pty_open" => self.inner.clone().open(frame, context).await,

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1189,6 +1189,7 @@ fn public_pty_error_message(code: &str) -> &'static str {
         "terminal_gone" => "terminal is no longer available",
         "overflow" => "terminal output overflowed; reattach to continue",
         "busy" => "terminal is busy",
+        "failed" => "terminal open failed",
         _ => "terminal operation failed",
     }
 }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -650,9 +650,14 @@ impl PtyManager {
             return;
         }
         let frame_type = frame.get("type").and_then(Value::as_str).unwrap_or_default();
-        if !self.inner.cache_transport_auth(context) {
-            return;
-        }
+        // Keep the cache result for operations that enumerate state, but do
+        // not turn a failed cache admission into a silent drop for terminal
+        // verbs. `pty_open` validates its trust before allocation, while the
+        // existing-attachment verbs must reach their authorization path so a
+        // stale or malformed context emits `trust_revoked` and retires the
+        // attachment. The cache never stores an invalid snapshot, so this
+        // does not let an untrusted frame acquire authority.
+        let authority_current = self.inner.cache_transport_auth(context);
         match frame_type {
             "pty_open" => {
                 let Some(cancellation) = cancellation.or_else(|| self.new_open_cancellation())
@@ -667,9 +672,6 @@ impl PtyManager {
             }
             "pty_input" => {
                 let Some(pty_id) = frame.get("ptyId").and_then(Value::as_str) else { return };
-                if !self.inner.tunnel_authority_generation_current(context) {
-                    return;
-                }
                 if !self.inner.transport_owns(pty_id, context) {
                     return;
                 }
@@ -687,9 +689,6 @@ impl PtyManager {
             }
             "pty_resize" => {
                 let Some(pty_id) = frame.get("ptyId").and_then(Value::as_str) else { return };
-                if !self.inner.tunnel_authority_generation_current(context) {
-                    return;
-                }
                 if !self.inner.transport_owns(pty_id, context) {
                     return;
                 }
@@ -704,9 +703,6 @@ impl PtyManager {
             }
             "pty_flow" => {
                 let Some(pty_id) = frame.get("ptyId").and_then(Value::as_str) else { return };
-                if !self.inner.tunnel_authority_generation_current(context) {
-                    return;
-                }
                 if !self.inner.transport_owns(pty_id, context) {
                     return;
                 }
@@ -721,15 +717,14 @@ impl PtyManager {
             }
             "pty_close" => {
                 let Some(pty_id) = frame.get("ptyId").and_then(Value::as_str) else { return };
-                if !self.inner.tunnel_authority_generation_current(context) {
-                    return;
-                }
                 if !self.inner.transport_owns(pty_id, context) {
                     return;
                 }
                 self.inner.close_authorized(pty_id, context);
             }
-            "surface_list" => self.inner.clone().list_surfaces(frame, context).await,
+            "surface_list" if authority_current => {
+                self.inner.clone().list_surfaces(frame, context).await
+            }
             _ => {}
         }
     }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1013,6 +1013,13 @@ impl PtyManager {
             opening.reservations.remove(pty_id);
             opening.cancellations.remove(&owner);
             opening.cancelled.insert(pty_id.to_owned(), owner);
+        } else if opening
+            .active_openings
+            .get(pty_id)
+            .is_some_and(|(active_owner, _)| active_owner == &owner)
+        {
+            opening.active_openings.remove(pty_id);
+            opening.cancelled.insert(pty_id.to_owned(), owner);
         }
     }
 

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -397,6 +397,10 @@ struct Attachment {
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 struct OpeningOwner {
     owner: TransportOwner,
+    /// Unique for the lifetime of an open attempt. A transport may reuse a
+    /// pty id after a timed-out attempt has been removed from reservations;
+    /// this token keeps the late task from touching the replacement.
+    attempt_id: u64,
 }
 
 #[derive(Default)]
@@ -432,6 +436,9 @@ struct Inner {
     /// Monotonic floor for managed tunnel authority generations. It remains
     /// effective while a stale open is still unwinding after revocation.
     tunnel_authority_generation: AtomicU64,
+    /// Monotonic identity for in-flight open attempts. Zero is reserved as
+    /// the exhausted state so a wrapped token is never reused.
+    next_open_attempt: AtomicU64,
     /// Bounds provider/PTY opens, including opens that have timed out while
     /// their provider task is still unwinding. A permit is owned by the open
     /// task and is released only when that task has returned, so a hung
@@ -480,6 +487,29 @@ pub struct PtyManager {
     inner: Arc<Inner>,
 }
 
+/// Cancellation and identity for one terminal-open attempt. The identity is
+/// allocated by the manager before a task is spawned, so timeout cleanup can
+/// name the exact reservation even when the task is still unwinding.
+#[derive(Clone)]
+pub(crate) struct OpenCancellation {
+    token: CancellationToken,
+    attempt_id: u64,
+}
+
+impl OpenCancellation {
+    pub(crate) fn cancel(&self) {
+        self.token.cancel();
+    }
+
+    fn is_cancelled(&self) -> bool {
+        self.token.is_cancelled()
+    }
+
+    fn attempt_id(&self) -> u64 {
+        self.attempt_id
+    }
+}
+
 /// Attachments whose ownership has already been removed from the manager.
 /// The controls are retired after the caller releases any outer trust lock,
 /// so a slow platform kill cannot block authorization readers or a later
@@ -525,6 +555,7 @@ impl PtyManager {
                 transport_auth: Mutex::new(HashMap::new()),
                 tunnel_state: Mutex::new(()),
                 tunnel_authority_generation: AtomicU64::new(0),
+                next_open_attempt: AtomicU64::new(1),
                 open_slots: Arc::new(Semaphore::new(MAX_PTYS)),
             }),
         }
@@ -553,6 +584,7 @@ impl PtyManager {
                 transport_auth: Mutex::new(HashMap::new()),
                 tunnel_state: Mutex::new(()),
                 tunnel_authority_generation: AtomicU64::new(0),
+                next_open_attempt: AtomicU64::new(1),
                 open_slots: Arc::new(Semaphore::new(max_ptys)),
             }),
         }
@@ -571,9 +603,9 @@ impl PtyManager {
         &self,
         frame: &Value,
         context: &FrameContext,
-        cancellation: Option<CancellationToken>,
+        cancellation: Option<OpenCancellation>,
     ) {
-        if cancellation.as_ref().is_some_and(|token| token.is_cancelled()) {
+        if cancellation.as_ref().is_some_and(OpenCancellation::is_cancelled) {
             return;
         }
         let frame_type = frame.get("type").and_then(Value::as_str).unwrap_or_default();
@@ -581,7 +613,18 @@ impl PtyManager {
             return;
         }
         match frame_type {
-            "pty_open" => self.inner.clone().open(frame, context, cancellation).await,
+            "pty_open" => {
+                let Some(cancellation) =
+                    cancellation.or_else(|| self.new_open_cancellation())
+                else {
+                    let pty_id = frame.get("ptyId").and_then(Value::as_str).unwrap_or_default();
+                    if !pty_id.is_empty() {
+                        send_pty_error(context, pty_id, "session_limit", "terminal limit reached");
+                    }
+                    return;
+                };
+                self.inner.clone().open(frame, context, cancellation).await
+            }
             "pty_input" => {
                 let Some(pty_id) = frame.get("ptyId").and_then(Value::as_str) else { return };
                 if !self.inner.tunnel_authority_generation_current(context) {
@@ -736,17 +779,35 @@ impl PtyManager {
         self.detach_matching(|owner| owner.kind == TransportKind::Tunnel)
     }
 
-    /// Cancel one opening reservation at the timeout boundary. The
-    /// owner-specific tombstone rejects a late result without retaining the
-    /// reservation in the capacity count. Tombstones are bounded by
+    /// Cancel one opening reservation at the timeout boundary. The capability
+    /// carries both the cancellation signal and the unique attempt identity.
+    /// Its owner-specific tombstone rejects a late result without retaining
+    /// the reservation in the capacity count. Tombstones are bounded by
     /// `open_slots`, because each one belongs to an outstanding open permit.
-    pub fn cancel_open(&self, pty_id: &str, context: &FrameContext) {
-        let owner = OpeningOwner { owner: TransportOwner::from_context(context) };
+    pub(crate) fn cancel_open(
+        &self,
+        pty_id: &str,
+        context: &FrameContext,
+        cancellation: &OpenCancellation,
+    ) {
+        cancellation.cancel();
+        let owner = OpeningOwner {
+            owner: TransportOwner::from_context(context),
+            attempt_id: cancellation.attempt_id(),
+        };
         let _state = self.inner.tunnel_state.lock().expect("tunnel state lock");
         let mut opening = self.inner.opening_state.lock().expect("opening state lock");
-        if opening.reservations.get(pty_id) == Some(&owner) {
+        // The attempt identity check is added in the follow-up fix commit.
+        // Keeping only the transport comparison here makes the regression
+        // test fail against the red commit when a pty id is reused.
+        if let Some(current) = opening
+            .reservations
+            .get(pty_id)
+            .filter(|current| current.owner == owner.owner)
+            .cloned()
+        {
             opening.reservations.remove(pty_id);
-            opening.cancelled.insert(pty_id.to_owned(), owner);
+            opening.cancelled.insert(pty_id.to_owned(), current);
         }
     }
 
@@ -788,6 +849,32 @@ impl PtyManager {
         }
         drop(_state);
         RetiredAttachments { inner: Arc::clone(&self.inner), attachments: retired }
+    }
+
+    /// Allocate the capability that identifies one in-flight terminal open.
+    /// IDs are never reused. Exhaustion is a fail-closed terminal limit.
+    pub(crate) fn new_open_cancellation(&self) -> Option<OpenCancellation> {
+        let mut current = self.inner.next_open_attempt.load(Ordering::Relaxed);
+        loop {
+            if current == 0 {
+                return None;
+            }
+            let next = current.checked_add(1).unwrap_or(0);
+            match self.inner.next_open_attempt.compare_exchange_weak(
+                current,
+                next,
+                Ordering::AcqRel,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => {
+                    return Some(OpenCancellation {
+                        token: CancellationToken::new(),
+                        attempt_id: current,
+                    });
+                }
+                Err(observed) => current = observed,
+            }
+        }
     }
 }
 
@@ -842,9 +929,9 @@ impl Inner {
         self: Arc<Self>,
         frame: &Value,
         context: &FrameContext,
-        cancellation: Option<CancellationToken>,
+        cancellation: OpenCancellation,
     ) {
-        if cancellation.as_ref().is_some_and(|token| token.is_cancelled()) {
+        if cancellation.is_cancelled() {
             return;
         }
         let pty_id = frame.get("ptyId").and_then(Value::as_str).unwrap_or_default().to_owned();
@@ -862,7 +949,7 @@ impl Inner {
                 return;
             }
         };
-        if cancellation.as_ref().is_some_and(|token| token.is_cancelled()) {
+        if cancellation.is_cancelled() {
             return;
         }
         if !self.tunnel_authority_generation_current(context) {
@@ -870,7 +957,10 @@ impl Inner {
             return;
         }
         let fail = |code: &str, message: &str| send_pty_error(context, &pty_id, code, message);
-        let reservation_owner = OpeningOwner { owner: TransportOwner::from_context(context) };
+        let reservation_owner = OpeningOwner {
+            owner: TransportOwner::from_context(context),
+            attempt_id: cancellation.attempt_id(),
+        };
         let reservation_result = {
             let _state = self.tunnel_state.lock().expect("tunnel state lock");
             let mut opening = self.opening_state.lock().expect("opening state lock");
@@ -969,7 +1059,7 @@ impl Inner {
         let env = pty_env(&self.env);
 
         let cmux_tui = self.deps.resolve_cmux_tui().await;
-        if cancellation.as_ref().is_some_and(|token| token.is_cancelled()) {
+        if cancellation.is_cancelled() {
             return;
         }
         let opened = if let (Some(cmux_tui), Some(surface_ref)) =
@@ -1061,8 +1151,7 @@ impl Inner {
                 });
             let mut opening = self.opening_state.lock().expect("opening state lock");
             let cancelled = opening.cancelled.get(&pty_id) == Some(&reservation_owner);
-            let externally_cancelled =
-                cancellation.as_ref().is_some_and(|token| token.is_cancelled());
+            let externally_cancelled = cancellation.is_cancelled();
             let authority_changed = !self.tunnel_authority_generation_current(context);
             let reservation_owned = opening.reservations.get(&pty_id) == Some(&reservation_owner);
             if !reservation_owned
@@ -3506,9 +3595,11 @@ mod tests {
         let id = "reused".to_owned();
         let owner_a = OpeningOwner {
             owner: TransportOwner { id: Some("tunnel-a".to_owned()), kind: TransportKind::Tunnel },
+            attempt_id: 1,
         };
         let owner_b = OpeningOwner {
             owner: TransportOwner { id: Some("tunnel-b".to_owned()), kind: TransportKind::Tunnel },
+            attempt_id: 2,
         };
         let old = OpeningReservation {
             inner: Arc::clone(&inner),
@@ -3536,7 +3627,11 @@ mod tests {
         let inner = Arc::clone(&h.manager.inner);
         let mut context = h.context_with_transport("supervised", h.owner.clone(), Some("tunnel-a"));
         context.transport_kind = TransportKind::Tunnel;
-        let owner = OpeningOwner { owner: TransportOwner::from_context(&context) };
+        let cancellation = h.manager.new_open_cancellation().expect("open attempt token");
+        let owner = OpeningOwner {
+            owner: TransportOwner::from_context(&context),
+            attempt_id: cancellation.attempt_id(),
+        };
         let reservation = OpeningReservation {
             inner: Arc::clone(&inner),
             id: "p1".to_owned(),
@@ -3545,7 +3640,7 @@ mod tests {
         };
         inner.opening_state.lock().unwrap().reservations.insert("p1".to_owned(), owner.clone());
 
-        h.manager.cancel_open("p1", &context);
+        h.manager.cancel_open("p1", &context, &cancellation);
 
         {
             let state = inner.opening_state.lock().unwrap();
@@ -3554,6 +3649,36 @@ mod tests {
         }
         drop(reservation);
         assert!(!inner.opening_state.lock().unwrap().cancelled.contains_key("p1"));
+    }
+
+    #[test]
+    fn stale_open_cancellation_cannot_touch_a_same_owner_replacement() {
+        let h = harness(None, None);
+        let inner = Arc::clone(&h.manager.inner);
+        let mut context = h.context_with_transport("supervised", h.owner.clone(), Some("tunnel-a"));
+        context.transport_kind = TransportKind::Tunnel;
+        let old_cancellation = h.manager.new_open_cancellation().expect("old token");
+        let new_cancellation = h.manager.new_open_cancellation().expect("new token");
+        let replacement = OpeningOwner {
+            owner: TransportOwner::from_context(&context),
+            attempt_id: new_cancellation.attempt_id(),
+        };
+        inner
+            .opening_state
+            .lock()
+            .unwrap()
+            .reservations
+            .insert("reused".to_owned(), replacement.clone());
+
+        // The old timeout arrives after the caller has reused the pty id on
+        // the same transport. Its capability must not cancel the replacement.
+        h.manager.cancel_open("reused", &context, &old_cancellation);
+
+        let state = inner.opening_state.lock().unwrap();
+        assert_eq!(state.reservations.get("reused"), Some(&replacement));
+        assert!(!state.cancelled.contains_key("reused"));
+        assert!(old_cancellation.is_cancelled());
+        assert!(!new_cancellation.is_cancelled());
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -3569,7 +3694,7 @@ mod tests {
             "cols": 80,
             "rows": 24,
         });
-        let cancellation = CancellationToken::new();
+        let cancellation = manager.new_open_cancellation().expect("open attempt token");
         let task_cancellation = cancellation.clone();
         let task_manager = Arc::clone(&manager);
         let task = tokio::spawn(async move {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1977,6 +1977,7 @@ impl Inner {
             // Killing a PTY can acquire a platform mutex. Keep it outside the
             // lifecycle barrier and the per-attachment operation gate.
             drop(_operation);
+            drop(_publication);
             attachment.control.kill();
         }
     }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -57,14 +57,18 @@ const RAW_ATTACH_BACKLOG_CAP: usize = 1024 * 1024;
 const PTY_INPUT_B64_CAP: usize = 4 * 1024 * 1024;
 
 /// Random lowercase-hex identity for transports and tunnel attachments.
-pub fn random_hex(bytes: usize) -> String {
+///
+/// Identity generation is security-sensitive. Callers must reject the
+/// operation when the operating system cannot provide entropy instead of
+/// continuing with a predictable identifier.
+pub fn random_hex(bytes: usize) -> Result<String, getrandom::Error> {
     let mut buffer = vec![0_u8; bytes];
-    let _ = getrandom::fill(&mut buffer);
+    getrandom::fill(&mut buffer)?;
     let mut out = String::with_capacity(bytes * 2);
     for byte in buffer {
         out.push_str(&format!("{byte:02x}"));
     }
-    out
+    Ok(out)
 }
 
 pub fn session_name_ok(name: &str) -> bool {
@@ -348,7 +352,11 @@ struct Inner {
     cancelled_openings: Mutex<std::collections::HashSet<String>>,
     shell_sessions: Mutex<HashMap<String, Arc<ShellSession>>>,
     shell_starting: Mutex<HashMap<String, Arc<Notify>>>,
-    auth: Mutex<Option<AuthSnapshot>>,
+    /// Authentication is scoped to the transport that owns an attachment.
+    /// A single manager serves the relay socket and managed tunnel sockets;
+    /// one global snapshot would let the last frame on either transport
+    /// authorize asynchronous output for every other attachment.
+    transport_auth: Mutex<HashMap<Option<String>, AuthSnapshot>>,
 }
 
 struct ShellStartReservation {
@@ -399,7 +407,7 @@ impl PtyManager {
                 cancelled_openings: Mutex::new(std::collections::HashSet::new()),
                 shell_sessions: Mutex::new(HashMap::new()),
                 shell_starting: Mutex::new(HashMap::new()),
-                auth: Mutex::new(None),
+                transport_auth: Mutex::new(HashMap::new()),
             }),
         }
     }
@@ -425,14 +433,18 @@ impl PtyManager {
                 cancelled_openings: Mutex::new(std::collections::HashSet::new()),
                 shell_sessions: Mutex::new(HashMap::new()),
                 shell_starting: Mutex::new(HashMap::new()),
-                auth: Mutex::new(None),
+                transport_auth: Mutex::new(HashMap::new()),
             }),
         }
     }
 
     /// Handle one Worker -> relay PTY frame.
     pub async fn handle_frame(&self, frame: &Value, context: &FrameContext) {
-        *self.inner.auth.lock().expect("auth lock") = Some(AuthSnapshot {
+        self.inner
+            .transport_auth
+            .lock()
+            .expect("transport auth lock")
+            .insert(context.transport_id.clone(), AuthSnapshot {
             trust: context.trust.clone(),
             owner_user_id: context.owner_user_id.clone(),
             send: Arc::clone(&context.send),
@@ -524,6 +536,13 @@ impl PtyManager {
         self.detach_matching(|owner| owner == Some(transport_id));
     }
 
+    /// Release all managed tunnel attachments. The relay connection clears
+    /// tunnel authority on disconnect or trust renegotiation; existing tunnel
+    /// viewers must lose their attachments at the same boundary.
+    pub fn detach_tunnel_transports(&self) {
+        self.detach_matching(|owner| owner.is_some_and(|id| id.starts_with("tunnel-")));
+    }
+
     fn detach_matching(&self, owns: impl Fn(Option<&str>) -> bool) {
         // Openings first: close() records cancellation for a reserved id, so
         // a late open cannot install an attachment after its transport died.
@@ -547,6 +566,11 @@ impl PtyManager {
         for id in ids {
             self.inner.close(&id);
         }
+        self.inner
+            .transport_auth
+            .lock()
+            .expect("transport auth lock")
+            .retain(|owner, _| !owns(owner.as_deref()));
     }
 }
 
@@ -816,7 +840,9 @@ impl Inner {
     }
 
     fn emit_output(&self, pty_id: &str, chunk: &Bytes, context: &FrameContext) {
-        let Some(auth) = self.auth.lock().expect("auth lock").clone() else { return };
+        let Some(auth) = self.auth_for_transport(context.transport_id.as_deref()) else {
+            return;
+        };
         if self.authorize_snapshot(pty_id, &auth, context, "output").is_none() {
             return;
         }
@@ -851,7 +877,9 @@ impl Inner {
     }
 
     fn emit_exit(&self, pty_id: &str, code: i64, context: &FrameContext) {
-        let Some(auth) = self.auth.lock().expect("auth lock").clone() else { return };
+        let Some(auth) = self.auth_for_transport(context.transport_id.as_deref()) else {
+            return;
+        };
         if self.authorize_snapshot(pty_id, &auth, context, "exit").is_none() {
             return;
         }
@@ -905,8 +933,13 @@ impl Inner {
     }
 
     fn authorize(&self, pty_id: &str, context: &FrameContext, action: &str) -> Option<Attachment> {
-        let auth = self.auth.lock().expect("auth lock").clone()?;
+        let auth = self.auth_for_transport(context.transport_id.as_deref())?;
         self.authorize_snapshot(pty_id, &auth, context, action)
+    }
+
+    fn auth_for_transport(&self, transport_id: Option<&str>) -> Option<AuthSnapshot> {
+        let key = transport_id.map(str::to_owned);
+        self.transport_auth.lock().expect("transport auth lock").get(&key).cloned()
     }
 
     fn authorize_snapshot(
@@ -2810,6 +2843,47 @@ mod tests {
         assert!(h.manager.has_attachment("p-tunnel"), "the tunnel viewer must survive");
         h.manager.detach_all();
         assert!(!h.manager.has_attachment("p-tunnel"));
+    }
+
+    #[tokio::test]
+    async fn asynchronous_output_stays_bound_to_the_transport_that_opened_it() {
+        let h = harness(None, None);
+        let sent_a = Arc::new(StdMutex::new(Vec::<Value>::new()));
+        let sent_b = Arc::new(StdMutex::new(Vec::<Value>::new()));
+        let context = |sent: Arc<StdMutex<Vec<Value>>>, transport: &str| FrameContext {
+            send: Arc::new(move |frame| sent.lock().unwrap().push(frame)),
+            buffered_amount: Arc::new(|| 0),
+            trust: "supervised".to_owned(),
+            local_roots: None,
+            owner_user_id: Some("user_owner".to_owned()),
+            transport_id: Some(transport.to_owned()),
+        };
+        let context_a = context(Arc::clone(&sent_a), "transport-a");
+        let context_b = context(Arc::clone(&sent_b), "transport-b");
+        let open = |pty_id: &str, session: &str| {
+            serde_json::json!({
+                "version": 4,
+                "type": "pty_open",
+                "ptyId": pty_id,
+                "session": session,
+                "cols": 80,
+                "rows": 24,
+                "actorId": "user_owner",
+            })
+        };
+        h.manager.handle_frame(&open("p-a", "session-a"), &context_a).await;
+        h.manager.handle_frame(&open("p-b", "session-b"), &context_b).await;
+        let spawned = h.spawned();
+        assert_eq!(spawned.len(), 2);
+
+        spawned[0].emit("output-a");
+        spawned[1].emit("output-b");
+        let a = sent_a.lock().unwrap().clone();
+        let b = sent_b.lock().unwrap().clone();
+        assert!(a.iter().any(|frame| frame["ptyId"] == "p-a"));
+        assert!(!a.iter().any(|frame| frame["ptyId"] == "p-b"));
+        assert!(b.iter().any(|frame| frame["ptyId"] == "p-b"));
+        assert!(!b.iter().any(|frame| frame["ptyId"] == "p-a"));
     }
 
     #[test]

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -843,20 +843,33 @@ impl PtyManager {
                 .is_some_and(|current| !auth_snapshot_matches(current, &snapshot));
             changed
         };
-        if changed {
-            self.detach_matching(|candidate| candidate == &owner).retire();
-        }
-        let _state = self.inner.tunnel_state.lock().expect("tunnel state lock");
-        if context.cancellation.is_cancelled()
-            || !self.inner.tunnel_authority_generation_current(context)
+        // `detach_matching` acquires `transport_auth_updates` itself. We
+        // already hold that lock here, so call the locked variant to avoid a
+        // non-reentrant mutex deadlock when a transport refresh changes its
+        // authority. Retire controls after publishing the replacement and
+        // releasing the update lock, so platform cleanup cannot block a
+        // concurrent authority refresh.
+        let retired = if changed {
+            Some(self.detach_matching_locked(|candidate| candidate == &owner))
+        } else {
+            None
+        };
         {
-            return;
+            let _state = self.inner.tunnel_state.lock().expect("tunnel state lock");
+            if !context.cancellation.is_cancelled()
+                && self.inner.tunnel_authority_generation_current(context)
+            {
+                self.inner
+                    .transport_auth
+                    .lock()
+                    .expect("transport auth lock")
+                    .insert(owner.clone(), snapshot);
+            }
         }
-        self.inner
-            .transport_auth
-            .lock()
-            .expect("transport auth lock")
-            .insert(owner.clone(), snapshot);
+        drop(_update);
+        if let Some(retired) = retired {
+            retired.retire();
+        }
     }
 
     /// Advance the managed tunnel authority floor before publishing the

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -4241,7 +4241,12 @@ mod tests {
         // Close must signal the exact open before allowing the provider to
         // continue, independent of scheduler timing.
         entered.notified().await;
-        manager.inner.close("p1");
+        manager
+            .handle_frame(
+                &serde_json::json!({ "type": "pty_close", "ptyId": "p1" }),
+                &context,
+            )
+            .await;
         assert!(cancellation.is_cancelled());
 
         release.notify_one();

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1379,6 +1379,9 @@ impl Inner {
             }
         };
         if let Err((code, message)) = reservation_result {
+            if cancellation.is_cancelled() {
+                return;
+            }
             fail(code, &message);
             return;
         }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -19,7 +19,7 @@
 //! every non-empty allowed root list; env scrubbed; per-pty buffered output capped; no
 //! empty frames; unknown ptyIds tolerated; refusals answer pty_error.
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -443,6 +443,10 @@ struct OpeningOwner {
 #[derive(Default)]
 struct OpeningState {
     reservations: HashMap<String, OpeningOwner>,
+    /// Every open attempt is registered before admission can await a
+    /// provider. Authority replacement can therefore cancel an attempt even
+    /// when it has not reached the capacity reservation yet.
+    active_openings: HashMap<String, (OpeningOwner, OpenCancellation)>,
     /// Cancellation capability for each live reservation. The owner key
     /// keeps a late timeout from cancelling a replacement that reused the
     /// same pty id.
@@ -471,6 +475,10 @@ struct Inner {
     /// one global snapshot would let the last frame on either transport
     /// authorize asynchronous output for every other attachment.
     transport_auth: Mutex<HashMap<TransportOwner, AuthSnapshot>>,
+    /// A transport being replaced is fenced before its old snapshot is
+    /// removed. This closes the gap in which a stale frame could otherwise
+    /// repopulate the cache while its opening is being cancelled.
+    revoked_transports: Mutex<HashSet<TransportOwner>>,
     /// Serializes short authority and attachment state transitions. It is
     /// never held while a PTY control method, callback, or provider await runs.
     tunnel_state: Mutex<()>,
@@ -519,6 +527,31 @@ struct OpeningReservation {
     id: String,
     owner: OpeningOwner,
     active: bool,
+}
+
+struct ActiveOpening {
+    inner: Arc<Inner>,
+    id: String,
+    owner: OpeningOwner,
+    active: bool,
+}
+
+impl ActiveOpening {
+    fn disarm(&mut self) {
+        self.active = false;
+    }
+}
+
+impl Drop for ActiveOpening {
+    fn drop(&mut self) {
+        if !self.active {
+            return;
+        }
+        let mut state = self.inner.opening_state.lock().expect("opening state lock");
+        if state.active_openings.get(&self.id).is_some_and(|(owner, _)| owner == &self.owner) {
+            state.active_openings.remove(&self.id);
+        }
+    }
 }
 impl Drop for OpeningReservation {
     fn drop(&mut self) {
@@ -609,6 +642,7 @@ impl PtyManager {
                 shell_sessions: Mutex::new(HashMap::new()),
                 shell_starting: Mutex::new(HashMap::new()),
                 transport_auth: Mutex::new(HashMap::new()),
+                revoked_transports: Mutex::new(HashSet::new()),
                 tunnel_state: Mutex::new(()),
                 tunnel_authority_generation: AtomicU64::new(0),
                 next_open_attempt: AtomicU64::new(1),
@@ -638,6 +672,7 @@ impl PtyManager {
                 shell_sessions: Mutex::new(HashMap::new()),
                 shell_starting: Mutex::new(HashMap::new()),
                 transport_auth: Mutex::new(HashMap::new()),
+                revoked_transports: Mutex::new(HashSet::new()),
                 tunnel_state: Mutex::new(()),
                 tunnel_authority_generation: AtomicU64::new(0),
                 next_open_attempt: AtomicU64::new(1),
@@ -752,15 +787,40 @@ impl PtyManager {
         if Trust::parse(&context.trust).is_none() {
             return;
         }
+        let owner = TransportOwner::from_context(context);
+        let snapshot = AuthSnapshot::from_context(context);
+        // Fence a changed snapshot before removing its reservations. The
+        // marker makes stale frames fail closed while the per-attachment gate
+        // drains any operation already in progress.
+        let changed = {
+            let _state = self.inner.tunnel_state.lock().expect("tunnel state lock");
+            if !self.inner.tunnel_authority_generation_current(context) {
+                return;
+            }
+            let mut revoked = self.inner.revoked_transports.lock().expect("revoked transport lock");
+            let transport_auth = self.inner.transport_auth.lock().expect("transport auth lock");
+            let changed = transport_auth.get(&owner).is_some_and(|current| {
+                current.trust != snapshot.trust
+                    || current.local_roots != snapshot.local_roots
+                    || current.owner_user_id != snapshot.owner_user_id
+                    || current.auth_generation != snapshot.auth_generation
+                    || current.transport_kind != snapshot.transport_kind
+            });
+            if changed {
+                revoked.insert(owner.clone());
+            }
+            changed
+        };
+        if changed {
+            self.inner.detach_matching(|candidate| candidate == &owner).retire();
+        }
         let _state = self.inner.tunnel_state.lock().expect("tunnel state lock");
         if !self.inner.tunnel_authority_generation_current(context) {
             return;
         }
-        self.inner
-            .transport_auth
-            .lock()
-            .expect("transport auth lock")
-            .insert(TransportOwner::from_context(context), AuthSnapshot::from_context(context));
+        let mut revoked = self.inner.revoked_transports.lock().expect("revoked transport lock");
+        self.inner.transport_auth.lock().expect("transport auth lock").insert(owner, snapshot);
+        revoked.remove(&TransportOwner::from_context(context));
     }
 
     /// Advance the managed tunnel authority floor before publishing the
@@ -882,6 +942,16 @@ impl PtyManager {
                     cancellation.cancel();
                 }
                 opening.cancelled.insert(id, owner);
+            }
+            let active: Vec<(String, OpenCancellation)> = opening
+                .active_openings
+                .iter()
+                .filter(|(_, (owner, _))| owns(&owner.owner))
+                .map(|(id, (_, cancellation))| (id.clone(), cancellation.clone()))
+                .collect();
+            for (id, cancellation) in active {
+                opening.active_openings.remove(&id);
+                cancellation.cancel();
             }
 
             self.inner
@@ -1028,6 +1098,17 @@ impl Inner {
         if pty_id.is_empty() {
             return;
         }
+        let Some(auth) = self.auth_for_transport(context) else {
+            return;
+        };
+        if !self.transport_auth_is_current(context, &auth) {
+            send_pty_error(context, &pty_id, "trust_revoked", "terminal trust is not current");
+            return;
+        }
+        let reservation_owner = OpeningOwner {
+            owner: TransportOwner::from_context(context),
+            attempt_id: cancellation.attempt_id(),
+        };
         // Read the actor once at the boundary. The same immutable identity is
         // used for admission and for the attachment ownership record.
         let actor = frame.get("actorId").and_then(Value::as_str).unwrap_or_default().to_owned();
@@ -1035,6 +1116,39 @@ impl Inner {
             send_pty_error(context, &pty_id, "trust_refused", "terminal trust is not established");
             return;
         }
+        // Register before any provider boundary. This gives authority
+        // replacement a cancellation handle even if the task has not yet
+        // installed its capacity reservation.
+        let active_registered = {
+            let _state = self.tunnel_state.lock().expect("tunnel state lock");
+            let mut opening = self.opening_state.lock().expect("opening state lock");
+            let attachments = self.attachments.lock().expect("attach lock");
+            if attachments.contains_key(&pty_id)
+                || opening.reservations.contains_key(&pty_id)
+                || opening.active_openings.contains_key(&pty_id)
+            {
+                Err(("bad_request", "ptyId is already attached"))
+            } else if attachments.len() + opening.reservations.len() + opening.active_openings.len()
+                >= self.max_ptys
+            {
+                Err(("session_limit", "terminal limit reached"))
+            } else {
+                opening
+                    .active_openings
+                    .insert(pty_id.clone(), (reservation_owner.clone(), cancellation.clone()));
+                Ok(())
+            }
+        };
+        if let Err((code, message)) = active_registered {
+            send_pty_error(context, &pty_id, code, message);
+            return;
+        }
+        let mut active_opening = ActiveOpening {
+            inner: Arc::clone(&self),
+            id: pty_id.clone(),
+            owner: reservation_owner.clone(),
+            active: true,
+        };
         // Keep one permit for the complete provider/PTY open. A timeout may
         // leave that task unwinding in the background, so the permit remains
         // owned until the task returns. This is the supervisor boundary that
@@ -1054,22 +1168,30 @@ impl Inner {
             return;
         }
         let fail = |code: &str, message: &str| send_pty_error(context, &pty_id, code, message);
-        let reservation_owner = OpeningOwner {
-            owner: TransportOwner::from_context(context),
-            attempt_id: cancellation.attempt_id(),
-        };
         let reservation_result = {
             let _state = self.tunnel_state.lock().expect("tunnel state lock");
             let mut opening = self.opening_state.lock().expect("opening state lock");
             let attachments = self.attachments.lock().expect("attach lock");
-            if attachments.contains_key(&pty_id) || opening.reservations.contains_key(&pty_id) {
+            let active_owned = opening
+                .active_openings
+                .get(&pty_id)
+                .is_some_and(|(owner, _)| owner == &reservation_owner);
+            if attachments.contains_key(&pty_id)
+                || opening.reservations.contains_key(&pty_id)
+                || !active_owned
+            {
                 Err(("bad_request", "ptyId is already attached".to_owned()))
-            } else if attachments.len() + opening.reservations.len() >= self.max_ptys {
+            } else if attachments.len()
+                + opening.reservations.len()
+                + opening.active_openings.len().saturating_sub(1)
+                >= self.max_ptys
+            {
                 Err((
                     "session_limit",
                     format!("this relay caps concurrent terminals at {}", self.max_ptys),
                 ))
             } else {
+                opening.active_openings.remove(&pty_id);
                 opening.reservations.insert(pty_id.clone(), reservation_owner.clone());
                 opening.cancellations.insert(reservation_owner.clone(), cancellation.clone());
                 Ok(())
@@ -1079,6 +1201,7 @@ impl Inner {
             fail(code, &message);
             return;
         }
+        active_opening.disarm();
         let mut reservation = OpeningReservation {
             inner: Arc::clone(&self),
             id: pty_id.clone(),
@@ -1461,6 +1584,17 @@ impl Inner {
             return owner.owner.id.as_deref() == Some(transport_id)
                 && owner.owner.kind == context.transport_kind;
         }
+        if let Some((owner, _)) = self
+            .opening_state
+            .lock()
+            .expect("opening state lock")
+            .active_openings
+            .get(pty_id)
+            .cloned()
+        {
+            return owner.owner.id.as_deref() == Some(transport_id)
+                && owner.owner.kind == context.transport_kind;
+        }
         if let Some(attachment) = self.attachments.lock().expect("attach lock").get(pty_id) {
             return attachment.owner.id.as_deref() == Some(transport_id)
                 && attachment.owner.kind == context.transport_kind;
@@ -1507,6 +1641,10 @@ impl Inner {
 
     fn auth_for_transport(&self, context: &FrameContext) -> Option<AuthSnapshot> {
         let key = TransportOwner::from_context(context);
+        let _state = self.tunnel_state.lock().expect("tunnel state lock");
+        if self.revoked_transports.lock().expect("revoked transport lock").contains(&key) {
+            return None;
+        }
         self.transport_auth.lock().expect("transport auth lock").get(&key).cloned()
     }
 
@@ -1539,18 +1677,20 @@ impl Inner {
         let Some(auth) = self.auth_for_transport(context) else { return };
 
         // A close may arrive while the PTY provider is still resolving. In
-        // that window there is no attachment to authorize, but the opening
-        // reservation is already consuming capacity. Cancel only the exact
-        // owner that the caller is allowed to retire, so a late close cannot
-        // cancel a replacement that reused the same pty id.
-        let opening_owner = self
-            .opening_state
-            .lock()
-            .expect("opening state lock")
-            .reservations
-            .get(pty_id)
-            .cloned();
-        if let Some(owner) = opening_owner {
+        // that window there is no attachment to authorize, but the open is
+        // already consuming an attempt. Cancel only the exact owner that the
+        // caller is allowed to retire, so a late close cannot cancel a
+        // replacement that reused the same pty id.
+        let opening = {
+            let state = self.opening_state.lock().expect("opening state lock");
+            state.reservations.get(pty_id).cloned().map(|owner| (owner, None)).or_else(|| {
+                state
+                    .active_openings
+                    .get(pty_id)
+                    .map(|(owner, cancellation)| (owner.clone(), Some(cancellation.clone())))
+            })
+        };
+        if let Some((owner, active_cancellation)) = opening {
             let owner_matches = context.transport_id.is_none()
                 || owner.owner == TransportOwner::from_context(context);
             let authorized = owner_matches
@@ -1563,16 +1703,25 @@ impl Inner {
             let cancellation = {
                 let _state = self.tunnel_state.lock().expect("tunnel state lock");
                 let mut opening = self.opening_state.lock().expect("opening state lock");
-                if opening.reservations.get(pty_id) != Some(&owner) {
-                    None
-                } else {
+                if opening.reservations.get(pty_id) == Some(&owner) {
                     opening.reservations.remove(pty_id);
                     let cancellation = opening.cancellations.remove(&owner);
                     opening.cancelled.insert(pty_id.to_owned(), owner);
                     cancellation
+                } else if opening
+                    .active_openings
+                    .get(pty_id)
+                    .is_some_and(|(active_owner, _)| active_owner == &owner)
+                {
+                    let (_, cancellation) =
+                        opening.active_openings.remove(pty_id).expect("active opening present");
+                    opening.cancelled.insert(pty_id.to_owned(), owner);
+                    Some(cancellation)
+                } else {
+                    None
                 }
             };
-            if let Some(cancellation) = cancellation {
+            if let Some(cancellation) = cancellation.or(active_cancellation) {
                 cancellation.cancel();
             }
             return;
@@ -1623,17 +1772,17 @@ impl Inner {
         if Self::matching_trust(auth, context).is_none() {
             return false;
         }
-        self.transport_auth
-            .lock()
-            .expect("transport auth lock")
-            .get(&TransportOwner::from_context(context))
-            .is_some_and(|current| {
-                current.trust == auth.trust
-                    && current.local_roots == auth.local_roots
-                    && current.owner_user_id == auth.owner_user_id
-                    && current.auth_generation == auth.auth_generation
-                    && current.transport_kind == auth.transport_kind
-            })
+        let key = TransportOwner::from_context(context);
+        if self.revoked_transports.lock().expect("revoked transport lock").contains(&key) {
+            return false;
+        }
+        self.transport_auth.lock().expect("transport auth lock").get(&key).is_some_and(|current| {
+            current.trust == auth.trust
+                && current.local_roots == auth.local_roots
+                && current.owner_user_id == auth.owner_user_id
+                && current.auth_generation == auth.auth_generation
+                && current.transport_kind == auth.transport_kind
+        })
     }
 
     fn handle_authorization_failure(
@@ -1777,6 +1926,11 @@ impl Inner {
         }
         let snapshot = AuthSnapshot::from_context(context);
         let owner = TransportOwner::from_context(context);
+        let revoked =
+            self.revoked_transports.lock().expect("revoked transport lock").contains(&owner);
+        if revoked {
+            return false;
+        }
         let mut transport_auth = self.transport_auth.lock().expect("transport auth lock");
         if context.transport_id.is_none() {
             // Legacy whole-manager callers use `None` and provide the

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1914,6 +1914,16 @@ impl Inner {
         }
     }
 
+    fn close_if_generation(&self, pty_id: &str, generation: &Arc<AtomicBool>) {
+        let Some(attachment) = self
+            .attachment(pty_id)
+            .filter(|attachment| Arc::ptr_eq(&attachment.closing, generation))
+        else {
+            return;
+        };
+        self.retire_if_current(pty_id, &attachment);
+    }
+
     /// Frame-level transport fence. Unknown ids retain the protocol's silent
     /// no-op behavior; once an id is reserved or attached, a different
     /// transport may not act on it. A `None` caller owns everything (legacy).
@@ -3616,7 +3626,7 @@ impl Inner {
         let exit_generation = Arc::clone(&closing);
         let on_exit: ExitSink = Arc::new(move |code| {
             if stream_for_exit.overflowed() {
-                relay.close(&pty_id_for_exit);
+                relay.close_if_generation(&pty_id_for_exit, &exit_generation);
                 send_pty_error(
                     &context_for_exit,
                     &pty_id_for_exit,

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -418,6 +418,10 @@ struct ViewerSink {
 /// fans output out to every attachment (multi-viewer, tmux-style).
 struct ShellSession {
     control: Arc<dyn PtyControl>,
+    /// Existing-session opens that have selected this session but have not
+    /// published their viewer yet. Cancellation cleanup must not kill the
+    /// session while one of these opens can still attach.
+    pending_viewers: AtomicUsize,
     /// Serializes pause ownership transitions before touching the shared PTY.
     flow_lock: Mutex<()>,
     /// Serializes output delivery with paused-viewer replay.
@@ -551,7 +555,9 @@ fn remove_cached_shell_if_same_without_viewers(
     // Serialize with viewer start. A concurrent opener may have cloned this
     // session but cannot publish its viewer while this dispatch lock is held.
     let _dispatch = target.dispatch_lock.lock().expect("shell dispatch lock");
-    if !target.inner.lock().expect("shell inner lock").viewers.is_empty() {
+    if !target.inner.lock().expect("shell inner lock").viewers.is_empty()
+        || target.pending_viewers.load(Ordering::Acquire) != 0
+    {
         return false;
     }
     let mut shells = inner.shell_sessions.lock().expect("shell lock");
@@ -2339,34 +2345,27 @@ impl Inner {
             )
             .await
             else {
-                control.end();
                 return Err("cannot inspect existing daemon surfaces".to_owned());
             };
             if listed.get("ok").and_then(Value::as_bool) != Some(true) {
-                control.end();
                 return Err("cannot inspect existing daemon surfaces".to_owned());
             }
             let Some(data) = listed.get("data").and_then(Value::as_object) else {
-                control.end();
                 return Err("cannot inspect existing daemon surfaces".to_owned());
             };
             if !data.get("workspaces").is_some_and(Value::is_array) {
-                control.end();
                 return Err("cannot inspect existing daemon surfaces".to_owned());
             }
             if !workspace_shape_valid(listed.get("data")) {
-                control.end();
                 return Err("cannot inspect existing daemon surfaces".to_owned());
             }
             let tabs = match collect_pty_tabs_strict(listed.get("data")) {
                 Ok(tabs) => tabs,
                 Err(_) => {
-                    control.end();
                     return Err("cannot inspect existing daemon surfaces".to_owned());
                 }
             };
             if tabs.len() > MAX_ENUM_TERMINALS || (tabs.is_empty() && !ensured.created) {
-                control.end();
                 return Err("cannot prove existing daemon cwd is within allowed roots".to_owned());
             }
             for tab in tabs {
@@ -2381,23 +2380,19 @@ impl Inner {
                 )
                 .await
                 else {
-                    control.end();
                     return Err("cannot inspect existing surface cwd".to_owned());
                 };
                 if info.get("ok").and_then(Value::as_bool) != Some(true) {
-                    control.end();
                     return Err("cannot inspect existing surface cwd".to_owned());
                 }
                 let Some(actual) =
                     info.get("data").and_then(|v| v.get("cwd")).and_then(Value::as_str)
                 else {
-                    control.end();
                     return Err(
                         "cannot prove existing surface cwd is within allowed roots".to_owned()
                     );
                 };
                 if actual.is_empty() || !Path::new(actual).is_absolute() {
-                    control.end();
                     return Err(
                         "cannot prove existing surface cwd is within allowed roots".to_owned()
                     );
@@ -2410,7 +2405,6 @@ impl Inner {
                 )
                 .is_err()
                 {
-                    control.end();
                     return Err("existing surface cwd is outside allowed roots".to_owned());
                 }
             }
@@ -2472,6 +2466,7 @@ impl Inner {
         open_permit: &OpenPermit,
     ) -> Result<Opened, String> {
         let mut created = false;
+        let mut pending_viewer = false;
         let shell_session = loop {
             if let Some(existing) =
                 self.shell_sessions.lock().expect("shell lock").get(session).cloned()
@@ -2482,6 +2477,8 @@ impl Inner {
                     return Err("cannot reattach existing shell under scoped roots".to_owned());
                 }
                 existing.control.resize(cols, rows);
+                existing.pending_viewers.fetch_add(1, Ordering::AcqRel);
+                pending_viewer = true;
                 break existing;
             }
             let (notify, owner, waiter) = {
@@ -2546,6 +2543,7 @@ impl Inner {
                 let PtyHandle { control, output, banner } = handle;
                 let shell_session = Arc::new(ShellSession {
                     control,
+                    pending_viewers: AtomicUsize::new(0),
                     flow_lock: Mutex::new(()),
                     dispatch_lock: Mutex::new(()),
                     banner,
@@ -2671,6 +2669,11 @@ impl Inner {
 
         let start_session = Arc::clone(&shell_session);
         let start: Box<dyn FnOnce() + Send> = Box::new(move || {
+            // This open has reached its publication callback. It no longer
+            // counts as a pending viewer for cancellation cleanup.
+            if pending_viewer {
+                start_session.pending_viewers.fetch_sub(1, Ordering::AcqRel);
+            }
             let (banner, replay, alive, delivery_lock) = {
                 let _dispatch = start_session.dispatch_lock.lock().expect("shell dispatch lock");
                 let _flow = start_session.flow_lock.lock().expect("shell flow lock");

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2186,6 +2186,12 @@ impl Inner {
         if context.cancellation.is_cancelled() || Trust::parse(&context.trust).is_none() {
             return false;
         }
+        // Legacy callers have no transport identity, so their cache write is
+        // the only disconnect fence available. Serialize it with detach and
+        // identified-authority replacement. A frame admitted before a detach
+        // is then included in that detach's cleanup scan rather than
+        // re-registering authority halfway through it.
+        let _update = self.transport_auth_updates.lock().expect("transport auth update lock");
         let _state = self.tunnel_state.lock().expect("tunnel state lock");
         if context.cancellation.is_cancelled() || !self.tunnel_authority_generation_current(context)
         {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -285,6 +285,40 @@ pub struct FrameContext {
     pub transport_id: Option<String>,
     /// Raised when the transport that requested this work disconnects.
     pub cancellation: CancellationToken,
+    /// Structured transport class. IDs are opaque and must not be classified
+    /// by string prefixes at a security boundary.
+    pub transport_kind: TransportKind,
+    /// Generation of the managed tunnel authority that admitted this frame.
+    /// `None` is retained for legacy whole-manager and relay-socket callers.
+    pub auth_generation: Option<u64>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum TransportKind {
+    /// The legacy whole-manager caller, which owns all non-tunnel state.
+    Legacy,
+    /// The authenticated relay WebSocket.
+    Relay,
+    /// The managed-sandbox loopback tunnel.
+    Tunnel,
+}
+
+impl Default for TransportKind {
+    fn default() -> Self {
+        Self::Legacy
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct TransportOwner {
+    id: Option<String>,
+    kind: TransportKind,
+}
+
+impl TransportOwner {
+    fn from_context(context: &FrameContext) -> Self {
+        Self { id: context.transport_id.clone(), kind: context.transport_kind }
+    }
 }
 
 #[derive(Clone)]
@@ -294,6 +328,8 @@ struct AuthSnapshot {
     owner_user_id: Option<String>,
     send: Arc<dyn Fn(Value) + Send + Sync>,
     buffered_amount: Arc<dyn Fn() -> u64 + Send + Sync>,
+    auth_generation: Option<u64>,
+    transport_kind: TransportKind,
 }
 
 impl AuthSnapshot {
@@ -304,6 +340,8 @@ impl AuthSnapshot {
             owner_user_id: context.owner_user_id.clone(),
             send: Arc::clone(&context.send),
             buffered_amount: Arc::clone(&context.buffered_amount),
+            auth_generation: context.auth_generation,
+            transport_kind: context.transport_kind,
         }
     }
 }
@@ -348,8 +386,13 @@ struct Attachment {
     /// kill a viewer PTY) — never kills a shared session.
     control: Arc<dyn PtyControl>,
     actor_id: String,
-    /// Transport that opened this attachment (see FrameContext::transport_id).
-    transport_id: Option<String>,
+    /// Typed transport that opened this attachment.
+    owner: TransportOwner,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct OpeningOwner {
+    owner: TransportOwner,
 }
 
 struct Inner {
@@ -360,8 +403,8 @@ struct Inner {
     scrollback_limit: usize,
     output_cap: u64,
     attachments: Mutex<HashMap<String, Attachment>>,
-    /// ptyId -> transport that reserved it (None = legacy whole-manager owner).
-    opening_ids: Mutex<HashMap<String, Option<String>>>,
+    /// ptyId -> typed transport that reserved it.
+    opening_ids: Mutex<HashMap<String, OpeningOwner>>,
     cancelled_openings: Mutex<std::collections::HashSet<String>>,
     shell_sessions: Mutex<HashMap<String, Arc<ShellSession>>>,
     shell_starting: Mutex<HashMap<String, Arc<Notify>>>,
@@ -369,7 +412,14 @@ struct Inner {
     /// A single manager serves the relay socket and managed tunnel sockets;
     /// one global snapshot would let the last frame on either transport
     /// authorize asynchronous output for every other attachment.
-    transport_auth: Mutex<HashMap<Option<String>, AuthSnapshot>>,
+    transport_auth: Mutex<HashMap<TransportOwner, AuthSnapshot>>,
+    /// Serializes tunnel authorization side effects with authority revocation.
+    /// The lock is held only across synchronous PTY operations and final
+    /// attachment installation, never across provider awaits.
+    tunnel_lifecycle: Mutex<()>,
+    /// Monotonic floor for managed tunnel authority generations. It remains
+    /// effective while a stale open is still unwinding after revocation.
+    tunnel_authority_generation: AtomicU64,
 }
 
 struct ShellStartReservation {
@@ -391,12 +441,18 @@ impl Drop for ShellStartReservation {
 struct OpeningReservation {
     inner: Arc<Inner>,
     id: String,
+    owner: OpeningOwner,
     active: bool,
 }
 impl Drop for OpeningReservation {
     fn drop(&mut self) {
         if self.active {
-            self.inner.opening_ids.lock().expect("opening lock").remove(&self.id);
+            let mut opening = self.inner.opening_ids.lock().expect("opening lock");
+            if opening.get(&self.id) == Some(&self.owner) {
+                opening.remove(&self.id);
+            }
+            drop(opening);
+            self.inner.cancelled_openings.lock().expect("cancelled openings lock").remove(&self.id);
         }
     }
 }
@@ -421,6 +477,8 @@ impl PtyManager {
                 shell_sessions: Mutex::new(HashMap::new()),
                 shell_starting: Mutex::new(HashMap::new()),
                 transport_auth: Mutex::new(HashMap::new()),
+                tunnel_lifecycle: Mutex::new(()),
+                tunnel_authority_generation: AtomicU64::new(0),
             }),
         }
     }
@@ -447,34 +505,27 @@ impl PtyManager {
                 shell_sessions: Mutex::new(HashMap::new()),
                 shell_starting: Mutex::new(HashMap::new()),
                 transport_auth: Mutex::new(HashMap::new()),
+                tunnel_lifecycle: Mutex::new(()),
+                tunnel_authority_generation: AtomicU64::new(0),
             }),
         }
     }
 
     /// Handle one Worker -> relay PTY frame.
     pub async fn handle_frame(&self, frame: &Value, context: &FrameContext) {
-        {
-            let snapshot = AuthSnapshot::from_context(context);
-            let mut transport_auth = self.inner.transport_auth.lock().expect("transport auth lock");
-            if context.transport_id.is_none() {
-                // Legacy whole-manager callers use `None` and provide the
-                // current trust on each frame. Keep that contract for non-
-                // transport code.
-                transport_auth.insert(context.transport_id.clone(), snapshot);
-            } else {
-                // A connection can have an open in flight while trust is
-                // renegotiated. Do not let that stale frame overwrite the
-                // authoritative snapshot; session code calls
-                // `update_transport_auth` at each reconciliation boundary.
-                transport_auth.entry(context.transport_id.clone()).or_insert(snapshot);
-            }
-        }
         let frame_type = frame.get("type").and_then(Value::as_str).unwrap_or_default();
+        if !self.inner.cache_transport_auth(context) {
+            return;
+        }
         match frame_type {
             "pty_open" => self.inner.clone().open(frame, context).await,
             "pty_input" => {
                 let Some(pty_id) = frame.get("ptyId").and_then(Value::as_str) else { return };
-                if !self.inner.transport_owns(pty_id, context.transport_id.as_deref()) {
+                let _lifecycle = self.inner.tunnel_lifecycle_guard(context);
+                if !self.inner.tunnel_authority_generation_current(context) {
+                    return;
+                }
+                if !self.inner.transport_owns(pty_id, context) {
                     return;
                 }
                 let Some(data) = frame
@@ -491,7 +542,11 @@ impl PtyManager {
             }
             "pty_resize" => {
                 let Some(pty_id) = frame.get("ptyId").and_then(Value::as_str) else { return };
-                if !self.inner.transport_owns(pty_id, context.transport_id.as_deref()) {
+                let _lifecycle = self.inner.tunnel_lifecycle_guard(context);
+                if !self.inner.tunnel_authority_generation_current(context) {
+                    return;
+                }
+                if !self.inner.transport_owns(pty_id, context) {
                     return;
                 }
                 let (Some(cols), Some(rows)) =
@@ -505,7 +560,11 @@ impl PtyManager {
             }
             "pty_flow" => {
                 let Some(pty_id) = frame.get("ptyId").and_then(Value::as_str) else { return };
-                if !self.inner.transport_owns(pty_id, context.transport_id.as_deref()) {
+                let _lifecycle = self.inner.tunnel_lifecycle_guard(context);
+                if !self.inner.tunnel_authority_generation_current(context) {
+                    return;
+                }
+                if !self.inner.transport_owns(pty_id, context) {
                     return;
                 }
                 let pause = frame.get("pause").and_then(Value::as_bool).unwrap_or(false);
@@ -519,7 +578,11 @@ impl PtyManager {
             }
             "pty_close" => {
                 let Some(pty_id) = frame.get("ptyId").and_then(Value::as_str) else { return };
-                if !self.inner.transport_owns(pty_id, context.transport_id.as_deref()) {
+                let _lifecycle = self.inner.tunnel_lifecycle_guard(context);
+                if !self.inner.tunnel_authority_generation_current(context) {
+                    return;
+                }
+                if !self.inner.transport_owns(pty_id, context) {
                     return;
                 }
                 self.inner.close_authorized(pty_id, context);
@@ -534,11 +597,34 @@ impl PtyManager {
     /// Network frames never get to replace an existing snapshot implicitly.
     pub fn update_transport_auth(&self, context: &FrameContext) {
         debug_assert!(context.transport_id.is_some(), "transport refresh needs an id");
+        let _lifecycle = self.inner.tunnel_lifecycle_guard(context);
+        if !self.inner.tunnel_authority_generation_current(context) {
+            return;
+        }
         self.inner
             .transport_auth
             .lock()
             .expect("transport auth lock")
-            .insert(context.transport_id.clone(), AuthSnapshot::from_context(context));
+            .insert(TransportOwner::from_context(context), AuthSnapshot::from_context(context));
+    }
+
+    /// Advance the managed tunnel authority floor before publishing the
+    /// matching snapshot. A stale in-flight frame cannot recreate a removed
+    /// transport entry after this point.
+    pub fn set_tunnel_authority_generation(&self, generation: u64) {
+        let _lifecycle = self.inner.tunnel_lifecycle.lock().expect("tunnel lifecycle lock");
+        let mut current = self.inner.tunnel_authority_generation.load(Ordering::Acquire);
+        while generation > current {
+            match self.inner.tunnel_authority_generation.compare_exchange_weak(
+                current,
+                generation,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => break,
+                Err(observed) => current = observed,
+            }
+        }
     }
 
     /// True while `pty_id` has a live attachment. The tunnel listener uses
@@ -564,24 +650,38 @@ impl PtyManager {
     /// One transport dropped: release only its attachments and cancel only
     /// its in-flight opens. Sessions live on either way (docs/TERMINAL.md).
     pub fn detach_transport(&self, transport_id: &str) {
-        self.detach_matching(|owner| owner == Some(transport_id));
+        self.detach_matching(|owner| owner.id.as_deref() == Some(transport_id));
+    }
+
+    /// One typed transport dropped. This avoids treating an opaque relay ID
+    /// as a namespace discriminator.
+    pub fn detach_transport_kind(&self, transport_id: &str, kind: TransportKind) {
+        self.detach_matching(|owner| {
+            owner.id.as_deref() == Some(transport_id) && owner.kind == kind
+        });
     }
 
     /// Release all managed tunnel attachments. The relay connection clears
     /// tunnel authority on disconnect or trust renegotiation; existing tunnel
     /// viewers must lose their attachments at the same boundary.
     pub fn detach_tunnel_transports(&self) {
-        self.detach_matching(|owner| owner.is_some_and(|id| id.starts_with("tunnel-")));
+        let _lifecycle = self.inner.tunnel_lifecycle.lock().expect("tunnel lifecycle lock");
+        self.detach_matching_unlocked(|owner| owner.kind == TransportKind::Tunnel);
     }
 
     fn detach_matching(&self, owns: impl Fn(Option<&str>) -> bool) {
+        let _lifecycle = self.inner.tunnel_lifecycle.lock().expect("tunnel lifecycle lock");
+        self.detach_matching_unlocked(|owner| owns(owner.id.as_deref()));
+    }
+
+    fn detach_matching_unlocked(&self, owns: impl Fn(&TransportOwner) -> bool) {
         // Openings first: close() records cancellation for a reserved id, so
         // a late open cannot install an attachment after its transport died.
         let mut ids: Vec<String> = {
             let opening = self.inner.opening_ids.lock().expect("opening lock");
             opening
                 .iter()
-                .filter(|(_, owner)| owns(owner.as_deref()))
+                .filter(|(_, owner)| owns(&owner.owner))
                 .map(|(id, _)| id.clone())
                 .collect()
         };
@@ -590,7 +690,7 @@ impl PtyManager {
             ids.extend(
                 attachments
                     .iter()
-                    .filter(|(_, attachment)| owns(attachment.transport_id.as_deref()))
+                    .filter(|(_, attachment)| owns(&attachment.owner))
                     .map(|(id, _)| id.clone()),
             );
         }
@@ -601,7 +701,7 @@ impl PtyManager {
             .transport_auth
             .lock()
             .expect("transport auth lock")
-            .retain(|owner, _| !owns(owner.as_deref()));
+            .retain(|owner, _| !owns(owner));
     }
 }
 
@@ -657,7 +757,12 @@ impl Inner {
         if pty_id.is_empty() {
             return;
         }
+        if !self.tunnel_authority_generation_current(context) {
+            send_pty_error(context, &pty_id, "trust_revoked", "tunnel authority changed");
+            return;
+        }
         let fail = |code: &str, message: &str| send_pty_error(context, &pty_id, code, message);
+        let reservation_owner = OpeningOwner { owner: TransportOwner::from_context(context) };
         let reservation_result = {
             let mut opening = self.opening_ids.lock().expect("opening lock");
             let attached = self.attachments.lock().expect("attach lock").contains_key(&pty_id);
@@ -671,7 +776,7 @@ impl Inner {
                     format!("this relay caps concurrent terminals at {}", self.max_ptys),
                 ))
             } else {
-                opening.insert(pty_id.clone(), context.transport_id.clone());
+                opening.insert(pty_id.clone(), reservation_owner.clone());
                 Ok(())
             }
         };
@@ -680,7 +785,12 @@ impl Inner {
             return;
         }
         let mut reservation =
-            OpeningReservation { inner: Arc::clone(&self), id: pty_id.clone(), active: true };
+            OpeningReservation {
+                inner: Arc::clone(&self),
+                id: pty_id.clone(),
+                owner: reservation_owner.clone(),
+                active: true,
+            };
 
         let session = frame.get("session").and_then(Value::as_str).unwrap_or_default().to_owned();
         let (Some(cols), Some(rows)) = (clamp_dim(frame.get("cols")), clamp_dim(frame.get("rows")))
@@ -826,6 +936,7 @@ impl Inner {
         // Keep the opening reservation held until the attachment is installed.
         // `close` takes this lock first, so it cannot observe a gap between
         // removing the opening marker and inserting the attachment.
+        let _lifecycle = self.tunnel_lifecycle_guard(context);
         let mut opening = self.opening_ids.lock().expect("opening lock");
         let cancelled =
             self.cancelled_openings.lock().expect("cancelled openings lock").remove(&pty_id);
@@ -833,14 +944,20 @@ impl Inner {
             .transport_auth
             .lock()
             .expect("transport auth lock")
-            .get(&context.transport_id)
+            .get(&TransportOwner::from_context(context))
             .is_none_or(|auth| {
                 auth.trust != context.trust
-                    || auth.local_roots != context.local_roots
-                    || auth.owner_user_id != context.owner_user_id
+                || auth.local_roots != context.local_roots
+                || auth.owner_user_id != context.owner_user_id
+                || auth.auth_generation != context.auth_generation
+                || auth.transport_kind != context.transport_kind
             });
-        if cancelled || auth_changed {
-            opening.remove(&pty_id);
+        let authority_changed = !self.tunnel_authority_generation_current(context);
+        let reservation_owned = opening.get(&pty_id) == Some(&reservation_owner);
+        if !reservation_owned || cancelled || auth_changed || authority_changed {
+            if reservation_owned {
+                opening.remove(&pty_id);
+            }
             drop(opening);
             reservation.active = false;
             return;
@@ -858,7 +975,7 @@ impl Inner {
                 closing,
                 control,
                 actor_id: actor.to_owned(),
-                transport_id: context.transport_id.clone(),
+                owner: TransportOwner::from_context(context),
             },
         );
         if let Some(previous) = previous {
@@ -906,7 +1023,11 @@ impl Inner {
     }
 
     fn emit_output(&self, pty_id: &str, chunk: &Bytes, context: &FrameContext) {
-        let Some(auth) = self.auth_for_transport(context.transport_id.as_deref()) else {
+        let _lifecycle = self.tunnel_lifecycle_guard(context);
+        if !self.tunnel_authority_generation_current(context) {
+            return;
+        }
+        let Some(auth) = self.auth_for_transport(context) else {
             return;
         };
         if self.authorize_snapshot(pty_id, &auth, context, "output").is_none() {
@@ -943,7 +1064,11 @@ impl Inner {
     }
 
     fn emit_exit(&self, pty_id: &str, code: i64, context: &FrameContext) {
-        let Some(auth) = self.auth_for_transport(context.transport_id.as_deref()) else {
+        let _lifecycle = self.tunnel_lifecycle_guard(context);
+        if !self.tunnel_authority_generation_current(context) {
+            return;
+        }
+        let Some(auth) = self.auth_for_transport(context) else {
             return;
         };
         if self.authorize_snapshot(pty_id, &auth, context, "exit").is_none() {
@@ -987,24 +1112,26 @@ impl Inner {
     /// Frame-level transport fence. Unknown ids retain the protocol's silent
     /// no-op behavior; once an id is reserved or attached, a different
     /// transport may not act on it. A `None` caller owns everything (legacy).
-    fn transport_owns(&self, pty_id: &str, transport_id: Option<&str>) -> bool {
-        let Some(transport_id) = transport_id else { return true };
+    fn transport_owns(&self, pty_id: &str, context: &FrameContext) -> bool {
+        let Some(transport_id) = context.transport_id.as_deref() else { return true };
         if let Some(attachment) = self.attachments.lock().expect("attach lock").get(pty_id) {
-            return attachment.transport_id.as_deref() == Some(transport_id);
+            return attachment.owner.id.as_deref() == Some(transport_id)
+                && attachment.owner.kind == context.transport_kind;
         }
         if let Some(owner) = self.opening_ids.lock().expect("opening lock").get(pty_id) {
-            return owner.as_deref() == Some(transport_id);
+            return owner.owner.id.as_deref() == Some(transport_id)
+                && owner.owner.kind == context.transport_kind;
         }
         true
     }
 
     fn authorize(&self, pty_id: &str, context: &FrameContext, action: &str) -> Option<Attachment> {
-        let auth = self.auth_for_transport(context.transport_id.as_deref())?;
+        let auth = self.auth_for_transport(context)?;
         self.authorize_snapshot(pty_id, &auth, context, action)
     }
 
-    fn auth_for_transport(&self, transport_id: Option<&str>) -> Option<AuthSnapshot> {
-        let key = transport_id.map(str::to_owned);
+    fn auth_for_transport(&self, context: &FrameContext) -> Option<AuthSnapshot> {
+        let key = TransportOwner::from_context(context);
         self.transport_auth.lock().expect("transport auth lock").get(&key).cloned()
     }
 
@@ -1085,6 +1212,43 @@ fn drive_handle(
 }
 
 impl Inner {
+    fn tunnel_lifecycle_guard(
+        &self,
+        context: &FrameContext,
+    ) -> Option<std::sync::MutexGuard<'_, ()>> {
+        (context.transport_kind == TransportKind::Tunnel)
+            .then(|| self.tunnel_lifecycle.lock().expect("tunnel lifecycle lock"))
+    }
+
+    fn cache_transport_auth(&self, context: &FrameContext) -> bool {
+        let _lifecycle = self.tunnel_lifecycle_guard(context);
+        if !self.tunnel_authority_generation_current(context) {
+            return false;
+        }
+        let snapshot = AuthSnapshot::from_context(context);
+        let owner = TransportOwner::from_context(context);
+        let mut transport_auth = self.transport_auth.lock().expect("transport auth lock");
+        if context.transport_id.is_none() {
+            // Legacy whole-manager callers use `None` and provide the
+            // current trust on each frame. Keep that contract for non-
+            // transport code.
+            transport_auth.insert(owner, snapshot);
+        } else {
+            // A connection can have an open in flight while trust is
+            // renegotiated. Do not let that stale frame overwrite the
+            // authoritative snapshot; session code calls
+            // `update_transport_auth` at each reconciliation boundary.
+            transport_auth.entry(owner).or_insert(snapshot);
+        }
+        true
+    }
+
+    fn tunnel_authority_generation_current(&self, context: &FrameContext) -> bool {
+        context.auth_generation.is_none_or(|generation| {
+            generation >= self.tunnel_authority_generation.load(Ordering::Acquire)
+        })
+    }
+
     /// cmux-tui path: daemon owns the session; the viewer is disposable.
     #[allow(clippy::too_many_arguments)]
     async fn open_cmux(
@@ -2024,6 +2188,10 @@ impl Inner {
                 }));
             }
         }
+        let _lifecycle = self.tunnel_lifecycle_guard(context);
+        if !self.tunnel_authority_generation_current(context) {
+            return;
+        }
         (context.send)(json!({
             "version": PTY_PROTOCOL_VERSION,
             "type": "surface_list_result",
@@ -2374,6 +2542,8 @@ mod tests {
                 owner_user_id: owner,
                 transport_id: None,
                 cancellation: CancellationToken::new(),
+                transport_kind: TransportKind::Legacy,
+                auth_generation: None,
             }
         }
 
@@ -2385,6 +2555,7 @@ mod tests {
         ) -> FrameContext {
             let mut context = self.context(trust, owner);
             context.transport_id = transport_id.map(str::to_owned);
+            context.transport_kind = transport_id.map_or(TransportKind::Legacy, |_| TransportKind::Relay);
             context
         }
 
@@ -2950,6 +3121,8 @@ mod tests {
             local_roots: None,
             owner_user_id: Some("user_owner".to_owned()),
             transport_id: Some(transport.to_owned()),
+            transport_kind: TransportKind::Relay,
+            auth_generation: None,
         };
         let context_a = context(Arc::clone(&sent_a), "transport-a");
         let context_b = context(Arc::clone(&sent_b), "transport-b");
@@ -3124,6 +3297,8 @@ mod tests {
             local_roots: None,
             owner_user_id: None,
             transport_id: None,
+            transport_kind: TransportKind::Legacy,
+            auth_generation: None,
         };
         super::send_pty_error(
             &context,

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -3354,6 +3354,9 @@ mod tests {
                 sink(Bytes::copy_from_slice(text.as_bytes()));
             }
         }
+        fn emit_while_paused(&self, text: &str) {
+            self.emit(text);
+        }
         fn exit(&self, code: i64) {
             let sink = self.state.lock().unwrap().on_exit.clone();
             if let Some(sink) = sink {
@@ -4078,6 +4081,43 @@ mod tests {
             .collect();
         ids.sort();
         assert_eq!(ids, vec!["p1", "p2"]);
+    }
+
+    #[tokio::test]
+    async fn paused_shell_viewer_does_not_receive_continued_output() {
+        let h = harness(None, None);
+        h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;
+        h.open("p2", "main", Value::Null, "supervised", h.owner.clone()).await;
+        let pty = h.spawned()[0].clone();
+
+        h.frame(serde_json::json!({ "type": "pty_flow", "ptyId": "p1", "pause": true })).await;
+        let before = h.sent().len();
+        pty.emit_while_paused("continued output");
+        let continued: Vec<(String, String)> = h.sent()[before..]
+            .iter()
+            .filter(|frame| ty(frame) == "pty_output")
+            .map(|frame| {
+                (
+                    frame["ptyId"].as_str().unwrap().to_owned(),
+                    from_b64(frame["dataB64"].as_str().unwrap()),
+                )
+            })
+            .collect();
+        assert_eq!(continued, vec![("p2".to_owned(), "continued output".to_owned())]);
+
+        let before_resume = h.sent().len();
+        h.frame(serde_json::json!({ "type": "pty_flow", "ptyId": "p1", "pause": false })).await;
+        let replayed: Vec<(String, String)> = h.sent()[before_resume..]
+            .iter()
+            .filter(|frame| ty(frame) == "pty_output")
+            .map(|frame| {
+                (
+                    frame["ptyId"].as_str().unwrap().to_owned(),
+                    from_b64(frame["dataB64"].as_str().unwrap()),
+                )
+            })
+            .collect();
+        assert_eq!(replayed, vec![("p1".to_owned(), "continued output".to_owned())]);
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -4535,6 +4535,76 @@ mod tests {
     }
 
     #[test]
+    fn detaching_does_not_wait_for_a_blocked_output_sink() {
+        let h = harness(None, None);
+        let entered = Arc::new(Barrier::new(2));
+        let release = Arc::new(Barrier::new(2));
+        let sent = Arc::new(StdMutex::new(Vec::new()));
+        let context = FrameContext {
+            send: {
+                let entered = Arc::clone(&entered);
+                let release = Arc::clone(&release);
+                Arc::new(move |frame| {
+                    sent.lock().unwrap().push(frame);
+                    entered.wait();
+                    release.wait();
+                })
+            },
+            buffered_amount: Arc::new(|| 0),
+            trust: "supervised".to_owned(),
+            local_roots: None,
+            owner_user_id: h.owner.clone(),
+            transport_id: Some("relay-blocked".to_owned()),
+            cancellation: CancellationToken::new(),
+            transport_kind: TransportKind::Relay,
+            auth_generation: None,
+        };
+        h.manager.update_transport_auth(&context);
+        let pty = FakePty {
+            state: Arc::new(StdMutex::new(FakeState::default())),
+            spawn_file: String::new(),
+            spawn_cwd: PathBuf::new(),
+            spawn_term: String::new(),
+            cancel_on_subscribe: Arc::new(AtomicBool::new(false)),
+            cancellation: CancellationToken::new(),
+        };
+        let attachment = Attachment {
+            closing: Arc::new(AtomicBool::new(false)),
+            operation_gate: Arc::new(Mutex::new(())),
+            control: Arc::new(pty),
+            actor_id: "user_owner".to_owned(),
+            owner: TransportOwner {
+                id: Some("relay-blocked".to_owned()),
+                kind: TransportKind::Relay,
+            },
+        };
+        h.manager.inner.attachments.lock().unwrap().insert("p1".to_owned(), attachment);
+
+        let inner = Arc::clone(&h.manager.inner);
+        let output_context = context.clone();
+        let output = thread::spawn(move || {
+            inner.emit_output("p1", &Bytes::from_static(b"blocked"), &output_context);
+        });
+        entered.wait();
+
+        let manager = Arc::new(h.manager);
+        let (detached_tx, detached_rx) = sync_channel(0);
+        let detach_manager = Arc::clone(&manager);
+        let detach = thread::spawn(move || {
+            detach_manager.detach_transport_kind("relay-blocked", TransportKind::Relay);
+            detached_tx.send(()).unwrap();
+        });
+        assert!(
+            detached_rx.recv_timeout(Duration::from_millis(100)).is_ok(),
+            "detach must not wait for a blocked output callback"
+        );
+
+        release.wait();
+        output.join().unwrap();
+        detach.join().unwrap();
+    }
+
+    #[test]
     fn an_old_open_drop_cannot_clear_a_new_owner_cancellation_marker() {
         let h = harness(None, None);
         let inner = Arc::clone(&h.manager.inner);

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1657,22 +1657,22 @@ impl Inner {
         // callback and retire the exact attachment when the capability is no
         // longer current.
         let Some(current_attachment) = self
-            .attachment(pty_id)
+            .attachment(&pty_id)
             .filter(|attachment| Arc::ptr_eq(&attachment.publication_gate, &publication_gate))
         else {
             return;
         };
         let Some(auth) = self.auth_for_transport(context) else {
-            self.retire_if_current(pty_id, &current_attachment);
+            self.retire_if_current(&pty_id, &current_attachment);
             return;
         };
         if context.cancellation.is_cancelled()
             || cancellation.is_cancelled()
             || !self.transport_auth_is_current(context, &auth)
-            || !self.attachment_snapshot_is_current(pty_id, &current_attachment)
+            || !self.attachment_snapshot_is_current(&pty_id, &current_attachment)
             || !Self::try_claim_publication(&current_attachment)
         {
-            self.retire_if_current(pty_id, &current_attachment);
+            self.retire_if_current(&pty_id, &current_attachment);
             return;
         }
         (context.send)(Value::Object(opened_frame));
@@ -1685,10 +1685,10 @@ impl Inner {
                 .auth_for_transport(context)
                 .is_some_and(|auth| self.transport_auth_is_current(context, &auth))
             || !self
-                .attachment(pty_id)
-                .is_some_and(|attachment| self.attachment_snapshot_is_current(pty_id, &attachment))
+                .attachment(&pty_id)
+                .is_some_and(|attachment| self.attachment_snapshot_is_current(&pty_id, &attachment))
         {
-            self.retire_if_current(pty_id, &current_attachment);
+            self.retire_if_current(&pty_id, &current_attachment);
             return;
         }
         start();
@@ -1697,10 +1697,10 @@ impl Inner {
         // cannot leave a quiet attachment running without an owner.
         if cancellation.is_cancelled() {
             if let Some(attachment) = self
-                .attachment(pty_id)
+                .attachment(&pty_id)
                 .filter(|attachment| Arc::ptr_eq(&attachment.publication_gate, &publication_gate))
             {
-                self.retire_if_current(pty_id, &attachment);
+                self.retire_if_current(&pty_id, &attachment);
             }
         }
     }
@@ -2545,7 +2545,7 @@ impl Inner {
         let handle = tokio::select! {
             biased;
             _ = cancellation.token().cancelled() => {
-                return Err((RelayPtyErrorCode::Failed, "terminal open cancelled".to_owned()));
+                return Err("terminal open cancelled".to_owned());
             }
             handle = self.deps.spawn_pty(
                 SpawnSpec {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1199,9 +1199,23 @@ impl Inner {
         // installed its capacity reservation.
         let active_registered = {
             let _state = self.tunnel_state.lock().expect("tunnel state lock");
+            // Revalidate at the same state boundary as registration. A stale
+            // frame may have passed the earlier snapshot read while a detach
+            // was waiting for this lock; do not admit provider work after the
+            // active transport snapshot has been removed or replaced.
+            let authority_current = !context.cancellation.is_cancelled()
+                && self.tunnel_authority_generation_current(context)
+                && self
+                    .transport_auth
+                    .lock()
+                    .expect("transport auth lock")
+                    .get(&reservation_owner.owner)
+                    .is_some_and(|current| auth_snapshot_matches(current, &auth));
             let mut opening = self.opening_state.lock().expect("opening state lock");
             let attachments = self.attachments.lock().expect("attach lock");
-            if attachments.contains_key(&pty_id)
+            if !authority_current {
+                Err(("trust_revoked", "terminal trust is not current"))
+            } else if attachments.contains_key(&pty_id)
                 || opening.reservations.contains_key(&pty_id)
                 || opening.active_openings.contains_key(&pty_id)
             {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -4171,7 +4171,8 @@ mod tests {
         let gate =
             Arc::new(ResolveGate { entered: Arc::clone(&entered), release: Arc::clone(&release) });
         let h = harness_with_control_and_gate(None, None, None, None, Some(gate));
-        let context = h.context_with_transport("supervised", h.owner.clone(), Some("tunnel-a"));
+        let mut context = h.context_with_transport("supervised", h.owner.clone(), Some("tunnel-a"));
+        context.transport_kind = TransportKind::Tunnel;
         let manager = Arc::new(h.manager);
         let frame = serde_json::json!({
             "version": 4,

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -4201,10 +4201,11 @@ mod tests {
         });
         let cancellation = h.manager.new_open_cancellation().expect("open attempt token");
         let task_manager = Arc::new(h.manager);
+        let spawned_task_manager = Arc::clone(&task_manager);
         let task_context = context.clone();
         let task_cancellation = cancellation.clone();
         let task = tokio::spawn(async move {
-            task_manager
+            spawned_task_manager
                 .handle_frame_with_open_cancellation(&frame, &task_context, Some(task_cancellation))
                 .await;
         });
@@ -5042,6 +5043,7 @@ mod tests {
             local_roots: None,
             owner_user_id: Some("user_owner".to_owned()),
             transport_id: Some(transport.to_owned()),
+            cancellation: CancellationToken::new(),
             transport_kind: TransportKind::Relay,
             auth_generation: None,
         };
@@ -5220,6 +5222,7 @@ mod tests {
             local_roots: None,
             owner_user_id: None,
             transport_id: None,
+            cancellation: CancellationToken::new(),
             transport_kind: TransportKind::Legacy,
             auth_generation: None,
         };

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -432,6 +432,10 @@ struct Attachment {
     /// Serializes operations for this attachment only. The relay state lock
     /// must never be held while a PTY control method runs.
     operation_gate: Arc<Mutex<()>>,
+    /// Serializes open success publication with attachment retirement. This
+    /// is separate because start callbacks can emit output and re-enter the
+    /// operation gate.
+    publication_gate: Arc<Mutex<()>>,
     /// Releases this attachment (detach a viewer, close a control stream,
     /// kill a viewer PTY) — never kills a shared session.
     control: Arc<dyn PtyControl>,
@@ -1033,6 +1037,8 @@ impl PtyManager {
         // identity is gone and cannot publish after revocation.
         let mut retired = Vec::new();
         for (id, candidate) in candidates {
+            let publication =
+                candidate.publication_gate.lock().expect("attachment publication lock");
             let operation = candidate.operation_gate.lock().expect("attachment operation lock");
             let removed = {
                 let _state = self.inner.tunnel_state.lock().expect("tunnel state lock");
@@ -1047,6 +1053,7 @@ impl PtyManager {
                 retired.push(removed);
             }
             drop(operation);
+            drop(publication);
         }
         RetiredAttachments { inner: Arc::clone(&self.inner), attachments: retired }
     }
@@ -1498,11 +1505,13 @@ impl Inner {
             let control = opened.control.take().expect("opened control handle");
             let start = opened.start.take().expect("opened start callback");
             let surface = opened.surface.take();
+            let publication_gate = Arc::new(Mutex::new(()));
             let previous = self.attachments.lock().expect("attach lock").insert(
                 pty_id.clone(),
                 Attachment {
                     closing,
                     operation_gate: Arc::new(Mutex::new(())),
+                    publication_gate: Arc::clone(&publication_gate),
                     control,
                     actor_id: actor.to_owned(),
                     owner: TransportOwner::from_context(context),
@@ -1512,10 +1521,36 @@ impl Inner {
             opening.cancellations.remove(&reservation_owner);
             opening.cancelled.remove(&pty_id);
             reservation.active = false;
-            (surface, start, previous)
+            (surface, start, previous, publication_gate)
         };
         if let Some(previous) = previous {
             self.retire_attachment(previous);
+        }
+
+        // Keep retirement behind the success frame and startup callbacks.
+        // Every attachment removal takes this gate, so a concurrent detach
+        // cannot revoke the attachment between the final check and publish.
+        let _publication = publication_gate.lock().expect("attachment publication lock");
+        let authority_current = self
+            .auth_for_transport(context)
+            .is_some_and(|auth| self.transport_auth_is_current(context, &auth));
+        let attachment_current = self
+            .attachments
+            .lock()
+            .expect("attach lock")
+            .get(&pty_id)
+            .is_some_and(|current| Arc::ptr_eq(&current.publication_gate, &publication_gate));
+        if !authority_current || !attachment_current {
+            let removed = {
+                let _state = self.tunnel_state.lock().expect("tunnel state lock");
+                let mut attachments = self.attachments.lock().expect("attach lock");
+                attachments.remove(&pty_id)
+            };
+            if let Some(removed) = removed {
+                removed.closing.store(true, Ordering::SeqCst);
+                self.retire_attachment(removed);
+            }
+            return;
         }
 
         let mut opened_frame = serde_json::Map::new();
@@ -1624,6 +1659,7 @@ impl Inner {
         let Some(attachment) = self.attachment(pty_id) else {
             return;
         };
+        let _publication = attachment.publication_gate.lock().expect("attachment publication lock");
         let _operation = attachment.operation_gate.lock().expect("attachment operation lock");
         let authorized = {
             let _state = self.tunnel_state.lock().expect("tunnel state lock");
@@ -1631,6 +1667,7 @@ impl Inner {
         };
         if !authorized {
             drop(_operation);
+            drop(_publication);
             self.handle_authorization_failure(pty_id, &attachment, &auth, context, "exit");
             return;
         }
@@ -1655,6 +1692,7 @@ impl Inner {
             "ptyId": pty_id,
             "code": code,
         }));
+        drop(_publication);
     }
 
     /// Detach, NOT kill: idempotent, unknown ptyId tolerated.
@@ -1672,10 +1710,25 @@ impl Inner {
                 opening.cancelled.insert(pty_id.to_owned(), owner);
                 return;
             }
-            self.attachments.lock().expect("attach lock").remove(pty_id)
+            self.attachments.lock().expect("attach lock").get(pty_id).cloned()
         };
         if let Some(attachment) = attachment {
-            self.retire_attachment(attachment);
+            let _publication =
+                attachment.publication_gate.lock().expect("attachment publication lock");
+            let _operation = attachment.operation_gate.lock().expect("attachment operation lock");
+            let removed = {
+                let _state = self.tunnel_state.lock().expect("tunnel state lock");
+                let mut attachments = self.attachments.lock().expect("attach lock");
+                let same = attachments.get(pty_id).is_some_and(|current| {
+                    Arc::ptr_eq(&current.publication_gate, &attachment.publication_gate)
+                });
+                if same { attachments.remove(pty_id) } else { None }
+            };
+            drop(_operation);
+            drop(_publication);
+            if let Some(removed) = removed {
+                self.retire_attachment(removed);
+            }
         }
     }
 
@@ -1834,6 +1887,7 @@ impl Inner {
         }
 
         let Some(attachment) = self.attachment(pty_id) else { return };
+        let _publication = attachment.publication_gate.lock().expect("attachment publication lock");
         let _operation = attachment.operation_gate.lock().expect("attachment operation lock");
         let authorized = {
             let _state = self.tunnel_state.lock().expect("tunnel state lock");
@@ -1841,6 +1895,7 @@ impl Inner {
         };
         if !authorized {
             drop(_operation);
+            drop(_publication);
             self.handle_authorization_failure(pty_id, &attachment, &auth, context, "close");
             return;
         }
@@ -1921,8 +1976,10 @@ impl Inner {
     }
 
     fn retire_if_current(&self, pty_id: &str, attachment: &Attachment) {
-        // The operation gate is the publication/removal linearization point.
+        // The publication gate serializes open success with removal. The
+        // operation gate then protects the attachment's control lifecycle.
         // Callers must release any prior guard before entering this helper.
+        let publication = attachment.publication_gate.lock().expect("attachment publication lock");
         let operation = attachment.operation_gate.lock().expect("attachment operation lock");
         let removed = {
             let _state = self.tunnel_state.lock().expect("tunnel state lock");
@@ -1936,6 +1993,7 @@ impl Inner {
             removed.closing.store(true, Ordering::SeqCst);
         }
         drop(operation);
+        drop(publication);
         if let Some(removed) = removed {
             self.retire_attachment(removed);
         }
@@ -4440,6 +4498,7 @@ mod tests {
                 Attachment {
                     closing: Arc::new(AtomicBool::new(false)),
                     operation_gate: Arc::new(Mutex::new(())),
+                    publication_gate: Arc::new(Mutex::new(())),
                     control: slow,
                     actor_id: "user_owner".to_owned(),
                     owner: owner_a,
@@ -4450,6 +4509,7 @@ mod tests {
                 Attachment {
                     closing: Arc::new(AtomicBool::new(false)),
                     operation_gate: Arc::new(Mutex::new(())),
+                    publication_gate: Arc::new(Mutex::new(())),
                     control: Arc::new(fast),
                     actor_id: "user_owner".to_owned(),
                     owner: owner_b,
@@ -4503,6 +4563,7 @@ mod tests {
                 Attachment {
                     closing: Arc::new(AtomicBool::new(false)),
                     operation_gate: Arc::new(Mutex::new(())),
+                    publication_gate: Arc::new(Mutex::new(())),
                     control: Arc::new(BlockingControl {
                         entered: Arc::clone(&entered),
                         release: Arc::clone(&release),
@@ -4555,6 +4616,7 @@ mod tests {
                 Attachment {
                     closing: Arc::new(AtomicBool::new(false)),
                     operation_gate: Arc::new(Mutex::new(())),
+                    publication_gate: Arc::new(Mutex::new(())),
                     control: Arc::new(BlockingControl {
                         entered: Arc::clone(&entered),
                         release: Arc::clone(&release),
@@ -4628,6 +4690,7 @@ mod tests {
         let attachment = Attachment {
             closing: Arc::new(AtomicBool::new(false)),
             operation_gate: Arc::new(Mutex::new(())),
+            publication_gate: Arc::new(Mutex::new(())),
             control: Arc::new(pty),
             actor_id: "user_owner".to_owned(),
             owner: TransportOwner {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -402,6 +402,14 @@ fn auth_snapshot_matches(left: &AuthSnapshot, right: &AuthSnapshot) -> bool {
         && left.transport_kind == right.transport_kind
 }
 
+fn auth_context_matches(snapshot: &AuthSnapshot, context: &FrameContext) -> bool {
+    snapshot.trust == context.trust
+        && snapshot.local_roots.as_deref() == context.local_roots.as_deref()
+        && snapshot.owner_user_id == context.owner_user_id
+        && snapshot.auth_generation == context.auth_generation
+        && snapshot.transport_kind == context.transport_kind
+}
+
 /// Scrubbed env for interactive PTYs (actions.mjs base, real TERM).
 pub fn pty_env(base: &HashMap<String, String>) -> HashMap<String, String> {
     let mut env = scrubbed_env(base);
@@ -891,13 +899,22 @@ impl PtyManager {
     /// first frame for an identified transport.
     pub fn update_transport_auth(&self, context: &FrameContext) {
         debug_assert!(context.transport_id.is_some(), "transport refresh needs an id");
-        if context.transport_id.is_none()
-            || context.cancellation.is_cancelled()
-            || Trust::parse(&context.trust).is_none()
-        {
+        let Some(transport_id) = context.transport_id.as_deref() else {
+            return;
+        };
+        let owner = TransportOwner::from_context(context);
+        if context.cancellation.is_cancelled() {
             return;
         }
-        let owner = TransportOwner::from_context(context);
+        if Trust::parse(&context.trust).is_none() {
+            let _update =
+                self.inner.transport_auth_updates.lock().expect("transport auth update lock");
+            let retired = self.inner.detach_matching_locked(|candidate| candidate == &owner);
+            drop(_update);
+            retired.retire();
+            debug_assert_eq!(owner.id.as_deref(), Some(transport_id));
+            return;
+        }
         let snapshot = AuthSnapshot::from_context(context);
         // Serialize replacement. A changed snapshot is removed before the
         // new one is published, so stale frames cannot re-register it during
@@ -2399,12 +2416,12 @@ impl Inner {
         {
             return false;
         }
-        let snapshot = AuthSnapshot::from_context(context);
         let owner = TransportOwner::from_context(context);
         if context.transport_kind == TransportKind::Legacy && context.transport_id.is_none() {
             // Legacy whole-manager callers use `None` and provide the
             // current trust on each frame. Keep that contract for non-
             // transport code.
+            let snapshot = AuthSnapshot::from_context(context);
             self.transport_auth.lock().expect("transport auth lock").insert(owner, snapshot);
             return true;
         }
@@ -2421,7 +2438,7 @@ impl Inner {
             .lock()
             .expect("transport auth lock")
             .get(&owner)
-            .is_some_and(|cached| auth_snapshot_matches(cached, &snapshot))
+            .is_some_and(|cached| auth_context_matches(cached, context))
     }
 
     fn matching_trust(auth: &AuthSnapshot, context: &FrameContext) -> Option<Trust> {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -3050,6 +3050,17 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn unknown_trust_refuses_before_a_pty_is_spawned() {
+        let h = harness(None, None);
+        h.open("p1", "main", Value::Null, "forged-trust", h.owner.clone()).await;
+        let sent = h.sent();
+        assert_eq!(sent.len(), 1);
+        assert_eq!(sent[0]["type"], "pty_error");
+        assert_eq!(sent[0]["code"], "trust_refused");
+        assert!(h.spawned().is_empty(), "malformed authority must not allocate a PTY");
+    }
+
+    #[tokio::test]
     async fn shell_open_output_input_resize_flow_round_trip() {
         let h = harness(None, None);
         h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -314,12 +314,6 @@ pub enum TransportKind {
     Tunnel,
 }
 
-impl Default for TransportKind {
-    fn default() -> Self {
-        Self::Legacy
-    }
-}
-
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 struct TransportOwner {
     id: Option<String>,
@@ -1884,6 +1878,10 @@ impl Inner {
                         cancellation.token(),
                     )
                     .await;
+                if cancellation.is_cancelled() {
+                    handle.control.kill();
+                    return Err("terminal open cancelled".to_owned());
+                }
                 let PtyHandle { control, output, banner } = handle;
                 let shell_session = Arc::new(ShellSession {
                     control,
@@ -1931,6 +1929,10 @@ impl Inner {
                         (viewer.on_exit)(code);
                     }
                 });
+                if cancellation.is_cancelled() {
+                    shell_session.control.kill();
+                    return Err("terminal open cancelled".to_owned());
+                }
                 output.subscribe(on_session_data, on_session_exit);
                 self.shell_sessions
                     .lock()
@@ -3248,6 +3250,28 @@ mod tests {
         assert!(pty.state.lock().unwrap().paused);
         h.frame(serde_json::json!({ "type": "pty_flow", "ptyId": "p1", "pause": false })).await;
         assert!(!pty.state.lock().unwrap().paused);
+    }
+
+    #[tokio::test]
+    async fn cancelled_shell_spawn_is_not_cached() {
+        let h = harness(None, None);
+        let cancellation = h.manager.new_open_cancellation().expect("open attempt token");
+        cancellation.cancel();
+        let context = h.context("supervised", h.owner.clone());
+        let env = env_map(&h.home);
+
+        // The fake returns a handle even for a cancelled token. This models a
+        // blocking provider that finishes its spawn while cancellation wins.
+        let result = Arc::clone(&h.manager.inner)
+            .open_shell("cancelled", 80, 24, &h.home, &env, "p1", None, &context, &cancellation)
+            .await;
+
+        assert_eq!(result.err().as_deref(), Some("terminal open cancelled"));
+        assert!(h.manager.inner.shell_sessions.lock().unwrap().is_empty());
+        assert!(h.manager.inner.shell_starting.lock().unwrap().is_empty());
+        let spawned = h.spawned();
+        assert_eq!(spawned.len(), 1);
+        assert!(spawned[0].state.lock().unwrap().killed);
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -495,6 +495,16 @@ struct ShellStartReservation {
     active: bool,
 }
 
+fn remove_cached_shell_if_same(inner: &Inner, session: &str, target: &Arc<ShellSession>) -> bool {
+    let mut shells = inner.shell_sessions.lock().expect("shell lock");
+    if shells.get(session).is_some_and(|cached| Arc::ptr_eq(cached, target)) {
+        shells.remove(session);
+        true
+    } else {
+        false
+    }
+}
+
 impl Drop for ShellStartReservation {
     fn drop(&mut self) {
         if self.active {
@@ -2014,6 +2024,15 @@ impl Inner {
                     .lock()
                     .expect("shell lock")
                     .insert(session.to_owned(), Arc::clone(&shell_session));
+                // Cancellation can arrive while `subscribe` is replaying its
+                // backlog (the callback is synchronous). Re-check after the
+                // identity is cached, and remove only this exact session so a
+                // replacement cannot be disturbed.
+                if cancellation.is_cancelled() {
+                    remove_cached_shell_if_same(&self, session, &shell_session);
+                    shell_session.control.kill();
+                    return Err("terminal open cancelled".to_owned());
+                }
                 self.shell_starting.lock().expect("shell starting lock").remove(session);
                 reservation.active = false;
                 reservation.notify.notify_waiters();
@@ -2883,6 +2902,8 @@ mod tests {
         spawn_file: String,
         spawn_cwd: PathBuf,
         spawn_term: String,
+        cancel_on_subscribe: Arc<AtomicBool>,
+        cancellation: CancellationToken,
     }
 
     impl FakePty {
@@ -2926,6 +2947,9 @@ mod tests {
             let mut state = self.state.lock().unwrap();
             state.on_data = Some(on_data);
             state.on_exit = Some(on_exit);
+            if self.cancel_on_subscribe.swap(false, Ordering::SeqCst) {
+                self.cancellation.cancel();
+            }
         }
     }
 
@@ -2970,6 +2994,7 @@ mod tests {
         ensure_socket_path: Option<PathBuf>,
         control: Option<Arc<dyn ControlHandle>>,
         resolve_gate: Option<Arc<ResolveGate>>,
+        cancel_on_subscribe: Arc<AtomicBool>,
     }
 
     #[async_trait]
@@ -2977,7 +3002,7 @@ mod tests {
         async fn spawn_pty(
             &self,
             spec: SpawnSpec,
-            _cancellation: CancellationToken,
+            cancellation: CancellationToken,
             _permit: OpenPermit,
         ) -> PtyHandle {
             let pty = FakePty {
@@ -2985,6 +3010,8 @@ mod tests {
                 spawn_file: spec.file.clone(),
                 spawn_cwd: spec.cwd.clone(),
                 spawn_term: spec.env.get("TERM").cloned().unwrap_or_default(),
+                cancel_on_subscribe: Arc::clone(&self.cancel_on_subscribe),
+                cancellation,
             };
             self.recorded.lock().unwrap().spawned.push(pty.clone());
             let control: Arc<dyn PtyControl> = Arc::new(pty.clone());
@@ -3048,6 +3075,7 @@ mod tests {
         owner: Option<String>,
         home: PathBuf,
         _home: TestDirectory,
+        cancel_on_subscribe: Arc<AtomicBool>,
     }
 
     fn env_map(home: &Path) -> HashMap<String, String> {
@@ -3090,6 +3118,7 @@ mod tests {
         let home_path = home.path.clone();
         let env = env_map(&home_path);
         let recorded = Arc::new(StdMutex::new(Recorded::default()));
+        let cancel_on_subscribe = Arc::new(AtomicBool::new(false));
         let socket_dir = PathBuf::from("/run/cmux-tui-501");
         let deps = Arc::new(FakeDeps {
             env: env.clone(),
@@ -3100,6 +3129,7 @@ mod tests {
             ensure_socket_path,
             control,
             resolve_gate,
+            cancel_on_subscribe: Arc::clone(&cancel_on_subscribe),
         });
         let manager = PtyManager::with_limits(
             deps,
@@ -3117,6 +3147,7 @@ mod tests {
             owner: Some("user_owner".to_owned()),
             home: home_path,
             _home: home,
+            cancel_on_subscribe,
         }
     }
 
@@ -3395,6 +3426,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cancellation_during_shell_subscribe_is_not_cached_and_killed() {
+        let h = harness(None, None);
+        h.cancel_on_subscribe.store(true, Ordering::SeqCst);
+        let cancellation = h.manager.new_open_cancellation().expect("open attempt token");
+        let context = h.context("supervised", h.owner.clone());
+        let env = env_map(&h.home);
+        let open_permit = OpenPermit::new(
+            h.manager.inner.open_slots.clone().try_acquire_owned().expect("open permit"),
+        );
+
+        // The fake cancels from inside subscribe, after the session callbacks
+        // have been installed. The completed open must remove only its own
+        // cached session and kill the newly spawned child.
+        let result = Arc::clone(&h.manager.inner)
+            .open_shell(
+                "cancelled-subscribe",
+                80,
+                24,
+                &h.home,
+                &env,
+                "p1",
+                None,
+                &context,
+                &cancellation,
+                &open_permit,
+            )
+            .await;
+
+        assert_eq!(result.err().as_deref(), Some("terminal open cancelled"));
+        assert!(h.manager.inner.shell_sessions.lock().unwrap().is_empty());
+        assert!(h.manager.inner.shell_starting.lock().unwrap().is_empty());
+        let spawned = h.spawned();
+        assert_eq!(spawned.len(), 1);
+        assert!(spawned[0].state.lock().unwrap().killed);
+    }
+
+    #[tokio::test]
     async fn trust_downgrade_revokes_existing_non_owner_controls() {
         let h = harness(None, None);
         h.open(
@@ -3522,6 +3590,7 @@ mod tests {
             ensure_socket_path: None,
             control: None,
             resolve_gate: None,
+            cancel_on_subscribe: Arc::new(AtomicBool::new(false)),
         });
         let manager =
             PtyManager::with_limits(deps, home_path.clone(), env, MAX_PTYS, 32, OUTPUT_BUFFER_CAP);
@@ -3533,6 +3602,7 @@ mod tests {
             owner: Some("user_owner".to_owned()),
             home: home_path,
             _home: home,
+            cancel_on_subscribe: Arc::new(AtomicBool::new(false)),
         };
         h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;
         let pty = h.spawned()[0].clone();

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1319,12 +1319,11 @@ impl Inner {
         let Some(attachment) = self.attachment(pty_id) else {
             return;
         };
-        // The gate protects the authorization snapshot only. Never hold it
-        // while backpressure or the send callback runs: PTY input can block
-        // until the child drains, while the reader needs this same path to
-        // publish output.
+        // Serialize authorization, revocation, and publication for this
+        // attachment. This prevents a close from racing the final snapshot
+        // check and sending stale output after retirement.
+        let _operation = attachment.operation_gate.lock().expect("attachment operation lock");
         let authorized = {
-            let _operation = attachment.operation_gate.lock().expect("attachment operation lock");
             let _state = self.tunnel_state.lock().expect("tunnel state lock");
             self.attachment_is_authorized(pty_id, &attachment, &auth, context)
         };
@@ -1354,9 +1353,7 @@ impl Inner {
             );
             return;
         }
-        // Closing can race the snapshot once the gate is released. Do not
-        // publish a frame for an attachment that has already been retired or
-        // replaced under the same pty id.
+        // The operation gate remains held through this check and send.
         if !self.attachment_snapshot_is_current(pty_id, &attachment) {
             return;
         }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2759,7 +2759,6 @@ impl Inner {
             if start_pending_viewer.swap(false, Ordering::AcqRel) {
                 start_session.pending_viewers.fetch_sub(1, Ordering::AcqRel);
             }
-            cleanup_if_empty.store(false, Ordering::Release);
             let (banner, replay, alive, delivery_lock) = {
                 let _dispatch = start_session.dispatch_lock.lock().expect("shell dispatch lock");
                 let _flow = start_session.flow_lock.lock().expect("shell flow lock");
@@ -2781,6 +2780,11 @@ impl Inner {
                         delivery_lock: Arc::clone(delivery_lock),
                     });
                     inner.draining_viewers.insert(viewer_id);
+                    // Keep cleanup armed until the viewer is published while
+                    // holding the flow lock. A close racing this callback
+                    // then either cleans up before publication, or observes
+                    // the published viewer and performs normal detach.
+                    cleanup_if_empty.store(false, Ordering::Release);
                 }
                 (banner, replay, alive, delivery_lock)
             };

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -559,6 +559,10 @@ fn remove_cached_shell_if_same_without_viewers(
     session: &str,
     target: &Arc<ShellSession>,
 ) -> bool {
+    let mut shells = inner.shell_sessions.lock().expect("shell lock");
+    if !shells.get(session).is_some_and(|cached| Arc::ptr_eq(cached, target)) {
+        return false;
+    }
     // Serialize with viewer start. A concurrent opener may have cloned this
     // session but cannot publish its viewer while this dispatch lock is held.
     let _dispatch = target.dispatch_lock.lock().expect("shell dispatch lock");
@@ -567,13 +571,19 @@ fn remove_cached_shell_if_same_without_viewers(
     {
         return false;
     }
-    let mut shells = inner.shell_sessions.lock().expect("shell lock");
-    if shells.get(session).is_some_and(|cached| Arc::ptr_eq(cached, target)) {
-        shells.remove(session);
-        true
-    } else {
-        false
+    shells.remove(session);
+    true
+}
+
+fn reserve_cached_shell(inner: &Inner, session: &str) -> Option<Arc<ShellSession>> {
+    let shells = inner.shell_sessions.lock().expect("shell lock");
+    let existing = shells.get(session).cloned()?;
+    let _dispatch = existing.dispatch_lock.lock().expect("shell dispatch lock");
+    if !existing.inner.lock().expect("shell inner lock").alive {
+        return None;
     }
+    existing.pending_viewers.fetch_add(1, Ordering::AcqRel);
+    Some(existing)
 }
 
 impl Drop for ShellStartReservation {
@@ -2420,7 +2430,7 @@ impl Inner {
         if roots_scoped {
             let control = tokio::select! {
                 biased;
-                _ = cancellation.cancelled() => {
+            _ = cancellation.token().cancelled() => {
                     return Err("terminal open cancelled".to_owned());
                 }
                 result = self.deps.connect_control(&ensured.socket_path, cancellation.token()) => {
@@ -2563,15 +2573,12 @@ impl Inner {
         let mut created = false;
         let pending_viewer = Arc::new(AtomicBool::new(false));
         let shell_session = loop {
-            if let Some(existing) =
-                self.shell_sessions.lock().expect("shell lock").get(session).cloned()
-            {
+            if let Some(existing) = reserve_cached_shell(&self, session) {
                 if context.local_roots.as_deref().is_some_and(|r| !r.is_empty())
                     || server_roots.is_some_and(|r| !r.is_empty())
                 {
                     return Err("cannot reattach existing shell under scoped roots".to_owned());
                 }
-                existing.pending_viewers.fetch_add(1, Ordering::AcqRel);
                 pending_viewer.store(true, Ordering::Release);
                 existing.control.resize(cols, rows);
                 break existing;

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -303,9 +303,10 @@ pub struct FrameContext {
     pub auth_generation: Option<u64>,
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub enum TransportKind {
     /// The legacy whole-manager caller, which owns all non-tunnel state.
+    #[default]
     Legacy,
     /// The authenticated relay WebSocket.
     Relay,
@@ -635,7 +636,7 @@ impl PtyManager {
                     }
                     return;
                 };
-                self.inner.clone().open(frame, context, cancellation).await
+                self.inner.clone().open(frame, context, cancellation).await;
             }
             "pty_input" => {
                 let Some(pty_id) = frame.get("ptyId").and_then(Value::as_str) else { return };
@@ -3649,7 +3650,7 @@ mod tests {
                     operation_gate: Arc::new(Mutex::new(())),
                     control: slow,
                     actor_id: "user_owner".to_owned(),
-                    owner: owner_a.clone(),
+                    owner: owner_a,
                 },
             );
             attachments.insert(
@@ -3659,7 +3660,7 @@ mod tests {
                     operation_gate: Arc::new(Mutex::new(())),
                     control: Arc::new(fast),
                     actor_id: "user_owner".to_owned(),
-                    owner: owner_b.clone(),
+                    owner: owner_b,
                 },
             );
         }
@@ -3673,7 +3674,7 @@ mod tests {
         inner.cache_transport_auth(&context_b);
 
         let slow_inner = Arc::clone(&inner);
-        let slow_context = context_a.clone();
+        let slow_context = context_a;
         let slow_thread = thread::spawn(move || {
             slow_inner.with_authorized("p1", &slow_context, "input", |attachment| {
                 attachment.control.write(b"slow");
@@ -3683,7 +3684,7 @@ mod tests {
 
         let (done_tx, done_rx) = sync_channel(1);
         let fast_inner = Arc::clone(&inner);
-        let fast_context = context_b.clone();
+        let fast_context = context_b;
         let fast_thread = thread::spawn(move || {
             fast_inner.with_authorized("p2", &fast_context, "input", |attachment| {
                 attachment.control.write(b"fast");
@@ -3715,7 +3716,7 @@ mod tests {
                         release: Arc::clone(&release),
                     }),
                     actor_id: "user_owner".to_owned(),
-                    owner: owner.clone(),
+                    owner,
                 },
             );
         }
@@ -3724,7 +3725,7 @@ mod tests {
         inner.cache_transport_auth(&context);
 
         let operation_inner = Arc::clone(&inner);
-        let operation_context = context.clone();
+        let operation_context = context;
         let operation = thread::spawn(move || {
             operation_inner.with_authorized("p1", &operation_context, "input", |attachment| {
                 attachment.control.write(b"blocked");
@@ -3768,7 +3769,7 @@ mod tests {
         {
             let mut state = inner.opening_state.lock().unwrap();
             state.reservations.insert(id.clone(), owner_a.clone());
-            state.cancelled.insert(id.clone(), owner_a.clone());
+            state.cancelled.insert(id.clone(), owner_a);
             state.reservations.remove(&id);
             state.reservations.insert(id.clone(), owner_b.clone());
             state.cancelled.insert(id.clone(), owner_b.clone());
@@ -4082,7 +4083,7 @@ mod tests {
             transport_kind: TransportKind::Legacy,
             auth_generation: None,
         };
-        super::send_pty_error(
+        send_pty_error(
             &context,
             "pty-1",
             "failed",

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -3089,5 +3089,30 @@ mod tests {
         let frame = harness.sent().pop().unwrap();
         assert_eq!(frame["type"], "pty_error");
         assert_eq!(frame["code"], "overflow");
+        assert_eq!(frame["message"], "terminal output overflowed; reattach to continue");
+    }
+
+    #[test]
+    fn pty_errors_never_echo_remote_diagnostics() {
+        let sent = Arc::new(StdMutex::new(Vec::<Value>::new()));
+        let sink = Arc::clone(&sent);
+        let context = FrameContext {
+            send: Arc::new(move |frame| sink.lock().unwrap().push(frame)),
+            buffered_amount: Arc::new(|| 0),
+            trust: "supervised".to_owned(),
+            local_roots: None,
+            owner_user_id: None,
+            transport_id: None,
+        };
+        super::send_pty_error(
+            &context,
+            "pty-1",
+            "failed",
+            "attach-surface failed for terminal \"s:1\": /home/alice/.ssh/id_ed25519",
+        );
+        let frame = sent.lock().unwrap().pop().expect("error frame");
+        assert_eq!(frame["code"], "failed");
+        assert_eq!(frame["message"], "terminal operation failed");
+        assert!(!frame.to_string().contains("id_ed25519"));
     }
 }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1608,7 +1608,8 @@ impl Inner {
             self.retire_if_current(pty_id, &current_attachment);
             return;
         };
-        if !self.transport_auth_is_current(context, &auth)
+        if context.cancellation.is_cancelled()
+            || !self.transport_auth_is_current(context, &auth)
             || !self.attachment_snapshot_is_current(pty_id, &current_attachment)
         {
             self.retire_if_current(pty_id, &current_attachment);
@@ -1626,6 +1627,7 @@ impl Inner {
                 .attachment(pty_id)
                 .is_some_and(|attachment| self.attachment_snapshot_is_current(pty_id, &attachment))
         {
+            self.retire_if_current(pty_id, &current_attachment);
             return;
         }
         start();
@@ -2703,16 +2705,13 @@ struct ShellViewerControl {
 impl ShellViewerControl {
     fn release(&self) {
         self.released.store(true, Ordering::SeqCst);
-        let should_resume = {
+        {
             let _flow = self.session.flow_lock.lock().expect("shell flow lock");
             let mut inner = self.session.inner.lock().expect("shell inner lock");
             inner.viewers.retain(|viewer| viewer.id != self.viewer_id);
             inner.paused_backlog.remove(&self.viewer_id);
             inner.draining_viewers.remove(&self.viewer_id);
-            inner.paused_viewers.remove(&self.viewer_id) && inner.paused_viewers.is_empty()
-        };
-        if should_resume {
-            self.session.control.resume();
+            inner.paused_viewers.remove(&self.viewer_id);
         }
     }
 }
@@ -2730,20 +2729,8 @@ impl PtyControl for ShellViewerControl {
             let mut inner = self.session.inner.lock().expect("shell inner lock");
             inner.paused_viewers.insert(self.viewer_id) && inner.paused_viewers.len() == 1
         };
-        if should_pause {
-            self.session.control.pause();
-            // A release may have removed the last paused viewer while the
-            // control call was in flight. Re-check the shared state and
-            // undo the stale pause so the shell cannot remain wedged.
-            let should_resume = {
-                let _flow = self.session.flow_lock.lock().expect("shell flow lock");
-                let inner = self.session.inner.lock().expect("shell inner lock");
-                inner.paused_viewers.is_empty()
-            };
-            if should_resume {
-                self.session.control.resume();
-            }
-        }
+        // The shared shell PTY stays running. Output fanout buffers only this
+        // viewer while it is paused, so one slow client cannot stall peers.
     }
     fn resume(&self) {
         let should_resume = {
@@ -2756,9 +2743,6 @@ impl PtyControl for ShellViewerControl {
             }
             removed && inner.paused_viewers.is_empty()
         };
-        if should_resume {
-            self.session.control.resume();
-        }
         self.drain_backlog();
     }
 
@@ -4117,7 +4101,7 @@ mod tests {
         assert!(pty.state.lock().unwrap().resized.contains(&(132, 43)));
 
         h.frame(serde_json::json!({ "type": "pty_flow", "ptyId": "p1", "pause": true })).await;
-        assert!(pty.state.lock().unwrap().paused);
+        assert!(!pty.state.lock().unwrap().paused);
         h.frame(serde_json::json!({ "type": "pty_flow", "ptyId": "p1", "pause": false })).await;
         assert!(!pty.state.lock().unwrap().paused);
     }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -732,7 +732,7 @@ impl Inner {
         } else {
             None
         };
-        let opened = match opened {
+        let mut opened = match opened {
             Some(opened) => opened,
             None => {
                 let result = if let Some(cmux_tui) = cmux_tui.as_ref() {
@@ -798,11 +798,15 @@ impl Inner {
         // The value is now owned by the attachment map. Its Drop handler
         // must not release a live viewer when this local is consumed below.
         opened.cleanup_on_drop = false;
+        let closing = opened.closing.take().expect("opened closing handle");
+        let control = opened.control.take().expect("opened control handle");
+        let start = opened.start.take().expect("opened start callback");
+        let surface = opened.surface.take();
         let previous = self.attachments.lock().expect("attach lock").insert(
             pty_id.clone(),
             Attachment {
-                closing: opened.closing,
-                control: opened.control,
+                closing,
+                control,
                 actor_id: actor.to_owned(),
                 transport_id: context.transport_id.clone(),
             },
@@ -819,7 +823,7 @@ impl Inner {
         opened_frame.insert("type".to_owned(), Value::from("pty_opened"));
         opened_frame.insert("ptyId".to_owned(), Value::from(pty_id.clone()));
         opened_frame.insert("session".to_owned(), Value::from(session));
-        if let Some(surface) = opened.surface {
+        if let Some(surface) = surface {
             opened_frame.insert("surface".to_owned(), Value::from(surface));
         }
         opened_frame.insert("created".to_owned(), Value::from(opened.created));
@@ -829,7 +833,7 @@ impl Inner {
 
         // Output only AFTER pty_opened (ordering): banner, then scrollback
         // replay, then live bytes.
-        (opened.start)();
+        start();
     }
 
     /// Build the per-attachment emit closures (output + exit framing).
@@ -990,9 +994,9 @@ impl Inner {
 struct Opened {
     created: bool,
     surface: Option<String>,
-    control: Arc<dyn PtyControl>,
-    closing: Arc<AtomicBool>,
-    start: Box<dyn FnOnce() + Send>,
+    control: Option<Arc<dyn PtyControl>>,
+    closing: Option<Arc<AtomicBool>>,
+    start: Option<Box<dyn FnOnce() + Send>>,
     /// A cancelled open can finish after the caller's deadline. Until the
     /// attachment is installed, dropping this value must release the spawned
     /// viewer instead of leaking a PTY and its process group.
@@ -1002,8 +1006,12 @@ struct Opened {
 impl Drop for Opened {
     fn drop(&mut self) {
         if self.cleanup_on_drop {
-            self.closing.store(true, Ordering::SeqCst);
-            self.control.kill();
+            if let Some(closing) = &self.closing {
+                closing.store(true, Ordering::SeqCst);
+            }
+            if let Some(control) = &self.control {
+                control.kill();
+            }
         }
     }
 }
@@ -1148,9 +1156,9 @@ impl Inner {
         Ok(Opened {
             created: ensured.created,
             surface: None,
-            control,
-            closing: Arc::new(AtomicBool::new(false)),
-            start: Box::new(move || drive_handle(output, banner, on_data, on_exit)),
+            control: Some(control),
+            closing: Some(Arc::new(AtomicBool::new(false))),
+            start: Some(Box::new(move || drive_handle(output, banner, on_data, on_exit))),
             cleanup_on_drop: true,
         })
     }
@@ -1329,7 +1337,14 @@ impl Inner {
             }
         });
 
-        Ok(Opened { created, surface: None, control: proxy, closing, start, cleanup_on_drop: true })
+        Ok(Opened {
+            created,
+            surface: None,
+            control: Some(proxy),
+            closing: Some(closing),
+            start: Some(start),
+            cleanup_on_drop: true,
+        })
     }
 }
 
@@ -1884,9 +1899,9 @@ impl Inner {
         Ok(Some(Opened {
             created: ensured.created,
             surface: Some(surface_ref.to_owned()),
-            control: proxy,
-            closing: Arc::new(AtomicBool::new(false)),
-            start: Box::new(move || start_stream.go_live(on_data, on_exit)),
+            control: Some(proxy),
+            closing: Some(Arc::new(AtomicBool::new(false))),
+            start: Some(Box::new(move || start_stream.go_live(on_data, on_exit))),
             cleanup_on_drop: true,
         }))
     }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2577,6 +2577,8 @@ impl Inner {
                         draining_viewers: HashSet::new(),
                     }),
                 });
+                shell_session.pending_viewers.fetch_add(1, Ordering::AcqRel);
+                pending_viewer.store(true, Ordering::Release);
                 // Session-level plumbing runs for the session's whole life:
                 // the ring fills even while detached, and exit ends the
                 // session for every attached viewer. One fanout sink is
@@ -2676,6 +2678,7 @@ impl Inner {
         // A stable viewer id lets release remove exactly this sink.
         let viewer_id = next_viewer_id();
         let released = Arc::new(AtomicBool::new(false));
+        let cleanup_if_empty = Arc::new(AtomicBool::new(created));
         let closing = Arc::new(AtomicBool::new(false));
         let (on_data, on_exit) = self.sinks(pty_id, context);
 
@@ -2686,6 +2689,9 @@ impl Inner {
             viewer_id,
             released: Arc::clone(&released),
             pending_viewer: Arc::clone(&pending_viewer),
+            manager: Arc::clone(&self),
+            session_name: session.to_owned(),
+            cleanup_if_empty: Arc::clone(&cleanup_if_empty),
         });
 
         let start_session = Arc::clone(&shell_session);
@@ -2696,6 +2702,7 @@ impl Inner {
             if start_pending_viewer.swap(false, Ordering::AcqRel) {
                 start_session.pending_viewers.fetch_sub(1, Ordering::AcqRel);
             }
+            cleanup_if_empty.store(false, Ordering::Release);
             let (banner, replay, alive, delivery_lock) = {
                 let _dispatch = start_session.dispatch_lock.lock().expect("shell dispatch lock");
                 let _flow = start_session.flow_lock.lock().expect("shell flow lock");
@@ -2775,10 +2782,13 @@ impl Inner {
 }
 
 struct ShellViewerControl {
+    manager: Arc<Inner>,
+    session_name: String,
     session: Arc<ShellSession>,
     viewer_id: u64,
     released: Arc<AtomicBool>,
     pending_viewer: Arc<AtomicBool>,
+    cleanup_if_empty: Arc<AtomicBool>,
 }
 
 impl ShellViewerControl {
@@ -2794,6 +2804,17 @@ impl ShellViewerControl {
             inner.paused_backlog.remove(&self.viewer_id);
             inner.draining_viewers.remove(&self.viewer_id);
             inner.paused_viewers.remove(&self.viewer_id);
+        }
+        if self.cleanup_if_empty.load(Ordering::Acquire)
+            && self.session.pending_viewers.load(Ordering::Acquire) == 0
+            && self.session.inner.lock().expect("shell inner lock").viewers.is_empty()
+            && remove_cached_shell_if_same_without_viewers(
+                &self.manager,
+                &self.session_name,
+                &self.session,
+            )
+        {
+            self.session.control.kill();
         }
     }
 }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -479,6 +479,12 @@ struct Inner {
     /// removed. This closes the gap in which a stale frame could otherwise
     /// repopulate the cache while its opening is being cancelled.
     revoked_transports: Mutex<HashSet<TransportOwner>>,
+    /// A transport that has disconnected is permanently fenced for the life
+    /// of this manager. Relay transport ids are random per connection and
+    /// must never be reused, so a late frame cannot clear this tombstone by
+    /// publishing another snapshot with the same id. A reconnect receives a
+    /// new owner instead.
+    detached_transports: Mutex<HashSet<TransportOwner>>,
     /// Serializes short authority and attachment state transitions. It is
     /// never held while a PTY control method, callback, or provider await runs.
     tunnel_state: Mutex<()>,
@@ -664,6 +670,7 @@ impl PtyManager {
                 shell_starting: Mutex::new(HashMap::new()),
                 transport_auth: Mutex::new(HashMap::new()),
                 revoked_transports: Mutex::new(HashSet::new()),
+                detached_transports: Mutex::new(HashSet::new()),
                 tunnel_state: Mutex::new(()),
                 tunnel_authority_generation: AtomicU64::new(0),
                 next_open_attempt: AtomicU64::new(1),
@@ -694,6 +701,7 @@ impl PtyManager {
                 shell_starting: Mutex::new(HashMap::new()),
                 transport_auth: Mutex::new(HashMap::new()),
                 revoked_transports: Mutex::new(HashSet::new()),
+                detached_transports: Mutex::new(HashSet::new()),
                 tunnel_state: Mutex::new(()),
                 tunnel_authority_generation: AtomicU64::new(0),
                 next_open_attempt: AtomicU64::new(1),
@@ -818,6 +826,17 @@ impl PtyManager {
             if !self.inner.tunnel_authority_generation_current(context) {
                 return;
             }
+            if self
+                .inner
+                .detached_transports
+                .lock()
+                .expect("detached transport lock")
+                .contains(&owner)
+            {
+                // A disconnected owner is never re-authorized. A reconnect
+                // must use its freshly generated transport id.
+                return;
+            }
             let mut revoked = self.inner.revoked_transports.lock().expect("revoked transport lock");
             let transport_auth = self.inner.transport_auth.lock().expect("transport auth lock");
             let changed = transport_auth.get(&owner).is_some_and(|current| {
@@ -833,15 +852,23 @@ impl PtyManager {
             changed
         };
         if changed {
-            self.inner.detach_matching(|candidate| candidate == &owner).retire();
+            self.inner.detach_matching(|candidate| candidate == &owner, false).retire();
         }
         let _state = self.inner.tunnel_state.lock().expect("tunnel state lock");
         if !self.inner.tunnel_authority_generation_current(context) {
             return;
         }
+        if self.inner.detached_transports.lock().expect("detached transport lock").contains(&owner)
+        {
+            return;
+        }
         let mut revoked = self.inner.revoked_transports.lock().expect("revoked transport lock");
-        self.inner.transport_auth.lock().expect("transport auth lock").insert(owner, snapshot);
-        revoked.remove(&TransportOwner::from_context(context));
+        self.inner
+            .transport_auth
+            .lock()
+            .expect("transport auth lock")
+            .insert(owner.clone(), snapshot);
+        revoked.remove(&owner);
     }
 
     /// Advance the managed tunnel authority floor before publishing the
@@ -880,22 +907,25 @@ impl PtyManager {
     /// must use `detach_transport` so it cannot detach attachments the
     /// managed tunnel listener (or another socket) owns.
     pub fn detach_all(&self) {
-        self.detach_matching(|_| true).retire();
+        self.detach_matching(|_| true, true).retire();
     }
 
     /// One transport dropped: release only its attachments and cancel only
     /// its in-flight opens. Sessions live on either way (docs/TERMINAL.md).
     pub fn detach_transport(&self, transport_id: &str) {
-        self.detach_matching(|owner| owner.id.as_deref() == Some(transport_id)).retire();
+        // This legacy entry point does not carry a transport class. The
+        // matcher fences every typed identity for this opaque id.
+        self.detach_matching(|owner| owner.id.as_deref() == Some(transport_id), true).retire();
     }
 
     /// One typed transport dropped. This avoids treating an opaque relay ID
     /// as a namespace discriminator.
     pub fn detach_transport_kind(&self, transport_id: &str, kind: TransportKind) {
-        self.detach_matching(|owner| {
-            owner.id.as_deref() == Some(transport_id) && owner.kind == kind
-        })
-        .retire();
+        let owner = TransportOwner { id: Some(transport_id.to_owned()), kind };
+        let target_owner = owner;
+        // The matcher publishes the disconnect fence before removing state.
+        // A queued frame can then never repopulate the vacant cache.
+        self.detach_matching(move |candidate| candidate == &target_owner, true).retire();
     }
 
     /// Release all managed tunnel attachments. The relay connection clears
@@ -910,7 +940,7 @@ impl PtyManager {
     /// This lets session reconciliation release the global trust lock before
     /// touching platform PTY state.
     pub fn detach_tunnel_transports_deferred(&self) -> RetiredAttachments {
-        self.detach_matching(|owner| owner.kind == TransportKind::Tunnel)
+        self.detach_matching(|owner| owner.kind == TransportKind::Tunnel, true)
     }
 
     /// Cancel one opening reservation at the timeout boundary. The capability
@@ -938,18 +968,32 @@ impl PtyManager {
         }
     }
 
-    fn detach_matching(&self, owns: impl Fn(&TransportOwner) -> bool) -> RetiredAttachments {
+    fn detach_matching(
+        &self,
+        owns: impl Fn(&TransportOwner) -> bool,
+        fence_detached: bool,
+    ) -> RetiredAttachments {
         // Revoke the transport snapshot and opening reservations at one
         // authority boundary. Do not wait for an attachment operation while
         // holding the state lock: output/control callbacks take the gate
         // before that lock, so waiting here would deadlock the relay.
         let candidates = {
             let _state = self.inner.tunnel_state.lock().expect("tunnel state lock");
-            self.inner
-                .transport_auth
-                .lock()
-                .expect("transport auth lock")
-                .retain(|owner, _| !owns(owner));
+            let mut detached =
+                self.inner.detached_transports.lock().expect("detached transport lock");
+            let mut transport_auth = self.inner.transport_auth.lock().expect("transport auth lock");
+            // Every live opening and attachment is admitted through an auth
+            // snapshot. On a real disconnect, fence matching identities
+            // before removing state. Authority replacement uses the same
+            // cleanup without a terminal disconnect fence.
+            if fence_detached {
+                for owner in transport_auth.keys().filter(|owner| owns(owner)) {
+                    if owner.id.is_some() {
+                        detached.insert(owner.clone());
+                    }
+                }
+            }
+            transport_auth.retain(|owner, _| !owns(owner));
             let mut opening = self.inner.opening_state.lock().expect("opening state lock");
             let cancelled: Vec<(String, OpeningOwner)> = opening
                 .reservations
@@ -957,6 +1001,13 @@ impl PtyManager {
                 .filter(|(_, owner)| owns(&owner.owner))
                 .map(|(id, owner)| (id.clone(), owner.clone()))
                 .collect();
+            if fence_detached {
+                for (_, owner) in &cancelled {
+                    if owner.owner.id.is_some() {
+                        detached.insert(owner.owner.clone());
+                    }
+                }
+            }
             for (id, owner) in cancelled {
                 opening.reservations.remove(&id);
                 if let Some(cancellation) = opening.cancellations.remove(&owner) {
@@ -964,25 +1015,39 @@ impl PtyManager {
                 }
                 opening.cancelled.insert(id, owner);
             }
-            let active: Vec<(String, OpenCancellation)> = opening
+            let active: Vec<(String, OpeningOwner, OpenCancellation)> = opening
                 .active_openings
                 .iter()
                 .filter(|(_, (owner, _))| owns(&owner.owner))
-                .map(|(id, (_, cancellation))| (id.clone(), cancellation.clone()))
+                .map(|(id, (owner, cancellation))| {
+                    (id.clone(), owner.clone(), cancellation.clone())
+                })
                 .collect();
-            for (id, cancellation) in active {
+            for (id, owner, cancellation) in active {
+                if fence_detached && owner.owner.id.is_some() {
+                    detached.insert(owner.owner.clone());
+                }
                 opening.active_openings.remove(&id);
                 cancellation.cancel();
             }
 
-            self.inner
+            let candidates = self
+                .inner
                 .attachments
                 .lock()
                 .expect("attach lock")
                 .iter()
                 .filter(|(_, attachment)| owns(&attachment.owner))
                 .map(|(id, attachment)| (id.clone(), attachment.clone()))
-                .collect::<Vec<_>>()
+                .collect::<Vec<_>>();
+            if fence_detached {
+                for (_, attachment) in &candidates {
+                    if attachment.owner.id.is_some() {
+                        detached.insert(attachment.owner.clone());
+                    }
+                }
+            }
+            candidates
         };
 
         // Removal is linearized with publication by the same per-attachment
@@ -1671,6 +1736,9 @@ impl Inner {
     fn auth_for_transport(&self, context: &FrameContext) -> Option<AuthSnapshot> {
         let key = TransportOwner::from_context(context);
         let _state = self.tunnel_state.lock().expect("tunnel state lock");
+        if self.detached_transports.lock().expect("detached transport lock").contains(&key) {
+            return None;
+        }
         if self.revoked_transports.lock().expect("revoked transport lock").contains(&key) {
             return None;
         }
@@ -1955,6 +2023,11 @@ impl Inner {
         }
         let snapshot = AuthSnapshot::from_context(context);
         let owner = TransportOwner::from_context(context);
+        if self.detached_transports.lock().expect("detached transport lock").contains(&owner) {
+            // Disconnect is terminal for this transport identity. Do not let
+            // a queued frame recreate an entry after detach removed it.
+            return false;
+        }
         let revoked =
             self.revoked_transports.lock().expect("revoked transport lock").contains(&owner);
         if revoked {
@@ -2797,7 +2870,11 @@ impl Inner {
         if cancellation.is_cancelled() {
             return Err((RelayPtyErrorCode::Failed, "terminal open cancelled".to_owned()));
         }
-        let identify = control.request("identify", json!({})).await;
+        let identify =
+            request_control_with_cancellation(&control, "identify", json!({}), cancellation).await;
+        if cancellation.is_cancelled() {
+            return Err((RelayPtyErrorCode::Failed, "terminal open cancelled".to_owned()));
+        }
         let info = identify.as_ref().filter(|v| v.get("ok").and_then(Value::as_bool) == Some(true));
         let protocol = info
             .and_then(|v| v.get("data"))
@@ -2826,7 +2903,16 @@ impl Inner {
             if cancellation.is_cancelled() {
                 return Err((RelayPtyErrorCode::Failed, "terminal open cancelled".to_owned()));
             }
-            let listed = control.request("list-workspaces", json!({})).await;
+            let listed = request_control_with_cancellation(
+                &control,
+                "list-workspaces",
+                json!({}),
+                cancellation,
+            )
+            .await;
+            if cancellation.is_cancelled() {
+                return Err((RelayPtyErrorCode::Failed, "terminal open cancelled".to_owned()));
+            }
             let tabs = listed
                 .as_ref()
                 .filter(|v| v.get("ok").and_then(Value::as_bool) == Some(true))
@@ -2856,7 +2942,16 @@ impl Inner {
             if cancellation.is_cancelled() {
                 return Err((RelayPtyErrorCode::Failed, "terminal open cancelled".to_owned()));
             }
-            let info = control.request("process-info", json!({ "surface": surface_id })).await;
+            let info = request_control_with_cancellation(
+                &control,
+                "process-info",
+                json!({ "surface": surface_id }),
+                cancellation,
+            )
+            .await;
+            if cancellation.is_cancelled() {
+                return Err((RelayPtyErrorCode::Failed, "terminal open cancelled".to_owned()));
+            }
             let actual = info
                 .as_ref()
                 .filter(|v| v.get("ok").and_then(Value::as_bool) == Some(true))

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1779,15 +1779,18 @@ impl Inner {
         ]);
         let handle = self
             .deps
-            .spawn_pty(SpawnSpec {
-                file: cmux_tui.file.clone(),
-                args,
-                cols,
-                rows,
-                cwd: cwd.to_path_buf(),
-                env: env.clone(),
-                cancellation: cancellation.token(),
-            }, cancellation.token())
+            .spawn_pty(
+                SpawnSpec {
+                    file: cmux_tui.file.clone(),
+                    args,
+                    cols,
+                    rows,
+                    cwd: cwd.to_path_buf(),
+                    env: env.clone(),
+                    cancellation: cancellation.token(),
+                },
+                cancellation.token(),
+            )
             .await;
         let control = Arc::clone(&handle.control);
         let output = Arc::clone(&handle.output);
@@ -1865,15 +1868,18 @@ impl Inner {
                 let shell = self.deps.shell();
                 let handle = self
                     .deps
-                    .spawn_pty(SpawnSpec {
-                        file: shell,
-                        args: Vec::new(),
-                        cols,
-                        rows,
-                        cwd: cwd.to_path_buf(),
-                        env: env.clone(),
-                        cancellation: cancellation.token(),
-                    }, cancellation.token())
+                    .spawn_pty(
+                        SpawnSpec {
+                            file: shell,
+                            args: Vec::new(),
+                            cols,
+                            rows,
+                            cwd: cwd.to_path_buf(),
+                            env: env.clone(),
+                            cancellation: cancellation.token(),
+                        },
+                        cancellation.token(),
+                    )
                     .await;
                 let PtyHandle { control, output, banner } = handle;
                 let shell_session = Arc::new(ShellSession {
@@ -2388,20 +2394,14 @@ impl Inner {
         let socket_dir = self.deps.socket_dir();
         let ensured = self
             .deps
-            .ensure_daemon(
-                cmux_tui,
-                session,
-                &socket_dir,
-                cwd,
-                env,
-                cancellation.token(),
-            )
+            .ensure_daemon(cmux_tui, session, &socket_dir, cwd, env, cancellation.token())
             .await
             .map_err(|message| (RelayPtyErrorCode::Failed, message))?;
-        let control = match self.deps.connect_control(&ensured.socket_path, cancellation.token()).await {
-            Ok(control) => control,
-            Err(_) => return Ok(None), // degrade to the whole-session attach
-        };
+        let control =
+            match self.deps.connect_control(&ensured.socket_path, cancellation.token()).await {
+                Ok(control) => control,
+                Err(_) => return Ok(None), // degrade to the whole-session attach
+            };
         let mut control_guard = ControlEndOnDrop::new(Arc::clone(&control));
 
         if cancellation.is_cancelled() {
@@ -2663,8 +2663,7 @@ impl Inner {
         socket_path: &Path,
         home: &str,
     ) -> Vec<(String, String)> {
-        let Ok(control) =
-            self.deps.connect_control(socket_path, CancellationToken::new()).await
+        let Ok(control) = self.deps.connect_control(socket_path, CancellationToken::new()).await
         else {
             return Vec::new();
         };
@@ -2884,11 +2883,7 @@ mod tests {
 
     #[async_trait]
     impl PtyDeps for FakeDeps {
-        async fn spawn_pty(
-            &self,
-            spec: SpawnSpec,
-            _cancellation: CancellationToken,
-        ) -> PtyHandle {
+        async fn spawn_pty(&self, spec: SpawnSpec, _cancellation: CancellationToken) -> PtyHandle {
             let pty = FakePty {
                 state: Arc::new(StdMutex::new(FakeState::default())),
                 spawn_file: spec.file.clone(),
@@ -2900,10 +2895,7 @@ mod tests {
             let output: Arc<dyn PtyOutput> = Arc::new(pty);
             PtyHandle { control, output, banner: None }
         }
-        async fn resolve_cmux_tui(
-            &self,
-            _cancellation: CancellationToken,
-        ) -> Option<CmuxTui> {
+        async fn resolve_cmux_tui(&self, _cancellation: CancellationToken) -> Option<CmuxTui> {
             self.resolve.clone()
         }
         async fn ensure_daemon(

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -296,6 +296,18 @@ struct AuthSnapshot {
     buffered_amount: Arc<dyn Fn() -> u64 + Send + Sync>,
 }
 
+impl AuthSnapshot {
+    fn from_context(context: &FrameContext) -> Self {
+        Self {
+            trust: context.trust.clone(),
+            local_roots: context.local_roots.clone(),
+            owner_user_id: context.owner_user_id.clone(),
+            send: Arc::clone(&context.send),
+            buffered_amount: Arc::clone(&context.buffered_amount),
+        }
+    }
+}
+
 /// Scrubbed env for interactive PTYs (actions.mjs base, real TERM).
 pub fn pty_env(base: &HashMap<String, String>) -> HashMap<String, String> {
     let mut env = scrubbed_env(base);
@@ -441,16 +453,20 @@ impl PtyManager {
 
     /// Handle one Worker -> relay PTY frame.
     pub async fn handle_frame(&self, frame: &Value, context: &FrameContext) {
-        self.inner.transport_auth.lock().expect("transport auth lock").insert(
-            context.transport_id.clone(),
-            AuthSnapshot {
-                trust: context.trust.clone(),
-                local_roots: context.local_roots.clone(),
-                owner_user_id: context.owner_user_id.clone(),
-                send: Arc::clone(&context.send),
-                buffered_amount: Arc::clone(&context.buffered_amount),
-            },
-        );
+        let snapshot = AuthSnapshot::from_context(context);
+        let mut transport_auth = self.inner.transport_auth.lock().expect("transport auth lock");
+        if context.transport_id.is_none() {
+            // Legacy whole-manager callers use `None` and provide the current
+            // trust on each frame. Keep that contract for non-transport code.
+            transport_auth.insert(context.transport_id.clone(), snapshot);
+        } else {
+            // A connection can have an open in flight while trust is
+            // renegotiated. Do not let that stale frame overwrite the
+            // authoritative snapshot; session code calls
+            // `update_transport_auth` at each reconciliation boundary.
+            transport_auth.entry(context.transport_id.clone()).or_insert(snapshot);
+        }
+        drop(transport_auth);
         let frame_type = frame.get("type").and_then(Value::as_str).unwrap_or_default();
         match frame_type {
             "pty_open" => self.inner.clone().open(frame, context).await,
@@ -509,6 +525,18 @@ impl PtyManager {
             "surface_list" => self.inner.clone().list_surfaces(frame, context).await,
             _ => {}
         }
+    }
+
+    /// Publish the authoritative snapshot for one live transport. This is
+    /// called only after the relay has reconciled trust, roots, and owner.
+    /// Network frames never get to replace an existing snapshot implicitly.
+    pub fn update_transport_auth(&self, context: &FrameContext) {
+        debug_assert!(context.transport_id.is_some(), "transport refresh needs an id");
+        self.inner
+            .transport_auth
+            .lock()
+            .expect("transport auth lock")
+            .insert(context.transport_id.clone(), AuthSnapshot::from_context(context));
     }
 
     /// True while `pty_id` has a live attachment. The tunnel listener uses

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -465,6 +465,8 @@ struct Attachment {
     /// Serializes PTY control calls for one attachment. Retirement never
     /// waits on this gate, so a blocked provider cannot block detach.
     control_gate: Arc<Mutex<()>>,
+    /// Serializes output and exit delivery for one attachment.
+    delivery_gate: Arc<Mutex<()>>,
     /// Serializes open success publication with attachment retirement. This
     /// is separate because start callbacks can emit output and re-enter the
     /// operation gate.
@@ -1585,6 +1587,7 @@ impl Inner {
                     active_operations: Arc::new(AtomicUsize::new(0)),
                     operation_gate: Arc::new(Mutex::new(())),
                     control_gate: Arc::new(Mutex::new(())),
+                    delivery_gate: Arc::new(Mutex::new(())),
                     publication_gate: Arc::clone(&publication_gate),
                     publication_state: Arc::new(AtomicU64::new(0)),
                     control,
@@ -1799,6 +1802,7 @@ impl Inner {
         {
             return;
         }
+        let _delivery = attachment.delivery_gate.lock().expect("attachment delivery lock");
         (auth.send)(json!({
             "version": PTY_PROTOCOL_VERSION,
             "type": "pty_output",
@@ -1864,6 +1868,7 @@ impl Inner {
         // lifecycle state before invoking the callback.
         drop(_operation);
         drop(_publication);
+        let _delivery = attachment.delivery_gate.lock().expect("attachment delivery lock");
         (auth.send)(json!({
             "version": PTY_PROTOCOL_VERSION,
             "type": "pty_exit",
@@ -2683,6 +2688,9 @@ impl Inner {
                 let exit_session = Arc::clone(&shell_session);
                 let manager = Arc::clone(&self);
                 let on_session_data: DataSink = Arc::new(move |chunk: Bytes| {
+                    if chunk.is_empty() {
+                        return;
+                    }
                     let _dispatch = data_session.dispatch_lock.lock().expect("shell dispatch lock");
                     let (viewers_to_notify, viewers_to_exit) = {
                         let mut inner = data_session.inner.lock().expect("shell inner lock");
@@ -5084,6 +5092,7 @@ mod tests {
                     active_operations: Arc::new(AtomicUsize::new(0)),
                     operation_gate: Arc::new(Mutex::new(())),
                     control_gate: Arc::new(Mutex::new(())),
+                    delivery_gate: Arc::new(Mutex::new(())),
                     publication_gate: Arc::new(Mutex::new(())),
                     publication_state: Arc::new(AtomicU64::new(0)),
                     control: slow,
@@ -5098,6 +5107,7 @@ mod tests {
                     active_operations: Arc::new(AtomicUsize::new(0)),
                     operation_gate: Arc::new(Mutex::new(())),
                     control_gate: Arc::new(Mutex::new(())),
+                    delivery_gate: Arc::new(Mutex::new(())),
                     publication_gate: Arc::new(Mutex::new(())),
                     publication_state: Arc::new(AtomicU64::new(0)),
                     control: Arc::new(fast),
@@ -5155,6 +5165,7 @@ mod tests {
                     active_operations: Arc::new(AtomicUsize::new(0)),
                     operation_gate: Arc::new(Mutex::new(())),
                     control_gate: Arc::new(Mutex::new(())),
+                    delivery_gate: Arc::new(Mutex::new(())),
                     publication_gate: Arc::new(Mutex::new(())),
                     publication_state: Arc::new(AtomicU64::new(0)),
                     control: Arc::new(BlockingControl {
@@ -5211,6 +5222,7 @@ mod tests {
                     active_operations: Arc::new(AtomicUsize::new(0)),
                     operation_gate: Arc::new(Mutex::new(())),
                     control_gate: Arc::new(Mutex::new(())),
+                    delivery_gate: Arc::new(Mutex::new(())),
                     publication_gate: Arc::new(Mutex::new(())),
                     publication_state: Arc::new(AtomicU64::new(0)),
                     control: Arc::new(BlockingControl {
@@ -5288,6 +5300,7 @@ mod tests {
             active_operations: Arc::new(AtomicUsize::new(0)),
             operation_gate: Arc::new(Mutex::new(())),
             control_gate: Arc::new(Mutex::new(())),
+            delivery_gate: Arc::new(Mutex::new(())),
             publication_gate: Arc::new(Mutex::new(())),
             publication_state: Arc::new(AtomicU64::new(0)),
             control: Arc::new(pty),

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -597,6 +597,10 @@ fn reserve_cached_shell(inner: &Inner, session: &str) -> Option<Arc<ShellSession
     let existing = inner.shell_sessions.lock().expect("shell lock").get(session).cloned()?;
     let _dispatch = existing.dispatch_lock.lock().expect("shell dispatch lock");
     if !existing.inner.lock().expect("shell inner lock").alive {
+        let mut shells = inner.shell_sessions.lock().expect("shell lock");
+        if shells.get(session).is_some_and(|cached| Arc::ptr_eq(cached, &existing)) {
+            shells.remove(session);
+        }
         return None;
     }
     if !inner

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -440,16 +440,15 @@ impl PtyManager {
 
     /// Handle one Worker -> relay PTY frame.
     pub async fn handle_frame(&self, frame: &Value, context: &FrameContext) {
-        self.inner
-            .transport_auth
-            .lock()
-            .expect("transport auth lock")
-            .insert(context.transport_id.clone(), AuthSnapshot {
-            trust: context.trust.clone(),
-            owner_user_id: context.owner_user_id.clone(),
-            send: Arc::clone(&context.send),
-            buffered_amount: Arc::clone(&context.buffered_amount),
-        });
+        self.inner.transport_auth.lock().expect("transport auth lock").insert(
+            context.transport_id.clone(),
+            AuthSnapshot {
+                trust: context.trust.clone(),
+                owner_user_id: context.owner_user_id.clone(),
+                send: Arc::clone(&context.send),
+                buffered_amount: Arc::clone(&context.buffered_amount),
+            },
+        );
         let frame_type = frame.get("type").and_then(Value::as_str).unwrap_or_default();
         match frame_type {
             "pty_open" => self.inner.clone().open(frame, context).await,

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -3227,16 +3227,33 @@ impl Inner {
         open_permit: &OpenPermit,
     ) -> Result<Option<Opened>, (RelayPtyErrorCode, String)> {
         let socket_dir = self.deps.socket_dir();
-        let ensured = self
-            .deps
-            .ensure_daemon(cmux_tui, session, &socket_dir, cwd, env, cancellation.token())
-            .await
-            .map_err(|message| (RelayPtyErrorCode::Failed, message))?;
-        let control =
-            match self.deps.connect_control(&ensured.socket_path, cancellation.token()).await {
-                Ok(control) => control,
-                Err(_) => return Ok(None), // degrade to the whole-session attach
-            };
+        let cancellation_token = cancellation.token();
+        let ensured = tokio::select! {
+            biased;
+            _ = cancellation_token.cancelled() => {
+                return Err((RelayPtyErrorCode::Failed, "terminal open cancelled".to_owned()));
+            }
+            result = self.deps.ensure_daemon(
+                cmux_tui,
+                session,
+                &socket_dir,
+                cwd,
+                env,
+                cancellation_token.clone(),
+            ) => result.map_err(|message| (RelayPtyErrorCode::Failed, message))?,
+        };
+        let control = tokio::select! {
+            biased;
+            _ = cancellation_token.cancelled() => {
+                return Err((RelayPtyErrorCode::Failed, "terminal open cancelled".to_owned()));
+            }
+            result = self.deps.connect_control(&ensured.socket_path, cancellation_token.clone()) => {
+                match result {
+                    Ok(control) => control,
+                    Err(_) => return Ok(None), // degrade to the whole-session attach
+                }
+            }
+        };
         let mut control_guard = ControlEndOnDrop::new(Arc::clone(&control));
 
         if cancellation.is_cancelled() {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1401,6 +1401,9 @@ impl Inner {
             let mut opening = self.opening_state.lock().expect("opening state lock");
             if let Some(owner) = opening.reservations.get(pty_id).cloned() {
                 opening.reservations.remove(pty_id);
+                if let Some(cancellation) = opening.cancellations.remove(&owner) {
+                    cancellation.cancel();
+                }
                 opening.cancelled.insert(pty_id.to_owned(), owner);
                 return;
             }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -614,8 +614,7 @@ impl PtyManager {
         }
         match frame_type {
             "pty_open" => {
-                let Some(cancellation) =
-                    cancellation.or_else(|| self.new_open_cancellation())
+                let Some(cancellation) = cancellation.or_else(|| self.new_open_cancellation())
                 else {
                     let pty_id = frame.get("ptyId").and_then(Value::as_str).unwrap_or_default();
                     if !pty_id.is_empty() {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -21,7 +21,7 @@
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::sync::{Notify, OwnedSemaphorePermit, Semaphore};
 use tokio_util::sync::CancellationToken;
@@ -448,6 +448,9 @@ struct PausedBacklog {
 #[derive(Clone)]
 struct Attachment {
     closing: Arc<AtomicBool>,
+    /// Number of control operations admitted before retirement. Admission
+    /// uses a closing double-check so revocation cannot race a new operation.
+    active_operations: Arc<AtomicUsize>,
     /// Serializes operations for this attachment only. The relay state lock
     /// must never be held while a PTY control method runs.
     operation_gate: Arc<Mutex<()>>,
@@ -1060,6 +1063,7 @@ impl PtyManager {
             let publication =
                 candidate.publication_gate.lock().expect("attachment publication lock");
             let operation = candidate.operation_gate.lock().expect("attachment operation lock");
+            candidate.closing.store(true, Ordering::Release);
             let removed = {
                 let _state = self.inner.tunnel_state.lock().expect("tunnel state lock");
                 let mut attachments = self.inner.attachments.lock().expect("attach lock");
@@ -1069,7 +1073,6 @@ impl PtyManager {
                 if same { attachments.remove(&id) } else { None }
             };
             if let Some(removed) = removed {
-                removed.closing.store(true, Ordering::SeqCst);
                 retired.push(removed);
             }
             drop(operation);
@@ -1530,6 +1533,7 @@ impl Inner {
                 pty_id.clone(),
                 Attachment {
                     closing,
+                    active_operations: Arc::new(AtomicUsize::new(0)),
                     operation_gate: Arc::new(Mutex::new(())),
                     publication_gate: Arc::clone(&publication_gate),
                     control,
@@ -1564,10 +1568,12 @@ impl Inner {
             let removed = {
                 let _state = self.tunnel_state.lock().expect("tunnel state lock");
                 let mut attachments = self.attachments.lock().expect("attach lock");
+                if let Some(current) = attachments.get(&pty_id) {
+                    current.closing.store(true, Ordering::Release);
+                }
                 attachments.remove(&pty_id)
             };
             if let Some(removed) = removed {
-                removed.closing.store(true, Ordering::SeqCst);
                 self.retire_attachment(removed);
             }
             return;
@@ -1696,6 +1702,7 @@ impl Inner {
             return;
         }
         let removed = {
+            attachment.closing.store(true, Ordering::Release);
             let _state = self.tunnel_state.lock().expect("tunnel state lock");
             let mut attachments = self.attachments.lock().expect("attach lock");
             let same = attachments.get(pty_id).is_some_and(|current| {
@@ -1706,7 +1713,6 @@ impl Inner {
         if !removed {
             return;
         }
-        attachment.closing.store(true, Ordering::SeqCst);
         // Exit publication crosses the transport boundary. Release the
         // lifecycle state before invoking the callback.
         drop(_operation);
@@ -1812,16 +1818,39 @@ impl Inner {
             self.handle_authorization_failure(pty_id, &attachment, &auth, context, action);
             return false;
         }
-        // A close may have won immediately after the state snapshot. Avoid
-        // starting a new control call once the attachment is retired.
+        // Couple admission to retirement with a closing double-check. A
+        // detach that stores `closing` before removal wins the race and the
+        // operation is rejected. An operation that increments first is
+        // already admitted and may finish without blocking retirement.
+        if !Self::try_admit_operation(&attachment) {
+            return false;
+        }
         if !self.attachment_snapshot_is_current(pty_id, &attachment) {
+            Self::release_operation(&attachment);
             return false;
         }
         operation(&attachment);
+        Self::release_operation(&attachment);
         // The operation was admitted at the snapshot boundary and may finish
         // concurrently with retirement. Re-read the attachment identity so
         // callers never treat a replaced or closed generation as current.
         self.attachment_snapshot_is_current(pty_id, &attachment)
+    }
+
+    fn try_admit_operation(attachment: &Attachment) -> bool {
+        if attachment.closing.load(Ordering::Acquire) {
+            return false;
+        }
+        attachment.active_operations.fetch_add(1, Ordering::AcqRel);
+        if attachment.closing.load(Ordering::Acquire) {
+            attachment.active_operations.fetch_sub(1, Ordering::AcqRel);
+            return false;
+        }
+        true
+    }
+
+    fn release_operation(attachment: &Attachment) {
+        attachment.active_operations.fetch_sub(1, Ordering::AcqRel);
     }
 
     fn auth_for_transport(&self, context: &FrameContext) -> Option<AuthSnapshot> {
@@ -1936,6 +1965,7 @@ impl Inner {
             return;
         }
         let removed = {
+            attachment.closing.store(true, Ordering::Release);
             let _state = self.tunnel_state.lock().expect("tunnel state lock");
             let mut attachments = self.attachments.lock().expect("attach lock");
             let same = attachments.get(pty_id).is_some_and(|current| {
@@ -1944,7 +1974,6 @@ impl Inner {
             if same { attachments.remove(pty_id).is_some() } else { false }
         };
         if removed {
-            attachment.closing.store(true, Ordering::SeqCst);
             // Killing a PTY can acquire a platform mutex. Keep it outside the
             // lifecycle barrier and the per-attachment operation gate.
             drop(_operation);
@@ -2017,6 +2046,7 @@ impl Inner {
         // Callers must release any prior guard before entering this helper.
         let publication = attachment.publication_gate.lock().expect("attachment publication lock");
         let operation = attachment.operation_gate.lock().expect("attachment operation lock");
+        attachment.closing.store(true, Ordering::Release);
         let removed = {
             let _state = self.tunnel_state.lock().expect("tunnel state lock");
             let mut attachments = self.attachments.lock().expect("attach lock");
@@ -2025,9 +2055,6 @@ impl Inner {
             });
             if same { attachments.remove(pty_id) } else { None }
         };
-        if let Some(ref removed) = removed {
-            removed.closing.store(true, Ordering::SeqCst);
-        }
         drop(operation);
         drop(publication);
         if let Some(removed) = removed {
@@ -4757,6 +4784,7 @@ mod tests {
                 "p1".to_owned(),
                 Attachment {
                     closing: Arc::new(AtomicBool::new(false)),
+                    active_operations: Arc::new(AtomicUsize::new(0)),
                     operation_gate: Arc::new(Mutex::new(())),
                     publication_gate: Arc::new(Mutex::new(())),
                     control: slow,
@@ -4768,6 +4796,7 @@ mod tests {
                 "p2".to_owned(),
                 Attachment {
                     closing: Arc::new(AtomicBool::new(false)),
+                    active_operations: Arc::new(AtomicUsize::new(0)),
                     operation_gate: Arc::new(Mutex::new(())),
                     publication_gate: Arc::new(Mutex::new(())),
                     control: Arc::new(fast),
@@ -4822,6 +4851,7 @@ mod tests {
                 "p1".to_owned(),
                 Attachment {
                     closing: Arc::new(AtomicBool::new(false)),
+                    active_operations: Arc::new(AtomicUsize::new(0)),
                     operation_gate: Arc::new(Mutex::new(())),
                     publication_gate: Arc::new(Mutex::new(())),
                     control: Arc::new(BlockingControl {
@@ -4875,6 +4905,7 @@ mod tests {
                 "p1".to_owned(),
                 Attachment {
                     closing: Arc::new(AtomicBool::new(false)),
+                    active_operations: Arc::new(AtomicUsize::new(0)),
                     operation_gate: Arc::new(Mutex::new(())),
                     publication_gate: Arc::new(Mutex::new(())),
                     control: Arc::new(BlockingControl {
@@ -4949,6 +4980,7 @@ mod tests {
         };
         let attachment = Attachment {
             closing: Arc::new(AtomicBool::new(false)),
+            active_operations: Arc::new(AtomicUsize::new(0)),
             operation_gate: Arc::new(Mutex::new(())),
             publication_gate: Arc::new(Mutex::new(())),
             control: Arc::new(pty),

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -605,13 +605,33 @@ impl PtyManager {
     }
 }
 
-fn send_pty_error(context: &FrameContext, pty_id: &str, code: &str, message: &str) {
+/// Convert an internal refusal into the stable public error vocabulary.
+///
+/// `open_cmux_terminal` and provider-backed daemon calls can return text that
+/// contains paths, command lines, or remote response bodies. A PTY error is a
+/// network boundary, so truncating that text would still disclose secrets.
+/// Keep the caller's message parameter for the internal call-site contract,
+/// but never put it on the wire.
+fn public_pty_error_message(code: &str) -> &'static str {
+    match code {
+        "bad_request" => "invalid terminal request",
+        "trust_refused" => "terminal access denied",
+        "trust_revoked" => "terminal access revoked",
+        "session_limit" => "terminal limit reached",
+        "terminal_gone" => "terminal is no longer available",
+        "overflow" => "terminal output overflowed; reattach to continue",
+        "busy" => "terminal is busy",
+        _ => "terminal operation failed",
+    }
+}
+
+fn send_pty_error(context: &FrameContext, pty_id: &str, code: &str, _message: &str) {
     (context.send)(json!({
         "version": PTY_PROTOCOL_VERSION,
         "type": "pty_error",
         "ptyId": pty_id,
         "code": code,
-        "message": message,
+        "message": public_pty_error_message(code),
     }));
 }
 
@@ -2842,12 +2862,13 @@ mod tests {
         let sent = h.sent();
         let error = sent.iter().find(|f| ty(f) == "pty_error").expect("pty_error frame");
         // The typed code is the contract (chatmux protocol RelayPtyErrorCode);
-        // the message keeps the human wording the Node relay used.
+        // the public message is stable and contains no surface or session
+        // identifiers.
         assert_eq!(error["code"], "terminal_gone");
         let decoded: crate::relay_wire::RelayPtyError =
             serde_json::from_value(error.clone()).expect("generated pty_error fixture");
         assert_eq!(decoded.code, RelayPtyErrorCode::TerminalGone);
-        assert!(error["message"].as_str().unwrap_or_default().contains("not found in session"),);
+        assert_eq!(error["message"], "terminal is no longer available");
         // A gone terminal must NOT degrade to a whole-session attach.
         assert!(!sent.iter().any(|f| ty(f) == "pty_opened"));
     }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1047,7 +1047,13 @@ impl Inner {
             return;
         };
         let _operation = attachment.operation_gate.lock().expect("attachment operation lock");
-        if !self.attachment_is_authorized(pty_id, &attachment, &auth, context) {
+        // The state lock is only the authorization linearization point. Do
+        // not keep it while backpressure or the send callback runs.
+        let authorized = {
+            let _state = self.tunnel_state.lock().expect("tunnel state lock");
+            self.attachment_is_authorized(pty_id, &attachment, &auth, context)
+        };
+        if !authorized {
             drop(_operation);
             self.handle_authorization_failure(pty_id, &attachment, &auth, context, "output");
             return;
@@ -1094,7 +1100,11 @@ impl Inner {
             return;
         };
         let _operation = attachment.operation_gate.lock().expect("attachment operation lock");
-        if !self.attachment_is_authorized(pty_id, &attachment, &auth, context) {
+        let authorized = {
+            let _state = self.tunnel_state.lock().expect("tunnel state lock");
+            self.attachment_is_authorized(pty_id, &attachment, &auth, context)
+        };
+        if !authorized {
             drop(_operation);
             self.handle_authorization_failure(pty_id, &attachment, &auth, context, "exit");
             return;
@@ -1111,6 +1121,8 @@ impl Inner {
             return;
         }
         attachment.closing.store(true, Ordering::SeqCst);
+        // Exit publication crosses the transport boundary. Release the
+        // lifecycle state before invoking the callback.
         drop(_operation);
         (auth.send)(json!({
             "version": PTY_PROTOCOL_VERSION,
@@ -1164,7 +1176,13 @@ impl Inner {
         let Some(attachment) = self.attachment(pty_id) else { return };
         let operation_gate = Arc::clone(&attachment.operation_gate);
         let _operation = operation_gate.lock().expect("attachment operation lock");
-        if !self.attachment_is_authorized(pty_id, &attachment, &auth, context) {
+        // The state lock is only the authorization linearization point. The
+        // control operation can block on a child that does not read stdin.
+        let authorized = {
+            let _state = self.tunnel_state.lock().expect("tunnel state lock");
+            self.attachment_is_authorized(pty_id, &attachment, &auth, context)
+        };
+        if !authorized {
             drop(_operation);
             self.handle_authorization_failure(pty_id, &attachment, &auth, context, action);
             return;
@@ -1206,7 +1224,11 @@ impl Inner {
         let Some(auth) = self.auth_for_transport(context) else { return };
         let Some(attachment) = self.attachment(pty_id) else { return };
         let _operation = attachment.operation_gate.lock().expect("attachment operation lock");
-        if !self.attachment_is_authorized(pty_id, &attachment, &auth, context) {
+        let authorized = {
+            let _state = self.tunnel_state.lock().expect("tunnel state lock");
+            self.attachment_is_authorized(pty_id, &attachment, &auth, context)
+        };
+        if !authorized {
             drop(_operation);
             self.handle_authorization_failure(pty_id, &attachment, &auth, context, "close");
             return;
@@ -1221,6 +1243,9 @@ impl Inner {
         };
         if removed {
             attachment.closing.store(true, Ordering::SeqCst);
+            // Killing a PTY can acquire a platform mutex. Keep it outside the
+            // lifecycle barrier and the per-attachment operation gate.
+            drop(_operation);
             attachment.control.kill();
         }
     }
@@ -1289,7 +1314,10 @@ impl Inner {
     }
 
     fn retire_attachment(&self, attachment: Attachment) {
-        let _operation = attachment.operation_gate.lock().expect("attachment operation lock");
+        // Revocation must not wait for an admitted PTY write. The operation
+        // was linearized before removal from the attachment map; killing the
+        // control concurrently closes that admitted operation when the
+        // platform permits it, while this transition remains bounded.
         attachment.closing.store(true, Ordering::SeqCst);
         attachment.control.kill();
     }
@@ -1365,7 +1393,10 @@ impl Inner {
 
     fn tunnel_authority_generation_current(&self, context: &FrameContext) -> bool {
         context.auth_generation.is_none_or(|generation| {
-            generation >= self.tunnel_authority_generation.load(Ordering::Acquire)
+            // A frame is valid only for the exact published generation. A
+            // future generation has not passed the authority publication
+            // boundary and must fail closed as well as an old generation.
+            generation == self.tunnel_authority_generation.load(Ordering::Acquire)
         })
     }
 
@@ -3308,6 +3339,56 @@ mod tests {
         release.wait();
         slow_thread.join().unwrap();
         fast_thread.join().unwrap();
+    }
+
+    #[test]
+    fn tunnel_revocation_does_not_wait_for_a_blocking_operation() {
+        let h = harness(None, None);
+        let inner = Arc::clone(&h.manager.inner);
+        let entered = Arc::new(Barrier::new(2));
+        let release = Arc::new(Barrier::new(2));
+        let owner = TransportOwner { id: Some("tunnel-a".to_owned()), kind: TransportKind::Tunnel };
+        {
+            let mut attachments = inner.attachments.lock().unwrap();
+            attachments.insert(
+                "p1".to_owned(),
+                Attachment {
+                    closing: Arc::new(AtomicBool::new(false)),
+                    operation_gate: Arc::new(Mutex::new(())),
+                    control: Arc::new(BlockingControl {
+                        entered: Arc::clone(&entered),
+                        release: Arc::clone(&release),
+                    }),
+                    actor_id: "user_owner".to_owned(),
+                    owner: owner.clone(),
+                },
+            );
+        }
+        let mut context = h.context_with_transport("supervised", h.owner.clone(), Some("tunnel-a"));
+        context.transport_kind = TransportKind::Tunnel;
+        inner.cache_transport_auth(&context);
+
+        let operation_inner = Arc::clone(&inner);
+        let operation_context = context.clone();
+        let operation = thread::spawn(move || {
+            operation_inner.with_authorized("p1", &operation_context, "input", |attachment| {
+                attachment.control.write(b"blocked");
+            });
+        });
+        entered.wait();
+
+        let (done_tx, done_rx) = sync_channel(1);
+        let revoke_inner = Arc::clone(&inner);
+        let revoke = thread::spawn(move || {
+            revoke_inner.detach_tunnel_transports();
+            done_tx.send(()).unwrap();
+        });
+        let completed_without_waiting = done_rx.recv_timeout(Duration::from_millis(250)).is_ok();
+        release.wait();
+        operation.join().unwrap();
+        revoke.join().unwrap();
+        assert!(completed_without_waiting, "revocation must not wait for PTY I/O");
+        assert!(!h.manager.has_attachment("p1"));
     }
 
     #[test]

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1479,7 +1479,7 @@ impl Inner {
         // Keep the opening reservation held until the attachment is installed.
         // The short state lock couples this transition with revocation, while
         // no PTY operation runs under it.
-        let (surface, start, previous) = {
+        let (surface, start, previous, publication_gate) = {
             let _state = self.tunnel_state.lock().expect("tunnel state lock");
             let auth_changed = self
                 .transport_auth
@@ -1580,6 +1580,10 @@ impl Inner {
         opened_frame.insert("created".to_owned(), Value::from(opened.created));
         opened_frame.insert("cols".to_owned(), Value::from(cols));
         opened_frame.insert("rows".to_owned(), Value::from(rows));
+        // The attachment is fully visible in the registry. Release the
+        // ordering gate before crossing the transport boundary so a blocked
+        // client cannot stall detach or authority revocation.
+        drop(_publication);
         (context.send)(Value::Object(opened_frame));
 
         // Output only AFTER pty_opened (ordering): banner, then scrollback
@@ -1702,6 +1706,7 @@ impl Inner {
         // Exit publication crosses the transport boundary. Release the
         // lifecycle state before invoking the callback.
         drop(_operation);
+        drop(_publication);
         (auth.send)(json!({
             "version": PTY_PROTOCOL_VERSION,
             "type": "pty_exit",
@@ -2596,6 +2601,17 @@ impl PtyControl for ShellViewerControl {
         };
         if should_pause {
             self.session.control.pause();
+            // A release may have removed the last paused viewer while the
+            // control call was in flight. Re-check the shared state and
+            // undo the stale pause so the shell cannot remain wedged.
+            let should_resume = {
+                let _flow = self.session.flow_lock.lock().expect("shell flow lock");
+                let inner = self.session.inner.lock().expect("shell inner lock");
+                inner.paused_viewers.is_empty()
+            };
+            if should_resume {
+                self.session.control.resume();
+            }
         }
     }
     fn resume(&self) {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -4320,6 +4320,48 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn changed_transport_auth_cancels_an_in_flight_relay_open() {
+        let h = harness(None, None);
+        let inner = Arc::clone(&h.manager.inner);
+        let old = h.context_with_transport("supervised", h.owner.clone(), Some("relay-a"));
+        h.manager.update_transport_auth(&old);
+
+        let cancellation = h.manager.new_open_cancellation().expect("open attempt token");
+        let owner = OpeningOwner {
+            owner: TransportOwner::from_context(&old),
+            attempt_id: cancellation.attempt_id(),
+        };
+        {
+            let mut state = inner.opening_state.lock().unwrap();
+            state.active_openings.insert("p1".to_owned(), (owner.clone(), cancellation.clone()));
+        }
+
+        let mut changed = old.clone();
+        changed.trust = "observe".to_owned();
+        h.manager.update_transport_auth(&changed);
+
+        assert!(cancellation.is_cancelled());
+        let state = inner.opening_state.lock().unwrap();
+        assert!(!state.reservations.contains_key("p1"));
+        assert!(!state.active_openings.contains_key("p1"));
+        assert!(!state.cancelled.contains_key("p1"));
+        drop(state);
+        assert!(!inner.cache_transport_auth(&old));
+        assert!(inner.cache_transport_auth(&changed));
+
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "stale",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+        });
+        h.manager.handle_frame(&frame, &old).await;
+        assert!(h.spawned().is_empty(), "a stale relay context must not start a PTY");
+    }
+
+    #[tokio::test]
     async fn blocking_open_worker_keeps_its_permit_until_completion() {
         let slots = Arc::new(Semaphore::new(1));
         let permit = OpenPermit::new(slots.clone().try_acquire_owned().expect("open permit"));

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2637,7 +2637,13 @@ impl Inner {
                         inner.draining_viewers.clear();
                         std::mem::take(&mut inner.viewers)
                     };
-                    manager.shell_sessions.lock().expect("shell lock").remove(&session_name);
+                    let mut shells = manager.shell_sessions.lock().expect("shell lock");
+                    if shells
+                        .get(&session_name)
+                        .is_some_and(|cached| Arc::ptr_eq(cached, &exit_session))
+                    {
+                        shells.remove(&session_name);
+                    }
                     for viewer in viewers {
                         let _delivery = viewer.delivery_lock.lock().expect("viewer delivery lock");
                         (viewer.on_exit)(code);
@@ -2657,6 +2663,9 @@ impl Inner {
                 // identity is cached, and remove only this exact session so a
                 // replacement cannot be disturbed.
                 if cancellation.is_cancelled() {
+                    if pending_viewer.swap(false, Ordering::AcqRel) {
+                        shell_session.pending_viewers.fetch_sub(1, Ordering::AcqRel);
+                    }
                     let removed =
                         remove_cached_shell_if_same_without_viewers(&self, session, &shell_session);
                     if removed {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1804,7 +1804,7 @@ impl Inner {
         {
             return;
         }
-        let _delivery = attachment.delivery_gate.lock().expect("attachment delivery lock");
+        let delivery = attachment.delivery_gate.lock().expect("attachment delivery lock");
         // Retirement takes the same delivery gate before revocation. Recheck
         // after a wait so a claim made before detach cannot call the
         // transport after that attachment has been revoked or removed.
@@ -1813,6 +1813,10 @@ impl Inner {
         {
             return;
         }
+        // The gate protects the final lifecycle check. Do not hold it across
+        // the transport callback because a stalled sink must not block detach
+        // or trust revocation.
+        drop(delivery);
         (auth.send)(json!({
             "version": PTY_PROTOCOL_VERSION,
             "type": "pty_output",
@@ -1877,6 +1881,7 @@ impl Inner {
         }
         // Exit publication crosses the transport boundary. Release the
         // lifecycle state before invoking the callback.
+        drop(_delivery);
         drop(_operation);
         drop(_publication);
         (auth.send)(json!({

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -4058,6 +4058,22 @@ mod tests {
         fn kill(&self) {}
     }
 
+    struct BlockingKillControl {
+        entered: Arc<Barrier>,
+        release: Arc<Barrier>,
+    }
+
+    impl PtyControl for BlockingKillControl {
+        fn write(&self, _data: &[u8]) {}
+        fn resize(&self, _cols: u16, _rows: u16) {}
+        fn pause(&self) {}
+        fn resume(&self) {}
+        fn kill(&self) {
+            self.entered.wait();
+            self.release.wait();
+        }
+    }
+
     /// Pauses provider resolution after the open reservation is published.
     /// This gives lifecycle tests a deterministic boundary at which a
     /// transport can detach while its provider task is still in flight.
@@ -4520,6 +4536,35 @@ mod tests {
         let spawned = h.spawned();
         assert_eq!(spawned.len(), 1);
         assert!(spawned[0].state.lock().unwrap().killed);
+    }
+
+    #[tokio::test]
+    async fn dropping_opened_does_not_block_on_control_kill() {
+        let entered = Arc::new(Barrier::new(2));
+        let release = Arc::new(Barrier::new(2));
+        let opened = Opened {
+            created: false,
+            surface: None,
+            control: Some(Arc::new(BlockingKillControl {
+                entered: Arc::clone(&entered),
+                release: Arc::clone(&release),
+            })),
+            closing: Some(Arc::new(AtomicBool::new(false))),
+            start: None,
+            cleanup_on_drop: true,
+        };
+        let drop_task = tokio::spawn(async move { drop(opened) });
+
+        tokio::task::spawn_blocking(move || entered.wait())
+            .await
+            .expect("kill must start");
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), drop_task).await.is_ok(),
+            "Opened::drop must not wait for a blocking PTY kill"
+        );
+        tokio::task::spawn_blocking(move || release.wait())
+            .await
+            .expect("kill release");
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -551,6 +551,14 @@ impl Drop for ActiveOpening {
         if state.active_openings.get(&self.id).is_some_and(|(owner, _)| owner == &self.owner) {
             state.active_openings.remove(&self.id);
         }
+        // A close can remove this pre-reservation attempt and leave an
+        // owner-specific tombstone so a late task cannot claim a replacement
+        // with the same pty id. The tombstone is needed only until this task
+        // has unwound. Match the full owner, including attempt_id, so an old
+        // task cannot clear a newer attempt's fence.
+        if state.cancelled.get(&self.id) == Some(&self.owner) {
+            state.cancelled.remove(&self.id);
+        }
     }
 }
 impl Drop for OpeningReservation {
@@ -1109,6 +1117,14 @@ impl Inner {
         }
         let pty_id = frame.get("ptyId").and_then(Value::as_str).unwrap_or_default().to_owned();
         if pty_id.is_empty() {
+            return;
+        }
+        // `cache_transport_auth` deliberately rejects malformed trust before
+        // touching the authority cache. Keep the protocol response here,
+        // before the cache lookup can return `None`, so a malformed open is a
+        // typed refusal rather than a silent drop.
+        if Trust::parse(&context.trust).is_none() {
+            send_pty_error(context, &pty_id, "trust_refused", "terminal trust is not established");
             return;
         }
         let Some(auth) = self.auth_for_transport(context) else {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -4382,6 +4382,45 @@ mod tests {
         assert!(!new_cancellation.is_cancelled());
     }
 
+    #[tokio::test]
+    async fn cancelled_active_open_drop_clears_its_tombstone() {
+        let h = harness(None, None);
+        let inner = Arc::clone(&h.manager.inner);
+        let mut context = h.context_with_transport("supervised", h.owner.clone(), Some("tunnel-a"));
+        context.transport_kind = TransportKind::Tunnel;
+        h.manager.update_transport_auth(&context);
+
+        let cancellation = h.manager.new_open_cancellation().expect("open attempt token");
+        let owner = OpeningOwner {
+            owner: TransportOwner::from_context(&context),
+            attempt_id: cancellation.attempt_id(),
+        };
+        let active = ActiveOpening {
+            inner: Arc::clone(&inner),
+            id: "p1".to_owned(),
+            owner: owner.clone(),
+            active: true,
+        };
+        inner
+            .opening_state
+            .lock()
+            .unwrap()
+            .active_openings
+            .insert("p1".to_owned(), (owner.clone(), cancellation.clone()));
+
+        h.manager
+            .handle_frame(&serde_json::json!({ "type": "pty_close", "ptyId": "p1" }), &context)
+            .await;
+
+        {
+            let state = inner.opening_state.lock().unwrap();
+            assert!(!state.active_openings.contains_key("p1"));
+            assert_eq!(state.cancelled.get("p1"), Some(&owner));
+        }
+        drop(active);
+        assert!(!inner.opening_state.lock().unwrap().cancelled.contains_key("p1"));
+    }
+
     #[test]
     fn open_attempt_tokens_fail_closed_before_reuse_on_counter_wrap() {
         let h = harness(None, None);

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1635,6 +1635,7 @@ impl Inner {
             || cancellation.is_cancelled()
             || !self.transport_auth_is_current(context, &auth)
             || !self.attachment_snapshot_is_current(pty_id, &current_attachment)
+            || !Self::try_claim_publication(&current_attachment)
         {
             self.retire_if_current(pty_id, &current_attachment);
             return;

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -4700,6 +4700,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn creator_detach_then_last_viewer_cleans_created_shell() {
+        let h = harness(None, None);
+        h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;
+        let pty = h.spawned()[0].clone();
+        h.open("p2", "main", Value::Null, "supervised", h.owner.clone()).await;
+
+        h.frame(serde_json::json!({ "type": "pty_close", "ptyId": "p1" })).await;
+        assert_eq!(h.manager.inner.shell_sessions.lock().unwrap().len(), 1);
+        h.frame(serde_json::json!({ "type": "pty_close", "ptyId": "p2" })).await;
+
+        assert!(h.manager.inner.shell_sessions.lock().unwrap().is_empty());
+        assert!(pty.state.lock().unwrap().killed);
+    }
+
+    #[tokio::test]
     async fn zero_byte_chunks_never_become_output_frames() {
         let h = harness(None, None);
         h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1667,6 +1667,17 @@ impl Inner {
             return;
         }
         start();
+        // Replay/start callbacks are synchronous and may outlive the open
+        // deadline. Reconcile a timeout after they return so a canceled open
+        // cannot leave a quiet attachment running without an owner.
+        if cancellation.is_cancelled() {
+            if let Some(attachment) = self
+                .attachment(pty_id)
+                .filter(|attachment| Arc::ptr_eq(&attachment.publication_gate, &publication_gate))
+            {
+                self.retire_if_current(pty_id, &attachment);
+            }
+        }
     }
 
     /// Build the per-attachment emit closures (output + exit framing).

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -4364,6 +4364,47 @@ mod tests {
         assert_eq!(h.spawned().len(), 1, "a new transport identity remains usable");
     }
 
+    #[tokio::test]
+    async fn identified_transport_must_publish_auth_before_its_first_frame() {
+        let h = harness(None, None);
+        let context = h.context_with_transport("supervised", h.owner.clone(), Some("relay-new"));
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "unregistered",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+        });
+
+        h.manager.handle_frame(&frame, &context).await;
+        assert!(h.spawned().is_empty(), "an unregistered transport cannot open a PTY");
+
+        h.manager.update_transport_auth(&context);
+        h.manager.handle_frame(&frame, &context).await;
+        assert_eq!(h.spawned().len(), 1, "published authority admits the transport");
+    }
+
+    #[test]
+    fn transport_authority_registry_releases_every_disconnected_identity() {
+        let h = harness(None, None);
+        for index in 0..4096 {
+            let context = h.context_with_transport(
+                "supervised",
+                h.owner.clone(),
+                Some(&format!("relay-{index}")),
+            );
+            h.manager.update_transport_auth(&context);
+            assert_eq!(h.manager.inner.transport_auth.lock().unwrap().len(), 1);
+            context.cancellation.cancel();
+            h.manager.detach_transport_kind(
+                context.transport_id.as_deref().unwrap(),
+                context.transport_kind,
+            );
+            assert!(h.manager.inner.transport_auth.lock().unwrap().is_empty());
+        }
+    }
+
     #[test]
     fn tunnel_operations_on_different_attachments_do_not_share_a_gate() {
         let h = harness(None, None);
@@ -4415,8 +4456,8 @@ mod tests {
             h.context_with_transport("supervised", h.owner.clone(), Some("tunnel-b"));
         context_a.transport_kind = TransportKind::Tunnel;
         context_b.transport_kind = TransportKind::Tunnel;
-        inner.cache_transport_auth(&context_a);
-        inner.cache_transport_auth(&context_b);
+        h.manager.update_transport_auth(&context_a);
+        h.manager.update_transport_auth(&context_b);
 
         let slow_inner = Arc::clone(&inner);
         let slow_context = context_a;
@@ -4467,7 +4508,7 @@ mod tests {
         }
         let mut context = h.context_with_transport("supervised", h.owner.clone(), Some("tunnel-a"));
         context.transport_kind = TransportKind::Tunnel;
-        inner.cache_transport_auth(&context);
+        h.manager.update_transport_auth(&context);
 
         let operation_inner = Arc::clone(&inner);
         let operation_context = context.clone();
@@ -4519,7 +4560,7 @@ mod tests {
         }
         let mut context = h.context_with_transport("supervised", h.owner.clone(), Some("tunnel-a"));
         context.transport_kind = TransportKind::Tunnel;
-        inner.cache_transport_auth(&context);
+        h.manager.update_transport_auth(&context);
 
         let operation_inner = Arc::clone(&inner);
         let operation_context = context;
@@ -4653,6 +4694,7 @@ mod tests {
         let inner = Arc::clone(&h.manager.inner);
         let mut context = h.context_with_transport("supervised", h.owner.clone(), Some("tunnel-a"));
         context.transport_kind = TransportKind::Tunnel;
+        h.manager.update_transport_auth(&context);
         let cancellation = h.manager.new_open_cancellation().expect("open attempt token");
         let owner = OpeningOwner {
             owner: TransportOwner::from_context(&context),
@@ -4760,6 +4802,7 @@ mod tests {
         let h = harness(None, None);
         let mut context = h.context_with_transport("supervised", h.owner.clone(), Some("tunnel-a"));
         context.transport_kind = TransportKind::Tunnel;
+        h.manager.update_transport_auth(&context);
         let manager = Arc::new(h.manager);
         let frame = serde_json::json!({
             "version": 4,
@@ -4796,6 +4839,7 @@ mod tests {
         let h = harness_with_control_and_gate(None, None, None, None, Some(gate));
         let mut context = h.context_with_transport("supervised", h.owner.clone(), Some("tunnel-a"));
         context.transport_kind = TransportKind::Tunnel;
+        h.manager.update_transport_auth(&context);
         let manager = Arc::new(h.manager);
         let frame = serde_json::json!({
             "version": 4,
@@ -4835,6 +4879,7 @@ mod tests {
             Arc::new(ResolveGate { entered: Arc::clone(&entered), release: Arc::clone(&release) });
         let h = harness_with_control_and_gate(None, None, None, None, Some(gate));
         let context = h.context_with_transport("supervised", h.owner.clone(), Some("tunnel-a"));
+        h.manager.update_transport_auth(&context);
         let manager = Arc::new(h.manager);
         let frame = serde_json::json!({
             "version": 4,
@@ -4876,6 +4921,7 @@ mod tests {
             Arc::new(ResolveGate { entered: Arc::clone(&entered), release: Arc::clone(&release) });
         let h = harness_with_control_and_gate(None, None, None, None, Some(gate));
         let context = h.context_with_transport("supervised", h.owner.clone(), Some("tunnel-a"));
+        h.manager.update_transport_auth(&context);
         let manager = Arc::new(h.manager);
         let frame = serde_json::json!({
             "version": 4,
@@ -4905,7 +4951,7 @@ mod tests {
         let old = h.context_with_transport("supervised", h.owner.clone(), Some("relay-never-seen"));
 
         // No frame from this owner reached the manager before disconnect.
-        // The disconnect boundary must still publish a tombstone.
+        // The absent active snapshot is enough to reject a late frame.
         h.manager.detach_transport_kind("relay-never-seen", TransportKind::Relay);
 
         let frame = serde_json::json!({
@@ -5015,6 +5061,8 @@ mod tests {
         };
         let context_a = context(Arc::clone(&sent_a), "transport-a");
         let context_b = context(Arc::clone(&sent_b), "transport-b");
+        h.manager.update_transport_auth(&context_a);
+        h.manager.update_transport_auth(&context_b);
         let open = |pty_id: &str, session: &str| {
             serde_json::json!({
                 "version": 4,

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -543,7 +543,17 @@ struct ShellStartReservation {
     active: bool,
 }
 
-fn remove_cached_shell_if_same(inner: &Inner, session: &str, target: &Arc<ShellSession>) -> bool {
+fn remove_cached_shell_if_same_without_viewers(
+    inner: &Inner,
+    session: &str,
+    target: &Arc<ShellSession>,
+) -> bool {
+    // Serialize with viewer start. A concurrent opener may have cloned this
+    // session but cannot publish its viewer while this dispatch lock is held.
+    let _dispatch = target.dispatch_lock.lock().expect("shell dispatch lock");
+    if !target.inner.lock().expect("shell inner lock").viewers.is_empty() {
+        return false;
+    }
     let mut shells = inner.shell_sessions.lock().expect("shell lock");
     if shells.get(session).is_some_and(|cached| Arc::ptr_eq(cached, target)) {
         shells.remove(session);
@@ -2627,8 +2637,10 @@ impl Inner {
                 // identity is cached, and remove only this exact session so a
                 // replacement cannot be disturbed.
                 if cancellation.is_cancelled() {
-                    remove_cached_shell_if_same(&self, session, &shell_session);
-                    shell_session.control.kill();
+                    let removed = remove_cached_shell_if_same_without_viewers(&self, session, &shell_session);
+                    if removed {
+                        shell_session.control.kill();
+                    }
                     self.shell_starting.lock().expect("shell starting lock").remove(session);
                     reservation.active = false;
                     reservation.notify.notify_waiters();

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1586,7 +1586,7 @@ impl Inner {
             .expect("attach lock")
             .get(&pty_id)
             .is_some_and(|current| Arc::ptr_eq(&current.publication_gate, &publication_gate));
-        if !authority_current || !attachment_current {
+        if cancellation.is_cancelled() || !authority_current || !attachment_current {
             let removed = {
                 let _state = self.tunnel_state.lock().expect("tunnel state lock");
                 let mut attachments = self.attachments.lock().expect("attach lock");
@@ -1632,6 +1632,7 @@ impl Inner {
             return;
         };
         if context.cancellation.is_cancelled()
+            || cancellation.is_cancelled()
             || !self.transport_auth_is_current(context, &auth)
             || !self.attachment_snapshot_is_current(pty_id, &current_attachment)
         {
@@ -1643,6 +1644,7 @@ impl Inner {
         // Output only AFTER pty_opened (ordering): banner, then scrollback
         // replay, then live bytes.
         if context.cancellation.is_cancelled()
+            || cancellation.is_cancelled()
             || !self
                 .auth_for_transport(context)
                 .is_some_and(|auth| self.transport_auth_is_current(context, &auth))
@@ -2466,7 +2468,7 @@ impl Inner {
         open_permit: &OpenPermit,
     ) -> Result<Opened, String> {
         let mut created = false;
-        let mut pending_viewer = false;
+        let pending_viewer = Arc::new(AtomicBool::new(false));
         let shell_session = loop {
             if let Some(existing) =
                 self.shell_sessions.lock().expect("shell lock").get(session).cloned()
@@ -2478,7 +2480,7 @@ impl Inner {
                 }
                 existing.control.resize(cols, rows);
                 existing.pending_viewers.fetch_add(1, Ordering::AcqRel);
-                pending_viewer = true;
+                pending_viewer.store(true, Ordering::Release);
                 break existing;
             }
             let (notify, owner, waiter) = {
@@ -2665,13 +2667,15 @@ impl Inner {
             session: Arc::clone(&shell_session),
             viewer_id,
             released: Arc::clone(&released),
+            pending_viewer: Arc::clone(&pending_viewer),
         });
 
         let start_session = Arc::clone(&shell_session);
+        let start_pending_viewer = Arc::clone(&pending_viewer);
         let start: Box<dyn FnOnce() + Send> = Box::new(move || {
             // This open has reached its publication callback. It no longer
             // counts as a pending viewer for cancellation cleanup.
-            if pending_viewer {
+            if start_pending_viewer.swap(false, Ordering::AcqRel) {
                 start_session.pending_viewers.fetch_sub(1, Ordering::AcqRel);
             }
             let (banner, replay, alive, delivery_lock) = {
@@ -2756,11 +2760,15 @@ struct ShellViewerControl {
     session: Arc<ShellSession>,
     viewer_id: u64,
     released: Arc<AtomicBool>,
+    pending_viewer: Arc<AtomicBool>,
 }
 
 impl ShellViewerControl {
     fn release(&self) {
         self.released.store(true, Ordering::SeqCst);
+        if self.pending_viewer.swap(false, Ordering::AcqRel) {
+            self.session.pending_viewers.fetch_sub(1, Ordering::AcqRel);
+        }
         {
             let _flow = self.session.flow_lock.lock().expect("shell flow lock");
             let mut inner = self.session.inner.lock().expect("shell inner lock");

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1919,7 +1919,10 @@ impl Inner {
                     }),
                     Arc::clone(&exit_live),
                 );
-                Self::revoke_publication(&attachment);
+                // A normal PTY exit ends new publication but keeps the live
+                // token for frames already queued. The writer must preserve
+                // opened/output ordering before delivering this exit frame.
+                Self::revoke_for_exit(&attachment);
                 attachment.closing.store(true, Ordering::Release);
                 attachments.remove(pty_id).is_some()
             }
@@ -2256,6 +2259,10 @@ impl Inner {
 
     fn revoke_publication(attachment: &Attachment) {
         attachment.delivery_live.store(false, Ordering::Release);
+        attachment.publication_state.fetch_or(1, Ordering::AcqRel);
+    }
+
+    fn revoke_for_exit(attachment: &Attachment) {
         attachment.publication_state.fetch_or(1, Ordering::AcqRel);
     }
 

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -4755,6 +4755,60 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn frame_context_cancellation_cancels_a_default_open() {
+        let entered = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        let gate =
+            Arc::new(ResolveGate { entered: Arc::clone(&entered), release: Arc::clone(&release) });
+        let h = harness_with_control_and_gate(None, None, None, None, Some(gate));
+        let context = h.context_with_transport("supervised", h.owner.clone(), Some("tunnel-a"));
+        let manager = Arc::new(h.manager);
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "p1",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+        });
+        let task_manager = Arc::clone(&manager);
+        let task_context = context.clone();
+        let task = tokio::spawn(async move {
+            task_manager.handle_frame(&frame, &task_context).await;
+        });
+
+        entered.notified().await;
+        context.cancellation.cancel();
+        release.notify_one();
+        task.await.unwrap();
+        assert_eq!(manager.attachment_count(), 0);
+        assert!(manager.inner.opening_state.lock().unwrap().reservations.is_empty());
+    }
+
+    #[tokio::test]
+    async fn detached_unknown_transport_rejects_a_late_frame() {
+        let h = harness(None, None);
+        let old = h.context_with_transport("supervised", h.owner.clone(), Some("relay-never-seen"));
+
+        // No frame from this owner reached the manager before disconnect.
+        // The disconnect boundary must still publish a tombstone.
+        h.manager.detach_transport_kind("relay-never-seen", TransportKind::Relay);
+
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "late",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+        });
+        h.manager.handle_frame(&frame, &old).await;
+
+        assert!(h.spawned().is_empty(), "a disconnected owner must stay fenced");
+        assert!(!h.manager.inner.cache_transport_auth(&old));
+    }
+
+    #[tokio::test]
     async fn changed_transport_auth_cancels_an_in_flight_relay_open() {
         let h = harness(None, None);
         let inner = Arc::clone(&h.manager.inner);

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -984,6 +984,12 @@ impl Inner {
         opening.remove(&pty_id);
         drop(opening);
         reservation.active = false;
+
+        // The attachment is installed. Release the lifecycle guard before
+        // callbacks: `start` can synchronously emit output, which takes this
+        // guard again.
+        drop(_lifecycle);
+
         let mut opened_frame = serde_json::Map::new();
         opened_frame.insert("version".to_owned(), Value::from(PTY_PROTOCOL_VERSION));
         opened_frame.insert("type".to_owned(), Value::from("pty_opened"));

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -271,8 +271,10 @@ where
     T: Send + 'static,
     F: FnOnce() -> T + Send + 'static,
 {
-    let _ = permit;
-    tokio::task::spawn_blocking(operation)
+    tokio::task::spawn_blocking(move || {
+        let _permit = permit;
+        operation()
+    })
 }
 
 #[async_trait]

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2026,12 +2026,21 @@ impl Inner {
     }
 
     fn tunnel_authority_generation_current(&self, context: &FrameContext) -> bool {
-        context.auth_generation.is_none_or(|generation| {
-            // A frame is valid only for the exact published generation. A
-            // future generation has not passed the authority publication
-            // boundary and must fail closed as well as an old generation.
-            generation == self.tunnel_authority_generation.load(Ordering::Acquire)
-        })
+        let current = self.tunnel_authority_generation.load(Ordering::Acquire);
+        match context.transport_kind {
+            TransportKind::Tunnel => {
+                // Managed tunnel frames always carry the generation that was
+                // published to their connection. Missing metadata is an
+                // invalid capability, even while the floor is zero.
+                context.auth_generation == Some(current)
+            }
+            TransportKind::Legacy | TransportKind::Relay => {
+                // Legacy and relay callers predate managed tunnel
+                // generations. They may omit the field, but a supplied
+                // generation still has to match exactly.
+                context.auth_generation.is_none_or(|generation| generation == current)
+            }
+        }
     }
 
     /// cmux-tui path: daemon owns the session; the viewer is disposable.
@@ -4325,7 +4334,8 @@ mod tests {
     #[tokio::test]
     async fn tunnel_authority_without_a_generation_is_rejected_after_revoke() {
         let h = harness(None, None);
-        let mut context = h.context_with_transport("supervised", h.owner.clone(), Some("tunnel-old"));
+        let mut context =
+            h.context_with_transport("supervised", h.owner.clone(), Some("tunnel-old"));
         context.transport_kind = TransportKind::Tunnel;
         context.auth_generation = None;
         h.manager.update_transport_auth(&context);

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1757,7 +1757,9 @@ impl Inner {
     /// no-op behavior; once an id is reserved or attached, a different
     /// transport may not act on it. A `None` caller owns everything (legacy).
     fn transport_owns(&self, pty_id: &str, context: &FrameContext) -> bool {
-        let Some(transport_id) = context.transport_id.as_deref() else { return true };
+        let Some(transport_id) = context.transport_id.as_deref() else {
+            return context.transport_kind == TransportKind::Legacy;
+        };
         if let Some(owner) =
             self.opening_state.lock().expect("opening state lock").reservations.get(pty_id).cloned()
         {
@@ -1839,6 +1841,7 @@ impl Inner {
         auth: &AuthSnapshot,
         context: &FrameContext,
     ) -> bool {
+        let transport_id = context.transport_id.as_deref();
         let Some(trust) = Self::matching_trust(auth, context) else { return false };
         let owner = auth.owner_user_id.as_deref();
         let trust_allowed = trust != Trust::Observe
@@ -1848,9 +1851,13 @@ impl Inner {
             && self.tunnel_authority_generation_current(context)
             && self.attachment_is_current(pty_id, attachment)
             && self.transport_auth_is_current(context, auth)
-            && (context.transport_id.is_none()
-                || (attachment.owner.id == context.transport_id
-                    && attachment.owner.kind == context.transport_kind))
+            && match context.transport_kind {
+                TransportKind::Legacy => context.transport_id.is_none(),
+                TransportKind::Relay | TransportKind::Tunnel => {
+                    transport_id.is_some_and(|id| attachment.owner.id.as_deref() == Some(id))
+                        && attachment.owner.kind == context.transport_kind
+                }
+            }
     }
 
     fn close_authorized(&self, pty_id: &str, context: &FrameContext) {
@@ -1871,8 +1878,13 @@ impl Inner {
             })
         };
         if let Some((owner, active_cancellation)) = opening {
-            let owner_matches = context.transport_id.is_none()
-                || owner.owner == TransportOwner::from_context(context);
+            let owner_matches = match context.transport_kind {
+                TransportKind::Legacy => context.transport_id.is_none(),
+                TransportKind::Relay | TransportKind::Tunnel => {
+                    context.transport_id.is_some()
+                        && owner.owner == TransportOwner::from_context(context)
+                }
+            };
             let authorized = owner_matches
                 && Self::matching_trust(&auth, context).is_some()
                 && self.tunnel_authority_generation_current(context)
@@ -2113,12 +2125,17 @@ impl Inner {
         }
         let snapshot = AuthSnapshot::from_context(context);
         let owner = TransportOwner::from_context(context);
-        if context.transport_id.is_none() {
+        if context.transport_kind == TransportKind::Legacy && context.transport_id.is_none() {
             // Legacy whole-manager callers use `None` and provide the
             // current trust on each frame. Keep that contract for non-
             // transport code.
             self.transport_auth.lock().expect("transport auth lock").insert(owner, snapshot);
             return true;
+        }
+        if context.transport_id.is_none() {
+            // Relay and managed tunnel contexts require an explicit transport
+            // identity. A missing ID is not a legacy capability.
+            return false;
         }
         // Identified transports must publish authority through
         // `update_transport_auth` before their first frame. A frame cannot
@@ -3283,6 +3300,9 @@ impl Inner {
     }
 
     async fn list_surfaces(self: Arc<Self>, frame: &Value, context: &FrameContext) {
+        if context.cancellation.is_cancelled() {
+            return;
+        }
         let request_id =
             frame.get("requestId").and_then(Value::as_str).unwrap_or_default().to_owned();
         if request_id.is_empty() {
@@ -3309,6 +3329,9 @@ impl Inner {
         // Inner terminals per session (W86), best-effort.
         let home = self.home.display().to_string();
         for session in &sessions {
+            if context.cancellation.is_cancelled() {
+                return;
+            }
             if surfaces.len() >= MAX_ENUM_SURFACES {
                 break;
             }
@@ -3319,7 +3342,9 @@ impl Inner {
                 "subtitle": "cmux-tui",
             }));
             let socket_path = socket_dir.join(format!("{session}.sock"));
-            for terminal in self.list_session_terminals(&socket_path, &home).await {
+            for terminal in
+                self.list_session_terminals(&socket_path, &home, context.cancellation.clone()).await
+            {
                 if surfaces.len() >= MAX_ENUM_SURFACES {
                     break;
                 }
@@ -3350,7 +3375,10 @@ impl Inner {
                 }));
             }
         }
-        if !self.tunnel_authority_generation_current(context) {
+        let Some(auth) = self.auth_for_transport(context) else { return };
+        if !self.tunnel_authority_generation_current(context)
+            || !self.transport_auth_is_current(context, &auth)
+        {
             return;
         }
         (context.send)(json!({
@@ -3367,13 +3395,16 @@ impl Inner {
         &self,
         socket_path: &Path,
         home: &str,
+        cancellation: CancellationToken,
     ) -> Vec<(String, String)> {
-        let Ok(control) = self.deps.connect_control(socket_path, CancellationToken::new()).await
-        else {
+        let Ok(control) = self.deps.connect_control(socket_path, cancellation.clone()).await else {
             return Vec::new();
         };
         let mut control_guard = ControlEndOnDrop::new(Arc::clone(&control));
-        let identify = control.request("identify", json!({})).await;
+        let identify = tokio::select! {
+            _ = cancellation.cancelled() => return Vec::new(),
+            result = control.request("identify", json!({})) => result,
+        };
         let protocol = identify
             .as_ref()
             .filter(|v| v.get("ok").and_then(Value::as_bool) == Some(true))
@@ -3385,7 +3416,10 @@ impl Inner {
             control.end();
             return Vec::new();
         }
-        let listed = control.request("list-workspaces", json!({})).await;
+        let listed = tokio::select! {
+            _ = cancellation.cancelled() => return Vec::new(),
+            result = control.request("list-workspaces", json!({})) => result,
+        };
         let tabs: Vec<PtyTab> = listed
             .as_ref()
             .filter(|v| v.get("ok").and_then(Value::as_bool) == Some(true))
@@ -3400,8 +3434,10 @@ impl Inner {
             let mut title =
                 if !tab.title.is_empty() { tab.title.clone() } else { tab.name.clone() };
             if title.is_empty() {
-                let proc =
-                    control.request("process-info", json!({ "surface": tab.surface_id })).await;
+                let proc = tokio::select! {
+                    _ = cancellation.cancelled() => return Vec::new(),
+                    result = control.request("process-info", json!({ "surface": tab.surface_id })) => result,
+                };
                 if let Some(data) = proc
                     .as_ref()
                     .filter(|v| v.get("ok").and_then(Value::as_bool) == Some(true))

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -3518,6 +3518,7 @@ mod tests {
             context.transport_id = transport_id.map(str::to_owned);
             context.transport_kind =
                 transport_id.map_or(TransportKind::Legacy, |_| TransportKind::Relay);
+            context.auth_generation = transport_id.map(|_| 0);
             context
         }
 
@@ -4319,6 +4320,27 @@ mod tests {
             );
             assert!(h.manager.inner.transport_auth.lock().unwrap().is_empty());
         }
+    }
+
+    #[tokio::test]
+    async fn tunnel_authority_without_a_generation_is_rejected_after_revoke() {
+        let h = harness(None, None);
+        let mut context = h.context_with_transport("supervised", h.owner.clone(), Some("tunnel-old"));
+        context.transport_kind = TransportKind::Tunnel;
+        context.auth_generation = None;
+        h.manager.update_transport_auth(&context);
+        h.manager.set_tunnel_authority_generation(1);
+
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "revoked",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+        });
+        h.manager.handle_frame(&frame, &context).await;
+        assert!(h.spawned().is_empty(), "a tunnel without a generation cannot survive revoke");
     }
 
     #[test]

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2931,6 +2931,14 @@ mod tests {
         fn kill(&self) {}
     }
 
+    /// Pauses provider resolution after the open reservation is published.
+    /// This gives lifecycle tests a deterministic boundary at which a
+    /// transport can detach while its provider task is still in flight.
+    struct ResolveGate {
+        entered: Arc<Notify>,
+        release: Arc<Notify>,
+    }
+
     #[derive(Default)]
     struct Recorded {
         spawned: Vec<FakePty>,
@@ -2946,6 +2954,7 @@ mod tests {
         read_dir: Option<Vec<String>>,
         ensure_socket_path: Option<PathBuf>,
         control: Option<Arc<dyn ControlHandle>>,
+        resolve_gate: Option<Arc<ResolveGate>>,
     }
 
     #[async_trait]
@@ -2968,6 +2977,10 @@ mod tests {
             PtyHandle { control, output, banner: None }
         }
         async fn resolve_cmux_tui(&self, _cancellation: CancellationToken) -> Option<CmuxTui> {
+            if let Some(gate) = &self.resolve_gate {
+                gate.entered.notify_one();
+                gate.release.notified().await;
+            }
             self.resolve.clone()
         }
         async fn ensure_daemon(
@@ -3048,6 +3061,16 @@ mod tests {
         ensure_socket_path: Option<PathBuf>,
         control: Option<Arc<dyn ControlHandle>>,
     ) -> Harness {
+        harness_with_control_and_gate(resolve, read_dir, ensure_socket_path, control, None)
+    }
+
+    fn harness_with_control_and_gate(
+        resolve: Option<CmuxTui>,
+        read_dir: Option<Vec<String>>,
+        ensure_socket_path: Option<PathBuf>,
+        control: Option<Arc<dyn ControlHandle>>,
+        resolve_gate: Option<Arc<ResolveGate>>,
+    ) -> Harness {
         let home = TestDirectory::new("harness");
         let home_path = home.path.clone();
         let env = env_map(&home_path);
@@ -3061,6 +3084,7 @@ mod tests {
             read_dir,
             ensure_socket_path,
             control,
+            resolve_gate,
         });
         let manager = PtyManager::with_limits(
             deps,
@@ -3482,6 +3506,7 @@ mod tests {
             read_dir: None,
             ensure_socket_path: None,
             control: None,
+            resolve_gate: None,
         });
         let manager =
             PtyManager::with_limits(deps, home_path.clone(), env, MAX_PTYS, 32, OUTPUT_BUFFER_CAP);
@@ -4009,7 +4034,8 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn cancelled_open_is_fenced_before_its_task_is_first_polled() {
         let h = harness(None, None);
-        let context = h.context_with_transport("supervised", h.owner.clone(), Some("tunnel-a"));
+        let mut context = h.context_with_transport("supervised", h.owner.clone(), Some("tunnel-a"));
+        context.transport_kind = TransportKind::Tunnel;
         let manager = Arc::new(h.manager);
         let frame = serde_json::json!({
             "version": 4,
@@ -4034,6 +4060,45 @@ mod tests {
         cancellation.cancel();
         task.await.unwrap();
         assert!(h.recorded.lock().unwrap().spawned.is_empty());
+        assert_eq!(manager.attachment_count(), 0);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn detaching_transport_cancels_an_in_flight_open() {
+        let entered = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        let gate =
+            Arc::new(ResolveGate { entered: Arc::clone(&entered), release: Arc::clone(&release) });
+        let h = harness_with_control_and_gate(None, None, None, None, Some(gate));
+        let context = h.context_with_transport("supervised", h.owner.clone(), Some("tunnel-a"));
+        let manager = Arc::new(h.manager);
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "p1",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+        });
+        let cancellation = manager.new_open_cancellation().expect("open attempt token");
+        let task_manager = Arc::clone(&manager);
+        let task_context = context.clone();
+        let task_cancellation = cancellation.clone();
+        let task = tokio::spawn(async move {
+            task_manager
+                .handle_frame_with_open_cancellation(&frame, &task_context, Some(task_cancellation))
+                .await;
+        });
+
+        // Provider resolution is paused only after the reservation is live.
+        // Detach must signal the exact open before allowing the provider to
+        // continue, independent of scheduler timing.
+        entered.notified().await;
+        manager.detach_transport_kind("tunnel-a", TransportKind::Tunnel);
+        assert!(cancellation.is_cancelled());
+
+        release.notify_one();
+        task.await.unwrap();
         assert_eq!(manager.attachment_count(), 0);
     }
 

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1293,15 +1293,16 @@ impl Inner {
         let Some(attachment) = self.attachment(pty_id) else {
             return;
         };
-        let _operation = attachment.operation_gate.lock().expect("attachment operation lock");
-        // The state lock is only the authorization linearization point. Do
-        // not keep it while backpressure or the send callback runs.
+        // The gate protects the authorization snapshot only. Never hold it
+        // while backpressure or the send callback runs: PTY input can block
+        // until the child drains, while the reader needs this same path to
+        // publish output.
         let authorized = {
+            let _operation = attachment.operation_gate.lock().expect("attachment operation lock");
             let _state = self.tunnel_state.lock().expect("tunnel state lock");
             self.attachment_is_authorized(pty_id, &attachment, &auth, context)
         };
         if !authorized {
-            drop(_operation);
             self.handle_authorization_failure(pty_id, &attachment, &auth, context, "output");
             return;
         }
@@ -1315,7 +1316,6 @@ impl Inner {
         // frame exactly at the cap, but must reject one that would push the
         // buffered amount over the cap.
         if buffered.saturating_add(chunk.len() as u64) > self.output_cap {
-            drop(_operation);
             self.retire_if_current(pty_id, &attachment);
             send_pty_error(
                 context,
@@ -1326,6 +1326,12 @@ impl Inner {
                     self.output_cap
                 ),
             );
+            return;
+        }
+        // Closing can race the snapshot once the gate is released. Do not
+        // publish a frame for an attachment that has already been retired or
+        // replaced under the same pty id.
+        if !self.attachment_snapshot_is_current(pty_id, &attachment) {
             return;
         }
         (auth.send)(json!({
@@ -1416,26 +1422,41 @@ impl Inner {
         true
     }
 
-    fn with_authorized<F>(&self, pty_id: &str, context: &FrameContext, action: &str, operation: F)
+    fn with_authorized<F>(
+        &self,
+        pty_id: &str,
+        context: &FrameContext,
+        action: &str,
+        operation: F,
+    ) -> bool
     where
         F: FnOnce(&Attachment),
     {
-        let Some(auth) = self.auth_for_transport(context) else { return };
-        let Some(attachment) = self.attachment(pty_id) else { return };
-        let operation_gate = Arc::clone(&attachment.operation_gate);
-        let _operation = operation_gate.lock().expect("attachment operation lock");
-        // The state lock is only the authorization linearization point. The
-        // control operation can block on a child that does not read stdin.
+        let Some(auth) = self.auth_for_transport(context) else { return false };
+        let Some(attachment) = self.attachment(pty_id) else { return false };
+        // The gate and state lock form the authorization linearization point.
+        // Snapshot that decision, then release both before entering platform
+        // I/O. A child that does not read stdin must not block its output
+        // callback or a close on this attachment.
         let authorized = {
+            let _operation = attachment.operation_gate.lock().expect("attachment operation lock");
             let _state = self.tunnel_state.lock().expect("tunnel state lock");
             self.attachment_is_authorized(pty_id, &attachment, &auth, context)
         };
         if !authorized {
-            drop(_operation);
             self.handle_authorization_failure(pty_id, &attachment, &auth, context, action);
-            return;
+            return false;
+        }
+        // A close may have won immediately after the state snapshot. Avoid
+        // starting a new control call once the attachment is retired.
+        if !self.attachment_snapshot_is_current(pty_id, &attachment) {
+            return false;
         }
         operation(&attachment);
+        // The operation was admitted at the snapshot boundary and may finish
+        // concurrently with retirement. Re-read the attachment identity so
+        // callers never treat a replaced or closed generation as current.
+        self.attachment_snapshot_is_current(pty_id, &attachment)
     }
 
     fn auth_for_transport(&self, context: &FrameContext) -> Option<AuthSnapshot> {
@@ -1504,6 +1525,11 @@ impl Inner {
             .expect("attach lock")
             .get(pty_id)
             .is_some_and(|current| Arc::ptr_eq(&current.operation_gate, &attachment.operation_gate))
+    }
+
+    fn attachment_snapshot_is_current(&self, pty_id: &str, attachment: &Attachment) -> bool {
+        !attachment.closing.load(Ordering::Acquire)
+            && self.attachment_is_current(pty_id, attachment)
     }
 
     fn transport_auth_is_current(&self, context: &FrameContext, auth: &AuthSnapshot) -> bool {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -251,8 +251,11 @@ pub struct EnsureDaemon {
 
 #[async_trait]
 pub trait PtyDeps: Send + Sync {
-    async fn spawn_pty(&self, spec: SpawnSpec) -> PtyHandle;
-    async fn resolve_cmux_tui(&self) -> Option<CmuxTui>;
+    /// Start a PTY while observing the lifetime of its open operation. An
+    /// implementation must reclaim any process or descriptor it creates when
+    /// the token is cancelled before ownership is returned.
+    async fn spawn_pty(&self, spec: SpawnSpec, cancellation: CancellationToken) -> PtyHandle;
+    async fn resolve_cmux_tui(&self, cancellation: CancellationToken) -> Option<CmuxTui>;
     async fn ensure_daemon(
         &self,
         cmux_tui: &CmuxTui,
@@ -260,8 +263,13 @@ pub trait PtyDeps: Send + Sync {
         socket_dir: &Path,
         cwd: &Path,
         env: &HashMap<String, String>,
+        cancellation: CancellationToken,
     ) -> Result<EnsureDaemon, String>;
-    async fn connect_control(&self, socket_path: &Path) -> Result<Arc<dyn ControlHandle>, String>;
+    async fn connect_control(
+        &self,
+        socket_path: &Path,
+        cancellation: CancellationToken,
+    ) -> Result<Arc<dyn ControlHandle>, String>;
     async fn read_dir(&self, path: &Path) -> Result<Vec<String>, ()>;
     fn socket_dir(&self) -> PathBuf;
     fn shell(&self) -> String;
@@ -504,6 +512,10 @@ impl OpenCancellation {
 
     fn is_cancelled(&self) -> bool {
         self.token.is_cancelled()
+    }
+
+    fn token(&self) -> CancellationToken {
+        self.token.clone()
     }
 
     fn attempt_id(&self) -> u64 {
@@ -1059,7 +1071,10 @@ impl Inner {
         };
         let env = pty_env(&self.env);
 
-        let cmux_tui = self.deps.resolve_cmux_tui().await;
+        let cmux_tui = tokio::select! {
+            _ = cancellation.token().cancelled() => return,
+            resolved = self.deps.resolve_cmux_tui(cancellation.token()) => resolved,
+        };
         if cancellation.is_cancelled() {
             return;
         }
@@ -1079,6 +1094,7 @@ impl Inner {
                     &pty_id,
                     server_roots.as_deref(),
                     context,
+                    &cancellation,
                 )
                 .await
             {
@@ -1107,6 +1123,7 @@ impl Inner {
                             &pty_id,
                             server_roots.as_deref(),
                             context,
+                            &cancellation,
                         )
                         .await
                 } else {
@@ -1120,6 +1137,7 @@ impl Inner {
                             &pty_id,
                             server_roots.as_deref(),
                             context,
+                            &cancellation,
                         )
                         .await
                 };
@@ -1538,6 +1556,31 @@ struct Opened {
     cleanup_on_drop: bool,
 }
 
+/// Control sockets use an explicit `end()` operation. Own every probe until
+/// its async handshake has completed so cancellation cannot leave a reader or
+/// writer task attached to a timed-out terminal open.
+struct ControlEndOnDrop {
+    control: Option<Arc<dyn ControlHandle>>,
+}
+
+impl ControlEndOnDrop {
+    fn new(control: Arc<dyn ControlHandle>) -> Self {
+        Self { control: Some(control) }
+    }
+
+    fn disarm(&mut self) {
+        self.control = None;
+    }
+}
+
+impl Drop for ControlEndOnDrop {
+    fn drop(&mut self) {
+        if let Some(control) = self.control.take() {
+            control.end();
+        }
+    }
+}
+
 impl Drop for Opened {
     fn drop(&mut self) {
         if self.cleanup_on_drop {
@@ -1626,17 +1669,32 @@ impl Inner {
         pty_id: &str,
         server_roots: Option<&[String]>,
         context: &FrameContext,
+        cancellation: &OpenCancellation,
     ) -> Result<Opened, String> {
         let socket_dir = self.deps.socket_dir();
-        let ensured = self.deps.ensure_daemon(cmux_tui, session, &socket_dir, cwd, env).await?;
+        let ensured = tokio::select! {
+            _ = cancellation.token().cancelled() => return Err("terminal open cancelled".to_owned()),
+            result = self.deps.ensure_daemon(
+                cmux_tui,
+                session,
+                &socket_dir,
+                cwd,
+                env,
+                cancellation.token(),
+            ) => result,
+        }?;
         let roots_scoped = context.local_roots.as_deref().is_some_and(|r| !r.is_empty())
             || server_roots.is_some_and(|r| !r.is_empty());
         if roots_scoped {
             let control = self
                 .deps
-                .connect_control(&ensured.socket_path)
+                .connect_control(&ensured.socket_path, cancellation.token())
                 .await
                 .map_err(|_| "cannot inspect existing daemon cwd".to_owned())?;
+            let mut control_guard = ControlEndOnDrop::new(Arc::clone(&control));
+            if cancellation.is_cancelled() {
+                return Err("terminal open cancelled".to_owned());
+            }
             let Some(listed) = control.request("list-workspaces", json!({})).await else {
                 control.end();
                 return Err("cannot inspect existing daemon surfaces".to_owned());
@@ -1669,6 +1727,9 @@ impl Inner {
                 return Err("cannot prove existing daemon cwd is within allowed roots".to_owned());
             }
             for tab in tabs {
+                if cancellation.is_cancelled() {
+                    return Err("terminal open cancelled".to_owned());
+                }
                 let Some(info) =
                     control.request("process-info", json!({ "surface": tab.surface_id })).await
                 else {
@@ -1706,6 +1767,7 @@ impl Inner {
                 }
             }
             control.end();
+            control_guard.disarm();
         }
         let mut args = cmux_tui.prefix.clone();
         args.extend([
@@ -1724,8 +1786,8 @@ impl Inner {
                 rows,
                 cwd: cwd.to_path_buf(),
                 env: env.clone(),
-                cancellation: context.cancellation.clone(),
-            })
+                cancellation: cancellation.token(),
+            }, cancellation.token())
             .await;
         let control = Arc::clone(&handle.control);
         let output = Arc::clone(&handle.output);
@@ -1754,6 +1816,7 @@ impl Inner {
         pty_id: &str,
         server_roots: Option<&[String]>,
         context: &FrameContext,
+        cancellation: &OpenCancellation,
     ) -> Result<Opened, String> {
         let mut created = false;
         let shell_session = loop {
@@ -1809,8 +1872,8 @@ impl Inner {
                         rows,
                         cwd: cwd.to_path_buf(),
                         env: env.clone(),
-                        cancellation: context.cancellation.clone(),
-                    })
+                        cancellation: cancellation.token(),
+                    }, cancellation.token())
                     .await;
                 let PtyHandle { control, output, banner } = handle;
                 let shell_session = Arc::new(ShellSession {
@@ -2125,6 +2188,14 @@ struct ControlTerminalControl {
     surface_id: i64,
 }
 
+impl Drop for ControlTerminalControl {
+    fn drop(&mut self) {
+        // A cancelled open can drop this proxy before it reaches the
+        // attachment map. Explicitly close the underlying control stream.
+        self.control.end();
+    }
+}
+
 impl PtyControl for ControlTerminalControl {
     fn write(&self, data: &[u8]) {
         self.control
@@ -2312,18 +2383,30 @@ impl Inner {
         pty_id: &str,
         server_roots: Option<&[String]>,
         context: &FrameContext,
+        cancellation: &OpenCancellation,
     ) -> Result<Option<Opened>, (RelayPtyErrorCode, String)> {
         let socket_dir = self.deps.socket_dir();
         let ensured = self
             .deps
-            .ensure_daemon(cmux_tui, session, &socket_dir, cwd, env)
+            .ensure_daemon(
+                cmux_tui,
+                session,
+                &socket_dir,
+                cwd,
+                env,
+                cancellation.token(),
+            )
             .await
             .map_err(|message| (RelayPtyErrorCode::Failed, message))?;
-        let control = match self.deps.connect_control(&ensured.socket_path).await {
+        let control = match self.deps.connect_control(&ensured.socket_path, cancellation.token()).await {
             Ok(control) => control,
             Err(_) => return Ok(None), // degrade to the whole-session attach
         };
+        let mut control_guard = ControlEndOnDrop::new(Arc::clone(&control));
 
+        if cancellation.is_cancelled() {
+            return Err((RelayPtyErrorCode::Failed, "terminal open cancelled".to_owned()));
+        }
         let identify = control.request("identify", json!({})).await;
         let info = identify.as_ref().filter(|v| v.get("ok").and_then(Value::as_bool) == Some(true));
         let protocol = info
@@ -2350,6 +2433,9 @@ impl Inner {
             None
         };
         if surface_id.is_none() {
+            if cancellation.is_cancelled() {
+                return Err((RelayPtyErrorCode::Failed, "terminal open cancelled".to_owned()));
+            }
             let listed = control.request("list-workspaces", json!({})).await;
             let tabs = listed
                 .as_ref()
@@ -2377,6 +2463,9 @@ impl Inner {
         let roots_scoped = context.local_roots.as_deref().is_some_and(|r| !r.is_empty())
             || server_roots.is_some_and(|r| !r.is_empty());
         if roots_scoped {
+            if cancellation.is_cancelled() {
+                return Err((RelayPtyErrorCode::Failed, "terminal open cancelled".to_owned()));
+            }
             let info = control.request("process-info", json!({ "surface": surface_id })).await;
             let actual = info
                 .as_ref()
@@ -2410,6 +2499,9 @@ impl Inner {
         }
 
         let stream = Arc::new(TerminalStream::new());
+        if cancellation.is_cancelled() {
+            return Err((RelayPtyErrorCode::Failed, "terminal open cancelled".to_owned()));
+        }
         let event_stream = Arc::clone(&stream);
         control.on_event(Box::new(move |event| {
             if event.get("surface").and_then(Value::as_i64) != Some(surface_id) {
@@ -2455,6 +2547,7 @@ impl Inner {
         }
 
         let proxy = Arc::new(ControlTerminalControl { control, surface_id });
+        control_guard.disarm();
         let (on_data, _) = self.sinks(pty_id, context);
         let relay = Arc::clone(&self);
         let context_for_exit = context.clone();
@@ -2570,9 +2663,12 @@ impl Inner {
         socket_path: &Path,
         home: &str,
     ) -> Vec<(String, String)> {
-        let Ok(control) = self.deps.connect_control(socket_path).await else {
+        let Ok(control) =
+            self.deps.connect_control(socket_path, CancellationToken::new()).await
+        else {
             return Vec::new();
         };
+        let mut control_guard = ControlEndOnDrop::new(Arc::clone(&control));
         let identify = control.request("identify", json!({})).await;
         let protocol = identify
             .as_ref()
@@ -2637,6 +2733,7 @@ impl Inner {
             out.push((reference, title.chars().take(200).collect()));
         }
         control.end();
+        control_guard.disarm();
         out
     }
 }
@@ -2787,7 +2884,11 @@ mod tests {
 
     #[async_trait]
     impl PtyDeps for FakeDeps {
-        async fn spawn_pty(&self, spec: SpawnSpec) -> PtyHandle {
+        async fn spawn_pty(
+            &self,
+            spec: SpawnSpec,
+            _cancellation: CancellationToken,
+        ) -> PtyHandle {
             let pty = FakePty {
                 state: Arc::new(StdMutex::new(FakeState::default())),
                 spawn_file: spec.file.clone(),
@@ -2799,7 +2900,10 @@ mod tests {
             let output: Arc<dyn PtyOutput> = Arc::new(pty);
             PtyHandle { control, output, banner: None }
         }
-        async fn resolve_cmux_tui(&self) -> Option<CmuxTui> {
+        async fn resolve_cmux_tui(
+            &self,
+            _cancellation: CancellationToken,
+        ) -> Option<CmuxTui> {
             self.resolve.clone()
         }
         async fn ensure_daemon(
@@ -2809,6 +2913,7 @@ mod tests {
             socket_dir: &Path,
             _cwd: &Path,
             _env: &HashMap<String, String>,
+            _cancellation: CancellationToken,
         ) -> Result<EnsureDaemon, String> {
             self.recorded
                 .lock()
@@ -2824,6 +2929,7 @@ mod tests {
         async fn connect_control(
             &self,
             socket_path: &Path,
+            _cancellation: CancellationToken,
         ) -> Result<Arc<dyn ControlHandle>, String> {
             self.recorded.lock().unwrap().connected.push(socket_path.to_path_buf());
             match &self.control {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -3851,6 +3851,8 @@ mod tests {
             spawn_file: String::new(),
             spawn_cwd: PathBuf::new(),
             spawn_term: String::new(),
+            cancel_on_subscribe: Arc::new(AtomicBool::new(false)),
+            cancellation: CancellationToken::new(),
         };
         let owner_a =
             TransportOwner { id: Some("tunnel-a".to_owned()), kind: TransportKind::Tunnel };

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -304,7 +304,11 @@ pub trait PtyDeps: Send + Sync {
         socket_path: &Path,
         cancellation: CancellationToken,
     ) -> Result<Arc<dyn ControlHandle>, String>;
-    async fn read_dir(&self, path: &Path) -> Result<Vec<String>, ()>;
+    async fn read_dir(
+        &self,
+        path: &Path,
+        cancellation: CancellationToken,
+    ) -> Result<Vec<String>, ()>;
     fn socket_dir(&self) -> PathBuf;
     fn shell(&self) -> String;
 }
@@ -3596,7 +3600,7 @@ impl Inner {
         // reverse a digest socket name back to its original session. Callers
         // must open a session explicitly when the core resolver selected a
         // fallback directory or hashed leaf.
-        if let Ok(entries) = self.deps.read_dir(&socket_dir).await {
+        if let Ok(entries) = self.deps.read_dir(&socket_dir, context.cancellation.clone()).await {
             for name in entries {
                 let Some(id) = name.strip_suffix(".sock") else { continue };
                 if !session_name_ok(id) || seen.contains(id) {
@@ -3984,7 +3988,11 @@ mod tests {
                 None => Err("no control socket in tests unless injected".to_owned()),
             }
         }
-        async fn read_dir(&self, _path: &Path) -> Result<Vec<String>, ()> {
+        async fn read_dir(
+            &self,
+            _path: &Path,
+            _cancellation: CancellationToken,
+        ) -> Result<Vec<String>, ()> {
             self.read_dir.clone().ok_or(())
         }
         fn socket_dir(&self) -> PathBuf {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1963,6 +1963,10 @@ impl Inner {
             return false;
         }
         let _control = attachment.control_gate.lock().expect("attachment control lock");
+        if !self.attachment_snapshot_is_current(pty_id, &attachment) {
+            Self::release_operation(&attachment);
+            return false;
+        }
         operation(&attachment);
         Self::release_operation(&attachment);
         // The operation was admitted at the snapshot boundary and may finish

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1714,7 +1714,21 @@ impl Inner {
             // renegotiated. Do not let that stale frame overwrite the
             // authoritative snapshot; session code calls
             // `update_transport_auth` at each reconciliation boundary.
-            transport_auth.entry(owner).or_insert(snapshot);
+            match transport_auth.entry(owner) {
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    entry.insert(snapshot);
+                }
+                std::collections::hash_map::Entry::Occupied(entry) => {
+                    let cached = entry.get();
+                    if cached.trust != snapshot.trust
+                        || cached.local_roots != snapshot.local_roots
+                        || cached.owner_user_id != snapshot.owner_user_id
+                        || cached.auth_generation != snapshot.auth_generation
+                    {
+                        return false;
+                    }
+                }
+            }
         }
         true
     }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -23,7 +23,7 @@ use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
-use tokio::sync::Notify;
+use tokio::sync::{Notify, Semaphore};
 use tokio_util::sync::CancellationToken;
 
 use async_trait::async_trait;
@@ -431,6 +431,12 @@ struct Inner {
     /// Monotonic floor for managed tunnel authority generations. It remains
     /// effective while a stale open is still unwinding after revocation.
     tunnel_authority_generation: AtomicU64,
+    /// Bounds provider/PTY opens, including opens that have timed out while
+    /// their provider task is still unwinding. A permit is owned by the open
+    /// task and is released only when that task has returned, so a hung
+    /// provider can consume only the finite terminal budget, never an
+    /// unbounded number of reservations or tasks.
+    open_slots: Arc<Semaphore>,
 }
 
 struct ShellStartReservation {
@@ -461,9 +467,9 @@ impl Drop for OpeningReservation {
             let mut state = self.inner.opening_state.lock().expect("opening state lock");
             if state.reservations.get(&self.id) == Some(&self.owner) {
                 state.reservations.remove(&self.id);
-                if state.cancelled.get(&self.id) == Some(&self.owner) {
-                    state.cancelled.remove(&self.id);
-                }
+            }
+            if state.cancelled.get(&self.id) == Some(&self.owner) {
+                state.cancelled.remove(&self.id);
             }
         }
     }
@@ -471,6 +477,34 @@ impl Drop for OpeningReservation {
 
 pub struct PtyManager {
     inner: Arc<Inner>,
+}
+
+/// Attachments whose ownership has already been removed from the manager.
+/// The controls are retired after the caller releases any outer trust lock,
+/// so a slow platform kill cannot block authorization readers or a later
+/// reconciliation. Dropping this value still retires every control.
+pub struct RetiredAttachments {
+    inner: Arc<Inner>,
+    attachments: Vec<Attachment>,
+}
+
+impl RetiredAttachments {
+    /// Run the potentially blocking control cleanup after the state boundary.
+    pub fn retire(mut self) {
+        let attachments = std::mem::take(&mut self.attachments);
+        for attachment in attachments {
+            self.inner.retire_attachment(attachment);
+        }
+    }
+}
+
+impl Drop for RetiredAttachments {
+    fn drop(&mut self) {
+        let attachments = std::mem::take(&mut self.attachments);
+        for attachment in attachments {
+            self.inner.retire_attachment(attachment);
+        }
+    }
 }
 
 impl PtyManager {
@@ -490,6 +524,7 @@ impl PtyManager {
                 transport_auth: Mutex::new(HashMap::new()),
                 tunnel_state: Mutex::new(()),
                 tunnel_authority_generation: AtomicU64::new(0),
+                open_slots: Arc::new(Semaphore::new(MAX_PTYS)),
             }),
         }
     }
@@ -517,6 +552,7 @@ impl PtyManager {
                 transport_auth: Mutex::new(HashMap::new()),
                 tunnel_state: Mutex::new(()),
                 tunnel_authority_generation: AtomicU64::new(0),
+                open_slots: Arc::new(Semaphore::new(max_ptys)),
             }),
         }
     }
@@ -650,13 +686,13 @@ impl PtyManager {
     /// must use `detach_transport` so it cannot detach attachments the
     /// managed tunnel listener (or another socket) owns.
     pub fn detach_all(&self) {
-        self.detach_matching(|_| true);
+        self.detach_matching(|_| true).retire();
     }
 
     /// One transport dropped: release only its attachments and cancel only
     /// its in-flight opens. Sessions live on either way (docs/TERMINAL.md).
     pub fn detach_transport(&self, transport_id: &str) {
-        self.detach_matching(|owner| owner.id.as_deref() == Some(transport_id));
+        self.detach_matching(|owner| owner.id.as_deref() == Some(transport_id)).retire();
     }
 
     /// One typed transport dropped. This avoids treating an opaque relay ID
@@ -664,17 +700,40 @@ impl PtyManager {
     pub fn detach_transport_kind(&self, transport_id: &str, kind: TransportKind) {
         self.detach_matching(|owner| {
             owner.id.as_deref() == Some(transport_id) && owner.kind == kind
-        });
+        })
+        .retire();
     }
 
     /// Release all managed tunnel attachments. The relay connection clears
     /// tunnel authority on disconnect or trust renegotiation; existing tunnel
     /// viewers must lose their attachments at the same boundary.
     pub fn detach_tunnel_transports(&self) {
-        self.detach_matching(|owner| owner.kind == TransportKind::Tunnel);
+        self.detach_tunnel_transports_deferred().retire();
     }
 
-    fn detach_matching(&self, owns: impl Fn(&TransportOwner) -> bool) {
+    /// Remove managed tunnel ownership while the caller still holds its
+    /// authority boundary, but defer control kills until `retire` is called.
+    /// This lets session reconciliation release the global trust lock before
+    /// touching platform PTY state.
+    pub fn detach_tunnel_transports_deferred(&self) -> RetiredAttachments {
+        self.detach_matching(|owner| owner.kind == TransportKind::Tunnel)
+    }
+
+    /// Cancel one opening reservation at the timeout boundary. The
+    /// owner-specific tombstone rejects a late result without retaining the
+    /// reservation in the capacity count. Tombstones are bounded by
+    /// `open_slots`, because each one belongs to an outstanding open permit.
+    pub fn cancel_open(&self, pty_id: &str, context: &FrameContext) {
+        let owner = OpeningOwner { owner: TransportOwner::from_context(context) };
+        let _state = self.inner.tunnel_state.lock().expect("tunnel state lock");
+        let mut opening = self.inner.opening_state.lock().expect("opening state lock");
+        if opening.reservations.get(pty_id) == Some(&owner) {
+            opening.reservations.remove(pty_id);
+            opening.cancelled.insert(pty_id.to_owned(), owner);
+        }
+    }
+
+    fn detach_matching(&self, owns: impl Fn(&TransportOwner) -> bool) -> RetiredAttachments {
         // The state lock couples authority transitions with the final open
         // install. PTY kill calls happen after it is released, so one slow
         // attachment cannot block unrelated tunnel operations.
@@ -694,6 +753,7 @@ impl PtyManager {
                 .map(|(id, owner)| (id.clone(), owner.clone()))
                 .collect();
             for (id, owner) in cancelled {
+                opening.reservations.remove(&id);
                 opening.cancelled.insert(id, owner);
             }
 
@@ -710,9 +770,7 @@ impl PtyManager {
             }
         }
         drop(_state);
-        for attachment in retired {
-            self.inner.retire_attachment(attachment);
-        }
+        RetiredAttachments { inner: Arc::clone(&self.inner), attachments: retired }
     }
 }
 
@@ -768,6 +826,17 @@ impl Inner {
         if pty_id.is_empty() {
             return;
         }
+        // Keep one permit for the complete provider/PTY open. A timeout may
+        // leave that task unwinding in the background, so the permit remains
+        // owned until the task returns. This is the supervisor boundary that
+        // makes stalled providers consume only the finite terminal budget.
+        let _open_permit = match self.open_slots.clone().try_acquire_owned() {
+            Ok(permit) => permit,
+            Err(_) => {
+                send_pty_error(context, &pty_id, "session_limit", "terminal limit reached");
+                return;
+            }
+        };
         if !self.tunnel_authority_generation_current(context) {
             send_pty_error(context, &pty_id, "trust_revoked", "tunnel authority changed");
             return;
@@ -1140,6 +1209,7 @@ impl Inner {
             let _state = self.tunnel_state.lock().expect("tunnel state lock");
             let mut opening = self.opening_state.lock().expect("opening state lock");
             if let Some(owner) = opening.reservations.get(pty_id).cloned() {
+                opening.reservations.remove(pty_id);
                 opening.cancelled.insert(pty_id.to_owned(), owner);
                 return;
             }
@@ -3420,6 +3490,32 @@ mod tests {
         let state = inner.opening_state.lock().unwrap();
         assert_eq!(state.reservations.get(&id), Some(&owner_b));
         assert_eq!(state.cancelled.get(&id), Some(&owner_b));
+    }
+
+    #[test]
+    fn cancelling_an_open_releases_the_reservation_before_the_task_returns() {
+        let h = harness(None, None);
+        let inner = Arc::clone(&h.manager.inner);
+        let mut context = h.context_with_transport("supervised", h.owner.clone(), Some("tunnel-a"));
+        context.transport_kind = TransportKind::Tunnel;
+        let owner = OpeningOwner { owner: TransportOwner::from_context(&context) };
+        let reservation = OpeningReservation {
+            inner: Arc::clone(&inner),
+            id: "p1".to_owned(),
+            owner: owner.clone(),
+            active: true,
+        };
+        inner.opening_state.lock().unwrap().reservations.insert("p1".to_owned(), owner.clone());
+
+        h.manager.cancel_open("p1", &context);
+
+        {
+            let state = inner.opening_state.lock().unwrap();
+            assert!(!state.reservations.contains_key("p1"));
+            assert_eq!(state.cancelled.get("p1"), Some(&owner));
+        }
+        drop(reservation);
+        assert!(!inner.opening_state.lock().unwrap().cancelled.contains_key("p1"));
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2331,11 +2331,15 @@ impl Inner {
         let roots_scoped = context.local_roots.as_deref().is_some_and(|r| !r.is_empty())
             || server_roots.is_some_and(|r| !r.is_empty());
         if roots_scoped {
-            let control = self
-                .deps
-                .connect_control(&ensured.socket_path, cancellation.token())
-                .await
-                .map_err(|_| "cannot inspect existing daemon cwd".to_owned())?;
+            let control = tokio::select! {
+                biased;
+                _ = cancellation.cancelled() => {
+                    return Err("terminal open cancelled".to_owned());
+                }
+                result = self.deps.connect_control(&ensured.socket_path, cancellation.token()) => {
+                    result.map_err(|_| "cannot inspect existing daemon cwd".to_owned())?
+                }
+            };
             let mut control_guard = ControlEndOnDrop::new(Arc::clone(&control));
             if cancellation.is_cancelled() {
                 return Err("terminal open cancelled".to_owned());
@@ -3550,8 +3554,13 @@ impl Inner {
         home: &str,
         cancellation: CancellationToken,
     ) -> Vec<(String, String)> {
-        let Ok(control) = self.deps.connect_control(socket_path, cancellation.clone()).await else {
-            return Vec::new();
+        let control = tokio::select! {
+            biased;
+            _ = cancellation.cancelled() => return Vec::new(),
+            result = self.deps.connect_control(socket_path, cancellation.clone()) => {
+                let Ok(control) = result else { return Vec::new() };
+                control
+            }
         };
         let mut control_guard = ControlEndOnDrop::new(Arc::clone(&control));
         let identify = tokio::select! {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1939,7 +1939,7 @@ impl Inner {
                     .map(|(owner, cancellation)| (owner.clone(), Some(cancellation.clone())))
             })
         };
-        if let Some((owner, active_cancellation)) = opening {
+        if let Some((owner, _active_cancellation)) = opening {
             let owner_matches = match context.transport_kind {
                 TransportKind::Legacy => context.transport_id.is_none(),
                 TransportKind::Relay | TransportKind::Tunnel => {
@@ -1975,10 +1975,15 @@ impl Inner {
                     None
                 }
             };
-            if let Some(cancellation) = cancellation.or(active_cancellation) {
+            if let Some(cancellation) = cancellation {
                 cancellation.cancel();
+                return;
             }
-            return;
+            // The opening may have published an attachment between the
+            // snapshot above and the cancellation mutation. Fall through to
+            // the attachment path so this close frame still retires that
+            // exact generation. Do not cancel the stale token: it may belong
+            // to a completed open or to a replacement that won the race.
         }
 
         let Some(attachment) = self.attachment(pty_id) else { return };

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1713,7 +1713,6 @@ impl Inner {
             "ptyId": pty_id,
             "code": code,
         }));
-        drop(_publication);
     }
 
     /// Detach, NOT kill: idempotent, unknown ptyId tolerated.
@@ -2524,14 +2523,27 @@ impl Inner {
 
         let start_session = Arc::clone(&shell_session);
         let start: Box<dyn FnOnce() + Send> = Box::new(move || {
-            let _dispatch = start_session.dispatch_lock.lock().expect("shell dispatch lock");
             let (banner, replay, alive) = {
-                let inner = start_session.inner.lock().expect("shell inner lock");
+                let _dispatch = start_session.dispatch_lock.lock().expect("shell dispatch lock");
+                let _flow = start_session.flow_lock.lock().expect("shell flow lock");
+                let mut inner = start_session.inner.lock().expect("shell inner lock");
+                if released.load(Ordering::SeqCst) {
+                    return;
+                }
                 let banner = created.then(|| start_session.banner.clone()).flatten();
                 let replay = (!created && inner.ring_size > 0).then(|| {
                     inner.ring.iter().flat_map(|c| c.iter().copied()).collect::<Vec<u8>>()
                 });
-                (banner, replay, inner.alive)
+                let alive = inner.alive;
+                if alive {
+                    inner.viewers.push(ViewerSink {
+                        id: viewer_id,
+                        on_data: Arc::clone(&on_data),
+                        on_exit: Arc::clone(&on_exit),
+                    });
+                    inner.draining_viewers.insert(viewer_id);
+                }
+                (banner, replay, alive)
             };
             if let Some(banner) = banner {
                 on_data(Bytes::from(banner));
@@ -2546,9 +2558,29 @@ impl Inner {
                 on_exit(0);
                 return;
             }
-            let mut inner = start_session.inner.lock().expect("shell inner lock");
-            if !released.load(Ordering::SeqCst) && inner.alive {
-                inner.viewers.push(ViewerSink { id: viewer_id, on_data, on_exit });
+            loop {
+                let chunk = {
+                    let _flow = start_session.flow_lock.lock().expect("shell flow lock");
+                    let mut inner = start_session.inner.lock().expect("shell inner lock");
+                    if released.load(Ordering::SeqCst) {
+                        inner.paused_backlog.remove(&viewer_id);
+                        inner.draining_viewers.remove(&viewer_id);
+                        None
+                    } else {
+                        let chunk = inner.paused_backlog.get_mut(&viewer_id).and_then(|backlog| {
+                            let chunk = backlog.chunks.pop_front()?;
+                            backlog.bytes -= chunk.len();
+                            Some(chunk)
+                        });
+                        if chunk.is_none() {
+                            inner.paused_backlog.remove(&viewer_id);
+                            inner.draining_viewers.remove(&viewer_id);
+                        }
+                        chunk
+                    }
+                };
+                let Some(chunk) = chunk else { break };
+                on_data(chunk);
             }
         });
 
@@ -2632,7 +2664,6 @@ impl PtyControl for ShellViewerControl {
     }
 
     fn drain_backlog(&self) {
-        let _dispatch = self.session.dispatch_lock.lock().expect("shell dispatch lock");
         loop {
             let next = {
                 let _flow = self.session.flow_lock.lock().expect("shell flow lock");
@@ -2642,23 +2673,25 @@ impl PtyControl for ShellViewerControl {
                     inner.draining_viewers.remove(&self.viewer_id);
                     None
                 } else {
-                    let Some(on_data) = inner
+                    if let Some(on_data) = inner
                         .viewers
                         .iter()
                         .find(|viewer| viewer.id == self.viewer_id)
                         .map(|viewer| Arc::clone(&viewer.on_data))
-                    else {
-                        inner.paused_backlog.remove(&self.viewer_id);
-                        inner.draining_viewers.remove(&self.viewer_id);
-                        None
-                    };
-                    let chunk = inner.paused_backlog.get_mut(&self.viewer_id).and_then(|backlog| {
-                        let chunk = backlog.chunks.pop_front()?;
-                        backlog.bytes -= chunk.len();
-                        Some(chunk)
-                    });
-                    if let Some(chunk) = chunk {
-                        Some((on_data, chunk))
+                    {
+                        let chunk =
+                            inner.paused_backlog.get_mut(&self.viewer_id).and_then(|backlog| {
+                                let chunk = backlog.chunks.pop_front()?;
+                                backlog.bytes -= chunk.len();
+                                Some(chunk)
+                            });
+                        if let Some(chunk) = chunk {
+                            Some((on_data, chunk))
+                        } else {
+                            inner.paused_backlog.remove(&self.viewer_id);
+                            inner.draining_viewers.remove(&self.viewer_id);
+                            None
+                        }
                     } else {
                         inner.paused_backlog.remove(&self.viewer_id);
                         inner.draining_viewers.remove(&self.viewer_id);

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -758,7 +758,8 @@ fn spawn_real_pty(spec: &SpawnSpec, handoff: &SpawnHandoff) -> anyhow::Result<Pt
         killer: Mutex::new(killer),
         lifecycle: Arc::clone(&lifecycle),
     });
-    if !handoff.install(Arc::clone(&control)) {
+    let handoff_control: Arc<dyn PtyControl> = control.clone();
+    if !handoff.install(handoff_control) {
         return Err(anyhow::anyhow!("PTY spawn cancelled"));
     }
     output.set_overflow_control(&control);
@@ -898,7 +899,8 @@ fn spawn_pipe_mode(spec: &SpawnSpec, reason: &str, handoff: &SpawnHandoff) -> Pt
                 command_tx: command_tx.clone(),
                 kill_requested: AtomicBool::new(false),
             });
-            if !handoff.install(Arc::clone(&control)) {
+            let handoff_control: Arc<dyn PtyControl> = control.clone();
+            if !handoff.install(handoff_control) {
                 control.kill();
                 output.push_exit(1);
                 return PtyHandle { control: Arc::new(DeadControl), output, banner: None };

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -643,9 +643,7 @@ impl PtyControl for MasterControl {
     fn pause(&self) {}
     fn resume(&self) {}
     fn kill(&self) {
-        if let Ok(mut killer) = self.killer.lock() {
-            let _ = killer.kill();
-        }
+        self.terminate();
     }
 }
 

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -1271,30 +1271,27 @@ impl PtyDeps for RealPtyDeps {
                         process_guard.cleanup().await;
                         return Err("terminal open cancelled".to_owned());
                     }
-                    match tokio::select! {
+                    if let Ok(control) = tokio::select! {
                         _ = cancellation.cancelled() => {
                             process_guard.cleanup().await;
                             return Err("terminal open cancelled".to_owned());
                         }
                         result = connect_control(&socket_path, CONTROL_TIMEOUT_MS) => result,
                     } {
-                        Ok(control) => {
-                            let mut guard = ControlEndGuard::new(Arc::clone(&control));
-                            let ready = tokio::select! {
-                                _ = cancellation.cancelled() => {
-                                    process_guard.cleanup().await;
-                                    return Err("terminal open cancelled".to_owned());
-                                }
-                                result = control_ready(&control, session) => result,
-                            };
-                            control.end();
-                            guard.disarm();
-                            if ready {
-                                process_guard.disarm();
-                                return Ok(EnsureDaemon { created: true, socket_path });
+                        let mut guard = ControlEndGuard::new(Arc::clone(&control));
+                        let ready = tokio::select! {
+                            _ = cancellation.cancelled() => {
+                                process_guard.cleanup().await;
+                                return Err("terminal open cancelled".to_owned());
                             }
+                            result = control_ready(&control, session) => result,
+                        };
+                        control.end();
+                        guard.disarm();
+                        if ready {
+                            process_guard.disarm();
+                            return Ok(EnsureDaemon { created: true, socket_path });
                         }
-                        Err(_) => {}
                     }
                     tokio::select! {
                         _ = cancellation.cancelled() => {

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -1097,8 +1097,8 @@ impl PtyDeps for RealPtyDeps {
         let worker_handoff = Arc::clone(&handoff);
         let worker_output = Arc::clone(&output);
         let mut cancel_guard = CancelOnDrop::new(handoff);
-        let mut worker = tokio::task::spawn_blocking(move || {
-            match spawn_real_pty(&spec, &worker_handoff) {
+        let mut worker =
+            tokio::task::spawn_blocking(move || match spawn_real_pty(&spec, &worker_handoff) {
                 Ok(handle) => handle,
                 Err(error) if worker_handoff.is_cancelled() => {
                     let _ = error;
@@ -1110,8 +1110,7 @@ impl PtyDeps for RealPtyDeps {
                     }
                 }
                 Err(error) => spawn_pipe_mode(&spec, &error.to_string(), &worker_handoff),
-            }
-        });
+            });
         let result = tokio::select! {
             result = &mut worker => result,
             _ = cancellation.cancelled() => {

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -1399,6 +1399,72 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
+    struct TestChildKiller {
+        kills: TestArc<AtomicUsize>,
+    }
+
+    impl cmux_pty::ChildKiller for TestChildKiller {
+        fn kill(&mut self) -> std::io::Result<()> {
+            self.kills.fetch_add(1, AtomicOrdering::Relaxed);
+            Ok(())
+        }
+
+        fn clone_killer(&self) -> Box<dyn cmux_pty::ChildKiller + Send + Sync> {
+            Box::new(Self { kills: TestArc::clone(&self.kills) })
+        }
+    }
+
+    #[derive(Debug)]
+    struct TestMaster;
+
+    impl MasterPty for TestMaster {
+        fn resize(&self, _size: PtySize) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn get_size(&self) -> anyhow::Result<PtySize> {
+            Ok(PtySize { rows: 24, cols: 80, pixel_width: 0, pixel_height: 0 })
+        }
+
+        fn try_clone_reader(&self) -> anyhow::Result<Box<dyn Read + Send>> {
+            Ok(Box::new(std::io::empty()))
+        }
+
+        fn take_writer(&self) -> anyhow::Result<Box<dyn Write + Send>> {
+            Ok(Box::new(std::io::sink()))
+        }
+
+        fn process_group_leader(&self) -> Option<libc::pid_t> {
+            None
+        }
+
+        fn as_raw_fd(&self) -> Option<std::os::unix::io::RawFd> {
+            None
+        }
+
+        fn tty_name(&self) -> Option<PathBuf> {
+            None
+        }
+    }
+
+    #[test]
+    fn master_control_kill_does_not_signal_reaped_pid() {
+        let kills = TestArc::new(AtomicUsize::new(0));
+        let lifecycle = ChildLifecycle::new(Some(42));
+        lifecycle.lock().expect("lifecycle lock").exited = true;
+        let control = MasterControl {
+            master: Mutex::new(Box::new(TestMaster)),
+            writer: Mutex::new(Box::new(std::io::sink())),
+            killer: Mutex::new(Box::new(TestChildKiller { kills: TestArc::clone(&kills) })),
+            lifecycle,
+        };
+
+        control.kill();
+
+        assert_eq!(kills.load(AtomicOrdering::Relaxed), 0);
+    }
+
     #[test]
     fn session_socket_path_matches_core_fallback_order() {
         let session = format!("legacy-{}", "x".repeat(200));

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -580,7 +580,7 @@ impl Drop for PipeChildGuard {
 type PipeWaitTask = Box<dyn FnOnce() + Send + 'static>;
 
 fn spawn_pipe_wait_thread_with<F>(
-    child: std::process::Child,
+    child_guard: PipeChildGuard,
     command_rx: mpsc::Receiver<PipeChildCommand>,
     completion: Arc<ProcessOutputCompletion>,
     spawn: F,
@@ -589,21 +589,35 @@ where
     F: FnOnce(PipeWaitTask) -> std::io::Result<std::thread::JoinHandle<()>>,
 {
     let wait_task: PipeWaitTask = Box::new(move || {
-        let mut child = child;
+        // Keep the guard inside the task closure until the child has been
+        // accepted by a live wait thread. If spawning fails, dropping this
+        // closure invokes PipeChildGuard::drop, which kills and reaps it.
+        let mut child_guard = child_guard;
         let mut exit_ready = false;
         while !exit_ready {
             match command_rx.recv() {
                 Ok(PipeChildCommand::ExitReady) => exit_ready = true,
                 Ok(PipeChildCommand::Kill) => {
-                    let _ = child.kill();
+                    let _ = child_guard.child_mut().kill();
                 }
                 Err(_) => exit_ready = true,
             }
         }
+        let mut child = child_guard.take();
         let code = child.wait().map(|status| status.code().unwrap_or(0) as i64).unwrap_or(0);
         completion.child_exited(code);
     });
     spawn(wait_task)
+}
+
+fn spawn_pipe_wait_thread(
+    child_guard: PipeChildGuard,
+    command_rx: mpsc::Receiver<PipeChildCommand>,
+    completion: Arc<ProcessOutputCompletion>,
+) -> std::io::Result<std::thread::JoinHandle<()>> {
+    spawn_pipe_wait_thread_with(child_guard, command_rx, completion, |task| {
+        std::thread::Builder::new().name("cmux-pipe-wait".to_owned()).spawn(task)
+    })
 }
 
 /// Serialize process termination with the wait owner. A raw PID can be
@@ -948,22 +962,13 @@ fn spawn_pipe_mode(spec: &SpawnSpec, reason: &str, handoff: &SpawnHandoff) -> Pt
                 let _ = observer_tx.send(PipeChildCommand::ExitReady);
             });
             let wait_completion = Arc::clone(&completion);
-            let mut child = child_guard.take();
-            std::thread::spawn(move || {
-                let mut exit_ready = false;
-                while !exit_ready {
-                    match command_rx.recv() {
-                        Ok(PipeChildCommand::ExitReady) => exit_ready = true,
-                        Ok(PipeChildCommand::Kill) => {
-                            let _ = child.kill();
-                        }
-                        Err(_) => exit_ready = true,
-                    }
-                }
-                let code =
-                    child.wait().map(|status| status.code().unwrap_or(0) as i64).unwrap_or(0);
-                wait_completion.child_exited(code);
-            });
+            if spawn_pipe_wait_thread(child_guard, command_rx, wait_completion).is_err() {
+                // The failed spawn drops its task closure, which still owns
+                // PipeChildGuard and therefore kills and reaps the child.
+                handoff.cancel();
+                completion.child_exited(1);
+                return PtyHandle { control: Arc::new(DeadControl), output, banner: Some(banner) };
+            }
             PtyHandle { control, output, banner: Some(banner) }
         }
         Err(error) => {
@@ -1645,9 +1650,12 @@ mod tests {
         let output = ThreadOutput::new();
         let completion = ProcessOutputCompletion::with_post_exit_grace(0, output, None);
         let (_command_tx, command_rx) = mpsc::channel();
-        let result = spawn_pipe_wait_thread_with(child, command_rx, completion, |_task| {
-            Err(std::io::Error::other("injected thread creation failure"))
-        });
+        let result = spawn_pipe_wait_thread_with(
+            PipeChildGuard::new(child),
+            command_rx,
+            completion,
+            |_task| Err(std::io::Error::other("injected thread creation failure")),
+        );
 
         assert!(result.is_err());
         // PipeChildGuard must kill and reap the child before the failed open

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -577,6 +577,35 @@ impl Drop for PipeChildGuard {
     }
 }
 
+type PipeWaitTask = Box<dyn FnOnce() + Send + 'static>;
+
+fn spawn_pipe_wait_thread_with<F>(
+    child: std::process::Child,
+    command_rx: mpsc::Receiver<PipeChildCommand>,
+    completion: Arc<ProcessOutputCompletion>,
+    spawn: F,
+) -> std::io::Result<std::thread::JoinHandle<()>>
+where
+    F: FnOnce(PipeWaitTask) -> std::io::Result<std::thread::JoinHandle<()>>,
+{
+    let wait_task: PipeWaitTask = Box::new(move || {
+        let mut child = child;
+        let mut exit_ready = false;
+        while !exit_ready {
+            match command_rx.recv() {
+                Ok(PipeChildCommand::ExitReady) => exit_ready = true,
+                Ok(PipeChildCommand::Kill) => {
+                    let _ = child.kill();
+                }
+                Err(_) => exit_ready = true,
+            }
+        }
+        let code = child.wait().map(|status| status.code().unwrap_or(0) as i64).unwrap_or(0);
+        completion.child_exited(code);
+    });
+    spawn(wait_task)
+}
+
 /// Serialize process termination with the wait owner. A raw PID can be
 /// reused after the child exits, so a late control drop must not signal an
 /// unrelated process.
@@ -1604,6 +1633,28 @@ mod tests {
             .expect("spawn child");
         wait_for_child_exit_without_reaping(child.id() as libc::pid_t).expect("observe child");
         assert_eq!(child.wait().expect("reap child").code(), Some(23));
+    }
+
+    #[test]
+    fn failed_pipe_wait_thread_spawn_reaps_child() {
+        let child = std::process::Command::new("/bin/sh")
+            .args(["-c", "while :; do :; done"])
+            .spawn()
+            .expect("spawn child");
+        let pid = child.id() as libc::pid_t;
+        let output = ThreadOutput::new();
+        let completion = ProcessOutputCompletion::with_post_exit_grace(0, output, None);
+        let (_command_tx, command_rx) = mpsc::channel();
+        let result = spawn_pipe_wait_thread_with(child, command_rx, completion, |_task| {
+            Err(std::io::Error::other("injected thread creation failure"))
+        });
+
+        assert!(result.is_err());
+        // PipeChildGuard must kill and reap the child before the failed open
+        // returns. A zero signal only probes existence, so it does not alter
+        // any unrelated process.
+        let probe = unsafe { libc::kill(pid, 0) };
+        assert_eq!(probe, -1, "failed wait-thread setup must not leak child {pid}");
     }
 
     #[test]

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -627,13 +627,19 @@ struct ChildLifecycle {
     pid: Option<u32>,
     exited: bool,
     termination_started: bool,
+    reaping: bool,
 }
 
 type ChildLifecycleHandle = Arc<Mutex<ChildLifecycle>>;
 
 impl ChildLifecycle {
     fn new(pid: Option<u32>) -> ChildLifecycleHandle {
-        Arc::new(Mutex::new(Self { pid, exited: false, termination_started: false }))
+        Arc::new(Mutex::new(Self {
+            pid,
+            exited: false,
+            termination_started: false,
+            reaping: false,
+        }))
     }
 
     fn terminate(
@@ -641,7 +647,7 @@ impl ChildLifecycle {
         signal: impl FnOnce(Option<u32>) -> std::io::Result<()>,
     ) -> bool {
         let mut state = lifecycle.lock().expect("child lifecycle lock");
-        if state.exited || state.termination_started {
+        if state.exited || state.termination_started || state.reaping {
             return false;
         }
         state.termination_started = true;
@@ -651,6 +657,19 @@ impl ChildLifecycle {
             state.termination_started = false;
             return false;
         }
+        true
+    }
+
+    /// Claim the wait owner transition before a fallback reap. This fence
+    /// remains set even when the child kill request reports an error, so a
+    /// late control drop cannot signal a PID after `Child::wait` reaps it.
+    fn begin_reaping(lifecycle: &ChildLifecycleHandle) -> bool {
+        let mut state = lifecycle.lock().expect("child lifecycle lock");
+        if state.exited || state.reaping {
+            return false;
+        }
+        state.reaping = true;
+        state.termination_started = true;
         true
     }
 }
@@ -851,9 +870,9 @@ fn spawn_real_pty(spec: &SpawnSpec, handoff: &SpawnHandoff) -> anyhow::Result<Pt
                     // fallback wait can reap it. Claim termination before
                     // reaping so MasterControl::drop cannot signal this PID
                     // after the kernel makes it available for reuse.
-                    let _ = ChildLifecycle::terminate(&wait_lifecycle, |_| {
-                        child_cleanup.child_mut().kill()
-                    });
+                    if ChildLifecycle::begin_reaping(&wait_lifecycle) {
+                        let _ = child_cleanup.child_mut().kill();
+                    }
                     child_cleanup.wait()
                 }
             };

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -1536,6 +1536,16 @@ mod tests {
     }
 
     #[test]
+    fn reaping_fence_blocks_late_termination_attempts() {
+        let lifecycle = ChildLifecycle::new(Some(42));
+        assert!(ChildLifecycle::begin_reaping(&lifecycle));
+        assert!(!ChildLifecycle::terminate(&lifecycle, |_| Ok(())));
+        let state = lifecycle.lock().expect("lifecycle lock");
+        assert!(state.reaping);
+        assert!(state.termination_started);
+    }
+
+    #[test]
     fn session_socket_path_matches_core_fallback_order() {
         let session = format!("legacy-{}", "x".repeat(200));
         let preferred_dir = PathBuf::from("/run/user/501/cmux-tui-501");

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -1465,6 +1465,43 @@ mod tests {
     use std::sync::{Arc as TestArc, Barrier, Mutex as TestMutex, mpsc};
     use std::thread;
 
+    #[tokio::test]
+    async fn cancellation_before_pty_handoff_publishes_exit_to_late_subscriber() {
+        let deps = RealPtyDeps::new(HashMap::new());
+        let cancellation = CancellationToken::new();
+        cancellation.cancel();
+        let permit = OpenPermit::new(
+            std::sync::Arc::new(tokio::sync::Semaphore::new(1))
+                .acquire_owned()
+                .await
+                .expect("open permit"),
+        );
+        let handle = deps
+            .spawn_pty(
+                SpawnSpec {
+                    file: "/bin/sh".to_owned(),
+                    args: Vec::new(),
+                    cols: 80,
+                    rows: 24,
+                    cwd: std::env::temp_dir(),
+                    env: HashMap::new(),
+                    cancellation: cancellation.clone(),
+                },
+                cancellation,
+                permit,
+            )
+            .await;
+        let (exit_tx, exit_rx) = mpsc::channel();
+        handle.output.subscribe(
+            Arc::new(|_| {}),
+            Arc::new(move |code| exit_tx.send(code).expect("exit receiver is waiting")),
+        );
+        assert_eq!(
+            exit_rx.recv_timeout(Duration::from_secs(1)).expect("cancelled PTY must terminate"),
+            1
+        );
+    }
+
     struct TestControl {
         kills: TestArc<AtomicUsize>,
         drops: TestArc<AtomicUsize>,

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -636,13 +636,21 @@ impl ChildLifecycle {
         Arc::new(Mutex::new(Self { pid, exited: false, termination_started: false }))
     }
 
-    fn terminate(lifecycle: &ChildLifecycleHandle, signal: impl FnOnce(Option<u32>)) -> bool {
+    fn terminate(
+        lifecycle: &ChildLifecycleHandle,
+        signal: impl FnOnce(Option<u32>) -> std::io::Result<()>,
+    ) -> bool {
         let mut state = lifecycle.lock().expect("child lifecycle lock");
         if state.exited || state.termination_started {
             return false;
         }
         state.termination_started = true;
-        signal(state.pid);
+        if signal(state.pid).is_err() {
+            // A failed signal request did not establish termination. Keep the
+            // lifecycle open for a later close/cancellation/drop attempt.
+            state.termination_started = false;
+            return false;
+        }
         true
     }
 }
@@ -663,10 +671,12 @@ impl Drop for MasterControl {
 
 impl MasterControl {
     fn terminate(&self) {
-        ChildLifecycle::terminate(&self.lifecycle, |_| {
-            if let Ok(mut killer) = self.killer.lock() {
-                let _ = killer.kill();
-            }
+        let _ = ChildLifecycle::terminate(&self.lifecycle, |_| {
+            let mut killer = self
+                .killer
+                .lock()
+                .map_err(|_| std::io::Error::other("child killer lock poisoned"))?;
+            killer.kill()
         });
     }
 }
@@ -842,7 +852,7 @@ fn spawn_real_pty(spec: &SpawnSpec, handoff: &SpawnHandoff) -> anyhow::Result<Pt
                 // Keep the old error path: a failed wait requests termination
                 // through the lifecycle gate, then retries the blocking reap.
                 let _ = ChildLifecycle::terminate(&wait_lifecycle, |_| {
-                    let _ = child_cleanup.child_mut().kill();
+                    child_cleanup.child_mut().kill()
                 });
                 child_cleanup.wait()
             });

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -1401,10 +1401,20 @@ impl PtyDeps for RealPtyDeps {
         }
     }
 
-    async fn read_dir(&self, path: &Path) -> Result<Vec<String>, ()> {
-        let mut entries = tokio::fs::read_dir(path).await.map_err(|_| ())?;
+    async fn read_dir(
+        &self,
+        path: &Path,
+        cancellation: CancellationToken,
+    ) -> Result<Vec<String>, ()> {
+        let mut entries = tokio::select! {
+            _ = cancellation.cancelled() => return Err(()),
+            result = tokio::fs::read_dir(path) => result.map_err(|_| ())?,
+        };
         let mut names = Vec::new();
-        while let Ok(Some(entry)) = entries.next_entry().await {
+        while let Ok(Some(entry)) = tokio::select! {
+            _ = cancellation.cancelled() => return Err(()),
+            result = entries.next_entry() => result,
+        } {
             names.push(entry.file_name().to_string_lossy().into_owned());
         }
         Ok(names)

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -784,36 +784,29 @@ fn spawn_real_pty(spec: &SpawnSpec, handoff: &SpawnHandoff) -> anyhow::Result<Pt
     if std::thread::Builder::new()
         .name("cmux-relay-pty-wait".to_owned())
         .spawn(move || {
-            loop {
-                let code = {
-                    let mut lifecycle = wait_lifecycle.lock().expect("child lifecycle lock");
-                    match child_cleanup.child_mut().try_wait() {
-                        Ok(Some(status)) => {
-                            lifecycle.exited = true;
-                            Some(i64::from(status.exit_code() as i32))
-                        }
-                        Ok(None) => None,
-                        Err(_) => {
-                            if !lifecycle.termination_started {
-                                lifecycle.termination_started = true;
-                                let _ = child_cleanup.child_mut().kill();
-                            }
-                            let code = child_cleanup
-                                .wait()
-                                .map(|status| i64::from(status.exit_code() as i32))
-                                .unwrap_or(0);
-                            lifecycle.exited = true;
-                            Some(code)
-                        }
-                    }
-                };
-                if let Some(code) = code {
-                    child_cleanup.disarm();
-                    exit_completion.child_exited(code);
-                    return;
+            // `waitid(WNOWAIT)` blocks until the child exits while keeping its
+            // PID reserved. Mark the lifecycle exited before the owner calls
+            // `wait`, so a late control drop cannot signal a reused PID.
+            let pid = wait_lifecycle.lock().expect("child lifecycle lock").pid;
+            let wait_result = match pid {
+                Some(pid) if wait_for_child_exit_without_reaping(pid as libc::pid_t).is_ok() => {
+                    wait_lifecycle.lock().expect("child lifecycle lock").exited = true;
+                    child_cleanup.wait()
                 }
-                std::thread::sleep(Duration::from_millis(10));
-            }
+                _ => child_cleanup.wait(),
+            };
+            let wait_result = wait_result.or_else(|_| {
+                // Keep the old error path: a failed wait requests termination
+                // through the lifecycle gate, then retries the blocking reap.
+                let _ = ChildLifecycle::terminate(&wait_lifecycle, |_| {
+                    let _ = child_cleanup.child_mut().kill();
+                });
+                child_cleanup.wait()
+            });
+            let code = wait_result.map(|status| i64::from(status.exit_code() as i32)).unwrap_or(0);
+            wait_lifecycle.lock().expect("child lifecycle lock").exited = true;
+            child_cleanup.disarm();
+            exit_completion.child_exited(code);
         })
         .is_err()
     {

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -1828,6 +1828,18 @@ mod tests {
         assert_eq!(child.wait().expect("reap child").code(), Some(23));
     }
 
+    #[tokio::test]
+    async fn cancelled_spawn_wins_when_worker_is_already_ready() {
+        let cancellation = CancellationToken::new();
+        cancellation.cancel();
+        let mut worker = tokio::spawn(async { 23_u8 });
+
+        let result = await_spawn_or_cancel(&mut worker, &cancellation).await;
+
+        assert!(result.is_err(), "cancellation must win over a ready worker");
+        worker.abort();
+    }
+
     #[test]
     fn failed_pipe_wait_thread_spawn_reaps_child() {
         let child = std::process::Command::new("/bin/sh")

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -1497,6 +1497,26 @@ mod tests {
     }
 
     #[test]
+    fn failed_child_termination_can_be_retried() {
+        let lifecycle = ChildLifecycle::new(Some(42));
+        let attempts = AtomicUsize::new(0);
+
+        assert!(!ChildLifecycle::terminate(&lifecycle, |_| {
+            attempts.fetch_add(1, AtomicOrdering::Relaxed);
+            Err(std::io::Error::other("transient kill failure"))
+        }));
+        assert!(ChildLifecycle::terminate(&lifecycle, |_| {
+            attempts.fetch_add(1, AtomicOrdering::Relaxed);
+            Ok(())
+        }));
+        assert!(!ChildLifecycle::terminate(&lifecycle, |_| {
+            attempts.fetch_add(1, AtomicOrdering::Relaxed);
+            Ok(())
+        }));
+        assert_eq!(attempts.load(AtomicOrdering::Relaxed), 2);
+    }
+
+    #[test]
     fn session_socket_path_matches_core_fallback_order() {
         let session = format!("legacy-{}", "x".repeat(200));
         let preferred_dir = PathBuf::from("/run/user/501/cmux-tui-501");

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -27,8 +27,8 @@ use tokio_util::sync::CancellationToken;
 
 use crate::control::{CONTROL_TIMEOUT_MS, ControlHandle, connect_control};
 use crate::pty::{
-    CmuxTui, DataSink, EnsureDaemon, ExitSink, PtyControl, PtyDeps, PtyHandle, PtyOutput,
-    SpawnSpec, session_name_ok,
+    CmuxTui, DataSink, EnsureDaemon, ExitSink, OpenPermit, PtyControl, PtyDeps, PtyHandle,
+    SpawnSpec, session_name_ok, spawn_blocking_with_open_permit,
 };
 
 const DAEMON_SOCKET_WAIT_MS: u64 = 5_000;
@@ -1088,7 +1088,12 @@ impl Drop for DaemonProcessGuard {
 
 #[async_trait]
 impl PtyDeps for RealPtyDeps {
-    async fn spawn_pty(&self, spec: SpawnSpec, cancellation: CancellationToken) -> PtyHandle {
+    async fn spawn_pty(
+        &self,
+        spec: SpawnSpec,
+        cancellation: CancellationToken,
+        permit: OpenPermit,
+    ) -> PtyHandle {
         // PTY allocation and thread setup are blocking; run off the reactor.
         // On PTY allocation failure (ptmx exhaustion et al) degrade to a
         // pipe-mode shell so the terminal still functions, with a banner.
@@ -1097,8 +1102,8 @@ impl PtyDeps for RealPtyDeps {
         let worker_handoff = Arc::clone(&handoff);
         let worker_output = Arc::clone(&output);
         let mut cancel_guard = CancelOnDrop::new(handoff);
-        let mut worker =
-            tokio::task::spawn_blocking(move || match spawn_real_pty(&spec, &worker_handoff) {
+        let mut worker = spawn_blocking_with_open_permit(permit, move || {
+            match spawn_real_pty(&spec, &worker_handoff) {
                 Ok(handle) => handle,
                 Err(error) if worker_handoff.is_cancelled() => {
                     let _ = error;
@@ -1110,7 +1115,8 @@ impl PtyDeps for RealPtyDeps {
                     }
                 }
                 Err(error) => spawn_pipe_mode(&spec, &error.to_string(), &worker_handoff),
-            });
+            }
+        });
         let result = tokio::select! {
             result = &mut worker => result,
             _ = cancellation.cancelled() => {

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -846,7 +846,16 @@ fn spawn_real_pty(spec: &SpawnSpec, handoff: &SpawnHandoff) -> anyhow::Result<Pt
                     wait_lifecycle.lock().expect("child lifecycle lock").exited = true;
                     child_cleanup.wait()
                 }
-                _ => child_cleanup.wait(),
+                _ => {
+                    // A failed waitid may leave the child live, while the
+                    // fallback wait can reap it. Claim termination before
+                    // reaping so MasterControl::drop cannot signal this PID
+                    // after the kernel makes it available for reuse.
+                    let _ = ChildLifecycle::terminate(&wait_lifecycle, |_| {
+                        child_cleanup.child_mut().kill()
+                    });
+                    child_cleanup.wait()
+                }
             };
             let wait_result = wait_result.or_else(|_| {
                 // Keep the old error path: a failed wait requests termination

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -1970,4 +1970,29 @@ mod tests {
             .recv_timeout(Duration::from_secs(1))
             .expect("cancellation must wake a blocked PTY poll");
     }
+
+    #[test]
+    fn pty_wait_setup_failure_records_exit_and_wakes_reader() {
+        let output = ThreadOutput::new();
+        let (completion, cancel_reader) =
+            ProcessOutputCompletion::with_pty_cancellation(1, TestArc::clone(&output))
+                .expect("cancellation wake");
+        let (reader_stream, _writer_stream) = UnixStream::pair().expect("PTY-like stream pair");
+        let (reader_done_tx, reader_done_rx) = mpsc::channel();
+        let pump_output = TestArc::clone(&output);
+        let pump_completion = TestArc::clone(&completion);
+        thread::spawn(move || {
+            pump_pty(reader_stream, cancel_reader, pump_output, pump_completion);
+            reader_done_tx.send(()).expect("reader completion");
+        });
+
+        let kills = TestArc::new(AtomicUsize::new(0));
+        let control = TestControl { kills: TestArc::clone(&kills), drops: TestArc::new(AtomicUsize::new(0)) };
+        finish_pty_wait_setup_failure(&control, &completion);
+
+        reader_done_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("wait setup failure must wake a blocked PTY poll");
+        assert_eq!(kills.load(AtomicOrdering::Relaxed), 1);
+    }
 }

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -535,6 +535,12 @@ impl SpawnedChildCleanup {
         Ok(self.child_mut().wait()?)
     }
 
+    fn finish_wait(&mut self, wait_result: anyhow::Result<cmux_pty::ExitStatus>) -> i64 {
+        let code = wait_result.map(|status| i64::from(status.exit_code() as i32)).unwrap_or(0);
+        self.disarm();
+        code
+    }
+
     fn disarm(&mut self) {
         let _ = self.child.take();
     }
@@ -884,9 +890,8 @@ fn spawn_real_pty(spec: &SpawnSpec, handoff: &SpawnHandoff) -> anyhow::Result<Pt
                 });
                 child_cleanup.wait()
             });
-            let code = wait_result.map(|status| i64::from(status.exit_code() as i32)).unwrap_or(0);
+            let code = child_cleanup.finish_wait(wait_result);
             wait_lifecycle.lock().expect("child lifecycle lock").exited = true;
-            child_cleanup.disarm();
             exit_completion.child_exited(code);
         })
         .is_err()
@@ -1479,6 +1484,46 @@ mod tests {
     }
 
     #[derive(Debug)]
+    struct FailingChild {
+        kills: TestArc<AtomicUsize>,
+        waits: TestArc<AtomicUsize>,
+    }
+
+    impl Drop for FailingChild {
+        fn drop(&mut self) {
+            self.waits.fetch_add(1, AtomicOrdering::Relaxed);
+        }
+    }
+
+    impl cmux_pty::ChildKiller for FailingChild {
+        fn kill(&mut self) -> std::io::Result<()> {
+            self.kills.fetch_add(1, AtomicOrdering::Relaxed);
+            Ok(())
+        }
+
+        fn clone_killer(&self) -> Box<dyn cmux_pty::ChildKiller + Send + Sync> {
+            Box::new(Self {
+                kills: TestArc::clone(&self.kills),
+                waits: TestArc::clone(&self.waits),
+            })
+        }
+    }
+
+    impl cmux_pty::Child for FailingChild {
+        fn try_wait(&mut self) -> std::io::Result<Option<cmux_pty::ExitStatus>> {
+            Err(std::io::Error::other("wait failed"))
+        }
+
+        fn wait(&mut self) -> std::io::Result<cmux_pty::ExitStatus> {
+            Err(std::io::Error::other("wait failed"))
+        }
+
+        fn process_id(&self) -> Option<u32> {
+            Some(42)
+        }
+    }
+
+    #[derive(Debug)]
     struct TestChildKiller {
         kills: TestArc<AtomicUsize>,
     }
@@ -1706,6 +1751,21 @@ mod tests {
 
         assert!(matches!(command_rx.recv(), Ok(PipeChildCommand::Kill)));
         assert!(command_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn failed_wait_keeps_child_cleanup_armed() {
+        let kills = TestArc::new(AtomicUsize::new(0));
+        let waits = TestArc::new(AtomicUsize::new(0));
+        let child = FailingChild { kills: TestArc::clone(&kills), waits: TestArc::clone(&waits) };
+        let mut cleanup = SpawnedChildCleanup::new(Box::new(child));
+        let failed_wait: anyhow::Result<cmux_pty::ExitStatus> = Err(anyhow::anyhow!("wait failed"));
+
+        let _ = cleanup.finish_wait(failed_wait);
+        drop(cleanup);
+
+        assert_eq!(kills.load(AtomicOrdering::Relaxed), 1);
+        assert_eq!(waits.load(AtomicOrdering::Relaxed), 1);
     }
 
     #[test]

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -973,8 +973,7 @@ fn pump_pty(
     completion.reader_finished();
 }
 
-fn spawn_pipe_mode(spec: &SpawnSpec, reason: &str, handoff: &SpawnHandoff) -> PtyHandle {
-    let _ = reason;
+fn spawn_pipe_mode(spec: &SpawnSpec, handoff: &SpawnHandoff) -> PtyHandle {
     let output = ThreadOutput::new();
     let mut command = std::process::Command::new(&spec.file);
     command.args(&spec.args).current_dir(&spec.cwd).env_clear();
@@ -1213,7 +1212,7 @@ impl PtyDeps for RealPtyDeps {
                         banner: None,
                     }
                 }
-                Err(error) => spawn_pipe_mode(&spec, &error.to_string(), &worker_handoff),
+                Err(_) => spawn_pipe_mode(&spec, &worker_handoff),
             }
         });
         let result = match await_spawn_or_cancel(&mut worker, &cancellation).await {

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -23,6 +23,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use cmux_pty::{MasterPty, PtySize};
 use sha2::{Digest, Sha256};
+use tokio_util::sync::CancellationToken;
 
 use crate::control::{CONTROL_TIMEOUT_MS, ControlHandle, connect_control};
 use crate::pty::{
@@ -430,6 +431,72 @@ pub struct RealPtyDeps {
     shell: String,
 }
 
+/// Own the handoff between a cancellable async open and a blocking PTY
+/// worker. Tokio cannot stop a `spawn_blocking` closure after it starts, so
+/// cancellation must be able to take and kill a control handle created by
+/// that worker before the handle is published to the manager.
+struct SpawnHandoff {
+    cancelled: AtomicBool,
+    control: Mutex<Option<Arc<dyn PtyControl>>>,
+}
+
+impl SpawnHandoff {
+    fn new() -> Arc<Self> {
+        Arc::new(Self { cancelled: AtomicBool::new(false), control: Mutex::new(None) })
+    }
+
+    fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::Acquire)
+    }
+
+    fn install(&self, control: Arc<dyn PtyControl>) -> bool {
+        let mut slot = self.control.lock().expect("spawn handoff lock");
+        if self.cancelled.load(Ordering::Acquire) {
+            drop(slot);
+            control.kill();
+            return false;
+        }
+        *slot = Some(control);
+        true
+    }
+
+    fn cancel(&self) {
+        self.cancelled.store(true, Ordering::Release);
+        let control = self.control.lock().expect("spawn handoff lock").take();
+        if let Some(control) = control {
+            control.kill();
+        }
+    }
+
+    fn disarm(&self) {
+        let _ = self.control.lock().expect("spawn handoff lock").take();
+    }
+}
+
+struct CancelOnDrop {
+    handoff: Arc<SpawnHandoff>,
+    armed: bool,
+}
+
+impl CancelOnDrop {
+    fn new(handoff: Arc<SpawnHandoff>) -> Self {
+        Self { handoff, armed: true }
+    }
+
+    fn disarm(&mut self) {
+        self.handoff.disarm();
+        self.armed = false;
+    }
+}
+
+impl Drop for CancelOnDrop {
+    fn drop(&mut self) {
+        if self.armed {
+            self.handoff.cancel();
+        }
+    }
+}
+
 impl RealPtyDeps {
     pub fn new(env: HashMap<String, String>) -> RealPtyDeps {
         // SAFETY: getuid is always safe.
@@ -459,6 +526,18 @@ impl SpawnedChildCleanup {
     fn take(&mut self) -> Box<dyn cmux_pty::Child + Send + Sync> {
         self.child.take().expect("spawned child cleanup owns a child")
     }
+
+    fn child_mut(&mut self) -> &mut dyn cmux_pty::Child {
+        self.child.as_deref_mut().expect("spawned child cleanup owns a child")
+    }
+
+    fn wait(&mut self) -> anyhow::Result<cmux_pty::ExitStatus> {
+        Ok(self.child_mut().wait()?)
+    }
+
+    fn disarm(&mut self) {
+        let _ = self.child.take();
+    }
 }
 
 impl Drop for SpawnedChildCleanup {
@@ -469,11 +548,84 @@ impl Drop for SpawnedChildCleanup {
     }
 }
 
+/// Keep a pipe-mode child owned until its wait thread accepts it. Returning
+/// from setup without killing and reaping this child would leak a process.
+struct PipeChildGuard {
+    child: Option<std::process::Child>,
+}
+
+impl PipeChildGuard {
+    fn new(child: std::process::Child) -> Self {
+        Self { child: Some(child) }
+    }
+
+    fn child_mut(&mut self) -> &mut std::process::Child {
+        self.child.as_mut().expect("pipe child guard is armed")
+    }
+
+    fn take(&mut self) -> std::process::Child {
+        self.child.take().expect("pipe child guard is armed")
+    }
+}
+
+impl Drop for PipeChildGuard {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+/// Serialize process termination with the wait owner. A raw PID can be
+/// reused after the child exits, so a late control drop must not signal an
+/// unrelated process.
+struct ChildLifecycle {
+    pid: Option<u32>,
+    exited: bool,
+    termination_started: bool,
+}
+
+type ChildLifecycleHandle = Arc<Mutex<ChildLifecycle>>;
+
+impl ChildLifecycle {
+    fn new(pid: Option<u32>) -> ChildLifecycleHandle {
+        Arc::new(Mutex::new(Self { pid, exited: false, termination_started: false }))
+    }
+
+    fn terminate(lifecycle: &ChildLifecycleHandle, signal: impl FnOnce(Option<u32>)) -> bool {
+        let mut state = lifecycle.lock().expect("child lifecycle lock");
+        if state.exited || state.termination_started {
+            return false;
+        }
+        state.termination_started = true;
+        signal(state.pid);
+        true
+    }
+}
+
 /// A real PTY master behind a mutex; write/resize block briefly.
 struct MasterControl {
     master: Mutex<Box<dyn MasterPty + Send>>,
     writer: Mutex<Box<dyn Write + Send>>,
     killer: Mutex<Box<dyn cmux_pty::ChildKiller + Send + Sync>>,
+    lifecycle: ChildLifecycleHandle,
+}
+
+impl Drop for MasterControl {
+    fn drop(&mut self) {
+        self.terminate();
+    }
+}
+
+impl MasterControl {
+    fn terminate(&self) {
+        ChildLifecycle::terminate(&self.lifecycle, |_| {
+            if let Ok(mut killer) = self.killer.lock() {
+                let _ = killer.kill();
+            }
+        });
+    }
 }
 
 impl PtyControl for MasterControl {
@@ -514,6 +666,12 @@ struct PipeControl {
     stdin: Mutex<Option<std::process::ChildStdin>>,
     command_tx: mpsc::Sender<PipeChildCommand>,
     kill_requested: AtomicBool,
+}
+
+impl Drop for PipeControl {
+    fn drop(&mut self) {
+        self.kill();
+    }
 }
 
 impl PtyControl for PipeControl {
@@ -562,7 +720,10 @@ fn wait_for_child_exit_without_reaping(pid: libc::pid_t) -> std::io::Result<()> 
     }
 }
 
-fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
+fn spawn_real_pty(spec: &SpawnSpec, handoff: &SpawnHandoff) -> anyhow::Result<PtyHandle> {
+    if handoff.is_cancelled() {
+        return Err(anyhow::anyhow!("PTY spawn cancelled"));
+    }
     let pair = cmux_pty::open(PtySize {
         rows: spec.rows,
         cols: spec.cols,
@@ -577,21 +738,29 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
     for (key, value) in &spec.env {
         command.env(key, value);
     }
-    let output = ThreadOutput::new();
     // Set up every fallible cancellation primitive before spawning. This
     // keeps descriptor exhaustion on the no-child side of the boundary.
+    let output = ThreadOutput::new();
     let (completion, cancel_reader) =
         ProcessOutputCompletion::with_pty_cancellation(1, Arc::clone(&output))?;
     let spawned = pair.spawn(command)?;
     let cmux_pty::SpawnedPty { mut master, child } = spawned;
     let mut child_cleanup = SpawnedChildCleanup::new(child);
+    if handoff.is_cancelled() {
+        return Err(anyhow::anyhow!("PTY spawn cancelled"));
+    }
     let writer = master.take_writer()?;
     let killer = child_cleanup.child().clone_killer();
+    let lifecycle = ChildLifecycle::new(child_cleanup.child().process_id());
     let control = Arc::new(MasterControl {
         master: Mutex::new(master),
         writer: Mutex::new(writer),
         killer: Mutex::new(killer),
+        lifecycle: Arc::clone(&lifecycle),
     });
+    if !handoff.install(Arc::clone(&control)) {
+        return Err(anyhow::anyhow!("PTY spawn cancelled"));
+    }
     output.set_overflow_control(&control);
     // Use the same bounded post-exit grace as pipe fallback. A background
     // descendant can inherit the PTY slave, so waiting for terminal EOF here
@@ -599,16 +768,59 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
     // Blocking reader thread -> output sink.
     let data_output = Arc::clone(&output);
     let data_completion = Arc::clone(&completion);
-    std::thread::spawn(move || {
-        pump_pty(reader, cancel_reader, data_output, data_completion);
-    });
+    if std::thread::Builder::new()
+        .name("cmux-relay-pty-reader".to_owned())
+        .spawn(move || {
+            pump_pty(reader, cancel_reader, data_output, data_completion);
+        })
+        .is_err()
+    {
+        control.kill();
+        return Err(anyhow::anyhow!("PTY reader thread spawn failed"));
+    }
     // Blocking wait thread -> exit.
-    let mut child = child_cleanup.take();
+    let mut child_cleanup = child_cleanup;
     let exit_completion = Arc::clone(&completion);
-    std::thread::spawn(move || {
-        let code = child.wait().map(|status| i64::from(status.exit_code() as i32)).unwrap_or(0);
-        exit_completion.child_exited(code);
-    });
+    let wait_lifecycle = Arc::clone(&lifecycle);
+    if std::thread::Builder::new()
+        .name("cmux-relay-pty-wait".to_owned())
+        .spawn(move || {
+            loop {
+                let code = {
+                    let mut lifecycle = wait_lifecycle.lock().expect("child lifecycle lock");
+                    match child_cleanup.child_mut().try_wait() {
+                        Ok(Some(status)) => {
+                            lifecycle.exited = true;
+                            Some(i64::from(status.exit_code() as i32))
+                        }
+                        Ok(None) => None,
+                        Err(_) => {
+                            if !lifecycle.termination_started {
+                                lifecycle.termination_started = true;
+                                let _ = child_cleanup.child_mut().kill();
+                            }
+                            let code = child_cleanup
+                                .wait()
+                                .map(|status| i64::from(status.exit_code() as i32))
+                                .unwrap_or(0);
+                            lifecycle.exited = true;
+                            Some(code)
+                        }
+                    }
+                };
+                if let Some(code) = code {
+                    child_cleanup.disarm();
+                    exit_completion.child_exited(code);
+                    return;
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+        })
+        .is_err()
+    {
+        control.kill();
+        return Err(anyhow::anyhow!("PTY wait thread spawn failed"));
+    }
 
     Ok(PtyHandle { control, output, banner: None })
 }
@@ -654,7 +866,8 @@ fn pump_pty(
     completion.reader_finished();
 }
 
-fn spawn_pipe_mode(spec: &SpawnSpec, reason: &str) -> PtyHandle {
+fn spawn_pipe_mode(spec: &SpawnSpec, reason: &str, handoff: &SpawnHandoff) -> PtyHandle {
+    let _ = reason;
     let output = ThreadOutput::new();
     let mut command = std::process::Command::new(&spec.file);
     command.args(&spec.args).current_dir(&spec.cwd).env_clear();
@@ -665,32 +878,41 @@ fn spawn_pipe_mode(spec: &SpawnSpec, reason: &str) -> PtyHandle {
     command.stdin(std::process::Stdio::piped());
     command.stdout(std::process::Stdio::piped());
     command.stderr(std::process::Stdio::piped());
-    let banner = format!(
-        "[cmux-relay] PTY allocation failed ({reason}); running {} without a TTY.\r\n",
-        Path::new(&spec.file)
-            .file_name()
-            .map(|n| n.to_string_lossy().into_owned())
-            .unwrap_or_else(|| spec.file.clone()),
-    );
+    // Allocation errors and executable paths can contain local details. This
+    // banner crosses the relay boundary, so keep it stable and generic.
+    let banner = b"[cmux-relay] PTY allocation failed; running without a TTY.\r\n".to_vec();
     match command.spawn() {
         Ok(mut child) => {
-            let stdin = child.stdin.take();
-            let pid = child.id() as libc::pid_t;
+            if handoff.is_cancelled() {
+                let _ = child.kill();
+                let _ = child.wait();
+                output.push_exit(1);
+                return PtyHandle { control: Arc::new(DeadControl), output, banner: None };
+            }
+            let mut child_guard = PipeChildGuard::new(child);
+            let stdin = child_guard.child_mut().stdin.take();
+            let pid = child_guard.child_mut().id() as libc::pid_t;
             let (command_tx, command_rx) = mpsc::channel();
             let control = Arc::new(PipeControl {
                 stdin: Mutex::new(stdin),
                 command_tx: command_tx.clone(),
                 kill_requested: AtomicBool::new(false),
             });
+            if !handoff.install(Arc::clone(&control)) {
+                control.kill();
+                output.push_exit(1);
+                return PtyHandle { control: Arc::new(DeadControl), output, banner: None };
+            }
             output.set_overflow_control(&control);
-            let reader_count = child.stdout.is_some() as usize + child.stderr.is_some() as usize;
+            let reader_count = child_guard.child_mut().stdout.is_some() as usize
+                + child_guard.child_mut().stderr.is_some() as usize;
             let completion = ProcessOutputCompletion::new(reader_count, Arc::clone(&output));
-            if let Some(stdout) = child.stdout.take() {
+            if let Some(stdout) = child_guard.child_mut().stdout.take() {
                 let out = Arc::clone(&output);
                 let done = Arc::clone(&completion);
                 std::thread::spawn(move || pump_pipe(stdout, out, done));
             }
-            if let Some(stderr) = child.stderr.take() {
+            if let Some(stderr) = child_guard.child_mut().stderr.take() {
                 let out = Arc::clone(&output);
                 let done = Arc::clone(&completion);
                 std::thread::spawn(move || pump_pipe(stderr, out, done));
@@ -704,6 +926,7 @@ fn spawn_pipe_mode(spec: &SpawnSpec, reason: &str) -> PtyHandle {
                 let _ = observer_tx.send(PipeChildCommand::ExitReady);
             });
             let wait_completion = Arc::clone(&completion);
+            let mut child = child_guard.take();
             std::thread::spawn(move || {
                 let mut exit_ready = false;
                 while !exit_ready {
@@ -719,12 +942,12 @@ fn spawn_pipe_mode(spec: &SpawnSpec, reason: &str) -> PtyHandle {
                     child.wait().map(|status| status.code().unwrap_or(0) as i64).unwrap_or(0);
                 wait_completion.child_exited(code);
             });
-            PtyHandle { control, output, banner: Some(banner.into_bytes()) }
+            PtyHandle { control, output, banner: Some(banner) }
         }
         Err(error) => {
             let _ = error;
             output.push_exit(1);
-            PtyHandle { control: Arc::new(DeadControl), output, banner: Some(banner.into_bytes()) }
+            PtyHandle { control: Arc::new(DeadControl), output, banner: Some(banner) }
         }
     }
 }
@@ -797,56 +1020,122 @@ async fn cleanup_daemon(mut child: tokio::process::Child) {
     let _ = tokio::time::timeout(Duration::from_secs(1), child.wait()).await;
 }
 
+/// `ControlHandle` has an explicit end operation. Keep probes owned across
+/// every async request so cancellation cannot leave a socket task alive.
+struct ControlEndGuard {
+    control: Option<Arc<dyn ControlHandle>>,
+}
+
+impl ControlEndGuard {
+    fn new(control: Arc<dyn ControlHandle>) -> Self {
+        Self { control: Some(control) }
+    }
+
+    fn disarm(&mut self) {
+        self.control = None;
+    }
+}
+
+impl Drop for ControlEndGuard {
+    fn drop(&mut self) {
+        if let Some(control) = self.control.take() {
+            control.end();
+        }
+    }
+}
+
+/// Own a daemon child until readiness has been proven. If an async open is
+/// cancelled, `Drop` starts termination and schedules a reaper, so the child
+/// cannot survive after its PTY-open permit is released.
+struct DaemonProcessGuard {
+    child: Option<tokio::process::Child>,
+}
+
+impl DaemonProcessGuard {
+    fn new(child: tokio::process::Child) -> Self {
+        Self { child: Some(child) }
+    }
+
+    fn disarm(&mut self) {
+        self.child = None;
+    }
+
+    async fn cleanup(&mut self) {
+        if let Some(child) = self.child.take() {
+            cleanup_daemon(child).await;
+        }
+    }
+}
+
+impl Drop for DaemonProcessGuard {
+    fn drop(&mut self) {
+        let Some(mut child) = self.child.take() else { return };
+        if let Some(pid) = child.id() {
+            // SAFETY: this is the process group of the child spawned by this
+            // guard. The child handle remains owned until the reaper waits.
+            unsafe {
+                let _ = libc::kill(-(pid as libc::pid_t), libc::SIGKILL);
+            }
+        }
+        let _ = child.start_kill();
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(async move {
+                let _ = child.wait().await;
+            });
+        }
+    }
+}
+
 #[async_trait]
 impl PtyDeps for RealPtyDeps {
-    async fn spawn_pty(&self, spec: SpawnSpec) -> PtyHandle {
+    async fn spawn_pty(&self, spec: SpawnSpec, cancellation: CancellationToken) -> PtyHandle {
         // PTY allocation and thread setup are blocking; run off the reactor.
         // On PTY allocation failure (ptmx exhaustion et al) degrade to a
         // pipe-mode shell so the terminal still functions, with a banner.
         let output = ThreadOutput::new();
-        let task_output = Arc::clone(&output);
-        let fallback_output = Arc::clone(&output);
-        tokio::task::spawn_blocking(move || {
-            if spec.cancellation.is_cancelled() {
-                task_output.push_exit(1);
-                return PtyHandle {
-                    control: Arc::new(DeadControl),
-                    output: task_output,
-                    banner: None,
-                };
-            }
-            let handle = match spawn_real_pty(&spec) {
+        let handoff = SpawnHandoff::new();
+        let worker_handoff = Arc::clone(&handoff);
+        let worker_output = Arc::clone(&output);
+        let mut cancel_guard = CancelOnDrop::new(handoff);
+        let mut worker = tokio::task::spawn_blocking(move || {
+            match spawn_real_pty(&spec, &worker_handoff) {
                 Ok(handle) => handle,
-                Err(error) if !spec.cancellation.is_cancelled() => {
-                    spawn_pipe_mode(&spec, &error.to_string())
-                }
-                Err(_) => {
-                    task_output.push_exit(1);
-                    return PtyHandle {
+                Err(error) if worker_handoff.is_cancelled() => {
+                    let _ = error;
+                    worker_output.push_exit(1);
+                    PtyHandle {
                         control: Arc::new(DeadControl),
-                        output: task_output,
+                        output: worker_output,
                         banner: None,
-                    };
+                    }
                 }
-            };
-            if spec.cancellation.is_cancelled() {
-                handle.control.kill();
+                Err(error) => spawn_pipe_mode(&spec, &error.to_string(), &worker_handoff),
             }
-            handle
-        })
-        .await
-        .unwrap_or_else(|_| {
-            fallback_output.push_exit(1);
-            PtyHandle { control: Arc::new(DeadControl), output: fallback_output, banner: None }
+        });
+        let result = tokio::select! {
+            result = &mut worker => result,
+            _ = cancellation.cancelled() => {
+                cancel_guard.handoff.cancel();
+                worker.abort();
+                return PtyHandle { control: Arc::new(DeadControl), output, banner: None };
+            }
+        };
+        cancel_guard.disarm();
+        result.unwrap_or_else(|_| {
+            output.push_exit(1);
+            PtyHandle { control: Arc::new(DeadControl), output, banner: None }
         })
     }
 
-    async fn resolve_cmux_tui(&self) -> Option<CmuxTui> {
+    async fn resolve_cmux_tui(&self, cancellation: CancellationToken) -> Option<CmuxTui> {
         if let Some(override_path) =
             self.env.get("CHATMUX_RELAY_CMUX_TUI").filter(|value| !value.trim().is_empty())
         {
             let path = override_path.trim();
-            return if is_executable(Path::new(path)).await {
+            return if tokio::select! {
+                _ = cancellation.cancelled() => false,
+                result = is_executable(Path::new(path)) => result,
+            } {
                 Some(CmuxTui { file: path.to_owned(), prefix: Vec::new() })
             } else {
                 None
@@ -854,11 +1143,17 @@ impl PtyDeps for RealPtyDeps {
         }
         // Never a bare `cmux` on PATH — that name is ambiguous; only cmux-tui.
         for dir in self.env.get("PATH").map(String::as_str).unwrap_or("").split(':') {
+            if cancellation.is_cancelled() {
+                return None;
+            }
             if dir.is_empty() {
                 continue;
             }
             let candidate = Path::new(dir).join("cmux-tui");
-            if is_executable(&candidate).await {
+            if tokio::select! {
+                _ = cancellation.cancelled() => false,
+                result = is_executable(&candidate) => result,
+            } {
                 return Some(CmuxTui {
                     file: candidate.to_string_lossy().into_owned(),
                     prefix: Vec::new(),
@@ -875,26 +1170,52 @@ impl PtyDeps for RealPtyDeps {
         socket_dir: &Path,
         cwd: &Path,
         env: &HashMap<String, String>,
+        cancellation: CancellationToken,
     ) -> Result<EnsureDaemon, String> {
         use std::os::unix::fs::{MetadataExt, PermissionsExt};
-        tokio::fs::create_dir_all(socket_dir)
-            .await
-            .map_err(|error| format!("control socket directory create failed: {error}"))?;
-        let metadata = tokio::fs::metadata(socket_dir)
-            .await
-            .map_err(|error| format!("control socket directory stat failed: {error}"))?;
+        let created = tokio::select! {
+            _ = cancellation.cancelled() => return Err("terminal open cancelled".to_owned()),
+            result = tokio::fs::create_dir_all(socket_dir) => result,
+        };
+        created.map_err(|error| format!("control socket directory create failed: {error}"))?;
+        let metadata = tokio::select! {
+            _ = cancellation.cancelled() => return Err("terminal open cancelled".to_owned()),
+            result = tokio::fs::metadata(socket_dir) => result,
+        }
+        .map_err(|error| format!("control socket directory stat failed: {error}"))?;
+        if cancellation.is_cancelled() {
+            return Err("terminal open cancelled".to_owned());
+        }
         if !metadata.is_dir() || metadata.uid() != self.uid {
             return Err(format!("control socket directory is not owned by uid {}", self.uid));
         }
         let mut permissions = metadata.permissions();
         permissions.set_mode(0o700);
-        tokio::fs::set_permissions(socket_dir, permissions)
-            .await
-            .map_err(|error| format!("control socket directory permissions failed: {error}"))?;
+        tokio::select! {
+            _ = cancellation.cancelled() => return Err("terminal open cancelled".to_owned()),
+            result = tokio::fs::set_permissions(socket_dir, permissions) => result,
+        }
+        .map_err(|error| format!("control socket directory permissions failed: {error}"))?;
         let socket_path = session_socket_path(socket_dir, self.uid, session)?;
-        if socket_exists(&socket_path).await {
-            let ready = match connect_control(&socket_path, CONTROL_TIMEOUT_MS).await {
-                Ok(control) => control_ready(&control, session).await,
+        let socket_present = tokio::select! {
+            _ = cancellation.cancelled() => return Err("terminal open cancelled".to_owned()),
+            present = socket_exists(&socket_path) => present,
+        };
+        if socket_present {
+            let ready = match tokio::select! {
+                _ = cancellation.cancelled() => return Err("terminal open cancelled".to_owned()),
+                result = connect_control(&socket_path, CONTROL_TIMEOUT_MS) => result,
+            } {
+                Ok(control) => {
+                    let mut guard = ControlEndGuard::new(Arc::clone(&control));
+                    let ready = tokio::select! {
+                        _ = cancellation.cancelled() => return Err("terminal open cancelled".to_owned()),
+                        result = control_ready(&control, session) => result,
+                    };
+                    control.end();
+                    guard.disarm();
+                    ready
+                }
                 Err(_) => false,
             };
             if ready {
@@ -922,37 +1243,95 @@ impl PtyDeps for RealPtyDeps {
         command.stdout(std::process::Stdio::null());
         command.stderr(std::process::Stdio::null());
         command.process_group(0);
+        if cancellation.is_cancelled() {
+            return Err("terminal open cancelled".to_owned());
+        }
         let child =
             command.spawn().map_err(|error| format!("cmux-tui daemon spawn failed: {error}"))?;
+        let mut process_guard = DaemonProcessGuard::new(child);
 
         let deadline = Instant::now() + Duration::from_millis(DAEMON_SOCKET_WAIT_MS);
         while Instant::now() < deadline {
-            if socket_exists(&socket_path).await {
+            if cancellation.is_cancelled() {
+                process_guard.cleanup().await;
+                return Err("terminal open cancelled".to_owned());
+            }
+            let socket_present = tokio::select! {
+                _ = cancellation.cancelled() => {
+                    process_guard.cleanup().await;
+                    return Err("terminal open cancelled".to_owned());
+                }
+                present = socket_exists(&socket_path) => present,
+            };
+            if socket_present {
                 // Probe a control round-trip before declaring readiness.
                 while Instant::now() < deadline {
-                    match connect_control(&socket_path, CONTROL_TIMEOUT_MS).await {
-                        Ok(control) if control_ready(&control, session).await => {
-                            return Ok(EnsureDaemon { created: true, socket_path });
+                    if cancellation.is_cancelled() {
+                        process_guard.cleanup().await;
+                        return Err("terminal open cancelled".to_owned());
+                    }
+                    match tokio::select! {
+                        _ = cancellation.cancelled() => {
+                            process_guard.cleanup().await;
+                            return Err("terminal open cancelled".to_owned());
                         }
-                        _ => tokio::time::sleep(Duration::from_millis(50)).await,
+                        result = connect_control(&socket_path, CONTROL_TIMEOUT_MS) => result,
+                    } {
+                        Ok(control) => {
+                            let mut guard = ControlEndGuard::new(Arc::clone(&control));
+                            let ready = tokio::select! {
+                                _ = cancellation.cancelled() => {
+                                    process_guard.cleanup().await;
+                                    return Err("terminal open cancelled".to_owned());
+                                }
+                                result = control_ready(&control, session) => result,
+                            };
+                            control.end();
+                            guard.disarm();
+                            if ready {
+                                process_guard.disarm();
+                                return Ok(EnsureDaemon { created: true, socket_path });
+                            }
+                        }
+                        Err(_) => {}
+                    }
+                    tokio::select! {
+                        _ = cancellation.cancelled() => {
+                            process_guard.cleanup().await;
+                            return Err("terminal open cancelled".to_owned());
+                        }
+                        _ = tokio::time::sleep(Duration::from_millis(50)) => {}
                     }
                 }
                 // Do not unlink the path here. Another daemon may have won
                 // the socket race after our initial absence check; ownership
                 // of a pathname cannot be proven after the fact.
-                cleanup_daemon(child).await;
+                process_guard.cleanup().await;
                 return Err(format!(
                     "cmux-tui daemon for \"{session}\" did not become control-ready"
                 ));
             }
-            tokio::time::sleep(Duration::from_millis(50)).await;
+            tokio::select! {
+                _ = cancellation.cancelled() => {
+                    process_guard.cleanup().await;
+                    return Err("terminal open cancelled".to_owned());
+                }
+                _ = tokio::time::sleep(Duration::from_millis(50)) => {}
+            }
         }
-        cleanup_daemon(child).await;
+        process_guard.cleanup().await;
         Err(format!("cmux-tui daemon for \"{session}\" never created {}", socket_path.display()))
     }
 
-    async fn connect_control(&self, socket_path: &Path) -> Result<Arc<dyn ControlHandle>, String> {
-        connect_control(socket_path, CONTROL_TIMEOUT_MS).await
+    async fn connect_control(
+        &self,
+        socket_path: &Path,
+        cancellation: CancellationToken,
+    ) -> Result<Arc<dyn ControlHandle>, String> {
+        tokio::select! {
+            _ = cancellation.cancelled() => Err("terminal open cancelled".to_owned()),
+            result = connect_control(socket_path, CONTROL_TIMEOUT_MS) => result,
+        }
     }
 
     async fn read_dir(&self, path: &Path) -> Result<Vec<String>, ()> {

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -536,8 +536,11 @@ impl SpawnedChildCleanup {
     }
 
     fn finish_wait(&mut self, wait_result: anyhow::Result<cmux_pty::ExitStatus>) -> i64 {
+        let reaped = wait_result.is_ok();
         let code = wait_result.map(|status| i64::from(status.exit_code() as i32)).unwrap_or(0);
-        self.disarm();
+        if reaped {
+            self.disarm();
+        }
         code
     }
 

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -28,7 +28,7 @@ use tokio_util::sync::CancellationToken;
 use crate::control::{CONTROL_TIMEOUT_MS, ControlHandle, connect_control};
 use crate::pty::{
     CmuxTui, DataSink, EnsureDaemon, ExitSink, OpenPermit, PtyControl, PtyDeps, PtyHandle,
-    SpawnSpec, session_name_ok, spawn_blocking_with_open_permit,
+    PtyOutput, SpawnSpec, session_name_ok, spawn_blocking_with_open_permit,
 };
 
 const DAEMON_SOCKET_WAIT_MS: u64 = 5_000;

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -1191,10 +1191,20 @@ impl PtyDeps for RealPtyDeps {
             }
         });
         let result = tokio::select! {
+            biased;
+            // A pre-cancelled owner must win over a concurrently completing
+            // blocking worker so the returned dead handle gets its terminal
+            // exit event and no PTY is handed to a cancelled request.
             result = &mut worker => result,
             _ = cancellation.cancelled() => {
                 cancel_guard.handoff.cancel();
                 worker.abort();
+                // The async owner returns a dead handle when cancellation wins
+                // before the blocking worker can hand its PTY to us. Publish
+                // the terminal event as part of that handoff contract so a
+                // subscriber that attaches to the returned output cannot wait
+                // forever for an exit that the worker will never emit.
+                output.push_exit(1);
                 return PtyHandle { control: Arc::new(DeadControl), output, banner: None };
             }
         };
@@ -1465,7 +1475,7 @@ mod tests {
     use std::sync::{Arc as TestArc, Barrier, Mutex as TestMutex, mpsc};
     use std::thread;
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn cancellation_before_pty_handoff_publishes_exit_to_late_subscriber() {
         let deps = RealPtyDeps::new(HashMap::new());
         let cancellation = CancellationToken::new();

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -297,6 +297,17 @@ struct ProcessOutputCompletionState {
     child_exit: Option<i64>,
 }
 
+/// Complete a PTY setup that failed after the reader started. Recording the
+/// synthetic exit enters the bounded completion path, which signals the PTY
+/// reader's cancellation wake even when a descendant still owns the slave.
+fn finish_pty_wait_setup_failure(
+    control: &dyn PtyControl,
+    completion: &Arc<ProcessOutputCompletion>,
+) {
+    control.kill();
+    completion.child_exited(1);
+}
+
 /// Wakes a PTY reader that is waiting in `poll` when completion reaches its
 /// bounded grace deadline. A socket pair avoids closing a descriptor from a
 /// different thread, which can race with descriptor reuse.
@@ -914,7 +925,7 @@ fn spawn_real_pty(spec: &SpawnSpec, handoff: &SpawnHandoff) -> anyhow::Result<Pt
         })
         .is_err()
     {
-        control.kill();
+        finish_pty_wait_setup_failure(control.as_ref(), &completion);
         return Err(anyhow::anyhow!("PTY wait thread spawn failed"));
     }
 
@@ -1987,7 +1998,8 @@ mod tests {
         });
 
         let kills = TestArc::new(AtomicUsize::new(0));
-        let control = TestControl { kills: TestArc::clone(&kills), drops: TestArc::new(AtomicUsize::new(0)) };
+        let control =
+            TestControl { kills: TestArc::clone(&kills), drops: TestArc::new(AtomicUsize::new(0)) };
         finish_pty_wait_setup_failure(&control, &completion);
 
         reader_done_rx

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -40,6 +40,21 @@ const PIPE_READ_POLL_MS: i32 = 100;
 // This is distinct from the relay's lower-level CONTROL_MIN_PROTOCOL floor.
 const DAEMON_LIFECYCLE_PROTOCOL_MIN: u64 = 12;
 
+/// Await a blocking PTY worker while giving an already-cancelled owner
+/// priority over a concurrently-ready worker. The biased select is deliberate
+/// here: Tokio polls branches top to bottom in biased mode, so cancellation
+/// must be listed first to prevent a cancelled open from publishing a handle.
+async fn await_spawn_or_cancel<T>(
+    worker: &mut tokio::task::JoinHandle<T>,
+    cancellation: &CancellationToken,
+) -> Result<Result<T, tokio::task::JoinError>, ()> {
+    tokio::select! {
+        biased;
+        _ = cancellation.cancelled() => Err(()),
+        result = worker => Ok(result),
+    }
+}
+
 async fn control_ready(control: &Arc<dyn ControlHandle>, session: &str) -> bool {
     control.request("identify", serde_json::Value::Null).await.is_some_and(|response| {
         response.get("ok").and_then(serde_json::Value::as_bool) == Some(true)
@@ -1190,13 +1205,9 @@ impl PtyDeps for RealPtyDeps {
                 Err(error) => spawn_pipe_mode(&spec, &error.to_string(), &worker_handoff),
             }
         });
-        let result = tokio::select! {
-            biased;
-            // A pre-cancelled owner must win over a concurrently completing
-            // blocking worker so the returned dead handle gets its terminal
-            // exit event and no PTY is handed to a cancelled request.
-            result = &mut worker => result,
-            _ = cancellation.cancelled() => {
+        let result = match await_spawn_or_cancel(&mut worker, &cancellation).await {
+            Ok(result) => result,
+            Err(()) => {
                 cancel_guard.handoff.cancel();
                 worker.abort();
                 // The async owner returns a dead handle when cancellation wins

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -36,9 +36,9 @@ use crate::actions::{ActionContext, perform_action, process_env_snapshot, scrubb
 use crate::config::{Config, save_config};
 use crate::error::RelayError;
 use crate::pairing::websocket_url;
-use crate::pty::{FrameContext, TransportKind};
 #[cfg(unix)]
 use crate::pty::PtyManager;
+use crate::pty::{FrameContext, TransportKind};
 use crate::trust::{
     DEFAULT_RELAY_TRUST, Trust, clear_invalid_yolo_confirmation, effective_local_trust,
     has_yolo_confirmation, relay_trust,

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -904,17 +904,31 @@ async fn relay_session(
                 let Some(frame) = parse_server_frame(&text) else { continue };
                 match frame {
                     ServerFrame::HelloAccepted(hello) => {
+                        let local_trust = if state.managed {
+                            DEFAULT_RELAY_TRUST
+                        } else {
+                            effective_local_trust(config)
+                        };
+                        // Managed hello trust is server authority. Validate it
+                        // before changing connection, enrollment, token, or
+                        // trust state so an invalid acceptance cannot leave a
+                        // partially authenticated managed session behind.
+                        let effective_trust = if state.managed {
+                            let Some(trust) = Trust::parse(&hello.trust) else {
+                                break Err(RelayError::transient(
+                                    "server returned an invalid trust level; refusing terminal access",
+                                ));
+                            };
+                            trust
+                        } else {
+                            local_trust
+                        };
                         connected = true;
                         negotiated_version = hello.relay_protocol_version;
                         clear_invalid_yolo_confirmation(config);
                         let configured = relay_trust(
                             config.pending_trust.as_deref().or(config.trust.as_deref()),
                         );
-                        let local_trust = if state.managed {
-                            DEFAULT_RELAY_TRUST
-                        } else {
-                            effective_local_trust(config)
-                        };
                         if !state.managed
                             && (configured != local_trust || local_trust == Trust::Autonomous)
                         {
@@ -947,7 +961,7 @@ async fn relay_session(
                             hello.machine_name.clone()
                         };
                         let shown_trust = if state.managed {
-                            hello.trust.clone()
+                            effective_trust.as_str().to_owned()
                         } else {
                             local_trust.as_str().to_owned()
                         };
@@ -988,26 +1002,13 @@ async fn relay_session(
                             config.pending_trust = None;
                             save(config, config_path);
                         } else {
-                            config.trust = Some(hello.trust.clone());
+                            config.trust = Some(effective_trust.as_str().to_owned());
                         }
                         // Publish the reconciled auth for exec/PTY dispatch.
                         {
-                            let effective_trust = if state.managed {
-                                hello.trust.clone()
-                            } else {
-                                local_trust.as_str().to_owned()
-                            };
-                            // A server-supplied trust value is authority. Do
-                            // not treat an unknown string as a permissive
-                            // level in either the relay or tunnel data plane.
-                            if Trust::parse(&effective_trust).is_none() {
-                                break Err(RelayError::transient(
-                                    "server returned an invalid trust level; refusing terminal access",
-                                ));
-                            }
-                            let local_observe = effective_trust == Trust::Observe.as_str();
+                            let local_observe = effective_trust == Trust::Observe;
                             let mut snapshot = auth.lock().expect("auth lock");
-                            snapshot.trust = effective_trust;
+                            snapshot.trust = effective_trust.as_str().to_owned();
                             snapshot.roots = local_roots.clone();
                             snapshot.owner = config.owner_user_id.clone();
                             #[cfg(unix)]

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -1029,7 +1029,13 @@ async fn relay_session(
                             // frame context, but it cannot publish that stale
                             // authority back into the manager.
                             let snapshot = auth.lock().expect("auth lock").clone();
-                            let context = make_context(&out_tx, &pending, &snapshot, &transport_id);
+                            let context = make_context(
+                                &out_tx,
+                                &pending,
+                                &snapshot,
+                                &transport_id,
+                                &connection_cancellation,
+                            );
                             runtime.pty.update_transport_auth(&context);
                         }
                         let cadence = Duration::from_millis(hello.heartbeat_interval_ms);
@@ -1101,7 +1107,13 @@ async fn relay_session(
                                     owner_user_id: snapshot.owner.clone(),
                                 }),
                             );
-                            let context = make_context(&out_tx, &pending, &snapshot, &transport_id);
+                            let context = make_context(
+                                &out_tx,
+                                &pending,
+                                &snapshot,
+                                &transport_id,
+                                &connection_cancellation,
+                            );
                             runtime.pty.update_transport_auth(&context);
                         }
                         workspace.set_local_observe(ack == Trust::Observe);

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -614,7 +614,16 @@ fn make_context(
             let Some(text) = serde_json::to_string(&frame).ok() else { return };
             let size = text.len() as u64;
             pending_send_live.fetch_add(size, Ordering::SeqCst);
-            if live_sender.try_watch_text_with_token(text, Some(live)).is_err() {
+            let critical = matches!(
+                frame.get("type").and_then(Value::as_str),
+                Some("pty_opened" | "pty_error" | "pty_exit" | "pty_closed")
+            );
+            let result = if critical {
+                live_sender.try_critical_text_with_token(text, Some(live))
+            } else {
+                live_sender.try_watch_text_with_token(text, Some(live))
+            };
+            if result.is_err() {
                 pending_send_live.fetch_sub(
                     size.min(pending_send_live.load(Ordering::SeqCst)),
                     Ordering::SeqCst,

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -494,10 +494,8 @@ pub async fn stay_online(
         )
         .await
         {
-            Ok(_) => eprintln!("Tunnel terminal listener is up on loopback."),
-            Err(_) => eprintln!(
-                "Tunnel terminal listener is unavailable. Terminals stay on the relay socket path."
-            ),
+            Ok(_) => eprintln!("Terminal access is ready."),
+            Err(_) => eprintln!("Terminal access is unavailable. Reconnect and try again."),
         }
     }
     let mut attempt: u32 = 0;

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -584,7 +584,9 @@ fn make_context(
 ) -> FrameContext {
     let sender = out.clone();
     let pending_send = Arc::clone(pending);
+    let pending_send_live = Arc::clone(pending);
     let pending_probe = Arc::clone(pending);
+    let live_sender = out.clone();
     FrameContext {
         send: Arc::new(move |frame: Value| {
             let size = serde_json::to_string(&frame).map(|text| text.len() as u64).unwrap_or(0);
@@ -606,6 +608,17 @@ fn make_context(
                 );
                 pending_send
                     .fetch_sub(size.min(pending_send.load(Ordering::SeqCst)), Ordering::SeqCst);
+            }
+        }),
+        send_live: Arc::new(move |frame: Value, live: Arc<AtomicBool>| {
+            let Some(text) = serde_json::to_string(&frame).ok() else { return };
+            let size = text.len() as u64;
+            pending_send_live.fetch_add(size, Ordering::SeqCst);
+            if live_sender.try_watch_text_with_token(text, Some(live)).is_err() {
+                pending_send_live.fetch_sub(
+                    size.min(pending_send_live.load(Ordering::SeqCst)),
+                    Ordering::SeqCst,
+                );
             }
         }),
         buffered_amount: Arc::new(move || pending_probe.load(Ordering::SeqCst)),
@@ -846,6 +859,8 @@ async fn relay_session(
             }
             Wake::Outbound(is_critical, Some(frame)) => {
                 if !frame.is_live() {
+                    let size = frame.text.len() as u64;
+                    pending.fetch_sub(size.min(pending.load(Ordering::SeqCst)), Ordering::SeqCst);
                     if let Some(ack) = frame.ack {
                         let _ = ack.send(());
                     }

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -366,6 +366,24 @@ impl Default for SessionRuntime {
     }
 }
 
+#[cfg(unix)]
+fn reconcile_tunnel_authority(runtime: &SessionRuntime, auth: Option<TunnelAuth>) -> u64 {
+    // Publish or revoke the generation while holding the authority lock, then
+    // advance the PTY generation floor and detach old tunnel attachments
+    // before releasing it. Trust changes therefore have the same atomic
+    // boundary as hello reconciliation and disconnect cleanup.
+    let mut authority = runtime.tunnel_auth.write().expect("tunnel auth lock");
+    *authority = match auth {
+        Some(auth) => TunnelAuthority::published(authority.generation, auth),
+        None => TunnelAuthority::revoked(authority.generation),
+    };
+    let generation = authority.generation;
+    runtime.pty.set_tunnel_authority_generation(generation);
+    let _ = runtime.tunnel_generation.send(generation);
+    runtime.pty.detach_tunnel_transports();
+    generation
+}
+
 fn now_ms() -> i64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -991,28 +1009,14 @@ async fn relay_session(
                             snapshot.roots = local_roots.clone();
                             snapshot.owner = config.owner_user_id.clone();
                             #[cfg(unix)]
-                            if state.managed {
-                                // Publish the new generation while holding the
-                                // authority lock, then detach old attachments
-                                // before releasing it. Existing tunnel
-                                // sockets therefore see one atomic generation
-                                // change and cannot open in an old-authority
-                                // gap.
-                                let mut authority =
-                                    runtime.tunnel_auth.write().expect("tunnel auth lock");
-                                *authority = TunnelAuthority::published(
-                                    authority.generation,
-                                    TunnelAuth {
-                                        trust: snapshot.trust.clone(),
-                                        local_roots: snapshot.roots.clone(),
-                                        owner_user_id: snapshot.owner.clone(),
-                                    },
-                                );
-                                let generation = authority.generation;
-                                runtime.pty.set_tunnel_authority_generation(generation);
-                                let _ = runtime.tunnel_generation.send(generation);
-                                runtime.pty.detach_tunnel_transports();
-                            }
+                            reconcile_tunnel_authority(
+                                runtime,
+                                state.managed.then(|| TunnelAuth {
+                                    trust: snapshot.trust.clone(),
+                                    local_roots: snapshot.roots.clone(),
+                                    owner_user_id: snapshot.owner.clone(),
+                                }),
+                            );
                             workspace.set_local_observe(local_observe);
                         }
                         #[cfg(unix)]
@@ -1087,6 +1091,14 @@ async fn relay_session(
                         #[cfg(unix)]
                         {
                             let snapshot = auth.lock().expect("auth lock").clone();
+                            reconcile_tunnel_authority(
+                                runtime,
+                                state.managed.then(|| TunnelAuth {
+                                    trust: snapshot.trust.clone(),
+                                    local_roots: snapshot.roots.clone(),
+                                    owner_user_id: snapshot.owner.clone(),
+                                }),
+                            );
                             let context = make_context(&out_tx, &pending, &snapshot, &transport_id);
                             runtime.pty.update_transport_auth(&context);
                         }
@@ -1314,14 +1326,7 @@ async fn relay_session(
     // sockets authorized during that interval.
     #[cfg(unix)]
     {
-        {
-            let mut authority = runtime.tunnel_auth.write().expect("tunnel auth lock");
-            *authority = TunnelAuthority::revoked(authority.generation);
-            let generation = authority.generation;
-            runtime.pty.set_tunnel_authority_generation(generation);
-            let _ = runtime.tunnel_generation.send(generation);
-            runtime.pty.detach_tunnel_transports();
-        }
+        reconcile_tunnel_authority(runtime, None);
     }
 
     // Workspace requests own Git children. Give them a cooperative
@@ -1552,6 +1557,31 @@ mod cancellation_tests {
         process_cancellation.cancel();
         assert!(send.await.expect("send task joined").is_err());
         assert!(!connection_cancellation.is_cancelled());
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tunnel_authority_tests {
+    use super::{SessionRuntime, TunnelAuth, reconcile_tunnel_authority};
+
+    #[test]
+    fn trust_downgrade_revokes_old_tunnel_authority() {
+        let runtime = SessionRuntime::new();
+        let published = reconcile_tunnel_authority(
+            &runtime,
+            Some(TunnelAuth {
+                trust: "autonomous".to_owned(),
+                local_roots: None,
+                owner_user_id: None,
+            }),
+        );
+        assert!(runtime.tunnel_auth.read().expect("authority lock").auth.is_some());
+
+        let revoked = reconcile_tunnel_authority(&runtime, None);
+        let authority = runtime.tunnel_auth.read().expect("authority lock");
+        assert_eq!(revoked, published + 1);
+        assert!(authority.auth.is_none(), "a trust downgrade must revoke tunnel access");
+        assert_eq!(authority.generation, revoked);
     }
 }
 

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -39,6 +39,8 @@ use crate::pairing::websocket_url;
 use crate::pty::FrameContext;
 #[cfg(unix)]
 use crate::pty::PtyManager;
+#[cfg(unix)]
+use crate::tunnel_terminal::{TunnelAuth, TunnelAuthState};
 use crate::trust::{
     DEFAULT_RELAY_TRUST, Trust, clear_invalid_yolo_confirmation, effective_local_trust,
     has_yolo_confirmation, relay_trust,
@@ -325,6 +327,8 @@ pub struct SessionRuntime {
     pub(crate) workspace: Arc<crate::workspace::SharedRuntime>,
     #[cfg(unix)]
     pty: Arc<PtyManager>,
+    #[cfg(unix)]
+    pub(crate) tunnel_auth: TunnelAuthState,
 }
 
 impl SessionRuntime {
@@ -346,6 +350,8 @@ impl SessionRuntime {
             workspace: Arc::new(crate::workspace::SharedRuntime::new(local_roots)),
             #[cfg(unix)]
             pty,
+            #[cfg(unix)]
+            tunnel_auth: Arc::new(std::sync::RwLock::new(None)),
         }
     }
 }
@@ -449,17 +455,19 @@ pub async fn stay_online(
     cancellation: CancellationToken,
 ) -> Result<(), RelayError> {
     let runtime = SessionRuntime::with_roots(config.allowed_roots.clone());
-    // Tunnel-direct terminal data plane: serve terminals to spliced tunnel
-    // connections on loopback 127.0.0.1:9776. Managed sandboxes ONLY — this
-    // branch is the gate; paired human machines never start the listener.
-    // Best-effort: a failed bind degrades to the relay-socket terminal path.
+    // Tunnel-direct terminal data plane: bind the loopback listener once for
+    // managed sandboxes. It starts with no authority and therefore refuses
+    // opens until hello negotiation publishes authenticated trust. Authority
+    // is cleared on every disconnect, so a stale tunnel cannot survive a
+    // reconnect.
     #[cfg(unix)]
     if state.managed {
         match crate::tunnel_terminal::start_tunnel_terminal_listener(
             Arc::clone(&runtime.pty),
-            cancellation.child_token(),
+            cancellation.clone(),
             crate::tunnel_terminal::TUNNEL_TERMINAL_HOST,
             crate::tunnel_terminal::TUNNEL_TERMINAL_PORT,
+            Arc::clone(&runtime.tunnel_auth),
         )
         .await
         {
@@ -644,7 +652,9 @@ async fn relay_session(
     // this socket opens carries this connection's identity, so closing or
     // reconnecting the socket cannot detach an independent tunnel attachment.
     #[cfg(unix)]
-    let transport_id = format!("relay-{}", crate::pty::random_hex(16));
+    let transport_id = crate::pty::random_hex(16)
+        .map(|id| format!("relay-{id}"))
+        .map_err(|error| RelayError::transient(format!("unable to create relay transport identity: {error}")))?;
 
     // Ordered PTY frame dispatch on its own task so a slow open (daemon
     // spawn) never stalls heartbeats or other frames.
@@ -960,11 +970,33 @@ async fn relay_session(
                             } else {
                                 local_trust.as_str().to_owned()
                             };
+                            // A server-supplied trust value is authority. Do
+                            // not treat an unknown string as a permissive
+                            // level in either the relay or tunnel data plane.
+                            if Trust::parse(&effective_trust).is_none() {
+                                break Err(RelayError::transient(
+                                    "server returned an invalid trust level; refusing terminal access",
+                                ));
+                            }
                             let local_observe = effective_trust == Trust::Observe.as_str();
                             let mut snapshot = auth.lock().expect("auth lock");
                             snapshot.trust = effective_trust;
                             snapshot.roots = local_roots.clone();
                             snapshot.owner = config.owner_user_id.clone();
+                            #[cfg(unix)]
+                            if state.managed {
+                                // Trust and owner changes revoke all tunnel
+                                // attachments before the new snapshot is
+                                // published. This closes the old capability
+                                // at one clear lifecycle boundary.
+                                runtime.pty.detach_tunnel_transports();
+                                *runtime.tunnel_auth.write().expect("tunnel auth lock") =
+                                    Some(TunnelAuth {
+                                        trust: snapshot.trust.clone(),
+                                        local_roots: snapshot.roots.clone(),
+                                        owner_user_id: snapshot.owner.clone(),
+                                    });
+                            }
                             workspace.set_local_observe(local_observe);
                         }
                         let cadence = Duration::from_millis(hello.heartbeat_interval_ms);
@@ -1265,7 +1297,14 @@ async fn relay_session(
     // managed tunnel listener's attachments are another transport's — a
     // reconnect must never detach them (docs/TERMINAL.md).
     #[cfg(unix)]
-    runtime.pty.detach_transport(&transport_id);
+    {
+        // Clear the listener's authority before releasing relay attachments.
+        // New tunnel opens fail closed during reconnect, and old tunnel
+        // attachments are revoked instead of inheriting the next session.
+        *runtime.tunnel_auth.write().expect("tunnel auth lock") = None;
+        runtime.pty.detach_tunnel_transports();
+        runtime.pty.detach_transport(&transport_id);
+    }
     result
 }
 

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -44,7 +44,7 @@ use crate::trust::{
     has_yolo_confirmation, relay_trust,
 };
 #[cfg(unix)]
-use crate::tunnel_terminal::{TunnelAuth, TunnelAuthState};
+use crate::tunnel_terminal::{TunnelAuth, TunnelAuthState, TunnelAuthority};
 use crate::wire::{
     CLI_VERSION, EXEC_PROTOCOL_VERSION, FRAME_VERSION, HelloFrame, PTY_PROTOCOL_VERSION,
     ServerFrame, advertised_protocol, heartbeat_frame, parse_server_frame, set_trust_frame,
@@ -351,7 +351,7 @@ impl SessionRuntime {
             #[cfg(unix)]
             pty,
             #[cfg(unix)]
-            tunnel_auth: Arc::new(std::sync::RwLock::new(None)),
+            tunnel_auth: Arc::new(std::sync::RwLock::new(TunnelAuthority::default())),
         }
     }
 }
@@ -986,19 +986,36 @@ async fn relay_session(
                             snapshot.owner = config.owner_user_id.clone();
                             #[cfg(unix)]
                             if state.managed {
-                                // Trust and owner changes revoke all tunnel
-                                // attachments before the new snapshot is
-                                // published. This closes the old capability
-                                // at one clear lifecycle boundary.
-                                runtime.pty.detach_tunnel_transports();
-                                *runtime.tunnel_auth.write().expect("tunnel auth lock") =
-                                    Some(TunnelAuth {
+                                // Publish the new generation while holding the
+                                // authority lock, then detach old attachments
+                                // before releasing it. Existing tunnel
+                                // sockets therefore see one atomic generation
+                                // change and cannot open in an old-authority
+                                // gap.
+                                let mut authority =
+                                    runtime.tunnel_auth.write().expect("tunnel auth lock");
+                                *authority = TunnelAuthority::published(
+                                    authority.generation,
+                                    TunnelAuth {
                                         trust: snapshot.trust.clone(),
                                         local_roots: snapshot.roots.clone(),
                                         owner_user_id: snapshot.owner.clone(),
-                                    });
+                                    },
+                                );
+                                runtime.pty.detach_tunnel_transports();
                             }
                             workspace.set_local_observe(local_observe);
+                        }
+                        #[cfg(unix)]
+                        {
+                            // Replace the manager's connection snapshot only
+                            // at this authenticated reconciliation boundary.
+                            // An already-running open may still carry the old
+                            // frame context, but it cannot publish that stale
+                            // authority back into the manager.
+                            let snapshot = auth.lock().expect("auth lock").clone();
+                            let context = make_context(&out_tx, &pending, &snapshot, &transport_id);
+                            runtime.pty.update_transport_auth(&context);
                         }
                         let cadence = Duration::from_millis(hello.heartbeat_interval_ms);
                         let mut interval = tokio::time::interval(cadence);
@@ -1058,6 +1075,12 @@ async fn relay_session(
                             save(config, config_path);
                         }
                         auth.lock().expect("auth lock").trust = ack.as_str().to_owned();
+                        #[cfg(unix)]
+                        {
+                            let snapshot = auth.lock().expect("auth lock").clone();
+                            let context = make_context(&out_tx, &pending, &snapshot, &transport_id);
+                            runtime.pty.update_transport_auth(&context);
+                        }
                         workspace.set_local_observe(ack == Trust::Observe);
                         println!("Trust level set to {ack}.");
                     }
@@ -1277,6 +1300,18 @@ async fn relay_session(
         }
     };
 
+    // Revoke the managed tunnel capability before any potentially slow
+    // cleanup. Waiting for workspace or provider tasks would leave old tunnel
+    // sockets authorized during that interval.
+    #[cfg(unix)]
+    {
+        {
+            let mut authority = runtime.tunnel_auth.write().expect("tunnel auth lock");
+            *authority = TunnelAuthority::revoked(authority.generation);
+        }
+        runtime.pty.detach_tunnel_transports();
+    }
+
     // Workspace requests own Git children. Give them a cooperative
     // cancellation window so each request can kill its process group and
     // await the direct child before the socket connection is dropped.
@@ -1298,14 +1333,7 @@ async fn relay_session(
     // managed tunnel listener's attachments are another transport's — a
     // reconnect must never detach them (docs/TERMINAL.md).
     #[cfg(unix)]
-    {
-        // Clear the listener's authority before releasing relay attachments.
-        // New tunnel opens fail closed during reconnect, and old tunnel
-        // attachments are revoked instead of inheriting the next session.
-        *runtime.tunnel_auth.write().expect("tunnel auth lock") = None;
-        runtime.pty.detach_tunnel_transports();
-        runtime.pty.detach_transport(&transport_id);
-    }
+    runtime.pty.detach_transport(&transport_id);
     result
 }
 

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -24,7 +24,7 @@ use std::time::Duration;
 use futures_util::{SinkExt as _, StreamExt as _};
 use serde_json::Value;
 use tokio::sync::mpsc;
-use tokio::sync::{Mutex as AsyncMutex, OwnedSemaphorePermit, Semaphore};
+use tokio::sync::{Mutex as AsyncMutex, OwnedSemaphorePermit, Semaphore, watch};
 use tokio::task::JoinSet;
 use tokio::time::timeout;
 use tokio_tungstenite::connect_async_with_config;
@@ -36,7 +36,7 @@ use crate::actions::{ActionContext, perform_action, process_env_snapshot, scrubb
 use crate::config::{Config, save_config};
 use crate::error::RelayError;
 use crate::pairing::websocket_url;
-use crate::pty::FrameContext;
+use crate::pty::{FrameContext, TransportKind};
 #[cfg(unix)]
 use crate::pty::PtyManager;
 use crate::trust::{
@@ -329,6 +329,8 @@ pub struct SessionRuntime {
     pty: Arc<PtyManager>,
     #[cfg(unix)]
     pub(crate) tunnel_auth: TunnelAuthState,
+    #[cfg(unix)]
+    pub(crate) tunnel_generation: watch::Sender<u64>,
 }
 
 impl SessionRuntime {
@@ -352,6 +354,8 @@ impl SessionRuntime {
             pty,
             #[cfg(unix)]
             tunnel_auth: Arc::new(std::sync::RwLock::new(TunnelAuthority::default())),
+            #[cfg(unix)]
+            tunnel_generation: watch::channel(0).0,
         }
     }
 }
@@ -468,12 +472,13 @@ pub async fn stay_online(
             crate::tunnel_terminal::TUNNEL_TERMINAL_HOST,
             crate::tunnel_terminal::TUNNEL_TERMINAL_PORT,
             Arc::clone(&runtime.tunnel_auth),
+            runtime.tunnel_generation.subscribe(),
         )
         .await
         {
             Ok(_) => eprintln!("Tunnel terminal listener is up on loopback."),
-            Err(error) => eprintln!(
-                "Tunnel terminal listener bind failed: {error}. Terminals stay on the relay socket path."
+            Err(_) => eprintln!(
+                "Tunnel terminal listener is unavailable. Terminals stay on the relay socket path."
             ),
         }
     }
@@ -589,6 +594,8 @@ fn make_context(
         owner_user_id: auth.owner.clone(),
         transport_id: Some(transport_id.to_owned()),
         cancellation: cancellation.clone(),
+        transport_kind: TransportKind::Relay,
+        auth_generation: None,
     }
 }
 
@@ -652,10 +659,9 @@ async fn relay_session(
     // this socket opens carries this connection's identity, so closing or
     // reconnecting the socket cannot detach an independent tunnel attachment.
     #[cfg(unix)]
-    let transport_id =
-        crate::pty::random_hex(16).map(|id| format!("relay-{id}")).map_err(|error| {
-            RelayError::transient(format!("unable to create relay transport identity: {error}"))
-        })?;
+    let transport_id = crate::pty::random_hex(16)
+        .map(|id| format!("relay-{id}"))
+        .map_err(|_| RelayError::transient("unable to initialize relay transport identity"))?;
 
     // Ordered PTY frame dispatch on its own task so a slow open (daemon
     // spawn) never stalls heartbeats or other frames.
@@ -1002,6 +1008,9 @@ async fn relay_session(
                                         owner_user_id: snapshot.owner.clone(),
                                     },
                                 );
+                                let generation = authority.generation;
+                                runtime.pty.set_tunnel_authority_generation(generation);
+                                let _ = runtime.tunnel_generation.send(generation);
                                 runtime.pty.detach_tunnel_transports();
                             }
                             workspace.set_local_observe(local_observe);
@@ -1308,8 +1317,11 @@ async fn relay_session(
         {
             let mut authority = runtime.tunnel_auth.write().expect("tunnel auth lock");
             *authority = TunnelAuthority::revoked(authority.generation);
+            let generation = authority.generation;
+            runtime.pty.set_tunnel_authority_generation(generation);
+            let _ = runtime.tunnel_generation.send(generation);
+            runtime.pty.detach_tunnel_transports();
         }
-        runtime.pty.detach_tunnel_transports();
     }
 
     // Workspace requests own Git children. Give them a cooperative
@@ -1333,7 +1345,7 @@ async fn relay_session(
     // managed tunnel listener's attachments are another transport's — a
     // reconnect must never detach them (docs/TERMINAL.md).
     #[cfg(unix)]
-    runtime.pty.detach_transport(&transport_id);
+    runtime.pty.detach_transport_kind(&transport_id, TransportKind::Relay);
     result
 }
 

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -368,19 +368,23 @@ impl Default for SessionRuntime {
 
 #[cfg(unix)]
 fn reconcile_tunnel_authority(runtime: &SessionRuntime, auth: Option<TunnelAuth>) -> u64 {
-    // Publish or revoke the generation while holding the authority lock, then
-    // advance the PTY generation floor and detach old tunnel attachments
-    // before releasing it. Trust changes therefore have the same atomic
-    // boundary as hello reconciliation and disconnect cleanup.
-    let mut authority = runtime.tunnel_auth.write().expect("tunnel auth lock");
-    *authority = match auth {
-        Some(auth) => TunnelAuthority::published(authority.generation, auth),
-        None => TunnelAuthority::revoked(authority.generation),
+    // Publish or revoke the generation while holding the authority lock, and
+    // remove old tunnel ownership before releasing it. The returned controls
+    // are killed only after the lock is released, so platform cleanup cannot
+    // block trust readers or a later reconciliation.
+    let (generation, retired) = {
+        let mut authority = runtime.tunnel_auth.write().expect("tunnel auth lock");
+        *authority = match auth {
+            Some(auth) => TunnelAuthority::published(authority.generation, auth),
+            None => TunnelAuthority::revoked(authority.generation),
+        };
+        let generation = authority.generation;
+        runtime.pty.set_tunnel_authority_generation(generation);
+        let _ = runtime.tunnel_generation.send(generation);
+        let retired = runtime.pty.detach_tunnel_transports_deferred();
+        (generation, retired)
     };
-    let generation = authority.generation;
-    runtime.pty.set_tunnel_authority_generation(generation);
-    let _ = runtime.tunnel_generation.send(generation);
-    runtime.pty.detach_tunnel_transports();
+    retired.retire();
     generation
 }
 

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -39,12 +39,12 @@ use crate::pairing::websocket_url;
 use crate::pty::FrameContext;
 #[cfg(unix)]
 use crate::pty::PtyManager;
-#[cfg(unix)]
-use crate::tunnel_terminal::{TunnelAuth, TunnelAuthState};
 use crate::trust::{
     DEFAULT_RELAY_TRUST, Trust, clear_invalid_yolo_confirmation, effective_local_trust,
     has_yolo_confirmation, relay_trust,
 };
+#[cfg(unix)]
+use crate::tunnel_terminal::{TunnelAuth, TunnelAuthState};
 use crate::wire::{
     CLI_VERSION, EXEC_PROTOCOL_VERSION, FRAME_VERSION, HelloFrame, PTY_PROTOCOL_VERSION,
     ServerFrame, advertised_protocol, heartbeat_frame, parse_server_frame, set_trust_frame,
@@ -652,9 +652,10 @@ async fn relay_session(
     // this socket opens carries this connection's identity, so closing or
     // reconnecting the socket cannot detach an independent tunnel attachment.
     #[cfg(unix)]
-    let transport_id = crate::pty::random_hex(16)
-        .map(|id| format!("relay-{id}"))
-        .map_err(|error| RelayError::transient(format!("unable to create relay transport identity: {error}")))?;
+    let transport_id =
+        crate::pty::random_hex(16).map(|id| format!("relay-{id}")).map_err(|error| {
+            RelayError::transient(format!("unable to create relay transport identity: {error}"))
+        })?;
 
     // Ordered PTY frame dispatch on its own task so a slow open (daemon
     // spawn) never stalls heartbeats or other frames.

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -1574,6 +1574,79 @@ mod cancellation_tests {
     }
 }
 
+#[cfg(test)]
+mod managed_hello_tests {
+    use super::*;
+    use futures_util::{SinkExt as _, StreamExt as _};
+    use tokio::net::TcpListener;
+    use tokio_tungstenite::accept_async;
+
+    #[tokio::test]
+    async fn invalid_managed_hello_trust_cannot_mutate_enrollment_state() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind test backend");
+        let address = listener.local_addr().expect("test backend address");
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("relay connection");
+            let mut socket = accept_async(stream).await.expect("websocket handshake");
+            let _ = socket.next().await.expect("hello frame");
+            socket
+                .send(Message::Text(
+                    serde_json::json!({
+                        "version": FRAME_VERSION,
+                        "type": "hello_accepted",
+                        "relayProtocolVersion": advertised_protocol(),
+                        "heartbeatIntervalMs": 1000,
+                        "machineName": "managed-test",
+                        "scope": "managed",
+                        "trust": "not-a-trust-level",
+                        "ownerUserId": "attacker-owner",
+                        "managedSessionToken": "new-managed-session-token-12345678901234567890"
+                    })
+                    .to_string()
+                    .into(),
+                ))
+                .await
+                .expect("send hello acceptance");
+        });
+
+        let original_token = "original-managed-token-12345678901234567890".to_owned();
+        let mut config = Config {
+            backend: format!("http://{address}"),
+            device_id: "device".to_owned(),
+            token: original_token.clone(),
+            trust: Some("supervised".to_owned()),
+            owner_user_id: Some("original-owner".to_owned()),
+            managed: Some(crate::config::ManagedIdentity {
+                client: "client".to_owned(),
+                org_id: "org".to_owned(),
+                target_ref: "target".to_owned(),
+                generation: "generation".to_owned(),
+                provider: "provider".to_owned(),
+            }),
+            ..Config::default()
+        };
+        let mut state = SessionState { first_connect: true, first_run: true, managed: true };
+        let runtime = SessionRuntime::new();
+        let cancellation = CancellationToken::new();
+        let result = relay_session(
+            &mut config,
+            Path::new("/tmp/cmux-relay-invalid-managed-hello-test.json"),
+            &mut state,
+            &runtime,
+            &cancellation,
+        )
+        .await;
+
+        assert!(result.is_err(), "invalid trust must reject the connection");
+        assert_eq!(config.token, original_token);
+        assert!(!config.enrollment_claimed);
+        assert_eq!(config.trust.as_deref(), Some("supervised"));
+        assert_eq!(config.owner_user_id.as_deref(), Some("original-owner"));
+        cancellation.cancel();
+        let _ = server.await;
+    }
+}
+
 #[cfg(all(test, unix))]
 mod tunnel_authority_tests {
     use super::{SessionRuntime, TunnelAuth, reconcile_tunnel_authority};

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -48,7 +48,7 @@ use base64::engine::general_purpose::STANDARD as BASE64;
 use serde_json::{Value, json};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::{mpsc, watch, Semaphore};
+use tokio::sync::{Semaphore, mpsc, watch};
 use tokio_util::sync::CancellationToken;
 
 use crate::pty::{

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -39,8 +39,8 @@
 //! never run this listener: it starts from the managed branch only.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::RwLock;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
 
 use base64::Engine as _;

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -52,8 +52,8 @@ use tokio::sync::{Semaphore, mpsc, watch};
 use tokio_util::sync::CancellationToken;
 
 use crate::pty::{
-    FrameContext, PTY_PROTOCOL_VERSION, PtyManager, TransportKind, random_hex, session_name_ok,
-    surface_ref_ok,
+    FrameContext, OpenCancellation, PTY_PROTOCOL_VERSION, PtyManager, TransportKind, random_hex,
+    session_name_ok, surface_ref_ok,
 };
 
 /// Loopback port the gateway's spliced streams dial. The chatmux Worker
@@ -336,10 +336,11 @@ struct Connection {
     open_sent: AtomicBool,
     /// The manager answered pty_opened (clears the open deadline).
     opened_seen: AtomicBool,
-    /// Cancels an in-flight open on timeout, disconnect, or protocol error.
-    /// This token is created before the open task is spawned, so a task that
-    /// has not been polled cannot recreate a transport after its owner ends.
-    open_cancellation: CancellationToken,
+    /// Cancels and identifies an in-flight open on timeout, disconnect, or
+    /// protocol error. The capability is created before the open task is
+    /// spawned, so a task that has not been polled cannot recreate a
+    /// transport after its owner ends or collide with a reused pty id.
+    open_cancellation: OpenCancellation,
     finished: AtomicBool,
     done: CancellationToken,
 }
@@ -605,10 +606,11 @@ async fn handle_client_frame(connection: &Arc<Connection>, frame: TunnelFrame) {
             // Keep the manager future owned after the protocol deadline. A
             // direct timeout would drop `handle_frame` while its blocking PTY
             // spawn could still be running, leaving a late child with no
-            // owner. The detached task retains the opening reservation; the
-            // connection token also fences a task that has not reached the
-            // reservation yet. Cleanup marks any installed reservation
-            // cancelled, and `Opened` kills a handle that arrives late.
+            // owner. The detached task retains the opening reservation; its
+            // capability fences a task that has not reached the reservation
+            // yet and names this exact attempt if the pty id is reused.
+            // Cleanup marks any installed reservation cancelled, and `Opened`
+            // kills a handle that arrives late.
             let open_cancellation = connection.open_cancellation.clone();
             let mut open_task = tokio::spawn({
                 let manager = Arc::clone(&connection.manager);
@@ -633,8 +635,9 @@ async fn handle_client_frame(connection: &Arc<Connection>, frame: TunnelFrame) {
                     // manager task still owns its semaphore permit and any
                     // late PTY result, so it cannot install a resource for a
                     // connection that has already timed out.
-                    connection.open_cancellation.cancel();
-                    connection.manager.cancel_open(&connection.pty_id, &context);
+                    connection
+                        .manager
+                        .cancel_open(&connection.pty_id, &context, &connection.open_cancellation);
                     connection.protocol_error("failed");
                     // Dropping a JoinHandle detaches the task. The bounded
                     // open permit above prevents a permanently stalled
@@ -692,6 +695,10 @@ async fn serve_connection(
     };
     let auth_generation =
         auth_state.read().map(|authority| authority.generation).unwrap_or_default();
+    let Some(open_cancellation) = manager.new_open_cancellation() else {
+        let _ = write_half.shutdown().await;
+        return;
+    };
     let connection = Arc::new(Connection {
         pty_id,
         manager: Arc::clone(&manager),
@@ -705,7 +712,7 @@ async fn serve_connection(
         paused: AtomicBool::new(false),
         open_sent: AtomicBool::new(false),
         opened_seen: AtomicBool::new(false),
-        open_cancellation: CancellationToken::new(),
+        open_cancellation,
         finished: AtomicBool::new(false),
         done: CancellationToken::new(),
     });
@@ -1164,6 +1171,7 @@ mod tests {
         let (writer_tx, writer_rx) = mpsc::channel::<WriterMessage>(TUNNEL_WRITER_QUEUE_ITEMS);
         let end_permit = writer_tx.clone().reserve_owned().await.expect("reserve End slot");
         let (flow_tx, _) = watch::channel(false);
+        let open_cancellation = manager.new_open_cancellation().expect("open attempt token");
         (
             Connection {
                 pty_id: "queue-test".to_owned(),
@@ -1178,7 +1186,7 @@ mod tests {
                 paused: AtomicBool::new(false),
                 open_sent: AtomicBool::new(false),
                 opened_seen: AtomicBool::new(false),
-                open_cancellation: CancellationToken::new(),
+                open_cancellation,
                 finished: AtomicBool::new(false),
                 done: CancellationToken::new(),
             },

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -350,11 +350,7 @@ impl Connection {
         let mut current = self.pending_out.load(Ordering::Acquire);
         loop {
             let Some(next) = current.checked_add(length) else { return false };
-            let limit = if control {
-                TUNNEL_QUEUE_BYTES
-            } else {
-                TUNNEL_QUEUE_BYTES.saturating_sub(TUNNEL_CONTROL_QUEUE_RESERVE_BYTES)
-            };
+            let limit = queue_limit(control);
             if next > limit {
                 return false;
             }
@@ -515,6 +511,10 @@ impl Connection {
             authority.generation == self.auth_generation && authority.auth.is_some()
         })
     }
+}
+
+fn queue_limit(control: bool) -> u64 {
+    if control { TUNNEL_QUEUE_BYTES } else { TUNNEL_QUEUE_BYTES - TUNNEL_CONTROL_QUEUE_RESERVE_BYTES }
 }
 
 async fn handle_client_frame(connection: &Arc<Connection>, frame: TunnelFrame) {
@@ -1026,6 +1026,20 @@ mod tests {
     fn control_json(frame: &TunnelFrame) -> Value {
         assert_eq!(frame.kind, FRAME_KIND_CONTROL);
         serde_json::from_slice(&frame.payload).expect("control json")
+    }
+
+    #[test]
+    fn data_reservation_leaves_control_bytes_available() {
+        assert_eq!(queue_limit(false), TUNNEL_QUEUE_BYTES - TUNNEL_CONTROL_QUEUE_RESERVE_BYTES);
+        assert!(queue_limit(false) < queue_limit(true));
+        assert!(queue_limit(false) + TUNNEL_CONTROL_QUEUE_RESERVE_BYTES <= TUNNEL_QUEUE_BYTES);
+    }
+
+    #[test]
+    fn control_reservation_accepts_reserved_tail() {
+        let data_limit = queue_limit(false);
+        assert!(data_limit + TUNNEL_CONTROL_QUEUE_RESERVE_BYTES <= queue_limit(true));
+        assert!(TUNNEL_CONTROL_QUEUE_RESERVE_BYTES > 0);
     }
 
     /// Wait until the fake spawn landed (open settles asynchronously).

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -664,11 +664,7 @@ async fn handle_client_frame(connection: &Arc<Connection>, frame: TunnelFrame) {
                 let cancellation = connection.open_cancellation.clone();
                 async move {
                     manager
-                        .handle_frame_with_open_cancellation(
-                            &open,
-                            &context,
-                            Some(cancellation),
-                        )
+                        .handle_frame_with_open_cancellation(&open, &context, Some(cancellation))
                         .await
                 }
             }));
@@ -1039,11 +1035,7 @@ mod tests {
 
     #[async_trait]
     impl PtyDeps for FakeDeps {
-        async fn spawn_pty(
-            &self,
-            _spec: SpawnSpec,
-            _cancellation: CancellationToken,
-        ) -> PtyHandle {
+        async fn spawn_pty(&self, _spec: SpawnSpec, _cancellation: CancellationToken) -> PtyHandle {
             let pty = FakePty { state: Arc::new(StdMutex::new(FakeState::default())) };
             self.spawned.lock().unwrap().push(pty.clone());
             PtyHandle {
@@ -1052,10 +1044,7 @@ mod tests {
                 banner: self.banner.clone(),
             }
         }
-        async fn resolve_cmux_tui(
-            &self,
-            _cancellation: CancellationToken,
-        ) -> Option<CmuxTui> {
+        async fn resolve_cmux_tui(&self, _cancellation: CancellationToken) -> Option<CmuxTui> {
             None
         }
         async fn ensure_daemon(

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -1035,7 +1035,12 @@ mod tests {
 
     #[async_trait]
     impl PtyDeps for FakeDeps {
-        async fn spawn_pty(&self, _spec: SpawnSpec, _cancellation: CancellationToken) -> PtyHandle {
+        async fn spawn_pty(
+            &self,
+            _spec: SpawnSpec,
+            _cancellation: CancellationToken,
+            _permit: crate::pty::OpenPermit,
+        ) -> PtyHandle {
             let pty = FakePty { state: Arc::new(StdMutex::new(FakeState::default())) };
             self.spawned.lock().unwrap().push(pty.clone());
             PtyHandle {
@@ -1271,7 +1276,7 @@ mod tests {
         while let Some(message) = writer_rx.recv().await {
             match message {
                 WriterMessage::Frame(frame)
-                    if frame.len() > 1 && frame[1] == FRAME_KIND_CONTROL =>
+                    if frame.len() > HEADER_BYTES && frame[4] == FRAME_KIND_CONTROL =>
                 {
                     let payload = &frame[5..];
                     let value: Value = serde_json::from_slice(payload).expect("error frame");

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -38,9 +38,12 @@
 //! already attach terminals through the cmux CLI. Paired human machines
 //! never run this listener: it starts from the managed branch only.
 
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::RwLock;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
+use std::task::{Context, Poll};
 use std::time::Duration;
 
 use base64::Engine as _;
@@ -345,6 +348,53 @@ struct Connection {
     done: CancellationToken,
 }
 
+/// Keep an in-flight open task owned by the connection. Dropping a Tokio
+/// `JoinHandle` detaches the task, which would let it retain the manager's
+/// open permit after the protocol deadline. Aborting and joining gives the
+/// cancellation token and resource guards a defined cleanup boundary.
+struct AbortOnDrop<T> {
+    handle: Option<tokio::task::JoinHandle<T>>,
+}
+
+impl<T> AbortOnDrop<T> {
+    fn new(handle: tokio::task::JoinHandle<T>) -> Self {
+        Self { handle: Some(handle) }
+    }
+
+    fn abort(&self) {
+        if let Some(handle) = &self.handle {
+            handle.abort();
+        }
+    }
+}
+
+impl<T> Unpin for AbortOnDrop<T> {}
+
+impl<T> Future for AbortOnDrop<T> {
+    type Output = Result<T, tokio::task::JoinError>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let result = {
+            let handle = self.handle.as_mut().expect("open task polled after completion");
+            Pin::new(handle).poll(cx)
+        };
+        if let Poll::Ready(result) = result {
+            self.handle = None;
+            Poll::Ready(result)
+        } else {
+            result
+        }
+    }
+}
+
+impl<T> Drop for AbortOnDrop<T> {
+    fn drop(&mut self) {
+        if let Some(handle) = &self.handle {
+            handle.abort();
+        }
+    }
+}
+
 impl Connection {
     fn send_control(&self, frame: &Value) {
         let Some(encoded) = encode_control_frame(frame) else {
@@ -603,48 +653,41 @@ async fn handle_client_frame(connection: &Arc<Connection>, frame: TunnelFrame) {
             if let Some(surface) = surface {
                 open["surface"] = Value::from(surface);
             }
-            // Keep the manager future owned after the protocol deadline. A
-            // direct timeout would drop `handle_frame` while its blocking PTY
-            // spawn could still be running, leaving a late child with no
-            // owner. The detached task retains the opening reservation; its
-            // capability fences a task that has not reached the reservation
-            // yet and names this exact attempt if the pty id is reused.
-            // Cleanup marks any installed reservation cancelled, and `Opened`
-            // kills a handle that arrives late.
-            let open_cancellation = connection.open_cancellation.clone();
-            let mut open_task = tokio::spawn({
+            // Keep the manager future owned through the protocol deadline.
+            // The cancellation capability fences a task that has not reached
+            // the reservation yet and names this exact attempt if the pty id
+            // is reused. Provider guards reclaim resources when it is aborted.
+            let mut open_task = AbortOnDrop::new(tokio::spawn({
                 let manager = Arc::clone(&connection.manager);
                 let open = open.clone();
                 let context = context.clone();
+                let cancellation = connection.open_cancellation.clone();
                 async move {
                     manager
                         .handle_frame_with_open_cancellation(
                             &open,
                             &context,
-                            Some(open_cancellation),
+                            Some(cancellation),
                         )
                         .await
                 }
-            });
+            }));
             match tokio::time::timeout(OPEN_TIMEOUT, &mut open_task).await {
                 Ok(Ok(())) => {}
                 Ok(Err(_)) => connection.protocol_error("failed"),
                 Err(_) => {
-                    // Remove the reservation at the protocol deadline while
-                    // keeping an owner-specific tombstone. The supervised
-                    // manager task still owns its semaphore permit and any
-                    // late PTY result, so it cannot install a resource for a
-                    // connection that has already timed out.
+                    // Fence the exact attempt, then abort and join the task.
+                    // Provider implementations receive the same token and
+                    // own guards for any child, control socket, or PTY they
+                    // create, so no permit or process survives the deadline.
                     connection.manager.cancel_open(
                         &connection.pty_id,
                         &context,
                         &connection.open_cancellation,
                     );
+                    open_task.abort();
+                    let _ = (&mut open_task).await;
                     connection.protocol_error("failed");
-                    // Dropping a JoinHandle detaches the task. The bounded
-                    // open permit above prevents a permanently stalled
-                    // provider from creating unbounded tasks or reservations.
-                    drop(open_task);
                 }
             }
         }
@@ -996,7 +1039,11 @@ mod tests {
 
     #[async_trait]
     impl PtyDeps for FakeDeps {
-        async fn spawn_pty(&self, _spec: SpawnSpec) -> PtyHandle {
+        async fn spawn_pty(
+            &self,
+            _spec: SpawnSpec,
+            _cancellation: CancellationToken,
+        ) -> PtyHandle {
             let pty = FakePty { state: Arc::new(StdMutex::new(FakeState::default())) };
             self.spawned.lock().unwrap().push(pty.clone());
             PtyHandle {
@@ -1005,7 +1052,10 @@ mod tests {
                 banner: self.banner.clone(),
             }
         }
-        async fn resolve_cmux_tui(&self) -> Option<CmuxTui> {
+        async fn resolve_cmux_tui(
+            &self,
+            _cancellation: CancellationToken,
+        ) -> Option<CmuxTui> {
             None
         }
         async fn ensure_daemon(
@@ -1015,12 +1065,14 @@ mod tests {
             _socket_dir: &Path,
             _cwd: &Path,
             _env: &HashMap<String, String>,
+            _cancellation: CancellationToken,
         ) -> Result<EnsureDaemon, String> {
             Err("no daemon in tunnel tests".to_owned())
         }
         async fn connect_control(
             &self,
             _socket_path: &Path,
+            _cancellation: CancellationToken,
         ) -> Result<Arc<dyn crate::control::ControlHandle>, String> {
             Err("no control in tunnel tests".to_owned())
         }

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -308,7 +308,10 @@ pub fn generate_session_name() -> Result<String, getrandom::Error> {
 // ---------------------------------------------------------------------------
 
 enum WriterMessage {
-    Frame(Vec<u8>),
+    Frame {
+        bytes: Vec<u8>,
+        live: Option<Arc<AtomicBool>>,
+    },
     /// Flush what is queued, then close the write half. The slot for this
     /// message is reserved when the connection starts.
     End,
@@ -403,7 +406,7 @@ impl Connection {
             self.finish();
             return;
         };
-        let _ = self.enqueue_frame(encoded, true);
+        let _ = self.enqueue_frame(encoded, true, None);
     }
 
     fn reserve_bytes(&self, length: usize, control: bool) -> bool {
@@ -430,7 +433,7 @@ impl Connection {
         }
     }
 
-    fn enqueue_frame(&self, frame: Vec<u8>, control: bool) -> bool {
+    fn enqueue_frame(&self, frame: Vec<u8>, control: bool, live: Option<Arc<AtomicBool>>) -> bool {
         let mut accepted = false;
         let mut reserved = 0_u64;
         {
@@ -442,7 +445,7 @@ impl Connection {
                 && self.reserve_bytes(frame.len(), control)
             {
                 reserved = frame.len() as u64;
-                if self.writer_tx.try_send(WriterMessage::Frame(frame)).is_ok() {
+                if self.writer_tx.try_send(WriterMessage::Frame { bytes: frame, live }).is_ok() {
                     accepted = true;
                 }
             }
@@ -472,7 +475,7 @@ impl Connection {
         if self.reserve_bytes(overflow.len(), true) {
             if let Some(permit) = self.overflow_permit.lock().expect("overflow permit lock").take()
             {
-                permit.send(WriterMessage::Frame(overflow));
+                permit.send(WriterMessage::Frame { bytes: overflow, live: None });
             } else {
                 self.pending_out.fetch_sub(overflow_bytes, Ordering::AcqRel);
             }
@@ -516,6 +519,10 @@ impl Connection {
     /// The manager's reply sink (FrameContext::send). Synchronous: enqueue
     /// only, never block.
     fn on_manager_frame(&self, frame: &Value) {
+        self.on_manager_frame_with_liveness(frame, None);
+    }
+
+    fn on_manager_frame_with_liveness(&self, frame: &Value, live: Option<Arc<AtomicBool>>) {
         if self.finished.load(Ordering::SeqCst) {
             return;
         }
@@ -550,7 +557,7 @@ impl Connection {
                     self.protocol_error("overflow");
                     return;
                 };
-                if !self.enqueue_frame(encoded, false) {
+                if !self.enqueue_frame(encoded, false, live) {
                     return;
                 }
                 // Socket-side congestion: pause the source through the
@@ -584,6 +591,7 @@ impl Connection {
 
     fn frame_context(self: &Arc<Self>) -> FrameContext {
         let sink = Arc::clone(self);
+        let live_sink = Arc::clone(self);
         let probe = Arc::clone(self);
         let authority = self.auth_state.read().ok().map(|state| state.clone()).unwrap_or_default();
         let auth = if authority.generation == self.auth_generation {
@@ -593,6 +601,9 @@ impl Connection {
         };
         FrameContext {
             send: Arc::new(move |frame: Value| sink.on_manager_frame(&frame)),
+            send_live: Arc::new(move |frame: Value, live: Arc<AtomicBool>| {
+                live_sink.on_manager_frame_with_liveness(&frame, Some(live));
+            }),
             buffered_amount: Arc::new(move || probe.pending_out.load(Ordering::SeqCst)),
             trust: auth.trust,
             local_roots: auth.local_roots,
@@ -809,7 +820,18 @@ async fn serve_connection(
         tokio::spawn(async move {
             while let Some(message) = writer_rx.recv().await {
                 match message {
-                    WriterMessage::Frame(frame) => {
+                    WriterMessage::Frame { bytes: frame, live } => {
+                        if live.as_ref().is_some_and(|live| !live.load(Ordering::Acquire)) {
+                            let length = frame.len() as u64;
+                            let previous =
+                                connection.pending_out.fetch_sub(length, Ordering::SeqCst);
+                            if previous.saturating_sub(length) < FLOW_RESUME_BYTES
+                                && connection.paused.swap(false, Ordering::SeqCst)
+                            {
+                                let _ = connection.flow_tx.send(false);
+                            }
+                            continue;
+                        }
                         let written = write_half.write_all(&frame).await;
                         // Every dequeued frame added exactly its length at
                         // enqueue, so this never underflows.
@@ -1306,10 +1328,10 @@ mod tests {
         let rig = rig().await;
         let (connection, mut writer_rx) = queue_connection(Arc::clone(&rig.manager)).await;
         let frame = encode_pty_frame(&vec![b'x'; MAX_TUNNEL_FRAME_BYTES]).expect("valid frame");
-        assert!(connection.enqueue_frame(frame, false));
+        assert!(connection.enqueue_frame(frame, false, None));
         connection.finish();
         drop(connection);
-        assert!(matches!(writer_rx.recv().await, Some(WriterMessage::Frame(_))));
+        assert!(matches!(writer_rx.recv().await, Some(WriterMessage::Frame { .. })));
         assert!(matches!(writer_rx.recv().await, Some(WriterMessage::End)));
         rig.cancel.cancel();
     }
@@ -1326,7 +1348,7 @@ mod tests {
             - RESERVED_WRITER_QUEUE_ITEMS
             - TUNNEL_CONTROL_QUEUE_RESERVE_ITEMS;
         for _ in 0..accepted_data {
-            assert!(connection.enqueue_frame(vec![b'x'], false));
+            assert!(connection.enqueue_frame(vec![b'x'], false, None));
         }
         connection.send_control(&json!({ "t": "error", "code": "failed" }));
         connection.finish();
@@ -1336,7 +1358,7 @@ mod tests {
         let mut saw_end = false;
         while let Some(message) = writer_rx.recv().await {
             match message {
-                WriterMessage::Frame(frame)
+                WriterMessage::Frame { bytes: frame, .. }
                     if frame.len() > HEADER_BYTES && frame[4] == FRAME_KIND_CONTROL =>
                 {
                     let payload = &frame[5..];
@@ -1347,7 +1369,7 @@ mod tests {
                     saw_end = true;
                     break;
                 }
-                WriterMessage::Frame(_) => {}
+                WriterMessage::Frame { .. } => {}
             }
         }
         assert!(saw_error, "control error must survive data saturation");
@@ -1363,16 +1385,16 @@ mod tests {
             - RESERVED_WRITER_QUEUE_ITEMS
             - TUNNEL_CONTROL_QUEUE_RESERVE_ITEMS;
         for _ in 0..accepted_data {
-            assert!(connection.enqueue_frame(vec![b'x'], false));
+            assert!(connection.enqueue_frame(vec![b'x'], false, None));
         }
-        assert!(!connection.enqueue_frame(vec![b'x'], false));
+        assert!(!connection.enqueue_frame(vec![b'x'], false, None));
         drop(connection);
 
         let mut saw_overflow = false;
         let mut saw_end = false;
         while let Some(message) = writer_rx.recv().await {
             match message {
-                WriterMessage::Frame(frame)
+                WriterMessage::Frame { bytes: frame, .. }
                     if frame.len() > HEADER_BYTES && frame[4] == FRAME_KIND_CONTROL =>
                 {
                     let payload = &frame[5..];
@@ -1383,7 +1405,7 @@ mod tests {
                     saw_end = true;
                     break;
                 }
-                WriterMessage::Frame(_) => {}
+                WriterMessage::Frame { .. } => {}
             }
         }
         assert!(saw_overflow, "overflow error must survive data saturation");

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -402,11 +402,15 @@ impl<T> Drop for AbortOnDrop<T> {
 
 impl Connection {
     fn send_control(&self, frame: &Value) {
+        self.send_control_with_live(frame, None);
+    }
+
+    fn send_control_with_live(&self, frame: &Value, live: Option<Arc<AtomicBool>>) {
         let Some(encoded) = encode_control_frame(frame) else {
             self.finish();
             return;
         };
-        let _ = self.enqueue_frame(encoded, true, None);
+        let _ = self.enqueue_frame(encoded, true, live);
     }
 
     fn reserve_bytes(&self, length: usize, control: bool) -> bool {
@@ -542,7 +546,7 @@ impl Connection {
                 if let Some(surface) = frame.get("surface").and_then(Value::as_str) {
                     opened["surface"] = Value::from(surface);
                 }
-                self.send_control(&opened);
+                self.send_control_with_live(&opened, live);
             }
             Some("pty_output") => {
                 let Some(bytes) = frame
@@ -571,13 +575,13 @@ impl Connection {
             }
             Some("pty_exit") => {
                 let code = frame.get("code").and_then(Value::as_i64).unwrap_or(0);
-                self.send_control(&json!({ "t": "exit", "code": code }));
+                self.send_control_with_live(&json!({ "t": "exit", "code": code }), live);
                 self.finish();
             }
             Some("pty_error") => {
                 let code =
                     wire_error_code(frame.get("code").and_then(Value::as_str).unwrap_or("failed"));
-                self.send_control(&json!({ "t": "error", "code": code }));
+                self.send_control_with_live(&json!({ "t": "error", "code": code }), live);
                 // Non-fatal errors (an oversized input frame) keep the
                 // attachment; a refused open or a dropped attachment ends
                 // the connection.

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -52,7 +52,8 @@ use tokio::sync::{Semaphore, mpsc, watch};
 use tokio_util::sync::CancellationToken;
 
 use crate::pty::{
-    FrameContext, PTY_PROTOCOL_VERSION, PtyManager, random_hex, session_name_ok, surface_ref_ok,
+    FrameContext, PTY_PROTOCOL_VERSION, PtyManager, TransportKind, random_hex, session_name_ok,
+    surface_ref_ok,
 };
 
 /// Loopback port the gateway's spliced streams dial. The chatmux Worker
@@ -512,6 +513,8 @@ impl Connection {
             owner_user_id: auth.owner_user_id,
             transport_id: Some(self.pty_id.clone()),
             cancellation: self.done.clone(),
+            transport_kind: TransportKind::Tunnel,
+            auth_generation: Some(self.auth_generation),
         }
     }
 
@@ -619,6 +622,7 @@ async fn serve_connection(
     manager: Arc<PtyManager>,
     parent: CancellationToken,
     auth_state: TunnelAuthState,
+    mut authority_changes: watch::Receiver<u64>,
     _connection_permit: tokio::sync::OwnedSemaphorePermit,
 ) {
     let _ = stream.set_nodelay(true);
@@ -727,6 +731,19 @@ async fn serve_connection(
                 break;
             }
             _ = connection.done.cancelled() => break,
+            changed = authority_changes.changed() => {
+                match changed {
+                    Ok(()) if *authority_changes.borrow_and_update() != connection.auth_generation => {
+                        connection.protocol_error("trust_revoked");
+                        break;
+                    }
+                    Ok(()) => {}
+                    Err(_) => {
+                        connection.finish();
+                        break;
+                    }
+                }
+            }
             _ = &mut open_deadline, if !connection.opened_seen.load(Ordering::SeqCst) => {
                 connection.protocol_error("bad_request");
                 break;
@@ -775,7 +792,7 @@ async fn serve_connection(
     // Remove the per-transport authority even when the open was refused or
     // the peer disconnected before an attachment existed. Otherwise a busy
     // local tunnel endpoint could accumulate stale snapshots indefinitely.
-    manager.detach_transport(&connection.pty_id);
+    manager.detach_transport_kind(&connection.pty_id, TransportKind::Tunnel);
     // A peer that stopped reading can wedge the final flush forever; the
     // attachment is already released above, so cap the flush and reap.
     if tokio::time::timeout(Duration::from_secs(30), &mut writer).await.is_err() {
@@ -793,6 +810,7 @@ pub async fn start_tunnel_terminal_listener(
     host: &str,
     port: u16,
     auth_state: TunnelAuthState,
+    authority_changes: watch::Receiver<u64>,
 ) -> std::io::Result<u16> {
     // The gateway's capability check ends at this process. Binding any
     // address other than the fixed IPv4 loopback would turn a local-only
@@ -802,7 +820,7 @@ pub async fn start_tunnel_terminal_listener(
     if host != TUNNEL_TERMINAL_HOST {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
-            "tunnel terminal listener must bind 127.0.0.1",
+            "tunnel terminal listener is unavailable",
         ));
     }
     let listener = TcpListener::bind((host, port)).await?;
@@ -832,6 +850,7 @@ pub async fn start_tunnel_terminal_listener(
                         manager,
                         child,
                         Arc::clone(&auth_state),
+                        authority_changes.clone(),
                         permit,
                     ));
                 }
@@ -962,6 +981,7 @@ mod tests {
         spawned: Arc<StdMutex<Vec<FakePty>>>,
         port: u16,
         cancel: CancellationToken,
+        generation: watch::Sender<u64>,
     }
 
     async fn rig_with_limits(max_ptys: usize) -> Rig {
@@ -988,16 +1008,18 @@ mod tests {
                 owner_user_id: None,
             }),
         }));
+        let (generation, generation_rx) = watch::channel(0_u64);
         let port = start_tunnel_terminal_listener(
             Arc::clone(&manager),
             cancel.clone(),
             TUNNEL_TERMINAL_HOST,
             0,
             auth_state,
+            generation_rx,
         )
         .await
         .expect("bind test listener");
-        Rig { manager, spawned, port, cancel }
+        Rig { manager, spawned, port, cancel, generation }
     }
 
     async fn rig() -> Rig {
@@ -1045,6 +1067,13 @@ mod tests {
         let data_limit = queue_limit(false);
         assert!(data_limit + TUNNEL_CONTROL_QUEUE_RESERVE_BYTES <= queue_limit(true));
         assert!(TUNNEL_CONTROL_QUEUE_RESERVE_BYTES > 0);
+    }
+
+    #[test]
+    fn maximum_valid_data_frame_fits_the_reserved_budget() {
+        let encoded = encode_pty_frame(&vec![0_u8; MAX_TUNNEL_FRAME_BYTES]).expect("max frame");
+        assert_eq!(encoded.len(), MAX_TUNNEL_FRAME_BYTES + HEADER_BYTES);
+        assert!(encoded.len() as u64 <= queue_limit(false));
     }
 
     /// Wait until the fake spawn landed (open settles asynchronously).
@@ -1355,6 +1384,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn authority_revocation_closes_a_quiet_open_attachment() {
+        let rig = rig().await;
+        let stream = connect(&rig).await;
+        let (mut read, mut write) = stream.into_split();
+        write
+            .write_all(
+                &encode_control_frame(&json!({ "t": "open", "cols": 80, "rows": 24 })).unwrap(),
+            )
+            .await
+            .unwrap();
+        let mut decoder = TunnelFrameDecoder::new(MAX_TUNNEL_FRAME_BYTES);
+        let mut queue = Vec::new();
+        let opened = control_json(&next_frame(&mut read, &mut decoder, &mut queue).await);
+        assert_eq!(opened["t"], "opened");
+        assert_eq!(rig.manager.attachment_count(), 1);
+
+        // The session publishes the new floor before notifying sockets. A
+        // quiet connection must close without requiring another client frame.
+        rig.manager.set_tunnel_authority_generation(1);
+        rig.generation.send(1).unwrap();
+        read_eof(&mut read).await;
+        for _ in 0..100 {
+            if rig.manager.attachment_count() == 0 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert_eq!(rig.manager.attachment_count(), 0);
+        drop(write);
+        rig.cancel.cancel();
+    }
+
+    #[tokio::test]
     async fn duplicate_open_is_a_protocol_error() {
         let rig = rig().await;
         let stream = connect(&rig).await;
@@ -1455,6 +1517,7 @@ mod tests {
             "0.0.0.0",
             0,
             Arc::new(RwLock::new(TunnelAuthority::default())),
+            watch::channel(0_u64).1,
         )
         .await
         .expect_err("wildcard bind must be rejected");

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -78,6 +78,10 @@ const FLOW_RESUME_BYTES: u64 = 32_768;
 /// a queued output frame cannot prevent an exit or refusal from being sent,
 /// while still making the total writer memory bound explicit.
 const TUNNEL_QUEUE_BYTES: u64 = MAX_TUNNEL_FRAME_BYTES as u64 + 64 * 1024;
+/// Bytes held back for terminal control/error frames. Data frames cannot
+/// consume this budget, so a saturated output queue can still report failure
+/// or completion.
+const TUNNEL_CONTROL_QUEUE_RESERVE_BYTES: u64 = 64 * 1024;
 const TUNNEL_WRITER_QUEUE_ITEMS: usize = 256;
 /// Keep queue slots available for `opened`, `error`, and `exit` control
 /// frames. PTY output is rejected before it consumes the reserve.
@@ -301,8 +305,6 @@ pub fn generate_session_name() -> Result<String, getrandom::Error> {
 
 enum WriterMessage {
     Frame(Vec<u8>),
-    /// Flush what is queued, then close the write half.
-    End,
 }
 
 /// State shared between the reader task, the writer task, and the manager's
@@ -340,7 +342,7 @@ impl Connection {
         let _ = self.enqueue_frame(encoded, true);
     }
 
-    fn reserve_bytes(&self, length: usize) -> bool {
+    fn reserve_bytes(&self, length: usize, control: bool) -> bool {
         let length = length as u64;
         if length > TUNNEL_QUEUE_BYTES {
             return false;
@@ -348,7 +350,12 @@ impl Connection {
         let mut current = self.pending_out.load(Ordering::Acquire);
         loop {
             let Some(next) = current.checked_add(length) else { return false };
-            if next > TUNNEL_QUEUE_BYTES {
+            let limit = if control {
+                TUNNEL_QUEUE_BYTES
+            } else {
+                TUNNEL_QUEUE_BYTES.saturating_sub(TUNNEL_CONTROL_QUEUE_RESERVE_BYTES)
+            };
+            if next > limit {
                 return false;
             }
             match self.pending_out.compare_exchange_weak(
@@ -372,7 +379,7 @@ impl Connection {
                 control || self.writer_tx.capacity() > TUNNEL_CONTROL_QUEUE_RESERVE_ITEMS;
             if !self.finished.load(Ordering::SeqCst)
                 && queue_has_room
-                && self.reserve_bytes(frame.len())
+                && self.reserve_bytes(frame.len(), control)
             {
                 reserved = frame.len() as u64;
                 if self.writer_tx.try_send(WriterMessage::Frame(frame)).is_ok() {
@@ -400,7 +407,6 @@ impl Connection {
         if self.finished.swap(true, Ordering::SeqCst) {
             return;
         }
-        let _ = self.writer_tx.try_send(WriterMessage::End);
         self.done.cancel();
     }
 
@@ -635,7 +641,27 @@ async fn serve_connection(
     let mut writer = {
         let connection = Arc::clone(&connection);
         tokio::spawn(async move {
-            while let Some(message) = writer_rx.recv().await {
+            loop {
+                let message = tokio::select! {
+                    message = writer_rx.recv() => message,
+                    _ = connection.done.cancelled() => {
+                        // Cancellation is the reserved control path. Drain
+                        // already-accepted frames, then close without relying
+                        // on an additional bounded-channel End item.
+                        while let Ok(message) = writer_rx.try_recv() {
+                            match message {
+                                WriterMessage::Frame(frame) => {
+                                    let length = frame.len() as u64;
+                                    let written = write_half.write_all(&frame).await;
+                                    connection.pending_out.fetch_sub(length, Ordering::SeqCst);
+                                    if written.is_err() { break; }
+                                }
+                            }
+                        }
+                        break;
+                    }
+                };
+                let Some(message) = message else { break };
                 match message {
                     WriterMessage::Frame(frame) => {
                         let written = write_half.write_all(&frame).await;
@@ -653,7 +679,6 @@ async fn serve_connection(
                             let _ = connection.flow_tx.send(false);
                         }
                     }
-                    WriterMessage::End => break,
                 }
             }
             let _ = write_half.shutdown().await;

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -515,12 +515,9 @@ async fn handle_client_frame(connection: &Arc<Connection>, frame: TunnelFrame) {
                 open["surface"] = Value::from(surface);
             }
             let context = connection.frame_context();
-            if tokio::time::timeout(
-                OPEN_TIMEOUT,
-                connection.manager.handle_frame(&open, &context),
-            )
-            .await
-            .is_err()
+            if tokio::time::timeout(OPEN_TIMEOUT, connection.manager.handle_frame(&open, &context))
+                .await
+                .is_err()
             {
                 connection.protocol_error("failed");
             }
@@ -937,7 +934,8 @@ mod tests {
 
     #[test]
     fn codec_round_trips_frames_split_at_every_byte_boundary() {
-        let control = encode_control_frame(&json!({ "t": "open", "cols": 80, "rows": 24 })).unwrap();
+        let control =
+            encode_control_frame(&json!({ "t": "open", "cols": 80, "rows": 24 })).unwrap();
         let pty = encode_pty_frame(b"echo hi\r").unwrap();
         let stream = [control, pty].concat();
         let mut decoder = TunnelFrameDecoder::new(MAX_TUNNEL_FRAME_BYTES);
@@ -1034,7 +1032,9 @@ mod tests {
 
     #[test]
     fn tunnel_frame_encoding_rejects_oversized_and_unknown_frames_in_release() {
-        assert!(encode_tunnel_frame(FRAME_KIND_PTY, &vec![0_u8; MAX_TUNNEL_FRAME_BYTES + 1]).is_none());
+        assert!(
+            encode_tunnel_frame(FRAME_KIND_PTY, &vec![0_u8; MAX_TUNNEL_FRAME_BYTES + 1]).is_none()
+        );
         assert!(encode_tunnel_frame(7, b"x").is_none());
         assert!(encode_pty_frame(b"ok").is_some());
     }
@@ -1072,8 +1072,7 @@ mod tests {
         write.write_all(&encode_pty_frame(b"ls\r").unwrap()).await.unwrap();
         write
             .write_all(
-                &encode_control_frame(&json!({ "t": "resize", "cols": 132, "rows": 43 }))
-                    .unwrap(),
+                &encode_control_frame(&json!({ "t": "resize", "cols": 132, "rows": 43 })).unwrap(),
             )
             .await
             .unwrap();
@@ -1182,8 +1181,7 @@ mod tests {
         let (mut read, mut write) = stream.into_split();
         write
             .write_all(
-                &encode_control_frame(&json!({ "t": "open", "cols": 80, "rows": 24 }))
-                    .unwrap(),
+                &encode_control_frame(&json!({ "t": "open", "cols": 80, "rows": 24 })).unwrap(),
             )
             .await
             .unwrap();
@@ -1206,8 +1204,7 @@ mod tests {
         let (mut read, mut write) = stream.into_split();
         write
             .write_all(
-                &encode_control_frame(&json!({ "t": "open", "cols": 80, "rows": 24 }))
-                    .unwrap(),
+                &encode_control_frame(&json!({ "t": "open", "cols": 80, "rows": 24 })).unwrap(),
             )
             .await
             .unwrap();

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -48,7 +48,7 @@ use base64::engine::general_purpose::STANDARD as BASE64;
 use serde_json::{Value, json};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch, Semaphore};
 use tokio_util::sync::CancellationToken;
 
 use crate::pty::{
@@ -82,6 +82,10 @@ const TUNNEL_WRITER_QUEUE_ITEMS: usize = 256;
 /// Keep queue slots available for `opened`, `error`, and `exit` control
 /// frames. PTY output is rejected before it consumes the reserve.
 const TUNNEL_CONTROL_QUEUE_RESERVE_ITEMS: usize = 8;
+/// Bound pre-open sockets as well as live PTY attachments. A gateway retry
+/// storm must not allocate one reader, writer, and 64 KiB read buffer per
+/// unbounded connection.
+const TUNNEL_MAX_CONNECTIONS: usize = 64;
 
 /// Authority published by the authenticated relay session for local tunnel
 /// connections. `None` means the relay is disconnected or has not completed
@@ -108,10 +112,7 @@ impl TunnelAuthority {
     }
 
     pub fn published(previous_generation: u64, auth: TunnelAuth) -> Self {
-        Self {
-            generation: previous_generation.saturating_add(1),
-            auth: Some(auth),
-        }
+        Self { generation: previous_generation.saturating_add(1), auth: Some(auth) }
     }
 }
 
@@ -315,7 +316,7 @@ struct Connection {
     /// non-blocking channel operation.
     queue_gate: std::sync::Mutex<()>,
     /// pty_flow requests from the writer's water marks (true = pause).
-    flow_tx: mpsc::UnboundedSender<bool>,
+    flow_tx: watch::Sender<bool>,
     auth_state: TunnelAuthState,
     /// Authority generation captured when this socket was accepted.
     auth_generation: u64,
@@ -367,8 +368,8 @@ impl Connection {
         let mut reserved = 0_u64;
         {
             let _queue_gate = self.queue_gate.lock().expect("tunnel queue lock");
-            let queue_has_room = control
-                || self.writer_tx.capacity() > TUNNEL_CONTROL_QUEUE_RESERVE_ITEMS;
+            let queue_has_room =
+                control || self.writer_tx.capacity() > TUNNEL_CONTROL_QUEUE_RESERVE_ITEMS;
             if !self.finished.load(Ordering::SeqCst)
                 && queue_has_room
                 && self.reserve_bytes(frame.len())
@@ -504,12 +505,9 @@ impl Connection {
     }
 
     fn authority_current(&self) -> bool {
-        self.auth_state
-            .read()
-            .ok()
-            .is_some_and(|authority| {
-                authority.generation == self.auth_generation && authority.auth.is_some()
-            })
+        self.auth_state.read().ok().is_some_and(|authority| {
+            authority.generation == self.auth_generation && authority.auth.is_some()
+        })
     }
 }
 
@@ -602,11 +600,12 @@ async fn serve_connection(
     manager: Arc<PtyManager>,
     parent: CancellationToken,
     auth_state: TunnelAuthState,
+    _connection_permit: tokio::sync::OwnedSemaphorePermit,
 ) {
     let _ = stream.set_nodelay(true);
     let (mut read_half, mut write_half) = stream.into_split();
     let (writer_tx, mut writer_rx) = mpsc::channel::<WriterMessage>(TUNNEL_WRITER_QUEUE_ITEMS);
-    let (flow_tx, mut flow_rx) = mpsc::unbounded_channel::<bool>();
+    let (flow_tx, mut flow_rx) = watch::channel(false);
     let pty_id = match random_hex(8) {
         Ok(id) => format!("tunnel-{id}"),
         Err(_) => {
@@ -614,10 +613,8 @@ async fn serve_connection(
             return;
         }
     };
-    let auth_generation = auth_state
-        .read()
-        .map(|authority| authority.generation)
-        .unwrap_or_default();
+    let auth_generation =
+        auth_state.read().map(|authority| authority.generation).unwrap_or_default();
     let connection = Arc::new(Connection {
         pty_id,
         manager: Arc::clone(&manager),
@@ -668,7 +665,8 @@ async fn serve_connection(
     let flow = {
         let connection = Arc::clone(&connection);
         tokio::spawn(async move {
-            while let Some(pause) = flow_rx.recv().await {
+            while flow_rx.changed().await.is_ok() {
+                let pause = *flow_rx.borrow_and_update();
                 if connection.finished.load(Ordering::SeqCst) {
                     break;
                 }
@@ -768,6 +766,7 @@ pub async fn start_tunnel_terminal_listener(
 ) -> std::io::Result<u16> {
     let listener = TcpListener::bind((host, port)).await?;
     let bound = listener.local_addr()?.port();
+    let connection_slots = Arc::new(Semaphore::new(TUNNEL_MAX_CONNECTIONS));
     tokio::spawn(async move {
         loop {
             let accepted = tokio::select! {
@@ -777,9 +776,23 @@ pub async fn start_tunnel_terminal_listener(
             };
             match accepted {
                 Ok((stream, _)) => {
+                    let permit = match connection_slots.clone().try_acquire_owned() {
+                        Ok(permit) => permit,
+                        Err(_) => {
+                            let mut stream = stream;
+                            let _ = stream.shutdown().await;
+                            continue;
+                        }
+                    };
                     let manager = Arc::clone(&manager);
                     let child = cancellation.child_token();
-                    tokio::spawn(serve_connection(stream, manager, child, Arc::clone(&auth_state)));
+                    tokio::spawn(serve_connection(
+                        stream,
+                        manager,
+                        child,
+                        Arc::clone(&auth_state),
+                        permit,
+                    ));
                 }
                 Err(_) => {
                     // Transient accept errors (EMFILE and friends) must not

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -580,6 +580,7 @@ async fn handle_client_frame(connection: &Arc<Connection>, frame: TunnelFrame) {
                     }
                 },
             };
+            let context = connection.frame_context();
             let mut open = json!({
                 "version": PTY_PROTOCOL_VERSION,
                 "type": "pty_open",
@@ -588,15 +589,36 @@ async fn handle_client_frame(connection: &Arc<Connection>, frame: TunnelFrame) {
                 "cols": cols,
                 "rows": rows,
             });
+            // The manager's observe policy is owner-bound. Carry the actor
+            // from the locally reconciled authority, never from tunnel input.
+            if let Some(actor) = context.owner_user_id.clone() {
+                open["actorId"] = Value::from(actor);
+            }
             if let Some(surface) = surface {
                 open["surface"] = Value::from(surface);
             }
-            let context = connection.frame_context();
-            if tokio::time::timeout(OPEN_TIMEOUT, connection.manager.handle_frame(&open, &context))
-                .await
-                .is_err()
-            {
-                connection.protocol_error("failed");
+            // Keep the manager future owned after the protocol deadline. A
+            // direct timeout would drop `handle_frame` while its blocking PTY
+            // spawn could still be running, leaving a late child with no
+            // owner. The detached task retains the opening reservation; the
+            // connection cleanup marks that reservation cancelled, and
+            // `Opened` then kills any handle that arrives after the deadline.
+            let mut open_task = tokio::spawn({
+                let manager = Arc::clone(&connection.manager);
+                let open = open.clone();
+                let context = context.clone();
+                async move { manager.handle_frame(&open, &context).await }
+            });
+            match tokio::time::timeout(OPEN_TIMEOUT, &mut open_task).await {
+                Ok(Ok(())) => {}
+                Ok(Err(_)) => connection.protocol_error("failed"),
+                Err(_) => {
+                    connection.protocol_error("failed");
+                    // Dropping a JoinHandle detaches the task. It continues
+                    // to its ownership-aware cleanup path without blocking
+                    // this connection's reader or writer.
+                    drop(open_task);
+                }
             }
         }
         ClientFrame::Resize { cols, rows } => {

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -937,6 +937,7 @@ mod tests {
 
     struct FakeDeps {
         spawned: Arc<StdMutex<Vec<FakePty>>>,
+        banner: Option<Vec<u8>>,
     }
 
     #[async_trait]
@@ -944,7 +945,11 @@ mod tests {
         async fn spawn_pty(&self, _spec: SpawnSpec) -> PtyHandle {
             let pty = FakePty { state: Arc::new(StdMutex::new(FakeState::default())) };
             self.spawned.lock().unwrap().push(pty.clone());
-            PtyHandle { control: Arc::new(pty.clone()), output: Arc::new(pty), banner: None }
+            PtyHandle {
+                control: Arc::new(pty.clone()),
+                output: Arc::new(pty),
+                banner: self.banner.clone(),
+            }
         }
         async fn resolve_cmux_tui(&self) -> Option<CmuxTui> {
             None
@@ -984,9 +989,9 @@ mod tests {
         generation: watch::Sender<u64>,
     }
 
-    async fn rig_with_limits(max_ptys: usize) -> Rig {
+    async fn rig_with_limits_and_banner(max_ptys: usize, banner: Option<Vec<u8>>) -> Rig {
         let spawned = Arc::new(StdMutex::new(Vec::new()));
-        let deps = Arc::new(FakeDeps { spawned: Arc::clone(&spawned) });
+        let deps = Arc::new(FakeDeps { spawned: Arc::clone(&spawned), banner });
         let env = HashMap::from([
             ("SHELL".to_owned(), "/bin/fakesh".to_owned()),
             ("HOME".to_owned(), std::env::temp_dir().to_string_lossy().into_owned()),
@@ -1020,6 +1025,14 @@ mod tests {
         .await
         .expect("bind test listener");
         Rig { manager, spawned, port, cancel, generation }
+    }
+
+    async fn rig_with_limits(max_ptys: usize) -> Rig {
+        rig_with_limits_and_banner(max_ptys, None).await
+    }
+
+    async fn rig_with_start_banner(banner: &[u8]) -> Rig {
+        rig_with_limits_and_banner(8, Some(banner.to_vec())).await
     }
 
     async fn rig() -> Rig {
@@ -1365,6 +1378,41 @@ mod tests {
         let reopened = control_json(&next_frame(&mut read, &mut decoder, &mut queue).await);
         assert_eq!(reopened["t"], "opened");
         assert_eq!(reopened["created"], false);
+        rig.cancel.cancel();
+    }
+
+    #[tokio::test]
+    async fn tunnel_open_replays_start_output_without_deadlocking() {
+        let rig = rig_with_start_banner(b"startup").await;
+        let stream = connect(&rig).await;
+        let (mut read, mut write) = stream.into_split();
+        let mut decoder = TunnelFrameDecoder::new(MAX_TUNNEL_FRAME_BYTES);
+        let mut queue = Vec::new();
+        write
+            .write_all(
+                &encode_control_frame(&json!({ "t": "open", "cols": 80, "rows": 24 })).unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let opened = tokio::time::timeout(
+            Duration::from_secs(1),
+            next_frame(&mut read, &mut decoder, &mut queue),
+        )
+        .await
+        .expect("tunnel open must not deadlock while starting output");
+        assert_eq!(control_json(&opened)["t"], "opened");
+
+        let output = tokio::time::timeout(
+            Duration::from_secs(1),
+            next_frame(&mut read, &mut decoder, &mut queue),
+        )
+        .await
+        .expect("startup output must be delivered");
+        assert_eq!(output.kind, FRAME_KIND_PTY);
+        assert_eq!(output.payload, b"startup");
+
+        drop(write);
         rig.cancel.cancel();
     }
 

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -764,6 +764,17 @@ pub async fn start_tunnel_terminal_listener(
     port: u16,
     auth_state: TunnelAuthState,
 ) -> std::io::Result<u16> {
+    // The gateway's capability check ends at this process. Binding any
+    // address other than the fixed IPv4 loopback would turn a local-only
+    // listener into an unauthenticated network terminal service. Keep the
+    // host argument for the test and call-site contract, but fail closed if a
+    // future caller passes a configurable or wildcard address.
+    if host != TUNNEL_TERMINAL_HOST {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "tunnel terminal listener must bind 127.0.0.1",
+        ));
+    }
     let listener = TcpListener::bind((host, port)).await?;
     let bound = listener.local_addr()?.port();
     let connection_slots = Arc::new(Semaphore::new(TUNNEL_MAX_CONNECTIONS));
@@ -1301,5 +1312,29 @@ mod tests {
         assert_eq!(error["code"], "session_limit");
         read_eof(&mut read).await;
         rig.cancel.cancel();
+    }
+
+    #[tokio::test]
+    async fn listener_rejects_non_loopback_bind_addresses() {
+        let spawned = Arc::new(StdMutex::new(Vec::new()));
+        let deps = Arc::new(FakeDeps { spawned: Arc::clone(&spawned) });
+        let manager = Arc::new(PtyManager::with_limits(
+            deps,
+            std::env::temp_dir(),
+            HashMap::new(),
+            1,
+            32,
+            1_048_576,
+        ));
+        let error = start_tunnel_terminal_listener(
+            manager,
+            CancellationToken::new(),
+            "0.0.0.0",
+            0,
+            Arc::new(RwLock::new(TunnelAuthority::default())),
+        )
+        .await
+        .expect_err("wildcard bind must be rejected");
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
     }
 }

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -1305,6 +1305,40 @@ mod tests {
         rig.cancel.cancel();
     }
 
+    #[tokio::test]
+    async fn saturated_writer_queue_reports_overflow_before_end() {
+        let rig = rig().await;
+        let (connection, mut writer_rx) = queue_connection(Arc::clone(&rig.manager)).await;
+        let accepted_data = TUNNEL_WRITER_QUEUE_ITEMS - TUNNEL_CONTROL_QUEUE_RESERVE_ITEMS - 1;
+        for _ in 0..accepted_data {
+            assert!(connection.enqueue_frame(vec![b'x'], false));
+        }
+        assert!(!connection.enqueue_frame(vec![b'x'], false));
+        drop(connection);
+
+        let mut saw_overflow = false;
+        let mut saw_end = false;
+        while let Some(message) = writer_rx.recv().await {
+            match message {
+                WriterMessage::Frame(frame)
+                    if frame.len() > HEADER_BYTES && frame[4] == FRAME_KIND_CONTROL =>
+                {
+                    let payload = &frame[5..];
+                    let value: Value = serde_json::from_slice(payload).expect("overflow frame");
+                    saw_overflow = value["t"] == "error" && value["code"] == "overflow";
+                }
+                WriterMessage::End => {
+                    saw_end = true;
+                    break;
+                }
+                WriterMessage::Frame(_) => {}
+            }
+        }
+        assert!(saw_overflow, "overflow error must survive data saturation");
+        assert!(saw_end, "reserved End item must be delivered");
+        rig.cancel.cancel();
+    }
+
     // -- pure codec/parse ---------------------------------------------------
 
     #[test]

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -613,10 +613,16 @@ async fn handle_client_frame(connection: &Arc<Connection>, frame: TunnelFrame) {
                 Ok(Ok(())) => {}
                 Ok(Err(_)) => connection.protocol_error("failed"),
                 Err(_) => {
+                    // Remove the reservation at the protocol deadline while
+                    // keeping an owner-specific tombstone. The supervised
+                    // manager task still owns its semaphore permit and any
+                    // late PTY result, so it cannot install a resource for a
+                    // connection that has already timed out.
+                    connection.manager.cancel_open(&connection.pty_id, &context);
                     connection.protocol_error("failed");
-                    // Dropping a JoinHandle detaches the task. It continues
-                    // to its ownership-aware cleanup path without blocking
-                    // this connection's reader or writer.
+                    // Dropping a JoinHandle detaches the task. The bounded
+                    // open permit above prevents a permanently stalled
+                    // provider from creating unbounded tasks or reservations.
                     drop(open_task);
                 }
             }

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -1381,7 +1381,7 @@ mod tests {
         rig.cancel.cancel();
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn tunnel_open_replays_start_output_without_deadlocking() {
         let rig = rig_with_start_banner(b"startup").await;
         let stream = connect(&rig).await;

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -40,6 +40,7 @@
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::RwLock;
 use std::time::Duration;
 
 use base64::Engine as _;
@@ -73,6 +74,23 @@ const OPEN_TIMEOUT: Duration = Duration::from_secs(10);
 /// manager's own 1 MiB output cap stays the hard boundary above this.
 const FLOW_PAUSE_BYTES: u64 = 262_144;
 const FLOW_RESUME_BYTES: u64 = 32_768;
+/// The manager's output cap is one MiB. Keep a small control-frame reserve so
+/// a queued output frame cannot prevent an exit or refusal from being sent,
+/// while still making the total writer memory bound explicit.
+const TUNNEL_QUEUE_BYTES: u64 = MAX_TUNNEL_FRAME_BYTES as u64 + 64 * 1024;
+const TUNNEL_WRITER_QUEUE_ITEMS: usize = 256;
+
+/// Authority published by the authenticated relay session for local tunnel
+/// connections. `None` means the relay is disconnected or has not completed
+/// hello negotiation, so tunnel opens fail closed.
+#[derive(Clone, Debug, Default)]
+pub struct TunnelAuth {
+    pub trust: String,
+    pub local_roots: Option<Vec<String>>,
+    pub owner_user_id: Option<String>,
+}
+
+pub type TunnelAuthState = Arc<RwLock<Option<TunnelAuth>>>;
 
 /// Relay pty_error codes -> browser wire codes. Mirrors the Worker's
 /// browserErrorCode map (apps/backend/src/terminal/relay-pty.ts). KEEP IN
@@ -101,20 +119,24 @@ pub struct TunnelFrame {
 }
 
 /// Encode one frame: u32be payload length, u8 kind, payload.
-pub fn encode_tunnel_frame(kind: u8, payload: &[u8]) -> Vec<u8> {
-    debug_assert!(payload.len() <= MAX_TUNNEL_FRAME_BYTES);
+pub fn encode_tunnel_frame(kind: u8, payload: &[u8]) -> Option<Vec<u8>> {
+    if payload.len() > MAX_TUNNEL_FRAME_BYTES
+        || !matches!(kind, FRAME_KIND_CONTROL | FRAME_KIND_PTY)
+    {
+        return None;
+    }
     let mut frame = Vec::with_capacity(HEADER_BYTES + payload.len());
-    frame.extend_from_slice(&u32::try_from(payload.len()).unwrap_or(0).to_be_bytes());
+    frame.extend_from_slice(&u32::try_from(payload.len()).ok()?.to_be_bytes());
     frame.push(kind);
     frame.extend_from_slice(payload);
-    frame
+    Some(frame)
 }
 
-pub fn encode_control_frame(frame: &Value) -> Vec<u8> {
+pub fn encode_control_frame(frame: &Value) -> Option<Vec<u8>> {
     encode_tunnel_frame(FRAME_KIND_CONTROL, frame.to_string().as_bytes())
 }
 
-pub fn encode_pty_frame(bytes: &[u8]) -> Vec<u8> {
+pub fn encode_pty_frame(bytes: &[u8]) -> Option<Vec<u8>> {
     encode_tunnel_frame(FRAME_KIND_PTY, bytes)
 }
 
@@ -123,6 +145,9 @@ pub fn encode_pty_frame(bytes: &[u8]) -> Vec<u8> {
 /// the caller must close the connection.
 pub struct TunnelFrameDecoder {
     buffer: Vec<u8>,
+    /// Bytes before this cursor have already been emitted. Keeping a cursor
+    /// avoids repeatedly shifting the whole buffer for a busy PTY stream.
+    cursor: usize,
     failed: bool,
     max_frame_bytes: usize,
 }
@@ -131,6 +156,7 @@ impl TunnelFrameDecoder {
     pub fn new(max_frame_bytes: usize) -> TunnelFrameDecoder {
         TunnelFrameDecoder {
             buffer: Vec::new(),
+            cursor: 0,
             failed: false,
             max_frame_bytes: max_frame_bytes.clamp(1, MAX_TUNNEL_FRAME_BYTES),
         }
@@ -142,14 +168,14 @@ impl TunnelFrameDecoder {
         }
         self.buffer.extend_from_slice(chunk);
         let mut frames = Vec::new();
-        while self.buffer.len() >= HEADER_BYTES {
+        while self.buffer.len().saturating_sub(self.cursor) >= HEADER_BYTES {
             let length = u32::from_be_bytes([
-                self.buffer[0],
-                self.buffer[1],
-                self.buffer[2],
-                self.buffer[3],
+                self.buffer[self.cursor],
+                self.buffer[self.cursor + 1],
+                self.buffer[self.cursor + 2],
+                self.buffer[self.cursor + 3],
             ]) as usize;
-            let kind = self.buffer[4];
+            let kind = self.buffer[self.cursor + 4];
             if length > self.max_frame_bytes {
                 self.failed = true;
                 return Err("frame_too_large");
@@ -158,12 +184,17 @@ impl TunnelFrameDecoder {
                 self.failed = true;
                 return Err("unknown_frame_kind");
             }
-            if self.buffer.len() < HEADER_BYTES + length {
+            if self.buffer.len().saturating_sub(self.cursor) < HEADER_BYTES + length {
                 break;
             }
-            let payload = self.buffer[HEADER_BYTES..HEADER_BYTES + length].to_vec();
-            self.buffer.drain(..HEADER_BYTES + length);
+            let start = self.cursor + HEADER_BYTES;
+            let payload = self.buffer[start..start + length].to_vec();
+            self.cursor = start + length;
             frames.push(TunnelFrame { kind, payload });
+        }
+        if self.cursor > 0 && (self.cursor >= 64 * 1024 || self.cursor * 2 >= self.buffer.len()) {
+            self.buffer.drain(..self.cursor);
+            self.cursor = 0;
         }
         Ok(frames)
     }
@@ -229,13 +260,13 @@ pub fn parse_tunnel_client_frame(payload: &[u8]) -> Option<ClientFrame> {
 
 /// Server-generated session names: same alphabet and prefix the Worker route
 /// uses, so pickers and process tables read consistently.
-pub fn generate_session_name() -> String {
+pub fn generate_session_name() -> Result<String, getrandom::Error> {
     const ALPHABET: &[u8] = b"abcdefghjkmnpqrstuvwxyz23456789";
     let mut bytes = [0_u8; 4];
-    let _ = getrandom::fill(&mut bytes);
+    getrandom::fill(&mut bytes)?;
     let suffix: String =
         bytes.iter().map(|byte| ALPHABET[*byte as usize % ALPHABET.len()] as char).collect();
-    format!("web-{suffix}")
+    Ok(format!("web-{suffix}"))
 }
 
 // ---------------------------------------------------------------------------
@@ -253,9 +284,10 @@ enum WriterMessage {
 struct Connection {
     pty_id: String,
     manager: Arc<PtyManager>,
-    writer_tx: mpsc::UnboundedSender<WriterMessage>,
+    writer_tx: mpsc::Sender<WriterMessage>,
     /// pty_flow requests from the writer's water marks (true = pause).
     flow_tx: mpsc::UnboundedSender<bool>,
+    auth_state: TunnelAuthState,
     /// Bytes queued toward the socket and not yet written.
     pending_out: AtomicU64,
     paused: AtomicBool,
@@ -269,17 +301,55 @@ struct Connection {
 
 impl Connection {
     fn send_control(&self, frame: &Value) {
-        self.enqueue(WriterMessage::Frame(encode_control_frame(frame)));
+        let Some(encoded) = encode_control_frame(frame) else {
+            self.finish();
+            return;
+        };
+        let _ = self.enqueue_frame(encoded);
     }
 
-    fn enqueue(&self, message: WriterMessage) {
+    fn reserve_bytes(&self, length: usize) -> bool {
+        let length = length as u64;
+        if length > TUNNEL_QUEUE_BYTES {
+            return false;
+        }
+        let mut current = self.pending_out.load(Ordering::Acquire);
+        loop {
+            let Some(next) = current.checked_add(length) else { return false };
+            if next > TUNNEL_QUEUE_BYTES {
+                return false;
+            }
+            match self.pending_out.compare_exchange_weak(
+                current,
+                next,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return true,
+                Err(observed) => current = observed,
+            }
+        }
+    }
+
+    fn enqueue_frame(&self, frame: Vec<u8>) -> bool {
         if self.finished.load(Ordering::SeqCst) {
-            return;
+            return false;
         }
-        if let WriterMessage::Frame(frame) = &message {
-            self.pending_out.fetch_add(frame.len() as u64, Ordering::SeqCst);
+        if !self.reserve_bytes(frame.len()) {
+            self.finish();
+            return false;
         }
-        let _ = self.writer_tx.send(message);
+        let length = frame.len() as u64;
+        match self.writer_tx.try_send(WriterMessage::Frame(frame)) {
+            Ok(()) => true,
+            Err(_) => {
+                // The frame was never handed to the writer, so release its
+                // reservation before closing the connection.
+                self.pending_out.fetch_sub(length, Ordering::AcqRel);
+                self.finish();
+                false
+            }
+        }
     }
 
     /// Idempotent shutdown: flush queued frames, close the socket, and let
@@ -290,15 +360,18 @@ impl Connection {
         if self.finished.swap(true, Ordering::SeqCst) {
             return;
         }
-        let _ = self.writer_tx.send(WriterMessage::End);
+        let _ = self.writer_tx.try_send(WriterMessage::End);
         self.done.cancel();
     }
 
-    fn protocol_error(&self, code: &str, message: &str) {
+    fn protocol_error(&self, code: &str) {
         if self.finished.load(Ordering::SeqCst) {
             return;
         }
-        self.send_control(&json!({ "t": "error", "code": code, "message": message }));
+        // Do not forward parser or filesystem details over the tunnel. The
+        // code is stable protocol data; clients can localize it without
+        // exposing paths, command lines, or internal error strings.
+        self.send_control(&json!({ "t": "error", "code": wire_error_code(code) }));
         self.finish();
     }
 
@@ -335,7 +408,13 @@ impl Connection {
                 else {
                     return;
                 };
-                self.enqueue(WriterMessage::Frame(encode_pty_frame(&bytes)));
+                let Some(encoded) = encode_pty_frame(&bytes) else {
+                    self.protocol_error("overflow");
+                    return;
+                };
+                if !self.enqueue_frame(encoded) {
+                    return;
+                }
                 // Socket-side congestion: pause the source through the
                 // manager's own flow verb; the writer resumes it below the
                 // low-water mark.
@@ -353,11 +432,7 @@ impl Connection {
             Some("pty_error") => {
                 let code =
                     wire_error_code(frame.get("code").and_then(Value::as_str).unwrap_or("failed"));
-                let mut error = json!({ "t": "error", "code": code });
-                if let Some(message) = frame.get("message").and_then(Value::as_str) {
-                    error["message"] = Value::from(message);
-                }
-                self.send_control(&error);
+                self.send_control(&json!({ "t": "error", "code": code }));
                 // Non-fatal errors (an oversized input frame) keep the
                 // attachment; a refused open or a dropped attachment ends
                 // the connection.
@@ -372,29 +447,26 @@ impl Connection {
     fn frame_context(self: &Arc<Self>) -> FrameContext {
         let sink = Arc::clone(self);
         let probe = Arc::clone(self);
+        let auth = self.auth_state.read().ok().and_then(|state| state.clone()).unwrap_or_default();
         FrameContext {
             send: Arc::new(move |frame: Value| sink.on_manager_frame(&frame)),
             buffered_amount: Arc::new(move || probe.pending_out.load(Ordering::SeqCst)),
-            trust: "supervised".to_owned(),
-            local_roots: None,
-            owner_user_id: None,
+            trust: auth.trust,
+            local_roots: auth.local_roots,
+            owner_user_id: auth.owner_user_id,
             transport_id: Some(self.pty_id.clone()),
             cancellation: self.done.clone(),
         }
     }
 }
 
-async fn handle_client_frame(
-    connection: &Arc<Connection>,
-    context: &FrameContext,
-    frame: TunnelFrame,
-) {
+async fn handle_client_frame(connection: &Arc<Connection>, frame: TunnelFrame) {
     if connection.finished.load(Ordering::SeqCst) {
         return;
     }
     if frame.kind == FRAME_KIND_PTY {
         if !connection.open_sent.load(Ordering::SeqCst) {
-            connection.protocol_error("bad_request", "bytes before open");
+            connection.protocol_error("bad_request");
             return;
         }
         let input = json!({
@@ -403,31 +475,55 @@ async fn handle_client_frame(
             "ptyId": connection.pty_id,
             "dataB64": BASE64.encode(&frame.payload),
         });
-        connection.manager.handle_frame(&input, context).await;
+        let context = connection.frame_context();
+        connection.manager.handle_frame(&input, &context).await;
         return;
     }
     let Some(parsed) = parse_tunnel_client_frame(&frame.payload) else {
-        connection.protocol_error("bad_request", "invalid terminal request");
+        connection.protocol_error("bad_request");
         return;
     };
     match parsed {
         ClientFrame::Open { session, surface, cols, rows } => {
-            if connection.open_sent.swap(true, Ordering::SeqCst) {
-                connection.protocol_error("bad_request", "duplicate open");
+            if connection
+                .open_sent
+                .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+                .is_err()
+            {
+                connection.protocol_error("bad_request");
                 return;
             }
+            let session = match session {
+                Some(session) => session,
+                None => match generate_session_name() {
+                    Ok(session) => session,
+                    Err(_) => {
+                        connection.protocol_error("failed");
+                        return;
+                    }
+                },
+            };
             let mut open = json!({
                 "version": PTY_PROTOCOL_VERSION,
                 "type": "pty_open",
                 "ptyId": connection.pty_id,
-                "session": session.unwrap_or_else(generate_session_name),
+                "session": session,
                 "cols": cols,
                 "rows": rows,
             });
             if let Some(surface) = surface {
                 open["surface"] = Value::from(surface);
             }
-            connection.manager.handle_frame(&open, context).await;
+            let context = connection.frame_context();
+            if tokio::time::timeout(
+                OPEN_TIMEOUT,
+                connection.manager.handle_frame(&open, &context),
+            )
+            .await
+            .is_err()
+            {
+                connection.protocol_error("failed");
+            }
         }
         ClientFrame::Resize { cols, rows } => {
             if !connection.open_sent.load(Ordering::SeqCst) {
@@ -440,22 +536,36 @@ async fn handle_client_frame(
                 "cols": cols,
                 "rows": rows,
             });
-            connection.manager.handle_frame(&resize, context).await;
+            let context = connection.frame_context();
+            connection.manager.handle_frame(&resize, &context).await;
         }
         ClientFrame::Detach => connection.finish(),
     }
 }
 
-async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: CancellationToken) {
+async fn serve_connection(
+    stream: TcpStream,
+    manager: Arc<PtyManager>,
+    parent: CancellationToken,
+    auth_state: TunnelAuthState,
+) {
     let _ = stream.set_nodelay(true);
     let (mut read_half, mut write_half) = stream.into_split();
-    let (writer_tx, mut writer_rx) = mpsc::unbounded_channel::<WriterMessage>();
+    let (writer_tx, mut writer_rx) = mpsc::channel::<WriterMessage>(TUNNEL_WRITER_QUEUE_ITEMS);
     let (flow_tx, mut flow_rx) = mpsc::unbounded_channel::<bool>();
+    let pty_id = match random_hex(8) {
+        Ok(id) => format!("tunnel-{id}"),
+        Err(_) => {
+            let _ = write_half.shutdown().await;
+            return;
+        }
+    };
     let connection = Arc::new(Connection {
-        pty_id: format!("tunnel-{}", random_hex(8)),
+        pty_id,
         manager: Arc::clone(&manager),
         writer_tx,
         flow_tx,
+        auth_state,
         pending_out: AtomicU64::new(0),
         paused: AtomicBool::new(false),
         open_sent: AtomicBool::new(false),
@@ -463,8 +573,6 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
         finished: AtomicBool::new(false),
         done: CancellationToken::new(),
     });
-    let context = connection.frame_context();
-
     // Writer: the only task that touches the write half. Applies the flow
     // water marks as the queue drains.
     let mut writer = {
@@ -499,7 +607,6 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
     // slow open never delays a pause.
     let flow = {
         let connection = Arc::clone(&connection);
-        let context = context.clone();
         tokio::spawn(async move {
             while let Some(pause) = flow_rx.recv().await {
                 if connection.finished.load(Ordering::SeqCst) {
@@ -511,6 +618,7 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
                     "ptyId": connection.pty_id,
                     "pause": pause,
                 });
+                let context = connection.frame_context();
                 connection.manager.handle_frame(&frame, &context).await;
             }
         })
@@ -532,7 +640,7 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
             }
             _ = connection.done.cancelled() => break,
             _ = &mut open_deadline, if !connection.opened_seen.load(Ordering::SeqCst) => {
-                connection.protocol_error("bad_request", "no open frame");
+                connection.protocol_error("bad_request");
                 break;
             }
             read = read_half.read(&mut buffer) => {
@@ -548,11 +656,11 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
                 match decoder.push(&buffer[..count]) {
                     Ok(frames) => {
                         for frame in frames {
-                            handle_client_frame(&connection, &context, frame).await;
+                            handle_client_frame(&connection, frame).await;
                         }
                     }
                     Err(_) => {
-                        connection.protocol_error("bad_request", "malformed frame");
+                        connection.protocol_error("bad_request");
                         break;
                     }
                 }
@@ -568,6 +676,7 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
             "type": "pty_close",
             "ptyId": connection.pty_id,
         });
+        let context = connection.frame_context();
         manager.handle_frame(&close, &context).await;
     }
     flow.abort();
@@ -588,6 +697,7 @@ pub async fn start_tunnel_terminal_listener(
     cancellation: CancellationToken,
     host: &str,
     port: u16,
+    auth_state: TunnelAuthState,
 ) -> std::io::Result<u16> {
     let listener = TcpListener::bind((host, port)).await?;
     let bound = listener.local_addr()?.port();
@@ -602,7 +712,7 @@ pub async fn start_tunnel_terminal_listener(
                 Ok((stream, _)) => {
                     let manager = Arc::clone(&manager);
                     let child = cancellation.child_token();
-                    tokio::spawn(serve_connection(stream, manager, child));
+                    tokio::spawn(serve_connection(stream, manager, child, Arc::clone(&auth_state)));
                 }
                 Err(_) => {
                     // Transient accept errors (EMFILE and friends) must not
@@ -749,11 +859,17 @@ mod tests {
             1_048_576,
         ));
         let cancel = CancellationToken::new();
+        let auth_state = Arc::new(RwLock::new(Some(TunnelAuth {
+            trust: "supervised".to_owned(),
+            local_roots: None,
+            owner_user_id: None,
+        })));
         let port = start_tunnel_terminal_listener(
             Arc::clone(&manager),
             cancel.clone(),
             TUNNEL_TERMINAL_HOST,
             0,
+            auth_state,
         )
         .await
         .expect("bind test listener");
@@ -821,8 +937,8 @@ mod tests {
 
     #[test]
     fn codec_round_trips_frames_split_at_every_byte_boundary() {
-        let control = encode_control_frame(&json!({ "t": "open", "cols": 80, "rows": 24 }));
-        let pty = encode_pty_frame(b"echo hi\r");
+        let control = encode_control_frame(&json!({ "t": "open", "cols": 80, "rows": 24 })).unwrap();
+        let pty = encode_pty_frame(b"echo hi\r").unwrap();
         let stream = [control, pty].concat();
         let mut decoder = TunnelFrameDecoder::new(MAX_TUNNEL_FRAME_BYTES);
         let mut frames = Vec::new();
@@ -909,11 +1025,18 @@ mod tests {
     #[test]
     fn generated_session_names_use_the_web_prefix_and_alphabet() {
         for _ in 0..32 {
-            let name = generate_session_name();
+            let name = generate_session_name().expect("OS entropy");
             let suffix = name.strip_prefix("web-").expect("web- prefix");
             assert_eq!(suffix.len(), 4);
             assert!(suffix.chars().all(|c| "abcdefghjkmnpqrstuvwxyz23456789".contains(c)));
         }
+    }
+
+    #[test]
+    fn tunnel_frame_encoding_rejects_oversized_and_unknown_frames_in_release() {
+        assert!(encode_tunnel_frame(FRAME_KIND_PTY, &vec![0_u8; MAX_TUNNEL_FRAME_BYTES + 1]).is_none());
+        assert!(encode_tunnel_frame(7, b"x").is_none());
+        assert!(encode_pty_frame(b"ok").is_some());
     }
 
     // -- live listener ------------------------------------------------------
@@ -927,7 +1050,9 @@ mod tests {
         let mut queue = Vec::new();
 
         write
-            .write_all(&encode_control_frame(&json!({ "t": "open", "cols": 80, "rows": 24 })))
+            .write_all(
+                &encode_control_frame(&json!({ "t": "open", "cols": 80, "rows": 24 })).unwrap(),
+            )
             .await
             .unwrap();
         let opened = control_json(&next_frame(&mut read, &mut decoder, &mut queue).await);
@@ -944,9 +1069,12 @@ mod tests {
         assert_eq!(output.kind, FRAME_KIND_PTY);
         assert_eq!(output.payload, b"hello from the shell");
 
-        write.write_all(&encode_pty_frame(b"ls\r")).await.unwrap();
+        write.write_all(&encode_pty_frame(b"ls\r").unwrap()).await.unwrap();
         write
-            .write_all(&encode_control_frame(&json!({ "t": "resize", "cols": 132, "rows": 43 })))
+            .write_all(
+                &encode_control_frame(&json!({ "t": "resize", "cols": 132, "rows": 43 }))
+                    .unwrap(),
+            )
             .await
             .unwrap();
         for _ in 0..100 {
@@ -978,9 +1106,12 @@ mod tests {
         let mut decoder = TunnelFrameDecoder::new(MAX_TUNNEL_FRAME_BYTES);
         let mut queue = Vec::new();
         write
-            .write_all(&encode_control_frame(
-                &json!({ "t": "open", "session": session, "cols": 80, "rows": 24 }),
-            ))
+            .write_all(
+                &encode_control_frame(
+                    &json!({ "t": "open", "session": session, "cols": 80, "rows": 24 }),
+                )
+                .unwrap(),
+            )
             .await
             .unwrap();
         let reopened = control_json(&next_frame(&mut read, &mut decoder, &mut queue).await);
@@ -994,7 +1125,7 @@ mod tests {
         let rig = rig().await;
         let stream = connect(&rig).await;
         let (mut read, mut write) = stream.into_split();
-        write.write_all(&encode_pty_frame(b"sneaky")).await.unwrap();
+        write.write_all(&encode_pty_frame(b"sneaky").unwrap()).await.unwrap();
         let mut decoder = TunnelFrameDecoder::new(MAX_TUNNEL_FRAME_BYTES);
         let mut queue = Vec::new();
         let error = control_json(&next_frame(&mut read, &mut decoder, &mut queue).await);
@@ -1009,7 +1140,7 @@ mod tests {
         let rig = rig().await;
         let stream = connect(&rig).await;
         let (mut read, mut write) = stream.into_split();
-        let open = encode_control_frame(&json!({ "t": "open", "cols": 80, "rows": 24 }));
+        let open = encode_control_frame(&json!({ "t": "open", "cols": 80, "rows": 24 })).unwrap();
         write.write_all(&open).await.unwrap();
         write.write_all(&open).await.unwrap();
         let mut decoder = TunnelFrameDecoder::new(MAX_TUNNEL_FRAME_BYTES);
@@ -1031,7 +1162,10 @@ mod tests {
         let rig = rig().await;
         let stream = connect(&rig).await;
         let (mut read, mut write) = stream.into_split();
-        write.write_all(&encode_tunnel_frame(FRAME_KIND_CONTROL, b"{not json")).await.unwrap();
+        write
+            .write_all(&encode_tunnel_frame(FRAME_KIND_CONTROL, b"{not json").unwrap())
+            .await
+            .unwrap();
         let mut decoder = TunnelFrameDecoder::new(MAX_TUNNEL_FRAME_BYTES);
         let mut queue = Vec::new();
         let error = control_json(&next_frame(&mut read, &mut decoder, &mut queue).await);
@@ -1047,7 +1181,10 @@ mod tests {
         let stream = connect(&rig).await;
         let (mut read, mut write) = stream.into_split();
         write
-            .write_all(&encode_control_frame(&json!({ "t": "open", "cols": 80, "rows": 24 })))
+            .write_all(
+                &encode_control_frame(&json!({ "t": "open", "cols": 80, "rows": 24 }))
+                    .unwrap(),
+            )
             .await
             .unwrap();
         let mut decoder = TunnelFrameDecoder::new(MAX_TUNNEL_FRAME_BYTES);
@@ -1068,7 +1205,10 @@ mod tests {
         let stream = connect(&rig).await;
         let (mut read, mut write) = stream.into_split();
         write
-            .write_all(&encode_control_frame(&json!({ "t": "open", "cols": 80, "rows": 24 })))
+            .write_all(
+                &encode_control_frame(&json!({ "t": "open", "cols": 80, "rows": 24 }))
+                    .unwrap(),
+            )
             .await
             .unwrap();
         let mut decoder = TunnelFrameDecoder::new(MAX_TUNNEL_FRAME_BYTES);

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -897,6 +897,10 @@ async fn serve_connection(
     // attachment is already released above, so cap the flush and reap.
     if tokio::time::timeout(Duration::from_secs(30), &mut writer).await.is_err() {
         writer.abort();
+        // `abort` only requests cancellation. Await the handle so the writer
+        // task has completed before this connection returns and its socket
+        // state is dropped.
+        let _ = writer.await;
     }
 }
 

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -1119,7 +1119,11 @@ mod tests {
         ) -> Result<Arc<dyn crate::control::ControlHandle>, String> {
             Err("no control in tunnel tests".to_owned())
         }
-        async fn read_dir(&self, _path: &Path) -> Result<Vec<String>, ()> {
+        async fn read_dir(
+            &self,
+            _path: &Path,
+            _cancellation: CancellationToken,
+        ) -> Result<Vec<String>, ()> {
             Err(())
         }
         fn socket_dir(&self) -> PathBuf {

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -285,6 +285,10 @@ struct Connection {
     pty_id: String,
     manager: Arc<PtyManager>,
     writer_tx: mpsc::Sender<WriterMessage>,
+    /// Serializes enqueue and End so shutdown cannot overtake a frame that
+    /// already reserved bytes. The critical section only performs a
+    /// non-blocking channel operation.
+    queue_gate: std::sync::Mutex<()>,
     /// pty_flow requests from the writer's water marks (true = pause).
     flow_tx: mpsc::UnboundedSender<bool>,
     auth_state: TunnelAuthState,
@@ -332,24 +336,26 @@ impl Connection {
     }
 
     fn enqueue_frame(&self, frame: Vec<u8>) -> bool {
-        if self.finished.load(Ordering::SeqCst) {
-            return false;
-        }
-        if !self.reserve_bytes(frame.len()) {
-            self.finish();
-            return false;
-        }
-        let length = frame.len() as u64;
-        match self.writer_tx.try_send(WriterMessage::Frame(frame)) {
-            Ok(()) => true,
-            Err(_) => {
-                // The frame was never handed to the writer, so release its
-                // reservation before closing the connection.
-                self.pending_out.fetch_sub(length, Ordering::AcqRel);
-                self.finish();
-                false
+        let mut accepted = false;
+        let mut reserved = 0_u64;
+        {
+            let _queue_gate = self.queue_gate.lock().expect("tunnel queue lock");
+            if !self.finished.load(Ordering::SeqCst) && self.reserve_bytes(frame.len()) {
+                reserved = frame.len() as u64;
+                if self.writer_tx.try_send(WriterMessage::Frame(frame)).is_ok() {
+                    accepted = true;
+                }
             }
         }
+        if !accepted {
+            if reserved != 0 {
+                // The frame was never handed to the writer, so release its
+                // reservation before closing the connection.
+                self.pending_out.fetch_sub(reserved, Ordering::AcqRel);
+            }
+            self.finish();
+        }
+        accepted
     }
 
     /// Idempotent shutdown: flush queued frames, close the socket, and let
@@ -357,6 +363,7 @@ impl Connection {
     /// session lives on for a later re-attach, the same rule a dropped
     /// relay-socket viewer follows).
     fn finish(&self) {
+        let _queue_gate = self.queue_gate.lock().expect("tunnel queue lock");
         if self.finished.swap(true, Ordering::SeqCst) {
             return;
         }
@@ -561,6 +568,7 @@ async fn serve_connection(
         pty_id,
         manager: Arc::clone(&manager),
         writer_tx,
+        queue_gate: std::sync::Mutex::new(()),
         flow_tx,
         auth_state,
         pending_out: AtomicU64::new(0),
@@ -676,6 +684,10 @@ async fn serve_connection(
         let context = connection.frame_context();
         manager.handle_frame(&close, &context).await;
     }
+    // Remove the per-transport authority even when the open was refused or
+    // the peer disconnected before an attachment existed. Otherwise a busy
+    // local tunnel endpoint could accumulate stale snapshots indefinitely.
+    manager.detach_transport(&connection.pty_id);
     flow.abort();
     // A peer that stopped reading can wedge the final flush forever; the
     // attachment is already released above, so cap the flush and reap.

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -311,6 +311,10 @@ enum WriterMessage {
     Frame {
         bytes: Vec<u8>,
         live: Option<Arc<AtomicBool>>,
+        /// Revoke a generation only after this frame has been written. Exit
+        /// frames must remain deliverable, while later stale frames must be
+        /// rejected once the ordered exit reaches the socket.
+        revoke_live_after_write: Option<Arc<AtomicBool>>,
     },
     /// Flush what is queued, then close the write half. The slot for this
     /// message is reserved when the connection starts.
@@ -438,6 +442,16 @@ impl Connection {
     }
 
     fn enqueue_frame(&self, frame: Vec<u8>, control: bool, live: Option<Arc<AtomicBool>>) -> bool {
+        self.enqueue_frame_with_revoke(frame, control, live, None)
+    }
+
+    fn enqueue_frame_with_revoke(
+        &self,
+        frame: Vec<u8>,
+        control: bool,
+        live: Option<Arc<AtomicBool>>,
+        revoke_live_after_write: Option<Arc<AtomicBool>>,
+    ) -> bool {
         let mut accepted = false;
         let mut reserved = 0_u64;
         {
@@ -449,7 +463,11 @@ impl Connection {
                 && self.reserve_bytes(frame.len(), control)
             {
                 reserved = frame.len() as u64;
-                if self.writer_tx.try_send(WriterMessage::Frame { bytes: frame, live }).is_ok() {
+                if self
+                    .writer_tx
+                    .try_send(WriterMessage::Frame { bytes: frame, live, revoke_live_after_write })
+                    .is_ok()
+                {
                     accepted = true;
                 }
             }
@@ -479,7 +497,11 @@ impl Connection {
         if self.reserve_bytes(overflow.len(), true) {
             if let Some(permit) = self.overflow_permit.lock().expect("overflow permit lock").take()
             {
-                permit.send(WriterMessage::Frame { bytes: overflow, live: None });
+                permit.send(WriterMessage::Frame {
+                    bytes: overflow,
+                    live: None,
+                    revoke_live_after_write: None,
+                });
             } else {
                 self.pending_out.fetch_sub(overflow_bytes, Ordering::AcqRel);
             }
@@ -575,7 +597,12 @@ impl Connection {
             }
             Some("pty_exit") => {
                 let code = frame.get("code").and_then(Value::as_i64).unwrap_or(0);
-                self.send_control_with_live(&json!({ "t": "exit", "code": code }), live);
+                let Some(encoded) = encode_control_frame(&json!({ "t": "exit", "code": code }))
+                else {
+                    self.finish();
+                    return;
+                };
+                let _ = self.enqueue_frame_with_revoke(encoded, true, live.clone(), live);
                 self.finish();
             }
             Some("pty_error") => {
@@ -824,7 +851,7 @@ async fn serve_connection(
         tokio::spawn(async move {
             while let Some(message) = writer_rx.recv().await {
                 match message {
-                    WriterMessage::Frame { bytes: frame, live } => {
+                    WriterMessage::Frame { bytes: frame, live, revoke_live_after_write } => {
                         if live.as_ref().is_some_and(|live| !live.load(Ordering::Acquire)) {
                             let length = frame.len() as u64;
                             let previous =
@@ -837,6 +864,9 @@ async fn serve_connection(
                             continue;
                         }
                         let written = write_half.write_all(&frame).await;
+                        if let Some(live) = revoke_live_after_write {
+                            live.store(false, Ordering::Release);
+                        }
                         // Every dequeued frame added exactly its length at
                         // enqueue, so this never underflows.
                         let length = frame.len() as u64;

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -38,9 +38,9 @@
 //! already attach terminals through the cmux CLI. Paired human machines
 //! never run this listener: it starts from the managed branch only.
 
-use std::sync::Arc;
 use std::sync::RwLock;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 
 use base64::Engine as _;
@@ -305,6 +305,9 @@ pub fn generate_session_name() -> Result<String, getrandom::Error> {
 
 enum WriterMessage {
     Frame(Vec<u8>),
+    /// Flush what is queued, then close the write half. The slot for this
+    /// message is reserved when the connection starts.
+    End,
 }
 
 /// State shared between the reader task, the writer task, and the manager's
@@ -313,6 +316,9 @@ struct Connection {
     pty_id: String,
     manager: Arc<PtyManager>,
     writer_tx: mpsc::Sender<WriterMessage>,
+    /// A permanently reserved channel slot for the terminal shutdown frame.
+    /// `finish` is synchronous, so it cannot wait for queue capacity.
+    end_permit: StdMutex<Option<mpsc::OwnedPermit<WriterMessage>>>,
     /// Serializes enqueue and End so shutdown cannot overtake a frame that
     /// already reserved bytes. The critical section only performs a
     /// non-blocking channel operation.
@@ -402,6 +408,9 @@ impl Connection {
         let _queue_gate = self.queue_gate.lock().expect("tunnel queue lock");
         if self.finished.swap(true, Ordering::SeqCst) {
             return;
+        }
+        if let Some(permit) = self.end_permit.lock().expect("tunnel end permit lock").take() {
+            permit.send(WriterMessage::End);
         }
         self.done.cancel();
     }
@@ -514,7 +523,11 @@ impl Connection {
 }
 
 fn queue_limit(control: bool) -> u64 {
-    if control { TUNNEL_QUEUE_BYTES } else { TUNNEL_QUEUE_BYTES - TUNNEL_CONTROL_QUEUE_RESERVE_BYTES }
+    if control {
+        TUNNEL_QUEUE_BYTES
+    } else {
+        TUNNEL_QUEUE_BYTES - TUNNEL_CONTROL_QUEUE_RESERVE_BYTES
+    }
 }
 
 async fn handle_client_frame(connection: &Arc<Connection>, frame: TunnelFrame) {
@@ -611,6 +624,16 @@ async fn serve_connection(
     let _ = stream.set_nodelay(true);
     let (mut read_half, mut write_half) = stream.into_split();
     let (writer_tx, mut writer_rx) = mpsc::channel::<WriterMessage>(TUNNEL_WRITER_QUEUE_ITEMS);
+    // Reserve one item before any producer can fill the queue. Tokio's owned
+    // permit keeps this capacity unavailable to ordinary `try_send` calls and
+    // can later send End synchronously from `finish`.
+    let end_permit = match writer_tx.clone().reserve_owned().await {
+        Ok(permit) => permit,
+        Err(_) => {
+            let _ = write_half.shutdown().await;
+            return;
+        }
+    };
     let (flow_tx, mut flow_rx) = watch::channel(false);
     let pty_id = match random_hex(8) {
         Ok(id) => format!("tunnel-{id}"),
@@ -625,6 +648,7 @@ async fn serve_connection(
         pty_id,
         manager: Arc::clone(&manager),
         writer_tx,
+        end_permit: StdMutex::new(Some(end_permit)),
         queue_gate: std::sync::Mutex::new(()),
         flow_tx,
         auth_state,
@@ -641,27 +665,7 @@ async fn serve_connection(
     let mut writer = {
         let connection = Arc::clone(&connection);
         tokio::spawn(async move {
-            loop {
-                let message = tokio::select! {
-                    message = writer_rx.recv() => message,
-                    _ = connection.done.cancelled() => {
-                        // Cancellation is the reserved control path. Drain
-                        // already-accepted frames, then close without relying
-                        // on an additional bounded-channel End item.
-                        while let Ok(message) = writer_rx.try_recv() {
-                            match message {
-                                WriterMessage::Frame(frame) => {
-                                    let length = frame.len() as u64;
-                                    let written = write_half.write_all(&frame).await;
-                                    connection.pending_out.fetch_sub(length, Ordering::SeqCst);
-                                    if written.is_err() { break; }
-                                }
-                            }
-                        }
-                        break;
-                    }
-                };
-                let Some(message) = message else { break };
+            while let Some(message) = writer_rx.recv().await {
                 match message {
                     WriterMessage::Frame(frame) => {
                         let written = write_half.write_all(&frame).await;
@@ -679,6 +683,7 @@ async fn serve_connection(
                             let _ = connection.flow_tx.send(false);
                         }
                     }
+                    WriterMessage::End => break,
                 }
             }
             let _ = write_half.shutdown().await;
@@ -1064,6 +1069,63 @@ mod tests {
                 return;
             }
         }
+    }
+
+    #[tokio::test]
+    async fn saturated_writer_queue_still_delivers_error_and_end() {
+        let rig = rig().await;
+        let (writer_tx, mut writer_rx) = mpsc::channel::<WriterMessage>(TUNNEL_WRITER_QUEUE_ITEMS);
+        let end_permit = writer_tx.clone().reserve_owned().await.expect("reserve End slot");
+        let (flow_tx, _) = watch::channel(false);
+        let connection = Connection {
+            pty_id: "queue-test".to_owned(),
+            manager: Arc::clone(&rig.manager),
+            writer_tx,
+            end_permit: StdMutex::new(Some(end_permit)),
+            queue_gate: StdMutex::new(()),
+            flow_tx,
+            auth_state: Arc::new(RwLock::new(TunnelAuthority::default())),
+            auth_generation: 0,
+            pending_out: AtomicU64::new(0),
+            paused: AtomicBool::new(false),
+            open_sent: AtomicBool::new(false),
+            opened_seen: AtomicBool::new(false),
+            finished: AtomicBool::new(false),
+            done: CancellationToken::new(),
+        };
+
+        // Data can fill every ordinary slot, but the reserved permit keeps
+        // the shutdown item available and the item reserve leaves room for
+        // the control error.
+        let accepted_data = TUNNEL_WRITER_QUEUE_ITEMS - TUNNEL_CONTROL_QUEUE_RESERVE_ITEMS - 1;
+        for _ in 0..accepted_data {
+            assert!(connection.enqueue_frame(vec![b'x'], false));
+        }
+        connection.send_control(&json!({ "t": "error", "code": "failed" }));
+        connection.finish();
+        drop(connection);
+
+        let mut saw_error = false;
+        let mut saw_end = false;
+        while let Some(message) = writer_rx.recv().await {
+            match message {
+                WriterMessage::Frame(frame)
+                    if frame.len() > 1 && frame[1] == FRAME_KIND_CONTROL =>
+                {
+                    let payload = &frame[5..];
+                    let value: Value = serde_json::from_slice(payload).expect("error frame");
+                    saw_error = value["t"] == "error" && value["code"] == "failed";
+                }
+                WriterMessage::End => {
+                    saw_end = true;
+                    break;
+                }
+                WriterMessage::Frame(_) => {}
+            }
+        }
+        assert!(saw_error, "control error must survive data saturation");
+        assert!(saw_end, "reserved End item must be delivered");
+        rig.cancel.cancel();
     }
 
     // -- pure codec/parse ---------------------------------------------------

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -1550,7 +1550,7 @@ mod tests {
     #[tokio::test]
     async fn listener_rejects_non_loopback_bind_addresses() {
         let spawned = Arc::new(StdMutex::new(Vec::new()));
-        let deps = Arc::new(FakeDeps { spawned: Arc::clone(&spawned) });
+        let deps = Arc::new(FakeDeps { spawned: Arc::clone(&spawned), banner: None });
         let manager = Arc::new(PtyManager::with_limits(
             deps,
             std::env::temp_dir(),

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -320,6 +320,8 @@ struct Connection {
     pty_id: String,
     manager: Arc<PtyManager>,
     writer_tx: mpsc::Sender<WriterMessage>,
+    /// A permanently reserved channel slot for the explicit overflow frame.
+    overflow_permit: StdMutex<Option<mpsc::OwnedPermit<WriterMessage>>>,
     /// A permanently reserved channel slot for the terminal shutdown frame.
     /// `finish` is synchronous, so it cannot wait for queue capacity.
     end_permit: StdMutex<Option<mpsc::OwnedPermit<WriterMessage>>>,
@@ -451,9 +453,37 @@ impl Connection {
                 // reservation before closing the connection.
                 self.pending_out.fetch_sub(reserved, Ordering::AcqRel);
             }
-            self.finish();
+            if !self.finished.load(Ordering::SeqCst) {
+                self.reject_due_to_backpressure();
+            }
         }
         accepted
+    }
+
+    /// Report saturation using the reserved control slot, then close.
+    fn reject_due_to_backpressure(&self) {
+        let _queue_gate = self.queue_gate.lock().expect("tunnel queue lock");
+        if self.finished.load(Ordering::SeqCst) {
+            return;
+        }
+        let overflow = encode_control_frame(&json!({ "t": "error", "code": "overflow" }))
+            .expect("overflow frame fits protocol");
+        let overflow_bytes = overflow.len() as u64;
+        if self.reserve_bytes(overflow.len(), true) {
+            if let Some(permit) = self.overflow_permit.lock().expect("overflow permit lock").take()
+            {
+                permit.send(WriterMessage::Frame(overflow));
+            } else {
+                self.pending_out.fetch_sub(overflow_bytes, Ordering::AcqRel);
+            }
+        }
+        self.finished.store(true, Ordering::SeqCst);
+        self.open_cancellation.cancel();
+        if let Some(permit) = self.end_permit.lock().expect("tunnel end permit lock").take() {
+            permit.send(WriterMessage::End);
+        }
+        self.flow_tx.send_replace(true);
+        self.done.cancel();
     }
 
     /// Idempotent shutdown: flush queued frames, close the socket, and let
@@ -716,9 +746,16 @@ async fn serve_connection(
     let _ = stream.set_nodelay(true);
     let (mut read_half, mut write_half) = stream.into_split();
     let (writer_tx, mut writer_rx) = mpsc::channel::<WriterMessage>(TUNNEL_WRITER_QUEUE_ITEMS);
-    // Reserve one item before any producer can fill the queue. Tokio's owned
-    // permit keeps this capacity unavailable to ordinary `try_send` calls and
-    // can later send End synchronously from `finish`.
+    // Reserve control slots before any producer can fill the queue. Tokio's
+    // owned permits keep these capacities unavailable to ordinary sends and
+    // can later send overflow and End synchronously.
+    let overflow_permit = match writer_tx.clone().reserve_owned().await {
+        Ok(permit) => permit,
+        Err(_) => {
+            let _ = write_half.shutdown().await;
+            return;
+        }
+    };
     let end_permit = match writer_tx.clone().reserve_owned().await {
         Ok(permit) => permit,
         Err(_) => {
@@ -745,6 +782,7 @@ async fn serve_connection(
         pty_id,
         manager: Arc::clone(&manager),
         writer_tx,
+        overflow_permit: StdMutex::new(Some(overflow_permit)),
         end_permit: StdMutex::new(Some(end_permit)),
         queue_gate: std::sync::Mutex::new(()),
         flow_tx,
@@ -1228,6 +1266,8 @@ mod tests {
         manager: Arc<PtyManager>,
     ) -> (Connection, mpsc::Receiver<WriterMessage>) {
         let (writer_tx, writer_rx) = mpsc::channel::<WriterMessage>(TUNNEL_WRITER_QUEUE_ITEMS);
+        let overflow_permit =
+            writer_tx.clone().reserve_owned().await.expect("reserve overflow slot");
         let end_permit = writer_tx.clone().reserve_owned().await.expect("reserve End slot");
         let (flow_tx, _) = watch::channel(false);
         let open_cancellation = manager.new_open_cancellation().expect("open attempt token");
@@ -1236,6 +1276,7 @@ mod tests {
                 pty_id: "queue-test".to_owned(),
                 manager,
                 writer_tx,
+                overflow_permit: StdMutex::new(Some(overflow_permit)),
                 end_permit: StdMutex::new(Some(end_permit)),
                 queue_gate: StdMutex::new(()),
                 flow_tx,

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -336,6 +336,10 @@ struct Connection {
     open_sent: AtomicBool,
     /// The manager answered pty_opened (clears the open deadline).
     opened_seen: AtomicBool,
+    /// Cancels an in-flight open on timeout, disconnect, or protocol error.
+    /// This token is created before the open task is spawned, so a task that
+    /// has not been polled cannot recreate a transport after its owner ends.
+    open_cancellation: CancellationToken,
     finished: AtomicBool,
     done: CancellationToken,
 }
@@ -410,6 +414,7 @@ impl Connection {
         if self.finished.swap(true, Ordering::SeqCst) {
             return;
         }
+        self.open_cancellation.cancel();
         if let Some(permit) = self.end_permit.lock().expect("tunnel end permit lock").take() {
             permit.send(WriterMessage::End);
         }
@@ -601,13 +606,23 @@ async fn handle_client_frame(connection: &Arc<Connection>, frame: TunnelFrame) {
             // direct timeout would drop `handle_frame` while its blocking PTY
             // spawn could still be running, leaving a late child with no
             // owner. The detached task retains the opening reservation; the
-            // connection cleanup marks that reservation cancelled, and
-            // `Opened` then kills any handle that arrives after the deadline.
+            // connection token also fences a task that has not reached the
+            // reservation yet. Cleanup marks any installed reservation
+            // cancelled, and `Opened` kills a handle that arrives late.
+            let open_cancellation = connection.open_cancellation.clone();
             let mut open_task = tokio::spawn({
                 let manager = Arc::clone(&connection.manager);
                 let open = open.clone();
                 let context = context.clone();
-                async move { manager.handle_frame(&open, &context).await }
+                async move {
+                    manager
+                        .handle_frame_with_open_cancellation(
+                            &open,
+                            &context,
+                            Some(open_cancellation),
+                        )
+                        .await
+                }
             });
             match tokio::time::timeout(OPEN_TIMEOUT, &mut open_task).await {
                 Ok(Ok(())) => {}
@@ -618,6 +633,7 @@ async fn handle_client_frame(connection: &Arc<Connection>, frame: TunnelFrame) {
                     // manager task still owns its semaphore permit and any
                     // late PTY result, so it cannot install a resource for a
                     // connection that has already timed out.
+                    connection.open_cancellation.cancel();
                     connection.manager.cancel_open(&connection.pty_id, &context);
                     connection.protocol_error("failed");
                     // Dropping a JoinHandle detaches the task. The bounded
@@ -689,6 +705,7 @@ async fn serve_connection(
         paused: AtomicBool::new(false),
         open_sent: AtomicBool::new(false),
         opened_seen: AtomicBool::new(false),
+        open_cancellation: CancellationToken::new(),
         finished: AtomicBool::new(false),
         done: CancellationToken::new(),
     });
@@ -1161,6 +1178,7 @@ mod tests {
                 paused: AtomicBool::new(false),
                 open_sent: AtomicBool::new(false),
                 opened_seen: AtomicBool::new(false),
+                open_cancellation: CancellationToken::new(),
                 finished: AtomicBool::new(false),
                 done: CancellationToken::new(),
             },

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -635,9 +635,11 @@ async fn handle_client_frame(connection: &Arc<Connection>, frame: TunnelFrame) {
                     // manager task still owns its semaphore permit and any
                     // late PTY result, so it cannot install a resource for a
                     // connection that has already timed out.
-                    connection
-                        .manager
-                        .cancel_open(&connection.pty_id, &context, &connection.open_cancellation);
+                    connection.manager.cancel_open(
+                        &connection.pty_id,
+                        &context,
+                        &connection.open_cancellation,
+                    );
                     connection.protocol_error("failed");
                     // Dropping a JoinHandle detaches the task. The bounded
                     // open permit above prevents a permanently stalled

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -665,7 +665,7 @@ async fn handle_client_frame(connection: &Arc<Connection>, frame: TunnelFrame) {
                 async move {
                     manager
                         .handle_frame_with_open_cancellation(&open, &context, Some(cancellation))
-                        .await
+                        .await;
                 }
             }));
             match tokio::time::timeout(OPEN_TIMEOUT, &mut open_task).await {
@@ -1174,7 +1174,7 @@ mod tests {
     fn control_reservation_accepts_reserved_tail() {
         let data_limit = queue_limit(false);
         assert!(data_limit + TUNNEL_CONTROL_QUEUE_RESERVE_BYTES <= queue_limit(true));
-        assert!(TUNNEL_CONTROL_QUEUE_RESERVE_BYTES > 0);
+        const { assert!(TUNNEL_CONTROL_QUEUE_RESERVE_BYTES > 0) };
     }
 
     #[test]

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -1026,6 +1026,9 @@ mod tests {
     use std::sync::Mutex as StdMutex;
     use tokio::net::tcp::OwnedReadHalf;
 
+    /// The overflow and End owned permits permanently hold two queue slots.
+    const RESERVED_WRITER_QUEUE_ITEMS: usize = 2;
+
     #[derive(Default)]
     struct FakeState {
         on_data: Option<DataSink>,
@@ -1316,10 +1319,12 @@ mod tests {
         let rig = rig().await;
         let (connection, mut writer_rx) = queue_connection(Arc::clone(&rig.manager)).await;
 
-        // Data can fill every ordinary slot, but the reserved permit keeps
-        // the shutdown item available and the item reserve leaves room for
-        // the control error.
-        let accepted_data = TUNNEL_WRITER_QUEUE_ITEMS - TUNNEL_CONTROL_QUEUE_RESERVE_ITEMS - 1;
+        // Data can fill every ordinary slot after both owned permits and the
+        // item reserve are accounted for. The permits keep overflow and End
+        // available, while the item reserve leaves room for the control error.
+        let accepted_data = TUNNEL_WRITER_QUEUE_ITEMS
+            - RESERVED_WRITER_QUEUE_ITEMS
+            - TUNNEL_CONTROL_QUEUE_RESERVE_ITEMS;
         for _ in 0..accepted_data {
             assert!(connection.enqueue_frame(vec![b'x'], false));
         }
@@ -1354,7 +1359,9 @@ mod tests {
     async fn saturated_writer_queue_reports_overflow_before_end() {
         let rig = rig().await;
         let (connection, mut writer_rx) = queue_connection(Arc::clone(&rig.manager)).await;
-        let accepted_data = TUNNEL_WRITER_QUEUE_ITEMS - TUNNEL_CONTROL_QUEUE_RESERVE_ITEMS - 1;
+        let accepted_data = TUNNEL_WRITER_QUEUE_ITEMS
+            - RESERVED_WRITER_QUEUE_ITEMS
+            - TUNNEL_CONTROL_QUEUE_RESERVE_ITEMS;
         for _ in 0..accepted_data {
             assert!(connection.enqueue_frame(vec![b'x'], false));
         }

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -77,7 +77,7 @@ const FLOW_RESUME_BYTES: u64 = 32_768;
 /// The manager's output cap is one MiB. Keep a small control-frame reserve so
 /// a queued output frame cannot prevent an exit or refusal from being sent,
 /// while still making the total writer memory bound explicit.
-const TUNNEL_QUEUE_BYTES: u64 = MAX_TUNNEL_FRAME_BYTES as u64 + 64 * 1024;
+const TUNNEL_QUEUE_BYTES: u64 = MAX_TUNNEL_FRAME_BYTES as u64 + HEADER_BYTES as u64 + 64 * 1024;
 /// Bytes held back for terminal control/error frames. Data frames cannot
 /// consume this budget, so a saturated output queue can still report failure
 /// or completion.
@@ -1071,28 +1071,50 @@ mod tests {
         }
     }
 
+    async fn queue_connection(
+        manager: Arc<PtyManager>,
+    ) -> (Connection, mpsc::Receiver<WriterMessage>) {
+        let (writer_tx, writer_rx) = mpsc::channel::<WriterMessage>(TUNNEL_WRITER_QUEUE_ITEMS);
+        let end_permit = writer_tx.clone().reserve_owned().await.expect("reserve End slot");
+        let (flow_tx, _) = watch::channel(false);
+        (
+            Connection {
+                pty_id: "queue-test".to_owned(),
+                manager,
+                writer_tx,
+                end_permit: StdMutex::new(Some(end_permit)),
+                queue_gate: StdMutex::new(()),
+                flow_tx,
+                auth_state: Arc::new(RwLock::new(TunnelAuthority::default())),
+                auth_generation: 0,
+                pending_out: AtomicU64::new(0),
+                paused: AtomicBool::new(false),
+                open_sent: AtomicBool::new(false),
+                opened_seen: AtomicBool::new(false),
+                finished: AtomicBool::new(false),
+                done: CancellationToken::new(),
+            },
+            writer_rx,
+        )
+    }
+
+    #[tokio::test]
+    async fn maximum_valid_pty_frame_fits_the_bounded_data_budget() {
+        let rig = rig().await;
+        let (connection, mut writer_rx) = queue_connection(Arc::clone(&rig.manager)).await;
+        let frame = encode_pty_frame(&vec![b'x'; MAX_TUNNEL_FRAME_BYTES]).expect("valid frame");
+        assert!(connection.enqueue_frame(frame, false));
+        connection.finish();
+        drop(connection);
+        assert!(matches!(writer_rx.recv().await, Some(WriterMessage::Frame(_))));
+        assert!(matches!(writer_rx.recv().await, Some(WriterMessage::End)));
+        rig.cancel.cancel();
+    }
+
     #[tokio::test]
     async fn saturated_writer_queue_still_delivers_error_and_end() {
         let rig = rig().await;
-        let (writer_tx, mut writer_rx) = mpsc::channel::<WriterMessage>(TUNNEL_WRITER_QUEUE_ITEMS);
-        let end_permit = writer_tx.clone().reserve_owned().await.expect("reserve End slot");
-        let (flow_tx, _) = watch::channel(false);
-        let connection = Connection {
-            pty_id: "queue-test".to_owned(),
-            manager: Arc::clone(&rig.manager),
-            writer_tx,
-            end_permit: StdMutex::new(Some(end_permit)),
-            queue_gate: StdMutex::new(()),
-            flow_tx,
-            auth_state: Arc::new(RwLock::new(TunnelAuthority::default())),
-            auth_generation: 0,
-            pending_out: AtomicU64::new(0),
-            paused: AtomicBool::new(false),
-            open_sent: AtomicBool::new(false),
-            opened_seen: AtomicBool::new(false),
-            finished: AtomicBool::new(false),
-            done: CancellationToken::new(),
-        };
+        let (connection, mut writer_rx) = queue_connection(Arc::clone(&rig.manager)).await;
 
         // Data can fill every ordinary slot, but the reserved permit keeps
         // the shutdown item available and the item reserve leaves room for

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -736,7 +736,8 @@ async fn serve_connection(
     };
     let auth_generation =
         auth_state.read().map(|authority| authority.generation).unwrap_or_default();
-    let Some(open_cancellation) = manager.new_open_cancellation() else {
+    let done = CancellationToken::new();
+    let Some(open_cancellation) = manager.new_open_cancellation_with_parent(&done) else {
         let _ = write_half.shutdown().await;
         return;
     };
@@ -755,7 +756,7 @@ async fn serve_connection(
         opened_seen: AtomicBool::new(false),
         open_cancellation,
         finished: AtomicBool::new(false),
-        done: CancellationToken::new(),
+        done,
     });
     // Writer: the only task that touches the write half. Applies the flow
     // water marks as the queue drains.

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -758,6 +758,12 @@ async fn serve_connection(
         finished: AtomicBool::new(false),
         done,
     });
+    // Identified tunnel transports must be admitted before their first
+    // manager frame. The active snapshot itself is the disconnect fence, so
+    // no historical per-connection tombstone is needed.
+    if connection.authority_current() {
+        manager.update_transport_auth(&connection.frame_context());
+    }
     // Writer: the only task that touches the write half. Applies the flow
     // water marks as the queue drains.
     let mut writer = {

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -79,6 +79,9 @@ const FLOW_RESUME_BYTES: u64 = 32_768;
 /// while still making the total writer memory bound explicit.
 const TUNNEL_QUEUE_BYTES: u64 = MAX_TUNNEL_FRAME_BYTES as u64 + 64 * 1024;
 const TUNNEL_WRITER_QUEUE_ITEMS: usize = 256;
+/// Keep queue slots available for `opened`, `error`, and `exit` control
+/// frames. PTY output is rejected before it consumes the reserve.
+const TUNNEL_CONTROL_QUEUE_RESERVE_ITEMS: usize = 8;
 
 /// Authority published by the authenticated relay session for local tunnel
 /// connections. `None` means the relay is disconnected or has not completed
@@ -90,7 +93,29 @@ pub struct TunnelAuth {
     pub owner_user_id: Option<String>,
 }
 
-pub type TunnelAuthState = Arc<RwLock<Option<TunnelAuth>>>;
+/// A monotonically versioned authority slot. The generation changes whenever
+/// the relay reconnects or publishes a new trust snapshot, so a tunnel socket
+/// opened under an older capability cannot continue after that boundary.
+#[derive(Clone, Debug, Default)]
+pub struct TunnelAuthority {
+    pub generation: u64,
+    pub auth: Option<TunnelAuth>,
+}
+
+impl TunnelAuthority {
+    pub fn revoked(previous_generation: u64) -> Self {
+        Self { generation: previous_generation.saturating_add(1), auth: None }
+    }
+
+    pub fn published(previous_generation: u64, auth: TunnelAuth) -> Self {
+        Self {
+            generation: previous_generation.saturating_add(1),
+            auth: Some(auth),
+        }
+    }
+}
+
+pub type TunnelAuthState = Arc<RwLock<TunnelAuthority>>;
 
 /// Relay pty_error codes -> browser wire codes. Mirrors the Worker's
 /// browserErrorCode map (apps/backend/src/terminal/relay-pty.ts). KEEP IN
@@ -292,6 +317,8 @@ struct Connection {
     /// pty_flow requests from the writer's water marks (true = pause).
     flow_tx: mpsc::UnboundedSender<bool>,
     auth_state: TunnelAuthState,
+    /// Authority generation captured when this socket was accepted.
+    auth_generation: u64,
     /// Bytes queued toward the socket and not yet written.
     pending_out: AtomicU64,
     paused: AtomicBool,
@@ -309,7 +336,7 @@ impl Connection {
             self.finish();
             return;
         };
-        let _ = self.enqueue_frame(encoded);
+        let _ = self.enqueue_frame(encoded, true);
     }
 
     fn reserve_bytes(&self, length: usize) -> bool {
@@ -335,12 +362,17 @@ impl Connection {
         }
     }
 
-    fn enqueue_frame(&self, frame: Vec<u8>) -> bool {
+    fn enqueue_frame(&self, frame: Vec<u8>, control: bool) -> bool {
         let mut accepted = false;
         let mut reserved = 0_u64;
         {
             let _queue_gate = self.queue_gate.lock().expect("tunnel queue lock");
-            if !self.finished.load(Ordering::SeqCst) && self.reserve_bytes(frame.len()) {
+            let queue_has_room = control
+                || self.writer_tx.capacity() > TUNNEL_CONTROL_QUEUE_RESERVE_ITEMS;
+            if !self.finished.load(Ordering::SeqCst)
+                && queue_has_room
+                && self.reserve_bytes(frame.len())
+            {
                 reserved = frame.len() as u64;
                 if self.writer_tx.try_send(WriterMessage::Frame(frame)).is_ok() {
                     accepted = true;
@@ -419,7 +451,7 @@ impl Connection {
                     self.protocol_error("overflow");
                     return;
                 };
-                if !self.enqueue_frame(encoded) {
+                if !self.enqueue_frame(encoded, false) {
                     return;
                 }
                 // Socket-side congestion: pause the source through the
@@ -454,7 +486,12 @@ impl Connection {
     fn frame_context(self: &Arc<Self>) -> FrameContext {
         let sink = Arc::clone(self);
         let probe = Arc::clone(self);
-        let auth = self.auth_state.read().ok().and_then(|state| state.clone()).unwrap_or_default();
+        let authority = self.auth_state.read().ok().map(|state| state.clone()).unwrap_or_default();
+        let auth = if authority.generation == self.auth_generation {
+            authority.auth.unwrap_or_default()
+        } else {
+            TunnelAuth::default()
+        };
         FrameContext {
             send: Arc::new(move |frame: Value| sink.on_manager_frame(&frame)),
             buffered_amount: Arc::new(move || probe.pending_out.load(Ordering::SeqCst)),
@@ -465,10 +502,23 @@ impl Connection {
             cancellation: self.done.clone(),
         }
     }
+
+    fn authority_current(&self) -> bool {
+        self.auth_state
+            .read()
+            .ok()
+            .is_some_and(|authority| {
+                authority.generation == self.auth_generation && authority.auth.is_some()
+            })
+    }
 }
 
 async fn handle_client_frame(connection: &Arc<Connection>, frame: TunnelFrame) {
     if connection.finished.load(Ordering::SeqCst) {
+        return;
+    }
+    if !connection.authority_current() {
+        connection.protocol_error("trust_revoked");
         return;
     }
     if frame.kind == FRAME_KIND_PTY {
@@ -564,6 +614,10 @@ async fn serve_connection(
             return;
         }
     };
+    let auth_generation = auth_state
+        .read()
+        .map(|authority| authority.generation)
+        .unwrap_or_default();
     let connection = Arc::new(Connection {
         pty_id,
         manager: Arc::clone(&manager),
@@ -571,6 +625,7 @@ async fn serve_connection(
         queue_gate: std::sync::Mutex::new(()),
         flow_tx,
         auth_state,
+        auth_generation,
         pending_out: AtomicU64::new(0),
         paused: AtomicBool::new(false),
         open_sent: AtomicBool::new(false),
@@ -673,6 +728,11 @@ async fn serve_connection(
         }
     }
     connection.finish();
+    // Stop the independent flow task before removing the transport snapshot.
+    // Otherwise a queued pause/resume could enter `handle_frame` after the
+    // detach and recreate stale authorization for this connection.
+    flow.abort();
+    let _ = flow.await;
     // Detach, never kill: the owed close releases only this connection's
     // attachment (transport-fenced), and the session lives on.
     if connection.open_sent.load(Ordering::SeqCst) {
@@ -688,13 +748,11 @@ async fn serve_connection(
     // the peer disconnected before an attachment existed. Otherwise a busy
     // local tunnel endpoint could accumulate stale snapshots indefinitely.
     manager.detach_transport(&connection.pty_id);
-    flow.abort();
     // A peer that stopped reading can wedge the final flush forever; the
     // attachment is already released above, so cap the flush and reap.
     if tokio::time::timeout(Duration::from_secs(30), &mut writer).await.is_err() {
         writer.abort();
     }
-    let _ = flow.await;
 }
 
 /// Start the loopback listener. Managed mode only — the caller's managed
@@ -868,11 +926,14 @@ mod tests {
             1_048_576,
         ));
         let cancel = CancellationToken::new();
-        let auth_state = Arc::new(RwLock::new(Some(TunnelAuth {
-            trust: "supervised".to_owned(),
-            local_roots: None,
-            owner_user_id: None,
-        })));
+        let auth_state = Arc::new(RwLock::new(TunnelAuthority {
+            generation: 0,
+            auth: Some(TunnelAuth {
+                trust: "supervised".to_owned(),
+                local_roots: None,
+                owner_user_id: None,
+            }),
+        }));
         let port = start_tunnel_terminal_listener(
             Arc::clone(&manager),
             cancel.clone(),

--- a/cmux-tui/crates/cmux-tui/Cargo.toml
+++ b/cmux-tui/crates/cmux-tui/Cargo.toml
@@ -47,11 +47,11 @@ sha2.workspace = true
 uuid.workspace = true
 wait-timeout.workspace = true
 fs4.workspace = true
+tokio.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 cmux-remote.workspace = true
 cmux-remote-protocol.workspace = true
-tokio.workspace = true
 url.workspace = true
 async-trait.workspace = true
 


### PR DESCRIPTION
Current-main integration of the reviewed tunnel lifecycle fixes from PR #11386 and the bounded viewer behavior from PR #11379.

Includes:
- transport authority generation fencing and cancellation ownership
- PTY and daemon process cleanup with bounded output queues
- paused viewer replay and explicit overflow signaling
- stale transport metadata rejection and linearized PTY publication

The branch is based on current main and excludes unrelated PR #11155 changes. Hosted cmux-tui tests are required; no local Cargo tests were run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790845588&installation_model_id=21920&pr_number=11401&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11401&signature=2b049b1d7fb9d1bb9d242f1a88d79091437ed6cea1c0ba84e1d5381e44db2d3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens `cmux-tui` relay tunnels against stale authorization, cancelled opens, startup deadlocks, and saturated output queues. Detached or trust-changed transports now fail closed instead of publishing PTYs or keeping child processes alive, while saturated viewer queues report overflow instead of silently dropping output.

**Relay lifecycle and authorization**

- Revalidates transport generations, trust, message shape, and loopback binds before opening tunnels, and rejects unknown trust on existing PTYs.
- Types and serializes tunnel ownership across revocation, closure, opening, and output publication while bounding concurrent opens, connections, and per-attachment flow signals.
- Cancels detached, timed-out, and user-cancelled opens, safely reaps PTYs and daemon processes, and redacts terminal errors.

**Viewer behavior and validation**

- Preserves paused-viewer output across transport rebases and reserves capacity for control and shutdown frames.
- Moves `tokio` to common dependencies for Windows signal support; hosted `cmux-tui` tests are required, and local Cargo tests were not run.

<sup>Written for commit 648249b9fa6ddc0cb4057f30a6eaaa857eea157b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terminal and tunnel reliability during startup, cancellation, disconnection, and failure scenarios.
  - Prevented stale or unauthorized tunnel connections after trust changes or session termination.
  - Added safer handling for oversized, invalid, or unsupported tunnel messages.
  - Restricted tunnel connections to permitted local interfaces and improved connection capacity management.
  - Ensured background processes and control sessions are cleaned up consistently when operations are cancelled or fail.
  - Improved tunnel startup timeouts, authorization changes, and session recovery.

- **Tests**
  - Expanded coverage for authorization, cleanup, startup behavior, message validation, and connection restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->