### PR TITLE
fix(tui): retain semantic selection anchors on current main

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -23867,6 +23867,9 @@ impl App {
         modifiers: KeyModifiers,
         terminal_admission: Option<TerminalPointerAdmission>,
     ) -> anyhow::Result<RenderAction> {
+        // Scrolling is a distinct gesture and ends click-repeat state. Plain
+        // pointer motion is routed to handle_hover_with_admission and keeps
+        // the sequence alive until the next press.
         self.reset_selection_click_sequence();
         if self.menu.is_some() || self.prompt.is_some() {
             return Ok(RenderAction::None);

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -17043,6 +17043,9 @@ impl App {
         let range = handle
             .with_terminal(|terminal| match mode {
                 SelectionMode::Word => {
+                    // Query both directions: Ghostty's nearest-word lookup is
+                    // directional, and the paired bounds preserve reverse
+                    // drags through whitespace or punctuation.
                     let first = terminal
                         .select_word_between_screen(anchor_point, current_point)
                         .ok()

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -5350,11 +5350,20 @@ struct SelectionClickSequence {
     anchor: (u16, u64),
     dragged: bool,
     tracked_anchor: Option<TrackedScreenPoint>,
-    semantic_range: Option<SelectionRange>,
+    semantic_range: Option<GenerationTaggedSelectionRange>,
     /// A failed semantic press keeps `tracked_anchor` alive for a same-press
     /// cell drag, but it must not keep the repeat count alive for the next
     /// press.
     repeatable: bool,
+}
+
+/// A semantic range is valid only for the terminal content generation that
+/// produced it. Screen coordinates can move when output, reflow, or scrollback
+/// changes the terminal, so never union a range from an older generation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct GenerationTaggedSelectionRange {
+    content_generation: u64,
+    range: SelectionRange,
 }
 
 /// The most recent semantic drag result. Pointer reports often repeat the
@@ -17087,7 +17096,9 @@ impl App {
                 self.selection_click_sequence
                     .as_ref()
                     .and_then(|sequence| sequence.semantic_range)
+                    .filter(|initial| content_generation == Some(initial.content_generation))
                     .map(|initial| {
+                        let initial = initial.range;
                         let start = if (initial.start.row, initial.start.column)
                             <= (range.start.row, range.start.column)
                         {
@@ -22348,6 +22359,9 @@ impl App {
                         (x.saturating_sub(content.x), y.saturating_sub(content.y)),
                         modifiers,
                     );
+                    let content_generation = (mode != SelectionMode::Cell)
+                        .then(|| self.terminal_content_generation(area.surface))
+                        .flatten();
                     if mode == SelectionMode::Cell && modifiers == KeyModifiers::NONE {
                         // Ghostty's cell behavior returns no range on press.
                         // Keep only the tracked anchor until a drag moves it.
@@ -22360,16 +22374,22 @@ impl App {
                             if let Some(sequence) = self.selection_click_sequence.as_mut()
                                 && mode != SelectionMode::Cell
                             {
-                                sequence.semantic_range = Some(SelectionRange {
-                                    start: SelectionPoint {
-                                        column: selection.range().0.0,
-                                        row: selection.range().0.1 as u32,
-                                    },
-                                    end: SelectionPoint {
-                                        column: selection.range().1.0,
-                                        row: selection.range().1.1 as u32,
-                                    },
-                                });
+                                if let Some(content_generation) = content_generation {
+                                    sequence.semantic_range =
+                                        Some(GenerationTaggedSelectionRange {
+                                            content_generation,
+                                            range: SelectionRange {
+                                                start: SelectionPoint {
+                                                    column: selection.range().0.0,
+                                                    row: selection.range().0.1 as u32,
+                                                },
+                                                end: SelectionPoint {
+                                                    column: selection.range().1.0,
+                                                    row: selection.range().1.1 as u32,
+                                                },
+                                            },
+                                        });
+                                }
                             }
                             self.replace_selection(Some(selection));
                         } else {

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -16863,9 +16863,8 @@ impl App {
         modifiers: KeyModifiers,
         now: Instant,
     ) -> bool {
-        let host_selection_modifier = |modifiers| {
-            modifiers == KeyModifiers::NONE || modifiers == KeyModifiers::SHIFT
-        };
+        let host_selection_modifier =
+            |modifiers| modifiers == KeyModifiers::NONE || modifiers == KeyModifiers::SHIFT;
         if !previous.repeatable
             || screen.is_none()
             || previous.surface != surface
@@ -27565,11 +27564,8 @@ mod tests {
             modifiers: KeyModifiers::SHIFT,
         };
         app.handle_mouse(shift_click).unwrap();
-        app.handle_mouse(MouseEvent {
-            kind: MouseEventKind::Up(MouseButton::Left),
-            ..shift_click
-        })
-        .unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..shift_click })
+            .unwrap();
         let plain_click = MouseEvent {
             kind: MouseEventKind::Down(MouseButton::Left),
             modifiers: KeyModifiers::NONE,

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -22760,6 +22760,7 @@ impl App {
             // The selected endpoints are screen coordinates. If terminal
             // content changed while the button was held, copying them could
             // return unrelated text from the new generation.
+            self.reset_selection_click_sequence();
             self.replace_selection(None);
             return Ok(RenderAction::Draw);
         }
@@ -22791,6 +22792,7 @@ impl App {
         if let Some(expected) = expected_content_generation
             && self.terminal_content_generation(sel.surface) != Some(expected)
         {
+            self.reset_selection_click_sequence();
             self.replace_selection(None);
             return;
         }
@@ -22803,6 +22805,7 @@ impl App {
         if let Some(expected) = expected_content_generation
             && self.terminal_content_generation(sel.surface) != Some(expected)
         {
+            self.reset_selection_click_sequence();
             self.replace_selection(None);
             return;
         }

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -20853,14 +20853,17 @@ impl App {
                     terminal_admission,
                 )
             }
-            MouseEventKind::ScrollLeft | MouseEventKind::ScrollRight => self
-                .handle_horizontal_scroll_with_admission(
+            MouseEventKind::ScrollLeft | MouseEventKind::ScrollRight => {
+                // Scrolling is a distinct gesture and ends click-repeat state.
+                self.reset_selection_click_sequence();
+                self.handle_horizontal_scroll_with_admission(
                     mouse.column,
                     mouse.row,
                     matches!(mouse.kind, MouseEventKind::ScrollRight),
                     mouse.modifiers,
                     terminal_admission,
-                ),
+                )
+            }
         }
     }
 
@@ -23866,10 +23869,6 @@ impl App {
         modifiers: KeyModifiers,
         terminal_admission: Option<TerminalPointerAdmission>,
     ) -> anyhow::Result<RenderAction> {
-        // Scrolling is a distinct gesture and ends click-repeat state. Plain
-        // pointer motion is routed to handle_hover_with_admission and keeps
-        // the sequence alive until the next press.
-        self.reset_selection_click_sequence();
         if self.menu.is_some() || self.prompt.is_some() {
             return Ok(RenderAction::None);
         }

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -27617,6 +27617,44 @@ mod tests {
         );
         app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
             .unwrap();
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
+    fn failed_semantic_repeat_resets_the_click_sequence() {
+        let (mut app, mux, surface, content) =
+            selection_fixture("failed-semantic-repeat-reset-test", b"alpha\n");
+        let first_click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 1,
+            row: content.y,
+            modifiers: KeyModifiers::NONE,
+        };
+        app.handle_mouse(first_click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..first_click })
+            .unwrap();
+
+        let blank_click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            row: content.y + 1,
+            ..first_click
+        };
+        app.handle_mouse(blank_click).unwrap();
+        assert_eq!(app.selection_mode, SelectionMode::Word);
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..blank_click })
+            .unwrap();
+        assert!(app.selection.is_none(), "an unsupported semantic cell must not retain selection");
+
+        app.handle_mouse(blank_click).unwrap();
+        assert_eq!(
+            app.selection_mode,
+            SelectionMode::Cell,
+            "a failed semantic repeat must reset the next click to cell mode"
+        );
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..blank_click })
+            .unwrap();
+
         mux.close_surface(surface.id).unwrap();
     }
 

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -22690,6 +22690,12 @@ impl App {
         if !was_select {
             return Ok(if was_drag { RenderAction::Draw } else { RenderAction::None });
         }
+        if !semantic_select && !selection_dragged {
+            // A click without motion is not a selection. Clear the provisional
+            // cell anchor created on press, including any prior selection.
+            self.replace_selection(None);
+            return Ok(RenderAction::Draw);
+        }
         match self.selection {
             Some(sel) if sel.anchor != sel.head || semantic_select => {
                 self.copy_selection(sel);

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -27495,6 +27495,90 @@ mod tests {
     }
 
     #[test]
+    fn shift_double_click_selects_a_complete_word() {
+        let (mut app, mux, surface, content) =
+            selection_fixture("shift-double-click-word-selection-test", b"alpha beta gamma");
+
+        let click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 1,
+            row: content.y,
+            modifiers: KeyModifiers::SHIFT,
+        };
+        app.handle_mouse(click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+            .unwrap();
+        app.handle_mouse(click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+            .unwrap();
+
+        assert_eq!(
+            app.selection.map(|selection| selection.range()),
+            Some(((0, 0), (4, 0))),
+            "Shift double click must select the complete word when bypassing PTY mouse reporting"
+        );
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
+    fn shift_triple_click_selects_a_complete_line() {
+        let (mut app, mux, surface, content) =
+            selection_fixture("shift-triple-click-line-selection-test", b"alpha beta\ngamma");
+
+        let click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 1,
+            row: content.y,
+            modifiers: KeyModifiers::SHIFT,
+        };
+        for _ in 0..3 {
+            app.handle_mouse(click).unwrap();
+            app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+                .unwrap();
+        }
+
+        assert_eq!(
+            app.selection.map(|selection| selection.range()),
+            Some(((0, 0), (10, 0))),
+            "Shift triple click must select the complete line when bypassing PTY mouse reporting"
+        );
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
+    fn changing_shift_modifier_prevents_a_repeat_selection() {
+        let (mut app, mux, surface, content) =
+            selection_fixture("shift-repeat-modifier-mismatch-test", b"alpha beta gamma");
+
+        let shift_click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 1,
+            row: content.y,
+            modifiers: KeyModifiers::SHIFT,
+        };
+        app.handle_mouse(shift_click).unwrap();
+        app.handle_mouse(MouseEvent {
+            kind: MouseEventKind::Up(MouseButton::Left),
+            ..shift_click
+        })
+        .unwrap();
+        let plain_click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            modifiers: KeyModifiers::NONE,
+            ..shift_click
+        };
+        app.handle_mouse(plain_click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..plain_click })
+            .unwrap();
+
+        assert!(app.selection.is_none(), "a modifier change must reset the click sequence");
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
     fn a_failed_word_lookup_downgrades_to_a_cell_gesture() {
         let (mut app, mux, surface, content) =
             selection_fixture("failed-word-lookup-selection-state-test", b"alpha");

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -17102,10 +17102,7 @@ impl App {
                         } else {
                             range.end
                         };
-                        SelectionRange {
-                            start,
-                            end,
-                        }
+                        SelectionRange { start, end }
                     })
                     .unwrap_or(range)
             } else {

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -17072,6 +17072,22 @@ impl App {
                 SelectionMode::Cell => None,
             })
             .flatten();
+        let range = range.map(|range| {
+            if mode == SelectionMode::Word {
+                self.selection
+                    .filter(|selection| selection.surface == surface)
+                    .map(|selection| {
+                        let initial = selection.range();
+                        SelectionRange {
+                            start: initial.0.min(range.start),
+                            end: initial.1.max(range.end),
+                        }
+                    })
+                    .unwrap_or(range)
+            } else {
+                range
+            }
+        });
         if let Some(generation) = content_generation {
             self.semantic_selection_cache = Some(SemanticSelectionCache {
                 surface,

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -16863,12 +16863,15 @@ impl App {
         modifiers: KeyModifiers,
         now: Instant,
     ) -> bool {
+        let host_selection_modifier = |modifiers| {
+            modifiers == KeyModifiers::NONE || modifiers == KeyModifiers::SHIFT
+        };
         if !previous.repeatable
             || screen.is_none()
             || previous.surface != surface
             || previous.screen != screen
-            || previous.modifiers != KeyModifiers::NONE
-            || modifiers != KeyModifiers::NONE
+            || previous.modifiers != modifiers
+            || !host_selection_modifier(modifiers)
         {
             return false;
         }
@@ -21999,9 +22002,9 @@ impl App {
         self.finish_active_drag();
 
         // A repeat is valid only for presses that land directly in a PTY
-        // content cell. Any chrome, overlay, browser, or modified click ends
-        // the pending terminal click sequence.
-        let repeat_target = modifiers == KeyModifiers::NONE
+        // content cell. Shift is the host-selection override when an inner
+        // PTY application owns mouse input, so preserve it for repeats.
+        let repeat_target = (modifiers == KeyModifiers::NONE || modifiers == KeyModifiers::SHIFT)
             && self.hit_at(x, y).is_none()
             && self.pane_area_at(x, y).is_some_and(|area| {
                 self.surface_kind(area.surface) == Some(SurfaceKind::Pty)

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -5350,6 +5350,7 @@ struct SelectionClickSequence {
     anchor: (u16, u64),
     dragged: bool,
     tracked_anchor: Option<TrackedScreenPoint>,
+    semantic_range: Option<SelectionRange>,
     /// A failed semantic press keeps `tracked_anchor` alive for a same-press
     /// cell drag, but it must not keep the repeat count alive for the next
     /// press.
@@ -16941,6 +16942,7 @@ impl App {
             anchor: cell,
             dragged: false,
             tracked_anchor,
+            semantic_range: None,
             repeatable: true,
         });
         mode
@@ -17074,13 +17076,27 @@ impl App {
             .flatten();
         let range = range.map(|range| {
             if mode == SelectionMode::Word {
-                self.selection
-                    .filter(|selection| selection.surface == surface)
-                    .map(|selection| {
-                        let initial = selection.range();
+                self.selection_click_sequence
+                    .as_ref()
+                    .and_then(|sequence| sequence.semantic_range)
+                    .map(|initial| {
+                        let start = if (initial.start.row, initial.start.column)
+                            <= (range.start.row, range.start.column)
+                        {
+                            initial.start
+                        } else {
+                            range.start
+                        };
+                        let end = if (initial.end.row, initial.end.column)
+                            >= (range.end.row, range.end.column)
+                        {
+                            initial.end
+                        } else {
+                            range.end
+                        };
                         SelectionRange {
-                            start: initial.0.min(range.start),
-                            end: initial.1.max(range.end),
+                            start,
+                            end,
                         }
                     })
                     .unwrap_or(range)
@@ -22333,6 +22349,20 @@ impl App {
                         self.selection_mode_surface = Some(area.surface);
                         if let Some(selection) = self.selection_for_click(area.surface, cell, mode)
                         {
+                            if let Some(sequence) = self.selection_click_sequence.as_mut()
+                                && mode != SelectionMode::Cell
+                            {
+                                sequence.semantic_range = Some(SelectionRange {
+                                    start: SelectionPoint {
+                                        column: selection.range().0.0,
+                                        row: selection.range().0.1 as u32,
+                                    },
+                                    end: SelectionPoint {
+                                        column: selection.range().1.0,
+                                        row: selection.range().1.1 as u32,
+                                    },
+                                });
+                            }
                             self.replace_selection(Some(selection));
                         } else {
                             // A semantic lookup can legitimately return no

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -16896,6 +16896,9 @@ impl App {
         let repeated = previous.as_ref().is_some_and(|previous| {
             Self::selection_repeat_allowed(previous, surface, screen, position, modifiers, now)
         });
+        if !repeated {
+            self.replace_selection(None);
+        }
         let (mut count, mut tracked_anchor) = if repeated {
             let previous = previous.expect("repeated selection click has prior state");
             (previous.count.saturating_add(1).min(3), previous.tracked_anchor)
@@ -27614,6 +27617,17 @@ mod tests {
             Some(((6, 0), (15, 0))),
             "double-click drag must start at the selected word and end at the whole target word"
         );
+
+        let plain_click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 2,
+            row: content.y,
+            modifiers: KeyModifiers::NONE,
+        };
+        app.handle_mouse(plain_click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..plain_click })
+            .unwrap();
+        assert!(app.selection.is_none(), "a plain click after a selection drag must clear it");
 
         mux.close_surface(surface.id).unwrap();
     }

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -27526,6 +27526,30 @@ mod tests {
     }
 
     #[test]
+    fn plain_click_clears_an_existing_selection() {
+        let (mut app, mux, surface, content) =
+            selection_fixture("plain-click-clears-selection-test", b"alpha beta gamma");
+        app.replace_selection(Some(Selection {
+            surface: surface.id,
+            anchor: (0, 0),
+            head: (4, 0),
+        }));
+
+        let click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 1,
+            row: content.y,
+            modifiers: KeyModifiers::NONE,
+        };
+        app.handle_mouse(click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+            .unwrap();
+
+        assert!(app.selection.is_none(), "a plain click must clear an existing selection");
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
     fn double_click_selects_a_complete_whitespace_run() {
         let (mut app, mux, surface, content) =
             selection_fixture("double-click-whitespace-selection-test", b"alpha   beta");

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -27504,6 +27504,36 @@ mod tests {
     }
 
     #[test]
+    fn whitespace_double_click_drag_preserves_whitespace_anchor() {
+        let (mut app, mux, surface, content) =
+            selection_fixture("double-click-whitespace-drag-selection-test", b"alpha   beta");
+        let click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 6,
+            row: content.y,
+            modifiers: KeyModifiers::NONE,
+        };
+        app.handle_mouse(click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+            .unwrap();
+        app.handle_mouse(click).unwrap();
+        app.handle_mouse(MouseEvent {
+            kind: MouseEventKind::Drag(MouseButton::Left),
+            column: content.x + 9,
+            row: content.y,
+            modifiers: KeyModifiers::NONE,
+        })
+        .unwrap();
+
+        assert_eq!(
+            app.selection.map(|selection| selection.range()),
+            Some(((5, 0), (11, 0))),
+            "dragging from whitespace must retain its initial whitespace range"
+        );
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
     fn double_click_drag_extends_selection_by_complete_words() {
         let (mut app, mux, surface, content) =
             selection_fixture("double-click-word-drag-selection-test", b"alpha beta gamma");

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -27659,6 +27659,30 @@ mod tests {
     }
 
     #[test]
+    fn forwarded_pty_click_resets_host_repeat_sequence() {
+        let (mut app, mux, surface, content) =
+            selection_fixture("forwarded-pty-click-repeat-reset-test", b"alpha beta");
+        let click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 1,
+            row: content.y,
+            modifiers: KeyModifiers::NONE,
+        };
+        app.handle_mouse(click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+            .unwrap();
+        assert!(app.selection_click_sequence.is_some());
+
+        surface.with_terminal(|terminal| terminal.vt_write(b"\x1b[?1002h\x1b[?1006h"));
+        app.handle_mouse(click).unwrap();
+        assert!(app.selection_click_sequence.is_none());
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+            .unwrap();
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
     fn plain_click_clears_an_existing_selection() {
         let (mut app, mux, surface, content) =
             selection_fixture("plain-click-clears-selection-test", b"alpha beta gamma");

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -5350,6 +5350,10 @@ struct SelectionClickSequence {
     anchor: (u16, u64),
     dragged: bool,
     tracked_anchor: Option<TrackedScreenPoint>,
+    /// Generation of the semantic selection currently installed on `App`.
+    /// `None` means the range cannot be safely copied because no stable
+    /// terminal snapshot was available.
+    semantic_content_generation: Option<u64>,
     semantic_range: Option<GenerationTaggedSelectionRange>,
     /// A failed semantic press keeps `tracked_anchor` alive for a same-press
     /// cell drag, but it must not keep the repeat count alive for the next
@@ -16802,6 +16806,8 @@ impl App {
             && sequence.surface == surface
         {
             sequence.mode = SelectionMode::Cell;
+            sequence.semantic_content_generation = None;
+            sequence.semantic_range = None;
         }
     }
 
@@ -16956,6 +16962,7 @@ impl App {
             anchor: cell,
             dragged: false,
             tracked_anchor,
+            semantic_content_generation: None,
             semantic_range: None,
             repeatable: true,
         });
@@ -17003,7 +17010,20 @@ impl App {
             && sequence.surface == surface
         {
             sequence.mode = mode;
+            sequence.semantic_content_generation = None;
         }
+    }
+
+    fn current_semantic_selection_generation(&self, surface: SurfaceId) -> Option<u64> {
+        let Some(sequence) =
+            self.selection_click_sequence.as_ref().filter(|sequence| sequence.surface == surface)
+        else {
+            return None;
+        };
+        let Some(expected) = sequence.semantic_content_generation else {
+            return None;
+        };
+        (self.terminal_content_generation(surface) == Some(expected)).then_some(expected)
     }
 
     fn update_semantic_selection(
@@ -17131,6 +17151,19 @@ impl App {
             });
         } else {
             self.semantic_selection_cache = None;
+        }
+        if let Some(sequence) =
+            self.selection_click_sequence.as_mut().filter(|sequence| sequence.surface == surface)
+        {
+            if let (Some(content_generation), Some(range)) = (content_generation, range) {
+                sequence.semantic_content_generation = Some(content_generation);
+                if mode == SelectionMode::Word {
+                    sequence.semantic_range =
+                        Some(GenerationTaggedSelectionRange { content_generation, range });
+                }
+            } else {
+                sequence.semantic_content_generation = None;
+            }
         }
         match range {
             Some(range) => self.replace_selection(Some(Self::selection_from_range(surface, range))),
@@ -22389,6 +22422,10 @@ impl App {
                                                 },
                                             },
                                         });
+                                    sequence.semantic_content_generation = Some(content_generation);
+                                } else {
+                                    sequence.semantic_content_generation = None;
+                                    sequence.semantic_range = None;
                                 }
                             }
                             self.replace_selection(Some(selection));
@@ -22703,6 +22740,13 @@ impl App {
         let semantic_select = was_select
             && self.selection_mode_surface.is_some()
             && self.selection_mode != SelectionMode::Cell;
+        let semantic_content_generation = if semantic_select {
+            self.selection_mode_surface
+                .and_then(|surface| self.current_semantic_selection_generation(surface))
+        } else {
+            None
+        };
+        let stale_semantic_selection = semantic_select && semantic_content_generation.is_none();
         let selection_dragged = was_select
             && self.selection_click_sequence.as_ref().is_some_and(|sequence| sequence.dragged);
         let was_drag = self.drag.is_some();
@@ -22711,6 +22755,13 @@ impl App {
             // Keep the sequence through the gesture so word and line drags use
             // their semantic mode, then make the next press a plain click.
             self.reset_selection_click_sequence();
+        }
+        if stale_semantic_selection {
+            // The selected endpoints are screen coordinates. If terminal
+            // content changed while the button was held, copying them could
+            // return unrelated text from the new generation.
+            self.replace_selection(None);
+            return Ok(RenderAction::Draw);
         }
         if !was_select {
             return Ok(if was_drag { RenderAction::Draw } else { RenderAction::None });
@@ -22723,7 +22774,7 @@ impl App {
         }
         match self.selection {
             Some(sel) if sel.anchor != sel.head || semantic_select => {
-                self.copy_selection(sel);
+                self.copy_selection(sel, semantic_content_generation);
                 Ok(RenderAction::Draw)
             }
             _ => {
@@ -22736,13 +22787,25 @@ impl App {
 
     /// Copy the selected text to the host clipboard via OSC 52 (the host
     /// terminal owns the clipboard; this works over SSH too).
-    fn copy_selection(&mut self, sel: Selection) {
+    fn copy_selection(&mut self, sel: Selection, expected_content_generation: Option<u64>) {
+        if let Some(expected) = expected_content_generation
+            && self.terminal_content_generation(sel.surface) != Some(expected)
+        {
+            self.replace_selection(None);
+            return;
+        }
         let Some(surface) = self.session.surface(sel.surface) else { return };
         let (start, end) = sel.range();
         let Some(text) = surface.with_terminal(|t| t.selection_text_absolute(start, end)).flatten()
         else {
             return;
         };
+        if let Some(expected) = expected_content_generation
+            && self.terminal_content_generation(sel.surface) != Some(expected)
+        {
+            self.replace_selection(None);
+            return;
+        }
         if text.is_empty() {
             return;
         }


### PR DESCRIPTION
Current-main replacement for stale #11389/#11287.

Replays only the word/line selection gesture tests and fixes. It preserves whitespace anchors during semantic drags, prevents drag-seeded repeat clicks, and clears selection on plain clicks.

Verification: rustfmt --edition 2024 --check and git diff --check pass. Hosted cmux-tui focused verification will run after exact-head autoreview.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds double-click word and triple-click line selection to the TUI, keeping selections anchored to semantic word and line boundaries while dragging instead of collapsing to cell ranges.

**Bug Fixes**
- Double-click selects the complete Ghostty-defined word, including whitespace runs; triple-click selects the complete logical line.
- Dragging after the second or third press extends by complete words or lines in either direction, preserving the initial whitespace anchor.
- A plain click clears the existing selection, and a click after a selection drag is treated as plain.
- Shift-double-click and Shift-triple-click select complete words and lines when PTY mouse reporting is bypassed; repeats need matching modifiers and a direct hit in a PTY content cell, and forwarded PTY clicks reset the repeat sequence.
- Hovering between clicks keeps the repeat sequence intact; scrolling resets it.
- Word and line selections stay visible even when the anchor and head are the same cell.
- A repeated semantic click on an empty or unsupported cell clears the prior selection and aborts the repeat sequence.
- Semantic ranges are tied to the terminal content generation; on release, stale selections are dropped and the repeat sequence is retired when output, reflow, or scrollback shifts the screen coordinates.

<sup>Written for commit 217f3a8f840687cd254bba497921baa33f07a73a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved repeated selection behavior for word and line selections, including Shift-click support.
  * Preserved selection boundaries more accurately around whitespace and punctuation during dragging.
  * Added more reliable selection targeting after terminal content changes.

* **Bug Fixes**
  * Fixed stale selections being reused after content updates or horizontal scrolling.
  * Clicking without dragging now clears existing or provisional selections.
  * Improved handling when repeated semantic selections cannot be located.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->