### PR TITLE
ci: reject focused filters that only match ignored tests

### DIFF
--- a/.github/workflows/cmux-tui.yml
+++ b/.github/workflows/cmux-tui.yml
@@ -483,13 +483,17 @@ jobs:
           fi
           cargo test --workspace --locked "$TEST_FILTER" -- --list \
             | tee "$RUNNER_TEMP/cmux-tui-focused-tests.txt"
-          if ! grep -Eq ': test$' "$RUNNER_TEMP/cmux-tui-focused-tests.txt"; then
-            ignored_tests="$(cargo test --workspace --locked "$TEST_FILTER" -- --list --ignored)"
-            if grep -Eq ': test$' <<<"$ignored_tests"; then
-              echo "::error::test_filter '$TEST_FILTER' matches only ignored tests" >&2
-            else
-              echo "::error::test_filter '$TEST_FILTER' selected no Rust tests" >&2
-            fi
+          normal_names="$RUNNER_TEMP/cmux-tui-focused-normal.txt"
+          grep -E ': test$' "$RUNNER_TEMP/cmux-tui-focused-tests.txt" | sort > "$normal_names" || true
+          ignored_names="$RUNNER_TEMP/cmux-tui-focused-ignored.txt"
+          cargo test --workspace --locked "$TEST_FILTER" -- --list --ignored \
+            | grep -E ': test$' | sort > "$ignored_names" || true
+          if [[ -s "$normal_names" && -s "$ignored_names" ]] && cmp -s "$normal_names" "$ignored_names"; then
+            echo "::error::test_filter '$TEST_FILTER' matches only ignored tests" >&2
+            exit 1
+          fi
+          if [[ ! -s "$normal_names" ]]; then
+            echo "::error::test_filter '$TEST_FILTER' selected no Rust tests" >&2
             exit 1
           fi
           cargo test --workspace --locked "$TEST_FILTER"

--- a/.github/workflows/cmux-tui.yml
+++ b/.github/workflows/cmux-tui.yml
@@ -481,6 +481,11 @@ jobs:
             cargo test -p chatmux-relay --locked
             exit 0
           fi
+          ignored_tests="$(cargo test --workspace --locked "$TEST_FILTER" -- --list --ignored)"
+          if grep -Eq ': test$' <<<"$ignored_tests"; then
+            echo "::error::test_filter '$TEST_FILTER' matches ignored tests; focused runs must execute at least one non-ignored test" >&2
+            exit 1
+          fi
           cargo test --workspace --locked "$TEST_FILTER" -- --list \
             | tee "$RUNNER_TEMP/cmux-tui-focused-tests.txt"
           if ! grep -Eq ': test$' "$RUNNER_TEMP/cmux-tui-focused-tests.txt"; then

--- a/.github/workflows/cmux-tui.yml
+++ b/.github/workflows/cmux-tui.yml
@@ -486,8 +486,9 @@ jobs:
           normal_names="$RUNNER_TEMP/cmux-tui-focused-normal.txt"
           grep -E ': test$' "$RUNNER_TEMP/cmux-tui-focused-tests.txt" | sort > "$normal_names" || true
           ignored_names="$RUNNER_TEMP/cmux-tui-focused-ignored.txt"
-          cargo test --workspace --locked "$TEST_FILTER" -- --list --ignored \
-            | grep -E ': test$' | sort > "$ignored_names" || true
+          ignored_listing="$RUNNER_TEMP/cmux-tui-focused-ignored-list.txt"
+          cargo test --workspace --locked "$TEST_FILTER" -- --list --ignored > "$ignored_listing"
+          grep -E ': test$' "$ignored_listing" | sort > "$ignored_names" || [[ "$?" -eq 1 ]]
           if [[ -s "$normal_names" && -s "$ignored_names" ]] && cmp -s "$normal_names" "$ignored_names"; then
             echo "::error::test_filter '$TEST_FILTER' matches only ignored tests" >&2
             exit 1

--- a/.github/workflows/cmux-tui.yml
+++ b/.github/workflows/cmux-tui.yml
@@ -481,15 +481,15 @@ jobs:
             cargo test -p chatmux-relay --locked
             exit 0
           fi
-          ignored_tests="$(cargo test --workspace --locked "$TEST_FILTER" -- --list --ignored)"
-          if grep -Eq ': test$' <<<"$ignored_tests"; then
-            echo "::error::test_filter '$TEST_FILTER' matches ignored tests; focused runs must execute at least one non-ignored test" >&2
-            exit 1
-          fi
           cargo test --workspace --locked "$TEST_FILTER" -- --list \
             | tee "$RUNNER_TEMP/cmux-tui-focused-tests.txt"
           if ! grep -Eq ': test$' "$RUNNER_TEMP/cmux-tui-focused-tests.txt"; then
-            echo "::error::test_filter '$TEST_FILTER' selected no Rust tests" >&2
+            ignored_tests="$(cargo test --workspace --locked "$TEST_FILTER" -- --list --ignored)"
+            if grep -Eq ': test$' <<<"$ignored_tests"; then
+              echo "::error::test_filter '$TEST_FILTER' matches only ignored tests" >&2
+            else
+              echo "::error::test_filter '$TEST_FILTER' selected no Rust tests" >&2
+            fi
             exit 1
           fi
           cargo test --workspace --locked "$TEST_FILTER"


### PR DESCRIPTION
Focused verification first lists matching tests, then runs the filter. A selector matching only #[ignore] tests could therefore pass with zero executed tests. Run the ignored-only list and fail explicitly before the normal list/run path.

Verification: git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11434"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790852517&installation_model_id=21920&pr_number=11434&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11434&signature=0381629d31ed40b1652acb2184388dd8023283836e44e0fde931d41f92491f4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Focused CI now rejects test filters that match only ignored (`#[ignore]`) tests instead of passing with zero executed tests. Filters that match both runnable and ignored tests still run normally, and failures from the ignored-test listing now fail the check.

<sup>Written for commit 47d3753ed997506f9f78d4a3f71d06968ab396a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

