### PR TITLE
fix(tui): reject sparse journal replay sequences

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
@@ -298,8 +298,8 @@ impl RestoreReducer {
 
     pub(crate) fn finish(mut self, head_sequence: u64) -> anyhow::Result<Value> {
         anyhow::ensure!(
-            head_sequence >= self.last_sequence,
-            "restore preview head precedes the last reduced record"
+            head_sequence == self.last_sequence,
+            "restore preview did not reduce the exact journal tail"
         );
         let snapshot = self
             .state
@@ -829,7 +829,10 @@ mod tests {
             checkpoint_id: "checkpoint_test".into(),
             source_sequence: 3,
             reducer_version: JOURNAL_REDUCER_VERSION,
-            state: json!({"session_snapshot":{"cursor":{}},"journal_extensions":{"producers":[],"hooks":[]}}),
+            state: json!({
+                "session_snapshot":{"cursor":{}},
+                "journal_extensions":{"producers":[],"hooks":[]}
+            }),
             content_refs: vec![],
             sha256: "00".repeat(32),
             created_at_ms: 1,
@@ -859,6 +862,41 @@ mod tests {
         let mut gapped = record;
         gapped.sequence = 5;
         assert!(restore_preview(&checkpoint, &[gapped], 5).is_err());
+    }
+
+    #[test]
+    fn reducer_rejects_a_partial_tail() {
+        let checkpoint = JournalCheckpoint {
+            checkpoint_id: "checkpoint_test".into(),
+            source_sequence: 3,
+            reducer_version: JOURNAL_REDUCER_VERSION,
+            state: json!({"session_snapshot":{"cursor":{}},"journal_extensions":{"producers":[],"hooks":[]}}),
+            content_refs: vec![],
+            sha256: "00".repeat(32),
+            created_at_ms: 1,
+        };
+        let record = SessionJournalRecord {
+            sequence: 4,
+            event_id: "event_4".into(),
+            schema_version: 1,
+            kind: "unknown".into(),
+            class: JournalClass::State,
+            replay: JournalReplayPolicy::Ignored,
+            occurred_at_ms: 1,
+            committed_at_ms: 1,
+            producer: JournalProducer { kind: "test".into(), id: "test".into() },
+            authority: None,
+            causation_id: None,
+            correlation_id: None,
+            causation_depth: 0,
+            subjects: vec![],
+            sensitivity: JournalSensitivity::Sensitive,
+            payload: json!({}),
+            resource_revision: None,
+            previous_resource_revision: None,
+            terminal_output: None,
+        };
+        assert!(restore_preview(&checkpoint, &[record], 5).is_err());
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
@@ -273,7 +273,7 @@ impl RestoreReducer {
 
     pub(crate) fn apply(&mut self, record: &SessionJournalRecord) -> anyhow::Result<()> {
         anyhow::ensure!(
-            record.sequence == self.last_sequence.saturating_add(1),
+            self.last_sequence.checked_add(1) == Some(record.sequence),
             "journal records are not contiguous after checkpoint"
         );
         self.last_sequence = record.sequence;

--- a/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
@@ -4,7 +4,7 @@ use std::io::Write;
 use anyhow::Context;
 use base64::Engine;
 use flate2::{Compression, GzBuilder};
-use serde_json::{Map, Value, json};
+use serde_json::{json, Map, Value};
 use sha2::{Digest, Sha256};
 
 use crate::resource::TerminalPublicId;
@@ -273,8 +273,8 @@ impl RestoreReducer {
 
     pub(crate) fn apply(&mut self, record: &SessionJournalRecord) -> anyhow::Result<()> {
         anyhow::ensure!(
-            record.sequence > self.last_sequence,
-            "journal records are not strictly ordered after checkpoint"
+            record.sequence == self.last_sequence.saturating_add(1),
+            "journal records are not contiguous after checkpoint"
         );
         self.last_sequence = record.sequence;
         if record.replay != JournalReplayPolicy::Required {
@@ -821,6 +821,44 @@ mod tests {
         assert_eq!(preview["fully_reducible"], true);
         assert_eq!(preview["state"]["session_snapshot"]["workspaces"][0]["id"], "workspace_new");
         assert_eq!(preview["state"]["session_snapshot"]["cursor"]["revision"], "2");
+    }
+
+    #[test]
+    fn reducer_rejects_duplicate_and_gapped_sequences() {
+        let checkpoint = JournalCheckpoint {
+            checkpoint_id: "checkpoint_test".into(),
+            source_sequence: 3,
+            reducer_version: JOURNAL_REDUCER_VERSION,
+            state: json!({"session_snapshot":{"cursor":{}},"journal_extensions":{"producers":[],"hooks":[]}}),
+            content_refs: vec![],
+            sha256: "00".repeat(32),
+            created_at_ms: 1,
+        };
+        let record = SessionJournalRecord {
+            sequence: 4,
+            event_id: "event_4".into(),
+            schema_version: 1,
+            kind: "unknown".into(),
+            class: JournalClass::State,
+            replay: JournalReplayPolicy::Ignored,
+            occurred_at_ms: 1,
+            committed_at_ms: 1,
+            producer: JournalProducer { kind: "test".into(), id: "test".into() },
+            authority: None,
+            causation_id: None,
+            correlation_id: None,
+            causation_depth: 0,
+            subjects: vec![],
+            sensitivity: JournalSensitivity::Sensitive,
+            payload: json!({}),
+            resource_revision: None,
+            previous_resource_revision: None,
+            terminal_output: None,
+        };
+        assert!(restore_preview(&checkpoint, &[record.clone(), record.clone()], 4).is_err());
+        let mut gapped = record;
+        gapped.sequence = 5;
+        assert!(restore_preview(&checkpoint, &[gapped], 5).is_err());
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
@@ -4,7 +4,7 @@ use std::io::Write;
 use anyhow::Context;
 use base64::Engine;
 use flate2::{Compression, GzBuilder};
-use serde_json::{json, Map, Value};
+use serde_json::{Map, Value, json};
 use sha2::{Digest, Sha256};
 
 use crate::resource::TerminalPublicId;


### PR DESCRIPTION
Restore replay must consume a contiguous journal tail. Reject duplicate and gapped records at the reducer boundary so skipped events cannot produce false projections. Adds behavior coverage for duplicate and gap inputs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790855713&installation_model_id=21920&pr_number=11441&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11441&signature=3e6f7b3ef7c9690b5d958ab4bc7a8ae68a2e00433a4251087595e0700a0684bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes journal replay to require contiguous sequence numbers and an exact journal tail, rejecting duplicate, gapped, and partial-tail records so skipped events can't produce false projections.

- Replaces the "strictly ordered" check with a "contiguous" check at the reducer boundary.
- Requires the reduced tail to match the head sequence exactly.
- Adds tests covering duplicate, gap, and partial-tail inputs.

<sup>Written for commit 40c4635691ccf0004fa7561d8d4868b955b99e0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restore operations now reject journal records with duplicate or skipped sequence numbers.
  * Records must be applied in strict, contiguous order.
  * Restore operations now reject incomplete journal tails when the supplied head sequence does not match the restored records.

* **Tests**
  * Added coverage for duplicate, gapped, and incomplete journal sequences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->