### PR TITLE
perf(cmux-tui): avoid cloning sidebar layout per frame

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/ui/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/mod.rs
@@ -125,8 +125,13 @@ pub fn draw(app: &mut App, frame: &mut Frame) {
             sidebar::draw_tabs(app, frame);
         }
     } else {
-        for placement in app.sidebar_layout.ordered.clone() {
-            match placement.kind {
+        let ordered_len = app.sidebar_layout.ordered.len();
+        for index in 0..ordered_len {
+            // Copy only the discriminator before mutably borrowing `app` for
+            // the renderer. Cloning the full placement list allocates once per
+            // frame and keeps the immutable layout borrow alive unnecessarily.
+            let kind = app.sidebar_layout.ordered[index].kind;
+            match kind {
                 RailKind::Machine => sidebar::draw_machines(app, frame),
                 RailKind::Workspace => sidebar_input_cursor = sidebar::draw(app, frame),
                 RailKind::Tabs => sidebar::draw_tabs(app, frame),
@@ -765,6 +770,28 @@ mod tests {
         ReusableRowBuffer, copy_buffer_row_cropped, middle_truncate, sanitize_render_buffer,
         truncate,
     };
+
+    #[test]
+    fn ordered_sidebar_iteration_preserves_rail_sequence() {
+        use crate::app::{RailKind, RailPlacement, SidebarLayout};
+
+        let layout = SidebarLayout {
+            ordered: vec![
+                RailPlacement { kind: RailKind::Tabs, view_index: 0, rect: Rect::default() },
+                RailPlacement {
+                    kind: RailKind::Projection(3),
+                    view_index: 1,
+                    rect: Rect::default(),
+                },
+                RailPlacement { kind: RailKind::Workspace, view_index: 2, rect: Rect::default() },
+            ],
+            ..SidebarLayout::default()
+        };
+
+        let kinds =
+            (0..layout.ordered.len()).map(|index| layout.ordered[index].kind).collect::<Vec<_>>();
+        assert_eq!(kinds, vec![RailKind::Tabs, RailKind::Projection(3), RailKind::Workspace]);
+    }
 
     #[test]
     fn middle_truncates_for_narrow_columns() {

--- a/cmux-tui/crates/cmux-tui/src/ui/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/mod.rs
@@ -774,16 +774,17 @@ mod tests {
     #[test]
     fn ordered_sidebar_iteration_preserves_rail_sequence() {
         use crate::app::{RailKind, RailPlacement, SidebarLayout};
+        use cmux_tui_core::Rect as CoreRect;
 
         let layout = SidebarLayout {
             ordered: vec![
-                RailPlacement { kind: RailKind::Tabs, view_index: 0, rect: Rect::default() },
+                RailPlacement { kind: RailKind::Tabs, view_index: 0, rect: CoreRect::default() },
                 RailPlacement {
                     kind: RailKind::Projection(3),
                     view_index: 1,
-                    rect: Rect::default(),
+                    rect: CoreRect::default(),
                 },
-                RailPlacement { kind: RailKind::Workspace, view_index: 2, rect: Rect::default() },
+                RailPlacement { kind: RailKind::Workspace, view_index: 2, rect: CoreRect::default() },
             ],
             ..SidebarLayout::default()
         };

--- a/cmux-tui/crates/cmux-tui/src/ui/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/mod.rs
@@ -784,7 +784,11 @@ mod tests {
                     view_index: 1,
                     rect: CoreRect::default(),
                 },
-                RailPlacement { kind: RailKind::Workspace, view_index: 2, rect: CoreRect::default() },
+                RailPlacement {
+                    kind: RailKind::Workspace,
+                    view_index: 2,
+                    rect: CoreRect::default(),
+                },
             ],
             ..SidebarLayout::default()
         };


### PR DESCRIPTION
Rebuilds https://github.com/manaflow-ai/cmux/issues/11393 on current main.

Summary:
- copy each RailKind discriminator by index before mutable renderer calls
- preserve committed sidebar rail order without cloning the placement vector
- add a behavior test covering ordered rail sequence

Validation:
- rustfmt --edition 2024 --check cmux-tui/crates/cmux-tui/src/ui/mod.rs
- git diff --check
- Cargo build/tests not run locally per repository policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops cloning the full sidebar placement vector every frame in `cmux-tui`; the renderer now copies only each rail's `kind` discriminator by index before mutably borrowing `app`. Rendering order is unchanged, and a test locks in the ordered rail sequence.

<sup>Written for commit b4c613d3e2e5b7a22b94b8762123eff34b1192c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

