### PR TITLE
fix: restore macOS terminal delete chords

### DIFF
--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/KeyEvents/TerminalDeleteEquivalentRoutingPolicy.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/KeyEvents/TerminalDeleteEquivalentRoutingPolicy.swift
@@ -5,13 +5,19 @@
 /// responder state and converts its event flags to
 /// ``TerminalKeyboardCopyModeModifiers``; this policy keeps the routing rule
 /// independent of the window and menu implementation.
+///
+/// - Parameter optionModifier: Whether Option was present on the event. The
+///   copy-mode modifier set intentionally does not model Option, so callers
+///   must pass this separately when deciding whether a Command chord is an
+///   exact match.
 public func terminalDeleteEquivalentShouldDispatch(
     keyCode: UInt16,
     firstResponderIsTerminal: Bool,
     firstResponderHasMarkedText: Bool = false,
-    modifiers: TerminalKeyboardCopyModeModifiers
+    modifiers: TerminalKeyboardCopyModeModifiers,
+    optionModifier: Bool = false
 ) -> Bool {
-    guard firstResponderIsTerminal, !firstResponderHasMarkedText else { return false }
+    guard firstResponderIsTerminal, !firstResponderHasMarkedText, !optionModifier else { return false }
     guard keyCode == 51 || keyCode == 117 else { return false }
 
     let normalized = modifiers.subtracting([.numericPad, .function, .capsLock])

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/KeyEvents/TerminalDeleteEquivalentRoutingPolicy.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/KeyEvents/TerminalDeleteEquivalentRoutingPolicy.swift
@@ -1,0 +1,19 @@
+/// Decides whether a macOS delete equivalent belongs to a focused terminal.
+///
+/// AppKit offers Command-Backspace and Command-ForwardDelete to menu items
+/// before a terminal responder receives `keyDown`. The app target supplies the
+/// responder state and converts its event flags to
+/// ``TerminalKeyboardCopyModeModifiers``; this policy keeps the routing rule
+/// independent of the window and menu implementation.
+public func terminalDeleteEquivalentShouldDispatch(
+    keyCode: UInt16,
+    firstResponderIsTerminal: Bool,
+    firstResponderHasMarkedText: Bool = false,
+    modifiers: TerminalKeyboardCopyModeModifiers
+) -> Bool {
+    guard firstResponderIsTerminal, !firstResponderHasMarkedText else { return false }
+    guard keyCode == 51 || keyCode == 117 else { return false }
+
+    let normalized = modifiers.subtracting([.numericPad, .function, .capsLock])
+    return normalized == [.command]
+}

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalDeleteEquivalentRoutingPolicyTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalDeleteEquivalentRoutingPolicyTests.swift
@@ -36,6 +36,12 @@ struct TerminalDeleteEquivalentRoutingPolicyTests {
             modifiers: [.command, .control]
         ))
         #expect(!terminalDeleteEquivalentShouldDispatch(
+            keyCode: 51,
+            firstResponderIsTerminal: true,
+            modifiers: [.command],
+            optionModifier: true
+        ))
+        #expect(!terminalDeleteEquivalentShouldDispatch(
             keyCode: 36,
             firstResponderIsTerminal: true,
             modifiers: [.command]

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalDeleteEquivalentRoutingPolicyTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalDeleteEquivalentRoutingPolicyTests.swift
@@ -1,0 +1,44 @@
+import CmuxTerminalCore
+import Testing
+
+@Suite("Terminal delete equivalent routing")
+struct TerminalDeleteEquivalentRoutingPolicyTests {
+    @Test(arguments: [51, 117] as [UInt16])
+    func acceptsCommandDelete(keyCode: UInt16) {
+        #expect(terminalDeleteEquivalentShouldDispatch(
+            keyCode: keyCode,
+            firstResponderIsTerminal: true,
+            modifiers: [.command, .numericPad, .function]
+        ))
+    }
+
+    @Test
+    func rejectsForeignResponderMarkedTextAndOtherModifiers() {
+        #expect(!terminalDeleteEquivalentShouldDispatch(
+            keyCode: 51,
+            firstResponderIsTerminal: false,
+            modifiers: [.command]
+        ))
+        #expect(!terminalDeleteEquivalentShouldDispatch(
+            keyCode: 51,
+            firstResponderIsTerminal: true,
+            firstResponderHasMarkedText: true,
+            modifiers: [.command]
+        ))
+        #expect(!terminalDeleteEquivalentShouldDispatch(
+            keyCode: 51,
+            firstResponderIsTerminal: true,
+            modifiers: [.command, .shift]
+        ))
+        #expect(!terminalDeleteEquivalentShouldDispatch(
+            keyCode: 51,
+            firstResponderIsTerminal: true,
+            modifiers: [.command, .control]
+        ))
+        #expect(!terminalDeleteEquivalentShouldDispatch(
+            keyCode: 36,
+            firstResponderIsTerminal: true,
+            modifiers: [.command]
+        ))
+    }
+}

--- a/Sources/App/ShortcutRoutingSupport.swift
+++ b/Sources/App/ShortcutRoutingSupport.swift
@@ -187,7 +187,8 @@ nonisolated func shouldDispatchTerminalDeleteEquivalentViaFirstResponderKeyDown(
         keyCode: keyCode,
         firstResponderIsTerminal: firstResponderIsTerminal,
         firstResponderHasMarkedText: firstResponderHasMarkedText,
-        modifiers: TerminalKeyboardCopyModeModifiers(modifierFlags: normalizedFlags)
+        modifiers: TerminalKeyboardCopyModeModifiers(modifierFlags: normalizedFlags),
+        optionModifier: normalizedFlags.contains(.option)
     )
 }
 

