### PR TITLE
test: keep browser portal layout assertion synchronous

### DIFF
--- a/cmuxTests/BrowserPanelViewIdentityTests.swift
+++ b/cmuxTests/BrowserPanelViewIdentityTests.swift
@@ -45,14 +45,16 @@ import WebKit
         let expectedFrameInWindow = anchor.convert(anchor.bounds, to: nil)
 
         NotificationCenter.default.post(name: NSWindow.didResizeNotification, object: window)
-        await waitForNextMainActorTurn()
-        await waitForNextMainActorTurn()
-
+        // Assert before AppKit can service the intentionally dirty host on a later run-loop turn.
         #expect(
             referenceView.layoutPassCount == 0,
             "The browser portal must consume settled geometry without synchronously laying out SwiftUI's hosting view."
         )
         #expect(referenceView.needsLayout)
+
+        await waitForNextMainActorTurn()
+        await waitForNextMainActorTurn()
+
         let snapshot = try #require(
             portal.debugSnapshot(forWebViewId: ObjectIdentifier(webView))
         )


### PR DESCRIPTION
## Summary

Keep the browser portal geometry assertion synchronous. The previous test dirtied an NSHostingView, yielded twice, and then counted AppKit’s unrelated display-cycle layout as a portal violation. The assertion now runs before yielding; the existing post-yield snapshot check still verifies deferred geometry delivery.

## Verification

- `git diff --check` passed.
- The failure is recorded in https://github.com/manaflow-ai/cmux/actions/runs/33507208093, app-host shard 6.
- This PR changes test timing only; no production behavior changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the browser portal layout assertion run before yielding so AppKit's unrelated display-cycle layout can no longer count as a portal violation. The post-yield snapshot check still verifies deferred geometry delivery as before. Test timing only; no production behavior changes.

<sup>Written for commit 9008c759744e99ccd207d698fb612e28e2a120f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated browser panel geometry synchronization coverage to verify layout state immediately after a window resize.
  * Improved test timing to ensure deferred SwiftUI layout behavior is validated reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->