### PR TITLE
fix(tui): redact agent report internal errors on current main

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -8,8 +8,9 @@ mod resource_topology;
 pub(crate) use resource_content::ResourceEffectProjection;
 
 use public_projections::{RestoredPublicProjections, restore_public_projections};
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque, hash_map::DefaultHasher};
 use std::fmt;
+use std::hash::{Hash, Hasher};
 use std::ops::{Deref, DerefMut};
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
@@ -1991,6 +1992,8 @@ struct ClientFocusRecord {
 
 /// Bounded size of the per-client focus memory.
 const CLIENT_FOCUS_MEMORY_LIMIT: usize = 64;
+const COALESCED_DIAGNOSTIC_WINDOW: Duration = Duration::from_secs(60);
+const COALESCED_DIAGNOSTIC_LIMIT: usize = 128;
 
 pub struct Mux {
     /// Serializes durable workspace commits, their in-memory projection, and
@@ -2117,6 +2120,7 @@ pub struct Mux {
     /// in a per-mux slot until the first reporter arrives.
     diagnostic_reporter: OnceLock<DiagnosticReporter>,
     pending_diagnostic: Mutex<Option<String>>,
+    coalesced_diagnostic_keys: Mutex<HashMap<u64, Instant>>,
     #[cfg(test)]
     journal_segment_prepare_hook: Mutex<Option<Box<dyn FnOnce() + Send>>>,
     terminal_exit_waiters: TerminalExitWaiters,
@@ -2482,6 +2486,7 @@ impl Mux {
             reconnect_checkpoint_skip_reported: AtomicBool::new(false),
             diagnostic_reporter: OnceLock::new(),
             pending_diagnostic: Mutex::new(None),
+            coalesced_diagnostic_keys: Mutex::new(HashMap::new()),
             #[cfg(test)]
             journal_segment_prepare_hook: Mutex::new(None),
             terminal_exit_waiters: TerminalExitWaiters::default(),
@@ -5703,6 +5708,37 @@ impl Mux {
         } else {
             *pending = Some(message);
         }
+    }
+
+    /// Reports a diagnostic once per key during a bounded interval. Keys are
+    /// hashed and retained in a capped map so repeated failures cannot flood
+    /// the sink or grow memory without bound.
+    pub(crate) fn report_coalesced_internal_diagnostic(
+        &self,
+        key: &str,
+        message: impl Into<String>,
+    ) {
+        let now = Instant::now();
+        let mut keys = self.coalesced_diagnostic_keys.lock().unwrap();
+        keys.retain(|_, reported_at| {
+            now.duration_since(*reported_at) < COALESCED_DIAGNOSTIC_WINDOW
+        });
+        let mut hasher = DefaultHasher::new();
+        key.hash(&mut hasher);
+        let key = hasher.finish();
+        if keys.contains_key(&key) {
+            return;
+        }
+        if keys.len() >= COALESCED_DIAGNOSTIC_LIMIT {
+            if let Some(oldest) =
+                keys.iter().min_by_key(|(_, reported_at)| *reported_at).map(|(key, _)| *key)
+            {
+                keys.remove(&oldest);
+            }
+        }
+        keys.insert(key, now);
+        drop(keys);
+        self.report_internal_diagnostic(message);
     }
 
     /// Logs a skipped terminal-host reconnect checkpoint at most once

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -5685,7 +5685,7 @@ impl Mux {
     /// Sends a diagnostic to the frontend-owned sink without writing to a
     /// frontend terminal. One message is retained when startup races sink
     /// installation.
-    fn report_internal_diagnostic(&self, message: impl Into<String>) {
+    pub(crate) fn report_internal_diagnostic(&self, message: impl Into<String>) {
         let message = message.into();
         if let Some(reporter) = self.diagnostic_reporter.get().cloned() {
             reporter(&message);

--- a/cmux-tui/crates/cmux-tui-core/src/resource_router/auxiliary.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/resource_router/auxiliary.rs
@@ -3,12 +3,12 @@
 use std::sync::Arc;
 
 use base64::Engine;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use super::effects::{self, EffectPreparation, PreparedEffect};
 use super::{
-    expected_revision, mutation_result, operation_name, required_string, required_u64,
-    resource_operation_error, validation_error, ParsedResourceRequest,
+    ParsedResourceRequest, expected_revision, mutation_result, operation_name, required_string,
+    required_u64, resource_operation_error, validation_error,
 };
 use crate::resource::{
     FrontendProjectionPublicId, PairingRequestPublicId, ResourceError, ResourceOperation, Selector,
@@ -606,7 +606,7 @@ fn stored_intent_error(operation: &str, message: &str) -> ResourceError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::resource::{EnvelopeType, RequestEnvelope, RequestId, TerminalPublicId, PROTOCOL};
+    use crate::resource::{EnvelopeType, PROTOCOL, RequestEnvelope, RequestId, TerminalPublicId};
     use crate::{SidebarPluginOptions, SurfaceOptions};
     use std::time::{Duration, Instant};
 

--- a/cmux-tui/crates/cmux-tui-core/src/resource_router/auxiliary.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/resource_router/auxiliary.rs
@@ -112,8 +112,25 @@ fn report_agent(mux: &Arc<Mux>, request: ParsedResourceRequest) -> Result<Value,
             expected_revision(&request.fields)?,
             &mutation,
         )
-        .map_err(resource_operation_error)?;
+        .map_err(agent_report_operation_error)?;
     mutation_result(mux, commit.result, commit.revision, commit.replayed)
+}
+
+/// Keep registry and projection implementation details out of the public
+/// agent-report response while retaining typed client errors.
+fn agent_report_operation_error(error: anyhow::Error) -> ResourceError {
+    if let Some(resource) = error.downcast_ref::<ResourceError>() {
+        return resource.clone();
+    }
+
+    let detail = format!("{error:#}");
+    let public = resource_operation_error(error);
+    if public.code != "operation.failed" {
+        return public;
+    }
+
+    eprintln!("cmux-tui: agent.report internal failure: {detail}");
+    ResourceError::operation_failed("agent.report", "could not read agent state", json!({}))
 }
 
 fn parse_agent_state(value: &Value) -> Result<AgentState, ResourceError> {

--- a/cmux-tui/crates/cmux-tui-core/src/resource_router/auxiliary.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/resource_router/auxiliary.rs
@@ -3,12 +3,12 @@
 use std::sync::Arc;
 
 use base64::Engine;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use super::effects::{self, EffectPreparation, PreparedEffect};
 use super::{
-    expected_revision, mutation_result, operation_name, required_string, required_u64,
-    resource_operation_error, validation_error, ParsedResourceRequest,
+    ParsedResourceRequest, expected_revision, mutation_result, operation_name, required_string,
+    required_u64, resource_operation_error, validation_error,
 };
 use crate::resource::{
     FrontendProjectionPublicId, PairingRequestPublicId, ResourceError, ResourceOperation, Selector,
@@ -605,7 +605,7 @@ fn stored_intent_error(operation: &str, message: &str) -> ResourceError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::resource::{EnvelopeType, RequestEnvelope, RequestId, TerminalPublicId, PROTOCOL};
+    use crate::resource::{EnvelopeType, PROTOCOL, RequestEnvelope, RequestId, TerminalPublicId};
     use crate::{SidebarPluginOptions, SurfaceOptions};
     use std::time::{Duration, Instant};
 

--- a/cmux-tui/crates/cmux-tui-core/src/resource_router/auxiliary.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/resource_router/auxiliary.rs
@@ -1,6 +1,5 @@
 //! Session-scoped resources that are neither workspace topology nor content.
 
-use std::io::Write;
 use std::sync::Arc;
 
 use base64::Engine;
@@ -124,14 +123,11 @@ fn agent_report_operation_error(error: anyhow::Error) -> ResourceError {
         return resource.clone();
     }
 
-    let detail = format!("{error:#}");
     let public = resource_operation_error(error);
     if public.code != "operation.failed" {
         return public;
     }
 
-    let mut stderr = std::io::stderr().lock();
-    let _ = writeln!(stderr, "cmux-tui: agent.report internal failure: {detail}");
     ResourceError::operation_failed("agent.report", "could not read agent state", json!({}))
 }
 

--- a/cmux-tui/crates/cmux-tui-core/src/resource_router/auxiliary.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/resource_router/auxiliary.rs
@@ -760,6 +760,11 @@ mod tests {
     #[test]
     fn agent_report_lookup_failures_do_not_leak_internal_details() {
         let mux = Mux::new_for_test("aux-agent-error-privacy", SurfaceOptions::default());
+        let diagnostics = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+        let diagnostics_for_reporter = Arc::clone(&diagnostics);
+        assert!(mux.set_diagnostic_reporter(Arc::new(move |message| {
+            diagnostics_for_reporter.lock().unwrap().push(message.to_string());
+        })));
         crate::resource_router::handle_parsed_resource_request(
             &mux,
             request(
@@ -804,6 +809,15 @@ mod tests {
         for detail in [unknown_terminal_id.as_str(), "revision", "database", "projection"] {
             assert!(!encoded.contains(detail), "public error leaked {detail:?}: {encoded}");
         }
+        assert!(
+            diagnostics
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|message| message.contains("agent.report internal failure")
+                    && message.contains("unknown terminal")),
+            "the internal agent-report cause must reach the local diagnostic sink"
+        );
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/resource_router/auxiliary.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/resource_router/auxiliary.rs
@@ -606,7 +606,7 @@ fn stored_intent_error(operation: &str, message: &str) -> ResourceError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::resource::{EnvelopeType, RequestEnvelope, RequestId, PROTOCOL};
+    use crate::resource::{EnvelopeType, RequestEnvelope, RequestId, TerminalPublicId, PROTOCOL};
     use crate::{SidebarPluginOptions, SurfaceOptions};
     use std::time::{Duration, Instant};
 

--- a/cmux-tui/crates/cmux-tui-core/src/resource_router/auxiliary.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/resource_router/auxiliary.rs
@@ -128,7 +128,10 @@ fn agent_report_operation_error(mux: &Mux, error: anyhow::Error) -> ResourceErro
         return public;
     }
 
-    mux.report_internal_diagnostic(format!("agent.report internal failure: {detail}"));
+    mux.report_coalesced_internal_diagnostic(
+        &detail,
+        format!("agent.report internal failure: {detail}"),
+    );
     ResourceError::operation_failed("agent.report", "could not read agent state", json!({}))
 }
 

--- a/cmux-tui/crates/cmux-tui-core/src/resource_router/auxiliary.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/resource_router/auxiliary.rs
@@ -119,11 +119,10 @@ fn report_agent(mux: &Arc<Mux>, request: ParsedResourceRequest) -> Result<Value,
 /// Keep registry and projection implementation details out of the public
 /// agent-report response while retaining typed client errors.
 fn agent_report_operation_error(error: anyhow::Error) -> ResourceError {
-    if let Some(resource) = error.downcast_ref::<ResourceError>() {
-        return resource.clone();
-    }
-
-    let public = resource_operation_error(error);
+    let public = error
+        .downcast_ref::<ResourceError>()
+        .cloned()
+        .unwrap_or_else(|| resource_operation_error(error));
     if public.code != "operation.failed" {
         return public;
     }
@@ -803,6 +802,30 @@ mod tests {
         );
         let encoded = response.to_string();
         for detail in [unknown_terminal_id.as_str(), "revision", "database", "projection"] {
+            assert!(!encoded.contains(detail), "public error leaked {detail:?}: {encoded}");
+        }
+    }
+
+    #[test]
+    fn typed_agent_report_operation_failures_are_redacted() {
+        let error = anyhow::Error::new(ResourceError::operation_failed(
+            "registry.lookup",
+            "projection revision 42 is inconsistent with database row",
+            json!({"revision":"42","database":"internal"}),
+        ));
+        let public = agent_report_operation_error(error);
+
+        assert_eq!(public.code, "operation.failed");
+        assert_eq!(public.message, "could not read agent state");
+        assert_eq!(
+            public.details,
+            json!({
+                "operation":"agent.report",
+                "reason":"could not read agent state",
+            })
+        );
+        let encoded = serde_json::to_string(&public).unwrap();
+        for detail in ["projection revision", "revision", "database", "internal"] {
             assert!(!encoded.contains(detail), "public error leaked {detail:?}: {encoded}");
         }
     }

--- a/cmux-tui/crates/cmux-tui-core/src/resource_router/auxiliary.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/resource_router/auxiliary.rs
@@ -773,8 +773,8 @@ mod tests {
             ),
         )
         .unwrap();
-        let unknown_terminal_id = TerminalPublicId::parse("term_ffffffffffffffffffffffffffffffff")
-            .unwrap();
+        let unknown_terminal_id =
+            TerminalPublicId::parse("term_ffffffffffffffffffffffffffffffff").unwrap();
         let report_request = |key| {
             request(
                 ResourceOperation::AgentReport,

--- a/cmux-tui/crates/cmux-tui-core/src/resource_router/auxiliary.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/resource_router/auxiliary.rs
@@ -848,6 +848,21 @@ mod tests {
     }
 
     #[test]
+    fn repeated_agent_report_failures_coalesce_diagnostics() {
+        let mux = Mux::new_for_test("aux-agent-error-coalesce", SurfaceOptions::default());
+        let diagnostics = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+        let diagnostics_for_reporter = Arc::clone(&diagnostics);
+        assert!(mux.set_diagnostic_reporter(Arc::new(move |message| {
+            diagnostics_for_reporter.lock().unwrap().push(message.to_string());
+        })));
+        for _ in 0..3 {
+            let error = anyhow::anyhow!("unknown terminal term_deadbeef");
+            let _ = agent_report_operation_error(mux.as_ref(), error);
+        }
+        assert_eq!(diagnostics.lock().unwrap().len(), 1);
+    }
+
+    #[test]
     fn filtered_agent_list_does_not_decode_unrelated_projections() {
         let mux = Mux::new_for_test("filtered-agent-list", SurfaceOptions::default());
         let requested = mux.new_workspace(Some("requested".into()), None).unwrap();

--- a/cmux-tui/crates/cmux-tui-core/src/resource_router/auxiliary.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/resource_router/auxiliary.rs
@@ -3,12 +3,12 @@
 use std::sync::Arc;
 
 use base64::Engine;
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 
 use super::effects::{self, EffectPreparation, PreparedEffect};
 use super::{
-    ParsedResourceRequest, expected_revision, mutation_result, operation_name, required_string,
-    required_u64, resource_operation_error, validation_error,
+    expected_revision, mutation_result, operation_name, required_string, required_u64,
+    resource_operation_error, validation_error, ParsedResourceRequest,
 };
 use crate::resource::{
     FrontendProjectionPublicId, PairingRequestPublicId, ResourceError, ResourceOperation, Selector,
@@ -606,7 +606,7 @@ fn stored_intent_error(operation: &str, message: &str) -> ResourceError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::resource::{EnvelopeType, PROTOCOL, RequestEnvelope, RequestId};
+    use crate::resource::{EnvelopeType, RequestEnvelope, RequestId, PROTOCOL};
     use crate::{SidebarPluginOptions, SurfaceOptions};
     use std::time::{Duration, Instant};
 

--- a/cmux-tui/crates/cmux-tui-core/src/resource_router/auxiliary.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/resource_router/auxiliary.rs
@@ -1,5 +1,6 @@
 //! Session-scoped resources that are neither workspace topology nor content.
 
+use std::io::Write;
 use std::sync::Arc;
 
 use base64::Engine;
@@ -129,7 +130,8 @@ fn agent_report_operation_error(error: anyhow::Error) -> ResourceError {
         return public;
     }
 
-    eprintln!("cmux-tui: agent.report internal failure: {detail}");
+    let mut stderr = std::io::stderr().lock();
+    let _ = writeln!(stderr, "cmux-tui: agent.report internal failure: {detail}");
     ResourceError::operation_failed("agent.report", "could not read agent state", json!({}))
 }
 

--- a/cmux-tui/crates/cmux-tui-core/src/resource_router/auxiliary.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/resource_router/auxiliary.rs
@@ -112,13 +112,14 @@ fn report_agent(mux: &Arc<Mux>, request: ParsedResourceRequest) -> Result<Value,
             expected_revision(&request.fields)?,
             &mutation,
         )
-        .map_err(agent_report_operation_error)?;
+        .map_err(|error| agent_report_operation_error(mux.as_ref(), error))?;
     mutation_result(mux, commit.result, commit.revision, commit.replayed)
 }
 
 /// Keep registry and projection implementation details out of the public
 /// agent-report response while retaining typed client errors.
-fn agent_report_operation_error(error: anyhow::Error) -> ResourceError {
+fn agent_report_operation_error(mux: &Mux, error: anyhow::Error) -> ResourceError {
+    let detail = format!("{error:#}");
     let public = error
         .downcast_ref::<ResourceError>()
         .cloned()
@@ -127,6 +128,7 @@ fn agent_report_operation_error(error: anyhow::Error) -> ResourceError {
         return public;
     }
 
+    mux.report_internal_diagnostic(format!("agent.report internal failure: {detail}"));
     ResourceError::operation_failed("agent.report", "could not read agent state", json!({}))
 }
 
@@ -822,12 +824,13 @@ mod tests {
 
     #[test]
     fn typed_agent_report_operation_failures_are_redacted() {
+        let mux = Mux::new_for_test("aux-agent-error-privacy-typed", SurfaceOptions::default());
         let error = anyhow::Error::new(ResourceError::operation_failed(
             "registry.lookup",
             "projection revision 42 is inconsistent with database row",
             json!({"revision":"42","database":"internal"}),
         ));
-        let public = agent_report_operation_error(error);
+        let public = agent_report_operation_error(mux.as_ref(), error);
 
         assert_eq!(public.code, "operation.failed");
         assert_eq!(public.message, "could not read agent state");

--- a/cmux-tui/crates/cmux-tui-core/src/resource_router/auxiliary.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/resource_router/auxiliary.rs
@@ -3,12 +3,12 @@
 use std::sync::Arc;
 
 use base64::Engine;
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 
 use super::effects::{self, EffectPreparation, PreparedEffect};
 use super::{
-    ParsedResourceRequest, expected_revision, mutation_result, operation_name, required_string,
-    required_u64, resource_operation_error, validation_error,
+    expected_revision, mutation_result, operation_name, required_string, required_u64,
+    resource_operation_error, validation_error, ParsedResourceRequest,
 };
 use crate::resource::{
     FrontendProjectionPublicId, PairingRequestPublicId, ResourceError, ResourceOperation, Selector,
@@ -606,7 +606,7 @@ fn stored_intent_error(operation: &str, message: &str) -> ResourceError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::resource::{EnvelopeType, PROTOCOL, RequestEnvelope, RequestId, TerminalPublicId};
+    use crate::resource::{EnvelopeType, RequestEnvelope, RequestId, TerminalPublicId, PROTOCOL};
     use crate::{SidebarPluginOptions, SurfaceOptions};
     use std::time::{Duration, Instant};
 

--- a/cmux-tui/crates/cmux-tui-core/src/resource_router/auxiliary.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/resource_router/auxiliary.rs
@@ -744,6 +744,55 @@ mod tests {
     }
 
     #[test]
+    fn agent_report_lookup_failures_do_not_leak_internal_details() {
+        let mux = Mux::new_for_test("aux-agent-error-privacy", SurfaceOptions::default());
+        crate::resource_router::handle_parsed_resource_request(
+            &mux,
+            request(
+                ResourceOperation::WorkspaceCreate,
+                Some("aux-agent-error-privacy-create"),
+                session_selectors(),
+                json!({"initial_content":"terminal"}),
+            ),
+        )
+        .unwrap();
+        let unknown_terminal_id = TerminalPublicId::parse("term_ffffffffffffffffffffffffffffffff")
+            .unwrap();
+        let report_request = |key| {
+            request(
+                ResourceOperation::AgentReport,
+                Some(key),
+                session_selectors(),
+                json!({
+                    "terminal_id":unknown_terminal_id,
+                    "state":"working",
+                    "source":"socket",
+                    "source_session":"sdk-test",
+                }),
+            )
+        };
+        let response = super::super::handle_parsed_resource_request(
+            &mux,
+            report_request("aux-agent-error-privacy-unknown-terminal"),
+        )
+        .unwrap();
+        assert_eq!(response["ok"], false);
+        assert_eq!(response["error"]["code"], "operation.failed");
+        assert_eq!(response["error"]["message"], "could not read agent state");
+        assert_eq!(
+            response["error"]["details"],
+            json!({
+                "operation":"agent.report",
+                "reason":"could not read agent state",
+            })
+        );
+        let encoded = response.to_string();
+        for detail in [unknown_terminal_id.as_str(), "revision", "database", "projection"] {
+            assert!(!encoded.contains(detail), "public error leaked {detail:?}: {encoded}");
+        }
+    }
+
+    #[test]
     fn filtered_agent_list_does_not_decode_unrelated_projections() {
         let mux = Mux::new_for_test("filtered-agent-list", SurfaceOptions::default());
         let requested = mux.new_workspace(Some("requested".into()), None).unwrap();


### PR DESCRIPTION
Rebases the focused agent report privacy fix onto current main (e69058fe020d1ebf9464246f6532524dae1f6c5a).

Changes:
- preserve typed ResourceError responses
- redact internal projection and lookup failures to a stable operation.failed response
- log raw detail only on the trusted local process
- cover an unknown-terminal failure path and assert no internal detail leaks

This is a clean current-main replacement for https://github.com/manaflow-ai/cmux/pull/11391; the older PR remains open for comparison.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts agent report internal projection, lookup, and typed `operation.failed` errors so they return the stable "could not read agent state" response instead of leaking implementation details.

- Preserves typed `ResourceError` responses except `operation.failed`, which is redacted to a stable message with `operation: agent.report`.
- Logs raw error detail only on the trusted local process, asynchronously and coalescing repeats per key within a 60-second window capped at 128 entries.
- Adds regression tests covering the unknown-terminal lookup failure, typed `operation.failed` redaction, and repeated-failure diagnostic coalescing.

<sup>Written for commit c8d3a0b833a339a1c7c658979e1bb01c2f5c96c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when agent state cannot be read.
  * Internal failure details are no longer exposed in resulting error messages.
  * Added coverage for reporting an agent associated with an unknown terminal.
  * Preserved meaningful operation errors while recording diagnostic details internally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->