### PR TITLE
fix(tui): use stable self executable for Ghostty helper

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -4595,7 +4595,7 @@ pub(crate) fn run_ghostty_config_helper() -> i32 {
 
 #[cfg(not(test))]
 fn ghostty_defaults_from_helper() -> GhosttyHelperDefaults {
-    let Ok(exe) = std::env::current_exe() else {
+    let Ok(exe) = platform::self_exe_for_spawn() else {
         return GhosttyHelperDefaults::Unavailable;
     };
     let mut command = Command::new(exe);


### PR DESCRIPTION
## Summary
- route the Ghostty config helper through `platform::self_exe_for_spawn()`
- keep helper subprocess launches resilient to Linux in-place binary replacement

## Verification
- `rustfmt --edition 2024 --check cmux-tui/crates/cmux-tui/src/config.rs`
- `git diff --check`
- Rust source behavior follows the existing platform policy, which uses `/proc/self/exe` on Linux and `current_exe()` elsewhere.

No local Cargo or compiler run per cmux-tui Testbox policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the Ghostty config helper to resolve its executable through `platform::self_exe_for_spawn()` instead of `std::env::current_exe()`, so the helper subprocess stays launchable when the binary is replaced in-place on Linux. The platform policy uses `/proc/self/exe` on Linux and `current_exe()` elsewhere.

<sup>Written for commit ca562c7e6c04f1caae455230e0e6d8132d96fc87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

