### PR TITLE
fix(cmux-tui): rebuild manual IO relay stack on current main

### DIFF
--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/BetaFeaturesCatalogSection.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/BetaFeaturesCatalogSection.swift
@@ -76,6 +76,18 @@ public struct BetaFeaturesCatalogSection: SettingCatalogSection {
         userDefaultsKey: "cloud.beta.machines.enabled"
     )
 
+    /// Cloud terminal manual IO: a cloud machine's cmux-tui terminal renders
+    /// through a manual-mirror Ghostty surface fed by an `attach --pipe-io`
+    /// relay (structured replay, in-pane reconnect overlay) instead of
+    /// running the full `cmux-tui attach` TUI as the pane's process. Defaults
+    /// on; off (or a bundled client without `--pipe-io`) falls back to the
+    /// exec attach pane. Only cloud machine terminals are affected.
+    public let cloudTerminalManualIO = DefaultsKey<Bool>(
+        id: "cloud.beta.terminalManualIO.enabled",
+        defaultValue: true,
+        userDefaultsKey: "cloud.beta.terminalManualIO.enabled"
+    )
+
     /// Remote tmux: mirror a remote host's tmux sessions in the cmux sidebar
     /// over `ssh … tmux -CC` (iTerm2-style control mode). Sessions appear as
     /// sidebar workspaces, tmux windows as tabs, and tmux panes as splits;

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
@@ -307,6 +307,17 @@ extension Array where Element == CuratedSettingEntry {
                 paths: ["cloud.beta.machines.enabled"],
                 synonyms: "cloud machines vm virtual machine right sidebar persistent computer beta unstable"
             ),
+            .init(
+                section: .betaFeatures,
+                id: "cloudTerminalManualIO",
+                title: String(localized: "settings.betaFeatures.cloudTerminalManualIO", defaultValue: "Cloud Terminal Manual IO"),
+                detailText: [
+                    String(localized: "settings.betaFeatures.cloudTerminalManualIO.subtitleOn", defaultValue: "Cloud machine terminals render through a byte relay with structured replay and an in-pane reconnect overlay."),
+                    String(localized: "settings.betaFeatures.cloudTerminalManualIO.subtitleOff", defaultValue: "Cloud machine terminals run the cmux-tui attach client as the pane's process."),
+                ].joined(separator: " "),
+                paths: ["cloud.beta.terminalManualIO.enabled"],
+                synonyms: "cloud terminal manual io pipe-io relay reconnect replay tui beta unstable"
+            ),
             .init(section: .betaFeatures, id: "customSidebars", title: "Custom Sidebars", synonyms: "custom sidebars swift json interpreted vibe beta unstable"),
             .init(section: .betaFeatures, id: "remoteTmux", title: "Remote tmux", synonyms: "remote tmux ssh control mode -CC mirror session window pane sidebar workspace beta unstable"),
             .init(

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/BetaFeaturesSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/BetaFeaturesSection.swift
@@ -10,6 +10,7 @@ public struct BetaFeaturesSection: View {
     @State private var feed: DefaultsValueModel<Bool>
     @State private var dock: DefaultsValueModel<Bool>
     @State private var cloudMachines: DefaultsValueModel<Bool>
+    @State private var cloudTerminalManualIO: DefaultsValueModel<Bool>
     @State private var extensions: DefaultsValueModel<Bool>
     @State private var customSidebars: DefaultsValueModel<Bool>
     @State private var remoteTmux: DefaultsValueModel<Bool>
@@ -20,6 +21,7 @@ public struct BetaFeaturesSection: View {
         _feed = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.betaFeatures.rightSidebarFeed))
         _dock = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.betaFeatures.rightSidebarDock))
         _cloudMachines = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.betaFeatures.cloudMachines))
+        _cloudTerminalManualIO = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.betaFeatures.cloudTerminalManualIO))
         _extensions = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.betaFeatures.extensions))
         _customSidebars = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.betaFeatures.customSidebars))
         _remoteTmux = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.betaFeatures.remoteTmux))
@@ -41,6 +43,8 @@ public struct BetaFeaturesSection: View {
                 SettingsCardDivider()
                 cloudMachinesRow
                 SettingsCardDivider()
+                cloudTerminalManualIORow
+                SettingsCardDivider()
                 extensionsRow
                 SettingsCardDivider()
                 customSidebarsRow
@@ -60,6 +64,7 @@ public struct BetaFeaturesSection: View {
             feed,
             dock,
             cloudMachines,
+            cloudTerminalManualIO,
             extensions,
             customSidebars,
             remoteTmux,
@@ -158,6 +163,23 @@ public struct BetaFeaturesSection: View {
                 .labelsHidden()
                 .controlSize(.small)
                 .accessibilityIdentifier("SettingsBetaCloudMachinesToggle")
+        }
+    }
+
+    @ViewBuilder
+    private var cloudTerminalManualIORow: some View {
+        SettingsCardRow(
+            configurationReview: .json("cloud.beta.terminalManualIO.enabled"),
+            searchAnchorID: "setting:betaFeatures:cloudTerminalManualIO",
+            String(localized: "settings.betaFeatures.cloudTerminalManualIO", defaultValue: "Cloud Terminal Manual IO"),
+            subtitle: cloudTerminalManualIO.current
+                ? String(localized: "settings.betaFeatures.cloudTerminalManualIO.subtitleOn", defaultValue: "Cloud machine terminals render through a byte relay with structured replay and an in-pane reconnect overlay.")
+                : String(localized: "settings.betaFeatures.cloudTerminalManualIO.subtitleOff", defaultValue: "Cloud machine terminals run the cmux-tui attach client as the pane's process.")
+        ) {
+            Toggle("", isOn: Binding(get: { cloudTerminalManualIO.current }, set: { cloudTerminalManualIO.set($0) }))
+                .labelsHidden()
+                .controlSize(.small)
+                .accessibilityIdentifier("SettingsBetaCloudTerminalManualIOToggle")
         }
     }
 

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Input.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Input.swift
@@ -659,7 +659,8 @@ extension TerminalSurface {
         manualIONoReflow = value
     }
 
-    /// Enqueues remote tmux `%output` for the terminal parser.
+    /// Enqueues remote output (tmux `%output`, tui pipe-io bytes) for the
+    /// terminal parser.
     ///
     /// The native parser runs on the surface generation's FIFO output lane and
     /// this method returns without waiting for Ghostty's renderer-state mutex.

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -176471,6 +176471,27 @@
         }
       }
     },
+    "settings.betaFeatures.cloudTerminalManualIO": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Cloud Terminal Manual IO" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "クラウドターミナル マニュアルIO" } }
+      }
+    },
+    "settings.betaFeatures.cloudTerminalManualIO.subtitleOn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Cloud machine terminals render through a byte relay with structured replay and an in-pane reconnect overlay." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "クラウドマシンのターミナルは、構造化リプレイとペイン内再接続オーバーレイを備えたバイトリレーで描画されます。" } }
+      }
+    },
+    "settings.betaFeatures.cloudTerminalManualIO.subtitleOff": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Cloud machine terminals run the cmux-tui attach client as the pane's process." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "クラウドマシンのターミナルはcmux-tui attachクライアントをペインのプロセスとして実行します。" } }
+      }
+    },
     "settings.betaFeatures.warning": {
       "extractionState": "manual",
       "localizations": {
@@ -256316,6 +256337,48 @@
             "value": "分割窗格"
           }
         }
