### PR TITLE
fix(cmux-tui): join machine action worker on shutdown

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -586,6 +586,7 @@ impl FrontendJournalQueue {
 struct FrontendJournalWorker {
     queue: Option<Arc<FrontendJournalQueue>>,
     worker: Option<JoinHandle<()>>,
+    reaper: Option<JoinHandle<()>>,
 }
 
 impl FrontendJournalWorker {
@@ -8461,7 +8462,7 @@ impl MachineActionWorker {
                 }
                 controller.close();
             })?;
-        Ok(Self { sender: Some(sender), stop, worker: Some(worker) })
+        Ok(Self { sender: Some(sender), stop, worker: Some(worker), reaper: None })
     }
 
     fn perform(
@@ -8559,11 +8560,17 @@ impl MachineActionWorker {
             // Provider calls are synchronous and may remain blocked until
             // their transport deadline. Reap the owned handle asynchronously
             // so shutdown stays responsive without detaching the worker.
-            let _ = std::thread::Builder::new()
+            self.reaper = std::thread::Builder::new()
                 .name("machine-actions-reaper".into())
                 .spawn(move || {
                     let _ = worker.join();
-                });
+                })
+                .ok();
+        }
+        if self.reaper.as_ref().is_some_and(JoinHandle::is_finished)
+            && let Some(reaper) = self.reaper.take()
+        {
+            let _ = reaper.join();
         }
     }
 }
@@ -42726,6 +42733,7 @@ mod tests {
         assert!(started_shutdown.elapsed() < Duration::from_millis(50));
         release.send(()).unwrap();
         closes.recv_timeout(Duration::from_secs(1)).unwrap();
+        worker.shutdown();
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -8556,7 +8556,14 @@ impl MachineActionWorker {
         // at its transport deadline, then the worker observes stop and closes
         // the controller. Join so provider cleanup cannot outlive the owner.
         if let Some(worker) = self.worker.take() {
-            let _ = worker.join();
+            // Provider calls are synchronous and may remain blocked until
+            // their transport deadline. Reap the owned handle asynchronously
+            // so shutdown stays responsive without detaching the worker.
+            let _ = std::thread::Builder::new()
+                .name("machine-actions-reaper".into())
+                .spawn(move || {
+                    let _ = worker.join();
+                });
         }
     }
 }
