### PR TITLE
Guard PTY child during terminal host startup

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_protocol.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_protocol.rs
@@ -152,6 +152,7 @@ impl TerminalExit {
 pub(crate) fn wait_for_native_child_status(
     child: &mut (dyn cmux_pty::Child + Send + Sync),
 ) -> TerminalExit {
+<<<<<<< ours
     wait_for_native_child_status_with_reap_result(child).0
 }
 
@@ -161,6 +162,13 @@ pub(crate) fn wait_for_native_child_status(
 /// second kill against a PID that may already have been reused after a
 /// successful wait.
 pub(crate) fn wait_for_native_child_status_with_reap_result(
+=======
+    wait_for_native_child_status_with_reap(child).0
+}
+
+/// Wait for the native child and report whether the wait reaped it.
+pub(crate) fn wait_for_native_child_status_with_reap(
+>>>>>>> theirs
     child: &mut (dyn cmux_pty::Child + Send + Sync),
 ) -> (TerminalExit, bool) {
     let child: &mut dyn cmux_pty::Child = child;

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_protocol.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_protocol.rs
@@ -152,7 +152,6 @@ impl TerminalExit {
 pub(crate) fn wait_for_native_child_status(
     child: &mut (dyn cmux_pty::Child + Send + Sync),
 ) -> TerminalExit {
-<<<<<<< ours
     wait_for_native_child_status_with_reap_result(child).0
 }
 
@@ -162,13 +161,6 @@ pub(crate) fn wait_for_native_child_status(
 /// second kill against a PID that may already have been reused after a
 /// successful wait.
 pub(crate) fn wait_for_native_child_status_with_reap_result(
-=======
-    wait_for_native_child_status_with_reap(child).0
-}
-
-/// Wait for the native child and report whether the wait reaped it.
-pub(crate) fn wait_for_native_child_status_with_reap(
->>>>>>> theirs
     child: &mut (dyn cmux_pty::Child + Send + Sync),
 ) -> (TerminalExit, bool) {
     let child: &mut dyn cmux_pty::Child = child;

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -519,11 +519,40 @@ mod unix {
     /// leave the interactive child detached from its parent.
     struct SpawnedPtyChild {
         child: Option<Box<dyn cmux_pty::Child + Send + Sync>>,
+        process_groups: [Option<libc::pid_t>; 2],
+    }
+
+    fn validated_process_groups(
+        groups: impl IntoIterator<Item = Option<libc::pid_t>>,
+        host_group: libc::pid_t,
+    ) -> Vec<libc::pid_t> {
+        let mut valid = Vec::new();
+        for group in groups.into_iter().flatten() {
+            if group > 0 && group != host_group && !valid.contains(&group) {
+                valid.push(group);
+            }
+        }
+        valid
+    }
+
+    fn signal_validated_process_groups(
+        groups: impl IntoIterator<Item = Option<libc::pid_t>>,
+        host_group: libc::pid_t,
+        signal: libc::c_int,
+        mut send: impl FnMut(libc::pid_t, libc::c_int),
+    ) {
+        for group in validated_process_groups(groups, host_group) {
+            send(group, signal);
+        }
     }
 
     impl SpawnedPtyChild {
-        fn new(child: Box<dyn cmux_pty::Child + Send + Sync>) -> Self {
-            Self { child: Some(child) }
+        fn new(
+            child: Box<dyn cmux_pty::Child + Send + Sync>,
+            process_group_leader: Option<libc::pid_t>,
+        ) -> Self {
+            let child_pid = child.process_id().and_then(|pid| libc::pid_t::try_from(pid).ok());
+            Self { child: Some(child), process_groups: [child_pid, process_group_leader] }
         }
 
         fn child(&self) -> &dyn cmux_pty::Child {
@@ -549,8 +578,25 @@ mod unix {
 
     impl Drop for SpawnedPtyChild {
         fn drop(&mut self) {
+            let host_group = unsafe { libc::getpgrp() };
+            let groups = validated_process_groups(self.process_groups, host_group);
+            signal_validated_process_groups(
+                groups.iter().copied().map(Some),
+                host_group,
+                libc::SIGKILL,
+                |group, signal| {
+                    // SAFETY: the group was returned by the PTY or child, is
+                    // positive, and is not the terminal-host process group.
+                    let _ = unsafe { libc::killpg(group, signal) };
+                },
+            );
             if let Some(child) = self.child.as_deref_mut() {
-                let _ = child.kill();
+                // A valid process group already includes the child. Avoid a
+                // second direct PID signal, which could target a recycled PID
+                // if the group vanished before this guard was dropped.
+                if groups.is_empty() {
+                    let _ = child.kill();
+                }
                 let _ = child.wait();
             }
         }
@@ -4921,7 +4967,8 @@ mod unix {
             command.cwd(cwd);
         }
         let cmux_pty::SpawnedPty { master, child } = pty.spawn(command)?;
-        let mut child = SpawnedPtyChild::new(child);
+        let process_group_leader = master.process_group_leader();
+        let mut child = SpawnedPtyChild::new(child, process_group_leader);
         let pid = child.child().process_id();
         let killer = child.child().clone_killer();
         let pty_poll_fd = master.as_raw_fd().context("open terminal-host PTY poll fd")?;
@@ -6301,7 +6348,7 @@ mod unix {
         fn spawned_pty_child_disarm_prevents_late_kill() {
             let kills = Arc::new(AtomicUsize::new(0));
             let child = GuardTestChild { kills: Arc::clone(&kills) };
-            let mut guard = SpawnedPtyChild::new(Box::new(child));
+            let mut guard = SpawnedPtyChild::new(Box::new(child), None);
             let _ = guard.wait_and_disarm();
             drop(guard);
             assert_eq!(kills.load(Ordering::Relaxed), 0);
@@ -6310,13 +6357,14 @@ mod unix {
         #[test]
         fn startup_child_cleanup_excludes_host_process_group() {
             let host_group = unsafe { libc::getpgrp() };
-            assert_eq!(
-                validated_process_groups(
-                    [Some(host_group), Some(host_group + 1), Some(0), Some(-1)],
-                    host_group,
-                ),
-                vec![host_group + 1]
+            let mut signaled = Vec::new();
+            signal_validated_process_groups(
+                [Some(host_group), Some(host_group + 1), Some(0), Some(-1)],
+                host_group,
+                libc::SIGKILL,
+                |group, signal| signaled.push((group, signal)),
             );
+            assert_eq!(signaled, vec![(host_group + 1, libc::SIGKILL)]);
         }
 
         fn exited_host_fixture_with_parser_at(

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -539,11 +539,13 @@ mod unix {
         groups: impl IntoIterator<Item = Option<libc::pid_t>>,
         host_group: libc::pid_t,
         signal: libc::c_int,
-        mut send: impl FnMut(libc::pid_t, libc::c_int),
-    ) {
+        mut send: impl FnMut(libc::pid_t, libc::c_int) -> bool,
+    ) -> bool {
+        let mut all_succeeded = true;
         for group in validated_process_groups(groups, host_group) {
-            send(group, signal);
+            all_succeeded &= send(group, signal);
         }
+        all_succeeded
     }
 
     impl SpawnedPtyChild {
@@ -581,21 +583,21 @@ mod unix {
         fn drop(&mut self) {
             let host_group = unsafe { libc::getpgrp() };
             let groups = validated_process_groups(self.process_groups, host_group);
-            signal_validated_process_groups(
+            let groups_signaled = signal_validated_process_groups(
                 groups.iter().copied().map(Some),
                 host_group,
                 libc::SIGKILL,
                 |group, signal| {
                     // SAFETY: the group was returned by the PTY or child, is
                     // positive, and is not the terminal-host process group.
-                    let _ = unsafe { libc::killpg(group, signal) };
+                    unsafe { libc::killpg(group, signal) == 0 }
                 },
             );
             if let Some(child) = self.child.as_deref_mut() {
                 // A valid process group already includes the child. Avoid a
-                // second direct PID signal, which could target a recycled PID
-                // if the group vanished before this guard was dropped.
-                if groups.is_empty() {
+                // second direct PID signal unless group signaling failed, which
+                // could leave the child running while the guard waits below.
+                if groups.is_empty() || !groups_signaled {
                     let _ = child.kill();
                 }
                 let _ = child.wait();

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -6348,8 +6348,9 @@ mod unix {
         fn spawned_pty_child_disarm_prevents_late_kill() {
             let kills = Arc::new(AtomicUsize::new(0));
             let child = GuardTestChild { kills: Arc::clone(&kills) };
-            let mut guard = SpawnedPtyChild::new(Box::new(child), None);
+            let mut guard = SpawnedPtyChild::new(Box::new(child), Some(123));
             let _ = guard.wait_and_disarm();
+            assert_eq!(guard.process_groups, [None, None]);
             drop(guard);
             assert_eq!(kills.load(Ordering::Relaxed), 0);
         }

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -6364,9 +6364,24 @@ mod unix {
                 [Some(host_group), Some(host_group + 1), Some(0), Some(-1)],
                 host_group,
                 libc::SIGKILL,
-                |group, signal| signaled.push((group, signal)),
+                |group, signal| {
+                    signaled.push((group, signal));
+                    true
+                },
             );
             assert_eq!(signaled, vec![(host_group + 1, libc::SIGKILL)]);
+        }
+
+        #[test]
+        fn startup_child_cleanup_reports_group_signal_failure() {
+            let host_group = unsafe { libc::getpgrp() };
+            let all_succeeded = signal_validated_process_groups(
+                [Some(host_group + 1)],
+                host_group,
+                libc::SIGKILL,
+                |_group, _signal| false,
+            );
+            assert!(!all_succeeded);
         }
 
         fn exited_host_fixture_with_parser_at(

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -6254,6 +6254,46 @@ mod unix {
             }
         }
 
+        #[derive(Debug)]
+        struct GuardTestChild {
+            kills: Arc<AtomicUsize>,
+        }
+
+        impl ChildKiller for GuardTestChild {
+            fn kill(&mut self) -> std::io::Result<()> {
+                self.kills.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            }
+
+            fn clone_killer(&self) -> Box<dyn ChildKiller + Send + Sync> {
+                Box::new(Self { kills: Arc::clone(&self.kills) })
+            }
+        }
+
+        impl Child for GuardTestChild {
+            fn try_wait(&mut self) -> std::io::Result<Option<cmux_pty::ExitStatus>> {
+                Ok(Some(cmux_pty::ExitStatus::with_exit_code(0)))
+            }
+
+            fn wait(&mut self) -> std::io::Result<cmux_pty::ExitStatus> {
+                Ok(cmux_pty::ExitStatus::with_exit_code(0))
+            }
+
+            fn process_id(&self) -> Option<u32> {
+                Some(42)
+            }
+        }
+
+        #[test]
+        fn spawned_pty_child_disarm_prevents_late_kill() {
+            let kills = Arc::new(AtomicUsize::new(0));
+            let child = GuardTestChild { kills: Arc::clone(&kills) };
+            let mut guard = SpawnedPtyChild::new(Box::new(child));
+            guard.disarm();
+            drop(guard);
+            assert_eq!(kills.load(Ordering::Relaxed), 0);
+        }
+
         fn exited_host_fixture_with_parser_at(
             exit_record_parent: PathBuf,
         ) -> (Arc<HostShared>, Receiver<ParserCommand>) {

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -530,7 +530,7 @@ mod unix {
             self.child.as_deref().expect("PTY child is present")
         }
 
-        fn child_mut(&mut self) -> &mut dyn cmux_pty::Child {
+        fn child_mut(&mut self) -> &mut (dyn cmux_pty::Child + Send + Sync) {
             self.child.as_deref_mut().expect("PTY child is present")
         }
     }

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -33,8 +33,8 @@ use crate::terminal_host_protocol::{
     KITTY_IMAGE_ALIAS_COUNT_LEN, KITTY_IMAGE_ALIAS_ENCODED_LEN, LAUNCH_ACTIVATION_PROTOCOL_VERSION,
     MAX_FRAME_PAYLOAD, MAX_KITTY_IMAGE_ALIASES, MessageKind, PROTOCOL_VERSION,
     RESIZE_ACK_CANONICAL_CHANGED, TerminalExit, decode_host_launch_failure, decode_terminal_exit,
-    encode_host_launch_failure, encode_terminal_exit, read_frame, wait_for_native_child_status,
-    write_frame,
+    encode_host_launch_failure, encode_terminal_exit, read_frame,
+    wait_for_native_child_status_with_reap, write_frame,
 };
 
 const HOST_RECORD_VERSION: u32 = 4;
@@ -532,6 +532,18 @@ mod unix {
 
         fn child_mut(&mut self) -> &mut (dyn cmux_pty::Child + Send + Sync) {
             self.child.as_deref_mut().expect("PTY child is present")
+        }
+
+        fn wait_and_disarm(&mut self) -> TerminalExit {
+            let (exit, reaped) = wait_for_native_child_status_with_reap(self.child_mut());
+            if reaped {
+                self.disarm();
+            }
+            exit
+        }
+
+        fn disarm(&mut self) {
+            let _ = self.child.take();
         }
     }
 
@@ -5173,7 +5185,7 @@ mod unix {
                         child_host.termination_started.load(Ordering::Acquire);
                     let pty_drained = child_host.pty_drained.load(Ordering::Acquire);
                     if escalation_complete || (!termination_started && pty_drained) {
-                        let exit = wait_for_native_child_status(child.child_mut());
+                        let exit = child.wait_and_disarm();
                         child_host.child_reaped.store(true, Ordering::Release);
                         drop(signal);
                         *child_host.child_exit.0.lock().unwrap() = Some(exit);
@@ -5196,7 +5208,7 @@ mod unix {
             } else {
                 // Native Unix PTYs always expose a PID and support waitid;
                 // retain a conservative fallback for alternate backends.
-                let exit = wait_for_native_child_status(child.child_mut());
+                let exit = child.wait_and_disarm();
                 child_host.child_reaped.store(true, Ordering::Release);
                 child_host.mark_child_waitable();
                 let mut exited = child_host.child_exit.0.lock().unwrap();
@@ -6191,6 +6203,7 @@ mod unix {
     #[cfg(test)]
     mod tests {
         use super::*;
+        use cmux_pty::Child;
 
         fn test_kitty_state() -> KittyReplayState {
             KittyReplayState {
@@ -6289,7 +6302,7 @@ mod unix {
             let kills = Arc::new(AtomicUsize::new(0));
             let child = GuardTestChild { kills: Arc::clone(&kills) };
             let mut guard = SpawnedPtyChild::new(Box::new(child));
-            guard.disarm();
+            let _ = guard.wait_and_disarm();
             drop(guard);
             assert_eq!(kills.load(Ordering::Relaxed), 0);
         }

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -573,6 +573,7 @@ mod unix {
 
         fn disarm(&mut self) {
             let _ = self.child.take();
+            self.process_groups = [None, None];
         }
     }
 

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -6307,6 +6307,18 @@ mod unix {
             assert_eq!(kills.load(Ordering::Relaxed), 0);
         }
 
+        #[test]
+        fn startup_child_cleanup_excludes_host_process_group() {
+            let host_group = unsafe { libc::getpgrp() };
+            assert_eq!(
+                validated_process_groups(
+                    [Some(host_group), Some(host_group + 1), Some(0), Some(-1)],
+                    host_group,
+                ),
+                vec![host_group + 1]
+            );
+        }
+
         fn exited_host_fixture_with_parser_at(
             exit_record_parent: PathBuf,
         ) -> (Arc<HostShared>, Receiver<ParserCommand>) {

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -513,6 +513,37 @@ mod unix {
         }
     }
 
+    /// Own a PTY child until the host's reaper thread has taken responsibility
+    /// for it.  Every fallible setup step after `pty.spawn` keeps this guard
+    /// alive, so a failed reader, writer, callback, or thread setup cannot
+    /// leave the interactive child detached from its parent.
+    struct SpawnedPtyChild {
+        child: Option<Box<dyn cmux_pty::Child + Send + Sync>>,
+    }
+
+    impl SpawnedPtyChild {
+        fn new(child: Box<dyn cmux_pty::Child + Send + Sync>) -> Self {
+            Self { child: Some(child) }
+        }
+
+        fn child(&self) -> &dyn cmux_pty::Child {
+            self.child.as_deref().expect("PTY child is present")
+        }
+
+        fn child_mut(&mut self) -> &mut dyn cmux_pty::Child {
+            self.child.as_deref_mut().expect("PTY child is present")
+        }
+    }
+
+    impl Drop for SpawnedPtyChild {
+        fn drop(&mut self) {
+            if let Some(child) = self.child.as_deref_mut() {
+                let _ = child.kill();
+                let _ = child.wait();
+            }
+        }
+    }
+
     #[derive(Debug)]
     struct HostLaunch {
         endpoint: String,
@@ -4877,9 +4908,10 @@ mod unix {
         if let Some(cwd) = launch.cwd.as_deref() {
             command.cwd(cwd);
         }
-        let cmux_pty::SpawnedPty { master, mut child } = pty.spawn(command)?;
-        let pid = child.process_id();
-        let killer = child.clone_killer();
+        let cmux_pty::SpawnedPty { master, child } = pty.spawn(command)?;
+        let mut child = SpawnedPtyChild::new(child);
+        let pid = child.child().process_id();
+        let killer = child.child().clone_killer();
         let pty_poll_fd = master.as_raw_fd().context("open terminal-host PTY poll fd")?;
         let mut pty_reader = master.try_clone_reader()?;
         let pty_writer = master.take_writer()?;
@@ -5141,7 +5173,7 @@ mod unix {
                         child_host.termination_started.load(Ordering::Acquire);
                     let pty_drained = child_host.pty_drained.load(Ordering::Acquire);
                     if escalation_complete || (!termination_started && pty_drained) {
-                        let exit = wait_for_native_child_status(child.as_mut());
+                        let exit = wait_for_native_child_status(child.child_mut());
                         child_host.child_reaped.store(true, Ordering::Release);
                         drop(signal);
                         *child_host.child_exit.0.lock().unwrap() = Some(exit);
@@ -5164,7 +5196,7 @@ mod unix {
             } else {
                 // Native Unix PTYs always expose a PID and support waitid;
                 // retain a conservative fallback for alternate backends.
-                let exit = wait_for_native_child_status(child.as_mut());
+                let exit = wait_for_native_child_status(child.child_mut());
                 child_host.child_reaped.store(true, Ordering::Release);
                 child_host.mark_child_waitable();
                 let mut exited = child_host.child_exit.0.lock().unwrap();

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -34,7 +34,7 @@ use crate::terminal_host_protocol::{
     MAX_FRAME_PAYLOAD, MAX_KITTY_IMAGE_ALIASES, MessageKind, PROTOCOL_VERSION,
     RESIZE_ACK_CANONICAL_CHANGED, TerminalExit, decode_host_launch_failure, decode_terminal_exit,
     encode_host_launch_failure, encode_terminal_exit, read_frame,
-    wait_for_native_child_status_with_reap, write_frame,
+    wait_for_native_child_status_with_reap_result, write_frame,
 };
 
 const HOST_RECORD_VERSION: u32 = 4;
@@ -566,7 +566,7 @@ mod unix {
         }
 
         fn wait_and_disarm(&mut self) -> TerminalExit {
-            let (exit, reaped) = wait_for_native_child_status_with_reap(self.child_mut());
+            let (exit, reaped) = wait_for_native_child_status_with_reap_result(self.child_mut());
             if reaped {
                 self.disarm();
             }


### PR DESCRIPTION
Keep the PTY child under an RAII guard until the host child reaper thread owns it. If reader/writer setup or any reaper thread creation fails, the guard kills and waits the child instead of allowing it to detach.

Validation: rustfmt --edition 2024 and git diff --check. Rust builds/tests intentionally deferred to hosted verification.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790849166&installation_model_id=21920&pr_number=11425&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11425&signature=437acdc0b97b5082464969f8aea7085e1ab9a73ca432bee0907d65affa6171be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guards the PTY child during terminal host startup so any setup failure after spawn kills and reaps it instead of leaving it detached.

**Details**
- On drop, kills the child's process group, excluding the host's group; falls back to killing the child directly when no valid group exists or group signaling fails, then waits for it.
- Disarms after the reaper thread collects the exit status, preventing a late kill or wait on an already-reaped child.
- Preserves the child's `Send + Sync` bounds when ownership moves to the reaper thread.
- Adds unit tests for the disarm path, process-group filtering, and failed group signaling.

<sup>Written for commit e5d30faf577a7068556882d370236c9b5ed1c576. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability during terminal session startup by ensuring partially initialized processes are cleaned up properly.
  * Prevented orphaned terminal processes when setup fails or a terminal child cannot be started successfully.
  * Improved process cleanup during recovery, reducing the chance of lingering background processes after interrupted or unsuccessful terminal session initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->