### PR TITLE
relay: bound daemon process reaping

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -785,15 +785,22 @@ async fn cleanup_daemon(mut child: tokio::process::Child) {
             let _ = libc::kill(-(pid as libc::pid_t), libc::SIGTERM);
         }
     }
-    if tokio::time::timeout(Duration::from_millis(250), child.wait()).await.is_ok() {
-        return;
+    match tokio::time::timeout(Duration::from_millis(250), child.wait()).await {
+        Ok(Ok(_status)) => return,
+        Ok(Err(_wait_error)) | Err(_elapsed) => {
+            // A timeout completion is not enough. `wait` has its own I/O
+            // result, and a failed reap must still go through escalation.
+        }
     }
     if let Some(pid) = child.id() {
         unsafe {
             let _ = libc::kill(-(pid as libc::pid_t), libc::SIGKILL);
         }
     }
-    let _ = child.kill().await;
+    // `kill` also waits for the child, so using it here would make the
+    // supposedly bounded cleanup unbounded. Send SIGKILL, then bound the
+    // explicit reap below.
+    let _ = child.start_kill();
     let _ = tokio::time::timeout(Duration::from_secs(1), child.wait()).await;
 }
 

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -787,7 +787,7 @@ async fn cleanup_daemon(mut child: tokio::process::Child) {
     }
     match tokio::time::timeout(Duration::from_millis(250), child.wait()).await {
         Ok(Ok(_status)) => return,
-        Ok(Err(_wait_error)) | Err(_elapsed) => {
+        Ok(Err(_)) | Err(_) => {
             // A timeout completion is not enough. `wait` has its own I/O
             // result, and a failed reap must still go through escalation.
         }


### PR DESCRIPTION
## Summary
- distinguish Tokio timeout expiry from a successful daemon child reap
- use `start_kill` before the bounded final wait so cleanup cannot block inside `Child::kill`

## Testing
- `rustfmt --edition 2024 --check cmux-tui/crates/chatmux-relay/src/pty_deps.rs`
- `git diff --check`
- Cargo and rustc were not run by policy

## Context
- Follow-up audit for https://github.com/manaflow-ai/cmux/pull/11401
- Tokio timeout and Child process semantics: https://docs.rs/tokio/latest/tokio/time/fn.timeout.html and https://docs.rs/tokio/latest/tokio/process/struct.Child.html

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds daemon process cleanup so reaping cannot hang indefinitely.

Previously, a wait that completed before the deadline was treated as success even if it errored, and a deadline expiry led to `child.kill().await`, which can block. Now a timeout or failed wait escalates to SIGKILL, uses `start_kill` to avoid blocking, and completes with a bounded final wait.

<sup>Written for commit b4fcc403ae2dd238b60f51589f8b68b9a1f53482. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup reliability for background processes.
  * Processes that do not exit promptly after termination are now forcefully stopped within a bounded time, preventing cleanup from hanging indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->