### PR TITLE
Bound workspace HTTP token reads

### DIFF
--- a/cmux-tui/crates/cmux-remote/src/http.rs
+++ b/cmux-tui/crates/cmux-remote/src/http.rs
@@ -160,6 +160,11 @@ fn read_workspace_http_token(path: &Path) -> Result<WorkspaceHttpBearerToken, io
     options.custom_flags(libc::O_NOFOLLOW);
     let mut file = options.open(path)?;
     let metadata = file.metadata()?;
+    validate_workspace_http_token_metadata(&metadata)?;
+    read_workspace_http_token_contents(&mut file)
+}
+
+fn validate_workspace_http_token_metadata(metadata: &fs::Metadata) -> Result<(), io::Error> {
     if !metadata.is_file() {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -184,9 +189,17 @@ fn read_workspace_http_token(path: &Path) -> Result<WorkspaceHttpBearerToken, io
             ));
         }
     }
+    Ok(())
+}
+
+fn read_workspace_http_token_contents(
+    file: &mut fs::File,
+) -> Result<WorkspaceHttpBearerToken, io::Error> {
     let mut encoded = String::new();
-    file.take(MAX_HTTP_TOKEN_FILE_BYTES + 1).read_to_string(&mut encoded)?;
-    if encoded.len() > MAX_HTTP_TOKEN_FILE_BYTES as usize {
+    (&mut *file).take(MAX_HTTP_TOKEN_FILE_BYTES + 1).read_to_string(&mut encoded)?;
+    if encoded.len() > MAX_HTTP_TOKEN_FILE_BYTES as usize
+        || file.metadata()?.len() > MAX_HTTP_TOKEN_FILE_BYTES
+    {
         return Err(io::Error::new(io::ErrorKind::InvalidData, "HTTP token file is too large"));
     }
     let trimmed_length = encoded.trim_end_matches(['\r', '\n']).len();
@@ -757,9 +770,21 @@ mod tests {
     fn workspace_http_token_reader_bounds_growth_after_metadata_check() {
         let directory = tempdir().unwrap();
         let path = directory.path().join("workspace-http.token");
-        fs::write(&path, vec![b'x'; MAX_HTTP_TOKEN_FILE_BYTES as usize + 1]).unwrap();
+        fs::write(&path, b"x").unwrap();
+        #[cfg(unix)]
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
 
-        let error = read_workspace_http_token(&path).unwrap_err();
+        let mut file = OpenOptions::new().read(true).open(&path).unwrap();
+        let metadata = file.metadata().unwrap();
+        validate_workspace_http_token_metadata(&metadata).unwrap();
+        fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap()
+            .write_all(&vec![b'x'; MAX_HTTP_TOKEN_FILE_BYTES as usize])
+            .unwrap();
+
+        let error = read_workspace_http_token_contents(&mut file).unwrap_err();
         assert_eq!(error.kind(), io::ErrorKind::InvalidData);
         assert_eq!(error.to_string(), "HTTP token file is too large");
     }

--- a/cmux-tui/crates/cmux-remote/src/http.rs
+++ b/cmux-tui/crates/cmux-remote/src/http.rs
@@ -164,6 +164,7 @@ fn read_workspace_http_token(path: &Path) -> Result<WorkspaceHttpBearerToken, io
     read_workspace_http_token_contents(&mut file)
 }
 
+/// Validates the token file type, size, owner, and permissions from one opened descriptor.
 fn validate_workspace_http_token_metadata(metadata: &fs::Metadata) -> Result<(), io::Error> {
     if !metadata.is_file() {
         return Err(io::Error::new(
@@ -192,6 +193,7 @@ fn validate_workspace_http_token_metadata(metadata: &fs::Metadata) -> Result<(),
     Ok(())
 }
 
+/// Reads at most the configured token bound and rejects growth observed during the read.
 fn read_workspace_http_token_contents(
     file: &mut fs::File,
 ) -> Result<WorkspaceHttpBearerToken, io::Error> {

--- a/cmux-tui/crates/cmux-remote/src/http.rs
+++ b/cmux-tui/crates/cmux-remote/src/http.rs
@@ -185,7 +185,10 @@ fn read_workspace_http_token(path: &Path) -> Result<WorkspaceHttpBearerToken, io
         }
     }
     let mut encoded = String::new();
-    file.read_to_string(&mut encoded)?;
+    file.take(MAX_HTTP_TOKEN_FILE_BYTES + 1).read_to_string(&mut encoded)?;
+    if encoded.len() > MAX_HTTP_TOKEN_FILE_BYTES as usize {
+        return Err(io::Error::new(io::ErrorKind::InvalidData, "HTTP token file is too large"));
+    }
     let trimmed_length = encoded.trim_end_matches(['\r', '\n']).len();
     encoded.truncate(trimmed_length);
     WorkspaceHttpBearerToken::new(encoded)
@@ -748,6 +751,17 @@ mod tests {
         assert!(bool::from(first.0.as_bytes().ct_eq(second.0.as_bytes())));
         #[cfg(unix)]
         assert_eq!(fs::metadata(path).unwrap().permissions().mode() & 0o777, 0o600);
+    }
+
+    #[test]
+    fn workspace_http_token_reader_bounds_growth_after_metadata_check() {
+        let directory = tempdir().unwrap();
+        let path = directory.path().join("workspace-http.token");
+        fs::write(&path, vec![b'x'; MAX_HTTP_TOKEN_FILE_BYTES as usize + 1]).unwrap();
+
+        let error = read_workspace_http_token(&path).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert_eq!(error.to_string(), "HTTP token file is too large");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Use Read::take to cap token file reads after metadata validation. This prevents a file replaced or grown between metadata and read from causing unbounded allocation. Added behavior coverage for oversized token files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790852595&installation_model_id=21920&pr_number=11435&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11435&signature=0b6d1b4b7d3d87d30636182fe482a367c375506538597960b9257da4538ebef4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds workspace HTTP token file reads to a fixed byte cap so a token file that grows or is replaced after the initial metadata check can't cause unbounded allocation. Files over the cap now return an invalid-data error instead of being read fully, and a new test covers the growth-after-open case.

<sup>Written for commit 60df42aba61318ad5ff731fa86d1f2ace265fa57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of oversized authentication token files.
  * Files exceeding the supported size limit are now rejected reliably, including when they grow during reading.
* **Tests**
  * Added coverage to verify oversized token files are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->