### PR TITLE
perf(cmux-tui): keep sidebar filtering linear

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/sidebar_files/files.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_files/files.rs
@@ -67,12 +67,27 @@ fn compare_entries(left: &FileEntry, right: &FileEntry) -> Ordering {
 }
 
 pub fn filtered_indices(entries: &[FileEntry], query: &str) -> Vec<usize> {
-    let query = query.to_lowercase();
+    let normalized_query = query.to_lowercase();
     entries
         .iter()
         .enumerate()
-        .filter_map(|(index, entry)| entry.name.to_lowercase().contains(&query).then_some(index))
+        .filter_map(|(index, entry)| {
+            contains_case_insensitive(&entry.name, query, &normalized_query).then_some(index)
+        })
         .collect()
+}
+
+fn contains_case_insensitive(name: &str, query: &str, normalized_query: &str) -> bool {
+    if query.is_empty() {
+        return true;
+    }
+    if name.is_ascii() && query.is_ascii() {
+        return name
+            .as_bytes()
+            .windows(query.len())
+            .any(|window| window.eq_ignore_ascii_case(query.as_bytes()));
+    }
+    name.to_lowercase().contains(normalized_query)
 }
 
 #[cfg(test)]
@@ -136,8 +151,8 @@ mod tests {
     #[test]
     fn filters_case_insensitively() {
         let entries = vec![
-            FileEntry::new("ReadMe.md".into(), "ReadMe.md".into(), EntryKind::File),
-            FileEntry::new("src".into(), "src".into(), EntryKind::Directory),
+            FileEntry { name: "ReadMe.md".into(), path: "ReadMe.md".into(), kind: EntryKind::File },
+            FileEntry { name: "src".into(), path: "src".into(), kind: EntryKind::Directory },
         ];
         assert_eq!(filtered_indices(&entries, "README"), vec![0]);
         assert_eq!(filtered_indices(&entries, "r"), vec![0, 1]);
@@ -145,7 +160,11 @@ mod tests {
 
     #[test]
     fn filtering_matches_unicode_names_without_changing_visible_entries() {
-        let entries = vec![FileEntry::new("Résumé.txt".into(), "Résumé.txt".into(), EntryKind::File)];
+        let entries = vec![FileEntry {
+            name: "Résumé.txt".into(),
+            path: "Résumé.txt".into(),
+            kind: EntryKind::File,
+        }];
         assert_eq!(filtered_indices(&entries, "RÉSUMÉ"), vec![0]);
         assert_eq!(entries[0].name, "Résumé.txt");
     }

--- a/cmux-tui/crates/cmux-tui/src/sidebar_files/files.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_files/files.rs
@@ -68,24 +68,35 @@ fn compare_entries(left: &FileEntry, right: &FileEntry) -> Ordering {
 
 pub fn filtered_indices(entries: &[FileEntry], query: &str) -> Vec<usize> {
     let normalized_query = query.to_lowercase();
+    let mut normalized_ascii_name = String::new();
     entries
         .iter()
         .enumerate()
         .filter_map(|(index, entry)| {
-            contains_case_insensitive(&entry.name, query, &normalized_query).then_some(index)
+            contains_case_insensitive(
+                &entry.name,
+                query,
+                &normalized_query,
+                &mut normalized_ascii_name,
+            )
+            .then_some(index)
         })
         .collect()
 }
 
-fn contains_case_insensitive(name: &str, query: &str, normalized_query: &str) -> bool {
+fn contains_case_insensitive(
+    name: &str,
+    query: &str,
+    normalized_query: &str,
+    normalized_ascii_name: &mut String,
+) -> bool {
     if query.is_empty() {
         return true;
     }
     if name.is_ascii() && query.is_ascii() {
-        return name
-            .as_bytes()
-            .windows(query.len())
-            .any(|window| window.eq_ignore_ascii_case(query.as_bytes()));
+        normalized_ascii_name.clear();
+        normalized_ascii_name.extend(name.bytes().map(|byte| byte.to_ascii_lowercase() as char));
+        return normalized_ascii_name.contains(normalized_query);
     }
     name.to_lowercase().contains(normalized_query)
 }
@@ -167,5 +178,14 @@ mod tests {
         }];
         assert_eq!(filtered_indices(&entries, "RÉSUMÉ"), vec![0]);
         assert_eq!(entries[0].name, "Résumé.txt");
+    }
+
+    #[test]
+    fn filtering_handles_long_ascii_near_matches() {
+        let name = "A".repeat(4096);
+        let query = format!("{}B", "a".repeat(2048));
+        let entries = vec![FileEntry { name, path: "long-name".into(), kind: EntryKind::File }];
+
+        assert!(filtered_indices(&entries, &query).is_empty());
     }
 }

--- a/cmux-tui/crates/cmux-tui/src/sidebar_files/files.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_files/files.rs
@@ -136,10 +136,17 @@ mod tests {
     #[test]
     fn filters_case_insensitively() {
         let entries = vec![
-            FileEntry { name: "ReadMe.md".into(), path: "ReadMe.md".into(), kind: EntryKind::File },
-            FileEntry { name: "src".into(), path: "src".into(), kind: EntryKind::Directory },
+            FileEntry::new("ReadMe.md".into(), "ReadMe.md".into(), EntryKind::File),
+            FileEntry::new("src".into(), "src".into(), EntryKind::Directory),
         ];
         assert_eq!(filtered_indices(&entries, "README"), vec![0]);
         assert_eq!(filtered_indices(&entries, "r"), vec![0, 1]);
+    }
+
+    #[test]
+    fn filtering_matches_unicode_names_without_changing_visible_entries() {
+        let entries = vec![FileEntry::new("Résumé.txt".into(), "Résumé.txt".into(), EntryKind::File)];
+        assert_eq!(filtered_indices(&entries, "RÉSUMÉ"), vec![0]);
+        assert_eq!(entries[0].name, "Résumé.txt");
     }
 }

--- a/cmux-tui/crates/cmux-tui/src/sidebar_files/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_files/mod.rs
@@ -325,11 +325,7 @@ impl FileBrowser {
                 self.visible.iter().position(|index| self.entries[*index].path == path)
             })
             .unwrap_or_else(|| {
-                if self.visible.is_empty() {
-                    0
-                } else {
-                    self.selected.min(self.visible.len() - 1)
-                }
+                if self.visible.is_empty() { 0 } else { self.selected.min(self.visible.len() - 1) }
             });
     }
 }

