### PR TITLE
docs(tui): align protocol contracts with runtime

### DIFF
--- a/cmux-tui/spec/commands.md
+++ b/cmux-tui/spec/commands.md
@@ -147,7 +147,7 @@ Size-aware creation commands are `apply-layout`, `new-tab`, `new-browser-tab`, `
 | --- | --- |
 | both `cols` and `rows` supplied | Clamp each to `1..10000`, use the pair for the new surface or surfaces, and record the effective grid as the latest client size |
 | neither supplied | Use the latest active client size, or the configured server default when no client reports remain |
-| only one supplied | Preserve protocol-v6 behavior: the incomplete pair is ignored; clients must always send both |
+| only one supplied | Optional-size commands ignore the incomplete pair. `create-terminal` and `attach-surface` are strict exceptions: they return an error and require `cols` and `rows` together. |
 
 `resize-surface` requires both fields and clamps each to `1..10000`. Attached
 clients retain the report until release; an unattached one-shot report is
@@ -2847,7 +2847,13 @@ Errors:
 | status | implemented |
 | since | protocol 5 |
 
-Moves an existing tab, identified by `surface`, into `pane` at zero-based `index`. Moving a tab to its current pane and current index is an `ok:true` no-op. This command is documented from the consumer-side landed contract; it is not present in this branch's `server.rs`, so out-of-range index behavior and event emission could not be verified here.
+Moves an existing tab, identified by `surface`, into `pane` at zero-based `index`.
+The server clamps an out-of-range destination index to the end. For a same-pane
+move, the index is interpreted after removing the tab, so an index after the
+current position is reduced by one. Moving a tab to its current position is an
+`ok:true` no-op and leaves the active tab unchanged. A cross-pane move removes
+the tab from its source, collapses an empty source pane, and inserts it at the
+clamped destination index.
 
 Params:
 
@@ -2867,10 +2873,8 @@ Errors:
 
 | Error | Condition |
 | --- | --- |
-| `unknown surface <id>` | Surface id does not exist |
-| `unknown pane <id>` | Destination pane does not exist |
+| `unknown surface/pane` | The surface, destination pane, or the surface's current pane does not exist |
 | `bad request: ...` | Missing fields or wrong JSON type |
-| unverified error string | Non-same-position out-of-range index behavior could not be checked in this branch |
 
 CLI mapping:
 

--- a/cmux-tui/spec/commands.md
+++ b/cmux-tui/spec/commands.md
@@ -147,7 +147,7 @@ Size-aware creation commands are `apply-layout`, `new-tab`, `new-browser-tab`, `
 | --- | --- |
 | both `cols` and `rows` supplied | Clamp each to `1..10000`, use the pair for the new surface or surfaces, and record the effective grid as the latest client size |
 | neither supplied | Use the latest active client size, or the configured server default when no client reports remain |
-| only one supplied | Optional-size commands ignore the incomplete pair. `create-terminal` and `attach-surface` are strict exceptions: they return an error and require `cols` and `rows` together. |
+| only one supplied | Optional-size commands ignore the incomplete pair. `create-terminal`, `create-surface-with-receipt`, and `attach-surface` are strict exceptions: they return an error and require `cols` and `rows` together. |
 
 `resize-surface` requires both fields and clamps each to `1..10000`. Attached
 clients retain the report until release; an unattached one-shot report is

