### PR TITLE
What's New: compat notice becomes a fitted footnote; page fits every iPhone

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileWhatsNewCatalog.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileWhatsNewCatalog.swift
@@ -33,7 +33,7 @@ struct MobileWhatsNewPage: Identifiable {
     /// Remote announcements are visually marked to distinguish service news
     /// from binary release notes.
     let isAnnouncement: Bool
-    /// Build channels this catalog entry may render on
+/// Build channels this catalog entry may render on
     /// (``MobileBuildType/token`` values). `nil` (the norm) means the
     /// ``MobileWhatsNewChannelPolicy`` default: team lanes only, never the
     /// official App Store app. The remote list can override per entry
@@ -41,6 +41,9 @@ struct MobileWhatsNewPage: Identifiable {
     /// binary change. Only meaningful for binary catalog entries; resolved
     /// announcements are channel-filtered before page construction.
     var channels: [String]? = nil
+    /// One quiet line under the feature rows (compatibility notes and other
+    /// fine print that must not compete with the features). `nil` hides it.
+    var footnote: String? = nil
 
     /// SwiftUI list identity, namespaced by kind so an announcement id can
     /// never collide with a binary entry id in a mixed list (the server
@@ -58,13 +61,6 @@ struct MobileWhatsNewPage: Identifiable {
 /// (`/api/whats-new` `visibleEntryIds`) both reference it, and the
 /// unseen computation orders pages by catalog index.
 enum MobileWhatsNewCatalog {
-    /// Filled in precisely at the accompanying Mac release cut; the What's
-    /// New compat notice interpolates it. ONE value to edit at cut time.
-    static let requiredMacVersionLabel = L10n.string(
-        "mobile.connectionsUpdate.macUpdate.requiredVersion",
-        defaultValue: "the latest cmux NIGHTLY or cmux RELEASE"
-    )
-
     /// Newest first. The one-time sheet shows every visible entry newer than
     /// the acknowledgement marker.
     static var entries: [MobileWhatsNewPage] {
@@ -154,44 +150,39 @@ enum MobileWhatsNewCatalog {
                         defaultValue: "Choosing Tailscale Only shows exactly what's missing and offers the pairing-code scan right there. Nothing opens on its own."
                     )
                 ),
-                // Owner directive: this compat notice stays the LAST row so it
-                // reads as the prominent bottom section of the page.
-                .init(
-                    symbol: "exclamationmark.triangle.fill",
-                    title: L10n.string(
-                        "mobile.connectionsUpdate.macUpdate.title",
-                        defaultValue: "Action required: update your Mac"
-                    ),
-                    detail: macUpdateDetail()
-                ),
             ]),
-            isAnnouncement: false
+            isAnnouncement: false,
+            // The compat requirement is one compact notice under the feature
+            // rows (owner feedback: the old full-width warning row read as
+            // clutter, and BETA users need the revert path).
+            footnote: macUpdateFootnote()
         )
     }
 
-    /// The compat-notice body, gated per distribution channel.
+    /// The compat-notice footnote, gated per distribution channel.
     ///
     /// Team builds include the BETA TestFlight rollback recipe. The public
     /// App Store app has no older protocol version to revert to, so it gets
-    /// the update instruction only; App Review's Guideline 2.2 rejection also
+    /// the update requirement only; App Review's Guideline 2.2 rejection also
     /// bars beta-lane vocabulary from its UI.