--- a/cmux-tui/crates/cmux-tui/src/sidebar_files/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_files/mod.rs
@@ -325,7 +325,11 @@ impl FileBrowser {
                 self.visible.iter().position(|index| self.entries[*index].path == path)
             })
             .unwrap_or_else(|| {
-                if self.visible.is_empty() { 0 } else { self.selected.min(self.visible.len() - 1) }
+                if self.visible.is_empty() {
+                    0
+                } else {
+                    self.selected.min(self.visible.len() - 1)
+                }
             });
     }
 }


### PR DESCRIPTION
Replacement for https://github.com/manaflow-ai/cmux/pull/11392.

This branch starts from current main e69058fe02 and replays the sidebar filtering change plus the rustfmt and linear-search fixes. The prior branch diverged from live main and must not merge.

Changes:
- Reuse one ASCII-folding buffer and standard str::contains for linear case-insensitive matching.
- Keep Unicode lowercasing behavior.
- Add long ASCII near-match regression coverage.

Verification:
- rustfmt --edition 2024 --check changed files
- git diff --check
- canonical local autoreview: gpt-5.6-sol/high, clean at 0.96
- hosted focused cmux-tui workflow will run on exact head.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sidebar filtering in `cmux-tui` so ASCII file-name matching runs in linear time. Previously each entry lowercased its full name before matching; now a single reused ASCII-folding buffer and a cached lowercased query avoid repeated allocations. Unicode names keep the existing `to_lowercase()` behavior.

- Empty queries still show all entries.
- Adds regression tests for long ASCII near-matches and Unicode case-folding.

<sup>Written for commit ae93a113c403d61ac89fb4d4af5d447915070f07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar file filtering with case-insensitive search.
  * Added support for matching Unicode file names and queries.
  * Prevented incorrect matches for long, similar file names.
  * Empty searches continue to display all entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->