### PR TITLE
ci: derive CLA policy trust from base revision

### DIFF
--- a/.github/workflows/cla-policy-guard.yml
+++ b/.github/workflows/cla-policy-guard.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Checkout immutable guard revision
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          repository: ${{ github.repository }}
           ref: ${{ github.workflow_sha }}
           fetch-depth: 1
           persist-credentials: false

--- a/.github/workflows/cla-policy-guard.yml
+++ b/.github/workflows/cla-policy-guard.yml
@@ -12,7 +12,11 @@ permissions: {}
 jobs:
   validate:
     name: CLA policy guard
-    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    # This control-plane workflow parses attacker-controlled YAML and shell
+    # bytes. Use a GitHub-hosted ephemeral runner; a repository variable must
+    # not be able to redirect it to a persistent or contributor-controlled
+    # machine.
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: read

--- a/scripts/ci/validate-cla-policy.rb
+++ b/scripts/ci/validate-cla-policy.rb
@@ -27,7 +27,7 @@ EXPECTED_GUARD_WORKFLOW_DIGEST = "0f347a749f53d2e06f5b39b7a832476d39ab40a71c8634
 # EXPECTED_WORKFLOW_DIGEST is retained as a compatibility marker for the
 # immutable validator in the current base revision. Policy validation now
 # hashes the candidate workflow bytes after lexical YAML validation.
-EXPECTED_GUARD_SCRIPT_DIGEST = "b128b29f5d4868065142d6f111db7c88cba8d20173a55a12373f90c2e6f81027"
+EXPECTED_GUARD_SCRIPT_DIGEST = "374fa032f0635ee32804f7f1d5936e996565bcef4c8af15731ebc780a877c4b8"
 # Current organization administrators who may approve a trusted control-plane
 # update. IDs are used instead of names, and the review must target the exact
 # PR head. This is the human path for intentional policy maintenance.
@@ -498,6 +498,9 @@ def validate_workflow(raw, trusted_base_digest)
   fail!("CLA ledger writer must run only after successful admission") unless
     writer["if"].to_s.include?("needs.CLACommentGate.result == 'success'") &&
     writer["if"].to_s.include?("needs.CLACommentGate.outputs.admitted == 'true'")
+  fail!("CLA ledger writer must require signer authorization and a live head for sign comments") unless
+    writer["if"].to_s.include?("needs.CLACommentGate.outputs.signer_authorized == 'true'") &&
+    writer["if"].to_s.include?("needs.CLACommentGate.outputs.head_sha != ''")
   fail!("CLA Assistant result must depend on the ledger writer") unless dependencies(assistant, "CLAAssistant").include?("CLALedgerWriter")
   fail!("CLA Assistant result must always report the writer outcome") unless assistant["if"].to_s.include?("always()")
   fail!("CLA compatibility must depend on the v2 result") unless dependencies(compatibility, "CLACompatibility").include?("CLAAssistant")

--- a/scripts/ci/validate-cla-policy.rb
+++ b/scripts/ci/validate-cla-policy.rb
@@ -27,7 +27,7 @@ EXPECTED_GUARD_WORKFLOW_DIGEST = "0f347a749f53d2e06f5b39b7a832476d39ab40a71c8634
 # EXPECTED_WORKFLOW_DIGEST is retained as a compatibility marker for the
 # immutable validator in the current base revision. Policy validation now
 # hashes the candidate workflow bytes after lexical YAML validation.
-EXPECTED_GUARD_SCRIPT_DIGEST = "ffb481c630a5f2e1e601b61c855ffbb49a9f6a1d5d9397d1e0276ab0dd4dcc1c"
+EXPECTED_GUARD_SCRIPT_DIGEST = "b128b29f5d4868065142d6f111db7c88cba8d20173a55a12373f90c2e6f81027"
 # Current organization administrators who may approve a trusted control-plane
 # update. IDs are used instead of names, and the review must target the exact
 # PR head. This is the human path for intentional policy maintenance.
@@ -656,6 +656,9 @@ def validate_workflow(raw, trusted_base_digest)
     "admitted: ${{ steps.admission.outputs.admitted }}",
     "issues: write"
   ].each { |fragment| assert_text(raw, fragment) }