+      }
+    },
+    "tui.overlay.reconnecting.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Reconnecting to the terminal session" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "ターミナルセッションに再接続中" } }
+      }
+    },
+    "tui.overlay.reconnecting.detail": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "The session daemon is unreachable (attempt %lld). The terminal shows its last state; input is paused." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "セッションデーモンに接続できません（試行 %lld 回目）。ターミナルは最後の状態を表示しており、入力は一時停止中です。" } }
+      }
+    },
+    "tui.overlay.failed.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Terminal relay unavailable" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "ターミナルリレーを利用できません" } }
+      }
+    },
+    "tui.overlay.failed.detail": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "The relay for this terminal keeps failing. Retry now, or close the pane and reopen the terminal from the machine\u2019s tree." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "このターミナルのリレーが繰り返し失敗しています。今すぐ再試行するか、ペインを閉じてマシンのツリーからターミナルを開き直してください。" } }
+      }
+    },
+    "tui.overlay.ended.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Terminal session ended" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "ターミナルセッションが終了しました" } }
+      }
+    },
+    "tui.overlay.ended.detail": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "The daemon-backed terminal has ended. Close the tab, or keep it to read the final screen." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "デーモン管理のターミナルが終了しました。タブを閉じるか、最後の画面を確認するために残せます。" } }
       }
     },
     "uiTest.bonsplit.action.title": {

--- a/Sources/Cloud/CloudTuiManualIO.swift
+++ b/Sources/Cloud/CloudTuiManualIO.swift
@@ -1,0 +1,104 @@
+import CmuxSettings
+import Foundation
+#if DEBUG
+import CMUXDebugLog
+#endif
+
+/// Everything a workspace needs to run one `--pipe-io` relay for a cloud
+/// machine's cmux-tui terminal: the bundled client, the machine link's local
+/// mux socket, and the daemon terminal id.
+struct CloudTuiManualIOAttach: Equatable, Sendable {
+    let clientPath: String
+    let socketPath: String
+    let terminalID: String
+
+    @MainActor
+    func makePump() -> TuiManualIOPump {
+        TuiManualIOPump(
+            binaryPath: clientPath,
+            target: .socket(socketPath),
+            terminalID: terminalID,
+            // The relay only dials a local unix socket; the ambient
+            // environment (PATH, HOME, TMPDIR) is all it needs, same as the
+            // link client itself.
+            environment: ProcessInfo.processInfo.environment
+        )
+    }
+}
+
+/// Gate for the cloud manual-IO data path. On (the default) a cloud
+/// terminal pane renders through a manual-mirror Ghostty surface fed by
+/// `attach --pipe-io`; off (or when the bundled client predates the flag)
+/// it falls back to the exec attach pane running the full TUI renderer.
+enum CloudTuiManualIO {
+    nonisolated static var isEnabled: Bool {
+        let key = SettingCatalog().betaFeatures.cloudTerminalManualIO
+        return Bool.decodeFromUserDefaults(UserDefaults.standard.object(forKey: key.userDefaultsKey))
+            ?? key.defaultValue
+    }
+
+    /// True when `client` understands `attach --pipe-io`. The bundled
+    /// client comes from a rolling artifacts manifest, so a freshly built
+    /// app can carry a client older than this feature; probing keeps that
+    /// skew a silent fallback to the exec pane instead of a relay crash
+    /// loop. One probe per client path+mtime, cached for the process.
+    static func clientSupportsPipeIO(clientURL: URL) async -> Bool {
+        await CloudTuiPipeIOProbe.shared.supportsPipeIO(clientURL: clientURL)
+    }
+}
+
+/// Serializes `--help` probes and caches their results; an actor so the
+/// child `Process` and its deadline task stay on one isolation domain (the
+/// same shape as ``CloudMachineLink/run(arguments:timeout:)``).
+actor CloudTuiPipeIOProbe {
+    static let shared = CloudTuiPipeIOProbe()
+    private var results: [String: Bool] = [:]
+
+    func supportsPipeIO(clientURL: URL) async -> Bool {
+        let path = clientURL.path
+        let mtime = ((try? FileManager.default.attributesOfItem(atPath: path))?[.modificationDate] as? Date)?
+            .timeIntervalSince1970 ?? 0
+        let cacheKey = "\(path)#\(mtime)"
+        if let cached = results[cacheKey] {
+            return cached
+        }
+        let supported = await probeHelp(clientURL: clientURL)
+        results[cacheKey] = supported
+#if DEBUG
+        cmuxDebugLog("cloudTuiManualIO.probe client=\(path) supportsPipeIO=\(supported)")
+#endif
+        return supported
+    }
+
+    private func probeHelp(clientURL: URL) async -> Bool {
+        let process = Process()
+        process.executableURL = clientURL
+        // The top-level help is the short index; `--pipe-io` is documented
+        // only in the attach/start options help.
+        process.arguments = ["attach", "--help"]
+        process.standardInput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        let stdout = Pipe()
+        process.standardOutput = stdout
+        let exit = CloudLinkFirstValue<Int32>()
+        process.terminationHandler = { exit.resolve($0.terminationStatus) }
+        do {
+            try process.run()
+        } catch {
+            return false
+        }
+        async let output = CloudLinkPipe.readToEnd(stdout.fileHandleForReading)
+        let deadline = Task {
+            do {
+                try await Task.sleep(for: .seconds(10))
+            } catch {
+                return
+            }
+            process.terminate()
+        }
+        _ = await exit.result
+        deadline.cancel()
+        let text = String(decoding: await output, as: UTF8.self)
+        return text.contains("--pipe-io")
+    }
+}

--- a/Sources/Cloud/CloudTuiManualIO.swift
+++ b/Sources/Cloud/CloudTuiManualIO.swift
@@ -31,7 +31,7 @@ struct CloudTuiManualIOAttach: Equatable, Sendable {
 /// `attach --pipe-io`; off (or when the bundled client predates the flag)
 /// it falls back to the exec attach pane running the full TUI renderer.
 enum CloudTuiManualIO {
-    nonisolated static var isEnabled: Bool {
+    static var isEnabled: Bool {
         let key = SettingCatalog().betaFeatures.cloudTerminalManualIO
         return Bool.decodeFromUserDefaults(UserDefaults.standard.object(forKey: key.userDefaultsKey))
             ?? key.defaultValue

--- a/Sources/Cloud/CloudTuiManualIO.swift
+++ b/Sources/Cloud/CloudTuiManualIO.swift
@@ -1,5 +1,8 @@
 import CmuxSettings
 import Foundation
+#if canImport(Darwin)
+import Darwin
+#endif
 #if DEBUG
 import CMUXDebugLog
 #endif
@@ -87,18 +90,38 @@ actor CloudTuiPipeIOProbe {
         } catch {
             return false
         }
-        async let output = CloudLinkPipe.readToEnd(stdout.fileHandleForReading)
-        let deadline = Task {
-            do {
-                try await Task.sleep(for: .seconds(10))
-            } catch {
-                return
+        let outputTask = Task { await CloudLinkPipe.readToEnd(stdout.fileHandleForReading) }
+        let timedOut = await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                _ = await exit.result
+                return false
             }
-            process.terminate()
+            group.addTask {
+                do {
+                    try await Task.sleep(for: .seconds(10))
+                    return true
+                } catch {
+                    return false
+                }
+            }
+            let result = await group.next() ?? true
+            group.cancelAll()
+            return result
         }
-        _ = await exit.result
-        deadline.cancel()
-        let text = String(decoding: await output, as: UTF8.self)
+        guard !timedOut else {
+            // `terminate()` is cooperative and a wedged helper can ignore
+            // SIGTERM. Force-kill and reap the exact child, then close the
+            // pipe so its reader cannot keep this probe suspended.
+            process.terminate()
+#if canImport(Darwin)
+            _ = kill(process.processIdentifier, SIGKILL)
+#endif
+            stdout.fileHandleForReading.closeFile()
+            process.waitUntilExit()
+            outputTask.cancel()
+            return false
+        }
+        let text = String(decoding: await outputTask.value, as: UTF8.self)
         return text.contains("--pipe-io")
     }
 }

--- a/Sources/Cloud/CloudTuiManualIO.swift
+++ b/Sources/Cloud/CloudTuiManualIO.swift
@@ -91,24 +91,12 @@ actor CloudTuiPipeIOProbe {
             return false
         }
         let outputTask = Task { await CloudLinkPipe.readToEnd(stdout.fileHandleForReading) }
-        let timedOut = await withTaskGroup(of: Bool.self) { group in
-            group.addTask {
-                _ = await exit.result
-                return false
-            }
-            group.addTask {
-                do {
-                    try await Task.sleep(for: .seconds(10))
-                    return true
-                } catch {
-                    return false
-                }
-            }
-            let result = await group.next() ?? true
-            group.cancelAll()
-            return result
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(10))
+        while process.isRunning, clock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(100))
         }
-        guard !timedOut else {
+        guard !process.isRunning else {
             // `terminate()` is cooperative and a wedged helper can ignore
             // SIGTERM. Force-kill and reap the exact child, then close the
             // pipe so its reader cannot keep this probe suspended.

--- a/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
+++ b/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
@@ -392,8 +392,7 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
         let created: (workspaceID: UUID, panelID: UUID)
         switch resource.kind {
         case .terminal:
-            let command = try await attachCommand(terminalID: resource.id.key)
-            created = try SurfacePaneFactory.makeTerminalPane(initialCommand: command, workingDirectory: nil, at: destination, focus: focus)
+            created = try await openTerminalPane(terminalID: resource.id.key, at: destination, focus: focus)
         case .display, .browser:
             let desktop = resource.kind == .display
             guard let port = resource.port ?? (desktop ? CmuxTuiSnapshotParser.desktopPort : nil) else {
@@ -538,12 +537,36 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
         )
     }
 
-    private func attachCommand(terminalID: String) async throws -> String {
+    /// One decision point for how a cloud terminal renders in a pane, shared
+    /// by fresh materialization and restored-pane re-projection. Manual IO
+    /// (the default): a manual-mirror surface fed by `attach --pipe-io`
+    /// against the machine link's socket, with the pump's reconnect state
+    /// machine. Fallback (toggle off, or a bundled client that predates
+    /// `--pipe-io`): the exec attach pane running the full TUI renderer.
+    private func openTerminalPane(
+        terminalID: String,
+        at destination: SurfaceDestination,
+        focus: Bool
+    ) async throws -> (workspaceID: UUID, panelID: UUID) {
         let connected = try await links.connected(machineID: machineID)
         guard let clientURL = CloudTuiClientPaths.clientURL() else {
             throw CloudMachineLinkManager.ManagerError.clientMissing
         }
-        return CloudTuiCommandLine.attachShellCommand(clientPath: clientURL.path, socketPath: connected.socketPath, terminalID: terminalID)
+        if CloudTuiManualIO.isEnabled,
+           await CloudTuiManualIO.clientSupportsPipeIO(clientURL: clientURL) {
+            let attach = CloudTuiManualIOAttach(
+                clientPath: clientURL.path,
+                socketPath: connected.socketPath,
+                terminalID: terminalID
+            )
+            return try SurfacePaneFactory.makeCloudTuiTerminalPane(attach: attach, at: destination, focus: focus)
+        }
+        let command = CloudTuiCommandLine.attachShellCommand(
+            clientPath: clientURL.path,
+            socketPath: connected.socketPath,
+            terminalID: terminalID
+        )
+        return try SurfacePaneFactory.makeTerminalPane(initialCommand: command, workingDirectory: nil, at: destination, focus: focus)
     }
 
     /// The tokened wrapper URL the control plane mints for a port; the desktop adds the
@@ -641,10 +664,8 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
                 Task { @MainActor [weak self] in
                     guard let self else { return }
                     do {
-                        let command = try await self.attachCommand(terminalID: terminal.id.key)
-                        let created = try SurfacePaneFactory.makeTerminalPane(
-                            initialCommand: command,
-                            workingDirectory: nil,
+                        let created = try await self.openTerminalPane(
+                            terminalID: terminal.id.key,
                             at: .tab(workspaceID: projection.workspaceID, paneID: paneID, index: nil),
                             focus: false
                         )

--- a/Sources/Surfaces/SurfacePaneFactory.swift
+++ b/Sources/Surfaces/SurfacePaneFactory.swift
@@ -36,6 +36,18 @@ enum SurfacePaneFactory {
         try create(typeRaw: "terminal", url: nil, initialCommand: initialCommand, workingDirectory: workingDirectory, at: destination, focus: focus)
     }
 
+    /// A manual-IO terminal pane for one cloud cmux-tui terminal: the pane's
+    /// Ghostty surface parses daemon bytes fed by an `attach --pipe-io` relay
+    /// (no local process), placed with the same tab/split semantics as
+    /// ``makeTerminalPane(initialCommand:workingDirectory:at:focus:)``.
+    static func makeCloudTuiTerminalPane(
+        attach: CloudTuiManualIOAttach,
+        at destination: SurfaceDestination,
+        focus: Bool
+    ) throws -> (workspaceID: UUID, panelID: UUID) {
+        try create(typeRaw: "terminal", url: nil, initialCommand: nil, workingDirectory: nil, at: destination, focus: focus, cloudTuiManualIOAttach: attach)
+    }
+
     /// A browser pane loading `url` at the destination.
     static func makeBrowserPane(url: URL, at destination: SurfaceDestination, focus: Bool) throws -> (workspaceID: UUID, panelID: UUID) {
         try create(typeRaw: "browser", url: url.absoluteString, initialCommand: nil, workingDirectory: nil, at: destination, focus: focus)
@@ -129,7 +141,8 @@ enum SurfacePaneFactory {
         initialCommand: String?,
         workingDirectory: String?,
         at destination: SurfaceDestination,
-        focus: Bool
+        focus: Bool,
+        cloudTuiManualIOAttach: CloudTuiManualIOAttach? = nil
     ) throws -> (workspaceID: UUID, panelID: UUID) {
         let workspaceID = destination.workspaceID
         guard let workspace = workspace(id: workspaceID) else { throw FactoryError.workspaceNotFound(workspaceID) }
@@ -138,14 +151,14 @@ enum SurfacePaneFactory {
         switch destination {
         case .tab(_, let paneID, _):
             guard let requestedPane = UUID(uuidString: paneID) else { throw FactoryError.paneNotFound(paneID) }
-            return try tab(controller: controller, routing: routing, typeRaw: typeRaw, url: url, initialCommand: initialCommand, workingDirectory: workingDirectory, requestedPane: requestedPane, focus: focus)
+            return try tab(controller: controller, routing: routing, typeRaw: typeRaw, url: url, initialCommand: initialCommand, workingDirectory: workingDirectory, requestedPane: requestedPane, focus: focus, cloudTuiManualIOAttach: cloudTuiManualIOAttach)
         case .workspace(_, .tab):
-            return try tab(controller: controller, routing: routing, typeRaw: typeRaw, url: url, initialCommand: initialCommand, workingDirectory: workingDirectory, requestedPane: nil, focus: focus)
+            return try tab(controller: controller, routing: routing, typeRaw: typeRaw, url: url, initialCommand: initialCommand, workingDirectory: workingDirectory, requestedPane: nil, focus: focus, cloudTuiManualIOAttach: cloudTuiManualIOAttach)
         case .split(_, let paneID, let direction):
             let anchor = try anchorSurface(paneID: paneID, in: workspace)
-            return try split(controller: controller, routing: routing, typeRaw: typeRaw, url: url, initialCommand: initialCommand, workingDirectory: workingDirectory, direction: direction, anchor: anchor, focus: focus)
+            return try split(controller: controller, routing: routing, typeRaw: typeRaw, url: url, initialCommand: initialCommand, workingDirectory: workingDirectory, direction: direction, anchor: anchor, focus: focus, cloudTuiManualIOAttach: cloudTuiManualIOAttach)
         case .workspace(_, .split):
-            return try split(controller: controller, routing: routing, typeRaw: typeRaw, url: url, initialCommand: initialCommand, workingDirectory: workingDirectory, direction: .right, anchor: nil, focus: focus)
+            return try split(controller: controller, routing: routing, typeRaw: typeRaw, url: url, initialCommand: initialCommand, workingDirectory: workingDirectory, direction: .right, anchor: nil, focus: focus, cloudTuiManualIOAttach: cloudTuiManualIOAttach)
         }
     }
 
@@ -157,7 +170,8 @@ enum SurfacePaneFactory {
         initialCommand: String?,
         workingDirectory: String?,
         requestedPane: UUID?,
-        focus: Bool
+        focus: Bool,
+        cloudTuiManualIOAttach: CloudTuiManualIOAttach? = nil
     ) throws -> (workspaceID: UUID, panelID: UUID) {
         let resolution = controller.controlSurfaceCreate(
             routing: routing,
@@ -176,7 +190,8 @@ enum SurfacePaneFactory {
                 // the drop index, so it is not honored here either.
                 requestedPaneID: requestedPane,
                 requestedFocus: focus
-            )
+            ),
+            cloudTuiManualIOAttach: cloudTuiManualIOAttach
         )
         if case .created(_, let createdWorkspaceID, _, let surfaceID, _) = resolution {
             return (createdWorkspaceID, surfaceID)
@@ -193,7 +208,8 @@ enum SurfacePaneFactory {
         workingDirectory: String?,
         direction: SurfaceSplitDirection,
         anchor: UUID?,
-        focus: Bool
+        focus: Bool,
+        cloudTuiManualIOAttach: CloudTuiManualIOAttach? = nil
     ) throws -> (workspaceID: UUID, panelID: UUID) {
         let resolution = controller.controlSurfaceSplit(
             routing: routing,
@@ -211,7 +227,8 @@ enum SurfacePaneFactory {
                 clientUnsupportedRemoteTmuxOptions: [],
                 requestedFocus: focus,
                 initialDividerPosition: nil
-            )
+            ),
+            cloudTuiManualIOAttach: cloudTuiManualIOAttach
         )
         if case .created(_, let createdWorkspaceID, _, let surfaceID, _) = resolution {
             return (createdWorkspaceID, surfaceID)

--- a/Sources/TerminalController+ControlSurfaceContext2.swift
+++ b/Sources/TerminalController+ControlSurfaceContext2.swift
@@ -67,9 +67,21 @@ extension TerminalController {
 
     // MARK: - split
 
+    /// The ``ControlSurfaceContext`` requirement (socket dispatch): a
+    /// defaulted extra parameter cannot satisfy the protocol, so the exact
+    /// two-parameter shape forwards with no attach descriptor.
     func controlSurfaceSplit(
         routing: ControlRoutingSelectors,
         inputs: ControlSurfaceSplitInputs
+    ) -> ControlSurfaceSplitResolution {
+        controlSurfaceSplit(routing: routing, inputs: inputs, cloudTuiManualIOAttach: nil)
+    }
+
+    /// `cloudTuiManualIOAttach`: see ``controlSurfaceCreate(routing:inputs:cloudTuiManualIOAttach:)``.
+    func controlSurfaceSplit(
+        routing: ControlRoutingSelectors,
+        inputs: ControlSurfaceSplitInputs,
+        cloudTuiManualIOAttach: CloudTuiManualIOAttach?
     ) -> ControlSurfaceSplitResolution {
         guard let tabManager = resolveTabManager(routing: routing) else {
             return .tabManagerUnavailable
@@ -175,7 +187,8 @@ extension TerminalController {
                 initialDividerPosition: dividerPosition,
                 remotePTYSessionID: inputs.remotePTYSessionID,
                 suppressWorkspaceRemoteStartupCommand: useLocalContext,
-                allowTextBoxFocusDefault: false
+                allowTextBoxFocusDefault: false,
+                cloudTuiManualIOAttach: cloudTuiManualIOAttach
             ) {
             case .created(let panel):
                 newId = panel.id
@@ -281,9 +294,23 @@ extension TerminalController {
 
     // MARK: - create
 
+    /// The ``ControlSurfaceContext`` requirement (socket dispatch); see the
+    /// split wrapper above for why the exact shape must exist.
     func controlSurfaceCreate(
         routing: ControlRoutingSelectors,
         inputs: ControlSurfaceCreateInputs
+    ) -> ControlSurfaceCreateResolution {
+        controlSurfaceCreate(routing: routing, inputs: inputs, cloudTuiManualIOAttach: nil)
+    }
+
+    /// `cloudTuiManualIOAttach` is app-internal (never parsed from socket
+    /// params): when set, the terminal pane is a manual-mirror surface fed by
+    /// that relay descriptor instead of a spawned process. Only
+    /// ``SurfacePaneFactory`` passes it, for cloud machine terminals.
+    func controlSurfaceCreate(
+        routing: ControlRoutingSelectors,
+        inputs: ControlSurfaceCreateInputs,
+        cloudTuiManualIOAttach: CloudTuiManualIOAttach?
     ) -> ControlSurfaceCreateResolution {
         guard let tabManager = resolveTabManager(routing: routing) else {
             return .tabManagerUnavailable
@@ -408,7 +435,8 @@ extension TerminalController {
                 remotePTYSessionID: inputs.remotePTYSessionID,
                 suppressWorkspaceRemoteStartupCommand: useLocalContext,
                 inheritWorkingDirectoryFallback: true,
-                allowTextBoxFocusDefault: false
+                allowTextBoxFocusDefault: false,
+                cloudTuiManualIOAttach: cloudTuiManualIOAttach
             ) {
             case .created(let panel):
                 newPanelId = panel.id

--- a/Sources/TuiManualIOPump.swift
+++ b/Sources/TuiManualIOPump.swift
@@ -184,6 +184,76 @@ enum TuiManualIOPumpPolicy {
     }
 }
 
+/// One terminal grid size, as the pump schedules it.
+struct TuiManualIOGrid: Equatable {
+    var cols: Int
+    var rows: Int
+}
+
+/// Ack-clocked, latest-wins resize scheduling. The relay applies each
+/// resize as one synchronous daemon round trip and reports it with a
+/// `{"diag":{"resize":...}}` stderr line; sending faster than the link's
+/// round trip therefore queues stale sizes the daemon must chew through
+/// one by one (seconds of lag on a cloud link for one divider drag), and
+/// keystrokes on the same relay stdin stall behind them. This scheduler
+/// keeps at most ONE resize in flight and remembers only the NEWEST
+/// pending sample: on a local daemon (sub-ms ack) it degenerates to
+/// send-every-sample, on a slow link it sends one resize per round trip
+/// and always converges on the final size. Pure and unit-tested; the pump
+/// owns timers and I/O.
+struct TuiManualIOResizeScheduler: Equatable {
+    private(set) var inFlight: TuiManualIOGrid?
+    private(set) var pending: TuiManualIOGrid?
+    private(set) var lastDelivered: TuiManualIOGrid?
+
+    /// The relay was (re)spawned carrying `grid` in its argv; nothing is in
+    /// flight and nothing is pending.
+    mutating func seed(delivered grid: TuiManualIOGrid) {
+        inFlight = nil
+        pending = nil
+        lastDelivered = grid
+    }
+
+    /// The relay died; a respawn reseeds from its spawn grid.
+    mutating func reset() {
+        inFlight = nil
+        pending = nil
+        lastDelivered = nil
+    }
+
+    /// A new surface grid sample. Returns the grid to send NOW, or nil when
+    /// it was deduplicated or parked behind the in-flight resize.
+    mutating func sample(_ grid: TuiManualIOGrid) -> TuiManualIOGrid? {
+        if let inFlight {
+            // Latest wins; intermediate drag sizes are never sent.
+            pending = grid == inFlight ? nil : grid
+            return nil
+        }
+        if grid == lastDelivered {
+            pending = nil
+            return nil
+        }
+        inFlight = grid
+        return grid
+    }
+
+    /// The relay acknowledged (or errored, or the ack timed out — all three
+    /// free the channel). Returns the next grid to send, or nil.
+    mutating func acknowledged() -> TuiManualIOGrid? {
+        if let inFlight {
+            lastDelivered = inFlight
+        }
+        inFlight = nil
+        guard let next = pending, next != lastDelivered else {
+            pending = nil
+            return nil
+        }
+        pending = nil
+        inFlight = next
+        return next
+    }
+}
+
 /// Cross-thread input channel between the Ghostty IO thread (which delivers
 /// the surface's encoded input bytes) and the pump's relay stdin writer.
 /// Lock-guarded because `manualInputHandler` must not touch the main actor.
@@ -280,6 +350,7 @@ final class TuiManualIOPump {
     private var stdoutReader: RemoteTmuxProcessOutputReader?
     private var stdoutTask: Task<Void, Never>?
     private var stderrBox = TuiManualIOStderrBox()
+    private var stderrStream: TuiManualIOStderrStream?
     private var retryTask: Task<Void, Never>?
     /// Process termination and stderr EOF race (termination is not EOF);
     /// classification needs the relay's final stderr line, so it runs only
@@ -291,8 +362,13 @@ final class TuiManualIOPump {
     private var stopped = false
     private var everRenderedAttach = false
     private var consecutiveUnexplainedFailures = 0
-    private var lastKnownGrid: (cols: Int, rows: Int)?
-    private var lastSentGrid: (cols: Int, rows: Int)?
+    private var lastKnownGrid: TuiManualIOGrid?
+    private var resizeScheduler = TuiManualIOResizeScheduler()
+    private var resizeAckTimeoutTask: Task<Void, Never>?
+    /// Liveness bound for a lost or unsupported ack line; treating the
+    /// timeout as an ack keeps the pending size flowing on relays that stop
+    /// emitting resize diags.
+    static let resizeAckTimeout: Duration = .seconds(2)
 
     init(
         binaryPath: String,
@@ -374,10 +450,14 @@ final class TuiManualIOPump {
         stopped = true
         retryTask?.cancel()
         retryTask = nil
+        resizeAckTimeoutTask?.cancel()
+        resizeAckTimeoutTask = nil
         stdoutTask?.cancel()
         stdoutTask = nil
         stdoutReader?.close()
         stdoutReader = nil
+        stderrStream?.close()
+        stderrStream = nil
         inputChannel.closeHandle()
         generation += 1
         process?.terminationHandler = nil
@@ -393,14 +473,47 @@ final class TuiManualIOPump {
 
     private func handleSizingSample(cols: Int, rows: Int) {
         guard !stopped else { return }
-        lastKnownGrid = (cols, rows)
+        let grid = TuiManualIOGrid(cols: cols, rows: rows)
+        lastKnownGrid = grid
         if process == nil, retryTask == nil, case .connecting = state {
             spawnRelay()
             return
         }
-        if let sent = lastSentGrid, sent == (cols, rows) { return }
-        lastSentGrid = (cols, rows)
-        inputChannel.send(TuiManualIOPumpPolicy.resizeLine(cols: cols, rows: rows))
+        if let send = resizeScheduler.sample(grid) {
+            deliverResize(send)
+        }
+    }
+
+    private func deliverResize(_ grid: TuiManualIOGrid) {
+        inputChannel.send(TuiManualIOPumpPolicy.resizeLine(cols: grid.cols, rows: grid.rows))
+        startResizeAckTimeout()
+    }
+
+    /// The relay reported one resize round trip done (applied, deduplicated,
+    /// or errored — all free the channel), or the liveness timeout fired.
+    private func handleResizeAcknowledged(generation ackedGeneration: Int) {
+        guard ackedGeneration == generation, !stopped else { return }
+        resizeAckTimeoutTask?.cancel()
+        resizeAckTimeoutTask = nil
+        if let next = resizeScheduler.acknowledged() {
+            deliverResize(next)
+        }
+    }
+
+    private func startResizeAckTimeout() {
+        let timeoutGeneration = generation
+        let sleep = sleep
+        resizeAckTimeoutTask?.cancel()
+        resizeAckTimeoutTask = Task { @MainActor [weak self] in
+            do {
+                try await sleep(Self.resizeAckTimeout)
+            } catch {
+                return
+            }
+            guard !Task.isCancelled else { return }
+            self?.log("resize ack timeout generation=\(timeoutGeneration)")
+            self?.handleResizeAcknowledged(generation: timeoutGeneration)
+        }
     }
 
     // MARK: - Relay lifecycle
@@ -417,8 +530,10 @@ final class TuiManualIOPump {
         }
         generation += 1
         let spawnGeneration = generation
-        let grid = lastKnownGrid ?? (80, 24)
-        lastSentGrid = grid
+        let grid = lastKnownGrid ?? TuiManualIOGrid(cols: 80, rows: 24)
+        resizeScheduler.seed(delivered: grid)
+        resizeAckTimeoutTask?.cancel()
+        resizeAckTimeoutTask = nil
 
         // A respawned relay replays the daemon terminal from scratch; reset
         // the surface first so the replay replaces the stale frame instead
@@ -447,16 +562,24 @@ final class TuiManualIOPump {
         let stderrBox = TuiManualIOStderrBox()
         self.stderrBox = stderrBox
         pendingExitStatus = nil
-        // Blocking drain to EOF on a throwaway queue: it continuously
-        // empties the pipe (a full pipe would wedge the relay) and EOF is
-        // the only signal that the final exit-reason line has landed.
-        let stderrHandle = stderrPipe.fileHandleForReading
-        DispatchQueue(label: "cmux.tuiManualIO.stderr", qos: .utility).async { [weak self] in
-            stderrBox.append(stderrHandle.readDataToEndOfFile())
-            Task { @MainActor [weak self] in
-                self?.handleStderrDrained(generation: spawnGeneration)
+        // Streaming drain: it continuously empties the pipe (a full pipe
+        // would wedge the relay), surfaces per-resize diag lines as acks
+        // for the resize scheduler while the relay runs, and EOF is the
+        // only signal that the final exit-reason line has landed.
+        stderrStream = TuiManualIOStderrStream(
+            handle: stderrPipe.fileHandleForReading,
+            box: stderrBox,
+            onResizeDiag: { [weak self] in
+                Task { @MainActor [weak self] in
+                    self?.handleResizeAcknowledged(generation: spawnGeneration)
+                }
+            },
+            onEOF: { [weak self] in
+                Task { @MainActor [weak self] in
+                    self?.handleStderrDrained(generation: spawnGeneration)
+                }
             }
-        }
+        )
 
         let reader = RemoteTmuxProcessOutputReader(
             label: "cmux.tuiManualIO.stdout",
@@ -531,6 +654,11 @@ final class TuiManualIOPump {
         guard exitedGeneration == generation, !stopped else { return }
         inputChannel.setHandle(nil)
         process = nil
+        // A dead relay has no resize channel; the respawn reseeds the
+        // scheduler from its spawn grid.
+        resizeAckTimeoutTask?.cancel()
+        resizeAckTimeoutTask = nil
+        resizeScheduler.reset()
         let exit = forcedExit
             ?? TuiManualIOPumpPolicy.relayExit(status: status ?? -1, stderrText: stderrBox.text())
 #if DEBUG
@@ -622,6 +750,70 @@ final class TuiManualIOPumpRegistry {
     /// a detach transfer). The relay sees stdin EOF and detaches cleanly.
     func stopAndRemove(surfaceID: UUID) {
         pumps.removeValue(forKey: surfaceID)?.stop()
+    }
+}
+
+/// GCD-driven stderr reader for one relay: accumulates raw bytes in the
+/// exit-classification box AND surfaces each complete `{"diag":{"resize":…}}`
+/// line as a resize ack while the relay runs. `readabilityHandler` runs on a
+/// GCD queue and costs the cooperative pool nothing (same rationale as
+/// `CloudLinkPipe`); EOF is still the only signal that the final exit-reason
+/// line has landed.
+final class TuiManualIOStderrStream: @unchecked Sendable {
+    private let lock = NSLock()
+    private var handle: FileHandle?
+    private var pendingLine = Data()
+
+    init(
+        handle: FileHandle,
+        box: TuiManualIOStderrBox,
+        onResizeDiag: @escaping @Sendable () -> Void,
+        onEOF: @escaping @Sendable () -> Void
+    ) {
+        self.handle = handle
+        handle.readabilityHandler = { [weak self] fh in
+            let data = fh.availableData
+            if data.isEmpty {
+                fh.readabilityHandler = nil
+                onEOF()
+                return
+            }
+            box.append(data)
+            self?.scanLines(data, onResizeDiag: onResizeDiag)
+        }
+    }
+
+    /// Splits the byte stream into complete lines and fires the ack callback
+    /// for each resize diag. Partial trailing lines wait for the next chunk;
+    /// the final (exit) line needs no scan, EOF classification owns it.
+    private func scanLines(_ data: Data, onResizeDiag: @Sendable () -> Void) {
+        lock.lock()
+        pendingLine.append(data)
+        var lines: [Data] = []
+        while let newline = pendingLine.firstIndex(of: 0x0A) {
+            lines.append(Data(pendingLine[pendingLine.startIndex..<newline]))
+            pendingLine = Data(pendingLine[pendingLine.index(after: newline)...])
+        }
+        // Bound the buffer against a relay that misbehaves and never prints
+        // a newline; diag and exit lines are all short.
+        if pendingLine.count > 64 * 1024 {
+            pendingLine.removeFirst(pendingLine.count - 64 * 1024)
+        }
+        lock.unlock()
+        for line in lines {
+            if line.range(of: Data(#""diag""#.utf8)) != nil,
+               line.range(of: Data(#""resize""#.utf8)) != nil {
+                onResizeDiag()
+            }
+        }
+    }
+
+    func close() {
+        lock.lock()
+        let target = handle
+        handle = nil
+        lock.unlock()
+        target?.readabilityHandler = nil
     }
 }
 

--- a/Sources/TuiManualIOPump.swift
+++ b/Sources/TuiManualIOPump.swift
@@ -103,6 +103,21 @@ enum TuiManualIOPumpPolicy {
         Data(#"{"resize":{"cols":\#(max(1, cols)),"rows":\#(max(1, rows))}}"#.utf8 + [0x0A])
     }
 
+    /// One stdin line re-asserting this relay's geometry authority.
+    /// Authority is last-claim-wins across a terminal's attachments, and
+    /// stale panes (session restore recreates every workspace that ever
+    /// viewed the terminal) claim at attach in arbitrary order — so the
+    /// pane the user actually TYPES in re-claims, and the daemon's PTY size
+    /// follows user intent instead of restore order.
+    static let claimGeometryLine = Data(#"{"claim":{"geometry":true}}"#.utf8 + [0x0A])
+
+    /// Re-claim at most this often: a claim is one daemon round trip, so
+    /// claiming per keystroke would double interactive traffic. Within one
+    /// window the current pane already holds authority; switching panes
+    /// re-claims on the first keystroke because each pane throttles its own
+    /// channel.
+    static let claimInterval: TimeInterval = 5
+
     /// Relay argv (no shell, no quoting: the pump spawns the binary
     /// directly, so the exec-wrapper and env(1) classes of the exec attach
     /// pane cannot exist here). `--socket` is a global option and precedes
@@ -260,14 +275,19 @@ struct TuiManualIOResizeScheduler: Equatable {
 final class TuiManualIOInputChannel: @unchecked Sendable {
     private let lock = NSLock()
     private var handle: FileHandle?
+    private var lastGeometryClaim: TimeInterval = 0
     private let queue = DispatchQueue(label: "cmux.tuiManualIO.stdin", qos: .userInitiated)
 
     /// Swaps the live relay stdin. `nil` pauses input (dropped, never
     /// queued: replaying stale input into a shell after a reconnect is
-    /// worse than losing keystrokes typed into a dead pane).
-    func setHandle(_ newHandle: FileHandle?) {
+    /// worse than losing keystrokes typed into a dead pane). A fresh handle
+    /// counts as a claim: the relay claims geometry itself at attach.
+    func setHandle(_ newHandle: FileHandle?, now: TimeInterval = ProcessInfo.processInfo.systemUptime) {
         lock.lock()
         handle = newHandle
+        if newHandle != nil {
+            lastGeometryClaim = now
+        }
         lock.unlock()
     }
 
@@ -279,6 +299,33 @@ final class TuiManualIOInputChannel: @unchecked Sendable {
         queue.async {
             // A failed write means the relay just died; the pump's
             // termination handler owns that transition.
+            try? target.write(contentsOf: line)
+        }
+    }
+
+    /// Sends user input, preceded by a geometry re-claim when the last
+    /// claim on this channel is older than `claimInterval`. Ordering is
+    /// preserved by the serial queue, so the claim lands before the
+    /// keystroke that triggered it.
+    func sendUserInput(
+        _ line: Data,
+        claimInterval: TimeInterval = TuiManualIOPumpPolicy.claimInterval,
+        now: TimeInterval = ProcessInfo.processInfo.systemUptime
+    ) {
+        lock.lock()
+        let target = handle
+        var claim = false
+        if target != nil, now - lastGeometryClaim >= claimInterval {
+            lastGeometryClaim = now
+            claim = true
+        }
+        lock.unlock()
+        guard let target else { return }
+        let sendClaim = claim
+        queue.async {
+            if sendClaim {
+                try? target.write(contentsOf: TuiManualIOPumpPolicy.claimGeometryLine)
+            }
             try? target.write(contentsOf: line)
         }
     }
@@ -391,7 +438,7 @@ final class TuiManualIOPump {
         return { input in
             switch input {
             case .bytes(let bytes):
-                channel.send(TuiManualIOPumpPolicy.inputLine(bytes: bytes))
+                channel.sendUserInput(TuiManualIOPumpPolicy.inputLine(bytes: bytes))
             case .namedKey:
                 // No key-name resolver is installed on this surface, so
                 // Ghostty encodes every key itself; a named key here is a

--- a/Sources/TuiManualIOPump.swift
+++ b/Sources/TuiManualIOPump.swift
@@ -644,8 +644,8 @@ final class TuiManualIOPump {
         stdoutTask = Task { @MainActor [weak self] in
             for await chunk in reader.stream {
                 guard let self, self.generation == spawnGeneration, !self.stopped else { break }
-                reader.release(chunk)
                 self.surface?.processRemoteOutput(chunk)
+                reader.release(chunk)
                 self.everRenderedAttach = true
                 self.consecutiveUnexplainedFailures = 0
                 if self.state != .live {
@@ -699,6 +699,14 @@ final class TuiManualIOPump {
         forcedExit: TuiManualIOPumpPolicy.RelayExit? = nil
     ) {
         guard exitedGeneration == generation, !stopped else { return }
+        if forcedExit != nil {
+            // Overflow means the surface cannot keep up. Stop the relay
+            // before scheduling a replacement, and fence late callbacks
+            // from the terminated process.
+            process?.terminationHandler = nil
+            process?.terminate()
+            generation += 1
+        }
         inputChannel.setHandle(nil)
         process = nil
         // A dead relay has no resize channel; the respawn reseeds the

--- a/Sources/TuiManualIOPump.swift
+++ b/Sources/TuiManualIOPump.swift
@@ -1,0 +1,649 @@
+import CmuxTerminal
+import Foundation
+#if DEBUG
+import CMUXDebugLog
+#endif
+
+/// Where a `--pipe-io` relay finds its daemon: a named local session
+/// (`attach --session <name>`) or an explicit control socket
+/// (`--socket <path> attach`), e.g. the local mux socket a cloud machine's
+/// headless link exposes.
+enum TuiManualIORelayTarget: Equatable {
+    case session(String)
+    case socket(String)
+}
+
+/// Pure decision logic for the manual-IO tui pump: relay exit
+/// classification, reconnect pacing, stdin line encoding, and the per-pane
+/// overlay presentation. Everything here is deterministic and unit-testable;
+/// process and pipe I/O live in `TuiManualIOPump`.
+enum TuiManualIOPumpPolicy {
+    /// How one relay process ended, from its exit status and the final JSON
+    /// line it printed to stderr (`{"exit":{"reason":...}}`).
+    enum RelayExit: Equatable {
+        /// The daemon terminal ended; respawning is wrong.
+        case terminalEnded
+        /// The daemon connection was lost; respawning reattaches and
+        /// resyncs from a fresh replay.
+        case daemonLost
+        /// The pump closed the relay's stdin itself (teardown/respawn).
+        case parentClosed
+        /// Anything else (spawn failure, protocol error, unknown status).
+        case failure
+    }
+
+    static func relayExit(status: Int32, stderrText: String?) -> RelayExit {
+        let reason = stderrText?
+            .split(separator: "\n")
+            .reversed()
+            .compactMap { line -> String? in
+                guard let data = line.trimmingCharacters(in: .whitespaces).data(using: .utf8),
+                      let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                      let exit = object["exit"] as? [String: Any]
+                else { return nil }
+                return exit["reason"] as? String
+            }
+            .first
+        switch (status, reason) {
+        case (0, "terminal-ended"): return .terminalEnded
+        case (0, "parent-closed"): return .parentClosed
+        // Exit 2 is daemon-lost ONLY with the relay's own reason line: a
+        // binary without --pipe-io support also exits 2 (usage error), and
+        // that must not read as an endlessly-retryable daemon outage.
+        case (2, "daemon-lost"): return .daemonLost
+        case (0, _): return .terminalEnded
+        default: return .failure
+        }
+    }
+
+    enum NextAction: Equatable {
+        case end
+        case retry
+        case ignore
+    }
+
+    static func nextAction(after exit: RelayExit) -> NextAction {
+        switch exit {
+        case .terminalEnded: return .end
+        case .daemonLost, .failure: return .retry
+        // The pump closed stdin itself; its own state machine already
+        // decided what comes next.
+        case .parentClosed: return .ignore
+        }
+    }
+
+    /// Unexplained relay failures (no exit-reason line: bad binary, usage
+    /// error, crash) stop retrying after this many consecutive attempts
+    /// without a live interlude; explained daemon-lost exits retry forever.
+    static let maxConsecutiveUnexplainedFailures = 5
+
+    /// Reconnect backoff: fast first retries absorb a daemon restart or
+    /// handoff, the 30s cap keeps a long outage cheap while the pane shows
+    /// its last state. Attempts are 1-based.
+    static func retryDelay(attempt: Int) -> Duration {
+        let schedule: [Duration] = [
+            .milliseconds(500), .seconds(1), .seconds(2), .seconds(4), .seconds(8), .seconds(16),
+        ]
+        guard attempt >= 1 else { return schedule[0] }
+        guard attempt <= schedule.count else { return .seconds(30) }
+        return schedule[attempt - 1]
+    }
+
+    /// One stdin line forwarding raw input bytes to the relay.
+    static func inputLine(bytes: Data) -> Data {
+        var line = Data(#"{"input":""#.utf8)
+        line.append(Data(bytes.base64EncodedString().utf8))
+        line.append(Data(#""}"#.utf8))
+        line.append(0x0A)
+        return line
+    }
+
+    /// One stdin line driving the daemon-side viewer size.
+    static func resizeLine(cols: Int, rows: Int) -> Data {
+        Data(#"{"resize":{"cols":\#(max(1, cols)),"rows":\#(max(1, rows))}}"#.utf8 + [0x0A])
+    }
+
+    /// Relay argv (no shell, no quoting: the pump spawns the binary
+    /// directly, so the exec-wrapper and env(1) classes of the exec attach
+    /// pane cannot exist here). `--socket` is a global option and precedes
+    /// the subcommand, matching `CloudTuiCommandLine`.
+    static func relayArguments(
+        target: TuiManualIORelayTarget,
+        terminalID: String,
+        cols: Int,
+        rows: Int
+    ) -> [String] {
+        let scoped: [String]
+        switch target {
+        case .session(let name):
+            scoped = ["attach", "--session", name]
+        case .socket(let path):
+            scoped = ["--socket", path, "attach"]
+        }
+        return scoped + [
+            "--terminal", terminalID,
+            "--pipe-io",
+            "--cols", String(max(1, cols)),
+            "--rows", String(max(1, rows)),
+        ]
+    }
+
+    /// Emitted into the surface before a respawned relay's replay: the
+    /// replay REPLACES terminal state, and only the pump knows whether this
+    /// surface already rendered a previous attach.
+    static let resyncReset = Data([0x1B, 0x63, 0x1B, 0x5B, 0x33, 0x4A]) // ESC c, CSI 3 J
+
+    /// Overlay presentation for one pump state, in the same visual family
+    /// as the cloud terminal reconnect overlay.
+    static func overlayPresentation(
+        state: TuiManualIOPump.State
+    ) -> CloudTerminalReconnectOverlayPolicy.Presentation? {
+        switch state {
+        case .connecting, .live:
+            return nil
+        case .reconnecting(let attempt):
+            return CloudTerminalReconnectOverlayPolicy.Presentation(
+                title: String(
+                    localized: "tui.overlay.reconnecting.title",
+                    defaultValue: "Reconnecting to the terminal session"
+                ),
+                detail: String(
+                    localized: "tui.overlay.reconnecting.detail",
+                    defaultValue: "The session daemon is unreachable (attempt \(attempt)). The terminal shows its last state; input is paused."
+                ),
+                showsProgress: true,
+                showsReconnectButton: true
+            )
+        case .ended:
+            return CloudTerminalReconnectOverlayPolicy.Presentation(
+                title: String(
+                    localized: "tui.overlay.ended.title",
+                    defaultValue: "Terminal session ended"
+                ),
+                detail: String(
+                    localized: "tui.overlay.ended.detail",
+                    defaultValue: "The daemon-backed terminal has ended. Close the tab, or keep it to read the final screen."
+                ),
+                showsProgress: false,
+                showsReconnectButton: false
+            )
+        case .failed:
+            return CloudTerminalReconnectOverlayPolicy.Presentation(
+                title: String(
+                    localized: "tui.overlay.failed.title",
+                    defaultValue: "Terminal relay unavailable"
+                ),
+                detail: String(
+                    localized: "tui.overlay.failed.detail",
+                    defaultValue: "The relay for this terminal keeps failing. Retry now, or close the pane and reopen the terminal from the machine\u{2019}s tree."
+                ),
+                showsProgress: false,
+                showsReconnectButton: true
+            )
+        }
+    }
+}
+
+/// Cross-thread input channel between the Ghostty IO thread (which delivers
+/// the surface's encoded input bytes) and the pump's relay stdin writer.
+/// Lock-guarded because `manualInputHandler` must not touch the main actor.
+final class TuiManualIOInputChannel: @unchecked Sendable {
+    private let lock = NSLock()
+    private var handle: FileHandle?
+    private let queue = DispatchQueue(label: "cmux.tuiManualIO.stdin", qos: .userInitiated)
+
+    /// Swaps the live relay stdin. `nil` pauses input (dropped, never
+    /// queued: replaying stale input into a shell after a reconnect is
+    /// worse than losing keystrokes typed into a dead pane).
+    func setHandle(_ newHandle: FileHandle?) {
+        lock.lock()
+        handle = newHandle
+        lock.unlock()
+    }
+
+    func send(_ line: Data) {
+        lock.lock()
+        let target = handle
+        lock.unlock()
+        guard let target else { return }
+        queue.async {
+            // A failed write means the relay just died; the pump's
+            // termination handler owns that transition.
+            try? target.write(contentsOf: line)
+        }
+    }
+
+    /// Closes and detaches the current handle (relay stdin EOF = clean
+    /// detach on the relay side).
+    func closeHandle() {
+        lock.lock()
+        let target = handle
+        handle = nil
+        lock.unlock()
+        guard let target else { return }
+        queue.async {
+            try? target.close()
+        }
+    }
+}
+
+/// Owns the `cmux-tui attach --terminal <id> --pipe-io` relay for one
+/// manual-mirror terminal panel: pumps relay stdout into the Ghostty
+/// surface, forwards the surface's encoded input to relay stdin, drives
+/// daemon-side sizing from applied surface resizes, and runs the reconnect
+/// state machine when the relay dies.
+///
+/// Data-path invariant: the surface parses the same byte stream the daemon
+/// terminal emitted, so the surface's input encodings always match the
+/// daemon terminal's mode state. The mode-mirroring/re-encoding bug class
+/// of the exec attach pane cannot exist on this path.
+@MainActor
+final class TuiManualIOPump {
+    enum State: Equatable {
+        /// First attach in flight; the pane is empty, no overlay.
+        case connecting
+        /// Relay bytes are flowing.
+        case live
+        /// The relay died recoverably; a respawn is scheduled (1-based
+        /// attempt count shown in the overlay).
+        case reconnecting(attempt: Int)
+        /// The daemon terminal ended; the pane keeps its final frame.
+        case ended
+        /// The relay failed repeatedly with no explanation (bad binary,
+        /// crash loop); automatic retries stopped, manual retry offered.
+        case failed
+    }
+
+    private(set) var state: State = .connecting {
+        didSet {
+            guard oldValue != state else { return }
+            log("state \(oldValue) -> \(state)")
+            onStateChange?()
+        }
+    }
+
+    /// Posted on every state change (wired to the workspace's overlay
+    /// resynchronization).
+    var onStateChange: (() -> Void)?
+
+    let terminalID: String
+    private let binaryPath: String
+    private let target: TuiManualIORelayTarget
+    private let environment: [String: String]
+    private let inputChannel = TuiManualIOInputChannel()
+    /// Injected so tests can run the backoff deterministically. Production
+    /// is a cancellation-checking `Task.sleep`.
+    private let sleep: @Sendable (Duration) async throws -> Void
+
+    private weak var surface: TerminalSurface?
+    private var process: Process?
+    private var stdoutReader: RemoteTmuxProcessOutputReader?
+    private var stdoutTask: Task<Void, Never>?
+    private var stderrBox = TuiManualIOStderrBox()
+    private var retryTask: Task<Void, Never>?
+    /// Process termination and stderr EOF race (termination is not EOF);
+    /// classification needs the relay's final stderr line, so it runs only
+    /// once BOTH have arrived for the current generation.
+    private var pendingExitStatus: Int32?
+    private var stderrDrainedGeneration = 0
+    /// Fences callbacks from an old relay after a respawn or stop.
+    private var generation = 0
+    private var stopped = false
+    private var everRenderedAttach = false
+    private var consecutiveUnexplainedFailures = 0
+    private var lastKnownGrid: (cols: Int, rows: Int)?
+    private var lastSentGrid: (cols: Int, rows: Int)?
+
+    init(
+        binaryPath: String,
+        target: TuiManualIORelayTarget,
+        terminalID: String,
+        environment: [String: String],
+        sleep: @escaping @Sendable (Duration) async throws -> Void = { try await Task.sleep(for: $0) }
+    ) {
+        self.binaryPath = binaryPath
+        self.target = target
+        self.terminalID = terminalID
+        self.environment = environment
+        self.sleep = sleep
+    }
+
+    /// The surface's `manualInputHandler`: runs on Ghostty's IO thread, so
+    /// it only touches the lock-guarded input channel.
+    nonisolated func makeManualInputHandler() -> @Sendable (TerminalManualInput) -> Void {
+        let channel = inputChannel
+        return { input in
+            switch input {
+            case .bytes(let bytes):
+                channel.send(TuiManualIOPumpPolicy.inputLine(bytes: bytes))
+            case .namedKey:
+                // No key-name resolver is installed on this surface, so
+                // Ghostty encodes every key itself; a named key here is a
+                // wiring bug, and dropping it is safer than guessing bytes.
+                break
+            }
+        }
+    }
+
+    /// Binds the pump to its surface and starts the relay at the first
+    /// known grid size. Applied resizes are the steady-state signal, but a
+    /// session-restored panel can mount at exactly the runtime's initial
+    /// grid (no apply ever fires), so the pump also samples the grid
+    /// directly when the runtime is (or becomes) ready and attaches
+    /// eagerly; a later mount just resizes the daemon terminal.
+    func start(surface: TerminalSurface) {
+        self.surface = surface
+        surface.onManualSizeApplied = { [weak self] sample in
+            self?.handleSizingSample(cols: sample.columns, rows: sample.rows)
+        }
+        surface.onRuntimeReady = { [weak self, weak surface] in
+            guard let self, let surface else { return }
+            surface.flushPendingManualSizeReportIfAttached()
+            self.sampleCurrentGrid(of: surface)
+        }
+        surface.flushPendingManualSizeReportIfAttached()
+        sampleCurrentGrid(of: surface)
+    }
+
+    private func sampleCurrentGrid(of surface: TerminalSurface) {
+        guard let sample = surface.rawSizingSample(),
+              sample.columns > 1, sample.rows > 1 else { return }
+        handleSizingSample(cols: sample.columns, rows: sample.rows)
+    }
+
+    /// The overlay's Reconnect button: skip the remaining backoff, or leave
+    /// the failed state for another round of attempts.
+    func retryNow() {
+        switch state {
+        case .reconnecting, .failed:
+            guard !stopped else { return }
+            consecutiveUnexplainedFailures = 0
+            retryTask?.cancel()
+            retryTask = nil
+            state = .reconnecting(attempt: 1)
+            spawnRelay()
+        case .connecting, .live, .ended:
+            break
+        }
+    }
+
+    /// Tears the pump down (panel closed, app quitting, transfer discard).
+    /// The relay sees stdin EOF and detaches cleanly; the daemon terminal
+    /// itself stays alive in the machine's session.
+    func stop() {
+        stopped = true
+        retryTask?.cancel()
+        retryTask = nil
+        stdoutTask?.cancel()
+        stdoutTask = nil
+        stdoutReader?.close()
+        stdoutReader = nil
+        inputChannel.closeHandle()
+        generation += 1
+        process?.terminationHandler = nil
+        process?.terminate()
+        process = nil
+    }
+
+    var overlayPresentation: CloudTerminalReconnectOverlayPolicy.Presentation? {
+        TuiManualIOPumpPolicy.overlayPresentation(state: state)
+    }
+
+    // MARK: - Sizing
+
+    private func handleSizingSample(cols: Int, rows: Int) {
+        guard !stopped else { return }
+        lastKnownGrid = (cols, rows)
+        if process == nil, retryTask == nil, case .connecting = state {
+            spawnRelay()
+            return
+        }
+        if let sent = lastSentGrid, sent == (cols, rows) { return }
+        lastSentGrid = (cols, rows)
+        inputChannel.send(TuiManualIOPumpPolicy.resizeLine(cols: cols, rows: rows))
+    }
+
+    // MARK: - Relay lifecycle
+
+    private func spawnRelay() {
+        guard !stopped, let surface else { return }
+        // Terminal states only leave through retryNow (which transitions
+        // back to reconnecting first) or teardown; a straggler retry task
+        // or sizing sample must not resurrect the relay.
+        if state == .ended || state == .failed { return }
+        guard FileManager.default.isExecutableFile(atPath: binaryPath) else {
+            noteUnexplainedFailureThenRetryOrFail()
+            return
+        }
+        generation += 1
+        let spawnGeneration = generation
+        let grid = lastKnownGrid ?? (80, 24)
+        lastSentGrid = grid
+
+        // A respawned relay replays the daemon terminal from scratch; reset
+        // the surface first so the replay replaces the stale frame instead
+        // of stacking on it.
+        if everRenderedAttach {
+            surface.processRemoteOutput(TuiManualIOPumpPolicy.resyncReset)
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: binaryPath)
+        process.arguments = TuiManualIOPumpPolicy.relayArguments(
+            target: target,
+            terminalID: terminalID,
+            cols: grid.cols,
+            rows: grid.rows
+        )
+        process.environment = environment
+
+        let stdinPipe = Pipe()
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardInput = stdinPipe
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        let stderrBox = TuiManualIOStderrBox()
+        self.stderrBox = stderrBox
+        pendingExitStatus = nil
+        // Blocking drain to EOF on a throwaway queue: it continuously
+        // empties the pipe (a full pipe would wedge the relay) and EOF is
+        // the only signal that the final exit-reason line has landed.
+        let stderrHandle = stderrPipe.fileHandleForReading
+        DispatchQueue(label: "cmux.tuiManualIO.stderr", qos: .utility).async { [weak self] in
+            stderrBox.append(stderrHandle.readDataToEndOfFile())
+            Task { @MainActor [weak self] in
+                self?.handleStderrDrained(generation: spawnGeneration)
+            }
+        }
+
+        let reader = RemoteTmuxProcessOutputReader(
+            label: "cmux.tuiManualIO.stdout",
+            maxPendingChunks: 512,
+            maxPendingBytes: 8 * 1024 * 1024,
+            onOverflow: { [weak self] in
+                // The surface stopped consuming; treat like a dead relay so
+                // a respawn resyncs from a bounded replay.
+                self?.handleRelayExit(generation: spawnGeneration, forcedExit: .daemonLost)
+            }
+        )
+        stdoutReader?.close()
+        stdoutReader = reader
+        stdoutTask?.cancel()
+        stdoutTask = Task { @MainActor [weak self] in
+            for await chunk in reader.stream {
+                guard let self, self.generation == spawnGeneration, !self.stopped else { break }
+                reader.release(chunk)
+                self.surface?.processRemoteOutput(chunk)
+                self.everRenderedAttach = true
+                self.consecutiveUnexplainedFailures = 0
+                if self.state != .live {
+                    self.state = .live
+                }
+            }
+        }
+
+        process.terminationHandler = { [weak self] finished in
+            let status = finished.terminationStatus
+            Task { @MainActor [weak self] in
+                self?.handleRelayTermination(generation: spawnGeneration, status: status)
+            }
+        }
+
+        do {
+            try process.run()
+        } catch {
+            log("spawn failed: \(error)")
+            reader.close()
+            noteUnexplainedFailureThenRetryOrFail()
+            return
+        }
+        self.process = process
+        inputChannel.setHandle(stdinPipe.fileHandleForWriting)
+        reader.attach(to: stdoutPipe.fileHandleForReading)
+        log("relay spawned generation=\(spawnGeneration) grid=\(grid.cols)x\(grid.rows)")
+    }
+
+    private func handleStderrDrained(generation drainedGeneration: Int) {
+        guard drainedGeneration == generation, !stopped else { return }
+        stderrDrainedGeneration = drainedGeneration
+        if let status = pendingExitStatus {
+            pendingExitStatus = nil
+            handleRelayExit(generation: drainedGeneration, status: status)
+        }
+    }
+
+    private func handleRelayTermination(generation exitedGeneration: Int, status: Int32) {
+        guard exitedGeneration == generation, !stopped else { return }
+        guard stderrDrainedGeneration == exitedGeneration else {
+            pendingExitStatus = status
+            return
+        }
+        handleRelayExit(generation: exitedGeneration, status: status)
+    }
+
+    private func handleRelayExit(
+        generation exitedGeneration: Int,
+        status: Int32? = nil,
+        forcedExit: TuiManualIOPumpPolicy.RelayExit? = nil
+    ) {
+        guard exitedGeneration == generation, !stopped else { return }
+        inputChannel.setHandle(nil)
+        process = nil
+        let exit = forcedExit
+            ?? TuiManualIOPumpPolicy.relayExit(status: status ?? -1, stderrText: stderrBox.text())
+#if DEBUG
+        let stderrTail = (stderrBox.text() ?? "").suffix(300).replacingOccurrences(of: "\n", with: " | ")
+        log("relay exit \(exit) terminal=\(terminalID.prefix(12)) status=\(status.map(String.init) ?? "nil") stderr=\(stderrTail)")
+#else
+        log("relay exit \(exit)")
+#endif
+        switch TuiManualIOPumpPolicy.nextAction(after: exit) {
+        case .end:
+            state = .ended
+        case .retry:
+            if exit == .failure {
+                noteUnexplainedFailureThenRetryOrFail()
+            } else {
+                scheduleRetry()
+            }
+        case .ignore:
+            break
+        }
+    }
+
+    /// Unexplained failures (spawn failure, usage error, crash) stop
+    /// retrying after a bounded streak so a permanently broken binary
+    /// converges to a visible failed state instead of a silent retry loop.
+    private func noteUnexplainedFailureThenRetryOrFail() {
+        consecutiveUnexplainedFailures += 1
+        if consecutiveUnexplainedFailures
+            >= TuiManualIOPumpPolicy.maxConsecutiveUnexplainedFailures {
+            retryTask?.cancel()
+            retryTask = nil
+            state = .failed
+            return
+        }
+        scheduleRetry()
+    }
+
+    private func scheduleRetry() {
+        guard !stopped else { return }
+        let attempt: Int
+        if case .reconnecting(let previous) = state {
+            attempt = previous + 1
+        } else {
+            attempt = 1
+        }
+        state = .reconnecting(attempt: attempt)
+        let delay = TuiManualIOPumpPolicy.retryDelay(attempt: attempt)
+        let sleep = sleep
+        retryTask?.cancel()
+        retryTask = Task { @MainActor [weak self] in
+            do {
+                try await sleep(delay)
+            } catch {
+                return
+            }
+            guard let self, !self.stopped, !Task.isCancelled else { return }
+            self.retryTask = nil
+            self.spawnRelay()
+        }
+    }
+
+    private nonisolated func log(_ message: @autoclosure () -> String) {
+#if DEBUG
+        cmuxDebugLog("tuiManualIO.\(message())")
+#endif
+    }
+}
+
+/// Process-wide pump registry keyed by surface id. The surface id is stable
+/// across detach transfers between workspaces, so a global registry needs
+/// no transfer bookkeeping: overlays and close paths look pumps up by the
+/// surface they render.
+@MainActor
+final class TuiManualIOPumpRegistry {
+    static let shared = TuiManualIOPumpRegistry()
+
+    private var pumps: [UUID: TuiManualIOPump] = [:]
+
+    func register(_ pump: TuiManualIOPump, surfaceID: UUID) {
+        pumps[surfaceID]?.stop()
+        pumps[surfaceID] = pump
+    }
+
+    func pump(forSurfaceID surfaceID: UUID) -> TuiManualIOPump? {
+        pumps[surfaceID]
+    }
+
+    /// Stops and forgets the pump when its panel is discarded for real (not
+    /// a detach transfer). The relay sees stdin EOF and detaches cleanly.
+    func stopAndRemove(surfaceID: UUID) {
+        pumps.removeValue(forKey: surfaceID)?.stop()
+    }
+}
+
+/// Lock-guarded stderr accumulator: the relay prints its machine-readable
+/// exit reason as the final stderr line.
+final class TuiManualIOStderrBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var data = Data()
+
+    func append(_ new: Data) {
+        lock.lock()
+        // Only the tail matters (final JSON line); bound the buffer.
+        data.append(new)
+        if data.count > 64 * 1024 {
+            data.removeFirst(data.count - 64 * 1024)
+        }
+        lock.unlock()
+    }
+
+    func text() -> String? {
+        lock.lock()
+        defer { lock.unlock() }
+        return data.isEmpty ? nil : String(decoding: data, as: UTF8.self)
+    }
+}

--- a/Sources/TuiManualIOPump.swift
+++ b/Sources/TuiManualIOPump.swift
@@ -1,5 +1,8 @@
 import CmuxTerminal
 import Foundation
+#if canImport(Darwin)
+import Darwin
+#endif
 #if DEBUG
 import CMUXDebugLog
 #endif
@@ -308,6 +311,9 @@ final class TuiManualIOInputChannel: @unchecked Sendable {
     /// counts as a claim: the relay claims geometry itself at attach.
     func setHandle(_ newHandle: FileHandle?, now: TimeInterval = ProcessInfo.processInfo.systemUptime) {
         writeLock.lock()
+        if let newHandle {
+            makeNonBlocking(newHandle)
+        }
         lock.lock()
         generation &+= 1
         handle = newHandle
@@ -319,6 +325,18 @@ final class TuiManualIOInputChannel: @unchecked Sendable {
         }
         lock.unlock()
         writeLock.unlock()
+    }
+
+    private func makeNonBlocking(_ handle: FileHandle) {
+#if canImport(Darwin)
+        let descriptor = handle.fileDescriptor
+        let flags = fcntl(descriptor, F_GETFL)
+        if flags >= 0 {
+            _ = fcntl(descriptor, F_SETFL, flags | O_NONBLOCK)
+        }
+#else
+        _ = handle
+#endif
     }
 
     func send(_ line: Data) {
@@ -999,7 +1017,11 @@ final class TuiManualIOStderrStream: @unchecked Sendable {
               let diag = object["diag"] as? [String: Any],
               let resize = diag["resize"] as? [String: Any]
         else { return nil }
-        return resize["error"] == nil
+        guard resize["error"] == nil else { return false }
+        // Older relays did not include `accepted`; their lack of an error is
+        // still a successful acknowledgement. New relays must report true,
+        // and an explicit false keeps the scheduler retryable.
+        return (resize["accepted"] as? Bool) ?? true
     }
 }
 

--- a/Sources/TuiManualIOPump.swift
+++ b/Sources/TuiManualIOPump.swift
@@ -752,13 +752,22 @@ final class TuiManualIOPump {
         forcedExit: TuiManualIOPumpPolicy.RelayExit? = nil
     ) {
         guard exitedGeneration == generation, !stopped else { return }
+        let exit = forcedExit
+            ?? TuiManualIOPumpPolicy.relayExit(status: status ?? -1, stderrText: stderrBox.text())
+        // Retire the generation before changing state. This fences stdout
+        // chunks already buffered by the reader from moving an ended pane
+        // back to `.live` after its relay has exited.
+        generation += 1
+        stdoutTask?.cancel()
+        stdoutTask = nil
+        stdoutReader?.close()
+        stdoutReader = nil
         if forcedExit != nil {
             // Overflow means the surface cannot keep up. Stop the relay
             // before scheduling a replacement, and fence late callbacks
             // from the terminated process.
             process?.terminationHandler = nil
             process?.terminate()
-            generation += 1
         }
         inputChannel.setHandle(nil)
         process = nil
@@ -767,8 +776,6 @@ final class TuiManualIOPump {
         resizeAckTimeoutTask?.cancel()
         resizeAckTimeoutTask = nil
         resizeScheduler.reset()
-        let exit = forcedExit
-            ?? TuiManualIOPumpPolicy.relayExit(status: status ?? -1, stderrText: stderrBox.text())
 #if DEBUG
         let stderrTail = (stderrBox.text() ?? "").suffix(300).replacingOccurrences(of: "\n", with: " | ")
         log("relay exit \(exit) terminal=\(terminalID.prefix(12)) status=\(status.map(String.init) ?? "nil") stderr=\(stderrTail)")

--- a/Sources/TuiManualIOPump.swift
+++ b/Sources/TuiManualIOPump.swift
@@ -517,6 +517,7 @@ final class TuiManualIOPump {
     private var stopped = false
     private var everRenderedAttach = false
     private var consecutiveUnexplainedFailures = 0
+    private var reconnectAttempt = 0
     private var lastKnownGrid: TuiManualIOGrid?
     private var resizeScheduler = TuiManualIOResizeScheduler()
     private var resizeAckTimeoutTask: Task<Void, Never>?
@@ -608,6 +609,7 @@ final class TuiManualIOPump {
         case .reconnecting, .failed:
             guard !stopped else { return }
             consecutiveUnexplainedFailures = 0
+            reconnectAttempt = 0
             retryTask?.cancel()
             retryTask = nil
             state = .reconnecting(attempt: 1)
@@ -934,6 +936,7 @@ final class TuiManualIOPump {
             guard !Task.isCancelled, let self,
                   self.generation == liveGeneration, self.state == .live else { return }
             self.consecutiveUnexplainedFailures = 0
+            self.reconnectAttempt = 0
             self.liveStabilityTask = nil
         }
     }
@@ -944,8 +947,9 @@ final class TuiManualIOPump {
         if case .reconnecting(let previous) = state {
             attempt = previous + 1
         } else {
-            attempt = 1
+            attempt = max(1, reconnectAttempt + 1)
         }
+        reconnectAttempt = attempt
         state = .reconnecting(attempt: attempt)
         let delay = TuiManualIOPumpPolicy.retryDelay(attempt: attempt)
         let sleep = sleep

--- a/Sources/TuiManualIOPump.swift
+++ b/Sources/TuiManualIOPump.swift
@@ -54,7 +54,10 @@ enum TuiManualIOPumpPolicy {
         // binary without --pipe-io support also exits 2 (usage error), and
         // that must not read as an endlessly-retryable daemon outage.
         case (2, "daemon-lost"): return .daemonLost
-        case (0, _): return .terminalEnded
+        // A clean exit without a recognized reason is still unexplained.
+        // Retry it under the bounded failure streak instead of treating an
+        // unexpected protocol shutdown as a completed terminal.
+        case (0, _): return .failure
         default: return .failure
         }
     }
@@ -301,6 +304,7 @@ final class TuiManualIOInputChannel: @unchecked Sendable {
     private var handle: FileHandle?
     private var lastGeometryClaim: TimeInterval = 0
     private var needsGeometryClaim = false
+    private var writeFailureHandler: (@Sendable () -> Void)?
     private let queue = DispatchQueue(label: "cmux.tuiManualIO.stdin", qos: .userInitiated)
     private var generation: UInt64 = 0
     private var queuedWrites = 0
@@ -325,6 +329,12 @@ final class TuiManualIOInputChannel: @unchecked Sendable {
         }
         lock.unlock()
         writeLock.unlock()
+    }
+
+    func setWriteFailureHandler(_ handler: @escaping @Sendable () -> Void) {
+        lock.lock()
+        writeFailureHandler = handler
+        lock.unlock()
     }
 
     private func makeNonBlocking(_ handle: FileHandle) {
@@ -353,7 +363,7 @@ final class TuiManualIOInputChannel: @unchecked Sendable {
             self.writeIfCurrent(target, generation: writeGeneration) {
                 // A failed write means the relay just died; the pump's
                 // termination handler owns that transition.
-                try? target.write(contentsOf: line)
+                try target.write(contentsOf: line)
             }
         }
     }
@@ -386,9 +396,9 @@ final class TuiManualIOInputChannel: @unchecked Sendable {
         queue.async {
             self.writeIfCurrent(target, generation: writeGeneration) {
                 if sendClaim {
-                    try? target.write(contentsOf: TuiManualIOPumpPolicy.claimGeometryLine)
+                    try target.write(contentsOf: TuiManualIOPumpPolicy.claimGeometryLine)
                 }
-                try? target.write(contentsOf: line)
+                try target.write(contentsOf: line)
             }
         }
     }
@@ -399,19 +409,28 @@ final class TuiManualIOInputChannel: @unchecked Sendable {
     private func writeIfCurrent(
         _ target: FileHandle,
         generation writeGeneration: UInt64,
-        _ write: () -> Void
+        _ write: () throws -> Void
     ) {
         writeLock.lock()
         lock.lock()
         let current = handle != nil && generation == writeGeneration
+        let failureHandler = writeFailureHandler
         lock.unlock()
+        var failed = false
         if current {
-            write()
+            do {
+                try write()
+            } catch {
+                failed = true
+            }
         }
         writeLock.unlock()
         lock.lock()
         queuedWrites = max(0, queuedWrites - 1)
         lock.unlock()
+        if failed {
+            failureHandler?()
+        }
     }
 
     /// Closes and detaches the current handle (relay stdin EOF = clean
@@ -486,6 +505,7 @@ final class TuiManualIOPump {
     private var stderrStream: TuiManualIOStderrStream?
     private var retryTask: Task<Void, Never>?
     private var liveStabilityTask: Task<Void, Never>?
+    private var startupTimeoutTask: Task<Void, Never>?
     /// Process termination and stderr EOF race (termination is not EOF);
     /// classification needs the relay's final stderr line, so it runs only
     /// once BOTH have arrived for the current generation.
@@ -507,6 +527,7 @@ final class TuiManualIOPump {
     /// a generation that stays live through this interval clears a failure
     /// streak, so replay-then-crash loops remain bounded.
     static let liveStabilityInterval: Duration = .seconds(2)
+    static let startupTimeout: Duration = .seconds(5)
 
     init(
         binaryPath: String,
@@ -520,6 +541,11 @@ final class TuiManualIOPump {
         self.terminalID = terminalID
         self.environment = environment
         self.sleep = sleep
+        inputChannel.setWriteFailureHandler { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.handleInputWriteFailure()
+            }
+        }
     }
 
     /// The surface's `manualInputHandler`: runs on Ghostty's IO thread, so
@@ -590,6 +616,8 @@ final class TuiManualIOPump {
         retryTask = nil
         liveStabilityTask?.cancel()
         liveStabilityTask = nil
+        startupTimeoutTask?.cancel()
+        startupTimeoutTask = nil
         resizeAckTimeoutTask?.cancel()
         resizeAckTimeoutTask = nil
         stdoutTask?.cancel()
@@ -670,6 +698,8 @@ final class TuiManualIOPump {
         }
         generation += 1
         let spawnGeneration = generation
+        startupTimeoutTask?.cancel()
+        startupTimeoutTask = nil
         let grid = lastKnownGrid ?? TuiManualIOGrid(cols: 80, rows: 24)
         resizeScheduler.seed(delivered: grid)
         resizeAckTimeoutTask?.cancel()
@@ -744,6 +774,8 @@ final class TuiManualIOPump {
                 self.everRenderedAttach = true
                 if self.state != .live {
                     self.state = .live
+                    self.startupTimeoutTask?.cancel()
+                    self.startupTimeoutTask = nil
                     self.scheduleLiveStabilityReset(generation: spawnGeneration)
                 }
             }
@@ -767,6 +799,18 @@ final class TuiManualIOPump {
         self.process = process
         inputChannel.setHandle(stdinPipe.fileHandleForWriting)
         reader.attach(to: stdoutPipe.fileHandleForReading)
+        let startupSleep = sleep
+        startupTimeoutTask = Task { @MainActor [weak self] in
+            do {
+                try await startupSleep(Self.startupTimeout)
+            } catch {
+                return
+            }
+            guard !Task.isCancelled, let self,
+                  self.generation == spawnGeneration, self.state != .live else { return }
+            self.log("relay startup timeout generation=\(spawnGeneration)")
+            self.handleRelayExit(generation: spawnGeneration, forcedExit: .failure)
+        }
         log("relay spawned generation=\(spawnGeneration) grid=\(grid.cols)x\(grid.rows)")
     }
 
@@ -786,6 +830,11 @@ final class TuiManualIOPump {
             return
         }
         handleRelayExit(generation: exitedGeneration, status: status)
+    }
+
+    private func handleInputWriteFailure() {
+        guard !stopped, process != nil else { return }
+        handleRelayExit(generation: generation, forcedExit: .failure)
     }
 
     private func handleRelayExit(
@@ -819,6 +868,8 @@ final class TuiManualIOPump {
         resizeAckTimeoutTask = nil
         liveStabilityTask?.cancel()
         liveStabilityTask = nil
+        startupTimeoutTask?.cancel()
+        startupTimeoutTask = nil
         resizeScheduler.reset()
 #if DEBUG
         let stderrTail = (stderrBox.text() ?? "").suffix(300).replacingOccurrences(of: "\n", with: " | ")

--- a/Sources/TuiManualIOPump.swift
+++ b/Sources/TuiManualIOPump.swift
@@ -260,17 +260,26 @@ struct TuiManualIOResizeScheduler: Equatable {
 
     /// The relay acknowledged (or errored, or the ack timed out — all three
     /// free the channel). Returns the next grid to send, or nil.
-    mutating func acknowledged() -> TuiManualIOGrid? {
-        if let inFlight {
-            lastDelivered = inFlight
+    mutating func acknowledged(success: Bool = true) -> TuiManualIOGrid? {
+        guard let inFlight else { return nil }
+        if !success {
+            // A rejected or expired resize was not delivered. Retry it, or
+            // skip directly to the newest pending sample.
+            if let pending, pending != inFlight {
+                self.pending = nil
+                self.inFlight = pending
+                return pending
+            }
+            return inFlight
         }
-        inFlight = nil
+        lastDelivered = inFlight
+        self.inFlight = nil
         guard let next = pending, next != lastDelivered else {
-            pending = nil
+            self.pending = nil
             return nil
         }
-        pending = nil
-        inFlight = next
+        self.pending = nil
+        self.inFlight = next
         return next
     }
 }
@@ -582,11 +591,11 @@ final class TuiManualIOPump {
 
     /// The relay reported one resize round trip done (applied, deduplicated,
     /// or errored — all free the channel), or the liveness timeout fired.
-    private func handleResizeAcknowledged(generation ackedGeneration: Int) {
+    private func handleResizeAcknowledged(generation ackedGeneration: Int, success: Bool = true) {
         guard ackedGeneration == generation, !stopped else { return }
         resizeAckTimeoutTask?.cancel()
         resizeAckTimeoutTask = nil
-        if let next = resizeScheduler.acknowledged() {
+        if let next = resizeScheduler.acknowledged(success: success) {
             deliverResize(next)
         }
     }
@@ -603,7 +612,7 @@ final class TuiManualIOPump {
             }
             guard !Task.isCancelled else { return }
             self?.log("resize ack timeout generation=\(timeoutGeneration)")
-            self?.handleResizeAcknowledged(generation: timeoutGeneration)
+            self?.handleResizeAcknowledged(generation: timeoutGeneration, success: false)
         }
     }
 
@@ -660,9 +669,9 @@ final class TuiManualIOPump {
         stderrStream = TuiManualIOStderrStream(
             handle: stderrPipe.fileHandleForReading,
             box: stderrBox,
-            onResizeDiag: { [weak self] in
+            onResizeDiag: { [weak self] success in
                 Task { @MainActor [weak self] in
-                    self?.handleResizeAcknowledged(generation: spawnGeneration)
+                    self?.handleResizeAcknowledged(generation: spawnGeneration, success: success)
                 }
             },
             onEOF: { [weak self] in
@@ -866,7 +875,7 @@ final class TuiManualIOStderrStream: @unchecked Sendable {
     init(
         handle: FileHandle,
         box: TuiManualIOStderrBox,
-        onResizeDiag: @escaping @Sendable () -> Void,
+        onResizeDiag: @escaping @Sendable (Bool) -> Void,
         onEOF: @escaping @Sendable () -> Void
     ) {
         self.handle = handle
@@ -885,7 +894,7 @@ final class TuiManualIOStderrStream: @unchecked Sendable {
     /// Splits the byte stream into complete lines and fires the ack callback
     /// for each resize diag. Partial trailing lines wait for the next chunk;
     /// the final (exit) line needs no scan, EOF classification owns it.
-    private func scanLines(_ data: Data, onResizeDiag: @Sendable () -> Void) {
+    private func scanLines(_ data: Data, onResizeDiag: @Sendable (Bool) -> Void) {
         lock.lock()
         pendingLine.append(data)
         let split = Self.splitLines(pendingLine)
@@ -898,8 +907,8 @@ final class TuiManualIOStderrStream: @unchecked Sendable {
         }
         lock.unlock()
         for line in lines {
-            if Self.isResizeDiagLine(line) {
-                onResizeDiag()
+            if let success = Self.resizeDiagSucceeded(line) {
+                onResizeDiag(success)
             }
         }
     }
@@ -930,10 +939,18 @@ final class TuiManualIOStderrStream: @unchecked Sendable {
     /// Matching JSON fields avoids treating human-readable stderr text as an
     /// acknowledgement.
     static func isResizeDiagLine(_ line: Data) -> Bool {
+        resizeDiagSucceeded(line) != nil
+    }
+
+    /// Returns whether the structured resize diagnostic reports a successful
+    /// daemon operation. An explicit error keeps the scheduler in flight so
+    /// the requested size is retried instead of being marked delivered.
+    static func resizeDiagSucceeded(_ line: Data) -> Bool? {
         guard let object = try? JSONSerialization.jsonObject(with: line) as? [String: Any],
-              let diag = object["diag"] as? [String: Any]
-        else { return false }
-        return diag["resize"] != nil
+              let diag = object["diag"] as? [String: Any],
+              let resize = diag["resize"] as? [String: Any]
+        else { return nil }
+        return resize["error"] == nil
     }
 }
 

--- a/Sources/TuiManualIOPump.swift
+++ b/Sources/TuiManualIOPump.swift
@@ -100,7 +100,9 @@ enum TuiManualIOPumpPolicy {
 
     /// One stdin line driving the daemon-side viewer size.
     static func resizeLine(cols: Int, rows: Int) -> Data {
-        Data(#"{"resize":{"cols":\#(max(1, cols)),"rows":\#(max(1, rows))}}"#.utf8 + [0x0A])
+        var line = Data(#"{"resize":{"cols":\#(max(1, cols)),"rows":\#(max(1, rows))}}"#.utf8)
+        line.append(0x0A)
+        return line
     }
 
     /// One stdin line re-asserting this relay's geometry authority.
@@ -109,7 +111,11 @@ enum TuiManualIOPumpPolicy {
     /// viewed the terminal) claim at attach in arbitrary order — so the
     /// pane the user actually TYPES in re-claims, and the daemon's PTY size
     /// follows user intent instead of restore order.
-    static let claimGeometryLine = Data(#"{"claim":{"geometry":true}}"#.utf8 + [0x0A])
+    static let claimGeometryLine: Data = {
+        var line = Data(#"{"claim":{"geometry":true}}"#.utf8)
+        line.append(0x0A)
+        return line
+    }()
 
     /// Re-claim at most this often: a claim is one daemon round trip, so
     /// claiming per keystroke would double interactive traffic. Within one
@@ -273,10 +279,14 @@ struct TuiManualIOResizeScheduler: Equatable {
 /// the surface's encoded input bytes) and the pump's relay stdin writer.
 /// Lock-guarded because `manualInputHandler` must not touch the main actor.
 final class TuiManualIOInputChannel: @unchecked Sendable {
+    private static let maxQueuedWrites = 64
+
     private let lock = NSLock()
     private var handle: FileHandle?
     private var lastGeometryClaim: TimeInterval = 0
     private let queue = DispatchQueue(label: "cmux.tuiManualIO.stdin", qos: .userInitiated)
+    private var generation: UInt64 = 0
+    private var queuedWrites = 0
 
     /// Swaps the live relay stdin. `nil` pauses input (dropped, never
     /// queued: replaying stale input into a shell after a reconnect is
@@ -284,6 +294,7 @@ final class TuiManualIOInputChannel: @unchecked Sendable {
     /// counts as a claim: the relay claims geometry itself at attach.
     func setHandle(_ newHandle: FileHandle?, now: TimeInterval = ProcessInfo.processInfo.systemUptime) {
         lock.lock()
+        generation &+= 1
         handle = newHandle
         if newHandle != nil {
             lastGeometryClaim = now
@@ -294,12 +305,19 @@ final class TuiManualIOInputChannel: @unchecked Sendable {
     func send(_ line: Data) {
         lock.lock()
         let target = handle
+        guard let target, queuedWrites < Self.maxQueuedWrites else {
+            lock.unlock()
+            return
+        }
+        let writeGeneration = generation
+        queuedWrites += 1
         lock.unlock()
-        guard let target else { return }
         queue.async {
-            // A failed write means the relay just died; the pump's
-            // termination handler owns that transition.
-            try? target.write(contentsOf: line)
+            self.writeIfCurrent(target, generation: writeGeneration) {
+                // A failed write means the relay just died; the pump's
+                // termination handler owns that transition.
+                try? target.write(contentsOf: line)
+            }
         }
     }
 
@@ -314,20 +332,46 @@ final class TuiManualIOInputChannel: @unchecked Sendable {
     ) {
         lock.lock()
         let target = handle
+        guard let target, queuedWrites < Self.maxQueuedWrites else {
+            lock.unlock()
+            return
+        }
+        let writeGeneration = generation
         var claim = false
-        if target != nil, now - lastGeometryClaim >= claimInterval {
+        if now - lastGeometryClaim >= claimInterval {
             lastGeometryClaim = now
             claim = true
         }
+        queuedWrites += 1
         lock.unlock()
-        guard let target else { return }
         let sendClaim = claim
         queue.async {
-            if sendClaim {
-                try? target.write(contentsOf: TuiManualIOPumpPolicy.claimGeometryLine)
+            self.writeIfCurrent(target, generation: writeGeneration) {
+                if sendClaim {
+                    try? target.write(contentsOf: TuiManualIOPumpPolicy.claimGeometryLine)
+                }
+                try? target.write(contentsOf: line)
             }
-            try? target.write(contentsOf: line)
         }
+    }
+
+    /// Executes a queued write only for the handle generation that reserved
+    /// it. Writes waiting behind a stalled relay are therefore discarded when
+    /// the handle is replaced, instead of replaying into a new shell.
+    private func writeIfCurrent(
+        _ target: FileHandle,
+        generation writeGeneration: UInt64,
+        _ write: () -> Void
+    ) {
+        lock.lock()
+        let current = handle != nil && generation == writeGeneration
+        lock.unlock()
+        if current {
+            write()
+        }
+        lock.lock()
+        queuedWrites = max(0, queuedWrites - 1)
+        lock.unlock()
     }
 
     /// Closes and detaches the current handle (relay stdin EOF = clean

--- a/Sources/TuiManualIOPump.swift
+++ b/Sources/TuiManualIOPump.swift
@@ -95,6 +95,9 @@ enum TuiManualIOPumpPolicy {
         return schedule[attempt - 1]
     }
 
+    /// Keep each forwarded frame well below the relay's decoded input limit.
+    static let maxInputChunkBytes = 256 * 1024
+
     /// One stdin line forwarding raw input bytes to the relay.
     static func inputLine(bytes: Data) -> Data {
         var line = Data(#"{"input":""#.utf8)
@@ -352,8 +355,14 @@ final class TuiManualIOInputChannel: @unchecked Sendable {
     func send(_ line: Data) {
         lock.lock()
         let target = handle
-        guard let target, queuedWrites < Self.maxQueuedWrites else {
+        guard let target else {
             lock.unlock()
+            return
+        }
+        guard queuedWrites < Self.maxQueuedWrites else {
+            let failureHandler = writeFailureHandler
+            lock.unlock()
+            failureHandler?()
             return
         }
         let writeGeneration = generation
@@ -379,8 +388,14 @@ final class TuiManualIOInputChannel: @unchecked Sendable {
     ) {
         lock.lock()
         let target = handle
-        guard let target, queuedWrites < Self.maxQueuedWrites else {
+        guard let target else {
             lock.unlock()
+            return
+        }
+        guard queuedWrites < Self.maxQueuedWrites else {
+            let failureHandler = writeFailureHandler
+            lock.unlock()
+            failureHandler?()
             return
         }
         let writeGeneration = generation
@@ -555,7 +570,16 @@ final class TuiManualIOPump {
         return { input in
             switch input {
             case .bytes(let bytes):
-                channel.sendUserInput(TuiManualIOPumpPolicy.inputLine(bytes: bytes))
+                let chunkSize = TuiManualIOPumpPolicy.maxInputChunkBytes
+                var start = bytes.startIndex
+                while start < bytes.endIndex {
+                    let distance = bytes.distance(from: start, to: bytes.endIndex)
+                    let end = bytes.index(start, offsetBy: min(chunkSize, distance))
+                    channel.sendUserInput(
+                        TuiManualIOPumpPolicy.inputLine(bytes: Data(bytes[start..<end]))
+                    )
+                    start = end
+                }
             case .namedKey:
                 // No key-name resolver is installed on this surface, so
                 // Ghostty encodes every key itself; a named key here is a

--- a/Sources/TuiManualIOPump.swift
+++ b/Sources/TuiManualIOPump.swift
@@ -177,10 +177,10 @@ enum TuiManualIOPumpPolicy {
                     localized: "tui.overlay.reconnecting.title",
                     defaultValue: "Reconnecting to the terminal session"
                 ),
-                detail: String(
+                detail: String(format: String(
                     localized: "tui.overlay.reconnecting.detail",
-                    defaultValue: "The session daemon is unreachable (attempt \(attempt)). The terminal shows its last state; input is paused."
-                ),
+                    defaultValue: "The session daemon is unreachable (attempt %lld). The terminal shows its last state; input is paused."
+                ), Int64(attempt)),
                 showsProgress: true,
                 showsReconnectButton: true
             )

--- a/Sources/TuiManualIOPump.swift
+++ b/Sources/TuiManualIOPump.swift
@@ -291,6 +291,10 @@ final class TuiManualIOInputChannel: @unchecked Sendable {
     private static let maxQueuedWrites = 64
 
     private let lock = NSLock()
+    /// Serializes handle replacement with the check and actual write. The
+    /// generation check alone cannot fence a writer after it unlocks and
+    /// before FileHandle.write starts.
+    private let writeLock = NSLock()
     private var handle: FileHandle?
     private var lastGeometryClaim: TimeInterval = 0
     private let queue = DispatchQueue(label: "cmux.tuiManualIO.stdin", qos: .userInitiated)
@@ -302,6 +306,7 @@ final class TuiManualIOInputChannel: @unchecked Sendable {
     /// worse than losing keystrokes typed into a dead pane). A fresh handle
     /// counts as a claim: the relay claims geometry itself at attach.
     func setHandle(_ newHandle: FileHandle?, now: TimeInterval = ProcessInfo.processInfo.systemUptime) {
+        writeLock.lock()
         lock.lock()
         generation &+= 1
         handle = newHandle
@@ -309,6 +314,7 @@ final class TuiManualIOInputChannel: @unchecked Sendable {
             lastGeometryClaim = now
         }
         lock.unlock()
+        writeLock.unlock()
     }
 
     func send(_ line: Data) {
@@ -372,12 +378,14 @@ final class TuiManualIOInputChannel: @unchecked Sendable {
         generation writeGeneration: UInt64,
         _ write: () -> Void
     ) {
+        writeLock.lock()
         lock.lock()
         let current = handle != nil && generation == writeGeneration
         lock.unlock()
         if current {
             write()
         }
+        writeLock.unlock()
         lock.lock()
         queuedWrites = max(0, queuedWrites - 1)
         lock.unlock()
@@ -386,10 +394,12 @@ final class TuiManualIOInputChannel: @unchecked Sendable {
     /// Closes and detaches the current handle (relay stdin EOF = clean
     /// detach on the relay side).
     func closeHandle() {
+        writeLock.lock()
         lock.lock()
         let target = handle
         handle = nil
         lock.unlock()
+        writeLock.unlock()
         guard let target else { return }
         queue.async {
             try? target.close()

--- a/Sources/TuiManualIOPump.swift
+++ b/Sources/TuiManualIOPump.swift
@@ -844,11 +844,9 @@ final class TuiManualIOStderrStream: @unchecked Sendable {
     private func scanLines(_ data: Data, onResizeDiag: @Sendable () -> Void) {
         lock.lock()
         pendingLine.append(data)
-        var lines: [Data] = []
-        while let newline = pendingLine.firstIndex(of: 0x0A) {
-            lines.append(Data(pendingLine[pendingLine.startIndex..<newline]))
-            pendingLine = Data(pendingLine[pendingLine.index(after: newline)...])
-        }
+        let split = Self.splitLines(pendingLine)
+        let lines = split.completeLines
+        pendingLine = split.remainder
         // Bound the buffer against a relay that misbehaves and never prints
         // a newline; diag and exit lines are all short.
         if pendingLine.count > 64 * 1024 {
@@ -856,7 +854,7 @@ final class TuiManualIOStderrStream: @unchecked Sendable {
         }
         lock.unlock()
         for line in lines {
-            if isTuiManualIOResizeDiagLine(line) {
+            if Self.isResizeDiagLine(line) {
                 onResizeDiag()
             }
         }
@@ -869,29 +867,30 @@ final class TuiManualIOStderrStream: @unchecked Sendable {
         lock.unlock()
         target?.readabilityHandler = nil
     }
-}
 
-/// Returns true only for the relay's structured resize diagnostic. Matching
-/// JSON fields avoids treating human-readable stderr text as an ack.
-func isTuiManualIOResizeDiagLine(_ line: Data) -> Bool {
-    guard let object = try? JSONSerialization.jsonObject(with: line) as? [String: Any],
-          let diag = object["diag"] as? [String: Any]
-    else { return false }
-    return diag["resize"] != nil
-}
-
-/// Splits one accumulated stderr buffer in a single pass. Repeatedly
-/// searching and replacing a `Data` prefix copies the remaining suffix for
-/// every line, which makes a burst of short diagnostics quadratic.
-func splitTuiManualIOStderrLines(_ data: Data) -> (completeLines: [Data], remainder: Data) {
-    var completeLines: [Data] = []
-    var lineStart = data.startIndex
-    for index in data.indices where data[index] == 0x0A {
-        completeLines.append(Data(data[lineStart..<index]))
-        lineStart = data.index(after: index)
+    /// Splits one accumulated stderr buffer in a single pass. Repeatedly
+    /// searching and replacing a `Data` prefix copies the remaining suffix for
+    /// every line, which makes a burst of short diagnostics quadratic.
+    static func splitLines(_ data: Data) -> (completeLines: [Data], remainder: Data) {
+        var completeLines: [Data] = []
+        var lineStart = data.startIndex
+        for index in data.indices where data[index] == 0x0A {
+            completeLines.append(Data(data[lineStart..<index]))
+            lineStart = data.index(after: index)
+        }
+        let remainder = lineStart == data.startIndex ? data : Data(data[lineStart...])
+        return (completeLines, remainder)
     }
-    let remainder = lineStart == data.startIndex ? data : Data(data[lineStart...])
-    return (completeLines, remainder)
+
+    /// Returns true only for the relay's structured resize diagnostic.
+    /// Matching JSON fields avoids treating human-readable stderr text as an
+    /// acknowledgement.
+    static func isResizeDiagLine(_ line: Data) -> Bool {
+        guard let object = try? JSONSerialization.jsonObject(with: line) as? [String: Any],
+              let diag = object["diag"] as? [String: Any]
+        else { return false }
+        return diag["resize"] != nil
+    }
 }
 
 /// Lock-guarded stderr accumulator: the relay prints its machine-readable

--- a/Sources/TuiManualIOPump.swift
+++ b/Sources/TuiManualIOPump.swift
@@ -1,5 +1,8 @@
 import CmuxTerminal
 import Foundation
+#if canImport(Darwin)
+import Darwin
+#endif
 #if DEBUG
 import CMUXDebugLog
 #endif
@@ -277,9 +280,8 @@ struct TuiManualIOResizeScheduler: Equatable {
                 self.inFlight = pending
                 return pending
             }
-            lastDelivered = inFlight
             self.inFlight = nil
-            if pending == lastDelivered {
+            if pending == inFlight {
                 self.pending = nil
             }
             return nil
@@ -867,6 +869,12 @@ final class TuiManualIOPump {
             // from the terminated process.
             process?.terminationHandler = nil
             process?.terminate()
+#if canImport(Darwin)
+            if let process, process.isRunning {
+                _ = kill(process.processIdentifier, SIGKILL)
+            }
+#endif
+            process?.waitUntilExit()
         }
         inputChannel.setHandle(nil)
         process = nil

--- a/Sources/TuiManualIOPump.swift
+++ b/Sources/TuiManualIOPump.swift
@@ -270,9 +270,13 @@ struct TuiManualIOResizeScheduler: Equatable {
         guard let inFlight else { return nil }
         if !success {
             // A rejected resize must not be retried from the acknowledgement
-            // callback itself. Mark this size as observed and keep a newer
-            // pending sample for the next genuine geometry event, avoiding a
-            // tight reject/send loop when another pane owns authority.
+            // callback itself. Advance a newer pending sample once, while
+            // dropping the rejected in-flight value to avoid a tight loop.
+            if let pending, pending != inFlight {
+                self.pending = nil
+                self.inFlight = pending
+                return pending
+            }
             lastDelivered = inFlight
             self.inFlight = nil
             if pending == lastDelivered {

--- a/Sources/TuiManualIOPump.swift
+++ b/Sources/TuiManualIOPump.swift
@@ -688,7 +688,9 @@ final class TuiManualIOPump {
             onOverflow: { [weak self] in
                 // The surface stopped consuming; treat like a dead relay so
                 // a respawn resyncs from a bounded replay.
-                self?.handleRelayExit(generation: spawnGeneration, forcedExit: .daemonLost)
+                Task { @MainActor [weak self] in
+                    self?.handleRelayExit(generation: spawnGeneration, forcedExit: .daemonLost)
+                }
             }
         )
         stdoutReader?.close()
@@ -700,9 +702,13 @@ final class TuiManualIOPump {
                 self.surface?.processRemoteOutput(chunk)
                 reader.release(chunk)
                 self.everRenderedAttach = true
-                self.consecutiveUnexplainedFailures = 0
                 if self.state != .live {
                     self.state = .live
+                    // Count a failure streak across relay generations. A
+                    // single replay chunk proves this generation attached,
+                    // so reset once on the transition to live, not for every
+                    // subsequent output chunk from a crash-looping relay.
+                    self.consecutiveUnexplainedFailures = 0
                 }
             }
         }

--- a/Sources/TuiManualIOPump.swift
+++ b/Sources/TuiManualIOPump.swift
@@ -297,6 +297,7 @@ final class TuiManualIOInputChannel: @unchecked Sendable {
     private let writeLock = NSLock()
     private var handle: FileHandle?
     private var lastGeometryClaim: TimeInterval = 0
+    private var needsGeometryClaim = false
     private let queue = DispatchQueue(label: "cmux.tuiManualIO.stdin", qos: .userInitiated)
     private var generation: UInt64 = 0
     private var queuedWrites = 0
@@ -312,6 +313,9 @@ final class TuiManualIOInputChannel: @unchecked Sendable {
         handle = newHandle
         if newHandle != nil {
             lastGeometryClaim = now
+            needsGeometryClaim = true
+        } else {
+            needsGeometryClaim = false
         }
         lock.unlock()
         writeLock.unlock()
@@ -353,8 +357,9 @@ final class TuiManualIOInputChannel: @unchecked Sendable {
         }
         let writeGeneration = generation
         var claim = false
-        if now - lastGeometryClaim >= claimInterval {
+        if needsGeometryClaim || now - lastGeometryClaim >= claimInterval {
             lastGeometryClaim = now
+            needsGeometryClaim = false
             claim = true
         }
         queuedWrites += 1

--- a/Sources/TuiManualIOPump.swift
+++ b/Sources/TuiManualIOPump.swift
@@ -856,8 +856,7 @@ final class TuiManualIOStderrStream: @unchecked Sendable {
         }
         lock.unlock()
         for line in lines {
-            if line.range(of: Data(#""diag""#.utf8)) != nil,
-               line.range(of: Data(#""resize""#.utf8)) != nil {
+            if isTuiManualIOResizeDiagLine(line) {
                 onResizeDiag()
             }
         }
@@ -870,6 +869,29 @@ final class TuiManualIOStderrStream: @unchecked Sendable {
         lock.unlock()
         target?.readabilityHandler = nil
     }
+}
+
+/// Returns true only for the relay's structured resize diagnostic. Matching
+/// JSON fields avoids treating human-readable stderr text as an ack.
+func isTuiManualIOResizeDiagLine(_ line: Data) -> Bool {
+    guard let object = try? JSONSerialization.jsonObject(with: line) as? [String: Any],
+          let diag = object["diag"] as? [String: Any]
+    else { return false }
+    return diag["resize"] != nil
+}
+
+/// Splits one accumulated stderr buffer in a single pass. Repeatedly
+/// searching and replacing a `Data` prefix copies the remaining suffix for
+/// every line, which makes a burst of short diagnostics quadratic.
+func splitTuiManualIOStderrLines(_ data: Data) -> (completeLines: [Data], remainder: Data) {
+    var completeLines: [Data] = []
+    var lineStart = data.startIndex
+    for index in data.indices where data[index] == 0x0A {
+        completeLines.append(Data(data[lineStart..<index]))
+        lineStart = data.index(after: index)
+    }
+    let remainder = lineStart == data.startIndex ? data : Data(data[lineStart...])
+    return (completeLines, remainder)
 }
 
 /// Lock-guarded stderr accumulator: the relay prints its machine-readable

--- a/Sources/TuiManualIOPump.swift
+++ b/Sources/TuiManualIOPump.swift
@@ -467,6 +467,7 @@ final class TuiManualIOPump {
     private var stderrBox = TuiManualIOStderrBox()
     private var stderrStream: TuiManualIOStderrStream?
     private var retryTask: Task<Void, Never>?
+    private var liveStabilityTask: Task<Void, Never>?
     /// Process termination and stderr EOF race (termination is not EOF);
     /// classification needs the relay's final stderr line, so it runs only
     /// once BOTH have arrived for the current generation.
@@ -484,6 +485,10 @@ final class TuiManualIOPump {
     /// timeout as an ack keeps the pending size flowing on relays that stop
     /// emitting resize diags.
     static let resizeAckTimeout: Duration = .seconds(2)
+    /// A replay proves that attach started, not that the relay is stable. Only
+    /// a generation that stays live through this interval clears a failure
+    /// streak, so replay-then-crash loops remain bounded.
+    static let liveStabilityInterval: Duration = .seconds(2)
 
     init(
         binaryPath: String,
@@ -565,6 +570,8 @@ final class TuiManualIOPump {
         stopped = true
         retryTask?.cancel()
         retryTask = nil
+        liveStabilityTask?.cancel()
+        liveStabilityTask = nil
         resizeAckTimeoutTask?.cancel()
         resizeAckTimeoutTask = nil
         stdoutTask?.cancel()
@@ -719,11 +726,7 @@ final class TuiManualIOPump {
                 self.everRenderedAttach = true
                 if self.state != .live {
                     self.state = .live
-                    // Count a failure streak across relay generations. A
-                    // single replay chunk proves this generation attached,
-                    // so reset once on the transition to live, not for every
-                    // subsequent output chunk from a crash-looping relay.
-                    self.consecutiveUnexplainedFailures = 0
+                    self.scheduleLiveStabilityReset(generation: spawnGeneration)
                 }
             }
         }
@@ -796,6 +799,8 @@ final class TuiManualIOPump {
         // scheduler from its spawn grid.
         resizeAckTimeoutTask?.cancel()
         resizeAckTimeoutTask = nil
+        liveStabilityTask?.cancel()
+        liveStabilityTask = nil
         resizeScheduler.reset()
 #if DEBUG
         let stderrTail = (stderrBox.text() ?? "").suffix(300).replacingOccurrences(of: "\n", with: " | ")
@@ -830,6 +835,22 @@ final class TuiManualIOPump {
             return
         }
         scheduleRetry()
+    }
+
+    private func scheduleLiveStabilityReset(generation liveGeneration: Int) {
+        liveStabilityTask?.cancel()
+        let sleep = sleep
+        liveStabilityTask = Task { @MainActor [weak self] in
+            do {
+                try await sleep(Self.liveStabilityInterval)
+            } catch {
+                return
+            }
+            guard !Task.isCancelled, let self,
+                  self.generation == liveGeneration, self.state == .live else { return }
+            self.consecutiveUnexplainedFailures = 0
+            self.liveStabilityTask = nil
+        }
     }
 
     private func scheduleRetry() {

--- a/Sources/TuiManualIOPump.swift
+++ b/Sources/TuiManualIOPump.swift
@@ -269,14 +269,16 @@ struct TuiManualIOResizeScheduler: Equatable {
     mutating func acknowledged(success: Bool = true) -> TuiManualIOGrid? {
         guard let inFlight else { return nil }
         if !success {
-            // A rejected or expired resize was not delivered. Retry it, or
-            // skip directly to the newest pending sample.
-            if let pending, pending != inFlight {
+            // A rejected resize must not be retried from the acknowledgement
+            // callback itself. Mark this size as observed and keep a newer
+            // pending sample for the next genuine geometry event, avoiding a
+            // tight reject/send loop when another pane owns authority.
+            lastDelivered = inFlight
+            self.inFlight = nil
+            if pending == lastDelivered {
                 self.pending = nil
-                self.inFlight = pending
-                return pending
             }
-            return inFlight
+            return nil
         }
         lastDelivered = inFlight
         self.inFlight = nil

--- a/Sources/TuiManualIOPump.swift
+++ b/Sources/TuiManualIOPump.swift
@@ -1,8 +1,5 @@
 import CmuxTerminal
 import Foundation
-#if canImport(Darwin)
-import Darwin
-#endif
 #if DEBUG
 import CMUXDebugLog
 #endif
@@ -300,9 +297,8 @@ final class TuiManualIOInputChannel: @unchecked Sendable {
     private static let maxQueuedWrites = 64
 
     private let lock = NSLock()
-    /// Serializes handle replacement with the check and actual write. The
-    /// generation check alone cannot fence a writer after it unlocks and
-    /// before FileHandle.write starts.
+    /// Serializes queued writes so a handle replacement can invalidate later
+    /// writes without interleaving bytes from different relay generations.
     private let writeLock = NSLock()
     private var handle: FileHandle?
     private var lastGeometryClaim: TimeInterval = 0
@@ -317,10 +313,6 @@ final class TuiManualIOInputChannel: @unchecked Sendable {
     /// worse than losing keystrokes typed into a dead pane). A fresh handle
     /// counts as a claim: the relay claims geometry itself at attach.
     func setHandle(_ newHandle: FileHandle?, now: TimeInterval = ProcessInfo.processInfo.systemUptime) {
-        writeLock.lock()
-        if let newHandle {
-            makeNonBlocking(newHandle)
-        }
         lock.lock()
         generation &+= 1
         handle = newHandle
@@ -331,25 +323,12 @@ final class TuiManualIOInputChannel: @unchecked Sendable {
             needsGeometryClaim = false
         }
         lock.unlock()
-        writeLock.unlock()
     }
 
     func setWriteFailureHandler(_ handler: @escaping @Sendable () -> Void) {
         lock.lock()
         writeFailureHandler = handler
         lock.unlock()
-    }
-
-    private func makeNonBlocking(_ handle: FileHandle) {
-#if canImport(Darwin)
-        let descriptor = handle.fileDescriptor
-        let flags = fcntl(descriptor, F_GETFL)
-        if flags >= 0 {
-            _ = fcntl(descriptor, F_SETFL, flags | O_NONBLOCK)
-        }
-#else
-        _ = handle
-#endif
     }
 
     func send(_ line: Data) {
@@ -451,12 +430,11 @@ final class TuiManualIOInputChannel: @unchecked Sendable {
     /// Closes and detaches the current handle (relay stdin EOF = clean
     /// detach on the relay side).
     func closeHandle() {
-        writeLock.lock()
         lock.lock()
         let target = handle
         handle = nil
+        generation &+= 1
         lock.unlock()
-        writeLock.unlock()
         guard let target else { return }
         queue.async {
             try? target.close()

--- a/Sources/Workspace+PanelLifecycle.swift
+++ b/Sources/Workspace+PanelLifecycle.swift
@@ -460,6 +460,12 @@ extension Workspace {
                 panelID: panelId
             )
         }
+        // A manual-IO pump follows its surface: a detach transfer keeps the
+        // surface (and pump) alive; every other discard stops the relay. The
+        // daemon-side terminal stays alive in the machine's session.
+        if closePanel, !preservesTerminalForTransfer {
+            TuiManualIOPumpRegistry.shared.stopAndRemove(surfaceID: panelId)
+        }
         if closePanel {
             panel?.close()
         }

--- a/Sources/Workspace+RemoteSessionLifecycle.swift
+++ b/Sources/Workspace+RemoteSessionLifecycle.swift
@@ -193,6 +193,12 @@ extension Workspace {
 
     @discardableResult
     func reconnectCloudTerminalSurface(surfaceId: UUID) -> Bool {
+        // Manual-IO cloud terminal panes share the reconnect overlay; their
+        // Reconnect button skips the pump's remaining backoff.
+        if let pump = TuiManualIOPumpRegistry.shared.pump(forSurfaceID: surfaceId) {
+            pump.retryNow()
+            return true
+        }
         guard isManagedCloudVMWorkspace,
               isRemoteTerminalSurface(surfaceId) || remoteDisconnectPlaceholderPanelIds.contains(surfaceId) else {
             return false

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7333,7 +7333,12 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
     }
 
     func cloudTerminalReconnectOverlayPresentation(forSurfaceId surfaceId: UUID) -> CloudTerminalReconnectOverlayPolicy.Presentation? {
-        CloudTerminalReconnectOverlayPolicy.presentation(
+        // Manual-IO cloud terminal panes carry their own per-pane relay state
+        // machine; its overlay wins over the workspace-level presentation.
+        if let pump = TuiManualIOPumpRegistry.shared.pump(forSurfaceID: surfaceId) {
+            return pump.overlayPresentation
+        }
+        return CloudTerminalReconnectOverlayPolicy.presentation(
             isManagedCloudWorkspace: isManagedCloudVMWorkspace,
             isRemoteTerminalSurface: isRemoteTerminalSurface(surfaceId) || remoteDisconnectPlaceholderPanelIds.contains(surfaceId),
             connectionState: remoteConnectionState,
@@ -8550,7 +8555,8 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         initialDividerPosition: CGFloat? = nil,
         remotePTYSessionID: String? = nil,
         suppressWorkspaceRemoteStartupCommand: Bool = false,
-        allowTextBoxFocusDefault: Bool = true
+        allowTextBoxFocusDefault: Bool = true,
+        cloudTuiManualIOAttach: CloudTuiManualIOAttach? = nil
     ) -> TerminalPanelCreationOutcome {
         guard !isRetiredFromOwningTabManager else { return .failed }
         // In a remote tmux mirror workspace a split means "split the mirrored
@@ -8593,7 +8599,8 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
             initialDividerPosition: initialDividerPosition,
             remotePTYSessionID: remotePTYSessionID,
             suppressWorkspaceRemoteStartupCommand: suppressWorkspaceRemoteStartupCommand,
-            allowTextBoxFocusDefault: allowTextBoxFocusDefault
+            allowTextBoxFocusDefault: allowTextBoxFocusDefault,
+            cloudTuiManualIOAttach: cloudTuiManualIOAttach
         ) else { return .failed }
         return .created(panel)
     }
@@ -8610,7 +8617,8 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         initialDividerPosition: CGFloat?,
         remotePTYSessionID: String?,
         suppressWorkspaceRemoteStartupCommand: Bool,
-        allowTextBoxFocusDefault: Bool
+        allowTextBoxFocusDefault: Bool,
+        cloudTuiManualIOAttach: CloudTuiManualIOAttach? = nil
     ) -> TerminalPanel? {
 #if DEBUG
         let splitTimingStart = ProcessInfo.processInfo.systemUptime
@@ -8683,17 +8691,28 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
 #endif
 
         // Create the new terminal panel.
-        let newPanel = TerminalPanel(
-            id: newPanelID,
-            workspaceId: id,
-            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
-            configTemplate: inheritedConfig,
-            workingDirectory: splitWorkingDirectory,
-            portOrdinal: portOrdinal,
-            initialCommand: startupCommand,
-            tmuxStartCommand: tmuxStartCommand,
-            additionalEnvironment: effectiveStartupEnvironment
-        )
+        let newPanel: TerminalPanel
+        if let cloudTuiManualIOAttach {
+            // Same as the tab path: a cloud cmux-tui terminal has no local
+            // process, so the pump feeds the surface instead of a command.
+            newPanel = makeCloudTuiManualIOPanel(
+                id: newPanelID,
+                attach: cloudTuiManualIOAttach,
+                configTemplate: inheritedConfig
+            )
+        } else {
+            newPanel = TerminalPanel(
+                id: newPanelID,
+                workspaceId: id,
+                context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+                configTemplate: inheritedConfig,
+                workingDirectory: splitWorkingDirectory,
+                portOrdinal: portOrdinal,
+                initialCommand: startupCommand,
+                tmuxStartCommand: tmuxStartCommand,
+                additionalEnvironment: effectiveStartupEnvironment
+            )
+        }
         configureNewTerminalPanel(
             newPanel,
             allowTextBoxFocusDefault: focus && allowTextBoxFocusDefault
@@ -8815,7 +8834,8 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         terminalFontSizeCreationPolicy: TerminalFontSizeCreationPolicy = .inherit,
         inheritWorkingDirectoryFallback: Bool = false,
         workingDirectoryFallbackSourcePanelId: UUID? = nil,
-        allowTextBoxFocusDefault: Bool = true
+        allowTextBoxFocusDefault: Bool = true,
+        cloudTuiManualIOAttach: CloudTuiManualIOAttach? = nil
     ) -> TerminalPanel? {
         return newTerminalSurfaceOutcome(
             inPane: paneId,
@@ -8835,7 +8855,8 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
             terminalFontSizeCreationPolicy: terminalFontSizeCreationPolicy,
             inheritWorkingDirectoryFallback: inheritWorkingDirectoryFallback,
             workingDirectoryFallbackSourcePanelId: workingDirectoryFallbackSourcePanelId,
-            allowTextBoxFocusDefault: allowTextBoxFocusDefault
+            allowTextBoxFocusDefault: allowTextBoxFocusDefault,
+            cloudTuiManualIOAttach: cloudTuiManualIOAttach
         ).panel
     }
 
@@ -8860,7 +8881,8 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         terminalFontSizeCreationPolicy: TerminalFontSizeCreationPolicy = .inherit,
         inheritWorkingDirectoryFallback: Bool = false,
         workingDirectoryFallbackSourcePanelId: UUID? = nil,
-        allowTextBoxFocusDefault: Bool = true
+        allowTextBoxFocusDefault: Bool = true,
+        cloudTuiManualIOAttach: CloudTuiManualIOAttach? = nil
     ) -> TerminalPanelCreationOutcome {
         guard !isRetiredFromOwningTabManager else { return .failed }
         // In a remote tmux mirror, a new tab means "create a tmux window"; never
@@ -8922,7 +8944,8 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
             terminalFontSizeCreationPolicy: terminalFontSizeCreationPolicy,
             inheritWorkingDirectoryFallback: inheritWorkingDirectoryFallback,
             workingDirectoryFallbackSourcePanelId: workingDirectoryFallbackSourcePanelId,
-            allowTextBoxFocusDefault: allowTextBoxFocusDefault
+            allowTextBoxFocusDefault: allowTextBoxFocusDefault,
+            cloudTuiManualIOAttach: cloudTuiManualIOAttach
         ) else { return .failed }
         return .created(panel)
     }
@@ -8945,7 +8968,8 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         terminalFontSizeCreationPolicy: TerminalFontSizeCreationPolicy,
         inheritWorkingDirectoryFallback: Bool,
         workingDirectoryFallbackSourcePanelId: UUID?,
-        allowTextBoxFocusDefault: Bool
+        allowTextBoxFocusDefault: Bool,
+        cloudTuiManualIOAttach: CloudTuiManualIOAttach? = nil
     ) -> TerminalPanel? {
         let shouldFocusNewTab = focus ?? (bonsplitController.focusedPaneId == paneId)
         let previousFocusedPanelId = focusedPanelId
@@ -8994,23 +9018,36 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         // surface id (the panel/surface id IS the ghostty surface id, a
         // Swift-side UUID), so a session's terminal binding survives relaunch
         // and restore. The caller only passes an id it has verified is free.
-        let newPanel = TerminalPanel(
-            id: newPanelID,
-            workspaceId: id,
-            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
-            configTemplate: inheritedConfig,
-            workingDirectory: requestedWorkingDirectory,
-            portOrdinal: portOrdinal,
-            initialCommand: startupCommand,
-            tmuxStartCommand: tmuxStartCommand,
-            initialInput: initialInput,
-            additionalEnvironment: effectiveStartupEnvironment,
-            runtimeSpawnPolicy: terminalStartupRestoreCoordinator.runtimeSpawnPolicy(
-                requestedPolicy: runtimeSpawnPolicy,
-                willRunStartupCommand: false,
-                willRunStartupInput: startupRestoreAgent != nil && initialInput != nil
+        let newPanel: TerminalPanel
+        if let cloudTuiManualIOAttach {
+            // A cloud cmux-tui terminal has no local process: the surface
+            // parses daemon bytes fed by the pump's `--pipe-io` relay, and
+            // every startup-command/input/environment input above is
+            // meaningless for it by construction.
+            newPanel = makeCloudTuiManualIOPanel(
+                id: newPanelID,
+                attach: cloudTuiManualIOAttach,
+                configTemplate: inheritedConfig
             )
-        )
+        } else {
+            newPanel = TerminalPanel(
+                id: newPanelID,
+                workspaceId: id,
+                context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+                configTemplate: inheritedConfig,
+                workingDirectory: requestedWorkingDirectory,
+                portOrdinal: portOrdinal,
+                initialCommand: startupCommand,
+                tmuxStartCommand: tmuxStartCommand,
+                initialInput: initialInput,
+                additionalEnvironment: effectiveStartupEnvironment,
+                runtimeSpawnPolicy: terminalStartupRestoreCoordinator.runtimeSpawnPolicy(
+                    requestedPolicy: runtimeSpawnPolicy,
+                    willRunStartupCommand: false,
+                    willRunStartupInput: startupRestoreAgent != nil && initialInput != nil
+                )
+            )
+        }
         configureNewTerminalPanel(
             newPanel,
             allowTextBoxFocusDefault: shouldFocusNewTab && allowTextBoxFocusDefault
@@ -9090,6 +9127,34 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
             )
         }
         return newPanel
+    }
+
+    /// Builds the manual-IO panel + pump pair for one cloud cmux-tui
+    /// terminal: the pane renders daemon bytes through a manual-mirror
+    /// surface, and the pump owns the `attach --pipe-io` relay against the
+    /// machine link's local socket (reconnect state machine included). The
+    /// pump is registered by surface id, which stays stable across detach
+    /// transfers; ``Workspace/removePanel`` stops it on a real discard.
+    private func makeCloudTuiManualIOPanel(
+        id newPanelID: UUID,
+        attach: CloudTuiManualIOAttach,
+        configTemplate: CmuxSurfaceConfigTemplate?
+    ) -> TerminalPanel {
+        let pump = attach.makePump()
+        let surface = TerminalSurface(
+            id: newPanelID,
+            tabId: id,
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: configTemplate,
+            ioMode: .manualMirror,
+            manualInputHandler: pump.makeManualInputHandler()
+        )
+        pump.start(surface: surface)
+        pump.onStateChange = { [weak surface] in
+            surface?.owningWorkspace()?.postRemoteConnectionPresentationDidChange()
+        }
+        TuiManualIOPumpRegistry.shared.register(pump, surfaceID: surface.id)
+        return TerminalPanel(workspaceId: id, surface: surface)
     }
 
     /// Creates a configured manual-mirror ``TerminalPanel`` for one remote tmux pane,

--- a/cmux-tui/Cargo.lock
+++ b/cmux-tui/Cargo.lock
@@ -774,6 +774,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "socket2",
  "smallvec",
  "tempfile",
  "terminput",

--- a/cmux-tui/Cargo.lock
+++ b/cmux-tui/Cargo.lock
@@ -774,7 +774,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "socket2",
+ "socket2 0.5.10",
  "smallvec",
  "tempfile",
  "terminput",

--- a/cmux-tui/crates/cmux-tui/Cargo.toml
+++ b/cmux-tui/crates/cmux-tui/Cargo.toml
@@ -44,6 +44,7 @@ terminput.workspace = true
 terminput-crossterm.workspace = true
 parking_lot.workspace = true
 sha2.workspace = true
+socket2.workspace = true
 uuid.workspace = true
 wait-timeout.workspace = true
 fs4.workspace = true

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -26,6 +26,7 @@ mod machine_provider_client;
 #[cfg(unix)]
 mod machine_provider_runtime;
 mod machine_runtime;
+mod pipe_io;
 mod plugin_manager;
 mod process_diagnostics;
 #[cfg(target_os = "linux")]
@@ -428,6 +429,13 @@ START OPTIONS
   --session <name>   Session name (default: main). Determines the socket path.
   --socket <path>    Explicit control socket path.
   --terminal <id>    With attach, show only this terminal (use `cmux terminal list`).
+  --pipe-io          With attach --terminal, relay raw bytes over stdio for an
+                     embedder that parses them itself instead of rendering
+                     (stdout = replay then live output, stdin = JSON
+                     input/resize lines, exit 0 = terminal ended, exit 2 =
+                     daemon connection lost).
+  --cols <n>         Initial viewer columns for --pipe-io (default 80).
+  --rows <n>         Initial viewer rows for --pipe-io (default 24).
   --state <path>     Durable session-state root (default: platform state dir).
   --ephemeral        Keep workspace state in memory for this run only.
   --machine-provider <path>
@@ -491,6 +499,9 @@ struct Args {
     session: String,
     socket: Option<PathBuf>,
     terminal: Option<String>,
+    pipe_io: bool,
+    pipe_io_cols: Option<u16>,
+    pipe_io_rows: Option<u16>,
     state: Option<PathBuf>,
     ephemeral: bool,
     machine_provider: Option<PathBuf>,
@@ -565,6 +576,9 @@ fn parse_args_result(args: impl IntoIterator<Item = String>) -> Result<Args, Str
         session: "main".to_string(),
         socket: None,
         terminal: None,
+        pipe_io: false,
+        pipe_io_cols: None,
+        pipe_io_rows: None,
         state: None,
         ephemeral: false,
         machine_provider: None,
@@ -617,6 +631,19 @@ fn parse_args_result(args: impl IntoIterator<Item = String>) -> Result<Args, Str
             "--terminal" => {
                 out.terminal =
                     Some(args.next().ok_or_else(|| "--terminal needs a value".to_string())?);
+            }
+            "--pipe-io" => {
+                out.pipe_io = true;
+            }
+            "--cols" => {
+                let value = args.next().ok_or_else(|| "--cols needs a value".to_string())?;
+                out.pipe_io_cols =
+                    Some(value.parse().map_err(|_| "--cols needs a number".to_string())?);
+            }
+            "--rows" => {
+                let value = args.next().ok_or_else(|| "--rows needs a value".to_string())?;
+                out.pipe_io_rows =
+                    Some(value.parse().map_err(|_| "--rows needs a number".to_string())?);
             }
             "--machine-provider" => {
                 if out.machine_provider.is_some() {
@@ -811,6 +838,12 @@ fn parse_args_result(args: impl IntoIterator<Item = String>) -> Result<Args, Str
     }
     if out.terminal.is_some() && !out.attach {
         return Err("--terminal requires `cmux attach`".to_string());
+    }
+    if out.pipe_io && out.terminal.is_none() {
+        return Err("--pipe-io requires `cmux attach --terminal`".to_string());
+    }
+    if (out.pipe_io_cols.is_some() || out.pipe_io_rows.is_some()) && !out.pipe_io {
+        return Err("--cols/--rows require --pipe-io".to_string());
     }
     #[cfg(not(unix))]
     if out.agent_browser_provider {
@@ -1626,6 +1659,18 @@ fn run_terminal_host_process(args: &[String]) -> anyhow::Result<()> {
     cmux_tui_core::terminal_host_runtime::serve_terminal_host_stdio(args, &mut reader, &mut writer)
 }
 
+/// Ends a `--pipe-io` relay: the machine-readable exit reason is the final
+/// stderr line (the embedder localizes what it shows) and the exit code
+/// carries the respawn decision.
+fn exit_pipe_io(reason: pipe_io::PipeIoExitReason) -> ! {
+    {
+        let mut stderr = std::io::stderr().lock();
+        let _ = writeln!(stderr, "{}", serde_json::json!({"exit": {"reason": reason.as_str()}}));
+        let _ = stderr.flush();
+    }
+    std::process::exit(reason.exit_code());
+}
+
 fn run_attach(args: Args, config: config::StartupConfigSnapshot) -> anyhow::Result<()> {
     let socket_path = match args.socket {
         Some(path) => path,
@@ -1641,27 +1686,71 @@ fn run_attach(args: Args, config: config::StartupConfigSnapshot) -> anyhow::Resu
         })
         .transpose()?;
     let remote = if terminal.is_some() {
-        RemoteSession::connect_for_terminal_attach(&socket_path)?
+        match RemoteSession::connect_for_terminal_attach(&socket_path) {
+            Ok(remote) => remote,
+            // A pipe-io embedder retries daemon-lost forever (a daemon
+            // restart window looks exactly like this) but gives up on
+            // unexplained failures; a connect failure is the former.
+            Err(_) if args.pipe_io => exit_pipe_io(pipe_io::PipeIoExitReason::DaemonLost),
+            Err(error) => return Err(error),
+        }
     } else {
         RemoteSession::connect(&socket_path)?
     };
     let surface_only = if let Some(terminal) = terminal.as_ref() {
-        let tree = remote.refresh_tree()?;
-        let surface = tree
-            .resolve_terminal(terminal)
+        let tree = match remote.refresh_tree() {
+            Ok(tree) => tree,
+            Err(_) if args.pipe_io => exit_pipe_io(pipe_io::PipeIoExitReason::DaemonLost),
+            Err(error) => return Err(error),
+        };
+        let resolved = tree.resolve_terminal(terminal);
+        // A pipe-io embedder respawns on daemon loss; a terminal that no
+        // longer exists must read as terminal-ended (do not respawn), not
+        // as a startup failure it would retry forever.
+        if args.pipe_io && resolved.is_none() {
+            exit_pipe_io(pipe_io::PipeIoExitReason::TerminalEnded);
+        }
+        let surface = resolved
             .ok_or_else(|| anyhow::anyhow!(messages.unknown_terminal(terminal.as_str())))?;
         if !remote.supports_surface_subscription_filter() {
             anyhow::bail!(messages.filtered_subscription_unavailable);
         }
-        remote.scope_events_to_surface(surface)?;
-        let tree = remote.refresh_tree()?;
+        if let Err(error) = remote.scope_events_to_surface(surface) {
+            if args.pipe_io {
+                exit_pipe_io(pipe_io::PipeIoExitReason::DaemonLost);
+            }
+            return Err(error);
+        }
+        let tree = match remote.refresh_tree() {
+            Ok(tree) => tree,
+            Err(_) if args.pipe_io => exit_pipe_io(pipe_io::PipeIoExitReason::DaemonLost),
+            Err(error) => return Err(error),
+        };
         if tree.resolve_terminal(terminal) != Some(surface) {
+            if args.pipe_io {
+                exit_pipe_io(pipe_io::PipeIoExitReason::TerminalEnded);
+            }
             anyhow::bail!(messages.unknown_terminal(terminal.as_str()));
         }
         Some(surface)
     } else {
         None
     };
+    if args.pipe_io {
+        let surface = surface_only.expect("--pipe-io is validated to carry --terminal");
+        let terminal = terminal.as_ref().expect("--pipe-io is validated to carry --terminal");
+        let session = Session::Remote(remote.clone());
+        let reason = pipe_io::run(
+            &session,
+            &remote,
+            &socket_path,
+            terminal,
+            surface,
+            args.pipe_io_cols.unwrap_or(80),
+            args.pipe_io_rows.unwrap_or(24),
+        )?;
+        exit_pipe_io(reason);
+    }
     run_connected_session_client(
         socket_path,
         args.session,

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -1732,7 +1732,11 @@ fn run_attach(args: Args, config: config::StartupConfigSnapshot) -> anyhow::Resu
         let surface = resolved
             .ok_or_else(|| anyhow::anyhow!(messages.unknown_terminal(terminal.as_str())))?;
         if !remote.supports_surface_subscription_filter() {
-            anyhow::bail!(messages.filtered_subscription_unavailable);
+            let error = anyhow::anyhow!(messages.filtered_subscription_unavailable);
+            if args.pipe_io {
+                exit_pipe_io_startup_failure(&error);
+            }
+            return Err(error);
         }
         if let Err(error) = remote.scope_events_to_surface(surface) {
             if args.pipe_io {

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -1671,6 +1671,11 @@ fn exit_pipe_io(reason: pipe_io::PipeIoExitReason) -> ! {
     std::process::exit(reason.exit_code());
 }
 
+fn exit_pipe_io_startup_failure(error: &anyhow::Error) -> ! {
+    crate::client_log::stderr_log!("startup", "cmux-tui pipe-io startup failed: {error}");
+    exit_pipe_io(pipe_io::PipeIoExitReason::StartupFailure)
+}
+
 fn run_attach(args: Args, config: config::StartupConfigSnapshot) -> anyhow::Result<()> {
     let socket_path = match args.socket {
         Some(path) => path,
@@ -1688,10 +1693,17 @@ fn run_attach(args: Args, config: config::StartupConfigSnapshot) -> anyhow::Resu
     let remote = if terminal.is_some() {
         match RemoteSession::connect_for_terminal_attach(&socket_path) {
             Ok(remote) => remote,
-            // A pipe-io embedder retries daemon-lost forever (a daemon
-            // restart window looks exactly like this) but gives up on
-            // unexplained failures; a connect failure is the former.
-            Err(_) if args.pipe_io => exit_pipe_io(pipe_io::PipeIoExitReason::DaemonLost),
+            // Retry only transport/timeouts. Protocol, capability, and
+            // authentication failures are permanent until the client or
+            // daemon is corrected, so report a bounded startup failure.
+            Err(error)
+                if args.pipe_io
+                    && (session::is_remote_transport_failure(&error)
+                        || session::is_remote_timeout(&error)) =>
+            {
+                exit_pipe_io(pipe_io::PipeIoExitReason::DaemonLost)
+            }
+            Err(error) if args.pipe_io => exit_pipe_io_startup_failure(&error),
             Err(error) => return Err(error),
         }
     } else {
@@ -1700,7 +1712,14 @@ fn run_attach(args: Args, config: config::StartupConfigSnapshot) -> anyhow::Resu
     let surface_only = if let Some(terminal) = terminal.as_ref() {
         let tree = match remote.refresh_tree() {
             Ok(tree) => tree,
-            Err(_) if args.pipe_io => exit_pipe_io(pipe_io::PipeIoExitReason::DaemonLost),
+            Err(error)
+                if args.pipe_io
+                    && (session::is_remote_transport_failure(&error)
+                        || session::is_remote_timeout(&error)) =>
+            {
+                exit_pipe_io(pipe_io::PipeIoExitReason::DaemonLost)
+            }
+            Err(error) if args.pipe_io => exit_pipe_io_startup_failure(&error),
             Err(error) => return Err(error),
         };
         let resolved = tree.resolve_terminal(terminal);
@@ -1717,13 +1736,25 @@ fn run_attach(args: Args, config: config::StartupConfigSnapshot) -> anyhow::Resu
         }
         if let Err(error) = remote.scope_events_to_surface(surface) {
             if args.pipe_io {
-                exit_pipe_io(pipe_io::PipeIoExitReason::DaemonLost);
+                if session::is_remote_transport_failure(&error)
+                    || session::is_remote_timeout(&error)
+                {
+                    exit_pipe_io(pipe_io::PipeIoExitReason::DaemonLost);
+                }
+                exit_pipe_io_startup_failure(&error);
             }
             return Err(error);
         }
         let tree = match remote.refresh_tree() {
             Ok(tree) => tree,
-            Err(_) if args.pipe_io => exit_pipe_io(pipe_io::PipeIoExitReason::DaemonLost),
+            Err(error)
+                if args.pipe_io
+                    && (session::is_remote_transport_failure(&error)
+                        || session::is_remote_timeout(&error)) =>
+            {
+                exit_pipe_io(pipe_io::PipeIoExitReason::DaemonLost)
+            }
+            Err(error) if args.pipe_io => exit_pipe_io_startup_failure(&error),
             Err(error) => return Err(error),
         };
         if tree.resolve_terminal(terminal) != Some(surface) {

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -1,0 +1,321 @@
+//! Renderer-less byte relay for embedder-fed (manual-IO) surfaces.
+//!
+//! `cmux attach --terminal <id> --pipe-io` is the scoped attach client minus
+//! the renderer: the embedder (the macOS GUI's manual-mirror Ghostty
+//! surface) parses the byte stream itself, so this process only relays.
+//!
+//! Contract:
+//! - stdout: raw VT bytes — the daemon replay first, then live PTY output.
+//!   A replay that is not the relay's first output is prefixed with a full
+//!   reset (`ESC c` + erase-scrollback) because a daemon replay REPLACES
+//!   terminal state while a byte stream can only append.
+//! - stdin: JSON lines — `{"input":"<base64>"}` forwards raw bytes to the
+//!   daemon terminal's PTY; `{"resize":{"cols":N,"rows":N}}` drives the
+//!   daemon-side viewer size. Unknown keys are ignored (forward compat);
+//!   stdin EOF means the embedder is gone and ends the relay cleanly.
+//! - stderr: one final JSON line `{"exit":{"reason":...}}`.
+//! - exit code: 0 when the terminal ended or the embedder closed stdin (do
+//!   not respawn), 2 when the daemon connection was lost (respawning
+//!   reattaches and resyncs from a fresh replay).
+
+use std::io::{BufRead, Write};
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::mpsc::{Receiver, SyncSender};
+
+use base64::Engine as _;
+use cmux_tui_core::SurfaceId;
+use cmux_tui_core::resource::TerminalPublicId;
+
+use crate::session::{PipeIoEvent, RemoteSession, Session, SurfaceAttach, SurfaceHandle};
+
+/// The terminal ended, or the embedder walked away: respawning is wrong.
+pub const EXIT_DO_NOT_RESPAWN: i32 = 0;
+/// The daemon connection was lost: the embedder may respawn to resync.
+pub const EXIT_DAEMON_LOST: i32 = 2;
+
+/// Bounded event queue between the session reader thread and the stdout
+/// pump. A full queue means the embedder stopped reading; the session
+/// treats that as a lost transport rather than wedging its reader thread.
+const EVENT_QUEUE_CAPACITY: usize = 4096;
+
+/// Emitted before any replay that is not the relay's first output: full
+/// reset plus erase-scrollback, so the replacement replay does not stack on
+/// top of the embedder's previous terminal state.
+const REPLAY_RESET: &[u8] = b"\x1bc\x1b[3J";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PipeIoExitReason {
+    TerminalEnded,
+    DaemonLost,
+    ParentClosed,
+}
+
+impl PipeIoExitReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::TerminalEnded => "terminal-ended",
+            Self::DaemonLost => "daemon-lost",
+            Self::ParentClosed => "parent-closed",
+        }
+    }
+
+    pub fn exit_code(self) -> i32 {
+        match self {
+            Self::TerminalEnded | Self::ParentClosed => EXIT_DO_NOT_RESPAWN,
+            Self::DaemonLost => EXIT_DAEMON_LOST,
+        }
+    }
+}
+
+/// One parsed stdin line.
+#[derive(Debug, PartialEq, Eq)]
+pub enum PipeIoRequest {
+    Input(Vec<u8>),
+    Resize {
+        cols: u16,
+        rows: u16,
+    },
+    /// A well-formed line carrying no verb this relay knows: ignored, so a
+    /// newer embedder can talk to an older relay.
+    Unknown,
+}
+
+pub fn parse_request(line: &str) -> anyhow::Result<PipeIoRequest> {
+    let value: serde_json::Value = serde_json::from_str(line)?;
+    if let Some(encoded) = value.get("input").and_then(serde_json::Value::as_str) {
+        let bytes = base64::engine::general_purpose::STANDARD.decode(encoded)?;
+        return Ok(PipeIoRequest::Input(bytes));
+    }
+    if let Some(resize) = value.get("resize") {
+        let cols = resize.get("cols").and_then(serde_json::Value::as_u64);
+        let rows = resize.get("rows").and_then(serde_json::Value::as_u64);
+        let (Some(cols), Some(rows)) = (cols, rows) else {
+            anyhow::bail!("resize needs numeric cols and rows");
+        };
+        let (cols, rows) = (u16::try_from(cols)?, u16::try_from(rows)?);
+        return Ok(PipeIoRequest::Resize { cols: cols.max(1), rows: rows.max(1) });
+    }
+    Ok(PipeIoRequest::Unknown)
+}
+
+pub fn run(
+    session: &Session,
+    remote: &Arc<RemoteSession>,
+    socket_path: &Path,
+    terminal: &TerminalPublicId,
+    surface: SurfaceId,
+    cols: u16,
+    rows: u16,
+) -> anyhow::Result<PipeIoExitReason> {
+    let (sender, receiver) = std::sync::mpsc::sync_channel(EVENT_QUEUE_CAPACITY);
+    // Install before attach so the initial replay cannot be missed.
+    remote.install_pipe_io_tap(surface, sender.clone());
+    let handle = match session.try_surface_sized(surface, Some((cols.max(1), rows.max(1))))? {
+        SurfaceAttach::Attached(handle) => handle,
+        SurfaceAttach::Retired | SurfaceAttach::Missing => {
+            return Ok(PipeIoExitReason::TerminalEnded);
+        }
+        SurfaceAttach::Deferred => anyhow::bail!("terminal attach was deferred by the server"),
+    };
+    // The daemon resizes a terminal's PTY only for its geometry-authority
+    // client (the full TUI client claims this for its active surface). The
+    // relay is the embedder's only viewer of this terminal, so claim the
+    // authority or every embedder resize is recorded but never applied.
+    if let Err(error) = session.claim_terminal_geometry(surface) {
+        eprintln!(
+            "{}",
+            serde_json::json!({"diag": {"claim-terminal-geometry": {"error": error.to_string()}}})
+        );
+    }
+    spawn_stdin_pump(handle, sender);
+    let reason = pump_events_to_stdout(&receiver, &mut std::io::stdout().lock())?;
+    if reason == PipeIoExitReason::DaemonLost {
+        return Ok(classify_daemon_loss(remote, socket_path, terminal));
+    }
+    Ok(reason)
+}
+
+/// The stream ended without a terminal-exit event, but "stream lost" covers
+/// two situations the embedder must tell apart: the daemon really is
+/// unreachable (respawn until it returns), or the terminal was closed and
+/// the daemon tore the scoped stream down before the exit event reached us
+/// (never respawn). One bounded probe of the daemon resolves it: prefer the
+/// existing connection, and fall back to a fresh connect when the socket
+/// died with the stream.
+fn classify_daemon_loss(
+    remote: &Arc<RemoteSession>,
+    socket_path: &Path,
+    terminal: &TerminalPublicId,
+) -> PipeIoExitReason {
+    let terminal_still_exists =
+        remote.refresh_tree().ok().map(|tree| tree.resolve_terminal(terminal).is_some()).or_else(
+            || {
+                let probe = RemoteSession::connect_for_terminal_attach(socket_path).ok()?;
+                let tree = probe.refresh_tree().ok()?;
+                Some(tree.resolve_terminal(terminal).is_some())
+            },
+        );
+    match terminal_still_exists {
+        Some(false) => PipeIoExitReason::TerminalEnded,
+        Some(true) | None => PipeIoExitReason::DaemonLost,
+    }
+}
+
+/// Forwards embedder requests from stdin until EOF, then reports the closed
+/// parent through the shared event queue.
+fn spawn_stdin_pump(handle: SurfaceHandle, sender: SyncSender<PipeIoEvent>) {
+    std::thread::Builder::new()
+        .name("pipe-io-stdin".into())
+        .spawn(move || {
+            let stdin = std::io::stdin();
+            for line in stdin.lock().lines() {
+                let Ok(line) = line else { break };
+                if line.trim().is_empty() {
+                    continue;
+                }
+                match parse_request(&line) {
+                    Ok(PipeIoRequest::Input(bytes)) => {
+                        if handle.write_bytes(&bytes).is_err() {
+                            // The transport owns loss reporting; input can
+                            // only stop early.
+                            break;
+                        }
+                    }
+                    Ok(PipeIoRequest::Resize { cols, rows }) => {
+                        // Diagnostics only; the exit JSON stays the final
+                        // stderr line and embedders skip lines without an
+                        // "exit" key.
+                        match handle.resize(cols, rows) {
+                            Ok(accepted) => eprintln!(
+                                "{}",
+                                serde_json::json!({
+                                    "diag": {"resize": {"cols": cols, "rows": rows, "accepted": accepted}}
+                                })
+                            ),
+                            Err(error) => eprintln!(
+                                "{}",
+                                serde_json::json!({
+                                    "diag": {"resize": {"cols": cols, "rows": rows, "error": error.to_string()}}
+                                })
+                            ),
+                        }
+                    }
+                    Ok(PipeIoRequest::Unknown) => {}
+                    // A malformed line means the embedder side is broken;
+                    // stop consuming rather than misinterpreting input.
+                    Err(_) => break,
+                }
+            }
+            // Blocking send: the queue is drained until the main loop
+            // returns, and a dropped receiver just ends this thread.
+            let _ = sender.send(PipeIoEvent::StdinClosed);
+        })
+        .expect("spawn pipe-io stdin pump");
+}
+
+fn pump_events_to_stdout(
+    receiver: &Receiver<PipeIoEvent>,
+    stdout: &mut impl Write,
+) -> anyhow::Result<PipeIoExitReason> {
+    let mut emitted_output = false;
+    loop {
+        // A dropped sender without a prior event means the session went
+        // away wholesale: report it as a lost daemon.
+        let Ok(event) = receiver.recv() else {
+            return Ok(PipeIoExitReason::DaemonLost);
+        };
+        let write_result = match &event {
+            PipeIoEvent::Replay { bytes } => {
+                let reset = if emitted_output { stdout.write_all(REPLAY_RESET) } else { Ok(()) };
+                reset.and_then(|()| stdout.write_all(bytes)).and_then(|()| stdout.flush())
+            }
+            PipeIoEvent::Output(bytes) => stdout.write_all(bytes).and_then(|()| stdout.flush()),
+            PipeIoEvent::SurfaceExited => return Ok(PipeIoExitReason::TerminalEnded),
+            PipeIoEvent::TransportLost => return Ok(PipeIoExitReason::DaemonLost),
+            PipeIoEvent::StdinClosed => return Ok(PipeIoExitReason::ParentClosed),
+        };
+        if write_result.is_err() {
+            // stdout is the embedder; a failed write means it is gone.
+            return Ok(PipeIoExitReason::ParentClosed);
+        }
+        emitted_output = true;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn replay(bytes: &[u8]) -> PipeIoEvent {
+        PipeIoEvent::Replay { bytes: bytes.to_vec() }
+    }
+
+    #[test]
+    fn parse_request_decodes_input_resize_and_ignores_unknown_verbs() {
+        assert_eq!(
+            parse_request(r#"{"input":"aGk="}"#).unwrap(),
+            PipeIoRequest::Input(b"hi".to_vec())
+        );
+        assert_eq!(
+            parse_request(r#"{"resize":{"cols":100,"rows":30}}"#).unwrap(),
+            PipeIoRequest::Resize { cols: 100, rows: 30 }
+        );
+        assert_eq!(
+            parse_request(r#"{"resize":{"cols":0,"rows":0}}"#).unwrap(),
+            PipeIoRequest::Resize { cols: 1, rows: 1 }
+        );
+        assert_eq!(parse_request(r#"{"future-verb":true}"#).unwrap(), PipeIoRequest::Unknown);
+        assert!(parse_request("not json").is_err());
+        assert!(parse_request(r#"{"input":"@@not-base64@@"}"#).is_err());
+        assert!(parse_request(r#"{"resize":{"cols":100}}"#).is_err());
+    }
+
+    #[test]
+    fn exit_reasons_map_to_the_respawn_contract() {
+        assert_eq!(PipeIoExitReason::TerminalEnded.exit_code(), EXIT_DO_NOT_RESPAWN);
+        assert_eq!(PipeIoExitReason::ParentClosed.exit_code(), EXIT_DO_NOT_RESPAWN);
+        assert_eq!(PipeIoExitReason::DaemonLost.exit_code(), EXIT_DAEMON_LOST);
+        assert_eq!(PipeIoExitReason::TerminalEnded.as_str(), "terminal-ended");
+        assert_eq!(PipeIoExitReason::DaemonLost.as_str(), "daemon-lost");
+        assert_eq!(PipeIoExitReason::ParentClosed.as_str(), "parent-closed");
+    }
+
+    #[test]
+    fn stdout_pump_prefixes_only_non_initial_replays_with_a_full_reset() {
+        let (sender, receiver) = std::sync::mpsc::sync_channel(8);
+        sender.send(replay(b"FIRST")).unwrap();
+        sender.send(PipeIoEvent::Output(b"live".to_vec())).unwrap();
+        sender.send(replay(b"SECOND")).unwrap();
+        sender.send(PipeIoEvent::SurfaceExited).unwrap();
+        let mut stdout = Vec::new();
+        let reason = pump_events_to_stdout(&receiver, &mut stdout).unwrap();
+        assert_eq!(reason, PipeIoExitReason::TerminalEnded);
+        let mut expected = b"FIRSTlive".to_vec();
+        expected.extend_from_slice(REPLAY_RESET);
+        expected.extend_from_slice(b"SECOND");
+        assert_eq!(stdout, expected);
+    }
+
+    #[test]
+    fn stdout_pump_maps_lifecycle_events_to_exit_reasons() {
+        for (event, expected) in [
+            (PipeIoEvent::TransportLost, PipeIoExitReason::DaemonLost),
+            (PipeIoEvent::StdinClosed, PipeIoExitReason::ParentClosed),
+        ] {
+            let (sender, receiver) = std::sync::mpsc::sync_channel(8);
+            sender.send(event).unwrap();
+            let mut stdout = Vec::new();
+            assert_eq!(pump_events_to_stdout(&receiver, &mut stdout).unwrap(), expected);
+            assert!(stdout.is_empty());
+        }
+        // Sender dropped without any event: the session vanished wholesale.
+        let (sender, receiver) = std::sync::mpsc::sync_channel::<PipeIoEvent>(8);
+        drop(sender);
+        let mut stdout = Vec::new();
+        assert_eq!(
+            pump_events_to_stdout(&receiver, &mut stdout).unwrap(),
+            PipeIoExitReason::DaemonLost
+        );
+    }
+}

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -25,7 +25,7 @@ use std::io::{BufRead, Write};
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::mpsc::{Receiver, SyncSender};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use base64::Engine as _;
 use cmux_tui_core::SurfaceId;
@@ -162,14 +162,17 @@ fn classify_daemon_loss(
     socket_path: &Path,
     terminal: &TerminalPublicId,
 ) -> PipeIoExitReason {
-    let terminal_still_exists =
-        remote.refresh_tree_with_timeout(DAEMON_LOSS_PROBE_TIMEOUT).ok().map(|tree| tree.resolve_terminal(terminal).is_some()).or_else(
-            || {
-                let probe = RemoteSession::connect_for_terminal_attach(socket_path).ok()?;
-                let tree = probe.refresh_tree_with_timeout(DAEMON_LOSS_PROBE_TIMEOUT).ok()?;
-                Some(tree.resolve_terminal(terminal).is_some())
-            },
-        );
+    let deadline = Instant::now() + DAEMON_LOSS_PROBE_TIMEOUT;
+    let terminal_still_exists = remote
+        .refresh_tree_until(deadline)
+        .ok()
+        .map(|tree| tree.resolve_terminal(terminal).is_some())
+        .or_else(|| {
+            let probe =
+                RemoteSession::connect_for_terminal_attach_until(socket_path, deadline).ok()?;
+            let tree = probe.refresh_tree_until(deadline).ok()?;
+            Some(tree.resolve_terminal(terminal).is_some())
+        });
     match terminal_still_exists {
         Some(false) => PipeIoExitReason::TerminalEnded,
         Some(true) | None => PipeIoExitReason::DaemonLost,

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -11,8 +11,11 @@
 //!   terminal state while a byte stream can only append.
 //! - stdin: JSON lines — `{"input":"<base64>"}` forwards raw bytes to the
 //!   daemon terminal's PTY; `{"resize":{"cols":N,"rows":N}}` drives the
-//!   daemon-side viewer size. Unknown keys are ignored (forward compat);
-//!   stdin EOF means the embedder is gone and ends the relay cleanly.
+//!   daemon-side viewer size; `{"claim":{"geometry":true}}` re-asserts this
+//!   relay's geometry authority (last claim wins across attachments; the
+//!   embedder sends it when its pane receives user input). Unknown keys are
+//!   ignored (forward compat); stdin EOF means the embedder is gone and
+//!   ends the relay cleanly.
 //! - stderr: one final JSON line `{"exit":{"reason":...}}`.
 //! - exit code: 0 when the terminal ended or the embedder closed stdin (do
 //!   not respawn), 2 when the daemon connection was lost (respawning
@@ -76,6 +79,12 @@ pub enum PipeIoRequest {
         cols: u16,
         rows: u16,
     },
+    /// Re-assert this relay's geometry authority over the terminal. Sent by
+    /// the embedder when its pane receives user input: authority is
+    /// last-claim-wins across attachments, so with several panes (or stale
+    /// restored panes) viewing one terminal, the pane the user actually
+    /// types in must own the PTY size.
+    ClaimGeometry,
     /// A well-formed line carrying no verb this relay knows: ignored, so a
     /// newer embedder can talk to an older relay.
     Unknown,
@@ -95,6 +104,9 @@ pub fn parse_request(line: &str) -> anyhow::Result<PipeIoRequest> {
         };
         let (cols, rows) = (u16::try_from(cols)?, u16::try_from(rows)?);
         return Ok(PipeIoRequest::Resize { cols: cols.max(1), rows: rows.max(1) });
+    }
+    if value.get("claim").is_some() {
+        return Ok(PipeIoRequest::ClaimGeometry);
     }
     Ok(PipeIoRequest::Unknown)
 }
@@ -128,7 +140,7 @@ pub fn run(
             serde_json::json!({"diag": {"claim-terminal-geometry": {"error": error.to_string()}}})
         );
     }
-    spawn_stdin_pump(handle, sender);
+    spawn_stdin_pump(handle, sender, session.clone(), surface);
     let reason = pump_events_to_stdout(&receiver, &mut std::io::stdout().lock())?;
     if reason == PipeIoExitReason::DaemonLost {
         return Ok(classify_daemon_loss(remote, socket_path, terminal));
@@ -164,7 +176,12 @@ fn classify_daemon_loss(
 
 /// Forwards embedder requests from stdin until EOF, then reports the closed
 /// parent through the shared event queue.
-fn spawn_stdin_pump(handle: SurfaceHandle, sender: SyncSender<PipeIoEvent>) {
+fn spawn_stdin_pump(
+    handle: SurfaceHandle,
+    sender: SyncSender<PipeIoEvent>,
+    session: Session,
+    surface: SurfaceId,
+) {
     std::thread::Builder::new()
         .name("pipe-io-stdin".into())
         .spawn(move || {
@@ -197,6 +214,22 @@ fn spawn_stdin_pump(handle: SurfaceHandle, sender: SyncSender<PipeIoEvent>) {
                                 "{}",
                                 serde_json::json!({
                                     "diag": {"resize": {"cols": cols, "rows": rows, "error": error.to_string()}}
+                                })
+                            ),
+                        }
+                    }
+                    Ok(PipeIoRequest::ClaimGeometry) => {
+                        // Same diag discipline as resize: diagnostics only,
+                        // the exit JSON stays the final stderr line.
+                        match session.claim_terminal_geometry(surface) {
+                            Ok(()) => eprintln!(
+                                "{}",
+                                serde_json::json!({"diag": {"claim": {"accepted": true}}})
+                            ),
+                            Err(error) => eprintln!(
+                                "{}",
+                                serde_json::json!({
+                                    "diag": {"claim": {"error": error.to_string()}}
                                 })
                             ),
                         }

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -25,6 +25,7 @@ use std::io::{BufRead, Write};
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::mpsc::{Receiver, SyncSender};
+use std::time::Duration;
 
 use base64::Engine as _;
 use cmux_tui_core::SurfaceId;
@@ -46,6 +47,7 @@ const EVENT_QUEUE_CAPACITY: usize = 4096;
 /// reset plus erase-scrollback, so the replacement replay does not stack on
 /// top of the embedder's previous terminal state.
 const REPLAY_RESET: &[u8] = b"\x1bc\x1b[3J";
+const DAEMON_LOSS_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PipeIoExitReason {
@@ -161,10 +163,10 @@ fn classify_daemon_loss(
     terminal: &TerminalPublicId,
 ) -> PipeIoExitReason {
     let terminal_still_exists =
-        remote.refresh_tree().ok().map(|tree| tree.resolve_terminal(terminal).is_some()).or_else(
+        remote.refresh_tree_with_timeout(DAEMON_LOSS_PROBE_TIMEOUT).ok().map(|tree| tree.resolve_terminal(terminal).is_some()).or_else(
             || {
                 let probe = RemoteSession::connect_for_terminal_attach(socket_path).ok()?;
-                let tree = probe.refresh_tree().ok()?;
+                let tree = probe.refresh_tree_with_timeout(DAEMON_LOSS_PROBE_TIMEOUT).ok()?;
                 Some(tree.resolve_terminal(terminal).is_some())
             },
         );

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -24,14 +24,17 @@
 use std::io::{BufRead, Write};
 use std::path::Path;
 use std::sync::Arc;
-use std::sync::mpsc::{Receiver, SyncSender};
 use std::time::{Duration, Instant};
 
 use base64::Engine as _;
 use cmux_tui_core::SurfaceId;
 use cmux_tui_core::resource::TerminalPublicId;
+use crossbeam_channel::{Receiver, Sender};
 
-use crate::session::{PipeIoEvent, RemoteSession, Session, SurfaceAttach, SurfaceHandle};
+use crate::session::{
+    PipeIoEvent, RemoteSession, Session, SurfaceAttach, SurfaceHandle,
+    is_remote_surface_unavailable,
+};
 
 /// The terminal ended, or the embedder walked away: respawning is wrong.
 pub const EXIT_DO_NOT_RESPAWN: i32 = 0;
@@ -122,15 +125,21 @@ pub fn run(
     cols: u16,
     rows: u16,
 ) -> anyhow::Result<PipeIoExitReason> {
-    let (sender, receiver) = std::sync::mpsc::sync_channel(EVENT_QUEUE_CAPACITY);
+    let (sender, receiver) = crossbeam_channel::bounded(EVENT_QUEUE_CAPACITY);
+    // Lifecycle events have their own reserved signal path. A stalled
+    // embedder can fill the byte queue, but it must never be able to hide the
+    // transport-loss event that tells the embedder to respawn.
+    let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
     // Install before attach so the initial replay cannot be missed.
-    remote.install_pipe_io_tap(surface, sender.clone());
-    let handle = match session.try_surface_sized(surface, Some((cols.max(1), rows.max(1))))? {
-        SurfaceAttach::Attached(handle) => handle,
-        SurfaceAttach::Retired | SurfaceAttach::Missing => {
+    let tap_token = remote.install_pipe_io_tap(surface, sender.clone(), lifecycle_sender);
+    let tap_guard = PipeIoTapGuard { remote: remote.as_ref(), token: tap_token };
+    let handle = match session.try_surface_sized(surface, Some((cols.max(1), rows.max(1)))) {
+        Ok(SurfaceAttach::Attached(handle)) => handle,
+        Ok(SurfaceAttach::Retired | SurfaceAttach::Missing) => {
             return Ok(PipeIoExitReason::TerminalEnded);
         }
-        SurfaceAttach::Deferred => anyhow::bail!("terminal attach was deferred by the server"),
+        Ok(SurfaceAttach::Deferred) => return Ok(PipeIoExitReason::DaemonLost),
+        Err(error) => return Ok(attach_failure_exit_reason(&error, surface)),
     };
     // The daemon resizes a terminal's PTY only for its geometry-authority
     // client (the full TUI client claims this for its active surface). The
@@ -143,11 +152,39 @@ pub fn run(
         );
     }
     spawn_stdin_pump(handle, sender, session.clone(), surface);
-    let reason = pump_events_to_stdout(&receiver, &mut std::io::stdout().lock())?;
+    let reason =
+        pump_events_to_stdout(&receiver, &lifecycle_receiver, &mut std::io::stdout().lock())?;
+    // Stop forwarding while the daemon probe runs. The probe has its own
+    // request path, and events for the finished relay must not fill the data
+    // queue or tear down a replacement transport.
+    drop(tap_guard);
     if reason == PipeIoExitReason::DaemonLost {
         return Ok(classify_daemon_loss(remote, socket_path, terminal));
     }
     Ok(reason)
+}
+
+struct PipeIoTapGuard<'a> {
+    remote: &'a RemoteSession,
+    token: Arc<u8>,
+}
+
+impl Drop for PipeIoTapGuard<'_> {
+    fn drop(&mut self) {
+        self.remote.clear_pipe_io_tap(&self.token);
+    }
+}
+
+fn attach_failure_exit_reason(error: &anyhow::Error, surface: SurfaceId) -> PipeIoExitReason {
+    // A rejected attach naming this exact surface means the terminal ended
+    // between the tree lookup and the attach request. Every other failure is
+    // reported as retryable daemon loss so the embedder receives the normal
+    // final JSON record and exit code.
+    if is_remote_surface_unavailable(error, surface) {
+        PipeIoExitReason::TerminalEnded
+    } else {
+        PipeIoExitReason::DaemonLost
+    }
 }
 
 /// The stream ended without a terminal-exit event, but "stream lost" covers
@@ -183,7 +220,7 @@ fn classify_daemon_loss(
 /// parent through the shared event queue.
 fn spawn_stdin_pump(
     handle: SurfaceHandle,
-    sender: SyncSender<PipeIoEvent>,
+    sender: Sender<PipeIoEvent>,
     session: Session,
     surface: SurfaceId,
 ) {
@@ -254,14 +291,39 @@ fn spawn_stdin_pump(
 
 fn pump_events_to_stdout(
     receiver: &Receiver<PipeIoEvent>,
+    lifecycle_receiver: &Receiver<PipeIoEvent>,
     stdout: &mut impl Write,
 ) -> anyhow::Result<PipeIoExitReason> {
     let mut emitted_output = false;
     loop {
-        // A dropped sender without a prior event means the session went
-        // away wholesale: report it as a lost daemon.
-        let Ok(event) = receiver.recv() else {
-            return Ok(PipeIoExitReason::DaemonLost);
+        // Lifecycle signals have a separate bounded channel, so a full byte
+        // queue cannot delay or drop a transport-loss notification.
+        let event = crossbeam_channel::select_biased! {
+            recv(lifecycle_receiver) -> event => {
+                match event {
+                    Ok(PipeIoEvent::SurfaceExited) => {
+                        return Ok(PipeIoExitReason::TerminalEnded);
+                    }
+                    Ok(PipeIoEvent::TransportLost) => {
+                        return Ok(PipeIoExitReason::DaemonLost);
+                    }
+                    Ok(PipeIoEvent::StdinClosed) => {
+                        return Ok(PipeIoExitReason::ParentClosed);
+                    }
+                    Ok(PipeIoEvent::Replay { .. } | PipeIoEvent::Output(_)) => {
+                        // Lifecycle senders never carry byte events. Ignore a
+                        // malformed producer rather than violating framing.
+                        continue;
+                    }
+                    Err(_) => return Ok(PipeIoExitReason::DaemonLost),
+                }
+            }
+            recv(receiver) -> event => {
+                match event {
+                    Ok(event) => event,
+                    Err(_) => return Ok(PipeIoExitReason::DaemonLost),
+                }
+            }
         };
         let write_result = match &event {
             PipeIoEvent::Replay { bytes } => {
@@ -321,13 +383,14 @@ mod tests {
 
     #[test]
     fn stdout_pump_prefixes_only_non_initial_replays_with_a_full_reset() {
-        let (sender, receiver) = std::sync::mpsc::sync_channel(8);
+        let (sender, receiver) = crossbeam_channel::bounded(8);
+        let (_lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
         sender.send(replay(b"FIRST")).unwrap();
         sender.send(PipeIoEvent::Output(b"live".to_vec())).unwrap();
         sender.send(replay(b"SECOND")).unwrap();
         sender.send(PipeIoEvent::SurfaceExited).unwrap();
         let mut stdout = Vec::new();
-        let reason = pump_events_to_stdout(&receiver, &mut stdout).unwrap();
+        let reason = pump_events_to_stdout(&receiver, &lifecycle_receiver, &mut stdout).unwrap();
         assert_eq!(reason, PipeIoExitReason::TerminalEnded);
         let mut expected = b"FIRSTlive".to_vec();
         expected.extend_from_slice(REPLAY_RESET);
@@ -341,19 +404,52 @@ mod tests {
             (PipeIoEvent::TransportLost, PipeIoExitReason::DaemonLost),
             (PipeIoEvent::StdinClosed, PipeIoExitReason::ParentClosed),
         ] {
-            let (sender, receiver) = std::sync::mpsc::sync_channel(8);
+            let (sender, receiver) = crossbeam_channel::bounded(8);
+            let (_lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
             sender.send(event).unwrap();
             let mut stdout = Vec::new();
-            assert_eq!(pump_events_to_stdout(&receiver, &mut stdout).unwrap(), expected);
+            assert_eq!(
+                pump_events_to_stdout(&receiver, &lifecycle_receiver, &mut stdout).unwrap(),
+                expected
+            );
             assert!(stdout.is_empty());
         }
         // Sender dropped without any event: the session vanished wholesale.
-        let (sender, receiver) = std::sync::mpsc::sync_channel::<PipeIoEvent>(8);
+        let (sender, receiver) = crossbeam_channel::bounded::<PipeIoEvent>(8);
+        let (_lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
         drop(sender);
         let mut stdout = Vec::new();
         assert_eq!(
-            pump_events_to_stdout(&receiver, &mut stdout).unwrap(),
+            pump_events_to_stdout(&receiver, &lifecycle_receiver, &mut stdout).unwrap(),
             PipeIoExitReason::DaemonLost
         );
+    }
+
+    #[test]
+    fn stdout_pump_prioritizes_a_transport_loss_over_queued_bytes() {
+        let (sender, receiver) = crossbeam_channel::bounded(1);
+        let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
+        sender.send(PipeIoEvent::Output(b"stale".to_vec())).unwrap();
+        lifecycle_sender.send(PipeIoEvent::TransportLost).unwrap();
+
+        let mut stdout = Vec::new();
+        assert_eq!(
+            pump_events_to_stdout(&receiver, &lifecycle_receiver, &mut stdout).unwrap(),
+            PipeIoExitReason::DaemonLost
+        );
+        assert!(stdout.is_empty(), "stale bytes must not be emitted after transport loss");
+    }
+
+    #[test]
+    fn attach_failures_preserve_terminal_and_daemon_exit_contracts() {
+        let terminal_ended =
+            crate::session::test_remote_rejected_error_with_message("unknown surface 7");
+        assert_eq!(attach_failure_exit_reason(&terminal_ended, 7), PipeIoExitReason::TerminalEnded);
+
+        let daemon_lost = crate::session::test_remote_transport_error();
+        assert_eq!(attach_failure_exit_reason(&daemon_lost, 7), PipeIoExitReason::DaemonLost);
+
+        let unexpected = anyhow::anyhow!("attach capability negotiation failed");
+        assert_eq!(attach_failure_exit_reason(&unexpected, 7), PipeIoExitReason::DaemonLost);
     }
 }

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -380,6 +380,15 @@ fn pump_events_to_stdout(
             recv(lifecycle_receiver) -> event => {
                 match event {
                     Ok(PipeIoEvent::SurfaceExited) => {
+                        // Surface exit is ordered after the daemon's final
+                        // bytes. Drain those queued bytes before ending so a
+                        // closing terminal still leaves its final frame.
+                        while let Ok(event) = receiver.try_recv() {
+                            queued_bytes.fetch_sub(event.byte_len(), Ordering::AcqRel);
+                            if write_data_event(&event, stdout, &mut emitted_output).is_err() {
+                                return Ok(PipeIoExitReason::ParentClosed);
+                            }
+                        }
                         return Ok(PipeIoExitReason::TerminalEnded);
                     }
                     Ok(PipeIoEvent::TransportLost) => {
@@ -407,12 +416,18 @@ fn pump_events_to_stdout(
             }
         };
         let write_result = match &event {
-            PipeIoEvent::Replay { bytes } => {
-                let reset = if emitted_output { stdout.write_all(REPLAY_RESET) } else { Ok(()) };
-                reset.and_then(|()| stdout.write_all(bytes)).and_then(|()| stdout.flush())
+            PipeIoEvent::Replay { .. } | PipeIoEvent::Output(_) => {
+                write_data_event(&event, stdout, &mut emitted_output)
             }
-            PipeIoEvent::Output(bytes) => stdout.write_all(bytes).and_then(|()| stdout.flush()),
-            PipeIoEvent::SurfaceExited => return Ok(PipeIoExitReason::TerminalEnded),
+            PipeIoEvent::SurfaceExited => {
+                while let Ok(event) = receiver.try_recv() {
+                    queued_bytes.fetch_sub(event.byte_len(), Ordering::AcqRel);
+                    if write_data_event(&event, stdout, &mut emitted_output).is_err() {
+                        return Ok(PipeIoExitReason::ParentClosed);
+                    }
+                }
+                return Ok(PipeIoExitReason::TerminalEnded);
+            }
             PipeIoEvent::TransportLost => return Ok(PipeIoExitReason::DaemonLost),
             PipeIoEvent::StdinClosed => return Ok(PipeIoExitReason::ParentClosed),
         };
@@ -422,6 +437,23 @@ fn pump_events_to_stdout(
         }
         emitted_output = true;
     }
+}
+
+fn write_data_event(
+    event: &PipeIoEvent,
+    stdout: &mut impl Write,
+    emitted_output: &mut bool,
+) -> io::Result<()> {
+    match event {
+        PipeIoEvent::Replay { bytes } => {
+            let reset = if *emitted_output { stdout.write_all(REPLAY_RESET) } else { Ok(()) };
+            reset.and_then(|()| stdout.write_all(bytes)).and_then(|()| stdout.flush())?
+        }
+        PipeIoEvent::Output(bytes) => stdout.write_all(bytes).and_then(|()| stdout.flush())?,
+        PipeIoEvent::SurfaceExited | PipeIoEvent::TransportLost | PipeIoEvent::StdinClosed => {}
+    }
+    *emitted_output = true;
+    Ok(())
 }
 
 impl PipeIoEvent {

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -439,6 +439,15 @@ mod tests {
     }
 
     #[test]
+    fn request_line_reader_accepts_a_short_final_line_at_eof() {
+        let mut reader = std::io::Cursor::new(br#"{"claim":true}"#.to_vec());
+        let mut line = String::new();
+        assert!(read_request_line(&mut reader, &mut line).unwrap());
+        assert_eq!(line, r#"{"claim":true}"#);
+        assert!(!read_request_line(&mut reader, &mut line).unwrap());
+    }
+
+    #[test]
     fn exit_reasons_map_to_the_respawn_contract() {
         assert_eq!(PipeIoExitReason::TerminalEnded.exit_code(), EXIT_DO_NOT_RESPAWN);
         assert_eq!(PipeIoExitReason::ParentClosed.exit_code(), EXIT_DO_NOT_RESPAWN);

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -295,6 +295,7 @@ fn spawn_stdin_pump(
             let stdin = std::io::stdin();
             let mut reader = stdin.lock();
             let mut line = String::new();
+            let mut transport_lost = false;
             loop {
                 let Ok(has_line) = read_request_line(&mut reader, &mut line) else { break };
                 if !has_line {
@@ -308,6 +309,7 @@ fn spawn_stdin_pump(
                         if handle.write_bytes(&bytes).is_err() {
                             // The transport owns loss reporting; input can
                             // only stop early.
+                            transport_lost = true;
                             break;
                         }
                     }
@@ -355,7 +357,11 @@ fn spawn_stdin_pump(
             // Stdin closure is a lifecycle signal, not terminal output. Keep
             // it on the reserved channel so queued replay bytes cannot delay
             // relay shutdown after the embedder goes away.
-            let _ = lifecycle_sender.try_send(PipeIoEvent::StdinClosed);
+            let _ = lifecycle_sender.try_send(if transport_lost {
+                PipeIoEvent::TransportLost
+            } else {
+                PipeIoEvent::StdinClosed
+            });
         })
         .expect("spawn pipe-io stdin pump");
 }

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -21,7 +21,7 @@
 //!   not respawn), 2 when the daemon connection was lost (respawning
 //!   reattaches and resyncs from a fresh replay).
 
-use std::io::{BufRead, Write};
+use std::io::{self, BufRead, Read, Write};
 use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -45,6 +45,16 @@ pub const EXIT_DAEMON_LOST: i32 = 2;
 /// pump. A full queue means the embedder stopped reading; the session
 /// treats that as a lost transport rather than wedging its reader thread.
 const EVENT_QUEUE_CAPACITY: usize = 4096;
+
+/// Bound one stdin frame before JSON parsing and base64 decoding. The
+/// embedder sends keyboard and paste chunks, so a one-megabyte decoded limit
+/// is large enough for normal input while keeping a hostile parent from
+/// turning one line into an unbounded allocation.
+const MAX_PIPE_IO_INPUT_BYTES: usize = 1024 * 1024;
+/// The line bound includes the JSON bytes and its newline. It leaves room for
+/// base64 expansion and the small JSON envelope around one input chunk.
+const MAX_PIPE_IO_REQUEST_LINE_BYTES: usize = 2 * 1024 * 1024;
+const MAX_PIPE_IO_INPUT_BASE64_BYTES: usize = MAX_PIPE_IO_INPUT_BYTES.div_ceil(3) * 4;
 
 /// Emitted before any replay that is not the relay's first output: full
 /// reset plus erase-scrollback, so the replacement replay does not stack on
@@ -98,7 +108,15 @@ pub enum PipeIoRequest {
 pub fn parse_request(line: &str) -> anyhow::Result<PipeIoRequest> {
     let value: serde_json::Value = serde_json::from_str(line)?;
     if let Some(encoded) = value.get("input").and_then(serde_json::Value::as_str) {
+        anyhow::ensure!(
+            encoded.len() <= MAX_PIPE_IO_INPUT_BASE64_BYTES,
+            "input exceeds the {MAX_PIPE_IO_INPUT_BYTES}-byte limit"
+        );
         let bytes = base64::engine::general_purpose::STANDARD.decode(encoded)?;
+        anyhow::ensure!(
+            bytes.len() <= MAX_PIPE_IO_INPUT_BYTES,
+            "input exceeds the {MAX_PIPE_IO_INPUT_BYTES}-byte limit"
+        );
         return Ok(PipeIoRequest::Input(bytes));
     }
     if let Some(resize) = value.get("resize") {
@@ -114,6 +132,27 @@ pub fn parse_request(line: &str) -> anyhow::Result<PipeIoRequest> {
         return Ok(PipeIoRequest::ClaimGeometry);
     }
     Ok(PipeIoRequest::Unknown)
+}
+
+/// Read one complete JSON line without allowing `BufRead::lines` to allocate
+/// an attacker-controlled amount of memory. A final, shorter line at EOF is
+/// accepted, matching the standard `lines` behavior.
+fn read_request_line(reader: &mut impl BufRead, line: &mut String) -> io::Result<bool> {
+    line.clear();
+    let mut limited = reader.take((MAX_PIPE_IO_REQUEST_LINE_BYTES + 1) as u64);
+    let bytes_read = limited.read_line(line)?;
+    if bytes_read == 0 {
+        return Ok(false);
+    }
+    if bytes_read > MAX_PIPE_IO_REQUEST_LINE_BYTES
+        || (bytes_read == MAX_PIPE_IO_REQUEST_LINE_BYTES && !line.ends_with('\n'))
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "pipe-io request line exceeds its byte limit",
+        ));
+    }
+    Ok(true)
 }
 
 pub fn run(
@@ -228,8 +267,13 @@ fn spawn_stdin_pump(
         .name("pipe-io-stdin".into())
         .spawn(move || {
             let stdin = std::io::stdin();
-            for line in stdin.lock().lines() {
-                let Ok(line) = line else { break };
+            let mut reader = stdin.lock();
+            let mut line = String::new();
+            loop {
+                let Ok(has_line) = read_request_line(&mut reader, &mut line) else { break };
+                if !has_line {
+                    break;
+                }
                 if line.trim().is_empty() {
                     continue;
                 }
@@ -373,10 +417,25 @@ mod tests {
 
     #[test]
     fn parse_request_rejects_input_larger_than_the_frame_limit() {
-        let encoded = base64::engine::general_purpose::STANDARD
-            .encode(vec![b'x'; 1024 * 1024 + 1]);
+        let encoded =
+            base64::engine::general_purpose::STANDARD
+                .encode(vec![b'x'; MAX_PIPE_IO_INPUT_BYTES + 1]);
         let line = serde_json::json!({"input": encoded}).to_string();
         assert!(parse_request(&line).is_err());
+    }
+
+    #[test]
+    fn request_line_reader_rejects_unterminated_and_oversized_lines() {
+        let mut exact =
+            std::io::Cursor::new(format!("{}\n", "x".repeat(MAX_PIPE_IO_REQUEST_LINE_BYTES - 1)));
+        let mut line = String::new();
+        assert!(read_request_line(&mut exact, &mut line).unwrap());
+
+        let mut oversized = std::io::Cursor::new("x".repeat(MAX_PIPE_IO_REQUEST_LINE_BYTES + 1));
+        assert_eq!(
+            read_request_line(&mut oversized, &mut line).unwrap_err().kind(),
+            std::io::ErrorKind::InvalidData
+        );
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -24,6 +24,7 @@
 use std::io::{self, BufRead, Read, Write};
 use std::path::Path;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
 use base64::Engine as _;
@@ -40,11 +41,19 @@ use crate::session::{
 pub const EXIT_DO_NOT_RESPAWN: i32 = 0;
 /// The daemon connection was lost: the embedder may respawn to resync.
 pub const EXIT_DAEMON_LOST: i32 = 2;
+/// Startup/protocol errors are not retryable daemon outages.
+pub const EXIT_STARTUP_FAILURE: i32 = 1;
 
 /// Bounded event queue between the session reader thread and the stdout
 /// pump. A full queue means the embedder stopped reading; the session
 /// treats that as a lost transport rather than wedging its reader thread.
 const EVENT_QUEUE_CAPACITY: usize = 4096;
+/// Bound queued raw VT bytes as well as event count. A stalled embedder must
+/// not retain unbounded replay/output payloads in the relay process.
+pub(crate) const EVENT_QUEUE_MAX_BYTES: usize = 64 * 1024 * 1024;
+/// Reject one pathological frame before it can consume the entire byte
+/// budget. Normal replay chunks are far below this limit.
+pub(crate) const MAX_PIPE_IO_EVENT_BYTES: usize = 8 * 1024 * 1024;
 
 /// Bound one stdin frame before JSON parsing and base64 decoding. The
 /// embedder sends keyboard and paste chunks, so a one-megabyte decoded limit
@@ -67,6 +76,7 @@ pub enum PipeIoExitReason {
     TerminalEnded,
     DaemonLost,
     ParentClosed,
+    StartupFailure,
 }
 
 impl PipeIoExitReason {
@@ -75,6 +85,7 @@ impl PipeIoExitReason {
             Self::TerminalEnded => "terminal-ended",
             Self::DaemonLost => "daemon-lost",
             Self::ParentClosed => "parent-closed",
+            Self::StartupFailure => "startup-failed",
         }
     }
 
@@ -82,6 +93,7 @@ impl PipeIoExitReason {
         match self {
             Self::TerminalEnded | Self::ParentClosed => EXIT_DO_NOT_RESPAWN,
             Self::DaemonLost => EXIT_DAEMON_LOST,
+            Self::StartupFailure => EXIT_STARTUP_FAILURE,
         }
     }
 }
@@ -165,12 +177,18 @@ pub fn run(
     rows: u16,
 ) -> anyhow::Result<PipeIoExitReason> {
     let (sender, receiver) = crossbeam_channel::bounded(EVENT_QUEUE_CAPACITY);
+    let queued_bytes = Arc::new(AtomicUsize::new(0));
     // Lifecycle events have their own reserved signal path. A stalled
     // embedder can fill the byte queue, but it must never be able to hide the
     // transport-loss event that tells the embedder to respawn.
     let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
     // Install before attach so the initial replay cannot be missed.
-    let tap_token = remote.install_pipe_io_tap(surface, sender.clone(), lifecycle_sender);
+    let tap_token = remote.install_pipe_io_tap(
+        surface,
+        sender.clone(),
+        lifecycle_sender.clone(),
+        queued_bytes.clone(),
+    );
     let tap_guard = PipeIoTapGuard { remote: remote.as_ref(), token: tap_token };
     let handle = match session.try_surface_sized(surface, Some((cols.max(1), rows.max(1)))) {
         Ok(SurfaceAttach::Attached(handle)) => handle,
@@ -190,9 +208,13 @@ pub fn run(
             serde_json::json!({"diag": {"claim-terminal-geometry": {"error": error.to_string()}}})
         );
     }
-    spawn_stdin_pump(handle, sender, session.clone(), surface);
-    let reason =
-        pump_events_to_stdout(&receiver, &lifecycle_receiver, &mut std::io::stdout().lock())?;
+    spawn_stdin_pump(handle, lifecycle_sender, session.clone(), surface);
+    let reason = pump_events_to_stdout(
+        &receiver,
+        &lifecycle_receiver,
+        &queued_bytes,
+        &mut std::io::stdout().lock(),
+    )?;
     // Stop forwarding while the daemon probe runs. The probe has its own
     // request path, and events for the finished relay must not fill the data
     // queue or tear down a replacement transport.
@@ -221,8 +243,12 @@ fn attach_failure_exit_reason(error: &anyhow::Error, surface: SurfaceId) -> Pipe
     // final JSON record and exit code.
     if is_remote_surface_unavailable(error, surface) {
         PipeIoExitReason::TerminalEnded
-    } else {
+    } else if crate::session::is_remote_transport_failure(error)
+        || crate::session::is_remote_timeout(error)
+    {
         PipeIoExitReason::DaemonLost
+    } else {
+        PipeIoExitReason::StartupFailure
     }
 }
 
@@ -259,7 +285,7 @@ fn classify_daemon_loss(
 /// parent through the shared event queue.
 fn spawn_stdin_pump(
     handle: SurfaceHandle,
-    sender: Sender<PipeIoEvent>,
+    lifecycle_sender: Sender<PipeIoEvent>,
     session: Session,
     surface: SurfaceId,
 ) {
@@ -326,9 +352,10 @@ fn spawn_stdin_pump(
                     Err(_) => break,
                 }
             }
-            // Blocking send: the queue is drained until the main loop
-            // returns, and a dropped receiver just ends this thread.
-            let _ = sender.send(PipeIoEvent::StdinClosed);
+            // Stdin closure is a lifecycle signal, not terminal output. Keep
+            // it on the reserved channel so queued replay bytes cannot delay
+            // relay shutdown after the embedder goes away.
+            let _ = lifecycle_sender.try_send(PipeIoEvent::StdinClosed);
         })
         .expect("spawn pipe-io stdin pump");
 }
@@ -336,6 +363,7 @@ fn spawn_stdin_pump(
 fn pump_events_to_stdout(
     receiver: &Receiver<PipeIoEvent>,
     lifecycle_receiver: &Receiver<PipeIoEvent>,
+    queued_bytes: &AtomicUsize,
     stdout: &mut impl Write,
 ) -> anyhow::Result<PipeIoExitReason> {
     let mut emitted_output = false;
@@ -364,7 +392,10 @@ fn pump_events_to_stdout(
             }
             recv(receiver) -> event => {
                 match event {
-                    Ok(event) => event,
+                    Ok(event) => {
+                        queued_bytes.fetch_sub(event.byte_len(), Ordering::AcqRel);
+                        event
+                    }
                     Err(_) => return Ok(PipeIoExitReason::DaemonLost),
                 }
             }
@@ -384,6 +415,15 @@ fn pump_events_to_stdout(
             return Ok(PipeIoExitReason::ParentClosed);
         }
         emitted_output = true;
+    }
+}
+
+impl PipeIoEvent {
+    pub(crate) fn byte_len(&self) -> usize {
+        match self {
+            Self::Replay { bytes } | Self::Output(bytes) => bytes.len(),
+            Self::SurfaceExited | Self::TransportLost | Self::StdinClosed => 0,
+        }
     }
 }
 
@@ -452,9 +492,11 @@ mod tests {
         assert_eq!(PipeIoExitReason::TerminalEnded.exit_code(), EXIT_DO_NOT_RESPAWN);
         assert_eq!(PipeIoExitReason::ParentClosed.exit_code(), EXIT_DO_NOT_RESPAWN);
         assert_eq!(PipeIoExitReason::DaemonLost.exit_code(), EXIT_DAEMON_LOST);
+        assert_eq!(PipeIoExitReason::StartupFailure.exit_code(), EXIT_STARTUP_FAILURE);
         assert_eq!(PipeIoExitReason::TerminalEnded.as_str(), "terminal-ended");
         assert_eq!(PipeIoExitReason::DaemonLost.as_str(), "daemon-lost");
         assert_eq!(PipeIoExitReason::ParentClosed.as_str(), "parent-closed");
+        assert_eq!(PipeIoExitReason::StartupFailure.as_str(), "startup-failed");
     }
 
     #[test]
@@ -466,7 +508,10 @@ mod tests {
         sender.send(replay(b"SECOND")).unwrap();
         sender.send(PipeIoEvent::SurfaceExited).unwrap();
         let mut stdout = Vec::new();
-        let reason = pump_events_to_stdout(&receiver, &lifecycle_receiver, &mut stdout).unwrap();
+        let queued_bytes = AtomicUsize::new(0);
+        let reason =
+            pump_events_to_stdout(&receiver, &lifecycle_receiver, &queued_bytes, &mut stdout)
+                .unwrap();
         assert_eq!(reason, PipeIoExitReason::TerminalEnded);
         let mut expected = b"FIRSTlive".to_vec();
         expected.extend_from_slice(REPLAY_RESET);
@@ -484,8 +529,10 @@ mod tests {
             let (_lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
             sender.send(event).unwrap();
             let mut stdout = Vec::new();
+            let queued_bytes = AtomicUsize::new(0);
             assert_eq!(
-                pump_events_to_stdout(&receiver, &lifecycle_receiver, &mut stdout).unwrap(),
+                pump_events_to_stdout(&receiver, &lifecycle_receiver, &queued_bytes, &mut stdout)
+                    .unwrap(),
                 expected
             );
             assert!(stdout.is_empty());
@@ -495,8 +542,10 @@ mod tests {
         let (_lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
         drop(sender);
         let mut stdout = Vec::new();
+        let queued_bytes = AtomicUsize::new(0);
         assert_eq!(
-            pump_events_to_stdout(&receiver, &lifecycle_receiver, &mut stdout).unwrap(),
+            pump_events_to_stdout(&receiver, &lifecycle_receiver, &queued_bytes, &mut stdout)
+                .unwrap(),
             PipeIoExitReason::DaemonLost
         );
     }
@@ -509,15 +558,17 @@ mod tests {
         lifecycle_sender.send(PipeIoEvent::TransportLost).unwrap();
 
         let mut stdout = Vec::new();
+        let queued_bytes = AtomicUsize::new(0);
         assert_eq!(
-            pump_events_to_stdout(&receiver, &lifecycle_receiver, &mut stdout).unwrap(),
+            pump_events_to_stdout(&receiver, &lifecycle_receiver, &queued_bytes, &mut stdout)
+                .unwrap(),
             PipeIoExitReason::DaemonLost
         );
         assert!(stdout.is_empty(), "stale bytes must not be emitted after transport loss");
     }
 
     #[test]
-    fn attach_failures_preserve_terminal_and_daemon_exit_contracts() {
+    fn attach_failures_preserve_terminal_daemon_and_startup_exit_contracts() {
         let terminal_ended =
             crate::session::test_remote_rejected_error_with_message("unknown surface 7");
         assert_eq!(attach_failure_exit_reason(&terminal_ended, 7), PipeIoExitReason::TerminalEnded);
@@ -526,6 +577,6 @@ mod tests {
         assert_eq!(attach_failure_exit_reason(&daemon_lost, 7), PipeIoExitReason::DaemonLost);
 
         let unexpected = anyhow::anyhow!("attach capability negotiation failed");
-        assert_eq!(attach_failure_exit_reason(&unexpected, 7), PipeIoExitReason::DaemonLost);
+        assert_eq!(attach_failure_exit_reason(&unexpected, 7), PipeIoExitReason::StartupFailure);
     }
 }

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -372,6 +372,14 @@ mod tests {
     }
 
     #[test]
+    fn parse_request_rejects_input_larger_than_the_frame_limit() {
+        let encoded = base64::engine::general_purpose::STANDARD
+            .encode(vec![b'x'; 1024 * 1024 + 1]);
+        let line = serde_json::json!({"input": encoded}).to_string();
+        assert!(parse_request(&line).is_err());
+    }
+
+    #[test]
     fn exit_reasons_map_to_the_respawn_contract() {
         assert_eq!(PipeIoExitReason::TerminalEnded.exit_code(), EXIT_DO_NOT_RESPAWN);
         assert_eq!(PipeIoExitReason::ParentClosed.exit_code(), EXIT_DO_NOT_RESPAWN);

--- a/cmux-tui/crates/cmux-tui/src/session/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/mod.rs
@@ -36,8 +36,8 @@ use serde::Deserialize;
 use serde_json::{Map, Value, json};
 
 pub use remote::{
-    RemoteMessageReader, RemoteMessageWriter, RemoteSession, RemoteSurface, RemoteTransport,
-    RemoteTransportAbort,
+    PipeIoEvent, RemoteMessageReader, RemoteMessageWriter, RemoteSession, RemoteSurface,
+    RemoteTransport, RemoteTransportAbort,
 };
 pub use tree::{TabNotificationView, TreeView, WorkspaceView};
 

--- a/cmux-tui/crates/cmux-tui/src/session/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/mod.rs
@@ -145,15 +145,19 @@ fn request_receipted_creation(
 }
 
 pub(crate) fn is_remote_transport_failure(error: &anyhow::Error) -> bool {
-    error
-        .downcast_ref::<remote::RemoteRequestError>()
-        .is_some_and(remote::RemoteRequestError::is_transport_failure)
+    error.chain().any(|cause| {
+        cause
+            .downcast_ref::<remote::RemoteRequestError>()
+            .is_some_and(remote::RemoteRequestError::is_transport_failure)
+    })
 }
 
 pub(crate) fn is_remote_timeout(error: &anyhow::Error) -> bool {
-    error
-        .downcast_ref::<remote::RemoteRequestError>()
-        .is_some_and(remote::RemoteRequestError::is_timeout)
+    error.chain().any(|cause| {
+        cause
+            .downcast_ref::<remote::RemoteRequestError>()
+            .is_some_and(remote::RemoteRequestError::is_timeout)
+    })
 }
 
 pub(crate) fn is_remote_surface_unavailable(error: &anyhow::Error, surface: SurfaceId) -> bool {

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1516,6 +1516,25 @@ pub struct RemoteSession {
     capabilities: Mutex<HashSet<String>>,
     provider_workspace_authority: Option<BearerToken>,
     provider_workspaces_guarded: AtomicBool,
+    pipe_io_tap: Mutex<Option<PipeIoTap>>,
+}
+
+/// One event on the raw byte stream a `--pipe-io` relay serves to its
+/// embedder. `Replay` REPLACES all prior terminal state (the relay must
+/// emit a full reset before any replay that is not its first output);
+/// `Output` appends live PTY bytes.
+#[derive(Debug, PartialEq, Eq)]
+pub enum PipeIoEvent {
+    Replay { bytes: Vec<u8> },
+    Output(Vec<u8>),
+    SurfaceExited,
+    TransportLost,
+    StdinClosed,
+}
+
+struct PipeIoTap {
+    surface: SurfaceId,
+    sender: std::sync::mpsc::SyncSender<PipeIoEvent>,
 }
 
 pub(super) enum RemoteSurfaceAttach {
@@ -1872,6 +1891,7 @@ impl RemoteSession {
             capabilities: Mutex::new(HashSet::new()),
             provider_workspace_authority,
             provider_workspaces_guarded: AtomicBool::new(false),
+            pipe_io_tap: Mutex::new(None),
         });
 
         let reader_session = Arc::downgrade(&session);
@@ -2126,6 +2146,7 @@ impl RemoteSession {
                     id,
                     format_args!("vt-state cols={cols} rows={rows} bytes={}", replay.len()),
                 );
+                self.pipe_io_forward(id, || PipeIoEvent::Replay { bytes: replay.clone() });
                 let Ok(kitty_image_aliases) = parse_kitty_image_aliases(&value) else {
                     self.disconnect_transport();
                     return;
@@ -2190,6 +2211,7 @@ impl RemoteSession {
                 };
                 let colors = value.get("colors").and_then(parse_terminal_colors);
                 self.log_frame(id, format_args!("output bytes={}", bytes.len()));
+                self.pipe_io_forward(id, || PipeIoEvent::Output(bytes.clone()));
                 if let Some(surface) = self.surfaces.lock().unwrap().get(&id).cloned() {
                     surface.scan_cursor_provenance(&bytes);
                     let mut term = surface.term.lock().unwrap();
@@ -2239,6 +2261,9 @@ impl RemoteSession {
                         replay.as_ref().map(|bytes| bytes.len()).unwrap_or(0)
                     ),
                 );
+                if let Some(replay) = replay.as_ref() {
+                    self.pipe_io_forward(id, || PipeIoEvent::Replay { bytes: replay.clone() });
+                }
                 if let Some(surface) = self.surfaces.lock().unwrap().get(&id).cloned() {
                     if surface
                         .apply_stream_resize_with_colors(
@@ -2308,6 +2333,11 @@ impl RemoteSession {
             }
             Some("detached") => {
                 if let Some(id) = surface_id() {
+                    // A server-side stream detach (e.g. backpressure
+                    // overflow) ends the byte feed without ending the
+                    // terminal. The relay reports a lost connection so its
+                    // embedder respawns and resyncs from a fresh replay.
+                    self.pipe_io_forward(id, || PipeIoEvent::TransportLost);
                     self.surfaces.lock().unwrap().remove(&id);
                     self.emit(MuxEvent::SurfaceOutput(id));
                 }
@@ -2351,6 +2381,7 @@ impl RemoteSession {
             }
             Some("surface-exited") => {
                 if let Some(id) = surface_id() {
+                    self.pipe_io_forward(id, || PipeIoEvent::SurfaceExited);
                     // Retire the mirror immediately. The authoritative tree
                     // refresh may lag this event, but input and reattach must
                     // already fail closed for a known-exited surface.
@@ -2892,6 +2923,43 @@ impl RemoteSession {
         drop(state);
         self.begin_shutdown();
         self.interactive_writer.close();
+        // A pipe-io relay learns about every terminal-connection loss here
+        // (reader-thread EOF and every protocol-error disconnect path).
+        if let Some(tap) = self.pipe_io_tap.lock().unwrap().as_ref() {
+            let _ = tap.sender.try_send(PipeIoEvent::TransportLost);
+        }
+    }
+
+    /// Routes one scoped surface's raw byte stream to a `--pipe-io` relay.
+    /// Install before `attach-surface` so the initial replay is not missed.
+    pub fn install_pipe_io_tap(
+        &self,
+        surface: SurfaceId,
+        sender: std::sync::mpsc::SyncSender<PipeIoEvent>,
+    ) {
+        *self.pipe_io_tap.lock().unwrap() = Some(PipeIoTap { surface, sender });
+    }
+
+    /// Forwards one tap event, treating a full or dropped queue as a lost
+    /// transport: the relay's reader stalled, and silently dropping bytes
+    /// would corrupt the embedder's terminal state (bounded-backpressure
+    /// policy; never wedge the session reader thread).
+    fn pipe_io_forward(&self, surface: SurfaceId, event: impl FnOnce() -> PipeIoEvent) {
+        use std::sync::mpsc::TrySendError;
+        let stalled = {
+            let tap = self.pipe_io_tap.lock().unwrap();
+            let Some(tap) = tap.as_ref() else { return };
+            if tap.surface != surface {
+                return;
+            }
+            match tap.sender.try_send(event()) {
+                Ok(()) => false,
+                Err(TrySendError::Full(_) | TrySendError::Disconnected(_)) => true,
+            }
+        };
+        if stalled {
+            self.disconnect_transport();
+        }
     }
 
     /// Returns the first reason recorded when the remote reader stopped.
@@ -3824,6 +3892,7 @@ fn test_session_with_writer(
         capabilities: Mutex::new(capabilities),
         provider_workspace_authority,
         provider_workspaces_guarded: AtomicBool::new(false),
+        pipe_io_tap: Mutex::new(None),
     })
 }
 
@@ -5065,6 +5134,7 @@ mod tests {
             capabilities: Mutex::new(capabilities),
             provider_workspace_authority,
             provider_workspaces_guarded: AtomicBool::new(false),
+            pipe_io_tap: Mutex::new(None),
         })
     }
 

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -7,7 +7,7 @@ use std::io::{self, BufRead, BufReader, Read, Write};
 use std::net::Shutdown;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, channel};
+use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, channel, sync_channel};
 use std::sync::{Arc, Condvar, Mutex, Weak};
 use std::time::{Duration, Instant};
 
@@ -967,6 +967,25 @@ enum RequestDeadline {
     Standard,
     Attach,
     Fixed(Duration),
+    /// A deadline shared by a sequence of requests, such as reconnect
+    /// classification. Each phase consumes only the time that remains.
+    Until(Instant),
+}
+
+impl RequestDeadline {
+    fn remaining(self) -> Result<Duration, RemoteRequestError> {
+        match self {
+            Self::Standard => Ok(REMOTE_REQUEST_TIMEOUT),
+            Self::Fixed(timeout) => Ok(timeout),
+            Self::Until(deadline) => {
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                if remaining.is_zero() { Err(RemoteRequestError::Timeout) } else { Ok(remaining) }
+            }
+            // Attach has its own progress-aware response deadline, but its
+            // enqueue/write phase still needs the normal bounded write wait.
+            Self::Attach => Ok(remote_write_timeout()),
+        }
+    }
 }
 
 struct AttachResponseDeadline {
@@ -1617,6 +1636,19 @@ impl RemoteTransport {
 
     pub fn json_lines(stream: Box<dyn transport::Stream>) -> io::Result<Self> {
         stream.set_write_timeout(Some(remote_write_timeout()))?;
+        Self::json_lines_parts(stream)
+    }
+
+    fn json_lines_with_timeout(
+        stream: Box<dyn transport::Stream>,
+        timeout: Duration,
+    ) -> io::Result<Self> {
+        stream.set_read_timeout(Some(timeout))?;
+        stream.set_write_timeout(Some(timeout))?;
+        Self::json_lines_parts(stream)
+    }
+
+    fn json_lines_parts(stream: Box<dyn transport::Stream>) -> io::Result<Self> {
         let read_half = stream.try_clone_box()?;
         let abort_stream = stream.try_clone_box()?;
         Ok(Self {
@@ -1805,15 +1837,52 @@ impl RemoteSession {
         Self::connect_path(path, false)
     }
 
+    pub(crate) fn connect_for_terminal_attach_until(
+        path: &Path,
+        deadline: Instant,
+    ) -> anyhow::Result<Arc<Self>> {
+        Self::connect_path_until(path, false, deadline)
+    }
+
     fn connect_path(path: &Path, subscribe: bool) -> anyhow::Result<Arc<Self>> {
         let stream = transport::connect(path).map_err(|e| {
             anyhow::anyhow!("cannot connect to session socket {}: {e}", path.display())
         })?;
-        if subscribe {
-            Self::connect_stream(stream)
-        } else {
-            Self::connect_stream_with_subscription(stream, false)
-        }
+        Self::connect_stream_with_subscription(stream, subscribe)
+    }
+
+    fn connect_path_until(
+        path: &Path,
+        subscribe: bool,
+        deadline: Instant,
+    ) -> anyhow::Result<Arc<Self>> {
+        let path_for_thread = path.to_path_buf();
+        let display = path.display().to_string();
+        let (sender, receiver) = sync_channel(1);
+        let connector =
+            std::thread::Builder::new().name("remote-probe-connect".into()).spawn(move || {
+                let _ = sender.send(transport::connect(&path_for_thread));
+            })?;
+        let stream = match receiver.recv_timeout(deadline.saturating_duration_since(Instant::now()))
+        {
+            Ok(result) => {
+                let _ = connector.join();
+                result.map_err(|error| {
+                    anyhow::anyhow!("cannot connect to session socket {display}: {error}")
+                })?
+            }
+            Err(RecvTimeoutError::Disconnected) => {
+                let _ = connector.join();
+                anyhow::bail!("remote probe connector stopped without a result")
+            }
+            Err(RecvTimeoutError::Timeout) => {
+                // The pipe-io process exits after classification. Dropping the
+                // connector lets that process terminate any blocked connect.
+                drop(connector);
+                anyhow::bail!(RemoteRequestError::Timeout)
+            }
+        };
+        Self::connect_stream_with_subscription_until(stream, subscribe, deadline)
     }
 
     /// Connect over an already-established full-duplex byte stream.
@@ -1834,6 +1903,27 @@ impl RemoteSession {
             anyhow::anyhow!("cannot configure JSON-lines session transport: {error}")
         })?;
         Self::connect_transport_with_initial_subscription(transport, subscribe)
+    }
+
+    fn connect_stream_with_subscription_until(
+        stream: Box<dyn transport::Stream>,
+        subscribe: bool,
+        deadline: Instant,
+    ) -> anyhow::Result<Arc<Self>> {
+        let timeout = deadline.saturating_duration_since(Instant::now());
+        if timeout.is_zero() {
+            anyhow::bail!(RemoteRequestError::Timeout);
+        }
+        let transport =
+            RemoteTransport::json_lines_with_timeout(stream, timeout).map_err(|error| {
+                anyhow::anyhow!("cannot configure JSON-lines session transport: {error}")
+            })?;
+        Self::connect_transport_with_provider_authority_until(
+            transport,
+            None,
+            subscribe,
+            Some(deadline),
+        )
     }
 
     pub fn connect_transport(transport: RemoteTransport) -> anyhow::Result<Arc<Self>> {
@@ -1858,6 +1948,20 @@ impl RemoteSession {
         transport: RemoteTransport,
         provider_workspace_authority: Option<BearerToken>,
         subscribe: bool,
+    ) -> anyhow::Result<Arc<Self>> {
+        Self::connect_transport_with_provider_authority_until(
+            transport,
+            provider_workspace_authority,
+            subscribe,
+            None,
+        )
+    }
+
+    fn connect_transport_with_provider_authority_until(
+        transport: RemoteTransport,
+        provider_workspace_authority: Option<BearerToken>,
+        subscribe: bool,
+        deadline: Option<Instant>,
     ) -> anyhow::Result<Arc<Self>> {
         let RemoteTransport { mut reader, writer, abort } = transport;
         let interactive_writer = InteractiveWriter::spawn(writer, abort)
@@ -1923,7 +2027,11 @@ impl RemoteSession {
             }
         })?;
 
-        if let Err(error) = session.initialize(subscribe) {
+        let initialization = deadline.map_or_else(
+            || session.initialize(subscribe),
+            |deadline| session.initialize_until(subscribe, deadline),
+        );
+        if let Err(error) = initialization {
             session.disconnect_transport();
             return Err(error);
         }
@@ -1931,8 +2039,20 @@ impl RemoteSession {
     }
 
     fn initialize(&self, subscribe: bool) -> anyhow::Result<()> {
+        self.initialize_with_deadline(subscribe, RequestDeadline::Standard)
+    }
+
+    fn initialize_until(&self, subscribe: bool, deadline: Instant) -> anyhow::Result<()> {
+        self.initialize_with_deadline(subscribe, RequestDeadline::Until(deadline))
+    }
+
+    fn initialize_with_deadline(
+        &self,
+        subscribe: bool,
+        deadline: RequestDeadline,
+    ) -> anyhow::Result<()> {
         // Identify the endpoint and register this connection before any optional subscription.
-        let ident = self.request(json!({"cmd": "identify"}))?;
+        let ident = self.request_with_deadline(json!({"cmd": "identify"}), deadline)?;
         validate_remote_identity(&ident)?;
         *self.capabilities.lock().unwrap() = identity_capabilities(&ident);
         let mut client_info = json!({"cmd": "set-client-info", "kind": "tui"});
@@ -1958,10 +2078,10 @@ impl RemoteSession {
         if !negotiated.is_empty() {
             client_info["capabilities"] = json!(negotiated);
         }
-        self.request(client_info)?;
+        self.request_with_deadline(client_info, deadline)?;
         if subscribe {
             self.prime_local_subscription();
-            if let Err(error) = self.request(self.subscription_request()) {
+            if let Err(error) = self.request_with_deadline(self.subscription_request(), deadline) {
                 self.primed_subscription.lock().unwrap().take();
                 return Err(error);
             }
@@ -2631,6 +2751,12 @@ impl RemoteSession {
         mut cmd: Value,
         deadline: RequestDeadline,
     ) -> anyhow::Result<Value> {
+        // A shared deadline must cover enqueueing, the ordered write, and the
+        // response wait. Check it before creating a pending request so an
+        // expired reconnect probe cannot add work to the relay.
+        if let Err(error) = deadline.remaining() {
+            return Err(error.into());
+        }
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
         let progress = Arc::new(AtomicU64::new(0));
         let attach_progress = matches!(deadline, RequestDeadline::Attach)
@@ -2658,7 +2784,14 @@ impl RemoteSession {
                 return Err(RemoteRequestError::Transport(error).into());
             }
         };
-        if let Err(error) = self.wait_for_ordered_write(sequence) {
+        let write_timeout = match deadline.remaining() {
+            Ok(timeout) => timeout,
+            Err(error) => {
+                self.pending.lock().unwrap().remove(&id);
+                return Err(error.into());
+            }
+        };
+        if let Err(error) = self.wait_for_ordered_write_with_timeout(sequence, write_timeout) {
             self.pending.lock().unwrap().remove(&id);
             return Err(RemoteRequestError::Transport(error).into());
         }
@@ -2702,12 +2835,10 @@ impl RemoteSession {
         progress: Arc<AtomicU64>,
         attach_progress: Option<u64>,
     ) -> Result<Value, RemoteRequestError> {
-        if let RequestDeadline::Standard | RequestDeadline::Fixed(_) = deadline {
-            let timeout = match deadline {
-                RequestDeadline::Standard => REMOTE_REQUEST_TIMEOUT,
-                RequestDeadline::Fixed(timeout) => timeout,
-                RequestDeadline::Attach => unreachable!(),
-            };
+        if let RequestDeadline::Standard | RequestDeadline::Fixed(_) | RequestDeadline::Until(_) =
+            deadline
+        {
+            let timeout = deadline.remaining().map_err(|_| RemoteRequestError::Timeout)?;
             return match rx.recv_timeout(timeout) {
                 Ok(response) => Ok(response),
                 Err(RecvTimeoutError::Timeout) => Err(RemoteRequestError::Timeout),
@@ -2897,7 +3028,15 @@ impl RemoteSession {
     }
 
     fn wait_for_ordered_write(&self, sequence: u64) -> io::Result<()> {
-        match self.interactive_writer.wait_until_written(sequence, remote_write_timeout()) {
+        self.wait_for_ordered_write_with_timeout(sequence, remote_write_timeout())
+    }
+
+    fn wait_for_ordered_write_with_timeout(
+        &self,
+        sequence: u64,
+        timeout: Duration,
+    ) -> io::Result<()> {
+        match self.interactive_writer.wait_until_written(sequence, timeout) {
             Ok(()) => Ok(()),
             Err(error) => {
                 if error.kind() == io::ErrorKind::TimedOut {
@@ -3417,7 +3556,11 @@ impl RemoteSession {
     /// Refresh the workspace tree with a bounded request deadline. Used by
     /// reconnect classification, where a stale daemon must not hold the relay.
     pub fn refresh_tree_with_timeout(&self, timeout: Duration) -> anyhow::Result<TreeView> {
-        self.refresh_tree_inner_with_deadline(true, RequestDeadline::Fixed(timeout))
+        self.refresh_tree_until(Instant::now() + timeout)
+    }
+
+    pub(crate) fn refresh_tree_until(&self, deadline: Instant) -> anyhow::Result<TreeView> {
+        self.refresh_tree_inner_with_deadline(true, RequestDeadline::Until(deadline))
     }
 
     pub fn refresh_tree_background(&self) -> anyhow::Result<TreeView> {
@@ -3433,8 +3576,7 @@ impl RemoteSession {
         identity_refresh: bool,
         deadline: RequestDeadline,
     ) -> anyhow::Result<TreeView> {
-        let _refresh = if let RequestDeadline::Fixed(timeout) = deadline {
-            let deadline = Instant::now() + timeout;
+        let _refresh = if let RequestDeadline::Until(deadline) = deadline {
             loop {
                 match self.tree_refresh.try_lock() {
                     Ok(lock) => break lock,
@@ -6867,7 +7009,59 @@ mod tests {
             error.downcast_ref::<RemoteRequestError>(),
             Some(RemoteRequestError::Timeout)
         ));
-        assert!(started.elapsed() < Duration::from_secs(1));
+        assert!(
+            started.elapsed() < Duration::from_millis(100),
+            "5ms probe deadline was exceeded by {:?}",
+            started.elapsed()
+        );
+        assert!(session.pending.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn bounded_tree_refresh_does_not_wait_for_another_refresh_lock() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+        let _refresh = session.tree_refresh.lock().unwrap();
+        let started = Instant::now();
+        let error = session
+            .refresh_tree_with_timeout(Duration::from_millis(5))
+            .expect_err("a contended refresh lock must time out");
+
+        assert!(matches!(
+            error.downcast_ref::<RemoteRequestError>(),
+            Some(RemoteRequestError::Timeout)
+        ));
+        assert!(
+            started.elapsed() < Duration::from_millis(100),
+            "5ms lock deadline was exceeded by {:?}",
+            started.elapsed()
+        );
+        assert!(session.pending.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn bounded_tree_refresh_aborts_a_blocked_ordered_write() {
+        let (stream, control) = BlockingWriteStream::new();
+        let session = blocking_test_session(stream);
+        session.send_bytes(7, b"blocked").unwrap();
+        control.wait_until_entered();
+
+        let started = Instant::now();
+        let error = session
+            .refresh_tree_with_timeout(Duration::from_millis(5))
+            .expect_err("a blocked probe write must time out");
+
+        assert!(error.downcast_ref::<RemoteRequestError>().is_some_and(|error| {
+            matches!(error, RemoteRequestError::Transport(io_error)
+                if io_error.kind() == io::ErrorKind::TimedOut)
+        }));
+        assert!(
+            started.elapsed() < Duration::from_millis(100),
+            "5ms write deadline was exceeded by {:?}",
+            started.elapsed()
+        );
+        assert!(control.state.0.lock().unwrap().aborted);
         assert!(session.pending.lock().unwrap().is_empty());
     }
 

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -6840,6 +6840,24 @@ mod tests {
         assert!(closed.load(Ordering::Acquire));
     }
 
+    #[test]
+    fn bounded_tree_refresh_times_out_and_clears_pending_probe() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+        let started = Instant::now();
+        let error = session
+            .refresh_tree_with_timeout(Duration::from_millis(5))
+            .expect_err("a silent probe must time out");
+
+        assert!(matches!(
+            error.downcast_ref::<RemoteRequestError>(),
+            Some(RemoteRequestError::Timeout)
+        ));
+        assert!(started.elapsed() < Duration::from_secs(1));
+        assert!(session.pending.lock().unwrap().is_empty());
+    }
+
     #[cfg(unix)]
     #[test]
     fn eof_cancels_a_pending_request_without_waiting_for_the_request_timeout() {

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -7001,9 +7001,10 @@ mod tests {
             closed: Arc::new(AtomicBool::new(false)),
         }));
         let started = Instant::now();
-        let error = session
-            .refresh_tree_with_timeout(Duration::from_millis(5))
-            .expect_err("a silent probe must time out");
+        let error = match session.refresh_tree_with_timeout(Duration::from_millis(5)) {
+            Err(error) => error,
+            Ok(_) => panic!("a silent probe unexpectedly completed"),
+        };
 
         assert!(matches!(
             error.downcast_ref::<RemoteRequestError>(),
@@ -7024,9 +7025,10 @@ mod tests {
         }));
         let _refresh = session.tree_refresh.lock().unwrap();
         let started = Instant::now();
-        let error = session
-            .refresh_tree_with_timeout(Duration::from_millis(5))
-            .expect_err("a contended refresh lock must time out");
+        let error = match session.refresh_tree_with_timeout(Duration::from_millis(5)) {
+            Err(error) => error,
+            Ok(_) => panic!("a contended refresh lock unexpectedly completed"),
+        };
 
         assert!(matches!(
             error.downcast_ref::<RemoteRequestError>(),
@@ -7048,9 +7050,10 @@ mod tests {
         control.wait_until_entered();
 
         let started = Instant::now();
-        let error = session
-            .refresh_tree_with_timeout(Duration::from_millis(5))
-            .expect_err("a blocked probe write must time out");
+        let error = match session.refresh_tree_with_timeout(Duration::from_millis(5)) {
+            Err(error) => error,
+            Ok(_) => panic!("a blocked probe write unexpectedly completed"),
+        };
 
         assert!(error.downcast_ref::<RemoteRequestError>().is_some_and(|error| {
             matches!(error, RemoteRequestError::Transport(io_error)

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3433,7 +3433,20 @@ impl RemoteSession {
         identity_refresh: bool,
         deadline: RequestDeadline,
     ) -> anyhow::Result<TreeView> {
-        let _refresh = self.tree_refresh.lock().unwrap();
+        let _refresh = if let RequestDeadline::Fixed(timeout) = deadline {
+            let deadline = Instant::now() + timeout;
+            loop {
+                match self.tree_refresh.try_lock() {
+                    Ok(lock) => break lock,
+                    Err(_) if Instant::now() >= deadline => {
+                        anyhow::bail!(RemoteRequestError::Timeout)
+                    }
+                    Err(_) => std::thread::yield_now(),
+                }
+            }
+        } else {
+            self.tree_refresh.lock().unwrap()
+        };
         if identity_refresh {
             self.tree_stale.store(false, Ordering::Release);
         }

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -27,6 +27,7 @@ use cmux_tui_core::{
     },
 };
 use cmux_tui_machine_protocol::BearerToken;
+use crossbeam_channel::Sender as EventSender;
 use ghostty_vt::{
     Callbacks, CursorShape, KeyInput, KittyGraphicsLimits, KittyImageIdCursors, KittyReplayState,
     MouseEncoders, MouseInput, RenderState, Terminal, TerminalColorOverrides,
@@ -1554,7 +1555,9 @@ pub enum PipeIoEvent {
 
 struct PipeIoTap {
     surface: SurfaceId,
-    sender: std::sync::mpsc::SyncSender<PipeIoEvent>,
+    sender: EventSender<PipeIoEvent>,
+    lifecycle_sender: EventSender<PipeIoEvent>,
+    token: Arc<u8>,
 }
 
 pub(super) enum RemoteSurfaceAttach {
@@ -3061,13 +3064,12 @@ impl RemoteSession {
             };
         }
         drop(state);
+        // Signal the pipe-io relay before shutdown waits on any in-flight
+        // writer. The lifecycle channel is separate from the bounded byte
+        // queue, so this wake cannot be dropped behind queued output.
+        self.signal_pipe_io_event(None, None, PipeIoEvent::TransportLost);
         self.begin_shutdown();
         self.interactive_writer.close();
-        // A pipe-io relay learns about every terminal-connection loss here
-        // (reader-thread EOF and every protocol-error disconnect path).
-        if let Some(tap) = self.pipe_io_tap.lock().unwrap().as_ref() {
-            let _ = tap.sender.try_send(PipeIoEvent::TransportLost);
-        }
     }
 
     /// Routes one scoped surface's raw byte stream to a `--pipe-io` relay.
@@ -3075,9 +3077,51 @@ impl RemoteSession {
     pub fn install_pipe_io_tap(
         &self,
         surface: SurfaceId,
-        sender: std::sync::mpsc::SyncSender<PipeIoEvent>,
-    ) {
-        *self.pipe_io_tap.lock().unwrap() = Some(PipeIoTap { surface, sender });
+        sender: EventSender<PipeIoEvent>,
+        lifecycle_sender: EventSender<PipeIoEvent>,
+    ) -> Arc<u8> {
+        // A non-zero-sized allocation gives each tap a stable identity. A
+        // zero-sized Arc token could share the allocator's dangling pointer.
+        let token = Arc::new(0u8);
+        *self.pipe_io_tap.lock().unwrap() =
+            Some(PipeIoTap { surface, sender, lifecycle_sender, token: token.clone() });
+        token
+    }
+
+    pub fn clear_pipe_io_tap(&self, token: &Arc<u8>) {
+        let mut slot = self.pipe_io_tap.lock().unwrap();
+        if slot.as_ref().is_some_and(|tap| Arc::ptr_eq(&tap.token, token)) {
+            slot.take();
+        }
+    }
+
+    fn signal_pipe_io_event(
+        &self,
+        surface: Option<SurfaceId>,
+        token: Option<&Arc<u8>>,
+        event: PipeIoEvent,
+    ) -> bool {
+        let tap = {
+            let mut slot = self.pipe_io_tap.lock().unwrap();
+            if (surface.is_none() || slot.as_ref().is_some_and(|tap| Some(tap.surface) == surface))
+                && token.is_none_or(|token| {
+                    slot.as_ref().is_some_and(|tap| Arc::ptr_eq(&tap.token, token))
+                })
+            {
+                slot.take()
+            } else {
+                None
+            }
+        };
+        if let Some(tap) = tap {
+            // A second lifecycle event is redundant. If the one-slot signal
+            // channel is already occupied, the first event remains the
+            // authoritative reason and still wakes the relay.
+            let _ = tap.lifecycle_sender.try_send(event);
+            true
+        } else {
+            false
+        }
     }
 
     /// Forwards one tap event, treating a full or dropped queue as a lost
@@ -3085,20 +3129,32 @@ impl RemoteSession {
     /// would corrupt the embedder's terminal state (bounded-backpressure
     /// policy; never wedge the session reader thread).
     fn pipe_io_forward(&self, surface: SurfaceId, event: impl FnOnce() -> PipeIoEvent) {
-        use std::sync::mpsc::TrySendError;
-        let stalled = {
+        use crossbeam_channel::TrySendError;
+        let event = event();
+        if matches!(&event, PipeIoEvent::SurfaceExited | PipeIoEvent::TransportLost) {
+            self.signal_pipe_io_event(Some(surface), None, event);
+            return;
+        }
+        let stalled_token = {
             let tap = self.pipe_io_tap.lock().unwrap();
             let Some(tap) = tap.as_ref() else { return };
             if tap.surface != surface {
                 return;
             }
-            match tap.sender.try_send(event()) {
-                Ok(()) => false,
-                Err(TrySendError::Full(_) | TrySendError::Disconnected(_)) => true,
+            match tap.sender.try_send(event) {
+                Ok(()) => None,
+                Err(TrySendError::Full(_) | TrySendError::Disconnected(_)) => {
+                    Some(tap.token.clone())
+                }
             }
         };
-        if stalled {
-            self.disconnect_transport();
+        if let Some(token) = stalled_token {
+            // Signal only the tap that observed the stall. A replacement tap
+            // may have been installed while this reader thread released the
+            // mutex; it must not be torn down by an older relay.
+            if self.signal_pipe_io_event(Some(surface), Some(&token), PipeIoEvent::TransportLost) {
+                self.disconnect_transport();
+            }
         }
     }
 
@@ -6456,6 +6512,56 @@ mod tests {
 
         assert!(session.shutdown.load(Ordering::Acquire));
         assert!(closed.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn full_pipe_io_queue_signals_loss_on_the_reserved_lifecycle_channel() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+        let (sender, receiver) = crossbeam_channel::bounded(1);
+        let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
+        let _token = session.install_pipe_io_tap(7, sender, lifecycle_sender);
+
+        session.pipe_io_forward(7, || PipeIoEvent::Output(b"first".to_vec()));
+        // The byte queue is full. The second event must force a transport
+        // loss, and that lifecycle signal must remain observable even though
+        // no byte-queue slot is available.
+        session.pipe_io_forward(7, || PipeIoEvent::Output(b"second".to_vec()));
+
+        assert_eq!(
+            lifecycle_receiver.recv_timeout(Duration::from_secs(1)).unwrap(),
+            PipeIoEvent::TransportLost
+        );
+        assert!(session.pipe_io_tap.lock().unwrap().is_none());
+        assert!(session.shutdown.load(Ordering::Acquire));
+        assert_eq!(receiver.try_recv().unwrap(), PipeIoEvent::Output(b"first".to_vec()));
+    }
+
+    #[test]
+    fn stale_pipe_io_tap_cleanup_cannot_remove_a_replacement() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+        let (first_sender, _first_receiver) = crossbeam_channel::bounded(1);
+        let (first_lifecycle_sender, _first_lifecycle_receiver) = crossbeam_channel::bounded(1);
+        let first_token = session.install_pipe_io_tap(7, first_sender, first_lifecycle_sender);
+
+        let (second_sender, second_receiver) = crossbeam_channel::bounded(1);
+        let (second_lifecycle_sender, _second_lifecycle_receiver) = crossbeam_channel::bounded(1);
+        let second_token = session.install_pipe_io_tap(7, second_sender, second_lifecycle_sender);
+
+        session.clear_pipe_io_tap(&first_token);
+        session.pipe_io_forward(7, || PipeIoEvent::Output(b"replacement".to_vec()));
+
+        assert!(Arc::ptr_eq(
+            &session.pipe_io_tap.lock().unwrap().as_ref().unwrap().token,
+            &second_token
+        ));
+        assert_eq!(
+            second_receiver.try_recv().unwrap(),
+            PipeIoEvent::Output(b"replacement".to_vec())
+        );
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -32,6 +32,7 @@ use ghostty_vt::{
     MouseEncoders, MouseInput, RenderState, Terminal, TerminalColorOverrides,
     TerminalPointerSemanticSnapshot, parse_color,
 };
+use parking_lot::Mutex as ParkingMutex;
 use serde_json::{Value, json};
 use zeroize::{Zeroize, Zeroizing};
 
@@ -1519,7 +1520,7 @@ pub struct RemoteSession {
     retired_surfaces: Mutex<HashSet<SurfaceId>>,
     tree: Mutex<RemoteTreeCache>,
     browser_sources: Mutex<HashMap<SurfaceId, BrowserSource>>,
-    tree_refresh: Mutex<()>,
+    tree_refresh: ParkingMutex<()>,
     tree_stale: AtomicBool,
     subscription_started: AtomicBool,
     event_surface_filter: AtomicU64,
@@ -1979,7 +1980,7 @@ impl RemoteSession {
             retired_surfaces: Mutex::new(HashSet::new()),
             tree: Mutex::new(RemoteTreeCache::default()),
             browser_sources: Mutex::new(HashMap::new()),
-            tree_refresh: Mutex::new(()),
+            tree_refresh: ParkingMutex::new(()),
             tree_stale: AtomicBool::new(true),
             subscription_started: AtomicBool::new(false),
             event_surface_filter: AtomicU64::new(0),
@@ -3577,17 +3578,11 @@ impl RemoteSession {
         deadline: RequestDeadline,
     ) -> anyhow::Result<TreeView> {
         let _refresh = if let RequestDeadline::Until(deadline) = deadline {
-            loop {
-                match self.tree_refresh.try_lock() {
-                    Ok(lock) => break lock,
-                    Err(_) if Instant::now() >= deadline => {
-                        anyhow::bail!(RemoteRequestError::Timeout)
-                    }
-                    Err(_) => std::thread::yield_now(),
-                }
-            }
+            self.tree_refresh
+                .try_lock_for(deadline.saturating_duration_since(Instant::now()))
+                .ok_or(RemoteRequestError::Timeout)?
         } else {
-            self.tree_refresh.lock().unwrap()
+            self.tree_refresh.lock()
         };
         if identity_refresh {
             self.tree_stale.store(false, Ordering::Release);
@@ -4045,7 +4040,7 @@ fn test_session_with_writer(
         retired_surfaces: Mutex::new(HashSet::new()),
         tree: Mutex::new(RemoteTreeCache::default()),
         browser_sources: Mutex::new(HashMap::new()),
-        tree_refresh: Mutex::new(()),
+        tree_refresh: ParkingMutex::new(()),
         tree_stale: AtomicBool::new(true),
         subscription_started: AtomicBool::new(false),
         event_surface_filter: AtomicU64::new(0),
@@ -5287,7 +5282,7 @@ mod tests {
             retired_surfaces: Mutex::new(HashSet::new()),
             tree: Mutex::new(RemoteTreeCache::default()),
             browser_sources: Mutex::new(HashMap::new()),
-            tree_refresh: Mutex::new(()),
+            tree_refresh: ParkingMutex::new(()),
             tree_stale: AtomicBool::new(true),
             subscription_started: AtomicBool::new(false),
             event_surface_filter: AtomicU64::new(0),
@@ -7023,7 +7018,7 @@ mod tests {
         let session = test_session(Box::new(CloseTrackingWriter {
             closed: Arc::new(AtomicBool::new(false)),
         }));
-        let _refresh = session.tree_refresh.lock().unwrap();
+        let _refresh = session.tree_refresh.lock();
         let started = Instant::now();
         let error = match session.refresh_tree_with_timeout(Duration::from_millis(5)) {
             Err(error) => error,

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3414,11 +3414,25 @@ impl RemoteSession {
         self.refresh_tree_inner(true)
     }
 
+    /// Refresh the workspace tree with a bounded request deadline. Used by
+    /// reconnect classification, where a stale daemon must not hold the relay.
+    pub fn refresh_tree_with_timeout(&self, timeout: Duration) -> anyhow::Result<TreeView> {
+        self.refresh_tree_inner_with_deadline(true, RequestDeadline::Fixed(timeout))
+    }
+
     pub fn refresh_tree_background(&self) -> anyhow::Result<TreeView> {
         self.refresh_tree_inner(false)
     }
 
     fn refresh_tree_inner(&self, identity_refresh: bool) -> anyhow::Result<TreeView> {
+        self.refresh_tree_inner_with_deadline(identity_refresh, RequestDeadline::Standard)
+    }
+
+    fn refresh_tree_inner_with_deadline(
+        &self,
+        identity_refresh: bool,
+        deadline: RequestDeadline,
+    ) -> anyhow::Result<TreeView> {
         let _refresh = self.tree_refresh.lock().unwrap();
         if identity_refresh {
             self.tree_stale.store(false, Ordering::Release);
@@ -3427,7 +3441,7 @@ impl RemoteSession {
             let cache = self.tree.lock().unwrap();
             (cache.title_generation(), cache.agent_generation())
         };
-        let data = match self.request(json!({"cmd": "list-workspaces"})) {
+        let data = match self.request_with_deadline(json!({"cmd": "list-workspaces"}), deadline) {
             Ok(data) => data,
             Err(e) => {
                 if identity_refresh {
@@ -3438,7 +3452,7 @@ impl RemoteSession {
             }
         };
         let agents = self
-            .request(json!({"cmd": "list-agents"}))
+            .request_with_deadline(json!({"cmd": "list-agents"}), deadline)
             .ok()
             .and_then(|data| {
                 data.get("agents")

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3150,6 +3150,15 @@ impl RemoteSession {
     /// policy; never wedge the session reader thread).
     fn pipe_io_forward(&self, surface: SurfaceId, event: impl FnOnce() -> PipeIoEvent) {
         use crossbeam_channel::TrySendError;
+        // Avoid cloning every output frame on the normal path when no
+        // renderer-less relay is attached. Construct the owned event only
+        // after observing an active tap for this surface.
+        {
+            let tap = self.pipe_io_tap.lock().unwrap();
+            if tap.as_ref().is_none_or(|tap| tap.surface != surface) {
+                return;
+            }
+        }
         let event = event();
         if matches!(&event, PipeIoEvent::SurfaceExited | PipeIoEvent::TransportLost) {
             self.signal_pipe_io_event(Some(surface), None, event);

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -975,7 +975,7 @@ enum RequestDeadline {
 }
 
 impl RequestDeadline {
-    fn remaining(self) -> Result<Duration, RemoteRequestError> {
+    fn remaining(&self) -> Result<Duration, RemoteRequestError> {
         match self {
             Self::Standard => Ok(REMOTE_REQUEST_TIMEOUT),
             Self::Fixed(timeout) => Ok(timeout),

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -979,7 +979,7 @@ impl RequestDeadline {
     fn remaining(&self) -> Result<Duration, RemoteRequestError> {
         match self {
             Self::Standard => Ok(REMOTE_REQUEST_TIMEOUT),
-            Self::Fixed(timeout) => Ok(timeout),
+            Self::Fixed(timeout) => Ok(*timeout),
             Self::Until(deadline) => {
                 let remaining = deadline.saturating_duration_since(Instant::now());
                 if remaining.is_zero() { Err(RemoteRequestError::Timeout) } else { Ok(remaining) }

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -6,11 +6,12 @@ use std::fs;
 use std::io::{self, BufRead, BufReader, Read, Write};
 use std::net::Shutdown;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, channel, sync_channel};
 use std::sync::{Arc, Condvar, Mutex, Weak};
 use std::time::{Duration, Instant};
 
+use anyhow::Context;
 use base64::Engine;
 use cmux_tui_core::server::{VIEWPORT_COLUMN_RESIZE_CAPABILITY, VIEWPORT_SPLITS_CAPABILITY};
 use cmux_tui_core::{
@@ -1557,6 +1558,7 @@ struct PipeIoTap {
     surface: SurfaceId,
     sender: EventSender<PipeIoEvent>,
     lifecycle_sender: EventSender<PipeIoEvent>,
+    queued_bytes: Arc<AtomicUsize>,
     token: Arc<u8>,
 }
 
@@ -1849,8 +1851,9 @@ impl RemoteSession {
     }
 
     fn connect_path(path: &Path, subscribe: bool) -> anyhow::Result<Arc<Self>> {
-        let stream = transport::connect(path).map_err(|e| {
-            anyhow::anyhow!("cannot connect to session socket {}: {e}", path.display())
+        let stream = transport::connect(path).map_err(|error| {
+            anyhow::Error::new(RemoteRequestError::Transport(error))
+                .context(format!("cannot connect to session socket {}", path.display()))
         })?;
         Self::connect_stream_with_subscription(stream, subscribe)
     }
@@ -1884,7 +1887,8 @@ impl RemoteSession {
             // local UDS failures used by this probe; Unix uses socket2's
             // bounded poll above.
             let stream = transport::connect(path).map_err(|error| {
-                anyhow::anyhow!("cannot connect to session socket {}: {error}", path.display())
+                anyhow::Error::new(RemoteRequestError::Transport(error))
+                    .context(format!("cannot connect to session socket {}", path.display()))
             })?;
             return Self::connect_stream_with_subscription_until(stream, subscribe, deadline);
         }
@@ -1892,7 +1896,8 @@ impl RemoteSession {
         #[cfg(not(any(unix, windows)))]
         {
             let stream = transport::connect(path).map_err(|error| {
-                anyhow::anyhow!("cannot connect to session socket {}: {error}", path.display())
+                anyhow::Error::new(RemoteRequestError::Transport(error))
+                    .context(format!("cannot connect to session socket {}", path.display()))
             })?;
             Self::connect_stream_with_subscription_until(stream, subscribe, deadline)
         }
@@ -3088,12 +3093,18 @@ impl RemoteSession {
         surface: SurfaceId,
         sender: EventSender<PipeIoEvent>,
         lifecycle_sender: EventSender<PipeIoEvent>,
+        queued_bytes: Arc<AtomicUsize>,
     ) -> Arc<u8> {
         // A non-zero-sized allocation gives each tap a stable identity. A
         // zero-sized Arc token could share the allocator's dangling pointer.
         let token = Arc::new(0u8);
-        *self.pipe_io_tap.lock().unwrap() =
-            Some(PipeIoTap { surface, sender, lifecycle_sender, token: token.clone() });
+        *self.pipe_io_tap.lock().unwrap() = Some(PipeIoTap {
+            surface,
+            sender,
+            lifecycle_sender,
+            queued_bytes,
+            token: token.clone(),
+        });
         token
     }
 
@@ -3150,10 +3161,18 @@ impl RemoteSession {
             if tap.surface != surface {
                 return;
             }
-            match tap.sender.try_send(event) {
-                Ok(()) => None,
-                Err(TrySendError::Full(_) | TrySendError::Disconnected(_)) => {
-                    Some(tap.token.clone())
+            let byte_len = event.byte_len();
+            if byte_len > crate::pipe_io::MAX_PIPE_IO_EVENT_BYTES
+                || !reserve_pipe_io_bytes(&tap.queued_bytes, byte_len)
+            {
+                Some(tap.token.clone())
+            } else {
+                match tap.sender.try_send(event) {
+                    Ok(()) => None,
+                    Err(TrySendError::Full(_) | TrySendError::Disconnected(_)) => {
+                        release_pipe_io_bytes(&tap.queued_bytes, byte_len);
+                        Some(tap.token.clone())
+                    }
                 }
             }
         };
@@ -3757,6 +3776,26 @@ impl RemoteSession {
 
     pub fn tree_is_stale(&self) -> bool {
         self.tree_stale.load(Ordering::Acquire)
+    }
+}
+
+fn reserve_pipe_io_bytes(counter: &AtomicUsize, amount: usize) -> bool {
+    let mut current = counter.load(Ordering::Acquire);
+    loop {
+        let Some(next) = current.checked_add(amount) else { return false };
+        if next > crate::pipe_io::EVENT_QUEUE_MAX_BYTES {
+            return false;
+        }
+        match counter.compare_exchange_weak(current, next, Ordering::AcqRel, Ordering::Acquire) {
+            Ok(_) => return true,
+            Err(observed) => current = observed,
+        }
+    }
+}
+
+fn release_pipe_io_bytes(counter: &AtomicUsize, amount: usize) {
+    if amount != 0 {
+        counter.fetch_sub(amount, Ordering::AcqRel);
     }
 }
 
@@ -6530,7 +6569,8 @@ mod tests {
         }));
         let (sender, receiver) = crossbeam_channel::bounded(1);
         let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
-        let _token = session.install_pipe_io_tap(7, sender, lifecycle_sender);
+        let queued_bytes = Arc::new(AtomicUsize::new(0));
+        let _token = session.install_pipe_io_tap(7, sender, lifecycle_sender, queued_bytes);
 
         session.pipe_io_forward(7, || PipeIoEvent::Output(b"first".to_vec()));
         // The byte queue is full. The second event must force a transport
@@ -6554,11 +6594,21 @@ mod tests {
         }));
         let (first_sender, _first_receiver) = crossbeam_channel::bounded(1);
         let (first_lifecycle_sender, _first_lifecycle_receiver) = crossbeam_channel::bounded(1);
-        let first_token = session.install_pipe_io_tap(7, first_sender, first_lifecycle_sender);
+        let first_token = session.install_pipe_io_tap(
+            7,
+            first_sender,
+            first_lifecycle_sender,
+            Arc::new(AtomicUsize::new(0)),
+        );
 
         let (second_sender, second_receiver) = crossbeam_channel::bounded(1);
         let (second_lifecycle_sender, _second_lifecycle_receiver) = crossbeam_channel::bounded(1);
-        let second_token = session.install_pipe_io_tap(7, second_sender, second_lifecycle_sender);
+        let second_token = session.install_pipe_io_tap(
+            7,
+            second_sender,
+            second_lifecycle_sender,
+            Arc::new(AtomicUsize::new(0)),
+        );
 
         session.clear_pipe_io_tap(&first_token);
         session.pipe_io_forward(7, || PipeIoEvent::Output(b"replacement".to_vec()));

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1860,33 +1860,42 @@ impl RemoteSession {
         subscribe: bool,
         deadline: Instant,
     ) -> anyhow::Result<Arc<Self>> {
-        let path_for_thread = path.to_path_buf();
-        let display = path.display().to_string();
-        let (sender, receiver) = sync_channel(1);
-        let connector =
-            std::thread::Builder::new().name("remote-probe-connect".into()).spawn(move || {
-                let _ = sender.send(transport::connect(&path_for_thread));
-            })?;
-        let stream = match receiver.recv_timeout(deadline.saturating_duration_since(Instant::now()))
+        #[cfg(unix)]
         {
-            Ok(result) => {
-                let _ = connector.join();
-                result.map_err(|error| {
-                    anyhow::anyhow!("cannot connect to session socket {display}: {error}")
-                })?
+            let timeout = deadline.saturating_duration_since(Instant::now());
+            if timeout.is_zero() {
+                anyhow::bail!(RemoteRequestError::Timeout);
             }
-            Err(RecvTimeoutError::Disconnected) => {
-                let _ = connector.join();
-                anyhow::bail!("remote probe connector stopped without a result")
-            }
-            Err(RecvTimeoutError::Timeout) => {
-                // The pipe-io process exits after classification. Dropping the
-                // connector lets that process terminate any blocked connect.
-                drop(connector);
-                anyhow::bail!(RemoteRequestError::Timeout)
-            }
-        };
-        Self::connect_stream_with_subscription_until(stream, subscribe, deadline)
+            let address = socket2::SockAddr::unix(path)?;
+            let socket = socket2::Socket::new(socket2::Domain::UNIX, socket2::Type::STREAM, None)?;
+            socket.connect_timeout(&address, timeout)?;
+            let stream: std::os::unix::net::UnixStream = socket.into();
+            return Self::connect_stream_with_subscription_until(
+                Box::new(stream),
+                subscribe,
+                deadline,
+            );
+        }
+
+        #[cfg(windows)]
+        {
+            // Windows' uds_windows adapter does not expose a cancellable
+            // connect primitive. Its connect path returns promptly for the
+            // local UDS failures used by this probe; Unix uses socket2's
+            // bounded poll above.
+            let stream = transport::connect(path).map_err(|error| {
+                anyhow::anyhow!("cannot connect to session socket {}: {error}", path.display())
+            })?;
+            return Self::connect_stream_with_subscription_until(stream, subscribe, deadline);
+        }
+
+        #[cfg(not(any(unix, windows)))]
+        {
+            let stream = transport::connect(path).map_err(|error| {
+                anyhow::anyhow!("cannot connect to session socket {}: {error}", path.display())
+            })?;
+            Self::connect_stream_with_subscription_until(stream, subscribe, deadline)
+        }
     }
 
     /// Connect over an already-established full-duplex byte stream.

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -4153,6 +4153,11 @@ impl PipeIoRelay {
         self.stdin.as_mut().unwrap().write_all(line.as_bytes()).unwrap();
     }
 
+    fn send_claim(&mut self) {
+        let line = format!("{}\n", serde_json::json!({ "claim": { "geometry": true } }));
+        self.stdin.as_mut().unwrap().write_all(line.as_bytes()).unwrap();
+    }
+
     fn stdout_text(&self) -> String {
         String::from_utf8_lossy(&self.stdout.lock().unwrap()).into_owned()
     }
@@ -4380,6 +4385,54 @@ fn pipe_io_resize_reaches_the_daemon_pty() {
             relay.stderr_text()
         );
     }
+}
+
+/// Polls `stty size` through `relay` until `needle` (e.g. "30 100") shows,
+/// panicking with both streams on timeout. The daemon acknowledges resizes
+/// before the PTY winsize necessarily lands, hence the poll.
+#[cfg(unix)]
+fn wait_for_stty(relay: &mut PipeIoRelay, needle: &str, what: &str) {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    loop {
+        relay.send_input(b"stty size\n");
+        let poll_deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < poll_deadline {
+            if relay.stdout_text().contains(needle) {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for {what}\nstdout:\n{}\nstderr:\n{}",
+            relay.stdout_text(),
+            relay.stderr_text()
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn pipe_io_claim_line_reclaims_geometry_authority() {
+    let server = HeadlessServer::start("pipe-io-claim");
+    let terminal = pipe_io_terminal(&server);
+
+    let mut first = PipeIoRelay::start(&server, &terminal, 80, 24);
+    first.send_input(b"printf 'PIPEIO-%s\\n' CLAIM\n");
+    first.wait_for_stdout("PIPEIO-CLAIM", "shell readiness marker");
+
+    // A later attachment claims geometry authority (last claim wins), so
+    // the PTY follows the second relay's smaller grid.
+    let mut second = PipeIoRelay::start(&server, &terminal, 60, 20);
+    second.wait_for_stdout("PIPEIO-CLAIM", "replay on the second relay");
+    wait_for_stty(&mut first, "20 60", "the second attach claim to resize the PTY");
+
+    // The claim line is how an embedder re-asserts authority when its pane
+    // receives user input; the first relay's sizes apply again.
+    first.send_claim();
+    wait_for_stty(&mut first, "24 80", "the reclaim to restore the first relay's grid");
+    first.send_resize(100, 30);
+    wait_for_stty(&mut first, "30 100", "a post-reclaim resize to apply");
 }
 
 #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -4088,3 +4088,327 @@ fn unique_temp_dir(name: &str) -> PathBuf {
 fn bin() -> &'static str {
     env!("CARGO_BIN_EXE_cmux-tui")
 }
+
+// ---------------------------------------------------------------------------
+// `attach --pipe-io`: renderer-less byte relay for embedder-fed surfaces.
+//
+// Contract under test (GUI-frontend migration, manual-IO surface):
+//   stdout  = raw VT bytes (daemon replay first, then live output),
+//   stdin   = JSON lines ({"input":"<b64>"} | {"resize":{"cols":N,"rows":N}}),
+//   stderr  = one final JSON line {"exit":{"reason":...}},
+//   exit 0  = terminal ended (or parent closed stdin) — do not respawn,
+//   exit 2  = daemon connection lost — the embedder may respawn to resync.
+// ---------------------------------------------------------------------------
+
+#[cfg(unix)]
+struct PipeIoRelay {
+    child: Child,
+    stdin: Option<std::process::ChildStdin>,
+    stdout: std::sync::Arc<std::sync::Mutex<Vec<u8>>>,
+    stderr: std::sync::Arc<std::sync::Mutex<Vec<u8>>>,
+}
+
+#[cfg(unix)]
+impl PipeIoRelay {
+    fn start(server: &HeadlessServer, terminal: &str, cols: u16, rows: u16) -> Self {
+        let mut child = Command::new(bin())
+            .args(["attach", "--socket"])
+            .arg(&server.socket)
+            .args([
+                "--terminal",
+                terminal,
+                "--pipe-io",
+                "--cols",
+                &cols.to_string(),
+                "--rows",
+                &rows.to_string(),
+            ])
+            .env_remove("CMUX_TUI_SOCKET")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+        let stdin = child.stdin.take();
+        let stdout = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let stderr = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let out = child.stdout.take().unwrap();
+        let err = child.stderr.take().unwrap();
+        let stdout_sink = stdout.clone();
+        std::thread::spawn(move || drain_into(out, stdout_sink));
+        let stderr_sink = stderr.clone();
+        std::thread::spawn(move || drain_into(err, stderr_sink));
+        Self { child, stdin, stdout, stderr }
+    }
+
+    fn send_input(&mut self, bytes: &[u8]) {
+        use base64::Engine as _;
+        let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
+        let line = format!("{}\n", serde_json::json!({ "input": encoded }));
+        self.stdin.as_mut().unwrap().write_all(line.as_bytes()).unwrap();
+    }
+
+    fn send_resize(&mut self, cols: u16, rows: u16) {
+        let line = format!("{}\n", serde_json::json!({ "resize": { "cols": cols, "rows": rows } }));
+        self.stdin.as_mut().unwrap().write_all(line.as_bytes()).unwrap();
+    }
+
+    fn stdout_text(&self) -> String {
+        String::from_utf8_lossy(&self.stdout.lock().unwrap()).into_owned()
+    }
+
+    fn stderr_text(&self) -> String {
+        String::from_utf8_lossy(&self.stderr.lock().unwrap()).into_owned()
+    }
+
+    fn wait_for_stdout(&mut self, needle: &str, what: &str) {
+        let deadline = Instant::now() + Duration::from_secs(20);
+        while Instant::now() < deadline {
+            if self.stdout_text().contains(needle) {
+                return;
+            }
+            if let Some(status) = self.child.try_wait().unwrap() {
+                panic!(
+                    "pipe-io relay exited ({status}) before {what}\nstdout:\n{}\nstderr:\n{}",
+                    self.stdout_text(),
+                    String::from_utf8_lossy(&self.stderr.lock().unwrap())
+                );
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        panic!("timed out waiting for {what}\nstdout:\n{}", self.stdout_text());
+    }
+
+    fn wait_for_exit(&mut self) -> (i32, serde_json::Value) {
+        let deadline = Instant::now() + Duration::from_secs(20);
+        while Instant::now() < deadline {
+            if let Some(status) = self.child.try_wait().unwrap() {
+                // Let the drain threads observe EOF.
+                std::thread::sleep(Duration::from_millis(100));
+                let stderr_text =
+                    String::from_utf8_lossy(&self.stderr.lock().unwrap()).into_owned();
+                let exit_line = stderr_text
+                    .lines()
+                    .rev()
+                    .find(|line| line.trim_start().starts_with('{'))
+                    .unwrap_or_else(|| {
+                        panic!("pipe-io relay printed no JSON exit line\nstderr:\n{stderr_text}")
+                    })
+                    .to_string();
+                let value: serde_json::Value = serde_json::from_str(&exit_line).unwrap();
+                return (status.code().unwrap_or(-1), value);
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        panic!("pipe-io relay did not exit\nstdout:\n{}", self.stdout_text());
+    }
+}
+
+#[cfg(unix)]
+fn drain_into(mut source: impl Read, sink: std::sync::Arc<std::sync::Mutex<Vec<u8>>>) {
+    let mut buffer = [0u8; 4096];
+    loop {
+        match source.read(&mut buffer) {
+            Ok(0) | Err(_) => return,
+            Ok(count) => sink.lock().unwrap().extend_from_slice(&buffer[..count]),
+        }
+    }
+}
+
+/// Reaps the adoptable terminal hosts a deliberate daemon SIGKILL leaves
+/// behind. The fixture's Drop treats any surviving host as a leak, but this
+/// test kills the daemon on purpose (host adoption after a daemon death is
+/// covered elsewhere); the orphaned hosts are part of the arranged scene.
+#[cfg(unix)]
+fn reap_orphaned_hosts_after_daemon_kill(server: &HeadlessServer) {
+    let host_root = cmux_tui_core::terminal_host_runtime::terminal_host_root(&server.state, "main");
+    for pid in terminal_host_pids(&host_root) {
+        if let Ok(pid) = libc::pid_t::try_from(pid) {
+            // SAFETY: terminating a test-owned child process group member.
+            unsafe {
+                libc::kill(pid, libc::SIGKILL);
+            }
+        }
+    }
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while terminal_host_pids(&host_root).iter().any(|pid| process_exists(*pid)) {
+        assert!(Instant::now() < deadline, "orphaned terminal hosts survived SIGKILL");
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    let _ = fs::remove_dir_all(&host_root);
+}
+
+#[cfg(unix)]
+fn pipe_io_terminal(server: &HeadlessServer) -> String {
+    let created = json_cli(server, &["workspace", "create", "--name", "pipe-io"]);
+    assert_success(&created);
+    json_output(&created)["value"]["terminal_id"].as_str().unwrap().to_string()
+}
+
+/// Count literal `^[[<digits>;<digits>R` runs, the form `cat -v` uses to
+/// render a cursor-position report that reached the inner process.
+#[cfg(unix)]
+fn visible_cursor_position_reports(text: &str) -> usize {
+    let bytes = text.as_bytes();
+    let mut count = 0;
+    let mut index = 0;
+    while let Some(offset) = text[index..].find("^[[") {
+        let mut cursor = index + offset + 3;
+        let mut digits_then_semicolon = false;
+        while cursor < bytes.len() && bytes[cursor].is_ascii_digit() {
+            cursor += 1;
+        }
+        if cursor < bytes.len() && bytes[cursor] == b';' {
+            cursor += 1;
+            let row_end = cursor;
+            while cursor < bytes.len() && bytes[cursor].is_ascii_digit() {
+                cursor += 1;
+            }
+            digits_then_semicolon = cursor > row_end;
+        }
+        if digits_then_semicolon && cursor < bytes.len() && bytes[cursor] == b'R' {
+            count += 1;
+        }
+        index += offset + 3;
+    }
+    count
+}
+
+#[cfg(unix)]
+#[test]
+fn pipe_io_attach_streams_output_and_replays_on_reconnect() {
+    let server = HeadlessServer::start("pipe-io-basic");
+    let terminal = pipe_io_terminal(&server);
+
+    let mut first = PipeIoRelay::start(&server, &terminal, 80, 24);
+    first.send_input(b"printf 'PIPEIO-%s\\n' FIRST\n");
+    first.wait_for_stdout("PIPEIO-FIRST", "live output of the typed marker");
+
+    // Dropping stdin tells the relay its embedder is gone: clean exit 0.
+    first.stdin = None;
+    let (code, exit) = first.wait_for_exit();
+    assert_eq!(code, 0, "stdin EOF must be a clean detach, got {exit}");
+    assert_eq!(exit["exit"]["reason"], "parent-closed");
+
+    // A fresh relay must serve the daemon replay before live bytes: the
+    // marker typed through the first relay is visible without retyping.
+    let mut second = PipeIoRelay::start(&server, &terminal, 80, 24);
+    second.wait_for_stdout("PIPEIO-FIRST", "replayed marker after reconnect");
+}
+
+#[cfg(unix)]
+#[test]
+fn pipe_io_exit_distinguishes_terminal_end_from_daemon_loss() {
+    let mut server = HeadlessServer::start("pipe-io-exits");
+    let terminal = pipe_io_terminal(&server);
+
+    let mut relay = PipeIoRelay::start(&server, &terminal, 80, 24);
+    relay.send_input(b"printf 'PIPEIO-%s\\n' READY\n");
+    relay.wait_for_stdout("PIPEIO-READY", "shell readiness marker");
+    let closed = json_cli(&server, &["terminal", &terminal, "close"]);
+    assert_success(&closed);
+    let (code, exit) = relay.wait_for_exit();
+    assert_eq!(code, 0, "terminal close must exit 0, got {exit}");
+    assert_eq!(exit["exit"]["reason"], "terminal-ended");
+
+    let second_terminal = pipe_io_terminal(&server);
+    let mut survivor = PipeIoRelay::start(&server, &second_terminal, 80, 24);
+    survivor.send_input(b"printf 'PIPEIO-%s\\n' TWO\n");
+    survivor.wait_for_stdout("PIPEIO-TWO", "second shell readiness marker");
+    server.child.kill().unwrap();
+    let (code, exit) = survivor.wait_for_exit();
+    assert_eq!(code, 2, "daemon loss must exit 2, got {exit}");
+    assert_eq!(exit["exit"]["reason"], "daemon-lost");
+    reap_orphaned_hosts_after_daemon_kill(&server);
+}
+
+#[cfg(unix)]
+#[test]
+fn pipe_io_startup_connect_failure_reports_daemon_lost() {
+    // A daemon restart window (dead socket) must read as daemon-lost so
+    // the embedder keeps retrying; only unexplained failures make it stop.
+    let dir = unique_temp_dir("pipe-io-dead-socket");
+    fs::create_dir_all(&dir).unwrap();
+    let dead_socket = dir.join("mux.sock");
+    let output = Command::new(bin())
+        .args(["attach", "--socket"])
+        .arg(&dead_socket)
+        .args(["--terminal", "term_0123456789abcdef0123456789abcdef", "--pipe-io"])
+        .env_remove("CMUX_TUI_SOCKET")
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let exit_line = stderr.lines().rev().find(|line| line.trim_start().starts_with('{')).unwrap();
+    let value: serde_json::Value = serde_json::from_str(exit_line).unwrap();
+    assert_eq!(value["exit"]["reason"], "daemon-lost");
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[cfg(unix)]
+#[test]
+fn pipe_io_resize_reaches_the_daemon_pty() {
+    let server = HeadlessServer::start("pipe-io-resize");
+    let terminal = pipe_io_terminal(&server);
+
+    let mut relay = PipeIoRelay::start(&server, &terminal, 80, 24);
+    relay.send_input(b"printf 'PIPEIO-%s\\n' SIZED\n");
+    relay.wait_for_stdout("PIPEIO-SIZED", "shell readiness marker");
+    relay.send_resize(100, 30);
+    // The daemon acknowledges the resize before the PTY winsize necessarily
+    // lands; poll stty until the new geometry is visible.
+    let deadline = Instant::now() + Duration::from_secs(20);
+    loop {
+        relay.send_input(b"stty size\n");
+        let poll_deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < poll_deadline {
+            if relay.stdout_text().contains("30 100") {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for stty to report the resized PTY\nstdout:\n{}\nstderr:\n{}",
+            relay.stdout_text(),
+            relay.stderr_text()
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn pipe_io_inner_query_is_answered_exactly_once() {
+    let server = HeadlessServer::start("pipe-io-reply-authority");
+    let terminal = pipe_io_terminal(&server);
+
+    let mut relay = PipeIoRelay::start(&server, &terminal, 80, 24);
+    // The inner program emits a DSR cursor-position query and then renders
+    // its own stdin visibly. Exactly one authority (the daemon-side
+    // terminal) must answer; the relay and any embedder mirror stay silent.
+    relay.send_input(b"sh -c 'printf \"\\033[6n\"; exec cat -v'\n");
+    let deadline = Instant::now() + Duration::from_secs(20);
+    let mut seen = 0;
+    while Instant::now() < deadline {
+        seen = visible_cursor_position_reports(&relay.stdout_text());
+        if seen >= 1 {
+            // Give a duplicated reply time to surface before asserting.
+            std::thread::sleep(Duration::from_millis(500));
+            seen = visible_cursor_position_reports(&relay.stdout_text());
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    assert_eq!(
+        seen,
+        1,
+        "inner DSR query must be answered exactly once\nstdout:\n{}",
+        relay.stdout_text()
+    );
+}

--- a/cmux-tui/spec/cli.md
+++ b/cmux-tui/spec/cli.md
@@ -32,7 +32,12 @@ raw bytes: the daemon replay first, then live output, with a full reset
 first output, because a replay replaces state while a byte stream appends.
 stdin takes one JSON object per line: `{"input":"<base64>"}` forwards bytes to
 the terminal, `{"resize":{"cols":N,"rows":N}}` drives the attached viewer
-size; unknown keys are ignored. stderr ends with one JSON line
+size, and `{"claim":{"geometry":true}}` re-asserts this relay's geometry
+authority (authority is last-claim-wins across a terminal's attachments; an
+embedder sends it when its pane receives user input, so the typed-in pane
+owns the PTY size). Each applied resize and claim is reported as one
+`{"diag":...}` stderr line; unknown keys are ignored. stderr ends with one
+JSON line
 `{"exit":{"reason":"terminal-ended"|"daemon-lost"|"parent-closed"}}`. Exit
 code 0 means the terminal ended or the embedder closed stdin (do not
 respawn); exit code 2 means the daemon connection was lost and a respawn

--- a/cmux-tui/spec/cli.md
+++ b/cmux-tui/spec/cli.md
@@ -13,7 +13,7 @@ request:
 ```text
 cmux [START OPTIONS]
 cmux server start [START OPTIONS]
-cmux attach [START OPTIONS] [--terminal <terminal-id>]
+cmux attach [START OPTIONS] [--terminal <terminal-id>] [--pipe-io [--cols <n> --rows <n>]]
 cmux relay [ROUTING OPTIONS]
 cmux machine-agent [OPTIONS]
 ```
@@ -24,6 +24,20 @@ complete session TUI. `attach --terminal <terminal-id>` resolves an exact ID
 from `cmux terminal list` and renders only that terminal, without session
 chrome or unrelated event traffic. Startup attach does not accept internal
 runtime identifiers, abbreviated identifiers, names, or `current`.
+
+`attach --terminal <terminal-id> --pipe-io` is the same scoped attach without
+a renderer, for an embedder that parses terminal bytes itself. stdout carries
+raw bytes: the daemon replay first, then live output, with a full reset
+(`ESC c` plus erase-scrollback) before any replay that is not the relay's
+first output, because a replay replaces state while a byte stream appends.
+stdin takes one JSON object per line: `{"input":"<base64>"}` forwards bytes to
+the terminal, `{"resize":{"cols":N,"rows":N}}` drives the attached viewer
+size; unknown keys are ignored. stderr ends with one JSON line
+`{"exit":{"reason":"terminal-ended"|"daemon-lost"|"parent-closed"}}`. Exit
+code 0 means the terminal ended or the embedder closed stdin (do not
+respawn); exit code 2 means the daemon connection was lost and a respawn
+reattaches and resyncs from a fresh replay. `--cols` and `--rows` set the
+initial viewer size (default 80x24). `--pipe-io` requires `--terminal`.
 
 Interactive and headless ownership are intentionally separate:
 

--- a/cmux-tui/spec/cli.md
+++ b/cmux-tui/spec/cli.md
@@ -42,7 +42,8 @@ JSON line
 code 0 means the terminal ended or the embedder closed stdin (do not
 respawn); exit code 2 means the daemon connection was lost and a respawn
 reattaches and resyncs from a fresh replay. `--cols` and `--rows` set the
-initial viewer size (default 80x24). `--pipe-io` requires `--terminal`.
+initial viewer size (default 80x24). Input lines are limited to 2 MiB and
+decoded `input` payloads to 1 MiB. `--pipe-io` requires `--terminal`.
 
 Interactive and headless ownership are intentionally separate:
 

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -638,6 +638,7 @@
 		C986A0010000000000000001 /* CloudTreeSurfaceDragPasteboardWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C986A0020000000000000001 /* CloudTreeSurfaceDragPasteboardWriter.swift */; };
 		BB4657280E610A6935E1906B /* CloudTuiClientPaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C4E59490776669AA7257527 /* CloudTuiClientPaths.swift */; };
 		EFD39AB12F5DF90B066159C4 /* CloudTuiCommandLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47DA953E018A1329DF8C0255 /* CloudTuiCommandLine.swift */; };
+		F1A2B3C400000000000000A2 /* CloudTuiManualIO.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C400000000000000A1 /* CloudTuiManualIO.swift */; };
 		C10D00010000000000000001 /* CloudVMActionLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10D00020000000000000002 /* CloudVMActionLauncher.swift */; };
 		C75740010000000000000001 /* CloudVMMenuItemMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C75740010000000000000002 /* CloudVMMenuItemMetricsTests.swift */; };
 		B900000BA1B2C3D4E5F60719 /* cmux in Copy CLI */ = {isa = PBXBuildFile; fileRef = B9000004A1B2C3D4E5F60719 /* cmux */; };
@@ -2739,6 +2740,8 @@
 		E30760050000000000000002 /* TmuxWorkspacePaneOverlayRenderState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30760050000000000000001 /* TmuxWorkspacePaneOverlayRenderState.swift */; };
 		E30760000000000000000002 /* TmuxWorkspacePaneOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30760000000000000000001 /* TmuxWorkspacePaneOverlayView.swift */; };
 		D3284001A1B2C3D4E5F60718 /* TraditionalChineseIMENumpadRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3284002A1B2C3D4E5F60718 /* TraditionalChineseIMENumpadRegressionTests.swift */; };
+		F1A2B3C400000000000000A4 /* TuiManualIOPump.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C400000000000000A3 /* TuiManualIOPump.swift */; };
+		F1A2B3C400000000000000A6 /* TuiManualIOPumpTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C400000000000000A5 /* TuiManualIOPumpTests.swift */; };
 		468100000000000000000003 /* TypingHotPathRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 468100000000000000000004 /* TypingHotPathRegressionTests.swift */; };
 		A5001501 /* UITestRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001511 /* UITestRecorder.swift */; };
 		A500120D /* UpdateLogStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001223 /* UpdateLogStore.swift */; };
@@ -3700,6 +3703,7 @@
 		C986A0020000000000000001 /* CloudTreeSurfaceDragPasteboardWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudTreeSurfaceDragPasteboardWriter.swift; sourceTree = "<group>"; };
 		8C4E59490776669AA7257527 /* CloudTuiClientPaths.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudTuiClientPaths.swift; sourceTree = "<group>"; };
 		47DA953E018A1329DF8C0255 /* CloudTuiCommandLine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudTuiCommandLine.swift; sourceTree = "<group>"; };
+		F1A2B3C400000000000000A1 /* CloudTuiManualIO.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudTuiManualIO.swift; sourceTree = "<group>"; };
 		C10D00020000000000000002 /* CloudVMActionLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudVMActionLauncher.swift; sourceTree = "<group>"; };
 		C75740010000000000000002 /* CloudVMMenuItemMetricsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudVMMenuItemMetricsTests.swift; sourceTree = "<group>"; };
 		B9000004A1B2C3D4E5F60719 /* cmux */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = cmux; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -5704,6 +5708,8 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		E30760050000000000000001 /* TmuxWorkspacePaneOverlayRenderState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TmuxWorkspacePaneOverlayRenderState.swift; sourceTree = "<group>"; };
 		E30760000000000000000001 /* TmuxWorkspacePaneOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TmuxWorkspacePaneOverlayView.swift; sourceTree = "<group>"; };
 		D3284002A1B2C3D4E5F60718 /* TraditionalChineseIMENumpadRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraditionalChineseIMENumpadRegressionTests.swift; sourceTree = "<group>"; };
+		F1A2B3C400000000000000A3 /* TuiManualIOPump.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TuiManualIOPump.swift; sourceTree = "<group>"; };
+		F1A2B3C400000000000000A5 /* TuiManualIOPumpTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TuiManualIOPumpTests.swift; sourceTree = "<group>"; };
 		468100000000000000000004 /* TypingHotPathRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingHotPathRegressionTests.swift; sourceTree = "<group>"; };
 		A5001511 /* UITestRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestRecorder.swift; sourceTree = "<group>"; };
 		A5001223 /* UpdateLogStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Update/UpdateLogStore.swift; sourceTree = "<group>"; };
@@ -6393,6 +6399,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				874061DC8AD0C4E7297BF267 /* CloudMachineLinkManager.swift */,
 				49DC04B459E0132708ACD366 /* CloudMachineLink.swift */,
 				47DA953E018A1329DF8C0255 /* CloudTuiCommandLine.swift */,
+				F1A2B3C400000000000000A1 /* CloudTuiManualIO.swift */,
 				8C4E59490776669AA7257527 /* CloudTuiClientPaths.swift */,
 				48A1307BCCDB493F49179E0B /* SurfaceResourceDragPayload.swift */,
 				1CACA5A7C96FFDF0B931E7AA /* CloudTreeOutlineView.swift */,
@@ -7952,6 +7959,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 					793800000000000000000005 /* TerminalWindowPortal+DebugDiagnostics.swift */,
 					793800000000000000000007 /* GhosttyTerminalView+Sizing.swift */,
 					50FE16F529BD6FBA4FBDECFC /* RemoteTmuxController.swift */,
+					F1A2B3C400000000000000A3 /* TuiManualIOPump.swift */,
 					740600000000000000000001 /* RemoteTmuxController+Attach.swift */,
 					740600000000000000000010 /* RemoteTmuxAttachWindowTarget.swift */,
 					736200000000000000000001 /* RemoteTmuxController+Decisions.swift */,
@@ -8349,6 +8357,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				F2B7555E04A04849992547A2 /* TerminalClearScreenKeepScrollbackTests.swift */,
 				1718C0DE1718C0DE17180001 /* GhosttyCommandShiftForwardingTests.swift */,
 				D3284002A1B2C3D4E5F60718 /* TraditionalChineseIMENumpadRegressionTests.swift */,
+				F1A2B3C400000000000000A5 /* TuiManualIOPumpTests.swift */,
 				C0F15A000000000000000002 /* FishShellIntegrationTests.swift */,
 				947194719471947194719471 /* CmuxBundledBinPathIntegrationTests.swift */,
 				C0F16A000000000000000002 /* ShellStartupMatrixTests.swift */,
@@ -10002,6 +10011,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C986A0010000000000000001 /* CloudTreeSurfaceDragPasteboardWriter.swift in Sources */,
 				BB4657280E610A6935E1906B /* CloudTuiClientPaths.swift in Sources */,
 				EFD39AB12F5DF90B066159C4 /* CloudTuiCommandLine.swift in Sources */,
+				F1A2B3C400000000000000A2 /* CloudTuiManualIO.swift in Sources */,
 				C10D00010000000000000001 /* CloudVMActionLauncher.swift in Sources */,
 				A5001654 /* CmuxActionTrust.swift in Sources */,
 				C0DE43000000000000000001 /* CmuxAgentChatConfig.swift in Sources */,
@@ -11332,6 +11342,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				B35751000000000000000002 /* TmuxResumeParser.swift in Sources */,
 				E30760050000000000000002 /* TmuxWorkspacePaneOverlayRenderState.swift in Sources */,
 				E30760000000000000000002 /* TmuxWorkspacePaneOverlayView.swift in Sources */,
+				F1A2B3C400000000000000A4 /* TuiManualIOPump.swift in Sources */,
 				A5001501 /* UITestRecorder.swift in Sources */,
 				A500120D /* UpdateLogStore.swift in Sources */,
 				A5001208 /* UpdateTitlebarAccessory.swift in Sources */,
@@ -12430,6 +12441,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				A10507000000000000000001 /* TitleUpdateAmplificationRegressionTests.swift in Sources */,
 				E30760060000000000000002 /* TmuxWorkspacePaneOverlayModelTests.swift in Sources */,
 				D3284001A1B2C3D4E5F60718 /* TraditionalChineseIMENumpadRegressionTests.swift in Sources */,
+				F1A2B3C400000000000000A6 /* TuiManualIOPumpTests.swift in Sources */,
 				468100000000000000000003 /* TypingHotPathRegressionTests.swift in Sources */,
 				F2000000A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift in Sources */,
 				469200054692000146920001 /* VaultNativeDragSourceTests.swift in Sources */,

--- a/cmuxTests/TuiManualIOPumpTests.swift
+++ b/cmuxTests/TuiManualIOPumpTests.swift
@@ -1,0 +1,221 @@
+import CmuxTerminal
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Unit coverage for the manual-IO tui pump: relay exit classification, the
+/// respawn decision, backoff pacing, the relay stdin wire format, the relay
+/// argv, the overlay presentation mapping, and the cross-thread input
+/// channel. All pure or pipe-local; no daemon and no app launch involved.
+struct TuiManualIOPumpTests {
+    // MARK: - Relay exit classification
+
+    @Test
+    func relayExitReadsTheFinalStderrJSONLine() {
+        // Config warnings and other noise may precede the exit line.
+        let stderrText = """
+        warning: something unrelated
+        {"exit":{"reason":"terminal-ended"}}
+        """
+        #expect(TuiManualIOPumpPolicy.relayExit(status: 0, stderrText: stderrText) == .terminalEnded)
+        #expect(
+            TuiManualIOPumpPolicy.relayExit(
+                status: 0,
+                stderrText: "{\"exit\":{\"reason\":\"parent-closed\"}}\n"
+            ) == .parentClosed
+        )
+        #expect(
+            TuiManualIOPumpPolicy.relayExit(
+                status: 2,
+                stderrText: "{\"exit\":{\"reason\":\"daemon-lost\"}}\n"
+            ) == .daemonLost
+        )
+        // Exit 2 without the relay's reason line is a usage error (e.g. a
+        // binary without --pipe-io), not an endlessly-retryable outage.
+        #expect(TuiManualIOPumpPolicy.relayExit(status: 2, stderrText: nil) == .failure)
+        #expect(
+            TuiManualIOPumpPolicy.relayExit(status: 2, stderrText: "cmux: unknown argument")
+                == .failure
+        )
+    }
+
+    @Test
+    func relayExitTreatsUnknownStatusAsFailureAndBareZeroAsEnded() {
+        // Exit 0 with no reason line: the relay contract says 0 means "do
+        // not respawn", so a missing line must not turn into a retry loop.
+        #expect(TuiManualIOPumpPolicy.relayExit(status: 0, stderrText: nil) == .terminalEnded)
+        #expect(TuiManualIOPumpPolicy.relayExit(status: 0, stderrText: "garbage") == .terminalEnded)
+        #expect(TuiManualIOPumpPolicy.relayExit(status: 1, stderrText: "usage: ...") == .failure)
+        #expect(TuiManualIOPumpPolicy.relayExit(status: -1, stderrText: nil) == .failure)
+    }
+
+    @Test
+    func nextActionRespawnsOnlyForRecoverableExits() {
+        #expect(TuiManualIOPumpPolicy.nextAction(after: .terminalEnded) == .end)
+        #expect(TuiManualIOPumpPolicy.nextAction(after: .daemonLost) == .retry)
+        #expect(TuiManualIOPumpPolicy.nextAction(after: .failure) == .retry)
+        // The pump closed stdin itself (teardown/respawn): never a state
+        // transition of its own.
+        #expect(TuiManualIOPumpPolicy.nextAction(after: .parentClosed) == .ignore)
+    }
+
+    // MARK: - Backoff
+
+    @Test
+    func retryDelayGrowsAndCaps() {
+        #expect(TuiManualIOPumpPolicy.retryDelay(attempt: 1) == .milliseconds(500))
+        #expect(TuiManualIOPumpPolicy.retryDelay(attempt: 2) == .seconds(1))
+        #expect(TuiManualIOPumpPolicy.retryDelay(attempt: 6) == .seconds(16))
+        #expect(TuiManualIOPumpPolicy.retryDelay(attempt: 7) == .seconds(30))
+        #expect(TuiManualIOPumpPolicy.retryDelay(attempt: 100) == .seconds(30))
+        #expect(TuiManualIOPumpPolicy.retryDelay(attempt: 0) == .milliseconds(500))
+    }
+
+    // MARK: - Relay stdin wire format
+
+    @Test
+    func inputLineIsBase64JSONWithTrailingNewline() throws {
+        let line = TuiManualIOPumpPolicy.inputLine(bytes: Data("hi".utf8))
+        let text = String(decoding: line, as: UTF8.self)
+        #expect(text.hasSuffix("\n"))
+        let object = try JSONSerialization.jsonObject(
+            with: Data(text.dropLast().utf8)
+        ) as? [String: Any]
+        #expect(object?["input"] as? String == "aGk=")
+    }
+
+    @Test
+    func resizeLineCarriesClampedGrid() throws {
+        let line = TuiManualIOPumpPolicy.resizeLine(cols: 120, rows: 0)
+        let text = String(decoding: line, as: UTF8.self)
+        #expect(text.hasSuffix("\n"))
+        let object = try JSONSerialization.jsonObject(
+            with: Data(text.dropLast().utf8)
+        ) as? [String: Any]
+        let resize = object?["resize"] as? [String: Any]
+        #expect(resize?["cols"] as? Int == 120)
+        #expect(resize?["rows"] as? Int == 1)
+    }
+
+    // MARK: - Relay argv
+
+    @Test
+    func relayArgumentsAreDirectArgvWithoutShellQuoting() {
+        let sessionArguments = TuiManualIOPumpPolicy.relayArguments(
+            target: .session("cmux-tag"),
+            terminalID: "term_abc",
+            cols: 100,
+            rows: 30
+        )
+        #expect(sessionArguments == [
+            "attach", "--session", "cmux-tag", "--terminal", "term_abc",
+            "--pipe-io", "--cols", "100", "--rows", "30",
+        ])
+        // The cloud pane's form: the machine link's local mux socket is a
+        // global option and precedes the subcommand (CloudTuiCommandLine
+        // convention).
+        let socketArguments = TuiManualIOPumpPolicy.relayArguments(
+            target: .socket("/tmp/link.sock"),
+            terminalID: "term_abc",
+            cols: 80,
+            rows: 24
+        )
+        #expect(socketArguments == [
+            "--socket", "/tmp/link.sock", "attach", "--terminal", "term_abc",
+            "--pipe-io", "--cols", "80", "--rows", "24",
+        ])
+    }
+
+    @Test
+    func resyncResetIsFullResetPlusScrollbackErase() {
+        #expect(TuiManualIOPumpPolicy.resyncReset == Data("\u{1B}c\u{1B}[3J".utf8))
+    }
+
+    // MARK: - Overlay presentation
+
+    @Test
+    func overlayIsHiddenWhileConnectingOrLive() {
+        #expect(TuiManualIOPumpPolicy.overlayPresentation(state: .connecting) == nil)
+        #expect(TuiManualIOPumpPolicy.overlayPresentation(state: .live) == nil)
+    }
+
+    @Test
+    func reconnectingOverlayShowsProgressAndRetryButton() throws {
+        let presentation = try #require(
+            TuiManualIOPumpPolicy.overlayPresentation(state: .reconnecting(attempt: 3))
+        )
+        #expect(presentation.showsProgress)
+        #expect(presentation.showsReconnectButton)
+        #expect(presentation.detail.contains("3"))
+    }
+
+    @Test
+    func endedOverlayIsInformationalOnly() throws {
+        let presentation = try #require(
+            TuiManualIOPumpPolicy.overlayPresentation(state: .ended)
+        )
+        #expect(!presentation.showsProgress)
+        #expect(!presentation.showsReconnectButton)
+    }
+
+    @Test
+    func failedOverlayOffersManualRetryOnly() throws {
+        let presentation = try #require(
+            TuiManualIOPumpPolicy.overlayPresentation(state: .failed)
+        )
+        #expect(!presentation.showsProgress)
+        #expect(presentation.showsReconnectButton)
+    }
+
+    // MARK: - Input channel
+
+    @Test
+    func inputChannelWritesToTheLiveHandleAndDropsWhenPaused() throws {
+        let pipe = Pipe()
+        let channel = TuiManualIOInputChannel()
+        channel.setHandle(pipe.fileHandleForWriting)
+        channel.send(Data("first\n".utf8))
+        // Pause (relay died): input is dropped, never queued for a future
+        // relay, so stale keystrokes cannot replay into a resynced shell.
+        channel.setHandle(nil)
+        channel.send(Data("dropped\n".utf8))
+        channel.setHandle(pipe.fileHandleForWriting)
+        channel.send(Data("second\n".utf8))
+        channel.closeHandle()
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        #expect(String(decoding: data, as: UTF8.self) == "first\nsecond\n")
+    }
+
+    // MARK: - Registry
+
+    @MainActor
+    @Test
+    func registryReplacesAndRemovesPumps() {
+        let registry = TuiManualIOPumpRegistry()
+        let surfaceID = UUID()
+        let first = TuiManualIOPump(
+            binaryPath: "/nonexistent",
+            target: .socket("/tmp/link.sock"),
+            terminalID: "term_1",
+            environment: [:]
+        )
+        let second = TuiManualIOPump(
+            binaryPath: "/nonexistent",
+            target: .socket("/tmp/link.sock"),
+            terminalID: "term_2",
+            environment: [:]
+        )
+        registry.register(first, surfaceID: surfaceID)
+        #expect(registry.pump(forSurfaceID: surfaceID) === first)
+        registry.register(second, surfaceID: surfaceID)
+        #expect(registry.pump(forSurfaceID: surfaceID) === second)
+        registry.stopAndRemove(surfaceID: surfaceID)
+        #expect(registry.pump(forSurfaceID: surfaceID) == nil)
+    }
+}

--- a/cmuxTests/TuiManualIOPumpTests.swift
+++ b/cmuxTests/TuiManualIOPumpTests.swift
@@ -239,6 +239,25 @@ struct TuiManualIOPumpTests {
         #expect(String(decoding: data, as: UTF8.self) == "first\nsecond\n")
     }
 
+    @Test
+    func userInputReclaimsGeometryOnlyAfterTheThrottleInterval() throws {
+        let pipe = Pipe()
+        let channel = TuiManualIOInputChannel()
+        // Attach at t=100: the relay's own attach claim covers this moment.
+        channel.setHandle(pipe.fileHandleForWriting, now: 100)
+        channel.sendUserInput(Data("a\n".utf8), claimInterval: 5, now: 101)
+        channel.sendUserInput(Data("b\n".utf8), claimInterval: 5, now: 104)
+        // Past the interval: this keystroke re-claims first.
+        channel.sendUserInput(Data("c\n".utf8), claimInterval: 5, now: 106)
+        // Within the fresh window again: no second claim.
+        channel.sendUserInput(Data("d\n".utf8), claimInterval: 5, now: 107)
+        channel.closeHandle()
+
+        let text = String(decoding: pipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+        let claim = String(decoding: TuiManualIOPumpPolicy.claimGeometryLine, as: UTF8.self)
+        #expect(text == "a\nb\n\(claim)c\nd\n")
+    }
+
     // MARK: - Registry
 
     @MainActor

--- a/cmuxTests/TuiManualIOPumpTests.swift
+++ b/cmuxTests/TuiManualIOPumpTests.swift
@@ -172,6 +172,53 @@ struct TuiManualIOPumpTests {
         #expect(presentation.showsReconnectButton)
     }
 
+    // MARK: - Resize scheduling
+
+    @Test
+    func resizeSchedulerSendsFirstSampleImmediatelyAndParksTheRest() {
+        var scheduler = TuiManualIOResizeScheduler()
+        scheduler.seed(delivered: TuiManualIOGrid(cols: 80, rows: 24))
+        // The spawn grid is already delivered; resampling it sends nothing.
+        #expect(scheduler.sample(TuiManualIOGrid(cols: 80, rows: 24)) == nil)
+        // First new size goes out immediately (local daemons keep their
+        // send-every-sample behavior because acks are instant).
+        #expect(scheduler.sample(TuiManualIOGrid(cols: 100, rows: 30)) == TuiManualIOGrid(cols: 100, rows: 30))
+        // A drag burst while one resize is in flight: only the newest
+        // pending size survives.
+        #expect(scheduler.sample(TuiManualIOGrid(cols: 101, rows: 30)) == nil)
+        #expect(scheduler.sample(TuiManualIOGrid(cols: 102, rows: 30)) == nil)
+        #expect(scheduler.sample(TuiManualIOGrid(cols: 103, rows: 30)) == nil)
+        // Ack frees the channel and flushes ONLY the newest size.
+        #expect(scheduler.acknowledged() == TuiManualIOGrid(cols: 103, rows: 30))
+        // Nothing else queued: the intermediate sizes were dropped.
+        #expect(scheduler.acknowledged() == nil)
+    }
+
+    @Test
+    func resizeSchedulerDropsPendingThatMatchesInFlightOrDelivered() {
+        var scheduler = TuiManualIOResizeScheduler()
+        scheduler.seed(delivered: TuiManualIOGrid(cols: 80, rows: 24))
+        #expect(scheduler.sample(TuiManualIOGrid(cols: 90, rows: 24)) == TuiManualIOGrid(cols: 90, rows: 24))
+        // The surface bounced back to the in-flight size: no follow-up send.
+        #expect(scheduler.sample(TuiManualIOGrid(cols: 90, rows: 24)) == nil)
+        #expect(scheduler.acknowledged() == nil)
+        // Bounce to the already-delivered size is also deduplicated.
+        #expect(scheduler.sample(TuiManualIOGrid(cols: 90, rows: 24)) == nil)
+    }
+
+    @Test
+    func resizeSchedulerResetRequiresReseedBeforeDedup() {
+        var scheduler = TuiManualIOResizeScheduler()
+        scheduler.seed(delivered: TuiManualIOGrid(cols: 80, rows: 24))
+        #expect(scheduler.sample(TuiManualIOGrid(cols: 90, rows: 24)) != nil)
+        // Relay died mid-flight: respawn seeds from the spawn argv, and the
+        // spawn grid needs no resend.
+        scheduler.reset()
+        scheduler.seed(delivered: TuiManualIOGrid(cols: 95, rows: 25))
+        #expect(scheduler.sample(TuiManualIOGrid(cols: 95, rows: 25)) == nil)
+        #expect(scheduler.sample(TuiManualIOGrid(cols: 96, rows: 25)) == TuiManualIOGrid(cols: 96, rows: 25))
+    }
+
     // MARK: - Input channel
 
     @Test

--- a/cmuxTests/TuiManualIOPumpTests.swift
+++ b/cmuxTests/TuiManualIOPumpTests.swift
@@ -212,8 +212,10 @@ struct TuiManualIOPumpTests {
         scheduler.seed(delivered: TuiManualIOGrid(cols: 80, rows: 24))
         let requested = TuiManualIOGrid(cols: 90, rows: 24)
         #expect(scheduler.sample(requested) == requested)
-        #expect(scheduler.acknowledged(success: false) == requested)
-        #expect(scheduler.acknowledged(success: true) == nil)
+        #expect(scheduler.acknowledged(success: false) == nil)
+        // A later, changed geometry sample can proceed after authority
+        // changes without an acknowledgement-driven retry loop.
+        #expect(scheduler.sample(TuiManualIOGrid(cols: 91, rows: 24)) == TuiManualIOGrid(cols: 91, rows: 24))
     }
 
     @Test

--- a/cmuxTests/TuiManualIOPumpTests.swift
+++ b/cmuxTests/TuiManualIOPumpTests.swift
@@ -268,6 +268,22 @@ struct TuiManualIOPumpTests {
     }
 
     @Test
+    func stderrResizeAckRequiresTheStructuredDiagObject() {
+        #expect(
+            isTuiManualIOResizeDiagLine(
+                Data(#"{"diag":{"resize":{"cols":80,"rows":24,"accepted":true}}}"#.utf8)
+            )
+        )
+        // Human-readable diagnostics can contain both words without being an
+        // acknowledgement. They must not release the resize backpressure.
+        #expect(
+            !isTuiManualIOResizeDiagLine(
+                Data("resize diag failed: retrying".utf8)
+            )
+        )
+    }
+
+    @Test
     func stderrAccumulatorCanAppendAndReadTheTail() {
         let box = TuiManualIOStderrBox()
         box.append(Data("first\n".utf8))

--- a/cmuxTests/TuiManualIOPumpTests.swift
+++ b/cmuxTests/TuiManualIOPumpTests.swift
@@ -261,7 +261,7 @@ struct TuiManualIOPumpTests {
     @Test
     func stderrLineSplitterKeepsCompleteLinesAndTrailingPartialData() {
         let data = Data("first\nsecond\npartial".utf8)
-        let split = splitTuiManualIOStderrLines(data)
+        let split = TuiManualIOStderrStream.splitLines(data)
 
         #expect(split.completeLines == [Data("first".utf8), Data("second".utf8)])
         #expect(split.remainder == Data("partial".utf8))
@@ -270,14 +270,14 @@ struct TuiManualIOPumpTests {
     @Test
     func stderrResizeAckRequiresTheStructuredDiagObject() {
         #expect(
-            isTuiManualIOResizeDiagLine(
+            TuiManualIOStderrStream.isResizeDiagLine(
                 Data(#"{"diag":{"resize":{"cols":80,"rows":24,"accepted":true}}}"#.utf8)
             )
         )
         // Human-readable diagnostics can contain both words without being an
         // acknowledgement. They must not release the resize backpressure.
         #expect(
-            !isTuiManualIOResizeDiagLine(
+            !TuiManualIOStderrStream.isResizeDiagLine(
                 Data("resize diag failed: retrying".utf8)
             )
         )

--- a/cmuxTests/TuiManualIOPumpTests.swift
+++ b/cmuxTests/TuiManualIOPumpTests.swift
@@ -212,6 +212,8 @@ struct TuiManualIOPumpTests {
         scheduler.seed(delivered: TuiManualIOGrid(cols: 80, rows: 24))
         let requested = TuiManualIOGrid(cols: 90, rows: 24)
         #expect(scheduler.sample(requested) == requested)
+        #expect(scheduler.sample(TuiManualIOGrid(cols: 91, rows: 24)) == nil)
+        #expect(scheduler.acknowledged(success: false) == TuiManualIOGrid(cols: 91, rows: 24))
         #expect(scheduler.acknowledged(success: false) == nil)
         // A later, changed geometry sample can proceed after authority
         // changes without an acknowledgement-driven retry loop.

--- a/cmuxTests/TuiManualIOPumpTests.swift
+++ b/cmuxTests/TuiManualIOPumpTests.swift
@@ -48,7 +48,7 @@ struct TuiManualIOPumpTests {
     func relayExitTreatsUnknownStatusAsFailureAndBareZeroAsEnded() {
         // Exit 0 with no reason line: the relay contract says 0 means "do
         // not respawn", so a missing line must not turn into a retry loop.
-        #expect(TuiManualIOPumpPolicy.relayExit(status: 0, stderrText: nil) == .terminalEnded)
+        #expect(TuiManualIOPumpPolicy.relayExit(status: 0, stderrText: nil) == .failure)
         #expect(TuiManualIOPumpPolicy.relayExit(status: 0, stderrText: "garbage") == .terminalEnded)
         #expect(TuiManualIOPumpPolicy.relayExit(status: 1, stderrText: "usage: ...") == .failure)
         #expect(TuiManualIOPumpPolicy.relayExit(status: -1, stderrText: nil) == .failure)
@@ -288,6 +288,11 @@ struct TuiManualIOPumpTests {
         #expect(
             TuiManualIOStderrStream.resizeDiagSucceeded(
                 Data(#"{"diag":{"resize":{"cols":80,"rows":24,"error":"stale"}}}"#.utf8)
+            ) == false
+        )
+        #expect(
+            TuiManualIOStderrStream.resizeDiagSucceeded(
+                Data(#"{"diag":{"resize":{"cols":80,"rows":24,"accepted":false}}}"#.utf8)
             ) == false
         )
         // Human-readable diagnostics can contain both words without being an

--- a/cmuxTests/TuiManualIOPumpTests.swift
+++ b/cmuxTests/TuiManualIOPumpTests.swift
@@ -250,10 +250,11 @@ struct TuiManualIOPumpTests {
     }
 
     @Test
-    func userInputReclaimsGeometryOnlyAfterTheThrottleInterval() throws {
+    func userInputReclaimsGeometryOnAttachThenThrottles() throws {
         let pipe = Pipe()
         let channel = TuiManualIOInputChannel()
-        // Attach at t=100: the relay's own attach claim covers this moment.
+        // Attach at t=100: the first user input reclaims in case another
+        // pane took geometry authority immediately after this attachment.
         channel.setHandle(pipe.fileHandleForWriting, now: 100)
         channel.sendUserInput(Data("a\n".utf8), claimInterval: 5, now: 101)
         channel.sendUserInput(Data("b\n".utf8), claimInterval: 5, now: 104)
@@ -265,7 +266,7 @@ struct TuiManualIOPumpTests {
 
         let text = String(decoding: pipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
         let claim = String(decoding: TuiManualIOPumpPolicy.claimGeometryLine, as: UTF8.self)
-        #expect(text == "a\nb\n\(claim)c\nd\n")
+        #expect(text == "\(claim)a\nb\n\(claim)c\nd\n")
     }
 
     @Test

--- a/cmuxTests/TuiManualIOPumpTests.swift
+++ b/cmuxTests/TuiManualIOPumpTests.swift
@@ -207,6 +207,16 @@ struct TuiManualIOPumpTests {
     }
 
     @Test
+    func resizeSchedulerRetriesRejectedOrExpiredDelivery() {
+        var scheduler = TuiManualIOResizeScheduler()
+        scheduler.seed(delivered: TuiManualIOGrid(cols: 80, rows: 24))
+        let requested = TuiManualIOGrid(cols: 90, rows: 24)
+        #expect(scheduler.sample(requested) == requested)
+        #expect(scheduler.acknowledged(success: false) == requested)
+        #expect(scheduler.acknowledged(success: true) == nil)
+    }
+
+    @Test
     func resizeSchedulerResetRequiresReseedBeforeDedup() {
         var scheduler = TuiManualIOResizeScheduler()
         scheduler.seed(delivered: TuiManualIOGrid(cols: 80, rows: 24))
@@ -273,6 +283,11 @@ struct TuiManualIOPumpTests {
             TuiManualIOStderrStream.isResizeDiagLine(
                 Data(#"{"diag":{"resize":{"cols":80,"rows":24,"accepted":true}}}"#.utf8)
             )
+        )
+        #expect(
+            TuiManualIOStderrStream.resizeDiagSucceeded(
+                Data(#"{"diag":{"resize":{"cols":80,"rows":24,"error":"stale"}}}"#.utf8)
+            ) == false
         )
         // Human-readable diagnostics can contain both words without being an
         // acknowledgement. They must not release the resize backpressure.

--- a/cmuxTests/TuiManualIOPumpTests.swift
+++ b/cmuxTests/TuiManualIOPumpTests.swift
@@ -258,6 +258,23 @@ struct TuiManualIOPumpTests {
         #expect(text == "a\nb\n\(claim)c\nd\n")
     }
 
+    @Test
+    func stderrLineSplitterKeepsCompleteLinesAndTrailingPartialData() {
+        let data = Data("first\nsecond\npartial".utf8)
+        let split = splitTuiManualIOStderrLines(data)
+
+        #expect(split.completeLines == [Data("first".utf8), Data("second".utf8)])
+        #expect(split.remainder == Data("partial".utf8))
+    }
+
+    @Test
+    func stderrAccumulatorCanAppendAndReadTheTail() {
+        let box = TuiManualIOStderrBox()
+        box.append(Data("first\n".utf8))
+        box.append(Data("exit\n".utf8))
+
+        #expect(box.text() == "first\nexit\n")
+    }
     // MARK: - Registry
 
     @MainActor


### PR DESCRIPTION
## Summary
- Rebuild the manual-IO TUI relay stack on current main, preserving the 15-commit bounded pipe-IO history.
- Replay stderr line-splitting and structured resize acknowledgement tests and fixes from the stale follow-up stack.
- Keep test-first commits in order so each boundary remains reviewable.

## Testing
- rustfmt --edition 2024 --check on changed Rust files
- git diff --check origin/main...HEAD
- Hosted TUI checks will run on this exact head.

## Related pull requests
- Replaces https://github.com/manaflow-ai/cmux/pull/11221
- Includes https://github.com/manaflow-ai/cmux/pull/11382
- Includes https://github.com/manaflow-ai/cmux/pull/11394

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790845633&installation_model_id=21920&pr_number=11402&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11402&signature=517a89cec2368d6ea8d08abb23c1d1d1a5a6d7ccfeebab10f06ac0119e0e93f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilds cloud machine terminals on a manual-mirror Ghostty surface fed by an `attach --pipe-io` relay instead of running the full cmux-tui attach TUI as the pane's process.

- `attach --pipe-io` is a renderer-less relay: stdout carries daemon replay then live bytes, stdin takes JSON input/resize/claim lines, and exit 0/2 distinguish terminal-ended from daemon-lost.
- `TuiManualIOPump` owns one relay per pane with ack-clocked latest-wins resizes, geometry authority that follows user input, and a backoff-driven reconnect state machine that retries explained daemon-lost exits and parks after five unexplained failures.
- Relay frames, writes, daemon probes, lock waits, and resize acks are bounded; the latest commits harden probe and relay cleanup and preserve reconnect backoff across relay generations.
- Gated by a beta toggle that defaults on; bundled clients that predate `--pipe-io` fall back to the exec attach pane. Local terminals, ssh workspaces, and remote tmux mirrors are untouched.

<sup>Written for commit c741eaadc5ed81af326d1cc768e761ea2ebb5662. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Cloud Terminal Manual IO** beta setting, enabled by default.
  * Cloud terminals can now use a responsive embedded terminal relay with input, resizing, and automatic reconnection.
  * Added connection-status overlays for reconnecting, relay failures, and ended sessions.
  * Added `--pipe-io` support for terminal attachment, including configurable dimensions.
* **Bug Fixes**
  * Improved detection and handling of remote connection failures and timeouts.
* **Documentation**
  * Documented the new terminal relay mode and control protocol.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->