### PR TITLE
Refactor cmux-tui socket resolution

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/cli/raw.rs
+++ b/cmux-tui/crates/cmux-tui/src/cli/raw.rs
@@ -3,7 +3,6 @@
 //! This module is intentionally named `raw`: its request object may contain
 //! internal fields and receives no public compatibility guarantees.
 
-use std::ffi::OsString;
 use std::io::{self, BufRead, BufReader, Read, Write};
 use std::path::PathBuf;
 use std::time::Duration;
@@ -140,30 +139,7 @@ fn read_line_limited(
 }
 
 fn resolve_socket(global: &GlobalArgs) -> anyhow::Result<PathBuf> {
-    resolve_socket_with_env(global, |name| std::env::var_os(name))
-}
-
-fn resolve_socket_with_env(
-    global: &GlobalArgs,
-    env: impl Fn(&str) -> Option<OsString>,
-) -> anyhow::Result<PathBuf> {
-    if let Some(path) = &global.socket {
-        return Ok(path.clone());
-    }
-    // An explicit session selects that session's canonical socket. Keep this
-    // ahead of environment fallbacks so `--session` cannot route raw requests
-    // through a stale socket inherited from the shell.
-    if let Some(session) = &global.session {
-        return cmux_tui_core::server::try_default_socket_path(session);
-    }
-    for name in ["CMUX_TUI_SOCKET", "CMUX_MUX_SOCKET"] {
-        if let Some(path) = env(name)
-            && !path.is_empty()
-        {
-            return Ok(PathBuf::from(path));
-        }
-    }
-    cmux_tui_core::server::try_default_socket_path(global.session.as_deref().unwrap_or("main"))
+    Ok(super::wire::resolve_socket_with_origin(global)?.0)
 }
 
 #[cfg(test)]
@@ -180,11 +156,12 @@ mod tests {
     #[test]
     fn explicit_session_precedes_ambient_socket_fallbacks() {
         let global = GlobalArgs { session: Some("session-alpha".into()), ..GlobalArgs::default() };
-        let socket = resolve_socket_with_env(&global, |_| Some("/tmp/stale.sock".into()))
-            .expect("session socket path should resolve");
+        let socket =
+            super::wire::resolve_socket_with_env(&global, |_| Some("/tmp/stale.sock".into()))
+                .expect("session socket path should resolve");
 
         assert_eq!(
-            socket,
+            socket.0,
             cmux_tui_core::server::try_default_socket_path("session-alpha")
                 .expect("session socket path should resolve")
         );

--- a/cmux-tui/crates/cmux-tui/src/cli/raw.rs
+++ b/cmux-tui/crates/cmux-tui/src/cli/raw.rs
@@ -156,9 +156,10 @@ mod tests {
     #[test]
     fn explicit_session_precedes_ambient_socket_fallbacks() {
         let global = GlobalArgs { session: Some("session-alpha".into()), ..GlobalArgs::default() };
-        let socket =
-            super::wire::resolve_socket_with_env(&global, |_| Some("/tmp/stale.sock".into()))
-                .expect("session socket path should resolve");
+        let socket = super::super::wire::resolve_socket_with_env(&global, |_| {
+            Some("/tmp/stale.sock".into())
+        })
+        .expect("session socket path should resolve");
 
         assert_eq!(
             socket.0,

--- a/cmux-tui/crates/cmux-tui/src/cli/wire.rs
+++ b/cmux-tui/crates/cmux-tui/src/cli/wire.rs
@@ -721,6 +721,13 @@ pub(super) fn resolve_socket(global: &GlobalArgs) -> anyhow::Result<PathBuf> {
 /// Resolve a socket and report whether it belongs to cmux's private runtime
 /// directory. Environment-selected and explicit paths remain caller-managed.
 pub(super) fn resolve_socket_with_origin(global: &GlobalArgs) -> anyhow::Result<(PathBuf, bool)> {
+    resolve_socket_with_env(global, |name| std::env::var_os(name))
+}
+
+pub(super) fn resolve_socket_with_env(
+    global: &GlobalArgs,
+    env: impl Fn(&str) -> Option<std::ffi::OsString>,
+) -> anyhow::Result<(PathBuf, bool)> {
     if let Some(path) = &global.socket {
         return Ok((path.clone(), false));
     }
@@ -728,7 +735,7 @@ pub(super) fn resolve_socket_with_origin(global: &GlobalArgs) -> anyhow::Result<
         return Ok((cmux_tui_core::server::try_default_socket_path(session)?, true));
     }
     for name in ["CMUX_TUI_SOCKET", "CMUX_MUX_SOCKET"] {
-        if let Some(path) = std::env::var_os(name)
+        if let Some(path) = env(name)
             && !path.is_empty()
         {
             return Ok((PathBuf::from(path), false));


### PR DESCRIPTION
Consolidate raw and wire CLI socket resolution into one shared implementation. Preserve explicit session precedence and test injection while removing duplicated fallback logic.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Previously, raw and wire CLI commands duplicated socket-resolution logic. They now share one implementation in `wire.rs`, preserving explicit session precedence and environment fallback order without changing selected sockets.

**Refactors**
- `raw.rs` delegates through `resolve_socket_with_origin` and uses the resolved path.
- Adds a shared `resolve_socket_with_env` helper that accepts an environment lookup, keeping tests deterministic.
- Wire callers keep origin tracking for sockets in cmux’s private runtime directory.

<sup>Written for commit f978ffe01102b2e15b449bc0170321ed39094df6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Standardized socket selection across command-line operations.
  * Continued support for explicit socket paths, sessions, environment-based configuration, and the default socket.

* **Tests**
  * Updated socket-resolution coverage to validate the shared selection flow.
  * Verified environment-based socket selection and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->