-    static func macUpdateDetail(buildType: MobileBuildType = .current()) -> String {
-        guard buildType.usesInternalBuildVocabulary else {
-            return String(
-                format: L10n.string(
-                    "mobile.connectionsUpdate.macUpdate.detail.official",
-                    defaultValue: "This iPhone update speaks a new connection protocol and only pairs with an updated Mac. Update cmux on your Mac to %@ before connecting."
-                ),
-                requiredMacVersionLabel
-            )
-        }
-        return String(
+    static func macUpdateFootnote(buildType: MobileBuildType = .current()) -> String {
+        let requirement = String(
             format: L10n.string(
-                "mobile.connectionsUpdate.macUpdate.detail",
-                defaultValue: "This iPhone update speaks a new connection protocol and only pairs with an updated Mac. Update cmux on your Mac to %@ before connecting. Not ready to update your Mac? Stay on (or revert to) cmux BETA TestFlight version 1.0.4 (20260817224846), the last version that works with older Macs."
+                "mobile.macUpdate.requiredOnMacFormat",
+                defaultValue: "Requires %@ on your Mac."
             ),
             requiredMacVersionLabel
         )
+        guard buildType.usesInternalBuildVocabulary else {
+            return requirement
+        }
+        return [
+            requirement,
+            L10n.string(
+                "mobile.macUpdate.revertShort",
+                defaultValue: "Not ready? Stay on (or revert to) cmux BETA 1.0.4 (20260817224846)."
+            ),
+        ].joined(separator: " ")
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileWhatsNewCatalog.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileWhatsNewCatalog.swift
@@ -61,6 +61,13 @@ struct MobileWhatsNewPage: Identifiable {
 /// (`/api/whats-new` `visibleEntryIds`) both reference it, and the
 /// unseen computation orders pages by catalog index.
 enum MobileWhatsNewCatalog {
+    /// Filled in precisely at the accompanying Mac release cut; the What's
+    /// New compat notice interpolates it. ONE value to edit at cut time.
+    static let requiredMacVersionLabel = L10n.string(
+        "mobile.connectionsUpdate.macUpdate.requiredVersion",
+        defaultValue: "the latest cmux NIGHTLY or cmux RELEASE"
+    )
+
     /// Newest first. The one-time sheet shows every visible entry newer than
     /// the acknowledgement marker.
     static var entries: [MobileWhatsNewPage] {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileWhatsNewContent.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileWhatsNewContent.swift
@@ -2,48 +2,181 @@
 import CmuxMobileSupport
 import SwiftUI
 
+/// Density for the What's New page. `regular` is the HIG template look;
+/// `compact` tightens fonts and spacing so the whole page still fits without
+/// scrolling on the smallest iPhones (owner contract: standard type sizes
+/// never scroll; only accessibility sizes may fall back to a scroll view).
+enum MobileWhatsNewPageLayout {
+    case regular
+    case compact
+
+    var topPadding: CGFloat {
+        switch self {
+        case .regular: 40
+        case .compact: 12
+        }
+    }
+
+    var headerSpacing: CGFloat {
+        switch self {
+        case .regular: 36
+        case .compact: 18
+        }
+    }
+
+    var titleFont: Font {
+        switch self {
+        case .regular: .largeTitle.bold()
+        case .compact: .title2.bold()
+        }
+    }
+
+    var rowSpacing: CGFloat {
+        switch self {
+        case .regular: 28
+        case .compact: 13
+        }
+    }
+
+    var iconFont: Font {
+        switch self {
+        case .regular: .title2
+        case .compact: .title3
+        }
+    }
+
+    var iconWidth: CGFloat {
+        switch self {
+        case .regular: 40
+        case .compact: 30
+        }
+    }
+
+    var featureTitleFont: Font {
+        switch self {
+        case .regular: .headline
+        case .compact: .subheadline.weight(.semibold)
+        }
+    }
+
+    var detailFont: Font {
+        switch self {
+        case .regular: .subheadline
+        case .compact: .footnote
+        }
+    }
+
+    var noticeFont: Font {
+        switch self {
+        case .regular: .footnote
+        case .compact: .caption
+        }
+    }
+
+    var noticePadding: CGFloat {
+        switch self {
+        case .regular: 12
+        case .compact: 10
+        }
+    }
+
+    var bottomPadding: CGFloat {
+        switch self {
+        case .regular: 24
+        case .compact: 12
+        }
+    }
+}
+
+/// Picks the densest What's New layout that shows the whole page with no
+/// scrolling. The scroll tier is the last-resort fallback: accessibility
+/// type sizes and geometries where even compact cannot fit (short
+/// landscape); clipping content is never acceptable, so the fallback is not
+/// gated by type size. Portrait iPhones at standard type fit the compact
+/// tier (verified down to the 375x667 iPhone SE).
+struct MobileWhatsNewFittingPage: View {
+    let page: MobileWhatsNewPage
+
+    var body: some View {
+        ViewThatFits(in: .vertical) {
+            MobileWhatsNewContent(page: page, layout: .regular)
+            MobileWhatsNewContent(page: page, layout: .compact)
+            ScrollView {
+                MobileWhatsNewContent(page: page, layout: .compact)
+            }
+            .scrollBounceBehavior(.basedOnSize)
+        }
+    }
+}
+
 /// The shared What's New title + feature-row layout, HIG What's New template
 /// shape: plain background, centered large title, accent symbol rows.
 /// Announcements carry a tinted badge above the title so service news reads
 /// differently from binary release notes.
 struct MobileWhatsNewContent: View {
     let page: MobileWhatsNewPage
+    var layout: MobileWhatsNewPageLayout = .regular
 
     var body: some View {
-        VStack(spacing: 36) {
+        VStack(spacing: layout.headerSpacing) {
             VStack(spacing: 8) {
                 if page.isAnnouncement {
                     MobileWhatsNewAnnouncementBadge()
                 }
                 Text(page.title)
-                    .font(.largeTitle.bold())
+                    .font(layout.titleFont)
                     .multilineTextAlignment(.center)
             }
-            .padding(.top, 56)
+            .padding(.top, layout.topPadding)
             .padding(.horizontal, 32)
             if case .features(let features) = page.body {
-                VStack(alignment: .leading, spacing: 28) {
+                VStack(alignment: .leading, spacing: layout.rowSpacing) {
                     // Positional identity: remote feature rows carry no id
                     // and duplicate titles must not merge or drop rows.
                     ForEach(Array(features.enumerated()), id: \.offset) { _, feature in
                         HStack(alignment: .top, spacing: 16) {
                             Image(systemName: feature.symbol)
-                                .font(.title2)
+                                .font(layout.iconFont)
                                 .foregroundStyle(.tint)
-                                .frame(width: 40)
+                                .frame(width: layout.iconWidth)
                                 .accessibilityHidden(true)
                             VStack(alignment: .leading, spacing: 2) {
                                 Text(feature.title)
-                                    .font(.headline)
+                                    .font(layout.featureTitleFont)
                                 Text(feature.detail)
-                                    .font(.subheadline)
+                                    .font(layout.detailFont)
                                     .foregroundStyle(.secondary)
                             }
                         }
                     }
                 }
                 .padding(.horizontal, 28)
-                .padding(.bottom, 24)
+                .padding(.bottom, page.footnote == nil ? layout.bottomPadding : 0)
+            }
+            if let footnote = page.footnote {
+                // A compact tinted notice, not plain fine print: owner
+                // feedback was that secondary-style text gets missed, and
+                // BETA users need the revert path. Still ambient (no alert,
+                // HIG) and visually below the feature rows.
+                HStack(alignment: .top, spacing: 10) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.subheadline)
+                        .foregroundStyle(.orange)
+                        .accessibilityHidden(true)
+                    Text(footnote)
+                        .font(layout.noticeFont)
+                        .foregroundStyle(.primary)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .padding(layout.noticePadding)
+                .background(
+                    Color.orange.opacity(0.12),
+                    in: RoundedRectangle(cornerRadius: 12, style: .continuous)
+                )
+                .padding(.horizontal, 28)
+                .padding(.bottom, layout.bottomPadding)
+                .accessibilityIdentifier("MobileWhatsNewFootnote")
             }
         }
     }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileWhatsNewListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileWhatsNewListView.swift
@@ -64,11 +64,10 @@ private struct MobileWhatsNewArchiveRow: View {
     private var destination: some View {
         switch page.body {
         case .features:
-            ScrollView {
-                MobileWhatsNewContent(page: page)
-            }
-            .background(PlatformPalette.systemBackground)
-            .navigationBarTitleDisplayMode(.inline)
+            MobileWhatsNewFittingPage(page: page)
+                .frame(maxHeight: .infinity, alignment: .top)
+                .background(PlatformPalette.systemBackground)
+                .navigationBarTitleDisplayMode(.inline)
         case .web(let url):
             MobileWhatsNewWebView(url: url, allowedHosts: allowedHosts)
                 .navigationBarTitleDisplayMode(.inline)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileWhatsNewSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileWhatsNewSheet.swift
@@ -7,6 +7,13 @@ import SwiftUI
 /// onboarding). Shows every unseen page newest first; a user who skipped
 /// several updates gets one sheet covering all of them. Every page stays
 /// readable later in Settings > What's New.
+///
+/// The common single-page case renders as a compact, content-fitted card
+/// (owner contract: no scrolling at standard type sizes on any iPhone and no
+/// trailing white space); the Auto-Connect migration sheet pioneered the
+/// measurement mechanics. Accessibility type sizes, web pages, and the
+/// multi-page catch-up keep a full-height sheet, where scrolling is the
+/// correct behavior.
 struct MobileWhatsNewSheet: View {
     let pages: [MobileWhatsNewPage]
     let allowedWebHosts: Set<String>
@@ -16,46 +23,84 @@ struct MobileWhatsNewSheet: View {
     var webLoads: [String: MobileWhatsNewWebPageLoad] = [:]
     let dismiss: () -> Void
     @State private var pageIndex = 0
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @State private var contentHeight: CGFloat = 1
+
+    /// Fixed-viewport presentations: the TabView catch-up and web pages need
+    /// full height, and accessibility sizes legitimately scroll.
+    private var usesFullHeight: Bool {
+        if dynamicTypeSize.isAccessibilitySize { return true }
+        if pages.count > 1 { return true }
+        if case .web = pages.first?.body { return true }
+        return false
+    }
 
     var body: some View {
-        VStack(spacing: 0) {
+        Group {
             if pages.count > 1 {
-                TabView(selection: $pageIndex) {
-                    ForEach(Array(pages.enumerated()), id: \.element.listID) { index, page in
-                        pageView(page)
-                            .tag(index)
+                VStack(spacing: 0) {
+                    TabView(selection: $pageIndex) {
+                        ForEach(Array(pages.enumerated()), id: \.element.listID) { index, page in
+                            fullHeightPage(page)
+                                .tag(index)
+                        }
+                    }
+                    .tabViewStyle(.page(indexDisplayMode: .always))
+                    .indexViewStyle(.page(backgroundDisplayMode: .always))
+                    continueButton
+                }
+            } else if let page = pages.first {
+                switch page.body {
+                case .features where !dynamicTypeSize.isAccessibilitySize:
+                    // Content-fitted card: compact density measured at its
+                    // natural height; the scroll tier only takes over when
+                    // the screen caps the sheet below that height (short
+                    // landscape phones), never in portrait at standard type.
+                    ViewThatFits(in: .vertical) {
+                        measuredSinglePage(page)
+                        ScrollView {
+                            measuredSinglePage(page)
+                        }
+                        .scrollBounceBehavior(.basedOnSize)
+                    }
+                default:
+                    VStack(spacing: 0) {
+                        fullHeightPage(page)
+                        continueButton
                     }
                 }
-                .tabViewStyle(.page(indexDisplayMode: .always))
-                .indexViewStyle(.page(backgroundDisplayMode: .always))
-            } else if let page = pages.first {
-                pageView(page)
             }
-            Button(action: advance) {
-                Text(L10n.string(
-                    "mobile.whatsNew.cta",
-                    defaultValue: "Continue"
-                ))
-                .frame(maxWidth: .infinity)
-            }
-            .buttonStyle(.borderedProminent)
-            .controlSize(.large)
-            .tint(.blue)
-            .accessibilityIdentifier("MobileWhatsNewContinue")
-            .padding(.horizontal, 24)
-            .padding(.bottom, 16)
         }
         .background(PlatformPalette.systemBackground)
         .accessibilityIdentifier("MobileWhatsNewSheet")
+        .modifier(MobileWhatsNewPresentationSizing(
+            contentHeight: contentHeight,
+            usesFullHeight: usesFullHeight
+        ))
+    }
+
+    /// The measured single-page body: content at natural height (fixedSize)
+    /// plus the Continue button, reported to drive the fitted detent. The
+    /// report is proposal-independent, so the detent cannot oscillate.
+    private func measuredSinglePage(_ page: MobileWhatsNewPage) -> some View {
+        VStack(spacing: 0) {
+            MobileWhatsNewContent(page: page, layout: .compact)
+                .fixedSize(horizontal: false, vertical: true)
+            continueButton
+        }
+        .onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.size.height
+        } action: { newHeight in
+            guard newHeight.isFinite, newHeight > 0 else { return }
+            contentHeight = newHeight
+        }
     }
 
     @ViewBuilder
-    private func pageView(_ page: MobileWhatsNewPage) -> some View {
+    private func fullHeightPage(_ page: MobileWhatsNewPage) -> some View {
         switch page.body {
         case .features:
-            ScrollView {
-                MobileWhatsNewContent(page: page)
-            }
+            MobileWhatsNewFittingPage(page: page)
         case .web(let url):
             MobileWhatsNewWebView(
                 url: url,
@@ -63,6 +108,23 @@ struct MobileWhatsNewSheet: View {
                 preloadedLoad: webLoads[page.listID]
             )
         }
+    }
+
+    private var continueButton: some View {
+        Button(action: advance) {
+            Text(L10n.string(
+                "mobile.whatsNew.cta",
+                defaultValue: "Continue"
+            ))
+            .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.borderedProminent)
+        .controlSize(.large)
+        .tint(.blue)
+        .accessibilityIdentifier("MobileWhatsNewContinue")
+        .padding(.horizontal, 24)
+        .padding(.top, 4)
+        .padding(.bottom, 16)
     }
 
     /// Continue advances through unseen pages and dismisses from the last
@@ -75,6 +137,25 @@ struct MobileWhatsNewSheet: View {
             }
         } else {
             dismiss()
+        }
+    }
+}
+
+/// Fits the sheet to its measured content height for the common single-page
+/// standard-type case; full height only where a fixed viewport is required.
+private struct MobileWhatsNewPresentationSizing: ViewModifier {
+    let contentHeight: CGFloat
+    let usesFullHeight: Bool
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if usesFullHeight {
+            content
+                .presentationDetents([.large])
+        } else {
+            content
+                .presentationSizing(.fitted)
+                .presentationDetents([.height(contentHeight)])
         }
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -542,13 +542,15 @@ struct WorkspaceShellView: View {
             whatsNewSheetPages = []
             whatsNewWebLoads = [:]
         }) {
+            // Presentation sizing lives inside the sheet: fitted to content
+            // for the common single-page case, full height only for web
+            // pages, multi-page catch-up, and accessibility type.
             MobileWhatsNewSheet(
                 pages: whatsNewSheetPages,
                 allowedWebHosts: whatsNewCenter?.allowedWebHosts ?? [],
                 webLoads: whatsNewWebLoads,
                 dismiss: { showsWhatsNewSheet = false }
             )
-            .presentationDetents([.large])
             // Acknowledge on the sheet's ACTUAL appearance, not at gate time:
             // a competing presentation (e.g. a state-restored Settings sheet)
             // can swallow this presentation entirely, and gate-time

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileOfficialChannelCopyTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileOfficialChannelCopyTests.swift
@@ -10,17 +10,26 @@ import Testing
 /// vocabulary in production UI.
 @MainActor
 @Suite struct MobileOfficialChannelCopyTests {
-    @Test func whatsNewCompatNoticeIsNeutralOnOfficialBuilds() {
-        let official = MobileWhatsNewCatalog.macUpdateDetail(buildType: .prod)
-        #expect(!official.contains("TestFlight"))
+    @Test func whatsNewCompatFootnoteIsNeutralOnOfficialBuilds() {
+        let official = MobileWhatsNewCatalog.macUpdateFootnote(buildType: .prod)
         #expect(!official.contains("BETA"))
-        #expect(official.contains("Update cmux on your Mac"))
+        #expect(official.contains("Requires"))
     }
 
-    @Test func whatsNewCompatNoticeKeepsRollbackRecipeOnTeamBuilds() {
-        let team = MobileWhatsNewCatalog.macUpdateDetail(buildType: .beta)
-        #expect(team.contains("TestFlight"))
-        #expect(team.contains("Update cmux on your Mac"))
+    @Test func whatsNewCompatFootnoteKeepsRollbackRecipeOnTeamBuilds() {
+        let team = MobileWhatsNewCatalog.macUpdateFootnote(buildType: .beta)
+        #expect(team.contains("cmux BETA 1.0.4"))
+        #expect(team.contains("Requires"))
+    }
+
+    @Test func whatsNewCarriesTheCompatNoticeAsFootnoteNotFeatureRow() {
+        let page = MobileWhatsNewCatalog.connectionsUpdate
+        #expect(page.footnote != nil)
+        guard case .features(let features) = page.body else {
+            Issue.record("connections update page lost its feature rows")
+            return
+        }
+        #expect(!features.contains { $0.symbol == "exclamationmark.triangle.fill" })
     }
 
     @Test func presenceFooterIsNeutralOnOfficialBuilds() {

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -82972,6 +82972,40 @@
         }
       }
     },
+    "mobile.macUpdate.requiredOnMacFormat": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requires %@ on your Mac."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac に %@ が必要です。"
+          }
+        }
+      }
+    },
+    "mobile.macUpdate.revertShort": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not ready? Stay on (or revert to) cmux BETA 1.0.4 (20260817224846)."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "まだの場合は、cmux BETA 1.0.4 (20260817224846) をそのままご利用ください（または戻してください）。"
+          }
+        }
+      }
+    },
     "computers.listauth.unverified.title": {
       "extractionState": "manual",
       "localizations": {
@@ -83288,7 +83322,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-          "value": "「Macをスリープさせない」を操作するには、このMacに接続してください。"
+            "value": "「Macをスリープさせない」を操作するには、このMacに接続してください。"
           }
         },
         "de": {


### PR DESCRIPTION
Extracted from https://github.com/manaflow-ai/cmux/pull/11054 per owner direction: the What's New page changes only, nothing else. The Computers badge, detail callout, new-user copy, and docs land separately (consolidating with the in-flight list-auth verification warning).

## What

- The "Action required: update your Mac" feature row is gone; the compat requirement renders as a compact orange-tinted notice (warning glyph, primary text) under the feature rows, where it cannot be missed but no longer competes with the features.
- Channel-gated copy through the existing split: official App Store builds get the requirement sentence only (Guideline 2.2 keeps beta-lane vocabulary out), team lanes add "Not ready? Stay on (or revert to) cmux BETA 1.0.4 (20260817224846)."
- The page fits every iPhone with no scrolling at standard Dynamic Type: `ViewThatFits` picks regular or compact density; scrolling remains only for accessibility type sizes and short-landscape geometries (never clip). Verified no-scroll on iPhone SE 375x667, iPhone 16e, and iPhone 17 Pro Max on the source branch.
- The one-time sheet renders the common single-page case as a compact content-fitted card (measured-height detent, the Auto-Connect migration sheet's mechanics), so no trailing white space below Continue. Web pages, the multi-page catch-up, and accessibility sizes keep full height; main's web-page preload plumbing is preserved.

## Remote controls (unchanged)

`visibleEntryIds` still hides the page; `entryChannels` still overrides its audience per channel. The notice inherits the page's channel targeting, and its copy is additionally channel-gated as above.

## HIG

https://developer.apple.com/design/human-interface-guidelines/alerts — the compat requirement stays ambient in context instead of an alert; the fitted card and density tiers follow the migration sheet's precedent.

## Tests

`MobileOfficialChannelCopyTests` updated: footnote is neutral on official builds, keeps the rollback recipe on team builds, and the page carries the notice as a footnote, not a warning feature row.

## Evidence

Source-branch screenshots in hq `artifacts/macfl-floor-evidence/` (SE/16e/Pro Max fit, AX-XL wrapping, notice rounds); a fresh tagged sim screenshot for this branch follows in comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the What's New compat warning row with a compact orange-tinted footnote under the feature rows, and makes the page fit on every iPhone without scrolling at standard type sizes.

- The one-time sheet renders the common single-page case as a compact content-fitted card; web pages, multi-page catch-up, and accessibility sizes keep full height.
- Copy stays channel-gated: official App Store builds get the requirement sentence only; team lanes add the cmux BETA rollback recipe.
- `ViewThatFits` picks regular or compact density; scrolling remains only for accessibility type sizes and short-landscape geometries.
- Remote controls `visibleEntryIds` and `entryChannels` keep working unchanged.

<sup>Written for commit 953894c0e656e1bb00a34bb351ee705d6dedfb04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added adaptive What's New layouts that fit content to available screen space and scroll only when necessary.
  - Added compact compatibility footnotes for features requiring a Mac update.
  - Improved presentation sizing for single-page, multi-page, web, and accessibility-focused content.
- **Bug Fixes**
  - Prevented compatibility requirements from appearing as full feature rows.
  - Improved alignment and readability across device sizes.
- **Localization**
  - Added English and Japanese text for Mac update and rollback messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->