### PR TITLE
Avoid cloning sidebar layout during TUI render

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -6883,6 +6883,10 @@ pub struct App {
     tab_locations: HashMap<SurfaceId, [usize; 4]>,
     pub render_states: HashMap<SurfaceId, RenderState>,
     pub(crate) chrome_row_scratch: ReusableRowBuffer,
+    /// Reusable storage for the ordered sidebar kind snapshot taken during a
+    /// frame. The draw loop takes this out while dispatching so mutable rail
+    /// renderers do not borrow the layout across calls.
+    pub(crate) sidebar_kind_scratch: Vec<RailKind>,
     /// Terminal grid dimensions from the frame actually drawn for each
     /// surface. Pointer routing uses this snapshot so resize transitions do
     /// not target blank pane margins or wait on the PTY's terminal lock.
@@ -9151,6 +9155,7 @@ fn run_with_machine_updates_inner(
         tab_locations: HashMap::new(),
         render_states: HashMap::new(),
         chrome_row_scratch: ReusableRowBuffer::default(),
+        sidebar_kind_scratch: Vec::new(),
         rendered_terminal_sizes: HashMap::new(),
         rendered_terminal_pointer_semantics: HashMap::new(),
         rendered_pane_content_generations: HashMap::new(),
@@ -44980,6 +44985,7 @@ mod tests {
             tab_locations: HashMap::new(),
             render_states: HashMap::<u64, RenderState>::new(),
             chrome_row_scratch: crate::ui::ReusableRowBuffer::default(),
+            sidebar_kind_scratch: Vec::new(),
             rendered_terminal_sizes: HashMap::new(),
             rendered_terminal_pointer_semantics: HashMap::new(),
             rendered_pane_content_generations: HashMap::new(),

--- a/cmux-tui/crates/cmux-tui/src/ui/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/mod.rs
@@ -128,8 +128,13 @@ pub fn draw(app: &mut App, frame: &mut Frame) {
         // `kind` is `Copy`; avoid cloning the whole ordered placement list on
         // every frame. The draw functions may mutate `app`, so copy only the
         // small discriminant before dispatching.
-        for index in 0..app.sidebar_layout.ordered.len() {
-            let kind = app.sidebar_layout.ordered[index].kind;
+        let ordered_kinds: Vec<_> = app
+            .sidebar_layout
+            .ordered
+            .iter()
+            .map(|placement| placement.kind)
+            .collect();
+        for kind in ordered_kinds {
             match kind {
                 RailKind::Machine => sidebar::draw_machines(app, frame),
                 RailKind::Workspace => sidebar_input_cursor = sidebar::draw(app, frame),

--- a/cmux-tui/crates/cmux-tui/src/ui/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/mod.rs
@@ -125,12 +125,17 @@ pub fn draw(app: &mut App, frame: &mut Frame) {
             sidebar::draw_tabs(app, frame);
         }
     } else {
-        // `kind` is `Copy`; avoid cloning the whole ordered placement list on
-        // every frame. The draw functions may mutate `app`, so copy only the
-        // small discriminant before dispatching.
-        let ordered_kinds: Vec<_> =
-            app.sidebar_layout.ordered.iter().map(|placement| placement.kind).collect();
-        for kind in ordered_kinds {
+        // `kind` is `Copy`; snapshot only the discriminants before dispatching
+        // so mutable rail renderers do not borrow the layout across calls.
+        // Reuse the App-owned capacity to keep this snapshot allocation-free
+        // on steady-state frames.
+        let mut ordered_kinds = std::mem::take(&mut app.sidebar_kind_scratch);
+        ordered_kinds.clear();
+        ordered_kinds.reserve(app.sidebar_layout.ordered.len());
+        for placement in &app.sidebar_layout.ordered {
+            ordered_kinds.push(placement.kind);
+        }
+        for kind in ordered_kinds.iter().copied() {
             match kind {
                 RailKind::Machine => sidebar::draw_machines(app, frame),
                 RailKind::Workspace => sidebar_input_cursor = sidebar::draw(app, frame),
@@ -138,6 +143,7 @@ pub fn draw(app: &mut App, frame: &mut Frame) {
                 RailKind::Projection(index) => sidebar::draw_projection(app, frame, index),
             }
         }
+        app.sidebar_kind_scratch = ordered_kinds;
     }
 
     let pane_cursors = if draw_machine_transition(app, frame) {

--- a/cmux-tui/crates/cmux-tui/src/ui/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/mod.rs
@@ -125,8 +125,11 @@ pub fn draw(app: &mut App, frame: &mut Frame) {
             sidebar::draw_tabs(app, frame);
         }
     } else {
-        for placement in app.sidebar_layout.ordered.clone() {
-            match placement.kind {
+        // `kind` is `Copy`; avoid cloning the whole ordered placement list on
+        // every frame. The draw functions may mutate `app`, so copy only the
+        // small discriminant before dispatching.
+        for kind in app.sidebar_layout.ordered.iter().map(|placement| placement.kind) {
+            match kind {
                 RailKind::Machine => sidebar::draw_machines(app, frame),
                 RailKind::Workspace => sidebar_input_cursor = sidebar::draw(app, frame),
                 RailKind::Tabs => sidebar::draw_tabs(app, frame),

--- a/cmux-tui/crates/cmux-tui/src/ui/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/mod.rs
@@ -128,12 +128,8 @@ pub fn draw(app: &mut App, frame: &mut Frame) {
         // `kind` is `Copy`; avoid cloning the whole ordered placement list on
         // every frame. The draw functions may mutate `app`, so copy only the
         // small discriminant before dispatching.
-        let ordered_kinds: Vec<_> = app
-            .sidebar_layout
-            .ordered
-            .iter()
-            .map(|placement| placement.kind)
-            .collect();
+        let ordered_kinds: Vec<_> =
+            app.sidebar_layout.ordered.iter().map(|placement| placement.kind).collect();
         for kind in ordered_kinds {
             match kind {
                 RailKind::Machine => sidebar::draw_machines(app, frame),

--- a/cmux-tui/crates/cmux-tui/src/ui/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/mod.rs
@@ -128,7 +128,8 @@ pub fn draw(app: &mut App, frame: &mut Frame) {
         // `kind` is `Copy`; avoid cloning the whole ordered placement list on
         // every frame. The draw functions may mutate `app`, so copy only the
         // small discriminant before dispatching.
-        for kind in app.sidebar_layout.ordered.iter().map(|placement| placement.kind) {
+        for index in 0..app.sidebar_layout.ordered.len() {
+            let kind = app.sidebar_layout.ordered[index].kind;
             match kind {
                 RailKind::Machine => sidebar::draw_machines(app, frame),
                 RailKind::Workspace => sidebar_input_cursor = sidebar::draw(app, frame),


### PR DESCRIPTION
The sidebar render loop now snapshots only the `Copy` `kind` discriminants into an App-owned scratch `Vec` before dispatching. It clears and refills retained capacity, then iterates the owned snapshot while rail renderers mutably borrow `App`; the first non-empty frame or a larger rail set can allocate, while steady-state frames do not allocate for this snapshot. This preserves configured rail order and Ratatui’s later-render-wins behavior.

Validation: `rustfmt --edition 2024 --check` and `git diff --check`. Local Rust/Cargo commands were not run per cmux-tui policy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11440"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790855271&installation_model_id=21920&pr_number=11440&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11440&signature=cf5281bb808fd70b877a3a24b390b985f3dcbef37c9a64747f9ae216fb0a7484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops cloning the full sidebar placement list on every render frame. Instead, the render loop snapshots each placement's `Copy` `kind` into an App-owned scratch Vec before dispatching, so rail renderers can mutate `app` without holding a borrow across calls. The scratch Vec is reused across frames, keeping steady-state rendering allocation-free. Sidebar behavior and appearance are unchanged.

<sup>Written for commit c0fe21fcf75693f054b0e92bf619124fba24d4b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved sidebar rendering efficiency, reducing unnecessary work during each frame.
  * Preserved existing sidebar behavior and appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