+  # YAML block scalars normalize the expression at runtime, but the raw
+  # source can contain `if: >-` or `if: |`; accept only those scalar markers
+  # while still requiring the literal success() guard.
   fail!("CLA workflow is missing a successful-step guard") unless raw.match?(/if:\s*(?:[>|]-?\s*)?(?:\$\{\{\s*)?success\(\)/)
   [gate["if"], assistant["if"]].each do |expression|
     fail!("CLA signing trigger is missing from a signer job") unless expression.is_a?(String) && expression.include?(CLA_SIGN_PHRASE)

--- a/scripts/ci/validate-cla-policy.rb
+++ b/scripts/ci/validate-cla-policy.rb
@@ -29,7 +29,7 @@ EXPECTED_GUARD_WORKFLOW_DIGEST = "01b3eed13d54db27ed195781dc0f6926a04cb9557de81f
 # The guard workflow remains pinned to its reviewed immutable bytes. The CLA
 # policy itself is validated structurally, then authorized by an exact-head
 # trusted review.
-EXPECTED_GUARD_SCRIPT_DIGEST = "518d54e5d7bec1978dbfaf6a164e51853f93898761f868b70709801f90e847be"
+EXPECTED_GUARD_SCRIPT_DIGEST = "579790b38d6e34a08354cee77be1504749fbd9185e871ca4754081bad8347a82"
 # Migration marker for the base v2 guard validator. That validator requires
 # the literal EXPECTED_WORKFLOW_DIGEST while it checks this candidate. The v3
 # validator does not use this inert marker for policy authorization.
@@ -99,7 +99,10 @@ RERUN_ENV = {
   "TARGET_BASE_REF" => "main",
   "SIGNATURE_RECORDED" => "${{ needs.CLALedgerWriter.outputs.signature_recorded || '' }}"
 }.freeze
-GITHUB_CONTEXT_IN_RUN = /\$\{\{[^}]*\bgithub\b[^}]*\}\}/im
+# Run blocks are shell text, not an expression surface. Reject every GitHub
+# expression here, including bracket notation and nested format/toJSON calls
+# that a token-specific regular expression cannot parse safely.
+GITHUB_CONTEXT_IN_RUN = /\$\{\{/m
 TOKEN_ENV_IN_RUN = /(?:\A|[^A-Za-z0-9_])(?:GITHUB_TOKEN|GH_TOKEN|ACTIONS_RUNTIME_TOKEN|ACTIONS_ID_TOKEN_REQUEST_TOKEN|RUNNER_TOKEN)(?:\z|[^A-Za-z0-9_])/i
 
 # The guard workflow is itself a privileged control-plane input. Keep its
@@ -741,7 +744,7 @@ end
 
 def assert_safe_run_text(run, name)
   fail!("#{name} must be a shell string") unless run.is_a?(String)
-  fail!("#{name} may not interpolate the GitHub context") if run.match?(GITHUB_CONTEXT_IN_RUN)
+  fail!("#{name} may not interpolate GitHub expressions") if run.match?(GITHUB_CONTEXT_IN_RUN)
   fail!("#{name} may not access a token environment variable") if run.match?(TOKEN_ENV_IN_RUN)
 end
 
@@ -1065,6 +1068,9 @@ def run_environment_regression_matrix!
   end
   expect_failure.call("serialized GitHub context") do
     assert_safe_run_text("echo '${{ toJSON(github) }}'", "regression run")
+  end
+  expect_failure.call("nested expression") do
+    assert_safe_run_text("echo '${{ format('{0}', 'value') }}'", "regression run")
   end
   expect_failure.call("token environment variable") do
     assert_safe_run_text("echo \"$ACTIONS_RUNTIME_TOKEN\"", "regression run")

--- a/scripts/ci/validate-cla-policy.rb
+++ b/scripts/ci/validate-cla-policy.rb
@@ -18,16 +18,16 @@ class PolicyError < StandardError; end
 SHA = /\A[0-9a-f]{40}\z/
 REPOSITORY = /\A[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\z/
 MAX_FILE_BYTES = 300_000
-CLA_ACTION = "manaflow-ai/cla-github-action@af7ae9ac7de23b982ea494d8200fc9b40bbc6690"
+CLA_ACTION = "manaflow-ai/cla-github-action@0502e16018c7c71dc7647e0d41d056a11903941a"
 # The privileged workflow is an explicit reviewed policy, not an extensible
 # script. Its exact bytes are compared with the trusted base revision, so a
 # policy change requires trusted review without a fragile follow-up hash bump.
 EXPECTED_RERUN_DIGEST = "f4f1fa51bb05b062ebf3f60cc949d8d5b4b501e7849cb065e9a07d7a34030840"
-EXPECTED_GUARD_WORKFLOW_DIGEST = "63a96bd533e09afaa8aecfe871362b07e28697cf2a1ed85459b5991001d885f8"
+EXPECTED_GUARD_WORKFLOW_DIGEST = "0f347a749f53d2e06f5b39b7a832476d39ab40a71c8634b48c029bc728f5c1d1"
 # EXPECTED_WORKFLOW_DIGEST is retained as a compatibility marker for the
 # immutable validator in the current base revision. Policy validation now
 # hashes the candidate workflow bytes after lexical YAML validation.
-EXPECTED_GUARD_SCRIPT_DIGEST = "70b149bbd9ffee6015cb2b09f840ce811010da4af444cf429685d6516770e22a"
+EXPECTED_GUARD_SCRIPT_DIGEST = "936d334455c3e3e91b9ea9936e1e7b436796a8c2d0b6f0ac1675f698b2c19751"
 # Current organization administrators who may approve a trusted control-plane
 # update. IDs are used instead of names, and the review must target the exact
 # PR head. This is the human path for intentional policy maintenance.
@@ -38,9 +38,28 @@ TRUSTED_REVIEWER_IDS = %w[54008264 38676809].freeze
 # run by this privileged workflow because it comes from an untrusted revision.
 CLA_SIGN_PHRASE = "I have read the CLA Document v2.2 and I hereby sign the CLA"
 CLA_RECHECK_PHRASE = "recheck"
+CLA_DOCUMENT_INPUT = "https://github.com/${{ github.repository }}/blob/${{ github.workflow_sha }}/CLA.md"
 CLA_LIFECYCLE_ACTIONS = %w[opened edited reopened synchronize].freeze
 CLA_TRUSTED_ASSOCIATIONS = %w[OWNER MEMBER COLLABORATOR].freeze
 POSITIVE_ID = /\A[1-9][0-9]*\z/
+
+# The guard validates a deliberately closed workflow vocabulary. A policy
+# change may alter messages and implementation details inside the listed
+# steps, but it may not add a job, permission, action, runner feature, or
+# workflow-level control that this validator does not understand.
+WORKFLOW_KEYS = %w[name on permissions env jobs].freeze
+WORKFLOW_JOB_NAMES = %w[
+  CLACommentGate
+  CLAAssistant
+  CLALedgerWriter
+  CLACompatibility
+  RerunFailedCLA
+  LockMergedPullRequest
+].freeze
+ALLOWED_ACTIONS = [
+  CLA_ACTION,
+  "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"
+].freeze
 
 def fail!(message)
   raise PolicyError, message
@@ -53,12 +72,32 @@ def required_env(name, pattern = nil)
   value
 end
 
+def api_failure_status(stdout, stderr)
+  [stderr, stdout].each do |text|
+    if (match = text.to_s.match(/\bHTTP(?:\/\d(?:\.\d+)?)?\s+([1-5]\d{2})\b/i))
+      return match[1].to_i
+    end
+  end
+  begin
+    payload = JSON.parse(stdout)
+    value = payload.is_a?(Hash) ? payload["status"] : nil
+    return value.to_i if value.to_s.match?(/\A[1-5]\d{2}\z/)
+  rescue JSON::ParserError
+    # The caller reports the original API failure below.
+  end
+  nil
+end
+
 def api_json(repository, endpoint, allow_missing: false)
   stdout, stderr, status = Open3.capture3(
     "gh", "api", "--header", "Accept: application/vnd.github+json", endpoint
   )
-  return nil if allow_missing && !status.success? && stderr.match?(/404|Not Found/i)
-  fail!("GitHub API request failed for #{endpoint}: #{stderr.strip}") unless status.success?
+  unless status.success?
+    response_status = api_failure_status(stdout, stderr)
+    return nil if allow_missing && response_status == 404
+
+    fail!("GitHub API request failed for #{endpoint}: #{stderr.strip}")
+  end
   JSON.parse(stdout)
 rescue JSON::ParserError
   fail!("GitHub API returned malformed JSON for #{endpoint}")
@@ -200,6 +239,65 @@ def assert_permission(job_value, name, permission, expected)
   fail!("#{name}.permissions.#{permission} must be #{expected}") unless permissions[permission] == expected
 end
 
+def assert_exact_keys(value, expected, name)
+  fail!("#{name} is not a mapping") unless value.is_a?(Hash)
+  actual = value.keys.map(&:to_s)
+  expected = expected.map(&:to_s)
+  unknown = actual - expected
+  missing = expected - actual
+  fail!("#{name} has unsupported keys: #{unknown.join(', ')}") unless unknown.empty?
+  fail!("#{name} is missing keys: #{missing.join(', ')}") unless missing.empty?
+end
+
+def assert_no_keys(value, forbidden, name)
+  return unless value.is_a?(Hash)
+
+  found = value.keys.map(&:to_s) & forbidden
+  fail!("#{name} contains forbidden keys: #{found.join(', ')}") unless found.empty?
+end
+
+def assert_positive_integer(value, name)
+  fail!("#{name} must be a positive integer") unless value.is_a?(Integer) && value.positive?
+end
+
+def assert_string(value, name)
+  fail!("#{name} must be a string") unless value.is_a?(String)
+  value
+end
+
+def assert_action_reference(reference, name)
+  fail!("#{name} must be a pinned action reference") unless reference.is_a?(String)
+  fail!("#{name} uses an unapproved action") unless ALLOWED_ACTIONS.include?(reference)
+end
+
+def assert_action_inputs(step, expected, name)
+  inputs = step["with"]
+  assert_exact_keys(inputs, expected.keys, "#{name}.with")
+  expected.each do |key, value|
+    fail!("#{name}.with.#{key} is unsafe") unless inputs[key].to_s == value.to_s
+  end
+end
+
+def assert_safe_job_common(job_value, name)
+  # These keys are the complete job-level surface used by the reviewed policy.
+  # In particular, environment, containers, services, defaults, and
+  # continue-on-error are intentionally absent. They can change where a
+  # token-bearing step runs or whether a failed guard is ignored.
+  assert_no_keys(
+    job_value,
+    %w[environment container services defaults strategy continue-on-error concurrency-group],
+    name
+  )
+  assert_string(job_value["runs-on"], "#{name}.runs-on")
+  assert_positive_integer(job_value["timeout-minutes"], "#{name}.timeout-minutes")
+  fail!("#{name}.runs-on may not be PR-controlled") if job_value["runs-on"].include?("github.event")
+end
+
+def assert_step_keys(step, name, allowed)
+  assert_exact_keys(step, allowed, name)
+  fail!("#{name} must be a mapping") unless step.is_a?(Hash)
+end
+
 # Return the observable result of the exact admission contract. `:ordinary`
 # means a valid human discussion comment that must not reach the signer. The
 # `:malformed` result represents a fail-closed event or metadata shape error.
@@ -330,6 +428,16 @@ def validate_workflow(raw, trusted_base_digest)
   candidate_digest = workflow_digest(raw)
   require_trusted_review!(ENV.fetch("GH_REPO"), ENV.fetch("PR_NUMBER"), ENV.fetch("HEAD_SHA")) unless candidate_digest == trusted_base_digest
 
+  # Keep the policy surface closed. YAML keys that are harmless in an
+  # ordinary workflow, such as `defaults`, `services`, or `concurrency` at the
+  # top level, can silently change the trust boundary here. A maintainer must
+  # update this validator in a separate control-plane PR before introducing a
+  # new surface.
+  top_level_keys = document.keys.map { |key| key == true ? "on" : key.to_s }
+  fail!("CLA workflow has unsupported top-level keys") unless
+    top_level_keys.uniq.sort == WORKFLOW_KEYS.sort
+  fail!("CLA workflow name is not the reviewed context") unless document["name"] == "CLA Assistant v3"
+
   triggers = document["on"] || document[true]
   fail!("CLA workflow has no mapping of triggers") unless triggers.is_a?(Hash)
   fail!("CLA workflow must not use pull_request") if triggers.key?("pull_request")
@@ -341,8 +449,11 @@ def validate_workflow(raw, trusted_base_digest)
   fail!("pull_request_target event set is unsafe") unless target["types"] == expected_types
   fail!("top-level permissions must be empty") unless document["permissions"] == {}
 
-  generation = document.dig("env", "CLA_GENERATION")
-  fail!("CLA_GENERATION is missing or malformed") unless generation.is_a?(String) && generation.match?(/\Av[0-9]+\.[0-9]+-action-[0-9a-f]{40}\z/)
+  env = document["env"]
+  assert_exact_keys(env, ["CLA_GENERATION"], "CLA workflow env")
+  generation = env["CLA_GENERATION"]
+  fail!("CLA_GENERATION is missing or malformed") unless
+    generation.is_a?(String) && generation.match?(/\Av[0-9]+\.[0-9]+-action-[0-9a-f]{40}\z/)
 
   gate = job(document, "CLACommentGate")
   assistant = job(document, "CLAAssistant")
@@ -350,15 +461,34 @@ def validate_workflow(raw, trusted_base_digest)
   compatibility = job(document, "CLACompatibility")
   rerun = job(document, "RerunFailedCLA")
   lock = job(document, "LockMergedPullRequest")
+  jobs = document["jobs"]
+  fail!("CLA workflow has unsupported jobs") unless jobs.keys.map(&:to_s).sort == WORKFLOW_JOB_NAMES.sort
+  job_keys = {
+    "CLACommentGate" => %w[name if runs-on timeout-minutes concurrency permissions outputs steps],
+    "CLAAssistant" => %w[name needs if runs-on timeout-minutes permissions steps],
+    "CLALedgerWriter" => %w[name needs if runs-on timeout-minutes concurrency permissions steps],
+    "CLACompatibility" => %w[name needs if runs-on timeout-minutes permissions steps],
+    "RerunFailedCLA" => %w[name needs if runs-on timeout-minutes permissions steps],
+    "LockMergedPullRequest" => %w[name if runs-on timeout-minutes concurrency permissions steps]
+  }
   [gate, assistant, writer, compatibility, rerun, lock].each_with_index do |value, index|
     names = %w[CLACommentGate CLAAssistant CLALedgerWriter CLACompatibility RerunFailedCLA LockMergedPullRequest]
     fail!("#{names[index]} has no runner") unless value.key?("runs-on")
+    assert_exact_keys(value, job_keys.fetch(names[index]), names[index])
+    assert_safe_job_common(value, names[index])
+    fail!("#{names[index]} must use the reviewed ephemeral runner") unless value["runs-on"] == "ubuntu-24.04"
   end
 
   fail!("CLACommentGate must use read-only permissions") unless
     gate["permissions"] == { "contents" => "read", "issues" => "read", "pull-requests" => "read" }
   fail!("CLACompatibility must have no permissions") unless compatibility["permissions"] == {}
   fail!("CLA Assistant result must have no permissions") unless assistant["permissions"] == {}
+  fail!("CLACommentGate outputs are not the reviewed contract") unless
+    gate["outputs"] == {
+      "admitted" => "${{ steps.admission.outputs.admitted }}",
+      "signer_authorized" => "${{ steps.signer_preflight.outputs.signer_authorized }}",
+      "head_sha" => "${{ steps.signer_preflight.outputs.head_sha }}"
+    }
   fail!("CLA ledger writer must depend on the admission gate") unless dependencies(writer, "CLALedgerWriter").include?("CLACommentGate")
   fail!("CLA ledger writer must not run with always()") if writer["if"].to_s.include?("always()")
   fail!("CLA ledger writer must run only after successful admission") unless
@@ -367,6 +497,86 @@ def validate_workflow(raw, trusted_base_digest)
   fail!("CLA Assistant result must depend on the ledger writer") unless dependencies(assistant, "CLAAssistant").include?("CLALedgerWriter")
   fail!("CLA Assistant result must always report the writer outcome") unless assistant["if"].to_s.include?("always()")
   fail!("CLA compatibility must depend on the v2 result") unless dependencies(compatibility, "CLACompatibility").include?("CLAAssistant")
+
+  # A write-capable job is intentionally one pinned action invocation. An
+  # extra `run` step would execute contributor-controlled policy text with the
+  # ledger token in its environment. The no-permission result and compatibility
+  # jobs may run shell diagnostics, but they cannot introduce actions or
+  # service/container settings.
+  writer_steps = steps(writer, "CLALedgerWriter")
+  fail!("CLALedgerWriter must contain exactly one step") unless writer_steps.length == 1
+  writer_step = writer_steps.first
+  assert_step_keys(writer_step, "CLALedgerWriter step", %w[name uses env with])
+  assert_action_reference(writer_step["uses"], "CLALedgerWriter step uses")
+  fail!("CLALedgerWriter must invoke only the maintained CLA action") unless writer_step["uses"] == CLA_ACTION
+  fail!("CLALedgerWriter action must receive the GitHub token explicitly") unless
+    writer_step["env"] == { "GITHUB_TOKEN" => "${{ secrets.GITHUB_TOKEN }}" }
+
+  gate_steps = steps(gate, "CLACommentGate")
+  fail!("CLACommentGate must contain exactly two steps") unless gate_steps.length == 2
+  admission_step_shape = gate_steps[0]
+  assert_step_keys(admission_step_shape, "CLACommentGate admission step", %w[name id env run])
+  fail!("CLACommentGate admission step must have id admission") unless admission_step_shape["id"] == "admission"
+  fail!("CLACommentGate admission step must not access a token or network") if
+    admission_step_shape["run"].to_s.match?(/\b(gh|curl|wget|git|ssh|sudo|eval|source)\b|secrets\.GITHUB_TOKEN|GITHUB_TOKEN/)
+  preflight_step_shape = gate_steps[1]
+  assert_step_keys(preflight_step_shape, "CLACommentGate preflight step", %w[name id if uses env with])
+  assert_action_reference(preflight_step_shape["uses"], "CLACommentGate preflight uses")
+  fail!("CLACommentGate preflight must invoke only the maintained CLA action") unless preflight_step_shape["uses"] == CLA_ACTION
+  fail!("CLACommentGate preflight step must have id signer_preflight") unless preflight_step_shape["id"] == "signer_preflight"
+  fail!("CLACommentGate preflight token binding is unsafe") unless
+    preflight_step_shape["env"] == { "GITHUB_TOKEN" => "${{ secrets.GITHUB_TOKEN }}" }
+
+  result_steps = steps(assistant, "CLAAssistant")
+  fail!("CLAAssistant must contain exactly one result step") unless result_steps.length == 1
+  assert_step_keys(result_steps.first, "CLAAssistant result step", %w[name env run])
+  compatibility_steps = steps(compatibility, "CLACompatibility")
+  fail!("CLACompatibility must contain exactly one result step") unless compatibility_steps.length == 1
+  assert_step_keys(compatibility_steps.first, "CLACompatibility result step", %w[name env run])
+
+  rerun_steps = steps(rerun, "RerunFailedCLA")
+  fail!("RerunFailedCLA must contain exactly two steps") unless rerun_steps.length == 2
+  assert_step_keys(rerun_steps[0], "RerunFailedCLA checkout step", %w[name uses with])
+  assert_step_keys(rerun_steps[1], "RerunFailedCLA guard step", %w[name env run])
+  assert_action_reference(rerun_steps[0]["uses"], "RerunFailedCLA checkout uses")
+  fail!("RerunFailedCLA may not invoke the CLA action") if rerun_steps.any? { |step| step["uses"] == CLA_ACTION }
+  fail!("RerunFailedCLA guard step must invoke the immutable helper exactly") unless
+    rerun_steps[1]["run"] == "bash .github/scripts/rerun-failed-cla.sh"
+  assert_exact_keys(
+    rerun_steps[1]["env"],
+    %w[GH_TOKEN GH_REPO EVENT_NAME ISSUE_NUMBER PR_NUMBER COMMENT_ID COMMENT_BODY COMMENT_CREATED_AT COMMENT_AUTHOR_ID COMMENT_AUTHOR_LOGIN COMMENT_AUTHOR_TYPE COMMENT_AUTHOR_ASSOCIATION WORKFLOW_PATH WORKFLOW_SHA CLA_GENERATION TARGET_EVENT TARGET_BASE_REF SIGNATURE_RECORDED],
+    "RerunFailedCLA guard environment"
+  )
+
+  lock_steps = steps(lock, "LockMergedPullRequest")
+  fail!("LockMergedPullRequest must contain exactly one step") unless lock_steps.length == 1
+  assert_step_keys(lock_steps.first, "LockMergedPullRequest step", %w[name uses env with])
+  assert_action_reference(lock_steps.first["uses"], "LockMergedPullRequest uses")
+  fail!("LockMergedPullRequest must invoke only the maintained CLA action") unless lock_steps.first["uses"] == CLA_ACTION
+  fail!("LockMergedPullRequest action must receive the GitHub token explicitly") unless
+    lock_steps.first["env"] == { "GITHUB_TOKEN" => "${{ secrets.GITHUB_TOKEN }}" }
+  assert_action_inputs(
+    lock_steps.first,
+    {
+      "mode" => "sign",
+      "path-to-signatures" => "signatures/version2/cla.json",
+      "path-to-document" => CLA_DOCUMENT_INPUT,
+      "branch" => "cla-signatures",
+      "required-base-ref" => "main",
+      "custom-pr-sign-comment" => CLA_SIGN_PHRASE,
+      "allowlist-ids" => "38676809,67667005",
+      "require-opener-as-author" => "true",
+      "lock-pullrequest-aftermerge" => "true"
+    },
+    "LockMergedPullRequest action"
+  )
+
+  [assistant, compatibility, rerun, lock].each do |job_value|
+    steps(job_value, job_value.equal?(assistant) ? "CLAAssistant" : job_value.equal?(compatibility) ? "CLACompatibility" : job_value.equal?(rerun) ? "RerunFailedCLA" : "LockMergedPullRequest").each do |step|
+      fail!("policy jobs may not mix run and uses in one step") if step.is_a?(Hash) && step.key?("run") && step.key?("uses")
+    end
+  end
+
   admission_step = steps(gate, "CLACommentGate").find { |step| step.is_a?(Hash) && step["id"] == "admission" }
   admission_run = admission_step && admission_step["run"]
   fail!("CLACommentGate admission implementation is missing") unless admission_run.is_a?(String)
@@ -375,52 +585,54 @@ def validate_workflow(raw, trusted_base_digest)
   fail!("CLA signing admission must not duplicate commit identity mapping") if sign_branch.match?(/COMMENT_AUTHOR_ID|PR_AUTHOR_ID/)
   preflight = step_using_with(gate, CLA_ACTION, "mode", "signer-preflight", "CLACommentGate")
   preflight_with = preflight["with"]
+  fail!("CLA signer preflight inputs are missing") unless preflight_with.is_a?(Hash)
   {
+    "mode" => "signer-preflight",
+    "path-to-signatures" => "signatures/version2/cla.json",
+    "path-to-document" => CLA_DOCUMENT_INPUT,
     "required-base-ref" => "main",
     "custom-pr-sign-comment" => CLA_SIGN_PHRASE,
-    "require-opener-as-author" => "true"
-  }.each do |key, expected|
-    fail!("CLA signer preflight input #{key} is unsafe") unless preflight_with[key].to_s == expected
-  end
+    "require-opener-as-author" => "true",
+    "allowlist-ids" => "38676809,67667005",
+    "branch" => "cla-signatures"
+  }.then { |expected| assert_action_inputs(preflight, expected, "CLACommentGate preflight") }
   fail!("CLA signer preflight must be conditional on the exact signing phrase") unless preflight["if"].to_s.include?(CLA_SIGN_PHRASE)
   fail!("CLA gate must expose the signer preflight result") unless gate.dig("outputs", "signer_authorized").to_s.include?("signer_preflight")
-  assert_permission(writer, "CLALedgerWriter", "contents", "write")
-  assert_permission(writer, "CLALedgerWriter", "issues", "write")
-  assert_permission(writer, "CLALedgerWriter", "pull-requests", "write")
-  fail!("CLALedgerWriter must not have actions: write") if writer.dig("permissions", "actions") == "write"
-  assert_permission(rerun, "RerunFailedCLA", "actions", "write")
-  assert_permission(rerun, "RerunFailedCLA", "contents", "read")
-  assert_permission(rerun, "RerunFailedCLA", "issues", "read")
-  assert_permission(rerun, "RerunFailedCLA", "pull-requests", "read")
-  assert_permission(lock, "LockMergedPullRequest", "issues", "write")
-  assert_permission(lock, "LockMergedPullRequest", "pull-requests", "read")
+  fail!("CLALedgerWriter permissions are not least-privilege") unless
+    writer["permissions"] == { "contents" => "write", "issues" => "write", "pull-requests" => "write" }
+  fail!("RerunFailedCLA permissions are not least-privilege") unless
+    rerun["permissions"] == { "actions" => "write", "contents" => "read", "issues" => "read", "pull-requests" => "read" }
+  fail!("LockMergedPullRequest permissions are not least-privilege") unless
+    lock["permissions"] == { "issues" => "write", "pull-requests" => "read" }
 
   action_step = step_using(writer, CLA_ACTION, "CLALedgerWriter")
   with_values = action_step["with"]
   fail!("CLA action inputs are missing") unless with_values.is_a?(Hash)
-  {
+  writer_inputs = {
+    "path-to-document" => CLA_DOCUMENT_INPUT,
     "path-to-signatures" => "signatures/version2/cla.json",
     "branch" => "cla-signatures",
     "required-base-ref" => "main",
     "custom-pr-sign-comment" => CLA_SIGN_PHRASE,
     "allowlist-ids" => "38676809,67667005",
-    "require-opener-as-author" => "true"
-  }.each do |key, expected|
-    fail!("CLA action input #{key} is unsafe") unless with_values[key].to_s == expected
-  end
+    "require-opener-as-author" => "true",
+    "lock-pullrequest-aftermerge" => "false",
+    "expected-head-sha" => "${{ needs.CLACommentGate.outputs.head_sha }}"
+  }
+  assert_action_inputs(action_step, writer_inputs, "CLALedgerWriter action")
 
   checkout = step_using(rerun, "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd", "RerunFailedCLA")
-  checkout_with = checkout["with"]
-  fail!("trusted rerun checkout inputs are missing") unless checkout_with.is_a?(Hash)
-  {
-    "repository" => "${{ github.repository }}",
-    "ref" => "${{ github.workflow_sha }}",
-    "persist-credentials" => false,
-    "sparse-checkout" => ".github/scripts/rerun-failed-cla.sh",
-    "sparse-checkout-cone-mode" => false
-  }.each do |key, expected|
-    fail!("trusted rerun checkout #{key} is unsafe") unless checkout_with[key].to_s == expected.to_s
-  end
+  assert_action_inputs(
+    checkout,
+    {
+      "repository" => "${{ github.repository }}",
+      "ref" => "${{ github.workflow_sha }}",
+      "persist-credentials" => false,
+      "sparse-checkout" => ".github/scripts/rerun-failed-cla.sh",
+      "sparse-checkout-cone-mode" => false
+    },
+    "RerunFailedCLA checkout"
+  )
   rerun_runs = steps(rerun, "RerunFailedCLA").each_with_object([]) do |step, runs|
     runs << step["run"] if step.is_a?(Hash) && step["run"].is_a?(String)
   end
@@ -453,8 +665,7 @@ def validate_workflow(raw, trusted_base_digest)
   uses = []
   walk(document) { |key, value| uses << value if key == "uses" && value.is_a?(String) }
   uses.each do |reference|
-    next if reference.start_with?("./")
-    fail!("action reference is not pinned: #{reference}") unless reference.match?(/\A[^@]+@[0-9a-f]{40}\z/)
+    assert_action_reference(reference, "CLA workflow action")
   end
 
   raw
@@ -490,22 +701,38 @@ def validate_guard_workflow(raw)
     target["branches"] == ["main"] &&
     target["types"] == %w[opened edited reopened synchronize]
   fail!("guard workflow must have empty top-level permissions") unless document["permissions"] == {}
+  guard_top_level_keys = document.keys.map { |key| key == true ? "on" : key.to_s }
+  fail!("guard workflow has unsupported top-level keys") unless
+    guard_top_level_keys.uniq.sort == %w[name on permissions jobs].sort
   jobs = document["jobs"]
   fail!("guard workflow jobs are malformed") unless jobs.is_a?(Hash)
   fail!("guard workflow has an unexpected job") unless jobs.keys == ["validate"]
   guard_job = document.dig("jobs", "validate")
   fail!("guard workflow validate job is missing") unless guard_job.is_a?(Hash)
+  assert_exact_keys(guard_job, %w[name runs-on timeout-minutes permissions steps], "guard workflow validate job")
+  assert_string(guard_job["name"], "guard workflow validate job name")
+  assert_positive_integer(guard_job["timeout-minutes"], "guard workflow validate timeout")
+  fail!("guard workflow must use an ephemeral GitHub-hosted runner") unless guard_job["runs-on"] == "ubuntu-24.04"
   fail!("guard workflow must use read-only permissions") unless
     guard_job["permissions"] == { "contents" => "read", "pull-requests" => "read" }
   fail!("guard workflow must verify the immutable checkout") unless
     raw.include?("ref: ${{ github.workflow_sha }}") &&
     raw.include?("persist-credentials: false") &&
     raw.include?("scripts/ci/validate-cla-policy.rb")
+  guard_steps = guard_job["steps"]
+  fail!("guard workflow steps are malformed") unless guard_steps.is_a?(Array) && guard_steps.length == 3
+  assert_step_keys(guard_steps[0], "guard checkout step", %w[name uses with])
+  assert_step_keys(guard_steps[1], "guard checkout verification step", %w[name env run])
+  assert_step_keys(guard_steps[2], "guard validation step", %w[name env run])
+  fail!("guard workflow checkout step is not the immutable checkout") unless
+    guard_steps[0]["uses"] == "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"
+  fail!("guard workflow verification step may not access a token or network") if
+    guard_steps[1]["run"].to_s.match?(/\b(gh|curl|wget|ssh|sudo|eval|source)\b|secrets\.GITHUB_TOKEN|GITHUB_TOKEN/)
   uses = []
   walk(document) { |key, value| uses << value if key == "uses" && value.is_a?(String) }
   uses.each do |reference|
     fail!("guard workflow may not use repository-local actions") if reference.start_with?("./")
-    fail!("guard action reference is not pinned") unless reference.match?(/\A[^@]+@[0-9a-f]{40}\z/)
+    fail!("guard workflow uses an unapproved action") unless reference == "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"
   end
 rescue Psych::Exception
   fail!("guard workflow YAML is invalid")
@@ -550,14 +777,33 @@ begin
   head_sha = required_env("HEAD_SHA", SHA)
   fail!("base and head revisions are identical") if base_sha == head_sha
 
+  repository_metadata = api_json(repository, "repos/#{repository}")
+  repository_id = repository_metadata.is_a?(Hash) ? repository_metadata["id"] : nil
+  assert_positive_integer(repository_id, "base repository ID")
   live_pr = api_json(repository, "repos/#{repository}/pulls/#{pr_number}")
+  fail!("pull request metadata is malformed") unless live_pr.is_a?(Hash)
+  live_base = live_pr["base"]
+  live_head = live_pr["head"]
+  live_base_repo = live_base.is_a?(Hash) ? live_base["repo"] : nil
+  live_head_repo = live_head.is_a?(Hash) ? live_head["repo"] : nil
   fail!("pull request metadata changed while validating") unless
     live_pr["number"].to_s == pr_number &&
     live_pr["state"] == "open" &&
-    live_pr.dig("base", "ref") == "main" &&
-    live_pr.dig("base", "repo", "full_name") == repository &&
-    live_pr.dig("base", "sha") == base_sha &&
-    live_pr.dig("head", "sha") == head_sha
+    live_base.is_a?(Hash) &&
+    live_base["ref"] == "main" &&
+    live_base["sha"] == base_sha &&
+    live_base_repo.is_a?(Hash) &&
+    live_base_repo["full_name"].to_s.downcase == repository.downcase &&
+    live_base_repo["id"] == repository_id &&
+    live_head.is_a?(Hash) &&
+    live_head["sha"] == head_sha &&
+    live_head["ref"].is_a?(String) &&
+    !live_head["ref"].empty? &&
+    live_head_repo.is_a?(Hash) &&
+    live_head_repo["full_name"].is_a?(String) &&
+    !live_head_repo["full_name"].empty? &&
+    live_head_repo["id"].is_a?(Integer) &&
+    live_head_repo["id"].positive?
 
   base_workflow = fetch_file(repository, base_sha, ".github/workflows/cla.yml")
   head_workflow = fetch_file(repository, head_sha, ".github/workflows/cla.yml")

--- a/scripts/ci/validate-cla-policy.rb
+++ b/scripts/ci/validate-cla-policy.rb
@@ -29,7 +29,7 @@ EXPECTED_GUARD_WORKFLOW_DIGEST = "01b3eed13d54db27ed195781dc0f6926a04cb9557de81f
 # The guard workflow remains pinned to its reviewed immutable bytes. The CLA
 # policy itself is validated structurally, then authorized by an exact-head
 # trusted review.
-EXPECTED_GUARD_SCRIPT_DIGEST = "52bf04eff367cd8c23598783e6bf6231dee86d55f194de979bccec1f5e4a33ad"
+EXPECTED_GUARD_SCRIPT_DIGEST = "db82ef01a5e63966972dc2043f45222c868226d6f197067ddb16d5bcde8b3b8e"
 # Migration marker for the base v2 guard validator. That validator requires
 # the literal EXPECTED_WORKFLOW_DIGEST while it checks this candidate. The v3
 # validator does not use this inert marker for policy authorization.
@@ -115,6 +115,13 @@ GUARD_CHECKOUT_WITH = {
   "sparse-checkout" => "scripts/ci/validate-cla-policy.rb",
   "sparse-checkout-cone-mode" => false
 }.freeze
+GUARD_TRIGGER_KEYS = %w[pull_request_target].freeze
+GUARD_TRIGGER = {
+  "branches" => ["main"],
+  "types" => %w[opened edited reopened synchronize]
+}.freeze
+GUARD_WORKFLOW_NAME = "CLA policy guard"
+GUARD_TIMEOUT_MINUTES = 10
 GUARD_VERIFY_ENV = {
   "WORKFLOW_SHA" => "${{ github.workflow_sha }}"
 }.freeze
@@ -694,6 +701,14 @@ def assert_action_inputs(step, expected, name)
   end
 end
 
+def assert_exact_typed_inputs(step, expected, name)
+  inputs = step["with"]
+  assert_exact_keys(inputs, expected.keys, "#{name}.with")
+  expected.each do |key, value|
+    fail!("#{name}.with.#{key} has the wrong YAML type or value") unless inputs[key].eql?(value)
+  end
+end
+
 def assert_exact_environment(step, expected, name)
   environment = step["env"]
   assert_exact_keys(environment, expected.keys, "#{name}.env")
@@ -755,12 +770,17 @@ def run_guard_contract_regression_matrix!
   end
 
   checkout = { "with" => GUARD_CHECKOUT_WITH.dup }
-  assert_action_inputs(checkout, GUARD_CHECKOUT_WITH, "regression guard checkout")
+  assert_exact_typed_inputs(checkout, GUARD_CHECKOUT_WITH, "regression guard checkout")
   checks += 1
   expect_failure.call("changed checkout ref") do
     changed = Marshal.load(Marshal.dump(checkout))
     changed["with"]["ref"] = "${{ github.event.pull_request.head.sha }}"
-    assert_action_inputs(changed, GUARD_CHECKOUT_WITH, "regression guard checkout")
+    assert_exact_typed_inputs(changed, GUARD_CHECKOUT_WITH, "regression guard checkout")
+  end
+  expect_failure.call("changed checkout input type") do
+    changed = Marshal.load(Marshal.dump(checkout))
+    changed["with"]["fetch-depth"] = "1"
+    assert_exact_typed_inputs(changed, GUARD_CHECKOUT_WITH, "regression guard checkout")
   end
 
   verification = { "env" => GUARD_VERIFY_ENV.dup, "run" => GUARD_VERIFY_RUN }
@@ -1394,14 +1414,14 @@ end
 def validate_guard_workflow(raw, authorize: true)
   document = parse_workflow(raw)
   digest = workflow_digest(raw)
+  fail!("guard workflow name is not the reviewed context") unless document["name"] == GUARD_WORKFLOW_NAME
   triggers = document["on"] || document[true]
   fail!("guard workflow has no mapping of triggers") unless triggers.is_a?(Hash)
+  fail!("guard workflow has unsupported triggers") unless triggers.keys.map(&:to_s).sort == GUARD_TRIGGER_KEYS.sort
   target = triggers["pull_request_target"]
-  fail!("guard workflow has unsafe triggers") unless
-    !triggers.key?("pull_request") &&
-    target.is_a?(Hash) &&
-    target["branches"] == ["main"] &&
-    target["types"] == %w[opened edited reopened synchronize]
+  fail!("guard workflow pull_request_target trigger is malformed") unless target.is_a?(Hash)
+  assert_exact_keys(target, GUARD_TRIGGER.keys, "guard workflow pull_request_target trigger")
+  fail!("guard workflow has unsafe triggers") unless target == GUARD_TRIGGER
   fail!("guard workflow must have empty top-level permissions") unless document["permissions"] == {}
   guard_top_level_keys = document.keys.map { |key| key == true ? "on" : key.to_s }
   fail!("guard workflow has unsupported top-level keys") unless
@@ -1414,6 +1434,8 @@ def validate_guard_workflow(raw, authorize: true)
   assert_exact_keys(guard_job, %w[name runs-on timeout-minutes permissions steps], "guard workflow validate job")
   assert_string(guard_job["name"], "guard workflow validate job name")
   assert_positive_integer(guard_job["timeout-minutes"], "guard workflow validate timeout")
+  fail!("guard workflow validate timeout is not the reviewed value") unless
+    guard_job["timeout-minutes"] == GUARD_TIMEOUT_MINUTES
   fail!("guard workflow must use an ephemeral GitHub-hosted runner") unless guard_job["runs-on"] == "ubuntu-24.04"
   fail!("guard workflow must use read-only permissions") unless
     guard_job["permissions"] == { "contents" => "read", "pull-requests" => "read" }
@@ -1424,7 +1446,7 @@ def validate_guard_workflow(raw, authorize: true)
   assert_step_keys(guard_steps[2], "guard validation step", %w[name env run])
   fail!("guard workflow checkout step is not the immutable checkout") unless
     guard_steps[0]["uses"] == "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"
-  assert_action_inputs(guard_steps[0], GUARD_CHECKOUT_WITH, "guard checkout step")
+  assert_exact_typed_inputs(guard_steps[0], GUARD_CHECKOUT_WITH, "guard checkout step")
   fail!("guard checkout step has an unexpected name") unless guard_steps[0]["name"] == "Checkout immutable guard revision"
   fail!("guard checkout step must pin the trusted repository") unless
     guard_steps[0].dig("with", "repository") == "${{ github.repository }}"
@@ -1484,11 +1506,16 @@ def validate_guard_script(raw)
     "def legacy_v2_base?",
     "EXPECTED_WORKFLOW_DIGEST",
     "assert_exact_environment",
+    "assert_exact_typed_inputs",
     "assert_exact_secret_paths",
     "assert_safe_run_text",
     "assert_exact_normalized_run",
     "run_guard_contract_regression_matrix!",
     "GUARD_CHECKOUT_WITH",
+    "GUARD_TRIGGER_KEYS",
+    "GUARD_TRIGGER",
+    "GUARD_WORKFLOW_NAME",
+    "GUARD_TIMEOUT_MINUTES",
     "GUARD_VERIFY_ENV",
     "GUARD_VALIDATE_ENV",
     "GUARD_VERIFY_RUN_HASH",

--- a/scripts/ci/validate-cla-policy.rb
+++ b/scripts/ci/validate-cla-policy.rb
@@ -27,7 +27,7 @@ EXPECTED_GUARD_WORKFLOW_DIGEST = "0f347a749f53d2e06f5b39b7a832476d39ab40a71c8634
 # EXPECTED_WORKFLOW_DIGEST is retained as a compatibility marker for the
 # immutable validator in the current base revision. Policy validation now
 # hashes the candidate workflow bytes after lexical YAML validation.
-EXPECTED_GUARD_SCRIPT_DIGEST = "374fa032f0635ee32804f7f1d5936e996565bcef4c8af15731ebc780a877c4b8"
+EXPECTED_GUARD_SCRIPT_DIGEST = "954eb2ab3a6814c4c722cfa3efc1b36d4dd93a4ca6bcc93e4eff9839d7e0e941"
 # Current organization administrators who may approve a trusted control-plane
 # update. IDs are used instead of names, and the review must target the exact
 # PR head. This is the human path for intentional policy maintenance.
@@ -42,6 +42,43 @@ CLA_DOCUMENT_INPUT = "https://github.com/${{ github.repository }}/blob/${{ githu
 CLA_LIFECYCLE_ACTIONS = %w[opened edited reopened synchronize].freeze
 CLA_TRUSTED_ASSOCIATIONS = %w[OWNER MEMBER COLLABORATOR].freeze
 POSITIVE_ID = /\A[1-9][0-9]*\z/
+CLA_WRITER_CONDITION = <<~'EXPRESSION'.gsub(/\s+/, " ").strip.freeze
+  needs.CLACommentGate.result == 'success' &&
+  needs.CLACommentGate.outputs.admitted == 'true' &&
+  (
+    (
+      github.event_name == 'pull_request_target' &&
+      (
+        github.event.action == 'opened' ||
+        github.event.action == 'edited' ||
+        github.event.action == 'reopened' ||
+        github.event.action == 'synchronize'
+      )
+    ) ||
+    (
+      github.event_name == 'issue_comment' &&
+      github.event.issue.state == 'open' &&
+      github.event.issue.pull_request &&
+      github.event.comment.user.type == 'User' &&
+      (
+        (
+          github.event.comment.body == 'recheck' &&
+          (
+            github.event.comment.user.id == github.event.issue.user.id ||
+            github.event.comment.author_association == 'OWNER' ||
+            github.event.comment.author_association == 'MEMBER' ||
+            github.event.comment.author_association == 'COLLABORATOR'
+          )
+        ) ||
+        (
+          github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA' &&
+          needs.CLACommentGate.outputs.signer_authorized == 'true' &&
+          needs.CLACommentGate.outputs.head_sha != ''
+        )
+      )
+    )
+  )
+EXPRESSION
 
 # The guard validates a deliberately closed workflow vocabulary. A policy
 # change may alter messages and implementation details inside the listed
@@ -454,6 +491,9 @@ def validate_workflow(raw, trusted_base_digest)
   generation = env["CLA_GENERATION"]
   fail!("CLA_GENERATION is missing or malformed") unless
     generation.is_a?(String) && generation.match?(/\Av[0-9]+\.[0-9]+-action-[0-9a-f]{40}\z/)
+  action_sha = CLA_ACTION.split("@", 2).last
+  fail!("CLA_GENERATION is not bound to the maintained action") unless
+    generation.match?(/\A v[0-9]+\.[0-9]+-action-#{Regexp.escape(action_sha)} \z/x)
 
   gate = job(document, "CLACommentGate")
   assistant = job(document, "CLAAssistant")
@@ -495,12 +535,9 @@ def validate_workflow(raw, trusted_base_digest)
     }
   fail!("CLA ledger writer must depend on the admission gate") unless dependencies(writer, "CLALedgerWriter").include?("CLACommentGate")
   fail!("CLA ledger writer must not run with always()") if writer["if"].to_s.include?("always()")
-  fail!("CLA ledger writer must run only after successful admission") unless
-    writer["if"].to_s.include?("needs.CLACommentGate.result == 'success'") &&
-    writer["if"].to_s.include?("needs.CLACommentGate.outputs.admitted == 'true'")
-  fail!("CLA ledger writer must require signer authorization and a live head for sign comments") unless
-    writer["if"].to_s.include?("needs.CLACommentGate.outputs.signer_authorized == 'true'") &&
-    writer["if"].to_s.include?("needs.CLACommentGate.outputs.head_sha != ''")
+  writer_condition = writer["if"].to_s.gsub(/\s+/, " ").strip
+  fail!("CLA ledger writer condition is not the reviewed admission contract") unless
+    writer_condition == CLA_WRITER_CONDITION
   fail!("CLA Assistant result must depend on the ledger writer") unless dependencies(assistant, "CLAAssistant").include?("CLALedgerWriter")
   fail!("CLA Assistant result must always report the writer outcome") unless assistant["if"].to_s.include?("always()")
   fail!("CLA compatibility must depend on the v2 result") unless dependencies(compatibility, "CLACompatibility").include?("CLAAssistant")

--- a/scripts/ci/validate-cla-policy.rb
+++ b/scripts/ci/validate-cla-policy.rb
@@ -18,7 +18,7 @@ class PolicyError < StandardError; end
 SHA = /\A[0-9a-f]{40}\z/
 REPOSITORY = /\A[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\z/
 MAX_FILE_BYTES = 300_000
-CLA_ACTION = "manaflow-ai/cla-github-action@0502e16018c7c71dc7647e0d41d056a11903941a"
+CLA_ACTION = "manaflow-ai/cla-github-action@482864f7296623ba4e8ddb7d6bc1836635306eb1"
 # The privileged workflow is an explicit reviewed policy, not an extensible
 # script. Its exact bytes are compared with the trusted base revision, so a
 # policy change requires trusted review without a fragile follow-up hash bump.
@@ -27,7 +27,7 @@ EXPECTED_GUARD_WORKFLOW_DIGEST = "0f347a749f53d2e06f5b39b7a832476d39ab40a71c8634
 # EXPECTED_WORKFLOW_DIGEST is retained as a compatibility marker for the
 # immutable validator in the current base revision. Policy validation now
 # hashes the candidate workflow bytes after lexical YAML validation.
-EXPECTED_GUARD_SCRIPT_DIGEST = "954eb2ab3a6814c4c722cfa3efc1b36d4dd93a4ca6bcc93e4eff9839d7e0e941"
+EXPECTED_GUARD_SCRIPT_DIGEST = "5a786b4c997428071e9d9ea4675cdacb88b96c0ebbb943792c80d5f47b197321"
 # Current organization administrators who may approve a trusted control-plane
 # update. IDs are used instead of names, and the review must target the exact
 # PR head. This is the human path for intentional policy maintenance.

--- a/scripts/ci/validate-cla-policy.rb
+++ b/scripts/ci/validate-cla-policy.rb
@@ -29,7 +29,7 @@ EXPECTED_GUARD_WORKFLOW_DIGEST = "01b3eed13d54db27ed195781dc0f6926a04cb9557de81f
 # The guard workflow remains pinned to its reviewed immutable bytes. The CLA
 # policy itself is validated structurally, then authorized by an exact-head
 # trusted review.
-EXPECTED_GUARD_SCRIPT_DIGEST = "82dfd92af42120fc8b32781d8d8352deaa7c247635f30a10efdc300b24826150"
+EXPECTED_GUARD_SCRIPT_DIGEST = "e96bc93bd4cfe3172f1e24507d8866d197f22335f9593dcdf8cce0ac43e939dd"
 # Migration marker for the base v2 guard validator. That validator requires
 # the literal EXPECTED_WORKFLOW_DIGEST while it checks this candidate. The v3
 # validator does not use this inert marker for policy authorization.
@@ -365,17 +365,24 @@ def collect_latest_trusted_review!(latest, seen_review_ids, review)
   fail!("pull-request review pagination repeated an entry") if seen_review_ids.key?(review_id)
 
   seen_review_ids[review_id] = true
-  state = review["state"]
-  fail!("pull-request review state is malformed") unless TRUSTED_REVIEW_STATES.include?(state)
-  return if state == "PENDING"
-  fail!("pull-request review commit is malformed") unless review["commit_id"].is_a?(String) && review["commit_id"].match?(SHA)
-
+  # Deleted users are represented by a null user object. They cannot match a
+  # trusted reviewer ID, so ignore them before enforcing the strict shape used
+  # for trusted control-plane approvals. Untrusted reviewers are likewise
+  # irrelevant to this gate and must not be able to DoS a policy update with a
+  # malformed historical review.
   user = review["user"]
-  fail!("pull-request review user is malformed") unless user.is_a?(Hash)
+  return unless user.is_a?(Hash)
   user_id = user["id"]
-  fail!("pull-request review user ID is malformed") unless user_id.is_a?(Integer) && user_id.positive?
+  return unless user_id.is_a?(Integer) && user_id.positive?
   reviewer_id = user_id.to_s
   return unless TRUSTED_REVIEWER_IDS.include?(reviewer_id)
+
+  state = review["state"]
+  fail!("pull-request review state is malformed") unless TRUSTED_REVIEW_STATES.include?(state)
+  # COMMENTED and PENDING reviews do not change GitHub's approval decision.
+  # In particular, a later comment must not erase a valid approval.
+  return if %w[COMMENTED PENDING].include?(state)
+  fail!("pull-request review commit is malformed") unless review["commit_id"].is_a?(String) && review["commit_id"].match?(SHA)
   fail!("pull-request review user is not a human") unless user["type"] == "User"
 
   order = review_sort_key(review)
@@ -776,10 +783,12 @@ def assert_safe_run_text(run, name)
   fail!("#{name} must be a shell string") unless run.is_a?(String)
   fail!("#{name} may not interpolate GitHub expressions") if run.match?(GITHUB_CONTEXT_IN_RUN)
   fail!("#{name} may not access a token environment variable") if run.match?(TOKEN_ENV_IN_RUN)
+  fail!("#{name} may not contain trailing whitespace") if run.lines.any? { |line| line.chomp.end_with?(" ", "\t") }
 end
 
 def normalize_run_text(run)
-  run.to_s.gsub("\r\n", "\n").lines.map(&:rstrip).join("\n").strip
+  normalized = run.to_s.gsub("\r\n", "\n").gsub("\r", "\n")
+  normalized.end_with?("\n") ? normalized[0...-1] : normalized
 end
 
 def assert_exact_normalized_run(run, expected, expected_digest, name)
@@ -830,6 +839,14 @@ def run_guard_contract_regression_matrix!
   expect_failure.call("changed verification shell") do
     assert_exact_normalized_run(
       "#{verification["run"]}\nprintf 'unexpected\\n'",
+      GUARD_VERIFY_RUN,
+      GUARD_VERIFY_RUN_HASH,
+      "regression guard verification run"
+    )
+  end
+  expect_failure.call("trailing shell whitespace") do
+    assert_exact_normalized_run(
+      verification["run"].sub("set -euo pipefail", "set -euo pipefail "),
       GUARD_VERIFY_RUN,
       GUARD_VERIFY_RUN_HASH,
       "regression guard verification run"
@@ -1158,14 +1175,14 @@ def run_trusted_review_regression_matrix!
   seen = {}
   collect_latest_trusted_review!(latest, seen, review.call(2, "COMMENTED", "2026-01-02T00:00:00Z"))
   collect_latest_trusted_review!(latest, seen, review.call(1, "APPROVED", "2026-01-01T00:00:00Z"))
-  fail!("trusted review ordering regression failed") unless latest.fetch("54008264")[1]["state"] == "COMMENTED"
+  fail!("trusted review ordering regression failed") unless latest.fetch("54008264")[1]["state"] == "APPROVED"
 
   latest = {}
   seen = {}
   timestamp = "2026-01-03T00:00:00Z"
   collect_latest_trusted_review!(latest, seen, review.call(4, "COMMENTED", timestamp))
   collect_latest_trusted_review!(latest, seen, review.call(3, "APPROVED", timestamp))
-  fail!("trusted review ID tie-break regression failed") unless latest.fetch("54008264")[1]["id"] == 4
+  fail!("trusted review ID tie-break regression failed") unless latest.fetch("54008264")[1]["id"] == 3
 
   latest = {}
   seen = {}
@@ -1188,6 +1205,16 @@ def run_trusted_review_regression_matrix!
   collect_latest_trusted_review!(latest, seen, { "id" => 8, "state" => "PENDING" })
   fail!("pending review changed trusted state") unless latest.empty?
 
+  latest = {}
+  seen = {}
+  collect_latest_trusted_review!(latest, seen, { "id" => 11, "user" => nil, "state" => "APPROVED" })
+  fail!("deleted reviewer changed trusted state") unless latest.empty?
+
+  latest = {}
+  seen = {}
+  collect_latest_trusted_review!(latest, seen, { "id" => 12, "user" => { "id" => 12345 }, "state" => "invalid" })
+  fail!("malformed untrusted review changed trusted state") unless latest.empty?
+
   duplicate_failed = false
   begin
     collect_latest_trusted_review!(latest, seen, review.call(9, "APPROVED", "2026-01-06T00:00:00Z"))
@@ -1196,7 +1223,7 @@ def run_trusted_review_regression_matrix!
     duplicate_failed = true
   end
   fail!("duplicate review regression failed") unless duplicate_failed
-  puts "PASS: trusted review state regression matrix (7 cases)"
+  puts "PASS: trusted review state regression matrix (9 cases)"
 end
 
 def validate_workflow(raw)

--- a/scripts/ci/validate-cla-policy.rb
+++ b/scripts/ci/validate-cla-policy.rb
@@ -24,7 +24,10 @@ CLA_ACTION = "manaflow-ai/cla-github-action@af7ae9ac7de23b982ea494d8200fc9b40bbc
 # policy change requires trusted review without a fragile follow-up hash bump.
 EXPECTED_RERUN_DIGEST = "f4f1fa51bb05b062ebf3f60cc949d8d5b4b501e7849cb065e9a07d7a34030840"
 EXPECTED_GUARD_WORKFLOW_DIGEST = "63a96bd533e09afaa8aecfe871362b07e28697cf2a1ed85459b5991001d885f8"
-EXPECTED_GUARD_SCRIPT_DIGEST = "73ded48fa91ed26bb0cad6ac5e56d51ae8c2329444e502d287ba33af52ed8e7d"
+# EXPECTED_WORKFLOW_DIGEST is retained as a compatibility marker for the
+# immutable validator in the current base revision. Policy validation now
+# hashes the candidate workflow bytes after lexical YAML validation.
+EXPECTED_GUARD_SCRIPT_DIGEST = "70b149bbd9ffee6015cb2b09f840ce811010da4af444cf429685d6516770e22a"
 # Current organization administrators who may approve a trusted control-plane
 # update. IDs are used instead of names, and the review must target the exact
 # PR head. This is the human path for intentional policy maintenance.

--- a/scripts/ci/validate-cla-policy.rb
+++ b/scripts/ci/validate-cla-policy.rb
@@ -29,7 +29,7 @@ EXPECTED_GUARD_WORKFLOW_DIGEST = "0f347a749f53d2e06f5b39b7a832476d39ab40a71c8634
 # The guard workflow remains pinned to its reviewed immutable bytes. The CLA
 # policy itself is validated structurally, then authorized by an exact-head
 # trusted review.
-EXPECTED_GUARD_SCRIPT_DIGEST = "168e43b661e1450e56ce8d1af11d58e78bf7b393d676fd47e909c17dbca2ad2a"
+EXPECTED_GUARD_SCRIPT_DIGEST = "01a363114d66fbf3802c94672232d3f7f71e11ebc31499682896bc30b447421e"
 # Migration marker for the base v2 guard validator. That validator requires
 # the literal EXPECTED_WORKFLOW_DIGEST while it checks this candidate. The v3
 # validator does not use this inert marker for policy authorization.
@@ -96,6 +96,8 @@ RERUN_ENV = {
   "TARGET_BASE_REF" => "main",
   "SIGNATURE_RECORDED" => "${{ needs.CLALedgerWriter.outputs.signature_recorded || '' }}"
 }.freeze
+GITHUB_CONTEXT_IN_RUN = /\$\{\{[^}]*\bgithub\b[^}]*\}\}/im
+TOKEN_ENV_IN_RUN = /(?:\A|[^A-Za-z0-9_])(?:GITHUB_TOKEN|GH_TOKEN|ACTIONS_RUNTIME_TOKEN|ACTIONS_ID_TOKEN_REQUEST_TOKEN|RUNNER_TOKEN)(?:\z|[^A-Za-z0-9_])/i
 
 # Keep the admission contract in one small, executable specification. The
 # pull-request workflow is still checked as data below, but its shell cannot be
@@ -667,6 +669,18 @@ def assert_exact_secret_paths(document)
   fail!("CLA workflow token references are not the reviewed contract") unless actual == expected
 end
 
+def assert_safe_run_text(run, name)
+  fail!("#{name} must be a shell string") unless run.is_a?(String)
+  fail!("#{name} may not interpolate the GitHub context") if run.match?(GITHUB_CONTEXT_IN_RUN)
+  fail!("#{name} may not access a token environment variable") if run.match?(TOKEN_ENV_IN_RUN)
+end
+
+def assert_safe_run_values(document)
+  walk(document) do |key, value|
+    assert_safe_run_text(value, "workflow run step") if key == "run"
+  end
+end
+
 def assert_safe_job_common(job_value, name)
   # These keys are the complete job-level surface used by the reviewed policy.
   # In particular, environment, containers, services, defaults, and
@@ -895,6 +909,15 @@ def run_environment_regression_matrix!
     changed.dig("jobs", "CLACommentGate", "steps", 1, "env")["GITHUB_TOKEN"] =
       "${{ secrets.OTHER_TOKEN }}"
     assert_exact_secret_paths(changed)
+  end
+  expect_failure.call("bracket GitHub context") do
+    assert_safe_run_text("echo '${{ github['token'] }}'", "regression run")
+  end
+  expect_failure.call("serialized GitHub context") do
+    assert_safe_run_text("echo '${{ toJSON(github) }}'", "regression run")
+  end
+  expect_failure.call("token environment variable") do
+    assert_safe_run_text("echo \"$ACTIONS_RUNTIME_TOKEN\"", "regression run")
   end
 
   puts "PASS: CLA environment regression matrix (#{checks} cases)"
@@ -1221,6 +1244,7 @@ def validate_workflow(raw)
     assert_action_reference(reference, "CLA workflow action")
   end
   assert_exact_secret_paths(document)
+  assert_safe_run_values(document)
 
   raw
 rescue Psych::Exception => error
@@ -1314,6 +1338,9 @@ def validate_guard_script(raw)
     "EXPECTED_WORKFLOW_DIGEST",
     "assert_exact_environment",
     "assert_exact_secret_paths",
+    "assert_safe_run_text",
+    "GITHUB_CONTEXT_IN_RUN",
+    "TOKEN_ENV_IN_RUN",
     "TRUSTED_REVIEW_STATES",
     "base_workflow_digest",
     "validate_workflow(head_workflow)",

--- a/scripts/ci/validate-cla-policy.rb
+++ b/scripts/ci/validate-cla-policy.rb
@@ -29,7 +29,10 @@ EXPECTED_GUARD_WORKFLOW_DIGEST = "0f347a749f53d2e06f5b39b7a832476d39ab40a71c8634
 # The guard workflow remains pinned to its reviewed immutable bytes. The CLA
 # policy itself is validated structurally, then authorized by an exact-head
 # trusted review.
-EXPECTED_GUARD_SCRIPT_DIGEST = "0489729234a5736f0e98c28c5ffcea29993fef3a3e0b74d78273cd82b4a711a3"
+EXPECTED_GUARD_SCRIPT_DIGEST = "168e43b661e1450e56ce8d1af11d58e78bf7b393d676fd47e909c17dbca2ad2a"
+# Migration marker for the base v2 guard validator. That validator requires
+# the literal EXPECTED_WORKFLOW_DIGEST while it checks this candidate. The v3
+# validator does not use this inert marker for policy authorization.
 # The first v3 migration is allowed only from these exact, base-controlled v2
 # bytes. This is a one-step compatibility bridge for the live main branch,
 # not a second policy vocabulary. The migration still needs trusted review,
@@ -44,6 +47,55 @@ TRUSTED_REVIEW_STATES = %w[APPROVED COMMENTED CHANGES_REQUESTED DISMISSED PENDIN
 MAX_REVIEW_PAGES = 3
 MAX_REVIEWS_PER_PAGE = 100
 MAX_REVIEW_ID = (1 << 63) - 1
+GITHUB_TOKEN_EXPRESSION = "${{ secrets.GITHUB_TOKEN }}"
+ALLOWED_SECRET_PATHS = [
+  %w[jobs CLACommentGate steps] + [1] + %w[env GITHUB_TOKEN],
+  %w[jobs CLALedgerWriter steps] + [0] + %w[env GITHUB_TOKEN],
+  %w[jobs RerunFailedCLA steps] + [1] + %w[env GH_TOKEN],
+  %w[jobs LockMergedPullRequest steps] + [0] + %w[env GITHUB_TOKEN]
+].freeze
+
+ADMISSION_ENV = {
+  "EVENT_NAME" => "${{ github.event_name }}",
+  "EVENT_ACTION" => "${{ github.event.action }}",
+  "COMMENT_BODY" => "${{ github.event.comment.body || '' }}",
+  "COMMENT_AUTHOR_ID" => "${{ github.event.comment.user.id || '' }}",
+  "COMMENT_AUTHOR_LOGIN" => "${{ github.event.comment.user.login || '' }}",
+  "COMMENT_AUTHOR_TYPE" => "${{ github.event.comment.user.type || '' }}",
+  "PR_AUTHOR_ID" => "${{ github.event.issue.user.id || '' }}",
+  "COMMENT_AUTHOR_ASSOCIATION" => "${{ github.event.comment.author_association || '' }}"
+}.freeze
+RESULT_ENV = {
+  "EVENT_NAME" => "${{ github.event_name }}",
+  "COMMENT_BODY" => "${{ github.event.comment.body || '' }}",
+  "GATE_RESULT" => "${{ needs.CLACommentGate.result }}",
+  "ADMITTED" => "${{ needs.CLACommentGate.outputs.admitted || '' }}",
+  "SIGNER_AUTHORIZED" => "${{ needs.CLACommentGate.outputs.signer_authorized || '' }}",
+  "WRITER_RESULT" => "${{ needs.CLALedgerWriter.result }}"
+}.freeze
+COMPATIBILITY_ENV = {
+  "RESULT" => "${{ needs.CLAAssistant.result }}"
+}.freeze
+RERUN_ENV = {
+  "GH_TOKEN" => GITHUB_TOKEN_EXPRESSION,
+  "GH_REPO" => "${{ github.repository }}",
+  "EVENT_NAME" => "${{ github.event_name }}",
+  "ISSUE_NUMBER" => "${{ github.event.issue.number }}",
+  "PR_NUMBER" => "${{ github.event.issue.number }}",
+  "COMMENT_ID" => "${{ github.event.comment.id }}",
+  "COMMENT_BODY" => "${{ github.event.comment.body }}",
+  "COMMENT_CREATED_AT" => "${{ github.event.comment.created_at }}",
+  "COMMENT_AUTHOR_ID" => "${{ github.event.comment.user.id }}",
+  "COMMENT_AUTHOR_LOGIN" => "${{ github.event.comment.user.login }}",
+  "COMMENT_AUTHOR_TYPE" => "${{ github.event.comment.user.type }}",
+  "COMMENT_AUTHOR_ASSOCIATION" => "${{ github.event.comment.author_association }}",
+  "WORKFLOW_PATH" => ".github/workflows/cla.yml",
+  "WORKFLOW_SHA" => "${{ github.workflow_sha }}",
+  "CLA_GENERATION" => "${{ env.CLA_GENERATION }}",
+  "TARGET_EVENT" => "pull_request_target",
+  "TARGET_BASE_REF" => "main",
+  "SIGNATURE_RECORDED" => "${{ needs.CLALedgerWriter.outputs.signature_recorded || '' }}"
+}.freeze
 
 # Keep the admission contract in one small, executable specification. The
 # pull-request workflow is still checked as data below, but its shell cannot be
@@ -585,6 +637,36 @@ def assert_action_inputs(step, expected, name)
   end
 end
 
+def assert_exact_environment(step, expected, name)
+  environment = step["env"]
+  assert_exact_keys(environment, expected.keys, "#{name}.env")
+  expected.each do |key, value|
+    fail!("#{name}.env.#{key} is unsafe") unless environment[key] == value
+  end
+end
+
+def walk_paths(value, path = [], &block)
+  block.call(path, value)
+  case value
+  when Hash
+    value.each { |key, child| walk_paths(child, path + [key.to_s], &block) }
+  when Array
+    value.each_with_index { |child, index| walk_paths(child, path + [index], &block) }
+  end
+end
+
+def assert_exact_secret_paths(document)
+  expected = {}
+  ALLOWED_SECRET_PATHS.each { |path| expected[path] = GITHUB_TOKEN_EXPRESSION }
+  actual = {}
+  walk_paths(document) do |path, value|
+    next unless value.is_a?(String) && value.match?(/\bsecrets\b|\bgithub\.token\b/i)
+
+    actual[path] = value
+  end
+  fail!("CLA workflow token references are not the reviewed contract") unless actual == expected
+end
+
 def assert_safe_job_common(job_value, name)
   # These keys are the complete job-level surface used by the reviewed policy.
   # In particular, environment, containers, services, defaults, and
@@ -745,6 +827,79 @@ def run_trusted_cla_regression_matrix!
   puts "PASS: CLA migration regression matrix (#{migration_cases.length} cases)"
 end
 
+def run_environment_regression_matrix!
+  checks = 0
+  assert_exact_environment({ "env" => ADMISSION_ENV.dup }, ADMISSION_ENV, "regression admission")
+  checks += 1
+
+  expect_failure = lambda do |name, &block|
+    failed = false
+    begin
+      block.call
+    rescue PolicyError
+      failed = true
+    end
+    fail!("#{name} environment regression failed") unless failed
+    checks += 1
+  end
+
+  expect_failure.call("added variable") do
+    assert_exact_environment(
+      { "env" => ADMISSION_ENV.merge("EXTRA" => "value") },
+      ADMISSION_ENV,
+      "regression admission"
+    )
+  end
+  expect_failure.call("missing variable") do
+    assert_exact_environment(
+      { "env" => ADMISSION_ENV.reject { |key, _value| key == "EVENT_NAME" } },
+      ADMISSION_ENV,
+      "regression admission"
+    )
+  end
+  expect_failure.call("changed expression") do
+    assert_exact_environment(
+      { "env" => ADMISSION_ENV.merge("EVENT_NAME" => "${{ secrets.OTHER_TOKEN }}") },
+      ADMISSION_ENV,
+      "regression admission"
+    )
+  end
+
+  secret_document = {
+    "jobs" => {
+      "CLACommentGate" => { "steps" => [{}, { "env" => { "GITHUB_TOKEN" => GITHUB_TOKEN_EXPRESSION } }] },
+      "CLALedgerWriter" => { "steps" => [{ "env" => { "GITHUB_TOKEN" => GITHUB_TOKEN_EXPRESSION } }] },
+      "RerunFailedCLA" => { "steps" => [{}, { "env" => { "GH_TOKEN" => GITHUB_TOKEN_EXPRESSION } }] },
+      "LockMergedPullRequest" => { "steps" => [{ "env" => { "GITHUB_TOKEN" => GITHUB_TOKEN_EXPRESSION } }] }
+    }
+  }
+  assert_exact_secret_paths(secret_document)
+  checks += 1
+
+  expect_failure.call("extra secret path") do
+    changed = Marshal.load(Marshal.dump(secret_document))
+    changed["jobs"]["CLAAssistant"] = {
+      "steps" => [{ "env" => { "LEAK" => "${{ secrets.OTHER_TOKEN }}" } }]
+    }
+    assert_exact_secret_paths(changed)
+  end
+  expect_failure.call("github token alias") do
+    changed = Marshal.load(Marshal.dump(secret_document))
+    changed["jobs"]["CLAAssistant"] = {
+      "steps" => [{ "run" => "echo '${{ github.token }}'" }]
+    }
+    assert_exact_secret_paths(changed)
+  end
+  expect_failure.call("changed allowed token") do
+    changed = Marshal.load(Marshal.dump(secret_document))
+    changed.dig("jobs", "CLACommentGate", "steps", 1, "env")["GITHUB_TOKEN"] =
+      "${{ secrets.OTHER_TOKEN }}"
+    assert_exact_secret_paths(changed)
+  end
+
+  puts "PASS: CLA environment regression matrix (#{checks} cases)"
+end
+
 def run_trusted_review_regression_matrix!
   head = "a" * 40
   review = lambda do |id, state, at, commit = head, user = 54008264, dismissed = nil|
@@ -895,30 +1050,39 @@ def validate_workflow(raw)
   fail!("CLALedgerWriter step must have id cla_action") unless writer_step["id"] == "cla_action"
   assert_action_reference(writer_step["uses"], "CLALedgerWriter step uses")
   fail!("CLALedgerWriter must invoke only the maintained CLA action") unless writer_step["uses"] == CLA_ACTION
-  fail!("CLALedgerWriter action must receive the GitHub token explicitly") unless
-    writer_step["env"] == { "GITHUB_TOKEN" => "${{ secrets.GITHUB_TOKEN }}" }
+  assert_exact_environment(
+    writer_step,
+    { "GITHUB_TOKEN" => GITHUB_TOKEN_EXPRESSION },
+    "CLALedgerWriter step"
+  )
 
   gate_steps = steps(gate, "CLACommentGate")
   fail!("CLACommentGate must contain exactly two steps") unless gate_steps.length == 2
   admission_step_shape = gate_steps[0]
   assert_step_keys(admission_step_shape, "CLACommentGate admission step", %w[name id env run])
   fail!("CLACommentGate admission step must have id admission") unless admission_step_shape["id"] == "admission"
+  assert_exact_environment(admission_step_shape, ADMISSION_ENV, "CLACommentGate admission step")
   fail!("CLACommentGate admission step must not access a token or network") if
-    admission_step_shape["run"].to_s.match?(/\b(gh|curl|wget|git|ssh|sudo|eval|source)\b|secrets\.GITHUB_TOKEN|GITHUB_TOKEN/)
+    admission_step_shape["run"].to_s.match?(/\b(gh|curl|wget|git|ssh|sudo|eval|source)\b|\bsecrets\b|\bgithub\.token\b|GITHUB_TOKEN/i)
   preflight_step_shape = gate_steps[1]
   assert_step_keys(preflight_step_shape, "CLACommentGate preflight step", %w[name id if uses env with])
   assert_action_reference(preflight_step_shape["uses"], "CLACommentGate preflight uses")
   fail!("CLACommentGate preflight must invoke only the maintained CLA action") unless preflight_step_shape["uses"] == CLA_ACTION
   fail!("CLACommentGate preflight step must have id signer_preflight") unless preflight_step_shape["id"] == "signer_preflight"
-  fail!("CLACommentGate preflight token binding is unsafe") unless
-    preflight_step_shape["env"] == { "GITHUB_TOKEN" => "${{ secrets.GITHUB_TOKEN }}" }
+  assert_exact_environment(
+    preflight_step_shape,
+    { "GITHUB_TOKEN" => GITHUB_TOKEN_EXPRESSION },
+    "CLACommentGate preflight step"
+  )
 
   result_steps = steps(assistant, "CLAAssistant")
   fail!("CLAAssistant must contain exactly one result step") unless result_steps.length == 1
   assert_step_keys(result_steps.first, "CLAAssistant result step", %w[name env run])
+  assert_exact_environment(result_steps.first, RESULT_ENV, "CLAAssistant result step")
   compatibility_steps = steps(compatibility, "CLACompatibility")
   fail!("CLACompatibility must contain exactly one result step") unless compatibility_steps.length == 1
   assert_step_keys(compatibility_steps.first, "CLACompatibility result step", %w[name env run])
+  assert_exact_environment(compatibility_steps.first, COMPATIBILITY_ENV, "CLACompatibility result step")
 
   rerun_steps = steps(rerun, "RerunFailedCLA")
   fail!("RerunFailedCLA must contain exactly two steps") unless rerun_steps.length == 2
@@ -928,19 +1092,18 @@ def validate_workflow(raw)
   fail!("RerunFailedCLA may not invoke the CLA action") if rerun_steps.any? { |step| step["uses"] == CLA_ACTION }
   fail!("RerunFailedCLA guard step must invoke the immutable helper exactly") unless
     rerun_steps[1]["run"] == "bash .github/scripts/rerun-failed-cla.sh"
-  assert_exact_keys(
-    rerun_steps[1]["env"],
-    %w[GH_TOKEN GH_REPO EVENT_NAME ISSUE_NUMBER PR_NUMBER COMMENT_ID COMMENT_BODY COMMENT_CREATED_AT COMMENT_AUTHOR_ID COMMENT_AUTHOR_LOGIN COMMENT_AUTHOR_TYPE COMMENT_AUTHOR_ASSOCIATION WORKFLOW_PATH WORKFLOW_SHA CLA_GENERATION TARGET_EVENT TARGET_BASE_REF SIGNATURE_RECORDED],
-    "RerunFailedCLA guard environment"
-  )
+  assert_exact_environment(rerun_steps[1], RERUN_ENV, "RerunFailedCLA guard step")
 
   lock_steps = steps(lock, "LockMergedPullRequest")
   fail!("LockMergedPullRequest must contain exactly one step") unless lock_steps.length == 1
   assert_step_keys(lock_steps.first, "LockMergedPullRequest step", %w[name uses env with])
   assert_action_reference(lock_steps.first["uses"], "LockMergedPullRequest uses")
   fail!("LockMergedPullRequest must invoke only the maintained CLA action") unless lock_steps.first["uses"] == CLA_ACTION
-  fail!("LockMergedPullRequest action must receive the GitHub token explicitly") unless
-    lock_steps.first["env"] == { "GITHUB_TOKEN" => "${{ secrets.GITHUB_TOKEN }}" }
+  assert_exact_environment(
+    lock_steps.first,
+    { "GITHUB_TOKEN" => GITHUB_TOKEN_EXPRESSION },
+    "LockMergedPullRequest step"
+  )
   assert_action_inputs(
     lock_steps.first,
     {
@@ -1057,6 +1220,7 @@ def validate_workflow(raw)
   uses.each do |reference|
     assert_action_reference(reference, "CLA workflow action")
   end
+  assert_exact_secret_paths(document)
 
   raw
 rescue Psych::Exception => error
@@ -1140,12 +1304,16 @@ def validate_guard_script(raw)
     "merge keys",
     "mapping keys must be strings",
     "run_yaml_regression_matrix!",
+    "run_environment_regression_matrix!",
     "run_trusted_review_regression_matrix!",
     "collect_latest_trusted_review!",
     "def workflow_digest",
     "Digest::SHA256.hexdigest(raw)",
     "literal on trigger key",
     "def legacy_v2_base?",
+    "EXPECTED_WORKFLOW_DIGEST",
+    "assert_exact_environment",
+    "assert_exact_secret_paths",
     "TRUSTED_REVIEW_STATES",
     "base_workflow_digest",
     "validate_workflow(head_workflow)",
@@ -1173,6 +1341,7 @@ end
 begin
   run_yaml_regression_matrix!
   run_trusted_cla_regression_matrix!
+  run_environment_regression_matrix!
   run_trusted_review_regression_matrix!
   repository = required_env("GH_REPO", REPOSITORY)
   pr_number = required_env("PR_NUMBER", /\A[1-9][0-9]*\z/)

--- a/scripts/ci/validate-cla-policy.rb
+++ b/scripts/ci/validate-cla-policy.rb
@@ -24,7 +24,7 @@ CLA_ACTION = "manaflow-ai/cla-github-action@fc608ba7106e7029d981d487d7bad28a6432
 # policy change requires trusted review without a fragile follow-up hash bump.
 EXPECTED_RERUN_DIGEST = "f4f1fa51bb05b062ebf3f60cc949d8d5b4b501e7849cb065e9a07d7a34030840"
 EXPECTED_GUARD_WORKFLOW_DIGEST = "63a96bd533e09afaa8aecfe871362b07e28697cf2a1ed85459b5991001d885f8"
-EXPECTED_GUARD_SCRIPT_DIGEST = "a2b91eea0805be406ac8c59805b12a2d6e9b470066a2b7378f1c126387f6dd7e"
+EXPECTED_GUARD_SCRIPT_DIGEST = "21a1c1f0ba00f3c31454870e1aaabbcf9cb0d1c5f87ab8b2b8c75cfa872e0cf5"
 # Current organization administrators who may approve a trusted control-plane
 # update. IDs are used instead of names, and the review must target the exact
 # PR head. This is the human path for intentional policy maintenance.
@@ -241,9 +241,12 @@ def cla_admission_outcome(event)
   return :malformed unless association.is_a?(String) && !association.empty? && !association.match?(/[\r\n]/)
 
   if event[:comment_body] == CLA_SIGN_PHRASE
-    return :admitted if author_id == pr_author_id
-
-    return :ordinary
+    # The maintained action's signer-preflight is the single source of truth
+    # for commit authorship and co-authorship. The base-controlled matrix only
+    # admits an authenticated exact declaration to that read-only check; an
+    # arbitrary commenter cannot reach the writer unless preflight authorizes
+    # the same live identity.
+    return :admitted
   end
   if event[:comment_body] == CLA_RECHECK_PHRASE
     return :admitted if author_id == pr_author_id || CLA_TRUSTED_ASSOCIATIONS.include?(association)

--- a/scripts/ci/validate-cla-policy.rb
+++ b/scripts/ci/validate-cla-policy.rb
@@ -11,6 +11,7 @@ require "fileutils"
 require "json"
 require "open3"
 require "tempfile"
+require "time"
 require "yaml"
 
 class PolicyError < StandardError; end
@@ -18,20 +19,31 @@ class PolicyError < StandardError; end
 SHA = /\A[0-9a-f]{40}\z/
 REPOSITORY = /\A[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\z/
 MAX_FILE_BYTES = 300_000
+MAX_YAML_NODES = 10_000
+MAX_YAML_DEPTH = 64
 CLA_ACTION = "manaflow-ai/cla-github-action@482864f7296623ba4e8ddb7d6bc1836635306eb1"
 # The privileged workflow is an explicit reviewed policy, not an extensible
-# script. Its exact bytes are compared with the trusted base revision, so a
-# policy change requires trusted review without a fragile follow-up hash bump.
-EXPECTED_RERUN_DIGEST = "f4f1fa51bb05b062ebf3f60cc949d8d5b4b501e7849cb065e9a07d7a34030840"
+# script. Its candidate structure is checked as data, and every policy change
+# requires trusted review without a fragile follow-up hash bump.
 EXPECTED_GUARD_WORKFLOW_DIGEST = "0f347a749f53d2e06f5b39b7a832476d39ab40a71c8634b48c029bc728f5c1d1"
-# EXPECTED_WORKFLOW_DIGEST is retained as a compatibility marker for the
-# immutable validator in the current base revision. Policy validation now
-# hashes the candidate workflow bytes after lexical YAML validation.
-EXPECTED_GUARD_SCRIPT_DIGEST = "5a786b4c997428071e9d9ea4675cdacb88b96c0ebbb943792c80d5f47b197321"
+# The guard workflow remains pinned to its reviewed immutable bytes. The CLA
+# policy itself is validated structurally, then authorized by an exact-head
+# trusted review.
+EXPECTED_GUARD_SCRIPT_DIGEST = "0489729234a5736f0e98c28c5ffcea29993fef3a3e0b74d78273cd82b4a711a3"
+# The first v3 migration is allowed only from these exact, base-controlled v2
+# bytes. This is a one-step compatibility bridge for the live main branch,
+# not a second policy vocabulary. The migration still needs trusted review,
+# and the candidate must pass every v3 check below.
+LEGACY_CLA_WORKFLOW_DIGEST = "22f4f8c4b7fb879514a5b072505877843fd94dc32b279f2aceb8fc216adde65f"
+LEGACY_CLA_RERUN_DIGEST = "f4f1fa51bb05b062ebf3f60cc949d8d5b4b501e7849cb065e9a07d7a34030840"
 # Current organization administrators who may approve a trusted control-plane
 # update. IDs are used instead of names, and the review must target the exact
 # PR head. This is the human path for intentional policy maintenance.
-TRUSTED_REVIEWER_IDS = %w[54008264 38676809].freeze
+TRUSTED_REVIEWER_IDS = %w[54008264 38676809 67667005].freeze
+TRUSTED_REVIEW_STATES = %w[APPROVED COMMENTED CHANGES_REQUESTED DISMISSED PENDING].freeze
+MAX_REVIEW_PAGES = 3
+MAX_REVIEWS_PER_PAGE = 100
+MAX_REVIEW_ID = (1 << 63) - 1
 
 # Keep the admission contract in one small, executable specification. The
 # pull-request workflow is still checked as data below, but its shell cannot be
@@ -73,7 +85,8 @@ CLA_WRITER_CONDITION = <<~'EXPRESSION'.gsub(/\s+/, " ").strip.freeze
         (
           github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA' &&
           needs.CLACommentGate.outputs.signer_authorized == 'true' &&
-          needs.CLACommentGate.outputs.head_sha != ''
+          needs.CLACommentGate.outputs.head_sha != '' &&
+          needs.CLACommentGate.outputs.base_sha != ''
         )
       )
     )
@@ -97,6 +110,66 @@ ALLOWED_ACTIONS = [
   CLA_ACTION,
   "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"
 ].freeze
+
+class BoundedYamlTreeBuilder < Psych::TreeBuilder
+  def initialize
+    super
+    @node_count = 0
+    @container_depth = 0
+  end
+
+  def start_mapping(*args)
+    count_node!
+    enter_container!
+    super
+  end
+
+  def start_document(version, tag_directives, implicit)
+    has_version = version.respond_to?(:empty?) ? !version.empty? : !version.nil?
+    has_tags = tag_directives.respond_to?(:empty?) ? !tag_directives.empty? : !tag_directives.nil?
+    fail!("CLA workflow YAML directives are not allowed") if has_version || has_tags
+    super
+  end
+
+  def end_mapping(*args)
+    @container_depth -= 1
+    super
+  end
+
+  def start_sequence(*args)
+    count_node!
+    enter_container!
+    super
+  end
+
+  def end_sequence(*args)
+    @container_depth -= 1
+    super
+  end
+
+  def scalar(*args)
+    count_node!
+    super
+  end
+
+  def alias(*_args)
+    fail!("YAML aliases are not allowed")
+  end
+
+  private
+
+  def count_node!
+    @node_count += 1
+    fail!("CLA workflow YAML has too many nodes") if @node_count > MAX_YAML_NODES
+  end
+
+  def enter_container!
+    @container_depth += 1
+    fail!("CLA workflow YAML is nested too deeply") if @container_depth > MAX_YAML_DEPTH
+  end
+end
+
+YAML_KEY_SCANNER = Psych::ScalarScanner.new(Psych::ClassLoader::Restricted.new([], [])).freeze
 
 def fail!(message)
   raise PolicyError, message
@@ -140,25 +213,68 @@ rescue JSON::ParserError
   fail!("GitHub API returned malformed JSON for #{endpoint}")
 end
 
+def review_sort_key(review)
+  timestamp = review["submitted_at"]
+  fail!("trusted review timestamp is malformed") unless timestamp.is_a?(String)
+  fail!("trusted review timestamp is malformed") unless timestamp.match?(
+    /\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\z/
+  )
+  review_id = review["id"]
+  fail!("pull-request review ID is malformed") unless
+    review_id.is_a?(Integer) && review_id.positive? && review_id <= MAX_REVIEW_ID
+  [Time.iso8601(timestamp).to_r, review_id]
+rescue ArgumentError
+  fail!("trusted review timestamp is malformed")
+end
+
+def collect_latest_trusted_review!(latest, seen_review_ids, review)
+  fail!("pull-request review entry is malformed") unless review.is_a?(Hash)
+  review_id = review["id"]
+  fail!("pull-request review ID is malformed") unless
+    review_id.is_a?(Integer) && review_id.positive? && review_id <= MAX_REVIEW_ID
+  fail!("pull-request review pagination repeated an entry") if seen_review_ids.key?(review_id)
+
+  seen_review_ids[review_id] = true
+  state = review["state"]
+  fail!("pull-request review state is malformed") unless TRUSTED_REVIEW_STATES.include?(state)
+  return if state == "PENDING"
+  fail!("pull-request review commit is malformed") unless review["commit_id"].is_a?(String) && review["commit_id"].match?(SHA)
+
+  user = review["user"]
+  fail!("pull-request review user is malformed") unless user.is_a?(Hash)
+  user_id = user["id"]
+  fail!("pull-request review user ID is malformed") unless user_id.is_a?(Integer) && user_id.positive?
+  reviewer_id = user_id.to_s
+  return unless TRUSTED_REVIEWER_IDS.include?(reviewer_id)
+  fail!("pull-request review user is not a human") unless user["type"] == "User"
+
+  order = review_sort_key(review)
+  previous = latest[reviewer_id]
+  latest[reviewer_id] = [order, review] if previous.nil? || (order <=> previous[0]).positive?
+end
+
 def require_trusted_review!(repository, pr_number, head_sha)
+  fail!("pull-request head SHA is malformed") unless head_sha.is_a?(String) && head_sha.match?(SHA)
   latest = {}
-  1.upto(3) do |page|
-    reviews = api_json(repository, "repos/#{repository}/pulls/#{pr_number}/reviews?per_page=100&page=#{page}")
+  seen_review_ids = {}
+  1.upto(MAX_REVIEW_PAGES) do |page|
+    reviews = api_json(
+      repository,
+      "repos/#{repository}/pulls/#{pr_number}/reviews?per_page=#{MAX_REVIEWS_PER_PAGE}&page=#{page}"
+    )
     fail!("pull-request review response is malformed") unless reviews.is_a?(Array)
-    reviews.each do |review|
-      user = review["user"]
-      next unless user.is_a?(Hash) && TRUSTED_REVIEWER_IDS.include?(user["id"].to_s)
-      next unless review["commit_id"] == head_sha
-      reviewer_id = user["id"].to_s
-      previous = latest[reviewer_id]
-      if previous.nil? || review["submitted_at"].to_s > previous["submitted_at"].to_s
-        latest[reviewer_id] = review
-      end
-    end
-    break if reviews.length < 100
-    fail!("pull-request review history is too large") if page == 3
+    fail!("pull-request review page is too large") if reviews.length > MAX_REVIEWS_PER_PAGE
+
+    reviews.each { |review| collect_latest_trusted_review!(latest, seen_review_ids, review) }
+
+    break if reviews.length < MAX_REVIEWS_PER_PAGE
+    fail!("pull-request review history is too large") if page == MAX_REVIEW_PAGES
   end
-  approved = latest.values.any? { |review| review["state"] == "APPROVED" }
+  approved = latest.values.any? do |_order, review|
+    review["state"] == "APPROVED" &&
+      review["commit_id"] == head_sha &&
+      review.fetch("dismissed_at", nil).nil?
+  end
   fail!("trusted approval for this control-plane update is required") unless approved
 end
 
@@ -189,9 +305,67 @@ def walk(value, &block)
   end
 end
 
-def parse_workflow(raw)
-  stream = Psych.parse_stream(raw)
+def reject_yaml_node_features!(node)
+  fail!("CLA workflow YAML tags are not allowed") if node.respond_to?(:tag) && node.tag
+  fail!("CLA workflow YAML anchors are not allowed") if node.respond_to?(:anchor) && node.anchor
+end
+
+def plain_yaml_key_is_string?(value)
+  YAML_KEY_SCANNER.tokenize(value).is_a?(String)
+rescue Psych::Exception
+  false
+end
+
+def validate_yaml_tree!(stream)
+  fail!("CLA workflow YAML stream is malformed") unless stream.is_a?(Psych::Nodes::Stream)
   fail!("CLA workflow must contain exactly one YAML document") unless stream.children.length == 1
+  fail!("CLA workflow YAML document is malformed") unless stream.children.first.is_a?(Psych::Nodes::Document)
+  stack = [[stream.children.first, 0]]
+  until stack.empty?
+    node, depth = stack.pop
+    fail!("CLA workflow YAML is malformed") unless node.is_a?(Psych::Nodes::Node)
+    reject_yaml_node_features!(node)
+    fail!("CLA workflow YAML is nested too deeply") if depth > MAX_YAML_DEPTH
+
+    case node
+    when Psych::Nodes::Stream, Psych::Nodes::Document
+      stack.concat(node.children.reverse_each.map { |child| [child, depth] })
+    when Psych::Nodes::Mapping
+      children = node.children
+      fail!("CLA workflow YAML mapping has an odd number of entries") unless children.length.even?
+      pairs = children.each_slice(2).to_a
+      seen_keys = {}
+      pairs.each do |key_node, _value_node|
+        fail!("CLA workflow has a non-scalar mapping key") unless key_node.is_a?(Psych::Nodes::Scalar)
+        reject_yaml_node_features!(key_node)
+        if key_node.style == Psych::Nodes::Scalar::PLAIN &&
+            !plain_yaml_key_is_string?(key_node.value) && !(depth.zero? && key_node.value == "on")
+          fail!("CLA workflow YAML mapping keys must be strings")
+        end
+        fail!("CLA workflow YAML merge keys are not allowed") if key_node.value == "<<"
+        fail!("CLA workflow YAML has duplicate mapping keys") if seen_keys.key?(key_node.value)
+
+        seen_keys[key_node.value] = true
+      end
+      stack.concat(pairs.reverse_each.map { |_key_node, value_node| [value_node, depth + 1] })
+    when Psych::Nodes::Sequence
+      stack.concat(node.children.reverse_each.map { |child| [child, depth + 1] })
+    when Psych::Nodes::Scalar
+      # Scalar anchors and tags were checked above. Their lexical values are
+      # intentionally left unchanged for the GitHub-specific `on` check.
+    when Psych::Nodes::Alias
+      fail!("CLA workflow YAML aliases are not allowed")
+    else
+      fail!("CLA workflow YAML contains an unsupported node")
+    end
+  end
+end
+
+def parse_workflow(raw)
+  builder = BoundedYamlTreeBuilder.new
+  Psych::Parser.new(builder).parse(raw)
+  stream = builder.root
+  validate_yaml_tree!(stream)
   root = stream.children.first.root
   fail!("CLA workflow is not a YAML mapping") unless root.is_a?(Psych::Nodes::Mapping)
   keys = root.children.each_slice(2).map do |key_node, _value_node|
@@ -199,7 +373,6 @@ def parse_workflow(raw)
 
     key_node.value
   end
-  fail!("CLA workflow has duplicate top-level keys") unless keys.uniq.length == keys.length
   # Psych applies YAML 1.1 boolean coercion to an unquoted `on` key. GitHub
   # uses the literal key, so accepting `true` here would validate a workflow
   # that GitHub does not trigger. Keep the lexical key check before loading.
@@ -218,6 +391,103 @@ def workflow_digest(raw)
   # digest can hide duplicate keys or YAML 1.1/GitHub parser differences.
   parse_workflow(raw)
   Digest::SHA256.hexdigest(raw)
+end
+
+def expect_policy_error(name)
+  raised = false
+  begin
+    yield
+  rescue PolicyError
+    raised = true
+  end
+  fail!("YAML regression case #{name} unexpectedly passed") unless raised
+end
+
+def run_yaml_regression_matrix!
+  valid = <<~YAML
+    name: test
+    on: {}
+    permissions: {}
+    env: {}
+    jobs: {}
+  YAML
+  parse_workflow(valid)
+  cases = {
+    "duplicate nested key" => <<~YAML,
+      name: test
+      on: {}
+      permissions: {}
+      env: {}
+      jobs:
+        duplicate: one
+        duplicate: two
+    YAML
+    "merge key" => <<~YAML,
+      name: test
+      on: {}
+      permissions: {}
+      env: {}
+      jobs:
+        merged:
+          <<: {}
+    YAML
+    "alias" => <<~YAML,
+      name: test
+      on: {}
+      permissions: {}
+      env: {}
+      jobs:
+        base: &anchor {}
+        copied: *anchor
+    YAML
+    "explicit tag" => <<~YAML,
+      name: !!str test
+      on: {}
+      permissions: {}
+      env: {}
+      jobs: {}
+    YAML
+    "multiple documents" => "---\nname: test\non: {}\n---\nname: second\non: {}\n",
+    "boolean trigger key" => <<~YAML,
+      name: test
+      true: {}
+      permissions: {}
+      env: {}
+      jobs: {}
+    YAML
+    "boolean key collision" => <<~YAML,
+      name: test
+      on: {}
+      yes: {}
+      permissions: {}
+      env: {}
+      jobs: {}
+    YAML
+    "numeric nested key" => <<~YAML
+      name: test
+      on: {}
+      permissions: {}
+      env: {}
+      jobs:
+        1: value
+    YAML
+  }
+  deep = +"name: test\non: {}\npermissions: {}\nenv: {}\njobs:\n"
+  MAX_YAML_DEPTH.times { |index| deep << "  " * (index + 1) << "k#{index}:\n" }
+  deep << "  " * (MAX_YAML_DEPTH + 1) << "value\n"
+  cases["excessive nesting"] = deep
+  cases["YAML directive"] = "%YAML 1.1\n---\nname: test\non: {}\npermissions: {}\nenv: {}\njobs: {}\n"
+  many = +"name: test\non: {}\npermissions: {}\nenv: {}\njobs:\n"
+  (MAX_YAML_NODES / 2).times { |index| many << "  k#{index}: value\n" }
+  cases["excessive nodes"] = many
+
+  cases.each { |name, raw| expect_policy_error(name) { parse_workflow(raw) } }
+  puts "PASS: bounded YAML regression matrix (#{cases.length + 1} cases)"
+end
+
+def legacy_v2_base?(base_workflow_digest:, base_script_digest:)
+  base_workflow_digest == LEGACY_CLA_WORKFLOW_DIGEST &&
+    base_script_digest == LEGACY_CLA_RERUN_DIGEST
 end
 
 def guard_script_digest(raw)
@@ -458,12 +728,82 @@ def run_trusted_cla_regression_matrix!
   end
   fail!("trusted CLA regression matrix failed: #{failures.join('; ')}") unless failures.empty?
   puts "PASS: trusted CLA regression matrix (#{cases.length} cases)"
+
+  migration_cases = [
+    ["exact legacy v2 bridge", LEGACY_CLA_WORKFLOW_DIGEST, LEGACY_CLA_RERUN_DIGEST, true],
+    ["different legacy workflow", "0" * 64, LEGACY_CLA_RERUN_DIGEST, false],
+    ["different legacy helper", LEGACY_CLA_WORKFLOW_DIGEST, "0" * 64, false]
+  ]
+  migration_failures = migration_cases.each_with_object([]) do |(name, workflow_digest, script_digest, expected), failures|
+    actual = legacy_v2_base?(
+      base_workflow_digest: workflow_digest,
+      base_script_digest: script_digest
+    )
+    failures << "#{name}: expected #{expected}, got #{actual}" unless actual == expected
+  end
+  fail!("CLA migration regression matrix failed: #{migration_failures.join('; ')}") unless migration_failures.empty?
+  puts "PASS: CLA migration regression matrix (#{migration_cases.length} cases)"
 end
 
-def validate_workflow(raw, trusted_base_digest)
+def run_trusted_review_regression_matrix!
+  head = "a" * 40
+  review = lambda do |id, state, at, commit = head, user = 54008264, dismissed = nil|
+    {
+      "id" => id,
+      "user" => { "id" => user, "type" => "User" },
+      "state" => state,
+      "commit_id" => commit,
+      "submitted_at" => at,
+      "dismissed_at" => dismissed
+    }
+  end
+  latest = {}
+  seen = {}
+  collect_latest_trusted_review!(latest, seen, review.call(2, "COMMENTED", "2026-01-02T00:00:00Z"))
+  collect_latest_trusted_review!(latest, seen, review.call(1, "APPROVED", "2026-01-01T00:00:00Z"))
+  fail!("trusted review ordering regression failed") unless latest.fetch("54008264")[1]["state"] == "COMMENTED"
+
+  latest = {}
+  seen = {}
+  timestamp = "2026-01-03T00:00:00Z"
+  collect_latest_trusted_review!(latest, seen, review.call(4, "COMMENTED", timestamp))
+  collect_latest_trusted_review!(latest, seen, review.call(3, "APPROVED", timestamp))
+  fail!("trusted review ID tie-break regression failed") unless latest.fetch("54008264")[1]["id"] == 4
+
+  latest = {}
+  seen = {}
+  collect_latest_trusted_review!(latest, seen, review.call(5, "APPROVED", "2026-01-04T00:00:00Z", head, 38676809))
+  collect_latest_trusted_review!(latest, seen, review.call(6, "DISMISSED", "2026-01-05T00:00:00Z", head, 38676809))
+  fail!("trusted review dismissal regression failed") unless latest.fetch("38676809")[1]["state"] == "DISMISSED"
+
+  latest = {}
+  seen = {}
+  collect_latest_trusted_review!(latest, seen, review.call(10, "APPROVED", "2026-01-05T00:00:00Z", head, 67667005))
+  fail!("Aziz trusted review regression failed") unless latest.fetch("67667005")[1]["state"] == "APPROVED"
+
+  latest = {}
+  seen = {}
+  collect_latest_trusted_review!(latest, seen, review.call(7, "APPROVED", "2026-01-06T00:00:00Z", head, 12345))
+  fail!("untrusted review was treated as trusted") unless latest.empty?
+
+  latest = {}
+  seen = {}
+  collect_latest_trusted_review!(latest, seen, { "id" => 8, "state" => "PENDING" })
+  fail!("pending review changed trusted state") unless latest.empty?
+
+  duplicate_failed = false
+  begin
+    collect_latest_trusted_review!(latest, seen, review.call(9, "APPROVED", "2026-01-06T00:00:00Z"))
+    collect_latest_trusted_review!(latest, seen, review.call(9, "APPROVED", "2026-01-06T00:00:01Z"))
+  rescue PolicyError
+    duplicate_failed = true
+  end
+  fail!("duplicate review regression failed") unless duplicate_failed
+  puts "PASS: trusted review state regression matrix (7 cases)"
+end
+
+def validate_workflow(raw)
   document = parse_workflow(raw)
-  candidate_digest = workflow_digest(raw)
-  require_trusted_review!(ENV.fetch("GH_REPO"), ENV.fetch("PR_NUMBER"), ENV.fetch("HEAD_SHA")) unless candidate_digest == trusted_base_digest
 
   # Keep the policy surface closed. YAML keys that are harmless in an
   # ordinary workflow, such as `defaults`, `services`, or `concurrency` at the
@@ -527,7 +867,8 @@ def validate_workflow(raw, trusted_base_digest)
     gate["outputs"] == {
       "admitted" => "${{ steps.admission.outputs.admitted }}",
       "signer_authorized" => "${{ steps.signer_preflight.outputs.signer_authorized }}",
-      "head_sha" => "${{ steps.signer_preflight.outputs.head_sha }}"
+      "head_sha" => "${{ steps.signer_preflight.outputs.head_sha }}",
+      "base_sha" => "${{ steps.signer_preflight.outputs.base_sha }}"
     }
   fail!("CLALedgerWriter outputs are not the reviewed contract") unless
     writer["outputs"] == {
@@ -662,7 +1003,8 @@ def validate_workflow(raw, trusted_base_digest)
     "allowlist-ids" => "38676809,67667005",
     "require-opener-as-author" => "true",
     "lock-pullrequest-aftermerge" => "false",
-    "expected-head-sha" => "${{ needs.CLACommentGate.outputs.head_sha }}"
+    "expected-head-sha" => "${{ needs.CLACommentGate.outputs.head_sha }}",
+    "expected-base-sha" => "${{ needs.CLACommentGate.outputs.base_sha }}"
   }
   assert_action_inputs(action_step, writer_inputs, "CLALedgerWriter action")
 
@@ -723,9 +1065,6 @@ end
 
 def validate_script(raw)
   fail!("CLA rerun script is missing a shell shebang") unless raw.start_with?("#!/usr/bin/env bash")
-  if Digest::SHA256.hexdigest(raw) != EXPECTED_RERUN_DIGEST
-    require_trusted_review!(ENV.fetch("GH_REPO"), ENV.fetch("PR_NUMBER"), ENV.fetch("HEAD_SHA"))
-  end
   Tempfile.create(["cla-rerun", ".sh"]) do |file|
     file.write(raw)
     file.close
@@ -793,15 +1132,29 @@ def validate_guard_script(raw)
   end
   [
     "def parse_workflow",
-    "Psych.parse_stream",
+    "class BoundedYamlTreeBuilder",
+    "Psych::Parser.new",
+    "MAX_YAML_NODES",
+    "MAX_YAML_DEPTH",
+    "duplicate mapping keys",
+    "merge keys",
+    "mapping keys must be strings",
+    "run_yaml_regression_matrix!",
+    "run_trusted_review_regression_matrix!",
+    "collect_latest_trusted_review!",
     "def workflow_digest",
     "Digest::SHA256.hexdigest(raw)",
     "literal on trigger key",
+    "def legacy_v2_base?",
+    "TRUSTED_REVIEW_STATES",
     "base_workflow_digest",
-    "validate_workflow(head_workflow, base_workflow_digest)",
+    "validate_workflow(head_workflow)",
+    "require_trusted_review!(repository, pr_number, head_sha) if policy_changed",
     "def validate_workflow",
     "signer-preflight",
     "CLALedgerWriter",
+    "base_sha",
+    "expected-base-sha",
     "base_workflow != head_workflow",
     "guard_changed && policy_changed",
     "pull-request revision deletes the rerun helper",
@@ -818,7 +1171,9 @@ def validate_guard_script(raw)
 end
 
 begin
+  run_yaml_regression_matrix!
   run_trusted_cla_regression_matrix!
+  run_trusted_review_regression_matrix!
   repository = required_env("GH_REPO", REPOSITORY)
   pr_number = required_env("PR_NUMBER", /\A[1-9][0-9]*\z/)
   base_sha = required_env("BASE_SHA", SHA)
@@ -885,12 +1240,29 @@ begin
   if base_script && head_script.nil?
     fail!("the pull-request revision deletes the rerun helper used by the base workflow")
   end
+  if base_workflow == head_workflow && base_script != head_script &&
+      Digest::SHA256.hexdigest(base_workflow.to_s) == LEGACY_CLA_WORKFLOW_DIGEST &&
+      Digest::SHA256.hexdigest(base_script.to_s) == LEGACY_CLA_RERUN_DIGEST
+    fail!("the legacy v2 CLA workflow must migrate to v3 before its helper changes")
+  end
   if base_workflow != head_workflow
     fail!("CLA rerun helper is missing from the changed workflow revision") if head_script.nil?
-    base_workflow_digest = workflow_digest(base_workflow)
-    validate_workflow(head_workflow, base_workflow_digest)
+    base_document = parse_workflow(base_workflow)
+    base_workflow_digest = Digest::SHA256.hexdigest(base_workflow)
+    base_script_digest = Digest::SHA256.hexdigest(base_script.to_s)
+    if base_document["name"] == "CLA Assistant v2" && !legacy_v2_base?(
+      base_workflow_digest: base_workflow_digest,
+      base_script_digest: base_script_digest
+    )
+      fail!("the legacy v2 CLA base is not the exact reviewed transition state")
+    end
+    validate_workflow(head_workflow)
   end
   validate_script(head_script) unless head_script.nil?
+  # Policy changes always need a current, exact-head trusted approval. The
+  # legacy digest bridge only identifies the permitted v2 base bytes. It never
+  # skips this review or any strict v3 candidate validation.
+  require_trusted_review!(repository, pr_number, head_sha) if policy_changed
 
   candidate_dir = ENV["CANDIDATE_DIR"].to_s
   unless candidate_dir.empty?

--- a/scripts/ci/validate-cla-policy.rb
+++ b/scripts/ci/validate-cla-policy.rb
@@ -20,14 +20,11 @@ REPOSITORY = /\A[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\z/
 MAX_FILE_BYTES = 300_000
 CLA_ACTION = "manaflow-ai/cla-github-action@fc608ba7106e7029d981d487d7bad28a64325956"
 # The privileged workflow is an explicit reviewed policy, not an extensible
-# script. A digest of its parsed document prevents a PR from adding a command,
-# secret reference, action input, or permission while retaining the fragments
-# checked below. Policy changes require a separate, reviewed update to this
-# base-controlled guard, followed by the workflow change.
-EXPECTED_WORKFLOW_DIGEST = "d4db98df5a1b1e6f3b006a82639761a0513eeeaf153a9eb2b98d42d1af782145"
+# script. Its parsed document is compared with the trusted base revision, so a
+# policy change requires trusted review without a fragile follow-up hash bump.
 EXPECTED_RERUN_DIGEST = "f4f1fa51bb05b062ebf3f60cc949d8d5b4b501e7849cb065e9a07d7a34030840"
 EXPECTED_GUARD_WORKFLOW_DIGEST = "cb08e6837d8065897016f12cf30c85e0153fc5c3c2d9ca1e6b409f4237541bc4"
-EXPECTED_GUARD_SCRIPT_DIGEST = "fba44dda662ef1ea91b0e840e8988d12a3856813b9bdd6ced72dc0d4dad81b2e"
+EXPECTED_GUARD_SCRIPT_DIGEST = "c83d3eb0092b562896157e542f0b638d5ab540c55d9bb88589bc5c72ef2a6c4c"
 # Current organization administrators who may approve a trusted control-plane
 # update. IDs are used instead of names, and the review must target the exact
 # PR head. This is the human path for intentional policy maintenance.
@@ -124,6 +121,20 @@ def canonical(value)
   else
     value
   end
+end
+
+def parse_workflow(raw)
+  document = YAML.safe_load(raw, aliases: false)
+  fail!("CLA workflow is not a YAML mapping") unless document.is_a?(Hash)
+  document
+rescue Psych::Exception => error
+  fail!("CLA workflow YAML is invalid: #{error.message.lines.first.to_s.strip}")
+end
+
+def workflow_digest(raw)
+  # Hash the parsed document so formatting-only edits do not trigger a
+  # privileged policy review.
+  Digest::SHA256.hexdigest(JSON.generate(canonical(parse_workflow(raw))))
 end
 
 def guard_script_digest(raw)
@@ -241,12 +252,12 @@ def run_trusted_cla_regression_matrix!
 
   add.call("author-recheck", {}, :admitted)
   add.call("exact-sign", { comment_body: CLA_SIGN_PHRASE }, :admitted)
-  add.call("non-author-sign", {
+  add.call("other-contributor-sign", {
     comment_body: CLA_SIGN_PHRASE,
     comment_author_id: "301",
     comment_author_login: "reviewer",
     comment_author_association: "MEMBER"
-  }, :ordinary)
+  }, :admitted)
   add.call("legacy-sign", { comment_body: "I have read the CLA Document and I hereby sign the CLA" }, :ordinary)
   add.call("uppercase-recheck", { comment_body: "RECHECK" }, :ordinary)
   add.call("padded-sign", { comment_body: " #{CLA_SIGN_PHRASE} " }, :ordinary)
@@ -286,11 +297,10 @@ def run_trusted_cla_regression_matrix!
   puts "PASS: trusted CLA regression matrix (#{cases.length} cases)"
 end
 
-def validate_workflow(raw)
-  document = YAML.safe_load(raw, aliases: false)
-  fail!("CLA workflow is not a YAML mapping") unless document.is_a?(Hash)
-  digest = Digest::SHA256.hexdigest(JSON.generate(canonical(document)))
-  require_trusted_review!(ENV.fetch("GH_REPO"), ENV.fetch("PR_NUMBER"), ENV.fetch("HEAD_SHA")) unless digest == EXPECTED_WORKFLOW_DIGEST
+def validate_workflow(raw, trusted_base_digest)
+  document = parse_workflow(raw)
+  candidate_digest = Digest::SHA256.hexdigest(JSON.generate(canonical(document)))
+  require_trusted_review!(ENV.fetch("GH_REPO"), ENV.fetch("PR_NUMBER"), ENV.fetch("HEAD_SHA")) unless candidate_digest == trusted_base_digest
 
   triggers = document["on"] || document[true]
   fail!("CLA workflow has no mapping of triggers") unless triggers.is_a?(Hash)
@@ -321,9 +331,9 @@ def validate_workflow(raw)
   admission_step = steps(gate, "CLACommentGate").find { |step| step.is_a?(Hash) && step["id"] == "admission" }
   admission_run = admission_step && admission_step["run"]
   fail!("CLACommentGate admission implementation is missing") unless admission_run.is_a?(String)
-  fail!("CLA signing must require the pull-request opener") unless admission_run.match?(
-    /if \[\[ "\$\{COMMENT_AUTHOR_ID\}" != "\$\{PR_AUTHOR_ID\}" \]\]; then\s+printf 'admitted=false\\n'/
-  )
+  sign_branch = admission_run[/if \[\[ "\$\{COMMENT_BODY\}" == "#{Regexp.escape(CLA_SIGN_PHRASE)}" \]\]; then(.*?)(?:\n\s*fi)/m]
+  fail!("CLA signing admission implementation is missing") unless sign_branch&.include?("printf 'admitted=true\\n'")
+  fail!("CLA signing admission must not duplicate commit identity mapping") if sign_branch.match?(/COMMENT_AUTHOR_ID|PR_AUTHOR_ID/)
   assert_permission(assistant, "CLAAssistant", "contents", "write")
   assert_permission(assistant, "CLAAssistant", "issues", "write")
   assert_permission(assistant, "CLAAssistant", "pull-requests", "write")
@@ -380,11 +390,14 @@ def validate_workflow(raw)
     "if: success()",
     "issues: write"
   ].each { |fragment| assert_text(raw, fragment) }
+  [gate["if"], assistant["if"]].each do |expression|
+    fail!("CLA signing trigger is missing from a signer job") unless expression.is_a?(String) && expression.include?(CLA_SIGN_PHRASE)
+  end
   sign_author_guard = Regexp.new(
-    "github\\.event\\.comment\\.body == '#{Regexp.escape(CLA_SIGN_PHRASE)}'\\s*&&\\s*" \
-    "github\\.event\\.comment\\.user\\.id == github\\.event\\.issue\\.user\\.id"
+    "github\\.event\\.comment\\.body\\s*==\\s*'#{Regexp.escape(CLA_SIGN_PHRASE)}'\\s*&&\\s*" \
+    "github\\.event\\.comment\\.user\\.id\\s*==\\s*github\\.event\\.issue\\.user\\.id"
   )
-  fail!("CLA signing trigger does not require the pull-request opener") unless raw.match?(sign_author_guard)
+  fail!("CLA signing trigger must admit authenticated contributors") if [gate["if"], assistant["if"], rerun["if"]].any? { |expression| expression.to_s.match?(sign_author_guard) }
   fail!("CLA workflow may not checkout a pull-request ref") if raw.match?(/ref:\s*\$\{\{\s*github\.event\.pull_request/)
 
   uses = []
@@ -452,7 +465,10 @@ def validate_guard_script(raw)
     require_trusted_review!(ENV.fetch("GH_REPO"), ENV.fetch("PR_NUMBER"), ENV.fetch("HEAD_SHA"))
   end
   [
-    "EXPECTED_WORKFLOW_DIGEST",
+    "def parse_workflow",
+    "def workflow_digest",
+    "base_workflow_digest",
+    "validate_workflow(head_workflow, base_workflow_digest)",
     "def validate_workflow",
     "base_workflow != head_workflow",
     "guard_changed && policy_changed",
@@ -520,7 +536,8 @@ begin
   end
   if base_workflow != head_workflow
     fail!("CLA rerun helper is missing from the changed workflow revision") if head_script.nil?
-    validate_workflow(head_workflow)
+    base_workflow_digest = workflow_digest(base_workflow)
+    validate_workflow(head_workflow, base_workflow_digest)
   end
   validate_script(head_script) unless head_script.nil?
 

--- a/scripts/ci/validate-cla-policy.rb
+++ b/scripts/ci/validate-cla-policy.rb
@@ -29,7 +29,7 @@ EXPECTED_GUARD_WORKFLOW_DIGEST = "01b3eed13d54db27ed195781dc0f6926a04cb9557de81f
 # The guard workflow remains pinned to its reviewed immutable bytes. The CLA
 # policy itself is validated structurally, then authorized by an exact-head
 # trusted review.
-EXPECTED_GUARD_SCRIPT_DIGEST = "db82ef01a5e63966972dc2043f45222c868226d6f197067ddb16d5bcde8b3b8e"
+EXPECTED_GUARD_SCRIPT_DIGEST = "518d54e5d7bec1978dbfaf6a164e51853f93898761f868b70709801f90e847be"
 # Migration marker for the base v2 guard validator. That validator requires
 # the literal EXPECTED_WORKFLOW_DIGEST while it checks this candidate. The v3
 # validator does not use this inert marker for policy authorization.
@@ -1623,6 +1623,17 @@ begin
       Digest::SHA256.hexdigest(base_workflow.to_s) == LEGACY_CLA_WORKFLOW_DIGEST &&
       Digest::SHA256.hexdigest(base_script.to_s) == LEGACY_CLA_RERUN_DIGEST
     fail!("the legacy v2 CLA workflow must migrate to v3 before its helper changes")
+  end
+  if base_workflow == head_workflow &&
+      !legacy_v2_base?(
+        base_workflow_digest: Digest::SHA256.hexdigest(base_workflow),
+        base_script_digest: Digest::SHA256.hexdigest(base_script.to_s)
+      )
+    # A guard-only change still has to prove that the policy already running
+    # on main is a reviewed v3 policy. The exact legacy v2 pair is the one
+    # intentional bridge: it is immutable base state and is allowed only
+    # until the separate v3 migration PR lands.
+    validate_workflow(head_workflow)
   end
   if base_workflow != head_workflow
     fail!("CLA rerun helper is missing from the changed workflow revision") if head_script.nil?

--- a/scripts/ci/validate-cla-policy.rb
+++ b/scripts/ci/validate-cla-policy.rb
@@ -29,7 +29,7 @@ EXPECTED_GUARD_WORKFLOW_DIGEST = "01b3eed13d54db27ed195781dc0f6926a04cb9557de81f
 # The guard workflow remains pinned to its reviewed immutable bytes. The CLA
 # policy itself is validated structurally, then authorized by an exact-head
 # trusted review.
-EXPECTED_GUARD_SCRIPT_DIGEST = "579790b38d6e34a08354cee77be1504749fbd9185e871ca4754081bad8347a82"
+EXPECTED_GUARD_SCRIPT_DIGEST = "82dfd92af42120fc8b32781d8d8352deaa7c247635f30a10efdc300b24826150"
 # Migration marker for the base v2 guard validator. That validator requires
 # the literal EXPECTED_WORKFLOW_DIGEST while it checks this candidate. The v3
 # validator does not use this inert marker for policy authorization.
@@ -104,6 +104,17 @@ RERUN_ENV = {
 # that a token-specific regular expression cannot parse safely.
 GITHUB_CONTEXT_IN_RUN = /\$\{\{/m
 TOKEN_ENV_IN_RUN = /(?:\A|[^A-Za-z0-9_])(?:GITHUB_TOKEN|GH_TOKEN|ACTIONS_RUNTIME_TOKEN|ACTIONS_ID_TOKEN_REQUEST_TOKEN|RUNNER_TOKEN)(?:\z|[^A-Za-z0-9_])/i
+EXPRESSION_MARKER = /\$\{\{/m
+GITHUB_CONTEXT_EXPRESSION = /\bgithub\b/i
+GITHUB_TOKEN_EXPRESSION_PATTERN = /\bgithub\b.*\btoken\b|\btoJSON\s*\(\s*github\b/i
+ALLOWED_EXPRESSION_PATHS = [
+  /\Aenv\.[^.]+\z/,
+  /\Ajobs\.[^.]+\.if\z/,
+  /\Ajobs\.[^.]+\.concurrency\.group\z/,
+  /\Ajobs\.[^.]+\.outputs\.[^.]+\z/,
+  /\Ajobs\.[^.]+\.steps\.\d+\.env\.[^.]+\z/,
+  /\Ajobs\.[^.]+\.steps\.\d+\.with\.[^.]+\z/
+].freeze
 
 # The guard workflow is itself a privileged control-plane input. Keep its
 # checkout, environment, and shell contracts as immutable data. Whitespace is
@@ -735,11 +746,30 @@ def assert_exact_secret_paths(document, allowed_paths: ALLOWED_SECRET_PATHS)
   allowed_paths.each { |path| expected[path] = GITHUB_TOKEN_EXPRESSION }
   actual = {}
   walk_paths(document) do |path, value|
-    next unless value.is_a?(String) && value.match?(/\bsecrets\b|\bgithub\.token\b/i)
+    next unless value.is_a?(String) && value.match?(
+      /\bsecrets\b|\bgithub\b.*\btoken\b|\btoJSON\s*\(\s*github\b/i
+    )
 
     actual[path] = value
   end
   fail!("workflow token references are not the reviewed contract") unless actual == expected
+end
+
+def assert_safe_expression_fields(document, name, allowed_secret_paths: ALLOWED_SECRET_PATHS)
+  walk_paths(document) do |path, value|
+    next unless value.is_a?(String) && value.match?(EXPRESSION_MARKER)
+
+    joined_path = path.map(&:to_s).join(".")
+    fail!("#{name} has an expression in an unreviewed field") unless
+      ALLOWED_EXPRESSION_PATHS.any? { |pattern| joined_path.match?(pattern) }
+    if value.match?(GITHUB_CONTEXT_EXPRESSION) && value.match?(GITHUB_TOKEN_EXPRESSION_PATTERN)
+      fail!("#{name} may not reference the GitHub token or serialized context")
+    end
+    if value.match?(/\bsecrets\b/i)
+      fail!("#{name} has an unapproved secret expression") unless
+        allowed_secret_paths.include?(path) && value == GITHUB_TOKEN_EXPRESSION
+    end
+  end
 end
 
 def assert_safe_run_text(run, name)
@@ -1076,6 +1106,39 @@ def run_environment_regression_matrix!
     assert_safe_run_text("echo \"$ACTIONS_RUNTIME_TOKEN\"", "regression run")
   end
 
+  safe_expression_document = {
+    "jobs" => {
+      "example" => {
+        "if" => "${{ github.event_name == 'issue_comment' }}",
+        "concurrency" => { "group" => "cla-${{ github.run_id }}" },
+        "outputs" => { "result" => "${{ steps.result.outputs.value }}" },
+        "steps" => [
+          {
+            "env" => { "EVENT" => "${{ github.event_name }}" },
+            "with" => { "repository" => "${{ github.repository }}" }
+          }
+        ]
+      }
+    }
+  }
+  assert_safe_expression_fields(safe_expression_document, "regression expressions")
+  checks += 1
+  expect_failure.call("expression in metadata") do
+    changed = Marshal.load(Marshal.dump(safe_expression_document))
+    changed["jobs"]["example"]["name"] = "${{ github['token'] }}"
+    assert_safe_expression_fields(changed, "regression expressions")
+  end
+  expect_failure.call("serialized context in metadata") do
+    changed = Marshal.load(Marshal.dump(safe_expression_document))
+    changed["jobs"]["example"]["name"] = "${{ toJSON(github) }}"
+    assert_safe_expression_fields(changed, "regression expressions")
+  end
+  expect_failure.call("indexed secret expression") do
+    changed = Marshal.load(Marshal.dump(safe_expression_document))
+    changed["jobs"]["example"]["steps"][0]["env"]["EVENT"] = "${{ secrets['OTHER_TOKEN'] }}"
+    assert_safe_expression_fields(changed, "regression expressions")
+  end
+
   puts "PASS: CLA environment regression matrix (#{checks} cases)"
 end
 
@@ -1400,6 +1463,7 @@ def validate_workflow(raw)
     assert_action_reference(reference, "CLA workflow action")
   end
   assert_exact_secret_paths(document)
+  assert_safe_expression_fields(document, "CLA workflow")
   assert_safe_run_values(document)
 
   raw
@@ -1474,6 +1538,7 @@ def validate_guard_workflow(raw, authorize: true)
     "guard validation step run"
   )
   assert_exact_secret_paths(document, allowed_paths: GUARD_ALLOWED_SECRET_PATHS)
+  assert_safe_expression_fields(document, "guard workflow", allowed_secret_paths: GUARD_ALLOWED_SECRET_PATHS)
   assert_safe_run_values(document)
   uses = []
   walk(document) { |key, value| uses << value if key == "uses" && value.is_a?(String) }
@@ -1514,6 +1579,7 @@ def validate_guard_script(raw)
     "assert_exact_environment",
     "assert_exact_typed_inputs",
     "assert_exact_secret_paths",
+    "assert_safe_expression_fields",
     "assert_safe_run_text",
     "assert_exact_normalized_run",
     "run_guard_contract_regression_matrix!",

--- a/scripts/ci/validate-cla-policy.rb
+++ b/scripts/ci/validate-cla-policy.rb
@@ -18,13 +18,13 @@ class PolicyError < StandardError; end
 SHA = /\A[0-9a-f]{40}\z/
 REPOSITORY = /\A[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\z/
 MAX_FILE_BYTES = 300_000
-CLA_ACTION = "manaflow-ai/cla-github-action@fc608ba7106e7029d981d487d7bad28a64325956"
+CLA_ACTION = "manaflow-ai/cla-github-action@af7ae9ac7de23b982ea494d8200fc9b40bbc6690"
 # The privileged workflow is an explicit reviewed policy, not an extensible
 # script. Its exact bytes are compared with the trusted base revision, so a
 # policy change requires trusted review without a fragile follow-up hash bump.
 EXPECTED_RERUN_DIGEST = "f4f1fa51bb05b062ebf3f60cc949d8d5b4b501e7849cb065e9a07d7a34030840"
 EXPECTED_GUARD_WORKFLOW_DIGEST = "63a96bd533e09afaa8aecfe871362b07e28697cf2a1ed85459b5991001d885f8"
-EXPECTED_GUARD_SCRIPT_DIGEST = "21a1c1f0ba00f3c31454870e1aaabbcf9cb0d1c5f87ab8b2b8c75cfa872e0cf5"
+EXPECTED_GUARD_SCRIPT_DIGEST = "73ded48fa91ed26bb0cad6ac5e56d51ae8c2329444e502d287ba33af52ed8e7d"
 # Current organization administrators who may approve a trusted control-plane
 # update. IDs are used instead of names, and the review must target the exact
 # PR head. This is the human path for intentional policy maintenance.

--- a/scripts/ci/validate-cla-policy.rb
+++ b/scripts/ci/validate-cla-policy.rb
@@ -25,11 +25,11 @@ CLA_ACTION = "manaflow-ai/cla-github-action@482864f7296623ba4e8ddb7d6bc183663530
 # The privileged workflow is an explicit reviewed policy, not an extensible
 # script. Its candidate structure is checked as data, and every policy change
 # requires trusted review without a fragile follow-up hash bump.
-EXPECTED_GUARD_WORKFLOW_DIGEST = "0f347a749f53d2e06f5b39b7a832476d39ab40a71c8634b48c029bc728f5c1d1"
+EXPECTED_GUARD_WORKFLOW_DIGEST = "01b3eed13d54db27ed195781dc0f6926a04cb9557de81f50762b532ea14e4440"
 # The guard workflow remains pinned to its reviewed immutable bytes. The CLA
 # policy itself is validated structurally, then authorized by an exact-head
 # trusted review.
-EXPECTED_GUARD_SCRIPT_DIGEST = "01a363114d66fbf3802c94672232d3f7f71e11ebc31499682896bc30b447421e"
+EXPECTED_GUARD_SCRIPT_DIGEST = "52bf04eff367cd8c23598783e6bf6231dee86d55f194de979bccec1f5e4a33ad"
 # Migration marker for the base v2 guard validator. That validator requires
 # the literal EXPECTED_WORKFLOW_DIGEST while it checks this candidate. The v3
 # validator does not use this inert marker for policy authorization.
@@ -53,6 +53,9 @@ ALLOWED_SECRET_PATHS = [
   %w[jobs CLALedgerWriter steps] + [0] + %w[env GITHUB_TOKEN],
   %w[jobs RerunFailedCLA steps] + [1] + %w[env GH_TOKEN],
   %w[jobs LockMergedPullRequest steps] + [0] + %w[env GITHUB_TOKEN]
+].freeze
+GUARD_ALLOWED_SECRET_PATHS = [
+  %w[jobs validate steps] + [2] + %w[env GH_TOKEN]
 ].freeze
 
 ADMISSION_ENV = {
@@ -98,6 +101,58 @@ RERUN_ENV = {
 }.freeze
 GITHUB_CONTEXT_IN_RUN = /\$\{\{[^}]*\bgithub\b[^}]*\}\}/im
 TOKEN_ENV_IN_RUN = /(?:\A|[^A-Za-z0-9_])(?:GITHUB_TOKEN|GH_TOKEN|ACTIONS_RUNTIME_TOKEN|ACTIONS_ID_TOKEN_REQUEST_TOKEN|RUNNER_TOKEN)(?:\z|[^A-Za-z0-9_])/i
+
+# The guard workflow is itself a privileged control-plane input. Keep its
+# checkout, environment, and shell contracts as immutable data. Whitespace is
+# normalized only at line boundaries so a YAML block scalar cannot gain an
+# extra command, redirection, or interpolation while retaining the reviewed
+# command sequence.
+GUARD_CHECKOUT_WITH = {
+  "repository" => "${{ github.repository }}",
+  "ref" => "${{ github.workflow_sha }}",
+  "fetch-depth" => 1,
+  "persist-credentials" => false,
+  "sparse-checkout" => "scripts/ci/validate-cla-policy.rb",
+  "sparse-checkout-cone-mode" => false
+}.freeze
+GUARD_VERIFY_ENV = {
+  "WORKFLOW_SHA" => "${{ github.workflow_sha }}"
+}.freeze
+GUARD_VALIDATE_ENV = {
+  "GH_TOKEN" => GITHUB_TOKEN_EXPRESSION,
+  "GH_REPO" => "${{ github.repository }}",
+  "PR_NUMBER" => "${{ github.event.pull_request.number }}",
+  "BASE_SHA" => "${{ github.event.pull_request.base.sha }}",
+  "HEAD_SHA" => "${{ github.event.pull_request.head.sha }}"
+}.freeze
+GUARD_VERIFY_RUN = <<~'SH'.strip.freeze
+  set -euo pipefail
+  [[ "$WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]]
+  [[ "$(git rev-parse HEAD)" == "$WORKFLOW_SHA" ]]
+  [[ -f scripts/ci/validate-cla-policy.rb ]]
+SH
+GUARD_VALIDATE_RUN = <<~'SH'.strip.freeze
+  set -euo pipefail
+  candidate_dir="$(mktemp -d "$RUNNER_TEMP/cla-policy.XXXXXX")"
+  trap 'rm -rf "$candidate_dir"' EXIT
+  CANDIDATE_DIR="$candidate_dir" ruby scripts/ci/validate-cla-policy.rb
+  if [[ -f "$candidate_dir/rerun-failed-cla.sh" ]]; then
+    shellcheck --shell=bash "$candidate_dir/rerun-failed-cla.sh"
+  fi
+  if [[ -f "$candidate_dir/cla.yml" ]]; then
+    archive="$RUNNER_TEMP/actionlint.tar.gz"
+    curl -fsSL -o "$archive" \
+      "https://github.com/rhysd/actionlint/releases/download/v1.7.7/actionlint_1.7.7_linux_amd64.tar.gz"
+    echo "023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757  $archive" | sha256sum --check --strict
+    tar -xzf "$archive" -C "$RUNNER_TEMP" actionlint
+    "$RUNNER_TEMP/actionlint" "$candidate_dir/cla.yml"
+  fi
+SH
+# These hashes make the reviewed command contracts auditable without relying
+# on YAML formatting. They are recomputed from normalize_run_text below when
+# this policy file changes intentionally.
+GUARD_VERIFY_RUN_HASH = "708659eb2df9c50e070dab49190c2c3712a1485a5292eadb86eb4ae3fb01cbb5"
+GUARD_VALIDATE_RUN_HASH = "759f3978ae0a2e0620eb2630cd4c1ec2cbff8f9bcc9a37f76b330b845091bda8"
 
 # Keep the admission contract in one small, executable specification. The
 # pull-request workflow is still checked as data below, but its shell cannot be
@@ -657,22 +712,97 @@ def walk_paths(value, path = [], &block)
   end
 end
 
-def assert_exact_secret_paths(document)
+def assert_exact_secret_paths(document, allowed_paths: ALLOWED_SECRET_PATHS)
   expected = {}
-  ALLOWED_SECRET_PATHS.each { |path| expected[path] = GITHUB_TOKEN_EXPRESSION }
+  allowed_paths.each { |path| expected[path] = GITHUB_TOKEN_EXPRESSION }
   actual = {}
   walk_paths(document) do |path, value|
     next unless value.is_a?(String) && value.match?(/\bsecrets\b|\bgithub\.token\b/i)
 
     actual[path] = value
   end
-  fail!("CLA workflow token references are not the reviewed contract") unless actual == expected
+  fail!("workflow token references are not the reviewed contract") unless actual == expected
 end
 
 def assert_safe_run_text(run, name)
   fail!("#{name} must be a shell string") unless run.is_a?(String)
   fail!("#{name} may not interpolate the GitHub context") if run.match?(GITHUB_CONTEXT_IN_RUN)
   fail!("#{name} may not access a token environment variable") if run.match?(TOKEN_ENV_IN_RUN)
+end
+
+def normalize_run_text(run)
+  run.to_s.gsub("\r\n", "\n").lines.map(&:rstrip).join("\n").strip
+end
+
+def assert_exact_normalized_run(run, expected, expected_digest, name)
+  assert_safe_run_text(run, name)
+  normalized = normalize_run_text(run)
+  fail!("#{name} is not the reviewed shell contract") unless
+    normalized == normalize_run_text(expected) && Digest::SHA256.hexdigest(normalized) == expected_digest
+end
+
+def run_guard_contract_regression_matrix!
+  checks = 0
+  expect_failure = lambda do |name, &block|
+    failed = false
+    begin
+      block.call
+    rescue PolicyError
+      failed = true
+    end
+    fail!("#{name} guard contract regression failed") unless failed
+    checks += 1
+  end
+
+  checkout = { "with" => GUARD_CHECKOUT_WITH.dup }
+  assert_action_inputs(checkout, GUARD_CHECKOUT_WITH, "regression guard checkout")
+  checks += 1
+  expect_failure.call("changed checkout ref") do
+    changed = Marshal.load(Marshal.dump(checkout))
+    changed["with"]["ref"] = "${{ github.event.pull_request.head.sha }}"
+    assert_action_inputs(changed, GUARD_CHECKOUT_WITH, "regression guard checkout")
+  end
+
+  verification = { "env" => GUARD_VERIFY_ENV.dup, "run" => GUARD_VERIFY_RUN }
+  assert_exact_environment(verification, GUARD_VERIFY_ENV, "regression guard verification")
+  assert_exact_normalized_run(
+    verification["run"], GUARD_VERIFY_RUN, GUARD_VERIFY_RUN_HASH, "regression guard verification run"
+  )
+  checks += 2
+  expect_failure.call("added verification token env") do
+    changed = Marshal.load(Marshal.dump(verification))
+    changed["env"]["GH_TOKEN"] = GITHUB_TOKEN_EXPRESSION
+    assert_exact_environment(changed, GUARD_VERIFY_ENV, "regression guard verification")
+  end
+  expect_failure.call("changed verification shell") do
+    assert_exact_normalized_run(
+      "#{verification["run"]}\nprintf 'unexpected\\n'",
+      GUARD_VERIFY_RUN,
+      GUARD_VERIFY_RUN_HASH,
+      "regression guard verification run"
+    )
+  end
+
+  validation = { "env" => GUARD_VALIDATE_ENV.dup, "run" => GUARD_VALIDATE_RUN }
+  assert_exact_environment(validation, GUARD_VALIDATE_ENV, "regression guard validation")
+  assert_exact_normalized_run(
+    validation["run"], GUARD_VALIDATE_RUN, GUARD_VALIDATE_RUN_HASH, "regression guard validation run"
+  )
+  checks += 2
+  expect_failure.call("added validation secret env") do
+    changed = Marshal.load(Marshal.dump(validation))
+    changed["env"]["EXTRA_TOKEN"] = "${{ secrets.OTHER_TOKEN }}"
+    assert_exact_environment(changed, GUARD_VALIDATE_ENV, "regression guard validation")
+  end
+  expect_failure.call("GitHub context in validation shell") do
+    assert_exact_normalized_run(
+      "#{validation["run"]}\nprintf '%s\\n' '${{ github['token'] }}'",
+      GUARD_VALIDATE_RUN,
+      GUARD_VALIDATE_RUN_HASH,
+      "regression guard validation run"
+    )
+  end
+  puts "PASS: guard workflow contract regression matrix (#{checks} cases)"
 end
 
 def assert_safe_run_values(document)
@@ -1261,12 +1391,9 @@ def validate_script(raw)
   end
 end
 
-def validate_guard_workflow(raw)
+def validate_guard_workflow(raw, authorize: true)
   document = parse_workflow(raw)
   digest = workflow_digest(raw)
-  if digest != EXPECTED_GUARD_WORKFLOW_DIGEST
-    require_trusted_review!(ENV.fetch("GH_REPO"), ENV.fetch("PR_NUMBER"), ENV.fetch("HEAD_SHA"))
-  end
   triggers = document["on"] || document[true]
   fail!("guard workflow has no mapping of triggers") unless triggers.is_a?(Hash)
   target = triggers["pull_request_target"]
@@ -1290,10 +1417,6 @@ def validate_guard_workflow(raw)
   fail!("guard workflow must use an ephemeral GitHub-hosted runner") unless guard_job["runs-on"] == "ubuntu-24.04"
   fail!("guard workflow must use read-only permissions") unless
     guard_job["permissions"] == { "contents" => "read", "pull-requests" => "read" }
-  fail!("guard workflow must verify the immutable checkout") unless
-    raw.include?("ref: ${{ github.workflow_sha }}") &&
-    raw.include?("persist-credentials: false") &&
-    raw.include?("scripts/ci/validate-cla-policy.rb")
   guard_steps = guard_job["steps"]
   fail!("guard workflow steps are malformed") unless guard_steps.is_a?(Array) && guard_steps.length == 3
   assert_step_keys(guard_steps[0], "guard checkout step", %w[name uses with])
@@ -1301,13 +1424,37 @@ def validate_guard_workflow(raw)
   assert_step_keys(guard_steps[2], "guard validation step", %w[name env run])
   fail!("guard workflow checkout step is not the immutable checkout") unless
     guard_steps[0]["uses"] == "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"
-  fail!("guard workflow verification step may not access a token or network") if
-    guard_steps[1]["run"].to_s.match?(/\b(gh|curl|wget|ssh|sudo|eval|source)\b|secrets\.GITHUB_TOKEN|GITHUB_TOKEN/)
+  assert_action_inputs(guard_steps[0], GUARD_CHECKOUT_WITH, "guard checkout step")
+  fail!("guard checkout step has an unexpected name") unless guard_steps[0]["name"] == "Checkout immutable guard revision"
+  fail!("guard checkout step must pin the trusted repository") unless
+    guard_steps[0].dig("with", "repository") == "${{ github.repository }}"
+  fail!("guard verification step has an unexpected name") unless guard_steps[1]["name"] == "Verify trusted checkout"
+  assert_exact_environment(guard_steps[1], GUARD_VERIFY_ENV, "guard checkout verification step")
+  assert_exact_normalized_run(
+    guard_steps[1]["run"],
+    GUARD_VERIFY_RUN,
+    GUARD_VERIFY_RUN_HASH,
+    "guard checkout verification step run"
+  )
+  fail!("guard validation step has an unexpected name") unless
+    guard_steps[2]["name"] == "Run trusted CLA regression matrix and validate policy as data"
+  assert_exact_environment(guard_steps[2], GUARD_VALIDATE_ENV, "guard validation step")
+  assert_exact_normalized_run(
+    guard_steps[2]["run"],
+    GUARD_VALIDATE_RUN,
+    GUARD_VALIDATE_RUN_HASH,
+    "guard validation step run"
+  )
+  assert_exact_secret_paths(document, allowed_paths: GUARD_ALLOWED_SECRET_PATHS)
+  assert_safe_run_values(document)
   uses = []
   walk(document) { |key, value| uses << value if key == "uses" && value.is_a?(String) }
   uses.each do |reference|
     fail!("guard workflow may not use repository-local actions") if reference.start_with?("./")
     fail!("guard workflow uses an unapproved action") unless reference == "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"
+  end
+  if authorize && digest != EXPECTED_GUARD_WORKFLOW_DIGEST
+    require_trusted_review!(ENV.fetch("GH_REPO"), ENV.fetch("PR_NUMBER"), ENV.fetch("HEAD_SHA"))
   end
 rescue Psych::Exception
   fail!("guard workflow YAML is invalid")
@@ -1339,6 +1486,14 @@ def validate_guard_script(raw)
     "assert_exact_environment",
     "assert_exact_secret_paths",
     "assert_safe_run_text",
+    "assert_exact_normalized_run",
+    "run_guard_contract_regression_matrix!",
+    "GUARD_CHECKOUT_WITH",
+    "GUARD_VERIFY_ENV",
+    "GUARD_VALIDATE_ENV",
+    "GUARD_VERIFY_RUN_HASH",
+    "GUARD_VALIDATE_RUN_HASH",
+    "GUARD_ALLOWED_SECRET_PATHS",
     "GITHUB_CONTEXT_IN_RUN",
     "TOKEN_ENV_IN_RUN",
     "TRUSTED_REVIEW_STATES",
@@ -1367,6 +1522,7 @@ end
 
 begin
   run_yaml_regression_matrix!
+  run_guard_contract_regression_matrix!
   run_trusted_cla_regression_matrix!
   run_environment_regression_matrix!
   run_trusted_review_regression_matrix!

--- a/scripts/ci/validate-cla-policy.rb
+++ b/scripts/ci/validate-cla-policy.rb
@@ -29,7 +29,7 @@ EXPECTED_GUARD_WORKFLOW_DIGEST = "01b3eed13d54db27ed195781dc0f6926a04cb9557de81f
 # The guard workflow remains pinned to its reviewed immutable bytes. The CLA
 # policy itself is validated structurally, then authorized by an exact-head
 # trusted review.
-EXPECTED_GUARD_SCRIPT_DIGEST = "e96bc93bd4cfe3172f1e24507d8866d197f22335f9593dcdf8cce0ac43e939dd"
+EXPECTED_GUARD_SCRIPT_DIGEST = "0b11a4abcf4b91b0ed3d862475dae345dcfa46569c2d75caedaa49f3ac8f7ccb"
 # Migration marker for the base v2 guard validator. That validator requires
 # the literal EXPECTED_WORKFLOW_DIGEST while it checks this candidate. The v3
 # validator does not use this inert marker for policy authorization.
@@ -44,6 +44,7 @@ LEGACY_CLA_RERUN_DIGEST = "f4f1fa51bb05b062ebf3f60cc949d8d5b4b501e7849cb065e9a07
 # PR head. This is the human path for intentional policy maintenance.
 TRUSTED_REVIEWER_IDS = %w[54008264 38676809 67667005].freeze
 TRUSTED_REVIEW_STATES = %w[APPROVED COMMENTED CHANGES_REQUESTED DISMISSED PENDING].freeze
+TRUSTED_REVIEW_DECISION_STATES = %w[APPROVED CHANGES_REQUESTED DISMISSED].freeze
 MAX_REVIEW_PAGES = 3
 MAX_REVIEWS_PER_PAGE = 100
 MAX_REVIEW_ID = (1 << 63) - 1
@@ -381,7 +382,7 @@ def collect_latest_trusted_review!(latest, seen_review_ids, review)
   fail!("pull-request review state is malformed") unless TRUSTED_REVIEW_STATES.include?(state)
   # COMMENTED and PENDING reviews do not change GitHub's approval decision.
   # In particular, a later comment must not erase a valid approval.
-  return if %w[COMMENTED PENDING].include?(state)
+  return unless TRUSTED_REVIEW_DECISION_STATES.include?(state)
   fail!("pull-request review commit is malformed") unless review["commit_id"].is_a?(String) && review["commit_id"].match?(SHA)
   fail!("pull-request review user is not a human") unless user["type"] == "User"
 

--- a/scripts/ci/validate-cla-policy.rb
+++ b/scripts/ci/validate-cla-policy.rb
@@ -27,7 +27,7 @@ EXPECTED_GUARD_WORKFLOW_DIGEST = "0f347a749f53d2e06f5b39b7a832476d39ab40a71c8634
 # EXPECTED_WORKFLOW_DIGEST is retained as a compatibility marker for the
 # immutable validator in the current base revision. Policy validation now
 # hashes the candidate workflow bytes after lexical YAML validation.
-EXPECTED_GUARD_SCRIPT_DIGEST = "936d334455c3e3e91b9ea9936e1e7b436796a8c2d0b6f0ac1675f698b2c19751"
+EXPECTED_GUARD_SCRIPT_DIGEST = "ffb481c630a5f2e1e601b61c855ffbb49a9f6a1d5d9397d1e0276ab0dd4dcc1c"
 # Current organization administrators who may approve a trusted control-plane
 # update. IDs are used instead of names, and the review must target the exact
 # PR head. This is the human path for intentional policy maintenance.
@@ -466,7 +466,7 @@ def validate_workflow(raw, trusted_base_digest)
   job_keys = {
     "CLACommentGate" => %w[name if runs-on timeout-minutes concurrency permissions outputs steps],
     "CLAAssistant" => %w[name needs if runs-on timeout-minutes permissions steps],
-    "CLALedgerWriter" => %w[name needs if runs-on timeout-minutes concurrency permissions steps],
+    "CLALedgerWriter" => %w[name needs if runs-on timeout-minutes concurrency permissions outputs steps],
     "CLACompatibility" => %w[name needs if runs-on timeout-minutes permissions steps],
     "RerunFailedCLA" => %w[name needs if runs-on timeout-minutes permissions steps],
     "LockMergedPullRequest" => %w[name if runs-on timeout-minutes concurrency permissions steps]
@@ -489,6 +489,10 @@ def validate_workflow(raw, trusted_base_digest)
       "signer_authorized" => "${{ steps.signer_preflight.outputs.signer_authorized }}",
       "head_sha" => "${{ steps.signer_preflight.outputs.head_sha }}"
     }
+  fail!("CLALedgerWriter outputs are not the reviewed contract") unless
+    writer["outputs"] == {
+      "signature_recorded" => "${{ steps.cla_action.outputs.signature_recorded }}"
+    }
   fail!("CLA ledger writer must depend on the admission gate") unless dependencies(writer, "CLALedgerWriter").include?("CLACommentGate")
   fail!("CLA ledger writer must not run with always()") if writer["if"].to_s.include?("always()")
   fail!("CLA ledger writer must run only after successful admission") unless
@@ -506,7 +510,8 @@ def validate_workflow(raw, trusted_base_digest)
   writer_steps = steps(writer, "CLALedgerWriter")
   fail!("CLALedgerWriter must contain exactly one step") unless writer_steps.length == 1
   writer_step = writer_steps.first
-  assert_step_keys(writer_step, "CLALedgerWriter step", %w[name uses env with])
+  assert_step_keys(writer_step, "CLALedgerWriter step", %w[name id uses env with])
+  fail!("CLALedgerWriter step must have id cla_action") unless writer_step["id"] == "cla_action"
   assert_action_reference(writer_step["uses"], "CLALedgerWriter step uses")
   fail!("CLALedgerWriter must invoke only the maintained CLA action") unless writer_step["uses"] == CLA_ACTION
   fail!("CLALedgerWriter action must receive the GitHub token explicitly") unless
@@ -649,9 +654,9 @@ def validate_workflow(raw, trusted_base_digest)
     "github.event.action == 'created'",
     "id: admission",
     "admitted: ${{ steps.admission.outputs.admitted }}",
-    "if: success()",
     "issues: write"
   ].each { |fragment| assert_text(raw, fragment) }
+  fail!("CLA workflow is missing a successful-step guard") unless raw.match?(/if:\s*(?:[>|]-?\s*)?(?:\$\{\{\s*)?success\(\)/)
   [gate["if"], assistant["if"]].each do |expression|
     fail!("CLA signing trigger is missing from a signer job") unless expression.is_a?(String) && expression.include?(CLA_SIGN_PHRASE)
   end

--- a/scripts/ci/validate-cla-policy.rb
+++ b/scripts/ci/validate-cla-policy.rb
@@ -20,11 +20,11 @@ REPOSITORY = /\A[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\z/
 MAX_FILE_BYTES = 300_000
 CLA_ACTION = "manaflow-ai/cla-github-action@fc608ba7106e7029d981d487d7bad28a64325956"
 # The privileged workflow is an explicit reviewed policy, not an extensible
-# script. Its parsed document is compared with the trusted base revision, so a
+# script. Its exact bytes are compared with the trusted base revision, so a
 # policy change requires trusted review without a fragile follow-up hash bump.
 EXPECTED_RERUN_DIGEST = "f4f1fa51bb05b062ebf3f60cc949d8d5b4b501e7849cb065e9a07d7a34030840"
-EXPECTED_GUARD_WORKFLOW_DIGEST = "cb08e6837d8065897016f12cf30c85e0153fc5c3c2d9ca1e6b409f4237541bc4"
-EXPECTED_GUARD_SCRIPT_DIGEST = "c83d3eb0092b562896157e542f0b638d5ab540c55d9bb88589bc5c72ef2a6c4c"
+EXPECTED_GUARD_WORKFLOW_DIGEST = "63a96bd533e09afaa8aecfe871362b07e28697cf2a1ed85459b5991001d885f8"
+EXPECTED_GUARD_SCRIPT_DIGEST = "a2b91eea0805be406ac8c59805b12a2d6e9b470066a2b7378f1c126387f6dd7e"
 # Current organization administrators who may approve a trusted control-plane
 # update. IDs are used instead of names, and the review must target the exact
 # PR head. This is the human path for intentional policy maintenance.
@@ -110,20 +110,23 @@ def walk(value, &block)
   end
 end
 
-def canonical(value)
-  case value
-  when Hash
-    value.keys.sort_by(&:to_s).each_with_object({}) do |key, result|
-      result[key.to_s] = canonical(value[key])
-    end
-  when Array
-    value.map { |child| canonical(child) }
-  else
-    value
-  end
-end
-
 def parse_workflow(raw)
+  stream = Psych.parse_stream(raw)
+  fail!("CLA workflow must contain exactly one YAML document") unless stream.children.length == 1
+  root = stream.children.first.root
+  fail!("CLA workflow is not a YAML mapping") unless root.is_a?(Psych::Nodes::Mapping)
+  keys = root.children.each_slice(2).map do |key_node, _value_node|
+    fail!("CLA workflow has a non-scalar top-level key") unless key_node.is_a?(Psych::Nodes::Scalar)
+
+    key_node.value
+  end
+  fail!("CLA workflow has duplicate top-level keys") unless keys.uniq.length == keys.length
+  # Psych applies YAML 1.1 boolean coercion to an unquoted `on` key. GitHub
+  # uses the literal key, so accepting `true` here would validate a workflow
+  # that GitHub does not trigger. Keep the lexical key check before loading.
+  fail!("CLA workflow must contain the literal on trigger key") unless keys.include?("on")
+  fail!("CLA workflow must not use a boolean trigger key") if keys.include?("true")
+
   document = YAML.safe_load(raw, aliases: false)
   fail!("CLA workflow is not a YAML mapping") unless document.is_a?(Hash)
   document
@@ -132,9 +135,10 @@ rescue Psych::Exception => error
 end
 
 def workflow_digest(raw)
-  # Hash the parsed document so formatting-only edits do not trigger a
-  # privileged policy review.
-  Digest::SHA256.hexdigest(JSON.generate(canonical(parse_workflow(raw))))
+  # Hash the exact bytes after validating the YAML lexical structure. A parsed
+  # digest can hide duplicate keys or YAML 1.1/GitHub parser differences.
+  parse_workflow(raw)
+  Digest::SHA256.hexdigest(raw)
 end
 
 def guard_script_digest(raw)
@@ -163,6 +167,24 @@ def step_using(job_value, action, name)
   found = steps(job_value, name).find { |step| step.is_a?(Hash) && step["uses"] == action }
   fail!("#{name} does not use #{action}") unless found
   found
+end
+
+def step_using_with(job_value, action, input, expected, name)
+  found = steps(job_value, name).find do |step|
+    step.is_a?(Hash) &&
+      step["uses"] == action &&
+      step["with"].is_a?(Hash) &&
+      step["with"][input].to_s == expected
+  end
+  fail!("#{name} does not use #{action} with #{input}=#{expected}") unless found
+  found
+end
+
+def dependencies(job_value, name)
+  value = job_value["needs"]
+  result = value.is_a?(Array) ? value : [value]
+  fail!("#{name}.needs is malformed") unless result.all? { |item| item.is_a?(String) && !item.empty? }
+  result
 end
 
 def assert_text(text, fragment)
@@ -299,7 +321,7 @@ end
 
 def validate_workflow(raw, trusted_base_digest)
   document = parse_workflow(raw)
-  candidate_digest = Digest::SHA256.hexdigest(JSON.generate(canonical(document)))
+  candidate_digest = workflow_digest(raw)
   require_trusted_review!(ENV.fetch("GH_REPO"), ENV.fetch("PR_NUMBER"), ENV.fetch("HEAD_SHA")) unless candidate_digest == trusted_base_digest
 
   triggers = document["on"] || document[true]
@@ -318,26 +340,48 @@ def validate_workflow(raw, trusted_base_digest)
 
   gate = job(document, "CLACommentGate")
   assistant = job(document, "CLAAssistant")
+  writer = job(document, "CLALedgerWriter")
   compatibility = job(document, "CLACompatibility")
   rerun = job(document, "RerunFailedCLA")
   lock = job(document, "LockMergedPullRequest")
-  [gate, assistant, compatibility, rerun, lock].each_with_index do |value, index|
-    names = %w[CLACommentGate CLAAssistant CLACompatibility RerunFailedCLA LockMergedPullRequest]
+  [gate, assistant, writer, compatibility, rerun, lock].each_with_index do |value, index|
+    names = %w[CLACommentGate CLAAssistant CLALedgerWriter CLACompatibility RerunFailedCLA LockMergedPullRequest]
     fail!("#{names[index]} has no runner") unless value.key?("runs-on")
   end
 
-  fail!("CLACommentGate must have no permissions") unless gate["permissions"] == {}
+  fail!("CLACommentGate must use read-only permissions") unless
+    gate["permissions"] == { "contents" => "read", "issues" => "read", "pull-requests" => "read" }
   fail!("CLACompatibility must have no permissions") unless compatibility["permissions"] == {}
+  fail!("CLA Assistant result must have no permissions") unless assistant["permissions"] == {}
+  fail!("CLA ledger writer must depend on the admission gate") unless dependencies(writer, "CLALedgerWriter").include?("CLACommentGate")
+  fail!("CLA ledger writer must not run with always()") if writer["if"].to_s.include?("always()")
+  fail!("CLA ledger writer must run only after successful admission") unless
+    writer["if"].to_s.include?("needs.CLACommentGate.result == 'success'") &&
+    writer["if"].to_s.include?("needs.CLACommentGate.outputs.admitted == 'true'")
+  fail!("CLA Assistant result must depend on the ledger writer") unless dependencies(assistant, "CLAAssistant").include?("CLALedgerWriter")
+  fail!("CLA Assistant result must always report the writer outcome") unless assistant["if"].to_s.include?("always()")
+  fail!("CLA compatibility must depend on the v2 result") unless dependencies(compatibility, "CLACompatibility").include?("CLAAssistant")
   admission_step = steps(gate, "CLACommentGate").find { |step| step.is_a?(Hash) && step["id"] == "admission" }
   admission_run = admission_step && admission_step["run"]
   fail!("CLACommentGate admission implementation is missing") unless admission_run.is_a?(String)
   sign_branch = admission_run[/if \[\[ "\$\{COMMENT_BODY\}" == "#{Regexp.escape(CLA_SIGN_PHRASE)}" \]\]; then(.*?)(?:\n\s*fi)/m]
   fail!("CLA signing admission implementation is missing") unless sign_branch&.include?("printf 'admitted=true\\n'")
   fail!("CLA signing admission must not duplicate commit identity mapping") if sign_branch.match?(/COMMENT_AUTHOR_ID|PR_AUTHOR_ID/)
-  assert_permission(assistant, "CLAAssistant", "contents", "write")
-  assert_permission(assistant, "CLAAssistant", "issues", "write")
-  assert_permission(assistant, "CLAAssistant", "pull-requests", "write")
-  fail!("CLAAssistant must not have actions: write") if assistant.dig("permissions", "actions") == "write"
+  preflight = step_using_with(gate, CLA_ACTION, "mode", "signer-preflight", "CLACommentGate")
+  preflight_with = preflight["with"]
+  {
+    "required-base-ref" => "main",
+    "custom-pr-sign-comment" => CLA_SIGN_PHRASE,
+    "require-opener-as-author" => "true"
+  }.each do |key, expected|
+    fail!("CLA signer preflight input #{key} is unsafe") unless preflight_with[key].to_s == expected
+  end
+  fail!("CLA signer preflight must be conditional on the exact signing phrase") unless preflight["if"].to_s.include?(CLA_SIGN_PHRASE)
+  fail!("CLA gate must expose the signer preflight result") unless gate.dig("outputs", "signer_authorized").to_s.include?("signer_preflight")
+  assert_permission(writer, "CLALedgerWriter", "contents", "write")
+  assert_permission(writer, "CLALedgerWriter", "issues", "write")
+  assert_permission(writer, "CLALedgerWriter", "pull-requests", "write")
+  fail!("CLALedgerWriter must not have actions: write") if writer.dig("permissions", "actions") == "write"
   assert_permission(rerun, "RerunFailedCLA", "actions", "write")
   assert_permission(rerun, "RerunFailedCLA", "contents", "read")
   assert_permission(rerun, "RerunFailedCLA", "issues", "read")
@@ -345,7 +389,7 @@ def validate_workflow(raw, trusted_base_digest)
   assert_permission(lock, "LockMergedPullRequest", "issues", "write")
   assert_permission(lock, "LockMergedPullRequest", "pull-requests", "read")
 
-  action_step = step_using(assistant, CLA_ACTION, "CLAAssistant")
+  action_step = step_using(writer, CLA_ACTION, "CLALedgerWriter")
   with_values = action_step["with"]
   fail!("CLA action inputs are missing") unless with_values.is_a?(Hash)
   {
@@ -426,9 +470,8 @@ def validate_script(raw)
 end
 
 def validate_guard_workflow(raw)
-  document = YAML.safe_load(raw, aliases: false)
-  fail!("guard workflow is not a YAML mapping") unless document.is_a?(Hash)
-  digest = Digest::SHA256.hexdigest(JSON.generate(canonical(document)))
+  document = parse_workflow(raw)
+  digest = workflow_digest(raw)
   if digest != EXPECTED_GUARD_WORKFLOW_DIGEST
     require_trusted_review!(ENV.fetch("GH_REPO"), ENV.fetch("PR_NUMBER"), ENV.fetch("HEAD_SHA"))
   end
@@ -441,6 +484,9 @@ def validate_guard_workflow(raw)
     target["branches"] == ["main"] &&
     target["types"] == %w[opened edited reopened synchronize]
   fail!("guard workflow must have empty top-level permissions") unless document["permissions"] == {}
+  jobs = document["jobs"]
+  fail!("guard workflow jobs are malformed") unless jobs.is_a?(Hash)
+  fail!("guard workflow has an unexpected job") unless jobs.keys == ["validate"]
   guard_job = document.dig("jobs", "validate")
   fail!("guard workflow validate job is missing") unless guard_job.is_a?(Hash)
   fail!("guard workflow must use read-only permissions") unless
@@ -452,7 +498,7 @@ def validate_guard_workflow(raw)
   uses = []
   walk(document) { |key, value| uses << value if key == "uses" && value.is_a?(String) }
   uses.each do |reference|
-    next if reference.start_with?("./")
+    fail!("guard workflow may not use repository-local actions") if reference.start_with?("./")
     fail!("guard action reference is not pinned") unless reference.match?(/\A[^@]+@[0-9a-f]{40}\z/)
   end
 rescue Psych::Exception
@@ -466,10 +512,15 @@ def validate_guard_script(raw)
   end
   [
     "def parse_workflow",
+    "Psych.parse_stream",
     "def workflow_digest",
+    "Digest::SHA256.hexdigest(raw)",
+    "literal on trigger key",
     "base_workflow_digest",
     "validate_workflow(head_workflow, base_workflow_digest)",
     "def validate_workflow",
+    "signer-preflight",
+    "CLALedgerWriter",
     "base_workflow != head_workflow",
     "guard_changed && policy_changed",
     "pull-request revision deletes the rerun helper",

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -18,17 +18,17 @@ IOS_FILE="$ROOT_DIR/.github/workflows/test-ios.yml"
 CLA_GUARD_FILE="$ROOT_DIR/.github/workflows/cla-policy-guard.yml"
 
 check_cla_guard_runner() {
-  if ! grep -Fqx '    runs-on: ${{ vars.LINUX_RUNNER || '\''blacksmith-4vcpu-ubuntu-2404'\'' }}' "$CLA_GUARD_FILE"; then
-    echo "FAIL: cla-policy-guard.yml must use the configured Linux runner with the Blacksmith fallback"
+  if ! grep -Fqx '    runs-on: ubuntu-24.04' "$CLA_GUARD_FILE"; then
+    echo "FAIL: cla-policy-guard.yml must use the fixed GitHub-hosted ubuntu-24.04 runner"
     exit 1
   fi
 
-  if grep -Eq '^    runs-on: ubuntu-' "$CLA_GUARD_FILE"; then
-    echo "FAIL: cla-policy-guard.yml must not use a bare GitHub-hosted runner"
+  if grep -Eq '^    runs-on:.*(vars\.LINUX_RUNNER|blacksmith-|self-hosted)' "$CLA_GUARD_FILE"; then
+    echo "FAIL: cla-policy-guard.yml must not allow a variable or self-hosted runner override"
     exit 1
   fi
 
-  echo "PASS: CLA policy guard uses the configured Linux runner"
+  echo "PASS: CLA policy guard uses the fixed GitHub-hosted runner"
 }
 
 check_macos_runner() {
@@ -1121,15 +1121,18 @@ check_tmux_terminal_nightly_isolation() {
 }
 
 check_no_bare_github_hosted_runners() {
-  # Every job must route its runner through a repo variable (LINUX_RUNNER,
+  # Every product CI job must route its runner through a repo variable (LINUX_RUNNER,
   # MACOS_RUNNER_*) so the Blacksmith<->Warp / Blacksmith<->macos-26 overflow
   # switch is a single repo-variable flip with no PR. A bare GitHub-hosted
   # label (ubuntu-*, macos-NN) cannot be redirected, so it is forbidden.
+  # The CLA policy guard is a separate immutable control-plane job and is
+  # intentionally exempted below because it must never honor a repository
+  # variable or self-hosted runner override.
   # Bare paid-provider labels (blacksmith-*, warp-*, depot-*) stay allowed for
   # deliberate single-runner pins such as the testmanagerd-wedged
   # `app-host-unit-tests` job.
   local hits
-  hits="$(grep -rnE "runs-on:[[:space:]]*(ubuntu-[a-z0-9.]+|macos-[a-z0-9]+)([[:space:]]*$|[[:space:]]+#)" "$ROOT_DIR/.github/workflows" | grep -v "github-hosted-required" || true)"
+  hits="$(grep -rnE "runs-on:[[:space:]]*(ubuntu-[a-z0-9.]+|macos-[a-z0-9]+)([[:space:]]*$|[[:space:]]+#)" "$ROOT_DIR/.github/workflows" | grep -v "github-hosted-required" | grep -v '/.github/workflows/cla-policy-guard.yml:' || true)"
   if [[ -n "$hits" ]]; then
     echo "FAIL: these jobs use a bare GitHub-hosted runner; route them through vars.LINUX_RUNNER / vars.MACOS_RUNNER_IOS so Blacksmith<->overflow stays a repo-variable flip:"
     echo "$hits"


### PR DESCRIPTION
The trusted guard now parses the base CLA workflow and compares the candidate canonical document to that trusted snapshot. Formatting-only changes do not require a hash follow-up, while policy changes still require an exact-head trusted approval. The guard admission matrix also permits exact signatures from non-opener contributors and rejects identity or metadata anomalies.

This is intentionally guard-only. The policy workflow change is in a separate pull request so a candidate cannot weaken its own reviewer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives CLA policy trust from the base revision instead of hardcoded workflow and helper digests. Policy changes now require exact-head trusted approval after lexical and raw-byte validation, with only the exact legacy v2 pair allowed as a one-step migration; the guard also runs on fixed GitHub-hosted `ubuntu-24.04` instead of a repository-configured runner.

- Bounds YAML parsing by node count and depth, and rejects aliases, tags, merge keys, duplicate keys, non-string keys, directives, and multi-document streams so raw-byte forks can't hide behind a canonical digest.
- Admits non-opener signatures only after the pinned action's read-only signer preflight authorizes the same identity, and binds the single-step `CLALedgerWriter` job to the preflight's head/base SHAs and the maintained action's generation marker.
- Locks policy and guard checkouts, triggers, environments, action inputs, and shell steps to reviewed contracts; run steps reject GitHub expressions and token environment variables, and token references are allowed only in fixed step env slots.
- Keeps exact-head approvals valid across later comments, ignores malformed untrusted reviews, adds a trusted reviewer, and validates the unchanged base policy during guard-only changes with the legacy v2 pair as the only bridge.

<sup>Written for commit cae6f4161a9880daff1eb15342934a7aab963690. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected contributor signing admission so trusted non-authors can be admitted.
  * Strengthened workflow validation, trusted-review handling, policy checks, and sign-trigger validation.
  * Added protections against unsafe workflow content, parsing edge cases, and invalid environments or secrets.
  * Ensured policy checks always run on a fixed GitHub-hosted runner.
  * Improved pull request metadata verification and exact-head approval enforcement.
* **Chores**
  * Updated validation integrity checks and signing action verification.
  * Added migration handling for legacy policy workflows.
  * Expanded regression coverage for policy and workflow validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->