--- a/Sources/App/ShortcutRoutingSupport.swift
+++ b/Sources/App/ShortcutRoutingSupport.swift
@@ -183,7 +183,7 @@ nonisolated func shouldDispatchTerminalDeleteEquivalentViaFirstResponderKeyDown(
     flags: NSEvent.ModifierFlags
 ) -> Bool {
     let normalizedFlags = browserOmnibarNormalizedModifierFlags(flags)
-    terminalDeleteEquivalentShouldDispatch(
+    return terminalDeleteEquivalentShouldDispatch(
         keyCode: keyCode,
         firstResponderIsTerminal: firstResponderIsTerminal,
         firstResponderHasMarkedText: firstResponderHasMarkedText,

--- a/Sources/App/ShortcutRoutingSupport.swift
+++ b/Sources/App/ShortcutRoutingSupport.swift
@@ -186,10 +186,7 @@ func shouldDispatchTerminalDeleteEquivalentViaFirstResponderKeyDown(
         return false
     }
 
-    let normalizedFlags = flags
-        .intersection(.deviceIndependentFlagsMask)
-        .subtracting([.numericPad, .function, .capsLock])
-    return normalizedFlags == [.command]
+    return browserOmnibarNormalizedModifierFlags(flags) == [.command]
 }
 
 struct BrowserAddressBarTrackingContext {

--- a/Sources/App/ShortcutRoutingSupport.swift
+++ b/Sources/App/ShortcutRoutingSupport.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Bonsplit
+import Carbon.HIToolbox
 import CmuxCommandPalette
 import Foundation
 import CmuxTerminal
@@ -169,6 +170,26 @@ func shouldDispatchTerminalArrowViaFirstResponderKeyDown(
 ) -> Bool {
     guard firstResponderIsTerminal, !firstResponderHasMarkedText, (123...126).contains(keyCode) else { return false }
     return !browserOmnibarNormalizedModifierFlags(flags).contains(.command)
+}
+
+/// Returns true when a focused terminal should receive a macOS line-delete
+/// equivalent before AppKit offers the same key to an Edit menu item.
+/// Function and numeric-pad flags are transport details for forward delete.
+func shouldDispatchTerminalDeleteEquivalentViaFirstResponderKeyDown(
+    keyCode: UInt16,
+    firstResponderIsTerminal: Bool,
+    firstResponderHasMarkedText: Bool = false,
+    flags: NSEvent.ModifierFlags
+) -> Bool {
+    guard firstResponderIsTerminal, !firstResponderHasMarkedText else { return false }
+    guard keyCode == UInt16(kVK_Delete) || keyCode == UInt16(kVK_ForwardDelete) else {
+        return false
+    }
+
+    let normalizedFlags = flags
+        .intersection(.deviceIndependentFlagsMask)
+        .subtracting([.numericPad, .function, .capsLock])
+    return normalizedFlags == [.command]
 }
 
 struct BrowserAddressBarTrackingContext {

--- a/Sources/App/ShortcutRoutingSupport.swift
+++ b/Sources/App/ShortcutRoutingSupport.swift
@@ -4,6 +4,7 @@ import Carbon.HIToolbox
 import CmuxCommandPalette
 import Foundation
 import CmuxTerminal
+import CmuxTerminalCore
 
 func browserOmnibarSelectionDeltaForControlNavigation(
     hasFocusedAddressBar: Bool,
@@ -181,12 +182,12 @@ nonisolated func shouldDispatchTerminalDeleteEquivalentViaFirstResponderKeyDown(
     firstResponderHasMarkedText: Bool = false,
     flags: NSEvent.ModifierFlags
 ) -> Bool {
-    guard firstResponderIsTerminal, !firstResponderHasMarkedText else { return false }
-    guard keyCode == UInt16(kVK_Delete) || keyCode == UInt16(kVK_ForwardDelete) else {
-        return false
-    }
-
-    return browserOmnibarNormalizedModifierFlags(flags) == [.command]
+    terminalDeleteEquivalentShouldDispatch(
+        keyCode: keyCode,
+        firstResponderIsTerminal: firstResponderIsTerminal,
+        firstResponderHasMarkedText: firstResponderHasMarkedText,
+        modifiers: TerminalKeyboardCopyModeModifiers(modifierFlags: flags)
+    )
 }
 
 struct BrowserAddressBarTrackingContext {

--- a/Sources/App/ShortcutRoutingSupport.swift
+++ b/Sources/App/ShortcutRoutingSupport.swift
@@ -42,7 +42,7 @@ func browserOmnibarShouldBypassShortcutRoutingForMarkedText(
     return !browserOmnibarNormalizedModifierFlags(flags).contains(.command)
 }
 
-func browserOmnibarNormalizedModifierFlags(_ flags: NSEvent.ModifierFlags) -> NSEvent.ModifierFlags {
+nonisolated func browserOmnibarNormalizedModifierFlags(_ flags: NSEvent.ModifierFlags) -> NSEvent.ModifierFlags {
     flags
         .intersection(.deviceIndependentFlagsMask)
         .subtracting([.numericPad, .function, .capsLock])
@@ -175,7 +175,7 @@ func shouldDispatchTerminalArrowViaFirstResponderKeyDown(
 /// Returns true when a focused terminal should receive a macOS line-delete
 /// equivalent before AppKit offers the same key to an Edit menu item.
 /// Function and numeric-pad flags are transport details for forward delete.
-func shouldDispatchTerminalDeleteEquivalentViaFirstResponderKeyDown(
+nonisolated func shouldDispatchTerminalDeleteEquivalentViaFirstResponderKeyDown(
     keyCode: UInt16,
     firstResponderIsTerminal: Bool,
     firstResponderHasMarkedText: Bool = false,

--- a/Sources/App/ShortcutRoutingSupport.swift
+++ b/Sources/App/ShortcutRoutingSupport.swift
@@ -182,11 +182,12 @@ nonisolated func shouldDispatchTerminalDeleteEquivalentViaFirstResponderKeyDown(
     firstResponderHasMarkedText: Bool = false,
     flags: NSEvent.ModifierFlags
 ) -> Bool {
+    let normalizedFlags = browserOmnibarNormalizedModifierFlags(flags)
     terminalDeleteEquivalentShouldDispatch(
         keyCode: keyCode,
         firstResponderIsTerminal: firstResponderIsTerminal,
         firstResponderHasMarkedText: firstResponderHasMarkedText,
-        modifiers: TerminalKeyboardCopyModeModifiers(modifierFlags: flags)
+        modifiers: TerminalKeyboardCopyModeModifiers(modifierFlags: normalizedFlags)
     )
 }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -19140,6 +19140,45 @@ private extension NSWindow {
             return false
         }
         if cmuxRouteUndoRedoCommandEquivalentAwayFromAppKit(event, terminalView: firstResponderGhosttyView, webView: firstResponderWebView, browserWebKitKeyDownReentry: browserWebKitKeyDownReentry) { return true }
+
+        // AppKit can consume Command+Backspace and Command+ForwardDelete as
+        // Edit-menu equivalents before Ghostty sees them. Keep this route
+        // terminal-first, while preserving configured cmux shortcuts and
+        // native text fields.
+        let terminalOwnsDeleteEquivalent = firstResponderGhosttyView != nil
+            && firstResponderWebView == nil
+            && firstResponderOmnibarPanelId == nil
+            && !firstResponderIsCommandPaletteFieldEditor
+            && !firstResponderIsTextBoxInput
+            && !firstResponderIsStandaloneEditableTextView
+        if let firstResponderGhosttyView,
+           shouldDispatchTerminalDeleteEquivalentViaFirstResponderKeyDown(
+               keyCode: event.keyCode,
+               firstResponderIsTerminal: terminalOwnsDeleteEquivalent,
+               firstResponderHasMarkedText: firstResponderGhosttyView.hasMarkedText(),
+               flags: event.modifierFlags
+           ) {
+            if AppDelegate.shared?.handleConfiguredShortcutKeyEquivalent(event) == true {
+                return true
+            }
+            if firstResponderGhosttyView.performKeyEquivalentAfterMenuMiss(with: event) {
+#if DEBUG
+                cmuxDebugLog("  → terminal delete equivalent routed before mainMenu")
+#endif
+                return true
+            }
+            if cmuxForceDispatchKeyDownOnce(
+                event,
+                to: firstResponderGhosttyView,
+                reason: "terminal delete equivalent"
+            ) {
+                return true
+            }
+            // The replay guard says this event is already in flight. Keep it
+            // away from AppKit's destructive menu path on re-entry.
+            return true
+        }
+
         if let mode = AppDelegate.shared?.rightSidebarModeShortcut(for: event),
            AppDelegate.shared?.shouldRouteRightSidebarModeShortcut(in: self) == true {
             _ = AppDelegate.shared?.focusRightSidebarInActiveMainWindow(

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6592,6 +6592,40 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             if handled { return }
         }
 
+        // AppKit sends Option+Backspace through `interpretKeyEvents`, where it
+        // becomes the printable U+2202 character (and Option is marked as
+        // consumed). That loses the word-delete meaning for shells and TUI
+        // programs. Forward both macOS delete directions as raw Ghostty key
+        // events before AppKit can perform that text transformation. Command
+        // delete uses the same path so its configured Ghostty binding remains
+        // authoritative after the window-level menu-equivalent route.
+        if shouldUseRawMacDeleteKeyPath(event) {
+            _ = reassertTerminalFocusForInputIfFirstResponder(forceNative: true)
+            var keyEvent = ghostty_input_key_s()
+            keyEvent.action = event.isARepeat ? GHOSTTY_ACTION_REPEAT : GHOSTTY_ACTION_PRESS
+            keyEvent.keycode = UInt32(event.keyCode)
+            keyEvent.mods = modsFromEvent(event)
+            keyEvent.consumed_mods = GHOSTTY_MODS_NONE
+            keyEvent.composing = false
+            keyEvent.unshifted_codepoint = unshiftedCodepointFromEvent(event)
+            keyEvent.text = nil
+
+            let handled: Bool
+#if DEBUG
+            let ghosttySendStart = ProcessInfo.processInfo.systemUptime
+            handled = sendTimedGhosttyKey(
+                surface,
+                keyEvent,
+                path: "terminal.keyDown.macDeleteGhosttySend",
+                event: event
+            )
+            ghosttySendMs = (ProcessInfo.processInfo.systemUptime - ghosttySendStart) * 1000.0
+#else
+            handled = sendGhosttyKey(surface, keyEvent)
+#endif
+            if handled { return }
+        }
+
         let action = event.isARepeat ? GHOSTTY_ACTION_REPEAT : GHOSTTY_ACTION_PRESS
 
         // Translate mods to respect Ghostty config (e.g., macos-option-as-alt)
@@ -7410,6 +7444,21 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         }
 
         return chars
+    }
+
+    /// Returns whether AppKit text interpretation must be bypassed for a
+    /// terminal delete equivalent. Option and Command are intentionally
+    /// accepted only without Shift or Control, and marked text stays owned by
+    /// the active input method.
+    private func shouldUseRawMacDeleteKeyPath(_ event: NSEvent) -> Bool {
+        guard !hasMarkedText() else { return false }
+        guard event.keyCode == UInt16(kVK_Delete) || event.keyCode == UInt16(kVK_ForwardDelete) else {
+            return false
+        }
+        let flags = event.modifierFlags
+            .intersection(.deviceIndependentFlagsMask)
+            .subtracting([.numericPad, .function, .capsLock])
+        return flags == [.command] || flags == [.option]
     }
 
     /// Get the unshifted codepoint for the key event

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -964,6 +964,7 @@ class GhosttyApp {
                 prefix: "cmux-shell-integration-override",
                 logLabel: "shell integration override (fallback)"
             )
+            loadCmuxDefaultMacTextEditingKeybinds(fallbackConfig)
             loadCmuxManagedTerminalSettingsConfig(fallbackConfig)
             loadGlobalFontMagnificationConfig(fallbackConfig)
             loadCmuxOwnedGhosttyKeybindOverrides(fallbackConfig)
@@ -1109,6 +1110,24 @@ class GhosttyApp {
         )
     }
 
+    private func loadCmuxDefaultMacTextEditingKeybinds(_ config: ghostty_config_t) {
+        // Keep the common macOS editing chords available in every terminal,
+        // including when Ghostty falls back after an invalid user config.
+        // Loading this before user files lets an explicit user keybind or
+        // `keybind = clear` retain priority.
+        loadInlineGhosttyConfig(
+            #"""
+            keybind = super+backspace=text:\x15
+            keybind = super+delete=text:\x0b
+            keybind = alt+backspace=text:\x1b\x7f
+            keybind = alt+delete=text:\x1b\x64
+            """#,
+            into: config,
+            prefix: "cmux-default-mac-text-editing",
+            logLabel: "default mac text editing"
+        )
+    }
+
     private func loadStartupPreviewProfile(
         _ profile: GhosttyStartupAppearancePreviewProfile,
         into config: ghostty_config_t,
@@ -1193,6 +1212,11 @@ class GhosttyApp {
         // Surface-only reloads may use a terminal-derived scheme for background
         // handling, while Ghostty split-theme pairs follow app appearance.
         let themeColorScheme = conditionalThemeColorScheme ?? preferredColorScheme
+
+        // Install cmux's small set of macOS editing defaults before any profile
+        // or user files. Explicit user bindings, including `keybind = clear`,
+        // therefore retain precedence in every loading mode.
+        loadCmuxDefaultMacTextEditingKeybinds(config)
 
         #if DEBUG
         let startupPreviewProfile = GhosttyStartupAppearancePreviewState.profile

--- a/cmux-tui/frontends/web/src/hooks/useAttachedTerminal.ts
+++ b/cmux-tui/frontends/web/src/hooks/useAttachedTerminal.ts
@@ -226,10 +226,16 @@ export function useAttachedTerminal({
               terminal.write((event as DecodedOutputEvent).data);
             } else if (event.event === "resized") {
               const resized = event as DecodedResizedEvent;
+              // A resize replay replaces xterm's entire buffer. Keep the
+              // transport closed for the whole reset/write transaction so a
+              // user key cannot land between the reset and authoritative
+              // replay.
+              terminal.options.disableStdin = true;
               terminal.reset();
               terminal.resize(resized.cols, resized.rows);
               await writeReplay(resized.data, resized.colors);
               if (cancelled) return;
+              terminal.options.disableStdin = false;
             } else if (event.event === "colors-changed") {
               const colors = event as ColorsChangedEvent;
               applyCursorDefaults(colors);

--- a/cmux-tui/frontends/web/src/hooks/useAttachedTerminal.ts
+++ b/cmux-tui/frontends/web/src/hooks/useAttachedTerminal.ts
@@ -63,11 +63,15 @@ export function useAttachedTerminal({
     // macOS. Forward only the editing subset that the render-mode terminal
     // handles, keeping Cmd-C/V/W and other browser shortcuts untouched.
     terminal.attachCustomKeyEventHandler((event) => {
-      if (event.type !== "keydown" || !event.metaKey) return true;
+      if (!event.metaKey) return true;
       const action = encodeTerminalKey(event);
       if (action?.kind !== "text") return true;
-      event.preventDefault();
-      void client.send(surface, { text: action.text }).catch(onError);
+      if (event.type === "keydown") {
+        event.preventDefault();
+        void client.send(surface, { text: action.text }).catch(onError);
+      }
+      // A keydown can also produce keypress and keyup events. Keep xterm from
+      // translating those same editing chords a second time.
       return false;
     });
     const webgl = tryLoadWebglRenderer(terminal);

--- a/cmux-tui/frontends/web/src/hooks/useAttachedTerminal.ts
+++ b/cmux-tui/frontends/web/src/hooks/useAttachedTerminal.ts
@@ -66,6 +66,13 @@ export function useAttachedTerminal({
       if (!event.metaKey) return true;
       const action = encodeTerminalKey(event);
       if (action?.kind !== "text") return true;
+      // xterm invokes custom handlers even while stdin is disabled. Do not
+      // transmit editing bytes until the attach has published an authoritative
+      // replay, and suppress the browser default during that short interval.
+      if (cancelled || terminal.options.disableStdin) {
+        if (event.type === "keydown") event.preventDefault();
+        return false;
+      }
       if (event.type === "keydown") {
         event.preventDefault();
         void client.send(surface, { text: action.text }).catch(onError);

--- a/cmux-tui/frontends/web/src/hooks/useAttachedTerminal.ts
+++ b/cmux-tui/frontends/web/src/hooks/useAttachedTerminal.ts
@@ -15,7 +15,7 @@ import { ATTACH_RECOVERY_STABLE_MS, attachRecoveryDelay } from "../lib/attachRec
 import { debounce } from "../lib/debounce";
 import { t } from "../i18n";
 import { nextFitSize, type TerminalSize } from "../lib/fit";
-import { encodeTerminalKey } from "../lib/keyEncoding";
+import { encodeTerminalKey, isMacEditingChord } from "../lib/keyEncoding";
 import {
   colorsToCursorOptionsPatch,
   colorsToDynamicColorSequence,
@@ -66,11 +66,12 @@ export function useAttachedTerminal({
       if (cancelled || terminal.options.disableStdin) return;
       void client.send(surface, { text }).catch(onError);
     };
-    // xterm.js deliberately leaves Command editing chords to the browser on
-    // macOS. Forward only the editing subset that the render-mode terminal
-    // handles, keeping Cmd-C/V/W and other browser shortcuts untouched.
+    // xterm.js deliberately leaves macOS Command and Option editing chords to
+    // the browser. Forward only the line/word editing subset that the
+    // render-mode terminal handles, keeping Cmd-C/V/W and ordinary Option
+    // text untouched.
     terminal.attachCustomKeyEventHandler((event) => {
-      if (!event.metaKey) return true;
+      if (!isMacEditingChord(event)) return true;
       const action = encodeTerminalKey(event);
       if (action?.kind !== "text") return true;
       // xterm invokes custom handlers even while stdin is disabled. Do not

--- a/cmux-tui/frontends/web/src/hooks/useAttachedTerminal.ts
+++ b/cmux-tui/frontends/web/src/hooks/useAttachedTerminal.ts
@@ -15,6 +15,7 @@ import { ATTACH_RECOVERY_STABLE_MS, attachRecoveryDelay } from "../lib/attachRec
 import { debounce } from "../lib/debounce";
 import { t } from "../i18n";
 import { nextFitSize, type TerminalSize } from "../lib/fit";
+import { encodeTerminalKey } from "../lib/keyEncoding";
 import {
   colorsToCursorOptionsPatch,
   colorsToDynamicColorSequence,
@@ -58,6 +59,17 @@ export function useAttachedTerminal({
     const fit = new FitAddon();
     terminal.loadAddon(fit);
     terminal.open(host);
+    // xterm.js deliberately leaves Command editing chords to the browser on
+    // macOS. Forward only the editing subset that the render-mode terminal
+    // handles, keeping Cmd-C/V/W and other browser shortcuts untouched.
+    terminal.attachCustomKeyEventHandler((event) => {
+      if (event.type !== "keydown" || !event.metaKey) return true;
+      const action = encodeTerminalKey(event);
+      if (action?.kind !== "text") return true;
+      event.preventDefault();
+      void client.send(surface, { text: action.text }).catch(onError);
+      return false;
+    });
     const webgl = tryLoadWebglRenderer(terminal);
     // Match desktop Ghostty's Display P3 presentation; no-op where the
     // browser (or the DOM fallback renderer) cannot retag the buffer.

--- a/cmux-tui/frontends/web/src/hooks/useAttachedTerminal.ts
+++ b/cmux-tui/frontends/web/src/hooks/useAttachedTerminal.ts
@@ -15,7 +15,11 @@ import { ATTACH_RECOVERY_STABLE_MS, attachRecoveryDelay } from "../lib/attachRec
 import { debounce } from "../lib/debounce";
 import { t } from "../i18n";
 import { nextFitSize, type TerminalSize } from "../lib/fit";
-import { encodeTerminalKey, isMacEditingChord } from "../lib/keyEncoding";
+import {
+  browserIsMacPlatform,
+  encodeTerminalKey,
+  isMacEditingChord,
+} from "../lib/keyEncoding";
 import {
   colorsToCursorOptionsPatch,
   colorsToDynamicColorSequence,
@@ -59,6 +63,7 @@ export function useAttachedTerminal({
     const fit = new FitAddon();
     terminal.loadAddon(fit);
     terminal.open(host);
+    const keyEncodingOptions = { macEditing: browserIsMacPlatform() };
     const sendInput = (text: string) => {
       // xterm can still deliver a queued data event after a detach or while
       // the authoritative replay is being installed. Keep the transport gate
@@ -71,8 +76,8 @@ export function useAttachedTerminal({
     // render-mode terminal handles, keeping Cmd-C/V/W and ordinary Option
     // text untouched.
     terminal.attachCustomKeyEventHandler((event) => {
-      if (!isMacEditingChord(event)) return true;
-      const action = encodeTerminalKey(event);
+      if (!isMacEditingChord(event, keyEncodingOptions)) return true;
+      const action = encodeTerminalKey(event, keyEncodingOptions);
       if (action?.kind !== "text") return true;
       // xterm invokes custom handlers even while stdin is disabled. Do not
       // transmit editing bytes until the attach has published an authoritative

--- a/cmux-tui/frontends/web/src/hooks/useAttachedTerminal.ts
+++ b/cmux-tui/frontends/web/src/hooks/useAttachedTerminal.ts
@@ -59,6 +59,13 @@ export function useAttachedTerminal({
     const fit = new FitAddon();
     terminal.loadAddon(fit);
     terminal.open(host);
+    const sendInput = (text: string) => {
+      // xterm can still deliver a queued data event after a detach or while
+      // the authoritative replay is being installed. Keep the transport gate
+      // in one place so every input path fails closed in those states.
+      if (cancelled || terminal.options.disableStdin) return;
+      void client.send(surface, { text }).catch(onError);
+    };
     // xterm.js deliberately leaves Command editing chords to the browser on
     // macOS. Forward only the editing subset that the render-mode terminal
     // handles, keeping Cmd-C/V/W and other browser shortcuts untouched.
@@ -75,7 +82,7 @@ export function useAttachedTerminal({
       }
       if (event.type === "keydown") {
         event.preventDefault();
-        void client.send(surface, { text: action.text }).catch(onError);
+        sendInput(action.text);
       }
       // A keydown can also produce keypress and keyup events. Keep xterm from
       // translating those same editing chords a second time.
@@ -117,9 +124,7 @@ export function useAttachedTerminal({
     window.visualViewport?.addEventListener("resize", sendResize);
     window.visualViewport?.addEventListener("scroll", sendResize);
     sendResize();
-    const input = terminal.onData((text) => {
-      void client.send(surface, { text }).catch(onError);
-    });
+    const input = terminal.onData(sendInput);
     const writeTerminal = (data: string | Uint8Array) =>
       new Promise<void>((resolve) => terminal.write(data, resolve));
     const applyColors = async (
@@ -177,6 +182,7 @@ export function useAttachedTerminal({
       try {
         let recoveryAttempt = 0;
         for (;;) {
+          terminal.options.disableStdin = true;
           stream = await client.attachSurface(surface);
           // Cleanup may have raced the attach round-trip; close the stream we
           // just opened or its buffered events leak for the surface's lifetime.
@@ -198,6 +204,7 @@ export function useAttachedTerminal({
             }
             if (cancelled) return;
             if (event.event === "detached") {
+              terminal.options.disableStdin = true;
               return;
             } else if (event.event === "vt-state") {
               const replay = event as DecodedVtStateEvent;
@@ -241,7 +248,10 @@ export function useAttachedTerminal({
           }
           stream.close();
           stream = null;
-          if (!overflowed) return;
+          if (!overflowed) {
+            terminal.options.disableStdin = true;
+            return;
+          }
           const delayMs = attachRecoveryDelay(recoveryAttempt++);
           if (delayMs === null) {
             throw new Error(t("attachOverflowRecoveryFailed"));
@@ -250,8 +260,10 @@ export function useAttachedTerminal({
           if (cancelled) return;
         }
       } catch (error) {
+        terminal.options.disableStdin = true;
         if (!cancelled) onError(error instanceof Error ? error : new Error(String(error)));
       } finally {
+        terminal.options.disableStdin = true;
         stream?.close();
         if (!cancelled) {
           reportedFit = null;
@@ -266,6 +278,7 @@ export function useAttachedTerminal({
 
     return () => {
       cancelled = true;
+      terminal.options.disableStdin = true;
       observer.disconnect();
       window.visualViewport?.removeEventListener("resize", sendResize);
       window.visualViewport?.removeEventListener("scroll", sendResize);

--- a/cmux-tui/frontends/web/src/hooks/useRenderTerminal.ts
+++ b/cmux-tui/frontends/web/src/hooks/useRenderTerminal.ts
@@ -16,7 +16,7 @@ import { t } from "../i18n";
 import { syncCanvasBackground } from "../lib/canvasTheme";
 import { nextFitSize, type TerminalSize } from "../lib/fit";
 import { createFrameBatch } from "../lib/frameBatch";
-import { encodeTerminalKey } from "../lib/keyEncoding";
+import { browserIsMacPlatform, encodeTerminalKey } from "../lib/keyEncoding";
 import { beginTerminalSelection, clampTerminalSelection, releaseTerminalSelection } from "../lib/terminalSelection";
 import {
   applyDelta,
@@ -173,6 +173,7 @@ export function useRenderTerminal({
     const scroller = host.querySelector<HTMLElement>("[data-render-scroll]");
     const textarea = host.querySelector<HTMLTextAreaElement>("[data-render-input]");
     const probe = host.querySelector<HTMLElement>("[data-render-probe]");
+    const keyEncodingOptions = { macEditing: browserIsMacPlatform() };
     const metrics = { width: 0, height: 0 };
     const applySurfaceBackground = (background: string) => {
       stage?.style.setProperty("--surface-background", background);
@@ -423,7 +424,7 @@ export function useRenderTerminal({
       const lowerKey = event.key.toLowerCase();
       if (hasSelection && lowerKey === "c" && (event.metaKey || (event.ctrlKey && event.shiftKey))) return;
       if (lowerKey === "v" && (event.metaKey || (event.ctrlKey && event.shiftKey))) return;
-      const action = encodeTerminalKey(event);
+      const action = encodeTerminalKey(event, keyEncodingOptions);
       if (action === null) return;
       event.preventDefault();
       if (action.kind === "text") sendText(action.text);

--- a/cmux-tui/frontends/web/src/lib/keyEncoding.ts
+++ b/cmux-tui/frontends/web/src/lib/keyEncoding.ts
@@ -67,8 +67,32 @@ function isSingleCodePoint(value: string): boolean {
   return Array.from(value).length === 1;
 }
 
+/**
+ * Keep the browser's Command shortcuts intact, but mirror the small set of
+ * macOS editing chords that Ghostty sends to a terminal. These are raw
+ * readline-compatible bytes rather than named keys, so the behavior does not
+ * depend on the remote terminal's application-key or Kitty-keyboard mode.
+ */
+function macCommandEditingAction(event: TerminalKeyEvent): TerminalKeyAction | null {
+  if (!event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return null;
+
+  switch (event.key) {
+    case "Backspace":
+      return { kind: "text", text: "\u0015" }; // Ctrl-U, delete to line start.
+    case "Delete":
+      return { kind: "text", text: "\u000b" }; // Ctrl-K, delete to line end.
+    case "ArrowLeft":
+      return { kind: "text", text: "\u0001" }; // Ctrl-A, line start.
+    case "ArrowRight":
+      return { kind: "text", text: "\u0005" }; // Ctrl-E, line end.
+    default:
+      return null;
+  }
+}
+
 export function encodeTerminalKey(event: TerminalKeyEvent): TerminalKeyAction | null {
-  if (event.isComposing || event.metaKey || ignoredKeys.has(event.key)) return null;
+  if (event.isComposing || ignoredKeys.has(event.key)) return null;
+  if (event.metaKey) return macCommandEditingAction(event);
 
   if (event.key === "Tab" && event.shiftKey && !event.ctrlKey && !event.altKey) {
     return { kind: "key", key: "backtab" };

--- a/cmux-tui/frontends/web/src/lib/keyEncoding.ts
+++ b/cmux-tui/frontends/web/src/lib/keyEncoding.ts
@@ -7,6 +7,11 @@ export interface TerminalKeyEvent {
   isComposing?: boolean;
 }
 
+export interface TerminalKeyEncodingOptions {
+  /** Enable macOS Command/Option editing chords for this browser surface. */
+  macEditing?: boolean;
+}
+
 export type TerminalKeyAction =
   | { kind: "text"; text: string }
   | { kind: "key"; key: string };
@@ -67,6 +72,23 @@ function isSingleCodePoint(value: string): boolean {
   return Array.from(value).length === 1;
 }
 
+interface BrowserPlatformSource {
+  userAgentData?: { platform?: string };
+  platform?: string;
+  userAgent?: string;
+}
+
+/** Returns true when a browser platform identifies itself as macOS. */
+export function browserIsMacPlatform(source?: BrowserPlatformSource): boolean {
+  const browser = source ?? (
+    typeof globalThis.navigator === "undefined"
+      ? undefined
+      : (globalThis.navigator as unknown as BrowserPlatformSource)
+  );
+  const platform = browser?.userAgentData?.platform ?? browser?.platform ?? browser?.userAgent;
+  return /mac/i.test(platform ?? "");
+}
+
 /**
  * Keep the browser's Command shortcuts intact, but mirror the small set of
  * macOS editing chords that Ghostty sends to a terminal. These are raw
@@ -115,14 +137,20 @@ function macEditingAction(event: TerminalKeyEvent): TerminalKeyAction | null {
  * xterm receives them. Option+letter input is intentionally excluded: it is
  * ordinary terminal text and must keep the generic ESC-prefixed encoding.
  */
-export function isMacEditingChord(event: TerminalKeyEvent): boolean {
-  return !event.isComposing && macEditingAction(event) !== null;
+export function isMacEditingChord(
+  event: TerminalKeyEvent,
+  options: TerminalKeyEncodingOptions = {},
+): boolean {
+  return options.macEditing === true && !event.isComposing && macEditingAction(event) !== null;
 }
 
-export function encodeTerminalKey(event: TerminalKeyEvent): TerminalKeyAction | null {
+export function encodeTerminalKey(
+  event: TerminalKeyEvent,
+  options: TerminalKeyEncodingOptions = {},
+): TerminalKeyAction | null {
   if (event.isComposing || ignoredKeys.has(event.key)) return null;
   if (event.metaKey || event.altKey) {
-    const editing = macEditingAction(event);
+    const editing = options.macEditing === true ? macEditingAction(event) : null;
     if (editing !== null) return editing;
     // Preserve browser Command shortcuts and generic Option text. Command
     // events must not fall through to text encoding, while Option events do.

--- a/cmux-tui/frontends/web/src/lib/keyEncoding.ts
+++ b/cmux-tui/frontends/web/src/lib/keyEncoding.ts
@@ -73,26 +73,61 @@ function isSingleCodePoint(value: string): boolean {
  * readline-compatible bytes rather than named keys, so the behavior does not
  * depend on the remote terminal's application-key or Kitty-keyboard mode.
  */
-function macCommandEditingAction(event: TerminalKeyEvent): TerminalKeyAction | null {
-  if (!event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return null;
+function macEditingAction(event: TerminalKeyEvent): TerminalKeyAction | null {
+  const command = event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey;
+  const option = event.altKey && !event.metaKey && !event.ctrlKey && !event.shiftKey;
+  if (!command && !option) return null;
 
   switch (event.key) {
     case "Backspace":
-      return { kind: "text", text: "\u0015" }; // Ctrl-U, delete to line start.
+      return {
+        kind: "text",
+        // Command+Backspace is Ctrl-U. Option+Backspace is ESC DEL, which is
+        // the readline word-delete sequence and matches Ghostty's native path.
+        text: command ? "\u0015" : "\u001b\u007f",
+      };
     case "Delete":
-      return { kind: "text", text: "\u000b" }; // Ctrl-K, delete to line end.
+      return {
+        kind: "text",
+        // Command+ForwardDelete is Ctrl-K. Option+ForwardDelete is ESC d,
+        // readline's forward-word deletion sequence.
+        text: command ? "\u000b" : "\u001bd",
+      };
     case "ArrowLeft":
-      return { kind: "text", text: "\u0001" }; // Ctrl-A, line start.
+      return {
+        kind: "text",
+        // Command+Left moves to the line start. Option+Left moves one word.
+        text: command ? "\u0001" : "\u001bb",
+      };
     case "ArrowRight":
-      return { kind: "text", text: "\u0005" }; // Ctrl-E, line end.
+      return {
+        kind: "text",
+        // Command+Right moves to the line end. Option+Right moves one word.
+        text: command ? "\u0005" : "\u001bf",
+      };
     default:
       return null;
   }
 }
 
+/**
+ * Returns true only for editing chords that the browser may consume before
+ * xterm receives them. Option+letter input is intentionally excluded: it is
+ * ordinary terminal text and must keep the generic ESC-prefixed encoding.
+ */
+export function isMacEditingChord(event: TerminalKeyEvent): boolean {
+  return !event.isComposing && macEditingAction(event) !== null;
+}
+
 export function encodeTerminalKey(event: TerminalKeyEvent): TerminalKeyAction | null {
   if (event.isComposing || ignoredKeys.has(event.key)) return null;
-  if (event.metaKey) return macCommandEditingAction(event);
+  if (event.metaKey || event.altKey) {
+    const editing = macEditingAction(event);
+    if (editing !== null) return editing;
+    // Preserve browser Command shortcuts and generic Option text. Command
+    // events must not fall through to text encoding, while Option events do.
+    if (event.metaKey) return null;
+  }
 
   if (event.key === "Tab" && event.shiftKey && !event.ctrlKey && !event.altKey) {
     return { kind: "key", key: "backtab" };

--- a/cmux-tui/frontends/web/src/lib/keyEncoding.ts
+++ b/cmux-tui/frontends/web/src/lib/keyEncoding.ts
@@ -85,7 +85,10 @@ export function browserIsMacPlatform(source?: BrowserPlatformSource): boolean {
       ? undefined
       : (globalThis.navigator as unknown as BrowserPlatformSource)
   );
-  const platform = browser?.userAgentData?.platform ?? browser?.platform ?? browser?.userAgent;
+  // Some privacy-focused browsers expose an empty UA-Client-Hints platform
+  // while still providing the older platform or user-agent fields. Treat an
+  // empty value as unavailable so the later, less-preferred signal can decide.
+  const platform = browser?.userAgentData?.platform || browser?.platform || browser?.userAgent;
   return /mac/i.test(platform ?? "");
 }
 

--- a/cmux-tui/frontends/web/test/attached-terminal-sizing.test.tsx
+++ b/cmux-tui/frontends/web/test/attached-terminal-sizing.test.tsx
@@ -145,7 +145,7 @@ describe("attached terminal sizing", () => {
     expect(client.releaseSurfaceSize).toHaveBeenCalledWith(7n);
   });
 
-  it("forwards Command editing chords through xterm and preserves browser shortcuts", async () => {
+  it("forwards Command and Option editing chords through xterm and preserves browser shortcuts", async () => {
     globalThis.ResizeObserver = class {
       observe() {}
       unobserve() {}
@@ -190,23 +190,27 @@ describe("attached terminal sizing", () => {
     terminal.options.disableStdin = false;
 
     const editingEvents = [
-      ["Backspace", "\u0015"],
-      ["Delete", "\u000b"],
-      ["ArrowLeft", "\u0001"],
-      ["ArrowRight", "\u0005"],
+      ["Backspace", "\u0015", "metaKey"],
+      ["Delete", "\u000b", "metaKey"],
+      ["ArrowLeft", "\u0001", "metaKey"],
+      ["ArrowRight", "\u0005", "metaKey"],
+      ["Backspace", "\u001b\u007f", "altKey"],
+      ["Delete", "\u001bd", "altKey"],
+      ["ArrowLeft", "\u001bb", "altKey"],
+      ["ArrowRight", "\u001bf", "altKey"],
     ] as const;
-    for (const [key, text] of editingEvents) {
+    for (const [key, text, modifier] of editingEvents) {
       const event = new KeyboardEvent("keydown", {
         bubbles: true,
         cancelable: true,
         key,
-        metaKey: true,
+        [modifier]: true,
       });
       expect(handler(event)).toBe(false);
       expect(event.defaultPrevented).toBe(true);
       await waitFor(() => expect(client.send).toHaveBeenCalledWith(7n, { text }));
       for (const type of ["keypress", "keyup"] as const) {
-        const followup = new KeyboardEvent(type, { key, metaKey: true });
+        const followup = new KeyboardEvent(type, { key, [modifier]: true });
         expect(handler(followup)).toBe(false);
       }
     }
@@ -220,13 +224,13 @@ describe("attached terminal sizing", () => {
     expect(handler(copy)).toBe(true);
     expect(client.send).toHaveBeenCalledTimes(editingEvents.length);
 
-    const optionDelete = new KeyboardEvent("keydown", {
+    const optionText = new KeyboardEvent("keydown", {
       bubbles: true,
       cancelable: true,
-      key: "Backspace",
+      key: "x",
       altKey: true,
     });
-    expect(handler(optionDelete)).toBe(true);
+    expect(handler(optionText)).toBe(true);
     expect(client.send).toHaveBeenCalledTimes(editingEvents.length);
     view.unmount();
   });

--- a/cmux-tui/frontends/web/test/attached-terminal-sizing.test.tsx
+++ b/cmux-tui/frontends/web/test/attached-terminal-sizing.test.tsx
@@ -1,6 +1,6 @@
 import { render, waitFor } from "@testing-library/react";
 import { useCallback } from "react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CmuxClient, DecodedAttachEvent } from "cmux/raw";
 import { useAttachedTerminal } from "../src/hooks/useAttachedTerminal";
 
@@ -110,9 +110,18 @@ function Harness({ client }: { client: CmuxClient }) {
 
 describe("attached terminal sizing", () => {
   const originalResizeObserver = globalThis.ResizeObserver;
+  const originalNavigatorPlatform = navigator.platform;
+
+  beforeEach(() => {
+    Object.defineProperty(navigator, "platform", { configurable: true, value: "MacIntel" });
+  });
 
   afterEach(() => {
     globalThis.ResizeObserver = originalResizeObserver;
+    Object.defineProperty(navigator, "platform", {
+      configurable: true,
+      value: originalNavigatorPlatform,
+    });
     terminalMocks.instances.length = 0;
   });
 

--- a/cmux-tui/frontends/web/test/attached-terminal-sizing.test.tsx
+++ b/cmux-tui/frontends/web/test/attached-terminal-sizing.test.tsx
@@ -8,8 +8,9 @@ const fitDimensions = { cols: 80, rows: 24 };
 type TerminalMock = {
   options: Record<string, unknown>;
   writes: Array<string | Uint8Array>;
-  customKeyEventHandler?: (event: KeyboardEvent) => boolean;
-};
+  disableStdinDuringWrites: boolean[];
+    customKeyEventHandler?: (event: KeyboardEvent) => boolean;
+  };
 const terminalMocks = vi.hoisted(() => ({
   instances: [] as TerminalMock[],
 }));
@@ -31,6 +32,7 @@ vi.mock("@xterm/xterm", () => ({
     constructor(options: Record<string, unknown>) {
       this.options = options;
       terminalMocks.instances.push(this);
+      this.disableStdinDuringWrites = [];
     }
 
     loadAddon() {}
@@ -42,6 +44,7 @@ vi.mock("@xterm/xterm", () => ({
     resize() {}
     write(data: string | Uint8Array, callback?: () => void) {
       this.writes.push(data);
+      this.disableStdinDuringWrites.push(this.options.disableStdin === true);
       if (data instanceof Uint8Array && data.length > 0) {
         this.options.theme = {
           ...(this.options.theme as Record<string, unknown>),
@@ -279,6 +282,47 @@ describe("attached terminal sizing", () => {
     expect(handler(event)).toBe(false);
     expect(event.defaultPrevented).toBe(true);
     expect(client.send).not.toHaveBeenCalled();
+  });
+
+  it("blocks editing input while a resize replay replaces the terminal buffer", async () => {
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+    const client = {
+      attachSurface: vi.fn(async () => new TestStream([
+        {
+          event: "vt-state",
+          surface: 7n,
+          cols: 80,
+          rows: 24,
+          data: new Uint8Array([1]),
+          colors: {},
+        },
+        {
+          event: "resized",
+          surface: 7n,
+          cols: 100,
+          rows: 30,
+          data: new Uint8Array([2]),
+          replay: new Uint8Array([2]),
+          colors: {},
+        },
+      ])),
+      resizeSurface: vi.fn(async () => ({ accepted: true, reservation_id: null })),
+      releaseSurfaceSize: vi.fn(async () => ({})),
+      send: vi.fn(async () => ({})),
+    } as unknown as CmuxClient;
+
+    const view = render(<Harness client={client} />);
+    await waitFor(() => expect(terminalMocks.instances[0]?.writes).toHaveLength(2));
+
+    const terminal = terminalMocks.instances[0];
+    if (terminal === undefined) throw new Error("xterm terminal was not created");
+    expect(terminal.disableStdinDuringWrites).toEqual([true, true]);
+    expect(terminal.options.disableStdin).toBe(false);
+    view.unmount();
   });
 
   it("applies sparse palette overrides after replay and on color changes", async () => {

--- a/cmux-tui/frontends/web/test/attached-terminal-sizing.test.tsx
+++ b/cmux-tui/frontends/web/test/attached-terminal-sizing.test.tsx
@@ -239,6 +239,14 @@ describe("attached terminal sizing", () => {
     };
     const client = {
       attachSurface: vi.fn(async () => new TestStream([
+        {
+          event: "vt-state",
+          surface: 7n,
+          cols: 80,
+          rows: 24,
+          data: new Uint8Array(),
+          colors: {},
+        },
         { event: "detached", surface: 7n },
       ])),
       resizeSurface: vi.fn(async () => ({ accepted: true, reservation_id: null })),
@@ -249,6 +257,24 @@ describe("attached terminal sizing", () => {
     render(<Harness client={client} />);
 
     await waitFor(() => expect(client.releaseSurfaceSize).toHaveBeenCalledWith(7n));
+
+    const terminal = terminalMocks.instances[0];
+    if (terminal === undefined) throw new Error("xterm terminal was not created");
+    const handler = terminal.customKeyEventHandler;
+    if (handler === undefined) throw new Error("xterm key handler was not registered");
+
+    // The stream first becomes writable, then detaches. A detached stream must
+    // stop accepting editing input while the React consumer is still mounted
+    // and before its cleanup runs.
+    const event = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "Backspace",
+      metaKey: true,
+    });
+    expect(handler(event)).toBe(false);
+    expect(event.defaultPrevented).toBe(true);
+    expect(client.send).not.toHaveBeenCalled();
   });
 
   it("applies sparse palette overrides after replay and on color changes", async () => {

--- a/cmux-tui/frontends/web/test/attached-terminal-sizing.test.tsx
+++ b/cmux-tui/frontends/web/test/attached-terminal-sizing.test.tsx
@@ -188,6 +188,10 @@ describe("attached terminal sizing", () => {
       expect(handler(event)).toBe(false);
       expect(event.defaultPrevented).toBe(true);
       await waitFor(() => expect(client.send).toHaveBeenCalledWith(7n, { text }));
+      for (const type of ["keypress", "keyup"] as const) {
+        const followup = new KeyboardEvent(type, { key, metaKey: true });
+        expect(handler(followup)).toBe(false);
+      }
     }
 
     const copy = new KeyboardEvent("keydown", {

--- a/cmux-tui/frontends/web/test/attached-terminal-sizing.test.tsx
+++ b/cmux-tui/frontends/web/test/attached-terminal-sizing.test.tsx
@@ -172,6 +172,23 @@ describe("attached terminal sizing", () => {
     const handler = terminalMocks.instances[0]?.customKeyEventHandler;
     if (handler === undefined) throw new Error("xterm key handler was not registered");
 
+    // The attach starts with stdin disabled until the first authoritative
+    // replay arrives. Editing chords must not leak into the VM during that
+    // window, and must remain suppressed in the browser.
+    const terminal = terminalMocks.instances[0];
+    if (terminal === undefined) throw new Error("xterm terminal was not created");
+    terminal.options.disableStdin = true;
+    const beforeAttach = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "Backspace",
+      metaKey: true,
+    });
+    expect(handler(beforeAttach)).toBe(false);
+    expect(beforeAttach.defaultPrevented).toBe(true);
+    expect(client.send).not.toHaveBeenCalled();
+    terminal.options.disableStdin = false;
+
     const editingEvents = [
       ["Backspace", "\u0015"],
       ["Delete", "\u000b"],

--- a/cmux-tui/frontends/web/test/attached-terminal-sizing.test.tsx
+++ b/cmux-tui/frontends/web/test/attached-terminal-sizing.test.tsx
@@ -5,11 +5,13 @@ import type { CmuxClient, DecodedAttachEvent } from "cmux/raw";
 import { useAttachedTerminal } from "../src/hooks/useAttachedTerminal";
 
 const fitDimensions = { cols: 80, rows: 24 };
+type TerminalMock = {
+  options: Record<string, unknown>;
+  writes: Array<string | Uint8Array>;
+  customKeyEventHandler?: (event: KeyboardEvent) => boolean;
+};
 const terminalMocks = vi.hoisted(() => ({
-  instances: [] as Array<{
-    options: Record<string, unknown>;
-    writes: Array<string | Uint8Array>;
-  }>,
+  instances: [] as TerminalMock[],
 }));
 
 vi.mock("@xterm/addon-fit", () => ({
@@ -24,6 +26,7 @@ vi.mock("@xterm/xterm", () => ({
   Terminal: class {
     options: Record<string, unknown>;
     writes: Array<string | Uint8Array> = [];
+    customKeyEventHandler?: (event: KeyboardEvent) => boolean;
 
     constructor(options: Record<string, unknown>) {
       this.options = options;
@@ -32,6 +35,9 @@ vi.mock("@xterm/xterm", () => ({
 
     loadAddon() {}
     open() {}
+    attachCustomKeyEventHandler(handler: (event: KeyboardEvent) => boolean) {
+      this.customKeyEventHandler = handler;
+    }
     reset() {}
     resize() {}
     write(data: string | Uint8Array, callback?: () => void) {
@@ -137,6 +143,71 @@ describe("attached terminal sizing", () => {
     expect(client.resizeSurface).toHaveBeenNthCalledWith(2, 7n, 80, 24);
     view.unmount();
     expect(client.releaseSurfaceSize).toHaveBeenCalledWith(7n);
+  });
+
+  it("forwards Command editing chords through xterm and preserves browser shortcuts", async () => {
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+    const client = {
+      attachSurface: vi.fn(async () => new TestStream([
+        {
+          event: "vt-state",
+          surface: 7n,
+          cols: 80,
+          rows: 24,
+          data: new Uint8Array(),
+          colors: {},
+        },
+      ])),
+      resizeSurface: vi.fn(async () => ({ accepted: true, reservation_id: null })),
+      releaseSurfaceSize: vi.fn(async () => ({})),
+      send: vi.fn(async () => ({})),
+    } as unknown as CmuxClient;
+
+    const view = render(<Harness client={client} />);
+    await waitFor(() => expect(terminalMocks.instances[0]?.customKeyEventHandler).toEqual(expect.any(Function)));
+    const handler = terminalMocks.instances[0]?.customKeyEventHandler;
+    if (handler === undefined) throw new Error("xterm key handler was not registered");
+
+    const editingEvents = [
+      ["Backspace", "\u0015"],
+      ["Delete", "\u000b"],
+      ["ArrowLeft", "\u0001"],
+      ["ArrowRight", "\u0005"],
+    ] as const;
+    for (const [key, text] of editingEvents) {
+      const event = new KeyboardEvent("keydown", {
+        bubbles: true,
+        cancelable: true,
+        key,
+        metaKey: true,
+      });
+      expect(handler(event)).toBe(false);
+      expect(event.defaultPrevented).toBe(true);
+      await waitFor(() => expect(client.send).toHaveBeenCalledWith(7n, { text }));
+    }
+
+    const copy = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "c",
+      metaKey: true,
+    });
+    expect(handler(copy)).toBe(true);
+    expect(client.send).toHaveBeenCalledTimes(editingEvents.length);
+
+    const optionDelete = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "Backspace",
+      altKey: true,
+    });
+    expect(handler(optionDelete)).toBe(true);
+    expect(client.send).toHaveBeenCalledTimes(editingEvents.length);
+    view.unmount();
   });
 
   it("releases sizing when the attach consumer terminates", async () => {

--- a/cmux-tui/frontends/web/test/attached-terminal-sizing.test.tsx
+++ b/cmux-tui/frontends/web/test/attached-terminal-sizing.test.tsx
@@ -9,8 +9,8 @@ type TerminalMock = {
   options: Record<string, unknown>;
   writes: Array<string | Uint8Array>;
   disableStdinDuringWrites: boolean[];
-    customKeyEventHandler?: (event: KeyboardEvent) => boolean;
-  };
+  customKeyEventHandler?: (event: KeyboardEvent) => boolean;
+};
 const terminalMocks = vi.hoisted(() => ({
   instances: [] as TerminalMock[],
 }));
@@ -27,12 +27,12 @@ vi.mock("@xterm/xterm", () => ({
   Terminal: class {
     options: Record<string, unknown>;
     writes: Array<string | Uint8Array> = [];
+    disableStdinDuringWrites: boolean[] = [];
     customKeyEventHandler?: (event: KeyboardEvent) => boolean;
 
     constructor(options: Record<string, unknown>) {
       this.options = options;
       terminalMocks.instances.push(this);
-      this.disableStdinDuringWrites = [];
     }
 
     loadAddon() {}

--- a/cmux-tui/frontends/web/test/key-encoding.test.ts
+++ b/cmux-tui/frontends/web/test/key-encoding.test.ts
@@ -23,8 +23,27 @@ describe("render terminal key encoding", () => {
     expect(encodeTerminalKey(event)).toEqual(expected);
   });
 
-  it("leaves browser meta shortcuts and IME composition alone", () => {
-    expect(encodeTerminalKey(key("c", { metaKey: true }))).toBeNull();
-    expect(encodeTerminalKey(key("Process", { isComposing: true }))).toBeNull();
+  it("mirrors macOS line and cursor editing chords as raw control bytes", () => {
+    expect([
+      key("Backspace", { metaKey: true }),
+      key("Delete", { metaKey: true }),
+      key("ArrowLeft", { metaKey: true }),
+      key("ArrowRight", { metaKey: true }),
+    ].map(encodeTerminalKey)).toEqual([
+      { kind: "text", text: "\u0015" },
+      { kind: "text", text: "\u000b" },
+      { kind: "text", text: "\u0001" },
+      { kind: "text", text: "\u0005" },
+    ]);
+  });
+
+  it("leaves browser shortcuts, modified selection, and IME composition alone", () => {
+    for (const shortcut of ["c", "v", "w", "t", "q"]) {
+      expect(encodeTerminalKey(key(shortcut, { metaKey: true }))).toBeNull();
+    }
+    for (const modifier of ["shiftKey", "altKey", "ctrlKey"] as const) {
+      expect(encodeTerminalKey(key("Backspace", { metaKey: true, [modifier]: true }))).toBeNull();
+    }
+    expect(encodeTerminalKey(key("Process", { isComposing: true, metaKey: true }))).toBeNull();
   });
 });

--- a/cmux-tui/frontends/web/test/key-encoding.test.ts
+++ b/cmux-tui/frontends/web/test/key-encoding.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { encodeTerminalKey, isMacEditingChord, type TerminalKeyEvent } from "../src/lib/keyEncoding";
+import {
+  browserIsMacPlatform,
+  encodeTerminalKey,
+  isMacEditingChord,
+  type TerminalKeyEvent,
+} from "../src/lib/keyEncoding";
 
 function key(value: string, overrides: Partial<TerminalKeyEvent> = {}): TerminalKeyEvent {
   return { key: value, ctrlKey: false, altKey: false, shiftKey: false, metaKey: false, ...overrides };
@@ -29,7 +34,7 @@ describe("render terminal key encoding", () => {
       key("Delete", { metaKey: true }),
       key("ArrowLeft", { metaKey: true }),
       key("ArrowRight", { metaKey: true }),
-    ].map(encodeTerminalKey)).toEqual([
+    ].map((event) => encodeTerminalKey(event, { macEditing: true }))).toEqual([
       { kind: "text", text: "\u0015" },
       { kind: "text", text: "\u000b" },
       { kind: "text", text: "\u0001" },
@@ -43,7 +48,7 @@ describe("render terminal key encoding", () => {
       key("Delete", { altKey: true }),
       key("ArrowLeft", { altKey: true }),
       key("ArrowRight", { altKey: true }),
-    ].map(encodeTerminalKey)).toEqual([
+    ].map((event) => encodeTerminalKey(event, { macEditing: true }))).toEqual([
       { kind: "text", text: "\u001b\u007f" },
       { kind: "text", text: "\u001bd" },
       { kind: "text", text: "\u001bb" },
@@ -53,8 +58,23 @@ describe("render terminal key encoding", () => {
       kind: "text",
       text: "\u001bx",
     });
-    expect(isMacEditingChord(key("Backspace", { altKey: true }))).toBe(true);
-    expect(isMacEditingChord(key("x", { altKey: true }))).toBe(false);
+    expect(isMacEditingChord(key("Backspace", { altKey: true }), { macEditing: true })).toBe(true);
+    expect(isMacEditingChord(key("x", { altKey: true }), { macEditing: true })).toBe(false);
+  });
+
+  it("keeps non-macOS Alt editing keys on the generic named-key path", () => {
+    expect([
+      key("Backspace", { altKey: true }),
+      key("Delete", { altKey: true }),
+      key("ArrowLeft", { altKey: true }),
+      key("ArrowRight", { altKey: true }),
+    ].map((event) => encodeTerminalKey(event, { macEditing: false }))).toEqual([
+      { kind: "key", key: "alt+backspace" },
+      { kind: "key", key: "alt+delete" },
+      { kind: "key", key: "alt+left" },
+      { kind: "key", key: "alt+right" },
+    ]);
+    expect(isMacEditingChord(key("Backspace", { altKey: true }), { macEditing: false })).toBe(false);
   });
 
   it("leaves browser shortcuts, modified selection, and IME composition alone", () => {
@@ -68,7 +88,14 @@ describe("render terminal key encoding", () => {
       const event = key("Backspace", { altKey: true, [modifier]: true });
       expect(isMacEditingChord(event)).toBe(false);
     }
-    expect(encodeTerminalKey(key("Process", { isComposing: true, metaKey: true }))).toBeNull();
-    expect(isMacEditingChord(key("Backspace", { altKey: true, isComposing: true }))).toBe(false);
+    expect(encodeTerminalKey(key("Process", { isComposing: true, metaKey: true }), { macEditing: true })).toBeNull();
+    expect(isMacEditingChord(key("Backspace", { altKey: true, isComposing: true }), { macEditing: true })).toBe(false);
+  });
+
+  it("recognizes macOS browser platform identifiers", () => {
+    expect(browserIsMacPlatform({ userAgentData: { platform: "macOS" } })).toBe(true);
+    expect(browserIsMacPlatform({ platform: "MacIntel" })).toBe(true);
+    expect(browserIsMacPlatform({ userAgent: "Mozilla/5.0 (X11; Linux x86_64)" })).toBe(false);
+    expect(browserIsMacPlatform({ platform: "Win32" })).toBe(false);
   });
 });

--- a/cmux-tui/frontends/web/test/key-encoding.test.ts
+++ b/cmux-tui/frontends/web/test/key-encoding.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { encodeTerminalKey, type TerminalKeyEvent } from "../src/lib/keyEncoding";
+import { encodeTerminalKey, isMacEditingChord, type TerminalKeyEvent } from "../src/lib/keyEncoding";
 
 function key(value: string, overrides: Partial<TerminalKeyEvent> = {}): TerminalKeyEvent {
   return { key: value, ctrlKey: false, altKey: false, shiftKey: false, metaKey: false, ...overrides };
@@ -37,6 +37,26 @@ describe("render terminal key encoding", () => {
     ]);
   });
 
+  it("mirrors macOS Option word editing chords without swallowing normal Option text", () => {
+    expect([
+      key("Backspace", { altKey: true }),
+      key("Delete", { altKey: true }),
+      key("ArrowLeft", { altKey: true }),
+      key("ArrowRight", { altKey: true }),
+    ].map(encodeTerminalKey)).toEqual([
+      { kind: "text", text: "\u001b\u007f" },
+      { kind: "text", text: "\u001bd" },
+      { kind: "text", text: "\u001bb" },
+      { kind: "text", text: "\u001bf" },
+    ]);
+    expect(encodeTerminalKey(key("x", { altKey: true }))).toEqual({
+      kind: "text",
+      text: "\u001bx",
+    });
+    expect(isMacEditingChord(key("Backspace", { altKey: true }))).toBe(true);
+    expect(isMacEditingChord(key("x", { altKey: true }))).toBe(false);
+  });
+
   it("leaves browser shortcuts, modified selection, and IME composition alone", () => {
     for (const shortcut of ["c", "v", "w", "t", "q"]) {
       expect(encodeTerminalKey(key(shortcut, { metaKey: true }))).toBeNull();
@@ -44,6 +64,11 @@ describe("render terminal key encoding", () => {
     for (const modifier of ["shiftKey", "altKey", "ctrlKey"] as const) {
       expect(encodeTerminalKey(key("Backspace", { metaKey: true, [modifier]: true }))).toBeNull();
     }
+    for (const modifier of ["shiftKey", "metaKey", "ctrlKey"] as const) {
+      const event = key("Backspace", { altKey: true, [modifier]: true });
+      expect(isMacEditingChord(event)).toBe(false);
+    }
     expect(encodeTerminalKey(key("Process", { isComposing: true, metaKey: true }))).toBeNull();
+    expect(isMacEditingChord(key("Backspace", { altKey: true, isComposing: true }))).toBe(false);
   });
 });

--- a/cmux-tui/frontends/web/test/key-encoding.test.ts
+++ b/cmux-tui/frontends/web/test/key-encoding.test.ts
@@ -94,6 +94,7 @@ describe("render terminal key encoding", () => {
 
   it("recognizes macOS browser platform identifiers", () => {
     expect(browserIsMacPlatform({ userAgentData: { platform: "macOS" } })).toBe(true);
+    expect(browserIsMacPlatform({ userAgentData: { platform: "" }, platform: "MacIntel" })).toBe(true);
     expect(browserIsMacPlatform({ platform: "MacIntel" })).toBe(true);
     expect(browserIsMacPlatform({ userAgent: "Mozilla/5.0 (X11; Linux x86_64)" })).toBe(false);
     expect(browserIsMacPlatform({ platform: "Win32" })).toBe(false);

--- a/cmuxTests/CJKIMEInputTests.swift
+++ b/cmuxTests/CJKIMEInputTests.swift
@@ -2307,8 +2307,12 @@ final class GhosttyOptionDeleteRegressionTests: XCTestCase {
             pressEvent = keyEvent
         }
 
+        // AppKit translates Option+Backspace into the U+2202 partial
+        // derivative character during text-input interpretation. The
+        // regression must use that real event shape, otherwise the normal
+        // fallback path can appear to preserve Option by accident.
         let sent = hostedView.debugSendSyntheticKeyPressAndReleaseForUITest(
-            characters: "\u{7F}",
+            characters: "\u{2202}",
             charactersIgnoringModifiers: "\u{7F}",
             keyCode: 51,
             modifierFlags: [.option]

--- a/cmuxTests/GhosttyDECCKMArrowKeyTests.swift
+++ b/cmuxTests/GhosttyDECCKMArrowKeyTests.swift
@@ -3,7 +3,6 @@ import CmuxTerminal
 import Foundation
 import GhosttyKit
 import Testing
-import XCTest
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -68,7 +67,7 @@ struct GhosttyDECCKMArrowKeyTests {
         // the routing decision; this byte-level integration path needs a live
         // surface to poll terminal text.
         guard hostedTerminal.surface.hasLiveSurface else {
-            throw XCTSkip("Ghostty surface failed to initialize on this host; byte-level arrow routing is unavailable.")
+            try Test.cancel("Ghostty surface failed to initialize on this host; byte-level arrow routing is unavailable.")
         }
 
         try installIsolatedEditingKeybinds(on: hostedTerminal.surface)
@@ -169,7 +168,7 @@ struct GhosttyDECCKMArrowKeyTests {
         // cover routing policy on headless runners, and this explicit skip keeps
         // the integration result honest when Metal is unavailable.
         guard hostedTerminal.surface.hasLiveSurface else {
-            throw XCTSkip("Ghostty surface failed to initialize on this host; byte-level editing routing is unavailable.")
+            try Test.cancel("Ghostty surface failed to initialize on this host; byte-level editing routing is unavailable.")
         }
         try installIsolatedEditingKeybinds(on: hostedTerminal.surface)
         #expect(window.makeFirstResponder(surfaceView), "Expected terminal surface to own first responder")

--- a/cmuxTests/GhosttyDECCKMArrowKeyTests.swift
+++ b/cmuxTests/GhosttyDECCKMArrowKeyTests.swift
@@ -3,6 +3,7 @@ import CmuxTerminal
 import Foundation
 import GhosttyKit
 import Testing
+@preconcurrency import XCTest
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -67,7 +68,7 @@ struct GhosttyDECCKMArrowKeyTests {
         // the routing decision; this byte-level integration path needs a live
         // surface to poll terminal text.
         guard hostedTerminal.surface.hasLiveSurface else {
-            try Test.cancel("Ghostty surface failed to initialize on this host; byte-level arrow routing is unavailable.")
+            throw XCTSkip("Ghostty surface failed to initialize on this host; byte-level arrow routing is unavailable.")
         }
 
         try installIsolatedEditingKeybinds(on: hostedTerminal.surface)
@@ -168,7 +169,7 @@ struct GhosttyDECCKMArrowKeyTests {
         // cover routing policy on headless runners, and this explicit skip keeps
         // the integration result honest when Metal is unavailable.
         guard hostedTerminal.surface.hasLiveSurface else {
-            try Test.cancel("Ghostty surface failed to initialize on this host; byte-level editing routing is unavailable.")
+            throw XCTSkip("Ghostty surface failed to initialize on this host; byte-level editing routing is unavailable.")
         }
         try installIsolatedEditingKeybinds(on: hostedTerminal.surface)
         #expect(window.makeFirstResponder(surfaceView), "Expected terminal surface to own first responder")

--- a/cmuxTests/GhosttyDECCKMArrowKeyTests.swift
+++ b/cmuxTests/GhosttyDECCKMArrowKeyTests.swift
@@ -65,9 +65,7 @@ struct GhosttyDECCKMArrowKeyTests {
         // surface. In that environment the predicate tests below still cover
         // the routing decision; this byte-level integration path needs a live
         // surface to poll terminal text.
-        if !hostedTerminal.surface.hasLiveSurface {
-            try Test.cancel("Ghostty surface failed to initialize on this host; byte-level arrow routing is unavailable.")
-        }
+        guard hostedTerminal.surface.hasLiveSurface else { return }
 
         #expect(window.makeFirstResponder(surfaceView), "Expected terminal surface to own first responder")
 
@@ -165,9 +163,7 @@ struct GhosttyDECCKMArrowKeyTests {
         // The byte assertion needs a live Metal surface. Predicate tests still
         // cover routing policy on headless runners, and this explicit skip keeps
         // the integration result honest when Metal is unavailable.
-        if !hostedTerminal.surface.hasLiveSurface {
-            try Test.cancel("Ghostty surface failed to initialize on this host; byte-level editing routing is unavailable.")
-        }
+        guard hostedTerminal.surface.hasLiveSurface else { return }
         #expect(window.makeFirstResponder(surfaceView), "Expected terminal surface to own first responder")
 
         let readyText = try waitForTerminalText(from: hostedTerminal) {

--- a/cmuxTests/GhosttyDECCKMArrowKeyTests.swift
+++ b/cmuxTests/GhosttyDECCKMArrowKeyTests.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Foundation
 import Testing
+import XCTest
 import CmuxTerminal
 
 #if canImport(cmux_DEV)
@@ -65,7 +66,10 @@ struct GhosttyDECCKMArrowKeyTests {
         // surface. In that environment the predicate tests below still cover
         // the routing decision; this byte-level integration path needs a live
         // surface to poll terminal text.
-        guard hostedTerminal.surface.hasLiveSurface else { return }
+        try XCTSkipUnless(
+            hostedTerminal.surface.hasLiveSurface,
+            "Ghostty surface failed to initialize on this host; byte-level arrow routing is unavailable."
+        )
 
         #expect(window.makeFirstResponder(surfaceView), "Expected terminal surface to own first responder")
 
@@ -162,8 +166,12 @@ struct GhosttyDECCKMArrowKeyTests {
         defer { window.orderOut(nil) }
 
         // The byte assertion needs a live Metal surface. Predicate tests still
-        // cover routing policy on headless runners.
-        guard hostedTerminal.surface.hasLiveSurface else { return }
+        // cover routing policy on headless runners, and this explicit skip keeps
+        // the integration result honest when Metal is unavailable.
+        try XCTSkipUnless(
+            hostedTerminal.surface.hasLiveSurface,
+            "Ghostty surface failed to initialize on this host; byte-level editing routing is unavailable."
+        )
         #expect(window.makeFirstResponder(surfaceView), "Expected terminal surface to own first responder")
 
         let readyText = try waitForTerminalText(from: hostedTerminal) {

--- a/cmuxTests/GhosttyDECCKMArrowKeyTests.swift
+++ b/cmuxTests/GhosttyDECCKMArrowKeyTests.swift
@@ -119,6 +119,103 @@ struct GhosttyDECCKMArrowKeyTests {
         )
     }
 
+    @Test
+    func windowKeyEquivalentMacTextEditingChordsReachShell() throws {
+        AppDelegate.installWindowResponderSwizzlesForTesting()
+
+        let captureReadyMarker = "CMUX_EDIT_READY_\(UUID().uuidString.replacingOccurrences(of: "-", with: ""))"
+        let captureMarker = "CMUX_EDIT_HEX_\(UUID().uuidString.replacingOccurrences(of: "-", with: ""))"
+        let scriptURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-editing-capture-\(UUID().uuidString).py")
+        let script = """
+        import os
+        import select
+        import sys
+        import termios
+        import time
+        import tty
+
+        fd = 0
+        sys.stdout.write("\\x1b[?1h\(captureReadyMarker)\\n")
+        sys.stdout.flush()
+        old = termios.tcgetattr(fd)
+        try:
+            tty.setraw(fd)
+            data = bytearray()
+            deadline = time.monotonic() + 3.0
+            while time.monotonic() < deadline and len(data) < 6:
+                if select.select([sys.stdin], [], [], 0.05)[0]:
+                    data.extend(os.read(fd, 64))
+        finally:
+            termios.tcsetattr(fd, termios.TCSADRAIN, old)
+
+        print("\\r\\n\(captureMarker)=" + data.hex(), flush=True)
+        """
+        try script.write(to: scriptURL, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: scriptURL) }
+
+        let hostedTerminal = try makeHostedTerminalWindow(
+            initialCommand: "/usr/bin/python3 \(shellSingleQuoted(scriptURL.path))"
+        )
+        let window = hostedTerminal.window
+        let surfaceView = hostedTerminal.surfaceView
+        defer { window.orderOut(nil) }
+
+        // The byte assertion needs a live Metal surface. Predicate tests still
+        // cover routing policy on headless runners.
+        guard hostedTerminal.surface.hasLiveSurface else { return }
+        #expect(window.makeFirstResponder(surfaceView), "Expected terminal surface to own first responder")
+
+        let readyText = try waitForTerminalText(from: hostedTerminal) {
+            $0.contains(captureReadyMarker)
+        }
+        #expect(readyText.contains(captureReadyMarker), "Expected editing capture harness to become ready")
+        RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+
+        let events: [(name: String, flags: NSEvent.ModifierFlags, keyCode: UInt16, characters: String)] = [
+            ("Command+Backspace", [.command], 51, "\u{8}"),
+            ("Command+ForwardDelete", [.command, .function], 117, "\u{f728}"),
+            ("Option+Backspace", [.option], 51, "\u{8}"),
+            ("Option+ForwardDelete", [.option, .function], 117, "\u{f728}"),
+        ]
+        let timestamp = ProcessInfo.processInfo.systemUptime
+
+        try withExtendedLifetime(hostedTerminal.surface) {
+            for (index, item) in events.enumerated() {
+                let event = try #require(NSEvent.keyEvent(
+                    with: .keyDown,
+                    location: .zero,
+                    modifierFlags: item.flags,
+                    timestamp: timestamp + (Double(index) * 0.001),
+                    windowNumber: window.windowNumber,
+                    context: nil,
+                    characters: item.characters,
+                    charactersIgnoringModifiers: item.characters,
+                    isARepeat: false,
+                    keyCode: item.keyCode
+                ))
+
+                #expect(
+                    window.performKeyEquivalent(with: event),
+                    "Terminal \(item.name) should be consumed by the editing route"
+                )
+            }
+        }
+
+        let captureText = try waitForTerminalText(from: hostedTerminal, timeout: 5) {
+            $0.contains(captureMarker)
+        }
+        let markerRange = try #require(captureText.range(of: "\(captureMarker)="))
+        let hexCharacters = Set("0123456789abcdefABCDEF")
+        let capturedHex = captureText[markerRange.upperBound...]
+            .prefix { hexCharacters.contains($0) }
+
+        #expect(
+            String(capturedHex) == "150b1b7f1b64",
+            "macOS line and word delete chords must reach the shell as readline-compatible bytes"
+        )
+    }
+
     @Test(arguments: [123, 124, 125, 126] as [UInt16])
     func terminalArrowPredicateAcceptsUnmodifiedTerminalArrows(keyCode: UInt16) {
         #expect(shouldDispatchTerminalArrowViaFirstResponderKeyDown(
@@ -158,6 +255,45 @@ struct GhosttyDECCKMArrowKeyTests {
             keyCode: 36,
             firstResponderIsTerminal: true,
             flags: [.numericPad, .function]
+        ))
+    }
+
+    @Test(arguments: [51, 117] as [UInt16])
+    func terminalDeletePredicateAcceptsCommandDelete(keyCode: UInt16) {
+        #expect(shouldDispatchTerminalDeleteEquivalentViaFirstResponderKeyDown(
+            keyCode: keyCode,
+            firstResponderIsTerminal: true,
+            flags: [.command, .function, .numericPad]
+        ))
+    }
+
+    @Test
+    func terminalDeletePredicateKeepsForeignAndModifiedDeleteKeysAlone() {
+        #expect(!shouldDispatchTerminalDeleteEquivalentViaFirstResponderKeyDown(
+            keyCode: 51,
+            firstResponderIsTerminal: false,
+            flags: [.command]
+        ))
+        #expect(!shouldDispatchTerminalDeleteEquivalentViaFirstResponderKeyDown(
+            keyCode: 51,
+            firstResponderIsTerminal: true,
+            firstResponderHasMarkedText: true,
+            flags: [.command]
+        ))
+        #expect(!shouldDispatchTerminalDeleteEquivalentViaFirstResponderKeyDown(
+            keyCode: 51,
+            firstResponderIsTerminal: true,
+            flags: [.command, .shift]
+        ))
+        #expect(!shouldDispatchTerminalDeleteEquivalentViaFirstResponderKeyDown(
+            keyCode: 51,
+            firstResponderIsTerminal: true,
+            flags: [.command, .option]
+        ))
+        #expect(!shouldDispatchTerminalDeleteEquivalentViaFirstResponderKeyDown(
+            keyCode: 36,
+            firstResponderIsTerminal: true,
+            flags: [.command]
         ))
     }
 

--- a/cmuxTests/GhosttyDECCKMArrowKeyTests.swift
+++ b/cmuxTests/GhosttyDECCKMArrowKeyTests.swift
@@ -37,11 +37,11 @@ struct GhosttyDECCKMArrowKeyTests {
         import tty
 
         fd = 0
-        sys.stdout.write("\\x1b[?1h\(captureReadyMarker)\\n")
-        sys.stdout.flush()
         old = termios.tcgetattr(fd)
         try:
             tty.setraw(fd)
+            sys.stdout.write("\\x1b[?1h\(captureReadyMarker)\\n")
+            sys.stdout.flush()
             data = bytearray()
             deadline = time.monotonic() + 3.0
             while time.monotonic() < deadline and len(data) < 12:
@@ -77,7 +77,6 @@ struct GhosttyDECCKMArrowKeyTests {
             $0.contains(captureReadyMarker)
         }
         #expect(readyText.contains(captureReadyMarker), "Expected DECCKM capture harness to become ready")
-        RunLoop.current.run(until: Date().addingTimeInterval(0.2))
 
         let arrows: [(name: String, characters: String, keyCode: UInt16)] = [
             ("up", String(UnicodeScalar(NSUpArrowFunctionKey)!), 126),
@@ -140,11 +139,11 @@ struct GhosttyDECCKMArrowKeyTests {
         import tty
 
         fd = 0
-        sys.stdout.write("\\x1b[?1h\(captureReadyMarker)\\n")
-        sys.stdout.flush()
         old = termios.tcgetattr(fd)
         try:
             tty.setraw(fd)
+            sys.stdout.write("\\x1b[?1h\(captureReadyMarker)\\n")
+            sys.stdout.flush()
             data = bytearray()
             deadline = time.monotonic() + 3.0
             while time.monotonic() < deadline and len(data) < 6:
@@ -178,7 +177,6 @@ struct GhosttyDECCKMArrowKeyTests {
             $0.contains(captureReadyMarker)
         }
         #expect(readyText.contains(captureReadyMarker), "Expected editing capture harness to become ready")
-        RunLoop.current.run(until: Date().addingTimeInterval(0.2))
 
         let events: [(name: String, flags: NSEvent.ModifierFlags, keyCode: UInt16, characters: String)] = [
             ("Command+Backspace", [.command], 51, "\u{8}"),

--- a/cmuxTests/GhosttyDECCKMArrowKeyTests.swift
+++ b/cmuxTests/GhosttyDECCKMArrowKeyTests.swift
@@ -1,8 +1,8 @@
 import AppKit
+import CmuxTerminal
 import Foundation
 import Testing
 import XCTest
-import CmuxTerminal
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV

--- a/cmuxTests/GhosttyDECCKMArrowKeyTests.swift
+++ b/cmuxTests/GhosttyDECCKMArrowKeyTests.swift
@@ -2,6 +2,7 @@ import AppKit
 import CmuxTerminal
 import Foundation
 import Testing
+import XCTest
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -65,7 +66,9 @@ struct GhosttyDECCKMArrowKeyTests {
         // surface. In that environment the predicate tests below still cover
         // the routing decision; this byte-level integration path needs a live
         // surface to poll terminal text.
-        guard hostedTerminal.surface.hasLiveSurface else { return }
+        guard hostedTerminal.surface.hasLiveSurface else {
+            throw XCTSkip("Ghostty surface failed to initialize on this host; byte-level arrow routing is unavailable.")
+        }
 
         #expect(window.makeFirstResponder(surfaceView), "Expected terminal surface to own first responder")
 
@@ -163,7 +166,9 @@ struct GhosttyDECCKMArrowKeyTests {
         // The byte assertion needs a live Metal surface. Predicate tests still
         // cover routing policy on headless runners, and this explicit skip keeps
         // the integration result honest when Metal is unavailable.
-        guard hostedTerminal.surface.hasLiveSurface else { return }
+        guard hostedTerminal.surface.hasLiveSurface else {
+            throw XCTSkip("Ghostty surface failed to initialize on this host; byte-level editing routing is unavailable.")
+        }
         #expect(window.makeFirstResponder(surfaceView), "Expected terminal surface to own first responder")
 
         let readyText = try waitForTerminalText(from: hostedTerminal) {

--- a/cmuxTests/GhosttyDECCKMArrowKeyTests.swift
+++ b/cmuxTests/GhosttyDECCKMArrowKeyTests.swift
@@ -1,6 +1,7 @@
 import AppKit
 import CmuxTerminal
 import Foundation
+import GhosttyKit
 import Testing
 import XCTest
 
@@ -11,7 +12,7 @@ import XCTest
 #endif
 
 @MainActor
-@Suite
+@Suite(.serialized)
 struct GhosttyDECCKMArrowKeyTests {
     private struct HostedTerminalWindow {
         let surface: TerminalSurface
@@ -70,6 +71,7 @@ struct GhosttyDECCKMArrowKeyTests {
             throw XCTSkip("Ghostty surface failed to initialize on this host; byte-level arrow routing is unavailable.")
         }
 
+        try installIsolatedEditingKeybinds(on: hostedTerminal.surface)
         #expect(window.makeFirstResponder(surfaceView), "Expected terminal surface to own first responder")
 
         let readyText = try waitForTerminalText(from: hostedTerminal) {
@@ -169,6 +171,7 @@ struct GhosttyDECCKMArrowKeyTests {
         guard hostedTerminal.surface.hasLiveSurface else {
             throw XCTSkip("Ghostty surface failed to initialize on this host; byte-level editing routing is unavailable.")
         }
+        try installIsolatedEditingKeybinds(on: hostedTerminal.surface)
         #expect(window.makeFirstResponder(surfaceView), "Expected terminal surface to own first responder")
 
         let readyText = try waitForTerminalText(from: hostedTerminal) {
@@ -347,6 +350,36 @@ struct GhosttyDECCKMArrowKeyTests {
             hostedView: hostedView,
             surfaceView: try #require(findGhosttyNSView(in: hostedView))
         )
+    }
+
+    /// Replace only this test surface's Ghostty configuration with a small,
+    /// deterministic key map. The app owns one process-wide configuration, so
+    /// `configTemplate` cannot isolate key bindings from a developer's
+    /// `~/.config/ghostty` file. Updating the surface after creation keeps the
+    /// production app configuration untouched while making the byte-level
+    /// assertion independent of the host's user settings.
+    private func installIsolatedEditingKeybinds(on surface: TerminalSurface) throws {
+        let runtimeSurface = try #require(surface.surface)
+        let config = try #require(ghostty_config_new())
+        defer { ghostty_config_free(config) }
+
+        let contents = #"""
+        keybind = clear
+        keybind = super+backspace=text:\x15
+        keybind = super+delete=text:\x0b
+        keybind = alt+backspace=text:\x1b\x7f
+        keybind = alt+delete=text:\x1b\x64
+        """#
+        contents.withCString { pointer in
+            ghostty_config_load_string(
+                config,
+                pointer,
+                UInt(contents.utf8.count),
+                "/__cmux_test__/mac-editing.conf"
+            )
+        }
+        ghostty_config_finalize(config)
+        ghostty_surface_update_config(runtimeSurface, config)
     }
 
     private func readTerminalText(from terminal: HostedTerminalWindow) throws -> String {

--- a/cmuxTests/GhosttyDECCKMArrowKeyTests.swift
+++ b/cmuxTests/GhosttyDECCKMArrowKeyTests.swift
@@ -2,7 +2,6 @@ import AppKit
 import CmuxTerminal
 import Foundation
 import Testing
-import XCTest
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -66,10 +65,9 @@ struct GhosttyDECCKMArrowKeyTests {
         // surface. In that environment the predicate tests below still cover
         // the routing decision; this byte-level integration path needs a live
         // surface to poll terminal text.
-        try XCTSkipUnless(
-            hostedTerminal.surface.hasLiveSurface,
-            "Ghostty surface failed to initialize on this host; byte-level arrow routing is unavailable."
-        )
+        if !hostedTerminal.surface.hasLiveSurface {
+            try Test.cancel("Ghostty surface failed to initialize on this host; byte-level arrow routing is unavailable.")
+        }
 
         #expect(window.makeFirstResponder(surfaceView), "Expected terminal surface to own first responder")
 
@@ -167,10 +165,9 @@ struct GhosttyDECCKMArrowKeyTests {
         // The byte assertion needs a live Metal surface. Predicate tests still
         // cover routing policy on headless runners, and this explicit skip keeps
         // the integration result honest when Metal is unavailable.
-        try XCTSkipUnless(
-            hostedTerminal.surface.hasLiveSurface,
-            "Ghostty surface failed to initialize on this host; byte-level editing routing is unavailable."
-        )
+        if !hostedTerminal.surface.hasLiveSurface {
+            try Test.cancel("Ghostty surface failed to initialize on this host; byte-level editing routing is unavailable.")
+        }
         #expect(window.makeFirstResponder(surfaceView), "Expected terminal surface to own first responder")
 
         let readyText = try waitForTerminalText(from: hostedTerminal) {

--- a/cmuxTests/GhosttyDECCKMArrowKeyTests.swift
+++ b/cmuxTests/GhosttyDECCKMArrowKeyTests.swift
@@ -120,7 +120,7 @@ struct GhosttyDECCKMArrowKeyTests {
     }
 
     @Test
-    func windowKeyEquivalentMacTextEditingChordsReachShell() throws {
+    func macTextEditingChordsReachShell() throws {
         AppDelegate.installWindowResponderSwizzlesForTesting()
 
         let captureReadyMarker = "CMUX_EDIT_READY_\(UUID().uuidString.replacingOccurrences(of: "-", with: ""))"
@@ -195,10 +195,19 @@ struct GhosttyDECCKMArrowKeyTests {
                     keyCode: item.keyCode
                 ))
 
-                #expect(
-                    window.performKeyEquivalent(with: event),
-                    "Terminal \(item.name) should be consumed by the editing route"
-                )
+                if item.flags.contains(.command) {
+                    // AppKit offers Command delete chords to the window's menu
+                    // equivalent path first. This is the route cmux repairs.
+                    #expect(
+                        window.performKeyEquivalent(with: event),
+                        "Terminal \(item.name) should be consumed by the editing route"
+                    )
+                } else {
+                    // Option-only delete chords use the normal responder
+                    // keyDown path on macOS. Exercise that path directly so
+                    // this test does not depend on AppKit's menu heuristics.
+                    surfaceView.keyDown(with: event)
+                }
             }
         }
 

--- a/web/services/vms/images/blaxel/Dockerfile
+++ b/web/services/vms/images/blaxel/Dockerfile
@@ -22,7 +22,7 @@
 FROM debian:trixie-slim
 
 # Cache-buster: bump to force a full rebuild on Blaxel's builder.
-ENV CMUX_IMAGE_EPOCH=2026-08-31-r13
+ENV CMUX_IMAGE_EPOCH=2026-09-01-r14
 
 # Blaxel's sandbox API binary is mandatory in every custom image: it is the control
 # plane (port 8080) the driver uses for filesystem and process operations.

--- a/web/services/vms/images/blaxel/Dockerfile
+++ b/web/services/vms/images/blaxel/Dockerfile
@@ -271,6 +271,7 @@ RUN bash -n /etc/cmux/agent-config.sh \
 # /entrypoint.sh is the path every official Blaxel template uses; the microVM
 # boot command comes from this ENTRYPOINT.
 COPY start-vnc.sh /usr/local/bin/start-vnc.sh
+COPY ghostty-defaults.conf /etc/cmux/ghostty-defaults.conf
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /usr/local/bin/start-vnc.sh /entrypoint.sh /usr/local/bin/sandbox-api \
   && bash -n /usr/local/bin/start-vnc.sh && bash -n /entrypoint.sh

--- a/web/services/vms/images/blaxel/cmux-bashrc
+++ b/web/services/vms/images/blaxel/cmux-bashrc
@@ -46,6 +46,21 @@ if [ -f /usr/local/share/blesh/ble.sh ] && [ -z "${BLE_VERSION:-}" ]; then
   # foreground gray.
   bleopt highlight_syntax= highlight_filename= highlight_variable=
   ble-face auto_complete=fg=245
+
+  # Keep macOS word deletion consistent across terminal encodings. Ghostty's
+  # C-u/C-k and M-d bindings already exist in ble.sh. Only replace the stock
+  # copy actions for the alternate spellings of Meta-Delete, in emacs and vi
+  # insert mode, while leaving vi command mode unchanged.
+  ble-bind -m emacs -f 'M-C-?' kill-backward-cword
+  ble-bind -m emacs -f 'M-C-h' kill-backward-cword
+  ble-bind -m emacs -f 'M-DEL' kill-backward-cword
+  ble-bind -m emacs -f 'M-BS' kill-backward-cword
+  ble-bind -m emacs -f 'M-delete' kill-forward-cword
+  ble-bind -m vi_imap -f 'M-C-?' kill-backward-cword
+  ble-bind -m vi_imap -f 'M-C-h' kill-backward-cword
+  ble-bind -m vi_imap -f 'M-DEL' kill-backward-cword
+  ble-bind -m vi_imap -f 'M-BS' kill-backward-cword
+  ble-bind -m vi_imap -f 'M-delete' kill-forward-cword
 fi
 
 # half-life palette: purple 135, lime 118, orange 166, hotpink 161. The machine

--- a/web/services/vms/images/blaxel/ghostty-defaults.conf
+++ b/web/services/vms/images/blaxel/ghostty-defaults.conf
@@ -1,0 +1,11 @@
+# cmux Cloud desktop defaults. This file is installed as Ghostty's legacy
+# config only when the desktop user's config does not already exist. A user's
+# config.ghostty therefore loads later and can override or clear these keys.
+keybind = super+backspace=text:\x15
+keybind = super+delete=text:\x0b
+keybind = super+left=text:\x01
+keybind = super+right=text:\x05
+keybind = alt+backspace=text:\x1b\x7f
+keybind = alt+delete=text:\x1b\x64
+keybind = alt+left=text:\x1b\x62
+keybind = alt+right=text:\x1b\x66

--- a/web/services/vms/images/blaxel/start-vnc.sh
+++ b/web/services/vms/images/blaxel/start-vnc.sh
@@ -32,6 +32,36 @@ VNC_BIN="$(command -v Xvnc || command -v Xtigervnc)" || exit 0
 
 listening() { ss -tln 2>/dev/null | grep -q ":$1 "; }
 
+# Ghostty on the Linux desktop does not inherit macOS's natural text-editing
+# defaults. Install a legacy config only on a fresh desktop home. Ghostty loads
+# config.ghostty after this file, so an explicit user config keeps precedence.
+ensure_ghostty_defaults() {
+  local config_dir="$HOME/.config/ghostty"
+  local config_file="$config_dir/config"
+  [ -f /etc/cmux/ghostty-defaults.conf ] || return 0
+  [ -e "$config_file" ] && return 0
+  [ -L "$config_dir" ] && return 0
+  if [ -e "$config_dir" ] && [ ! -d "$config_dir" ]; then return 0; fi
+  mkdir -p "$config_dir" 2>/dev/null || return 0
+  [ -O "$config_dir" ] || return 0
+  local tmp
+  tmp="$(mktemp "$config_dir/.cmux-defaults.XXXXXX" 2>/dev/null)" || return 0
+  if ! cp /etc/cmux/ghostty-defaults.conf "$tmp" 2>/dev/null; then
+    rm -f "$tmp"
+    return 0
+  fi
+  chmod 600 "$tmp" 2>/dev/null || { rm -f "$tmp"; return 0; }
+  # A hard link makes creation atomic without replacing a file that appeared
+  # after the existence check. The temporary inode stays in this directory.
+  if ! ln "$tmp" "$config_file" 2>/dev/null; then
+    rm -f "$tmp"
+    return 0
+  fi
+  rm -f "$tmp"
+}
+
+ensure_ghostty_defaults
+
 # TigerVNC on :1, RFB on 5901, loopback only: the sole ingress is Blaxel's
 # tokened preview in front of websockify, so VNC-level auth would be a second
 # password prompt noVNC's autoconnect cannot answer.

--- a/web/services/vms/images/devbox/Dockerfile
+++ b/web/services/vms/images/devbox/Dockerfile
@@ -129,7 +129,7 @@ RUN jq -e '.DefaultSearchProviderSearchURL | test("duckduckgo")' /etc/opt/chrome
 # cua computer-use driver, pinned (dormant until an X display exists).
 ENV CUA_DRIVER_RS_HOME=/opt/cua-driver
 RUN curl -fsSL https://cua.ai/driver/install.sh -o /tmp/cua-install.sh \
-  && CUA_DRIVER_RS_VERSION=0.19.3 CUA_DRIVER_BIN_DIR=/usr/local/bin CUA_DRIVER_NO_MODIFY_PATH=1 bash /tmp/cua-install.sh \
+  && CUA_DRIVER_RS_VERSION=0.23.2 CUA_DRIVER_BIN_DIR=/usr/local/bin CUA_DRIVER_NO_MODIFY_PATH=1 bash /tmp/cua-install.sh \
   && rm -f /tmp/cua-install.sh \
   && chmod -R a+rX /opt/cua-driver \
   && cua-driver --version
@@ -180,6 +180,30 @@ RUN bash -n /etc/cmux/bashrc \
   && echo '[ -f /etc/cmux/bashrc ] && . /etc/cmux/bashrc' >> /root/.bashrc \
   && echo 'set -g default-shell /bin/bash' >> /etc/tmux.conf \
   && bash -ic 'head -2 /root/.bash_history'
+
+# Seed ble.sh tput caches for the TERMs cmux uses, exactly as the Blaxel
+# template does (its Dockerfile carries the full rationale): without them the
+# FIRST shell on a machine prints "ble/term.sh: updating tput cache ... done"
+# into the pane before its first prompt. Both cache homes are seeded: the
+# XDG seed copied by cmux-bashrc from /etc/cmux/blesh-cache-seed, and
+# <blesh>/cache.d for uid 0 plus the provider-created uid-1000 user (numeric
+# chown: E2B/Daytona/Freestyle each name that user differently).
+RUN mkdir -p /etc/cmux/blesh-cache-seed \
+  && for term in xterm-256color screen-256color tmux-256color linux; do \
+       echo exit | TERM="$term" HOME=/tmp/blesh-seed-home XDG_CACHE_HOME=/etc/cmux/blesh-cache-seed \
+         script -qec 'bash -i' /dev/null >/dev/null 2>&1 || true; \
+     done \
+  && rm -rf /tmp/blesh-seed-home \
+  && test -s /etc/cmux/blesh-cache-seed/blesh/*/term.xterm-256color \
+  && test -s /etc/cmux/blesh-cache-seed/blesh/*/term.screen-256color \
+  && test -s /etc/cmux/blesh-cache-seed/blesh/*/term.tmux-256color \
+  && test -s /etc/cmux/blesh-cache-seed/blesh/*/term.linux \
+  && mkdir -p /usr/local/share/blesh/cache.d/0 /usr/local/share/blesh/cache.d/1000 \
+  && chmod a+rwxt /usr/local/share/blesh/cache.d \
+  && cp /etc/cmux/blesh-cache-seed/blesh/*/term.* /usr/local/share/blesh/cache.d/0/ \
+  && cp /etc/cmux/blesh-cache-seed/blesh/*/term.* /usr/local/share/blesh/cache.d/1000/ \
+  && chmod 700 /usr/local/share/blesh/cache.d/0 /usr/local/share/blesh/cache.d/1000 \
+  && chown -R 1000:1000 /usr/local/share/blesh/cache.d/1000
 
 # Agent harness config: every shell materializes per-harness model-proxy
 # configs from the machine boot env (the coderouter model-plane vars minted

--- a/web/services/vms/images/devbox/Dockerfile
+++ b/web/services/vms/images/devbox/Dockerfile
@@ -29,7 +29,7 @@ FROM debian:bookworm-slim
 # Cache-buster: bump the date to force remote builders past stale layer
 # caches (Daytona's cache served stale layers for chatmux on 2026-08-21 and
 # 2026-08-25; E2B skips cache by default).
-ENV CMUX_IMAGE_EPOCH=2026-09-01-r1
+ENV CMUX_IMAGE_EPOCH=2026-09-01-r3
 
 ENV LANG=C.UTF-8 \
     DEBIAN_FRONTEND=noninteractive
@@ -129,7 +129,7 @@ RUN jq -e '.DefaultSearchProviderSearchURL | test("duckduckgo")' /etc/opt/chrome
 # cua computer-use driver, pinned (dormant until an X display exists).
 ENV CUA_DRIVER_RS_HOME=/opt/cua-driver
 RUN curl -fsSL https://cua.ai/driver/install.sh -o /tmp/cua-install.sh \
-  && CUA_DRIVER_RS_VERSION=0.23.2 CUA_DRIVER_BIN_DIR=/usr/local/bin CUA_DRIVER_NO_MODIFY_PATH=1 bash /tmp/cua-install.sh \
+  && CUA_DRIVER_RS_VERSION=0.19.3 CUA_DRIVER_BIN_DIR=/usr/local/bin CUA_DRIVER_NO_MODIFY_PATH=1 bash /tmp/cua-install.sh \
   && rm -f /tmp/cua-install.sh \
   && chmod -R a+rX /opt/cua-driver \
   && cua-driver --version
@@ -180,30 +180,6 @@ RUN bash -n /etc/cmux/bashrc \
   && echo '[ -f /etc/cmux/bashrc ] && . /etc/cmux/bashrc' >> /root/.bashrc \
   && echo 'set -g default-shell /bin/bash' >> /etc/tmux.conf \
   && bash -ic 'head -2 /root/.bash_history'
-
-# Seed ble.sh tput caches for the TERMs cmux uses, exactly as the Blaxel
-# template does (its Dockerfile carries the full rationale): without them the
-# FIRST shell on a machine prints "ble/term.sh: updating tput cache ... done"
-# into the pane before its first prompt. Both cache homes are seeded: the
-# XDG seed copied by cmux-bashrc from /etc/cmux/blesh-cache-seed, and
-# <blesh>/cache.d for uid 0 plus the provider-created uid-1000 user (numeric
-# chown: E2B/Daytona/Freestyle each name that user differently).
-RUN mkdir -p /etc/cmux/blesh-cache-seed \
-  && for term in xterm-256color screen-256color tmux-256color linux; do \
-       echo exit | TERM="$term" HOME=/tmp/blesh-seed-home XDG_CACHE_HOME=/etc/cmux/blesh-cache-seed \
-         script -qec 'bash -i' /dev/null >/dev/null 2>&1 || true; \
-     done \
-  && rm -rf /tmp/blesh-seed-home \
-  && test -s /etc/cmux/blesh-cache-seed/blesh/*/term.xterm-256color \
-  && test -s /etc/cmux/blesh-cache-seed/blesh/*/term.screen-256color \
-  && test -s /etc/cmux/blesh-cache-seed/blesh/*/term.tmux-256color \
-  && test -s /etc/cmux/blesh-cache-seed/blesh/*/term.linux \
-  && mkdir -p /usr/local/share/blesh/cache.d/0 /usr/local/share/blesh/cache.d/1000 \
-  && chmod a+rwxt /usr/local/share/blesh/cache.d \
-  && cp /etc/cmux/blesh-cache-seed/blesh/*/term.* /usr/local/share/blesh/cache.d/0/ \
-  && cp /etc/cmux/blesh-cache-seed/blesh/*/term.* /usr/local/share/blesh/cache.d/1000/ \
-  && chmod 700 /usr/local/share/blesh/cache.d/0 /usr/local/share/blesh/cache.d/1000 \
-  && chown -R 1000:1000 /usr/local/share/blesh/cache.d/1000
 
 # Agent harness config: every shell materializes per-harness model-proxy
 # configs from the machine boot env (the coderouter model-plane vars minted

--- a/web/services/vms/images/devbox/cmux-bashrc
+++ b/web/services/vms/images/devbox/cmux-bashrc
@@ -48,6 +48,21 @@ if [ -f /usr/local/share/blesh/ble.sh ] && [ -z "${BLE_VERSION:-}" ]; then
   # foreground gray.
   bleopt highlight_syntax= highlight_filename= highlight_variable=
   ble-face auto_complete=fg=245
+
+  # Keep macOS word deletion consistent across terminal encodings. Ghostty's
+  # C-u/C-k and M-d bindings already exist in ble.sh. Only replace the stock
+  # copy actions for the alternate spellings of Meta-Delete, in emacs and vi
+  # insert mode, while leaving vi command mode unchanged.
+  ble-bind -m emacs -f 'M-C-?' kill-backward-cword
+  ble-bind -m emacs -f 'M-C-h' kill-backward-cword
+  ble-bind -m emacs -f 'M-DEL' kill-backward-cword
+  ble-bind -m emacs -f 'M-BS' kill-backward-cword
+  ble-bind -m emacs -f 'M-delete' kill-forward-cword
+  ble-bind -m vi_imap -f 'M-C-?' kill-backward-cword
+  ble-bind -m vi_imap -f 'M-C-h' kill-backward-cword
+  ble-bind -m vi_imap -f 'M-DEL' kill-backward-cword
+  ble-bind -m vi_imap -f 'M-BS' kill-backward-cword
+  ble-bind -m vi_imap -f 'M-delete' kill-forward-cword
 fi
 
 # half-life palette: purple 135, lime 118, orange 166, hotpink 161. The machine

--- a/web/tests/vm-blaxel-image.test.ts
+++ b/web/tests/vm-blaxel-image.test.ts
@@ -155,24 +155,20 @@ describe("Blaxel baked image template", () => {
   });
 
   test("macOS line and word delete bytes have delete actions in ble.sh", () => {
-    // Ghostty emits C-u/C-k for Command delete and ESC DEL/ESC d for Option
-    // delete. Remote clients can also decode the equivalent meta key names.
+    // Ghostty emits ESC DEL for Option+Backspace and ESC d for
+    // Option+ForwardDelete. ble.sh already owns C-u/C-k/M-d, so this contract
+    // only replaces the alternate Meta-Delete spellings whose stock actions
+    // copy instead of deleting.
     for (const bind of [
-      "ble-bind -m emacs -f 'C-u' kill-backward-line",
-      "ble-bind -m emacs -f 'C-k' kill-forward-line",
       "ble-bind -m emacs -f 'M-C-?' kill-backward-cword",
       "ble-bind -m emacs -f 'M-C-h' kill-backward-cword",
       "ble-bind -m emacs -f 'M-DEL' kill-backward-cword",
       "ble-bind -m emacs -f 'M-BS' kill-backward-cword",
-      "ble-bind -m emacs -f 'M-d' kill-forward-cword",
       "ble-bind -m emacs -f 'M-delete' kill-forward-cword",
-      "ble-bind -m vi_imap -f 'C-u' kill-backward-line",
-      "ble-bind -m vi_imap -f 'C-k' kill-forward-line",
       "ble-bind -m vi_imap -f 'M-C-?' kill-backward-cword",
       "ble-bind -m vi_imap -f 'M-C-h' kill-backward-cword",
       "ble-bind -m vi_imap -f 'M-DEL' kill-backward-cword",
       "ble-bind -m vi_imap -f 'M-BS' kill-backward-cword",
-      "ble-bind -m vi_imap -f 'M-d' kill-forward-cword",
       "ble-bind -m vi_imap -f 'M-delete' kill-forward-cword",
     ]) {
       expect(bashrc).toContain(bind);

--- a/web/tests/vm-blaxel-image.test.ts
+++ b/web/tests/vm-blaxel-image.test.ts
@@ -154,6 +154,34 @@ describe("Blaxel baked image template", () => {
     }
   });
 
+  test("macOS line and word delete bytes have delete actions in ble.sh", () => {
+    // Ghostty emits C-u/C-k for Command delete and ESC DEL/ESC d for Option
+    // delete. Remote clients can also decode the equivalent meta key names.
+    for (const bind of [
+      "ble-bind -m emacs -f 'C-u' kill-backward-line",
+      "ble-bind -m emacs -f 'C-k' kill-forward-line",
+      "ble-bind -m emacs -f 'M-C-?' kill-backward-cword",
+      "ble-bind -m emacs -f 'M-C-h' kill-backward-cword",
+      "ble-bind -m emacs -f 'M-DEL' kill-backward-cword",
+      "ble-bind -m emacs -f 'M-BS' kill-backward-cword",
+      "ble-bind -m emacs -f 'M-d' kill-forward-cword",
+      "ble-bind -m emacs -f 'M-delete' kill-forward-cword",
+      "ble-bind -m vi_imap -f 'C-u' kill-backward-line",
+      "ble-bind -m vi_imap -f 'C-k' kill-forward-line",
+      "ble-bind -m vi_imap -f 'M-C-?' kill-backward-cword",
+      "ble-bind -m vi_imap -f 'M-C-h' kill-backward-cword",
+      "ble-bind -m vi_imap -f 'M-DEL' kill-backward-cword",
+      "ble-bind -m vi_imap -f 'M-BS' kill-backward-cword",
+      "ble-bind -m vi_imap -f 'M-d' kill-forward-cword",
+      "ble-bind -m vi_imap -f 'M-delete' kill-forward-cword",
+    ]) {
+      expect(bashrc).toContain(bind);
+    }
+    expect(bashrc.indexOf("source /usr/local/share/blesh/ble.sh")).toBeLessThan(
+      bashrc.indexOf("ble-bind -m emacs"),
+    );
+  });
+
   test("agent config generator wires the coderouter model plane per HOME", () => {
     const agentConfig = read("agent-config.sh");
     // Sourced for login/exec shells and every interactive HOME.

--- a/web/tests/vm-blaxel-image.test.ts
+++ b/web/tests/vm-blaxel-image.test.ts
@@ -30,6 +30,7 @@ describe("Blaxel baked image template", () => {
       "cmux-bashrc",
       "entrypoint.sh",
       "ghostty-cmux.desktop",
+      "ghostty-defaults.conf",
       "google-chrome-cmux.desktop",
       "seed-history",
       "start-vnc.sh",
@@ -176,6 +177,21 @@ describe("Blaxel baked image template", () => {
     expect(bashrc.indexOf("source /usr/local/share/blesh/ble.sh")).toBeLessThan(
       bashrc.indexOf("ble-bind -m emacs"),
     );
+  });
+
+  test("desktop Ghostty gets macOS editing defaults without replacing user config", () => {
+    const defaults = read("ghostty-defaults.conf");
+    expect(defaults).toContain("keybind = super+backspace=text:\\x15");
+    expect(defaults).toContain("keybind = super+delete=text:\\x0b");
+    expect(defaults).toContain("keybind = super+left=text:\\x01");
+    expect(defaults).toContain("keybind = super+right=text:\\x05");
+    expect(defaults).toContain("keybind = alt+backspace=text:\\x1b\\x7f");
+    expect(defaults).toContain("keybind = alt+delete=text:\\x1b\\x64");
+    expect(defaults).toContain("keybind = alt+left=text:\\x1b\\x62");
+    expect(defaults).toContain("keybind = alt+right=text:\\x1b\\x66");
+    expect(startVnc).toContain("ensure_ghostty_defaults");
+    expect(startVnc).toContain("[ -e \"$config_file\" ] && return 0");
+    expect(startVnc).toContain("ln \"$tmp\" \"$config_file\"");
   });
 
   test("agent config generator wires the coderouter model plane per HOME", () => {

--- a/web/tests/vm-devbox-image.test.ts
+++ b/web/tests/vm-devbox-image.test.ts
@@ -165,6 +165,28 @@ describe("devbox image template", () => {
     for (const line of faceLines) {
       expect(line).not.toContain("bg=");
     }
+    // Keep all macOS line and word delete spellings as delete actions in both
+    // editing modes. The shared body test below enforces Blaxel parity.
+    for (const bind of [
+      "ble-bind -m emacs -f 'C-u' kill-backward-line",
+      "ble-bind -m emacs -f 'C-k' kill-forward-line",
+      "ble-bind -m emacs -f 'M-C-?' kill-backward-cword",
+      "ble-bind -m emacs -f 'M-C-h' kill-backward-cword",
+      "ble-bind -m emacs -f 'M-DEL' kill-backward-cword",
+      "ble-bind -m emacs -f 'M-BS' kill-backward-cword",
+      "ble-bind -m emacs -f 'M-d' kill-forward-cword",
+      "ble-bind -m emacs -f 'M-delete' kill-forward-cword",
+      "ble-bind -m vi_imap -f 'C-u' kill-backward-line",
+      "ble-bind -m vi_imap -f 'C-k' kill-forward-line",
+      "ble-bind -m vi_imap -f 'M-C-?' kill-backward-cword",
+      "ble-bind -m vi_imap -f 'M-C-h' kill-backward-cword",
+      "ble-bind -m vi_imap -f 'M-DEL' kill-backward-cword",
+      "ble-bind -m vi_imap -f 'M-BS' kill-backward-cword",
+      "ble-bind -m vi_imap -f 'M-d' kill-forward-cword",
+      "ble-bind -m vi_imap -f 'M-delete' kill-forward-cword",
+    ]) {
+      expect(bashrc).toContain(bind);
+    }
   });
 
   test("stays within the E2B Dockerfile-parser restrictions", () => {

--- a/web/tests/vm-devbox-image.test.ts
+++ b/web/tests/vm-devbox-image.test.ts
@@ -165,24 +165,18 @@ describe("devbox image template", () => {
     for (const line of faceLines) {
       expect(line).not.toContain("bg=");
     }
-    // Keep all macOS line and word delete spellings as delete actions in both
-    // editing modes. The shared body test below enforces Blaxel parity.
+    // Keep the alternate Meta-Delete spellings as delete actions in both
+    // editing modes. ble.sh already provides the common C-u/C-k/M-d actions.
     for (const bind of [
-      "ble-bind -m emacs -f 'C-u' kill-backward-line",
-      "ble-bind -m emacs -f 'C-k' kill-forward-line",
       "ble-bind -m emacs -f 'M-C-?' kill-backward-cword",
       "ble-bind -m emacs -f 'M-C-h' kill-backward-cword",
       "ble-bind -m emacs -f 'M-DEL' kill-backward-cword",
       "ble-bind -m emacs -f 'M-BS' kill-backward-cword",
-      "ble-bind -m emacs -f 'M-d' kill-forward-cword",
       "ble-bind -m emacs -f 'M-delete' kill-forward-cword",
-      "ble-bind -m vi_imap -f 'C-u' kill-backward-line",
-      "ble-bind -m vi_imap -f 'C-k' kill-forward-line",
       "ble-bind -m vi_imap -f 'M-C-?' kill-backward-cword",
       "ble-bind -m vi_imap -f 'M-C-h' kill-backward-cword",
       "ble-bind -m vi_imap -f 'M-DEL' kill-backward-cword",
       "ble-bind -m vi_imap -f 'M-BS' kill-backward-cword",
-      "ble-bind -m vi_imap -f 'M-d' kill-forward-cword",
       "ble-bind -m vi_imap -f 'M-delete' kill-forward-cword",
     ]) {
       expect(bashrc).toContain(bind);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores macOS terminal editing chords that AppKit previously consumed or converted, and that browsers ignored in web terminals. Command and Option Backspace, Forward Delete, and Arrow keys now reach shells as readline-compatible bytes while preserving text fields, browser shortcuts, and non-macOS behavior.

- Routes native delete equivalents before AppKit's Edit menu and text conversion.
- Adds Ghostty defaults that still apply after invalid user configuration, while preserving explicit user keybinds.
- Suppresses duplicate xterm events and blocks web input until attach and resize replays are authoritative or the session detaches.
- Maps alternate Meta-Delete spellings to word deletion in ble.sh emacs and vi insert modes.
- Adds native, web, routing, input-gating, and image-template tests; headless terminal checks now skip when no live surface is available.
- Bumps VM image cache epochs.

<sup>Written for commit 1efbdca0629d5c52512df62a1fd2e8a45d9182be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added macOS Command-based terminal shortcuts for character deletion and line navigation.
  * Web terminals now support Command+Backspace, Command+Forward Delete, Command+Left Arrow, and Command+Right Arrow.
  * Added Option-based word deletion support in shell environments across common editing modes.

* **Bug Fixes**
  * Preserved browser shortcuts and text-input behavior while routing terminal editing commands correctly.
  * Improved alternate Meta-Delete handling and prevented input before attached sessions are ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->