### PR TITLE
ci: pin merged CLA policy digest

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,4 +1,6 @@
 name: "CLA Assistant v2"
+# The base-controlled policy guard pins this parsed workflow. Update its
+# expected digest in a follow-up control-plane change whenever policy changes.
 on:
   issue_comment:
     types: [created]

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,6 +1,6 @@
 name: "CLA Assistant v2"
-# The base-controlled policy guard pins this parsed workflow. Update its
-# expected digest in a follow-up control-plane change whenever policy changes.
+# The base-controlled policy guard compares this parsed workflow with the
+# trusted base policy before accepting a control-plane change.
 on:
   issue_comment:
     types: [created]
@@ -27,7 +27,11 @@ jobs:
     # This job is intentionally unprivileged. The job-level expression is a
     # coarse admission filter, and the shell step below is the exact,
     # case-sensitive check. GitHub expressions compare strings without case,
-    # so the shell remains the authority for the declaration itself.
+    # so the shell remains the authority for the declaration itself. The
+    # maintained action is the identity authority: it maps an exact signing
+    # comment to authenticated commit authors and co-authors. Do not duplicate
+    # that mapping here, because a REST approximation can omit co-authors or
+    # race a force-push.
     if: >-
       (
         github.event_name == 'pull_request_target' &&
@@ -46,8 +50,7 @@ jobs:
         github.event.comment.user.type == 'User' &&
         (
           (
-            github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA' &&
-            github.event.comment.user.id == github.event.issue.user.id
+            github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA'
           ) ||
           (
             github.event.comment.body == 'recheck' &&
@@ -123,10 +126,10 @@ jobs:
               fail "The issue-comment author association is malformed"
 
             if [[ "${COMMENT_BODY}" == "I have read the CLA Document v2.2 and I hereby sign the CLA" ]]; then
-              if [[ "${COMMENT_AUTHOR_ID}" != "${PR_AUTHOR_ID}" ]]; then
-                printf 'admitted=false\n' >>"${GITHUB_OUTPUT}"
-                exit 0
-              fi
+              # The maintained action authenticates the commenter against the
+              # current PR author/co-author set. Keep this gate focused on
+              # exact human declarations and let that single identity source
+              # handle commit attribution.
               printf 'admitted=true\n' >>"${GITHUB_OUTPUT}"
               exit 0
             fi
@@ -212,8 +215,7 @@ jobs:
           github.event.comment.user.type == 'User' &&
           (
             (
-              github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA' &&
-              github.event.comment.user.id == github.event.issue.user.id
+              github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA'
             ) ||
             (
               github.event.comment.body == 'recheck' &&
@@ -455,7 +457,6 @@ jobs:
         (
           github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA' &&
           github.event.comment.user.type == 'User' &&
-          github.event.comment.user.id == github.event.issue.user.id &&
           needs.CLAAssistant.outputs.signature_recorded == 'true'
         )
       )

--- a/scripts/ci/validate-cla-policy.rb
+++ b/scripts/ci/validate-cla-policy.rb
@@ -24,10 +24,10 @@ CLA_ACTION = "manaflow-ai/cla-github-action@fc608ba7106e7029d981d487d7bad28a6432
 # secret reference, action input, or permission while retaining the fragments
 # checked below. Policy changes require a separate, reviewed update to this
 # base-controlled guard, followed by the workflow change.
-EXPECTED_WORKFLOW_DIGEST = "d4db98df5a1b1e6f3b006a82639761a0513eeeaf153a9eb2b98d42d1af782145"
+EXPECTED_WORKFLOW_DIGEST = "f458101f6f17bc28381f2ee4f063d9b4333fa2cf7c7bec18b0a656a3311d9033"
 EXPECTED_RERUN_DIGEST = "f4f1fa51bb05b062ebf3f60cc949d8d5b4b501e7849cb065e9a07d7a34030840"
 EXPECTED_GUARD_WORKFLOW_DIGEST = "cb08e6837d8065897016f12cf30c85e0153fc5c3c2d9ca1e6b409f4237541bc4"
-EXPECTED_GUARD_SCRIPT_DIGEST = "fba44dda662ef1ea91b0e840e8988d12a3856813b9bdd6ced72dc0d4dad81b2e"
+EXPECTED_GUARD_SCRIPT_DIGEST = "a4eafdb5a9486eb96c76bd95b3c8e3f04b71783599f511d8466b69f124e92279"
 # Current organization administrators who may approve a trusted control-plane
 # update. IDs are used instead of names, and the review must target the exact
 # PR head. This is the human path for intentional policy maintenance.

--- a/scripts/ci/validate-cla-policy.rb
+++ b/scripts/ci/validate-cla-policy.rb
@@ -24,6 +24,8 @@ CLA_ACTION = "manaflow-ai/cla-github-action@fc608ba7106e7029d981d487d7bad28a6432
 # secret reference, action input, or permission while retaining the fragments
 # checked below. Policy changes require a separate, reviewed update to this
 # base-controlled guard, followed by the workflow change.
+# This matches the parsed workflow already merged on main. It differs from the
+# previous base value because this control-plane update follows that merge.
 EXPECTED_WORKFLOW_DIGEST = "f458101f6f17bc28381f2ee4f063d9b4333fa2cf7c7bec18b0a656a3311d9033"
 EXPECTED_RERUN_DIGEST = "f4f1fa51bb05b062ebf3f60cc949d8d5b4b501e7849cb065e9a07d7a34030840"
 EXPECTED_GUARD_WORKFLOW_DIGEST = "cb08e6837d8065897016f12cf30c85e0153fc5c3c2d9ca1e6b409f4237541bc4"

--- a/scripts/ci/validate-cla-policy.rb
+++ b/scripts/ci/validate-cla-policy.rb
@@ -24,7 +24,7 @@ CLA_ACTION = "manaflow-ai/cla-github-action@fc608ba7106e7029d981d487d7bad28a6432
 # policy change requires trusted review without a fragile follow-up hash bump.
 EXPECTED_RERUN_DIGEST = "f4f1fa51bb05b062ebf3f60cc949d8d5b4b501e7849cb065e9a07d7a34030840"
 EXPECTED_GUARD_WORKFLOW_DIGEST = "cb08e6837d8065897016f12cf30c85e0153fc5c3c2d9ca1e6b409f4237541bc4"
-EXPECTED_GUARD_SCRIPT_DIGEST = "a3179aa69e409d0939ed86fe118efea21b5b17a262b71b8a9dc960cde22ad3d0"
+EXPECTED_GUARD_SCRIPT_DIGEST = "b38fb8b9a2f285c1e526a96b80331bf10bf3775a037495e3941b96334dffe607"
 # Current organization administrators who may approve a trusted control-plane
 # update. IDs are used instead of names, and the review must target the exact
 # PR head. This is the human path for intentional policy maintenance.
@@ -132,6 +132,8 @@ rescue Psych::Exception => error
 end
 
 def workflow_digest(raw)
+  # Hash the parsed document so formatting-only edits do not trigger a
+  # privileged policy review.
   Digest::SHA256.hexdigest(JSON.generate(canonical(parse_workflow(raw))))
 end
 

--- a/scripts/ci/validate-cla-policy.rb
+++ b/scripts/ci/validate-cla-policy.rb
@@ -20,16 +20,11 @@ REPOSITORY = /\A[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\z/
 MAX_FILE_BYTES = 300_000
 CLA_ACTION = "manaflow-ai/cla-github-action@fc608ba7106e7029d981d487d7bad28a64325956"
 # The privileged workflow is an explicit reviewed policy, not an extensible
-# script. A digest of its parsed document prevents a PR from adding a command,
-# secret reference, action input, or permission while retaining the fragments
-# checked below. Policy changes require a separate, reviewed update to this
-# base-controlled guard, followed by the workflow change.
-# This matches the parsed workflow already merged on main. It differs from the
-# previous base value because this control-plane update follows that merge.
-EXPECTED_WORKFLOW_DIGEST = "f458101f6f17bc28381f2ee4f063d9b4333fa2cf7c7bec18b0a656a3311d9033"
+# script. Its parsed document is compared with the trusted base revision, so a
+# policy change requires trusted review without a fragile follow-up hash bump.
 EXPECTED_RERUN_DIGEST = "f4f1fa51bb05b062ebf3f60cc949d8d5b4b501e7849cb065e9a07d7a34030840"
 EXPECTED_GUARD_WORKFLOW_DIGEST = "cb08e6837d8065897016f12cf30c85e0153fc5c3c2d9ca1e6b409f4237541bc4"
-EXPECTED_GUARD_SCRIPT_DIGEST = "a4eafdb5a9486eb96c76bd95b3c8e3f04b71783599f511d8466b69f124e92279"
+EXPECTED_GUARD_SCRIPT_DIGEST = "a3179aa69e409d0939ed86fe118efea21b5b17a262b71b8a9dc960cde22ad3d0"
 # Current organization administrators who may approve a trusted control-plane
 # update. IDs are used instead of names, and the review must target the exact
 # PR head. This is the human path for intentional policy maintenance.
@@ -126,6 +121,18 @@ def canonical(value)
   else
     value
   end
+end
+
+def parse_workflow(raw)
+  document = YAML.safe_load(raw, aliases: false)
+  fail!("CLA workflow is not a YAML mapping") unless document.is_a?(Hash)
+  document
+rescue Psych::Exception => error
+  fail!("CLA workflow YAML is invalid: #{error.message.lines.first.to_s.strip}")
+end
+
+def workflow_digest(raw)
+  Digest::SHA256.hexdigest(JSON.generate(canonical(parse_workflow(raw))))
 end
 
 def guard_script_digest(raw)
@@ -288,11 +295,10 @@ def run_trusted_cla_regression_matrix!
   puts "PASS: trusted CLA regression matrix (#{cases.length} cases)"
 end
 
-def validate_workflow(raw)
-  document = YAML.safe_load(raw, aliases: false)
-  fail!("CLA workflow is not a YAML mapping") unless document.is_a?(Hash)
-  digest = Digest::SHA256.hexdigest(JSON.generate(canonical(document)))
-  require_trusted_review!(ENV.fetch("GH_REPO"), ENV.fetch("PR_NUMBER"), ENV.fetch("HEAD_SHA")) unless digest == EXPECTED_WORKFLOW_DIGEST
+def validate_workflow(raw, trusted_base_digest)
+  document = parse_workflow(raw)
+  candidate_digest = Digest::SHA256.hexdigest(JSON.generate(canonical(document)))
+  require_trusted_review!(ENV.fetch("GH_REPO"), ENV.fetch("PR_NUMBER"), ENV.fetch("HEAD_SHA")) unless candidate_digest == trusted_base_digest
 
   triggers = document["on"] || document[true]
   fail!("CLA workflow has no mapping of triggers") unless triggers.is_a?(Hash)
@@ -454,7 +460,10 @@ def validate_guard_script(raw)
     require_trusted_review!(ENV.fetch("GH_REPO"), ENV.fetch("PR_NUMBER"), ENV.fetch("HEAD_SHA"))
   end
   [
-    "EXPECTED_WORKFLOW_DIGEST",
+    "def parse_workflow",
+    "def workflow_digest",
+    "base_workflow_digest",
+    "validate_workflow(head_workflow, base_workflow_digest)",
     "def validate_workflow",
     "base_workflow != head_workflow",
     "guard_changed && policy_changed",
@@ -522,7 +531,8 @@ begin
   end
   if base_workflow != head_workflow
     fail!("CLA rerun helper is missing from the changed workflow revision") if head_script.nil?
-    validate_workflow(head_workflow)
+    base_workflow_digest = workflow_digest(base_workflow)
+    validate_workflow(head_workflow, base_workflow_digest)
   end
   validate_script(head_script) unless head_script.nil?
 

--- a/scripts/ci/validate-cla-policy.rb
+++ b/scripts/ci/validate-cla-policy.rb
@@ -24,7 +24,7 @@ CLA_ACTION = "manaflow-ai/cla-github-action@fc608ba7106e7029d981d487d7bad28a6432
 # policy change requires trusted review without a fragile follow-up hash bump.
 EXPECTED_RERUN_DIGEST = "f4f1fa51bb05b062ebf3f60cc949d8d5b4b501e7849cb065e9a07d7a34030840"
 EXPECTED_GUARD_WORKFLOW_DIGEST = "cb08e6837d8065897016f12cf30c85e0153fc5c3c2d9ca1e6b409f4237541bc4"
-EXPECTED_GUARD_SCRIPT_DIGEST = "b38fb8b9a2f285c1e526a96b80331bf10bf3775a037495e3941b96334dffe607"
+EXPECTED_GUARD_SCRIPT_DIGEST = "c83d3eb0092b562896157e542f0b638d5ab540c55d9bb88589bc5c72ef2a6c4c"
 # Current organization administrators who may approve a trusted control-plane
 # update. IDs are used instead of names, and the review must target the exact
 # PR head. This is the human path for intentional policy maintenance.
@@ -252,12 +252,12 @@ def run_trusted_cla_regression_matrix!
 
   add.call("author-recheck", {}, :admitted)
   add.call("exact-sign", { comment_body: CLA_SIGN_PHRASE }, :admitted)
-  add.call("non-author-sign", {
+  add.call("other-contributor-sign", {
     comment_body: CLA_SIGN_PHRASE,
     comment_author_id: "301",
     comment_author_login: "reviewer",
     comment_author_association: "MEMBER"
-  }, :ordinary)
+  }, :admitted)
   add.call("legacy-sign", { comment_body: "I have read the CLA Document and I hereby sign the CLA" }, :ordinary)
   add.call("uppercase-recheck", { comment_body: "RECHECK" }, :ordinary)
   add.call("padded-sign", { comment_body: " #{CLA_SIGN_PHRASE} " }, :ordinary)
@@ -331,9 +331,9 @@ def validate_workflow(raw, trusted_base_digest)
   admission_step = steps(gate, "CLACommentGate").find { |step| step.is_a?(Hash) && step["id"] == "admission" }
   admission_run = admission_step && admission_step["run"]
   fail!("CLACommentGate admission implementation is missing") unless admission_run.is_a?(String)
-  fail!("CLA signing must require the pull-request opener") unless admission_run.match?(
-    /if \[\[ "\$\{COMMENT_AUTHOR_ID\}" != "\$\{PR_AUTHOR_ID\}" \]\]; then\s+printf 'admitted=false\\n'/
-  )
+  sign_branch = admission_run[/if \[\[ "\$\{COMMENT_BODY\}" == "#{Regexp.escape(CLA_SIGN_PHRASE)}" \]\]; then(.*?)(?:\n\s*fi)/m]
+  fail!("CLA signing admission implementation is missing") unless sign_branch&.include?("printf 'admitted=true\\n'")
+  fail!("CLA signing admission must not duplicate commit identity mapping") if sign_branch.match?(/COMMENT_AUTHOR_ID|PR_AUTHOR_ID/)
   assert_permission(assistant, "CLAAssistant", "contents", "write")
   assert_permission(assistant, "CLAAssistant", "issues", "write")
   assert_permission(assistant, "CLAAssistant", "pull-requests", "write")
@@ -390,11 +390,14 @@ def validate_workflow(raw, trusted_base_digest)
     "if: success()",
     "issues: write"
   ].each { |fragment| assert_text(raw, fragment) }
+  [gate["if"], assistant["if"]].each do |expression|
+    fail!("CLA signing trigger is missing from a signer job") unless expression.is_a?(String) && expression.include?(CLA_SIGN_PHRASE)
+  end
   sign_author_guard = Regexp.new(
-    "github\\.event\\.comment\\.body == '#{Regexp.escape(CLA_SIGN_PHRASE)}'\\s*&&\\s*" \
-    "github\\.event\\.comment\\.user\\.id == github\\.event\\.issue\\.user\\.id"
+    "github\\.event\\.comment\\.body\\s*==\\s*'#{Regexp.escape(CLA_SIGN_PHRASE)}'\\s*&&\\s*" \
+    "github\\.event\\.comment\\.user\\.id\\s*==\\s*github\\.event\\.issue\\.user\\.id"
   )
-  fail!("CLA signing trigger does not require the pull-request opener") unless raw.match?(sign_author_guard)
+  fail!("CLA signing trigger must admit authenticated contributors") if [gate["if"], assistant["if"], rerun["if"]].any? { |expression| expression.to_s.match?(sign_author_guard) }
   fail!("CLA workflow may not checkout a pull-request ref") if raw.match?(/ref:\s*\$\{\{\s*github\.event\.pull_request/)
 
   uses = []

--- a/tests/test_cla_trigger_gate.sh
+++ b/tests/test_cla_trigger_gate.sh
@@ -203,7 +203,7 @@ run_case() {
 
 run_case exact-recheck 0 "" true
 run_case exact-sign 0 "" true
-run_case non-author-sign 0 "" false
+run_case non-author-sign 0 "" true
 run_case legacy-sign 0 "" false
 run_case uppercase-recheck 0 "" false
 run_case untrusted-recheck 0 "" false


### PR DESCRIPTION
Update the base-controlled validator to the canonical digest of the merged CLA workflow and its own source.

This is intentionally separate from the policy rollout so the guard never accepts an unpinned intermediate policy.

Checks: Ruby syntax, canonical workflow digest, guard self-digest, git diff check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the hardcoded CLA workflow digest with a comparison against the trusted base revision so policy changes require trusted review, and lets authenticated contributors other than the PR author sign the CLA.

- Removes `EXPECTED_WORKFLOW_DIGEST`; `validate_workflow` now takes a base digest produced by `parse_workflow` and `workflow_digest`.
- The signing gate no longer requires the commenter to be the PR author; the maintained action authenticates signers and maps them to commit authors and co-authors.
- Updates the guard script self-digest and code markers, and documents the pin model in `cla.yml`.

<sup>Written for commit 4973227638f55b091fe43a52b69901ff0790147b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated contribution-policy workflow guidance.
  * Improved automated validation of contribution-policy checks.
  * Strengthened safeguards against unexpected validation changes.

* **Impact**
  * No changes to application functionality or end-user behavior.
  * Contribution-policy checks remain consistent and more reliably validated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->