### PR TITLE
cmux-tui: reap child when reaper thread spawn fails

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -2583,6 +2583,7 @@ impl Surface {
                 let _ = child.kill();
                 let _ = child.wait();
             }
+            close_local_terminal_master_after_exit(&surface);
             return Err(error.into());
         }
 

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -2563,9 +2563,13 @@ impl Surface {
 
         // Child reaper: retain the native status and rendezvous with PTY EOF
         // so final output is visible before the mux observes completion.
-        std::thread::Builder::new().name(format!("surface-{id}-wait")).spawn({
+        let child_slot = Arc::new(Mutex::new(Some(child)));
+        let child_for_reaper = child_slot.clone();
+        let reaper = std::thread::Builder::new().name(format!("surface-{id}-wait")).spawn({
             let surface = surface.clone();
             move || {
+                let mut child =
+                    child_for_reaper.lock().unwrap().take().expect("child reaper owns child");
                 let exit = wait_for_native_child_status(child.as_mut());
                 if let Some(pty) = surface.as_pty() {
                     *pty.exit.lock().unwrap() = Some(exit);
@@ -2573,7 +2577,14 @@ impl Surface {
                 close_local_terminal_master_after_exit(&surface);
                 publish_local_exit_if_ready(&surface);
             }
-        })?;
+        });
+        if let Err(error) = reaper {
+            if let Some(mut child) = child_slot.lock().unwrap().take() {
+                let _ = child.kill();
+                let _ = child.wait();
+            }
+            return Err(error.into());
+        }
 
         Ok(surface)
     }


### PR DESCRIPTION
If the PTY child reaper thread cannot be created, the child handle was previously dropped without kill or wait. Keep the child in recoverable shared ownership and synchronously kill and wait on thread creation failure.

No local Cargo/Rust build per task. Ran rustfmt (edition 2024) and git diff --check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a leak where a failed reaper thread spawn dropped the PTY child without kill or wait, leaving the process running and the PTY master open.

**Bug Fixes**
- Keeps the child in shared ownership so a failed spawn can kill and wait on it, then closes the PTY master and returns the spawn error.

<sup>Written for commit 4b9c086e4c9e869b46eb9cf9454a85149110ca25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cleanup when launching a local terminal process fails.
  - Ensures partially started processes are properly stopped and collected, preventing lingering background processes.
  - Failed launches now close associated terminal resources and report the original startup error cleanly.
  - Improves reliability by preventing incomplete process launches from remaining active after an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->