### PR TITLE
fix(relay): pin PTY cwd to validated descriptor

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -248,6 +248,10 @@ fn open_pinned_directory(path: &Path) -> Result<(File, Vec<DirectoryIdentity>), 
     const ACCESS_MODE: libc::c_int = libc::O_RDONLY;
     let flags = ACCESS_MODE | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC;
     let mut parent = std::fs::OpenOptions::new()
+        // Rust requires an access mode on the builder before it invokes the
+        // OS open call. O_EXEC remains the effective Darwin mode because
+        // custom_flags only adds non-O_ACCMODE bits.
+        .read(true)
         .custom_flags(flags)
         .open("/")
         .map_err(|_| "cwd is not accessible".to_owned())?;

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -237,13 +237,14 @@ fn open_pinned_directory(path: &Path) -> Result<(File, Vec<DirectoryIdentity>), 
     use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
     use std::os::unix::io::FromRawFd;
 
-    // Linux O_PATH avoids requiring read permission. Darwin's O_EXEC value is
-    // not exposed by every libc release, so keep the documented Darwin value
-    // local and retain execute-only cwd support.
+    // Linux O_PATH avoids requiring read permission. Darwin does not expose a
+    // supported O_EXEC or O_SEARCH flag, so use O_RDONLY there. This keeps the
+    // descriptor walk portable and fail-closed, at the cost of requiring read
+    // permission on macOS directories used as a PTY cwd.
     #[cfg(target_os = "linux")]
     const ACCESS_MODE: libc::c_int = libc::O_PATH;
     #[cfg(target_os = "macos")]
