### PR TITLE
fix(tui): enforce journal cursor continuity during restore

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
@@ -383,7 +383,7 @@ impl RestoreReducer {
             return Ok(false);
         };
         if !self.validate_resource_changes(changes)
-            || !self.cursor_accepts(record.resource_revision)?
+            || !self.cursor_accepts(record.resource_revision, record.previous_resource_revision)?
         {
             return Ok(false);
         }
@@ -538,16 +538,49 @@ impl RestoreReducer {
         Ok(true)
     }
 
-    fn cursor_accepts(&self, revision: Option<u64>) -> anyhow::Result<bool> {
-        if revision.is_none() {
-            return Ok(true);
-        }
+    fn cursor_accepts(
+        &self,
+        revision: Option<u64>,
+        previous_revision: Option<u64>,
+    ) -> anyhow::Result<bool> {
+        let Some(revision) = revision else {
+            return Ok(previous_revision.is_none());
+        };
         let snapshot = self
             .state
             .get("session_snapshot")
             .and_then(Value::as_object)
             .context("checkpoint session_snapshot is not an object")?;
-        Ok(snapshot.get("cursor").is_none_or(|cursor| cursor.is_null() || cursor.is_object()))
+        let Some(cursor) = snapshot.get("cursor") else {
+            return Ok(previous_revision.is_some_and(|previous| {
+                previous.checked_add(1) == Some(revision)
+            }));
+        };
+        if cursor.is_null() {
+            return Ok(previous_revision.is_some_and(|previous| {
+                previous.checked_add(1) == Some(revision)
+            }));
+        }
+        let Some(cursor) = cursor.as_object() else {
+            anyhow::bail!("checkpoint cursor is not an object");
+        };
+        let Some(cursor_revision) = cursor.get("revision") else { return Ok(false) };
+        let cursor_revision = match cursor_revision {
+            Value::String(value) => value
+                .parse::<u64>()
+                .context("checkpoint cursor revision is not an unsigned integer")?,
+            Value::Number(value) => {
+                value.as_u64().context("checkpoint cursor revision is not an unsigned integer")?
+            }
+            _ => anyhow::bail!("checkpoint cursor revision is not an unsigned integer"),
+        };
+        let expected_revision = cursor_revision.checked_add(1);
+        Ok(match previous_revision {
+            Some(previous_revision) => {
+                previous_revision == cursor_revision && expected_revision == Some(revision)
+            }
+            None => expected_revision == Some(revision),
+        })
     }
 
     fn validate_resource_changes(&self, changes: &[Value]) -> bool {
@@ -872,16 +905,45 @@ mod tests {
             sha256: "00".repeat(32),
             created_at_ms: 1,
         };
-        let records = vec![
-            resource_record(4, 2, 1, "workspace_one"),
-            resource_record(5, 3, 2, "workspace_two"),
-        ];
+        let mut first = resource_record(4, 2, 1, "workspace_one");
+        first.previous_resource_revision = None;
+        let records = vec![first, resource_record(5, 3, 2, "workspace_two")];
 
         let preview = restore_preview(&checkpoint, &records, 5).unwrap();
 
         assert_eq!(preview["fully_reducible"], true);
         assert_eq!(preview["unsupported_required_record_count"], "0");
         assert_eq!(preview["state"]["session_snapshot"]["cursor"]["revision"], "3");
+    }
+
+    #[test]
+    fn reducer_accepts_resource_revisions_without_checkpoint_cursor() {
+        let mut checkpoint = JournalCheckpoint {
+            checkpoint_id: "checkpoint_missing_resource_cursor".into(),
+            source_sequence: 3,
+            reducer_version: JOURNAL_REDUCER_VERSION,
+            state: json!({
+                "session_snapshot":{
+                    "workspaces":[],
+                },
+                "journal_extensions":{"producers":[],"hooks":[]},
+            }),
+            content_refs: vec![],
+            sha256: "00".repeat(32),
+            created_at_ms: 1,
+        };
+        let record = resource_record(4, 3, 2, "workspace_new");
+
+        let preview = restore_preview(&checkpoint, &[record], 4).unwrap();
+
+        assert_eq!(preview["fully_reducible"], true);
+        assert_eq!(preview["unsupported_required_record_count"], "0");
+        assert_eq!(preview["state"]["session_snapshot"]["cursor"]["revision"], "3");
+
+        checkpoint.state["session_snapshot"]["cursor"] = Value::Null;
+        let preview = restore_preview(&checkpoint, &[resource_record(4, 3, 2, "workspace_new")], 4)
+            .unwrap();
+        assert_eq!(preview["fully_reducible"], true);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
@@ -552,14 +552,14 @@ impl RestoreReducer {
             .and_then(Value::as_object)
             .context("checkpoint session_snapshot is not an object")?;
         let Some(cursor) = snapshot.get("cursor") else {
-            return Ok(
-                previous_revision.is_some_and(|previous| previous.checked_add(1) == Some(revision))
-            );
+            // A contiguous predecessor is not enough to anchor a chain to
+            // this checkpoint. Without durable cursor metadata, fail closed.
+            return Ok(false);
         };
         if cursor.is_null() {
-            return Ok(
-                previous_revision.is_some_and(|previous| previous.checked_add(1) == Some(revision))
-            );
+            // Null is the persisted representation of an unavailable cursor,
+            // so it has the same fail-closed behavior as an omitted cursor.
+            return Ok(false);
         }
         let Some(cursor) = cursor.as_object() else {
             anyhow::bail!("checkpoint cursor is not an object");

--- a/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
@@ -917,7 +917,7 @@ mod tests {
     }
 
     #[test]
-    fn reducer_accepts_resource_revisions_without_checkpoint_cursor() {
+    fn reducer_rejects_resource_revisions_without_checkpoint_cursor() {
         let mut checkpoint = JournalCheckpoint {
             checkpoint_id: "checkpoint_missing_resource_cursor".into(),
             source_sequence: 3,
@@ -936,14 +936,16 @@ mod tests {
 
         let preview = restore_preview(&checkpoint, &[record], 4).unwrap();
 
-        assert_eq!(preview["fully_reducible"], true);
-        assert_eq!(preview["unsupported_required_record_count"], "0");
-        assert_eq!(preview["state"]["session_snapshot"]["cursor"]["revision"], "3");
+        assert_eq!(preview["fully_reducible"], false);
+        assert_eq!(preview["unsupported_required_record_count"], "1");
+        assert!(preview["state"]["session_snapshot"].get("cursor").is_none());
 
         checkpoint.state["session_snapshot"]["cursor"] = Value::Null;
         let preview =
             restore_preview(&checkpoint, &[resource_record(4, 3, 2, "workspace_new")], 4).unwrap();
-        assert_eq!(preview["fully_reducible"], true);
+        assert_eq!(preview["fully_reducible"], false);
+        assert_eq!(preview["unsupported_required_record_count"], "1");
+        assert!(preview["state"]["session_snapshot"]["cursor"].is_null());
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
@@ -552,14 +552,14 @@ impl RestoreReducer {
             .and_then(Value::as_object)
             .context("checkpoint session_snapshot is not an object")?;
         let Some(cursor) = snapshot.get("cursor") else {
-            return Ok(previous_revision.is_some_and(|previous| {
-                previous.checked_add(1) == Some(revision)
-            }));
+            return Ok(
+                previous_revision.is_some_and(|previous| previous.checked_add(1) == Some(revision))
+            );
         };
         if cursor.is_null() {
-            return Ok(previous_revision.is_some_and(|previous| {
-                previous.checked_add(1) == Some(revision)
-            }));
+            return Ok(
+                previous_revision.is_some_and(|previous| previous.checked_add(1) == Some(revision))
+            );
         }
         let Some(cursor) = cursor.as_object() else {
             anyhow::bail!("checkpoint cursor is not an object");
@@ -941,8 +941,8 @@ mod tests {
         assert_eq!(preview["state"]["session_snapshot"]["cursor"]["revision"], "3");
 
         checkpoint.state["session_snapshot"]["cursor"] = Value::Null;
-        let preview = restore_preview(&checkpoint, &[resource_record(4, 3, 2, "workspace_new")], 4)
-            .unwrap();
+        let preview =
+            restore_preview(&checkpoint, &[resource_record(4, 3, 2, "workspace_new")], 4).unwrap();
         assert_eq!(preview["fully_reducible"], true);
     }
 

--- a/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
@@ -776,6 +776,38 @@ mod tests {
         }
     }
 
+    fn resource_record(
+        sequence: u64,
+        resource_revision: u64,
+        previous_resource_revision: u64,
+        workspace_id: &str,
+    ) -> SessionJournalRecord {
+        SessionJournalRecord {
+            sequence,
+            event_id: format!("event_resource_{sequence}"),
+            schema_version: 1,
+            kind: "workspace.create".into(),
+            class: JournalClass::State,
+            replay: JournalReplayPolicy::Required,
+            occurred_at_ms: sequence,
+            committed_at_ms: sequence,
+            producer: JournalProducer { kind: "test".into(), id: "test".into() },
+            authority: None,
+            causation_id: None,
+            correlation_id: None,
+            causation_depth: 0,
+            subjects: vec![JournalSubject { kind: "session".into(), id: "session".into() }],
+            sensitivity: JournalSensitivity::Sensitive,
+            payload: json!({"changes":[
+                {"kind":"upsert","resource":"workspace","id":workspace_id,
+                 "value":{"id":workspace_id,"index":0}},
+            ]}),
+            resource_revision: Some(resource_revision),
+            previous_resource_revision: Some(previous_resource_revision),
+            terminal_output: None,
+        }
+    }
+
     #[test]
     fn reducer_applies_resource_upserts_and_deletes() {
         let checkpoint = JournalCheckpoint {
@@ -821,6 +853,71 @@ mod tests {
         assert_eq!(preview["fully_reducible"], true);
         assert_eq!(preview["state"]["session_snapshot"]["workspaces"][0]["id"], "workspace_new");
         assert_eq!(preview["state"]["session_snapshot"]["cursor"]["revision"], "2");
+    }
+
+    #[test]
+    fn reducer_accepts_contiguous_resource_revisions() {
+        let checkpoint = JournalCheckpoint {
+            checkpoint_id: "checkpoint_contiguous_resource_revisions".into(),
+            source_sequence: 3,
+            reducer_version: JOURNAL_REDUCER_VERSION,
+            state: json!({
+                "session_snapshot":{
+                    "cursor":{"generation":"generation","revision":"1"},
+                    "workspaces":[],
+                },
+                "journal_extensions":{"producers":[],"hooks":[]},
+            }),
+            content_refs: vec![],
+            sha256: "00".repeat(32),
+            created_at_ms: 1,
+        };
+        let records = vec![
+            resource_record(4, 2, 1, "workspace_one"),
+            resource_record(5, 3, 2, "workspace_two"),
+        ];
+
+        let preview = restore_preview(&checkpoint, &records, 5).unwrap();
+
+        assert_eq!(preview["fully_reducible"], true);
+        assert_eq!(preview["unsupported_required_record_count"], "0");
+        assert_eq!(preview["state"]["session_snapshot"]["cursor"]["revision"], "3");
+    }
+
+    #[test]
+    fn reducer_rejects_resource_revision_gap_and_stale_predecessor() {
+        for (checkpoint_revision, resource_revision, previous_revision) in [(1, 3, 2), (2, 3, 1)] {
+            let checkpoint = JournalCheckpoint {
+                checkpoint_id: format!(
+                    "checkpoint_invalid_resource_revision_{checkpoint_revision}_{previous_revision}"
+                ),
+                source_sequence: 3,
+                reducer_version: JOURNAL_REDUCER_VERSION,
+                state: json!({
+                    "session_snapshot":{
+                        "cursor":{
+                            "generation":"generation",
+                            "revision":checkpoint_revision.to_string(),
+                        },
+                        "workspaces":[],
+                    },
+                    "journal_extensions":{"producers":[],"hooks":[]},
+                }),
+                content_refs: vec![],
+                sha256: "00".repeat(32),
+                created_at_ms: 1,
+            };
+            let record = resource_record(4, resource_revision, previous_revision, "workspace_new");
+
+            let preview = restore_preview(&checkpoint, &[record], 4).unwrap();
+
+            assert_eq!(preview["fully_reducible"], false);
+            assert_eq!(preview["unsupported_required_record_count"], "1");
+            assert_eq!(
+                preview["state"]["session_snapshot"]["cursor"]["revision"],
+                checkpoint_revision.to_string()
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- require each resource replay record to continue from the checkpoint or previous reducer cursor
- reject revision gaps and stale predecessors as unsupported records
- add focused contiguous, gap, and stale predecessor tests

## Verification
- rustfmt check passed
- git diff --check passed
- Rust tests not run locally per cmux-tui build policy

Regression coverage is split across two commits: test first, fix second.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens restore-time validation so replay records must continue the checkpoint cursor sequentially, and restores fail closed when the checkpoint has no usable cursor. Previously, resource records with contiguous revisions were accepted without a checkpoint cursor.

- A record's `resource_revision` must equal the checkpoint cursor revision plus one; a present `previous_resource_revision` must equal the cursor revision.
- Records without a `resource_revision` are accepted only when `previous_resource_revision` is also absent.
- Missing or null checkpoint cursors now reject all resource records; gap, stale-predecessor, and non-object or unparseable `revision` cursors also reject or error out.

**Tests**
- Added coverage for contiguous sequences (accepted), missing and null cursors, and gap/stale-predecessor cases (rejected).

<sup>Written for commit 9c5d69d61a8c3f9cae798641dd60563117be5abc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Journal restoration now rejects resource changes with missing checkpoints, revision gaps, stale predecessors, or non-contiguous revisions.
  * Resource changes are applied only when they follow the expected revision sequence, improving restore consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->