### PR TITLE
ci: admit the reviewed CLA workflow policy

### DIFF
--- a/scripts/ci/validate-cla-policy.rb
+++ b/scripts/ci/validate-cla-policy.rb
@@ -24,10 +24,10 @@ CLA_ACTION = "manaflow-ai/cla-github-action@fc608ba7106e7029d981d487d7bad28a6432
 # secret reference, action input, or permission while retaining the fragments
 # checked below. Policy changes require a separate, reviewed update to this
 # base-controlled guard, followed by the workflow change.
-EXPECTED_WORKFLOW_DIGEST = "d4db98df5a1b1e6f3b006a82639761a0513eeeaf153a9eb2b98d42d1af782145"
+EXPECTED_WORKFLOW_DIGEST = "f458101f6f17bc28381f2ee4f063d9b4333fa2cf7c7bec18b0a656a3311d9033"
 EXPECTED_RERUN_DIGEST = "f4f1fa51bb05b062ebf3f60cc949d8d5b4b501e7849cb065e9a07d7a34030840"
 EXPECTED_GUARD_WORKFLOW_DIGEST = "cb08e6837d8065897016f12cf30c85e0153fc5c3c2d9ca1e6b409f4237541bc4"
-EXPECTED_GUARD_SCRIPT_DIGEST = "fba44dda662ef1ea91b0e840e8988d12a3856813b9bdd6ced72dc0d4dad81b2e"
+EXPECTED_GUARD_SCRIPT_DIGEST = "a4eafdb5a9486eb96c76bd95b3c8e3f04b71783599f511d8466b69f124e92279"
 # Current organization administrators who may approve a trusted control-plane
 # update. IDs are used instead of names, and the review must target the exact
 # PR head. This is the human path for intentional policy maintenance.


### PR DESCRIPTION
Update the base-controlled policy digest to the exact reviewed CLA Assistant v2 workflow.

This is a guard-only change. It keeps policy and guard changes in separate pull requests.

Validation: Ruby syntax, digest recomputation, actionlint, and the existing CI guard tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790851342&installation_model_id=21920&pr_number=11429&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11429&signature=f75847ff7f2bb842c7ddc064efb39bfaa2d24620132fed30f69eff07384c76de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the base-controlled CLA policy digest to match the reviewed CLA Assistant v2 workflow, so the guard admits the approved policy.

- Updates `EXPECTED_WORKFLOW_DIGEST` and `EXPECTED_GUARD_SCRIPT_DIGEST` in `scripts/ci/validate-cla-policy.rb`.
- Keeps policy and guard changes in separate pull requests.

<sup>Written for commit eb1f8560b6b0a0d9cb966214baf690106308271e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated validation checks for trusted continuous integration workflows and scripts.
  * Improved compatibility with the latest approved security digests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->