### PR TITLE
ci: route CLA guard through configured runner

### DIFF
--- a/.github/workflows/cla-policy-guard.yml
+++ b/.github/workflows/cla-policy-guard.yml
@@ -12,7 +12,7 @@ permissions: {}
 jobs:
   validate:
     name: CLA policy guard
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 10
     permissions:
       contents: read

--- a/scripts/ci/validate-cla-policy.rb
+++ b/scripts/ci/validate-cla-policy.rb
@@ -26,8 +26,8 @@ CLA_ACTION = "manaflow-ai/cla-github-action@fc608ba7106e7029d981d487d7bad28a6432
 # base-controlled guard, followed by the workflow change.
 EXPECTED_WORKFLOW_DIGEST = "d4db98df5a1b1e6f3b006a82639761a0513eeeaf153a9eb2b98d42d1af782145"
 EXPECTED_RERUN_DIGEST = "f4f1fa51bb05b062ebf3f60cc949d8d5b4b501e7849cb065e9a07d7a34030840"
-EXPECTED_GUARD_WORKFLOW_DIGEST = "dfe6acc7a284001034c095fc50abd8bd4c64fc73e36bbe089c4c53169c062fdf"
-EXPECTED_GUARD_SCRIPT_DIGEST = "7e61437e6d623876d1bf7e7c7a06bbd82745e4d4a2a5397604dfd4ead24aef05"
+EXPECTED_GUARD_WORKFLOW_DIGEST = "cb08e6837d8065897016f12cf30c85e0153fc5c3c2d9ca1e6b409f4237541bc4"
+EXPECTED_GUARD_SCRIPT_DIGEST = "fba44dda662ef1ea91b0e840e8988d12a3856813b9bdd6ced72dc0d4dad81b2e"
 # Current organization administrators who may approve a trusted control-plane
 # update. IDs are used instead of names, and the review must target the exact
 # PR head. This is the human path for intentional policy maintenance.

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -15,6 +15,21 @@ COMPAT_FILE="$ROOT_DIR/.github/workflows/ci-macos-compat.yml"
 E2E_FILE="$ROOT_DIR/.github/workflows/test-e2e.yml"
 TMUX_CORPUS_FILE="$ROOT_DIR/.github/workflows/tmux-corpus.yml"
 IOS_FILE="$ROOT_DIR/.github/workflows/test-ios.yml"
+CLA_GUARD_FILE="$ROOT_DIR/.github/workflows/cla-policy-guard.yml"
+
+check_cla_guard_runner() {
+  if ! grep -Fqx '    runs-on: ${{ vars.LINUX_RUNNER || '\''blacksmith-4vcpu-ubuntu-2404'\'' }}' "$CLA_GUARD_FILE"; then
+    echo "FAIL: cla-policy-guard.yml must use the configured Linux runner with the Blacksmith fallback"
+    exit 1
+  fi
+
+  if grep -Eq '^    runs-on: ubuntu-' "$CLA_GUARD_FILE"; then
+    echo "FAIL: cla-policy-guard.yml must not use a bare GitHub-hosted runner"
+    exit 1
+  fi
+
+  echo "PASS: CLA policy guard uses the configured Linux runner"
+}
 
 check_macos_runner() {
   local file="$1" job="$2"
@@ -1238,6 +1253,7 @@ check_no_self_hosted_fleet_runners() {
 }
 
 # ci.yml jobs
+check_cla_guard_runner
 check_no_bare_github_hosted_runners
 check_no_self_hosted_fleet_runners
 check_macos_runner "$CI_FILE" "app-host-unit-tests"


### PR DESCRIPTION
Route the immutable CLA policy guard through vars.LINUX_RUNNER with the existing Blacksmith fallback. This keeps the guard aligned with the repository runner trust checks and updates the guard workflow digest constants.

Validation: Ruby syntax, trusted 26-case matrix, offline guard validators, actionlint, and workflow self-hosted guard tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11422"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790848612&installation_model_id=21920&pr_number=11422&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11422&signature=483fc48b889f62998725d24e69841b5b311c1c471b0d431693454452243fabab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes the CLA policy guard through `vars.LINUX_RUNNER` with the existing Blacksmith fallback instead of hardcoding `ubuntu-24.04`, and adds a self-hosted guard test enforcing the configured runner. Updates the expected guard workflow and script digest constants to match.

<sup>Written for commit b151b5a11a0462dde046ba17d16bdabc63b9b027. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI validation to use a configurable Linux runner, with a fallback runner when none is specified.
  * Refreshed integrity checks for the contribution agreement validation workflow and script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->