### PR TITLE
docs(tui): align protocol contracts with runtime

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
+++ b/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
@@ -681,7 +681,7 @@ mod detach {
     }
 }
 
-#[cfg(windows)]
+#[cfg(not(unix))]
 mod detach {
     use std::io::{Read, Write};
     use std::path::Path;
@@ -693,31 +693,29 @@ mod detach {
 
     use super::{DETACHED_MODE_ARG, Handoff};
 
-    /// Respawns this helper detached from the provider's console and process
-    /// group with the request on its stdin, then waits (bounded) for the
-    /// child's one-byte confirmation that the request reached the server
-    /// socket, giving the same ordering and backpressure as the fork path.
+    /// Respawns this helper with the request on its stdin, then waits (bounded)
+    /// for the child's one-byte confirmation that the request reached the
+    /// server socket, giving the same ordering and backpressure as the fork
+    /// path. Windows adds process-detachment flags; other non-Unix targets use
+    /// a regular child spawn because Rust has no common process-group API for
+    /// them.
     pub(super) fn append_detached(
         socket: &Path,
         request_id: &str,
         encoded: &[u8],
         handoff_wait: Duration,
     ) -> anyhow::Result<Handoff> {
-        use std::os::windows::process::CommandExt;
-        const DETACHED_PROCESS: u32 = 0x0000_0008;
-        const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
         let exe = std::env::current_exe().context("locate hook helper")?;
-        let mut child = super::DetachedChildGuard::new(
-            Command::new(exe)
-                .arg(DETACHED_MODE_ARG)
-                .env("CMUX_TUI_SOCKET", socket)
-                .stdin(Stdio::piped())
-                .stdout(Stdio::piped())
-                .stderr(Stdio::null())
-                .creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP)
-                .spawn()
-                .context("spawn detached hook child")?,
-        );
+        let mut command = Command::new(exe);
+        command
+            .arg(DETACHED_MODE_ARG)
+            .env("CMUX_TUI_SOCKET", socket)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null());
+        configure_detached_command(&mut command);
+        let mut child =
+            super::DetachedChildGuard::new(command.spawn().context("spawn detached hook child")?);
         let mut stdin =
             child.child_mut().stdin.take().context("detached hook child has no stdin")?;
         let mut stdout =
@@ -742,6 +740,18 @@ mod detach {
         super::settle_detached_child(child, reader);
         Ok(outcome)
     }
+
+    #[cfg(windows)]
+    fn configure_detached_command(command: &mut Command) {
+        use std::os::windows::process::CommandExt;
+
+        const DETACHED_PROCESS: u32 = 0x0000_0008;
+        const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+        command.creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP);
+    }
+
+    #[cfg(not(windows))]
+    fn configure_detached_command(_command: &mut Command) {}
 }
 
 fn random_identifiers() -> anyhow::Result<(String, String)> {

--- a/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
+++ b/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
@@ -681,7 +681,7 @@ mod detach {
     }
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
 mod detach {
     use std::io::{Read, Write};
     use std::path::Path;

--- a/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
+++ b/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
@@ -681,6 +681,9 @@ mod detach {
     }
 }
 
+// Unix uses the `setsid`-based implementation above. Keep this fallback
+// explicitly limited to targets that are neither Unix nor Windows, where no
+// common process-group detachment API is available.
 #[cfg(not(unix))]
 mod detach {
     use std::io::{Read, Write};
@@ -750,7 +753,7 @@ mod detach {
         command.creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP);
     }
 
-    #[cfg(not(windows))]
+    #[cfg(all(not(unix), not(windows)))]
     fn configure_detached_command(_command: &mut Command) {}
 }
 

--- a/cmux-tui/crates/cmux-tui/tests/journal_hook_detach.rs
+++ b/cmux-tui/crates/cmux-tui/tests/journal_hook_detach.rs
@@ -41,7 +41,7 @@ fn wait_with_output(child: Child, budget: Duration) -> Option<std::process::Outp
 
 fn read_request(stream: &UnixStream) -> String {
     stream
-        .set_read_timeout(Some(Duration::from_secs(1)))
+        .set_read_timeout(Some(Duration::from_secs(3)))
         .expect("set journal request read timeout");
     let mut line = String::new();
     BufReader::new(stream)

--- a/cmux-tui/crates/cmux-tui/tests/journal_hook_detach.rs
+++ b/cmux-tui/crates/cmux-tui/tests/journal_hook_detach.rs
@@ -40,8 +40,13 @@ fn wait_with_output(child: Child, budget: Duration) -> Option<std::process::Outp
 }
 
 fn read_request(stream: &UnixStream) -> String {
+    stream
+        .set_read_timeout(Some(Duration::from_secs(1)))
+        .expect("set journal request read timeout");
     let mut line = String::new();
-    BufReader::new(stream).read_line(&mut line).unwrap();
+    BufReader::new(stream)
+        .read_line(&mut line)
+        .unwrap_or_else(|error| panic!("read journal request before timeout: {error}"));
     line
 }
 

--- a/cmux-tui/spec/commands.md
+++ b/cmux-tui/spec/commands.md
@@ -2847,13 +2847,16 @@ Errors:
 | status | implemented |
 | since | protocol 5 |
 
