### PR TITLE
fix(cmux-tui): bound terminal journal retry cadence

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/journal_ingress.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_ingress.rs
@@ -1013,13 +1013,8 @@ fn run(mux: Weak<Mux>, receivers: JournalIngressReceivers) {
                             return;
                         }
                         if retryable_sqlite_error(&error) {
-                            // Do not retain the owning mux while sleeping. Shutdown and drop
-                            // must be able to release the writer even when SQLite stays locked.
-                            let journal = mux.shared_journal_handle();
-                            let epoch = journal.epoch();
-                            drop(mux);
-                            journal.wait(epoch, delay.min(remaining));
-                            delay = (delay * 2).min(JOURNAL_RETRY_MAX_DELAY);
+                            wait_for_journal_retry(mux, delay.min(remaining));
+                            delay = next_journal_retry_delay(delay);
                             continue;
                         }
                         if batch.len() > 1 {
@@ -1035,10 +1030,10 @@ fn run(mux: Weak<Mux>, receivers: JournalIngressReceivers) {
                             if receivers.state.pause_nonretryable_failure_for_test() {
                                 continue;
                             }
-                            let journal = mux.shared_journal_handle();
-                            let epoch = journal.epoch();
-                            drop(mux);
-                            journal.wait(epoch, JOURNAL_NONRETRYABLE_RETRY_DELAY.min(remaining));
+                            wait_for_journal_retry(
+                                mux,
+                                JOURNAL_NONRETRYABLE_RETRY_DELAY.min(remaining),
+                            );
                             continue;
                         } else if batch[0].completion.is_none() {
                             let failure = receivers.state.fail(format!(
@@ -1061,6 +1056,19 @@ fn run(mux: Weak<Mux>, receivers: JournalIngressReceivers) {
             }
         }
     }
+}
+
+fn wait_for_journal_retry(mux: Arc<Mux>, timeout: Duration) {
+    // Do not retain the owning mux while sleeping. Shutdown and drop must be
+    // able to release the writer even when SQLite stays locked.
+    let journal = mux.shared_journal_handle();
+    let epoch = journal.epoch();
+    drop(mux);
+    journal.wait(epoch, timeout);
+}
+
+fn next_journal_retry_delay(delay: Duration) -> Duration {
+    delay.saturating_mul(2).min(JOURNAL_RETRY_MAX_DELAY)
 }
 
 fn admit_batch_commit(
@@ -1250,10 +1258,27 @@ mod tests {
         let mut delay = JOURNAL_RETRY_INITIAL_DELAY;
         for expected in [100, 200, 400, 800, 1000, 1000] {
             assert_eq!(delay.as_millis(), expected);
-            delay = (delay * 2).min(JOURNAL_RETRY_MAX_DELAY);
+            delay = next_journal_retry_delay(delay);
         }
+        assert_eq!(JOURNAL_NONRETRYABLE_RETRY_DELAY, Duration::from_millis(10));
+        assert_eq!(next_journal_retry_delay(Duration::MAX), JOURNAL_RETRY_MAX_DELAY);
         let remaining = Duration::from_millis(3);
         assert_eq!(JOURNAL_NONRETRYABLE_RETRY_DELAY.min(remaining), remaining);
+    }
+
+    #[test]
+    fn retry_wait_releases_mux_before_waiting() {
+        let mux = Mux::new("journal-retry-wait-drop", crate::SurfaceOptions::default());
+        let weak = Arc::downgrade(&mux);
+        let started = Instant::now();
+
+        wait_for_journal_retry(mux, Duration::from_secs(5));
+
+        assert!(weak.upgrade().is_none(), "retry wait retained the owning mux");
+        assert!(
+            started.elapsed() < Duration::from_millis(500),
+            "shutdown wake did not interrupt the retry wait"
+        );
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/journal_ingress.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_ingress.rs
@@ -972,6 +972,11 @@ fn run(mux: Weak<Mux>, receivers: JournalIngressReceivers) {
                     for pending_batch in pending {
                         complete_batch_error(&pending_batch, error.clone());
                     }
+                    // The final Mux owner can disappear while this writer is
+                    // in a retry wait. Drain both ingress lanes so receipts
+                    // for events that never entered the active batch cannot
+                    // remain unresolved forever.
+                    complete_queued_error(&receivers, &error);
                     return;
                 };
                 if Instant::now() >= retry_deadline {
@@ -2614,6 +2619,28 @@ mod tests {
         completion_receiver
             .recv_timeout(Duration::from_millis(500))
             .expect("journal writer waited for its own completion during Mux::drop");
+    }
+
+    #[test]
+    fn mux_shutdown_completes_receipts_left_in_ingress_queues() {
+        let (sender, receivers) = JournalIngressSender::new(true);
+        let receivers = receivers.expect("journal receivers");
+        let (completion_sender, completion_receiver) = sync_channel(1);
+        let deadline = Instant::now() + JOURNAL_DURABLE_WAIT;
+        let queued = QueuedJournalEvent {
+            event: JournalIngressEvent::TerminalBarrier,
+            completion: Some(JournalIngressCompletion::Durable {
+                sender: completion_sender,
+                deadline,
+                commit_fence: Arc::new(AtomicU8::new(COMMIT_PENDING)),
+            }),
+        };
+        sender.terminal_sender.as_ref().unwrap().try_send(queued).unwrap();
+
+        complete_queued_error(&receivers, "session journal stopped");
+
+        let result = completion_receiver.recv_timeout(Duration::from_millis(100)).unwrap();
+        assert!(result.is_err(), "shutdown must resolve queued durable receipts");
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/journal_ingress.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_ingress.rs
@@ -1059,11 +1059,20 @@ fn run(mux: Weak<Mux>, receivers: JournalIngressReceivers) {
 }
 
 fn wait_for_journal_retry(mux: Arc<Mux>, timeout: Duration) {
+    wait_for_journal_retry_after_release(mux, timeout, || {});
+}
+
+fn wait_for_journal_retry_after_release(
+    mux: Arc<Mux>,
+    timeout: Duration,
+    after_release: impl FnOnce(),
+) {
     // Do not retain the owning mux while sleeping. Shutdown and drop must be
     // able to release the writer even when SQLite stays locked.
     let journal = mux.shared_journal_handle();
     let epoch = journal.epoch();
     drop(mux);
+    after_release();
     journal.wait(epoch, timeout);
 }
 
@@ -1269,16 +1278,33 @@ mod tests {
     #[test]
     fn retry_wait_releases_mux_before_waiting() {
         let mux = Mux::new("journal-retry-wait-drop", crate::SurfaceOptions::default());
-        let weak = Arc::downgrade(&mux);
-        let started = Instant::now();
+        let journal = mux.shared_journal_handle();
+        let (released_tx, released_rx) = std::sync::mpsc::sync_channel(1);
+        let (proceed_tx, proceed_rx) = std::sync::mpsc::sync_channel(1);
+        let (done_tx, done_rx) = std::sync::mpsc::sync_channel(1);
+        let waiter_mux = Arc::clone(&mux);
+        let waiter = std::thread::spawn(move || {
+            wait_for_journal_retry_after_release(waiter_mux, Duration::from_secs(60), || {
+                released_tx.send(()).unwrap();
+                proceed_rx.recv().unwrap();
+            });
+            done_tx.send(()).unwrap();
+        });
 
-        wait_for_journal_retry(mux, Duration::from_secs(5));
+        // Keep one caller-owned Arc so Mux::drop cannot wake the journal wait
+        // while the test observes that the waiter released its own Arc.
+        let released = released_rx.recv_timeout(Duration::from_secs(5)).is_ok();
+        let strong_count = Arc::strong_count(&mux);
 
-        assert!(weak.upgrade().is_none(), "retry wait retained the owning mux");
-        assert!(
-            started.elapsed() < Duration::from_millis(500),
-            "shutdown wake did not interrupt the retry wait"
-        );
+        let _ = proceed_tx.send(());
+        journal.wake_waiters();
+        let completed = done_rx.recv_timeout(Duration::from_secs(5)).is_ok();
+        let joined = waiter.join().is_ok();
+
+        assert!(released, "retry wait did not reach the release gate");
+        assert_eq!(strong_count, 1, "retry wait retained the owning mux");
+        assert!(completed, "retry wait did not return after its wake");
+        assert!(joined, "retry wait thread panicked");
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/journal_ingress.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_ingress.rs
@@ -1013,8 +1013,12 @@ fn run(mux: Weak<Mux>, receivers: JournalIngressReceivers) {
                             return;
                         }
                         if retryable_sqlite_error(&error) {
-                            let epoch = mux.journal_event_epoch();
-                            mux.wait_for_journal_event(epoch, delay.min(remaining));
+                            // Do not retain the owning mux while sleeping. Shutdown and drop
+                            // must be able to release the writer even when SQLite stays locked.
+                            let journal = mux.shared_journal_handle();
+                            let epoch = journal.epoch();
+                            drop(mux);
+                            journal.wait(epoch, delay.min(remaining));
                             delay = (delay * 2).min(JOURNAL_RETRY_MAX_DELAY);
                             continue;
                         }
@@ -1031,11 +1035,10 @@ fn run(mux: Weak<Mux>, receivers: JournalIngressReceivers) {
                             if receivers.state.pause_nonretryable_failure_for_test() {
                                 continue;
                             }
-                            let epoch = mux.journal_event_epoch();
-                            mux.wait_for_journal_event(
-                                epoch,
-                                JOURNAL_NONRETRYABLE_RETRY_DELAY.min(remaining),
-                            );
+                            let journal = mux.shared_journal_handle();
+                            let epoch = journal.epoch();
+                            drop(mux);
+                            journal.wait(epoch, JOURNAL_NONRETRYABLE_RETRY_DELAY.min(remaining));
                             continue;
                         } else if batch[0].completion.is_none() {
                             let failure = receivers.state.fail(format!(

--- a/cmux-tui/crates/cmux-tui-core/src/journal_ingress.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_ingress.rs
@@ -1032,7 +1032,10 @@ fn run(mux: Weak<Mux>, receivers: JournalIngressReceivers) {
                                 continue;
                             }
                             let epoch = mux.journal_event_epoch();
-                            mux.wait_for_journal_event(epoch, JOURNAL_NONRETRYABLE_RETRY_DELAY.min(remaining));
+                            mux.wait_for_journal_event(
+                                epoch,
+                                JOURNAL_NONRETRYABLE_RETRY_DELAY.min(remaining),
+                            );
                             continue;
                         } else if batch[0].completion.is_none() {
                             let failure = receivers.state.fail(format!(

--- a/cmux-tui/crates/cmux-tui-core/src/journal_ingress.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_ingress.rs
@@ -958,6 +958,7 @@ fn run(mux: Weak<Mux>, receivers: JournalIngressReceivers) {
         let mut pending = VecDeque::from([batch]);
         while let Some(mut batch) = pending.pop_front() {
             let mut delay = JOURNAL_RETRY_INITIAL_DELAY;
+            let mut nonretryable_delay = JOURNAL_NONRETRYABLE_RETRY_DELAY;
             let mut reported_error = None;
             let mut uncompleted_nonretryable_failures = 0_usize;
             let retry_deadline = batch
@@ -1035,10 +1036,8 @@ fn run(mux: Weak<Mux>, receivers: JournalIngressReceivers) {
                             if receivers.state.pause_nonretryable_failure_for_test() {
                                 continue;
                             }
-                            wait_for_journal_retry(
-                                mux,
-                                JOURNAL_NONRETRYABLE_RETRY_DELAY.min(remaining),
-                            );
+                            wait_for_journal_retry(mux, nonretryable_delay.min(remaining));
+                            nonretryable_delay = next_nonretryable_retry_delay(nonretryable_delay);
                             continue;
                         } else if batch[0].completion.is_none() {
                             let failure = receivers.state.fail(format!(
@@ -1083,6 +1082,10 @@ fn wait_for_journal_retry_after_release(
 
 fn next_journal_retry_delay(delay: Duration) -> Duration {
     delay.saturating_mul(2).min(JOURNAL_RETRY_MAX_DELAY)
+}
+
+fn next_nonretryable_retry_delay(delay: Duration) -> Duration {
+    next_journal_retry_delay(delay)
 }
 
 fn admit_batch_commit(

--- a/cmux-tui/crates/cmux-tui-core/src/journal_ingress.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_ingress.rs
@@ -2,17 +2,17 @@ use std::collections::VecDeque;
 use std::io;
 use std::mem::size_of;
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
-use std::sync::mpsc::{sync_channel, Receiver, SyncSender, TryRecvError, TrySendError};
+use std::sync::mpsc::{Receiver, SyncSender, TryRecvError, TrySendError, sync_channel};
 use std::sync::{Arc, Condvar, Mutex, Weak};
 use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 
+use crate::Mux;
 use crate::resource::{
     ContentPublicId, FrontendProjectionPublicId, PanePublicId, ScreenPublicId, TabPublicId,
     TerminalPublicId, WorkspacePublicId,
 };
-use crate::Mux;
 
 const JOURNAL_TERMINAL_QUEUE_CAPACITY: usize = 1024;
 const JOURNAL_DURABLE_QUEUE_CAPACITY: usize = 256;
@@ -2290,10 +2290,11 @@ mod tests {
             .find(|record| record.kind == "terminal.output")
             .expect("terminal output retained across writer recovery");
         assert_eq!(output.terminal_output.as_deref(), Some(b"must survive retry".as_slice()));
-        assert!(output
-            .subjects
-            .iter()
-            .any(|subject| { subject.kind == "terminal" && subject.id == terminal_id.as_str() }));
+        assert!(
+            output.subjects.iter().any(|subject| {
+                subject.kind == "terminal" && subject.id == terminal_id.as_str()
+            })
+        );
 
         drop(injector);
         drop(mux);
@@ -2414,11 +2415,13 @@ mod tests {
             Err(JournalIngressTrySendError::Failed { error, .. })
                 if error.contains("admission is closed")
         ));
-        assert!(sender
-            .send_durable(JournalIngressEvent::TerminalBarrier)
-            .unwrap_err()
-            .to_string()
-            .contains("admission is closed"));
+        assert!(
+            sender
+                .send_durable(JournalIngressEvent::TerminalBarrier)
+                .unwrap_err()
+                .to_string()
+                .contains("admission is closed")
+        );
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/journal_ingress.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_ingress.rs
@@ -27,6 +27,7 @@ const JOURNAL_WRITER_SHUTDOWN_WAIT: Duration = Duration::from_secs(1);
 const JOURNAL_SQLITE_RETRY_SLICE: Duration = Duration::from_millis(100);
 const JOURNAL_RETRY_INITIAL_DELAY: Duration = Duration::from_millis(100);
 const JOURNAL_RETRY_MAX_DELAY: Duration = Duration::from_secs(1);
+const JOURNAL_NONRETRYABLE_RETRY_DELAY: Duration = Duration::from_millis(10);
 const COMMIT_PENDING: u8 = 0;
 const COMMIT_ADMITTED: u8 = 1;
 const COMMIT_CANCELED: u8 = 2;
@@ -1031,8 +1032,7 @@ fn run(mux: Weak<Mux>, receivers: JournalIngressReceivers) {
                                 continue;
                             }
                             let epoch = mux.journal_event_epoch();
-                            mux.wait_for_journal_event(epoch, delay);
-                            delay = (delay * 2).min(JOURNAL_RETRY_MAX_DELAY);
+                            mux.wait_for_journal_event(epoch, JOURNAL_NONRETRYABLE_RETRY_DELAY.min(remaining));
                             continue;
                         } else if batch[0].completion.is_none() {
                             let failure = receivers.state.fail(format!(
@@ -1246,6 +1246,8 @@ mod tests {
             assert_eq!(delay.as_millis(), expected);
             delay = (delay * 2).min(JOURNAL_RETRY_MAX_DELAY);
         }
+        let remaining = Duration::from_millis(3);
+        assert_eq!(JOURNAL_NONRETRYABLE_RETRY_DELAY.min(remaining), remaining);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/journal_ingress.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_ingress.rs
@@ -1274,7 +1274,11 @@ mod tests {
             assert_eq!(delay.as_millis(), expected);
             delay = next_journal_retry_delay(delay);
         }
-        assert_eq!(JOURNAL_NONRETRYABLE_RETRY_DELAY, Duration::from_millis(10));
+        let mut nonretryable_delay = JOURNAL_NONRETRYABLE_RETRY_DELAY;
+        for expected in [10, 20, 40, 80, 160, 320, 640, 1000, 1000] {
+            assert_eq!(nonretryable_delay.as_millis(), expected);
+            nonretryable_delay = next_nonretryable_retry_delay(nonretryable_delay);
+        }
         assert_eq!(next_journal_retry_delay(Duration::MAX), JOURNAL_RETRY_MAX_DELAY);
         let remaining = Duration::from_millis(3);
         assert_eq!(JOURNAL_NONRETRYABLE_RETRY_DELAY.min(remaining), remaining);

--- a/cmux-tui/crates/cmux-tui-core/src/journal_ingress.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_ingress.rs
@@ -25,6 +25,8 @@ const JOURNAL_DURABLE_WAIT: Duration = Duration::from_secs(2);
 const JOURNAL_COMMIT_RESULT_WAIT: Duration = Duration::from_secs(1);
 const JOURNAL_WRITER_SHUTDOWN_WAIT: Duration = Duration::from_secs(1);
 const JOURNAL_SQLITE_RETRY_SLICE: Duration = Duration::from_millis(100);
+const JOURNAL_RETRY_INITIAL_DELAY: Duration = Duration::from_millis(100);
+const JOURNAL_RETRY_MAX_DELAY: Duration = Duration::from_secs(1);
 const COMMIT_PENDING: u8 = 0;
 const COMMIT_ADMITTED: u8 = 1;
 const COMMIT_CANCELED: u8 = 2;
@@ -954,7 +956,7 @@ fn run(mux: Weak<Mux>, receivers: JournalIngressReceivers) {
         let Some(batch) = receive_batch(&receivers) else { return };
         let mut pending = VecDeque::from([batch]);
         while let Some(mut batch) = pending.pop_front() {
-            let mut delay = Duration::from_millis(10);
+            let mut delay = JOURNAL_RETRY_INITIAL_DELAY;
             let mut reported_error = None;
             let mut uncompleted_nonretryable_failures = 0_usize;
             let retry_deadline = batch
@@ -1012,7 +1014,7 @@ fn run(mux: Weak<Mux>, receivers: JournalIngressReceivers) {
                         if retryable_sqlite_error(&error) {
                             let epoch = mux.journal_event_epoch();
                             mux.wait_for_journal_event(epoch, delay.min(remaining));
-                            delay = (delay * 2).min(Duration::from_secs(1));
+                            delay = (delay * 2).min(JOURNAL_RETRY_MAX_DELAY);
                             continue;
                         }
                         if batch.len() > 1 {
@@ -1030,7 +1032,7 @@ fn run(mux: Weak<Mux>, receivers: JournalIngressReceivers) {
                             }
                             let epoch = mux.journal_event_epoch();
                             mux.wait_for_journal_event(epoch, delay);
-                            delay = (delay * 2).min(Duration::from_secs(1));
+                            delay = (delay * 2).min(JOURNAL_RETRY_MAX_DELAY);
                             continue;
                         } else if batch[0].completion.is_none() {
                             let failure = receivers.state.fail(format!(
@@ -1235,6 +1237,15 @@ mod tests {
         parse: impl FnOnce(String) -> Result<T, crate::resource::ResourceError>,
     ) -> T {
         parse(format!("{prefix}_{value:032x}")).unwrap()
+    }
+
+    #[test]
+    fn retry_schedule_has_bounded_exponential_spacing() {
+        let mut delay = JOURNAL_RETRY_INITIAL_DELAY;
+        for expected in [100, 200, 400, 800, 1000, 1000] {
+            assert_eq!(delay.as_millis(), expected);
+            delay = (delay * 2).min(JOURNAL_RETRY_MAX_DELAY);
+        }
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/journal_ingress.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_ingress.rs
@@ -1505,6 +1505,58 @@ mod tests {
     }
 
     #[test]
+    fn retryable_sqlite_wait_releases_mux_before_backoff() {
+        let root = std::env::temp_dir().join(format!(
+            "cmux-terminal-journal-retry-release-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        let mux = Mux::open_persistent(
+            "terminal-journal-retry-release",
+            crate::SurfaceOptions::default(),
+            &root,
+        )
+        .unwrap();
+        let database_path = std::fs::read_dir(&root)
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|entry| entry.path().join("workspace-registry.sqlite3"))
+            .find(|path| path.is_file())
+            .expect("persistent journal database");
+        let blocker = rusqlite::Connection::open(database_path).unwrap();
+        blocker.execute_batch("BEGIN IMMEDIATE;").unwrap();
+
+        mux.journal_terminal_output(
+            Arc::new(public_id("term", 16, TerminalPublicId::parse)),
+            Arc::from("retry-release-generation"),
+            b"retry while sqlite is locked".to_vec(),
+        );
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Arc::strong_count(&mux) > 1 && Instant::now() < deadline {
+            std::thread::yield_now();
+        }
+        assert_eq!(
+            Arc::strong_count(&mux),
+            1,
+            "retryable SQLite backoff must not retain the owning Mux"
+        );
+
+        blocker.execute_batch("ROLLBACK;").unwrap();
+        mux.flush_terminal_journal().unwrap();
+        let records = mux.session_journal_after(0, 1024).unwrap().records;
+        assert!(records.iter().any(|record| {
+            record.kind == "terminal.output"
+                && record.terminal_output.as_deref()
+                    == Some(b"retry while sqlite is locked".as_slice())
+        }));
+
+        drop(blocker);
+        drop(mux);
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
     fn shutdown_has_a_deadline_when_the_journal_stays_locked() {
         let root = std::env::temp_dir().join(format!(
             "cmux-terminal-journal-locked-shutdown-{}-{}",

--- a/cmux-tui/crates/cmux-tui-core/src/journal_ingress.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_ingress.rs
@@ -2,17 +2,17 @@ use std::collections::VecDeque;
 use std::io;
 use std::mem::size_of;
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
-use std::sync::mpsc::{Receiver, SyncSender, TryRecvError, TrySendError, sync_channel};
+use std::sync::mpsc::{sync_channel, Receiver, SyncSender, TryRecvError, TrySendError};
 use std::sync::{Arc, Condvar, Mutex, Weak};
 use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 
-use crate::Mux;
 use crate::resource::{
     ContentPublicId, FrontendProjectionPublicId, PanePublicId, ScreenPublicId, TabPublicId,
     TerminalPublicId, WorkspacePublicId,
 };
+use crate::Mux;
 
 const JOURNAL_TERMINAL_QUEUE_CAPACITY: usize = 1024;
 const JOURNAL_DURABLE_QUEUE_CAPACITY: usize = 256;
@@ -2283,11 +2283,10 @@ mod tests {
             .find(|record| record.kind == "terminal.output")
             .expect("terminal output retained across writer recovery");
         assert_eq!(output.terminal_output.as_deref(), Some(b"must survive retry".as_slice()));
-        assert!(
-            output.subjects.iter().any(|subject| {
-                subject.kind == "terminal" && subject.id == terminal_id.as_str()
-            })
-        );
+        assert!(output
+            .subjects
+            .iter()
+            .any(|subject| { subject.kind == "terminal" && subject.id == terminal_id.as_str() }));
 
         drop(injector);
         drop(mux);
@@ -2408,13 +2407,11 @@ mod tests {
             Err(JournalIngressTrySendError::Failed { error, .. })
                 if error.contains("admission is closed")
         ));
-        assert!(
-            sender
-                .send_durable(JournalIngressEvent::TerminalBarrier)
-                .unwrap_err()
-                .to_string()
-                .contains("admission is closed")
-        );
+        assert!(sender
+            .send_durable(JournalIngressEvent::TerminalBarrier)
+            .unwrap_err()
+            .to_string()
+            .contains("admission is closed"));
     }
 
     #[test]


### PR DESCRIPTION
Bound persistent terminal journal retry cadence with exponential backoff and a behavior test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds terminal journal retry cadence so SQLite lock contention cannot stall shutdown. Retryable failures now back off from 100ms to a 1s cap, while nonretryable failures back off from 10ms to the same cap instead of using the previous 10ms start for both paths.

- The writer releases its mux reference before sleeping, allowing shutdown to proceed during retry waits.
- If the mux disappears, receipts queued in both ingress lanes are resolved with an error.
- Tests cover both backoff schedules, ownership release, and queued receipt resolution.

<sup>Written for commit 3cee0891ca1e7cdab268e5a08772832fcb9bb26f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved journal reliability when temporary storage locks occur.
  * Journal shutdown can now complete promptly, even during retry waits.
  * Added bounded retry timing from 100 ms to 1 s to support faster recovery while preventing excessive delays.
  * Added short delays for nonretryable events to improve recovery consistency.
  * Improved responsiveness when journal operations are interrupted during shutdown or storage contention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->