### PR TITLE
test: keep browser portal layout assertion synchronous

### DIFF
--- a/cmuxTests/BrowserPanelViewIdentityTests.swift
+++ b/cmuxTests/BrowserPanelViewIdentityTests.swift
@@ -45,14 +45,16 @@ import WebKit
         let expectedFrameInWindow = anchor.convert(anchor.bounds, to: nil)
 
         NotificationCenter.default.post(name: NSWindow.didResizeNotification, object: window)
-        await waitForNextMainActorTurn()
-        await waitForNextMainActorTurn()
-
+        // Assert before AppKit can service the intentionally dirty host on a later run-loop turn.
         #expect(
             referenceView.layoutPassCount == 0,
             "The browser portal must consume settled geometry without synchronously laying out SwiftUI's hosting view."
         )
         #expect(referenceView.needsLayout)
+
+        await waitForNextMainActorTurn()
+        await waitForNextMainActorTurn()
+
         let snapshot = try #require(
             portal.debugSnapshot(forWebViewId: ObjectIdentifier(webView))
         )


### PR DESCRIPTION
## Summary

Keep the browser portal geometry assertion before AppKit's display-cycle layout pass. This prevents a false failure where the notification itself performs one layout pass before the test checks the pre-layout contract.

## Testing

- Hosted main CI failure reference: https://github.com/manaflow-ai/cmux/actions/runs/33507208093
- No production behavior changes.

The regression test is the behavior change. No local Xcode tests were run.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the browser portal geometry assertion in the test so it runs synchronously before AppKit's display-cycle layout pass. Previously the test awaited two main-actor turns before asserting, which let the notification's own layout pass trigger a false failure. The assertion now executes immediately after posting the resize notification, with the waits moved after it. No production behavior changes.

<sup>Written for commit 9008c759744e99ccd207d698fb612e28e2a120f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