-    const ACCESS_MODE: libc::c_int = 0x4000_0000;
+    const ACCESS_MODE: libc::c_int = libc::O_RDONLY;
     #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     const ACCESS_MODE: libc::c_int = libc::O_RDONLY;
     let flags = ACCESS_MODE | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC;

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -234,7 +234,7 @@ fn scoped_cwd(
 fn open_pinned_directory(path: &Path) -> Result<(File, Vec<DirectoryIdentity>), String> {
     use std::ffi::CString;
     use std::os::unix::ffi::OsStrExt;
-    use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+    use std::os::unix::fs::MetadataExt;
     use std::os::unix::io::FromRawFd;
 
     // Linux O_PATH avoids requiring read permission. Darwin's O_EXEC combined
@@ -247,14 +247,15 @@ fn open_pinned_directory(path: &Path) -> Result<(File, Vec<DirectoryIdentity>), 
     #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     const ACCESS_MODE: libc::c_int = libc::O_RDONLY;
     let flags = ACCESS_MODE | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC;
-    let mut parent = std::fs::OpenOptions::new()
-        // Rust requires an access mode on the builder before it invokes the
-        // OS open call. O_EXEC remains the effective Darwin mode because
-        // custom_flags only adds non-O_ACCMODE bits.
-        .read(true)
-        .custom_flags(flags)
-        .open("/")
-        .map_err(|_| "cwd is not accessible".to_owned())?;
+    let root = CString::new("/").expect("literal root path has no NUL");
+    // SAFETY: `root` is a valid NUL-terminated path and `flags` requests a
+    // directory descriptor with the platform-specific access mode above.
+    let root_fd = unsafe { libc::open(root.as_ptr(), flags) };
+    if root_fd < 0 {
+        return Err("cwd is not accessible".to_owned());
+    }
+    // SAFETY: `root_fd` is a newly-owned descriptor from `open`.
+    let mut parent = unsafe { File::from_raw_fd(root_fd) };
     let mut expected_path = PathBuf::from("/");
     let mut ancestry = Vec::new();
     for component in path.components() {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -225,13 +225,13 @@ fn open_pinned_directory(path: &Path) -> Result<(File, Vec<DirectoryIdentity>), 
     use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
     use std::os::unix::io::FromRawFd;
 
-    // O_PATH (Linux) and O_SEARCH (macOS) keep execute-only directories
+    // O_PATH (Linux) and O_EXEC (macOS) keep execute-only directories
     // usable as cwd values. O_RDONLY is the portable fallback for other Unix
     // targets, where it preserves the previous behavior when readable.
     #[cfg(target_os = "linux")]
     const ACCESS_MODE: libc::c_int = libc::O_PATH;
     #[cfg(target_os = "macos")]
-    const ACCESS_MODE: libc::c_int = libc::O_SEARCH;
+    const ACCESS_MODE: libc::c_int = libc::O_EXEC;
     #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     const ACCESS_MODE: libc::c_int = libc::O_RDONLY;
     let flags = ACCESS_MODE | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC;

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -172,7 +172,6 @@ fn scoped_cwd(
         &raw_owned
     };
     let path = expand_path(raw, home, home);
-    let canonical = std::fs::canonicalize(&path).map_err(|_| "cwd is not accessible".to_owned())?;
     #[cfg(unix)]
     let allowed_root_groups: Vec<Vec<Vec<DirectoryIdentity>>> =
         [local_roots.filter(|r| !r.is_empty()), server_roots.filter(|r| !r.is_empty())]
@@ -182,39 +181,46 @@ fn scoped_cwd(
                 roots
                     .iter()
                     .filter_map(|root| {
-                        let canonical_root =
-                            std::fs::canonicalize(expand_path(root, home, home)).ok()?;
-                        Some(open_pinned_directory(&canonical_root).ok()?.1)
+                        Some(open_pinned_directory(&expand_path(root, home, home)).ok()?.1)
                     })
                     .collect()
             })
             .collect();
     #[cfg(not(unix))]
     let allowed_root_groups: Vec<Vec<Vec<()>>> = Vec::new();
+    #[cfg(not(unix))]
+    for roots in [local_roots.filter(|r| !r.is_empty()), server_roots.filter(|r| !r.is_empty())]
+        .into_iter()
+        .flatten()
+    {
+        let canonical =
+            std::fs::canonicalize(&path).map_err(|_| "cwd is not accessible".to_owned())?;
+        if !roots.iter().map(|root| expand_path(root, home, home)).any(|root| {
+            std::fs::canonicalize(root).map(|root| canonical.starts_with(root)).unwrap_or(false)
+        }) {
+            return Err("cwd is outside the allowed roots".to_owned());
+        }
+    }
     if allowed_root_groups.iter().any(|group| group.is_empty()) {
         return Err("cwd is outside the allowed roots".to_owned());
     }
-    if !canonical.is_dir() {
-        return Err("cwd is not a directory".to_owned());
-    }
     #[cfg(unix)]
     {
-        let (directory, ancestry) = open_pinned_directory(&canonical)?;
+        let (directory, ancestry) = open_pinned_directory(&path)?;
         if allowed_root_groups
             .iter()
             .any(|group| !group.iter().any(|root| ancestry.starts_with(root)))
         {
             return Err("cwd is outside the allowed roots".to_owned());
         }
-        Ok(ResolvedCwd {
-            path: canonical,
-            directory: Arc::new(directory),
-            ancestry: Arc::new(ancestry),
-        })
+        Ok(ResolvedCwd { path, directory: Arc::new(directory), ancestry: Arc::new(ancestry) })
     }
     #[cfg(not(unix))]
     {
-        Ok(ResolvedCwd { path: canonical })
+        if !path.is_dir() {
+            return Err("cwd is not a directory".to_owned());
+        }
+        Ok(ResolvedCwd { path })
     }
 }
 
@@ -2973,6 +2979,21 @@ mod tests {
         let after = resolved.directory.metadata().unwrap();
         assert_eq!(before.dev(), after.dev());
         assert_eq!(before.ino(), after.ino());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn scoped_cwd_rejects_symlink_components_before_spawn() {
+        let root = TestDirectory::new("cwd-symlink");
+        let target = root.path.join("target");
+        let link = root.path.join("link");
+        std::fs::create_dir(&target).unwrap();
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        let error = match scoped_cwd(Some(link.to_str().unwrap()), &root.path, None, None) {
+            Ok(_) => panic!("symlink cwd must be rejected"),
+            Err(error) => error,
+        };
+        assert_eq!(error, "cwd is not accessible");
     }
 
     #[test]

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -22,6 +22,8 @@
 use std::collections::{HashMap, VecDeque};
 #[cfg(unix)]
 use std::fs::File;
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -96,6 +98,15 @@ pub struct ResolvedCwd {
     pub path: PathBuf,
     #[cfg(unix)]
     pub directory: Arc<File>,
+    #[cfg(unix)]
+    ancestry: Arc<Vec<DirectoryIdentity>>,
+}
+
+#[cfg(unix)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct DirectoryIdentity {
+    dev: u64,
+    ino: u64,
 }
 
 /// Resolve a PTY working directory and enforce every configured root list.
@@ -162,23 +173,44 @@ fn scoped_cwd(
     };
     let path = expand_path(raw, home, home);
     let canonical = std::fs::canonicalize(&path).map_err(|_| "cwd is not accessible".to_owned())?;
-    for roots in [local_roots.filter(|r| !r.is_empty()), server_roots.filter(|r| !r.is_empty())]
-        .into_iter()
-        .flatten()
-    {
-        if !roots.iter().map(|root| expand_path(root, home, home)).any(|root| {
-            std::fs::canonicalize(root).map(|root| canonical.starts_with(root)).unwrap_or(false)
-        }) {
-            return Err("cwd is outside the allowed roots".to_owned());
-        }
+    #[cfg(unix)]
+    let allowed_root_groups: Vec<Vec<Vec<DirectoryIdentity>>> =
+        [local_roots.filter(|r| !r.is_empty()), server_roots.filter(|r| !r.is_empty())]
+            .into_iter()
+            .flatten()
+            .map(|roots| {
+                roots
+                    .iter()
+                    .filter_map(|root| {
+                        let canonical_root =
+                            std::fs::canonicalize(expand_path(root, home, home)).ok()?;
+                        Some(open_pinned_directory(&canonical_root).ok()?.1)
+                    })
+                    .collect()
+            })
+            .collect();
+    #[cfg(not(unix))]
+    let allowed_root_groups: Vec<Vec<Vec<()>>> = Vec::new();
+    if allowed_root_groups.iter().any(|group| group.is_empty()) {
+        return Err("cwd is outside the allowed roots".to_owned());
     }
     if !canonical.is_dir() {
         return Err("cwd is not a directory".to_owned());
     }
     #[cfg(unix)]
     {
-        let directory = open_pinned_directory(&canonical)?;
-        Ok(ResolvedCwd { path: canonical, directory: Arc::new(directory) })
+        let (directory, ancestry) = open_pinned_directory(&canonical)?;
+        if allowed_root_groups
+            .iter()
+            .any(|group| !group.iter().any(|root| ancestry.starts_with(root)))
+        {
+            return Err("cwd is outside the allowed roots".to_owned());
+        }
+        Ok(ResolvedCwd {
+            path: canonical,
+            directory: Arc::new(directory),
+            ancestry: Arc::new(ancestry),
+        })
     }
     #[cfg(not(unix))]
     {
@@ -187,7 +219,7 @@ fn scoped_cwd(
 }
 
 #[cfg(unix)]
-fn open_pinned_directory(path: &Path) -> Result<File, String> {
+fn open_pinned_directory(path: &Path) -> Result<(File, Vec<DirectoryIdentity>), String> {
     use std::ffi::CString;
     use std::os::unix::ffi::OsStrExt;
     use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
@@ -208,6 +240,7 @@ fn open_pinned_directory(path: &Path) -> Result<File, String> {
         .open("/")
         .map_err(|_| "cwd is not accessible".to_owned())?;
     let mut expected_path = PathBuf::from("/");
+    let mut ancestry = Vec::new();
     for component in path.components() {
         let std::path::Component::Normal(name) = component else {
             continue;
@@ -215,6 +248,7 @@ fn open_pinned_directory(path: &Path) -> Result<File, String> {
         expected_path.push(name);
         let expected =
             std::fs::metadata(&expected_path).map_err(|_| "cwd is not accessible".to_owned())?;
+        ancestry.push(DirectoryIdentity { dev: expected.dev(), ino: expected.ino() });
         let name = CString::new(name.as_os_str().as_bytes())
             .map_err(|_| "cwd is not accessible".to_owned())?;
         // SAFETY: `parent` is an open directory and `name` is NUL-free.
@@ -230,7 +264,7 @@ fn open_pinned_directory(path: &Path) -> Result<File, String> {
         }
         parent = child;
     }
-    Ok(parent)
+    Ok((parent, ancestry))
 }
 
 fn clamp_dim(value: Option<&Value>) -> Option<u16> {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -175,6 +175,7 @@ fn scoped_cwd(
     if path.components().any(|component| component == std::path::Component::ParentDir) {
         return Err("cwd parent traversal is not supported".to_owned());
     }
+    let path = std::fs::canonicalize(&path).map_err(|_| "cwd is not accessible".to_owned())?;
     #[cfg(unix)]
     let allowed_root_groups: Vec<Vec<Vec<DirectoryIdentity>>> =
         [local_roots.filter(|r| !r.is_empty()), server_roots.filter(|r| !r.is_empty())]
@@ -184,7 +185,9 @@ fn scoped_cwd(
                 roots
                     .iter()
                     .filter_map(|root| {
-                        Some(open_pinned_directory(&expand_path(root, home, home)).ok()?.1)
+                        let canonical_root =
+                            std::fs::canonicalize(expand_path(root, home, home)).ok()?;
+                        Some(open_pinned_directory(&canonical_root).ok()?.1)
                     })
                     .collect()
             })

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -275,7 +275,7 @@ fn open_pinned_directory(path: &Path) -> Result<(File, Vec<DirectoryIdentity>), 
         let child = unsafe { File::from_raw_fd(fd) };
         let observed = child.metadata().map_err(|_| "cwd is not accessible".to_owned())?;
         if expected.dev() != observed.dev() || expected.ino() != observed.ino() {
-            return Err("cwd changed while resolving".to_owned());
+            return Err("the selected folder changed; select it again".to_owned());
         }
         parent = child;
     }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2991,17 +2991,14 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn scoped_cwd_rejects_symlink_components_before_spawn() {
+    fn scoped_cwd_resolves_symlink_components_before_spawn() {
         let root = TestDirectory::new("cwd-symlink");
         let target = root.path.join("target");
         let link = root.path.join("link");
         std::fs::create_dir(&target).unwrap();
         std::os::unix::fs::symlink(&target, &link).unwrap();
-        let error = match scoped_cwd(Some(link.to_str().unwrap()), &root.path, None, None) {
-            Ok(_) => panic!("symlink cwd must be rejected"),
-            Err(error) => error,
-        };
-        assert_eq!(error, "cwd is not accessible");
+        let resolved = scoped_cwd(Some(link.to_str().unwrap()), &root.path, None, None).unwrap();
+        assert_eq!(resolved.path, std::fs::canonicalize(target).unwrap());
     }
 
     #[test]

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -20,6 +20,8 @@
 //! empty frames; unknown ptyIds tolerated; refusals answer pty_error.
 
 use std::collections::{HashMap, VecDeque};
+#[cfg(unix)]
+use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -86,14 +88,23 @@ pub fn surface_ref_ok(value: &str) -> bool {
         && value.chars().all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | ':' | '-'))
 }
 
+/// A cwd validated against the relay root policy and pinned to its directory
+/// descriptor on Unix. Child processes use the descriptor, not the pathname,
+/// so a same-uid rename or symlink swap cannot redirect the cwd after checks.
+#[derive(Clone)]
+pub struct ResolvedCwd {
+    pub path: PathBuf,
+    #[cfg(unix)]
+    pub directory: Arc<File>,
+}
+
 /// Resolve a PTY working directory and enforce every configured root list.
-/// Canonicalization closes symlink escapes before the path reaches spawn.
 fn scoped_cwd(
     requested: Option<&str>,
     home: &Path,
     local_roots: Option<&[String]>,
     server_roots: Option<&[String]>,
-) -> Result<PathBuf, String> {
+) -> Result<ResolvedCwd, String> {
     // Keep PTY paths on the same wire policy as file actions. The relay sends
     // this error to the peer, so the validator only returns policy text and
     // filesystem failures below are deliberately redacted.
@@ -164,7 +175,26 @@ fn scoped_cwd(
     if !canonical.is_dir() {
         return Err("cwd is not a directory".to_owned());
     }
-    Ok(canonical)
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+        let expected =
+            std::fs::metadata(&canonical).map_err(|_| "cwd is not accessible".to_owned())?;
+        let directory = std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
+            .open(&canonical)
+            .map_err(|_| "cwd is not accessible".to_owned())?;
+        let observed = directory.metadata().map_err(|_| "cwd is not accessible".to_owned())?;
+        if expected.dev() != observed.dev() || expected.ino() != observed.ino() {
+            return Err("cwd changed while resolving".to_owned());
+        }
+        Ok(ResolvedCwd { path: canonical, directory: Arc::new(directory) })
+    }
+    #[cfg(not(unix))]
+    {
+        Ok(ResolvedCwd { path: canonical })
+    }
 }
 
 fn clamp_dim(value: Option<&Value>) -> Option<u16> {
@@ -226,7 +256,7 @@ pub struct SpawnSpec {
     pub args: Vec<String>,
     pub cols: u16,
     pub rows: u16,
-    pub cwd: PathBuf,
+    pub cwd: ResolvedCwd,
     pub env: HashMap<String, String>,
     pub cancellation: CancellationToken,
 }
@@ -252,7 +282,7 @@ pub trait PtyDeps: Send + Sync {
         cmux_tui: &CmuxTui,
         session: &str,
         socket_dir: &Path,
-        cwd: &Path,
+        cwd: &ResolvedCwd,
         env: &HashMap<String, String>,
     ) -> Result<EnsureDaemon, String>;
     async fn connect_control(&self, socket_path: &Path) -> Result<Arc<dyn ControlHandle>, String>;
@@ -977,7 +1007,7 @@ impl Inner {
         session: &str,
         cols: u16,
         rows: u16,
-        cwd: &Path,
+        cwd: &ResolvedCwd,
         env: &HashMap<String, String>,
         pty_id: &str,
         server_roots: Option<&[String]>,
@@ -1078,7 +1108,7 @@ impl Inner {
                 args,
                 cols,
                 rows,
-                cwd: cwd.to_path_buf(),
+                cwd: cwd.clone(),
                 env: env.clone(),
                 cancellation: context.cancellation.clone(),
             })
@@ -1104,7 +1134,7 @@ impl Inner {
         session: &str,
         cols: u16,
         rows: u16,
-        cwd: &Path,
+        cwd: &ResolvedCwd,
         env: &HashMap<String, String>,
         pty_id: &str,
         server_roots: Option<&[String]>,
@@ -1162,7 +1192,7 @@ impl Inner {
                         args: Vec::new(),
                         cols,
                         rows,
-                        cwd: cwd.to_path_buf(),
+                        cwd: cwd.clone(),
                         env: env.clone(),
                         cancellation: context.cancellation.clone(),
                     })
@@ -1655,7 +1685,7 @@ impl Inner {
         surface_ref: &str,
         cols: u16,
         rows: u16,
-        cwd: &Path,
+        cwd: &ResolvedCwd,
         env: &HashMap<String, String>,
         pty_id: &str,
         server_roots: Option<&[String]>,
@@ -1995,6 +2025,8 @@ mod tests {
     use super::*;
     use crate::control::{CloseHandler, EventHandler};
     use std::future::Future;
+    #[cfg(unix)]
+    use std::os::unix::fs::MetadataExt;
     use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
     use std::sync::{Arc as TestArc, Barrier, Mutex as StdMutex};
     use std::thread;
@@ -2117,7 +2149,7 @@ mod tests {
             let pty = FakePty {
                 state: Arc::new(StdMutex::new(FakeState::default())),
                 spawn_file: spec.file.clone(),
-                spawn_cwd: spec.cwd.clone(),
+                spawn_cwd: spec.cwd.path.clone(),
                 spawn_term: spec.env.get("TERM").cloned().unwrap_or_default(),
             };
             self.recorded.lock().unwrap().spawned.push(pty.clone());
@@ -2133,7 +2165,7 @@ mod tests {
             _cmux_tui: &CmuxTui,
             session: &str,
             socket_dir: &Path,
-            _cwd: &Path,
+            _cwd: &ResolvedCwd,
             _env: &HashMap<String, String>,
         ) -> Result<EnsureDaemon, String> {
             self.recorded
@@ -2830,11 +2862,11 @@ mod tests {
         std::fs::create_dir_all(&nested).unwrap();
         let home = root.path.to_string_lossy().into_owned();
         assert_eq!(
-            scoped_cwd(Some(&home), Path::new(&home), None, None).unwrap(),
+            scoped_cwd(Some(&home), Path::new(&home), None, None).unwrap().path,
             std::fs::canonicalize(&root.path).unwrap()
         );
         assert_eq!(
-            scoped_cwd(Some("~/nested"), Path::new(&home), None, None).unwrap(),
+            scoped_cwd(Some("~/nested"), Path::new(&home), None, None).unwrap().path,
             std::fs::canonicalize(nested).unwrap()
         );
     }
@@ -2847,11 +2879,11 @@ mod tests {
             "cwd must be absolute or home-relative"
         );
         assert_eq!(
-            scoped_cwd(None, &root.path, None, None).unwrap(),
+            scoped_cwd(None, &root.path, None, None).unwrap().path,
             std::fs::canonicalize(&root.path).unwrap()
         );
         assert_eq!(
-            scoped_cwd(Some(""), &root.path, None, None).unwrap(),
+            scoped_cwd(Some(""), &root.path, None, None).unwrap().path,
             std::fs::canonicalize(&root.path).unwrap()
         );
     }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -3006,7 +3006,11 @@ mod tests {
         std::fs::create_dir(&directory).unwrap();
         std::fs::set_permissions(&directory, std::fs::Permissions::from_mode(0o111)).unwrap();
 
-        open_pinned_directory(&directory).expect("O_EXEC|O_DIRECTORY must open search-only cwd");
+        // `open_pinned_directory` intentionally rejects symlink components.
+        // Canonicalize the temporary path because macOS commonly exposes /var
+        // through a symlink, while preserving the execute-only target.
+        let canonical = std::fs::canonicalize(&directory).unwrap();
+        open_pinned_directory(&canonical).expect("O_EXEC|O_DIRECTORY must open search-only cwd");
     }
 
     #[cfg(target_os = "macos")]

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -225,14 +225,12 @@ fn open_pinned_directory(path: &Path) -> Result<(File, Vec<DirectoryIdentity>), 
     use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
     use std::os::unix::io::FromRawFd;
 
-    // O_PATH (Linux) and O_EXEC (macOS) keep execute-only directories
-    // usable as cwd values. O_RDONLY is the portable fallback for other Unix
-    // targets, where it preserves the previous behavior when readable.
+    // Linux O_PATH avoids requiring read permission. Darwin and other Unix
+    // targets use O_RDONLY because their libc does not expose a portable
+    // execute-only directory-open flag.
     #[cfg(target_os = "linux")]
     const ACCESS_MODE: libc::c_int = libc::O_PATH;
-    #[cfg(target_os = "macos")]
-    const ACCESS_MODE: libc::c_int = libc::O_EXEC;
-    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    #[cfg(not(target_os = "linux"))]
     const ACCESS_MODE: libc::c_int = libc::O_RDONLY;
     let flags = ACCESS_MODE | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC;
     let mut parent = std::fs::OpenOptions::new()

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -177,24 +177,60 @@ fn scoped_cwd(
     }
     #[cfg(unix)]
     {
-        use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
-        let expected =
-            std::fs::metadata(&canonical).map_err(|_| "cwd is not accessible".to_owned())?;
-        let directory = std::fs::OpenOptions::new()
-            .read(true)
-            .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
-            .open(&canonical)
-            .map_err(|_| "cwd is not accessible".to_owned())?;
-        let observed = directory.metadata().map_err(|_| "cwd is not accessible".to_owned())?;
-        if expected.dev() != observed.dev() || expected.ino() != observed.ino() {
-            return Err("cwd changed while resolving".to_owned());
-        }
+        let directory = open_pinned_directory(&canonical)?;
         Ok(ResolvedCwd { path: canonical, directory: Arc::new(directory) })
     }
     #[cfg(not(unix))]
     {
         Ok(ResolvedCwd { path: canonical })
     }
+}
+
+#[cfg(unix)]
+fn open_pinned_directory(path: &Path) -> Result<File, String> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+    use std::os::unix::io::FromRawFd;
+
+    // O_PATH (Linux) and O_SEARCH (macOS) keep execute-only directories
+    // usable as cwd values. O_RDONLY is the portable fallback for other Unix
+    // targets, where it preserves the previous behavior when readable.
+    #[cfg(target_os = "linux")]
+    const ACCESS_MODE: libc::c_int = libc::O_PATH;
+    #[cfg(target_os = "macos")]
+    const ACCESS_MODE: libc::c_int = libc::O_SEARCH;
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    const ACCESS_MODE: libc::c_int = libc::O_RDONLY;
+    let flags = ACCESS_MODE | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC;
+    let mut parent = std::fs::OpenOptions::new()
+        .custom_flags(flags)
+        .open("/")
+        .map_err(|_| "cwd is not accessible".to_owned())?;
+    let mut expected_path = PathBuf::from("/");
+    for component in path.components() {
+        let std::path::Component::Normal(name) = component else {
+            continue;
+        };
+        expected_path.push(name);
+        let expected =
+            std::fs::metadata(&expected_path).map_err(|_| "cwd is not accessible".to_owned())?;
+        let name = CString::new(name.as_os_str().as_bytes())
+            .map_err(|_| "cwd is not accessible".to_owned())?;
+        // SAFETY: `parent` is an open directory and `name` is NUL-free.
+        let fd = unsafe { libc::openat(parent.as_raw_fd(), name.as_ptr(), flags) };
+        if fd < 0 {
+            return Err("cwd is not accessible".to_owned());
+        }
+        // SAFETY: `fd` is a newly-owned descriptor from openat.
+        let child = unsafe { File::from_raw_fd(fd) };
+        let observed = child.metadata().map_err(|_| "cwd is not accessible".to_owned())?;
+        if expected.dev() != observed.dev() || expected.ino() != observed.ino() {
+            return Err("cwd changed while resolving".to_owned());
+        }
+        parent = child;
+    }
+    Ok(parent)
 }
 
 fn clamp_dim(value: Option<&Value>) -> Option<u16> {
@@ -2892,14 +2928,16 @@ mod tests {
     #[test]
     fn scoped_cwd_descriptor_remains_pinned_after_path_rebind() {
         let root = TestDirectory::new("cwd-pinned");
-        let checked = root.path.join("checked");
+        let scope = root.path.join("scope");
+        let checked = scope.join("checked");
         let outside = root.path.join("outside");
+        std::fs::create_dir(&scope).unwrap();
         std::fs::create_dir(&checked).unwrap();
-        std::fs::create_dir(&outside).unwrap();
+        std::fs::create_dir_all(outside.join("checked")).unwrap();
         let resolved = scoped_cwd(Some(checked.to_str().unwrap()), &root.path, None, None).unwrap();
         let before = resolved.directory.metadata().unwrap();
-        std::fs::rename(&checked, root.path.join("moved")).unwrap();
-        std::os::unix::fs::symlink(&outside, &checked).unwrap();
+        std::fs::rename(&scope, root.path.join("moved")).unwrap();
+        std::os::unix::fs::symlink(&outside, &scope).unwrap();
         let after = resolved.directory.metadata().unwrap();
         assert_eq!(before.dev(), after.dev());
         assert_eq!(before.ino(), after.ino());

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2962,7 +2962,10 @@ mod tests {
     fn scoped_cwd_rejects_relative_requests_and_defaults_null_or_empty() {
         let root = TestDirectory::new("cwd-default");
         assert_eq!(
-            scoped_cwd(Some("relative"), &root.path, None, None).unwrap_err(),
+            match scoped_cwd(Some("relative"), &root.path, None, None) {
+                Ok(_) => panic!("relative cwd must be rejected"),
+                Err(error) => error,
+            },
             "cwd must be absolute or home-relative"
         );
         assert_eq!(

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -261,8 +261,7 @@ fn open_pinned_directory(path: &Path) -> Result<(File, Vec<DirectoryIdentity>), 
         let expected =
             std::fs::metadata(&expected_path).map_err(|_| "cwd is not accessible".to_owned())?;
         ancestry.push(DirectoryIdentity { dev: expected.dev(), ino: expected.ino() });
-        let name = CString::new(name.as_os_str().as_bytes())
-            .map_err(|_| "cwd is not accessible".to_owned())?;
+        let name = CString::new(name.as_bytes()).map_err(|_| "cwd is not accessible".to_owned())?;
         // SAFETY: `parent` is an open directory and `name` is NUL-free.
         let fd = unsafe { libc::openat(parent.as_raw_fd(), name.as_ptr(), flags) };
         if fd < 0 {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -3008,6 +3008,19 @@ mod tests {
         open_pinned_directory(&directory).expect("O_EXEC|O_DIRECTORY must open search-only cwd");
     }
 
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn scoped_cwd_resolves_execute_only_directory() {
+        let root = TestDirectory::new("cwd-search-only-scoped");
+        let directory = root.path.join("search-only");
+        std::fs::create_dir(&directory).unwrap();
+        std::fs::set_permissions(&directory, std::fs::Permissions::from_mode(0o111)).unwrap();
+
+        let resolved = scoped_cwd(Some(directory.to_str().unwrap()), &root.path, None, None)
+            .expect("execute-only cwd must resolve through its pinned descriptor");
+        assert_eq!(resolved.path, std::fs::canonicalize(directory).unwrap());
+    }
+
     #[cfg(unix)]
     #[test]
     fn scoped_cwd_resolves_symlink_components_before_spawn() {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2856,6 +2856,23 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn scoped_cwd_descriptor_remains_pinned_after_path_rebind() {
+        let root = TestDirectory::new("cwd-pinned");
+        let checked = root.path.join("checked");
+        let outside = root.path.join("outside");
+        std::fs::create_dir(&checked).unwrap();
+        std::fs::create_dir(&outside).unwrap();
+        let resolved = scoped_cwd(Some(checked.to_str().unwrap()), &root.path, None, None).unwrap();
+        let before = resolved.directory.metadata().unwrap();
+        std::fs::rename(&checked, root.path.join("moved")).unwrap();
+        std::os::unix::fs::symlink(&outside, &checked).unwrap();
+        let after = resolved.directory.metadata().unwrap();
+        assert_eq!(before.dev(), after.dev());
+        assert_eq!(before.ino(), after.ino());
+    }
+
     #[test]
     fn malformed_process_info_cwd_is_cleaned_to_empty_picker_component() {
         assert_eq!(shorten_cwd("", "/home/u"), "");

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -172,6 +172,9 @@ fn scoped_cwd(
         &raw_owned
     };
     let path = expand_path(raw, home, home);
+    if path.components().any(|component| component == std::path::Component::ParentDir) {
+        return Err("cwd parent traversal is not supported".to_owned());
+    }
     #[cfg(unix)]
     let allowed_root_groups: Vec<Vec<Vec<DirectoryIdentity>>> =
         [local_roots.filter(|r| !r.is_empty()), server_roots.filter(|r| !r.is_empty())]
@@ -231,12 +234,14 @@ fn open_pinned_directory(path: &Path) -> Result<(File, Vec<DirectoryIdentity>), 
     use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
     use std::os::unix::io::FromRawFd;
 
-    // Linux O_PATH avoids requiring read permission. Darwin and other Unix
-    // targets use O_RDONLY because their libc does not expose a portable
-    // execute-only directory-open flag.
+    // Linux O_PATH avoids requiring read permission. Darwin's O_EXEC value is
+    // not exposed by every libc release, so keep the documented Darwin value
+    // local and retain execute-only cwd support.
     #[cfg(target_os = "linux")]
     const ACCESS_MODE: libc::c_int = libc::O_PATH;
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(target_os = "macos")]
+    const ACCESS_MODE: libc::c_int = 0x4000_0000;
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     const ACCESS_MODE: libc::c_int = libc::O_RDONLY;
     let flags = ACCESS_MODE | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC;
     let mut parent = std::fs::OpenOptions::new()

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -237,14 +237,13 @@ fn open_pinned_directory(path: &Path) -> Result<(File, Vec<DirectoryIdentity>), 
     use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
     use std::os::unix::io::FromRawFd;
 
-    // Linux O_PATH avoids requiring read permission. Darwin does not expose a
-    // supported O_EXEC or O_SEARCH flag, so use O_RDONLY there. This keeps the
-    // descriptor walk portable and fail-closed, at the cost of requiring read
-    // permission on macOS directories used as a PTY cwd.
+    // Linux O_PATH avoids requiring read permission. Darwin's O_EXEC combined
+    // with O_DIRECTORY requests search-only directory access, so execute-only
+    // cwd directories remain valid without relying on a pathname after checks.
     #[cfg(target_os = "linux")]
     const ACCESS_MODE: libc::c_int = libc::O_PATH;
     #[cfg(target_os = "macos")]
-    const ACCESS_MODE: libc::c_int = libc::O_RDONLY;
+    const ACCESS_MODE: libc::c_int = libc::O_EXEC;
     #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     const ACCESS_MODE: libc::c_int = libc::O_RDONLY;
     let flags = ACCESS_MODE | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC;
@@ -2109,6 +2108,8 @@ mod tests {
     use std::future::Future;
     #[cfg(unix)]
     use std::os::unix::fs::MetadataExt;
+    #[cfg(target_os = "macos")]
+    use std::os::unix::fs::PermissionsExt;
     use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
     use std::sync::{Arc as TestArc, Barrier, Mutex as StdMutex};
     use std::thread;
@@ -2987,6 +2988,17 @@ mod tests {
         let after = resolved.directory.metadata().unwrap();
         assert_eq!(before.dev(), after.dev());
         assert_eq!(before.ino(), after.ino());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn scoped_cwd_accepts_execute_only_directory() {
+        let root = TestDirectory::new("cwd-search-only");
+        let directory = root.path.join("search-only");
+        std::fs::create_dir(&directory).unwrap();
+        std::fs::set_permissions(&directory, std::fs::Permissions::from_mode(0o111)).unwrap();
+
+        open_pinned_directory(&directory).expect("O_EXEC|O_DIRECTORY must open search-only cwd");
     }
 
     #[cfg(unix)]

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -573,7 +573,12 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
     let reader = File::from(pair.try_clone_reader_descriptor()?);
     let mut command = cmux_pty::PtyCommand::new(spec.file.clone());
     command.args(spec.args.clone());
-    command.cwd_descriptor(spec.cwd.directory.try_clone()?);
+    let directory = spec
+        .cwd
+        .directory
+        .try_clone()
+        .map_err(|_| anyhow::anyhow!("cwd descriptor clone failed"))?;
+    command.cwd_descriptor(directory);
     command.env_clear();
     for (key, value) in &spec.env {
         command.env(key, value);
@@ -940,10 +945,8 @@ impl PtyDeps for RealPtyDeps {
         command.stdout(std::process::Stdio::null());
         command.stderr(std::process::Stdio::null());
         command.process_group(0);
-        let directory = cwd
-            .directory
-            .try_clone()
-            .map_err(|error| format!("cwd descriptor clone failed: {error}"))?;
+        let directory =
+            cwd.directory.try_clone().map_err(|_| "cwd descriptor clone failed".to_owned())?;
         // Tokio exposes the underlying std::process::Command for Unix
         // pre_exec setup. fchdir runs in the child after fork and pins the
         // daemon to the validated directory descriptor.

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -14,6 +14,7 @@ use std::io::{Read, Write};
 use std::mem::{offset_of, size_of};
 use std::os::fd::AsRawFd;
 use std::os::unix::net::UnixStream;
+use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Condvar, Mutex, mpsc};
@@ -27,7 +28,7 @@ use sha2::{Digest, Sha256};
 use crate::control::{CONTROL_TIMEOUT_MS, ControlHandle, connect_control};
 use crate::pty::{
     CmuxTui, DataSink, EnsureDaemon, ExitSink, PtyControl, PtyDeps, PtyHandle, PtyOutput,
-    SpawnSpec, session_name_ok,
+    ResolvedCwd, SpawnSpec, session_name_ok,
 };
 
 const DAEMON_SOCKET_WAIT_MS: u64 = 5_000;
@@ -572,7 +573,7 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
     let reader = File::from(pair.try_clone_reader_descriptor()?);
     let mut command = cmux_pty::PtyCommand::new(spec.file.clone());
     command.args(spec.args.clone());
-    command.cwd(&spec.cwd);
+    command.cwd_descriptor(spec.cwd.directory.try_clone()?);
     command.env_clear();
     for (key, value) in &spec.env {
         command.env(key, value);
@@ -657,7 +658,7 @@ fn pump_pty(
 fn spawn_pipe_mode(spec: &SpawnSpec, reason: &str) -> PtyHandle {
     let output = ThreadOutput::new();
     let mut command = std::process::Command::new(&spec.file);
-    command.args(&spec.args).current_dir(&spec.cwd).env_clear();
+    command.args(&spec.args).env_clear();
     for (key, value) in &spec.env {
         command.env(key, value);
     }
@@ -665,6 +666,24 @@ fn spawn_pipe_mode(spec: &SpawnSpec, reason: &str) -> PtyHandle {
     command.stdin(std::process::Stdio::piped());
     command.stdout(std::process::Stdio::piped());
     command.stderr(std::process::Stdio::piped());
+    let directory = match spec.cwd.directory.try_clone() {
+        Ok(directory) => directory,
+        Err(error) => {
+            output.push_exit(1);
+            return PtyHandle { control: Arc::new(DeadControl), output, banner: None };
+        }
+    };
+    // Keep cwd pinned to the validated directory descriptor. The descriptor
+    // is captured by the child-side pre_exec hook, after which path rebinding
+    // cannot redirect this process.
+    unsafe {
+        command.pre_exec(move || {
+            if libc::fchdir(directory.as_raw_fd()) == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
     let banner = format!(
         "[cmux-relay] PTY allocation failed ({reason}); running {} without a TTY.\r\n",
         Path::new(&spec.file)
@@ -872,7 +891,7 @@ impl PtyDeps for RealPtyDeps {
         cmux_tui: &CmuxTui,
         session: &str,
         socket_dir: &Path,
-        cwd: &Path,
+        cwd: &ResolvedCwd,
         env: &HashMap<String, String>,
     ) -> Result<EnsureDaemon, String> {
         use std::os::unix::fs::{MetadataExt, PermissionsExt};
@@ -913,7 +932,7 @@ impl PtyDeps for RealPtyDeps {
             socket_path.to_string_lossy().into_owned(),
         ]);
         let mut command = tokio::process::Command::new(&cmux_tui.file);
-        command.args(&args).current_dir(cwd).env_clear();
+        command.args(&args).env_clear();
         for (key, value) in env {
             command.env(key, value);
         }
@@ -921,6 +940,21 @@ impl PtyDeps for RealPtyDeps {
         command.stdout(std::process::Stdio::null());
         command.stderr(std::process::Stdio::null());
         command.process_group(0);
+        let directory = cwd
+            .directory
+            .try_clone()
+            .map_err(|error| format!("cwd descriptor clone failed: {error}"))?;
+        // Tokio exposes the underlying std::process::Command for Unix
+        // pre_exec setup. fchdir runs in the child after fork and pins the
+        // daemon to the validated directory descriptor.
+        unsafe {
+            command.as_std_mut().pre_exec(move || {
+                if libc::fchdir(directory.as_raw_fd()) == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
         let child =
             command.spawn().map_err(|error| format!("cmux-tui daemon spawn failed: {error}"))?;
 

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -673,7 +673,7 @@ fn spawn_pipe_mode(spec: &SpawnSpec, reason: &str) -> PtyHandle {
     command.stderr(std::process::Stdio::piped());
     let directory = match spec.cwd.directory.try_clone() {
         Ok(directory) => directory,
-        Err(error) => {
+        Err(_) => {
             output.push_exit(1);
             return PtyHandle { control: Arc::new(DeadControl), output, banner: None };
         }

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -719,7 +719,7 @@ mod tests {
             _cmux_tui: &CmuxTui,
             _session: &str,
             _socket_dir: &Path,
-            _cwd: &Path,
+            _cwd: &crate::pty::ResolvedCwd,
             _env: &HashMap<String, String>,
         ) -> Result<EnsureDaemon, String> {
             Err("no daemon in tunnel tests".to_owned())


### PR DESCRIPTION
Summary:
- Resolve relay cwd to a canonical path and an opened directory descriptor, verifying device/inode stability.
- Use descriptor-based fchdir for cmux-pty, pipe fallback, and cmux-tui daemon spawns to close pathname TOCTOU races.
- Add a Unix regression test for path rebinding after validation.

Validation:
- rustfmt --edition 2024 --check on changed Rust files
- git diff --check
- Hosted cmux-tui verification pending

The two commits intentionally separate the failing behavior test from the fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins relay PTY working directories to validated directory descriptors instead of pathnames, closing the TOCTOU race where a same-UID rename or symlink swap could redirect spawned processes after validation.

**Bug Fixes**
- Rejects `..` traversal and resolves symlink components before validation.
- Checks cwd ancestry and allowed roots using stable device/inode identities.
- Uses the pinned descriptor for `cmux-pty`, pipe fallback, and `cmux-tui` daemon launches.
- Supports Linux `O_PATH`, macOS `O_EXEC`, and portable Unix directory opens, including execute-only macOS directories.
- Redacts filesystem details from cwd errors and reports when the selected folder changed.
- Adds Unix coverage for path rebinding, symlink resolution, descriptor handling, and execute-only directories.

<sup>Written for commit dff2fcf28a76c4d3233fe083a60850f5e8b144d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved working-directory validation when launching terminals and processes.
  * Prevented symlink swaps, path traversal, and directory renames from redirecting processes after validation.
  * Ensured configured directory restrictions are consistently enforced across supported platforms.
  * Improved reliability when launching processes from directories that are temporarily or dynamically re-bound.
  * Ensured processes continue using the validated directory, even if its path changes afterward.

* **Tests**
  * Added coverage for directory rebinding, symlink resolution, restricted-directory enforcement, and process startup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->