### PR TITLE
fix(tui): reap PTY child on startup failure

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -30,7 +30,7 @@ use ghostty_vt::{
 use crate::mux::ResourceWaitWake;
 use crate::platform;
 use crate::resource::{ContentPublicId, TabResourceIdentity, TerminalPublicId};
-use crate::terminal_host_protocol::{TerminalExit, wait_for_native_child_status};
+use crate::terminal_host_protocol::{TerminalExit, wait_for_native_child_status_with_reap_result};
 use crate::{Mux, MuxEvent, SurfaceId};
 
 pub use crate::browser::{
@@ -1493,6 +1493,48 @@ enum PtyRuntime {
     ExitedHosted,
 }
 
+/// Owns a freshly spawned PTY child until the child reaper has taken over.
+///
+/// `portable_pty::Child` does not stop or reap a process when its handle is
+/// dropped. Startup performs several fallible operations after spawning, so a
+/// guard keeps every error path terminating and reaping the child. The guard
+/// moves into the reaper closure; if thread creation fails, dropping that
+/// closure runs this cleanup instead.
+struct PtyChildStartupGuard {
+    child: Box<dyn cmux_pty::Child + Send + Sync>,
+    reaped: bool,
+}
+
+impl PtyChildStartupGuard {
+    fn new(child: Box<dyn cmux_pty::Child + Send + Sync>) -> Self {
+        Self { child, reaped: false }
+    }
+
+    fn process_id(&self) -> Option<u32> {
+        self.child.process_id()
+    }
+
+    fn clone_killer(&self) -> Box<dyn ChildKiller + Send + Sync> {
+        self.child.clone_killer()
+    }
+
+    fn wait_for_exit(&mut self) -> TerminalExit {
+        let (exit, reaped) = wait_for_native_child_status_with_reap_result(self.child.as_mut());
+        self.reaped = reaped;
+        exit
+    }
+}
+
+impl Drop for PtyChildStartupGuard {
+    fn drop(&mut self) {
+        if self.reaped {
+            return;
+        }
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum PtyLifetime {
     SessionOwned,
@@ -2294,7 +2336,8 @@ impl Surface {
             cmd.cwd(cwd);
         }
 
-        let cmux_pty::SpawnedPty { master, mut child } = pty.spawn(cmd)?;
+        let cmux_pty::SpawnedPty { master, child } = pty.spawn(cmd)?;
+        let mut child = PtyChildStartupGuard::new(child);
         let pid = child.process_id();
         let killer = child.clone_killer();
         #[cfg(unix)]
@@ -2566,7 +2609,7 @@ impl Surface {
         std::thread::Builder::new().name(format!("surface-{id}-wait")).spawn({
             let surface = surface.clone();
             move || {
-                let exit = wait_for_native_child_status(child.as_mut());
+                let exit = child.wait_for_exit();
                 if let Some(pty) = surface.as_pty() {
                     *pty.exit.lock().unwrap() = Some(exit);
                 }
@@ -6098,6 +6141,47 @@ impl ChildKiller for TestChildKiller {
     }
 }
 
+#[cfg(test)]
+#[derive(Debug, Default)]
+struct StartupChildState {
+    kill_count: AtomicUsize,
+    wait_count: AtomicUsize,
+}
+
+#[cfg(test)]
+#[derive(Debug)]
+struct StartupChild {
+    state: Arc<StartupChildState>,
+}
+
+#[cfg(test)]
+impl cmux_pty::ChildKiller for StartupChild {
+    fn kill(&mut self) -> std::io::Result<()> {
+        self.state.kill_count.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+
+    fn clone_killer(&self) -> Box<dyn ChildKiller + Send + Sync> {
+        Box::new(TestChildKiller)
+    }
+}
+
+#[cfg(test)]
+impl cmux_pty::Child for StartupChild {
+    fn try_wait(&mut self) -> std::io::Result<Option<cmux_pty::ExitStatus>> {
+        Err(std::io::Error::other("test child has no process"))
+    }
+
+    fn wait(&mut self) -> std::io::Result<cmux_pty::ExitStatus> {
+        self.state.wait_count.fetch_add(1, Ordering::Relaxed);
+        Err(std::io::Error::other("test child has no process"))
+    }
+
+    fn process_id(&self) -> Option<u32> {
+        None
+    }
+}
+
 impl PtySurface {
     fn journal_target(&self) -> Option<(Arc<Mux>, Arc<TerminalPublicId>)> {
         let terminal_id = self.terminal_public_id.clone()?;
@@ -6850,6 +6934,17 @@ mod tests {
 
     use super::*;
     use crate::MuxEvent;
+
+    #[test]
+    fn pty_child_startup_guard_kills_and_waits_on_drop() {
+        let state = Arc::new(StartupChildState::default());
+        {
+            let _guard = PtyChildStartupGuard::new(Box::new(StartupChild { state: state.clone() }));
+        }
+
+        assert_eq!(state.kill_count.load(Ordering::Relaxed), 1);
+        assert_eq!(state.wait_count.load(Ordering::Relaxed), 1);
+    }
 
     #[test]
     fn agent_browser_provider_uses_a_terminal_local_daemon_session() {

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -2606,7 +2606,7 @@ impl Surface {
 
         // Child reaper: retain the native status and rendezvous with PTY EOF
         // so final output is visible before the mux observes completion.
-        std::thread::Builder::new().name(format!("surface-{id}-wait")).spawn({
+        let reaper = std::thread::Builder::new().name(format!("surface-{id}-wait")).spawn({
             let surface = surface.clone();
             move || {
                 let exit = child.wait_for_exit();
@@ -2616,7 +2616,14 @@ impl Surface {
                 close_local_terminal_master_after_exit(&surface);
                 publish_local_exit_if_ready(&surface);
             }
-        })?;
+        });
+        if let Err(error) = reaper {
+            // The failed spawn drops the closure and its child guard, which
+            // kills and waits for the child. Close the ConPTY master before
+            // returning so reader and frame threads can release the surface.
+            close_local_terminal_master_after_exit(&surface);
+            return Err(error.into());
+        }
 
         Ok(surface)
     }

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_protocol.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_protocol.rs
@@ -152,25 +152,39 @@ impl TerminalExit {
 pub(crate) fn wait_for_native_child_status(
     child: &mut (dyn cmux_pty::Child + Send + Sync),
 ) -> TerminalExit {
+    wait_for_native_child_status_with_reap_result(child).0
+}
+
+/// Wait for a PTY child and report whether the wait reaped it successfully.
+///
+/// Callers that retain an owning guard can use the boolean to avoid issuing a
+/// second kill against a PID that may already have been reused after a
+/// successful wait.
+pub(crate) fn wait_for_native_child_status_with_reap_result(
+    child: &mut (dyn cmux_pty::Child + Send + Sync),
+) -> (TerminalExit, bool) {
     let child: &mut dyn cmux_pty::Child = child;
     if let Some(child) = child.downcast_mut::<std::process::Child>() {
         return match child.wait() {
-            Ok(status) => TerminalExit::from_exit_status(&status),
-            Err(error) => TerminalExit::unknown(format!("wait failed: {error}")),
+            Ok(status) => (TerminalExit::from_exit_status(&status), true),
+            Err(error) => (TerminalExit::unknown(format!("wait failed: {error}")), false),
         };
     }
     match child.wait() {
         Ok(status) if status.signal().is_some() => {
-            TerminalExit::unknown(format!("numeric signal status unavailable: {status}"))
+            (TerminalExit::unknown(format!("numeric signal status unavailable: {status}")), true)
         }
         Ok(status) => match i32::try_from(status.exit_code()) {
-            Ok(code) => TerminalExit::now(TerminalExitOutcome::Exit { code }),
-            Err(_) => TerminalExit::unknown(format!(
-                "portable exit code exceeds signed 32-bit range: {}",
-                status.exit_code()
-            )),
+            Ok(code) => (TerminalExit::now(TerminalExitOutcome::Exit { code }), true),
+            Err(_) => (
+                TerminalExit::unknown(format!(
+                    "portable exit code exceeds signed 32-bit range: {}",
+                    status.exit_code()
+                )),
+                true,
+            ),
         },
-        Err(error) => TerminalExit::unknown(format!("wait failed: {error}")),
+        Err(error) => (TerminalExit::unknown(format!("wait failed: {error}")), false),
     }
 }
 


### PR DESCRIPTION
## Summary
- keep local PTY children owned through fallible startup setup
- kill and wait when setup or reaper-thread creation fails
- avoid a second kill after a successful wait

## Verification
- rustfmt and git diff --check
- hosted cmux-tui verification follows after PR creation

This change is limited to local PTY startup in `cmux-tui-core/src/surface.rs`; terminal-host runtime is unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a PTY child process leak where a spawned child stayed alive if local terminal startup failed after spawn. Terminal-host runtime is unchanged.

- A startup guard now kills and reaps the child on any failure path and tracks whether the wait already reaped it to avoid a second kill against a reused PID.
- Reaper-thread creation failure now closes the ConPTY master before returning so reader and frame threads can release the surface.

<sup>Written for commit 50ce113a7d2ec657a25f35d29dfcf7ec55702d78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

