### PR TITLE
ci: repair billing fixtures and App Store lane guard

### DIFF
--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -1333,7 +1333,7 @@ echo "signed IPA app symbols verified (Symbols/*.symbols present for ASC crash s
 echo "IPA_PATH=$IPA_PATH"
 
 EXPECTED_IPA_CRASH_REPORTING=""
-[[ "$LANE" == "appstore" ]] && EXPECTED_IPA_CRASH_REPORTING="NO"
+[[ "$LANE" == "appstore" ]] && EXPECTED_IPA_CRASH_REPORTING="$CRASH_REPORTING_ENABLED"
 if ! verify_ipa_bundle_identity "$IPA_PATH" "$PRODUCT_BUNDLE_IDENTIFIER" "$DEVELOPMENT_TEAM" "$EXPECTED_IPA_CRASH_REPORTING"; then
   echo "error: signed IPA bundle identity does not match lane '$LANE'; refusing to upload" >&2
   exit 1

--- a/tests/test_ios_appstore_lane_identity.py
+++ b/tests/test_ios_appstore_lane_identity.py
@@ -994,8 +994,8 @@ def test_upload_appstore_lane_uses_production_bundle_id(tmp: Path, fakebin: Path
         "archive command does not stamp the beta marketing version",
     )
     _check(
-        "CMUX_CRASH_REPORTING_ENABLED=NO" in archive_call,
-        "App Store archive disables crash reporting",
+        "CMUX_CRASH_REPORTING_ENABLED=YES" in archive_call,
+        "App Store archive keeps crash reporting enabled",
     )
     _check(
         all("PRODUCT_BUNDLE_IDENTIFIER=com.cmuxterm.app" not in call for call in archive_call),
@@ -1024,8 +1024,8 @@ def test_upload_appstore_lane_uses_production_bundle_id(tmp: Path, fakebin: Path
         "final signed IPA keeps the App Store marketing version",
     )
     _check(
-        info.get("CMUXCrashReportingEnabled") == "NO",
-        "final signed IPA disables crash reporting",
+        info.get("CMUXCrashReportingEnabled") == "YES",
+        "final signed IPA keeps crash reporting enabled",
     )
 
 

--- a/web/tests/billing-plan-route.test.ts
+++ b/web/tests/billing-plan-route.test.ts
@@ -111,7 +111,10 @@ describe("billing plan route", () => {
     currentUser = planUser({
       selectedTeam: { id: "team-plan", clientReadOnlyMetadata: {} },
     });
-    stripeSubscriptionResults = [[], [{ id: "sub_team" }]];
+    // The personal snapshot consumes its subscription and active-row queries
+    // before the team resolver reads the team subscription. Keep the fixture
+    // results aligned with those query boundaries.
+    stripeSubscriptionResults = [[], [], [{ id: "sub_team" }]];
 
     const response = await planResponse();
 

--- a/web/tests/dashboard-billing-page.test.tsx
+++ b/web/tests/dashboard-billing-page.test.tsx
@@ -205,6 +205,7 @@ describe("dashboard billing page", () => {
     subscriptionResults = [
       [],
       [],
+      [],
       [
         stripeSubscriptionRow({
           cancelAtPeriodEnd: false,
@@ -232,6 +233,7 @@ describe("dashboard billing page", () => {
     subscriptionResults = [
       [],
       [],
+      [],
       [
         stripeSubscriptionRow({
           cancelAtPeriodEnd: false,
@@ -252,6 +254,7 @@ describe("dashboard billing page", () => {
     subscriptionResults = [
       [],
       [],
+      [],
       [
         stripeSubscriptionRow({
           cancelAtPeriodEnd: false,
@@ -268,6 +271,7 @@ describe("dashboard billing page", () => {
     expect(await renderBillingPage()).toContain("$35/seat/mo");
 
     subscriptionResults = [
+      [],
       [],
       [],
       [
@@ -297,6 +301,7 @@ describe("dashboard billing page", () => {
       { id: "team-pro", displayName: "Team Pro", clientReadOnlyMetadata: { cmuxPlan: "team" } },
     ]);
     subscriptionResults = [
+      [],
       [],
       [],
       [


### PR DESCRIPTION
## Summary
- Align billing route and dashboard fixtures with the parallel personal snapshot and team query contract.
- Validate the signed App Store IPA against the lane's configured crash-reporting value, and update the behavioral guard for the current enabled policy.
- Keep the regression sequence in two commits: test alignment first, then the verifier fix.

## Verification
- `bun test tests/billing-plan-route.test.ts tests/dashboard-billing-page.test.tsx` (25 pass)
- `bun run typecheck` (clean)
- `GIT_EDITOR=: GIT_CONFIG_GLOBAL=/dev/null python3 tests/test_ios_appstore_lane_identity.py` (all pass)
- `bash -n ios/scripts/upload-testflight.sh ios/scripts/upload-app-store.sh`
- Full local web suite: 1851 pass, 175 skip, 3 existing 5-second process-test timeouts on this Mac; no changed-test failures.

This repairs the failures observed in https://github.com/manaflow-ai/cmux/actions/runs/33499396552 after https://github.com/manaflow-ai/cmux/pull/11286 merged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI failures from #11286 by aligning billing fixtures with the new query boundaries and updating the App Store crash-reporting verifier to the enabled policy.

**Bug Fixes**
- Billing tests insert an extra empty subscription result for the personal snapshot before the team resolver reads team subscriptions.
- The App Store lane guard now compares the IPA's crash-reporting value against `$CRASH_REPORTING_ENABLED` instead of hardcoding NO, with tests updated to expect YES.

<sup>Written for commit 04691b78fb0e9ec8e0f82437db736950e7edb60f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - App Store releases now retain crash reporting in the signed app, improving post-release diagnostics.
  - Improved billing plan and dashboard test coverage to better reflect subscription data loading and prevent regressions in billing experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->