### PR TITLE
chore(cmux-sidebar): remove duplicate serde_json declaration

### DIFF
--- a/cmux-tui/bindings/rust-sidebar/Cargo.toml
+++ b/cmux-tui/bindings/rust-sidebar/Cargo.toml
@@ -19,4 +19,3 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 base64 = { workspace = true }
-serde_json = { workspace = true }


### PR DESCRIPTION
Cargo documents that integration tests link both normal and dev dependencies. cmux-sidebar already declares serde_json as a normal workspace dependency, so the identical dev declaration is redundant. Removing it keeps one source of dependency configuration without changing test or library availability.

Verification: git diff --check only; no Cargo/Rust builds or tests run per task constraints.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11436"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790852606&installation_model_id=21920&pr_number=11436&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11436&signature=0ff4ed055240d334b139297cab8a028524ecc2df5e4127070008b0851a7266fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the duplicate `serde_json` dev-dependency from `cmux-tui/bindings/rust-sidebar/Cargo.toml`.

Cargo gives integration tests access to both regular and dev dependencies, so the redundant declaration has no effect on test or library availability. This leaves a single source of dependency configuration for `serde_json`.

<sup>Written for commit 896848417b2471ea504a3cdc000ced3f6e632424. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused development dependency.
  * No user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->