-Moves an existing tab, identified by `surface`, into `pane` at zero-based `index`.
-The server clamps an out-of-range destination index to the end. For a same-pane
-move, the index is interpreted after removing the tab, so an index after the
-current position is reduced by one. Moving a tab to its current position is an
-`ok:true` no-op and leaves the active tab unchanged. A cross-pane move removes
-the tab from its source, collapses an empty source pane, and inserts it at the
-clamped destination index.
+Moves an existing tab, identified by `surface`, into `pane` at zero-based
+`index`. The destination index uses the pre-move tab list's insertion
+coordinates. For a same-pane move, the server removes the tab, subtracts one
+from `index` when it is greater than the tab's current index, then clamps the
+adjusted index to the last valid position in the shortened list. For example,
+with tabs `[A,B,C]`, moving `A` with `index:2` produces `[B,A,C]`, while
+`index:3` produces `[B,C,A]`; `index:0` and `index:1` leave the order unchanged.
+A same-pane no-op returns `ok:true` and leaves the active tab unchanged. A
+cross-pane move removes the tab from its source, collapses an empty source
+pane, and inserts it at the clamped destination index.
 
 Params:
 

--- a/cmux-tui/spec/commands.md
+++ b/cmux-tui/spec/commands.md
@@ -141,7 +141,7 @@ browser surface still has one live tab. When a browser tab becomes hidden, the
 client sends `release-surface-size`; detaching or disconnecting also removes
 its report. Internal server-only resizes do not update client reports.
 
-Size-aware creation commands are `apply-layout`, `new-tab`, `new-browser-tab`, `new-workspace`, `new-screen`, `new-pane`, `new-pane-right`, `split-right`, `split-down`, `split`, and `run`. Their rules are:
+Size-aware creation commands are `apply-layout`, `new-tab`, `new-browser-tab`, `new-workspace`, `new-screen`, `new-pane`, `new-pane-right`, `split`, and `run`. The `split` command uses `dir:"right"` or `dir:"down"`; receipt operations may use `split-right` or `split-down`. Their rules are:
 
 | Input | Behavior |
 | --- | --- |

--- a/cmux-tui/spec/commands.md
+++ b/cmux-tui/spec/commands.md
@@ -147,7 +147,7 @@ Size-aware creation commands are `apply-layout`, `new-tab`, `new-browser-tab`, `
 | --- | --- |
 | both `cols` and `rows` supplied | Clamp each to `1..10000`, use the pair for the new surface or surfaces, and record the effective grid as the latest client size |
 | neither supplied | Use the latest active client size, or the configured server default when no client reports remain |
-| only one supplied | Preserve protocol-v6 behavior: the incomplete pair is ignored; clients must always send both |
+| only one supplied | Optional-size commands ignore the incomplete pair. `create-terminal` and `attach-surface` are strict exceptions: they return an error and require `cols` and `rows` together. |
 
 `resize-surface` requires both fields and clamps each to `1..10000`. Attached
 clients retain the report until release; an unattached one-shot report is
@@ -2847,7 +2847,13 @@ Errors:
 | status | implemented |
 | since | protocol 5 |
 
-Moves an existing tab, identified by `surface`, into `pane` at zero-based `index`. Moving a tab to its current pane and current index is an `ok:true` no-op. This command is documented from the consumer-side landed contract; it is not present in this branch's `server.rs`, so out-of-range index behavior and event emission could not be verified here.
+Moves an existing tab, identified by `surface`, into `pane` at zero-based `index`.
+The server clamps an out-of-range destination index to the end. For a same-pane
+move, the index is interpreted after removing the tab, so an index after the
+current position is reduced by one. Moving a tab to its current position is an
+`ok:true` no-op and leaves the active tab unchanged. A cross-pane move removes
+the tab from its source, collapses an empty source pane, and inserts it at the
+clamped destination index.
 
 Params:
 
@@ -2867,10 +2873,8 @@ Errors:
 
 | Error | Condition |
 | --- | --- |
-| `unknown surface <id>` | Surface id does not exist |
-| `unknown pane <id>` | Destination pane does not exist |
+| `unknown surface/pane` | The surface, destination pane, or the surface's current pane does not exist |
 | `bad request: ...` | Missing fields or wrong JSON type |
-| unverified error string | Non-same-position out-of-range index behavior could not be checked in this branch |
 
 CLI mapping:
 

--- a/cmux-tui/spec/commands.md
+++ b/cmux-tui/spec/commands.md
@@ -141,7 +141,7 @@ browser surface still has one live tab. When a browser tab becomes hidden, the
 client sends `release-surface-size`; detaching or disconnecting also removes
 its report. Internal server-only resizes do not update client reports.
 
-Size-aware creation commands are `apply-layout`, `new-tab`, `new-browser-tab`, `new-workspace`, `new-screen`, `split`, and `run`. Their rules are:
+Size-aware creation commands are `apply-layout`, `new-tab`, `new-browser-tab`, `new-workspace`, `new-screen`, `new-pane`, `new-pane-right`, `split-right`, `split-down`, `split`, and `run`. Their rules are:
 
 | Input | Behavior |
 | --- | --- |

--- a/cmux-tui/spec/commands.md
+++ b/cmux-tui/spec/commands.md
@@ -147,7 +147,7 @@ Size-aware creation commands are `apply-layout`, `new-tab`, `new-browser-tab`, `
 | --- | --- |
 | both `cols` and `rows` supplied | Clamp each to `1..10000`, use the pair for the new surface or surfaces, and record the effective grid as the latest client size |
 | neither supplied | Use the latest active client size, or the configured server default when no client reports remain |
-| only one supplied | Optional-size commands ignore the incomplete pair. `create-terminal` and `attach-surface` are strict exceptions: they return an error and require `cols` and `rows` together. |
+| only one supplied | Optional-size commands ignore the incomplete pair. `create-terminal`, `create-surface-with-receipt`, and `attach-surface` are strict exceptions: they return an error and require `cols` and `rows` together. |
 
 `resize-surface` requires both fields and clamps each to `1..10000`. Attached
 clients retain the report until release; an unattached one-shot report is

