### PR TITLE
perf(tui): avoid pane area frame clone

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -401,7 +401,7 @@ fn send_bounded_cancelable<T>(
 struct SessionEventWorker {
     cancellation: EventCancellation,
     start: Arc<AtomicBool>,
-    stop: Option<cmux_tui_core::MuxEventReceiver>,
+    stop: Arc<Mutex<Option<cmux_tui_core::MuxEventReceiver>>>,
     mux: Option<JoinHandle<()>>,
 }
 
@@ -415,7 +415,7 @@ impl SessionEventWorker {
         self.activate();
         // Closing the receiver wakes a worker blocked in recv(). This avoids
         // polling the session event mailbox on a fixed 100 ms timer.
-        if let Some(stop) = self.stop.take() {
+        if let Some(stop) = self.stop.lock().unwrap().take() {
             stop.close();
         }
         if let Some(mux) = self.mux.take() {
@@ -647,6 +647,7 @@ struct MuxTitleIngress {
 fn forward_mux_events(
     event_source: Session,
     mut session_events: cmux_tui_core::MuxEventReceiver,
+    stop_receiver: Arc<Mutex<Option<cmux_tui_core::MuxEventReceiver>>>,
     destination_mutation_committed: Arc<AtomicU64>,
     mux_recovery_generation: Arc<AtomicU64>,
     tx: SessionEventSender,
@@ -679,7 +680,16 @@ fn forward_mux_events(
         mux_recovery_generation.store(recovery_generation, Ordering::Release);
         // Subscribe before draining the closed mailbox so new events are
         // retained while every event accepted before overflow is delivered.
-        let overflowed_events = std::mem::replace(&mut session_events, event_source.events());
+        let next_session_events = event_source.events();
+        {
+            let mut stop = stop_receiver.lock().unwrap();
+            if tx.cancellation.stop.load(Ordering::Acquire) {
+                next_session_events.close();
+                return;
+            }
+            *stop = Some(next_session_events.clone());
+        }
+        let overflowed_events = std::mem::replace(&mut session_events, next_session_events);
         for event in overflowed_events.try_iter() {
             if tx.cancellation.stop.load(Ordering::Acquire) {
                 return;
@@ -818,12 +828,13 @@ fn start_ordered_session_inner(
     let mux_recovery_generation = Arc::new(AtomicU64::new(0));
     let event_source = session.inner.clone();
     let session_events = event_source.events();
-    let stop = session_events.clone();
+    let stop = Arc::new(Mutex::new(Some(session_events.clone())));
     let destination_mutation_committed = session.destination_mutation_committed.clone();
     let mux_recovery_sequence = mux_recovery_generation.clone();
     let worker_events = events;
     let worker_titles = mux_titles.clone();
     let worker_start = start.clone();
+    let worker_stop = stop.clone();
     let mux =
         std::thread::Builder::new().name(format!("mux-events-{generation}")).spawn(move || {
             while !worker_start.load(Ordering::Acquire)
@@ -837,6 +848,7 @@ fn start_ordered_session_inner(
             forward_mux_events(
                 event_source,
                 session_events,
+                worker_stop,
                 destination_mutation_committed,
                 mux_recovery_sequence,
                 worker_events,
@@ -845,7 +857,7 @@ fn start_ordered_session_inner(
         })?;
     Ok((
         session,
-        SessionEventWorker { cancellation, start, stop: Some(stop), mux: Some(mux) },
+        SessionEventWorker { cancellation, start, stop, mux: Some(mux) },
         mux_titles,
         mux_recovery_generation,
     ))
@@ -34119,6 +34131,7 @@ mod tests {
         let mux = Mux::new("mux-forwarder-overflow-test", SurfaceOptions::default());
         let event_source = Session::Local(mux.clone());
         let session_events = event_source.events();
+        let stop_receiver = Arc::new(Mutex::new(Some(session_events.clone())));
         for surface in 0..5_000 {
             mux.emit(MuxEvent::Bell(surface));
         }
@@ -34131,6 +34144,7 @@ mod tests {
             forward_mux_events(
                 event_source,
                 session_events,
+                stop_receiver,
                 destination_generation,
                 forwarder_recovery_generation,
                 SessionEventSender::unscoped(tx),
@@ -34183,6 +34197,53 @@ mod tests {
             AppEvent::Mux(MuxEvent::Empty)
         ));
         drop(rx);
+        forwarder.join().unwrap();
+    }
+
+    #[test]
+    fn mux_forwarder_stop_wakes_after_overflow_replaces_mailbox() {
+        let mux = Mux::new("mux-forwarder-overflow-stop-test", SurfaceOptions::default());
+        let event_source = Session::Local(mux.clone());
+        let session_events = event_source.events();
+        let stop_receiver = Arc::new(Mutex::new(Some(session_events.clone())));
+        let stop_for_test = stop_receiver.clone();
+        for surface in 0..5_000 {
+            mux.emit(MuxEvent::Bell(surface));
+        }
+        let (tx, rx) = crossbeam_channel::bounded(8_192);
+        let titles = Arc::new(MuxTitleIngress::default());
+        let destination_generation = Arc::new(AtomicU64::new(0));
+        let recovery_generation = Arc::new(AtomicU64::new(0));
+        let forwarder_recovery_generation = recovery_generation.clone();
+        let forwarder = std::thread::spawn(move || {
+            forward_mux_events(
+                event_source,
+                session_events,
+                stop_receiver,
+                destination_generation,
+                forwarder_recovery_generation,
+                SessionEventSender::unscoped(tx),
+                titles,
+            );
+        });
+
+        let deadline = Instant::now() + Duration::from_secs(1);
+        let mut recovered = false;
+        while Instant::now() < deadline {
+            match rx.recv_timeout(Duration::from_millis(50)) {
+                Ok(AppEvent::MuxRecoveryComplete { .. }) => {
+                    recovered = true;
+                    break;
+                }
+                Ok(_) => {}
+                Err(_) => break,
+            }
+        }
+        assert!(recovered, "overflow recovery must install a replacement mailbox");
+
+        // The forwarder is blocked on the replacement mailbox here. Closing
+        // the currently active receiver must wake it without timer polling.
+        stop_for_test.lock().unwrap().take().unwrap().close();
         forwarder.join().unwrap();
     }
 

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -401,6 +401,7 @@ fn send_bounded_cancelable<T>(
 struct SessionEventWorker {
     cancellation: EventCancellation,
     start: Arc<AtomicBool>,
+    stop: Option<cmux_tui_core::MuxEventReceiver>,
     mux: Option<JoinHandle<()>>,
 }
 
@@ -412,6 +413,11 @@ impl SessionEventWorker {
     fn stop_and_join(&mut self) {
         self.cancellation.cancel();
         self.activate();
+        // Closing the receiver wakes a worker blocked in recv(). This avoids
+        // polling the session event mailbox on a fixed 100 ms timer.
+        if let Some(stop) = self.stop.take() {
+            stop.close();
+        }
         if let Some(mux) = self.mux.take() {
             let _ = mux.join();
         }
@@ -648,15 +654,14 @@ fn forward_mux_events(
 ) {
     let mut next_recovery_generation = 0_u64;
     while !tx.cancellation.stop.load(Ordering::Acquire) {
-        let needs_recovery = match session_events.recv_timeout(Duration::from_millis(100)) {
+        let needs_recovery = match session_events.recv() {
             Ok(event) => {
                 if matches!(forward_mux_event(event, &tx, &mux_titles), ForwardMuxOutcome::Stop) {
                     return;
                 }
                 false
             }
-            Err(RecvTimeoutError::Timeout) => continue,
-            Err(RecvTimeoutError::Disconnected) => {
+            Err(_) => {
                 if session_events.overflowed() {
                     true
                 } else {
@@ -813,6 +818,7 @@ fn start_ordered_session_inner(
     let mux_recovery_generation = Arc::new(AtomicU64::new(0));
     let event_source = session.inner.clone();
     let session_events = event_source.events();
+    let stop = session_events.clone();
     let destination_mutation_committed = session.destination_mutation_committed.clone();
     let mux_recovery_sequence = mux_recovery_generation.clone();
     let worker_events = events;
@@ -839,7 +845,7 @@ fn start_ordered_session_inner(
         })?;
     Ok((
         session,
-        SessionEventWorker { cancellation, start, mux: Some(mux) },
+        SessionEventWorker { cancellation, start, stop: Some(stop), mux: Some(mux) },
         mux_titles,
         mux_recovery_generation,
     ))

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -34214,6 +34214,13 @@ mod tests {
         let titles = Arc::new(MuxTitleIngress::default());
         let destination_generation = Arc::new(AtomicU64::new(0));
         let recovery_generation = Arc::new(AtomicU64::new(0));
+        let cancellation = EventCancellation::new();
+        let forwarder_events = SessionEventSender {
+            tx,
+            generation: None,
+            surface_filter: None,
+            cancellation: cancellation.clone(),
+        };
         let forwarder_recovery_generation = recovery_generation.clone();
         let forwarder = std::thread::spawn(move || {
             forward_mux_events(
@@ -34222,7 +34229,7 @@ mod tests {
                 stop_receiver,
                 destination_generation,
                 forwarder_recovery_generation,
-                SessionEventSender::unscoped(tx),
+                forwarder_events,
                 titles,
             );
         });
@@ -34236,13 +34243,15 @@ mod tests {
                     break;
                 }
                 Ok(_) => {}
-                Err(_) => break,
+                Err(crossbeam_channel::RecvTimeoutError::Timeout) => {}
+                Err(crossbeam_channel::RecvTimeoutError::Disconnected) => break,
             }
         }
         assert!(recovered, "overflow recovery must install a replacement mailbox");
 
         // The forwarder is blocked on the replacement mailbox here. Closing
         // the currently active receiver must wake it without timer polling.
+        cancellation.cancel();
         stop_for_test.lock().unwrap().take().unwrap().close();
         forwarder.join().unwrap();
     }

--- a/cmux-tui/crates/cmux-tui/src/ui/pane.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/pane.rs
@@ -97,29 +97,32 @@ pub struct DrawCursors {
 pub fn draw_all(app: &mut App, frame: &mut Frame) -> DrawCursors {
     let active_pane = app.tree.active_screen().map(|screen| screen.active_pane);
     let panes_accept_focus = app.focus == FocusTarget::Pane;
-    let areas = app.pane_areas.clone();
-    let visible_surfaces: HashSet<_> = areas.iter().map(|area| area.surface).collect();
+    let visible_surfaces: HashSet<_> = app.pane_areas.iter().map(|area| area.surface).collect();
     app.rendered_terminal_bounds.retain(|surface, _| visible_surfaces.contains(surface));
     app.rendered_kitty_graphics.retain(|surface, _| visible_surfaces.contains(surface));
     app.rendered_terminal_pointer_semantics.retain(|surface, _| visible_surfaces.contains(surface));
     app.rendered_pane_content_generations.retain(|surface, _| visible_surfaces.contains(surface));
     let mut input_cursor = None;
     let mut terminal_cursor = None;
-    for area in &areas {
+    // PaneArea is Copy, so take one snapshot per iteration instead of cloning
+    // the entire vector on every frame. The copy also ends the borrow before
+    // the drawing helpers mutate the app's render hit maps.
+    for index in 0..app.pane_areas.len() {
+        let area = app.pane_areas[index];
         let focused = panes_accept_focus && Some(area.pane) == active_pane;
-        draw_box(app, frame, area, focused);
+        draw_box(app, frame, &area, focused);
         if area.bar.is_some() {
-            draw_tab_bar(app, frame, area, focused);
+            draw_tab_bar(app, frame, &area, focused);
         }
-        let cursors = draw_content(app, frame, area, focused);
+        let cursors = draw_content(app, frame, &area, focused);
         if cursors.input.is_some() {
             input_cursor = cursors.input;
         }
         if cursors.terminal.is_some() {
             terminal_cursor = cursors.terminal;
         }
-        draw_scrollbar(app, frame, area, focused);
-        push_resize_hits(app, area);
+        draw_scrollbar(app, frame, &area, focused);
+        push_resize_hits(app, &area);
     }
     DrawCursors { input: input_cursor, terminal: terminal_cursor }
 }


### PR DESCRIPTION
## Summary
- avoid cloning the full pane-area vector on every render frame by copying each `PaneArea` value as it is drawn
- close the session event receiver during worker shutdown so a blocked reader wakes immediately instead of polling every 100 ms

## Verification
- `rustfmt --edition 2024` on changed files
- `git diff --check`
- Rust build and tests are deferred to hosted cmux-tui workflows per repository policy

## Risk
The event worker now owns an explicit receiver close path. The existing blocked-reader shutdown test covers the join behavior. The pane-area list is assumed stable during one draw call, as it was when cloned at entry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Avoids cloning the full pane-area vector on every frame and makes session event worker shutdown wake a blocked reader immediately instead of polling every 100 ms.

- Copies each `PaneArea` value as it's drawn since `PaneArea` is `Copy`; the copy ends the borrow before drawing helpers mutate the render hit maps, and the pane-area list is assumed stable during one draw call.
- `stop_and_join` now closes the active session event receiver so a blocked `recv()` returns immediately; the replacement mailbox installed after overflow recovery is closed too.
- Tests cover direct shutdown and shutdown after overflow recovery replaces the mailbox.

<sup>Written for commit 2872848492cbe7b8f71742c7099bb6b62a2b9f17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