@@ -42714,8 +42721,10 @@ mod tests {
             .unwrap();
         assert_eq!(starts.recv_timeout(Duration::from_secs(1)).unwrap(), MachineKey(1));
 
-        release.send(()).unwrap();
+        let started_shutdown = Instant::now();
         worker.shutdown();
+        assert!(started_shutdown.elapsed() < Duration::from_millis(50));
+        release.send(()).unwrap();
         closes.recv_timeout(Duration::from_secs(1)).unwrap();
     }
 

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -8560,12 +8560,26 @@ impl MachineActionWorker {
             // Provider calls are synchronous and may remain blocked until
             // their transport deadline. Reap the owned handle asynchronously
             // so shutdown stays responsive without detaching the worker.
-            self.reaper = std::thread::Builder::new()
+            let worker = Arc::new(std::sync::Mutex::new(Some(worker)));
+            let worker_for_reaper = worker.clone();
+            match std::thread::Builder::new()
                 .name("machine-actions-reaper".into())
                 .spawn(move || {
-                    let _ = worker.join();
+                    if let Some(worker) = worker_for_reaper.lock().unwrap().take() {
+                        let _ = worker.join();
+                    }
                 })
-                .ok();
+            {
+                Ok(reaper) => self.reaper = Some(reaper),
+                Err(_) => {
+                    // Restore ownership when the reaper cannot start. This
+                    // is exceptional, so synchronously finish cleanup rather
+                    // than dropping the worker handle.
+                    if let Some(worker) = worker.lock().unwrap().take() {
+                        let _ = worker.join();
+                    }
+                }
+            }
         }
         if self.reaper.as_ref().is_some_and(JoinHandle::is_finished)
             && let Some(reaper) = self.reaper.take()

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -8552,15 +8552,12 @@ impl MachineActionWorker {
     fn shutdown(&mut self) {
         self.stop.store(true, Ordering::Release);
         self.sender.take();
-        if self.worker.as_ref().is_some_and(JoinHandle::is_finished)
-            && let Some(worker) = self.worker.take()
-        {
+        // The stop flag is cooperative: an in-flight provider action returns
+        // at its transport deadline, then the worker observes stop and closes
+        // the controller. Join so provider cleanup cannot outlive the owner.
+        if let Some(worker) = self.worker.take() {
             let _ = worker.join();
         }
-        // A provider action has a bounded transport deadline but may still be
-        // in progress. Dropping the handle detaches that bounded cleanup so
-        // quitting the TUI never waits for the provider deadline.
-        self.worker.take();
     }
 }
 
@@ -42698,7 +42695,7 @@ mod tests {
     }
 
     #[test]
-    fn machine_action_worker_shutdown_never_joins_a_blocked_action() {
+    fn machine_action_worker_shutdown_joins_after_cooperative_cancellation() {
         let (events, _event_receiver) = crossbeam_channel::bounded(4);
         let (started, starts) = std::sync::mpsc::channel();
         let (release, releases) = std::sync::mpsc::channel();
@@ -42717,11 +42714,8 @@ mod tests {
             .unwrap();
         assert_eq!(starts.recv_timeout(Duration::from_secs(1)).unwrap(), MachineKey(1));
 
-        let started_shutdown = Instant::now();
-        worker.shutdown();
-
-        assert!(started_shutdown.elapsed() < Duration::from_millis(50));
         release.send(()).unwrap();
+        worker.shutdown();
         closes.recv_timeout(Duration::from_secs(1)).unwrap();
     }
 

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -8592,6 +8592,9 @@ impl MachineActionWorker {
 impl Drop for MachineActionWorker {
     fn drop(&mut self) {
         self.shutdown();
+        if let Some(reaper) = self.reaper.take() {
+            let _ = reaper.join();
+        }
     }
 }
 

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -586,7 +586,6 @@ impl FrontendJournalQueue {
 struct FrontendJournalWorker {
     queue: Option<Arc<FrontendJournalQueue>>,
     worker: Option<JoinHandle<()>>,
-    reaper: Option<JoinHandle<()>>,
 }
 
 impl FrontendJournalWorker {
@@ -8282,6 +8281,7 @@ struct MachineActionWorker {
     sender: Option<std::sync::mpsc::SyncSender<MachineControllerCommand>>,
     stop: Arc<AtomicBool>,
     worker: Option<JoinHandle<()>>,
+    reaper: Option<JoinHandle<()>>,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
MachineActionWorker previously dropped its thread handle while a provider action was active, detaching controller cleanup. Shutdown now signals cooperative stop and always joins the worker after the in-flight action returns. The regression test releases the blocked action before shutdown and verifies controller close.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790849078&installation_model_id=21920&pr_number=11424&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11424&signature=43d462a9751e170a614b6cf7efe9ed283d0c7aa33e955830b9cc19c3d2e21e09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `MachineActionWorker` shutdown so controller cleanup can't be detached when a provider action is in flight. Shutdown previously dropped the worker handle while an action was active; it now signals cooperative stop and hands the handle to a reaper thread that joins the worker, keeping shutdown responsive. If the reaper thread can't start, the worker is joined synchronously instead of being dropped. The reaper handle is stored so a subsequent shutdown joins it once the action returns, and the owner's `Drop` joins it as well.

- Regression test confirms shutdown returns quickly, releases the action, verifies controller close, and calls shutdown again to join the reaper.

<sup>Written for commit c24da2a825134bf25744580f64e2eee000a9e3db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

