### PR TITLE
Fix invalid cmux-tui socket paths on Windows

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -1239,6 +1239,35 @@ mod tests {
         assert_eq!(path.parent(), Some(Path::new(r"C:\cmux-preferred-temp")));
     }
 
+    #[cfg(windows)]
+    #[test]
+    fn invalid_runtime_dir_falls_back_to_tmp_when_temp_is_unset() {
+        let _lock = RUNTIME_ENV_LOCK.lock().unwrap();
+        let old_temp = std::env::var_os("TEMP");
+        let old_tmp = std::env::var_os("TMP");
+        let tmp = OsString::from(r"D:\cmux-secondary-temp");
+
+        // SAFETY: this test serializes its process-global environment changes.
+        unsafe {
+            std::env::remove_var("TEMP");
+            std::env::set_var("TMP", &tmp);
+        }
+        let path = invalid_runtime_dir();
+        // SAFETY: this test serializes its process-global environment changes.
+        unsafe {
+            match old_temp {
+                Some(value) => std::env::set_var("TEMP", value),
+                None => std::env::remove_var("TEMP"),
+            }
+            match old_tmp {
+                Some(value) => std::env::set_var("TMP", value),
+                None => std::env::remove_var("TMP"),
+            }
+        }
+
+        assert_eq!(path.parent(), Some(Path::new(r"D:\cmux-secondary-temp")));
+    }
+
     #[test]
     fn explicit_ghostty_installation_remains_authoritative() {
         let explicit = PathBuf::from("/custom/pinned/bin/ghostty");

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -823,7 +823,7 @@ fn runtime_base_dir() -> PathBuf {
 
 #[cfg(windows)]
 fn runtime_base_dir() -> PathBuf {
-    env_path("TEMP").or_else(|| env_path("TMP")).unwrap_or_else(std::env::temp_dir)
+    std::env::temp_dir()
 }
 
 #[cfg(not(windows))]

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -1012,6 +1012,14 @@ fn restrict_permissions(_path: &Path, _mode: u32) -> std::io::Result<()> {
 mod tests {
     use super::*;
 
+    #[cfg(windows)]
+    use std::ffi::OsString;
+    #[cfg(windows)]
+    use std::sync::Mutex;
+
+    #[cfg(windows)]
+    static RUNTIME_ENV_LOCK: Mutex<()> = Mutex::new(());
+
     #[cfg(target_os = "macos")]
     #[test]
     fn explicit_xdg_ghostty_config_does_not_add_application_support_candidates() {
@@ -1199,6 +1207,36 @@ mod tests {
         ] {
             assert!(!windows_path_is_rooted_local_drive(path), "{path}");
         }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn invalid_runtime_dir_uses_the_runtime_temp_precedence() {
+        let _lock = RUNTIME_ENV_LOCK.lock().unwrap();
+        let old_temp = std::env::var_os("TEMP");
+        let old_tmp = std::env::var_os("TMP");
+        let temp = OsString::from(r"C:\cmux-preferred-temp");
+        let tmp = OsString::from(r"D:\cmux-secondary-temp");
+
+        // SAFETY: this test serializes its process-global environment changes.
+        unsafe {
+            std::env::set_var("TEMP", &temp);
+            std::env::set_var("TMP", &tmp);
+        }
+        let path = invalid_runtime_dir();
+        // SAFETY: this test serializes its process-global environment changes.
+        unsafe {
+            match old_temp {
+                Some(value) => std::env::set_var("TEMP", value),
+                None => std::env::remove_var("TEMP"),
+            }
+            match old_tmp {
+                Some(value) => std::env::set_var("TMP", value),
+                None => std::env::remove_var("TMP"),
+            }
+        }
+
+        assert_eq!(path.parent(), Some(Path::new(r"C:\cmux-preferred-temp")));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -1215,13 +1215,16 @@ mod tests {
         let _lock = RUNTIME_ENV_LOCK.lock().unwrap();
         let old_temp = std::env::var_os("TEMP");
         let old_tmp = std::env::var_os("TMP");
+        let old_userprofile = std::env::var_os("USERPROFILE");
         let temp = OsString::from(r"C:\cmux-preferred-temp");
         let tmp = OsString::from(r"D:\cmux-secondary-temp");
+        let userprofile = OsString::from(r"E:\cmux-user-profile");
 
         // SAFETY: this test serializes its process-global environment changes.
         unsafe {
             std::env::set_var("TEMP", &temp);
             std::env::set_var("TMP", &tmp);
+            std::env::set_var("USERPROFILE", &userprofile);
         }
         let path = invalid_runtime_dir();
         // SAFETY: this test serializes its process-global environment changes.
@@ -1234,9 +1237,13 @@ mod tests {
                 Some(value) => std::env::set_var("TMP", value),
                 None => std::env::remove_var("TMP"),
             }
+            match old_userprofile {
+                Some(value) => std::env::set_var("USERPROFILE", value),
+                None => std::env::remove_var("USERPROFILE"),
+            }
         }
 
-        assert_eq!(path.parent(), Some(Path::new(r"C:\cmux-preferred-temp")));
+        assert_eq!(path.parent(), Some(Path::new(r"D:\cmux-secondary-temp")));
     }
 
     #[cfg(windows)]
@@ -1266,6 +1273,41 @@ mod tests {
         }
 
         assert_eq!(path.parent(), Some(Path::new(r"D:\cmux-secondary-temp")));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn invalid_runtime_dir_falls_back_to_userprofile_when_temp_is_unset() {
+        let _lock = RUNTIME_ENV_LOCK.lock().unwrap();
+        let old_temp = std::env::var_os("TEMP");
+        let old_tmp = std::env::var_os("TMP");
+        let old_userprofile = std::env::var_os("USERPROFILE");
+        let userprofile = OsString::from(r"E:\cmux-user-profile");
+
+        // SAFETY: this test serializes its process-global environment changes.
+        unsafe {
+            std::env::remove_var("TEMP");
+            std::env::remove_var("TMP");
+            std::env::set_var("USERPROFILE", &userprofile);
+        }
+        let path = invalid_runtime_dir();
+        // SAFETY: this test serializes its process-global environment changes.
+        unsafe {
+            match old_temp {
+                Some(value) => std::env::set_var("TEMP", value),
+                None => std::env::remove_var("TEMP"),
+            }
+            match old_tmp {
+                Some(value) => std::env::set_var("TMP", value),
+                None => std::env::remove_var("TMP"),
+            }
+            match old_userprofile {
+                Some(value) => std::env::set_var("USERPROFILE", value),
+                None => std::env::remove_var("USERPROFILE"),
+            }
+        }
+
+        assert_eq!(path.parent(), Some(Path::new(r"E:\cmux-user-profile")));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -188,7 +188,7 @@ pub fn hashed_runtime_dir_for_base(base: &Path) -> PathBuf {
 /// These paths are never opened by a fallible connector.
 pub fn invalid_runtime_dir() -> PathBuf {
     #[cfg(windows)]
-    let base = std::env::temp_dir();
+    let base = runtime_base_dir();
     #[cfg(not(windows))]
     let base = PathBuf::from("/tmp");
     base.join(format!("cmux-tui-invalid-{}", user_id_component()))

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -187,7 +187,11 @@ pub fn hashed_runtime_dir_for_base(base: &Path) -> PathBuf {
 /// Private root for compatibility paths produced from invalid session text.
 /// These paths are never opened by a fallible connector.
 pub fn invalid_runtime_dir() -> PathBuf {
-    PathBuf::from("/tmp").join(format!("cmux-tui-invalid-{}", user_id_component()))
+    #[cfg(windows)]
+    let base = std::env::temp_dir();
+    #[cfg(not(windows))]
+    let base = PathBuf::from("/tmp");
+    base.join(format!("cmux-tui-invalid-{}", user_id_component()))
 }
 
 /// Default root for durable workspace/session state. Runtime sockets stay in


### PR DESCRIPTION
On Windows, invalid session names map to a hard-coded `/tmp` path. Windows Rust uses GetTempPath2/GetTempPath for temporary paths, and `/tmp` is not guaranteed to exist. Use `std::env::temp_dir()` on Windows while preserving the Unix compatibility path.

Verification: `git diff --check`. Cargo tests were not run per cmux-tui instructions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes invalid `cmux-tui` socket paths on Windows, which previously used a hard-coded `/tmp` that may not exist. Windows now derives runtime paths from `std::env::temp_dir()`, following the platform's TEMP/TMP/USERPROFILE precedence, while Unix keeps `/tmp`. Adds Windows tests covering the fallback chain.

<sup>Written for commit f7afd74b57467141d68f35698ddd02905f53e898. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility on Windows by using the system’s temporary directory for runtime files.
  * Preserved existing temporary directory behavior on other platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->