### PR TITLE
Bound pairing decision channel

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/pairing.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/pairing.rs
@@ -1,8 +1,8 @@
 use std::collections::{HashMap, VecDeque};
 use std::fmt;
 use std::net::IpAddr;
-use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
 use std::sync::Mutex;
+use std::sync::mpsc::{Receiver, SyncSender, sync_channel};
 use std::time::{Duration, Instant};
 
 use base64::Engine;

--- a/cmux-tui/crates/cmux-tui-core/src/pairing.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/pairing.rs
@@ -186,9 +186,11 @@ impl PairingBroker {
         } else {
             PairingDecision::Denied
         };
-        // The requesting connection may already be gone. Resolution remains
-        // authoritative and the credential, when approved, is still valid.
-        let _ = request.response.send(decision);
+        // The requesting connection may already be gone. A nonblocking send
+        // keeps the pairing mutex available even if its receiver stopped
+        // polling; the decision is advisory because resolution is already
+        // authoritative and the credential remains valid.
+        let _ = request.response.try_send(decision);
         Ok(Some(committed))
     }
 

--- a/cmux-tui/crates/cmux-tui-core/src/pairing.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/pairing.rs
@@ -1,8 +1,8 @@
 use std::collections::{HashMap, VecDeque};
 use std::fmt;
 use std::net::IpAddr;
+use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
 use std::sync::Mutex;
-use std::sync::mpsc::{Receiver, Sender, channel};
 use std::time::{Duration, Instant};
 
 use base64::Engine;
@@ -62,7 +62,7 @@ struct PendingPairing {
     challenge: PairingChallenge,
     peer: IpAddr,
     expires_at: Instant,
-    response: Sender<PairingDecision>,
+    response: SyncSender<PairingDecision>,
 }
 
 struct Credential {
@@ -125,7 +125,10 @@ impl PairingBroker {
             peer: peer.to_string(),
             expires_in: CHALLENGE_TTL.as_secs(),
         };
-        let (tx, rx) = channel();
+        // A pairing request produces exactly one decision, so a one-slot
+        // bounded channel prevents abandoned requests from growing memory
+        // without changing delivery semantics.
+        let (tx, rx) = sync_channel(1);
         state.recent.entry(peer).or_default().push_back(now);
         state.pending.insert(
             id,


### PR DESCRIPTION
Pairing requests produce one decision and already enforce a maximum of 16 pending requests. Replace the unbounded std mpsc channel with sync_channel(1) so abandoned requests cannot grow an unbounded queue. Delivery behavior is unchanged because each request sends at most one decision.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11432"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790852503&installation_model_id=21920&pr_number=11432&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11432&signature=6894e99f7c963a717227c9e3629c14742e110eab5efc81e959866c0f90792c42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the pairing decision channel to one slot and switches to nonblocking sends so abandoned requests can't accumulate memory or block pairing resolution. Delivery behavior is unchanged because each request sends at most one decision.

<sup>Written for commit 4b0f9026996b82454f345a2ae17e59f2687c80a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pairing request handling to prevent abandoned requests from accumulating in memory.
  * Pairing responses now complete more reliably when the requesting connection is no longer available.
  * Preserved existing pairing delivery behavior while adding safer limits for pending requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->