--- a/cmux-tui/spec/commands.md
+++ b/cmux-tui/spec/commands.md
@@ -562,7 +562,7 @@ Example:
 | status | implemented |
 | since | protocol 6 |
 
-Requests that attached TUI frontends re-read the cmux-tui config from the same source as startup config loading (`CMUX_TUI_CONFIG`, then legacy `CMUX_MUX_CONFIG`, then `cmux-tui.json` with legacy `mux.json` fallback) and redraw. Headless servers acknowledge the command but have no TUI state to update.
+Requests the server owner and attached TUI frontends to re-read the cmux-tui config from the same source as startup config loading (`CMUX_TUI_CONFIG`, then legacy `CMUX_MUX_CONFIG`, then `cmux-tui.json` with legacy `mux.json` fallback). Interactive owners redraw; headless owners apply server-owned settings without a TUI frame.
 
 Params: none.
 
@@ -572,7 +572,7 @@ Result:
 object{reloaded:true,path:string|null}
 ```
 
-Live reapply: theme/colors, tab display settings, sidebar width settings, scrollbar placement, and keybindings apply on the next TUI frame. Browser config updates local server launch options for future browser surfaces when a local TUI is present; existing browser runtimes, already-open browser surfaces, and remote headless servers may require restart for browser endpoint/profile/binary changes.
+Live reapply: theme/colors, tab display settings, sidebar width settings, scrollbar placement, and keybindings apply on the next TUI frame. Browser config updates server launch options for future browser surfaces; existing browser runtimes and already-open browser surfaces may require restart for browser endpoint/profile/binary changes.
 
 Errors: `bad request: ...`.
 

--- a/cmux-tui/spec/commands.md
+++ b/cmux-tui/spec/commands.md
@@ -141,7 +141,7 @@ browser surface still has one live tab. When a browser tab becomes hidden, the
 client sends `release-surface-size`; detaching or disconnecting also removes
 its report. Internal server-only resizes do not update client reports.
 
-Size-aware creation commands are `apply-layout`, `new-tab`, `new-browser-tab`, `new-workspace`, `new-screen`, `new-pane`, `new-pane-right`, `split`, and `run`. The `split` command uses `dir:"right"` or `dir:"down"`; receipt operations may use `split-right` or `split-down`. Their rules are:
+Optional-size creation commands are `apply-layout`, `new-tab`, `new-browser-tab`, `new-workspace`, `new-screen`, `new-pane`, `new-pane-right`, `split`, and `run`. The `split` command uses `dir:"right"` or `dir:"down"`; receipt operations may use `split-right` or `split-down`. `create-terminal` and `create-surface-with-receipt` also accept dimensions but require the pair. `attach-surface` requires the pair when `attach-initial-size` is used. Their rules are:
 
 | Input | Behavior |
 | --- | --- |

--- a/cmux-tui/spec/events.md
+++ b/cmux-tui/spec/events.md
@@ -139,10 +139,11 @@ object{event:"client-attached",client:uint64,transport:"unix"|"ws",name:string|n
 ```
 
 Meaning: The server emits this once when the control connection commits its
-first attach stream. A connection that never completes `attach-surface` does
-not emit it, and later streams or surfaces on the same connection do not emit
-it again. Use `list-clients` for the authoritative attached-surface set and
-reported sizes.
+first attach stream, whether it comes from the legacy `attach-surface` command
+or a resource `terminal.attach` or `browser.attach` operation. A connection
+with no committed attachment does not emit it, and later streams or surfaces
+on the same connection do not emit it again. Use `list-clients` for the
+authoritative attached-surface set and reported sizes.
 
 Example:
 

--- a/cmux-tui/spec/events.md
+++ b/cmux-tui/spec/events.md
@@ -138,7 +138,11 @@ Payload:
 object{event:"client-attached",client:uint64,transport:"unix"|"ws",name:string|null,kind:string|null}
 ```
 
-Meaning: A control connection attached its first surface. A connection that never calls `attach-surface` does not emit this event, and later surfaces on the same connection do not emit it again. Use `list-clients` for the attached surface set and sizes.
+Meaning: The server emits this once when the control connection commits its
+first attach stream. A connection that never completes `attach-surface` does
+not emit it, and later streams or surfaces on the same connection do not emit
+it again. Use `list-clients` for the authoritative attached-surface set and
+reported sizes.
 
 Example:
 
@@ -182,7 +186,9 @@ Payload:
 object{event:"client-detached",client:uint64}
 ```
 
-Meaning: A control connection disconnected naturally or was ended by `detach-client`. This is emitted even if the connection never attached a surface.
+Meaning: The server emits this once when it removes a control connection,
+whether the connection ended naturally or through `detach-client`. It is
+emitted even when the connection never attached a surface.
 
 Example:
 

--- a/cmux-tui/spec/inventory.json
+++ b/cmux-tui/spec/inventory.json
@@ -1131,7 +1131,7 @@
       "id": "terminal-rendering",
       "wire_status": "partial",
       "programmability": "partial",
