### PR TITLE
fix: clear Swift warning budget regressions

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -27106,7 +27106,7 @@ struct CMUXCLI {
                     throw CLIError(message: "set-hook --unset requires an event name")
                 }
                 try withLockedTmuxCompatStore { store in
-                    store.hooks.removeValue(forKey: event)
+                    _ = store.hooks.removeValue(forKey: event)
                 }
                 print("OK")
                 return

--- a/Sources/FileExplorerView.swift
+++ b/Sources/FileExplorerView.swift
@@ -1953,25 +1953,23 @@ extension FileExplorerContainerView: NSSearchFieldDelegate, NSTableViewDataSourc
         operation: NSDragOperation
     ) {
         guard tableView === searchResultsView else { return }
-        defer {
-            if searchResultsView.activeNativeDragSession === session {
-                if !searchResultsView.activeNativeDragOwnerships.isEmpty {
-                    for ownership in searchResultsView.activeNativeDragOwnerships {
-                        ownership.finish(from: session.draggingPasteboard)
-                    }
-                } else {
-                    // This is the matching generation, so the fallback cannot
-                    // accidentally parse a newer session's shared pasteboard.
-                    FilePreviewDragPasteboardWriter.discardRegisteredDrag(from: session)
+        if searchResultsView.activeNativeDragSession === session {
+            if !searchResultsView.activeNativeDragOwnerships.isEmpty {
+                for ownership in searchResultsView.activeNativeDragOwnerships {
+                    ownership.finish(from: session.draggingPasteboard)
                 }
-                searchResultsView.activeNativeDragDelegateMarker = nil
-                searchResultsView.activeNativeDragWriter?.releaseSourceGraph()
-                searchResultsView.activeNativeDragWriter = nil
-                searchResultsView.activeNativeDragOwnerships = []
-                searchResultsView.activeNativeDragOwnership = nil
-                searchResultsView.activeNativeDragSession = nil
-                coordinator.forgetTrackedNativeDrag(matching: session)
+            } else {
+                // This is the matching generation, so the fallback cannot
+                // accidentally parse a newer session's shared pasteboard.
+                FilePreviewDragPasteboardWriter.discardRegisteredDrag(from: session)
             }
+            searchResultsView.activeNativeDragDelegateMarker = nil
+            searchResultsView.activeNativeDragWriter?.releaseSourceGraph()
+            searchResultsView.activeNativeDragWriter = nil
+            searchResultsView.activeNativeDragOwnerships = []
+            searchResultsView.activeNativeDragOwnership = nil
+            searchResultsView.activeNativeDragSession = nil
+            coordinator.forgetTrackedNativeDrag(matching: session)
         }
     }
 

--- a/Sources/ProvisionalDragWriterOwnershipToken.swift
+++ b/Sources/ProvisionalDragWriterOwnershipToken.swift
@@ -4,9 +4,9 @@ import Foundation
 @MainActor
 final class ProvisionalDragWriterOwnershipToken {
     let id: UUID
-    // The callback is immutable and only ever invoked from a main-actor Task;
-    // ARC may read this one property from an arbitrary executor during deinit.
-    private let onDeallocated: @MainActor (UUID) -> Void
+    // A global-actor-isolated function value is safe to copy from the
+    // nonisolated deinit path. Invocation still hops to the main actor below.
+    nonisolated private let onDeallocated: @MainActor (UUID) -> Void
 
     init(onDeallocated: @escaping @MainActor (UUID) -> Void) {
         id = UUID()


### PR DESCRIPTION
## Summary

Fix three Swift warnings that made the main CI warning-budget gate fail after recent merges:

- discard the intentional `removeValue` result in the tmux-compatible `set-hook --unset` path;
- run file-preview drag terminal cleanup directly instead of an immediately executing `defer`;
- mark the immutable main-actor callback as nonisolated so the deallocation handoff can copy it safely before scheduling its main-actor call.

The changes preserve behavior and remove the warnings at their source. The warning budget is unchanged.

## Verification

- Tagged cloud build: `swarn` succeeded on the fleet in 414 seconds.
- Swift 6.3 typecheck of the actor-isolated callback shape passed.
- `git diff --check` passed.
- Main CI failure that motivated this PR: https://github.com/manaflow-ai/cmux/actions/runs/33501789633, `tests-build-and-lag`, Swift warning budget.
- Focused remote XCTest was attempted twice but did not reach Xcode tests because of host setup faults: missing Zig, then stale cache/result-bundle permissions. The attempts are recorded under `artifacts/reload-cloud/swarn-a3bf7ad47d22/`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11442"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790856235&installation_model_id=21920&pr_number=11442&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11442&signature=3174a7d1a59a184a07c997ee15ae22098ca683b9cea0cc2f3a011e0025b150f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three Swift warnings that were failing the CI warning-budget gate after recent merges. No behavior changes; the warning budget is restored.

- Discards the unused `removeValue` result in the `set-hook --unset` path.
- Runs file-preview drag cleanup directly instead of via an immediately executing `defer`.
- Marks the immutable main-actor callback as `nonisolated` so it can be safely copied during deallocation.

<sup>Written for commit 1d218002a120e616a9bafa9e4bfb1ee72e17149f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup after completing native drag-and-drop actions from search results.
  * Resolved cases where temporary drag data or session state could remain active after a drag ended.
  * Improved reliability when cancelling or completing drag operations.
  * Updated hook removal behavior for more consistent command-line operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->