### PR TITLE
Fix local TUI bootstrap race

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -29080,3 +29080,29 @@ mod tests {
         *mux.workspace_close_after_selector_resolution.lock().unwrap() = None;
     }
 }
+#[test]
+fn initial_bootstrap_lock_serializes_concurrent_callers() {
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+
+    let mux = Mux::new("bootstrap-lock-test", SurfaceOptions::default());
+    let barrier = Arc::new(Barrier::new(2));
+    let active = Arc::new(AtomicUsize::new(0));
+    let max_active = Arc::new(AtomicUsize::new(0));
+    thread::scope(|scope| {
+        for _ in 0..2 {
+            let barrier = barrier.clone();
+            let active = active.clone();
+            let max_active = max_active.clone();
+            let mux = mux.clone();
+            scope.spawn(move || {
+                barrier.wait();
+                let _guard = mux.lock_initial_bootstrap();
+                let now = active.fetch_add(1, Ordering::SeqCst) + 1;
+                max_active.fetch_max(now, Ordering::SeqCst);
+                active.fetch_sub(1, Ordering::SeqCst);
+            });
+        }
+    });
+    assert_eq!(max_active.load(Ordering::SeqCst), 1);
+}

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -2540,7 +2540,7 @@ impl Mux {
         Ok(mux)
     }
 
-    pub(crate) fn lock_initial_bootstrap(&self) -> MutexGuard<'_, ()> {
+    pub fn lock_initial_bootstrap(&self) -> MutexGuard<'_, ()> {
         self.initial_bootstrap.lock().unwrap()
     }
 

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -29090,27 +29090,38 @@ mod tests {
 }
 #[test]
 fn initial_bootstrap_lock_serializes_concurrent_callers() {
-    use std::sync::{Arc, Barrier};
+    use std::sync::{mpsc, Arc, Barrier};
     use std::thread;
 
     let mux = Mux::new("bootstrap-lock-test", SurfaceOptions::default());
     let barrier = Arc::new(Barrier::new(2));
-    let active = Arc::new(AtomicUsize::new(0));
-    let max_active = Arc::new(AtomicUsize::new(0));
+    let (event_tx, event_rx) = mpsc::sync_channel(0);
+    let (release_tx, release_rx) = mpsc::sync_channel(0);
     thread::scope(|scope| {
-        for _ in 0..2 {
-            let barrier = barrier.clone();
-            let active = active.clone();
-            let max_active = max_active.clone();
-            let mux = mux.clone();
-            scope.spawn(move || {
-                barrier.wait();
-                let _guard = mux.lock_initial_bootstrap();
-                let now = active.fetch_add(1, Ordering::SeqCst) + 1;
-                max_active.fetch_max(now, Ordering::SeqCst);
-                active.fetch_sub(1, Ordering::SeqCst);
-            });
-        }
+        let first_barrier = barrier.clone();
+        let first_mux = mux.clone();
+        let first_event_tx = event_tx.clone();
+        scope.spawn(move || {
+            let _guard = first_mux.lock_initial_bootstrap();
+            first_event_tx.send(()).unwrap();
+            first_barrier.wait();
+            release_rx.recv().unwrap();
+        });
+
+        let second_barrier = barrier.clone();
+        let second_mux = mux.clone();
+        scope.spawn(move || {
+            second_barrier.wait();
+            let _guard = second_mux.lock_initial_bootstrap();
+            event_tx.send(()).unwrap();
+        });
+
+        // The first caller holds the lock while the second caller attempts to
+        // acquire it. The second event must therefore remain blocked until
+        // the first caller is released.
+        event_rx.recv().unwrap();
+        assert!(event_rx.try_recv().is_err());
+        release_tx.send(()).unwrap();
+        event_rx.recv().unwrap();
     });
-    assert_eq!(max_active.load(Ordering::SeqCst), 1);
 }

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -2125,6 +2125,9 @@ pub struct Mux {
     /// Keeps a close from removing a just-created surface before legacy
     /// callers have resolved the committed public result back to its runtime.
     resource_creation_handoff: Mutex<()>,
+    /// Serializes the check-and-create sequence used when an attached local
+    /// frontend bootstraps an otherwise empty session.
+    initial_bootstrap: Mutex<()>,
     resource_creation_execution: Mutex<()>,
     resource_creation_active: AtomicBool,
     terminal_adoptions: Mutex<HashSet<String>>,
@@ -2488,6 +2491,7 @@ impl Mux {
             #[cfg(test)]
             terminal_exit_state_queries: AtomicU64::new(0),
             resource_creation_handoff: Mutex::new(()),
+            initial_bootstrap: Mutex::new(()),
             resource_creation_execution: Mutex::new(()),
             resource_creation_active: AtomicBool::new(false),
             terminal_adoptions: Mutex::new(HashSet::new()),
@@ -2534,6 +2538,10 @@ impl Mux {
         mux.retry_pending_agent_hooks()?;
         crate::journal_hooks::start(&mux)?;
         Ok(mux)
+    }
+
+    pub(crate) fn lock_initial_bootstrap(&self) -> MutexGuard<'_, ()> {
+        self.initial_bootstrap.lock().unwrap()
     }
 
     fn retry_pending_agent_hooks(&self) -> anyhow::Result<()> {

--- a/cmux-tui/crates/cmux-tui/src/session/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/mod.rs
@@ -700,6 +700,11 @@ impl Session {
     pub fn ensure_initial(&self, size: Option<(u16, u16)>) -> anyhow::Result<()> {
         match self {
             Session::Local(mux) => {
+                // Hold the per-mux bootstrap guard across the snapshot and
+                // mutation.  Without this, concurrent attaches can both
+                // observe a bare session and create duplicate workspaces or
+                // shells before either mutation becomes visible.
+                let _bootstrap = mux.lock_initial_bootstrap();
                 // One snapshot serves both the decision and the target
                 // selection; a second read could disagree with the first
                 // when another mux owner mutates the tree in between.


### PR DESCRIPTION
Serialize local ensure_initial check-and-create operations per mux to prevent duplicate workspaces or shells from concurrent attaches.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race where concurrent attaches to a local TUI session could both see an empty session and each create duplicate workspaces or shells. Adds a per-mux bootstrap mutex that serializes the check-and-create sequence so only the first attach bootstraps, and includes a deterministic test verifying the lock serializes concurrent callers.

<sup>Written for commit 337a0df6b15ba4f2ad684f5c1270c910da61fde1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local session startup when multiple attachments occur simultaneously.
  * Prevented duplicate workspaces or terminal shells from being created during initial session setup.

* **Tests**
  * Added coverage to verify that concurrent startup operations are properly serialized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->