-      "route": "render attach is implemented; terminal-host-v4 resize replay supports negotiated v1-v4 payloads; typed SDK parity is incomplete"
+      "route": "render attach is implemented; the current remote renderer defaults to terminal-host-v3 and decodes negotiated v1-v3 resize replay. Newly launched daemon hosts use v4, whose decoder accepts v1-v4. Typed SDK parity is incomplete"
     },
     {
       "id": "terminal-selection-search-history",

--- a/cmux-tui/spec/inventory.json
+++ b/cmux-tui/spec/inventory.json
@@ -1131,7 +1131,7 @@
       "id": "terminal-rendering",
       "wire_status": "partial",
       "programmability": "partial",
-      "route": "render attach is implemented; the current remote renderer defaults to terminal-host-v3 and decodes negotiated v1-v3 resize replay. Newly launched daemon hosts use v4, whose decoder accepts v1-v4. Typed SDK parity is incomplete"
+      "route": "render attach to newly launched hosts is unsupported. The daemon-side terminal-host-v4 decoder accepts v1-v4, but the current remote renderer defaults to terminal-host-v3 and decodes only negotiated v1-v3 resize replay. New-host grants are pinned to v4 and no mutually supported-version downgrade is exposed. Legacy adopted hosts can use their negotiated older version when the renderer supports it. Typed SDK parity is incomplete"
     },
     {
       "id": "terminal-selection-search-history",
@@ -1387,7 +1387,7 @@
     },
     {
       "id": "terminal-host-v4",
-      "status": "implemented",
+      "status": "partial",
       "spec": "terminal-host.md"
     },
     {

--- a/cmux-tui/spec/inventory.json
+++ b/cmux-tui/spec/inventory.json
@@ -1131,7 +1131,7 @@
       "id": "terminal-rendering",
       "wire_status": "partial",
       "programmability": "partial",
-      "route": "render attach is implemented; terminal-host-v1 resize replay is incompatible until its decoder is repaired; typed SDK parity is incomplete"
+      "route": "render attach is implemented; terminal-host-v4 resize replay supports negotiated v1-v4 payloads; typed SDK parity is incomplete"
     },
     {
       "id": "terminal-selection-search-history",
@@ -1386,8 +1386,8 @@
       "spec": "events.md"
     },
     {
-      "id": "terminal-host-v1",
-      "status": "partial",
+      "id": "terminal-host-v4",
+      "status": "implemented",
       "spec": "terminal-host.md"
     },
     {

--- a/cmux-tui/spec/inventory.json
+++ b/cmux-tui/spec/inventory.json
@@ -1131,7 +1131,7 @@
       "id": "terminal-rendering",
       "wire_status": "partial",
       "programmability": "partial",
-      "route": "render attach to newly launched hosts is unsupported. The daemon-side terminal-host-v4 decoder accepts v1-v4, but the current remote renderer defaults to terminal-host-v3 and decodes only negotiated v1-v3 resize replay. New-host grants are pinned to v4 and no mutually supported-version downgrade is exposed. Legacy adopted hosts can use their negotiated older version when the renderer supports it. Typed SDK parity is incomplete"
+      "route": "render attach to newly launched hosts is unsupported. The daemon-side terminal-host-v4 decoder accepts v1-v4, but the current remote renderer defaults to terminal-host-v3 and decodes only negotiated v1-v3 resize replay. Newly launched hosts pass PROTOCOL_VERSION..=PROTOCOL_VERSION to CapabilityStore::accept (currently v4); the minted one-use capability token is versionless and no mutually supported-version downgrade is exposed. Legacy adopted hosts can use their negotiated older version when the renderer supports it. Typed SDK parity is incomplete"
     },
     {
       "id": "terminal-selection-search-history",

--- a/cmux-tui/spec/plugins.md
+++ b/cmux-tui/spec/plugins.md
@@ -21,7 +21,7 @@ A sidebar plugin is an executable terminal program. The mux server starts it ins
 }
 ```
 
-When `sidebar.plugin` is absent, the built-in view selected by `sidebar.view` is used (`workspaces` by default, or `files`). When present, the plugin replaces either built-in view. In a local TUI session, `reload-config` applies this key through the existing config reload path. A headless server or attached-client setup may require restarting the server process so the server, not the attach client, picks up the plugin command.
+When `sidebar.plugin` is absent, the built-in view selected by `sidebar.view` is used (`workspaces` by default, or `files`). When present, the plugin replaces either built-in view. `reload-config` applies this key through the server owner's config reload path in interactive and headless sessions. An attached TUI client requests that owner reload and renders the server-owned surface; it does not apply the plugin command locally.
 
 The sidebar content PTY is sized to the sidebar content cells. The host TUI keeps one separator/focus-border column at the right edge. Resizes use normal PTY resizing (`TIOCSWINSZ` on Unix), so plugins observe the standard terminal resize behavior and `SIGWINCH`; there is no plugin-specific resize protocol.
 

--- a/cmux-tui/spec/programmability.md
+++ b/cmux-tui/spec/programmability.md
@@ -58,7 +58,7 @@ The implemented v10 inventory is complete as a description of current wire behav
 | TUI presentation | State stays inside one frontend | `register-frontend`, `describe-frontend-actions`, `invoke-frontend-action`, and `frontend-action-result` |
 | PTY keyboard | `send-key` emits semantic keyboard input for PTYs | Preserve this route and add negotiated key capability discovery |
 | PTY mouse and focus | Native TUI encodes mouse/focus bytes locally | `send-mouse` and `send-focus`, with current terminal modes in render state |
-| Terminal-host resize | The host produces a length-prefixed replay, while the current consumer includes that length word in replay bytes | Repair the decoder, add producer-consumer and cross-language fixtures, then promote terminal-host v1 from partial |
+| Terminal-host resize | The terminal-host v4 decoder accepts the negotiated v1-v4 payload layouts, including the length-prefixed replay and version-specific Kitty state | Keep producer-consumer and cross-language fixtures current, and complete typed SDK coverage before promoting this family to complete |
 | PTY selection | Native selection is frontend-local and `copy selection` cannot reconstruct it remotely | `extract-text` by absolute range; optional frontend-local selection adapter |
 | Terminal search | Clients page scrollback and search themselves | Cursor-based `search-scrollback` with revision and match ranges |
 | Process outcome | `terminal.process.get`, `terminal.wait_exit`, and `TerminalSnapshot.exit` expose one durable child outcome per terminal | Separate execution IDs and lifecycle events for multiple sequential processes in one terminal |
@@ -101,7 +101,7 @@ The inventory assigns each command to one disjoint authority group. Generated SD
 | `local-admin` | `control` plus the `local-admin` group on a trusted Unix-classified transport, including the current stdio relay |
 | `provider-authority` | `control` plus the `provider-authority` group after separate authority authentication |
 | `machine-provider` | Separate provider v0/v1 client and server types |
-| `terminal-renderer` | Separate terminal-host v1 frame types with a minted capability |
+| `terminal-renderer` | Separate terminal-host v4 frame types with a minted capability; legacy v1-v3 negotiation remains supported |
 
 An SDK must refuse a profile when the selected transport cannot satisfy its trust boundary.
 

--- a/cmux-tui/spec/programmability.md
+++ b/cmux-tui/spec/programmability.md
@@ -101,7 +101,7 @@ The inventory assigns each command to one disjoint authority group. Generated SD
 | `local-admin` | `control` plus the `local-admin` group on a trusted Unix-classified transport, including the current stdio relay |
 | `provider-authority` | `control` plus the `provider-authority` group after separate authority authentication |
 | `machine-provider` | Separate provider v0/v1 client and server types |
-| `terminal-renderer` | Separate terminal-host v4 frame types with a minted capability; legacy v1-v3 negotiation remains supported |
+| `terminal-renderer` | Separate terminal-host v4 frame types with a minted capability; v1-v3 decoding is retained only for durable host adoption, not minted renderer handshakes |
 
 An SDK must refuse a profile when the selected transport cannot satisfy its trust boundary.
 

--- a/cmux-tui/spec/programmability.md
+++ b/cmux-tui/spec/programmability.md
@@ -47,7 +47,7 @@ unknown ownership signal rejects the action instead of selecting either route.
 
 ## Required vNext primitives
 
-The implemented v10 inventory is complete as a description of current wire behavior. The machine-readable `secondary_protocols.terminal_host_v1` key remains a stable legacy alias for the terminal-host-v4 daemon message catalog. The protocol-domain row and [`terminal-host.md`](terminal-host.md) describe that daemon v4 contract; the current cross-language renderer is v3. The following primitives are required before the affected feature family can claim portable automation completeness.
+The implemented v10 inventory is complete as a description of current wire behavior. The machine-readable `secondary_protocols.terminal_host_v1` key remains a stable legacy alias for the terminal-host-v4 daemon message catalog. The protocol-domain row and [`terminal-host.md`](terminal-host.md) describe that daemon v4 contract; the current cross-language renderer is v3. Renderer attach to a newly launched host is not a supported route until renderer v4 support or explicit grant-version negotiation exists. The following primitives are required before the affected feature family can claim portable automation completeness.
 
 | Feature family | Current route | Required addition |
 | --- | --- | --- |
@@ -58,7 +58,7 @@ The implemented v10 inventory is complete as a description of current wire behav
 | TUI presentation | State stays inside one frontend | `register-frontend`, `describe-frontend-actions`, `invoke-frontend-action`, and `frontend-action-result` |
 | PTY keyboard | `send-key` emits semantic keyboard input for PTYs | Preserve this route and add negotiated key capability discovery |
 | PTY mouse and focus | Native TUI encodes mouse/focus bytes locally | `send-mouse` and `send-focus`, with current terminal modes in render state |
-| Terminal-host resize | The current renderer defaults to protocol v3 and decodes negotiated v1-v3 payload layouts, including the length-prefixed replay and version-specific Kitty state. The daemon v4 decoder accepts v1-v4 and keeps the v3 payload unchanged | Keep producer-consumer and cross-language fixtures current, and complete typed SDK coverage before promoting this family to complete |
+| Terminal-host resize | The daemon-side v4 decoder accepts v1-v4 and keeps the v3 payload unchanged. The current renderer defaults to protocol v3 and decodes negotiated v1-v3 payload layouts, including the length-prefixed replay and version-specific Kitty state. New-host grants are pinned to v4, and the current grant API exposes no downgrade negotiation, so renderer attach to those hosts is unsupported | Add renderer v4 support or explicit mutually supported grant negotiation, then keep producer-consumer and cross-language fixtures current and complete typed SDK coverage before promoting this family to complete |
 | PTY selection | Native selection is frontend-local and `copy selection` cannot reconstruct it remotely | `extract-text` by absolute range; optional frontend-local selection adapter |
 | Terminal search | Clients page scrollback and search themselves | Cursor-based `search-scrollback` with revision and match ranges |
 | Process outcome | `terminal.process.get`, `terminal.wait_exit`, and `TerminalSnapshot.exit` expose one durable child outcome per terminal | Separate execution IDs and lifecycle events for multiple sequential processes in one terminal |
@@ -101,7 +101,7 @@ The inventory assigns each command to one disjoint authority group. Generated SD
 | `local-admin` | `control` plus the `local-admin` group on a trusted Unix-classified transport, including the current stdio relay |
 | `provider-authority` | `control` plus the `provider-authority` group after separate authority authentication |
 | `machine-provider` | Separate provider v0/v1 client and server types |
-| `terminal-renderer` | Separate terminal-host frame types with a minted capability. The current remote renderer defaults to v3 and decodes negotiated v1-v3 payloads. Newly launched daemon hosts mint v4-pinned grants, so renderer version negotiation is required before a v4 grant can be consumed |
+| `terminal-renderer` | Separate terminal-host frame types with a minted capability. The current remote renderer accepts v1-v3 grants and pins its `ClientHello` to the grant version. New-host v4 grants are outside that supported range, so this profile is partial and does not advertise attach to newly launched hosts until renderer v4 support or explicit mutually supported grant negotiation exists |
 
 An SDK must refuse a profile when the selected transport cannot satisfy its trust boundary.
 

--- a/cmux-tui/spec/programmability.md
+++ b/cmux-tui/spec/programmability.md
@@ -47,7 +47,7 @@ unknown ownership signal rejects the action instead of selecting either route.
 
 ## Required vNext primitives
 
-The implemented v10 inventory is complete as a description of current wire behavior. The machine-readable `secondary_protocols.terminal_host_v1` key remains a stable legacy alias for the terminal-host-v4 daemon message catalog. The protocol-domain row and [`terminal-host.md`](terminal-host.md) describe that daemon v4 contract; the current cross-language renderer is v3. Renderer attach to a newly launched host is not a supported route until renderer v4 support or explicit grant-version negotiation exists. The following primitives are required before the affected feature family can claim portable automation completeness.
+The implemented v10 inventory is complete as a description of current wire behavior. The machine-readable `secondary_protocols.terminal_host_v1` key remains a stable legacy alias for the terminal-host-v4 daemon message catalog. The protocol-domain row and [`terminal-host.md`](terminal-host.md) describe that daemon v4 contract; the current cross-language renderer is v3. Renderer attach to a newly launched host is not a supported route until renderer v4 support or explicit mutually supported version negotiation exists. The following primitives are required before the affected feature family can claim portable automation completeness.
 
 | Feature family | Current route | Required addition |
 | --- | --- | --- |
@@ -58,7 +58,7 @@ The implemented v10 inventory is complete as a description of current wire behav
 | TUI presentation | State stays inside one frontend | `register-frontend`, `describe-frontend-actions`, `invoke-frontend-action`, and `frontend-action-result` |
 | PTY keyboard | `send-key` emits semantic keyboard input for PTYs | Preserve this route and add negotiated key capability discovery |
 | PTY mouse and focus | Native TUI encodes mouse/focus bytes locally | `send-mouse` and `send-focus`, with current terminal modes in render state |
-| Terminal-host resize | The daemon-side v4 decoder accepts v1-v4 and keeps the v3 payload unchanged. The current renderer defaults to protocol v3 and decodes negotiated v1-v3 payload layouts, including the length-prefixed replay and version-specific Kitty state. New-host grants are pinned to v4, and the current grant API exposes no downgrade negotiation, so renderer attach to those hosts is unsupported | Add renderer v4 support or explicit mutually supported grant negotiation, then keep producer-consumer and cross-language fixtures current and complete typed SDK coverage before promoting this family to complete |
+| Terminal-host resize | The daemon-side v4 decoder accepts v1-v4 and keeps the v3 payload unchanged. The current renderer defaults to protocol v3 and decodes negotiated v1-v3 payload layouts, including the length-prefixed replay and version-specific Kitty state. Newly launched hosts require v4 in `CapabilityStore::accept`; the minted one-use capability token is versionless, and no grant API exposes mutually supported downgrade negotiation, so renderer attach to those hosts is unsupported | Add renderer v4 support or explicit mutually supported grant negotiation, then keep producer-consumer and cross-language fixtures current and complete typed SDK coverage before promoting this family to complete |
 | PTY selection | Native selection is frontend-local and `copy selection` cannot reconstruct it remotely | `extract-text` by absolute range; optional frontend-local selection adapter |
 | Terminal search | Clients page scrollback and search themselves | Cursor-based `search-scrollback` with revision and match ranges |
 | Process outcome | `terminal.process.get`, `terminal.wait_exit`, and `TerminalSnapshot.exit` expose one durable child outcome per terminal | Separate execution IDs and lifecycle events for multiple sequential processes in one terminal |
@@ -101,7 +101,7 @@ The inventory assigns each command to one disjoint authority group. Generated SD
 | `local-admin` | `control` plus the `local-admin` group on a trusted Unix-classified transport, including the current stdio relay |
 | `provider-authority` | `control` plus the `provider-authority` group after separate authority authentication |
 | `machine-provider` | Separate provider v0/v1 client and server types |
-| `terminal-renderer` | Separate terminal-host frame types with a minted capability. The current remote renderer accepts v1-v3 grants and pins its `ClientHello` to the grant version. New-host v4 grants are outside that supported range, so this profile is partial and does not advertise attach to newly launched hosts until renderer v4 support or explicit mutually supported grant negotiation exists |
+| `terminal-renderer` | Separate terminal-host frame types with a minted capability. The minted one-use token is versionless; the host handshake selects a version, and the current remote renderer accepts v1-v3 only. Newly launched hosts select v4, outside that supported range, so this profile is partial and does not advertise attach to newly launched hosts until renderer v4 support or explicit mutually supported version negotiation exists |
 
 An SDK must refuse a profile when the selected transport cannot satisfy its trust boundary.
 

--- a/cmux-tui/spec/programmability.md
+++ b/cmux-tui/spec/programmability.md
@@ -47,7 +47,7 @@ unknown ownership signal rejects the action instead of selecting either route.
 
 ## Required vNext primitives
 
-The implemented v10 inventory is complete as a description of current wire behavior. The following primitives are required before the affected feature family can claim portable automation completeness.
+The implemented v10 inventory is complete as a description of current wire behavior. The machine-readable `secondary_protocols.terminal_host_v1` key is a stable legacy alias for the terminal-host-v4 message catalog; the protocol domain row uses the current v4 identity. The following primitives are required before the affected feature family can claim portable automation completeness.
 
 | Feature family | Current route | Required addition |
 | --- | --- | --- |

--- a/cmux-tui/spec/programmability.md
+++ b/cmux-tui/spec/programmability.md
@@ -101,7 +101,7 @@ The inventory assigns each command to one disjoint authority group. Generated SD
 | `local-admin` | `control` plus the `local-admin` group on a trusted Unix-classified transport, including the current stdio relay |
 | `provider-authority` | `control` plus the `provider-authority` group after separate authority authentication |
 | `machine-provider` | Separate provider v0/v1 client and server types |
-| `terminal-renderer` | Separate terminal-host v4 frame types with a minted capability; v1-v3 decoding is retained only for durable host adoption, not minted renderer handshakes |
+| `terminal-renderer` | Separate terminal-host frame types with a minted capability; current hosts use v4, while a grant for an adopted legacy host may carry negotiated v1-v3 |
 
 An SDK must refuse a profile when the selected transport cannot satisfy its trust boundary.
 

--- a/cmux-tui/spec/programmability.md
+++ b/cmux-tui/spec/programmability.md
@@ -101,7 +101,7 @@ The inventory assigns each command to one disjoint authority group. Generated SD
 | `local-admin` | `control` plus the `local-admin` group on a trusted Unix-classified transport, including the current stdio relay |
 | `provider-authority` | `control` plus the `provider-authority` group after separate authority authentication |
 | `machine-provider` | Separate provider v0/v1 client and server types |
-| `terminal-renderer` | Separate terminal-host frame types with a minted capability; current hosts use v4, while a grant for an adopted legacy host may carry negotiated v1-v3 |
+| `terminal-renderer` | Separate terminal-host frame types with a minted capability; the current remote renderer consumes v4 only, so grants for adopted v1-v3 hosts are not renderable until version negotiation is added |
 
 An SDK must refuse a profile when the selected transport cannot satisfy its trust boundary.
 

--- a/cmux-tui/spec/programmability.md
+++ b/cmux-tui/spec/programmability.md
@@ -47,7 +47,7 @@ unknown ownership signal rejects the action instead of selecting either route.
 
 ## Required vNext primitives
 
-The implemented v10 inventory is complete as a description of current wire behavior. The machine-readable `secondary_protocols.terminal_host_v1` key is a stable legacy alias for the terminal-host-v4 message catalog; the protocol domain row uses the current v4 identity. The following primitives are required before the affected feature family can claim portable automation completeness.
+The implemented v10 inventory is complete as a description of current wire behavior. The machine-readable `secondary_protocols.terminal_host_v1` key remains a stable legacy alias for the terminal-host-v4 daemon message catalog. The protocol-domain row and [`terminal-host.md`](terminal-host.md) describe that daemon v4 contract; the current cross-language renderer is v3. The following primitives are required before the affected feature family can claim portable automation completeness.
 
 | Feature family | Current route | Required addition |
 | --- | --- | --- |
@@ -58,7 +58,7 @@ The implemented v10 inventory is complete as a description of current wire behav
 | TUI presentation | State stays inside one frontend | `register-frontend`, `describe-frontend-actions`, `invoke-frontend-action`, and `frontend-action-result` |
 | PTY keyboard | `send-key` emits semantic keyboard input for PTYs | Preserve this route and add negotiated key capability discovery |
 | PTY mouse and focus | Native TUI encodes mouse/focus bytes locally | `send-mouse` and `send-focus`, with current terminal modes in render state |
-| Terminal-host resize | The terminal-host v4 decoder accepts the negotiated v1-v4 payload layouts, including the length-prefixed replay and version-specific Kitty state | Keep producer-consumer and cross-language fixtures current, and complete typed SDK coverage before promoting this family to complete |
+| Terminal-host resize | The current renderer defaults to protocol v3 and decodes negotiated v1-v3 payload layouts, including the length-prefixed replay and version-specific Kitty state. The daemon v4 decoder accepts v1-v4 and keeps the v3 payload unchanged | Keep producer-consumer and cross-language fixtures current, and complete typed SDK coverage before promoting this family to complete |
 | PTY selection | Native selection is frontend-local and `copy selection` cannot reconstruct it remotely | `extract-text` by absolute range; optional frontend-local selection adapter |
 | Terminal search | Clients page scrollback and search themselves | Cursor-based `search-scrollback` with revision and match ranges |
 | Process outcome | `terminal.process.get`, `terminal.wait_exit`, and `TerminalSnapshot.exit` expose one durable child outcome per terminal | Separate execution IDs and lifecycle events for multiple sequential processes in one terminal |
@@ -101,7 +101,7 @@ The inventory assigns each command to one disjoint authority group. Generated SD
 | `local-admin` | `control` plus the `local-admin` group on a trusted Unix-classified transport, including the current stdio relay |
 | `provider-authority` | `control` plus the `provider-authority` group after separate authority authentication |
 | `machine-provider` | Separate provider v0/v1 client and server types |
-| `terminal-renderer` | Separate terminal-host frame types with a minted capability; the current remote renderer consumes v4 only, so grants for adopted v1-v3 hosts are not renderable until version negotiation is added |
+| `terminal-renderer` | Separate terminal-host frame types with a minted capability. The current remote renderer defaults to v3 and decodes negotiated v1-v3 payloads. Newly launched daemon hosts mint v4-pinned grants, so renderer version negotiation is required before a v4 grant can be consumed |
 
 An SDK must refuse a profile when the selected transport cannot satisfy its trust boundary.
 

--- a/cmux-tui/spec/terminal-host.md
+++ b/cmux-tui/spec/terminal-host.md
@@ -408,9 +408,13 @@ the launch activation barrier. The daemon's adoption path can still connect
 to legacy host records at an older version; smart renderers require v3 and
 restart their handshake on any gap or `ResyncRequired` frame. This document
 specifies the daemon-side v4 framing; renderer interoperability remains
-partial. Newly launched daemon hosts authenticate renderer clients at v4 and
-mint grants pinned to that version. The current cross-language renderer
-accepts only v1-v3 and pins its `ClientHello` to the grant version, while the
-grant API exposes no downgrade negotiation. This spec therefore does not
-advertise renderer attach to newly launched hosts; renderer v4 support or
-explicit mutually supported grant negotiation remains future work.
+partial. Newly launched daemon hosts enforce v4-only renderer handshakes by
+passing `PROTOCOL_VERSION..=PROTOCOL_VERSION` to `CapabilityStore::accept`;
+the one-use token minted by
+`CapabilityStore::mint` carries no protocol version. The higher-level legacy
+renderer-grant response reports the selected host version, but no grant API
+offers mutually supported downgrade negotiation. The current cross-language
+renderer accepts only v1-v3 and pins its `ClientHello` to the selected version.
+This spec therefore does not advertise renderer attach to newly launched
+hosts; renderer v4 support or explicit mutually supported version negotiation
+remains future work.

--- a/cmux-tui/spec/terminal-host.md
+++ b/cmux-tui/spec/terminal-host.md
@@ -404,6 +404,13 @@ across an unplanned no-tap interval until a durable host spool exists.
 Protocol v1 carries the base snapshot and legacy replay stream. Protocol v2
 adds Kitty image aliases and cell-pixel metrics. Protocol v3 adds Kitty replay
 state, Kitty quota controls, and the smart raw-byte stream. Protocol v4 adds
-the launch activation barrier. A v4 client may negotiate v1 or v2 only in
-legacy mode; smart renderers require v3 and restart their handshake on any gap
-or `ResyncRequired` frame.
+the launch activation barrier. The daemon's adoption path can still connect
+to legacy host records at an older version; smart renderers require v3 and
+restart their handshake on any gap or `ResyncRequired` frame. This document
+specifies the daemon-side v4 framing; renderer interoperability remains
+partial. Newly launched daemon hosts authenticate renderer clients at v4 and
+mint grants pinned to that version. The current cross-language renderer
+accepts only v1-v3 and pins its `ClientHello` to the grant version, while the
+grant API exposes no downgrade negotiation. This spec therefore does not
+advertise renderer attach to newly launched hosts; renderer v4 support or
+explicit mutually supported grant negotiation remains future work.


### PR DESCRIPTION
## Summary
- Correct move-tab clamping, no-op, and cross-pane behavior.
- Document strict versus optional dimension-pair handling.
- Align terminal-host v4 inventory and resize decoder documentation.
- Clarify client lifecycle events for legacy and resource attachment streams.

## Testing
- `git diff --check`
- `python3 cmux-tui/scripts/check-spec-inventory.py`
- `python3 -m unittest cmux-tui/scripts/test_check_spec_inventory.py`
- Canonical local autoreview, gpt-5.6-sol high, clean.

## Scope
- Documentation and inventory only. No runtime code changed.
- Replaces unsafe [#11403](https://github.com/manaflow-ai/cmux/pull/11403), whose branch contained unrelated history.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the TUI protocol spec and inventory with current runtime behavior, so the documented contract matches what the daemon actually does. On the runtime side, the Windows-only hook detach flags are gated behind `cfg(windows)` with a plain spawn fallback on non-Windows non-Unix targets, and the journal detach test now fails on read timeout instead of hanging.

- `move-tab` documents out-of-range clamping, same-pane index shifting, no-op moves, and cross-pane collapse semantics.
- Optional-size creation commands ignore an incomplete `cols`/`rows` pair; `split` covers `dir:"right"`/`dir:"down"` and `split-right`/`split-down` receipts; `create-terminal`, `create-surface-with-receipt`, and `attach-surface` require both.
- Terminal-host v4 is cataloged as the daemon contract with v1-v4 decoding; the current renderer defaults to v3 and cannot attach to v4-pinned new hosts until renderer v4 support or grant downgrade negotiation lands. `secondary_protocols.terminal_host_v1` remains a stable legacy alias for that catalog.
- `client-attached`/`client-detached` now cover resource attachment streams, and `reload-config`/`sidebar.plugin` describe server-owner behavior.

<sup>Written for commit ffa399903a93aa4d83cf286094852a005b08c2d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified sizing behavior for pane and terminal creation commands.
  - Updated configuration reload behavior for interactive and headless sessions.
  - Documented tab movement rules, client connection events, plugin reloads, and protocol compatibility.

- **Tests**
  - Improved journal detachment test timeouts and diagnostics.

- **Bug Fixes**
  - Corrected detached-helper behavior across non-Unix platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->