### PR TITLE
cmux-tui: reject empty PTY program before spawn

### DIFF
--- a/cmux-tui/crates/cmux-pty/src/lib.rs
+++ b/cmux-tui/crates/cmux-pty/src/lib.rs
@@ -184,7 +184,7 @@ impl PtyPair {
     /// Spawn the command, close the parent's slave descriptor, and return the
     /// master and child as one ownership-safe unit.
     pub fn spawn(self, command: PtyCommand) -> anyhow::Result<SpawnedPty> {
-        if command.program.trim().is_empty() {
+        if command.program.is_empty() {
             anyhow::bail!("PTY command program must not be empty");
         }
         let Self { master, slave } = self;
@@ -283,7 +283,7 @@ mod tests {
     #[test]
     fn empty_program_is_rejected_before_platform_spawn() {
         let pair = open(PtySize { rows: 24, cols: 80, pixel_width: 0, pixel_height: 0 }).unwrap();
-        let error = match pair.spawn(PtyCommand::new("   ")) {
+        let error = match pair.spawn(PtyCommand::new("")) {
             Ok(_) => panic!("empty PTY program was spawned"),
             Err(error) => error,
         };

--- a/cmux-tui/crates/cmux-pty/src/lib.rs
+++ b/cmux-tui/crates/cmux-pty/src/lib.rs
@@ -184,7 +184,7 @@ impl PtyPair {
     /// Spawn the command, close the parent's slave descriptor, and return the
     /// master and child as one ownership-safe unit.
     pub fn spawn(self, command: PtyCommand) -> anyhow::Result<SpawnedPty> {
-        if command.program.is_empty() {
+        if command.program.trim().is_empty() {
             anyhow::bail!("PTY command program must not be empty");
         }
         let Self { master, slave } = self;
@@ -285,6 +285,16 @@ mod tests {
         let pair = open(PtySize { rows: 24, cols: 80, pixel_width: 0, pixel_height: 0 }).unwrap();
         let error = match pair.spawn(PtyCommand::new("")) {
             Ok(_) => panic!("empty PTY program was spawned"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("program must not be empty"));
+    }
+
+    #[test]
+    fn whitespace_only_program_is_rejected_before_platform_spawn() {
+        let pair = open(PtySize { rows: 24, cols: 80, pixel_width: 0, pixel_height: 0 }).unwrap();
+        let error = match pair.spawn(PtyCommand::new(" \t\n")) {
+            Ok(_) => panic!("whitespace-only PTY program was spawned"),
             Err(error) => error,
         };
         assert!(error.to_string().contains("program must not be empty"));

--- a/cmux-tui/crates/cmux-pty/src/lib.rs
+++ b/cmux-tui/crates/cmux-pty/src/lib.rs
@@ -184,6 +184,9 @@ impl PtyPair {
     /// Spawn the command, close the parent's slave descriptor, and return the
     /// master and child as one ownership-safe unit.
     pub fn spawn(self, command: PtyCommand) -> anyhow::Result<SpawnedPty> {
+        if command.program.trim().is_empty() {
+            anyhow::bail!("PTY command program must not be empty");
+        }
         let Self { master, slave } = self;
         let child = platform::spawn(&slave, command)?;
         drop(slave);
@@ -275,6 +278,16 @@ mod tests {
             let status = spawned.child.wait().unwrap();
             panic!("missing PTY program was published as child status {status:?}");
         }
+    }
+
+    #[test]
+    fn empty_program_is_rejected_before_platform_spawn() {
+        let pair = open(PtySize { rows: 24, cols: 80, pixel_width: 0, pixel_height: 0 }).unwrap();
+        let error = match pair.spawn(PtyCommand::new("   ")) {
+            Ok(_) => panic!("empty PTY program was spawned"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("program must not be empty"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- reject whitespace-only PTY program names before platform-specific spawn
- add behavior test proving fail-closed behavior

## Verification
- rustfmt --edition 2024
- git diff --check
- Cargo builds/tests not run per task constraints

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790852516&installation_model_id=21920&pr_number=11433&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11433&signature=28118f6a53ec8f6f3e154e65276c122b115ec0430763918d59aa043a81e52a15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects empty and whitespace-only PTY program names in `cmux-pty` before platform-specific spawn, so `spawn` fails with a clear error instead of reaching underlying spawn logic. Adds regression tests proving empty and whitespace-only programs are never spawned.

<sup>Written for commit 803dbd559514b1283925183dad92a2292d428127. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command launching by rejecting attempts with an empty or whitespace-only program name.
  * Prevented invalid processes from being started when no valid command is provided.
  * Added clearer validation feedback when a command cannot be launched because its program name is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->