--- a/cmux-tui/spec/events.md
+++ b/cmux-tui/spec/events.md
@@ -139,10 +139,11 @@ object{event:"client-attached",client:uint64,transport:"unix"|"ws",name:string|n
 ```
 
 Meaning: The server emits this once when the control connection commits its
-first attach stream. A connection that never completes `attach-surface` does
-not emit it, and later streams or surfaces on the same connection do not emit
-it again. Use `list-clients` for the authoritative attached-surface set and
-reported sizes.
+first attach stream, whether it comes from the legacy `attach-surface` command
+or a resource `terminal.attach` or `browser.attach` operation. A connection
+with no committed attachment does not emit it, and later streams or surfaces
+on the same connection do not emit it again. Use `list-clients` for the
+authoritative attached-surface set and reported sizes.
 
 Example:
 

--- a/cmux-tui/spec/events.md
+++ b/cmux-tui/spec/events.md
@@ -138,7 +138,11 @@ Payload:
 object{event:"client-attached",client:uint64,transport:"unix"|"ws",name:string|null,kind:string|null}
 ```
 
-Meaning: A control connection attached its first surface. A connection that never calls `attach-surface` does not emit this event, and later surfaces on the same connection do not emit it again. Use `list-clients` for the attached surface set and sizes.
+Meaning: The server emits this once when the control connection commits its
+first attach stream. A connection that never completes `attach-surface` does
+not emit it, and later streams or surfaces on the same connection do not emit
+it again. Use `list-clients` for the authoritative attached-surface set and
+reported sizes.
 
 Example:
 
@@ -182,7 +186,9 @@ Payload:
 object{event:"client-detached",client:uint64}
 ```
 
-Meaning: A control connection disconnected naturally or was ended by `detach-client`. This is emitted even if the connection never attached a surface.
+Meaning: The server emits this once when it removes a control connection,
+whether the connection ended naturally or through `detach-client`. It is
+emitted even when the connection never attached a surface.
 
 Example:
 

--- a/cmux-tui/spec/inventory.json
+++ b/cmux-tui/spec/inventory.json
@@ -1131,7 +1131,7 @@
       "id": "terminal-rendering",
       "wire_status": "partial",
       "programmability": "partial",
-      "route": "render attach is implemented; terminal-host-v1 resize replay is incompatible until its decoder is repaired; typed SDK parity is incomplete"
+      "route": "render attach is implemented; terminal-host-v4 resize replay supports negotiated v1-v4 payloads; typed SDK parity is incomplete"
     },
     {
       "id": "terminal-selection-search-history",
@@ -1386,8 +1386,8 @@
       "spec": "events.md"
     },
     {
-      "id": "terminal-host-v1",
-      "status": "partial",
+      "id": "terminal-host-v4",
+      "status": "implemented",
       "spec": "terminal-host.md"
     },
     {

--- a/cmux-tui/spec/programmability.md
+++ b/cmux-tui/spec/programmability.md
@@ -58,7 +58,7 @@ The implemented v10 inventory is complete as a description of current wire behav
 | TUI presentation | State stays inside one frontend | `register-frontend`, `describe-frontend-actions`, `invoke-frontend-action`, and `frontend-action-result` |
 | PTY keyboard | `send-key` emits semantic keyboard input for PTYs | Preserve this route and add negotiated key capability discovery |
 | PTY mouse and focus | Native TUI encodes mouse/focus bytes locally | `send-mouse` and `send-focus`, with current terminal modes in render state |
-| Terminal-host resize | The host produces a length-prefixed replay, while the current consumer includes that length word in replay bytes | Repair the decoder, add producer-consumer and cross-language fixtures, then promote terminal-host v1 from partial |
+| Terminal-host resize | The terminal-host v4 decoder accepts the negotiated v1-v4 payload layouts, including the length-prefixed replay and version-specific Kitty state | Keep producer-consumer and cross-language fixtures current, and complete typed SDK coverage before promoting this family to complete |
 | PTY selection | Native selection is frontend-local and `copy selection` cannot reconstruct it remotely | `extract-text` by absolute range; optional frontend-local selection adapter |
 | Terminal search | Clients page scrollback and search themselves | Cursor-based `search-scrollback` with revision and match ranges |
 | Process outcome | `terminal.process.get`, `terminal.wait_exit`, and `TerminalSnapshot.exit` expose one durable child outcome per terminal | Separate execution IDs and lifecycle events for multiple sequential processes in one terminal |
@@ -101,7 +101,7 @@ The inventory assigns each command to one disjoint authority group. Generated SD
 | `local-admin` | `control` plus the `local-admin` group on a trusted Unix-classified transport, including the current stdio relay |
 | `provider-authority` | `control` plus the `provider-authority` group after separate authority authentication |
 | `machine-provider` | Separate provider v0/v1 client and server types |
-| `terminal-renderer` | Separate terminal-host v1 frame types with a minted capability |
+| `terminal-renderer` | Separate terminal-host v4 frame types with a minted capability; legacy v1-v3 negotiation remains supported |
 
 An SDK must refuse a profile when the selected transport cannot satisfy its trust boundary.
 


### PR DESCRIPTION
## Summary
- Correct move-tab clamping, no-op, and cross-pane behavior in the command contract.
- Document strict versus optional dimension-pair handling.
- Align terminal-host v4 inventory and resize decoder documentation.
- Clarify client lifecycle events for legacy and resource attachment streams.

## Testing
- `git diff --check`
- `python3 cmux-tui/scripts/check-spec-inventory.py`
- `python3 -m unittest cmux-tui/scripts/test_check_spec_inventory.py`
- Canonical local autoreview, gpt-5.6-sol high, clean.

## Scope
- Documentation and inventory only. No runtime code changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the TUI protocol docs and inventory so they match the runtime implementation. No runtime code changes.

**Scope**
- Corrects `move-tab` clamping, no-op, and cross-pane behavior in the command contract.
- Documents strict versus optional dimension-pair handling for size-aware commands.
- Marks `terminal-host` inventory as v4 implemented, with v1-v3 negotiation still supported.
- Clarifies `client-attached` and `client-detached` events for legacy and resource attachment streams.

<sup>Written for commit b02f174116d718e517ee84fd6e4a1df8bab25ed6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified terminal sizing behavior, including errors for incomplete dimensions.
  * Documented `move-tab` behavior for clamped indexes, no-op moves, and pane cleanup.
  * Clarified when client attach and detach events are emitted.
  * Updated terminal host compatibility and rendering specifications to reflect v4 support and legacy negotiation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->