### PR TITLE
docs: clarify cmux-tui config reload path

### DIFF
--- a/cmux-tui/docs/configuration.md
+++ b/cmux-tui/docs/configuration.md
@@ -115,7 +115,10 @@ cmux sidebar plugin use fzf
 the optional build command, and verifies the resolved run command is
 executable. `sidebar plugin use <name>` writes `sidebar.plugin.command` as an absolute
 argv and `sidebar.plugin.cwd` as the plugin directory, preserving unrelated
-cmux-tui config keys. A running TUI applies it after config reload; `sidebar plugin use`
+cmux-tui config keys. A running TUI applies changes after `cmux server reload-config`; the
+reload reads the same resolved path selected at process startup. Changing `CMUX_TUI_CONFIG`
+or `CMUX_MUX_CONFIG` in the shell does not move an already-running session to another file.
+`sidebar plugin use`
 sends that reload automatically when the resolved session socket is reachable.
 
 Return to the built-in sidebar with:

--- a/cmux-tui/docs/configuration.md
+++ b/cmux-tui/docs/configuration.md
@@ -120,8 +120,8 @@ the reload re-evaluates the path precedence described above using the running pr
 environment and the files that exist. It therefore can switch between the default and
 legacy fallback files when those files appear or disappear. Changing `CMUX_TUI_CONFIG`
 or `CMUX_MUX_CONFIG` in a separate shell does not change the running process environment.
-`sidebar plugin use`
-sends that reload automatically when the resolved session socket is reachable.
+`sidebar plugin use` does not send this reload; run `cmux server reload-config`
+separately for a running local session whose socket is reachable.
 
 Return to the built-in sidebar with:
 

--- a/cmux-tui/docs/configuration.md
+++ b/cmux-tui/docs/configuration.md
@@ -115,9 +115,11 @@ cmux sidebar plugin use fzf
 the optional build command, and verifies the resolved run command is
 executable. `sidebar plugin use <name>` writes `sidebar.plugin.command` as an absolute
 argv and `sidebar.plugin.cwd` as the plugin directory, preserving unrelated
-cmux-tui config keys. A running TUI applies changes after `cmux server reload-config`; the
-reload reads the same resolved path selected at process startup. Changing `CMUX_TUI_CONFIG`
-or `CMUX_MUX_CONFIG` in the shell does not move an already-running session to another file.
+cmux-tui config keys. A running TUI applies changes after `cmux server reload-config`;
+the reload re-evaluates the path precedence described above using the running process's
+environment and the files that exist. It therefore can switch between the default and
+legacy fallback files when those files appear or disappear. Changing `CMUX_TUI_CONFIG`
+or `CMUX_MUX_CONFIG` in a separate shell does not change the running process environment.
 `sidebar plugin use`
 sends that reload automatically when the resolved session socket is reachable.
 


### PR DESCRIPTION
## Summary
- Clarify that config reload uses the startup-resolved config path.
- Document that changing config environment variables does not retarget a running session.

## Testing
- git diff --check

## Issues
- Related: configuration and CLI surface audit

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies that `cmux server reload-config` re-evaluates the config path using the running process's environment, so it can switch between the default and legacy fallback files when those files appear or disappear. Changing `CMUX_TUI_CONFIG` or `CMUX_MUX_CONFIG` in a separate shell does not affect the running session. `sidebar plugin use` no longer sends a reload automatically; run `cmux server reload-config` separately to apply plugin changes to a running local session.

<sup>Written for commit c1661c10be0a8fe077bdf5682ad8ad2266dc29db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that configuration changes take effect in a running TUI only after running `cmux server reload-config`.
  * Documented that environment variable changes in another shell do not affect the running process.
  * Noted that `sidebar plugin use` no longer reloads configuration automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->